### PR TITLE
Fix /learn editor theme leak and SQL lang-switcher z-index

### DIFF
--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -2047,7 +2047,11 @@ function SqlPlaygroundInner() {
                 </Select.Icon>
               </Select.Trigger>
               <Select.Portal>
-                <Select.Positioner sideOffset={6} alignItemWithTrigger={false}>
+                <Select.Positioner
+                  className="pg-lang-switcher-positioner"
+                  sideOffset={6}
+                  alignItemWithTrigger={false}
+                >
                   <Select.Popup className="bui-select-popup pg-lang-switcher-popup">
                     {PLAYGROUNDS.map((p) => {
                       const Icon = PLAYGROUND_ICONS[p.id];

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -197,8 +197,18 @@ body.pg-active {
   transition: opacity 0.15s, transform 0.15s;
 }
 
+/* Language-switcher popup must render above other in-page selects (e.g.
+   the SQL playground's database picker, whose wrapper uses
+   `position: relative; z-index: 2` and so creates a stacking context
+   that previously clipped the top of this popup). The z-index is set
+   on both the Floating UI positioner and the popup so it wins
+   regardless of which element Base UI uses as the stacking-context
+   anchor across versions. */
+.pg-lang-switcher-positioner {
+  z-index: 500;
+}
 .pg-lang-switcher-popup {
-  z-index: 202;
+  z-index: 500;
 }
 .bui-select-popup[data-starting-style],
 .bui-select-popup[data-ending-style] {
@@ -425,7 +435,14 @@ body.pg-active {
   flex: 1; overflow: hidden; position: relative;
 }
 
-.CodeMirror {
+/* All CodeMirror overrides below are scoped under `.pg-root` so they
+   only apply inside a playground page. Without this scoping, the
+   `!important` background/font rules leak globally and override the
+   embedded CodeBlock editors on `/learn` pages whenever the playground
+   stylesheet has been loaded (e.g. after an SPA navigation
+   /playground → /learn), making the learn-page editors render with the
+   playground's `--bg` / palette tokens instead of their own. */
+.pg-root .CodeMirror {
   height: 100% !important;
   font-family: var(--font-mono) !important;
   font-size: var(--cm-font-size, 13.5px) !important;
@@ -438,26 +455,26 @@ body.pg-active {
     "clig" 0,
     "dlig" 0 !important;
 }
-.CodeMirror pre,
-.CodeMirror span {
+.pg-root .CodeMirror pre,
+.pg-root .CodeMirror span {
   font-variant-ligatures: inherit !important;
   font-feature-settings: inherit !important;
 }
-.CodeMirror-scroll { height: 100%; }
-.CodeMirror-gutters { background: var(--bg) !important; border-right: 1px solid var(--border) !important; }
-.CodeMirror-linenumber { color: var(--text-dim) !important; }
+.pg-root .CodeMirror-scroll { height: 100%; }
+.pg-root .CodeMirror-gutters { background: var(--bg) !important; border-right: 1px solid var(--border) !important; }
+.pg-root .CodeMirror-linenumber { color: var(--text-dim) !important; }
 
 /* ─── Tomorrow Night Eighties — selection override ─── */
 /* The theme sets selection to #2D2D2D which is identical to the editor
    background after the playground palette override, making selected text
    invisible. Use a lighter shade that is clearly distinguishable. */
-.cm-s-tomorrow-night-eighties div.CodeMirror-selected { background: #515151 !important; }
-.cm-s-tomorrow-night-eighties .CodeMirror-line::selection,
-.cm-s-tomorrow-night-eighties .CodeMirror-line > span::selection,
-.cm-s-tomorrow-night-eighties .CodeMirror-line > span > span::selection { background: rgba(81, 81, 81, 0.99) !important; }
-.cm-s-tomorrow-night-eighties .CodeMirror-line::-moz-selection,
-.cm-s-tomorrow-night-eighties .CodeMirror-line > span::-moz-selection,
-.cm-s-tomorrow-night-eighties .CodeMirror-line > span > span::-moz-selection { background: rgba(81, 81, 81, 0.99) !important; }
+.pg-root .cm-s-tomorrow-night-eighties div.CodeMirror-selected { background: #515151 !important; }
+.pg-root .cm-s-tomorrow-night-eighties .CodeMirror-line::selection,
+.pg-root .cm-s-tomorrow-night-eighties .CodeMirror-line > span::selection,
+.pg-root .cm-s-tomorrow-night-eighties .CodeMirror-line > span > span::selection { background: rgba(81, 81, 81, 0.99) !important; }
+.pg-root .cm-s-tomorrow-night-eighties .CodeMirror-line::-moz-selection,
+.pg-root .cm-s-tomorrow-night-eighties .CodeMirror-line > span::-moz-selection,
+.pg-root .cm-s-tomorrow-night-eighties .CodeMirror-line > span > span::-moz-selection { background: rgba(81, 81, 81, 0.99) !important; }
 
 /* ─── Output pane ─── */
 .output-pane {
@@ -1447,11 +1464,11 @@ input[type="range"].fs-slider:disabled {
      on each line so tapping near the edge to position the caret /
      start a selection is easier (without the inset the very first
      character sits flush against the screen edge). */
-  .CodeMirror-gutters { display: none !important; }
-  .CodeMirror-gutter-wrapper { display: none !important; }
-  .CodeMirror-sizer { margin-left: 0 !important; }
-  .CodeMirror pre.CodeMirror-line,
-  .CodeMirror pre.CodeMirror-line-like {
+  .pg-root .CodeMirror-gutters { display: none !important; }
+  .pg-root .CodeMirror-gutter-wrapper { display: none !important; }
+  .pg-root .CodeMirror-sizer { margin-left: 0 !important; }
+  .pg-root .CodeMirror pre.CodeMirror-line,
+  .pg-root .CodeMirror pre.CodeMirror-line-like {
     padding-left: 10px !important;
     padding-right: 10px !important;
   }


### PR DESCRIPTION
## Summary

Two SPA-navigation bugs:

1. **`/learn` CodeBlock editor theme leak.** `playground.css` had unscoped global `.CodeMirror`, `.CodeMirror-gutters`, and `.CodeMirror-linenumber` rules with `!important` that forced `background: var(--bg)` and the playground's mono font onto every CodeMirror instance on the page. When the playground stylesheet was loaded (e.g. after navigating `/playground` → `/learn`), those rules leaked onto the embedded `CodeBlock` editors on `/learn`, so the editors rendered with the playground palette instead of their own light/dark theme. The previous fix (commit 105e576) namespaced `data-theme` → `data-pg-theme` but did not address the unscoped global selectors. All CodeMirror overrides — including the mobile-only gutter rules and the `tomorrow-night-eighties` selection overrides — are now scoped under `.pg-root` so they only apply inside a playground.

2. **SQL playground language-switcher z-index.** The popup was being clipped by the database-selector wrapper (`.sql-db-selector-wrap`, `position: relative; z-index: 2`, which creates a stacking context). The existing `.pg-lang-switcher-popup { z-index: 202 }` rule wasn't enough in practice. Raised the z-index to 500 and applied it to the Floating UI positioner as well as the popup, so the popup wins regardless of which element Base UI treats as the stacking-context anchor.

## Test plan

- [x] Visit `/playground/python`, then SPA-navigate to a `/learn` page that contains a `<CodeBlock>`. Verify the editor renders with the correct theme (light chrome → IDEA editor, dark chrome → Dracula editor) instead of inheriting the playground's `--bg`.
- [ ] Repeat from `/playground/sqlite` and `/playground/r` to cover the SQL and Python paths.
- [ ] Toggle the docs theme on `/learn` and confirm the embedded editor flips between light and dark.
- [ ] On `/playground/sqlite`, open the language-switcher dropdown in the header. Confirm the entire list (including the top "Python Playground" item) is visible and renders above the database-selector trigger.

https://claude.ai/code/session_015mUFSR5o1cPrr4X2vZ1ZWg

---
_Generated by [Claude Code](https://claude.ai/code/session_015mUFSR5o1cPrr4X2vZ1ZWg)_