### PR TITLE
feat(learn): add ChallengeCard component for coding challenges

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1,0 +1,772 @@
+/* Challenge card — an executable coding-challenge component for the
+   learning pages. Mirrors the "Python Challenge" mockup pixel-tokens
+   so it reads as a polished card: badge + title in the header,
+   instructions block, embedded editor with a run/check toolbar,
+   collapsible test-result panel, and pass/fail status banner.
+
+   Although the design originated for Python, every visual element here
+   is language-agnostic — the same component is meant to host R and
+   TypeScript challenges later. */
+
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap");
+
+.card {
+  /* Light, paper-style chrome distinct from the dark-by-default
+     CodeBlock — challenges are meant to feel like a worksheet, not a
+     console. Tokens duplicated locally so the card works even when
+     dropped into a page that doesn't load other DataSlope stylesheets. */
+  --ch-bg: #ffffff;
+  --ch-bg-muted: #fafafa;
+  --ch-bg-subtle: #f9fafb;
+  --ch-border: #e5e7eb;
+  --ch-border-light: #f0f1f3;
+  --ch-text: #111827;
+  --ch-text-secondary: #6b7280;
+  --ch-text-muted: #9ca3af;
+  --ch-accent: #2563eb;
+  --ch-accent-hover: #1d4ed8;
+  --ch-green: #16a34a;
+  --ch-green-dot: #22c55e;
+  --ch-green-bg: #f0fdf4;
+  --ch-red: #dc2626;
+  --ch-red-bg: #fef2f2;
+  --ch-purple: #7c3aed;
+  --ch-purple-bg: #f5f3ff;
+  --ch-purple-border: #ede9fe;
+  --ch-font-ui: "Inter", system-ui, -apple-system, sans-serif;
+  --ch-font-mono:
+    "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+  --ch-radius: 8px;
+  --ch-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.05);
+
+  background: var(--ch-bg);
+  border: 1px solid var(--ch-border);
+  border-radius: var(--ch-radius);
+  box-shadow: var(--ch-shadow);
+  overflow: hidden;
+  font-family: var(--ch-font-ui);
+  color: var(--ch-text);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 1rem 0;
+}
+
+/* ─── Header ──────────────────────────────────────────────────────── */
+
+.header {
+  padding: 16px 20px 14px;
+  border-bottom: 1px solid var(--ch-border-light);
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ch-purple);
+  background: var(--ch-purple-bg);
+  border: 1px solid var(--ch-purple-border);
+  border-radius: 5px;
+  padding: 2px 8px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+.badgeDot {
+  width: 5px;
+  height: 5px;
+  background: var(--ch-purple);
+  border-radius: 50%;
+}
+
+.titleArea {
+  flex: 1;
+  min-width: 0;
+}
+.title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ch-text);
+  margin-bottom: 2px;
+  line-height: 1.4;
+}
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 11.5px;
+  color: var(--ch-text-muted);
+  flex-wrap: wrap;
+}
+.metaPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.metaSep {
+  color: var(--ch-text-muted);
+}
+
+.statusArea {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.statusPass {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ch-green);
+}
+.statusPending {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--ch-text-secondary);
+}
+.statusPendingCount {
+  font-weight: 500;
+}
+.statusPendingLabel {
+  color: var(--ch-text-muted);
+}
+
+/* ─── Instructions ────────────────────────────────────────────────── */
+
+.instructions {
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--ch-border-light);
+  background: var(--ch-bg-muted);
+}
+.instructionsLabel {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--ch-text-muted);
+  margin-bottom: 10px;
+}
+.instructionsBody {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--ch-text-secondary);
+}
+.instructionsBody p {
+  margin: 0 0 8px;
+}
+.instructionsBody p:last-child {
+  margin-bottom: 0;
+}
+.instructionsBody strong {
+  color: var(--ch-text);
+  font-weight: 600;
+}
+.instructionsBody code {
+  font-family: var(--ch-font-mono);
+  font-size: 12px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: #0f172a;
+}
+.instructionsBody ul,
+.instructionsBody ol {
+  padding-left: 18px;
+  margin: 6px 0 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.instructionsBody li {
+  color: var(--ch-text-secondary);
+}
+
+/* Hint toggle + box */
+.hintToggle {
+  margin-top: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--ch-accent);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--ch-font-ui);
+}
+.hintToggle:hover {
+  text-decoration: underline;
+}
+.hintToggle svg {
+  width: 12px;
+  height: 12px;
+}
+.hintBox {
+  margin-top: 10px;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12.5px;
+  color: #1e40af;
+  line-height: 1.6;
+}
+.hintBox code {
+  background: #dbeafe;
+  border: 1px solid #bfdbfe;
+  color: #1e3a8a;
+  font-family: var(--ch-font-mono);
+  font-size: 11.5px;
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+
+/* ─── PyBlock-style topbar ────────────────────────────────────────── */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  height: 38px;
+  border-bottom: 1px solid var(--ch-border-light);
+  background: var(--ch-bg-muted);
+}
+.blockId {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--ch-text-muted);
+  font-family: var(--ch-font-mono);
+}
+.blockId svg {
+  opacity: 0.6;
+}
+.topbarDivider {
+  width: 1px;
+  height: 16px;
+  background: var(--ch-border);
+  margin: 0 12px;
+}
+.runtimeLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--ch-text-secondary);
+}
+.runtimeLabel svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ch-border);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.statusDot[data-status="ready"] {
+  background: var(--ch-green-dot);
+}
+.statusDot[data-status="loading"],
+.statusDot[data-status="running"] {
+  background: #f59e0b;
+  animation: ch-pulse 1s ease-in-out infinite;
+}
+.statusDot[data-status="error"] {
+  background: var(--ch-red);
+}
+@keyframes ch-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* ─── Editor ──────────────────────────────────────────────────────── */
+
+.editor {
+  background: var(--ch-bg);
+  position: relative;
+}
+.editor :global(.cm-editor) {
+  height: auto;
+  min-height: 120px;
+  font-family: var(--ch-font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+  font-variant-ligatures: none;
+  font-feature-settings: "calt" 0, "liga" 0, "dlig" 0, "clig" 0;
+}
+.editor :global(.cm-editor .cm-scroller) {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+/* Init code wrapper — collapsible read-only init panel. */
+.initWrap {
+  background: var(--ch-bg-muted);
+  border-bottom: 1px solid var(--ch-border-light);
+}
+.initToggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 14px;
+  background: transparent;
+  border: none;
+  color: var(--ch-text-muted);
+  font-family: var(--ch-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  text-align: left;
+}
+.initToggle:hover {
+  color: var(--ch-text);
+  background: #f4f4f5;
+}
+.initCaret {
+  display: inline-block;
+  font-size: 9px;
+  width: 10px;
+  transition: transform 0.15s ease;
+}
+.initCaretOpen {
+  transform: rotate(90deg);
+}
+.initLabel {
+  flex: 1;
+}
+.initMeta {
+  color: var(--ch-text-muted);
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.initEditor {
+  border-top: 1px solid var(--ch-border-light);
+  background: var(--ch-bg);
+}
+.initEditor :global(.cm-editor) {
+  height: auto;
+  min-height: 30px;
+  font-family: var(--ch-font-mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  font-variant-ligatures: none;
+  cursor: not-allowed;
+}
+.initEditor :global(.cm-editor .cm-cursor) {
+  display: none !important;
+}
+
+/* ─── Toolbar ─────────────────────────────────────────────────────── */
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  padding: 8px 14px;
+  border-top: 1px solid var(--ch-border-light);
+  border-bottom: 1px solid var(--ch-border-light);
+  background: var(--ch-bg-subtle);
+  gap: 0;
+}
+.runBtn {
+  background: var(--ch-accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  transition: background 0.15s;
+  font-family: var(--ch-font-ui);
+}
+.runBtn:hover:not(:disabled) {
+  background: var(--ch-accent-hover);
+}
+.runBtn:disabled {
+  background: #93c5fd;
+  cursor: not-allowed;
+}
+.runBtn svg {
+  width: 11px;
+  height: 11px;
+  fill: white;
+  stroke: white;
+}
+.runBtnSpinner {
+  animation: ch-spin 0.75s linear infinite;
+  fill: none !important;
+}
+@keyframes ch-spin {
+  to { transform: rotate(360deg); }
+}
+
+.kbdHint {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 10px;
+  color: var(--ch-text-muted);
+  font-size: 12px;
+}
+.kbd {
+  background: #fff;
+  border: 1px solid var(--ch-border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 11px;
+  font-family: var(--ch-font-mono);
+  color: var(--ch-text-muted);
+  box-shadow: 0 1px 0 var(--ch-border);
+  font-weight: 500;
+}
+.kbdPlus {
+  color: var(--ch-text-muted);
+  font-size: 12px;
+}
+
+.resetBtn {
+  margin-left: 10px;
+  background: none;
+  border: none;
+  color: var(--ch-text-muted);
+  font-size: 12.5px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 8px;
+  border-radius: 5px;
+  font-family: var(--ch-font-ui);
+  transition: color 0.15s, background 0.15s;
+}
+.resetBtn:hover:not(:disabled) {
+  color: var(--ch-text);
+  background: #f0f0f0;
+}
+.resetBtn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.copyBtn {
+  background: none;
+  border: none;
+  color: var(--ch-text-muted);
+  cursor: pointer;
+  padding: 5px;
+  border-radius: 5px;
+  display: inline-flex;
+  align-items: center;
+  transition: color 0.15s, background 0.15s;
+}
+.copyBtn:hover {
+  color: var(--ch-text);
+  background: #f0f0f0;
+}
+
+.toolbarSpacer {
+  flex: 1 1 auto;
+}
+
+.checkBtn {
+  background: none;
+  border: 1px solid var(--ch-border);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ch-text-secondary);
+  cursor: pointer;
+  font-family: var(--ch-font-ui);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: all 0.15s;
+}
+.checkBtn:hover:not(:disabled) {
+  border-color: #9ca3af;
+  color: var(--ch-text);
+  background: #f9fafb;
+}
+.checkBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ─── Output panel ────────────────────────────────────────────────── */
+
+.outputPanel {
+  background: var(--ch-bg);
+}
+.outputHeader {
+  display: flex;
+  align-items: center;
+  padding: 8px 14px;
+  border-top: 1px solid var(--ch-border-light);
+}
+.accentBar {
+  width: 3px;
+  height: 32px;
+  background: var(--ch-green-dot);
+  border-radius: 2px;
+  margin-right: 10px;
+  flex-shrink: 0;
+}
+.accentBar[data-error="true"] {
+  background: var(--ch-red);
+}
+.outputLabel {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ch-text-muted);
+}
+.outputTime {
+  margin-left: auto;
+  font-size: 11.5px;
+  color: var(--ch-text-muted);
+  font-family: var(--ch-font-mono);
+}
+.outputBody {
+  padding: 10px 14px 14px 27px;
+  font-family: var(--ch-font-mono);
+  font-size: 12.5px;
+  line-height: 1.8;
+  color: var(--ch-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.outputEmpty {
+  padding: 4px 14px 14px 27px;
+  color: var(--ch-text-muted);
+  font-size: 12px;
+  font-style: italic;
+}
+.outCellStdout {}
+.outCellStderr { color: var(--ch-red); }
+.outCellHtml,
+.outCellImage,
+.outCellPlot {
+  white-space: normal;
+}
+.outCellHtml :global(img),
+.outCellHtml :global(svg) {
+  max-width: 100%;
+}
+.outCellHtml :global(table) {
+  border-collapse: collapse;
+  font-family: var(--ch-font-mono);
+  font-size: 12px;
+}
+.outCellHtml :global(th) {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  padding: 5px 12px;
+  text-align: right;
+  font-size: 11.5px;
+  color: var(--ch-text-muted);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.outCellHtml :global(td) {
+  border: 1px solid #f1f5f9;
+  padding: 4px 12px;
+  text-align: right;
+  white-space: nowrap;
+  color: var(--ch-text);
+}
+.outCellHtml :global(tr:hover td) {
+  background: #f8fafc;
+}
+
+/* ─── Test panel ──────────────────────────────────────────────────── */
+
+.testPanel {
+  border-top: 1px solid var(--ch-border-light);
+  background: var(--ch-bg-muted);
+}
+.testPanelHeader {
+  display: flex;
+  align-items: center;
+  padding: 10px 14px;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: var(--ch-font-ui);
+}
+.testPanelHeader:hover {
+  background: #f4f4f5;
+}
+.testLabel {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ch-text-muted);
+}
+.testSummary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+.testPill {
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 2px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.testPill[data-state="pass"] {
+  background: var(--ch-green-bg);
+  color: var(--ch-green);
+  border: 1px solid #bbf7d0;
+}
+.testPill[data-state="fail"] {
+  background: var(--ch-red-bg);
+  color: var(--ch-red);
+  border: 1px solid #fecaca;
+}
+.testPill[data-state="pending"] {
+  background: #f3f4f6;
+  color: var(--ch-text-muted);
+  border: 1px solid #e5e7eb;
+}
+.testChevron {
+  color: var(--ch-text-muted);
+  transition: transform 0.2s;
+}
+.testChevronOpen {
+  transform: rotate(180deg);
+}
+
+.testList {
+  padding: 0 14px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.testItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: #fff;
+  border: 1px solid var(--ch-border-light);
+}
+.testIcon {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1px;
+}
+.testIcon[data-state="pass"] { background: var(--ch-green-bg); color: var(--ch-green); }
+.testIcon[data-state="fail"] { background: var(--ch-red-bg); color: var(--ch-red); }
+.testIcon[data-state="pending"] { background: #f3f4f6; color: var(--ch-text-muted); }
+
+.testItemBody {
+  flex: 1;
+  min-width: 0;
+}
+.testItemName {
+  font-family: var(--ch-font-mono);
+  font-size: 11.5px;
+  color: var(--ch-text);
+  font-weight: 500;
+  line-height: 1.4;
+}
+.testItemDesc {
+  font-size: 11.5px;
+  color: var(--ch-text-muted);
+  margin-top: 2px;
+}
+.testItemDetail {
+  margin-top: 4px;
+  font-size: 11.5px;
+  font-family: var(--ch-font-mono);
+  color: var(--ch-red);
+  background: var(--ch-red-bg);
+  border-radius: 4px;
+  padding: 3px 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ─── Status banner ───────────────────────────────────────────────── */
+
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--ch-border-light);
+  font-size: 13px;
+  font-weight: 500;
+}
+.banner[data-state="pass"] {
+  background: var(--ch-green-bg);
+  color: var(--ch-green);
+  border-top-color: #bbf7d0;
+}
+.banner[data-state="fail"] {
+  background: var(--ch-red-bg);
+  color: var(--ch-red);
+  border-top-color: #fecaca;
+}
+.bannerIcon {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.banner[data-state="pass"] .bannerIcon { background: #dcfce7; }
+.banner[data-state="fail"] .bannerIcon { background: #fee2e2; }
+.bannerSub {
+  font-size: 12px;
+  font-weight: 400;
+  opacity: 0.8;
+  margin-left: 2px;
+}

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -1,0 +1,927 @@
+"use client";
+
+/**
+ * `ChallengeCard` — an executable coding-challenge embeddable for the
+ * `/learn` pages. Visually matches the "Python Challenge" design from
+ * the handoff bundle, but is intentionally language-agnostic so the
+ * same component will host upcoming R and TypeScript challenges.
+ *
+ * Architecture mirrors `<CodeBlock>`:
+ *   - A shared per-adapter runtime is fetched via `getSharedRuntime`,
+ *     so multiple challenge cards on the same page share one worker.
+ *   - The CodeMirror editor uses the same theme + language loader as
+ *     the surrounding playground / code blocks.
+ *
+ * What's different from a CodeBlock:
+ *   - There's a header (badge + title + meta + status), an
+ *     instructions panel with an optional hint, and a Check Answer
+ *     button that runs a test harness on top of the user's submission.
+ *   - Test results render in a collapsible panel with a pass/fail
+ *     banner. The harness is language-specific and lives in
+ *     `challengeHarness.ts`.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { Box, RotateCcw, Check, X, ChevronDown, Clock } from "lucide-react";
+import { EditorState, Compartment } from "@codemirror/state";
+import {
+  EditorView,
+  keymap,
+  lineNumbers as lineNumbersExt,
+  highlightActiveLineGutter,
+  highlightActiveLine,
+  drawSelection,
+  dropCursor,
+} from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  bracketMatching,
+  indentOnInput,
+  indentUnit,
+} from "@codemirror/language";
+import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+import { loadLanguage, themeFor } from "./cmExtensions";
+import {
+  LANGUAGE_ICONS,
+  LANGUAGE_ICON_COLORS,
+  LANGUAGE_ICON_SIZE_FACTOR,
+} from "./languageIcons";
+import type {
+  LanguageAdapter,
+  LanguageRuntime,
+  OutputCell,
+} from "./types";
+import {
+  buildHarness,
+  hasHarness,
+  parseHarnessOutput,
+  type ChallengeTest,
+  type ParsedTestResult,
+} from "./challengeHarness";
+import styles from "./ChallengeCard.module.css";
+
+type Status = "idle" | "loading" | "ready" | "running" | "error";
+type TestState = "pending" | "pass" | "fail";
+
+interface DisplayedTest {
+  id: string;
+  name: string;
+  description: string;
+  state: TestState;
+  detail: string | null;
+}
+
+export interface ChallengeCardProps {
+  /** Language adapter used for both running the code and building the
+   *  test harness. Pass the same instance as a CodeBlock would. */
+  adapter: LanguageAdapter;
+  /** Challenge title shown in the header. */
+  title: string;
+  /** Optional uppercase badge label. Defaults to "Challenge". */
+  badge?: string;
+  /** Optional category descriptor, rendered after the time pill.
+   *  Free-form — e.g. "pandas · groupby · agg". */
+  category?: string;
+  /** Optional estimated time, e.g. "~5 min". */
+  estimatedTime?: string;
+  /** Rendered above the editor. Pass MDX content or React elements. */
+  instructions: React.ReactNode;
+  /** Optional hint, revealed when the user clicks "Show hint". */
+  hint?: React.ReactNode;
+  /** Optional initialization code prepended verbatim to the user's
+   *  code on every run. Rendered in a collapsed-by-default read-only
+   *  panel above the editor, mirroring `<CodeBlock>`'s `initCode`. */
+  initCode?: string;
+  /** Starting source loaded into the editor. The Reset button restores
+   *  this exact text. */
+  initialCode: string;
+  /** Tests run when "Check Answer" is pressed. Each test's `code`
+   *  should `assert`/`throw`/`stop()` on failure and be silent on
+   *  success — the language-specific harness wraps the rest. */
+  tests: ChallengeTest[];
+}
+
+function detectIsMac(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const platform = navigator.platform || "";
+  const ua = navigator.userAgent || "";
+  return /Mac|iPhone|iPod/.test(platform) || /Macintosh/.test(ua);
+}
+
+// The challenge card is intentionally light-themed even when the
+// surrounding docs are dark — the design treats it as a "worksheet"
+// card rather than a console. We always render the IntelliJ IDEA
+// CodeMirror theme so the editor matches the card chrome.
+const CM_EDITOR_THEME = "idea";
+
+function CopyIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function PlayIcon() {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" aria-hidden>
+      <path d="M2 1l9 5-9 5V1z" fill="currentColor" />
+    </svg>
+  );
+}
+
+function HelpIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+}
+
+function LanguageGlyph({ adapter }: { adapter: LanguageAdapter }) {
+  const Icon = LANGUAGE_ICONS[adapter.id];
+  const color = LANGUAGE_ICON_COLORS[adapter.id];
+  const factor = LANGUAGE_ICON_SIZE_FACTOR[adapter.id] ?? 1;
+  if (!Icon) return <span aria-hidden>{adapter.logoText}</span>;
+  return (
+    <Icon
+      style={{
+        color,
+        width: `${Math.round(14 * factor)}px`,
+        height: `${Math.round(14 * factor)}px`,
+      }}
+      aria-hidden
+    />
+  );
+}
+
+function useBlockId(adapter: LanguageAdapter): string {
+  const reactId = useId();
+  return useMemo(() => {
+    let h = 0;
+    for (let i = 0; i < reactId.length; i++) {
+      h = (h * 31 + reactId.charCodeAt(i)) >>> 0;
+    }
+    const suffix = h.toString(16).slice(0, 4).padStart(4, "0");
+    const prefix =
+      adapter.logoText.charAt(0).toUpperCase() +
+      adapter.logoText.slice(1).toLowerCase();
+    return `${prefix}Block-${suffix}`;
+  }, [reactId, adapter.logoText]);
+}
+
+export default function ChallengeCard({
+  adapter,
+  title,
+  badge = "Challenge",
+  category,
+  estimatedTime,
+  instructions,
+  hint,
+  initCode,
+  initialCode,
+  tests,
+}: ChallengeCardProps) {
+  const blockId = useBlockId(adapter);
+  const trimmedInit = initCode?.trimEnd() ?? "";
+  const hasInit = trimmedInit.length > 0;
+  const initLineCount = hasInit ? trimmedInit.split("\n").length : 0;
+  const initPanelId = `${blockId}-init`;
+
+  const editorHostRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<EditorView | null>(null);
+  const initEditorHostRef = useRef<HTMLDivElement | null>(null);
+  const initEditorRef = useRef<EditorView | null>(null);
+  // Per-card runtime. Each `<ChallengeCard>` gets its own instance —
+  // sharing across cards would let one challenge's state (Pyodide
+  // globals, micropip installs, monkey-patched modules) influence
+  // another's, which would make challenge results dependent on page
+  // history. The runtime is initialised lazily on first Run / Check
+  // and cached in this ref for subsequent runs of the same card.
+  const runtimePromiseRef = useRef<Promise<LanguageRuntime> | null>(null);
+  const runSeqRef = useRef(0);
+  // Latest run handler — keeps the CodeMirror keymap closure
+  // (registered once at mount) wired to the current function.
+  const runRef = useRef<() => void>(() => {});
+
+  const [status, setStatus] = useState<Status>("idle");
+  const [statusMessage, setStatusMessage] = useState<string>("");
+  const [outputs, setOutputs] = useState<OutputCell[]>([]);
+  const [elapsed, setElapsed] = useState<string>("");
+  const [initExpanded, setInitExpanded] = useState(false);
+  const [hintOpen, setHintOpen] = useState(false);
+  const [testResults, setTestResults] = useState<DisplayedTest[]>([]);
+  const [testListOpen, setTestListOpen] = useState(true);
+  const [bannerState, setBannerState] = useState<"pass" | "fail" | null>(null);
+
+  const isMac = useSyncExternalStore(
+    () => () => {},
+    () => detectIsMac(),
+    () => false,
+  );
+
+  const canCheck = hasHarness(adapter.id) && tests.length > 0;
+
+  // ─── Editor mount ───────────────────────────────────────────────────
+  useEffect(() => {
+    if (!editorHostRef.current || editorRef.current) return;
+    const themeComp = new Compartment();
+    const languageComp = new Compartment();
+    const lineOffset = hasInit ? initLineCount : 0;
+
+    const view = new EditorView({
+      doc: initialCode,
+      parent: editorHostRef.current,
+      extensions: [
+        history(),
+        drawSelection(),
+        dropCursor(),
+        EditorState.allowMultipleSelections.of(true),
+        indentOnInput(),
+        bracketMatching(),
+        closeBrackets(),
+        lineNumbersExt({
+          formatNumber: lineOffset
+            ? (n) => String(n + lineOffset)
+            : undefined,
+        }),
+        highlightActiveLineGutter(),
+        highlightActiveLine(),
+        EditorState.tabSize.of(4),
+        indentUnit.of("    "),
+        EditorView.lineWrapping,
+        keymap.of([
+          {
+            key: "Mod-Enter",
+            run: () => {
+              runRef.current();
+              return true;
+            },
+          },
+          ...closeBracketsKeymap,
+          ...defaultKeymap,
+          ...historyKeymap,
+        ]),
+        languageComp.of([]),
+        themeComp.of(themeFor(CM_EDITOR_THEME)),
+      ],
+    });
+    editorRef.current = view;
+
+    void loadLanguage(adapter.codeMirrorMode).then((ext) => {
+      if (ext && editorRef.current === view) {
+        view.dispatch({ effects: languageComp.reconfigure(ext) });
+      }
+    });
+    return () => {
+      view.destroy();
+      editorRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Mount the read-only init editor lazily when expanded.
+  useEffect(() => {
+    if (!hasInit || !initExpanded) return;
+    if (!initEditorHostRef.current || initEditorRef.current) return;
+    const languageComp = new Compartment();
+    const view = new EditorView({
+      doc: trimmedInit,
+      parent: initEditorHostRef.current,
+      extensions: [
+        EditorState.readOnly.of(true),
+        EditorView.editable.of(false),
+        drawSelection(),
+        lineNumbersExt(),
+        EditorState.tabSize.of(4),
+        indentUnit.of("    "),
+        EditorView.lineWrapping,
+        languageComp.of([]),
+        themeFor(CM_EDITOR_THEME),
+      ],
+    });
+    initEditorRef.current = view;
+    void loadLanguage(adapter.codeMirrorMode).then((ext) => {
+      if (ext && initEditorRef.current === view) {
+        view.dispatch({ effects: languageComp.reconfigure(ext) });
+      }
+    });
+    return () => {
+      view.destroy();
+      initEditorRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasInit, initExpanded]);
+
+  // ─── Execution helpers ─────────────────────────────────────────────
+
+  /** Execute a single combined snippet against the shared runtime,
+   *  capturing output cells via the streaming emitter. Returns the
+   *  collected cells and total elapsed milliseconds.
+   *
+   *  Sentinel-line filtering for the test harness is handled by the
+   *  caller (so plain Run can stream raw output, but Check can post-
+   *  process the stdout to peel off `__DSTEST__:…` lines). */
+  const execute = useCallback(
+    async (code: string): Promise<{ cells: OutputCell[]; elapsedMs: number }> => {
+      const mySeq = ++runSeqRef.current;
+      setOutputs([]);
+      setStatus("loading");
+      setStatusMessage("Initializing runtime…");
+
+      // Lazily spin up an isolated runtime for this card on first run.
+      // Cache the promise (not just the resolved runtime) so two near-
+      // simultaneous calls — e.g. clicking Run then Check in quick
+      // succession before the first init resolves — share the same init
+      // instead of racing to create two workers. Each subsequent
+      // `runtime.run(...)` call starts with fresh globals because every
+      // adapter resets its scope at the start of `run()`.
+      if (!runtimePromiseRef.current) {
+        runtimePromiseRef.current = adapter
+          .init((msg) => {
+            if (runSeqRef.current === mySeq) setStatusMessage(msg);
+          })
+          .catch((err) => {
+            // Don't poison the cache with a failed init — let the next
+            // attempt try again.
+            runtimePromiseRef.current = null;
+            throw err;
+          });
+      }
+      const runtime = await runtimePromiseRef.current;
+      if (runSeqRef.current !== mySeq)
+        return { cells: [], elapsedMs: 0 };
+
+      setStatus("running");
+      setStatusMessage("Running…");
+
+      const startedAt = performance.now();
+      let nextOutputId = 0;
+      const cells: OutputCell[] = [];
+
+      await runtime.run(code, (cell) => {
+        if (runSeqRef.current !== mySeq) return;
+        const elapsedMs = performance.now() - startedAt;
+        const fmt =
+          elapsedMs < 1000
+            ? `${elapsedMs.toFixed(0)}ms`
+            : `${(elapsedMs / 1000).toFixed(2)}s`;
+        const full: OutputCell = {
+          id: ++nextOutputId,
+          elapsed: fmt,
+          ...cell,
+        };
+        cells.push(full);
+      });
+
+      const elapsedMs = performance.now() - startedAt;
+      return { cells, elapsedMs };
+    },
+    [adapter],
+  );
+
+  const formatElapsed = (ms: number) =>
+    ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`;
+
+  // ─── Run (no tests) ────────────────────────────────────────────────
+  const run = useCallback(async () => {
+    const userCode = editorRef.current?.state.doc.toString() ?? "";
+    const combined = hasInit ? `${trimmedInit}\n${userCode}` : userCode;
+    try {
+      const { cells, elapsedMs } = await execute(combined);
+      setOutputs(cells);
+      setElapsed(formatElapsed(elapsedMs));
+      const erred = cells.some((c) => c.type === "stderr");
+      setStatus(erred ? "error" : "ready");
+      setStatusMessage(erred ? "Errored" : "Done");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setOutputs([
+        {
+          id: 1,
+          type: "stderr",
+          content: message,
+          elapsed: "",
+        },
+      ]);
+      setStatus("error");
+      setStatusMessage(message);
+    }
+  }, [execute, hasInit, trimmedInit]);
+
+  // ─── Check Answer (run + tests) ─────────────────────────────────────
+  const check = useCallback(async () => {
+    if (!canCheck) return;
+    const userCode = editorRef.current?.state.doc.toString() ?? "";
+    const userPart = hasInit ? `${trimmedInit}\n${userCode}` : userCode;
+    const harness = buildHarness(adapter.id, tests);
+    const combined = `${userPart}\n${harness}`;
+
+    // Pre-populate the test panel in pending state so the user sees the
+    // list immediately while the runtime warms up.
+    setTestResults(
+      tests.map((t) => ({
+        id: t.id,
+        name: t.name,
+        description: t.description,
+        state: "pending",
+        detail: null,
+      })),
+    );
+    setBannerState(null);
+    setTestListOpen(true);
+
+    try {
+      const { cells, elapsedMs } = await execute(combined);
+
+      // Split stdout cells into "user-visible" + parsed harness results.
+      // Non-stdout cells (html / image / plot / stderr) pass through
+      // untouched — the harness only emits text.
+      const finalCells: OutputCell[] = [];
+      const allResults: ParsedTestResult[] = [];
+      for (const cell of cells) {
+        if (cell.type !== "stdout") {
+          finalCells.push(cell);
+          continue;
+        }
+        const { clean, results } = parseHarnessOutput(cell.content);
+        allResults.push(...results);
+        if (clean.length > 0) {
+          finalCells.push({ ...cell, content: clean });
+        }
+      }
+      setOutputs(finalCells);
+      setElapsed(formatElapsed(elapsedMs));
+
+      const byId = new Map(allResults.map((r) => [r.id, r]));
+      const displayed: DisplayedTest[] = tests.map((t) => {
+        const r = byId.get(t.id);
+        return {
+          id: t.id,
+          name: t.name,
+          description: t.description,
+          state: r ? (r.pass ? "pass" : "fail") : "fail",
+          detail: r
+            ? r.detail
+            : "Test did not produce a result (the runtime may have errored before reaching this check).",
+        };
+      });
+      setTestResults(displayed);
+
+      const passed = displayed.filter((d) => d.state === "pass").length;
+      const allPass = passed === displayed.length && displayed.length > 0;
+      setBannerState(allPass ? "pass" : "fail");
+
+      const erred = finalCells.some((c) => c.type === "stderr");
+      setStatus(erred && !allPass ? "error" : "ready");
+      setStatusMessage(
+        allPass ? "All tests passed" : `${passed}/${displayed.length} passed`,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setOutputs([
+        { id: 1, type: "stderr", content: message, elapsed: "" },
+      ]);
+      setStatus("error");
+      setStatusMessage(message);
+      setTestResults((prev) =>
+        prev.map((t) => ({
+          ...t,
+          state: "fail",
+          detail: t.detail ?? "Runtime error before test could execute.",
+        })),
+      );
+      setBannerState("fail");
+    }
+  }, [adapter.id, canCheck, execute, hasInit, tests, trimmedInit]);
+
+  // Keep the keymap closure pointing at the latest `run` handler.
+  useEffect(() => {
+    runRef.current = run;
+  }, [run]);
+
+  // ─── Reset ─────────────────────────────────────────────────────────
+  const reset = useCallback(() => {
+    runSeqRef.current++;
+    const view = editorRef.current;
+    if (view) {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: initialCode },
+      });
+    }
+    setOutputs([]);
+    setElapsed("");
+    setStatus("idle");
+    setStatusMessage("");
+    setTestResults([]);
+    setBannerState(null);
+  }, [initialCode]);
+
+  const copyCode = useCallback(async () => {
+    const code = editorRef.current?.state.doc.toString() ?? "";
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(code);
+      }
+    } catch {
+      // Non-fatal: clipboard permission may be unavailable in this
+      // context. Mirrors `<CodeBlock>`'s silent fallback.
+    }
+  }, []);
+
+  const isBusy = status === "loading" || status === "running";
+  const passedCount = testResults.filter((t) => t.state === "pass").length;
+  const totalTests = testResults.length;
+  const allPassed = totalTests > 0 && passedCount === totalTests;
+  const summaryState: TestState = allPassed
+    ? "pass"
+    : testResults.some((t) => t.state === "pending")
+      ? "pending"
+      : totalTests > 0
+        ? "fail"
+        : "pending";
+
+  return (
+    <div
+      className={styles.card}
+      aria-label={`${adapter.runtimeInfo.language} coding challenge: ${title}`}
+    >
+      {/* ── Header ── */}
+      <div className={styles.header}>
+        <div className={styles.badge}>
+          <span className={styles.badgeDot} /> {badge}
+        </div>
+        <div className={styles.titleArea}>
+          <div className={styles.title}>{title}</div>
+          <div className={styles.meta}>
+            {estimatedTime && (
+              <span className={styles.metaPill}>
+                <Clock size={11} aria-hidden />
+                {estimatedTime}
+              </span>
+            )}
+            {estimatedTime && category && (
+              <span className={styles.metaSep}>·</span>
+            )}
+            {category && <span>{category}</span>}
+          </div>
+        </div>
+        <div className={styles.statusArea}>
+          {totalTests > 0 && bannerState !== null ? (
+            allPassed ? (
+              <div className={styles.statusPass}>
+                <Check size={14} strokeWidth={2.5} aria-hidden />
+                Passed
+              </div>
+            ) : (
+              <div className={styles.statusPending}>
+                <span className={styles.statusPendingCount}>
+                  {passedCount}/{totalTests}
+                </span>
+                <span className={styles.statusPendingLabel}>tests</span>
+              </div>
+            )
+          ) : null}
+        </div>
+      </div>
+
+      {/* ── Instructions ── */}
+      <div className={styles.instructions}>
+        <div className={styles.instructionsLabel}>Instructions</div>
+        <div className={styles.instructionsBody}>{instructions}</div>
+        {hint && (
+          <>
+            <button
+              type="button"
+              className={styles.hintToggle}
+              onClick={() => setHintOpen((v) => !v)}
+              aria-expanded={hintOpen}
+            >
+              <HelpIcon />
+              {hintOpen ? "Hide hint" : "Show hint"}
+            </button>
+            {hintOpen && <div className={styles.hintBox}>{hint}</div>}
+          </>
+        )}
+      </div>
+
+      {/* ── PyBlock-style topbar ── */}
+      <div className={styles.topbar}>
+        <span className={styles.blockId}>
+          <Box size={13} aria-hidden /> {blockId}
+        </span>
+        <span className={styles.topbarDivider} aria-hidden />
+        <span className={styles.runtimeLabel}>
+          <LanguageGlyph adapter={adapter} />
+          {adapter.runtimeInfo.language} {adapter.runtimeInfo.version}
+        </span>
+        <span
+          className={styles.statusDot}
+          data-status={status}
+          title={statusMessage || status}
+          aria-label={statusMessage || status}
+        />
+      </div>
+
+      {/* ── Init code (collapsed by default) ── */}
+      {hasInit && (
+        <div className={styles.initWrap}>
+          <button
+            type="button"
+            className={styles.initToggle}
+            aria-expanded={initExpanded}
+            aria-controls={initPanelId}
+            onClick={() => setInitExpanded((v) => !v)}
+          >
+            <span
+              className={`${styles.initCaret} ${
+                initExpanded ? styles.initCaretOpen : ""
+              }`}
+              aria-hidden
+            >
+              ▶
+            </span>
+            <span className={styles.initLabel}>
+              Initialization code ({adapter.runtimeInfo.language})
+            </span>
+            <span className={styles.initMeta}>
+              {initLineCount} line{initLineCount === 1 ? "" : "s"} · read-only
+            </span>
+          </button>
+          {initExpanded && (
+            <div
+              id={initPanelId}
+              className={styles.initEditor}
+              ref={initEditorHostRef}
+              aria-label="Initialization code (read-only)"
+            />
+          )}
+        </div>
+      )}
+
+      {/* ── Editor ── */}
+      <div
+        className={styles.editor}
+        ref={editorHostRef}
+        aria-label={`${adapter.runtimeInfo.language} solution editor`}
+      />
+
+      {/* ── Toolbar ── */}
+      <div className={styles.toolbar} role="toolbar" aria-label="Challenge controls">
+        <button
+          type="button"
+          className={styles.runBtn}
+          onClick={() => void run()}
+          disabled={isBusy}
+        >
+          {isBusy ? (
+            <svg
+              viewBox="0 0 12 12"
+              className={styles.runBtnSpinner}
+              aria-hidden
+            >
+              <circle
+                cx="6"
+                cy="6"
+                r="4.5"
+                fill="none"
+                stroke="white"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeDasharray="14 8"
+              />
+            </svg>
+          ) : (
+            <PlayIcon />
+          )}
+          <span>{isBusy ? "Running…" : "Run"}</span>
+        </button>
+        {!isBusy && (
+          <span
+            className={styles.kbdHint}
+            title={isMac ? "Cmd + Enter" : "Ctrl + Enter"}
+          >
+            <kbd className={styles.kbd}>{isMac ? "⌘" : "Ctrl"}</kbd>
+            <span className={styles.kbdPlus} aria-hidden>+</span>
+            <kbd className={styles.kbd}>Enter</kbd>
+          </span>
+        )}
+        <button
+          type="button"
+          className={styles.resetBtn}
+          onClick={reset}
+          disabled={isBusy}
+        >
+          <RotateCcw size={12} strokeWidth={2.4} aria-hidden />
+          Reset
+        </button>
+        <button
+          type="button"
+          className={styles.copyBtn}
+          onClick={() => void copyCode()}
+          title="Copy code"
+          aria-label="Copy code"
+        >
+          <CopyIcon />
+        </button>
+        <span className={styles.toolbarSpacer} />
+        {canCheck && (
+          <button
+            type="button"
+            className={styles.checkBtn}
+            onClick={() => void check()}
+            disabled={isBusy}
+          >
+            <Check size={12} strokeWidth={2.5} aria-hidden />
+            Check Answer
+          </button>
+        )}
+      </div>
+
+      {/* ── Output panel ── */}
+      {(outputs.length > 0 || isBusy) && (
+        <div className={styles.outputPanel} aria-live="polite">
+          <div className={styles.outputHeader}>
+            <div
+              className={styles.accentBar}
+              data-error={outputs.some((c) => c.type === "stderr")}
+            />
+            <span className={styles.outputLabel}>Output</span>
+            {elapsed && <span className={styles.outputTime}>{elapsed}</span>}
+          </div>
+          {outputs.length === 0 ? (
+            <div className={styles.outputEmpty}>Running…</div>
+          ) : (
+            <div className={styles.outputBody}>
+              {outputs.map((cell) => (
+                <OutputCellView key={cell.id} cell={cell} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Test results ── */}
+      {testResults.length > 0 && (
+        <div className={styles.testPanel}>
+          <button
+            type="button"
+            className={styles.testPanelHeader}
+            onClick={() => setTestListOpen((v) => !v)}
+            aria-expanded={testListOpen}
+          >
+            <span className={styles.testLabel}>Test Results</span>
+            <div className={styles.testSummary}>
+              <span className={styles.testPill} data-state={summaryState}>
+                {summaryState === "pending" ? (
+                  "Running…"
+                ) : summaryState === "pass" ? (
+                  <>
+                    <Check size={10} strokeWidth={3} aria-hidden /> {passedCount}/{totalTests} passed
+                  </>
+                ) : (
+                  <>
+                    <X size={10} strokeWidth={3} aria-hidden /> {passedCount}/{totalTests} passed
+                  </>
+                )}
+              </span>
+            </div>
+            <ChevronDown
+              size={14}
+              aria-hidden
+              className={`${styles.testChevron} ${
+                testListOpen ? styles.testChevronOpen : ""
+              }`}
+            />
+          </button>
+          {testListOpen && (
+            <div className={styles.testList}>
+              {testResults.map((t) => (
+                <div key={t.id} className={styles.testItem}>
+                  <div className={styles.testIcon} data-state={t.state}>
+                    {t.state === "pass" ? (
+                      <Check size={9} strokeWidth={3} aria-hidden />
+                    ) : t.state === "fail" ? (
+                      <X size={9} strokeWidth={3} aria-hidden />
+                    ) : (
+                      <svg
+                        width="9"
+                        height="9"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2.5"
+                        aria-hidden
+                      >
+                        <circle cx="12" cy="12" r="5" />
+                      </svg>
+                    )}
+                  </div>
+                  <div className={styles.testItemBody}>
+                    <div className={styles.testItemName}>{t.name}</div>
+                    <div className={styles.testItemDesc}>{t.description}</div>
+                    {t.state === "fail" && t.detail && (
+                      <div className={styles.testItemDetail}>{t.detail}</div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Banner ── */}
+      {bannerState && (
+        <div className={styles.banner} data-state={bannerState}>
+          <div className={styles.bannerIcon}>
+            {bannerState === "pass" ? (
+              <Check size={14} strokeWidth={2.5} aria-hidden />
+            ) : (
+              <X size={14} strokeWidth={2.5} aria-hidden />
+            )}
+          </div>
+          {bannerState === "pass" ? (
+            <span>
+              All tests passed!{" "}
+              <span className={styles.bannerSub}>
+                Great work — your solution is correct.
+              </span>
+            </span>
+          ) : (
+            <span>
+              {totalTests - passedCount} test
+              {totalTests - passedCount === 1 ? "" : "s"} failed{" "}
+              <span className={styles.bannerSub}>
+                — review the details and try again.
+              </span>
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Minimal output cell renderer — text cells use mono-spaced pre-wrap,
+ *  HTML cells (DataFrames) get the table styles defined in the
+ *  module, image / plot cells fall through to inline rendering. This
+ *  is a trimmed copy of `<CodeBlock>`'s `OutputCellView` adjusted for
+ *  the lighter challenge-card chrome. */
+function OutputCellView({ cell }: { cell: OutputCell }) {
+  if (cell.type === "html") {
+    return (
+      <div
+        className={styles.outCellHtml}
+        // Same trust assumption as the playground / code block: HTML
+        // cells originate from code the user typed in this very widget.
+        dangerouslySetInnerHTML={{ __html: cell.content }}
+      />
+    );
+  }
+  if (cell.type === "image") {
+    return (
+      <div className={styles.outCellImage}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={`data:image/png;base64,${cell.content}`}
+          alt=""
+          style={{ maxWidth: "100%" }}
+        />
+      </div>
+    );
+  }
+  if (cell.type === "stderr") {
+    return <div className={styles.outCellStderr}>{cell.content}</div>;
+  }
+  return <div className={styles.outCellStdout}>{cell.content}</div>;
+}

--- a/app/_components/MdxChallengeCard.tsx
+++ b/app/_components/MdxChallengeCard.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * MDX-friendly wrapper around `<ChallengeCard>`.
+ *
+ * MDX content can't import TypeScript modules, so this component
+ * accepts the adapter as a string id (e.g. `"python"`) and resolves it
+ * to the corresponding adapter instance — mirroring `<MdxCodeBlock>`.
+ *
+ * Usage in MDX:
+ * ```mdx
+ * <ChallengeCard
+ *   adapter="python"
+ *   title="Summarize Sales by Category"
+ *   category="pandas · groupby · agg"
+ *   estimatedTime="~5 min"
+ *   instructions={<>
+ *     <p>You have a DataFrame called <code>df</code>…</p>
+ *   </>}
+ *   hint={<>Try <code>groupby(...).agg(...)</code>.</>}
+ *   initCode={`import pandas as pd\ndf = pd.DataFrame(...)`}
+ *   initialCode={`summary = None`}
+ *   tests={[
+ *     {
+ *       id: "summary_exists",
+ *       name: "`summary` exists",
+ *       description: "A variable named `summary` is defined",
+ *       code: `assert summary is not None`,
+ *     },
+ *   ]}
+ * />
+ * ```
+ */
+
+import ChallengeCard, { type ChallengeCardProps } from "./ChallengeCard";
+import { getAdapterById, type AdapterId } from "./runtime/adapters";
+import type { ChallengeTest } from "./challengeHarness";
+
+interface MdxChallengeCardProps
+  extends Omit<ChallengeCardProps, "adapter" | "tests"> {
+  adapter: AdapterId;
+  tests: ChallengeTest[];
+}
+
+export default function MdxChallengeCard({
+  adapter,
+  ...rest
+}: MdxChallengeCardProps) {
+  const resolved = getAdapterById(adapter);
+  if (!resolved) {
+    return (
+      <div role="alert" style={{ color: "#ef4444", padding: "0.75rem" }}>
+        Unknown ChallengeCard adapter id: <code>{adapter}</code>
+      </div>
+    );
+  }
+  return <ChallengeCard adapter={resolved} {...rest} />;
+}

--- a/app/_components/challengeHarness.ts
+++ b/app/_components/challengeHarness.ts
@@ -1,0 +1,249 @@
+/**
+ * Language-specific test harnesses for the `ChallengeCard` component.
+ *
+ * The component is otherwise language-agnostic: each test is a `{ id,
+ * name, description, code }` record where `code` is a snippet of the
+ * target language that throws / raises on failure and is silent on
+ * success. The harness wraps every test with a try/catch idiom and
+ * frames each result with a sentinel line:
+ *
+ *   __DSTEST__:<id>:PASS
+ *   __DSTEST__:<id>:FAIL:<json-encoded detail>
+ *
+ * Anything between the `__DSTEST_BEGIN__` sentinel and the end of
+ * stdout belongs to the harness — the component strips those lines
+ * from the user-visible output and parses them into test results.
+ *
+ * To extend support for a new language (e.g. JavaScript / TypeScript /
+ * SQL), add a builder here keyed by the adapter id. The component
+ * looks the builder up at check time and surfaces a clear error if
+ * none is registered.
+ */
+
+export interface ChallengeTest {
+  id: string;
+  name: string;
+  description: string;
+  /** Test body in the target language. Should `assert` / `throw` on
+   *  failure and execute silently on success. */
+  code: string;
+}
+
+/** Sentinel printed once, before any per-test result, so the component
+ *  can locate where the harness output begins inside captured stdout. */
+export const HARNESS_BEGIN = "__DSTEST_BEGIN__";
+
+/** Per-test result marker. Result form is exactly:
+ *      __DSTEST__:<id>:PASS
+ *      __DSTEST__:<id>:FAIL:<json-encoded detail string> */
+export const HARNESS_RESULT_PREFIX = "__DSTEST__:";
+
+/** Parsed individual test outcome. */
+export interface ParsedTestResult {
+  id: string;
+  pass: boolean;
+  detail: string | null;
+}
+
+/**
+ * Parse stdout text emitted by a challenge run. Returns:
+ *   - `clean`: stdout with all harness lines removed (user-visible).
+ *   - `results`: every `__DSTEST__:` line seen, in order.
+ */
+export function parseHarnessOutput(stdout: string): {
+  clean: string;
+  results: ParsedTestResult[];
+} {
+  const lines = stdout.split("\n");
+  const cleanLines: string[] = [];
+  const results: ParsedTestResult[] = [];
+  let seenBegin = false;
+
+  for (const line of lines) {
+    if (line === HARNESS_BEGIN) {
+      seenBegin = true;
+      continue;
+    }
+    if (line.startsWith(HARNESS_RESULT_PREFIX)) {
+      const rest = line.slice(HARNESS_RESULT_PREFIX.length);
+      // Form: <id>:PASS  or  <id>:FAIL:<json>
+      const firstColon = rest.indexOf(":");
+      if (firstColon === -1) continue;
+      const id = rest.slice(0, firstColon);
+      const after = rest.slice(firstColon + 1);
+      if (after === "PASS") {
+        results.push({ id, pass: true, detail: null });
+      } else if (after.startsWith("FAIL")) {
+        const detailJson = after.startsWith("FAIL:")
+          ? after.slice("FAIL:".length)
+          : "";
+        let detail: string | null = null;
+        if (detailJson) {
+          try {
+            detail = String(JSON.parse(detailJson));
+          } catch {
+            // Fall back to the raw payload so the user sees *something*
+            // rather than a silent failure if the harness emitted a
+            // malformed result line.
+            detail = detailJson;
+          }
+        }
+        results.push({ id, pass: false, detail });
+      }
+      continue;
+    }
+    // Once we've crossed into the harness region, also suppress any
+    // incidental stdout the harness produced (shouldn't happen, but a
+    // misbehaving assertion that prints before raising shouldn't leak
+    // into the user-facing output).
+    if (seenBegin) continue;
+    cleanLines.push(line);
+  }
+
+  return { clean: cleanLines.join("\n"), results };
+}
+
+type HarnessBuilder = (tests: ChallengeTest[]) => string;
+
+/**
+ * Python harness — uses a per-test wrapper function so the assertion
+ * can read globals defined by the learner's code (e.g. `summary`) while
+ * still isolating exceptions per test. Detail strings are JSON-encoded
+ * so newlines / quotes in error messages round-trip cleanly.
+ */
+const buildPythonHarness: HarnessBuilder = (tests) => {
+  const lines: string[] = [];
+  lines.push(`print("${HARNESS_BEGIN}")`);
+  lines.push("import json as __dstest_json");
+  lines.push("def __dstest_run(_tid, _fn):");
+  lines.push("    try:");
+  lines.push("        _fn()");
+  lines.push(`        print("${HARNESS_RESULT_PREFIX}" + _tid + ":PASS")`);
+  lines.push("    except AssertionError as _e:");
+  lines.push("        _msg = str(_e) or 'Assertion failed'");
+  lines.push(
+    `        print("${HARNESS_RESULT_PREFIX}" + _tid + ":FAIL:" + __dstest_json.dumps(_msg))`,
+  );
+  lines.push("    except Exception as _e:");
+  lines.push("        _msg = type(_e).__name__ + ': ' + str(_e)");
+  lines.push(
+    `        print("${HARNESS_RESULT_PREFIX}" + _tid + ":FAIL:" + __dstest_json.dumps(_msg))`,
+  );
+  lines.push("");
+  tests.forEach((t, i) => {
+    const fnName = `__dstest_t${i}`;
+    lines.push(`def ${fnName}():`);
+    // Indent every line of the user-supplied body by 4 spaces so it
+    // becomes the function body. An empty body is still legal (renders
+    // as `pass`).
+    const body = t.code.trim();
+    if (!body) {
+      lines.push("    pass");
+    } else {
+      for (const raw of body.split("\n")) {
+        lines.push("    " + raw);
+      }
+    }
+    lines.push(`__dstest_run(${JSON.stringify(t.id)}, ${fnName})`);
+    lines.push("");
+  });
+  return lines.join("\n");
+};
+
+/**
+ * JavaScript / TypeScript harness — used by both adapters since their
+ * runtime surface for `console.log` and exception handling is the same.
+ * Test bodies execute inside an IIFE so `return` is legal and lexical
+ * bindings don't pollute the global scope.
+ */
+const buildJsHarness: HarnessBuilder = (tests) => {
+  const lines: string[] = [];
+  lines.push(`console.log("${HARNESS_BEGIN}");`);
+  lines.push("function __dstestRun(tid, fn) {");
+  lines.push("  try { fn();");
+  lines.push(`    console.log("${HARNESS_RESULT_PREFIX}" + tid + ":PASS");`);
+  lines.push("  } catch (e) {");
+  lines.push(
+    "    const msg = e && e.message ? e.message : String(e);",
+  );
+  lines.push(
+    `    console.log("${HARNESS_RESULT_PREFIX}" + tid + ":FAIL:" + JSON.stringify(msg));`,
+  );
+  lines.push("  }");
+  lines.push("}");
+  lines.push("");
+  tests.forEach((t) => {
+    const body = t.code.trim() || "/* empty */";
+    lines.push(
+      `__dstestRun(${JSON.stringify(t.id)}, function () {\n${body}\n});`,
+    );
+    lines.push("");
+  });
+  return lines.join("\n");
+};
+
+/**
+ * R harness — same shape as the Python one, using `tryCatch` for the
+ * pass / fail framing. Test bodies should call `stop("…")` (or any
+ * function that calls it, e.g. `stopifnot()`) to signal failure.
+ */
+const buildRHarness: HarnessBuilder = (tests) => {
+  const lines: string[] = [];
+  lines.push(`cat("${HARNESS_BEGIN}\\n")`);
+  lines.push("__dstest_run <- function(tid, fn) {");
+  lines.push("  tryCatch({ fn();");
+  lines.push(
+    `    cat(paste0("${HARNESS_RESULT_PREFIX}", tid, ":PASS\\n"))`,
+  );
+  lines.push("  }, error = function(e) {");
+  lines.push("    msg <- conditionMessage(e)");
+  lines.push(
+    `    cat(paste0("${HARNESS_RESULT_PREFIX}", tid, ":FAIL:", jsonlite::toJSON(msg, auto_unbox = TRUE), "\\n"))`,
+  );
+  lines.push("  })");
+  lines.push("}");
+  lines.push("");
+  tests.forEach((t, i) => {
+    const fnName = `__dstest_t${i}`;
+    const body = t.code.trim() || "invisible(NULL)";
+    lines.push(`${fnName} <- function() {`);
+    for (const raw of body.split("\n")) lines.push("  " + raw);
+    lines.push("}");
+    lines.push(
+      `__dstest_run(${JSON.stringify(t.id)}, ${fnName})`,
+    );
+    lines.push("");
+  });
+  return lines.join("\n");
+};
+
+const HARNESS_BUILDERS: Record<string, HarnessBuilder> = {
+  python: buildPythonHarness,
+  javascript: buildJsHarness,
+  typescript: buildJsHarness,
+  r: buildRHarness,
+};
+
+/** Build the harness snippet for the given adapter. Throws if no
+ *  builder is registered — callers should surface that as a UI error
+ *  rather than silently dropping the check button. */
+export function buildHarness(
+  adapterId: string,
+  tests: ChallengeTest[],
+): string {
+  const builder = HARNESS_BUILDERS[adapterId];
+  if (!builder) {
+    throw new Error(
+      `No challenge test harness registered for adapter "${adapterId}". ` +
+        `Add one to challengeHarness.ts.`,
+    );
+  }
+  return builder(tests);
+}
+
+/** True iff a harness exists for the given adapter id. The component
+ *  uses this to disable the check button (rather than blow up at click
+ *  time) when an adapter doesn't yet support challenges. */
+export function hasHarness(adapterId: string): boolean {
+  return adapterId in HARNESS_BUILDERS;
+}

--- a/content/learn/challenge-test.mdx
+++ b/content/learn/challenge-test.mdx
@@ -1,0 +1,150 @@
+---
+title: Challenge Card test page
+description: Sandbox page for the new `<ChallengeCard>` component.
+---
+
+This page exercises the new `<ChallengeCard>` component across a few
+shapes so we can iterate on it visually.
+
+## Pandas DataFrame challenge
+
+The canonical example from the design handoff — a Pandas groupby
+challenge with init code, a hint, and six tests.
+
+<ChallengeCard
+  adapter="python"
+  title="Summarize Sales by Category"
+  category="pandas · groupby · agg"
+  estimatedTime="~5 min"
+  instructions={<>
+    <p>
+      You have a DataFrame called <code>df</code> with sales data. It has
+      the following columns: <code>category</code>, <code>product</code>,{' '}
+      <code>units_sold</code>, and <code>revenue</code>.
+    </p>
+    <p>
+      Your task is to create a summary DataFrame called{' '}
+      <strong><code>summary</code></strong> that groups by{' '}
+      <code>category</code> and computes:
+    </p>
+    <ul>
+      <li>Total <code>units_sold</code> (sum)</li>
+      <li>Total <code>revenue</code> (sum)</li>
+      <li>Average <code>revenue</code> per transaction, named <code>avg_revenue</code></li>
+    </ul>
+    <p>
+      Round all numeric results to <strong>2 decimal places</strong> and
+      sort by <code>revenue</code> descending.
+    </p>
+  </>}
+  hint={<>
+    Use <code>.groupby("category").agg(...)</code> with keyword aggregations
+    like <code>units_sold=("units_sold", "sum")</code> to rename columns
+    inline. Then chain <code>.round(2)</code> and{' '}
+    <code>.sort_values("revenue", ascending=False)</code>.
+  </>}
+  initCode={`import pandas as pd
+
+_data = {
+    "category":   ["Electronics","Electronics","Electronics","Clothing","Clothing","Clothing","Food","Food","Food","Books","Books","Books","Electronics","Clothing","Food"],
+    "product":    ["Laptop","Phone","Tablet","Jacket","Shirt","Pants","Coffee","Tea","Juice","Novel","Textbook","Comic","Headphones","Dress","Snacks"],
+    "units_sold": [42, 128, 67, 95, 210, 180, 340, 200, 150, 88, 55, 120, 73, 140, 275],
+    "revenue":    [52080.0, 76800.0, 26130.0, 9025.0, 4200.0, 7200.0, 3400.0, 1400.0, 1050.0, 1320.0, 2750.0, 720.0, 18980.0, 8400.0, 1375.0]
+}
+df = pd.DataFrame(_data)
+`}
+  initialCode={`# df is already loaded — explore it first
+print(df.head())
+print()
+
+# Your solution:
+summary = None  # TODO: replace with your groupby + agg expression
+
+print(summary)
+`}
+  tests={[
+    {
+      id: "summary_exists",
+      name: "`summary` DataFrame exists",
+      description: "A variable named `summary` should be a pandas DataFrame",
+      code: `import pandas as pd
+assert isinstance(summary, pd.DataFrame), "summary is not a DataFrame"`,
+    },
+    {
+      id: "correct_columns",
+      name: "Has correct columns",
+      description: "summary must have: units_sold, revenue, avg_revenue",
+      code: `expected = {"units_sold", "revenue", "avg_revenue"}
+actual = set(summary.columns.tolist())
+missing = expected - actual
+assert not missing, f"Missing columns: {', '.join(sorted(missing))}"`,
+    },
+    {
+      id: "grouped_by_category",
+      name: "Grouped by category (4 rows)",
+      description: "One row per category — should have exactly 4 rows",
+      code: `assert len(summary) == 4, f"Expected 4 rows (one per category), got {len(summary)}"`,
+    },
+    {
+      id: "correct_revenue",
+      name: "Revenue totals are correct",
+      description: "Electronics total revenue should be ~173,990",
+      code: `elec_rev = float(summary.loc["Electronics", "revenue"])
+assert abs(elec_rev - 173990.0) < 1, f"Electronics revenue: got {elec_rev}, expected 173990.0"`,
+    },
+    {
+      id: "sorted_descending",
+      name: "Sorted by revenue (descending)",
+      description: "Highest revenue category should come first",
+      code: `revs = summary["revenue"].tolist()
+assert all(revs[i] >= revs[i+1] for i in range(len(revs)-1)), \
+    f"Revenue order {revs} is not descending"`,
+    },
+    {
+      id: "rounded",
+      name: "Values rounded to 2 decimal places",
+      description: "avg_revenue should be rounded",
+      code: `avg_vals = summary["avg_revenue"].tolist()
+assert all(round(v, 2) == v for v in avg_vals), \
+    f"Some avg_revenue values not rounded to 2dp: {avg_vals}"`,
+    },
+  ]}
+/>
+
+## Minimal challenge (no init, no hint)
+
+A no-frills challenge so we can verify the layout still works when the
+optional elements are omitted.
+
+<ChallengeCard
+  adapter="python"
+  title="Compute the mean of a list"
+  initialCode={`# Compute the average of the values below.
+values = [12, 7, 4, 21, 9, 18, 3]
+
+mean = None  # your code here
+print("mean =", mean)
+`}
+  instructions={<>
+    <p>
+      Assign the arithmetic mean of <code>values</code> to a variable
+      called <code>mean</code>.
+    </p>
+  </>}
+  tests={[
+    {
+      id: "mean_is_defined",
+      name: "`mean` is defined and numeric",
+      description: "`mean` should hold a number",
+      code: `assert mean is not None, "mean was not assigned"
+assert isinstance(mean, (int, float)), f"mean should be a number, got {type(mean).__name__}"`,
+    },
+    {
+      id: "mean_correct",
+      name: "Mean matches the expected value",
+      description: "The arithmetic mean of the seven inputs",
+      code: `import math
+assert math.isclose(mean, 74/7, rel_tol=1e-9), f"Expected {74/7}, got {mean}"`,
+    },
+  ]}
+/>

--- a/content/learn/meta.json
+++ b/content/learn/meta.json
@@ -11,6 +11,8 @@
     "c",
     "cpp",
     "java",
-    "csharp"
+    "csharp",
+    "---",
+    "challenge-test"
   ]
 }

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -13,11 +13,13 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 import MdxCodeBlock from "@/app/_components/MdxCodeBlock";
+import MdxChallengeCard from "@/app/_components/MdxChallengeCard";
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
     CodeBlock: MdxCodeBlock,
+    ChallengeCard: MdxChallengeCard,
     ...components,
   };
 }


### PR DESCRIPTION
## Summary

Implements the `.challenge-card` design from the Python Challenge handoff bundle as a reusable, language-agnostic MDX component for the `/learn` route.

- **`<ChallengeCard>`** — light "worksheet" card with badge + title + meta header, instructions panel, optional hint, init-code support, CodeMirror editor, run + check-answer toolbar, streaming output panel, collapsible test-results list, and pass/fail banner.
- **Isolated runtime per card** — each `<ChallengeCard>` calls `adapter.init(...)` itself (not the shared registry), so two challenges on the same page never share Pyodide globals. Per-run state is reset by the adapter, so user code always starts clean.
- **Pluggable test harness** (`challengeHarness.ts`) — tests are `{ id, name, description, code }`; the harness wraps each test body with a per-language try/catch and emits sentinel stdout lines that the component parses into pass/fail results. Python is wired up now; JavaScript/TypeScript and R builders are included so dropping in challenges for those languages is just a matter of writing the test data.
- **MDX wrapper** (`MdxChallengeCard`) — exposes `<ChallengeCard adapter="python" .../>` to MDX content, mirroring `<MdxCodeBlock>`.
- **Test page** — `content/learn/challenge-test.mdx` exercises a full Pandas groupby challenge (with init, hint, and six tests) and a minimal no-frills challenge.

Reuses the existing Python adapter / Pyodide worker, the shared CodeMirror language loader, and the same `initCode` semantics as `<CodeBlock>`.

## Test plan

- [ ] Visit `/learn/challenge-test` and verify the card renders with badge, title, meta pills, instructions, hint toggle, init-code panel, editor, toolbar, and Check Answer button.
- [ ] Click **Run** — output panel streams stdout from the user's code only (no harness machinery leaks through).
- [ ] Click **Check Answer** before solving — the test list appears with failing tests + detail messages, the banner shows fail.
- [ ] Click **Show hint** — apply the hint, run **Check Answer** again — all six tests pass and the banner shows "All tests passed!".
- [ ] Click **Reset** — editor reverts, output / tests / banner clear.
- [ ] Confirm the minimal second card (no init / no hint) lays out cleanly.
- [ ] Verify the second card's runtime is independent from the first (state defined in one challenge does not leak into the other).

---
_Generated by [Claude Code](https://claude.ai/code/session_011VkV9MMwLKKawThvd1gJ4f)_