### PR TITLE
Fix ER diagram node spacing and add result set export menu

### DIFF
--- a/app/_components/ErDiagramPane.tsx
+++ b/app/_components/ErDiagramPane.tsx
@@ -306,7 +306,11 @@ async function computeElkLayout(
       "elk.algorithm": "layered",
       "elk.direction": "RIGHT",
       "elk.spacing.nodeNode": "80",
-      "elk.layered.spacing.edgeNodeBetweenLayers": "60",
+      // Minimum gap between nodes in adjacent layers (i.e. between two
+      // connected tables laid out left-to-right). The default (20px) is
+      // far too tight for edge labels to render without being clipped.
+      "elk.layered.spacing.nodeNodeBetweenLayers": "160",
+      "elk.layered.spacing.edgeNodeBetweenLayers": "80",
       "elk.edgeRouting": "ORTHOGONAL",
       "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
       "elk.layered.nodePlacement.strategy": "BRANDES_KOEPF",

--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -230,6 +230,72 @@ function escapeCsvCell(val: unknown): string {
   return s;
 }
 
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
+function exportResultToCsv(
+  columns: string[],
+  rows: QueryExecResult["values"],
+  filename: string,
+): void {
+  const lines = [
+    columns.map(escapeCsvCell).join(","),
+    ...rows.map((row) => row.map(escapeCsvCell).join(",")),
+  ];
+  triggerDownload(
+    new Blob([lines.join("\r\n")], { type: "text/csv;charset=utf-8" }),
+    filename,
+  );
+}
+
+function exportResultToJson(
+  columns: string[],
+  rows: QueryExecResult["values"],
+  filename: string,
+): void {
+  const data = rows.map((row) => {
+    const obj: Record<string, unknown> = {};
+    columns.forEach((col, i) => {
+      obj[col] = row[i] ?? null;
+    });
+    return obj;
+  });
+  triggerDownload(
+    new Blob([JSON.stringify(data, null, 2)], { type: "application/json" }),
+    filename,
+  );
+}
+
+function exportResultToSql(
+  columns: string[],
+  rows: QueryExecResult["values"],
+  filename: string,
+): void {
+  const quotedCols = columns
+    .map((c) => `"${c.replace(/"/g, '""')}"`)
+    .join(", ");
+  const lines = rows.map((row) => {
+    const vals = row
+      .map((v) => {
+        if (v === null || v === undefined) return "NULL";
+        if (typeof v === "number") return String(v);
+        return `'${String(v).replace(/'/g, "''")}'`;
+      })
+      .join(", ");
+    return `INSERT INTO result_set (${quotedCols}) VALUES (${vals});`;
+  });
+  triggerDownload(
+    new Blob([lines.join("\n")], { type: "text/plain;charset=utf-8" }),
+    filename,
+  );
+}
+
 // ────────────────────────────────────────────────────────────────────────
 // Modify Structure drawer
 // ────────────────────────────────────────────────────────────────────────
@@ -1343,6 +1409,20 @@ function SqlPlaygroundInner() {
       );
     },
     [runSqlForTab],
