### PR TITLE
SQLite playground: tab template, empty-table button, export scope selector

### DIFF
--- a/app/_components/SqlPlayground.tsx
+++ b/app/_components/SqlPlayground.tsx
@@ -75,7 +75,6 @@ import { Dialog } from "@base-ui-components/react/dialog";
 import { Toast } from "@base-ui-components/react/toast";
 import { Select } from "@base-ui-components/react/select";
 import { Checkbox } from "@base-ui-components/react/checkbox";
-import { Switch } from "@base-ui-components/react/switch";
 import { Menu } from "@base-ui-components/react/menu";
 import { ContextMenu } from "@base-ui-components/react/context-menu";
 import {
@@ -2556,7 +2555,7 @@ function SqlPlaygroundInner() {
         const finalTabs =
           next.length > 0
             ? next
-            : [{ id: newTabId(), title: "Query 1", code: "", pristineCode: "" }];
+            : [{ id: newTabId(), title: "Query 1", code: "-- New query\nSELECT 1;", pristineCode: "-- New query\nSELECT 1;" }];
         setTabs(finalTabs);
         saveTabs(activeDbId, finalTabs);
         activeTabIdRef.current = finalTabs[0].id;
@@ -2606,8 +2605,8 @@ function SqlPlaygroundInner() {
               {
                 id: newTabId(),
                 title: "Query 1",
-                code: "",
-                pristineCode: "",
+                code: "-- New query\nSELECT 1;",
+                pristineCode: "-- New query\nSELECT 1;",
               },
             ];
       setTabs(finalTabs);
@@ -2632,8 +2631,8 @@ function SqlPlaygroundInner() {
             {
               id: newTabId(),
               title: "Query 1",
-              code: "",
-              pristineCode: "",
+              code: "-- New query\nSELECT 1;",
+              pristineCode: "-- New query\nSELECT 1;",
             },
           ];
     setTabs(finalTabs);
@@ -2695,7 +2694,7 @@ function SqlPlaygroundInner() {
 
   const closeAllTabs = useCallback(() => {
     const fresh = [
-      { id: newTabId(), title: "Query 1", code: "", pristineCode: "" },
+      { id: newTabId(), title: "Query 1", code: "-- New query\nSELECT 1;", pristineCode: "-- New query\nSELECT 1;" },
     ];
     // Order matters: synchronously update the refs the editor's
     // `change` listener reads from BEFORE we call `editor.setValue`.
@@ -6147,6 +6146,35 @@ function ResultPager({
         <Menu.Portal>
           <Menu.Positioner sideOffset={6} align="end">
             <Menu.Popup className="bui-popup export-dropdown sql-result-export-popup">
+              {canExportCurrentPage && (
+                <>
+                  <div className="sql-result-export-group-label">Scope</div>
+                  <div className="sql-result-export-scope-options">
+                    <button
+                      type="button"
+                      className={`sql-result-export-scope-option${exportCurrentPageOnly ? " is-selected" : ""}`}
+                      onClick={(e) => { e.stopPropagation(); setExportCurrentPageOnly(true); }}
+                    >
+                      <span className="scope-radio-indicator" aria-hidden="true">
+                        {exportCurrentPageOnly ? "●" : "○"}
+                      </span>
+                      <span>Current page ({(end - start).toLocaleString()} rows)</span>
+                    </button>
+                    <button
+                      type="button"
+                      className={`sql-result-export-scope-option${!exportCurrentPageOnly ? " is-selected" : ""}`}
+                      onClick={(e) => { e.stopPropagation(); setExportCurrentPageOnly(false); }}
+                    >
+                      <span className="scope-radio-indicator" aria-hidden="true">
+                        {!exportCurrentPageOnly ? "●" : "○"}
+                      </span>
+                      <span>Entire result ({totalRows.toLocaleString()} rows)</span>
+                    </button>
+                  </div>
+                  <div className="sql-result-export-sep" />
+                </>
+              )}
+              <div className="sql-result-export-group-label">Format</div>
               <Menu.Item
                 className="example-item export-item"
                 onClick={() => handleExport(exportCurrentPageOnly ? "page" : "all", "csv")}
@@ -6177,24 +6205,6 @@ function ResultPager({
                   <div className="ex-desc">INSERT statements</div>
                 </div>
               </Menu.Item>
-              {canExportCurrentPage && (
-                <div className="sql-result-export-toggle-row">
-                  <span className="sql-result-export-toggle-label">
-                    Only rows in current page
-                  </span>
-                  <Switch.Root
-                    checked={!exportCurrentPageOnly}
-                    onCheckedChange={(v) => setExportCurrentPageOnly(!v)}
-                    className="bui-switch sql-export-switch"
-                    aria-label="Export all rows"
-                  >
-                    <Switch.Thumb className="bui-switch-thumb" />
-                  </Switch.Root>
-                  <span className="sql-result-export-toggle-label">
-                    All rows
-                  </span>
-                </div>
-              )}
             </Menu.Popup>
           </Menu.Positioner>
         </Menu.Portal>
@@ -6854,7 +6864,18 @@ function SchemaSection({
       {expanded && (
         <div className="sql-tree-section-body">
           {count === 0 ? (
-            <div className="sql-tree-empty">{emptyMessage}</div>
+            onAdd ? (
+              <button
+                type="button"
+                className="sql-tree-create-btn"
+                onClick={onAdd}
+              >
+                <Table2 size={12} aria-hidden="true" />
+                <span>Create a {label.toLowerCase().replace(/s$/, "")}</span>
+              </button>
+            ) : (
+              <div className="sql-tree-empty">{emptyMessage}</div>
+            )
           ) : (
             children
           )}

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -382,6 +382,26 @@
   margin-left: 12px;
 }
 
+.sql-tree-create-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin: 4px 12px 4px 20px;
+  padding: 3px 8px;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  cursor: pointer;
+  transition: color 0.12s;
+}
+
+.sql-tree-create-btn:hover {
+  color: var(--text);
+}
+
 .sql-sidebar-footer {
   border-top: 1px solid var(--border);
   font-size: 10px;
@@ -900,42 +920,43 @@
   margin: 4px 0;
 }
 
-.sql-result-export-toggle-row {
+.sql-result-export-scope-options {
+  display: flex;
+  flex-direction: column;
+  padding: 2px 8px 4px;
+  gap: 1px;
+}
+
+.sql-result-export-scope-option {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 6px 10px 7px;
-  border-top: 1px solid var(--border);
-  margin-top: 2px;
-}
-
-.sql-result-export-toggle-label {
+  gap: 6px;
+  padding: 4px 6px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-dim);
   font-family: var(--font-ui);
   font-size: 11px;
-  color: var(--text-dim);
-  user-select: none;
-  flex: 1;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: background 0.1s, color 0.1s;
 }
 
-.sql-result-export-toggle-label:last-child {
-  text-align: right;
+.sql-result-export-scope-option:hover {
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  color: var(--text);
 }
 
-.sql-export-switch {
-  width: 28px;
-  height: 16px;
+.sql-result-export-scope-option.is-selected {
+  color: var(--text);
+}
+
+.scope-radio-indicator {
+  font-size: 10px;
   flex-shrink: 0;
-}
-
-.sql-export-switch .bui-switch-thumb {
-  width: 11px;
-  height: 11px;
-  transform: translateX(3px);
-}
-
-.sql-export-switch[data-checked] .bui-switch-thumb {
-  transform: translateX(14px);
+  line-height: 1;
 }
 
 /* ─── View DDL dialog ─── */


### PR DESCRIPTION
## Summary

- **Tab template**: The fallback "Query 1" tab created when the last tab is closed (via `closeTab`, `confirmCloseTab`, `closeAllTabs`, or ER-diagram toggle) now pre-fills with the same default template (`-- New query\nSELECT 1;`) used by the "+" button, instead of opening blank.
- **Empty tables state**: Replaced the italic "No tables." text in `.sql-tree` with a hollow "Create a table" button (border and font share `currentColor`) that includes a `Table2` icon and calls the existing `openAddTable` handler.
- **Export scope selector**: Replaced the toggle switch in the export popup with a radio-style "Scope" section showing row counts — "Current page (N rows)" and "Entire result (N rows)" — placed above the existing Format section. Removed the now-unused `Switch` import.

## Test plan

- [ ] Open the SQLite playground, close all tabs — the new tab should contain `-- New query\nSELECT 1;`
- [ ] Close the last remaining tab — same template should appear
- [ ] Use a blank database (no tables); verify the Tables section shows a "Create a table" button; clicking it opens the Add Table dialog
- [ ] Run a query with pagination active, click Export — verify "Scope" section appears with page/total row counts; selecting an option changes which rows are exported; clicking a format triggers the download

https://claude.ai/code/session_01U916APteEm2LQaHm59Y8AQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01U916APteEm2LQaHm59Y8AQ)_