### PR TITLE
Fix playground switcher gap, DB selector z-index, diagonal lines, and export popup

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -1274,7 +1274,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                 </Select.Icon>
               </Select.Trigger>
               <Select.Portal>
-                <Select.Positioner sideOffset={6} alignItemWithTrigger={false}>
+                <Select.Positioner sideOffset={0} alignItemWithTrigger={false}>
                   <Select.Popup className="bui-select-popup">
                     {PLAYGROUNDS.map((p) => {
                       const Icon = PLAYGROUND_ICONS[p.id];

--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -4021,6 +4021,7 @@ function SqlPlaygroundInner() {
                   </Select.Trigger>
                   <Select.Portal>
                     <Select.Positioner
+                      className="sql-db-positioner"
                       sideOffset={6}
                       alignItemWithTrigger={false}
                     >
@@ -6177,26 +6178,22 @@ function ResultPager({
                 </div>
               </Menu.Item>
               {canExportCurrentPage && (
-                <>
-                  <div
-                    role="separator"
-                    aria-orientation="horizontal"
-                    className="sql-result-export-sep"
-                  />
-                  <div className="sql-result-export-toggle-row">
-                    <span className="sql-result-export-toggle-label">
-                      Current page only
-                    </span>
-                    <Switch.Root
-                      checked={exportCurrentPageOnly}
-                      onCheckedChange={setExportCurrentPageOnly}
-                      className="bui-switch sql-export-switch"
-                      aria-label="Export current page only"
-                    >
-                      <Switch.Thumb className="bui-switch-thumb" />
-                    </Switch.Root>
-                  </div>
-                </>
+                <div className="sql-result-export-toggle-row">
+                  <span className="sql-result-export-toggle-label">
+                    Only rows in current page
+                  </span>
+                  <Switch.Root
+                    checked={!exportCurrentPageOnly}
+                    onCheckedChange={(v) => setExportCurrentPageOnly(!v)}
+                    className="bui-switch sql-export-switch"
+                    aria-label="Export all rows"
+                  >
+                    <Switch.Thumb className="bui-switch-thumb" />
+                  </Switch.Root>
+                  <span className="sql-result-export-toggle-label">
+                    All rows
+                  </span>
+                </div>
               )}
             </Menu.Popup>
           </Menu.Positioner>

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -94,8 +94,13 @@
   white-space: nowrap;
 }
 
+.sql-db-positioner {
+  z-index: 500;
+}
+
 .sql-db-popup {
   min-width: 260px;
+  z-index: 500;
 }
 
 .sql-db-item {
@@ -867,7 +872,6 @@
 
 .sql-result-export-popup {
   width: 220px;
-  border: none !important;
 }
 
 .sql-result-export-popup .sql-result-export-group-label {
@@ -875,8 +879,8 @@
 }
 
 .sql-result-export-popup .export-item {
-  padding-top: 3px;
-  padding-bottom: 3px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .sql-result-export-group-label {
@@ -899,16 +903,23 @@
 .sql-result-export-toggle-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 5px 10px 6px;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 10px 7px;
+  border-top: 1px solid var(--border);
+  margin-top: 2px;
 }
 
 .sql-result-export-toggle-label {
   font-family: var(--font-ui);
-  font-size: 12px;
+  font-size: 11px;
   color: var(--text-dim);
   user-select: none;
+  flex: 1;
+}
+
+.sql-result-export-toggle-label:last-child {
+  text-align: right;
 }
 
 .sql-export-switch {
@@ -2172,14 +2183,14 @@
 }
 
 /* ─── Disabled state diagonal marker ─── */
-/* Draws a subtle 45° line through the center of disabled checkboxes
+/* Draws a subtle line through the center of disabled checkboxes
    and select wrappers to signal the field is not interactive. */
 .sql-modify-flag.is-disabled .sql-modify-flag-box::after {
   content: '';
   position: absolute;
   inset: 0;
   background: linear-gradient(
-    45deg,
+    135deg,
     transparent calc(50% - 0.75px),
     color-mix(in srgb, var(--text) 45%, transparent) calc(50% - 0.75px),
     color-mix(in srgb, var(--text) 45%, transparent) calc(50% + 0.75px),
@@ -2197,7 +2208,7 @@
   position: absolute;
   inset: 0;
   background: linear-gradient(
-    45deg,
+    135deg,
     transparent calc(50% - 0.75px),
     color-mix(in srgb, var(--text) 30%, transparent) calc(50% - 0.75px),
     color-mix(in srgb, var(--text) 30%, transparent) calc(50% + 0.75px),


### PR DESCRIPTION
## Summary

- **Update 1:** Remove the gap between the `.playground-switcher` trigger and its popup by setting `sideOffset={0}` on the Select.Positioner
- **Update 2:** Fix `.sql-db-selector` popup rendering behind `.sql-db-selector-wrap` by adding `z-index: 500` to both the new `.sql-db-positioner` class and `.sql-db-popup`
- **Update 3:** Change disabled field diagonal lines in the "View structure" drawer from top-left→bottom-right (45deg) to bottom-left→top-right (135deg) for both checkbox and select field markers
- **Update 4:** Redesign the result set export popup:
  - 3-part switch row layout: "Only rows in current page" | switch | "All rows"
  - Switch defaults to right/checked position ("All rows") — inverted logic from previous "Current page only" default
  - Removed the explicit separator `<div>` and replaced with a `border-top` on the toggle row to eliminate the double border and extra gap above the switch section
  - Increased export file format item padding (3px → 6px) for more vertical breathing room
  - Restored the popup border by removing `border: none !important` from `.sql-result-export-popup`

## Test plan

- [ ] Open the playground switcher dropdown — popup should open flush against the trigger with no gap
- [ ] Open the database selector in the SQL playground — popup should appear above the selector wrap, not behind it
- [ ] Open the "View structure" drawer and inspect disabled checkboxes/inputs — diagonal lines should run bottom-left to top-right
- [ ] Open the export menu on a result set with multiple pages — verify 3-part layout, switch starts on "All rows" (right), border appears on popup, no double border above switch row, items have adequate vertical spacing

https://claude.ai/code/session_01B1mbFaD94sax6dZNN5H4F5

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1mbFaD94sax6dZNN5H4F5)_