### PR TITLE
Update logos to SVG, style drawer inputs, settings checkbox, and export menu

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -1233,7 +1233,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
           <div className="logo">
             <Link href="/" aria-label="Dataslope home">
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/dataslope-blue@4x.png" alt="Dataslope logo" className="brand-logo" />
+              <img src="/dataslope-logo-blue.svg" alt="Dataslope logo" className="brand-logo" />
             </Link>
             <Link href="/" className="brand-name">Dataslope</Link>
             <Select.Root

--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -75,6 +75,7 @@ import { Dialog } from "@base-ui-components/react/dialog";
 import { Toast } from "@base-ui-components/react/toast";
 import { Select } from "@base-ui-components/react/select";
 import { Checkbox } from "@base-ui-components/react/checkbox";
+import { Switch } from "@base-ui-components/react/switch";
 import { Menu } from "@base-ui-components/react/menu";
 import { ContextMenu } from "@base-ui-components/react/context-menu";
 import {
@@ -2939,7 +2940,7 @@ function SqlPlaygroundInner() {
           <div className="logo">
             <Link href="/" aria-label="Dataslope home">
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/dataslope-blue@4x.png" alt="Dataslope logo" className="brand-logo" />
+              <img src="/dataslope-logo-blue.svg" alt="Dataslope logo" className="brand-logo" />
             </Link>
             <Link href="/" className="brand-name">
               Dataslope
@@ -5959,9 +5960,10 @@ function ResultPager({
   const start = safePage * effective;
   const end = Math.min(totalRows, start + effective);
 
-  // Show "Current page" export section only when pagination is active
-  // (i.e. there are more rows than the current page holds).
-  const showCurrentPageExport = pageSize > 0 && totalRows > pageSize;
+  // Whether the export toggle is available (pagination is active).
+  const canExportCurrentPage = pageSize > 0 && totalRows > pageSize;
+  // Toggle: false = entire result set (default), true = current page only.
+  const [exportCurrentPageOnly, setExportCurrentPageOnly] = useState(false);
 
   // Controlled input for direct page navigation.
   const [pageInput, setPageInput] = useState(String(safePage + 1));
@@ -6144,54 +6146,9 @@ function ResultPager({
         <Menu.Portal>
           <Menu.Positioner sideOffset={6} align="end">
             <Menu.Popup className="bui-popup export-dropdown sql-result-export-popup">
-              {showCurrentPageExport && (
-                <>
-                  <div className="sql-result-export-group-label">
-                    Current page
-                  </div>
-                  <Menu.Item
-                    className="example-item export-item"
-                    onClick={() => handleExport("page", "csv")}
-                  >
-                    <span className="ext-badge">.csv</span>
-                    <div className="export-item-text">
-                      <div className="ex-title">CSV</div>
-                      <div className="ex-desc">Comma-separated values</div>
-                    </div>
-                  </Menu.Item>
-                  <Menu.Item
-                    className="example-item export-item"
-                    onClick={() => handleExport("page", "json")}
-                  >
-                    <span className="ext-badge">.json</span>
-                    <div className="export-item-text">
-                      <div className="ex-title">JSON</div>
-                      <div className="ex-desc">Array of objects</div>
-                    </div>
-                  </Menu.Item>
-                  <Menu.Item
-                    className="example-item export-item"
-                    onClick={() => handleExport("page", "sql")}
-                  >
-                    <span className="ext-badge">.sql</span>
-                    <div className="export-item-text">
-                      <div className="ex-title">SQL</div>
-                      <div className="ex-desc">INSERT statements</div>
-                    </div>
-                  </Menu.Item>
-                  <div
-                    role="separator"
-                    aria-orientation="horizontal"
-                    className="sql-result-export-sep"
-                  />
-                </>
-              )}
-              <div className="sql-result-export-group-label">
-                Entire result set
-              </div>
               <Menu.Item
                 className="example-item export-item"
-                onClick={() => handleExport("all", "csv")}
+                onClick={() => handleExport(exportCurrentPageOnly ? "page" : "all", "csv")}
               >
                 <span className="ext-badge">.csv</span>
                 <div className="export-item-text">
@@ -6201,7 +6158,7 @@ function ResultPager({
               </Menu.Item>
               <Menu.Item
                 className="example-item export-item"
-                onClick={() => handleExport("all", "json")}
+                onClick={() => handleExport(exportCurrentPageOnly ? "page" : "all", "json")}
               >
                 <span className="ext-badge">.json</span>
                 <div className="export-item-text">
@@ -6211,7 +6168,7 @@ function ResultPager({
               </Menu.Item>
               <Menu.Item
                 className="example-item export-item"
-                onClick={() => handleExport("all", "sql")}
+                onClick={() => handleExport(exportCurrentPageOnly ? "page" : "all", "sql")}
               >
                 <span className="ext-badge">.sql</span>
                 <div className="export-item-text">
@@ -6219,6 +6176,28 @@ function ResultPager({
                   <div className="ex-desc">INSERT statements</div>
                 </div>
               </Menu.Item>
+              {canExportCurrentPage && (
+                <>
+                  <div
+                    role="separator"
+                    aria-orientation="horizontal"
+                    className="sql-result-export-sep"
+                  />
+                  <div className="sql-result-export-toggle-row">
+                    <span className="sql-result-export-toggle-label">
+                      Current page only
+                    </span>
+                    <Switch.Root
+                      checked={exportCurrentPageOnly}
+                      onCheckedChange={setExportCurrentPageOnly}
+                      className="bui-switch sql-export-switch"
+                      aria-label="Export current page only"
+                    >
+                      <Switch.Thumb className="bui-switch-thumb" />
+                    </Switch.Root>
+                  </div>
+                </>
+              )}
             </Menu.Popup>
           </Menu.Positioner>
         </Menu.Portal>

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -979,7 +979,38 @@ input[type="range"].fs-slider:disabled {
   user-select: none;
 }
 .setting-checkbox-row input[type="checkbox"] {
-  width: 14px; height: 14px; cursor: pointer; accent-color: var(--accent);
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  cursor: pointer;
+  border: none;
+  border-radius: 4px;
+  background: var(--bg3);
+  box-shadow: none;
+  outline: none;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.12s;
+}
+.setting-checkbox-row input[type="checkbox"]:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+.setting-checkbox-row input[type="checkbox"]:checked {
+  background: color-mix(in srgb, var(--accent) 80%, var(--bg3));
+}
+.setting-checkbox-row input[type="checkbox"]:checked::after {
+  content: '';
+  display: block;
+  width: 4px;
+  height: 7px;
+  border: 1.5px solid var(--bg);
+  border-top: none;
+  border-left: none;
+  transform: rotate(40deg) translate(-1px, -1px);
 }
 
 /* Setting row using a Base UI Switch (e.g. Word Wrap, Clear Output). The

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -896,6 +896,37 @@
   margin: 4px 0;
 }
 
+.sql-result-export-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 5px 10px 6px;
+}
+
+.sql-result-export-toggle-label {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--text-dim);
+  user-select: none;
+}
+
+.sql-export-switch {
+  width: 28px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.sql-export-switch .bui-switch-thumb {
+  width: 11px;
+  height: 11px;
+  transform: translateX(3px);
+}
+
+.sql-export-switch[data-checked] .bui-switch-thumb {
+  transform: translateX(14px);
+}
+
 /* ─── View DDL dialog ─── */
 .sql-ddl-popup {
   width: min(720px, calc(100vw - 64px));
@@ -1470,7 +1501,7 @@
 
 .sql-modify-col-type {
   background: var(--bg3);
-  border: none;
+  border: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
   border-radius: 5px;
   color: var(--text);
   font-family: var(--font-ui);
@@ -1484,6 +1515,7 @@
 
 .sql-modify-col-type:focus {
   box-shadow: 0 0 0 2px var(--accent-glow);
+  border-color: var(--accent);
 }
 
 .sql-modify-col-remove {
@@ -1531,13 +1563,14 @@
   align-items: center;
   justify-content: center;
   background: var(--bg3);
-  border: none;
+  border: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
   border-radius: 3px;
   flex-shrink: 0;
   box-shadow: none;
   appearance: none;
   -webkit-appearance: none;
   outline: none;
+  position: relative;
 }
 
 .sql-modify-flag-box:focus-visible {
@@ -2136,6 +2169,42 @@
 .sql-modify-fk-cascade:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+/* ─── Disabled state diagonal marker ─── */
+/* Draws a subtle 45° line through the center of disabled checkboxes
+   and select wrappers to signal the field is not interactive. */
+.sql-modify-flag.is-disabled .sql-modify-flag-box::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    45deg,
+    transparent calc(50% - 0.75px),
+    color-mix(in srgb, var(--text) 45%, transparent) calc(50% - 0.75px),
+    color-mix(in srgb, var(--text) 45%, transparent) calc(50% + 0.75px),
+    transparent calc(50% + 0.75px)
+  );
+  border-radius: 2px;
+  pointer-events: none;
+}
+
+.sql-modify-cell-field {
+  position: relative;
+}
+.sql-modify-cell-field:has(select:disabled)::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    45deg,
+    transparent calc(50% - 0.75px),
+    color-mix(in srgb, var(--text) 30%, transparent) calc(50% - 0.75px),
+    color-mix(in srgb, var(--text) 30%, transparent) calc(50% + 0.75px),
+    transparent calc(50% + 0.75px)
+  );
+  pointer-events: none;
+  border-radius: 4px;
 }
 
 /* ─── ER Diagram tab icon ─── */

--- a/app/learn/layout.tsx
+++ b/app/learn/layout.tsx
@@ -16,8 +16,6 @@ import { RootProvider } from "fumadocs-ui/provider/next";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { source } from "@/lib/source";
 import Link from "next/link";
-import Image from "next/image";
-import dataslopeLogoSrc from "@/public/dataslope-blue@4x.png";
 
 export default function LearnLayout({ children }: { children: ReactNode }) {
   return (
@@ -30,8 +28,9 @@ export default function LearnLayout({ children }: { children: ReactNode }) {
               href="/"
               style={{ display: "flex", alignItems: "center", gap: "8px", textDecoration: "none", color: "inherit" }}
             >
-              <Image
-                src={dataslopeLogoSrc}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="/dataslope-logo-blue.svg"
                 alt="Dataslope logo"
                 style={{ height: "10px", width: "auto" }}
               />


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Logo**: Replace `dataslope-blue@4x.png` with `dataslope-logo-blue.svg` in all playgrounds and the `/learn` layout
- **View Structure drawer**: Add subtle borders (`color-mix(in srgb, var(--text) 10%, transparent)`) to all inputs, checkboxes, and select dropdowns in `.sql-modify-table`; draw a 45° diagonal line via `linear-gradient` pseudo-element on disabled checkboxes and selects
- **General settings checkbox**: Custom-styled `appearance: none` checkbox for "Use Different Font Size for Results" — no border, `var(--bg3)` background, muted accent for checked state with a checkmark `::after`
- **Export menu**: Collapse the two-section (Current page / Entire result set) layout into a single section; add a compact toggle switch at the bottom labeled "Current page only" (off by default = exports entire result set)

## Test plan

- [ ] Verify SVG logo appears correctly in all playground headers and `/learn` nav
- [ ] Open SQLite "View Structure" drawer — check subtle borders on name/type/default inputs, checkboxes, and dropdowns; verify disabled FK column and cascade selects show the diagonal line
- [ ] Open playground General settings — confirm the font-size checkbox has no native border and shows the accent-tinted checked state
- [ ] Open the SQLite result export menu with a paginated result set — confirm single section, toggle appears, and toggling between entire set / current page exports the correct rows

https://claude.ai/code/session_01MvPGDwTG8kQH4JwPwnHZuk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvPGDwTG8kQH4JwPwnHZuk)_