### PR TITLE
SQLite autocomplete: context-aware keywords + schema-aware completions

### DIFF
--- a/__tests__/sqlCompletion.test.ts
+++ b/__tests__/sqlCompletion.test.ts
@@ -41,6 +41,10 @@ function labels(result: CompletionResult | null): string[] {
   return result?.options.map((option) => option.label) ?? [];
 }
 
+function findOption(result: CompletionResult | null, label: string) {
+  return result?.options.find((option) => option.label === label);
+}
+
 describe("SQLite SQL completion source", () => {
   it("suggests tables after FROM", () => {
     const result = complete("SELECT * FROM ");
@@ -68,5 +72,201 @@ describe("SQLite SQL completion source", () => {
     const result = complete("SEL");
     expect(labels(result)).toContain("SELECT");
     expect(result?.from).toBe(0);
+  });
+
+  it("suggests keywords (not tables) after a referenced table", () => {
+    const result = complete("SELECT * FROM customers ");
+    const labelSet = new Set(labels(result));
+    expect(labelSet.has("WHERE")).toBe(true);
+    expect(labelSet.has("JOIN")).toBe(true);
+    // Tables can still appear as low-priority extras, but the top-ranked
+    // suggestions must be keywords — tables should never crowd out the
+    // expected next-clause keywords here.
+    const top = result?.options
+      .slice()
+      .sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0))
+      .slice(0, 5)
+      .map((option) => option.label);
+    expect(top).toContain("WHERE");
+  });
+
+  it("suggests tables after a comma in the FROM clause", () => {
+    const result = complete("SELECT * FROM customers, ");
+    expect(labels(result).slice(0, 3)).toEqual([
+      "customers",
+      "orders",
+      "recent_orders",
+    ]);
+  });
+
+  it("suggests scoped columns from multiple referenced tables", () => {
+    const result = complete(
+      "SELECT * FROM customers c JOIN orders o ON ",
+    );
+    const labelSet = new Set(labels(result));
+    // Both sides of the JOIN are in scope. Ambiguous columns (id) get
+    // qualified labels so they don't collide.
+    expect(labelSet.has("name")).toBe(true);
+    expect(labelSet.has("customer_id")).toBe(true);
+    expect(labelSet.has("customers.id")).toBe(true);
+    expect(labelSet.has("orders.id")).toBe(true);
+  });
+
+  it("places the cursor inside parens for function completions", () => {
+    const result = complete("SELECT COUN");
+    const opt = findOption(result, "COUNT");
+    expect(opt).toBeDefined();
+    // snippetCompletion produces a function-style apply rather than a
+    // plain string; that's how we know the cursor will land inside ().
+    expect(typeof opt?.apply).toBe("function");
+  });
+
+  it("suggests CTE names after FROM", () => {
+    const result = complete(
+      "WITH active AS (SELECT * FROM customers WHERE name IS NOT NULL) SELECT * FROM ",
+    );
+    expect(labels(result)).toContain("active");
+  });
+
+  it("resolves CTE columns after a qualifier when declared in WITH cte(cols)", () => {
+    const result = complete(
+      "WITH summary(total_count, latest) AS (SELECT 1, 2) SELECT summary.",
+    );
+    expect(labels(result)).toEqual(["total_count", "latest"]);
+  });
+
+  it("does not suggest existing tables in CREATE TABLE name slot", () => {
+    const result = complete("CREATE TABLE ", true);
+    const labelList = labels(result);
+    expect(labelList).not.toContain("customers");
+    expect(labelList).not.toContain("orders");
+  });
+
+  it("suggests columns of the target table inside INSERT INTO column list", () => {
+    const result = complete("INSERT INTO orders (");
+    expect(labels(result)).toEqual(["id", "customer_id", "total"]);
+  });
+
+  it("suggests columns inside USING (...)", () => {
+    const result = complete(
+      "SELECT * FROM customers JOIN orders USING (",
+    );
+    const labelSet = new Set(labels(result));
+    // USING columns must be present in both joined tables. Even without
+    // a strict intersection filter, the suggestions should still include
+    // columns from the referenced tables.
+    expect(labelSet.has("customers.id")).toBe(true);
+    expect(labelSet.has("orders.id")).toBe(true);
+  });
+
+  it("does not suggest columns when no FROM clause provides scope", () => {
+    const result = complete("SELECT ");
+    const labelList = labels(result);
+    expect(labelList).not.toContain("name");
+    expect(labelList).not.toContain("email");
+    // But keywords like DISTINCT and tables remain available.
+    expect(labelList).toContain("DISTINCT");
+  });
+
+  function topKeywords(
+    result: CompletionResult | null,
+    n = 8,
+  ): string[] {
+    return (result?.options ?? [])
+      .filter((option) => option.type === "keyword")
+      .slice()
+      .sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0))
+      .slice(0, n)
+      .map((option) => option.label);
+  }
+
+  describe("context-aware keyword ranking", () => {
+    it("ranks statement-starter keywords first at start of buffer", () => {
+      const result = complete("", true);
+      const top = topKeywords(result, 6);
+      expect(top).toContain("SELECT");
+      expect(top).toContain("INSERT");
+      expect(top).toContain("WITH");
+      // Mid-clause keywords should not crowd the top.
+      expect(top).not.toContain("WHERE");
+    });
+
+    it("ranks FROM after a SELECT list", () => {
+      const result = complete("SELECT id ", true);
+      const top = topKeywords(result, 6);
+      expect(top).toContain("FROM");
+    });
+
+    it("ranks JOIN/WHERE/GROUP/ORDER after a FROM table reference", () => {
+      const result = complete("SELECT * FROM customers ", true);
+      const top = topKeywords(result, 10);
+      expect(top).toContain("WHERE");
+      expect(top).toContain("JOIN");
+      expect(top).toContain("GROUP");
+      expect(top).toContain("ORDER");
+      // Statement starters should be downranked here.
+      expect(top).not.toContain("CREATE");
+      expect(top).not.toContain("INSERT");
+    });
+
+    it("ranks ON/USING right after a JOIN target", () => {
+      const result = complete("SELECT * FROM customers JOIN orders ", true);
+      const top = topKeywords(result, 8);
+      expect(top).toContain("ON");
+      expect(top).toContain("USING");
+    });
+
+    it("ranks AND/OR/IS/LIKE/IN inside WHERE after an identifier", () => {
+      const result = complete("SELECT * FROM customers WHERE name ", true);
+      const top = topKeywords(result, 10);
+      expect(top).toContain("AND");
+      expect(top).toContain("OR");
+      expect(top).toContain("IS");
+      expect(top).toContain("LIKE");
+      expect(top).toContain("IN");
+    });
+
+    it("limits CREATE keyword to TABLE/VIEW/INDEX/TRIGGER family", () => {
+      const result = complete("CREATE ", true);
+      const top = topKeywords(result, 10);
+      expect(top).toContain("TABLE");
+      expect(top).toContain("VIEW");
+      expect(top).toContain("INDEX");
+      expect(top).toContain("TRIGGER");
+      expect(top).toContain("UNIQUE");
+      expect(top).toContain("TEMP");
+    });
+
+    it("after ORDER, requires BY", () => {
+      const result = complete("SELECT * FROM customers ORDER ", true);
+      const labelSet = new Set(labels(result));
+      expect(labelSet.has("BY")).toBe(true);
+      // Restricted slot — other keywords should not appear at all.
+      expect(labelSet.has("SELECT")).toBe(false);
+      expect(labelSet.has("WHERE")).toBe(false);
+    });
+
+    it("offers OFFSET after LIMIT <n>", () => {
+      const result = complete("SELECT * FROM customers LIMIT ", true);
+      const top = topKeywords(result, 5);
+      expect(top).toContain("OFFSET");
+    });
+
+    it("offers ALL/SELECT after UNION", () => {
+      const result = complete(
+        "SELECT * FROM customers UNION ",
+        true,
+      );
+      const top = topKeywords(result, 5);
+      expect(top).toContain("ALL");
+      expect(top).toContain("SELECT");
+    });
+
+    it("only offers IF/NOT/EXISTS in CREATE TABLE name slot", () => {
+      const result = complete("CREATE TABLE ", true);
+      const labelList = labels(result);
+      // Restricted to the name-slot keyword set.
+      expect(labelList.sort()).toEqual(["EXISTS", "IF", "NOT"]);
+    });
   });
 });

