### PR TITLE
Add --text-complementary variable and /color-test UI preview route

### DIFF
--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -25,6 +25,10 @@
      before a theme has been applied. */
   --text-soft: oklch(68% 0.12 240);
   --text-accent: oklch(68% 0.16 145);
+  /* Complementary accent drawn from the theme's function-highlight color —
+     a vibrant hue that pairs well against `--text-soft` and `--text-accent`
+     and is populated per-theme by `applyThemePalette`. */
+  --text-complementary: oklch(75% 0.20 85);
   --primary: oklch(68% 0.18 250);
   --primary-glow: oklch(68% 0.18 250 / 0.15);
   --blue: oklch(68% 0.18 250);

--- a/app/_components/playgroundTheme.ts
+++ b/app/_components/playgroundTheme.ts
@@ -183,6 +183,7 @@ export function applyThemePalette(theme: string): void {
   // tree icons, and ER table headers.
   root.style.setProperty("--text-soft", p.dim);
   root.style.setProperty("--text-accent", p.muted);
+  root.style.setProperty("--text-complementary", p.fn);
   root.style.setProperty("--theme-primary", p.kw);
 }
 
@@ -198,6 +199,7 @@ export function clearThemePalette(): void {
     "--text-muted",
     "--text-soft",
     "--text-accent",
+    "--text-complementary",
     "--theme-primary",
   ]) {
     root.style.removeProperty(name);

--- a/app/color-test/color-test.module.css
+++ b/app/color-test/color-test.module.css
@@ -180,6 +180,7 @@
   gap: 3px;
   width: 100%;
   justify-content: center;
+  margin-top: 4px;
 }
 
 .swatchHex {

--- a/app/color-test/color-test.module.css
+++ b/app/color-test/color-test.module.css
@@ -1,0 +1,604 @@
+/* ─── Color Theme Test Page ───────────────────────────────────────────────── */
+
+.root {
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+}
+
+/* ── Header / theme switcher ── */
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--bg2);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 24px 12px;
+}
+
+.headerInner {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.pageTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.pageSubtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.themeGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.themeCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 4px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.themeCard:hover {
+  background: var(--bg3);
+  border-color: var(--border);
+}
+
+.themeCardActive {
+  border-color: var(--text-complementary) !important;
+  background: color-mix(in srgb, var(--text-complementary) 10%, var(--bg2)) !important;
+}
+
+.themePreview {
+  position: relative;
+  width: 48px;
+  height: 30px;
+  border-radius: 5px;
+  border: 1px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.activeCheck {
+  position: absolute;
+  top: 2px;
+  right: 3px;
+}
+
+.themeLabel {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-align: center;
+  white-space: nowrap;
+  max-width: 56px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Main content ── */
+.content {
+  padding: 24px;
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── Section ── */
+.section {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+.sectionTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 16px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* ── Color swatches ── */
+.swatchGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.swatch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 80px;
+}
+
+.swatchHighlight .swatchColor {
+  outline: 2px solid var(--text-complementary);
+  outline-offset: 2px;
+}
+
+.swatchColor {
+  width: 64px;
+  height: 40px;
+  border-radius: 6px;
+  border: 1px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.swatchSample {
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.swatchName {
+  font-size: 9px;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  text-align: center;
+  word-break: break-all;
+}
+
+.swatchLabel {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* ── Typography ── */
+.typoGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 640px) {
+  .typoGrid { grid-template-columns: 1fr; }
+}
+
+.typoCard {
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 16px;
+}
+
+.typoCardTitle {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 12px;
+}
+
+.typoSamples {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.typoH1 { font-size: 24px; font-weight: 700; margin: 0; }
+.typoH2 { font-size: 20px; font-weight: 600; margin: 0; }
+.typoH3 { font-size: 16px; font-weight: 500; margin: 0; }
+
+/* ── Buttons ── */
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 12px;
+  transition: opacity 0.15s, filter 0.15s;
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.btn:not(:disabled):hover {
+  filter: brightness(1.1);
+}
+
+.btnPrimary {
+  background: var(--text-complementary);
+  color: var(--bg);
+}
+
+.btnSecondary {
+  background: var(--bg3);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.btnGhost {
+  background: transparent;
+  color: var(--text-soft);
+  border: 1px solid var(--border);
+}
+
+.btnDanger {
+  background: color-mix(in srgb, var(--red) 18%, var(--bg3));
+  color: var(--red);
+  border: 1px solid color-mix(in srgb, var(--red) 35%, transparent);
+}
+
+.btnSm { font-size: 11px; padding: 4px 8px; }
+.btnLg { font-size: 15px; padding: 9px 18px; }
+
+/* ── Badges ── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+}
+
+.badgeDefault {
+  background: var(--bg3);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+
+.badgeSoft {
+  background: color-mix(in srgb, var(--text-soft) 16%, var(--bg3));
+  color: var(--text-soft);
+}
+
+.badgeAccent {
+  background: color-mix(in srgb, var(--text-accent) 16%, var(--bg3));
+  color: var(--text-accent);
+}
+
+.badgeComplementary {
+  background: color-mix(in srgb, var(--text-complementary) 16%, var(--bg3));
+  color: var(--text-complementary);
+}
+
+.badgeSuccess {
+  background: color-mix(in srgb, var(--green) 16%, var(--bg3));
+  color: var(--green);
+}
+
+.badgeWarning {
+  background: color-mix(in srgb, var(--yellow) 16%, var(--bg3));
+  color: var(--yellow);
+}
+
+.badgeError {
+  background: color-mix(in srgb, var(--red) 16%, var(--bg3));
+  color: var(--red);
+}
+
+/* ── Tags ── */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  font-size: 12px;
+  padding: 2px 7px;
+}
+
+.tagAccent {
+  border-color: color-mix(in srgb, var(--text-accent) 40%, transparent);
+  color: var(--text-accent);
+  background: color-mix(in srgb, var(--text-accent) 10%, var(--bg3));
+}
+
+/* ── Icons ── */
+.iconGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.iconItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 60px;
+}
+
+.iconBox {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.iconLabel {
+  font-size: 10px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
+/* ── Form elements ── */
+.formGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 640px) {
+  .formGrid { grid-template-columns: 1fr; }
+}
+
+.formField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.input,
+.select,
+.textarea {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  padding: 7px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+  width: 100%;
+}
+
+.input::placeholder,
+.textarea::placeholder {
+  color: var(--text-dim);
+}
+
+.input:focus,
+.select:focus,
+.textarea:focus {
+  border-color: var(--text-complementary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--text-complementary) 15%, transparent);
+}
+
+.select {
+  cursor: pointer;
+}
+
+.textarea {
+  resize: vertical;
+}
+
+.inputIcon {
+  position: relative;
+}
+
+.inputIconEl {
+  position: absolute;
+  left: 9px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-dim);
+  pointer-events: none;
+}
+
+.inputWithIcon {
+  padding-left: 30px;
+}
+
+/* ── Alerts ── */
+.alertStack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  padding: 10px 14px;
+  border-left-width: 3px;
+  border-left-style: solid;
+  border-top: 1px solid;
+  border-right: 1px solid;
+  border-bottom: 1px solid;
+}
+
+.alertInfo {
+  background: color-mix(in srgb, var(--text-soft) 10%, var(--bg3));
+  border-color: color-mix(in srgb, var(--text-soft) 30%, transparent);
+  border-left-color: var(--text-soft);
+  color: var(--text);
+}
+
+.alertInfo svg { color: var(--text-soft); flex-shrink: 0; margin-top: 1px; }
+
+.alertSuccess {
+  background: color-mix(in srgb, var(--text-accent) 10%, var(--bg3));
+  border-color: color-mix(in srgb, var(--text-accent) 30%, transparent);
+  border-left-color: var(--text-accent);
+  color: var(--text);
+}
+
+.alertSuccess svg { color: var(--text-accent); flex-shrink: 0; margin-top: 1px; }
+
+.alertComplementary {
+  background: color-mix(in srgb, var(--text-complementary) 10%, var(--bg3));
+  border-color: color-mix(in srgb, var(--text-complementary) 30%, transparent);
+  border-left-color: var(--text-complementary);
+  color: var(--text);
+}
+
+.alertComplementary svg { color: var(--text-complementary); flex-shrink: 0; margin-top: 1px; }
+
+.alertWarning {
+  background: color-mix(in srgb, var(--yellow) 10%, var(--bg3));
+  border-color: color-mix(in srgb, var(--yellow) 30%, transparent);
+  border-left-color: var(--yellow);
+  color: var(--text);
+}
+
+.alertWarning svg { color: var(--yellow); flex-shrink: 0; margin-top: 1px; }
+
+.alertError {
+  background: color-mix(in srgb, var(--red) 10%, var(--bg3));
+  border-color: color-mix(in srgb, var(--red) 30%, transparent);
+  border-left-color: var(--red);
+  color: var(--text);
+}
+
+.alertError svg { color: var(--red); flex-shrink: 0; margin-top: 1px; }
+
+/* ── Lists / Navigation ── */
+.listGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 640px) {
+  .listGrid { grid-template-columns: 1fr; }
+}
+
+.navList {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.navItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.navItem:last-child { border-bottom: none; }
+
+.navItem:hover { background: var(--bg3); color: var(--text); }
+
+.navItemActive {
+  background: color-mix(in srgb, var(--text-complementary) 8%, var(--bg));
+  color: var(--text);
+}
+
+.bulletList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.bulletItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+/* ── Code ── */
+.prose {
+  font-size: 14px;
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin: 0 0 12px;
+}
+
+.inlineCode {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-complementary);
+  padding: 1px 5px;
+}
+
+.codeBlock {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.8;
+  margin: 0;
+  overflow-x: auto;
+  padding: 14px 18px;
+  color: var(--text);
+}

--- a/app/color-test/color-test.module.css
+++ b/app/color-test/color-test.module.css
@@ -14,30 +14,7 @@
   z-index: 100;
   background: var(--bg2);
   border-bottom: 1px solid var(--border);
-  padding: 16px 24px 12px;
-}
-
-.headerInner {
-  display: flex;
-  align-items: baseline;
-  gap: 16px;
-  margin-bottom: 12px;
-}
-
-.pageTitle {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text);
-  margin: 0;
-}
-
-.pageSubtitle {
-  font-size: 13px;
-  color: var(--text-muted);
-  margin: 0;
+  padding: 10px 16px;
 }
 
 .themeGrid {
@@ -137,35 +114,103 @@
 .swatchGrid {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 10px;
+  align-items: flex-start;
 }
 
+/* Single-color swatch item */
 .swatch {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
-  width: 80px;
+  width: 76px;
 }
 
-.swatchHighlight .swatchColor {
+/* Dual-color swatch item (text colors showing both "Aa on bg" and solid fill) */
+.swatchDual {
+  width: 114px;
+}
+
+/* Highlight the --text-complementary swatch */
+.swatchHighlight .swatchColors {
   outline: 2px solid var(--text-complementary);
   outline-offset: 2px;
+  border-radius: 7px;
 }
 
+/* Flex row holding one or two color boxes */
+.swatchColors {
+  display: flex;
+  gap: 4px;
+  width: 100%;
+}
+
+/* Main color box: for non-text colors it is the solid fill;
+   for text colors it shows "Aa" text on --bg */
 .swatchColor {
-  width: 64px;
+  flex: 1;
   height: 40px;
   border-radius: 6px;
   border: 1px solid;
   display: flex;
   align-items: center;
   justify-content: center;
+  min-width: 0;
+}
+
+/* Secondary box: solid fill of the text color */
+.swatchColorSolid {
+  width: 48px;
+  height: 40px;
+  border-radius: 6px;
+  border: 1px solid;
+  flex-shrink: 0;
 }
 
 .swatchSample {
   font-size: 17px;
   font-weight: 700;
+}
+
+/* Hex value + copy button row */
+.swatchMeta {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  width: 100%;
+  justify-content: center;
+}
+
+.swatchHex {
+  font-size: 9px;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+}
+
+.copyBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-radius: 3px;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 1px 3px;
+  transition: color 0.12s, background 0.12s;
+  flex-shrink: 0;
+}
+
+.copyBtn:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--bg3);
+}
+
+.copyBtn:disabled {
+  opacity: 0.3;
+  cursor: default;
 }
 
 .swatchName {
@@ -183,17 +228,20 @@
 }
 
 /* ── Typography ── */
