### PR TITLE
Fix Postgres data-type combobox: add chevron trigger and proper Base UI structure

### DIFF
--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -412,32 +412,37 @@ function PgTypeSelector({
       openOnInputClick
       autoHighlight
     >
-      <Combobox.Input
-        className="sql-rename-input sql-modify-col-type pg-type-input"
-        placeholder="e.g. varchar(255)"
-        aria-label="Column type"
-        onBlur={() => {
-          const typed = inputVal.trim();
-          let finalVal: string;
-          if (
-            PG_TYPE_OPTIONS.includes(value) &&
-            !PG_TYPE_OPTIONS.includes(typed) &&
-            !PG_TYPE_VALIDATION_REGEX.test(typed)
-          ) {
-            // Original was a known type; typed value is neither a known type
-            // nor a valid custom type (e.g. varchar(255)) → revert.
-            finalVal = value;
-          } else {
-            finalVal = typed || value;
-            if (finalVal !== value) onChange(finalVal);
-          }
-          blurLockRef.current = finalVal;
-          setInputVal(finalVal);
-          setTimeout(() => {
-            blurLockRef.current = null;
-          }, 100);
-        }}
-      />
+      <div className="pg-type-input-group">
+        <Combobox.Input
+          className="sql-rename-input sql-modify-col-type pg-type-input"
+          placeholder="e.g. varchar(255)"
+          aria-label="Column type"
+          onBlur={() => {
+            const typed = inputVal.trim();
+            let finalVal: string;
+            if (
+              PG_TYPE_OPTIONS.includes(value) &&
+              !PG_TYPE_OPTIONS.includes(typed) &&
+              !PG_TYPE_VALIDATION_REGEX.test(typed)
+            ) {
+              // Original was a known type; typed value is neither a known type
+              // nor a valid custom type (e.g. varchar(255)) → revert.
+              finalVal = value;
+            } else {
+              finalVal = typed || value;
+              if (finalVal !== value) onChange(finalVal);
+            }
+            blurLockRef.current = finalVal;
+            setInputVal(finalVal);
+            setTimeout(() => {
+              blurLockRef.current = null;
+            }, 100);
+          }}
+        />
+        <Combobox.Trigger className="pg-type-trigger" aria-label="Open type list">
+          <ChevronDown size={14} />
+        </Combobox.Trigger>
+      </div>
       <Combobox.Portal>
         <Combobox.Positioner sideOffset={4} align="start" className="pg-type-positioner">
           <Combobox.Popup className="bui-select-popup pg-type-popup">

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -3129,7 +3129,9 @@
 }
 
 .pg-type-positioner {
-  z-index: 80;
+  /* Must sit above .sql-modify-drawer (z-index: 401) since the popup is
+     portaled to the body and would otherwise render behind the drawer. */
+  z-index: 500;
 }
 
 .pg-type-popup {

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -3080,9 +3080,52 @@
   color: var(--text-dim);
 }
 
-.pg-type-input {
-  min-width: 160px;
+.pg-type-input-group {
+  position: relative;
+  display: flex;
+  align-items: center;
   width: 100%;
+  min-width: 160px;
+}
+
+.pg-type-input {
+  min-width: 0;
+  width: 100%;
+  padding-right: 26px;
+}
+
+.pg-type-trigger {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: 0;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  outline: none;
+}
+
+.pg-type-trigger:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+.pg-type-trigger:focus-visible {
+  box-shadow: 0 0 0 2px var(--primary-glow);
+}
+
+.pg-type-trigger[data-popup-open] svg {
+  transform: rotate(180deg);
+}
+
+.pg-type-trigger svg {
+  transition: transform 0.15s ease;
 }
 
 .pg-type-positioner {


### PR DESCRIPTION
## Summary

The data-type combobox in the Postgres playground's "View/Edit Structure" drawer was rendering as a plain text input — no chevron icon and no obvious affordance to open the popup. Cause: `PgTypeSelector` only rendered `Combobox.Input` without a sibling `Combobox.Trigger`, so the field looked identical to a regular `<input>`.

This change matches the standard Base UI Combobox pattern (the "Choose a fruit" reference): a flex wrapper containing the typable input plus a chevron trigger button on the right.

## Changes

- `app/_components/postgres/PostgresPlayground.tsx` — wrap `Combobox.Input` and a new `Combobox.Trigger` (with a `ChevronDown` icon from `lucide-react`) inside a `pg-type-input-group` flex container. (Note: this version of `@base-ui-components/react` doesn't export `Combobox.InputGroup`, so a plain div is used.)
- `app/_components/sqlPlayground.css` — add styles for `.pg-type-input-group` (relative flex container), `.pg-type-trigger` (absolutely-positioned chevron button with hover/focus states), and a chevron rotation when `[data-popup-open]` is set on the trigger. Also adds `padding-right` on `.pg-type-input` so the typed value doesn't sit underneath the chevron.

## Test plan

- [ ] Open the Postgres playground → "View/Edit Structure" drawer
- [ ] Confirm each row's Type cell now shows a chevron icon on the right
- [ ] Click the chevron → popup opens with grouped types (Numbers, Text, …)
- [ ] Click into the input and type "var" → list filters to varchar/varchar(255)
- [ ] Pick a type → value commits to the row
- [ ] Type a custom parameterized type like `numeric(12,4)`, blur → value preserved (not reverted)
- [ ] Type a known type like `integer`, blur → value preserved
- [ ] Tab key navigates focus into and out of the trigger

https://claude.ai/code/session_01ARWEGLbNfnW9TQ9cUvHbWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARWEGLbNfnW9TQ9cUvHbWQ)_