### PR TITLE
Fix table view height and trigger validation in SQL playground

### DIFF
--- a/app/_components/runtime/sqlite.ts
+++ b/app/_components/runtime/sqlite.ts
@@ -598,17 +598,24 @@ export async function createSqliteEngine(
         }
       }
 
-      // Collect trigger DDLs attached to the original table.
+      // Collect ALL trigger DDLs so we can drop them before the table
+      // rebuild and recreate them afterward. SQLite validates trigger
+      // bodies at schema-change time, so any trigger that references the
+      // table being rebuilt (even if it is ON a different table) will
+      // fail validation the moment that table is temporarily absent
+      // between DROP TABLE and ALTER TABLE … RENAME TO. Dropping all
+      // triggers up front — just like we do with views — avoids this.
       const triggerSqls: string[] = [];
+      const triggerNames: string[] = [];
       {
         const stmt = d.prepare(
-          `SELECT sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = $n AND sql IS NOT NULL ORDER BY name`,
+          `SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND sql IS NOT NULL ORDER BY name`,
         );
         try {
-          stmt.bind({ $n: spec.originalName });
           while (stmt.step()) {
             const row = stmt.get();
-            if (typeof row[0] === "string") triggerSqls.push(row[0]);
+            triggerNames.push(String(row[0]));
+            if (typeof row[1] === "string") triggerSqls.push(row[1]);
           }
         } finally {
           stmt.free();
@@ -673,11 +680,18 @@ export async function createSqliteEngine(
       d.run("PRAGMA foreign_keys = OFF;");
       d.run("BEGIN");
       try {
-        // Drop all views before touching the table so SQLite doesn't
-        // attempt to validate their SQL during the interim state where
-        // the original table has been dropped but not yet renamed back.
+        // Drop all views and all triggers before touching the table so
+        // SQLite doesn't attempt to validate their SQL during the interim
+        // state where the original table has been dropped but not yet
+        // renamed back. This mirrors the same issue found for views:
+        // triggers that reference the table (even if ON a different
+        // table) are validated at schema-change time and will fail with
+        // "no such table" if the target is temporarily absent.
         for (const name of viewNames) {
           d.run(`DROP VIEW IF EXISTS ${quoteIdent(name)}`);
+        }
+        for (const name of triggerNames) {
+          d.run(`DROP TRIGGER IF EXISTS ${quoteIdent(name)}`);
         }
         d.run(`CREATE TABLE ${quoteIdent(tmpName)} (${defs.join(", ")})`);
         if (sourceCols.length > 0) {
@@ -693,7 +707,8 @@ export async function createSqliteEngine(
         for (const sql of indexSqls) {
           d.run(patchDdl(sql));
         }
-        // Recreate triggers with potentially patched DDL.
+        // Recreate all triggers with potentially patched DDL (handles
+        // table/column renames when the rebuilt table is also renamed).
         for (const sql of triggerSqls) {
           d.run(patchDdl(sql));
         }

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -412,6 +412,11 @@
 }
 
 .sql-results-pane {
+  /* Explicitly anchor to track 4 so that when .sql-editor-pane and
+     .sql-resizer are display:none in view-data mode, CSS Grid
+     auto-placement doesn't shift the results pane into the collapsed
+     track 2 (height 0). */
+  grid-row: 4;
   position: relative;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- **Bug 1 (table view height):** When double-clicking a table name, `.sql-results-pane` had height 0 because `display:none` on `.sql-editor-pane` and `.sql-resizer` in view-data mode removed them from CSS Grid auto-placement. This caused `.sql-results-pane` to land in grid track 2 (height: 0) instead of track 4 (height: 1fr). Fixed by adding `grid-row: 4` to `.sql-results-pane`, anchoring it to the correct track regardless of whether adjacent items participate in layout.

- **Bug 2 (trigger validation on save):** Reordering columns on the `users` table failed with "error in trigger trg_users_card_count_ad: no such table: main.users". This trigger is `AFTER DELETE ON cards` (not on `users`), so it wasn't collected by the existing per-table trigger query — but SQLite still validates all trigger bodies at schema-change time. When `users` was temporarily absent (between `DROP TABLE` and `ALTER TABLE … RENAME TO`), SQLite rejected the commit. Fixed by extending `rebuildTable` to drop **all** triggers before the rebuild and recreate them all afterward, mirroring the existing view-drop fix.

## Test plan

- [ ] Open the SQLite playground with the `credit_card_transactions` sample database
- [ ] Double-click a table name in the schema tree — the table view should fill the full available height with no 0-height pane
- [ ] Open "View Structure" for the `users` table, reorder columns via drag-and-drop, and click Save — should succeed without any error toast
- [ ] Verify that triggers (`trg_users_card_count_ai`, `trg_users_card_count_ad`, `trg_transactions_block_negative`) and views (`foreign_transactions`, `vendor_summary`) still work after saving

https://claude.ai/code/session_01U9JTSwUnrq9vSaUQiyYBuc

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9JTSwUnrq9vSaUQiyYBuc)_