### PR TITLE
Fix SQL result table cell input overflowing cell boundary

### DIFF
--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -2509,6 +2509,7 @@
 
 /* ─── Inline cell editor ─── */
 .sql-cell-input {
+  box-sizing: border-box;
   width: 100%;
   min-width: 60px;
   background: var(--bg2);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `box-sizing: border-box` to `.sql-cell-input` in `sqlPlayground.css`
- Without it, `width: 100%` on the input excluded the border (1px) and padding (2px 5px) from the width calculation, causing the input to be wider than the cell and shifting the table layout on double-click
- With `border-box` sizing, the input's total width — including border and padding — stays within the `td` content area

## Test plan

- [ ] Open a SQL playground with a result table
- [ ] Double-click a cell to enter edit mode
- [ ] Verify the input stays within the cell boundary with no layout shift
- [ ] Verify the input focus ring (box-shadow) appears correctly
- [ ] Test with narrow columns to confirm `min-width: 60px` still applies

https://claude.ai/code/session_01JeT6juy6my5sDenjWCzyEJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeT6juy6my5sDenjWCzyEJ)_