### PR TITLE
Optimize C++ playground performance by using printf instead of iostream

### DIFF
--- a/__tests__/adapters.test.ts
+++ b/__tests__/adapters.test.ts
@@ -182,10 +182,15 @@ describe("C++ adapter specifics", () => {
     expect(cppAdapter.hasImport("// no include", "iostream")).toBe(false);
   });
 
-  it("hello-world example uses iostream and main()", () => {
+  it("hello-world example uses cstdio and main()", () => {
+    // The default Hello World example deliberately avoids <iostream>
+    // because compiling libc++-heavy templates with the wasm-targeted
+    // clang in this package is dramatically slower than compiling C —
+    // see the long-form note in `app/_components/runtime/cpp.tsx`.
+    // iostream-using examples still appear further down the list.
     const hello = cppAdapter.examples.find((e) => e.key === "hello");
     expect(hello).toBeTruthy();
-    expect(hello!.code).toContain("#include <iostream>");
+    expect(hello!.code).toContain("#include <cstdio>");
     expect(hello!.code).toMatch(/int\s+main\s*\(/);
   });
 });

--- a/app/_components/runtime/cpp.tsx
+++ b/app/_components/runtime/cpp.tsx
@@ -36,16 +36,24 @@ const EXAMPLES: ExampleSnippet[] = [
   {
     key: "hello",
     title: "Hello World",
-    desc: "iostream, std::string, range-based for",
-    code: `#include <iostream>
-#include <string>
+    desc: "cstdio printf with a range-based for over an array",
+    // The default example deliberately uses <cstdio> rather than
+    // <iostream>. Compiling iostream-using C++ with the wasm-targeted
+    // clang in this package is dramatically slower than compiling C —
+    // the user-reported "C++ playground hangs" symptom was the spinner
+    // sitting on a libc++ template-instantiation pass that takes many
+    // minutes to clear. printf-based Hello World finishes in well
+    // under a minute, which is what we want for a fresh page load.
+    // The iostream-heavy examples below still run; they're just opt-in.
+    code: `#include <cstdio>
 
 int main() {
-    std::cout << "Hello, C++ Playground!\\n";
-    std::cout << "Compiled with clang -> WebAssembly, run in your browser.\\n\\n";
+    std::printf("Hello, C++ Playground!\\n");
+    std::printf("Compiled with clang -> WebAssembly, run in your browser.\\n\\n");
 
-    for (const std::string &name : {"Ada", "Linus", "Grace"}) {
-        std::cout << "  hello, " << name << "!\\n";
+    const char *names[] = {"Ada", "Linus", "Grace"};
+    for (const char *name : names) {
+        std::printf("  hello, %s!\\n", name);
     }
 
     return 0;
@@ -262,12 +270,23 @@ class CppRuntime implements LanguageRuntime {
     //    makes clang treat inputs as C++ AND auto-link libc++/libc++abi
     //    — without it, we'd have to pass `-x c++ -lc++ -lc++abi`
     //    ourselves.
+    //
+    // We deliberately compile at `-O0`. The clang in this Wasmer
+    // package is itself a wasm32-wasi binary running inside the
+    // browser's WASI sandbox, and its mid/back-end optimizer is
+    // dramatically slower in that environment than native clang —
+    // enough that compiling iostream-heavy C++ at `-O2` runs for many
+    // minutes (in practice, the user sees the spinner spin forever).
+    // `-O0` finishes the same Hello World in well under a minute, and
+    // the produced binary is plenty fast for an interactive
+    // playground; we trade runtime perf we don't need for compile
+    // time we very much do.
     const compile = await clangCmd.run({
       args: [
         "--driver-mode=g++",
         "--target=wasm32-wasi",
         "-std=c++17",
-        "-O2",
+        "-O0",
         "-o",
         "main.wasm",
         "main.cpp",
@@ -348,7 +367,7 @@ export const cppAdapter: LanguageAdapter = {
     engine: "Wasmer + clang/clang",
     engineUrl: "https://wasmer.io/clang/clang",
     notes:
-      "C++ is compiled in your browser by clang (WebAssembly) in C++ driver mode, and the resulting WASI binary is then executed in a sandboxed Wasmer runtime — no server roundtrip.",
+      "C++ is compiled in your browser by clang (WebAssembly) in C++ driver mode, and the resulting WASI binary is then executed in a sandboxed Wasmer runtime — no server roundtrip. Code is built at -O0; iostream and other libc++-heavy headers compile noticeably slower than printf-based equivalents.",
   },
   // CodeMirror's clike mode handles C++ syntax. `text/x-c++src` is the
   // standard MIME alias for C++ inside that mode.


### PR DESCRIPTION
## Summary
This change optimizes the C++ playground's default example and compilation settings to improve performance when running in the browser's WebAssembly sandbox.

## Key Changes

- **Updated default Hello World example**: Replaced `<iostream>` with `<cstdio>` and `std::cout` with `std::printf()` to reduce compilation time. The example now uses a C-style array instead of `std::string` for names.

- **Changed default optimization level**: Reduced compilation from `-O2` to `-O0` to significantly speed up the clang optimizer pass, which runs much slower in the WASI sandbox environment.

- **Updated documentation**: Added detailed comments explaining why these performance-focused choices were made, noting that iostream-heavy templates cause multi-minute compilation times in the wasm-targeted clang.

- **Updated adapter notes**: Added a note to the C++ adapter description informing users that code is built at `-O0` and that iostream compiles noticeably slower than printf-based equivalents.

- **Updated test expectations**: Changed the hello-world example test to verify `#include <cstdio>` instead of `#include <iostream>`, with explanatory comments about why the default avoids iostream.

## Implementation Details

The changes address a critical UX issue where the C++ playground would appear to hang on page load due to slow libc++ template instantiation during compilation. By using printf-based C code for the default example and disabling optimizations, the Hello World example now compiles in under a minute instead of many minutes. Users can still opt-in to iostream-heavy examples that are further down the list. The `-O0` setting trades runtime performance (not critical for a playground) for compile time (essential for interactivity).

https://claude.ai/code/session_01DSYuqjcMagoeXiMyxkTtxF