### PR TITLE
Simplify query history design and fix ER diagram height

### DIFF
--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -3013,6 +3013,14 @@
   grid-template-rows: auto 0 0 1fr;
 }
 
+/* ER-diagram and query-history modes: collapse rows 3 & 4 and give the
+   content row all available space. These must come after .postgres-panes
+   to win the specificity tie (same as --view-data above). */
+.postgres-panes.sql-panes--er-diagram,
+.postgres-panes.sql-panes--query-history {
+  grid-template-rows: auto 1fr 0 0;
+}
+
 /* ─── Postgres View Structure drawer ───────────────────────────────── */
 .sql-modify-col-type-cell {
   white-space: nowrap;
@@ -3179,7 +3187,6 @@
 
 /* ─── Individual history entry ─── */
 .sql-history-entry {
-  border: 1px solid var(--border);
   border-radius: 6px;
   overflow: hidden;
   background: var(--bg2);
@@ -3201,7 +3208,6 @@
   font-family: var(--font-ui);
   font-size: 11px;
   background: var(--bg3);
-  border-bottom: 1px solid var(--border);
   flex-wrap: wrap;
 }
 
@@ -3245,10 +3251,7 @@
 .sql-history-entry-elapsed {
   font-size: 11px;
   font-family: var(--font-mono, monospace);
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  padding: 0 5px;
+  color: var(--text-dim);
 }
 
 .sql-history-entry-error {
@@ -3257,7 +3260,6 @@
   font-size: 11px;
   color: var(--err-accent, #ef4444);
   background: color-mix(in srgb, var(--err-accent, #ef4444) 8%, transparent);
-  border-bottom: 1px solid var(--border);
   word-break: break-word;
 }
 
@@ -3269,4 +3271,14 @@
 .sql-history-entry-editor .cm-editor {
   max-height: 200px;
   overflow-y: auto;
+}
+
+/* Read-only history editors: suppress the active-line highlight that
+   appears when a line is clicked. */
+.sql-history-entry-editor .cm-activeLineMarker {
+  background-color: transparent !important;
+}
+
+.sql-history-entry-editor .cm-activeLineGutter {
+  background-color: transparent !important;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Query history – fewer borders**: Removed the outer card border and all internal section borders (header bottom, error bottom). Only the left status-accent stripe and the `var(--bg2)` fill remain, giving a cleaner look. Also stripped the badge border/background from the elapsed-time chip.
- **Query history – no active-line highlight**: Added CSS to suppress `cm-activeLineMarker` and `cm-activeLineGutter` inside `.sql-history-entry-editor` so clicking a line in a read-only CodeMirror block no longer shows a highlight rectangle.
- **ER diagram height (Postgres)**: `.postgres-panes` was declared after `.sql-panes--er-diagram` in the stylesheet, so it won the specificity tie and kept the default `0.55fr / 6px / 1.45fr` row template, confining the diagram to the small editor track. Added `.postgres-panes.sql-panes--er-diagram` and `.postgres-panes.sql-panes--query-history` rules (mirroring the existing `--view-data` fix) so both tabs now get `auto 1fr 0 0` and fill all available vertical space.

## Test plan

- [ ] Open the SQLite playground → Query History tab: verify cards have no outer border, no divider between header and code block, and elapsed time shows as plain text
- [ ] Click a line in a read-only history code block: verify no highlight appears
- [ ] Open the Postgres playground → ER Diagram tab: verify the diagram fills the full height below the tab bar
- [ ] Open the Postgres playground → Query History tab: verify same full-height behaviour
- [ ] Confirm normal query tabs (editor + results pane) still resize correctly

https://claude.ai/code/session_01JpG3cmonr9UPxd5dTREcci
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpG3cmonr9UPxd5dTREcci)_