### PR TITLE
SQLite playground: export filename, UI polish, ER diagram toggle

### DIFF
--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -230,6 +230,10 @@ function escapeCsvCell(val: unknown): string {
   return s;
 }
 
+function toFileSafeName(title: string): string {
+  return title.replace(/[/\\:*?"<>|\x00-\x1f]/g, "_").trim() || "result_set";
+}
+
 function triggerDownload(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -2543,9 +2547,22 @@ function SqlPlaygroundInner() {
     // this keeps revisiting the ERD from rendering with stale partial
     // column caches.
     refreshTableMetadata();
-    // If an ER diagram tab is already open, just switch to it.
     const existing = tabs.find((t) => t.kind === "er-diagram");
     if (existing) {
+      // If the ER Diagram tab is already the active tab, close it (toggle).
+      if (existing.id === activeTabId) {
+        const next = tabs.filter((t) => t.id !== existing.id);
+        const finalTabs =
+          next.length > 0
+            ? next
+            : [{ id: newTabId(), title: "Query 1", code: "", pristineCode: "" }];
+        setTabs(finalTabs);
+        saveTabs(activeDbId, finalTabs);
+        activeTabIdRef.current = finalTabs[0].id;
+        setActiveTabId(finalTabs[0].id);
+        return;
+      }
+      // Otherwise switch to it.
       activeTabIdRef.current = existing.id;
       setActiveTabId(existing.id);
       return;
@@ -2562,7 +2579,7 @@ function SqlPlaygroundInner() {
     saveTabs(activeDbId, next);
     activeTabIdRef.current = tab.id;
     setActiveTabId(tab.id);
-  }, [tabs, activeDbId, refreshTableMetadata]);
+  }, [tabs, activeTabId, activeDbId, refreshTableMetadata]);
 
   const closeTab = useCallback(
     (id: string) => {
@@ -4336,6 +4353,7 @@ function SqlPlaygroundInner() {
                   onSetGlobalPageSize={setGlobalPageSize}
                   onLoadPage={handleLoadPage}
                   onFetchAllRows={handleFetchAllRows}
+                  tabTitle={activeTab?.title ?? "result_set"}
                 />
               </div>
               <DataslopeRunOverlay running={statusState === "running"} />
@@ -4547,6 +4565,7 @@ function ResultView({
   onSetGlobalPageSize,
   onLoadPage,
   onFetchAllRows,
+  tabTitle,
 }: {
   result: QueryRunResult | null;
   loading: boolean;
@@ -4580,6 +4599,8 @@ function ResultView({
   /** Fetches all rows for the given SQL (used to export lazy results without
    *  loading all pages into React state). */
   onFetchAllRows: (sql: string) => QueryExecResult["values"];
+  /** Title of the active tab, used to generate the export filename. */
+  tabTitle: string;
 }) {
   // Pagination state lives at the ResultView level (one record per
   // result-set index) so the pagers can be rendered in a footer that
@@ -4940,7 +4961,7 @@ function ResultView({
         <h3>Run a query to see results</h3>
         <p>
           Press <kbd className="kbd">Run</kbd> or use the keyboard shortcut to
-          execute the active tab. Click any table or view in the sidebar to open
+          execute the active tab. Double-click any table or view in the sidebar to open
           it in a new tab.
         </p>
       </div>
@@ -5200,6 +5221,7 @@ function ResultView({
               isLazy={isLazy}
               effectiveLazySql={effectiveLazySql}
               onFetchAllRows={onFetchAllRows}
+              tabTitle={tabTitle}
             />
           );
         })}
@@ -5897,6 +5919,7 @@ function ResultPager({
   isLazy,
   effectiveLazySql,
   onFetchAllRows,
+  tabTitle,
 }: {
   /** Total number of rows across all pages. For lazy results this is the
    *  COUNT(*) from the engine; for non-lazy results it is set.values.length. */
@@ -5927,6 +5950,8 @@ function ResultPager({
   effectiveLazySql: string;
   /** Fetches all rows by running effectiveLazySql against the engine. */
   onFetchAllRows: (sql: string) => QueryExecResult["values"];
+  /** Title of the active tab, used to generate the export filename. */
+  tabTitle: string;
 }) {
   const effective = pageSize > 0 ? pageSize : Math.max(totalRows, 1);
   const totalPages = Math.max(1, Math.ceil(totalRows / effective));
@@ -5967,7 +5992,7 @@ function ResultPager({
         : isLazy
           ? onFetchAllRows(effectiveLazySql)
           : allRows;
-    const filename = `result_set.${format}`;
+    const filename = `${toFileSafeName(tabTitle)}.${format}`;
     if (format === "csv") exportResultToCsv(columns, rows, filename);
     else if (format === "json") exportResultToJson(columns, rows, filename);
     else exportResultToSql(columns, rows, filename);

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -379,34 +379,34 @@
 
 .sql-sidebar-footer {
   border-top: 1px solid var(--border);
-  padding: 6px 12px;
   font-size: 10px;
   color: var(--text-dim);
   font-family: var(--font-ui);
   display: flex;
-  align-items: center;
+  align-items: stretch;
 }
 
 /* ─── ER Diagram button in sidebar footer ─── */
 .sql-er-btn {
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  justify-content: center;
   gap: 5px;
-  padding: 4px 8px;
-  border-radius: 5px;
-  border: 1px solid var(--border);
+  flex: 1;
+  padding: 7px 12px;
+  border: none;
+  border-radius: 0;
   background: transparent;
   color: var(--text-dim);
   font-family: var(--font-ui);
   font-size: 11px;
   cursor: pointer;
-  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+  transition: background 120ms ease, color 120ms ease;
 }
 
 .sql-er-btn:hover {
   background: var(--bg3);
   color: var(--text);
-  border-color: var(--accent);
 }
 
 /* ─── Panes ─── */
@@ -849,25 +849,34 @@
   align-items: center;
   gap: 5px;
   padding: 3px 8px;
-  border: 1px solid var(--border);
+  border: none;
   border-radius: 5px;
-  background: transparent;
+  background: color-mix(in srgb, var(--text) 6%, transparent);
   color: var(--text-dim);
   font-family: var(--font-ui);
   font-size: 11px;
   font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.12s, color 0.12s, border-color 0.12s;
+  transition: background 0.12s, color 0.12s;
 }
 .sql-result-export-btn:hover {
-  background: var(--bg3);
+  background: color-mix(in srgb, var(--text) 12%, transparent);
   color: var(--text);
-  border-color: var(--accent);
 }
 
 .sql-result-export-popup {
   width: 220px;
+  border: none !important;
+}
+
+.sql-result-export-popup .sql-result-export-group-label {
+  padding: 4px 8px 2px;
+}
+
+.sql-result-export-popup .export-item {
+  padding-top: 3px;
+  padding-bottom: 3px;
 }
 
 .sql-result-export-group-label {
@@ -1453,6 +1462,10 @@
   padding: 6px 6px 6px 8px;
   min-width: 0;
   width: 100%;
+  background: var(--bg);
+  border: 1px solid color-mix(in srgb, var(--text) 14%, transparent);
+  border-radius: 4px;
+  color: var(--text);
 }
 
 .sql-modify-col-type {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Export filename**: Uses the filename-safe tab title instead of always `result_set.{ext}` (e.g. tab "Browse tracks" → `Browse tracks.json`)
- **Export menu**: Removed border from the popup, tightened group label padding
- **View Structure drawer**: Name/default inputs now have a solid `--bg` background + subtle border so they are visually distinct from the striped row background in light themes
- **Welcome text**: "Click any table or view…" → "Double-click any table or view…"
- **ER Diagram sidebar button**: Fills the entire `.sql-sidebar-footer` area — no border, full height and width; footer still has its top border
- **Export button** (`.sql-result-export-btn`): Removed border, applied a subtle background with a softer hover state
- **ER Diagram toggle**: Clicking the ER Diagram button while the ER Diagram tab is active now closes that tab instead of switching to it

## Test plan

- [ ] Open a tab named "Browse tracks", run a query, export as JSON → file should download as `Browse tracks.json`
- [ ] Open the export menu — no border around the popup, spacing is slightly tighter
- [ ] Open "View Structure" for any table in a light theme — input fields should look distinct from the striped row backgrounds
- [ ] Results pane welcome state shows "Double-click any table or view…"
- [ ] `.sql-sidebar-footer` is entirely the ER Diagram button with no inner border
- [ ] Export button has no border, subtle background, soft hover
- [ ] Click ER Diagram button → ER Diagram tab opens; click again → tab closes

https://claude.ai/code/session_01TQZPViZVbeLsk4tSdu5nuN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQZPViZVbeLsk4tSdu5nuN)_