### PR TITLE
Disable run button with spinner animation while code executes

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -1090,16 +1090,22 @@ export default function Playground({ adapter }: PlaygroundProps) {
               <span className="kbd">⌘ Enter</span>
               <button
                 type="button"
-                className="run-btn"
-                disabled={!loaded}
+                className={`run-btn${statusState === "running" ? " running" : ""}`}
+                disabled={!loaded || statusState === "running"}
                 onClick={() => {
                   void runCode();
                 }}
               >
-                <svg viewBox="0 0 12 12">
-                  <polygon points="2,1 11,6 2,11" />
-                </svg>
-                Run
+                {statusState === "running" ? (
+                  <svg viewBox="0 0 12 12" className="run-btn-spinner">
+                    <circle cx="6" cy="6" r="4.5" fill="none" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeDasharray="14 8" />
+                  </svg>
+                ) : (
+                  <svg viewBox="0 0 12 12">
+                    <polygon points="2,1 11,6 2,11" />
+                  </svg>
+                )}
+                {statusState === "running" ? "Running…" : "Run"}
               </button>
             </div>
             <div className="editor-wrap">

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -228,6 +228,9 @@ body.pg-active {
 .run-btn:disabled { opacity: 0.45; cursor: not-allowed; filter: none; }
 
 .run-btn svg { width: 12px; height: 12px; fill: white; flex-shrink: 0; }
+.run-btn.running { opacity: 0.75; cursor: not-allowed; }
+.run-btn-spinner { animation: pg-spin 0.75s linear infinite; }
+@keyframes pg-spin { to { transform: rotate(360deg); } }
 
 .editor-wrap {
   flex: 1; overflow: hidden; position: relative;


### PR DESCRIPTION
When statusState is "running", the run button is now disabled and shows
a spinning arc icon with "Running…" text instead of the play triangle,
preventing duplicate execution and giving clear visual feedback.

https://claude.ai/code/session_01HFiDfSzknVCep3cFYWeTsk