-.typoGrid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-
-@media (max-width: 640px) {
-  .typoGrid { grid-template-columns: 1fr; }
+.typoStack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .typoCard {
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 16px;
+}
+
+.cmCard {
   background: var(--bg3);
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -218,6 +266,21 @@
 .typoH1 { font-size: 24px; font-weight: 700; margin: 0; }
 .typoH2 { font-size: 20px; font-weight: 600; margin: 0; }
 .typoH3 { font-size: 16px; font-weight: 500; margin: 0; }
+
+/* ── Code block (pre) ── */
+.codeBlock {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.8;
+  margin: 0;
+  overflow-x: auto;
+  padding: 14px 18px;
+  color: var(--text);
+  white-space: pre;
+}
 
 /* ── Buttons ── */
 .row {
@@ -515,6 +578,17 @@
 
 .alertError svg { color: var(--red); flex-shrink: 0; margin-top: 1px; }
 
+/* ── Inline code (used in alerts) ── */
+.inlineCode {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-complementary);
+  padding: 1px 5px;
+}
+
 /* ── Lists / Navigation ── */
 .listGrid {
   display: grid;
@@ -570,35 +644,4 @@
   color: var(--text-muted);
   font-size: 13px;
   line-height: 1.5;
-}
-
-/* ── Code ── */
-.prose {
-  font-size: 14px;
-  color: var(--text-muted);
-  line-height: 1.6;
-  margin: 0 0 12px;
-}
-
-.inlineCode {
-  font-family: var(--font-mono);
-  font-size: 0.85em;
-  background: var(--bg3);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  color: var(--text-complementary);
-  padding: 1px 5px;
-}
-
-.codeBlock {
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1.8;
-  margin: 0;
-  overflow-x: auto;
-  padding: 14px 18px;
-  color: var(--text);
 }

--- a/app/color-test/color-test.module.css
+++ b/app/color-test/color-test.module.css
@@ -72,11 +72,11 @@
 }
 
 .themeLabel {
-  font-size: 10px;
+  font-size: 11px;
   color: var(--text-muted);
   text-align: center;
   white-space: nowrap;
-  max-width: 56px;
+  max-width: 64px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -124,12 +124,12 @@
   flex-direction: column;
   align-items: center;
   gap: 4px;
-  width: 76px;
+  width: 90px;
 }
 
 /* Dual-color swatch item (text colors showing both "Aa on bg" and solid fill) */
 .swatchDual {
-  width: 114px;
+  width: 132px;
 }
 
 /* Highlight the --text-complementary swatch */
@@ -183,7 +183,7 @@
 }
 
 .swatchHex {
-  font-size: 9px;
+  font-size: 11px;
   font-family: var(--font-mono);
   color: var(--text-dim);
   letter-spacing: 0.02em;
@@ -214,7 +214,7 @@
 }
 
 .swatchName {
-  font-size: 9px;
+  font-size: 11px;
   font-family: var(--font-mono);
   color: var(--text-dim);
   text-align: center;
@@ -222,7 +222,7 @@
 }
 
 .swatchLabel {
-  font-size: 10px;
+  font-size: 12px;
   color: var(--text-muted);
   text-align: center;
 }
@@ -249,7 +249,7 @@
 }
 
 .typoCardTitle {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--text-soft);
   text-transform: uppercase;
@@ -336,7 +336,7 @@
   border: 1px solid color-mix(in srgb, var(--red) 35%, transparent);
 }
 
-.btnSm { font-size: 11px; padding: 4px 8px; }
+.btnSm { font-size: 12px; padding: 4px 8px; }
 .btnLg { font-size: 15px; padding: 9px 18px; }
 
 /* ── Badges ── */
@@ -345,7 +345,7 @@
   align-items: center;
   gap: 4px;
   border-radius: 20px;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   padding: 2px 8px;
 }
