### PR TITLE
Move JavaScript and TypeScript execution to Web Workers

### DIFF
--- a/app/_components/runtime/javascript-worker.ts
+++ b/app/_components/runtime/javascript-worker.ts
@@ -10,8 +10,6 @@
 //                  { kind: "stderr"; id: number; content: string }
 //                  { kind: "done";   id: number }
 
-declare const self: DedicatedWorkerGlobalScope;
-
 type InMessage = { kind: "run"; id: number; code: string };
 
 type OutMessage =

--- a/app/_components/runtime/javascript-worker.ts
+++ b/app/_components/runtime/javascript-worker.ts
@@ -1,0 +1,131 @@
+/// <reference lib="webworker" />
+
+// Web Worker that executes JavaScript code via AsyncFunction so that
+// user-code execution is off the main thread and can't block the UI.
+//
+// Protocol
+//   Main → Worker  { kind: "run"; id: number; code: string }
+//   Worker → Main  { kind: "ready" }
+//                  { kind: "stdout"; id: number; content: string }
+//                  { kind: "stderr"; id: number; content: string }
+//                  { kind: "done";   id: number }
+
+declare const self: DedicatedWorkerGlobalScope;
+
+type InMessage = { kind: "run"; id: number; code: string };
+
+type OutMessage =
+  | { kind: "ready" }
+  | { kind: "stdout"; id: number; content: string }
+  | { kind: "stderr"; id: number; content: string }
+  | { kind: "done"; id: number };
+
+function post(msg: OutMessage) {
+  self.postMessage(msg);
+}
+
+function formatArg(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "function") return value.toString();
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value, jsonReplacer, 2);
+    } catch {
+      try {
+        return String(value);
+      } catch {
+        return "[object]";
+      }
+    }
+  }
+  if (typeof value === "bigint") return `${value.toString()}n`;
+  return String(value);
+}
+
+function jsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") return `${value.toString()}n`;
+  if (typeof value === "function")
+    return `[Function: ${value.name || "anonymous"}]`;
+  if (typeof value === "undefined") return "undefined";
+  return value;
+}
+
+function formatArgs(args: unknown[]): string {
+  return args.map(formatArg).join(" ");
+}
+
+async function runCode(id: number, code: string): Promise<void> {
+  let stdoutBuf = "";
+  let stderrBuf = "";
+
+  const sandboxConsole = {
+    log: (...args: unknown[]) => {
+      stdoutBuf += formatArgs(args) + "\n";
+    },
+    info: (...args: unknown[]) => {
+      stdoutBuf += formatArgs(args) + "\n";
+    },
+    debug: (...args: unknown[]) => {
+      stdoutBuf += formatArgs(args) + "\n";
+    },
+    warn: (...args: unknown[]) => {
+      stderrBuf += formatArgs(args) + "\n";
+    },
+    error: (...args: unknown[]) => {
+      stderrBuf += formatArgs(args) + "\n";
+    },
+    table: (value: unknown) => {
+      stdoutBuf += formatArg(value) + "\n";
+    },
+    dir: (value: unknown) => {
+      stdoutBuf += formatArg(value) + "\n";
+    },
+  };
+
+  const AsyncFunction = Object.getPrototypeOf(
+    async function () {},
+  ).constructor as new (...args: string[]) => (
+    console: typeof sandboxConsole,
+  ) => Promise<unknown>;
+
+  try {
+    const fn = new AsyncFunction("console", `"use strict";\n${code}`);
+    const result = await fn(sandboxConsole);
+    if (stdoutBuf)
+      post({ kind: "stdout", id, content: stdoutBuf.replace(/\n$/, "") });
+    if (stderrBuf)
+      post({ kind: "stderr", id, content: stderrBuf.replace(/\n$/, "") });
+    if (result !== undefined) {
+      post({ kind: "stdout", id, content: formatArg(result) });
+    }
+  } catch (err) {
+    if (stdoutBuf)
+      post({ kind: "stdout", id, content: stdoutBuf.replace(/\n$/, "") });
+    if (stderrBuf)
+      post({ kind: "stderr", id, content: stderrBuf.replace(/\n$/, "") });
+    const message =
+      err instanceof Error
+        ? err.stack || `${err.name}: ${err.message}`
+        : String(err);
+    post({ kind: "stderr", id, content: message });
+  }
+  post({ kind: "done", id });
+}
+
+// Serialise concurrent run requests so async user code can't interleave.
+let workQueue: Promise<unknown> = Promise.resolve();
+function enqueue(task: () => Promise<void>): void {
+  workQueue = workQueue.then(task, task).catch(() => {});
+}
+
+// No async init — JS runs natively, signal readiness immediately.
+post({ kind: "ready" });
+
+self.addEventListener("message", (ev: MessageEvent<InMessage>) => {
+  if (ev.data.kind === "run") {
+    const { id, code } = ev.data;
+    enqueue(() => runCode(id, code));
+  }
+});

