### PR TITLE
Refine settings UI: subtle buttons/switches, reorder themes, default Lucario

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -431,7 +431,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   const [outputFontSizeEnabled, setOutputFontSizeEnabledState] =
     useState<boolean>(false);
   const [outputFontSize, setOutputFontSizeState] = useState<number>(13);
-  const [editorTheme, setEditorThemeState] = useState<string>("dracula");
+  const [editorTheme, setEditorThemeState] = useState<string>("lucario");
   const [wordWrap, setWordWrapState] = useState<boolean>(true);
   const [clearBeforeRun, setClearBeforeRunState] = useState<boolean>(false);
 
@@ -621,10 +621,10 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
           // Read the persisted theme directly so the editor is created with
           // the same theme that the rest of the UI was hydrated with.
           // Otherwise CodeMirror would briefly render with the default
-          // `editorTheme` state ("dracula") while the surrounding UI uses
+          // `editorTheme` state ("lucario") while the surrounding UI uses
           // the saved theme, producing a visible mismatch on load.
           const initialTheme =
-            getStoredEditorTheme(storageKey("editortheme")) ?? "dracula";
+            getStoredEditorTheme(storageKey("editortheme")) ?? "lucario";
           const initialWordWrap =
             localStorage.getItem(storageKey("wordwrap")) !== "false";
           const triggerAutocomplete = () => {

--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -558,7 +558,7 @@ function SqlPlaygroundInner() {
   const [outputFontSizeEnabled, setOutputFontSizeEnabledState] =
     useState<boolean>(false);
   const [outputFontSize, setOutputFontSizeState] = useState<number>(13);
-  const [editorTheme, setEditorThemeState] = useState<string>("dracula");
+  const [editorTheme, setEditorThemeState] = useState<string>("lucario");
   const [wordWrap, setWordWrapState] = useState<boolean>(true);
   const [clearBeforeRun, setClearBeforeRunState] = useState<boolean>(false);
 
@@ -906,7 +906,7 @@ function SqlPlaygroundInner() {
         setCmApi(() => CM);
         if (textareaRef.current && !editorRef.current) {
           const initialTheme =
-            getStoredEditorTheme(storageKey("editortheme")) ?? "dracula";
+            getStoredEditorTheme(storageKey("editortheme")) ?? "lucario";
           const initialWordWrap =
             localStorage.getItem(storageKey("wordwrap")) !== "false";
           const editor = CM.fromTextArea(textareaRef.current, {

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -802,22 +802,20 @@ body.pg-active {
 .settings-action-btn {
   display: inline-flex; align-items: center; gap: 8px;
   padding: 8px 12px;
-  background: var(--bg3);
-  border: 1px solid var(--border);
-  color: var(--text);
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
   font-family: var(--font-ui); font-size: 13px; font-weight: 500;
   border-radius: var(--radius);
   cursor: pointer;
-  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+  transition: background-color 0.15s, color 0.15s;
 }
 .settings-action-btn:hover {
-  background: var(--bg2);
-  border-color: var(--accent);
-  color: var(--accent);
+  background: var(--bg3);
+  color: var(--text);
 }
 .settings-action-btn svg { flex-shrink: 0; color: currentColor; }
 .settings-action-danger:hover {
-  border-color: var(--red);
   color: var(--red);
 }
 
@@ -866,7 +864,13 @@ body.pg-active {
   color: var(--text);
   font-weight: 500;
 }
-.theme-card-name { letter-spacing: -0.01em; }
+.theme-card-name { letter-spacing: -0.01em; display: flex; align-items: center; gap: 6px; }
+.theme-card-default-badge {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.03em;
+  color: var(--text-muted); opacity: 0.7;
+  background: var(--bg2); border-radius: 4px;
+  padding: 1px 5px;
+}
 .theme-card-check { color: var(--accent); font-weight: 700; }
 
 /* On narrow viewports the settings panel takes (almost) the full screen
@@ -986,16 +990,15 @@ input[type="range"].fs-slider:disabled {
   height: 20px;
   border-radius: 999px;
   background: var(--bg3);
-  border: 1px solid var(--border);
+  border: none;
   cursor: pointer;
   outline: none;
   padding: 0;
   flex-shrink: 0;
-  transition: background-color 0.15s, border-color 0.15s;
+  transition: background-color 0.15s;
 }
 .bui-switch[data-checked] {
   background: var(--accent);
-  border-color: var(--accent);
 }
 .bui-switch:focus-visible {
   box-shadow: 0 0 0 3px var(--accent-glow);

--- a/app/_components/playgroundShared.tsx
+++ b/app/_components/playgroundShared.tsx
@@ -33,7 +33,7 @@ export const DEFAULT_PLAYGROUND_SETTINGS = {
   fontSize: 13,
   outputFontSize: 13,
   outputFontSizeEnabled: false,
-  editorTheme: "dracula",
+  editorTheme: "lucario",
   wordWrap: true,
   clearBeforeRun: false,
 } as const;
@@ -478,7 +478,14 @@ export function SettingsPanel({
                           />
                         </div>
                         <div className="theme-card-label">
-                          <span className="theme-card-name">{t.label}</span>
+                          <span className="theme-card-name">
+                            {t.label}
+                            {t.value === "lucario" && (
+                              <span className="theme-card-default-badge">
+                                Default
+                              </span>
+                            )}
+                          </span>
                           {selected && (
                             <span
                               className="theme-card-check"

--- a/app/_components/playgroundTheme.ts
+++ b/app/_components/playgroundTheme.ts
@@ -16,24 +16,24 @@ export interface ThemeEntry {
 }
 
 export const ALL_THEMES: ThemeEntry[] = [
+  { value: "lucario", label: "Lucario" },
   { value: "dracula", label: "Dracula" },
   { value: "monokai", label: "Monokai" },
-  { value: "material-darker", label: "Material Darker" },
-  { value: "material-palenight", label: "Material Palenight" },
   { value: "nord", label: "Nord" },
+  { value: "material-darker", label: "Material Darker" },
   { value: "tomorrow-night-eighties", label: "Tomorrow Night" },
-  { value: "ayu-mirage", label: "Ayu Mirage" },
+  { value: "solarized dark", label: "Solarized Dark" },
+  { value: "eclipse", label: "Eclipse" },
   { value: "gruvbox-dark", label: "Gruvbox Dark" },
   { value: "oceanic-next", label: "Oceanic Next" },
-  { value: "panda-syntax", label: "Panda" },
-  { value: "darcula", label: "Darcula" },
-  { value: "zenburn", label: "Zenburn" },
-  { value: "lucario", label: "Lucario" },
-  { value: "solarized dark", label: "Solarized Dark" },
+  { value: "material-palenight", label: "Material Palenight" },
   { value: "solarized light", label: "Solarized Light" },
-  { value: "eclipse", label: "Eclipse" },
-  { value: "mdn-like", label: "MDN-like" },
+  { value: "darcula", label: "Darcula" },
+  { value: "ayu-mirage", label: "Ayu Mirage" },
   { value: "idea", label: "IntelliJ IDEA" },
+  { value: "panda-syntax", label: "Panda" },
+  { value: "zenburn", label: "Zenburn" },
+  { value: "mdn-like", label: "MDN-like" },
   { value: "base16-light", label: "Base16 Light" },
 ];
 
@@ -163,7 +163,7 @@ export const THEME_PREVIEWS: Record<string, ThemePalette> = {
  *  so every surface that consumes `--bg`/`--bg2`/`--text`/etc. retints
  *  in lockstep with the editor. */
 export function applyThemePalette(theme: string): void {
-  const p = THEME_PREVIEWS[theme] ?? THEME_PREVIEWS.dracula;
+  const p = THEME_PREVIEWS[theme] ?? THEME_PREVIEWS.lucario;
   const root = document.documentElement;
   root.style.setProperty("--bg", p.bg);
   root.style.setProperty("--bg2", p.bg2);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Settings buttons**: Removed borders and made action buttons visually quieter — transparent background by default, subtle `--bg3` fill on hover, no accent-colored text flash
- **Switches**: Removed the border from the Base UI Switch in both checked and unchecked states for a cleaner look
- **Editor themes**: Reordered `ALL_THEMES` by popularity (dark and light themes interleaved), with **Lucario pinned as the first item and new default**; a small "Default" badge appears next to its name in the theme grid

## Changes

- `playground.css` — button and switch style updates + `.theme-card-default-badge` style
- `playgroundTheme.ts` — reordered `ALL_THEMES`, fallback palette updated to lucario
- `playgroundShared.tsx` — `DEFAULT_PLAYGROUND_SETTINGS.editorTheme` → `"lucario"`, added Default badge in theme card render
- `Playground.tsx` — initial state and localStorage fallback updated to `"lucario"`
- `SqlPlayground.tsx` — same as above

## Test plan

- [ ] Open any playground, verify settings panel buttons have no border and hover is subtle
- [ ] Toggle Word Wrap and Clear Output switches — confirm no border visible in either state
- [ ] Open Editor Themes tab — Lucario appears first with a "Default" badge
- [ ] Reload with no localStorage — Lucario should be the active theme
- [ ] Verify theme order matches popularity ranking (dark/light mixed)

https://claude.ai/code/session_01DxkMna7mh5JSRwstWQLGCG
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxkMna7mh5JSRwstWQLGCG)_