### PR TITLE
Add export functionality and mobile tab layout to playground

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -27,6 +27,7 @@ import type {
 } from "./runtime/globals";
 import type {
   ExampleSnippet,
+  ExportFormat,
   LanguageAdapter,
   LanguageRuntime,
   OutputCell,
@@ -357,6 +358,35 @@ function ExamplesDropdown({ open, examples, onPick }: ExamplesDropdownProps) {
   );
 }
 
+interface ExportDropdownProps {
+  open: boolean;
+  formats: ExportFormat[];
+  onPick: (format: ExportFormat) => void;
+}
+
+function ExportDropdown({ open, formats, onPick }: ExportDropdownProps) {
+  if (!open) return null;
+  return (
+    <div className="examples-dropdown export-dropdown">
+      {formats.map((fmt) => (
+        <div
+          key={fmt.extension}
+          className="example-item"
+          onClick={() => onPick(fmt)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onPick(fmt);
+          }}
+        >
+          <div className="ex-title">{fmt.label}</div>
+          <div className="ex-desc">Download .{fmt.extension} file</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 interface SettingsPanelProps {
   fontSize: number;
   setFontSize: (n: number) => void;
@@ -529,8 +559,10 @@ export default function Playground({ adapter }: PlaygroundProps) {
 
   // ─── UI state ───────────────────────────────────────────────────────────
   const [examplesOpen, setExamplesOpen] = useState(false);
+  const [exportOpen, setExportOpen] = useState(false);
   const [packagesOpen, setPackagesOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [mobileTab, setMobileTab] = useState<"editor" | "output">("editor");
   const router = useRouter();
 
   // ─── Runtime state ──────────────────────────────────────────────────────
@@ -784,6 +816,11 @@ export default function Playground({ adapter }: PlaygroundProps) {
         setStatusState("ready");
         setStatusText(adapter.readyStatus);
       }, 3000);
+    } finally {
+      // On narrow viewports the panes share the screen via a tab switcher;
+      // surface the result tab automatically once the run is done so the
+      // user doesn't have to swipe back themselves.
+      setMobileTab("output");
     }
   }, [adapter.readyStatus]);
 
@@ -808,6 +845,23 @@ export default function Playground({ adapter }: PlaygroundProps) {
     setExamplesOpen(false);
     editorRef.current?.focus();
   }, []);
+
+  const exportCode = useCallback(
+    (format: ExportFormat) => {
+      const code = editorRef.current?.getValue() ?? "";
+      const blob = new Blob([code], { type: format.mimeType });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${adapter.exportBaseFilename}.${format.extension}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setExportOpen(false);
+    },
+    [adapter.exportBaseFilename],
+  );
 
   // Auto-scroll output on new cells.
   useEffect(() => {
@@ -875,6 +929,22 @@ export default function Playground({ adapter }: PlaygroundProps) {
     return () => document.removeEventListener("click", onDocClick);
   }, [examplesOpen]);
 
+  // Close export dropdown when clicking outside.
+  useEffect(() => {
+    if (!exportOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        !target?.closest(".export-dropdown") &&
+        !target?.closest("[data-export-trigger]")
+      ) {
+        setExportOpen(false);
+      }
+    };
+    document.addEventListener("click", onDocClick);
+    return () => document.removeEventListener("click", onDocClick);
+  }, [exportOpen]);
+
   const typeLabel: Record<OutputCell["type"], string> = {
     stdout: "OUTPUT",
     stderr: "ERROR",
@@ -938,6 +1008,26 @@ export default function Playground({ adapter }: PlaygroundProps) {
             />
           </div>
 
+          <div style={{ position: "relative" }}>
+            <button
+              type="button"
+              className="examples-btn"
+              data-export-trigger
+              onClick={() => setExportOpen((v) => !v)}
+              title="Export code"
+            >
+              <svg viewBox="0 0 16 16" width={13} height={13} fill="currentColor">
+                <path d="M8 1l3 3h-2v5H7V4H5l3-3zM2 11h12v2H2z" />
+              </svg>
+              Export
+            </button>
+            <ExportDropdown
+              open={exportOpen}
+              formats={adapter.exportFormats}
+              onPick={exportCode}
+            />
+          </div>
+
           <button
             type="button"
             className="examples-btn"
@@ -992,7 +1082,28 @@ export default function Playground({ adapter }: PlaygroundProps) {
           onClose={() => setPackagesOpen(false)}
         />
 
-        <div className="panes" ref={panesRef}>
+        <div className="mobile-tabs" role="tablist" aria-label="Pane">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mobileTab === "editor"}
+            className={`mobile-tab${mobileTab === "editor" ? " active" : ""}`}
+            onClick={() => setMobileTab("editor")}
+          >
+            Editor
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mobileTab === "output"}
+            className={`mobile-tab${mobileTab === "output" ? " active" : ""}`}
+            onClick={() => setMobileTab("output")}
+          >
+            Output
+          </button>
+        </div>
+
+        <div className="panes" data-mobile-tab={mobileTab} ref={panesRef}>
           <div className="editor-pane" ref={editorPaneRef}>
             <div className="pane-bar">
               <span className="pane-label">Editor</span>
@@ -1033,7 +1144,11 @@ export default function Playground({ adapter }: PlaygroundProps) {
 
           <div className="output-pane">
             <div className="pane-bar">
-              <span className="pane-label">Output</span>
+              <span className="pane-label">
+                {outputs.length === 0
+                  ? "Output"
+                  : `${outputs.length} ${outputs.length === 1 ? "Output" : "Outputs"}`}
+              </span>
               <div className="pane-bar-sep" />
               <button
                 type="button"

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -89,23 +89,24 @@ body.pg-active {
 
 /* Dropdown that lets the user switch between playgrounds (sits where the
    plain-text title used to be in the header). Styled to look like a
-   subtle button rather than a default <select>. */
+   subtle button rather than a default <select>. The triangle is painted
+   in `currentColor` so it always matches the dropdown's text color. */
 .playground-switcher {
   appearance: none;
   -webkit-appearance: none;
-  background: transparent;
+  background-color: var(--bg3);
   border: 1px solid transparent;
   color: var(--text);
   font-family: var(--font-ui);
   font-weight: 600;
   font-size: 15px;
   letter-spacing: -0.01em;
-  padding: 4px 26px 4px 6px;
+  padding: 4px 26px 4px 10px;
   border-radius: 6px;
   cursor: pointer;
   background-image:
-    linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
-    linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+    linear-gradient(45deg, transparent 50%, currentColor 50%),
+    linear-gradient(135deg, currentColor 50%, transparent 50%);
   background-position:
     calc(100% - 13px) 50%,
     calc(100% - 8px) 50%;
@@ -114,8 +115,7 @@ body.pg-active {
   transition: background-color 0.15s, border-color 0.15s;
 }
 .playground-switcher:hover {
-  background-color: var(--bg3);
-  border-color: var(--border);
+  background-color: var(--border);
 }
 .playground-switcher:focus-visible {
   outline: none;
@@ -672,4 +672,95 @@ input[type="range"].fs-slider:disabled {
 .resizer:hover,
 .resizer.dragging {
   background: var(--accent-glow);
+}
+
+/* Export dropdown reuses the examples-dropdown layout but anchors below
+   its own trigger button (which sits to the right of "Examples"). */
+.export-dropdown {
+  right: auto;
+  left: 0;
+  top: calc(100% + 6px);
+  width: 200px;
+}
+
+/* ─── Mobile tab bar (hidden on desktop) ─────────────────────────────────
+   On narrow viewports the editor and output share the screen via this
+   tab switcher. On desktop the tab bar is hidden and both panes show
+   side-by-side as before. */
+.mobile-tabs {
+  display: none;
+}
+
+.mobile-tab {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s;
+}
+.mobile-tab:hover { color: var(--text); }
+.mobile-tab.active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+}
+
+@media (max-width: 768px) {
+  .pg-app {
+    grid-template-rows: 48px auto 1fr;
+  }
+
+  /* Header gets tight on small screens — keep the "Run" affordances and
+     status pill, but let secondary buttons wrap by allowing horizontal
+     scroll. */
+  .pg-header {
+    overflow-x: auto;
+    gap: 8px;
+    padding: 0 12px;
+  }
+  .pg-header::-webkit-scrollbar { display: none; }
+
+  .mobile-tabs {
+    display: flex;
+    align-items: stretch;
+    background: var(--bg2);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .panes {
+    grid-template-columns: 1fr;
+  }
+
+  /* Show only the active pane on narrow viewports. Each pane fills the
+     remaining viewport so the editor / output area gets the entire
+     screen below the header + tab bar. */
+  .panes .editor-pane,
+  .panes .output-pane {
+    display: none;
+  }
+  .panes[data-mobile-tab="editor"] .editor-pane {
+    display: flex;
+    border-right: none;
+  }
+  .panes[data-mobile-tab="output"] .output-pane {
+    display: flex;
+  }
+
+  /* The drag-to-resize divider doesn't make sense in a tabbed layout. */
+  .resizer { display: none; }
+
+  /* Anchor the examples / export dropdowns to their triggers instead of
+     the right edge of the header so they don't get clipped. */
+  .examples-dropdown {
+    right: auto;
+    left: 0;
+    top: calc(100% + 6px);
+  }
 }

--- a/app/_components/runtime/python.tsx
+++ b/app/_components/runtime/python.tsx
@@ -370,6 +370,10 @@ export const pythonAdapter: LanguageAdapter = {
   codeMirrorMode: "python",
   examples: EXAMPLES,
   packages: PACKAGES,
+  exportFormats: [
+    { extension: "py", label: "Python (.py)", mimeType: "text/x-python" },
+  ],
+  exportBaseFilename: "script",
   packagesFooter: (
     <>
       Packages run in WebAssembly via{" "}

--- a/app/_components/runtime/r.tsx
+++ b/app/_components/runtime/r.tsx
@@ -535,6 +535,10 @@ export const rAdapter: LanguageAdapter = {
   codeMirrorMode: "r",
   examples: EXAMPLES,
   packages: PACKAGES,
+  exportFormats: [
+    { extension: "r", label: "R (.r)", mimeType: "text/x-r-source" },
+  ],
+  exportBaseFilename: "script",
   packagesFooter: (
     <>
       Packages run in WebAssembly via{" "}

--- a/app/_components/types.ts
+++ b/app/_components/types.ts
@@ -34,6 +34,15 @@ export interface PackageInfo {
   desc: string;
 }
 
+export interface ExportFormat {
+  /** File extension without the leading dot, e.g. "py" or "r". */
+  extension: string;
+  /** Label shown in the export dropdown, e.g. "Python (.py)". */
+  label: string;
+  /** MIME type used when constructing the download Blob. */
+  mimeType: string;
+}
+
 /** Emitter passed to `runtime.run` so the adapter can stream cells as they
  *  become available. */
 export type EmitOutput = (cell: Omit<OutputCell, "id" | "elapsed">) => void;
@@ -57,6 +66,11 @@ export interface LanguageAdapter {
   codeMirrorMode: string;
   examples: ExampleSnippet[];
   packages: PackageInfo[];
+  /** Formats offered by the "Export" dropdown. The editor's current contents
+   *  are written to a client-side download with the chosen extension. */
+  exportFormats: ExportFormat[];
+  /** Base filename (without extension) used when exporting, e.g. "script". */
+  exportBaseFilename: string;
   /** Render-only: footer note shown at the bottom of the packages drawer. */
   packagesFooter: React.ReactNode;
   /** Build the snippet that the "import" copy button puts on the clipboard. */


### PR DESCRIPTION
## Summary
This PR adds code export functionality to the playground and implements a responsive mobile layout with tabbed panes for narrow viewports.

## Key Changes

### Export Feature
- Added `ExportFormat` interface to define export options (extension, label, MIME type)
- Created `ExportDropdown` component to display available export formats
- Implemented `exportCode` callback to download editor contents as a file
- Added export button to the header toolbar with dropdown menu
- Configured Python and R adapters with their respective export formats

### Mobile Responsive Layout
- Introduced mobile tab bar that switches between Editor and Output panes on narrow viewports (≤768px)
- Added `mobileTab` state to track active pane
- Modified panes container to show only the active pane on mobile using `data-mobile-tab` attribute
- Auto-switches to Output tab when code execution completes for better UX
- Hidden resizer divider on mobile since panes no longer display side-by-side

### UI Improvements
- Updated playground switcher styling with better hover states and color consistency
- Enhanced Output pane label to show count of output cells
- Added proper keyboard navigation (Enter key) to export dropdown items
- Implemented click-outside detection to close export dropdown
- Added horizontal scroll to header on mobile to prevent button wrapping

### Accessibility
- Export dropdown items have proper `role="button"` and keyboard support
- Mobile tabs use semantic `role="tab"` and `aria-selected` attributes
- Tab bar has `role="tablist"` with proper `aria-label`

## Implementation Details
- Export uses Blob API and `URL.createObjectURL` for client-side downloads
- Mobile layout uses CSS media query and grid layout adjustments
- Dropdown positioning adjusted for export menu to anchor left instead of right
- Examples dropdown also repositioned on mobile to prevent clipping

https://claude.ai/code/session_01D9qosQh5o5gHemmtFjttt7