--- a/app/_components/runtime/javascript.tsx
+++ b/app/_components/runtime/javascript.tsx
@@ -7,10 +7,10 @@ import type {
 } from "../types";
 import { getWebFmt } from "./webFmt";
 
-// JavaScript runs natively in the browser — no WebAssembly runtime is
-// needed. We wrap user code in an `AsyncFunction` so top-level `await`
-// works, and override `console.*` for the duration of the run so we can
-// stream output into the playground's output pane.
+// JavaScript runs in a dedicated Web Worker via the AsyncFunction constructor
+// so that user code (including top-level `await`) never blocks the UI.
+// The worker handles console.* interception and streams stdout/stderr back
+// to the main thread via postMessage.
 
 const EXAMPLES: ExampleSnippet[] = [
   {
@@ -145,118 +145,33 @@ const PACKAGES: PackageInfo[] = [
   // without any import statement, so there are no packages to list here.
 ];
 
-/** Format `console.log`-style argument lists the way browsers/Node do:
- *  primitives via String(), objects via JSON with a fallback to a tag. */
-function formatArg(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value === null) return "null";
-  if (value === undefined) return "undefined";
-  if (typeof value === "function") {
-    return value.toString();
-  }
-  if (typeof value === "object") {
-    try {
-      return JSON.stringify(value, jsonReplacer, 2);
-    } catch {
-      try {
-        return String(value);
-      } catch {
-        return "[object]";
-      }
-    }
-  }
-  if (typeof value === "bigint") return `${value.toString()}n`;
-  return String(value);
-}
+type WorkerOutMessage =
+  | { kind: "ready" }
+  | { kind: "stdout"; id: number; content: string }
+  | { kind: "stderr"; id: number; content: string }
+  | { kind: "done"; id: number };
 
-/** Replacer used to make objects with circular references / non-JSON values
- *  (BigInt, undefined, functions) survive `JSON.stringify`. */
-function jsonReplacer(_key: string, value: unknown): unknown {
-  if (typeof value === "bigint") return `${value.toString()}n`;
-  if (typeof value === "function") return `[Function: ${value.name || "anonymous"}]`;
-  if (typeof value === "undefined") return "undefined";
-  return value;
-}
+class JavaScriptWorkerRuntime implements LanguageRuntime {
+  private nextId = 0;
+  constructor(private worker: Worker) {}
 
-function formatArgs(args: unknown[]): string {
-  return args.map(formatArg).join(" ");
-}
-
-class JavaScriptRuntime implements LanguageRuntime {
   async run(code: string, emit: EmitOutput): Promise<void> {
-    let stdoutBuf = "";
-    let stderrBuf = "";
-
-    const flushStdout = () => {
-      if (stdoutBuf) {
-        emit({ type: "stdout", content: stdoutBuf.replace(/\n$/, "") });
-        stdoutBuf = "";
-      }
-    };
-    const flushStderr = () => {
-      if (stderrBuf) {
-        emit({ type: "stderr", content: stderrBuf.replace(/\n$/, "") });
-        stderrBuf = "";
-      }
-    };
-
-    // Build a console proxy that streams into our buffers. We deliberately
-    // don't replace the global `console` — instead we pass our proxy in
-    // as a parameter so concurrent tabs / unrelated UI logging is
-    // unaffected by user code.
-    const sandboxConsole = {
-      log: (...args: unknown[]) => {
-        stdoutBuf += formatArgs(args) + "\n";
-      },
-      info: (...args: unknown[]) => {
-        stdoutBuf += formatArgs(args) + "\n";
-      },
-      debug: (...args: unknown[]) => {
-        stdoutBuf += formatArgs(args) + "\n";
-      },
-      warn: (...args: unknown[]) => {
-        stderrBuf += formatArgs(args) + "\n";
-      },
-      error: (...args: unknown[]) => {
-        stderrBuf += formatArgs(args) + "\n";
-      },
-      table: (value: unknown) => {
-        stdoutBuf += formatArg(value) + "\n";
-      },
-      dir: (value: unknown) => {
-        stdoutBuf += formatArg(value) + "\n";
-      },
-    };
-
-    // `AsyncFunction` lets user code use top-level `await`. Wrapping in
-    // its own scope means user `var`/`let` declarations don't leak onto
-    // `globalThis`. We also enable strict mode so implicit-global
-    // assignments (`foo = 1` without `var`/`let`) throw instead of
-    // silently persisting onto `globalThis` between runs — keeping the
-    // playground's "fresh state per execution" guarantee.
-    const AsyncFunction = Object.getPrototypeOf(
-      async function () {},
-    ).constructor as new (...args: string[]) => (
-      console: typeof sandboxConsole,
-    ) => Promise<unknown>;
-
-    try {
-      const fn = new AsyncFunction("console", `"use strict";\n${code}`);
-      const result = await fn(sandboxConsole);
-      flushStdout();
-      flushStderr();
-      if (result !== undefined) {
-        emit({ type: "stdout", content: formatArg(result) });
-      }
-    } catch (err) {
-      flushStdout();
-      flushStderr();
-      const message =
-        err instanceof Error
-          ? err.stack || `${err.name}: ${err.message}`
-          : String(err);
-      emit({ type: "stderr", content: message });
-    }
+    const id = ++this.nextId;
+    return new Promise<void>((resolve) => {
+      const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
+        const msg = ev.data;
+        if (msg.kind === "stdout" || msg.kind === "stderr") {
+          if (msg.id === id) emit({ type: msg.kind, content: msg.content });
+          return;
+        }
+        if (msg.kind === "done" && msg.id === id) {
+          this.worker.removeEventListener("message", onMessage);
+          resolve();
+        }
+      };
+      this.worker.addEventListener("message", onMessage);
+      this.worker.postMessage({ kind: "run", id, code });
+    });
   }
 }
 
@@ -272,7 +187,7 @@ export const javascriptAdapter: LanguageAdapter = {
     engine: "Native browser",
     engineUrl: "https://developer.mozilla.org/docs/Web/JavaScript",
     notes:
-      "Runs natively in your browser via the AsyncFunction constructor — top-level await is supported.",
+      "Runs in a Web Worker via the AsyncFunction constructor — top-level await is supported and the UI stays responsive while your code executes.",
   },
   codeMirrorMode: "javascript",
   examples: EXAMPLES,
@@ -313,7 +228,22 @@ export const javascriptAdapter: LanguageAdapter = {
     return format(code, "script.js");
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Preparing JavaScript runtime…");
-    return new JavaScriptRuntime();
+    setLoadingMessage("Starting JavaScript worker…");
+    const worker = new Worker(
+      new URL("./javascript-worker.ts", import.meta.url),
+    );
+    return new Promise<LanguageRuntime>((resolve, reject) => {
+      const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
+        if (ev.data.kind === "ready") {
+          worker.removeEventListener("message", onMessage);
+          resolve(new JavaScriptWorkerRuntime(worker));
+        }
+      };
+      worker.addEventListener("message", onMessage);
+      worker.addEventListener("error", (ev) => {
+        worker.removeEventListener("message", onMessage);
+        reject(new Error(ev.message || "JavaScript worker failed to start"));
+      });
+    });
   },
 };

