### PR TITLE
Update SQLite playground UX: cell edit label, tab context menu, tab shrink, and logo

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -1231,9 +1231,10 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       <div className="pg-app">
         <header className="pg-header">
           <div className="logo">
-            {/* Placeholder for the DataSlope brand logo image. The
-                per-language icon previously rendered here was removed
-                so the brand mark can sit in this slot once available. */}
+            <Link href="/" aria-label="Dataslope home">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="/dataslope-blue@4x.png" alt="Dataslope logo" className="brand-logo" />
+            </Link>
             <Link href="/" className="brand-name">Dataslope</Link>
             <Select.Root
               value={adapter.id}

--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -2892,6 +2892,10 @@ function SqlPlaygroundInner() {
       <div className="pg-app">
         <header className="pg-header">
           <div className="logo">
+            <Link href="/" aria-label="Dataslope home">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="/dataslope-blue@4x.png" alt="Dataslope logo" className="brand-logo" />
+            </Link>
             <Link href="/" className="brand-name">
               Dataslope
             </Link>
@@ -4389,7 +4393,23 @@ function SqlTab({
               {tab.kind === "view-data" && (
                 <Table2 size={11} className="sql-tab-kind-icon" aria-hidden="true" />
               )}
-              <span className="sql-tab-title">{tab.title}</span>
+              <Popover.Root>
+                <Popover.Trigger
+                  openOnHover
+                  delay={600}
+                  closeDelay={100}
+                  render={<span className="sql-tab-title" />}
+                >
+                  {tab.title}
+                </Popover.Trigger>
+                <Popover.Portal>
+                  <Popover.Positioner side="top" sideOffset={6} align="center">
+                    <Popover.Popup className="bui-popup sql-tab-name-popover">
+                      {tab.title}
+                    </Popover.Popup>
+                  </Popover.Positioner>
+                </Popover.Portal>
+              </Popover.Root>
               <button
                 type="button"
                 className="sql-tab-close"
@@ -4407,9 +4427,11 @@ function SqlTab({
         <ContextMenu.Portal>
           <ContextMenu.Positioner sideOffset={6}>
             <ContextMenu.Popup className="bui-popup">
-              <ContextMenu.Item className="example-item" onClick={openRename}>
-                <div className="ex-title">Rename</div>
-              </ContextMenu.Item>
+              {tab.kind !== "view-data" && (
+                <ContextMenu.Item className="example-item" onClick={openRename}>
+                  <div className="ex-title">Rename</div>
+                </ContextMenu.Item>
+              )}
               <ContextMenu.Item className="example-item" onClick={onDuplicate}>
                 <div className="ex-title">Duplicate</div>
               </ContextMenu.Item>
@@ -5578,7 +5600,7 @@ function ResultTableBody({
                               setModalEditCell({ cellKey, colName, value: current });
                             }}
                           >
-                            <div className="ex-title">Edit in modal</div>
+                            <div className="ex-title">Edit cell in modal</div>
                           </ContextMenu.Item>
                         )}
                         <ContextMenu.Item

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -129,6 +129,12 @@ body.pg-active {
   letter-spacing: -0.01em;
 }
 
+.brand-logo {
+  height: 22px;
+  width: auto;
+  display: block;
+}
+
 /* Placeholder text for the DataSlope brand mark. Sits in the slot
    where the per-language logo tile used to live; will be swapped for
    an actual logo image once available. Rendered as an anchor linking

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -895,16 +895,7 @@
   align-items: stretch;
   flex: 1;
   min-width: 0;
-  overflow-x: auto;
-  /* Setting `overflow-x: auto` while leaving `overflow-y` at its
-     default of `visible` causes the spec's "if one axis is not
-     visible, the visible axis becomes auto" rule to kick in, which
-     made Chromium on Windows render a phantom vertical scrollbar in
-     the tab strip even though no content overflowed vertically.
-     Pinning Y to `hidden` removes that scrollbar while keeping the
-     horizontal overflow scroller working. */
-  overflow-y: hidden;
-  scrollbar-width: thin;
+  overflow: hidden;
   gap: 2px;
 }
 
@@ -923,9 +914,10 @@
   font-family: var(--font-ui);
   font-size: 12px;
   cursor: pointer;
-  white-space: nowrap;
   position: relative;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 60px;
+  overflow: hidden;
   /* Sit on top of the tabbar's bottom border so the active tab can
      "punch through" it and visually merge with the editor below. */
   margin-bottom: -1px;
@@ -953,9 +945,11 @@
 }
 
 .sql-tab-title {
-  max-width: 160px;
+  flex: 1 1 0;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   font-weight: 500;
 }
 
@@ -976,6 +970,13 @@
 .sql-tab-close:hover {
   background: var(--border);
   color: var(--text);
+}
+
+.sql-tab-name-popover {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  padding: 4px 8px;
+  white-space: nowrap;
 }
 
 .sql-tab-add {

--- a/app/learn/layout.tsx
+++ b/app/learn/layout.tsx
@@ -15,13 +15,30 @@ import type { ReactNode } from "react";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { source } from "@/lib/source";
+import Link from "next/link";
+import Image from "next/image";
+import dataslopeLogoSrc from "@/public/dataslope-blue@4x.png";
 
 export default function LearnLayout({ children }: { children: ReactNode }) {
   return (
     <RootProvider>
       <DocsLayout
         tree={source.pageTree}
-        nav={{ title: "Dataslope · Learn" }}
+        nav={{
+          title: (
+            <Link
+              href="/"
+              style={{ display: "flex", alignItems: "center", gap: "8px", textDecoration: "none", color: "inherit" }}
+            >
+              <Image
+                src={dataslopeLogoSrc}
+                alt="Dataslope logo"
+                style={{ height: "20px", width: "auto" }}
+              />
+              Dataslope · Learn
+            </Link>
+          ),
+        }}
         githubUrl="https://github.com/subwaymatch/dataslope-playground/"
       >
         {children}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2189,7 +2189,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -2876,7 +2876,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
       "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -3305,7 +3305,7 @@
       "version": "19.0.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.7.tgz",
       "integrity": "sha512-MoFsEJKkAtZCrC1r6CM8U22GzhG7u2Wir8ons/aCKH6MBdD1ibV24zOSSkdZVUKqN5i396zG5VKLYZ3yaUZdLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3315,7 +3315,7 @@
       "version": "19.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.3.tgz",
       "integrity": "sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -4670,7 +4670,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -10788,7 +10788,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -10807,7 +10807,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -12163,7 +12163,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tapable": {


### PR DESCRIPTION
## Summary

- **Update 1:** Renamed "Edit in modal" → "Edit cell in modal" in the cell context menu to reduce confusion with row editing
- **Update 2:** Hide the "Rename" context menu item for view-data (table) tabs — these tabs use the table name and don't need renaming
- **Update 3:** Replaced horizontal tab scrolling with a flex-shrink layout — tabs compress to fit available width, show `...` when truncated, and display a hover popover with the full tab name
- **Update 4:** Added `dataslope-blue@4x.png` logo to the left of the "Dataslope" text link in the SQLite playground header, the general Playground header, and the `/learn` docs nav

## Test plan

- [ ] Open the SQLite playground and right-click a result cell — verify "Edit cell in modal" label
- [ ] Double-click a table to open a view-data tab, right-click its tab — verify "Rename" is absent from the context menu; right-click a query tab — verify "Rename" is still present
- [ ] Open many query tabs until they would overflow — verify tabs shrink to fit without a horizontal scrollbar; verify `...` on truncated tab titles; hover a tab title to see the full name popover
- [ ] Visit `/playground/sqlite` and `/learn` — verify the Dataslope logo image appears to the left of the "Dataslope" text link in both headers

https://claude.ai/code/session_01BJWLNAw6hBjzw44h7pJgzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJWLNAw6hBjzw44h7pJgzt)_