--- a/app/_components/sql/sqlCompletion.ts
+++ b/app/_components/sql/sqlCompletion.ts
@@ -1,26 +1,47 @@
-import type {
-  Completion,
-  CompletionContext,
-  CompletionResult,
-  CompletionSource,
+import {
+  snippetCompletion,
+  type Completion,
+  type CompletionContext,
+  type CompletionResult,
+  type CompletionSource,
 } from "@codemirror/autocomplete";
 
 export interface SqlCompletionEntity {
   name: string;
   columns: string[];
-  kind: "table" | "view";
+  kind: "table" | "view" | "cte";
 }
 
 export interface SqlCompletionSchema {
   entities: SqlCompletionEntity[];
 }
 
-type SqlCompletionMode = "columns" | "tables" | "keywords" | "qualified-columns";
+type SqlCompletionMode =
+  | "columns"
+  | "tables"
+  | "keywords"
+  | "qualified-columns"
+  | "naming";
 
 interface SqlCompletionContextInfo {
   mode: SqlCompletionMode;
   from: number;
   qualifier?: string;
+  // When set, only these keywords are emitted at high boost; other
+  // keywords are either downranked or omitted entirely. Drives the
+  // "show only the keywords that make sense at this cursor" behavior.
+  keywordContext?: KeywordContext;
+}
+
+interface KeywordContext {
+  // Most-likely follow-ups (highest keyword boost).
+  primary: readonly string[];
+  // Plausible-but-less-likely follow-ups (default keyword boost).
+  secondary?: readonly string[];
+  // When `restrict` is true, *only* primary+secondary keywords are emitted;
+  // everything else is suppressed (used for tightly-scoped slots like
+  // CREATE TABLE name, ORDER, etc.).
+  restrict?: boolean;
 }
 
 const completeIdentifierPattern = /^[A-Za-z_][A-Za-z0-9_$]*$/;
@@ -32,22 +53,41 @@ const sqlIdentifierPattern =
 const qualifiedIdentifierPattern = new RegExp(
   `(${sqlIdentifierPattern})\\.\\s*([A-Za-z_][A-Za-z0-9_$]*)?$`,
 );
+// Words that look like identifiers but introduce a new clause and so must
+// never be captured as a table alias — without this guard the alias group
+// would greedily eat the next clause keyword (e.g. "FROM t JOIN" → alias=JOIN)
+// and we'd lose the second table from the reference set.
+const aliasBlockListSource =
+  String.raw`(?:FROM|JOIN|WHERE|GROUP|ORDER|HAVING|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|ON|USING|INNER|LEFT|RIGHT|FULL|CROSS|OUTER|SET|VALUES|RETURNING|AS|WHEN|CASE)`;
+const aliasGroupSource =
+  String.raw`(?:\s+(?:AS\s+)?(?!${aliasBlockListSource}\b)([A-Za-z_][A-Za-z0-9_$]*))?`;
 const tableReferencePattern = new RegExp(
-  String.raw`\b(?:FROM|JOIN|UPDATE|INTO)\s+(${sqlIdentifierPattern})(?:\s+(?:AS\s+)?([A-Za-z_][A-Za-z0-9_$]*))?`,
+  String.raw`\b(?:FROM|JOIN|UPDATE|INTO)\s+(${sqlIdentifierPattern})${aliasGroupSource}`,
   "gi",
 );
 const commaTableReferencePattern = new RegExp(
-  String.raw`,\s*(${sqlIdentifierPattern})(?:\s+(?:AS\s+)?([A-Za-z_][A-Za-z0-9_$]*))?`,
+  String.raw`,\s*(${sqlIdentifierPattern})${aliasGroupSource}`,
   "g",
+);
+const insertColumnListPattern = new RegExp(
+  String.raw`\bINSERT\s+INTO\s+(${sqlIdentifierPattern})\s*\(([^()]*)$`,
+  "i",
+);
+const usingClausePattern = /\bUSING\s*\(\s*[A-Za-z0-9_$,\s]*$/i;
+const createNewObjectPattern = new RegExp(
+  String.raw`\bCREATE\s+(?:TEMP(?:ORARY)?\s+)?(?:UNIQUE\s+)?(?:TABLE|VIEW|INDEX|TRIGGER)\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:[A-Za-z_][A-Za-z0-9_$]*)?$`,
+  "i",
 );
 
 const tableSection = { name: "Tables", rank: 10 };
 const viewSection = { name: "Views", rank: 11 };
+const cteSection = { name: "CTEs", rank: 12 };
 const columnSection = { name: "Columns", rank: 20 };
 const keywordSection = { name: "Keywords", rank: 30 };
 
 const BOOST = {
   tableInTableContext: 80,
+  cteInTableContext: 85,
   keywordInTableContext: 5,
   columnInColumnContext: 90,
   keywordInColumnContext: 20,
@@ -70,10 +110,13 @@ const SQL_KEYWORDS = [
   "FULL",
   "CROSS",
   "ON",
+  "USING",
   "GROUP",
   "BY",
   "HAVING",
   "ORDER",
+  "ASC",
+  "DESC",
   "LIMIT",
   "OFFSET",
   "INSERT",
@@ -113,6 +156,8 @@ const SQL_KEYWORDS = [
   "AS",
   "DISTINCT",
   "UNION",
+  "INTERSECT",
+  "EXCEPT",
   "ALL",
   "WITH",
   "RECURSIVE",
@@ -121,6 +166,37 @@ const SQL_KEYWORDS = [
   "BEGIN",
   "COMMIT",
   "ROLLBACK",
+  "IF",
+  "REPLACE",
+  "CONFLICT",
+  "TEMP",
+  "TEMPORARY",
+  "RENAME",
+  "ADD",
+  "COLUMN",
+  "TO",
+  "NULLS",
+  "FIRST",
+  "LAST",
+  "TRUE",
+  "FALSE",
+  "GLOB",
+  "REGEXP",
+  "MATCH",
+  "ESCAPE",
+  "COLLATE",
+  "ATTACH",
+  "DETACH",
+  "DATABASE",
+  "EXPLAIN",
+  "ANALYZE",
+  "VACUUM",
+  "REINDEX",
+  "AUTOINCREMENT",
+  "GENERATED",
+  "ALWAYS",
+  "STORED",
+  "VIRTUAL",
 ];
 
 const SQL_FUNCTIONS = [
@@ -151,12 +227,15 @@ const clauseBoundaryKeywords = new Set([
   "WHERE",
   "JOIN",
   "ON",
+  "USING",
   "GROUP",
   "ORDER",
   "HAVING",
   "LIMIT",
   "OFFSET",
   "UNION",
+  "INTERSECT",
+  "EXCEPT",
   "INSERT",
   "UPDATE",
   "DELETE",
@@ -165,6 +244,8 @@ const clauseBoundaryKeywords = new Set([
   "DROP",
   "VALUES",
   "SET",
+  "WITH",
+  "RETURNING",
 ]);
 
 const tableTargetKeywords = new Set([
@@ -187,6 +268,27 @@ const columnTargetKeywords = new Set([
   "SET",
   "ORDER",
   "GROUP",
+  "RETURNING",
+]);
+
+// Tokens that indicate the user is mid-expression and probably wants a column
+// or value-style identifier next: comparison ops, arithmetic, boolean glue.
+const expressionContinuationTokens = new Set([
+  "=",
+  "<",
+  ">",
+  "+",
+  "-",
+  "*",
+  "/",
+  "AND",
+  "OR",
+  "NOT",
+  "IN",
+  "IS",
+  "LIKE",
+  "BETWEEN",
+  "(",
 ]);
 
 function normalizeIdentifier(identifier: string | undefined): string {
@@ -209,7 +311,11 @@ function quoteIdentifier(identifier: string): string {
   return `"${identifier.replace(/"/g, '""')}"`;
 }
 
-function maskRangePreservingNewlines(sql: string, start: number, end: number): string {
+function maskRangePreservingNewlines(
+  sql: string,
+  start: number,
+  end: number,
+): string {
   return sql
     .slice(start, end)
     .split("")
@@ -275,13 +381,312 @@ function tokenize(sql: string): string[] {
   // Operators and punctuation are kept as clause boundaries so nearby SQL
   // expressions don't get folded into identifier/keyword context detection.
   return (
-    maskCommentsAndStrings(sql).match(/[A-Za-z_][A-Za-z0-9_$]*|[,().;=*<>+\-/]/g) ??
-    []
+    maskCommentsAndStrings(sql).match(
+      /[A-Za-z_][A-Za-z0-9_$]*|[,().;=*<>+\-/]/g,
+    ) ?? []
   );
 }
 
-function isKeyword(value: string | undefined): boolean {
+function isClauseBoundaryKeyword(value: string | undefined): boolean {
   return value ? clauseBoundaryKeywords.has(value.toUpperCase()) : false;
+}
+
+// Keyword tiers per syntactic context. `primary` is the strongest match,
+// `secondary` is plausible-but-less-likely. The resolver picks the tier list
+// that fits the cursor's surroundings; the keyword emitter then ranks the
+// SQL keyword catalog accordingly.
+const KW_NAME_TAIL: KeywordContext = {
+  primary: ["IF", "NOT", "EXISTS"],
+  restrict: true,
+};
+
+const STATEMENT_STARTERS: KeywordContext = {
+  primary: [
+    "SELECT",
+    "WITH",
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "CREATE",
+    "DROP",
+    "ALTER",
+    "REPLACE",
+  ],
+  secondary: [
+    "BEGIN",
+    "COMMIT",
+    "ROLLBACK",
+    "PRAGMA",
+    "ATTACH",
+    "DETACH",
+    "EXPLAIN",
+    "ANALYZE",
+    "VACUUM",
+    "REINDEX",
+  ],
+};
+
+function isIdentifierToken(token: string | undefined): boolean {
+  if (!token) return false;
+  if (!/^[A-Z_][A-Z0-9_$]*$/.test(token)) return false;
+  return !clauseBoundaryKeywords.has(token);
+}
+
+function isExpressionOperator(token: string | undefined): boolean {
+  if (!token) return false;
+  return expressionContinuationTokens.has(token);
+}
+
+// Resolve which keywords to surface at the cursor. Returns `null` when no
+// specific context applies and all keywords should be shown at default rank.
+function resolveKeywordContext(
+  tokens: string[],
+  lastToken: string | undefined,
+  lastClauseKeyword: string | undefined,
+): KeywordContext | null {
+  if (tokens.length === 0) return STATEMENT_STARTERS;
+
+  // ── Direct follow-ups: the previous *token* dictates a tightly-scoped slot.
+  switch (lastToken) {
+    case "ORDER":
+    case "GROUP":
+      return { primary: ["BY"], restrict: true };
+    case "BY":
+      return {
+        primary: ["ASC", "DESC"],
+        secondary: ["NULLS", "HAVING", "LIMIT", "OFFSET", "UNION"],
+      };
+    case "LIMIT":
+      return { primary: ["OFFSET"], secondary: ["UNION"], restrict: true };
+    case "UNION":
+    case "INTERSECT":
+    case "EXCEPT":
+      return { primary: ["ALL", "SELECT"], restrict: true };
+    case "INSERT":
+      return { primary: ["INTO", "OR"], restrict: true };
+    case "DELETE":
+      return { primary: ["FROM"], restrict: true };
+    case "UPDATE":
+      return { primary: ["OR"], secondary: ["REPLACE"] };
+    case "CREATE":
+      return {
+        primary: ["TABLE", "VIEW", "INDEX", "TRIGGER"],
+        secondary: ["UNIQUE", "TEMP", "TEMPORARY", "VIRTUAL"],
+      };
+    case "DROP":
+      return {
+        primary: ["TABLE", "VIEW", "INDEX", "TRIGGER"],
+        secondary: ["IF", "EXISTS"],
+        restrict: true,
+      };
+    case "ALTER":
+      return { primary: ["TABLE"], restrict: true };
+    case "WITH":
+      return { primary: ["RECURSIVE"], secondary: ["AS"] };
+    case "AS":
+      return { primary: [], restrict: true };
+    case "USING":
+      return { primary: [], restrict: true };
+    case "VALUES":
+      return { primary: ["DEFAULT", "NULL"] };
+    case "SET":
+      return { primary: [] };
+    case "ASC":
+    case "DESC":
+      return {
+        primary: ["LIMIT", "OFFSET"],
+        secondary: ["NULLS", "UNION"],
+      };
+    case "NULLS":
+      return { primary: ["FIRST", "LAST"], restrict: true };
+    case "IS":
+      return { primary: ["NULL", "NOT"], restrict: true };
+    case "NOT":
+      return {
+        primary: ["NULL", "EXISTS", "IN", "LIKE", "BETWEEN"],
+        secondary: ["GLOB", "REGEXP", "MATCH"],
+        restrict: true,
+      };
+    case "BETWEEN":
+      return { primary: [], secondary: ["AND"] };
+    case "DISTINCT":
+    case "ALL":
+      return { primary: ["FROM"] };
+    case "TEMP":
+    case "TEMPORARY":
+      return { primary: ["TABLE", "VIEW", "TRIGGER"], restrict: true };
+    case "UNIQUE":
+      return { primary: ["INDEX"], restrict: true };
+    case "RENAME":
+      return { primary: ["TO", "COLUMN"], restrict: true };
+    case "ADD":
+      return { primary: ["COLUMN", "CONSTRAINT"], restrict: true };
+    default:
+      break;
+  }
+
+  // ── Clause-relative defaults: where in the larger statement are we?
+  switch (lastClauseKeyword) {
+    case "SELECT":
+      if (isIdentifierToken(lastToken)) {
+        return {
+          primary: ["AS", "FROM"],
+          secondary: [
+            "AND",
+            "OR",
+            "NOT",
+            "IS",
+            "NULL",
+            "LIKE",
+            "IN",
+            "BETWEEN",
+            "CASE",
+            "WHEN",
+            "THEN",
+            "ELSE",
+            "END",
+          ],
+        };
+      }
+      return {
+        primary: ["DISTINCT", "ALL"],
+        secondary: ["FROM", "CASE", "CAST", "NOT", "NULL"],
+      };
+    case "FROM":
+      if (isIdentifierToken(lastToken)) {
+        return {
+          primary: ["WHERE", "JOIN", "GROUP", "ORDER", "LIMIT", "AS"],
+          secondary: [
+            "LEFT",
+            "RIGHT",
+            "INNER",
+            "OUTER",
+            "FULL",
+            "CROSS",
+            "HAVING",
+            "OFFSET",
+            "UNION",
+            "INTERSECT",
+            "EXCEPT",
+          ],
+        };
+      }
+      return {
+        primary: ["AS"],
+        secondary: ["JOIN", "WHERE"],
+      };
+    case "JOIN":
+      if (isIdentifierToken(lastToken)) {
+        return {
+          primary: ["ON", "USING", "AS"],
+          secondary: [
+            "WHERE",
+            "JOIN",
+            "LEFT",
+            "RIGHT",
+            "INNER",
+            "OUTER",
+            "FULL",
+            "CROSS",
+            "GROUP",
+            "ORDER",
+            "HAVING",
+            "LIMIT",
+          ],
+        };
+      }
+      return { primary: ["AS"] };
+    case "ON":
+    case "WHERE":
+    case "HAVING": {
+      if (isExpressionOperator(lastToken)) {
+        return {
+          primary: ["NOT", "NULL", "EXISTS", "CASE"],
+          secondary: ["CAST", "TRUE", "FALSE"],
+        };
+      }
+      if (isIdentifierToken(lastToken)) {
+        return {
+          primary: ["AND", "OR", "IS", "NOT", "LIKE", "IN", "BETWEEN"],
+          secondary: [
+            "GROUP",
+            "ORDER",
+            "HAVING",
+            "LIMIT",
+            "OFFSET",
+            "UNION",
+            "GLOB",
+            "REGEXP",
+            "MATCH",
+            "ESCAPE",
+            "COLLATE",
+          ],
+        };
+      }
+      return {
+        primary: ["NOT", "EXISTS", "CASE"],
+        secondary: ["NULL", "CAST"],
+      };
+    }
+    case "GROUP":
+    case "ORDER":
+      return {
+        primary: ["BY"],
+        secondary: ["ASC", "DESC", "HAVING", "LIMIT", "OFFSET", "UNION"],
+      };
+    case "INSERT":
+      return {
+        primary: ["INTO", "VALUES", "SELECT"],
+        secondary: ["DEFAULT", "OR", "REPLACE", "RETURNING"],
+      };
+    case "UPDATE":
+      return {
+        primary: ["SET"],
+        secondary: ["WHERE", "OR", "REPLACE", "RETURNING"],
+      };
+    case "DELETE":
+      return { primary: ["FROM"], secondary: ["WHERE", "RETURNING"] };
+    case "CREATE":
+      return {
+        primary: ["TABLE", "VIEW", "INDEX", "TRIGGER"],
+        secondary: ["UNIQUE", "TEMP", "TEMPORARY", "IF", "NOT", "EXISTS"],
+      };
+    case "DROP":
+      return {
+        primary: ["TABLE", "VIEW", "INDEX", "TRIGGER"],
+        secondary: ["IF", "EXISTS"],
+      };
+    case "ALTER":
+      return {
+        primary: ["TABLE", "RENAME", "ADD", "DROP"],
+        secondary: ["COLUMN", "TO"],
+      };
+    case "SET":
+      return { primary: ["WHERE"], secondary: ["AND", "OR", "RETURNING"] };
+    case "VALUES":
+      return { primary: ["DEFAULT", "NULL"], secondary: ["RETURNING"] };
+    case "USING":
+      return { primary: [], restrict: true };
+    case "WITH":
+      return { primary: ["AS", "RECURSIVE"] };
+    case "UNION":
+    case "INTERSECT":
+    case "EXCEPT":
+      return { primary: ["ALL", "SELECT"] };
+    default:
+      return null;
+  }
+}
+
+function isInsideUnclosedParen(prefix: string): boolean {
+  const masked = maskCommentsAndStrings(prefix);
+  let depth = 0;
+  for (let i = 0; i < masked.length; i += 1) {
+    const ch = masked[i];
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth = Math.max(0, depth - 1);
+  }
+  return depth > 0;
 }
 
 function inferCompletionContext(
@@ -304,31 +709,80 @@ function inferCompletionContext(
 
   const from = word?.from ?? context.pos;
   const currentWord = word?.text ?? "";
-  if (!context.explicit && !currentWord && !/\s$/.test(statement)) return null;
+  if (!context.explicit && !currentWord && !/\s$|[(,.=<>+\-*/]$/.test(statement))
+    return null;
 
   const prefixWithoutWord = currentWord
     ? statement.slice(0, Math.max(0, statement.length - currentWord.length))
     : statement;
-  const tokens = tokenize(prefixWithoutWord).map((token) => token.toUpperCase());
-  const lastToken = tokens.at(-1);
-  const lastKeyword = [...tokens].reverse().find((token) =>
-    clauseBoundaryKeywords.has(token),
-  );
 
-  if (lastToken && tableTargetKeywords.has(lastToken)) {
-    return { mode: "tables", from };
+  // INSERT INTO <table> (col1, col2, |) — suggest columns of <table>.
+  const insertMatch = insertColumnListPattern.exec(prefixWithoutWord);
+  if (insertMatch) {
+    return {
+      mode: "qualified-columns",
+      qualifier: normalizeIdentifier(insertMatch[1]),
+      from,
+    };
   }
-  if (lastToken === ".") return null;
-  if (lastKeyword && tableTargetKeywords.has(lastKeyword)) {
-    return { mode: "tables", from };
-  }
-  if (lastKeyword && columnTargetKeywords.has(lastKeyword)) {
+
+  // JOIN ... USING (col1, |) — suggest columns from joined tables.
+  if (
+    usingClausePattern.test(prefixWithoutWord) &&
+    isInsideUnclosedParen(prefixWithoutWord)
+  ) {
     return { mode: "columns", from };
   }
-  if (context.explicit || currentWord.length > 0) {
-    return { mode: "keywords", from };
+
+  // CREATE [TEMP] [UNIQUE] TABLE|VIEW|INDEX|TRIGGER [IF NOT EXISTS] <newName>
+  // — user is naming a new object, so suppress existing-table suggestions
+  // and only surface the few keywords that legally appear in this slot.
+  if (createNewObjectPattern.test(prefixWithoutWord)) {
+    return {
+      mode: "naming",
+      from,
+      keywordContext: KW_NAME_TAIL,
+    };
   }
-  return null;
+
+  const tokens = tokenize(prefixWithoutWord).map((token) => token.toUpperCase());
+  const lastToken = tokens.at(-1);
+  const lastClauseKeyword = [...tokens]
+    .reverse()
+    .find((token) => clauseBoundaryKeywords.has(token));
+  const keywordContext =
+    resolveKeywordContext(tokens, lastToken, lastClauseKeyword) ?? undefined;
+
+  // Right after a clause keyword that introduces tables / columns.
+  if (lastToken && tableTargetKeywords.has(lastToken)) {
+    return { mode: "tables", from, keywordContext };
+  }
+  if (lastToken && columnTargetKeywords.has(lastToken)) {
+    return { mode: "columns", from, keywordContext };
+  }
+
+  // After a comma or open-paren, stay in the surrounding clause's mode.
+  if (lastToken === "," || lastToken === "(") {
+    if (lastClauseKeyword && tableTargetKeywords.has(lastClauseKeyword)) {
+      return { mode: "tables", from, keywordContext };
+    }
+    if (lastClauseKeyword && columnTargetKeywords.has(lastClauseKeyword)) {
+      return { mode: "columns", from, keywordContext };
+    }
+  }
+
+  // Mid-expression operators / boolean glue inside a column-flavored clause.
+  if (lastToken && expressionContinuationTokens.has(lastToken)) {
+    if (lastClauseKeyword && columnTargetKeywords.has(lastClauseKeyword)) {
+      return { mode: "columns", from, keywordContext };
+    }
+  }
+
+  if (lastToken === ".") return null;
+
+  // Fall back to keywords (e.g. user has typed `SELECT *` or
+  // `SELECT * FROM customers ` and the next token should be FROM/JOIN/WHERE).
+  return { mode: "keywords", from, keywordContext };
 }
 
 function extractTableReferences(sql: string): Map<string, string> {
@@ -339,7 +793,8 @@ function extractTableReferences(sql: string): Map<string, string> {
     if (!tableName) return;
     references.set(tableName.toLowerCase(), tableName);
     const alias = normalizeIdentifier(aliasToken);
-    if (alias && !isKeyword(alias)) references.set(alias.toLowerCase(), tableName);
+    if (alias && !isClauseBoundaryKeyword(alias))
+      references.set(alias.toLowerCase(), tableName);
   };
 
   let match: RegExpExecArray | null;
@@ -358,7 +813,10 @@ function extractTableReferences(sql: string): Map<string, string> {
       beforeComma.lastIndexOf(" GROUP "),
       beforeComma.lastIndexOf(" ORDER "),
     );
-    if (lastBoundary >= 0 && /\b(FROM|JOIN)\b/.test(beforeComma.slice(lastBoundary))) {
+    if (
+      lastBoundary >= 0 &&
+      /\b(FROM|JOIN)\b/.test(beforeComma.slice(lastBoundary))
+    ) {
       addReference(match[1], match[2]);
     }
   }
@@ -366,33 +824,183 @@ function extractTableReferences(sql: string): Map<string, string> {
   return references;
 }
 
-function tableOptions(schema: SqlCompletionSchema, boost: number): Completion[] {
+const cteHeadPattern = new RegExp(
+  String.raw`\bWITH\s+(?:RECURSIVE\s+)?(${sqlIdentifierPattern})\s*(?:\(([^)]*)\))?\s*AS\s*\(`,
+  "gi",
+);
+const cteContinuationPattern = new RegExp(
+  String.raw`,\s*(${sqlIdentifierPattern})\s*(?:\(([^)]*)\))?\s*AS\s*\(`,
+  "g",
+);
+
+function parseColumnList(list: string | undefined): string[] {
+  if (!list) return [];
+  return list
+    .split(",")
+    .map((part) => normalizeIdentifier(part.trim()))
+    .filter((name) => name.length > 0);
+}
+
+function extractCtes(sql: string): SqlCompletionEntity[] {
+  const masked = maskCommentsAndStrings(sql);
+  const seen = new Set<string>();
+  const result: SqlCompletionEntity[] = [];
+
+  const addCte = (rawName: string, columnList: string | undefined) => {
+    const name = normalizeIdentifier(rawName);
+    if (!name) return;
+    const key = name.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.push({
+      name,
+      kind: "cte",
+      columns: parseColumnList(columnList),
+    });
+  };
+
+  let match: RegExpExecArray | null;
+  cteHeadPattern.lastIndex = 0;
+  while ((match = cteHeadPattern.exec(masked))) {
+    addCte(match[1], match[2]);
+  }
+
+  // Continuation `, name AS (...)` — only honor those that fall outside any
+  // open CTE body, otherwise we'd pick up commas from inside subqueries.
+  cteContinuationPattern.lastIndex = 0;
+  while ((match = cteContinuationPattern.exec(masked))) {
+    const upTo = masked.slice(0, match.index);
+    if (parenDepth(upTo) === 0) {
+      addCte(match[1], match[2]);
+    }
+  }
+
+  return result;
+}
+
+function parenDepth(masked: string): number {
+  let depth = 0;
+  for (let i = 0; i < masked.length; i += 1) {
+    const ch = masked[i];
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth = Math.max(0, depth - 1);
+  }
+  return depth;
+}
+
+function effectiveSchema(
+  base: SqlCompletionSchema,
+  statement: string,
+): SqlCompletionSchema {
+  const ctes = extractCtes(statement);
+  if (ctes.length === 0) return base;
+  const knownNames = new Set(
+    base.entities.map((entity) => entity.name.toLowerCase()),
+  );
+  const merged = [
+    ...base.entities,
+    ...ctes.filter((cte) => !knownNames.has(cte.name.toLowerCase())),
+  ];
+  return { entities: merged };
+}
+
+function entitySection(
+  entity: SqlCompletionEntity,
+): typeof tableSection | typeof viewSection | typeof cteSection {
+  if (entity.kind === "view") return viewSection;
+  if (entity.kind === "cte") return cteSection;
+  return tableSection;
+}
+
+function entityType(entity: SqlCompletionEntity): string {
+  if (entity.kind === "view") return "namespace";
+  if (entity.kind === "cte") return "class";
+  return "type";
+}
+
+function tableOptions(
+  schema: SqlCompletionSchema,
+  defaultBoost: number,
+): Completion[] {
   return schema.entities.map((entity) => ({
     label: entity.name,
     apply: quoteIdentifier(entity.name),
     detail: entity.kind,
-    type: entity.kind === "view" ? "namespace" : "type",
-    section: entity.kind === "view" ? viewSection : tableSection,
-    boost,
+    type: entityType(entity),
+    section: entitySection(entity),
+    boost:
+      entity.kind === "cte" ? BOOST.cteInTableContext : defaultBoost,
   }));
 }
 
-function keywordOptions(boost: number): Completion[] {
-  return [
-    ...SQL_KEYWORDS.map((keyword) => ({
+// Boost adjustments applied when the cursor's syntactic position predicts a
+// narrower keyword set. Values are tuned so context-relevant keywords sort
+// among the user's likely picks while keeping table/column suggestions
+// dominant when those are what the slot wants.
+const KEYWORD_PRIMARY_BUMP = 30;
+const KEYWORD_SECONDARY_BUMP = 5;
+const KEYWORD_OFF_CONTEXT_PENALTY = 25;
+
+function keywordOptions(
+  boost: number,
+  keywordContext?: KeywordContext,
+  options: { includeFunctions?: boolean } = {},
+): Completion[] {
+  const { includeFunctions = true } = options;
+  const primary = keywordContext ? new Set(keywordContext.primary) : null;
+  const secondary = keywordContext?.secondary
+    ? new Set(keywordContext.secondary)
+    : null;
+  const restrict = keywordContext?.restrict ?? false;
+  const hasContext = primary !== null;
+
+  const orderedKeywords = primary
+    ? [
+        // Stable boost ordering means iteration order also drives display
+        // order — list primaries first so the popup shows them up top even
+        // before we sort by boost.
+        ...keywordContext!.primary.filter((kw) => SQL_KEYWORDS.includes(kw)),
+        ...(keywordContext!.secondary ?? []).filter((kw) =>
+          SQL_KEYWORDS.includes(kw),
+        ),
+        ...SQL_KEYWORDS.filter(
+          (kw) => !primary.has(kw) && !(secondary?.has(kw) ?? false),
+        ),
+      ]
+    : SQL_KEYWORDS;
+
+  const out: Completion[] = [];
+  for (const keyword of orderedKeywords) {
+    const isPrimary = primary?.has(keyword) ?? false;
+    const isSecondary = secondary?.has(keyword) ?? false;
+    if (restrict && !isPrimary && !isSecondary) continue;
+    let kwBoost = boost;
+    if (hasContext) {
+      if (isPrimary) kwBoost = boost + KEYWORD_PRIMARY_BUMP;
+      else if (isSecondary) kwBoost = boost + KEYWORD_SECONDARY_BUMP;
+      else kwBoost = boost - KEYWORD_OFF_CONTEXT_PENALTY;
+    }
+    out.push({
       label: keyword,
       type: "keyword",
       section: keywordSection,
-      boost,
-    })),
-    ...SQL_FUNCTIONS.map((fn) => ({
-      label: fn,
-      apply: `${fn}()`,
-      type: "function",
-      section: keywordSection,
-      boost: boost - BOOST.functionPenalty,
-    })),
-  ];
+      boost: kwBoost,
+    });
+  }
+  if (includeFunctions && !restrict) {
+    for (const fn of SQL_FUNCTIONS) {
+      out.push(
+        snippetCompletion(`${fn}(#{})`, {
+          label: fn,
+          detail: "function",
+          type: "function",
+          section: keywordSection,
+          boost: boost - BOOST.functionPenalty,
+        }),
+      );
+    }
+  }
+  return out;
 }
 
 function columnOptions(
@@ -401,10 +1009,16 @@ function columnOptions(
   boost: number,
 ): Completion[] {
   const references = extractTableReferences(statement);
-  const referencedTables = new Set([...references.values()].map((name) => name.toLowerCase()));
+  const referencedTables = new Set(
+    [...references.values()].map((name) => name.toLowerCase()),
+  );
   const entities = referencedTables.size
-    ? schema.entities.filter((entity) => referencedTables.has(entity.name.toLowerCase()))
-    : schema.entities;
+    ? schema.entities.filter((entity) =>
+        referencedTables.has(entity.name.toLowerCase()),
+      )
+    : [];
+
+  if (entities.length === 0) return [];
 
   const columnOwners = new Map<string, SqlCompletionEntity[]>();
   for (const entity of entities) {
@@ -415,12 +1029,16 @@ function columnOptions(
   }
 
   const options: Completion[] = [];
+  const seen = new Set<string>();
   for (const entity of entities) {
     for (const column of entity.columns) {
       const owners = columnOwners.get(column.toLowerCase()) ?? [];
       const ambiguous = owners.length > 1;
+      const label = ambiguous ? `${entity.name}.${column}` : column;
+      if (seen.has(label)) continue;
+      seen.add(label);
       options.push({
-        label: ambiguous ? `${entity.name}.${column}` : column,
+        label,
         apply: ambiguous
           ? `${quoteIdentifier(entity.name)}.${quoteIdentifier(column)}`
           : quoteIdentifier(column),
@@ -442,7 +1060,8 @@ function qualifiedColumnOptions(
 ): Completion[] {
   if (!qualifier) return [];
   const references = extractTableReferences(statement);
-  const tableName = references.get(qualifier.toLowerCase()) ?? qualifier;
+  const tableName =
+    references.get(qualifier.toLowerCase()) ?? qualifier;
   const entity = schema.entities.find(
     (item) => item.name.toLowerCase() === tableName.toLowerCase(),
   );
@@ -460,7 +1079,9 @@ function qualifiedColumnOptions(
 function dedupeOptions(options: Completion[]): Completion[] {
   const seen = new Set<string>();
   return options.filter((option) => {
-    const key = `${option.type}:${option.label}:${option.apply ?? ""}`;
+    const applyKey =
+      typeof option.apply === "string" ? option.apply : option.label;
+    const key = `${option.type}:${option.label}:${applyKey}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;
@@ -478,30 +1099,54 @@ export function createSqlCompletionSource(
       context.state.doc.toString(),
       context.pos,
     );
+    const localSchema = effectiveSchema(schema, statement);
+
+    const kw = info.keywordContext;
     const options = (() => {
       switch (info.mode) {
         case "tables":
           return [
-            ...tableOptions(schema, BOOST.tableInTableContext),
-            ...keywordOptions(BOOST.keywordInTableContext),
+            ...tableOptions(localSchema, BOOST.tableInTableContext),
+            ...keywordOptions(BOOST.keywordInTableContext, kw),
           ];
-        case "columns":
+        case "columns": {
+          const cols = columnOptions(
+            localSchema,
+            statement,
+            BOOST.columnInColumnContext,
+          );
+          if (cols.length === 0) {
+            // No FROM/JOIN/UPDATE/INTO target in scope yet — column suggestions
+            // would be misleading, so offer keywords + tables instead.
+            return [
+              ...keywordOptions(BOOST.keywordInColumnContext, kw),
+              ...tableOptions(localSchema, BOOST.tableInColumnContext),
+            ];
+          }
           return [
-            ...columnOptions(schema, statement, BOOST.columnInColumnContext),
-            ...keywordOptions(BOOST.keywordInColumnContext),
-            ...tableOptions(schema, BOOST.tableInColumnContext),
+            ...cols,
+            ...keywordOptions(BOOST.keywordInColumnContext, kw),
+            ...tableOptions(localSchema, BOOST.tableInColumnContext),
           ];
+        }
         case "qualified-columns":
           return qualifiedColumnOptions(
-            schema,
+            localSchema,
             statement,
             info.qualifier,
             BOOST.qualifiedColumn,
           );
+        case "naming":
+          // New-object name slot: only legal trailing keywords like
+          // `IF NOT EXISTS`. Tables and free functions would mislead the user
+          // here, so we suppress them entirely.
+          return keywordOptions(BOOST.keywordInKeywordContext, kw, {
+            includeFunctions: false,
+          });
         case "keywords":
           return [
-            ...keywordOptions(BOOST.keywordInKeywordContext),
-            ...tableOptions(schema, BOOST.tableInKeywordContext),
+            ...keywordOptions(BOOST.keywordInKeywordContext, kw),
+            ...tableOptions(localSchema, BOOST.tableInKeywordContext),
           ];
       }
     })();


### PR DESCRIPTION
## Summary

Reworks the SQLite playground's autocomplete (`app/_components/sql/sqlCompletion.ts`) so suggestions reflect *where the cursor actually is* in the statement.

### Context-aware keyword ranking
Each cursor position resolves to a `KeywordContext` with `primary` (highest boost) and `secondary` (default boost) tiers; everything else is downranked or omitted. Examples:
- After `FROM <table> ` → `WHERE`, `JOIN`, `GROUP`, `ORDER`, `LIMIT`, `AS` ranked first
- After `JOIN <table> ` → `ON`, `USING`, `AS` ranked first
- After `WHERE <ident> ` → `AND`, `OR`, `IS`, `NOT`, `LIKE`, `IN`, `BETWEEN`
- After `IS` → restricted to `NULL`, `NOT`
- After `ORDER`/`GROUP` → restricted to `BY`
- At buffer start → `SELECT`, `WITH`, `INSERT`, `UPDATE`, etc.

### Schema awareness
- **CTE detection**: `WITH name [(cols)] AS (...)` makes `name` available as a table-like suggestion; declared columns surface for `name.col` qualified completion.
- **CREATE TABLE/VIEW/INDEX/TRIGGER name slot**: existing tables are suppressed (you're naming a *new* object); only `IF NOT EXISTS` is offered.
- **`INSERT INTO <table> (...)`**: the open column list now suggests columns of the target table.
- **`JOIN ... USING (...)`**: suggests columns from the joined tables.
- **No-FROM column suggestions removed**: prevents misleading "first matching table" attribution when nothing is in scope.
- **Function snippets**: function completions now place the cursor inside `()` via `snippetCompletion`.

### Bug fixes
- Table-reference regex no longer eats clause keywords as aliases — `FROM t JOIN u USING (...)` correctly registers both tables.
- After a referenced table, keyword fallback (WHERE/JOIN/etc.) shows up instead of the previous behavior of re-suggesting tables.

## Test plan
- [x] `npm test` — 149/149 passing (24 in `sqlCompletion.test.ts`, including 10 new context-ranking tests)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [ ] Manual sanity check in the playground UI (browser)

https://claude.ai/code/session_01QbBLnGobfbnwZ5BpGRdNHH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbBLnGobfbnwZ5BpGRdNHH)_