--- a/app/_components/runtime/typescript-worker.ts
+++ b/app/_components/runtime/typescript-worker.ts
@@ -1,0 +1,176 @@
+/// <reference lib="webworker" />
+
+// Web Worker that transpiles TypeScript → JavaScript (via the official
+// TypeScript compiler) then executes the result via AsyncFunction — keeping
+// both the compilation and the execution off the main thread so the UI
+// stays responsive.
+//
+// Protocol (mirrors javascript-worker.ts)
+//   Main → Worker  { kind: "run"; id: number; code: string }  (code is TS source)
+//   Worker → Main  { kind: "loading"; message: string }       (while loading ts pkg)
+//                  { kind: "ready" }
+//                  { kind: "stdout"; id: number; content: string }
+//                  { kind: "stderr"; id: number; content: string }
+//                  { kind: "done";   id: number }
+
+import * as ts from "typescript";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+type InMessage = { kind: "run"; id: number; code: string };
+
+type OutMessage =
+  | { kind: "loading"; message: string }
+  | { kind: "ready" }
+  | { kind: "stdout"; id: number; content: string }
+  | { kind: "stderr"; id: number; content: string }
+  | { kind: "done"; id: number };
+
+function post(msg: OutMessage) {
+  self.postMessage(msg);
+}
+
+function formatArg(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "function") return value.toString();
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value, jsonReplacer, 2);
+    } catch {
+      try {
+        return String(value);
+      } catch {
+        return "[object]";
+      }
+    }
+  }
+  if (typeof value === "bigint") return `${value.toString()}n`;
+  return String(value);
+}
+
+function jsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") return `${value.toString()}n`;
+  if (typeof value === "function")
+    return `[Function: ${value.name || "anonymous"}]`;
+  if (typeof value === "undefined") return "undefined";
+  return value;
+}
+
+function formatArgs(args: unknown[]): string {
+  return args.map(formatArg).join(" ");
+}
+
+async function runCode(id: number, tsSource: string): Promise<void> {
+  // Step 1: Transpile TS → JS (syntactic-only, same settings as before).
+  let outputText: string;
+  try {
+    const result = ts.transpileModule(tsSource, {
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.ESNext,
+        isolatedModules: true,
+        esModuleInterop: true,
+        allowJs: true,
+        strict: false,
+        removeComments: false,
+      },
+      reportDiagnostics: true,
+      fileName: "playground.ts",
+    });
+
+    const errors = (result.diagnostics ?? [])
+      .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+      .filter(Boolean);
+    if (errors.length > 0) {
+      post({
+        kind: "stderr",
+        id,
+        content: errors.map((m) => `TS: ${m}`).join("\n"),
+      });
+    }
+    outputText = result.outputText;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    post({
+      kind: "stderr",
+      id,
+      content: `TypeScript transpile error: ${message}`,
+    });
+    post({ kind: "done", id });
+    return;
+  }
+
+  // Step 2: Execute transpiled JS via AsyncFunction.
+  let stdoutBuf = "";
+  let stderrBuf = "";
+
+  const sandboxConsole = {
+    log: (...args: unknown[]) => {
+      stdoutBuf += formatArgs(args) + "\n";
+    },
+    info: (...args: unknown[]) => {
+      stdoutBuf += formatArgs(args) + "\n";
+    },
+    debug: (...args: unknown[]) => {
+      stdoutBuf += formatArgs(args) + "\n";
+    },
+    warn: (...args: unknown[]) => {
+      stderrBuf += formatArgs(args) + "\n";
+    },
+    error: (...args: unknown[]) => {
+      stderrBuf += formatArgs(args) + "\n";
+    },
+    table: (value: unknown) => {
+      stdoutBuf += formatArg(value) + "\n";
+    },
+    dir: (value: unknown) => {
+      stdoutBuf += formatArg(value) + "\n";
+    },
+  };
+
+  const AsyncFunction = Object.getPrototypeOf(
+    async function () {},
+  ).constructor as new (...args: string[]) => (
+    console: typeof sandboxConsole,
+  ) => Promise<unknown>;
+
+  try {
+    const fn = new AsyncFunction("console", `"use strict";\n${outputText}`);
+    const result = await fn(sandboxConsole);
+    if (stdoutBuf)
+      post({ kind: "stdout", id, content: stdoutBuf.replace(/\n$/, "") });
+    if (stderrBuf)
+      post({ kind: "stderr", id, content: stderrBuf.replace(/\n$/, "") });
+    if (result !== undefined) {
+      post({ kind: "stdout", id, content: formatArg(result) });
+    }
+  } catch (err) {
+    if (stdoutBuf)
+      post({ kind: "stdout", id, content: stdoutBuf.replace(/\n$/, "") });
+    if (stderrBuf)
+      post({ kind: "stderr", id, content: stderrBuf.replace(/\n$/, "") });
+    const message =
+      err instanceof Error
+        ? err.stack || `${err.name}: ${err.message}`
+        : String(err);
+    post({ kind: "stderr", id, content: message });
+  }
+  post({ kind: "done", id });
+}
+
+// Serialise concurrent run requests.
+let workQueue: Promise<unknown> = Promise.resolve();
+function enqueue(task: () => Promise<void>): void {
+  workQueue = workQueue.then(task, task).catch(() => {});
+}
+
+post({ kind: "ready" });
+
+self.addEventListener("message", (ev: MessageEvent<InMessage>) => {
+  if (ev.data.kind === "run") {
+    const { id, code } = ev.data;
+    enqueue(() => runCode(id, code));
+  }
+});

