### PR TITLE
Remove light/dark mode toggle, tie theme to editor theme

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -46,8 +46,6 @@ interface PlotlyAPI {
   ): Promise<unknown>;
 }
 
-type Mode = "light" | "dark" | "system";
-
 const ALL_THEMES = [
   { value: "dracula", label: "Dracula" },
   { value: "monokai", label: "Monokai" },
@@ -60,14 +58,6 @@ const ALL_THEMES = [
   { value: "mdn-like", label: "MDN-like" },
 ];
 
-const DARK_THEMES = new Set([
-  "dracula",
-  "monokai",
-  "material-darker",
-  "nord",
-  "tomorrow-night-eighties",
-  "solarized dark",
-]);
 const LIGHT_THEMES = new Set(["eclipse", "mdn-like", "solarized light"]);
 
 interface ThemePalette {
@@ -149,13 +139,8 @@ function applyThemePalette(theme: string): void {
   root.style.setProperty("--text-muted", p.muted);
 }
 
-function applyMode(mode: Mode): void {
-  const resolved =
-    mode === "system"
-      ? window.matchMedia("(prefers-color-scheme: light)").matches
-        ? "light"
-        : "dark"
-      : mode;
+function applyMode(theme: string): void {
+  const resolved = LIGHT_THEMES.has(theme) ? "light" : "dark";
   document.documentElement.setAttribute("data-theme", resolved);
 }
 
@@ -373,8 +358,6 @@ function ExamplesDropdown({ open, examples, onPick }: ExamplesDropdownProps) {
 }
 
 interface SettingsPanelProps {
-  mode: Mode;
-  setMode: (m: Mode) => void;
   fontSize: number;
   setFontSize: (n: number) => void;
   outputFontSizeEnabled: boolean;
@@ -388,8 +371,6 @@ interface SettingsPanelProps {
 }
 
 function SettingsPanel({
-  mode,
-  setMode,
   fontSize,
   setFontSize,
   outputFontSizeEnabled,
@@ -424,44 +405,6 @@ function SettingsPanel({
           </button>
         </div>
         <div className="settings-body">
-          <div className="setting-row">
-            <div className="setting-label">Appearance</div>
-            <div className="mode-toggle">
-              <button
-                type="button"
-                className={`mode-btn${mode === "light" ? " active" : ""}`}
-                onClick={() => setMode("light")}
-              >
-                <svg viewBox="0 0 24 24">
-                  <circle cx="12" cy="12" r="4" />
-                  <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
-                </svg>
-                Light
-              </button>
-              <button
-                type="button"
-                className={`mode-btn${mode === "dark" ? " active" : ""}`}
-                onClick={() => setMode("dark")}
-              >
-                <svg viewBox="0 0 24 24">
-                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-                </svg>
-                Dark
-              </button>
-              <button
-                type="button"
-                className={`mode-btn${mode === "system" ? " active" : ""}`}
-                onClick={() => setMode("system")}
-              >
-                <svg viewBox="0 0 24 24">
-                  <rect x="2" y="3" width="20" height="14" rx="2" />
-                  <path d="M8 21h8M12 17v4" />
-                </svg>
-                System
-              </button>
-            </div>
-          </div>
-
           <div className="setting-row">
             <div className="setting-label">Editor Font Size</div>
             <div className="font-size-row">
@@ -578,7 +521,6 @@ export interface PlaygroundProps {
 export default function Playground({ adapter }: PlaygroundProps) {
   // ─── Initial settings (persisted in localStorage, namespaced per-language) ─
   const storageKey = (k: string) => `pg_${adapter.id}_${k}`;
-  const [mode, setModeState] = useState<Mode>("system");
   const [fontSize, setFontSizeState] = useState<number>(13);
   const [outputFontSizeEnabled, setOutputFontSizeEnabledState] =
     useState<boolean>(false);
@@ -627,7 +569,6 @@ export default function Playground({ adapter }: PlaygroundProps) {
     document.title = adapter.documentTitle;
     document.body.classList.add("pg-active");
 
-    const savedMode = (localStorage.getItem(storageKey("mode")) as Mode | null) ?? "system";
     const savedSize = Number(localStorage.getItem(storageKey("fontsize")) ?? 13) || 13;
     const savedTheme = localStorage.getItem(storageKey("editortheme")) ?? "dracula";
     const savedOutputEnabled =
@@ -640,13 +581,12 @@ export default function Playground({ adapter }: PlaygroundProps) {
        useState initialisers because that would cause a hydration mismatch
        between SSR (no `window`) and CSR. */
     /* eslint-disable react-hooks/set-state-in-effect */
-    setModeState(savedMode);
     setFontSizeState(savedSize);
     setOutputFontSizeEnabledState(savedOutputEnabled);
     setOutputFontSizeState(savedOutputSize);
     setEditorThemeState(savedTheme);
     /* eslint-enable react-hooks/set-state-in-effect */
-    applyMode(savedMode);
+    applyMode(savedTheme);
     applyThemePalette(savedTheme);
     document.documentElement.style.setProperty(
       "--cm-font-size",
@@ -657,15 +597,7 @@ export default function Playground({ adapter }: PlaygroundProps) {
       `${savedOutputEnabled ? savedOutputSize : savedSize}px`,
     );
 
-    const mql = window.matchMedia("(prefers-color-scheme: light)");
-    const onSysChange = () => {
-      if ((localStorage.getItem(storageKey("mode")) ?? "system") === "system") {
-        applyMode("system");
-      }
-    };
-    mql.addEventListener("change", onSysChange);
     return () => {
-      mql.removeEventListener("change", onSysChange);
       document.body.classList.remove("pg-active");
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -743,6 +675,7 @@ export default function Playground({ adapter }: PlaygroundProps) {
   useEffect(() => {
     editorRef.current?.setOption("theme", editorTheme);
     applyThemePalette(editorTheme);
+    applyMode(editorTheme);
   }, [editorTheme]);
 
   // Update the editor font size via CSS variable. This is what makes the
@@ -765,27 +698,6 @@ export default function Playground({ adapter }: PlaygroundProps) {
       `${effective}px`,
     );
   }, [outputFontSizeEnabled, outputFontSize, fontSize]);
-
-  useEffect(() => {
-    applyMode(mode);
-  }, [mode]);
-
-  // Auto-pick a sensible editor theme when the user toggles light/dark mode.
-  const setMode = useCallback(
-    (m: Mode) => {
-      setModeState(m);
-      localStorage.setItem(storageKey("mode"), m);
-      if (m === "light" && DARK_THEMES.has(editorTheme)) {
-        setEditorThemeState("eclipse");
-        localStorage.setItem(storageKey("editortheme"), "eclipse");
-      } else if (m === "dark" && LIGHT_THEMES.has(editorTheme)) {
-        setEditorThemeState("dracula");
-        localStorage.setItem(storageKey("editortheme"), "dracula");
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [editorTheme, adapter.id],
-  );
 
   const setFontSize = useCallback(
     (n: number) => {
@@ -1059,8 +971,6 @@ export default function Playground({ adapter }: PlaygroundProps) {
 
         {settingsOpen && (
           <SettingsPanel
-            mode={mode}
-            setMode={setMode}
             fontSize={fontSize}
             setFontSize={setFontSize}
             outputFontSizeEnabled={outputFontSizeEnabled}
@@ -1111,7 +1021,14 @@ export default function Playground({ adapter }: PlaygroundProps) {
             <div className="editor-wrap">
               <textarea ref={textareaRef} defaultValue="" />
             </div>
-            <div className="resizer" ref={resizerRef} />
+            <div
+              className="resizer"
+              ref={resizerRef}
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Drag to resize editor and output panes"
+              title="Drag to resize"
+            />
           </div>
 
           <div className="output-pane">

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -261,7 +261,9 @@ body.pg-active {
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 16px;
+  /* Extra bottom padding lets the user scroll the final output well above
+     the fold so the last cell is easy to read. */
+  padding: 16px 16px 360px 16px;
   display: flex; flex-direction: column; gap: 12px;
 }
 .out-cell { flex-shrink: 0; }
@@ -279,9 +281,10 @@ body.pg-active {
 .welcome h3 { font-size: 15px; color: var(--text-muted); font-weight: 500; }
 .welcome p  { font-size: 12px; line-height: 1.6; max-width: 240px; }
 
-/* Output cells */
+/* Output cells — minimal chrome. A single colored left accent identifies the
+   cell type; the header's darker background separates it from the body. No
+   outer box border so cells don't look nested. */
 .out-cell {
-  border: 1px solid var(--border);
   border-radius: var(--radius);
   overflow: hidden;
   animation: pg-fadeSlide 0.2s ease;
@@ -295,18 +298,17 @@ body.pg-active {
   display: flex; align-items: center; gap: 8px;
   padding: 6px 10px;
   background: var(--bg2);
-  border-bottom: 1px solid var(--border);
   font-size: 11px; font-family: var(--font-mono);
   color: var(--text-dim);
 }
 .out-cell-header .cell-type { font-weight: 600; }
 .out-cell-header .cell-time { margin-left: auto; }
 
-.out-cell.stdout .out-cell-header { border-left: 3px solid var(--green); }
-.out-cell.stderr .out-cell-header { border-left: 3px solid var(--red); }
-.out-cell.html   .out-cell-header { border-left: 3px solid var(--accent); }
-.out-cell.plot   .out-cell-header { border-left: 3px solid var(--yellow); }
-.out-cell.image  .out-cell-header { border-left: 3px solid var(--yellow); }
+.out-cell.stdout { border-left: 3px solid var(--green); }
+.out-cell.stderr { border-left: 3px solid var(--red); }
+.out-cell.html   { border-left: 3px solid var(--accent); }
+.out-cell.plot   { border-left: 3px solid var(--yellow); }
+.out-cell.image  { border-left: 3px solid var(--yellow); }
 
 .out-cell-body { padding: 12px; }
 
@@ -429,28 +431,6 @@ body.pg-active {
 .setting-label {
   font-size: 11px; font-weight: 600; letter-spacing: 0.05em;
   text-transform: uppercase; color: var(--text-dim);
-}
-
-/* Mode toggle */
-.mode-toggle {
-  display: grid; grid-template-columns: 1fr 1fr 1fr;
-  background: var(--bg3); border-radius: 8px; padding: 3px; gap: 3px;
-}
-.mode-btn {
-  display: flex; align-items: center; justify-content: center; gap: 5px;
-  padding: 7px 4px; border-radius: 6px; border: none;
-  background: transparent; color: var(--text-dim);
-  font-family: var(--font-ui); font-size: 12px; font-weight: 500;
-  cursor: pointer; transition: all 0.15s;
-}
-.mode-btn svg { width: 13px; height: 13px; fill: none; stroke: currentColor; stroke-width: 1.8; flex-shrink: 0; }
-.mode-btn:hover { color: var(--text); }
-.mode-btn.active {
-  background: var(--bg2); color: var(--text);
-  box-shadow: 0 1px 4px #0003;
-}
-html[data-theme="light"] .mode-btn.active {
-  box-shadow: 0 1px 4px #0001, 0 0 0 1px var(--border);
 }
 
 /* Font size slider */
@@ -663,10 +643,33 @@ input[type="range"].fs-slider:disabled {
 }
 .loading-msg { font-size: 13px; color: var(--text-dim); font-family: var(--font-mono); }
 
-/* Resizer */
+/* Resizer — draggable divider between editor and output panes. A persistent
+   grip indicator makes it discoverable without requiring the user to hover to
+   find the hit area. */
 .resizer {
-  width: 4px; background: transparent; cursor: col-resize;
-  transition: background 0.15s; position: absolute; top: 0; bottom: 0;
-  right: -2px; z-index: 10;
+  position: absolute; top: 0; bottom: 0;
+  right: -4px; width: 8px; z-index: 10;
+  cursor: col-resize;
+  display: flex; align-items: center; justify-content: center;
+  background: transparent;
+  transition: background 0.15s;
 }
-.resizer:hover, .resizer.dragging { background: var(--accent); }
+.resizer::before {
+  content: "";
+  width: 2px; height: 36px;
+  background: var(--text-dim);
+  opacity: 0.55;
+  border-radius: 1px;
+  transition: all 0.15s;
+}
+.resizer:hover::before,
+.resizer.dragging::before {
+  background: var(--accent);
+  opacity: 1;
+  height: 64px;
+  width: 3px;
+}
+.resizer:hover,
+.resizer.dragging {
+  background: var(--accent-glow);
+}


### PR DESCRIPTION
This PR simplifies the appearance settings by removing the explicit light/dark mode toggle and instead deriving the UI theme directly from the selected editor theme.

## Summary
The playground previously allowed users to independently control the light/dark mode and editor theme, with logic to auto-switch themes when toggling modes. This change removes that complexity by determining whether to use light or dark mode based solely on the editor theme selection.

## Key Changes
- **Removed mode toggle UI**: Deleted the "Appearance" setting with Light/Dark/System buttons from the settings panel
- **Simplified theme logic**: Replaced the `Mode` type and `applyMode()` function that accepted "light"/"dark"/"system" with a simpler version that takes a theme string and determines the mode based on whether it's in `LIGHT_THEMES`
- **Removed mode state management**: Eliminated `mode` state, `setMode` callback, and localStorage persistence of mode preference
- **Removed system preference listener**: Deleted the `matchMedia` listener that responded to OS-level color scheme changes
- **Updated theme application**: Modified the editor theme effect hook to call `applyMode()` with the theme, ensuring the UI mode updates whenever the editor theme changes
- **Improved resizer accessibility**: Enhanced the editor/output pane divider with semantic HTML attributes (`role="separator"`, `aria-orientation`, `aria-label`) and added a visual grip indicator that animates on hover
- **Refined output pane styling**: 
  - Increased bottom padding to 360px to allow scrolling final output well above the fold
  - Removed outer borders from output cells for a cleaner look
  - Moved colored left accent from header to the cell itself
  - Removed header bottom border for minimal chrome design
- **Removed unused constants**: Deleted `DARK_THEMES` set which is no longer needed

## Implementation Details
The theme determination now uses a simple lookup: if the editor theme is in `LIGHT_THEMES`, the UI uses light mode; otherwise, it uses dark mode. This eliminates the need for separate mode state and localStorage persistence, reducing complexity while maintaining the same visual behavior.

https://claude.ai/code/session_01DtWcVPdE8KuxybZKXHZt8X