### PR TITLE
Update settings panel buttons and switch styling

### DIFF
--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -88,6 +88,7 @@ import {
   Hash,
   Play,
   Plus,
+  RotateCcw,
   Table2,
   Trash2,
   TriangleAlert,
@@ -2938,6 +2939,7 @@ function SqlPlaygroundInner() {
                 className="settings-action-btn"
                 onClick={resetTabsForCurrentDb}
               >
+                <RotateCcw size={14} aria-hidden="true" />
                 <span>Reset query tabs for {activeSample.label}</span>
               </button>
             </div>

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -802,7 +802,7 @@ body.pg-active {
 .settings-action-btn {
   display: inline-flex; align-items: center; gap: 8px;
   padding: 8px 12px;
-  background: transparent;
+  background: color-mix(in srgb, var(--bg3) 40%, transparent);
   border: none;
   color: var(--text-dim);
   font-family: var(--font-ui); font-size: 13px; font-weight: 500;
@@ -811,10 +811,13 @@ body.pg-active {
   transition: background-color 0.15s, color 0.15s;
 }
 .settings-action-btn:hover {
-  background: var(--bg3);
+  background: color-mix(in srgb, var(--bg3) 70%, transparent);
   color: var(--text);
 }
 .settings-action-btn svg { flex-shrink: 0; color: currentColor; }
+.settings-action-danger {
+  color: var(--red);
+}
 .settings-action-danger:hover {
   color: var(--red);
 }
@@ -1009,7 +1012,7 @@ input[type="range"].fs-slider:disabled {
   height: 14px;
   border-radius: 50%;
   background: var(--text);
-  transform: translateX(2px);
+  transform: translateX(4px);
   transition: transform 0.15s, background-color 0.15s;
 }
 .bui-switch[data-checked] .bui-switch-thumb {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Settings buttons default background**: Added a very subtle background (`color-mix(in srgb, var(--bg3) 40%, transparent)`) to action buttons so they're always slightly visible, not just on hover. Hover background is now softer (`70%` mix instead of solid `var(--bg3)`).
- **"Clear all localStorage data" button**: Now shows red text by default, not only on hover.
- **"Reset query tabs for …" button (SQLite)**: Added a `RotateCcw` icon to match the style of the other action buttons.
- **Switch thumb alignment**: Fixed the off-state thumb position (`translateX(2px)` → `translateX(4px)`) to balance the 4px right-side margin and eliminate the slight visual misalignment.

## Test plan

- [ ] Open Settings in any playground — action buttons should have a faint background at rest
- [ ] Hover over action buttons — background should darken slightly (more subtle than before)
- [ ] "Clear all localStorage data" text should appear red by default
- [ ] Open Settings in the SQLite playground — "Reset query tabs for …" button should show a rotate icon
- [ ] Toggle switches in Settings — off-state thumb should sit centered with equal side margins

https://claude.ai/code/session_01UC58S8hZMjHBHZ4jxNFFZK
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UC58S8hZMjHBHZ4jxNFFZK)_