+  );
+
+  const handleFetchAllRows = useCallback(
+    (sql: string): QueryExecResult["values"] => {
+      const engine = engineRef.current;
+      if (!engine) return [];
+      try {
+        const results = engine.exec(sql);
+        return results[0]?.values ?? [];
+      } catch {
+        return [];
+      }
+    },
+    [],
   );
 
   const runActiveTab = useCallback(() => {
@@ -4255,6 +4335,7 @@ function SqlPlaygroundInner() {
                   globalPageSize={globalPageSize}
                   onSetGlobalPageSize={setGlobalPageSize}
                   onLoadPage={handleLoadPage}
+                  onFetchAllRows={handleFetchAllRows}
                 />
               </div>
               <DataslopeRunOverlay running={statusState === "running"} />
@@ -4465,6 +4546,7 @@ function ResultView({
   globalPageSize,
   onSetGlobalPageSize,
   onLoadPage,
+  onFetchAllRows,
 }: {
   result: QueryRunResult | null;
   loading: boolean;
@@ -4495,6 +4577,9 @@ function ResultView({
   onSetGlobalPageSize: (n: number) => void;
   /** Called when the user navigates to a different page in lazy mode. */
   onLoadPage: (sql: string, page: number) => void;
+  /** Fetches all rows for the given SQL (used to export lazy results without
+   *  loading all pages into React state). */
+  onFetchAllRows: (sql: string) => QueryExecResult["values"];
 }) {
   // Pagination state lives at the ResultView level (one record per
   // result-set index) so the pagers can be rendered in a footer that
@@ -5021,11 +5106,14 @@ function ResultView({
           let currentPage: number;
           let handlePageChange: (p: number) => void;
           let handlePageSizeChange: (s: number) => void;
+          let currentPageRows: QueryExecResult["values"];
+          let allRows: QueryExecResult["values"];
+          let effectiveLazySql: string;
           if (isLazy) {
             totalRows = result.lazyTotalCount ?? set.values.length;
             currentPage = result.lazyPage ?? 0;
             const baseSql = result.lazyBaseSql ?? result.lazySql ?? "";
-            let effectiveLazySql = baseSql;
+            effectiveLazySql = baseSql;
             if (sorting.length > 0) {
               const parsed = parseColumnId(sorting[0].id);
               if (parsed) {
@@ -5039,6 +5127,9 @@ function ResultView({
               // For "All" (s === 0), onLoadPage triggers a non-lazy full load.
               onLoadPage(effectiveLazySql, 0);
             };
+            // For lazy, set.values is already the current page.
+            currentPageRows = set.values;
+            allRows = []; // unused for lazy — onFetchAllRows handles export
           } else {
             const st = getState(idx);
             totalRows = set.values.length;
@@ -5048,6 +5139,39 @@ function ResultView({
               onSetGlobalPageSize(s);
               setPage(idx, 0);
             };
+            effectiveLazySql = "";
+            const effective =
+              globalPageSize > 0 ? globalPageSize : Math.max(totalRows, 1);
+            const totalPagesLocal = Math.max(
+              1,
+              Math.ceil(totalRows / effective),
+            );
+            const safePage = Math.min(currentPage, totalPagesLocal - 1);
+            const startIdx = safePage * effective;
+            // Apply the same sorting used by the table body so exported
+            // rows match what the user sees on screen.
+            const indexed = set.values.map((values, i) => ({
+              values,
+              originalIndex: i,
+            }));
+            let sortedIndexed = indexed;
+            if (sorting.length > 0) {
+              const parsed = parseColumnId(sorting[0].id);
+              if (parsed) {
+                sortedIndexed = [...indexed].sort((a, b) => {
+                  const cmp = compareCellValues(
+                    a.values[parsed.ci],
+                    b.values[parsed.ci],
+                  );
+                  return sorting[0].desc ? -cmp : cmp;
+                });
+              }
+            }
+            allRows = sortedIndexed.map((item) => item.values);
+            currentPageRows =
+              globalPageSize > 0
+                ? allRows.slice(startIdx, startIdx + effective)
+                : allRows;
           }
           const pkCols = pkColumnsForSet(set);
           const selected = selectedByIndex[idx];
@@ -5070,6 +5194,12 @@ function ResultView({
               selectedCount={selectedCount}
               onRequestDelete={() => requestDelete(idx)}
               onCommitEdits={() => commitEdits(idx, set)}
+              columns={set.columns}
+              currentPageRows={currentPageRows}
+              allRows={allRows}
+              isLazy={isLazy}
+              effectiveLazySql={effectiveLazySql}
+              onFetchAllRows={onFetchAllRows}
             />
           );
         })}
@@ -5761,6 +5891,12 @@ function ResultPager({
   selectedCount,
   onRequestDelete,
   onCommitEdits,
+  columns,
+  currentPageRows,
+  allRows,
+  isLazy,
+  effectiveLazySql,
+  onFetchAllRows,
 }: {
   /** Total number of rows across all pages. For lazy results this is the
    *  COUNT(*) from the engine; for non-lazy results it is set.values.length. */
@@ -5777,12 +5913,30 @@ function ResultPager({
   selectedCount: number;
   onRequestDelete: () => void;
   onCommitEdits: () => void;
+  /** Column names for the result set, used for export. */
+  columns: string[];
+  /** Rows visible on the current page (already sorted and sliced). */
+  currentPageRows: QueryExecResult["values"];
+  /** All rows in the result set (sorted but not sliced). For lazy results
+   *  this is unused — rows are fetched on demand via onFetchAllRows. */
+  allRows: QueryExecResult["values"];
+  /** Whether this result uses server-side (lazy) pagination. */
+  isLazy: boolean;
+  /** For lazy results: the SQL (possibly with ORDER BY) to use when
+   *  fetching the entire result set for export. */
+  effectiveLazySql: string;
+  /** Fetches all rows by running effectiveLazySql against the engine. */
+  onFetchAllRows: (sql: string) => QueryExecResult["values"];
 }) {
   const effective = pageSize > 0 ? pageSize : Math.max(totalRows, 1);
   const totalPages = Math.max(1, Math.ceil(totalRows / effective));
   const safePage = Math.min(page, totalPages - 1);
   const start = safePage * effective;
   const end = Math.min(totalRows, start + effective);
+
+  // Show "Current page" export section only when pagination is active
+  // (i.e. there are more rows than the current page holds).
+  const showCurrentPageExport = pageSize > 0 && totalRows > pageSize;
 
   // Controlled input for direct page navigation.
   const [pageInput, setPageInput] = useState(String(safePage + 1));
@@ -5801,6 +5955,22 @@ function ResultPager({
     } else {
       setPageInput(String(safePage + 1));
     }
+  };
+
+  const handleExport = (
+    scope: "page" | "all",
+    format: "csv" | "json" | "sql",
+  ) => {
+    const rows =
+      scope === "page"
+        ? currentPageRows
+        : isLazy
+          ? onFetchAllRows(effectiveLazySql)
+          : allRows;
+    const filename = `result_set.${format}`;
+    if (format === "csv") exportResultToCsv(columns, rows, filename);
+    else if (format === "json") exportResultToJson(columns, rows, filename);
+    else exportResultToSql(columns, rows, filename);
   };
 
   return (
@@ -5941,6 +6111,93 @@ function ResultPager({
           </button>
         )}
       </div>
+      <Menu.Root>
+        <Menu.Trigger className="sql-result-export-btn" aria-label="Export result set">
+          <ArrowDownToLine size={12} aria-hidden="true" />
+          <span>Export</span>
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner sideOffset={6} align="end">
+            <Menu.Popup className="bui-popup export-dropdown sql-result-export-popup">
+              {showCurrentPageExport && (
+                <>
+                  <div className="sql-result-export-group-label">
+                    Current page
+                  </div>
+                  <Menu.Item
+                    className="example-item export-item"
+                    onClick={() => handleExport("page", "csv")}
+                  >
+                    <span className="ext-badge">.csv</span>
+                    <div className="export-item-text">
+                      <div className="ex-title">CSV</div>
+                      <div className="ex-desc">Comma-separated values</div>
+                    </div>
+                  </Menu.Item>
+                  <Menu.Item
+                    className="example-item export-item"
+                    onClick={() => handleExport("page", "json")}
+                  >
+                    <span className="ext-badge">.json</span>
+                    <div className="export-item-text">
+                      <div className="ex-title">JSON</div>
+                      <div className="ex-desc">Array of objects</div>
+                    </div>
+                  </Menu.Item>
+                  <Menu.Item
+                    className="example-item export-item"
+                    onClick={() => handleExport("page", "sql")}
+                  >
+                    <span className="ext-badge">.sql</span>
+                    <div className="export-item-text">
+                      <div className="ex-title">SQL</div>
+                      <div className="ex-desc">INSERT statements</div>
+                    </div>
+                  </Menu.Item>
+                  <div
+                    role="separator"
+                    aria-orientation="horizontal"
+                    className="sql-result-export-sep"
+                  />
+                </>
+              )}
+              <div className="sql-result-export-group-label">
+                Entire result set
+              </div>
+              <Menu.Item
+                className="example-item export-item"
+                onClick={() => handleExport("all", "csv")}
+              >
+                <span className="ext-badge">.csv</span>
+                <div className="export-item-text">
+                  <div className="ex-title">CSV</div>
+                  <div className="ex-desc">Comma-separated values</div>
+                </div>
+              </Menu.Item>
+              <Menu.Item
+                className="example-item export-item"
+                onClick={() => handleExport("all", "json")}
+              >
+                <span className="ext-badge">.json</span>
+                <div className="export-item-text">
+                  <div className="ex-title">JSON</div>
+                  <div className="ex-desc">Array of objects</div>
+                </div>
+              </Menu.Item>
+              <Menu.Item
+                className="example-item export-item"
+                onClick={() => handleExport("all", "sql")}
+              >
+                <span className="ext-badge">.sql</span>
+                <div className="export-item-text">
+                  <div className="ex-title">SQL</div>
+                  <div className="ex-desc">INSERT statements</div>
+                </div>
+              </Menu.Item>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
     </div>
   );
 }

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -843,6 +843,50 @@
   font-weight: 600;
 }
 
+/* ─── Result set export button & menu ─── */
+.sql-result-export-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.sql-result-export-btn:hover {
+  background: var(--bg3);
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.sql-result-export-popup {
+  width: 220px;
+}
+
+.sql-result-export-group-label {
+  padding: 6px 10px 3px;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.sql-result-export-sep {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
 /* ─── View DDL dialog ─── */
 .sql-ddl-popup {
   width: min(720px, calc(100vw - 64px));


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **ER diagram spacing**: Increased ELK `nodeNodeBetweenLayers` from the default (~20px) to 160px so connected tables have enough horizontal clearance for edge labels to render fully instead of being clipped between nodes.
- **Result set export menu**: Added an "Export" button (BaseUI `Menu`) to the pager footer below every result table. It has two sections separated by a divider:
  - **Current page** — exports only the rows on the current paginated page (hidden when all rows fit on one page, i.e. `totalRows ≤ pageSize`)
  - **Entire result set** — exports all rows (for lazy/server-side pagination this re-runs the query via the engine; for in-memory results it uses the already-loaded sorted data)
  - Both sections offer CSV, JSON, and SQL (INSERT statements) formats.

## Test plan

- [ ] Open the SQLite playground with `chinook.db` and navigate to the ER Diagram tab — verify tables are further apart and FK edge labels (e.g. `customer_id → customer_id`) are fully visible
- [ ] Run a SELECT that returns more than 50 rows — verify the pager footer shows an "Export" button with both "Current page" and "Entire result set" sections
- [ ] Run a SELECT that returns ≤ 50 rows (fits on one page) — verify only the "Entire result set" section is shown (no "Current page" section)
- [ ] Export as CSV, JSON, and SQL from both sections and verify file downloads with correct content
- [ ] For lazy pagination (large tables), verify "Entire result set" fetches all rows correctly

https://claude.ai/code/session_01MnsPnvP6WX3vVtz7hYQ7Gv
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnsPnvP6WX3vVtz7hYQ7Gv)_