--- a/app/_components/runtime/typescript.tsx
+++ b/app/_components/runtime/typescript.tsx
@@ -7,19 +7,13 @@ import type {
 } from "../types";
 import { getWebFmt } from "./webFmt";
 
-// TypeScript runs in a two-step pipeline:
-//   1. Use the official TypeScript compiler API (loaded dynamically from
-//      the `typescript` npm package) to transpile the user's source down
-//      to ES2022 JavaScript. We deliberately stick to `transpileModule`
-//      so we get the same behaviour as `tsc --isolatedModules` — no
-//      cross-file type-checking is needed for a single-file playground.
-//   2. Hand the resulting JS to an `AsyncFunction` so top-level `await`
-//      works, with `console.*` overridden so output streams into the
-//      playground's output pane.
+// TypeScript runs in a dedicated Web Worker (typescript-worker.ts) that:
+//   1. Imports the official TypeScript compiler and transpiles the user's
+//      source to ES2022 JavaScript via `transpileModule`.
+//   2. Executes the resulting JS via `AsyncFunction` (top-level await works).
 //
-// TypeScript's bundle is ~10MB unminified, so we lazy-load it on the
-// first run via dynamic import — that keeps the playground UI from
-// having to wait on it during the initial page load.
+// Moving both steps to a worker keeps the ~10MB compiler bundle off the
+// main thread and ensures heavy transpilation / execution never blocks the UI.
 
 const EXAMPLES: ExampleSnippet[] = [
   {
@@ -192,175 +186,34 @@ const PACKAGES: PackageInfo[] = [
   // without any import statement, so there are no packages to list here.
 ];
 
-function formatArg(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value === null) return "null";
-  if (value === undefined) return "undefined";
-  if (typeof value === "function") return value.toString();
-  if (typeof value === "object") {
-    try {
-      return JSON.stringify(value, jsonReplacer, 2);
-    } catch {
-      try {
-        return String(value);
-      } catch {
-        return "[object]";
-      }
-    }
-  }
-  if (typeof value === "bigint") return `${value.toString()}n`;
-  return String(value);
-}
+type WorkerOutMessage =
+  | { kind: "loading"; message: string }
+  | { kind: "ready" }
+  | { kind: "stdout"; id: number; content: string }
+  | { kind: "stderr"; id: number; content: string }
+  | { kind: "done"; id: number };
 
-function jsonReplacer(_key: string, value: unknown): unknown {
-  if (typeof value === "bigint") return `${value.toString()}n`;
-  if (typeof value === "function") return `[Function: ${value.name || "anonymous"}]`;
-  if (typeof value === "undefined") return "undefined";
-  return value;
-}
-
-function formatArgs(args: unknown[]): string {
-  return args.map(formatArg).join(" ");
-}
-
-/** Minimal slice of the `typescript` module surface we use. Declaring
- *  it locally keeps the import boundary explicit and means downstream
- *  TS users of this file aren't forced to take a `typescript` type
- *  dependency. */
-interface TsCompilerModule {
-  transpileModule(
-    input: string,
-    options: {
-      compilerOptions: Record<string, unknown>;
-      reportDiagnostics?: boolean;
-      fileName?: string;
-    },
-  ): {
-    outputText: string;
-    diagnostics?: Array<{
-      messageText: string | { messageText: string };
-      category: number;
-    }>;
-  };
-  ScriptTarget: { ES2022: number };
-  ModuleKind: { ESNext: number };
-  JsxEmit: { Preserve: number };
-  flattenDiagnosticMessageText(
-    diag: string | { messageText: string } | undefined,
-    newLine: string,
-  ): string;
-}
-
-class TypeScriptRuntime implements LanguageRuntime {
-  constructor(private ts: TsCompilerModule) {}
+class TypeScriptWorkerRuntime implements LanguageRuntime {
+  private nextId = 0;
+  constructor(private worker: Worker) {}
 
   async run(code: string, emit: EmitOutput): Promise<void> {
-    // 1) Transpile TS → JS. transpileModule does syntactic-only checks,
-    // which is the right trade-off for a single-file playground.
-    let outputText: string;
-    try {
-      const result = this.ts.transpileModule(code, {
-        compilerOptions: {
-          target: this.ts.ScriptTarget.ES2022,
-          module: this.ts.ModuleKind.ESNext,
-          // Allow top-level `await` in the generated JS so user code
-          // can use it without wrapping it in an IIFE.
-          isolatedModules: true,
-          esModuleInterop: true,
-          allowJs: true,
-          strict: false,
-          // Keep the output clean — strip type-only constructs.
-          removeComments: false,
-        },
-        reportDiagnostics: true,
-        fileName: "playground.ts",
-      });
-
-      const diagnostics = result.diagnostics ?? [];
-      const errors = diagnostics
-        .map((d) => this.ts.flattenDiagnosticMessageText(d.messageText, "\n"))
-        .filter(Boolean);
-      if (errors.length > 0) {
-        emit({
-          type: "stderr",
-          content: errors.map((m) => `TS: ${m}`).join("\n"),
-        });
-      }
-      outputText = result.outputText;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      emit({ type: "stderr", content: `TypeScript transpile error: ${message}` });
-      return;
-    }
-
-    // 2) Execute the transpiled JS in an AsyncFunction with a captured
-    // console. This mirrors what the JavaScript playground does.
-    let stdoutBuf = "";
-    let stderrBuf = "";
-
-    const flushStdout = () => {
-      if (stdoutBuf) {
-        emit({ type: "stdout", content: stdoutBuf.replace(/\n$/, "") });
-        stdoutBuf = "";
-      }
-    };
-    const flushStderr = () => {
-      if (stderrBuf) {
-        emit({ type: "stderr", content: stderrBuf.replace(/\n$/, "") });
-        stderrBuf = "";
-      }
-    };
-
-    const sandboxConsole = {
-      log: (...args: unknown[]) => {
-        stdoutBuf += formatArgs(args) + "\n";
-      },
-      info: (...args: unknown[]) => {
-        stdoutBuf += formatArgs(args) + "\n";
-      },
-      debug: (...args: unknown[]) => {
-        stdoutBuf += formatArgs(args) + "\n";
-      },
-      warn: (...args: unknown[]) => {
-        stderrBuf += formatArgs(args) + "\n";
-      },
-      error: (...args: unknown[]) => {
-        stderrBuf += formatArgs(args) + "\n";
-      },
-      table: (value: unknown) => {
-        stdoutBuf += formatArg(value) + "\n";
-      },
-      dir: (value: unknown) => {
-        stdoutBuf += formatArg(value) + "\n";
-      },
-    };
-
-    const AsyncFunction = Object.getPrototypeOf(
-      async function () {},
-    ).constructor as new (...args: string[]) => (
-      console: typeof sandboxConsole,
-    ) => Promise<unknown>;
-
-    try {
-      // Prepend "use strict" so implicit-global assignments fail loudly
-      // instead of leaking onto `globalThis` between runs — the
-      // playground's contract is "fresh state per execution".
-      const fn = new AsyncFunction("console", `"use strict";\n${outputText}`);
-      const result = await fn(sandboxConsole);
-      flushStdout();
-      flushStderr();
-      if (result !== undefined) {
-        emit({ type: "stdout", content: formatArg(result) });
-      }
-    } catch (err) {
-      flushStdout();
-      flushStderr();
-      const message =
-        err instanceof Error
-          ? err.stack || `${err.name}: ${err.message}`
-          : String(err);
-      emit({ type: "stderr", content: message });
-    }
+    const id = ++this.nextId;
+    return new Promise<void>((resolve) => {
+      const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
+        const msg = ev.data;
+        if (msg.kind === "stdout" || msg.kind === "stderr") {
+          if (msg.id === id) emit({ type: msg.kind, content: msg.content });
+          return;
+        }
+        if (msg.kind === "done" && msg.id === id) {
+          this.worker.removeEventListener("message", onMessage);
+          resolve();
+        }
+      };
+      this.worker.addEventListener("message", onMessage);
+      this.worker.postMessage({ kind: "run", id, code });
+    });
   }
 }
 
@@ -376,7 +229,7 @@ export const typescriptAdapter: LanguageAdapter = {
     engine: "TypeScript compiler (in-browser) + native JS",
     engineUrl: "https://www.typescriptlang.org/",
     notes:
-      "Your code is transpiled to JavaScript in the browser using the official TypeScript compiler, then executed natively.",
+      "Your code is transpiled and executed in a Web Worker using the official TypeScript compiler — the UI stays responsive while your code runs.",
   },
   // The JS CodeMirror mode handles TypeScript via a typescript flag —
   // CodeMirror v5 exposes that as the `text/typescript` MIME alias.
@@ -412,14 +265,25 @@ export const typescriptAdapter: LanguageAdapter = {
     return format(code, "script.ts");
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Loading TypeScript compiler…");
-    // Dynamic import keeps the ~10MB compiler out of the initial page
-    // bundle — it's only fetched on the first visit to /typescript.
-    const tsMod = (await import("typescript")) as unknown as {
-      default?: TsCompilerModule;
-    } & TsCompilerModule;
-    const ts: TsCompilerModule = tsMod.default ?? tsMod;
-    setLoadingMessage("Initialising TypeScript runtime…");
-    return new TypeScriptRuntime(ts);
+    setLoadingMessage("Starting TypeScript worker…");
+    const worker = new Worker(
+      new URL("./typescript-worker.ts", import.meta.url),
+    );
+    return new Promise<LanguageRuntime>((resolve, reject) => {
+      const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
+        const msg = ev.data;
+        if (msg.kind === "loading") {
+          setLoadingMessage(msg.message);
+        } else if (msg.kind === "ready") {
+          worker.removeEventListener("message", onMessage);
+          resolve(new TypeScriptWorkerRuntime(worker));
+        }
+      };
+      worker.addEventListener("message", onMessage);
+      worker.addEventListener("error", (ev) => {
+        worker.removeEventListener("message", onMessage);
+        reject(new Error(ev.message || "TypeScript worker failed to start"));
+      });
+    });
   },
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **JavaScript playground**: Replaced `JavaScriptRuntime` (main-thread `AsyncFunction`) with `JavaScriptWorkerRuntime` backed by a new `javascript-worker.ts` Web Worker. The worker posts `ready` immediately on startup, then accepts `{ kind: "run", id, code }` messages and streams stdout/stderr back before posting `done`.
- **TypeScript playground**: Replaced `TypeScriptRuntime` (main-thread transpile + execute) with `TypeScriptWorkerRuntime` backed by a new `typescript-worker.ts` Web Worker. The worker statically imports the TypeScript compiler, transpiles the source via `transpileModule`, and executes the resulting JS — keeping the ~10MB compiler bundle entirely off the main thread.
- Both workers use the same request/response protocol as the existing `pyodide-worker.ts` and serialise concurrent runs via a work queue.

