### PR TITLE
fix: resolve three SqlTab popover/button issues

### DIFF
--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -4398,29 +4398,43 @@ function SqlTab({
                   openOnHover
                   delay={100}
                   closeDelay={100}
+                  nativeButton={false}
                   render={<span className="sql-tab-title" />}
                 >
                   {tab.title}
                 </Popover.Trigger>
                 <Popover.Portal>
-                  <Popover.Positioner side="top" sideOffset={6} align="center">
+                  <Popover.Positioner
+                    side="top"
+                    sideOffset={6}
+                    align="center"
+                    className="sql-tab-name-positioner"
+                  >
                     <Popover.Popup className="bui-popup sql-tab-name-popover">
                       {tab.title}
                     </Popover.Popup>
                   </Popover.Positioner>
                 </Popover.Portal>
               </Popover.Root>
-              <button
-                type="button"
+              <span
+                role="button"
+                tabIndex={-1}
                 className="sql-tab-close"
                 aria-label={`Close ${tab.title}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   onClose();
                 }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onClose();
+                  }
+                }}
               >
                 <X size={10} aria-hidden="true" />
-              </button>
+              </span>
             </button>
           )}
         />

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -972,6 +972,10 @@
   color: var(--text);
 }
 
+.sql-tab-name-positioner {
+  z-index: 9999;
+}
+
 .sql-tab-name-popover {
   font-family: var(--font-ui);
   font-size: 12px;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Popover z-index**: Added `className="sql-tab-name-positioner"` to `Popover.Positioner` and set `z-index: 9999` in CSS so the tab-title popover renders above the `.pg-header` bar instead of being hidden behind it
- **Nested button**: Replaced the close `<button>` inside the tab `<button>` with a `<span role="button">` (including keyboard handler) to fix the invalid HTML and React hydration error
- **nativeButton warning**: Added `nativeButton={false}` to `Popover.Trigger` since it renders as a `<span>` via the `render` prop, silencing the Base UI console warning

## Test plan

- [ ] Hover over a truncated tab title — popover appears above the tab bar and is not clipped by the header
- [ ] Click the × close button on a tab — tab closes correctly
- [ ] Press Enter/Space while the close span is focused — tab closes correctly
- [ ] No `<button> cannot be a descendant of <button>` hydration error in the console
- [ ] No Base UI `nativeButton` warning in the console

https://claude.ai/code/session_01MZ9NGRupEGp1ua3xEPhjEN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZ9NGRupEGp1ua3xEPhjEN)_