### PR TITLE
Fix SQLite playground crash: strip seed function before postMessage

### DIFF
--- a/app/_components/runtime/sqlite-core.ts
+++ b/app/_components/runtime/sqlite-core.ts
@@ -20,7 +20,7 @@ import type {
   SqlJsStatic,
   SqlValue,
 } from "sql.js";
-import { findSampleDatabase, type SqliteSampleDatabase } from "./sqliteSamples";
+import { findSampleDatabase, type SqliteSampleDatabase, type SqliteSampleMetadata } from "./sqliteSamples";
 
 export type { QueryExecResult } from "sql.js";
 
@@ -133,7 +133,7 @@ export interface TableRebuildSpec {
 export interface SqliteEngine {
   /** Replace the active in-memory database with a fresh build of the
    *  given sample. Returns the active sample for convenience. */
-  loadSampleDatabase: (id: string) => Promise<SqliteSampleDatabase>;
+  loadSampleDatabase: (id: string) => Promise<SqliteSampleMetadata>;
   /** Execute a (potentially multi-statement) SQL string against the
    *  active database. Throws on syntax / runtime errors. */
   exec: (sql: string) => Promise<QueryExecResult[]>;
@@ -199,7 +199,7 @@ export interface SqliteEngine {
    *  (system tables, certain virtual tables). */
   getDDL: (name: string) => Promise<string>;
   /** The sample database currently loaded into memory. */
-  activeSample: () => Promise<SqliteSampleDatabase>;
+  activeSample: () => Promise<SqliteSampleMetadata>;
   /** Serialise the active database to a SQLite file image. The bytes
    *  are exactly what would land on disk if SQLite wrote the database
    *  to a `.sqlite` file, so the result can be downloaded as-is or
@@ -232,12 +232,12 @@ export interface SqliteEngine {
   ) => Promise<number>;
   /** Replace the active in-memory database with a fresh empty database.
    *  Returns a synthetic SqliteSampleDatabase descriptor for the blank DB. */
-  loadBlankDatabase: () => Promise<SqliteSampleDatabase>;
+  loadBlankDatabase: () => Promise<SqliteSampleMetadata>;
   /** Replace the active in-memory database with a database loaded from
    *  the given bytes (e.g., a user-uploaded .sqlite file). The filename
    *  parameter is used only for display purposes. Returns a synthetic
    *  SqliteSampleDatabase descriptor. */
-  loadFromBytes: (bytes: Uint8Array, filename: string) => Promise<SqliteSampleDatabase>;
+  loadFromBytes: (bytes: Uint8Array, filename: string) => Promise<SqliteSampleMetadata>;
   /** Returns per-column constraint info for `<tableName>`, combining
    *  `PRAGMA table_info` (for primary key membership) with
    *  `PRAGMA index_list` / `PRAGMA index_info` (for UNIQUE constraints)
@@ -557,7 +557,8 @@ export async function createSqliteEngineInProcess(
   return {
     loadSampleDatabase(id: string) {
       build(findSampleDatabase(id));
-      return active;
+      const { seed: _seed, ...meta } = active;
+      return meta;
     },
     exec(sql: string) {
       return require().exec(sql);
@@ -1045,7 +1046,8 @@ export async function createSqliteEngineInProcess(
       return parts.map((p) => (p.endsWith(";") ? p : `${p};`)).join("\n\n");
     },
     activeSample() {
-      return active;
+      const { seed: _seed, ...meta } = active;
+      return meta;
     },
     exportDatabase() {
       // sql.js's `Database.export()` returns a `Uint8Array` containing
@@ -1175,7 +1177,8 @@ export async function createSqliteEngineInProcess(
         defaultTabs: [{ title: "Query 1", code: "" }],
       };
       active = blank;
-      return active;
+      const { seed: _seed, ...meta } = active;
+      return meta;
     },
     loadFromBytes(bytes: Uint8Array, filename: string) {
       if (db) {
@@ -1204,7 +1207,8 @@ export async function createSqliteEngineInProcess(
         defaultTabs: [{ title: "Query 1", code: "" }],
       };
       active = imported;
-      return imported;
+      const { seed: _seed, ...meta } = imported;
+      return meta;
     },
     getColumnConstraintInfo(tableName: string): ColumnConstraintInfo[] {
       const d = require();

--- a/app/_components/runtime/sqlite.ts
+++ b/app/_components/runtime/sqlite.ts
@@ -10,7 +10,7 @@ export type {
 } from "./sqlite-core";
 
 import type { QueryExecResult } from "sql.js";
-import type { SqliteSampleDatabase } from "./sqliteSamples";
+import type { SqliteSampleMetadata } from "./sqliteSamples";
 import type {
   ColumnConstraintInfo,
   ForeignKeyInfo,
@@ -74,7 +74,7 @@ export async function createSqliteEngine(
   await call("loadSampleDatabase", [initialSampleId]);
 
   return {
-    loadSampleDatabase: (id) => call("loadSampleDatabase", [id]) as Promise<SqliteSampleDatabase>,
+    loadSampleDatabase: (id) => call("loadSampleDatabase", [id]) as Promise<SqliteSampleMetadata>,
     exec: (sql) => call("exec", [sql]) as Promise<QueryExecResult[]>,
     execAll: (sql) => call("execAll", [sql]) as Promise<(QueryExecResultWithTypes | null)[]>,
     listTables: () => call("listTables") as Promise<string[]>,
@@ -90,15 +90,15 @@ export async function createSqliteEngine(
     listForeignKeys: (name) => call("listForeignKeys", [name]) as Promise<ForeignKeyInfo[]>,
     rebuildTable: (spec) => call("rebuildTable", [spec]) as Promise<void>,
     getDDL: (name) => call("getDDL", [name]) as Promise<string>,
-    activeSample: () => call("activeSample") as Promise<SqliteSampleDatabase>,
+    activeSample: () => call("activeSample") as Promise<SqliteSampleMetadata>,
     exportDatabase: () => call("exportDatabase") as Promise<Uint8Array>,
     deleteRows: (tableName, pkColumns, pkRows) =>
       call("deleteRows", [tableName, pkColumns, pkRows]) as Promise<number>,
     updateRows: (tableName, updates) =>
       call("updateRows", [tableName, updates]) as Promise<number>,
-    loadBlankDatabase: () => call("loadBlankDatabase") as Promise<SqliteSampleDatabase>,
+    loadBlankDatabase: () => call("loadBlankDatabase") as Promise<SqliteSampleMetadata>,
     loadFromBytes: (bytes, filename) =>
-      call("loadFromBytes", [bytes, filename]) as Promise<SqliteSampleDatabase>,
+      call("loadFromBytes", [bytes, filename]) as Promise<SqliteSampleMetadata>,
     getColumnConstraintInfo: (tableName) =>
       call("getColumnConstraintInfo", [tableName]) as Promise<ColumnConstraintInfo[]>,
     insertRow: (tableName, columnNames, values) =>

--- a/app/_components/runtime/sqliteSamples.ts
+++ b/app/_components/runtime/sqliteSamples.ts
@@ -34,6 +34,10 @@ export interface SqliteSampleDatabase {
   defaultTabs: QueryTabSeed[];
 }
 
+/** Serialisable subset of SqliteSampleDatabase — safe to send through
+ *  postMessage (no function properties). */
+export type SqliteSampleMetadata = Omit<SqliteSampleDatabase, "seed">;
+
 // ────────────────────────────────────────────────────────────────────────
 // Sample 1: credit_card_transactions.db
 // Ported from public/SQL Playground.html, then extended with foreign

--- a/app/_components/sql/hooks/useDatabaseActions.ts
+++ b/app/_components/sql/hooks/useDatabaseActions.ts
@@ -27,7 +27,7 @@ import { useEngineStore } from "../stores/useEngineStore";
 import { useTabStore } from "../stores/useTabStore";
 import { useDialogStore } from "../stores/useDialogStore";
 import type { PragmaSettings } from "../stores/usePragmaStore";
-import type { SqliteSampleDatabase } from "../../runtime/sqliteSamples";
+import type { SqliteSampleMetadata } from "../../runtime/sqliteSamples";
 
 export interface DatabaseActionsRefs {
   engineRef: React.MutableRefObject<SqliteEngine | null>;
@@ -124,7 +124,7 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
   );
 
   const applyDbLoad = useCallback(
-    async (sample: SqliteSampleDatabase) => {
+    async (sample: SqliteSampleMetadata) => {
       const engine = engineRef.current;
       if (!engine) return;
       saveTabs(activeDbIdRef.current, tabsRef.current);

--- a/app/_components/sql/stores/useEngineStore.ts
+++ b/app/_components/sql/stores/useEngineStore.ts
@@ -6,7 +6,7 @@ import type {
   ForeignKeyInfo,
   ColumnConstraintInfo,
 } from "../../runtime/sqlite";
-import type { SqliteSampleDatabase } from "../../runtime/sqliteSamples";
+import type { SqliteSampleMetadata } from "../../runtime/sqliteSamples";
 import { SQLITE_SAMPLE_DATABASES } from "../../runtime/sqliteSamples";
 import { storageKey } from "../../sqlitePlaygroundTabs";
 
@@ -29,7 +29,7 @@ interface EngineState {
   tablesSectionExpanded: boolean;
   viewsSectionExpanded: boolean;
   activeDbId: string;
-  customDb: SqliteSampleDatabase | null;
+  customDb: SqliteSampleMetadata | null;
   customFilenames: Record<string, string>;
   // Setters
   setLoaded: (loaded: boolean) => void;
@@ -65,9 +65,9 @@ interface EngineState {
   setActiveDbId: (id: string) => void;
   setCustomDb: (
     db:
-      | SqliteSampleDatabase
+      | SqliteSampleMetadata
       | null
-      | ((prev: SqliteSampleDatabase | null) => SqliteSampleDatabase | null),
+      | ((prev: SqliteSampleMetadata | null) => SqliteSampleMetadata | null),
   ) => void;
   setCustomFilenames: (
     updater:


### PR DESCRIPTION
## Summary

- The SQLite playground was crashing on load with "Failed to execute 'postMessage' on 'DedicatedWorkerGlobalScope': ... could not be cloned"
- Root cause: `SqliteSampleDatabase` objects returned by `loadSampleDatabase`, `activeSample`, `loadBlankDatabase`, and `loadFromBytes` included a `seed: (db: Database) => void` function property — functions cannot be serialized through the Web Worker `postMessage` boundary
- Fix: add `SqliteSampleMetadata = Omit<SqliteSampleDatabase, "seed">` as the serialisable return type for those four engine methods, and destructure out `seed` before returning so it never crosses the worker boundary

## Test plan

- [ ] Load the SQLite playground — it should no longer show "Failed to load" and should display tables correctly
- [ ] Switch between sample databases (credit_card_transactions, chinook, northwind)
- [ ] Load a blank database
- [ ] Import a `.sqlite` file via the import dialog
- [ ] Export the active database


---
_Generated by [Claude Code](https://claude.ai/code/session_01LCoBaZgdKswnYeqaJyvur3)_