## Current state of all playgrounds

| Playground | Before | After |
|------------|--------|-------|
| **Python** | ✅ Worker (pyodide-worker.ts) | ✅ Worker |
| **R** | ✅ Worker (WebR manages internally) | ✅ Worker |
| **DuckDB** | ✅ Worker (explicit `new Worker`) | ✅ Worker |
| **JavaScript** | ❌ Main thread | ✅ Worker (this PR) |
| **TypeScript** | ❌ Main thread | ✅ Worker (this PR) |
| **SQLite** | ❌ Main thread | ⚠️ Needs follow-up |
| **PostgreSQL** | ❌ Main thread | ⚠️ Needs follow-up |
| **PHP** | ❌ Main thread | ⚠️ Needs follow-up |
| **Java** | ❌ Main thread | 🔍 CheerpJ needs DOM — may not be feasible |
| **C#** | ❌ Main thread | 🔍 .NET WASM — needs investigation |
| **C / C++** | ❌ Main thread | 🔍 browsercc explicitly avoids workers (no SAB needed) |

## Remaining work

**SQLite / PostgreSQL**: The `SqliteEngine` interface has ~25 synchronous methods called throughout `useQueryRunner.ts`, `useDatabaseActions.ts`, and other hooks. Moving to workers requires making all those call sites async — that's a larger refactor tracked separately. PGlite has first-class `@electric-sql/pglite/worker` support which makes the PostgreSQL migration more approachable.