@@ -432,7 +432,7 @@
 }
 
 .iconLabel {
-  font-size: 10px;
+  font-size: 12px;
   color: var(--text-dim);
   text-align: center;
 }
@@ -455,7 +455,7 @@
 }
 
 .label {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--text-muted);
 }

--- a/app/color-test/page.tsx
+++ b/app/color-test/page.tsx
@@ -9,6 +9,7 @@ import {
   ChevronRight,
   Circle,
   Code2,
+  Copy,
   Database,
   Info,
   Play,
@@ -33,8 +34,52 @@ import {
 import "../_components/playground.css";
 import styles from "./color-test.module.css";
 
+const SWATCH_DEFS = [
+  { name: "--bg", label: "Background" },
+  { name: "--bg2", label: "Background 2" },
+  { name: "--bg3", label: "Background 3" },
+  { name: "--border", label: "Border" },
+  { name: "--text", label: "Text", isTextColor: true },
+  { name: "--text-muted", label: "Text Muted", isTextColor: true },
+  { name: "--text-dim", label: "Text Dim", isTextColor: true },
+  { name: "--text-soft", label: "Text Soft", isTextColor: true },
+  { name: "--text-accent", label: "Text Accent", isTextColor: true },
+  {
+    name: "--text-complementary",
+    label: "Text Complementary",
+    isTextColor: true,
+    highlight: true,
+  },
+  { name: "--theme-primary", label: "Theme Primary", isTextColor: true },
+  { name: "--primary", label: "Primary" },
+  { name: "--blue", label: "Blue" },
+  { name: "--green", label: "Green" },
+  { name: "--red", label: "Red" },
+  { name: "--yellow", label: "Yellow" },
+] as const;
+
+function resolveCssVarToHex(varName: string): string {
+  const el = document.createElement("div");
+  el.style.cssText = `position:fixed;left:-9999px;top:0;width:1px;height:1px;background:var(${varName})`;
+  document.body.appendChild(el);
+  const rgb = getComputedStyle(el).backgroundColor;
+  document.body.removeChild(el);
+  const m = rgb.match(/\d+/g);
+  if (!m || m.length < 3) return "";
+  return (
+    "#" +
+    (m as string[])
+      .slice(0, 3)
+      .map((n: string) => parseInt(n).toString(16).padStart(2, "0"))
+      .join("")
+  );
+}
+
+
 export default function ColorTestPage() {
   const [activeTheme, setActiveTheme] = useState("lucario");
+  const [resolvedHex, setResolvedHex] = useState<Record<string, string>>({});
+  const [copiedVar, setCopiedVar] = useState<string | null>(null);
 
   useEffect(() => {
     const stored = getStoredEditorTheme();
@@ -44,6 +89,15 @@ export default function ColorTestPage() {
     applyMode(theme);
   }, []);
 
+  // Re-resolve hex values whenever the theme changes (after CSS vars update).
+  useEffect(() => {
+    const map: Record<string, string> = {};
+    for (const { name } of SWATCH_DEFS) {
+      map[name] = resolveCssVarToHex(name);
+    }
+    setResolvedHex(map);
+  }, [activeTheme]);
+
   function handleThemeChange(theme: string) {
     setActiveTheme(theme);
     applyThemePalette(theme);
@@ -51,20 +105,18 @@ export default function ColorTestPage() {
     setStoredEditorTheme(theme);
   }
 
+  function handleCopy(varName: string) {
+    const hex = resolvedHex[varName];
+    if (!hex) return;
+    navigator.clipboard.writeText(hex.slice(1)); // strip leading #
+    setCopiedVar(varName);
+    setTimeout(() => setCopiedVar((v) => (v === varName ? null : v)), 1500);
+  }
+
   return (
     <div className={`pg-root ${styles.root}`}>
       {/* ── Theme switcher ── */}
       <header className={styles.header}>
-        <div className={styles.headerInner}>
-          <h1 className={styles.pageTitle}>
-            <Zap size={20} />
-            Color Theme Test
-          </h1>
-          <p className={styles.pageSubtitle}>
-            Select a theme to preview all UI colors and elements.
-          </p>
-        </div>
-
         <div className={styles.themeGrid}>
           {ALL_THEMES.map(({ value, label }) => {
             const p = THEME_PREVIEWS[value];
@@ -80,18 +132,9 @@ export default function ColorTestPage() {
                   className={styles.themePreview}
                   style={{ background: p.bg, borderColor: p.border }}
                 >
-                  <span
-                    className={styles.dot}
-                    style={{ background: p.kw }}
-                  />
-                  <span
-                    className={styles.dot}
-                    style={{ background: p.fn }}
-                  />
-                  <span
-                    className={styles.dot}
-                    style={{ background: p.str }}
-                  />
+                  <span className={styles.dot} style={{ background: p.kw }} />
+                  <span className={styles.dot} style={{ background: p.fn }} />
+                  <span className={styles.dot} style={{ background: p.str }} />
                   {activeTheme === value && (
                     <Check
                       size={10}
@@ -112,62 +155,84 @@ export default function ColorTestPage() {
         {/* Color swatches */}
         <Section title="Color Variables">
           <div className={styles.swatchGrid}>
-            {[
-              { name: "--bg", label: "Background" },
-              { name: "--bg2", label: "Background 2" },
-              { name: "--bg3", label: "Background 3" },
-              { name: "--border", label: "Border", text: true },
-              { name: "--text", label: "Text", onBg: true },
-              { name: "--text-muted", label: "Text Muted", onBg: true },
-              { name: "--text-dim", label: "Text Dim", onBg: true },
-              { name: "--text-soft", label: "Text Soft", onBg: true },
-              { name: "--text-accent", label: "Text Accent", onBg: true },
-              {
-                name: "--text-complementary",
-                label: "Text Complementary",
-                onBg: true,
-                highlight: true,
-              },
-              { name: "--theme-primary", label: "Theme Primary", onBg: true },
-              { name: "--primary", label: "Primary" },
-              { name: "--blue", label: "Blue" },
-              { name: "--green", label: "Green" },
-              { name: "--red", label: "Red" },
-              { name: "--yellow", label: "Yellow" },
-            ].map(({ name, label, onBg, highlight }) => (
-              <div
-                key={name}
-                className={`${styles.swatch} ${highlight ? styles.swatchHighlight : ""}`}
-              >
+            {SWATCH_DEFS.map(({ name, label, isTextColor, highlight }) => {
+              const hex = resolvedHex[name] ?? "";
+              return (
                 <div
-                  className={styles.swatchColor}
-                  style={{
-                    background: onBg ? "var(--bg)" : `var(${name})`,
-                    borderColor: "var(--border)",
-                  }}
+                  key={name}
+                  className={[
+                    styles.swatch,
+                    isTextColor ? styles.swatchDual : "",
+                    highlight ? styles.swatchHighlight : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
                 >
-                  {onBg ? (
-                    <span
-                      className={styles.swatchSample}
-                      style={{ color: `var(${name})` }}
+                  <div className={styles.swatchColors}>
+                    <div
+                      className={styles.swatchColor}
+                      style={{
+                        background: isTextColor
+                          ? "var(--bg)"
+                          : `var(${name})`,
+                        borderColor: "var(--border)",
+                      }}
                     >
-                      Aa
+                      {isTextColor && (
+                        <span
+                          className={styles.swatchSample}
+                          style={{ color: `var(${name})` }}
+                        >
+                          Aa
+                        </span>
+                      )}
+                    </div>
+                    {isTextColor && (
+                      <div
+                        className={styles.swatchColorSolid}
+                        style={{
+                          background: `var(${name})`,
+                          borderColor: "var(--border)",
+                        }}
+                      />
+                    )}
+                  </div>
+
+                  <div className={styles.swatchMeta}>
+                    <span className={styles.swatchHex}>
+                      {hex || "—"}
                     </span>
-                  ) : null}
+                    <button
+                      className={styles.copyBtn}
+                      onClick={() => handleCopy(name)}
+                      title="Copy hex (without #)"
+                      disabled={!hex}
+                    >
+                      {copiedVar === name ? (
+                        <Check size={9} />
+                      ) : (
+                        <Copy size={9} />
+                      )}
+                    </button>
+                  </div>
+
+                  <span className={styles.swatchName}>{name}</span>
+                  <span className={styles.swatchLabel}>{label}</span>
                 </div>
-                <span className={styles.swatchName}>{name}</span>
-                <span className={styles.swatchLabel}>{label}</span>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </Section>
 
         {/* Typography */}
         <Section title="Typography">
-          <div className={styles.typoGrid}>
+          <div className={styles.typoStack}>
             <div className={styles.typoCard}>
               <h3 className={styles.typoCardTitle}>Sans-serif — UI Font</h3>
-              <div className={styles.typoSamples} style={{ fontFamily: "var(--font-ui)" }}>
+              <div
+                className={styles.typoSamples}
+                style={{ fontFamily: "var(--font-ui)" }}
+              >
                 <p className={styles.typoH1} style={{ color: "var(--text)" }}>
                   Heading One
                 </p>
@@ -177,58 +242,80 @@ export default function ColorTestPage() {
                 <p className={styles.typoH3} style={{ color: "var(--text)" }}>
                   Heading Three
                 </p>
-                <p style={{ color: "var(--text)", fontSize: 15, lineHeight: 1.6 }}>
+                <p
+                  style={{ color: "var(--text)", fontSize: 15, lineHeight: 1.6 }}
+                >
                   Body text — The quick brown fox jumps over the lazy dog. Pack
                   my box with five dozen liquor jugs.
                 </p>
-                <p style={{ color: "var(--text-muted)", fontSize: 14, lineHeight: 1.6 }}>
+                <p
+                  style={{
+                    color: "var(--text-muted)",
+                    fontSize: 14,
+                    lineHeight: 1.6,
+                  }}
+                >
                   Muted body — Secondary descriptions and helper text appear
                   here, blended toward the background.
                 </p>
-                <p style={{ color: "var(--text-dim)", fontSize: 13, lineHeight: 1.6 }}>
+                <p
+                  style={{
+                    color: "var(--text-dim)",
+                    fontSize: 13,
+                    lineHeight: 1.6,
+                  }}
+                >
                   Dimmed caption — Timestamps, metadata, and low-priority labels
                   rendered at reduced opacity.
                 </p>
               </div>
             </div>
 
-            <div className={styles.typoCard}>
+            <div className={styles.cmCard}>
               <h3 className={styles.typoCardTitle}>Monospace — Code Font</h3>
-              <div className={styles.typoSamples} style={{ fontFamily: "var(--font-mono)" }}>
-                <p style={{ color: "var(--text)", fontSize: 14, lineHeight: 1.8 }}>
+              <pre className={styles.codeBlock}>
+                <code>
                   <span style={{ color: "var(--theme-primary)" }}>def </span>
                   <span style={{ color: "var(--text-complementary)" }}>fibonacci</span>
                   <span style={{ color: "var(--text)" }}>(</span>
                   <span style={{ color: "var(--text-soft)" }}>n: int</span>
-                  <span style={{ color: "var(--text)" }}>) -&gt; int:</span>
-                </p>
-                <p style={{ color: "var(--text-muted)", fontSize: 14, lineHeight: 1.8 }}>
-                  &nbsp;&nbsp;<span style={{ color: "var(--text-dim)" }}># base cases</span>
-                </p>
-                <p style={{ color: "var(--text)", fontSize: 14, lineHeight: 1.8 }}>
-                  &nbsp;&nbsp;<span style={{ color: "var(--theme-primary)" }}>if </span>
-                  <span style={{ color: "var(--text)" }}>n &lt;= 1: </span>
-                  <span style={{ color: "var(--theme-primary)" }}>return </span>
-                  <span style={{ color: "var(--text-accent)" }}>n</span>
-                </p>
-                <p style={{ color: "var(--text)", fontSize: 14, lineHeight: 1.8 }}>
-                  &nbsp;&nbsp;<span style={{ color: "var(--theme-primary)" }}>return </span>
+                  <span style={{ color: "var(--text)" }}>) -&gt; int:{"\n"}</span>
+                  <span style={{ color: "var(--text-dim)" }}>{"    "}"""Return the nth Fibonacci number."""{"\n"}</span>
+                  {"    "}<span style={{ color: "var(--theme-primary)" }}>if </span>
+                  <span style={{ color: "var(--text)" }}>n &lt;= </span>
+                  <span style={{ color: "var(--text-accent)" }}>1</span>
+                  <span style={{ color: "var(--text)" }}>:{"\n"}</span>
+                  {"        "}<span style={{ color: "var(--theme-primary)" }}>return </span>
+                  <span style={{ color: "var(--text-accent)" }}>n{"\n"}</span>
+                  {"    "}<span style={{ color: "var(--theme-primary)" }}>return </span>
                   <span style={{ color: "var(--text-complementary)" }}>fibonacci</span>
-                  <span style={{ color: "var(--text)" }}>(n-</span>
+                  <span style={{ color: "var(--text)" }}>(n - </span>
                   <span style={{ color: "var(--text-accent)" }}>1</span>
                   <span style={{ color: "var(--text)" }}>) + </span>
                   <span style={{ color: "var(--text-complementary)" }}>fibonacci</span>
-                  <span style={{ color: "var(--text)" }}>(n-</span>
+                  <span style={{ color: "var(--text)" }}>(n - </span>
                   <span style={{ color: "var(--text-accent)" }}>2</span>
+                  <span style={{ color: "var(--text)" }}>){"\n\n"}</span>
+                  <span style={{ color: "var(--text-dim)" }}># Compute first 10 values{"\n"}</span>
+                  <span style={{ color: "var(--text-complementary)" }}>results</span>
+                  <span style={{ color: "var(--text)" }}> = [</span>
+                  <span style={{ color: "var(--text-complementary)" }}>fibonacci</span>
+                  <span style={{ color: "var(--text)" }}>(i) </span>
+                  <span style={{ color: "var(--theme-primary)" }}>for </span>
+                  <span style={{ color: "var(--text)" }}>i </span>
+                  <span style={{ color: "var(--theme-primary)" }}>in </span>
+                  <span style={{ color: "var(--text-complementary)" }}>range</span>
+                  <span style={{ color: "var(--text)" }}>(</span>
+                  <span style={{ color: "var(--text-accent)" }}>10</span>
+                  <span style={{ color: "var(--text)" }}>)]{"\n"}</span>
+                  <span style={{ color: "var(--text-complementary)" }}>print</span>
+                  <span style={{ color: "var(--text)" }}>(</span>
+                  <span style={{ color: "var(--text-soft)" }}>f"Sequence: {"{"}</span>
+                  <span style={{ color: "var(--text-complementary)" }}>results</span>
+                  <span style={{ color: "var(--text-soft)" }}>{"}"}"</span>
                   <span style={{ color: "var(--text)" }}>)</span>
-                </p>
-                <p style={{ color: "var(--text-soft)", fontSize: 13, marginTop: 8 }}>
-                  &gt; fibonacci(10)
-                </p>
-                <p style={{ color: "var(--text-accent)", fontSize: 13 }}>
-                  55
-                </p>
-              </div>
+                </code>
+              </pre>
             </div>
           </div>
         </Section>
@@ -257,13 +344,17 @@ export default function ColorTestPage() {
             </button>
           </div>
           <div className={styles.row} style={{ marginTop: 8 }}>
-            <button className={`${styles.btn} ${styles.btnSm} ${styles.btnPrimary}`}>
+            <button
+              className={`${styles.btn} ${styles.btnSm} ${styles.btnPrimary}`}
+            >
               Small
             </button>
             <button className={`${styles.btn} ${styles.btnPrimary}`}>
               Medium
             </button>
-            <button className={`${styles.btn} ${styles.btnLg} ${styles.btnPrimary}`}>
+            <button
+              className={`${styles.btn} ${styles.btnLg} ${styles.btnPrimary}`}
+            >
               Large
             </button>
           </div>
@@ -272,9 +363,13 @@ export default function ColorTestPage() {
         {/* Badges & Tags */}
         <Section title="Badges & Tags">
           <div className={styles.row}>
-            <span className={`${styles.badge} ${styles.badgeDefault}`}>Default</span>
+            <span className={`${styles.badge} ${styles.badgeDefault}`}>
+              Default
+            </span>
             <span className={`${styles.badge} ${styles.badgeSoft}`}>Soft</span>
-            <span className={`${styles.badge} ${styles.badgeAccent}`}>Accent</span>
+            <span className={`${styles.badge} ${styles.badgeAccent}`}>
+              Accent
+            </span>
             <span className={`${styles.badge} ${styles.badgeComplementary}`}>
               Complementary
             </span>
@@ -421,7 +516,7 @@ export default function ColorTestPage() {
               <div>
                 <strong>Complementary</strong> — Highlighted state using{" "}
                 <code className={styles.inlineCode}>--text-complementary</code>{" "}
-                — the new function-color variable.
+                — the function-color variable.
               </div>
             </div>
             <div className={`${styles.alert} ${styles.alertWarning}`}>
@@ -446,7 +541,11 @@ export default function ColorTestPage() {
           <div className={styles.listGrid}>
             <nav className={styles.navList}>
               {[
-                { icon: <Terminal size={15} />, label: "Python Playground", active: true },
+                {
+                  icon: <Terminal size={15} />,
+                  label: "Python Playground",
+                  active: true,
+                },
                 { icon: <Code2 size={15} />, label: "JavaScript" },
                 { icon: <Database size={15} />, label: "SQLite" },
                 { icon: <Code2 size={15} />, label: "TypeScript" },
@@ -465,67 +564,46 @@ export default function ColorTestPage() {
                     {icon}
                   </span>
                   <span>{label}</span>
-                  <ChevronRight size={13} style={{ marginLeft: "auto", color: "var(--text-dim)" }} />
+                  <ChevronRight
+                    size={13}
+                    style={{ marginLeft: "auto", color: "var(--text-dim)" }}
+                  />
                 </div>
               ))}
             </nav>
 
             <ul className={styles.bulletList}>
               {[
-                { color: "var(--text-soft)", text: "--text-soft — muted secondary (dim slot)" },
-                { color: "var(--text-accent)", text: "--text-accent — accent (muted slot)" },
-                { color: "var(--text-complementary)", text: "--text-complementary — fn slot (new)" },
-                { color: "var(--theme-primary)", text: "--theme-primary — keyword highlight" },
+                {
+                  color: "var(--text-soft)",
+                  text: "--text-soft — muted secondary (dim slot)",
+                },
+                {
+                  color: "var(--text-accent)",
+                  text: "--text-accent — accent (muted slot)",
+                },
+                {
+                  color: "var(--text-complementary)",
+                  text: "--text-complementary — fn slot (new)",
+                },
+                {
+                  color: "var(--theme-primary)",
+                  text: "--theme-primary — keyword highlight",
+                },
               ].map(({ color, text }) => (
                 <li key={text} className={styles.bulletItem}>
-                  <Circle size={8} style={{ color, flexShrink: 0 }} fill={color} />
-                  <span style={{ fontFamily: "var(--font-mono)", fontSize: 13 }}>{text}</span>
+                  <Circle
+                    size={8}
+                    style={{ color, flexShrink: 0 }}
+                    fill={color}
+                  />
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: 13 }}>
+                    {text}
+                  </span>
                 </li>
               ))}
             </ul>
           </div>
-        </Section>
-
-        {/* Code block */}
-        <Section title="Inline & Block Code">
-          <p className={styles.prose}>
-            Use <code className={styles.inlineCode}>--text-complementary</code>{" "}
-            alongside{" "}
-            <code className={styles.inlineCode}>--text-soft</code> and{" "}
-            <code className={styles.inlineCode}>--text-accent</code> to add a
-            third distinct accent drawn straight from the active editor theme's{" "}
-            <code className={styles.inlineCode}>fn</code> color slot.
-          </p>
-          <pre className={styles.codeBlock}>
-            <code>
-              <span style={{ color: "var(--theme-primary)" }}>SELECT</span>
-              {`\n  `}
-              <span style={{ color: "var(--text-complementary)" }}>id</span>
-              {`, `}
-              <span style={{ color: "var(--text-complementary)" }}>name</span>
-              {`, `}
-              <span style={{ color: "var(--text-complementary)" }}>created_at</span>
-              {`\n`}
-              <span style={{ color: "var(--theme-primary)" }}>FROM</span>
-              {`  `}
-              <span style={{ color: "var(--text-soft)" }}>users</span>
-              {`\n`}
-              <span style={{ color: "var(--theme-primary)" }}>WHERE</span>
-              {` active = `}
-              <span style={{ color: "var(--text-accent)" }}>true</span>
-              {`\n`}
-              <span style={{ color: "var(--theme-primary)" }}>ORDER BY</span>
-              {` `}
-              <span style={{ color: "var(--text-complementary)" }}>created_at</span>
-              {` `}
-              <span style={{ color: "var(--theme-primary)" }}>DESC</span>
-              {`\n`}
-              <span style={{ color: "var(--theme-primary)" }}>LIMIT</span>
-              {`  `}
-              <span style={{ color: "var(--text-accent)" }}>100</span>
-              {`;`}
-            </code>
-          </pre>
         </Section>
       </main>
     </div>

--- a/app/color-test/page.tsx
+++ b/app/color-test/page.tsx
@@ -1,0 +1,548 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  AlertTriangle,
+  Bell,
+  Check,
+  CheckCircle2,
+  ChevronRight,
+  Circle,
+  Code2,
+  Database,
+  Info,
+  Play,
+  Search,
+  Settings,
+  Star,
+  Tag,
+  Terminal,
+  X,
+  XCircle,
+  Zap,
+} from "lucide-react";
+import {
+  ALL_THEMES,
+  LIGHT_THEMES,
+  THEME_PREVIEWS,
+  applyMode,
+  applyThemePalette,
+  getStoredEditorTheme,
+  setStoredEditorTheme,
+} from "../_components/playgroundTheme";
+import "../_components/playground.css";
+import styles from "./color-test.module.css";
+
+export default function ColorTestPage() {
+  const [activeTheme, setActiveTheme] = useState("lucario");
+
+  useEffect(() => {
+    const stored = getStoredEditorTheme();
+    const theme = stored ?? "lucario";
+    setActiveTheme(theme);
+    applyThemePalette(theme);
+    applyMode(theme);
+  }, []);
+
+  function handleThemeChange(theme: string) {
+    setActiveTheme(theme);
+    applyThemePalette(theme);
+    applyMode(theme);
+    setStoredEditorTheme(theme);
+  }
+
+  return (
+    <div className={`pg-root ${styles.root}`}>
+      {/* ── Theme switcher ── */}
+      <header className={styles.header}>
+        <div className={styles.headerInner}>
+          <h1 className={styles.pageTitle}>
+            <Zap size={20} />
+            Color Theme Test
+          </h1>
+          <p className={styles.pageSubtitle}>
+            Select a theme to preview all UI colors and elements.
+          </p>
+        </div>
+
+        <div className={styles.themeGrid}>
+          {ALL_THEMES.map(({ value, label }) => {
+            const p = THEME_PREVIEWS[value];
+            const isLight = LIGHT_THEMES.has(value);
+            return (
+              <button
+                key={value}
+                className={`${styles.themeCard} ${activeTheme === value ? styles.themeCardActive : ""}`}
+                onClick={() => handleThemeChange(value)}
+                title={label}
+              >
+                <div
+                  className={styles.themePreview}
+                  style={{ background: p.bg, borderColor: p.border }}
+                >
+                  <span
+                    className={styles.dot}
+                    style={{ background: p.kw }}
+                  />
+                  <span
+                    className={styles.dot}
+                    style={{ background: p.fn }}
+                  />
+                  <span
+                    className={styles.dot}
+                    style={{ background: p.str }}
+                  />
+                  {activeTheme === value && (
+                    <Check
+                      size={10}
+                      className={styles.activeCheck}
+                      style={{ color: isLight ? "#000" : "#fff" }}
+                    />
+                  )}
+                </div>
+                <span className={styles.themeLabel}>{label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </header>
+
+      {/* ── Content ── */}
+      <main className={styles.content}>
+        {/* Color swatches */}
+        <Section title="Color Variables">
+          <div className={styles.swatchGrid}>
+            {[
+              { name: "--bg", label: "Background" },
+              { name: "--bg2", label: "Background 2" },
+              { name: "--bg3", label: "Background 3" },
+              { name: "--border", label: "Border", text: true },
+              { name: "--text", label: "Text", onBg: true },
+              { name: "--text-muted", label: "Text Muted", onBg: true },
+              { name: "--text-dim", label: "Text Dim", onBg: true },
+              { name: "--text-soft", label: "Text Soft", onBg: true },
+              { name: "--text-accent", label: "Text Accent", onBg: true },
+              {
+                name: "--text-complementary",
+                label: "Text Complementary",
+                onBg: true,
+                highlight: true,
+              },
+              { name: "--theme-primary", label: "Theme Primary", onBg: true },
+              { name: "--primary", label: "Primary" },
+              { name: "--blue", label: "Blue" },
+              { name: "--green", label: "Green" },
+              { name: "--red", label: "Red" },
+              { name: "--yellow", label: "Yellow" },
+            ].map(({ name, label, onBg, highlight }) => (
+              <div
+                key={name}
+                className={`${styles.swatch} ${highlight ? styles.swatchHighlight : ""}`}
+              >
+                <div
+                  className={styles.swatchColor}
+                  style={{
+                    background: onBg ? "var(--bg)" : `var(${name})`,
+                    borderColor: "var(--border)",
+                  }}
+                >
+                  {onBg ? (
+                    <span
+                      className={styles.swatchSample}
+                      style={{ color: `var(${name})` }}
+                    >
+                      Aa
+                    </span>
+                  ) : null}
+                </div>
+                <span className={styles.swatchName}>{name}</span>
+                <span className={styles.swatchLabel}>{label}</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* Typography */}
+        <Section title="Typography">
+          <div className={styles.typoGrid}>
+            <div className={styles.typoCard}>
+              <h3 className={styles.typoCardTitle}>Sans-serif — UI Font</h3>
+              <div className={styles.typoSamples} style={{ fontFamily: "var(--font-ui)" }}>
+                <p className={styles.typoH1} style={{ color: "var(--text)" }}>
+                  Heading One
+                </p>
+                <p className={styles.typoH2} style={{ color: "var(--text)" }}>
+                  Heading Two
+                </p>
+                <p className={styles.typoH3} style={{ color: "var(--text)" }}>
+                  Heading Three
+                </p>
+                <p style={{ color: "var(--text)", fontSize: 15, lineHeight: 1.6 }}>
+                  Body text — The quick brown fox jumps over the lazy dog. Pack
+                  my box with five dozen liquor jugs.
+                </p>
+                <p style={{ color: "var(--text-muted)", fontSize: 14, lineHeight: 1.6 }}>
+                  Muted body — Secondary descriptions and helper text appear
+                  here, blended toward the background.
+                </p>
+                <p style={{ color: "var(--text-dim)", fontSize: 13, lineHeight: 1.6 }}>
+                  Dimmed caption — Timestamps, metadata, and low-priority labels
+                  rendered at reduced opacity.
+                </p>
+              </div>
+            </div>
+
+            <div className={styles.typoCard}>
+              <h3 className={styles.typoCardTitle}>Monospace — Code Font</h3>
+              <div className={styles.typoSamples} style={{ fontFamily: "var(--font-mono)" }}>
+                <p style={{ color: "var(--text)", fontSize: 14, lineHeight: 1.8 }}>
+                  <span style={{ color: "var(--theme-primary)" }}>def </span>
+                  <span style={{ color: "var(--text-complementary)" }}>fibonacci</span>
+                  <span style={{ color: "var(--text)" }}>(</span>
+                  <span style={{ color: "var(--text-soft)" }}>n: int</span>
+                  <span style={{ color: "var(--text)" }}>) -&gt; int:</span>
+                </p>
+                <p style={{ color: "var(--text-muted)", fontSize: 14, lineHeight: 1.8 }}>
+                  &nbsp;&nbsp;<span style={{ color: "var(--text-dim)" }}># base cases</span>
+                </p>
+                <p style={{ color: "var(--text)", fontSize: 14, lineHeight: 1.8 }}>
+                  &nbsp;&nbsp;<span style={{ color: "var(--theme-primary)" }}>if </span>
+                  <span style={{ color: "var(--text)" }}>n &lt;= 1: </span>
+                  <span style={{ color: "var(--theme-primary)" }}>return </span>
+                  <span style={{ color: "var(--text-accent)" }}>n</span>
+                </p>
+                <p style={{ color: "var(--text)", fontSize: 14, lineHeight: 1.8 }}>
+                  &nbsp;&nbsp;<span style={{ color: "var(--theme-primary)" }}>return </span>
+                  <span style={{ color: "var(--text-complementary)" }}>fibonacci</span>
+                  <span style={{ color: "var(--text)" }}>(n-</span>
+                  <span style={{ color: "var(--text-accent)" }}>1</span>
+                  <span style={{ color: "var(--text)" }}>) + </span>
+                  <span style={{ color: "var(--text-complementary)" }}>fibonacci</span>
+                  <span style={{ color: "var(--text)" }}>(n-</span>
+                  <span style={{ color: "var(--text-accent)" }}>2</span>
+                  <span style={{ color: "var(--text)" }}>)</span>
+                </p>
+                <p style={{ color: "var(--text-soft)", fontSize: 13, marginTop: 8 }}>
+                  &gt; fibonacci(10)
+                </p>
+                <p style={{ color: "var(--text-accent)", fontSize: 13 }}>
+                  55
+                </p>
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        {/* Buttons */}
+        <Section title="Buttons">
+          <div className={styles.row}>
+            <button className={`${styles.btn} ${styles.btnPrimary}`}>
+              <Play size={14} />
+              Run
+            </button>
+            <button className={`${styles.btn} ${styles.btnSecondary}`}>
+              <Settings size={14} />
+              Settings
+            </button>
+            <button className={`${styles.btn} ${styles.btnGhost}`}>
+              <Search size={14} />
+              Search
+            </button>
+            <button className={`${styles.btn} ${styles.btnDanger}`}>
+              <X size={14} />
+              Clear
+            </button>
+            <button className={`${styles.btn} ${styles.btnPrimary}`} disabled>
+              Disabled
+            </button>
+          </div>
+          <div className={styles.row} style={{ marginTop: 8 }}>
+            <button className={`${styles.btn} ${styles.btnSm} ${styles.btnPrimary}`}>
+              Small
+            </button>
+            <button className={`${styles.btn} ${styles.btnPrimary}`}>
+              Medium
+            </button>
+            <button className={`${styles.btn} ${styles.btnLg} ${styles.btnPrimary}`}>
+              Large
+            </button>
+          </div>
+        </Section>
+
+        {/* Badges & Tags */}
+        <Section title="Badges & Tags">
+          <div className={styles.row}>
+            <span className={`${styles.badge} ${styles.badgeDefault}`}>Default</span>
+            <span className={`${styles.badge} ${styles.badgeSoft}`}>Soft</span>
+            <span className={`${styles.badge} ${styles.badgeAccent}`}>Accent</span>
+            <span className={`${styles.badge} ${styles.badgeComplementary}`}>
+              Complementary
+            </span>
+            <span className={`${styles.badge} ${styles.badgeSuccess}`}>
+              <Check size={10} />
+              Success
+            </span>
+            <span className={`${styles.badge} ${styles.badgeWarning}`}>
+              <AlertTriangle size={10} />
+              Warning
+            </span>
+            <span className={`${styles.badge} ${styles.badgeError}`}>
+              <X size={10} />
+              Error
+            </span>
+          </div>
+          <div className={styles.row} style={{ marginTop: 8 }}>
+            <span className={styles.tag}>
+              <Tag size={11} />
+              python
+            </span>
+            <span className={styles.tag}>
+              <Tag size={11} />
+              sql
+            </span>
+            <span className={styles.tag}>
+              <Tag size={11} />
+              data-science
+            </span>
+            <span className={`${styles.tag} ${styles.tagAccent}`}>
+              <Star size={11} />
+              featured
+            </span>
+          </div>
+        </Section>
+
+        {/* Icons */}
+        <Section title="Icons">
+          <div className={styles.iconGrid}>
+            {[
+              { icon: <Play size={20} />, label: "Play" },
+              { icon: <Terminal size={20} />, label: "Terminal" },
+              { icon: <Code2 size={20} />, label: "Code" },
+              { icon: <Database size={20} />, label: "Database" },
+              { icon: <Settings size={20} />, label: "Settings" },
+              { icon: <Search size={20} />, label: "Search" },
+              { icon: <Bell size={20} />, label: "Bell" },
+              { icon: <Star size={20} />, label: "Star" },
+              { icon: <Info size={20} />, label: "Info" },
+              { icon: <AlertTriangle size={20} />, label: "Warning" },
+              { icon: <CheckCircle2 size={20} />, label: "Success" },
+              { icon: <XCircle size={20} />, label: "Error" },
+            ].map(({ icon, label }, i) => (
+              <div key={label} className={styles.iconItem}>
+                <div
+                  className={styles.iconBox}
+                  style={{
+                    color: [
+                      "var(--text)",
+                      "var(--text-muted)",
+                      "var(--text-soft)",
+                      "var(--text-accent)",
+                      "var(--text-complementary)",
+                      "var(--theme-primary)",
+                      "var(--text-dim)",
+                      "var(--yellow)",
+                      "var(--blue)",
+                      "var(--yellow)",
+                      "var(--green)",
+                      "var(--red)",
+                    ][i],
+                  }}
+                >
+                  {icon}
+                </div>
+                <span className={styles.iconLabel}>{label}</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* Form elements */}
+        <Section title="Form Elements">
+          <div className={styles.formGrid}>
+            <div className={styles.formField}>
+              <label className={styles.label}>Text Input</label>
+              <input
+                className={styles.input}
+                type="text"
+                placeholder="Enter a value…"
+                defaultValue=""
+              />
+            </div>
+            <div className={styles.formField}>
+              <label className={styles.label}>Select</label>
+              <select className={styles.select}>
+                <option>Python</option>
+                <option>JavaScript</option>
+                <option>SQL</option>
+              </select>
+            </div>
+            <div className={styles.formField}>
+              <label className={styles.label}>Textarea</label>
+              <textarea
+                className={styles.textarea}
+                rows={3}
+                placeholder="Multi-line input…"
+              />
+            </div>
+            <div className={styles.formField}>
+              <label className={styles.label}>Search</label>
+              <div className={styles.inputIcon}>
+                <Search size={14} className={styles.inputIconEl} />
+                <input
+                  className={`${styles.input} ${styles.inputWithIcon}`}
+                  type="search"
+                  placeholder="Search tables…"
+                />
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        {/* Alerts / Callouts */}
+        <Section title="Alerts & Callouts">
+          <div className={styles.alertStack}>
+            <div className={`${styles.alert} ${styles.alertInfo}`}>
+              <Info size={16} />
+              <div>
+                <strong>Info</strong> — This is an informational message using{" "}
+                <code className={styles.inlineCode}>--text-soft</code> for the
+                icon and border accent.
+              </div>
+            </div>
+            <div className={`${styles.alert} ${styles.alertSuccess}`}>
+              <CheckCircle2 size={16} />
+              <div>
+                <strong>Success</strong> — Operation completed using{" "}
+                <code className={styles.inlineCode}>--text-accent</code> tones.
+              </div>
+            </div>
+            <div className={`${styles.alert} ${styles.alertComplementary}`}>
+              <Zap size={16} />
+              <div>
+                <strong>Complementary</strong> — Highlighted state using{" "}
+                <code className={styles.inlineCode}>--text-complementary</code>{" "}
+                — the new function-color variable.
+              </div>
+            </div>
+            <div className={`${styles.alert} ${styles.alertWarning}`}>
+              <AlertTriangle size={16} />
+              <div>
+                <strong>Warning</strong> — Caution state using{" "}
+                <code className={styles.inlineCode}>--yellow</code>.
+              </div>
+            </div>
+            <div className={`${styles.alert} ${styles.alertError}`}>
+              <XCircle size={16} />
+              <div>
+                <strong>Error</strong> — Destructive state using{" "}
+                <code className={styles.inlineCode}>--red</code>.
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        {/* List / Navigation */}
+        <Section title="Lists & Navigation">
+          <div className={styles.listGrid}>
+            <nav className={styles.navList}>
+              {[
+                { icon: <Terminal size={15} />, label: "Python Playground", active: true },
+                { icon: <Code2 size={15} />, label: "JavaScript" },
+                { icon: <Database size={15} />, label: "SQLite" },
+                { icon: <Code2 size={15} />, label: "TypeScript" },
+              ].map(({ icon, label, active }) => (
+                <div
+                  key={label}
+                  className={`${styles.navItem} ${active ? styles.navItemActive : ""}`}
+                >
+                  <span
+                    style={{
+                      color: active
+                        ? "var(--text-complementary)"
+                        : "var(--text-soft)",
+                    }}
+                  >
+                    {icon}
+                  </span>
+                  <span>{label}</span>
+                  <ChevronRight size={13} style={{ marginLeft: "auto", color: "var(--text-dim)" }} />
+                </div>
+              ))}
+            </nav>
+
+            <ul className={styles.bulletList}>
+              {[
+                { color: "var(--text-soft)", text: "--text-soft — muted secondary (dim slot)" },
+                { color: "var(--text-accent)", text: "--text-accent — accent (muted slot)" },
+                { color: "var(--text-complementary)", text: "--text-complementary — fn slot (new)" },
+                { color: "var(--theme-primary)", text: "--theme-primary — keyword highlight" },
+              ].map(({ color, text }) => (
+                <li key={text} className={styles.bulletItem}>
+                  <Circle size={8} style={{ color, flexShrink: 0 }} fill={color} />
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: 13 }}>{text}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Section>
+
+        {/* Code block */}
+        <Section title="Inline & Block Code">
+          <p className={styles.prose}>
+            Use <code className={styles.inlineCode}>--text-complementary</code>{" "}
+            alongside{" "}
+            <code className={styles.inlineCode}>--text-soft</code> and{" "}
+            <code className={styles.inlineCode}>--text-accent</code> to add a
+            third distinct accent drawn straight from the active editor theme's{" "}
+            <code className={styles.inlineCode}>fn</code> color slot.
+          </p>
+          <pre className={styles.codeBlock}>
+            <code>
+              <span style={{ color: "var(--theme-primary)" }}>SELECT</span>
+              {`\n  `}
+              <span style={{ color: "var(--text-complementary)" }}>id</span>
+              {`, `}
+              <span style={{ color: "var(--text-complementary)" }}>name</span>
+              {`, `}
+              <span style={{ color: "var(--text-complementary)" }}>created_at</span>
+              {`\n`}
+              <span style={{ color: "var(--theme-primary)" }}>FROM</span>
+              {`  `}
+              <span style={{ color: "var(--text-soft)" }}>users</span>
+              {`\n`}
+              <span style={{ color: "var(--theme-primary)" }}>WHERE</span>
+              {` active = `}
+              <span style={{ color: "var(--text-accent)" }}>true</span>
+              {`\n`}
+              <span style={{ color: "var(--theme-primary)" }}>ORDER BY</span>
+              {` `}
+              <span style={{ color: "var(--text-complementary)" }}>created_at</span>
+              {` `}
+              <span style={{ color: "var(--theme-primary)" }}>DESC</span>
+              {`\n`}
+              <span style={{ color: "var(--theme-primary)" }}>LIMIT</span>
+              {`  `}
+              <span style={{ color: "var(--text-accent)" }}>100</span>
+              {`;`}
+            </code>
+          </pre>
+        </Section>
+      </main>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.sectionTitle}>{title}</h2>
+      {children}
+    </section>
+  );
+}

--- a/app/color-test/page.tsx
+++ b/app/color-test/page.tsx
@@ -34,7 +34,14 @@ import {
 import "../_components/playground.css";
 import styles from "./color-test.module.css";
 
-const SWATCH_DEFS = [
+interface SwatchDef {
+  name: string;
+  label: string;
+  isTextColor?: boolean;
+  highlight?: boolean;
+}
+
+const SWATCH_DEFS: SwatchDef[] = [
   { name: "--bg", label: "Background" },
   { name: "--bg2", label: "Background 2" },
   { name: "--bg3", label: "Background 3" },
@@ -56,7 +63,7 @@ const SWATCH_DEFS = [
   { name: "--green", label: "Green" },
   { name: "--red", label: "Red" },
   { name: "--yellow", label: "Yellow" },
-] as const;
+];
 
 function resolveCssVarToHex(varName: string): string {
   const el = document.createElement("div");

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,15 +27,15 @@ const themeBootstrapScript = `
     // editor's comments and atoms) and DO need to be set inline so the
     // first paint matches the persisted theme.
     var palettes = {
-      "dracula":         {bg:"#282a36",bg2:"#21222c",bg3:"#343746",border:"#44475a",text:"#f8f8f2",soft:"#6272a4",accent:"#bd93f9"},
-      "monokai":         {bg:"#272822",bg2:"#1e1f1c",bg3:"#3e3d32",border:"#49483e",text:"#f8f8f2",soft:"#75715e",accent:"#ae81ff"},
-      "material-darker": {bg:"#212121",bg2:"#1a1a1a",bg3:"#2d2d2d",border:"#3d3d3d",text:"#eeffff",soft:"#546e7a",accent:"#82aaff"},
-      "nord":            {bg:"#2e3440",bg2:"#272c36",bg3:"#3b4252",border:"#434c5e",text:"#d8dee9",soft:"#4c566a",accent:"#88c0d0"},
-      "tomorrow-night-eighties":{bg:"#2d2d2d",bg2:"#252525",bg3:"#393939",border:"#515151",text:"#cccccc",soft:"#777777",accent:"#cc99cc"},
-      "solarized dark":  {bg:"#002b36",bg2:"#00212b",bg3:"#073642",border:"#094b5a",text:"#839496",soft:"#586e75",accent:"#657b83"},
-      "solarized light": {bg:"#fdf6e3",bg2:"#eee8d5",bg3:"#f5efdc",border:"#ddd6c0",text:"#657b83",soft:"#93a1a1",accent:"#586e75"},
-      "eclipse":         {bg:"#ffffff",bg2:"#f5f5f5",bg3:"#ebebeb",border:"#d8d8d8",text:"#1a1a1a",soft:"#aaaaaa",accent:"#555555"},
-      "mdn-like":        {bg:"#ffffff",bg2:"#f9f9fb",bg3:"#f0f0f4",border:"#dcdce0",text:"#333333",soft:"#aaaaaa",accent:"#666666"}
+      "dracula":         {bg:"#282a36",bg2:"#21222c",bg3:"#343746",border:"#44475a",text:"#f8f8f2",soft:"#6272a4",accent:"#bd93f9",complementary:"#50fa7b"},
+      "monokai":         {bg:"#272822",bg2:"#1e1f1c",bg3:"#3e3d32",border:"#49483e",text:"#f8f8f2",soft:"#75715e",accent:"#ae81ff",complementary:"#a6e22e"},
+      "material-darker": {bg:"#212121",bg2:"#1a1a1a",bg3:"#2d2d2d",border:"#3d3d3d",text:"#eeffff",soft:"#546e7a",accent:"#82aaff",complementary:"#82aaff"},
+      "nord":            {bg:"#2e3440",bg2:"#272c36",bg3:"#3b4252",border:"#434c5e",text:"#d8dee9",soft:"#4c566a",accent:"#88c0d0",complementary:"#88c0d0"},
+      "tomorrow-night-eighties":{bg:"#2d2d2d",bg2:"#252525",bg3:"#393939",border:"#515151",text:"#cccccc",soft:"#777777",accent:"#cc99cc",complementary:"#6699cc"},
+      "solarized dark":  {bg:"#002b36",bg2:"#00212b",bg3:"#073642",border:"#094b5a",text:"#839496",soft:"#586e75",accent:"#657b83",complementary:"#268bd2"},
+      "solarized light": {bg:"#fdf6e3",bg2:"#eee8d5",bg3:"#f5efdc",border:"#ddd6c0",text:"#657b83",soft:"#93a1a1",accent:"#586e75",complementary:"#268bd2"},
+      "eclipse":         {bg:"#ffffff",bg2:"#f5f5f5",bg3:"#ebebeb",border:"#d8d8d8",text:"#1a1a1a",soft:"#aaaaaa",accent:"#555555",complementary:"#0000c0"},
+      "mdn-like":        {bg:"#ffffff",bg2:"#f9f9fb",bg3:"#f0f0f4",border:"#dcdce0",text:"#333333",soft:"#aaaaaa",accent:"#666666",complementary:"#005cc5"}
     };
     var lightThemes = {"eclipse":1,"mdn-like":1,"solarized light":1};
     if (!/^\/playground(?:\/|$)/.test(location.pathname)) return;
@@ -50,6 +50,7 @@ const themeBootstrapScript = `
     r.style.setProperty("--text", p.text);
     r.style.setProperty("--text-soft", p.soft);
     r.style.setProperty("--text-accent", p.accent);
+    r.style.setProperty("--text-complementary", p.complementary);
     r.setAttribute("data-theme", lightThemes[theme] ? "light" : "dark");
   } catch (e) { /* localStorage unavailable — fall back to default theme */ }
 })();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,6 +38,9 @@ export default function Home() {
           <Link href="/playground" className={styles.ctaSecondary}>
             Open the Playground
           </Link>
+          <Link href="/color-test" className={styles.ctaSecondary}>
+            Color Theme Test
+          </Link>
           <a
             href="https://github.com/subwaymatch/dataslope-playground/"
             target="_blank"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **New CSS variable `--text-complementary`** — maps to each theme's `fn` (function-highlight) color slot, giving a third distinct palette accent alongside the existing `--text-soft` (dim slot) and `--text-accent` (muted slot). Default fallback in `playground.css` is `oklch(75% 0.20 85)` (warm gold).
- **Updated `applyThemePalette`** in `playgroundTheme.ts` to write `--text-complementary` on theme switch, and `clearThemePalette` to remove it.
- **Updated FOUC-prevention bootstrap** in `layout.tsx` — each palette entry in the inline script gains a `complementary` field (the theme's `fn` color) so the variable is set synchronously before React hydrates.
- **New `/color-test` route** (`app/color-test/page.tsx` + `color-test.module.css`) — a standalone test page with:
  - Sticky **theme switcher** showing all 19 themes as color-dot preview cards; clicking one applies the theme live
  - **Color variable swatches** for every `--bg*`, `--text*`, `--border`, and semantic colors; `--text-complementary` is highlighted with an outline
  - **Typography specimens** — sans-serif (Inter) headings + body text and a monospace (JetBrains Mono) syntax-highlighted code snippet using the new variable for function names
  - **Buttons** — primary (uses `--text-complementary`), secondary, ghost, danger, disabled; three sizes
  - **Badges & tags** — default, soft, accent, complementary, success, warning, error variants
  - **Icons** — 12 lucide-react icons each tinted with a different CSS variable
  - **Form inputs** — text input, select, textarea, icon-search input; focus ring uses `--text-complementary`
  - **Alerts / callouts** — info, success, complementary, warning, error with left-border accent
  - **Navigation list** — active item highlighted with `--text-complementary` tint
  - **Code block** — SQL snippet with all token colors driven by CSS custom properties

## Test plan

- [ ] Visit `/color-test` — page renders with Lucario theme active by default
- [ ] Click through all 19 theme cards; verify every section repaints instantly (background, text, buttons, badges, alerts, code tokens)
- [ ] Confirm light themes (Eclipse, MDN-like, Solarized Light, IntelliJ IDEA, Base16 Light) invert the UI correctly
- [ ] Verify `--text-complementary` swatch card has an outline and shows the `fn` color for the active theme
- [ ] Verify selected theme persists across a page reload (stored in `localStorage`)
- [ ] In an existing playground (e.g. `/playground/python`), switch themes via the Settings panel — confirm the playground still retints normally and `--text-complementary` is set alongside the other variables

https://claude.ai/code/session_0174xwYbmsJ24yhE11ef4K1A
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0174xwYbmsJ24yhE11ef4K1A)_