### PR TITLE
Fix SQL playground UI: popover z-index, tab-add position, drawer width, logo size

### DIFF
--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -4396,7 +4396,7 @@ function SqlTab({
               <Popover.Root>
                 <Popover.Trigger
                   openOnHover
-                  delay={600}
+                  delay={100}
                   closeDelay={100}
                   render={<span className="sql-tab-title" />}
                 >

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -130,7 +130,7 @@ body.pg-active {
 }
 
 .brand-logo {
-  height: 22px;
+  height: 11px;
   width: auto;
   display: block;
 }
@@ -1497,7 +1497,7 @@ input[type="range"].fs-slider:disabled {
   border-radius: var(--radius);
   box-shadow: 0 8px 32px #0008;
   overflow: hidden;
-  z-index: 200;
+  z-index: 9999;
   transform-origin: var(--transform-origin, top center);
   transition: opacity 0.16s ease, transform 0.16s cubic-bezier(0.32, 0.72, 0, 1);
 }

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -893,7 +893,7 @@
 .sql-tabs {
   display: flex;
   align-items: stretch;
-  flex: 1;
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   gap: 2px;
@@ -1145,7 +1145,7 @@
   /* Cap the drawer width so wide displays don't get a sea of
      whitespace; on narrower screens it shrinks to leave a small
      gap on the left so the underlying UI stays peeking through. */
-  width: min(1040px, calc(100vw - 32px));
+  width: min(1280px, calc(100vw - 32px));
   background: var(--bg2);
   border-left: 1px solid var(--border);
   box-shadow: -16px 0 48px #000a;
@@ -1287,12 +1287,12 @@
   color: var(--text-dim);
   font-weight: 600;
   text-align: center;
-  padding: 10px 8px;
+  padding: 6px 6px;
   white-space: nowrap;
 }
 
 .sql-modify-table td {
-  padding: 7px 8px;
+  padding: 3px 6px;
   text-align: center;
   vertical-align: middle;
   min-width: 0;
@@ -1363,7 +1363,7 @@
 .sql-modify-col-default {
   font-family: var(--font-ui);
   font-size: 12px;
-  padding: 6px 8px;
+  padding: 3px 6px;
   min-width: 0;
   width: 100%;
 }
@@ -1375,7 +1375,7 @@
   color: var(--text);
   font-family: var(--font-ui);
   font-size: 12px;
-  padding: 6px 8px;
+  padding: 3px 6px;
   width: 100%;
   min-width: 0;
   box-shadow: none;

--- a/app/learn/layout.tsx
+++ b/app/learn/layout.tsx
@@ -33,7 +33,7 @@ export default function LearnLayout({ children }: { children: ReactNode }) {
               <Image
                 src={dataslopeLogoSrc}
                 alt="Dataslope logo"
-                style={{ height: "20px", width: "auto" }}
+                style={{ height: "10px", width: "auto" }}
               />
               Dataslope · Learn
             </Link>


### PR DESCRIPTION
## Summary

- **Update 1 (Popover):** Raise `.bui-popup` z-index from 200 → 9999 so tab-name popovers render above `.pg-header`. Reduce open delay from 600ms → 100ms for snappier feedback.
- **Update 2 (Tab-add position):** Change `.sql-tabs` from `flex: 1` to `flex: 0 1 auto` so `.sql-tab-add` sits dynamically next to the last tab rather than always being pinned at the right end of the bar. When tabs fill the available space, it still appears at the right end naturally. Width of the button remains constant (`flex-shrink: 0` unchanged).
- **Update 3 (View structure drawer):** Increase drawer max-width from 1040px → 1280px. Reduce `th`/`td` cell padding and input/select padding in the column editor for a denser, more readable layout.
- **Update 4 (Logo size):** Halve the Dataslope logo height in the SQLite playground (22px → 11px via `.brand-logo`) and in the `/learn` layout (20px → 10px).

## Test plan

- [ ] Open SQLite playground, hover a tab — popover appears above the header with a short delay
- [ ] Add several tabs; verify `+` button sits right after the last tab when there's space, and moves to the right end when tabs fill the bar
- [ ] Open "View structure" drawer — wider, and column editing table is more compact
- [ ] Check logo size in playground header and `/learn` pages

https://claude.ai/code/session_01QebvhxTFntch6a5i6Vv3WD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QebvhxTFntch6a5i6Vv3WD)_