### PR TITLE
fix(c): spawn Wasmer worker via same-origin Blob URL; hide empty Packages menu; add Playwright E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache
 
 # next.js
 /.next/

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -1183,18 +1183,20 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
               </Menu.Portal>
             </Menu.Root>
 
-            <button
-              type="button"
-              className="header-btn"
-              onClick={() => setPackagesOpen(true)}
-              title="Available Packages"
-              aria-label="Packages"
-            >
-              <svg viewBox="0 0 16 16" width={13} height={13} fill="currentColor">
-                <path d="M8 1L1 4.5v7L8 15l7-3.5v-7L8 1zm0 1.8l4.5 2.2L8 7.2 3.5 5 8 2.8zM2 6.1l5 2.5v5.3L2 11.4V6.1zm6 7.8V8.6l5-2.5v5.3l-5 2.5z" />
-              </svg>
-              <span className="btn-label">Packages</span>
-            </button>
+            {adapter.packages.length > 0 && (
+              <button
+                type="button"
+                className="header-btn"
+                onClick={() => setPackagesOpen(true)}
+                title="Available Packages"
+                aria-label="Packages"
+              >
+                <svg viewBox="0 0 16 16" width={13} height={13} fill="currentColor">
+                  <path d="M8 1L1 4.5v7L8 15l7-3.5v-7L8 1zm0 1.8l4.5 2.2L8 7.2 3.5 5 8 2.8zM2 6.1l5 2.5v5.3L2 11.4V6.1zm6 7.8V8.6l5-2.5v5.3l-5 2.5z" />
+                </svg>
+                <span className="btn-label">Packages</span>
+              </button>
+            )}
 
             <Popover.Root>
               <Popover.Trigger
@@ -1330,16 +1332,18 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                     </div>
                   </details>
 
-                  <button
-                    type="button"
-                    className="mobile-menu-action"
-                    onClick={() => {
-                      setMobileMenuOpen(false);
-                      setPackagesOpen(true);
-                    }}
-                  >
-                    <span>Packages</span>
-                  </button>
+                  {adapter.packages.length > 0 && (
+                    <button
+                      type="button"
+                      className="mobile-menu-action"
+                      onClick={() => {
+                        setMobileMenuOpen(false);
+                        setPackagesOpen(true);
+                      }}
+                    >
+                      <span>Packages</span>
+                    </button>
+                  )}
 
                   {/* Information — collapsible inline section */}
                   <details className="mobile-menu-section">

