### PR TITLE
Fix SQL tab popover: hover on tab, truncation-gated, dim total count

### DIFF
--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -4327,6 +4327,8 @@ function SqlTab({
 }: SqlTabProps) {
   const [renameOpen, setRenameOpen] = useState(false);
   const [draftTitle, setDraftTitle] = useState(tab.title);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const titleRef = useRef<HTMLSpanElement>(null);
 
   const openRename = useCallback(() => {
     setDraftTitle(tab.title);
@@ -4389,17 +4391,21 @@ function SqlTab({
               onClick={onActivate}
               aria-selected={active}
               role="tab"
+              onMouseEnter={() => {
+                const el = titleRef.current;
+                if (el && el.scrollWidth > el.clientWidth) {
+                  setPopoverOpen(true);
+                }
+              }}
+              onMouseLeave={() => setPopoverOpen(false)}
             >
               {tab.kind === "view-data" && (
                 <Table2 size={11} className="sql-tab-kind-icon" aria-hidden="true" />
               )}
-              <Popover.Root>
+              <Popover.Root open={popoverOpen} onOpenChange={setPopoverOpen}>
                 <Popover.Trigger
-                  openOnHover
-                  delay={100}
-                  closeDelay={100}
                   nativeButton={false}
-                  render={<span className="sql-tab-title" />}
+                  render={<span ref={titleRef} className="sql-tab-title" />}
                 >
                   {tab.title}
                 </Popover.Trigger>

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -680,7 +680,7 @@
 /* The total row count is highlighted so the user can see at a glance
    how many rows the query returned, even when paginated. */
 .sql-result-pager-total {
-  color: var(--theme-primary, var(--accent, #f0b400));
+  color: var(--text-dim);
   font-weight: 600;
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Update 1**: Popover now fires when hovering anywhere on `.sql-tab` (the full tab button), not just the inner `.sql-tab-title` span
- **Update 2**: Popover only opens when the tab title is actually truncated with ellipsis (`scrollWidth > clientWidth`), so non-truncated tabs never show a redundant tooltip
- **Update 3**: `.sql-result-pager-total` color changed from `var(--theme-primary, var(--accent, …))` to `var(--text-dim)` so the total row count reads as secondary information rather than a highlighted accent

## Test plan

- [ ] Open the SQLite playground with several tabs
- [ ] Resize the tab bar so some tabs truncate — confirm hovering a truncated tab shows its full name in the popover
- [ ] With enough space that no tabs truncate — confirm hovering does NOT show any popover
- [ ] Run a query and confirm the total row count in the pager footer renders in the dim color (no longer accent/gold)

https://claude.ai/code/session_01DuSTGX8H9Gqua3EBcC6YuC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuSTGX8H9Gqua3EBcC6YuC)_