### PR TITLE
Add ERD cardinality toggle, attribution removal, table context menu, and conditional fade animation

### DIFF
--- a/app/_components/ErDiagramPane.tsx
+++ b/app/_components/ErDiagramPane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useContext, createContext, useMemo } from "react";
+import { useState, useEffect, useRef, useContext, createContext, useMemo, useCallback } from "react";
 import {
   ReactFlow,
   Background,
@@ -23,7 +23,9 @@ import type { ElkExtendedEdge, ElkEdgeSection, ElkPoint } from "elkjs";
 import type { TableColumnInfo, ForeignKeyInfo } from "./runtime/sqlite";
 import { MdOutlineKey } from "react-icons/md";
 import { IoLink } from "react-icons/io5";
+import { ChevronRight } from "lucide-react";
 import { ContextMenu } from "@base-ui-components/react/context-menu";
+import { Menu } from "@base-ui-components/react/menu";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Contexts — cardinality visibility + table action callbacks
@@ -38,7 +40,8 @@ interface ErTableActions {
   onTruncate?: (name: string) => void;
   onDrop: (name: string) => void;
   onViewDDL: (name: string) => void;
-  onExportCsv: (name: string) => void;
+  onExport: (name: string, format: "csv" | "json" | "sql" | "parquet") => void;
+  onGetRowCount: (name: string) => number;
 }
 
 const CardinalityContext = createContext<boolean>(true);
@@ -79,6 +82,14 @@ function columnHandleId(
 function ErTableNode({ data }: NodeProps) {
   const { tableName, columns, fkColumns } = data as ErTableNodeData;
   const actions = useContext(TableActionsContext);
+
+  // Row count is fetched lazily the first time the Export submenu opens.
+  const [exportRowCount, setExportRowCount] = useState<number | null>(null);
+  const ensureRowCount = useCallback(() => {
+    if (exportRowCount === null && actions?.onGetRowCount) {
+      setExportRowCount(actions.onGetRowCount(tableName));
+    }
+  }, [exportRowCount, actions, tableName]);
 
   const nodeContent = (
     <div className="er-table-node">
@@ -187,12 +198,75 @@ function ErTableNode({ data }: NodeProps) {
             >
               <div className="ex-title">Copy Name</div>
             </ContextMenu.Item>
-            <ContextMenu.Item
-              className="example-item"
-              onClick={() => actions.onExportCsv(tableName)}
-            >
-              <div className="ex-title">Export to CSV</div>
-            </ContextMenu.Item>
+            {/* Export submenu — opens to the side showing all 4 formats */}
+            <Menu.Root>
+              <Menu.Trigger
+                className="example-item ctx-export-trigger"
+                onPointerDown={ensureRowCount}
+              >
+                <div className="ex-title ctx-export-title">
+                  Export
+                  <ChevronRight size={10} className="ctx-export-arrow" />
+                </div>
+              </Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner side="right" align="start" sideOffset={4}>
+                  <Menu.Popup className="bui-popup examples-dropdown export-dropdown">
+                    {exportRowCount !== null && (
+                      <div className="sql-result-export-group-label">
+                        {exportRowCount.toLocaleString()} rows
+                      </div>
+                    )}
+                    <Menu.Item
+                      className="example-item export-item"
+                      onClick={() => actions.onExport(tableName, "csv")}
+                    >
+                      <div className="export-item-text">
+                        <div className="ex-title">
+                          CSV <span className="ext-badge">.csv</span>
+                        </div>
+                        <div className="ex-desc">Comma-separated values</div>
+                      </div>
+                    </Menu.Item>
+                    <Menu.Item
+                      className="example-item export-item"
+                      onClick={() => actions.onExport(tableName, "json")}
+                    >
+                      <div className="export-item-text">
+                        <div className="ex-title">
+                          JSON <span className="ext-badge">.json</span>
+                        </div>
+                        <div className="ex-desc">Array of objects</div>
+                      </div>
+                    </Menu.Item>
+                    <Menu.Item
+                      className="example-item export-item"
+                      onClick={() => actions.onExport(tableName, "sql")}
+                    >
+                      <div className="export-item-text">
+                        <div className="ex-title">
+                          SQL <span className="ext-badge">.sql</span>
+                        </div>
+                        <div className="ex-desc">INSERT statements</div>
+                      </div>
+                    </Menu.Item>
+                    <Menu.Item
+                      className="example-item export-item"
+                      onClick={() => actions.onExport(tableName, "parquet")}
+                    >
+                      <div className="export-item-text">
+                        <div className="ex-title">
+                          Parquet <span className="ext-badge">.parquet</span>
+                        </div>
+                        <div className="ex-desc">
+                          Apache Parquet columnar format
+                        </div>
+                      </div>
+                    </Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
             {actions.onTruncate && (
               <ContextMenu.Item
                 className="example-item"
@@ -229,6 +303,87 @@ interface ElkEdgeData {
   [key: string]: unknown;
 }
 
+/**
+ * Render crow's-foot cardinality markers directly into the edge SVG.
+ *
+ * The source (FK / "many") end gets a crow's foot: three lines radiating
+ * outward from the entity boundary in the direction the edge travels.
+ * The target (PK / "one") end gets a single perpendicular tick.
+ *
+ * Angles are derived from the first and last edge segments so the symbols
+ * always align with the actual line direction.
+ */
+function renderCardinalityMarkers(
+  pts: { x: number; y: number }[],
+  stroke: string,
+  sw: number,
+): React.ReactElement {
+  const n = pts.length;
+  // Direction the edge leaves the source point.
+  const startAngle =
+    Math.atan2(pts[1].y - pts[0].y, pts[1].x - pts[0].x) * (180 / Math.PI);
+  // Direction the edge arrives at the target point.
+  const endAngle =
+    Math.atan2(pts[n - 1].y - pts[n - 2].y, pts[n - 1].x - pts[n - 2].x) *
+    (180 / Math.PI);
+
+  return (
+    <>
+      {/* ── Crow's foot (N / many) at the source / FK end ──
+          rotate(startAngle): the +x direction aligns with the edge direction,
+          so the fork lines radiate *away* from the source entity. */}
+      <g
+        transform={`translate(${pts[0].x},${pts[0].y}) rotate(${startAngle})`}
+      >
+        {/* Centre line — reinforces the main edge path */}
+        <line
+          x1="0"
+          y1="0"
+          x2="12"
+          y2="0"
+          stroke={stroke}
+          strokeWidth={sw}
+        />
+        {/* Upper fork */}
+        <line
+          x1="0"
+          y1="0"
+          x2="12"
+          y2="-6"
+          stroke={stroke}
+          strokeWidth={sw}
+        />
+        {/* Lower fork */}
+        <line
+          x1="0"
+          y1="0"
+          x2="12"
+          y2="6"
+          stroke={stroke}
+          strokeWidth={sw}
+        />
+      </g>
+
+      {/* ── Single tick (1 / one) at the target / PK end ──
+          rotate(endAngle + 180): flips so the +x axis points *away* from the
+          target entity, making the bar perpendicular to the incoming edge. */}
+      <g
+        transform={`translate(${pts[n - 1].x},${pts[n - 1].y}) rotate(${endAngle + 180})`}
+      >
+        {/* Perpendicular tick right at the entity boundary */}
+        <line
+          x1="0"
+          y1="-6"
+          x2="0"
+          y2="6"
+          stroke={stroke}
+          strokeWidth={sw}
+        />
+      </g>
+    </>
+  );
+}
+
 function ElkEdgeComponent({ data, style, markerEnd }: EdgeProps) {
   const showCardinality = useContext(CardinalityContext);
   const { path, label, labelX, labelY } = data as ElkEdgeData;
@@ -250,84 +405,7 @@ function ElkEdgeComponent({ data, style, markerEnd }: EdgeProps) {
   return (
     <>
       <BaseEdge path={path} style={style} markerEnd={markerEnd} />
-
-      {pts &&
-        (() => {
-          const n = pts.length;
-          // Angle the edge travels as it leaves the source (start of path).
-          const startAngle =
-            Math.atan2(pts[1].y - pts[0].y, pts[1].x - pts[0].x) *
-            (180 / Math.PI);
-          // Angle the edge travels as it arrives at the target (end of path).
-          const endAngle =
-            Math.atan2(
-              pts[n - 1].y - pts[n - 2].y,
-              pts[n - 1].x - pts[n - 2].x,
-            ) *
-            (180 / Math.PI);
-
-          return (
-            <>
-              {/* ── Crow's foot (N / many) at the source / FK end ── */}
-              <g
-                transform={`translate(${pts[0].x},${pts[0].y}) rotate(${startAngle + 180})`}
-              >
-                {/* Centre line */}
-                <line
-                  x1="0"
-                  y1="0"
-                  x2="10"
-                  y2="0"
-                  stroke={stroke}
-                  strokeWidth={sw}
-                />
-                {/* Upper fork */}
-                <line
-                  x1="0"
-                  y1="0"
-                  x2="10"
-                  y2="-5"
-                  stroke={stroke}
-                  strokeWidth={sw}
-                />
-                {/* Lower fork */}
-                <line
-                  x1="0"
-                  y1="0"
-                  x2="10"
-                  y2="5"
-                  stroke={stroke}
-                  strokeWidth={sw}
-                />
-              </g>
-
-              {/* ── Single bar (1 / one) at the target / PK end ── */}
-              <g
-                transform={`translate(${pts[n - 1].x},${pts[n - 1].y}) rotate(${endAngle})`}
-              >
-                {/* Short connector back along the edge */}
-                <line
-                  x1="0"
-                  y1="0"
-                  x2="8"
-                  y2="0"
-                  stroke={stroke}
-                  strokeWidth={sw}
-                />
-                {/* Perpendicular tick */}
-                <line
-                  x1="8"
-                  y1="-5"
-                  x2="8"
-                  y2="5"
-                  stroke={stroke}
-                  strokeWidth={sw}
-                />
-              </g>
-            </>
-          );
-        })()}
-
+      {pts && renderCardinalityMarkers(pts, stroke, sw)}
       {label && (
         <EdgeLabelRenderer>
           <div
@@ -567,7 +645,8 @@ export interface ErDiagramPaneProps {
   onTruncate?: (name: string) => void;
   onDrop?: (name: string, kind: "table" | "view") => void;
   onViewDDL?: (name: string, kind: "table" | "view") => void;
-  onExportCsv?: (name: string) => void;
+  onExport?: (name: string, format: "csv" | "json" | "sql" | "parquet") => void;
+  onGetRowCount?: (name: string) => number;
 }
 
 export function ErDiagramPane({
@@ -583,7 +662,8 @@ export function ErDiagramPane({
   onTruncate,
   onDrop,
   onViewDDL,
-  onExportCsv,
+  onExport,
+  onGetRowCount,
 }: ErDiagramPaneProps) {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
@@ -593,7 +673,7 @@ export function ErDiagramPane({
   // Build stable action object for the context menu context. All ERD nodes
   // are tables, so we lock `kind` to "table" when forwarding to the parent.
   const tableActions = useMemo<ErTableActions | null>(() => {
-    if (!onPreview || !onCount || !onCopy || !onDrop || !onViewDDL || !onExportCsv)
+    if (!onPreview || !onCount || !onCopy || !onDrop || !onViewDDL || !onExport || !onGetRowCount)
       return null;
     return {
       onPreview: (name) => onPreview(name, "table"),
@@ -604,7 +684,8 @@ export function ErDiagramPane({
       onTruncate,
       onDrop: (name) => onDrop(name, "table"),
       onViewDDL: (name) => onViewDDL(name, "table"),
-      onExportCsv,
+      onExport,
+      onGetRowCount,
     };
   }, [
     onPreview,
@@ -615,7 +696,8 @@ export function ErDiagramPane({
     onTruncate,
     onDrop,
     onViewDDL,
-    onExportCsv,
+    onExport,
+    onGetRowCount,
   ]);
 
   useEffect(() => {

--- a/app/_components/ErDiagramPane.tsx
+++ b/app/_components/ErDiagramPane.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useContext, createContext, useMemo } from "react";
 import {
   ReactFlow,
   Background,
   Controls,
   Handle,
+  Panel,
   Position,
   BaseEdge,
   EdgeLabelRenderer,
@@ -22,6 +23,26 @@ import type { ElkExtendedEdge, ElkEdgeSection, ElkPoint } from "elkjs";
 import type { TableColumnInfo, ForeignKeyInfo } from "./runtime/sqlite";
 import { MdOutlineKey } from "react-icons/md";
 import { IoLink } from "react-icons/io5";
+import { ContextMenu } from "@base-ui-components/react/context-menu";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Contexts — cardinality visibility + table action callbacks
+// ────────────────────────────────────────────────────────────────────────────
+
+interface ErTableActions {
+  onPreview: (name: string) => void;
+  onModifyStructure?: (name: string) => void;
+  onAddRow?: (name: string) => void;
+  onCount: (name: string) => void;
+  onCopy: (name: string) => void;
+  onTruncate?: (name: string) => void;
+  onDrop: (name: string) => void;
+  onViewDDL: (name: string) => void;
+  onExportCsv: (name: string) => void;
+}
+
+const CardinalityContext = createContext<boolean>(true);
+const TableActionsContext = createContext<ErTableActions | null>(null);
 
 // ────────────────────────────────────────────────────────────────────────────
 // Node dimensions (must match CSS for correct port positions)
@@ -57,7 +78,9 @@ function columnHandleId(
 
 function ErTableNode({ data }: NodeProps) {
   const { tableName, columns, fkColumns } = data as ErTableNodeData;
-  return (
+  const actions = useContext(TableActionsContext);
+
+  const nodeContent = (
     <div className="er-table-node">
       <div className="er-table-header">{tableName}</div>
       <div className="er-table-columns">
@@ -113,12 +136,89 @@ function ErTableNode({ data }: NodeProps) {
       </div>
     </div>
   );
+
+  if (!actions) return nodeContent;
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger
+        render={(props) => <div {...props}>{nodeContent}</div>}
+      />
+      <ContextMenu.Portal>
+        <ContextMenu.Positioner sideOffset={6}>
+          <ContextMenu.Popup className="bui-popup examples-dropdown">
+            <ContextMenu.Item
+              className="example-item"
+              onClick={() => actions.onPreview(tableName)}
+            >
+              <div className="ex-title">View Data</div>
+            </ContextMenu.Item>
+            {actions.onAddRow && (
+              <ContextMenu.Item
+                className="example-item"
+                onClick={() => actions.onAddRow!(tableName)}
+              >
+                <div className="ex-title">Add Row</div>
+              </ContextMenu.Item>
+            )}
+            {actions.onModifyStructure && (
+              <ContextMenu.Item
+                className="example-item"
+                onClick={() => actions.onModifyStructure!(tableName)}
+              >
+                <div className="ex-title">View Structure</div>
+              </ContextMenu.Item>
+            )}
+            <ContextMenu.Item
+              className="example-item"
+              onClick={() => actions.onCount(tableName)}
+            >
+              <div className="ex-title">Count Rows</div>
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              className="example-item"
+              onClick={() => actions.onViewDDL(tableName)}
+            >
+              <div className="ex-title">View DDL</div>
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              className="example-item"
+              onClick={() => actions.onCopy(tableName)}
+            >
+              <div className="ex-title">Copy Name</div>
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              className="example-item"
+              onClick={() => actions.onExportCsv(tableName)}
+            >
+              <div className="ex-title">Export to CSV</div>
+            </ContextMenu.Item>
+            {actions.onTruncate && (
+              <ContextMenu.Item
+                className="example-item"
+                onClick={() => actions.onTruncate!(tableName)}
+              >
+                <div className="ex-title">Truncate</div>
+              </ContextMenu.Item>
+            )}
+            <ContextMenu.Item
+              className="example-item"
+              onClick={() => actions.onDrop(tableName)}
+            >
+              <div className="ex-title">Drop Table</div>
+            </ContextMenu.Item>
+          </ContextMenu.Popup>
+        </ContextMenu.Positioner>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
+  );
 }
 
 const nodeTypes: NodeTypes = { erTable: ErTableNode };
 
 // ────────────────────────────────────────────────────────────────────────────
-// Custom ELK edge — renders bend-point paths produced by the ELK router
+// Custom ELK edge — renders bend-point paths produced by the ELK router,
+// with optional crow's-foot cardinality markers
 // ────────────────────────────────────────────────────────────────────────────
 
 interface ElkEdgeData {
@@ -130,11 +230,104 @@ interface ElkEdgeData {
 }
 
 function ElkEdgeComponent({ data, style, markerEnd }: EdgeProps) {
+  const showCardinality = useContext(CardinalityContext);
   const { path, label, labelX, labelY } = data as ElkEdgeData;
   if (!path) return null;
+
+  const stroke = (style?.stroke as string) ?? "var(--text-muted)";
+  const sw = (style?.strokeWidth as number) ?? 1.5;
+
+  // Parse the polyline path into discrete points so we can compute the
+  // direction at each end (for rotating the cardinality markers).
+  const pts = useMemo(() => {
+    if (!showCardinality) return null;
+    const arr = [
+      ...path.matchAll(/[ML]\s*([\d.eE+-]+)\s+([\d.eE+-]+)/g),
+    ].map((m) => ({ x: parseFloat(m[1]), y: parseFloat(m[2]) }));
+    return arr.length >= 2 ? arr : null;
+  }, [path, showCardinality]);
+
   return (
     <>
       <BaseEdge path={path} style={style} markerEnd={markerEnd} />
+
+      {pts &&
+        (() => {
+          const n = pts.length;
+          // Angle the edge travels as it leaves the source (start of path).
+          const startAngle =
+            Math.atan2(pts[1].y - pts[0].y, pts[1].x - pts[0].x) *
+            (180 / Math.PI);
+          // Angle the edge travels as it arrives at the target (end of path).
+          const endAngle =
+            Math.atan2(
+              pts[n - 1].y - pts[n - 2].y,
+              pts[n - 1].x - pts[n - 2].x,
+            ) *
+            (180 / Math.PI);
+
+          return (
+            <>
+              {/* ── Crow's foot (N / many) at the source / FK end ── */}
+              <g
+                transform={`translate(${pts[0].x},${pts[0].y}) rotate(${startAngle + 180})`}
+              >
+                {/* Centre line */}
+                <line
+                  x1="0"
+                  y1="0"
+                  x2="10"
+                  y2="0"
+                  stroke={stroke}
+                  strokeWidth={sw}
+                />
+                {/* Upper fork */}
+                <line
+                  x1="0"
+                  y1="0"
+                  x2="10"
+                  y2="-5"
+                  stroke={stroke}
+                  strokeWidth={sw}
+                />
+                {/* Lower fork */}
+                <line
+                  x1="0"
+                  y1="0"
+                  x2="10"
+                  y2="5"
+                  stroke={stroke}
+                  strokeWidth={sw}
+                />
+              </g>
+
+              {/* ── Single bar (1 / one) at the target / PK end ── */}
+              <g
+                transform={`translate(${pts[n - 1].x},${pts[n - 1].y}) rotate(${endAngle})`}
+              >
+                {/* Short connector back along the edge */}
+                <line
+                  x1="0"
+                  y1="0"
+                  x2="8"
+                  y2="0"
+                  stroke={stroke}
+                  strokeWidth={sw}
+                />
+                {/* Perpendicular tick */}
+                <line
+                  x1="8"
+                  y1="-5"
+                  x2="8"
+                  y2="5"
+                  stroke={stroke}
+                  strokeWidth={sw}
+                />
+              </g>
+            </>
+          );
+        })()}
+
       {label && (
         <EdgeLabelRenderer>
           <div
@@ -364,6 +557,17 @@ export interface ErDiagramPaneProps {
   columnsByEntity: Record<string, TableColumnInfo[]>;
   foreignKeysByEntity: Record<string, ForeignKeyInfo[]>;
   isDark?: boolean;
+  // Context-menu callbacks — same actions as the .sql-tree sidebar.
+  // All are optional; if none are provided the context menu is omitted.
+  onPreview?: (name: string, kind: "table" | "view") => void;
+  onModifyStructure?: (name: string) => void;
+  onAddRow?: (name: string) => void;
+  onCount?: (name: string, kind: "table" | "view") => void;
+  onCopy?: (name: string) => void;
+  onTruncate?: (name: string) => void;
+  onDrop?: (name: string, kind: "table" | "view") => void;
+  onViewDDL?: (name: string, kind: "table" | "view") => void;
+  onExportCsv?: (name: string) => void;
 }
 
 export function ErDiagramPane({
@@ -371,10 +575,48 @@ export function ErDiagramPane({
   columnsByEntity,
   foreignKeysByEntity,
   isDark = true,
+  onPreview,
+  onModifyStructure,
+  onAddRow,
+  onCount,
+  onCopy,
+  onTruncate,
+  onDrop,
+  onViewDDL,
+  onExportCsv,
 }: ErDiagramPaneProps) {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
+  const [showCardinality, setShowCardinality] = useState(true);
   const layoutGen = useRef(0);
+
+  // Build stable action object for the context menu context. All ERD nodes
+  // are tables, so we lock `kind` to "table" when forwarding to the parent.
+  const tableActions = useMemo<ErTableActions | null>(() => {
+    if (!onPreview || !onCount || !onCopy || !onDrop || !onViewDDL || !onExportCsv)
+      return null;
+    return {
+      onPreview: (name) => onPreview(name, "table"),
+      onModifyStructure,
+      onAddRow,
+      onCount: (name) => onCount(name, "table"),
+      onCopy,
+      onTruncate,
+      onDrop: (name) => onDrop(name, "table"),
+      onViewDDL: (name) => onViewDDL(name, "table"),
+      onExportCsv,
+    };
+  }, [
+    onPreview,
+    onModifyStructure,
+    onAddRow,
+    onCount,
+    onCopy,
+    onTruncate,
+    onDrop,
+    onViewDDL,
+    onExportCsv,
+  ]);
 
   useEffect(() => {
     let cancelled = false;
@@ -411,27 +653,48 @@ export function ErDiagramPane({
   }
 
   return (
-    <div className="er-diagram-wrap">
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        fitView
-        fitViewOptions={{ padding: 0.15 }}
-        minZoom={0.2}
-        maxZoom={2}
-        // Nodes are not draggable: ELK edge paths are absolute coordinates
-        // and would not follow node movements.
-        nodesDraggable={false}
-        nodesConnectable={false}
-        elementsSelectable
-        colorMode={isDark ? "dark" : "light"}
-        style={{ background: "var(--bg)" }}
-      >
-        <Background color="var(--border)" />
-        <Controls />
-      </ReactFlow>
-    </div>
+    <CardinalityContext.Provider value={showCardinality}>
+      <TableActionsContext.Provider value={tableActions}>
+        <div className="er-diagram-wrap">
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
+            fitView
+            fitViewOptions={{ padding: 0.15 }}
+            minZoom={0.2}
+            maxZoom={2}
+            // Nodes are not draggable: ELK edge paths are absolute coordinates
+            // and would not follow node movements.
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable
+            colorMode={isDark ? "dark" : "light"}
+            style={{ background: "var(--bg)" }}
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background color="var(--border)" />
+            <Controls />
+            <Panel position="top-left" className="er-cardinality-panel">
+              <label className="er-cardinality-toggle-label">
+                <input
+                  type="checkbox"
+                  className="er-cardinality-checkbox"
+                  checked={showCardinality}
+                  onChange={(e) => setShowCardinality(e.target.checked)}
+                />
+                <span>Cardinality</span>
+              </label>
+              {showCardinality && (
+                <div className="er-cardinality-note">
+                  Inferred from FK constraints
+                </div>
+              )}
+            </Panel>
+          </ReactFlow>
+        </div>
+      </TableActionsContext.Provider>
+    </CardinalityContext.Provider>
   );
 }

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -3375,6 +3375,48 @@ function SqlPlaygroundInner() {
     [quoteIdent, showToast],
   );
 
+  // ─── Export table / view to any format ───────────────────────────
+  const exportEntityToFormat = useCallback(
+    (name: string, format: "csv" | "json" | "sql" | "parquet") => {
+      const engine = engineRef.current;
+      if (!engine) return;
+      try {
+        const sets = engine.exec(`SELECT * FROM ${quoteIdent(name)}`);
+        if (!sets || sets.length === 0) {
+          showToast(`"${name}" is empty — no data to export.`, "warn");
+          return;
+        }
+        const { columns, values: rows } = sets[0];
+        const filename = `${name}.${format}`;
+        if (format === "csv") exportResultToCsv(columns, rows, filename);
+        else if (format === "json") exportResultToJson(columns, rows, filename);
+        else if (format === "parquet") exportResultToParquet(columns, rows, filename);
+        else exportResultToSql(columns, rows, filename);
+        showToast(`Exported ${filename}.`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        showToast(`Export failed: ${msg}`, "warn");
+      }
+    },
+    [quoteIdent, showToast],
+  );
+
+  // ─── Get row count for a table / view ────────────────────────────
+  const getEntityRowCount = useCallback(
+    (name: string): number => {
+      const engine = engineRef.current;
+      if (!engine) return 0;
+      try {
+        const sets = engine.exec(`SELECT COUNT(*) FROM ${quoteIdent(name)}`);
+        if (!sets || sets.length === 0 || sets[0].values.length === 0) return 0;
+        return Number(sets[0].values[0][0]) || 0;
+      } catch {
+        return 0;
+      }
+    },
+    [quoteIdent],
+  );
+
   // ─── Tab actions ────────────────────────────────────────────────────
   const addTab = useCallback(() => {
     const nextNum = tabs.length + 1;
@@ -5345,7 +5387,8 @@ function SqlPlaygroundInner() {
                     onTruncate={truncateEntity}
                     onDrop={dropEntity}
                     onViewDDL={viewDDL}
-                    onExportCsv={exportEntityToCsv}
+                    onExport={exportEntityToFormat}
+                    onGetRowCount={getEntityRowCount}
                   />
                 ))}
               </SchemaSection>
@@ -5383,7 +5426,8 @@ function SqlPlaygroundInner() {
                     onCopy={copyEntityName}
                     onDrop={dropEntity}
                     onViewDDL={viewDDL}
-                    onExportCsv={exportEntityToCsv}
+                    onExport={exportEntityToFormat}
+                    onGetRowCount={getEntityRowCount}
                   />
                 ))}
               </SchemaSection>
@@ -5655,7 +5699,8 @@ function SqlPlaygroundInner() {
                   onTruncate={truncateEntity}
                   onDrop={dropEntity}
                   onViewDDL={viewDDL}
-                  onExportCsv={exportEntityToCsv}
+                  onExport={exportEntityToFormat}
+                  onGetRowCount={getEntityRowCount}
                 />
               </div>
             )}
@@ -8088,7 +8133,8 @@ interface SchemaItemProps {
   onTruncate?: (name: string) => void;
   onDrop: (name: string, kind: "table" | "view") => void;
   onViewDDL: (name: string, kind: "table" | "view") => void;
-  onExportCsv: (name: string) => void;
+  onExport: (name: string, format: "csv" | "json" | "sql" | "parquet") => void;
+  onGetRowCount: (name: string) => number;
 }
 
 function SchemaItem({
@@ -8107,8 +8153,15 @@ function SchemaItem({
   onTruncate,
   onDrop,
   onViewDDL,
-  onExportCsv,
+  onExport,
+  onGetRowCount,
 }: SchemaItemProps) {
+  const [exportRowCount, setExportRowCount] = useState<number | null>(null);
+  const ensureRowCount = useCallback(() => {
+    if (exportRowCount === null) {
+      setExportRowCount(onGetRowCount(name));
+    }
+  }, [exportRowCount, onGetRowCount, name]);
   const Icon = kind === "view" ? Eye : Table;
   const fkByCol = useMemo(() => {
     const m = new Map<string, ForeignKeyInfo>();
@@ -8303,12 +8356,64 @@ function SchemaItem({
               >
                 <div className="ex-title">Copy Name</div>
               </ContextMenu.Item>
-              <ContextMenu.Item
-                className="example-item"
-                onClick={() => onExportCsv(name)}
-              >
-                <div className="ex-title">Export to CSV</div>
-              </ContextMenu.Item>
+              <Menu.Root>
+                <Menu.Trigger
+                  className="example-item ctx-export-trigger"
+                  onPointerDown={ensureRowCount}
+                >
+                  <div className="ex-title ctx-export-title">
+                    Export
+                    <ChevronRight size={10} className="ctx-export-arrow" />
+                  </div>
+                </Menu.Trigger>
+                <Menu.Portal>
+                  <Menu.Positioner side="right" align="start" sideOffset={4}>
+                    <Menu.Popup className="bui-popup examples-dropdown export-dropdown">
+                      {exportRowCount !== null && (
+                        <div className="sql-result-export-group-label">
+                          {exportRowCount.toLocaleString()} rows
+                        </div>
+                      )}
+                      <Menu.Item
+                        className="example-item export-item"
+                        onClick={() => onExport(name, "csv")}
+                      >
+                        <div className="export-item-text">
+                          <div className="ex-title">CSV <span className="ext-badge">.csv</span></div>
+                          <div className="ex-desc">Comma-separated values</div>
+                        </div>
+                      </Menu.Item>
+                      <Menu.Item
+                        className="example-item export-item"
+                        onClick={() => onExport(name, "json")}
+                      >
+                        <div className="export-item-text">
+                          <div className="ex-title">JSON <span className="ext-badge">.json</span></div>
+                          <div className="ex-desc">Array of row objects</div>
+                        </div>
+                      </Menu.Item>
+                      <Menu.Item
+                        className="example-item export-item"
+                        onClick={() => onExport(name, "sql")}
+                      >
+                        <div className="export-item-text">
+                          <div className="ex-title">SQL <span className="ext-badge">.sql</span></div>
+                          <div className="ex-desc">INSERT statements</div>
+                        </div>
+                      </Menu.Item>
+                      <Menu.Item
+                        className="example-item export-item"
+                        onClick={() => onExport(name, "parquet")}
+                      >
+                        <div className="export-item-text">
+                          <div className="ex-title">Parquet <span className="ext-badge">.parquet</span></div>
+                          <div className="ex-desc">Apache Parquet binary</div>
+                        </div>
+                      </Menu.Item>
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
               {kind === "table" && onTruncate && (
                 <ContextMenu.Item
                   className="example-item"

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -5647,6 +5647,15 @@ function SqlPlaygroundInner() {
                   columnsByEntity={columnsByEntity}
                   foreignKeysByEntity={foreignKeysByEntity}
                   isDark={!LIGHT_THEMES.has(editorTheme)}
+                  onPreview={previewTable}
+                  onModifyStructure={openModifyStructure}
+                  onAddRow={openAddRow}
+                  onCount={countEntityRows}
+                  onCopy={copyEntityName}
+                  onTruncate={truncateEntity}
+                  onDrop={dropEntity}
+                  onViewDDL={viewDDL}
+                  onExportCsv={exportEntityToCsv}
                 />
               </div>
             )}
@@ -5655,6 +5664,52 @@ function SqlPlaygroundInner() {
       </div>
     </div>
   );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Result comparison — used to decide whether the fade animation should play.
+// The animation is only shown when the new result is identical to the previous
+// one (same columns, same rows, same values in the same order), so a rerun
+// of a query that returns the same data provides visual feedback that the
+// query actually ran without the table appearing to "jump".
+// ────────────────────────────────────────────────────────────────────────────
+
+function sqlValueEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  // Uint8Array BLOBs: compare byte by byte
+  if (a instanceof Uint8Array && b instanceof Uint8Array) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+function queryResultsIdentical(
+  a: QueryRunResult | null,
+  b: QueryRunResult | null,
+): boolean {
+  if (a === null && b === null) return true;
+  if (a === null || b === null) return false;
+  if (a.sets.length !== b.sets.length) return false;
+  for (let i = 0; i < a.sets.length; i++) {
+    const sa = a.sets[i];
+    const sb = b.sets[i];
+    if (sa.columns.length !== sb.columns.length) return false;
+    if (!sa.columns.every((col, j) => col === sb.columns[j])) return false;
+    if (sa.values.length !== sb.values.length) return false;
+    for (let r = 0; r < sa.values.length; r++) {
+      const ra = sa.values[r];
+      const rb = sb.values[r];
+      if (ra.length !== rb.length) return false;
+      for (let c = 0; c < ra.length; c++) {
+        if (!sqlValueEqual(ra[c], rb[c])) return false;
+      }
+    }
+  }
+  return true;
 }
 
 function ResultView({
@@ -5763,6 +5818,9 @@ function ResultView({
   // Ref to the flash wrapper div — used to replay the CSS animation on
   // each new result without unmounting the component tree.
   const flashWrapperRef = useRef<HTMLDivElement>(null);
+  // Tracks the previous result so we can compare data identity before
+  // deciding whether to play the fade animation.
+  const prevResultRef = useRef<QueryRunResult | null>(null);
 
   // Reset pagination + transient actions whenever a new result lands.
   // Table-edit actions refresh the result in place, so they can opt into
@@ -5780,16 +5838,21 @@ function ResultView({
     setPendingEditsByIndex(preserved?.pendingEditsByIndex ?? {});
     setActiveEditCellByIndex({});
     setActiveSetIdx(0);
-    // Replay the flash animation: remove the class, access offsetWidth to
-    // force the browser to reflow and reset the CSS animation timeline
-    // (without this, re-adding the class has no effect because the animation
-    // is still in its "finished" state from the previous run), then re-add
-    // the class so the animation plays from the start.
+    // Only replay the fade animation when the new result data is identical to
+    // the previous one (same columns, rows, and values in the same order).
+    // For a genuinely different result the table content changes visibly, so
+    // the animation would be distracting rather than informative.
     const el = flashWrapperRef.current;
     if (el) {
+      const identical = queryResultsIdentical(result, prevResultRef.current);
+      prevResultRef.current = result;
       el.classList.remove("sql-result-flash-anim");
-      void el.offsetWidth; // force reflow — resets animation timeline
-      el.classList.add("sql-result-flash-anim");
+      if (identical && result !== null) {
+        void el.offsetWidth; // force reflow — resets animation timeline
+        el.classList.add("sql-result-flash-anim");
+      }
+    } else {
+      prevResultRef.current = result;
     }
   }, [result]);
 

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -2243,6 +2243,25 @@
   color: var(--red);
 }
 
+/* ─── Export submenu trigger inside sidebar / ERD context menus ─── */
+.ctx-export-trigger {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: default;
+}
+.ctx-export-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+}
+.ctx-export-arrow {
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+
 /* Small popover explaining the unique constraint. */
 .sql-unique-popover {
   padding: 8px 10px;

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -2509,6 +2509,49 @@
   height: 100%;
 }
 
+/* Hide the React Flow attribution badge */
+.er-diagram-wrap .react-flow__attribution {
+  display: none;
+}
+
+/* ── Cardinality toggle panel (rendered via React Flow <Panel>) ── */
+.er-cardinality-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.er-cardinality-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  color: var(--text);
+  font-weight: 500;
+  user-select: none;
+}
+
+.er-cardinality-checkbox {
+  accent-color: var(--accent);
+  cursor: pointer;
+  width: 12px;
+  height: 12px;
+}
+
+.er-cardinality-note {
+  color: var(--text-dim);
+  font-size: 10px;
+  line-height: 1.3;
+  max-width: 140px;
+}
+
 .er-diagram-empty {
   display: flex;
   align-items: center;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **ERD – Cardinality toggle (Update 1):** A panel in the top-left of the ERD (via React Flow `<Panel>`) lets users toggle crow's-foot cardinality symbols on edges. The N/many end shows a crow's foot (3-line SVG) and the 1/one end shows a perpendicular bar — both rendered as inline SVG within the edge component so they scale with zoom. A note "Inferred from FK constraints" appears below the toggle while it is enabled. State flows via `CardinalityContext` so no React Flow node/edge data needs to be rebuilt on toggle.

- **ERD – Attribution removal (Update 2):** The React Flow attribution badge is hidden via `proOptions={{ hideAttribution: true }}` on `<ReactFlow>` plus a CSS rule on `.react-flow__attribution`.

- **ERD – Table context menu (Update 3):** Right-clicking any table node in the ERD now opens the same context menu as right-clicking the table in the `.sql-tree` sidebar (View Data, Add Row, View Structure, Count Rows, View DDL, Copy Name, Export to CSV, Truncate, Drop Table). Callbacks are forwarded via `TableActionsContext` so the node component stays decoupled from the parent. The menu renders via `ContextMenu.Portal` (document-body level), avoiding z-index clipping from the React Flow stacking context.

- **Result table – Conditional fade animation (Update 4):** The fade-in on `.sql-result-flash-wrapper` now only plays when the new query result is data-identical to the previous one (same columns, row count, and cell values in the same order, including `Uint8Array` BLOBs). For genuinely different results the table updates without animation, removing distracting flashes on normal query runs.

## Test plan

- [ ] Open the ERD tab; confirm cardinality symbols appear on edges (crow's foot at FK end, bar at PK end)
- [ ] Toggle the cardinality checkbox off; confirm symbols disappear and the label hides
- [ ] Confirm the React Flow attribution badge is gone
- [ ] Right-click a table node in the ERD; confirm the context menu appears with the same items as the sidebar tree
- [ ] Select "View Data", "Count Rows", "Copy Name", etc. from the ERD context menu and verify they work
- [ ] Run two identical queries back-to-back; confirm the fade animation plays on the second run
- [ ] Run a query that returns different data; confirm no fade animation plays (table updates directly)

https://claude.ai/code/session_01CQenW2B5TQwQxpPx5Hwi8F
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQenW2B5TQwQxpPx5Hwi8F)_