--- a/app/_components/runtime/c.tsx
+++ b/app/_components/runtime/c.tsx
@@ -364,17 +364,40 @@ async function loadWasmerSdk(): Promise<WasmerSdk> {
     // Dynamic import keeps the SDK out of the SSR bundle — at module
     // init it touches `Worker` and `SharedArrayBuffer`.
     const mod = (await import("@wasmer/sdk")) as unknown as WasmerSdk;
+
+    // `workerUrl` must resolve to a same-origin URL: the threadpool
+    // spawns its workers via `new Worker(url, { type: "module" })`, and
+    // some browsers refuse cross-origin module worker scripts even when
+    // the CDN sends permissive CORS headers. Failing the spawn drops
+    // the task's response channel, surfacing as "oneshot canceled" the
+    // moment the user clicks Run.
+    //
+    // We sidestep that by fetching the bootstrap from the CDN once and
+    // re-serving it as a `blob:` URL, which counts as same-origin to
+    // the document that created it. The bootstrap then dynamically
+    // imports the main SDK from `sdkUrl` (still on jsDelivr — module
+    // worker `import()` honours CORS, so cross-origin is fine here).
+    const workerSource = await fetch(`${WASMER_SDK_CDN}/worker.mjs`).then(
+      (r) => {
+        if (!r.ok) {
+          throw new Error(
+            `Failed to fetch Wasmer worker bootstrap (HTTP ${r.status}).`,
+          );
+        }
+        return r.text();
+      },
+    );
+    const workerBlobUrl = URL.createObjectURL(
+      new Blob([workerSource], { type: "text/javascript" }),
+    );
+
     await mod.init({
-      // Resolve the SDK's own `.wasm` and worker bootstrap script
-      // against jsDelivr instead of Next.js so we don't have to teach
-      // webpack how to emit them. jsDelivr serves both with permissive
-      // CORS / CORP headers, which is what COEP=require-corp needs.
-      //
-      // `workerUrl` must point to the Web Worker bootstrap (`worker.mjs`),
-      // not the main module. The worker dynamically imports the main SDK
-      // at runtime using `sdkUrl`, which is why both URLs are provided.
+      // Resolve the SDK's own `.wasm` against jsDelivr so we don't
+      // have to teach webpack how to emit it. jsDelivr serves it with
+      // permissive CORS / CORP headers, which is what COEP=require-corp
+      // needs.
       module: new URL(`${WASMER_SDK_CDN}/wasmer_js_bg.wasm`),
-      workerUrl: new URL(`${WASMER_SDK_CDN}/worker.mjs`),
+      workerUrl: workerBlobUrl,
       sdkUrl: new URL(`${WASMER_SDK_CDN}/index.mjs`),
     });
     return mod;

--- a/e2e/playgrounds.spec.ts
+++ b/e2e/playgrounds.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// E2E coverage for every playground route. Each test loads the route,
+// waits for the runtime to finish initializing (Run becomes enabled),
+// presses Run on the default Hello World example, and asserts that the
+// expected output snippet shows up in the output pane. This is what
+// catches regressions like the Wasmer SDK "oneshot canceled" error
+// where the page renders but execution silently fails.
+//
+// The Wasmer-, Pyodide- and WebR-backed playgrounds fetch real
+// runtimes from a CDN on first load, so the per-test timeouts in
+// `playwright.config.ts` are intentionally generous.
+
+async function waitForRuntimeReady(page: Page) {
+  // The Run button is disabled until `setLoaded(true)` fires, which
+  // only happens after `adapter.init()` resolves successfully. If
+  // initialization throws, the loading banner shows the error message
+  // — surface that instead of waiting out the timeout.
+  await page.waitForFunction(
+    () => {
+      const banner = document.querySelector(".loading-banner, .pg-status");
+      const text = banner?.textContent ?? "";
+      if (text.startsWith("Failed to load")) {
+        throw new Error(text);
+      }
+      const btn = document.querySelector(".run-btn");
+      return !!btn && !btn.hasAttribute("disabled");
+    },
+    null,
+    { timeout: 150_000 },
+  );
+}
+
+async function runAndCollectOutput(page: Page) {
+  await page.locator(".run-btn").first().click();
+  // Wait for at least one output cell that finished — the elapsed
+  // timestamp ("Done in N.NNs") only renders after the run completes.
+  await page.waitForFunction(
+    () => {
+      const cells = document.querySelectorAll(".out-cell");
+      return cells.length > 0 &&
+        Array.from(cells).every((c) =>
+          c.querySelector(".cell-time")?.textContent?.startsWith("Done in"),
+        );
+    },
+    null,
+    { timeout: 150_000 },
+  );
+  const cells = await page.locator(".out-cell").all();
+  const collected: { type: string; body: string }[] = [];
+  for (const cell of cells) {
+    const cls = (await cell.getAttribute("class")) ?? "";
+    const type = cls
+      .split(/\s+/)
+      .find((c) => ["stdout", "stderr", "html", "image", "plot"].includes(c)) ??
+      "unknown";
+    const body = (await cell.locator(".out-cell-body").textContent()) ?? "";
+    collected.push({ type, body });
+  }
+  return collected;
+}
+
+test.describe("Playgrounds (fast)", () => {
+  test("JavaScript runs the default example", async ({ page }) => {
+    await page.goto("/javascript");
+    await waitForRuntimeReady(page);
+    const cells = await runAndCollectOutput(page);
+    const stdout = cells.find((c) => c.type === "stdout");
+    expect(stdout, "expected a stdout cell").toBeTruthy();
+    expect(stdout!.body.length).toBeGreaterThan(0);
+    expect(cells.find((c) => c.type === "stderr")).toBeUndefined();
+  });
+
+  test("TypeScript runs the default example", async ({ page }) => {
+    await page.goto("/typescript");
+    await waitForRuntimeReady(page);
+    const cells = await runAndCollectOutput(page);
+    const stdout = cells.find((c) => c.type === "stdout");
+    expect(stdout, "expected a stdout cell").toBeTruthy();
+    expect(stdout!.body.length).toBeGreaterThan(0);
+    expect(cells.find((c) => c.type === "stderr")).toBeUndefined();
+  });
+
+  test("PHP runs the default example", async ({ page }) => {
+    await page.goto("/php");
+    await waitForRuntimeReady(page);
+    const cells = await runAndCollectOutput(page);
+    const stdout = cells.find((c) => c.type === "stdout");
+    expect(stdout, "expected a stdout cell").toBeTruthy();
+    expect(stdout!.body.length).toBeGreaterThan(0);
+    expect(cells.find((c) => c.type === "stderr")).toBeUndefined();
+  });
+
+  test("C compiles and runs the default example", async ({ page }) => {
+    await page.goto("/c");
+    await waitForRuntimeReady(page);
+    const cells = await runAndCollectOutput(page);
+    // The default Hello World example prints "Hello, C Playground!".
+    // Anything else (in particular "oneshot canceled" stderr) means
+    // the threadpool failed to spawn — exactly the regression this
+    // test exists to catch.
+    const stdout = cells.find((c) => c.type === "stdout");
+    expect(stdout, "expected a stdout cell").toBeTruthy();
+    expect(stdout!.body).toContain("Hello, C Playground!");
+    const stderr = cells.find((c) => c.type === "stderr");
+    expect(
+      stderr,
+      `unexpected stderr: ${stderr?.body ?? ""}`,
+    ).toBeUndefined();
+  });
+});
+
+test.describe("Packages button visibility", () => {
+  test("PHP playground hides the Packages button (no installable packages)", async ({
+    page,
+  }) => {
+    await page.goto("/php");
+    await waitForRuntimeReady(page);
+    // Desktop button: rendered only when packages.length > 0.
+    await expect(page.getByRole("button", { name: "Packages" })).toHaveCount(0);
+
+    // Mobile button lives inside the menu drawer. Open it via the
+    // hamburger and verify the Packages action is omitted.
+    await page.locator(".mobile-menu-btn").click();
+    await expect(
+      page.locator(".mobile-menu-drawer-body").getByText("Packages", {
+        exact: true,
+      }),
+    ).toHaveCount(0);
+  });
+
+  test("JavaScript playground hides the Packages button (native runtime)", async ({
+    page,
+  }) => {
+    await page.goto("/javascript");
+    await waitForRuntimeReady(page);
+    await expect(page.getByRole("button", { name: "Packages" })).toHaveCount(0);
+  });
+
+  test("TypeScript playground hides the Packages button (transpile-only)", async ({
+    page,
+  }) => {
+    await page.goto("/typescript");
+    await waitForRuntimeReady(page);
+    await expect(page.getByRole("button", { name: "Packages" })).toHaveCount(0);
+  });
+
+  test("C playground shows the Packages button (stdlib headers)", async ({
+    page,
+  }) => {
+    await page.goto("/c");
+    await waitForRuntimeReady(page);
+    await expect(
+      page.getByRole("button", { name: "Packages" }).first(),
+    ).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,13 @@
         "webr": "^0.5.9"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/node": "22.10.7",
         "@types/react": "19.0.7",
         "@types/react-dom": "19.0.3",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.4",
+        "playwright": "^1.59.1",
         "typescript": "5.7.3",
         "vitest": "^4.1.5"
       }
@@ -1977,6 +1979,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6415,6 +6433,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plotly.js-dist-min": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-rc.0",
@@ -24,11 +26,13 @@
     "webr": "^0.5.9"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "22.10.7",
     "@types/react": "19.0.7",
     "@types/react-dom": "19.0.3",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.4",
+    "playwright": "^1.59.1",
     "typescript": "5.7.3",
     "vitest": "^4.1.5"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// E2E tests run against the Next.js dev server, which Playwright
+// boots automatically via the `webServer` block below. The dev server
+// is reused across local runs so an interactive `next dev` session
+// doesn't conflict with `npm run test:e2e`.
+//
+// The `/c` route depends on cross-origin-isolated headers (set in
+// `next.config.ts`) so the Wasmer SDK can use `SharedArrayBuffer`,
+// and several playgrounds dynamically import scripts from CDNs at
+// runtime — both work fine with the shipped Chromium.
+
+const PORT = Number(process.env.E2E_PORT ?? 3457);
+
+export default defineConfig({
+  testDir: "./e2e",
+  // Per-playground initialization (Wasmer fetching clang, Pyodide, WebR)
+  // is the slow part — give each test enough headroom to finish even on
+  // a cold cache.
+  timeout: 180_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : [["list"]],
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: "retain-on-failure",
+    // The sandboxed test runner trips on jsDelivr's certificate via the
+    // synthetic test environment. Real browsers in production accept
+    // the same chain, so skipping here doesn't reduce real coverage.
+    ignoreHTTPSErrors: true,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `npx next dev -p ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,9 @@ export default defineConfig({
     // are tagged as "browser" and skipped in the Node environment.
     // Run the full test suite with:  npm test
     environment: "node",
+    // E2E tests live in `e2e/` and are run by Playwright
+    // (`npm run test:e2e`). Keep Vitest from picking them up so that
+    // `npm test` stays a fast Node-only check.
+    exclude: ["node_modules/**", "dist/**", ".next/**", "e2e/**"],
   },
 });


### PR DESCRIPTION
The C playground was emitting "oneshot canceled" the instant Run was
clicked. Tracing it through the SDK: `clangCmd.run()` dispatches a
task to the Wasmer threadpool, which spawns a module Worker from the
configured `workerUrl`. We were pointing that URL at jsDelivr so
webpack didn't have to bundle it, but spawning module workers from a
cross-origin URL is unreliable across browser/COEP combinations even
when the CDN sends permissive CORS — when the spawn drops, the task's
oneshot response channel is dropped too, and the Rust side surfaces
that as "oneshot canceled".

Fetching `worker.mjs` once and re-serving it as a `blob:` URL keeps
the bootstrap same-origin to the document. The bootstrap then
dynamically `import()`s the main SDK from `sdkUrl` (still on
jsDelivr), which is fine because module-worker dynamic imports honour
CORS.

Also:
- Hide the Packages button (desktop + mobile menu) when the adapter
  exposes no packages — PHP/JS/TS no longer render a dead button.
- Add Playwright E2E tests under `e2e/` that load each playground,
  press Run on the default example, and assert the expected output
  cell. The C test specifically covers this regression. New scripts:
  `npm run test:e2e` and `npm run test:e2e:ui`. Vitest is configured
  to skip `e2e/` so `npm test` stays a fast Node-only check.