### PR TITLE
Fix table view height, column reorder save error, and drag scrollbar

### DIFF
--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -2752,6 +2752,17 @@ function SqlPlaygroundInner() {
     };
   }, []);
 
+  // Clear any inline gridTemplateRows set by the resizer when entering
+  // view-data mode, so the CSS class `.sql-panes--view-data` can take
+  // effect (inline styles otherwise win over class rules).
+  useEffect(() => {
+    const panes = panesRef.current;
+    if (!panes) return;
+    if (activeTab?.kind === "view-data") {
+      panes.style.gridTemplateRows = "";
+    }
+  }, [activeTab?.kind]);
+
   // ─── Sidebar resizer (horizontal, between sidebar and panes) ────────
   // The sidebar width is persisted as a CSS custom property on the
   // `.sql-shell` element and mirrored to localStorage so it survives
@@ -5962,6 +5973,7 @@ function ModifyStructureForm({
   engine: SqliteEngine | null;
 }) {
   const [activeTab, setActiveTab] = useState<"columns" | "indexes" | "triggers">("columns");
+  const [isDragging, setIsDragging] = useState(false);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -6008,6 +6020,7 @@ function ModifyStructureForm({
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
+    setIsDragging(false);
     const { active, over } = event;
     if (!over || active.id === over.id) return;
     const oldIndex = state.columns.findIndex((c) => c.id === active.id);
@@ -6078,7 +6091,10 @@ function ModifyStructureForm({
         <>
           <div className="sql-modify-columns">
             {state.columns.length > 0 ? (
-              <div className="sql-modify-table-wrap">
+              <div
+                className="sql-modify-table-wrap"
+                style={isDragging ? { overflowX: "hidden" } : undefined}
+              >
                 <table className="sql-modify-table">
                   <thead>
                     <tr>
@@ -6104,6 +6120,7 @@ function ModifyStructureForm({
                   <DndContext
                     sensors={sensors}
                     collisionDetection={closestCenter}
+                    onDragStart={() => setIsDragging(true)}
                     onDragEnd={handleDragEnd}
                   >
                     <SortableContext

--- a/app/_components/runtime/sqlite.ts
+++ b/app/_components/runtime/sqlite.ts
@@ -643,6 +643,29 @@ export async function createSqliteEngine(
         return patched;
       }
 
+      // Collect all view DDLs so we can drop them before the table
+      // rebuild and recreate them after. SQLite validates view
+      // references at schema-change time, so leaving views in place
+      // while the table is temporarily absent (between DROP TABLE and
+      // ALTER TABLE ... RENAME TO) causes a spurious "no such table"
+      // error on COMMIT.
+      const viewSqls: string[] = [];
+      const viewNames: string[] = [];
+      {
+        const stmt = d.prepare(
+          `SELECT name, sql FROM sqlite_master WHERE type = 'view' AND sql IS NOT NULL ORDER BY name`,
+        );
+        try {
+          while (stmt.step()) {
+            const row = stmt.get();
+            viewNames.push(String(row[0]));
+            viewSqls.push(String(row[1]));
+          }
+        } finally {
+          stmt.free();
+        }
+      }
+
       const tmpName = `${spec.newName}__new`;
       // Compose the multi-statement script. We toggle foreign keys off
       // explicitly inside the transaction so referencing tables stay
@@ -650,6 +673,12 @@ export async function createSqliteEngine(
       d.run("PRAGMA foreign_keys = OFF;");
       d.run("BEGIN");
       try {
+        // Drop all views before touching the table so SQLite doesn't
+        // attempt to validate their SQL during the interim state where
+        // the original table has been dropped but not yet renamed back.
+        for (const name of viewNames) {
+          d.run(`DROP VIEW IF EXISTS ${quoteIdent(name)}`);
+        }
         d.run(`CREATE TABLE ${quoteIdent(tmpName)} (${defs.join(", ")})`);
         if (sourceCols.length > 0) {
           d.run(
@@ -666,6 +695,10 @@ export async function createSqliteEngine(
         }
         // Recreate triggers with potentially patched DDL.
         for (const sql of triggerSqls) {
+          d.run(patchDdl(sql));
+        }
+        // Recreate all views with patched DDL (handles table/column renames).
+        for (const sql of viewSqls) {
           d.run(patchDdl(sql));
         }
         d.run("COMMIT");


### PR DESCRIPTION
## Summary

- **Bug 1 (table view height):** Double-clicking a table in the sidebar opens a view-data tab but the results pane had height 0. Root cause: the horizontal resizer writes an inline `gridTemplateRows` style on `.sql-panes`, which has higher CSS specificity than the `.sql-panes--view-data` class rule (`grid-template-rows: auto 0 0 1fr`). Fix: added a `useEffect` that clears the inline style whenever the active tab's kind becomes `"view-data"`, letting the class rule take over.

- **Bug 2a (column reorder save fails for `users` table):** Saving a reordered column list on the `credit_card_transactions` sample DB's `users` table raised `"error in view foreign_transactions: no such table: main.users"`. Root cause: SQLite validates view references at schema-change time; during the rebuild the table is temporarily absent (between `DROP TABLE` and `ALTER TABLE ... RENAME TO`), and SQLite catches this on `COMMIT`. Fix: in `rebuildTable()`, collect all view DDLs before the transaction, drop every view inside the transaction before touching the table, and recreate them (with any patched table/column names) after the rename.

- **Bug 2b (horizontal scrollbar during drag):** A brief horizontal scrollbar appeared on the columns table while dragging a row to reorder it, because the pointer's slight horizontal movement translated into a small x-axis CSS transform on the dragged row that caused overflow. Fix: added `isDragging` state to `ModifyStructureForm`, toggled via `onDragStart`/`onDragEnd` on `DndContext`, and conditionally applied `overflow-x: hidden` to `.sql-modify-table-wrap` while a drag is in progress.

## Test plan

- [ ] Open any table in the sidebar via double-click → results pane should fill the full available height
- [ ] Open the "View Structure" drawer for the `users` table in the `credit_card_transactions` sample DB, reorder columns, click Save → should succeed without error toast
- [ ] Drag a column row in the "View Structure" drawer → no horizontal scrollbar should appear

https://claude.ai/code/session_011HGwwX3zzWe5sV5WoQa73a

---
_Generated by [Claude Code](https://claude.ai/code/session_011HGwwX3zzWe5sV5WoQa73a)_