**PHP**: `php-wasm` accesses `document.currentScript` at import time (used by Emscripten to locate `.wasm` files). Workers don't have `document`, so compatibility needs to be verified against the actual CDN build before a worker can be created.

**Java / C# / C / C++**: CheerpJ requires DOM access for its virtual display; .NET WASM's bootstrap needs investigation; browsercc explicitly avoids SharedArrayBuffer to remove COOP/COEP header requirements — adding a worker there would reintroduce that constraint.

## Test plan

- [ ] Visit `/playground/javascript`, run the "Async / Await" example — UI should remain responsive and output should appear after the awaits resolve
- [ ] Visit `/playground/typescript`, run the "Discriminated Unions" example — should compile and execute without freezing the tab
- [ ] Run a CPU-heavy snippet (e.g. a tight loop) in both playgrounds and confirm the browser tab stays interactive while it executes
- [ ] Check browser DevTools → Performance to confirm execution appears on a Worker thread, not the main thread
- [ ] Verify multiple sequential runs work correctly (each run gets a fresh scope due to `"use strict"` + scoped `AsyncFunction`)
- [ ] Confirm `console.warn` / `console.error` appear in the stderr output cell, `console.log` in stdout

https://claude.ai/code/session_01FpKvHSLQPr7wo94FZX1CTS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpKvHSLQPr7wo94FZX1CTS)_