### PR TITLE
DuckDB playground: perf hot-fixes, lazy bundles, and dedup pass

### DIFF
--- a/agent-output/2026-05-15-sql-playground-shell-stage-3-handoff.md
+++ b/agent-output/2026-05-15-sql-playground-shell-stage-3-handoff.md
@@ -1,0 +1,306 @@
+# Stage 3 Handoff — SQL Playground Shell Extraction
+
+**Date:** 2026-05-15
+**Predecessor PR:** [#304 — DuckDB perf hot-fixes, lazy bundles, and dedup pass](https://github.com/subwaymatch/dataslope-playground/pull/304)
+**Branch the predecessor work merged from:** `claude/audit-playgrounds-performance-AYvzX`
+
+This document hands off Stage 3 of the playgrounds audit/refactor plan. Stages 1, 2, and 5 are already landed (or in PR #304). Stage 3 is the largest, riskiest piece — the SQL playground shell extraction — and was deliberately deferred to its own PR sequence so it can be reviewed and validated incrementally.
+
+---
+
+## 1 — What's already done (context for the next agent)
+
+These shipped in PR #304 — start from `main` after that merges.
+
+### Perf hot-fixes (DuckDB)
+- `persistTabs` now debounces `saveTabs` to localStorage (500 ms trailing edge; flushed on tab/db switch, `visibilitychange`, `pagehide`, unmount). The CodeMirror updateListener no longer pays a synchronous `JSON.stringify(tabs)` + `localStorage.setItem` per keystroke. `app/_components/duckdb/DuckDbPlayground.tsx:1265–1335`.
+- The schema-reconfigure effect now skips its `view.dispatch(...)` when the structural completion-schema hash is unchanged. Previously fired after every query and CSV import because `refreshSchema()` always built fresh `columnsByEntity` / `foreignKeysByEntity` objects. Same file, around L1879.
+- `SELECT COUNT(*)` per table dropped from `refreshSchema`; row counts fetched lazily on first sidebar use, cached, in-flight de-duplicated. `listColumns` + `listForeignKeys` fan-out capped at concurrency 6.
+
+### Bundle wins (all three SQL playgrounds)
+- `ErDiagramPane` → `next/dynamic` (defers `@xyflow/react` + `elkjs/lib/elk.bundled.js`).
+- `sql-formatter` (~150 KB) moved to call-site dynamic import in the Format button handler.
+- `next.config.ts`: enabled `experimental.optimizePackageImports` for `lucide-react` and `react-icons`.
+
+### Dedup pass
+- `app/_components/sql/utils/importUtils.ts` now owns the RFC-4180 CSV parser, `tableNameFromFilename`, and the parquet-wasm loader / `readParquetFile`. Dialect import modules re-export from there.
+- `app/_components/sql/stores/createSchemaSettingsStore.ts` is the factory for the DuckDB + Postgres settings stores (SQLite has its own with PRAGMA integration and different theme defaults — left untouched).
+- `app/_components/sql/shared/editorSetup.ts` owns the canonical CodeMirror extension list + reconfigure helpers. All three playgrounds mount their editor through `createSqlEditorExtensions({...})` and reconfigure their lang / completion compartments via `makeSqlLangExtension` / `makeSqlAutocompletionExtension`.
+- `SqlPlayground.tsx`: 245 lines of dead inline exporter copies (already-shared in `sql/utils/exportUtils.ts`) removed.
+
+### Net diff so far in PR #304
+- `+317 / -668` for the editor-setup commit alone.
+- Total branch diff: ~700 new lines / ~1,150 deleted across editor setup, schema settings, CSV/Parquet helpers, perf hot-fixes, and bundle plumbing.
+
+### File sizes after PR #304
+| File | Lines |
+|---|---|
+| `app/_components/sql/SqlPlayground.tsx` | 4,549 |
+| `app/_components/postgres/PostgresPlayground.tsx` | 5,877 |
+| `app/_components/duckdb/DuckDbPlayground.tsx` | 6,401 |
+| `app/_components/sql/shared/editorSetup.ts` | 223 |
+
+The shell extraction has to chip away at the three monoliths.
+
+---
+
+## 2 — Target architecture
+
+The three SQL playgrounds share ~80% of their shell. The end state is a single `SqlPlaygroundShell` component parameterized by a `SqlEngineAdapter` interface. Each `app/playground/{sqlite,postgres,duckdb}/page.tsx` (or a tiny wrapper file under `_components/*`) becomes a ~50-line file that constructs an adapter and renders `<SqlPlaygroundShell adapter={…} />`.
+
+### 2.1 Proposed adapter interface
+
+Put this in `app/_components/sql/shared/SqlEngineAdapter.ts`. The shapes below are what the shell needs to be dialect-agnostic; refine against the real engine APIs as you go.
+
+```ts
+import type { QueryExecResult } from "sql.js";
+import type { Extension } from "@codemirror/state";
+import type {
+  SqlDialect,
+  SqlCompletionSchema,
+} from "../sqlCompletion";
+
+export interface SqlSample {
+  id: string;
+  label: string;
+  filename: string;
+  defaultTabs?: ReadonlyArray<{ title: string; code: string }>;
+  // anything else the dialect-specific sample list needs
+}
+
+export interface SqlColumnInfo {
+  name: string;
+  type: string;
+  notNull?: boolean;
+  defaultValue?: string | null;
+  pk?: number;
+}
+
+export interface SqlForeignKeyInfo {
+  from: string;
+  to_table: string;
+  to_column: string;
+  on_delete?: string;
+  on_update?: string;
+}
+
+/** Result of a single SQL statement run. Mirrors sql.js's QueryExecResult
+ *  for sqlite; postgres/duckdb adapters convert their native shape into
+ *  this. */
+export interface SqlRunResult {
+  sets: QueryExecResult[];
+  elapsedMs: number;
+  error?: string;
+  // optional dialect-specific payloads (e.g. EXPLAIN plan rows)
+}
+
+export interface SqlEntityRef {
+  name: string;
+  kind: "table" | "view" | "index" | "trigger";
+  schema?: string;
+}
+
+/** Lifecycle + queries for a live engine instance. Implementations:
+ *  sqlite → wraps SqliteEngine from runtime/sqlite.ts
+ *  postgres → wraps PostgresEngine from runtime/postgres.ts
+ *  duckdb → wraps DuckDbEngine from runtime/duckdb.ts */
+export interface SqlEngineHandle {
+  exec(sql: string): Promise<QueryExecResult[]>;
+  execParams?(sql: string, params: unknown[]): Promise<QueryExecResult[]>;
+  listTables(schema?: string): Promise<string[]>;
+  listViews(schema?: string): Promise<string[]>;
+  listIndexes(schema?: string): Promise<string[]>;
+  listTriggers(): Promise<string[]>;
+  listColumns(name: string, schema?: string): Promise<SqlColumnInfo[]>;
+  listForeignKeys(name: string, schema?: string): Promise<SqlForeignKeyInfo[]>;
+  listSchemas?(showSystem: boolean): Promise<string[]>;
+  destroy(): Promise<void> | void;
+}
+
+export interface SqlEngineAdapter {
+  // ─── Static identity ─────────────────────────────────────────────
+  dialect: SqlDialect; // "sqlite" | "postgres" | "duckdb"
+  displayName: string; // "SQLite" | "PostgreSQL" | "DuckDB"
+  storagePrefix: string; // "sqlite" | "pgplayground" | "duckdb"
+  defaultPageSize: number; // existing per-dialect constant
+
+  // ─── Engine + samples ────────────────────────────────────────────
+  createEngine(sampleId: string): Promise<SqlEngineHandle>;
+  listSamples(): SqlSample[];
+  findSample(id: string): SqlSample | undefined;
+
+  // ─── SQL conventions ─────────────────────────────────────────────
+  quoteIdent(name: string): string;
+  // Whether the dialect has a schema selector (postgres + duckdb yes, sqlite no).
+  supportsSchemas: boolean;
+  // Whether the playground exposes a PRAGMA tab (sqlite only).
+  supportsPragmas: boolean;
+
+  // ─── Capabilities the shell delegates back to the adapter ────────
+  /** Build the SET statement / DDL for column-type changes etc. */
+  generateAddColumnSql?(opts: {…}): string;
+  /** Render the dialect-specific "Add Table" / "Modify Structure"
+   *  dialog. The shell mounts this in a portal when needed. */
+  renderAddTableDialog?: React.ComponentType<{…}>;
+  renderModifyStructureDrawer?: React.ComponentType<{…}>;
+}
+```
+
+The interface should grow as you migrate, not be designed all up front. Start with the smallest surface that lets you mount the shell and have it render a working SQLite playground.
+
+### 2.2 What the shell owns
+
+These are the truly dialect-agnostic concerns that should move into `SqlPlaygroundShell`:
+
+- Tab list state (`tabs`, `activeTabId`, `tabHistoryRef`, drag-reorder via `@dnd-kit`).
+- Tab persistence (the debounced `persistTabs` from PR #304's perf work).
+- CodeMirror mount via `createSqlEditorExtensions(...)` and reconfigure plumbing.
+- Settings panel (font size, theme, word wrap, clear-before-run).
+- Run controls (Run / Run Selection split button, status indicator, schema-change overlay).
+- Query history pane (already shared as `<QueryHistoryPane>`).
+- ER diagram pane (already shared as `<ErDiagramPane>`).
+- Schema sidebar wrapper that delegates to existing `<SchemaSection>`. Lazy row-count plumbing.
+- Results panel wrapper that delegates to existing `<ResultView>`.
+- Generic dialogs: Drop Confirm, Truncate Confirm, View DDL.
+- CSV/JSON/Parquet import wizard shell (uses the dialect-agnostic `parseCsv` + `readParquetFile` already extracted in PR #304). Calls back into `adapter.importRows(...)`.
+
+### 2.3 What stays per-dialect
+
+- Engine lifecycle (`createSqliteEngine`, `createPostgresEngine`, `createDuckDbEngine`).
+- Sample database list (chinook, ecommerce, …) — see Stage 4 in the plan for consolidating these.
+- PRAGMA tab and pragma application (SQLite only).
+- Schema selector dropdown + system-schemas toggle (Postgres + DuckDB).
+- "Add Table" / "Modify Structure" / "Add Row" dialog forms — dialect-specific column types, FK semantics, generated columns, etc.
+- Sample-data import logic for the "Load sample" path (each engine has its own `loadSample()`).
+- SQL identifier quoting (`adapter.quoteIdent`).
+- Row-insert SQL building (VARCHAR for DuckDB, TEXT for Postgres, `INSERT … VALUES (...)` strategy differences).
+
+---
+
+## 3 — Suggested sub-PR sequence
+
+Do **not** try to land Stage 3 in one PR. The recommended sequence:
+
+### Sub-PR A — Adapter interface + shell scaffold (no behavior change)
+- Add `app/_components/sql/shared/SqlEngineAdapter.ts` with the interface from §2.1.
+- Add `app/_components/sql/shared/SqlPlaygroundShell.tsx` with the bare skeleton: accepts `adapter`, renders the editor host + a `<pre>`-style debug panel showing `dialect`/`sample.id`/the active tab's code.
+- Add `app/_components/sql/shared/SqlPlaygroundShell.test.tsx` (Vitest) covering the shell's tab management + persistence in isolation.
+- Do not modify the three existing playgrounds. Build is green; nothing is wired in.
+- **Goal:** a foundation other PRs can build on without touching any user-facing behavior.
+
+### Sub-PR B — Migrate SQLite
+- Implement `createSqliteAdapter()` in `app/_components/sql/sqliteAdapter.ts` that wraps `SqliteEngine`, returns SQLite samples, etc.
+- Move SQLite-specific dialogs (Add Table, Modify Structure, Add Row, Pragmas) into their own files under `app/_components/sql/dialogs/`, exported as components. The shell receives them via adapter props (or via a `children`/`slots` pattern).
+- Replace `app/_components/sql/SqlPlayground.tsx`'s body with `<SqlPlaygroundShell adapter={sqliteAdapter} />` — the whole file shrinks to ~50 lines plus dialog wiring.
+- E2E: run the SQLite Playwright spec. Diff-check the rendered HTML against `main` for the major UI states (initial load, sample switch, query run, CSV import, ER tab).
+- **Goal:** SQLite playground works exactly as before, but on the shell.
+
+### Sub-PR C — Migrate Postgres
+- Same shape as B, but for `PostgresEngine`. Postgres adds `listSchemas` + system-schemas toggle — refine the shell's schema-selector slot.
+- Decide whether to also lazy-load `@codemirror/lang-sql` here (the per-dialect dialect data — `SQLite`, `PostgreSQL` — is currently dragged into every SQL playground bundle; once each adapter provides its own dialect, this becomes possible). See Stage 5 item 3 in the original audit plan.
+
+### Sub-PR D — Migrate DuckDB
+- Largest playground (6,401 lines). Migrate last so any rough edges in the shell are sanded down by the time you tackle the most complex case.
+- DuckDB's `Combobox` column-type selector, `SET` statements vs SQLite PRAGMAs, and Parquet-import-into-table flow all need adapter hooks. Add them as needed; don't try to anticipate all of them up front.
+
+### Sub-PR E (optional, follow-up) — Stage 4 sample consolidation
+- After all three playgrounds are on the shell, the parallel `runtime/sqliteSamples.ts` / `runtime/postgresSamples.ts` / `runtime/duckdbSamples.ts` files are clear candidates for a single `runtime/sqlSamples.ts` with a schema template + per-dialect emitter. The shell only depends on `adapter.listSamples()`, so this is a per-adapter internal refactor by then.
+
+---
+
+## 4 — Specific code locations to attack
+
+### Tab bar (Sub-PR A or B, low-risk warmup)
+- `app/_components/sql/SqlPlayground.tsx:4168–4250` — the SQLite tabbar JSX, plus `SqlTab` and `SqlTabDragOverlay` defined elsewhere in the file.
+- `app/_components/postgres/PostgresPlayground.tsx:5127` and `app/_components/duckdb/DuckDbPlayground.tsx:5651` — the same tabbar shape with slightly renamed components (`PgTab`, `DuckTab`).
+- Extract a generic `<SqlTabBar tabs={...} activeId={...} onActivate onClose onRename onDuplicate onCloseOthers onCloseAll onAdd dragSensors />` into `sql/shared/SqlTabBar.tsx`. Each playground can adopt this independently — does not require the full shell.
+
+### Run controls + status indicator (Sub-PR A or B)
+- `app/_components/sql/SqlPlayground.tsx` around L4100–4160, `PostgresPlayground.tsx` ~L5060–5120, `DuckDbPlayground.tsx` ~L5580–5650. The Run / Run Selection split-button + status pill is duplicated.
+- Extract into `sql/shared/SqlRunControls.tsx` taking `{statusState, hasSelection, loaded, onRun, onRunSelection}`.
+
+### Settings panel (Sub-PR B)
+- `SettingsPanel` is already shared from `playgroundShared`. Each playground passes a dialect-specific list of "extra" toggles. The shell can pass `adapter.extraSettingsItems` (or render via children).
+
+### Schema sidebar wrapper (Sub-PR B)
+- `<SchemaSection>` is already shared. The wrapper logic — section collapse state, "show system schemas" toggle, schema-selector dropdown — is currently inlined per playground. Extract this into `sql/shared/SqlSchemaSidebar.tsx`.
+
+### Drop/Truncate/View-DDL dialogs (Sub-PR B)
+- Same `<AlertDialog>` shape in all three playgrounds. Pull into `sql/shared/DropEntityDialog.tsx`, `TruncateEntityDialog.tsx`, `ViewDdlDialog.tsx`. Each takes `{adapter, entity, open, onClose}`.
+
+### Settings hydration on mount (Sub-PR A scaffold work)
+- The localStorage-keyed hydration of font/theme/wrap/clear-before-run lives in three places; lift into a `useSqlPlaygroundSettings(adapter.storagePrefix)` hook in `sql/shared/`.
+
+---
+
+## 5 — Risk areas and pitfalls
+
+1. **Tab persistence keying.** Each playground uses a different `storageKey` prefix (`sqlite`, `pgplayground`, `duckdb`). The shell must thread `adapter.storagePrefix` through `saveTabs` / `loadTabs`. Make sure no key collisions when both playgrounds are visited in the same session.
+
+2. **Pragma application order (SQLite only).** `applyPragmasToEngine(engine, pragmaSettingsRef.current)` runs after the engine is created but before the first schema refresh. Preserve that ordering in the shell — easiest is to expose `adapter.afterEngineCreated(engine)` and have the SQLite adapter run pragmas there.
+
+3. **Cancellation guards.** `let cancelled = false;` + `if (cancelled) { void engine.destroy(); return; }` patterns are scattered throughout each playground's bootstrap effect. The shell needs an identical pattern, and every adapter's `createEngine` must return a destroyable handle that's safe to call even after a cancelled bootstrap.
+
+4. **Refs threaded into CodeMirror callbacks.** The editor's keymap closures call `runSelectionRef.current(...)` / `runActiveTabRef.current()`. The shell owns the editor, but the actual run functions are constructed from adapter behavior (the shell calls `adapter.run(sql)` and threads results back). Keep the indirection-via-ref pattern PR #304 already established — don't tear down/rebuild the editor on tab change.
+
+5. **The schema-reconfigure debounce fix from PR #304** lives in `DuckDbPlayground.tsx` only. Port the same `lastReconfigureKeyRef` pattern into the shell so SQLite and Postgres also benefit. (See `DuckDbPlayground.tsx` post-PR-304 around L1850–1890.)
+
+6. **`activeDbIdRef` vs `selectedSchemaRef`.** DuckDB and Postgres distinguish "active database" from "active schema" within a database. SQLite has only one DB at a time. The shell should default to the simpler SQLite model and let `adapter.supportsSchemas = true` switch on schema-selector UI.
+
+7. **Tests.** The repo has Vitest unit tests in `__tests__/`. Add shell-level tests for tab management, persistence, and editor-mount lifecycle. Playwright specs in `e2e/` exist for each dialect — re-run them after each sub-PR.
+
+---
+
+## 6 — Plan-of-record verification per sub-PR
+
+For every sub-PR:
+1. `npm run lint` — no new errors vs `main`.
+2. `npx tsc --noEmit` — clean.
+3. `npx vitest run` — all tests pass; add tests for new shared modules.
+4. `npm run build` — all 12 playground routes green.
+5. `npm run test:e2e -- --grep <dialect>` (Playwright) for the migrated dialect.
+6. Manual smoke (golden path):
+   - Initial load with default sample.
+   - Switch sample → tabs reset / persist correctly.
+   - Run query (Mod-Enter + button).
+   - Run Selection (highlight + Mod-Enter).
+   - Open ER diagram tab.
+   - Open query history tab.
+   - CSV import (small file).
+   - Toggle settings (font / wrap / theme).
+   - Drag-reorder tabs.
+   - Close tab / close others / close all.
+   - DevTools Performance recording during typing — confirm no long tasks > 50 ms per keystroke.
+
+---
+
+## 7 — References
+
+- Original audit + refactor plan: `/root/.claude/plans/can-you-audit-the-snoopy-pony.md` (Stages 1–5 detailed there).
+- PR #304: https://github.com/subwaymatch/dataslope-playground/pull/304 — Stages 1, 2, 5 (in part).
+- Already-shared modules to leverage:
+  - `app/_components/sql/components/ResultView.tsx`
+  - `app/_components/sql/components/SchemaSection.tsx`
+  - `app/_components/sql/components/QueryHistoryPane.tsx`
+  - `app/_components/ErDiagramPane.tsx`
+  - `app/_components/sql/utils/importUtils.ts`
+  - `app/_components/sql/utils/exportUtils.ts`
+  - `app/_components/sql/shared/editorSetup.ts`
+  - `app/_components/sql/stores/createSchemaSettingsStore.ts`
+  - `app/_components/cmExtensions.ts` (themeFor)
+
+---
+
+## 8 — Suggested first commit on the new branch
+
+Start small. Open Sub-PR A with just these files:
+
+```
+app/_components/sql/shared/SqlEngineAdapter.ts        (~120 lines, type-only)
+app/_components/sql/shared/SqlPlaygroundShell.tsx     (~200 lines, scaffold)
+__tests__/sqlPlaygroundShell.test.tsx                 (~100 lines)
+```
+
+No production code paths change. Tests prove the shell can mount, manage tabs, and dispatch through the adapter interface. Reviewing this PR is fast; landing it unlocks the migration PRs.
+
+Sub-PR B then ships `createSqliteAdapter` and rewrites `SqlPlayground.tsx`. Plan for that PR to be ~1,500 lines of net diff (mostly deletions from the 4,549-line monolith) and budget reviewer time accordingly.

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -1273,11 +1273,53 @@ function DuckDbPlaygroundInner() {
     ? tabs.find((t) => t.id === draggingTabId) ?? null
     : null;
 
+  // Trailing-edge debounce of `saveTabs` so a fast typist doesn't pay a
+  // synchronous JSON.stringify + localStorage.setItem on every keystroke.
+  // We still update `tabsRef.current` + React state immediately so the rest
+  // of the component sees fresh tab text right away — only the persist
+  // is deferred. Pending writes are flushed on tab/db switch and unmount.
+  const pendingSaveRef = useRef<{ dbId: string; tabs: QueryTab[] } | null>(
+    null,
+  );
+  const saveTimerRef = useRef<number | null>(null);
+  const flushPendingSave = useCallback(() => {
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    const pending = pendingSaveRef.current;
+    if (pending) {
+      pendingSaveRef.current = null;
+      saveTabs(pending.dbId, pending.tabs);
+    }
+  }, []);
+  useEffect(() => {
+    // Best-effort persistence when the tab is hidden or unloaded.
+    const handler = () => flushPendingSave();
+    window.addEventListener("visibilitychange", handler);
+    window.addEventListener("pagehide", handler);
+    return () => {
+      window.removeEventListener("visibilitychange", handler);
+      window.removeEventListener("pagehide", handler);
+      flushPendingSave();
+    };
+  }, [flushPendingSave]);
+
   const persistTabs = useCallback(
     (nextTabs: QueryTab[], dbId = activeDbIdRef.current) => {
       tabsRef.current = nextTabs;
       setTabs(nextTabs);
-      saveTabs(dbId, nextTabs);
+      pendingSaveRef.current = { dbId, tabs: nextTabs };
+      if (saveTimerRef.current === null) {
+        saveTimerRef.current = window.setTimeout(() => {
+          saveTimerRef.current = null;
+          const pending = pendingSaveRef.current;
+          if (pending) {
+            pendingSaveRef.current = null;
+            saveTabs(pending.dbId, pending.tabs);
+          }
+        }, 500);
+      }
     },
     [],
   );
@@ -1317,22 +1359,33 @@ function DuckDbPlaygroundInner() {
         engine.listIndexes(schema),
         engine.listTriggers(),
       ]);
-    const entries = await Promise.all(
-      [...nextTables, ...nextViews].map(async (name) => {
-        const [colsResult, fksResult, countResult] = await Promise.allSettled([
+    // Cap concurrency so a large catalog doesn't queue dozens of queries
+    // on the DuckDB worker at once. Two queries per table (columns + FKs)
+    // are cheap, so a small pool keeps the worker responsive.
+    const entityNames = [...nextTables, ...nextViews];
+    const entries: Array<readonly [string, TableColumnInfo[], ForeignKeyInfo[]]> =
+      new Array(entityNames.length);
+    const CONCURRENCY = 6;
+    let cursor = 0;
+    const workers = Array.from({ length: Math.min(CONCURRENCY, entityNames.length) }, async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= entityNames.length) return;
+        const name = entityNames[i];
+        const [colsResult, fksResult] = await Promise.allSettled([
           engine.listColumns(name, schema),
           engine.listForeignKeys(name, schema),
-          engine.exec(`SELECT COUNT(*) FROM ${quoteIdent(schema)}.${quoteIdent(name)}`),
         ]);
         const cols = colsResult.status === "fulfilled" ? colsResult.value : [];
         const fks = fksResult.status === "fulfilled" ? fksResult.value : [];
-        const count =
-          countResult.status === "fulfilled"
-            ? Number(countResult.value[0]?.values?.[0]?.[0] ?? 0)
-            : 0;
-        return [name, cols, fks, count] as const;
-      }),
-    );
+        entries[i] = [name, cols, fks] as const;
+      }
+    });
+    await Promise.all(workers);
+    // Drop stale row-count cache entries for entities that no longer
+    // exist; keep cached counts for still-present tables so the
+    // sidebar doesn't blink between "(N rows)" and a Promise resolution.
+    const surviving = new Set(entityNames);
     setTables(nextTables);
     setViews(nextViews);
     setIndexes(nextIndexes);
@@ -1343,9 +1396,18 @@ function DuckDbPlaygroundInner() {
     setForeignKeysByEntity(
       Object.fromEntries(entries.map(([name, , fks]) => [name, fks])),
     );
-    setRowCountByTable(
-      Object.fromEntries(entries.map(([name, , , count]) => [name, count])),
-    );
+    setRowCountByTable((prev) => {
+      let changed = false;
+      const next: Record<string, number> = {};
+      for (const k of Object.keys(prev)) {
+        if (surviving.has(k)) {
+          next[k] = prev[k];
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
   }, [quoteIdent]);
 
   const refreshSchemas = useCallback(async () => {
@@ -1844,7 +1906,13 @@ function DuckDbPlaygroundInner() {
     void refreshSchemas();
   }, [showSystemSchemas, refreshSchemas]);
 
-  // Keep autocomplete schema in sync with current tables/views.
+  // Keep autocomplete schema in sync with current tables/views. Skip the
+  // dispatch when nothing actually changed — refreshSchema() always
+  // creates fresh `columnsByEntity` / `foreignKeysByEntity` objects, so
+  // reference equality would fire this effect (and re-parse the entire
+  // editor doc) on every query / CSV import even when the visible schema
+  // hasn't moved.
+  const lastReconfigureKeyRef = useRef<string>("");
   useEffect(() => {
     const view = editorRef.current;
     const langComp = langCompRef.current;
@@ -1862,6 +1930,9 @@ function DuckDbPlaygroundInner() {
       schema[name] = cols;
       completionSchema.entities.push({ name, columns: cols, kind: "view" });
     }
+    const key = JSON.stringify(completionSchema.entities);
+    if (key === lastReconfigureKeyRef.current) return;
+    lastReconfigureKeyRef.current = key;
     view.dispatch({
       effects: [
         langComp.reconfigure(
@@ -1902,6 +1973,9 @@ function DuckDbPlaygroundInner() {
     async (nextId: string) => {
       const engine = engineRef.current;
       if (!engine || nextId === activeDbIdRef.current) return;
+      // Persist any pending edits to the outgoing database before
+      // its tabs go out of scope.
+      flushPendingSave();
       setStatusState("loading");
       setDbLoading(true);
       // Clear the sidebar schema state up front so the previous database's
@@ -1965,7 +2039,7 @@ function DuckDbPlaygroundInner() {
         setDbLoading(false);
       }
     },
-    [persistTabs, refreshSchema, refreshSchemas, showToast],
+    [flushPendingSave, persistTabs, refreshSchema, refreshSchemas, showToast],
   );
 
   const requestDbSwitch = useCallback(
@@ -3002,11 +3076,40 @@ function DuckDbPlaygroundInner() {
     [],
   );
 
-  // Row counts are precomputed by `refreshSchema` so this is a synchronous
-  // lookup. SchemaItem caches the first non-null result it sees, so we
-  // can't hand back a stale 0 while a real count is in flight.
+  // Row counts are fetched lazily on first use to avoid an N+1
+  // `SELECT COUNT(*)` fan-out during refreshSchema (which fires after
+  // every query and every CSV import). Cached results are returned
+  // synchronously so the sidebar doesn't blink. In-flight requests are
+  // de-duplicated per table.
+  const rowCountInFlightRef = useRef<Map<string, Promise<number>>>(new Map());
   const fetchEntityRowCount = useCallback(
-    (name: string): number => rowCountByTable[name] ?? 0,
+    (name: string): number | Promise<number> => {
+      const cached = rowCountByTable[name];
+      if (cached !== undefined) return cached;
+      const inflight = rowCountInFlightRef.current.get(name);
+      if (inflight) return inflight;
+      const engine = engineRef.current;
+      if (!engine) return 0;
+      const schema = selectedSchemaRef.current;
+      const promise = (async () => {
+        try {
+          const result = await engine.exec(
+            `SELECT COUNT(*) FROM ${quoteIdent(schema)}.${quoteIdent(name)}`,
+          );
+          const count = Number(result[0]?.values?.[0]?.[0] ?? 0);
+          setRowCountByTable((prev) =>
+            prev[name] === count ? prev : { ...prev, [name]: count },
+          );
+          return count;
+        } catch {
+          return 0;
+        } finally {
+          rowCountInFlightRef.current.delete(name);
+        }
+      })();
+      rowCountInFlightRef.current.set(name, promise);
+      return promise;
+    },
     [rowCountByTable],
   );
 

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -20,40 +20,14 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS as DndCSS } from "@dnd-kit/utilities";
+import type { Compartment } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
 import {
-  autocompletion,
-  closeBrackets,
-  closeBracketsKeymap,
-  completionKeymap,
-  startCompletion,
-  acceptCompletion,
-} from "@codemirror/autocomplete";
-import {
-  defaultKeymap,
-  history,
-  historyKeymap,
-  indentWithTab,
-} from "@codemirror/commands";
-import {
-  bracketMatching,
-  indentOnInput,
-  indentUnit,
-} from "@codemirror/language";
-import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
-import { EditorState, Compartment } from "@codemirror/state";
-import {
-  EditorView,
-  crosshairCursor,
-  drawSelection,
-  dropCursor,
-  highlightActiveLine,
-  highlightActiveLineGutter,
-  keymap,
-  lineNumbers,
-  rectangularSelection,
-  tooltips,
-} from "@codemirror/view";
-import { sql as sqlLang } from "@codemirror/lang-sql";
+  createSqlEditorExtensions,
+  makeSqlAutocompletionExtension,
+  makeSqlEditorCompartments,
+  makeSqlLangExtension,
+} from "../sql/shared/editorSetup";
 import { AlertDialog } from "@base-ui-components/react/alert-dialog";
 import { Combobox } from "@base-ui-components/react/combobox";
 import { Dialog } from "@base-ui-components/react/dialog";
@@ -183,10 +157,7 @@ import type {
   ResultSetExportSnapshot,
 } from "../sql/types";
 import type { RuntimeInfo } from "../types";
-import {
-  createSqlCompletionSource,
-  type SqlCompletionSchema,
-} from "../sql/sqlCompletion";
+import type { SqlCompletionSchema } from "../sql/sqlCompletion";
 import { useDuckDbSettingsStore } from "./stores/useDuckDbSettingsStore";
 import {
   importRowsIntoDuckDb,
@@ -1695,10 +1666,7 @@ function DuckDbPlaygroundInner() {
   useEffect(() => {
     let cancelled = false;
     if (editorHostRef.current && !editorRef.current) {
-      const langComp = new Compartment();
-      const completionComp = new Compartment();
-      const themeComp = new Compartment();
-      const wrapComp = new Compartment();
+      const compartments = makeSqlEditorCompartments();
       const initialTheme =
         getStoredEditorTheme(storageKey("editortheme")) ??
         DEFAULT_PLAYGROUND_SETTINGS.editorTheme;
@@ -1709,96 +1677,30 @@ function DuckDbPlaygroundInner() {
       const view = new EditorView({
         doc: activeTab?.code ?? "",
         parent: editorHostRef.current,
-        extensions: [
-          history(),
-          drawSelection(),
-          dropCursor(),
-          EditorState.allowMultipleSelections.of(true),
-          indentOnInput(),
-          bracketMatching(),
-          closeBrackets(),
-          rectangularSelection(),
-          tooltips({ parent: document.body }),
-          lineNumbers(),
-          highlightActiveLineGutter(),
-          highlightActiveLine(),
-          highlightSelectionMatches(),
-          crosshairCursor(),
-          EditorState.tabSize.of(2),
-          indentUnit.of("  "),
-          langComp.of(
-            sqlLang({ upperCaseKeywords: false }),
-          ),
-          completionComp.of(
-            autocompletion({
-              override: [
-                createSqlCompletionSource(
-                  { entities: [] },
-                  { dialect: "duckdb" },
-                ),
-              ],
-            }),
-          ),
-          themeComp.of(themeFor(initialTheme)),
-          wrapComp.of(initialWordWrap ? EditorView.lineWrapping : []),
-          EditorView.updateListener.of((update) => {
-            if (update.selectionSet) {
-              const sel = update.state.selection.main;
-              setHasEditorSelectionRef.current(!sel.empty);
-            }
-            if (!update.docChanged) return;
+        extensions: createSqlEditorExtensions({
+          dialect: "duckdb",
+          compartments,
+          initialTheme,
+          initialWordWrap,
+          onSelectionChange: (hasSelection) => {
+            setHasEditorSelectionRef.current(hasSelection);
+          },
+          onDocChange: (code) => {
             const id = activeTabIdRef.current;
-            const code = update.state.doc.toString();
             const next = tabsRef.current.map((tab) =>
               tab.id === id ? { ...tab, code } : tab,
             );
             persistTabs(next);
-          }),
-          keymap.of([
-            {
-              // Run selection if text is selected, otherwise run all.
-              key: "Mod-Enter",
-              run: (v) => {
-                const sel = v.state.selection.main;
-                if (!sel.empty) {
-                  const selected = v.state.sliceDoc(sel.from, sel.to);
-                  runSelectionRef.current(selected);
-                } else {
-                  runActiveTabRef.current();
-                }
-                return true;
-              },
-            },
-            {
-              // Always run all queries (ignores any selection).
-              key: "Mod-Shift-Enter",
-              run: () => {
-                runActiveTabRef.current();
-                return true;
-              },
-            },
-            {
-              key: "Ctrl-Space",
-              run: (v) => {
-                startCompletion(v);
-                return true;
-              },
-            },
-            ...closeBracketsKeymap,
-            ...defaultKeymap,
-            ...searchKeymap,
-            ...historyKeymap,
-            ...completionKeymap.filter((b) => b.key !== "Enter"),
-            { key: "Tab", run: acceptCompletion },
-            indentWithTab,
-          ]),
-        ],
+          },
+          onRunSelection: (text) => runSelectionRef.current(text),
+          onRunAll: () => runActiveTabRef.current(),
+        }),
       });
       editorRef.current = view;
-      langCompRef.current = langComp;
-      completionCompRef.current = completionComp;
-      themeCompRef.current = themeComp;
-      wrapCompRef.current = wrapComp;
+      langCompRef.current = compartments.lang;
+      completionCompRef.current = compartments.completion;
+      themeCompRef.current = compartments.theme;
+      wrapCompRef.current = compartments.wrap;
     }
     (async () => {
       try {
@@ -1942,17 +1844,9 @@ function DuckDbPlaygroundInner() {
     lastReconfigureKeyRef.current = key;
     view.dispatch({
       effects: [
-        langComp.reconfigure(
-          sqlLang({ schema, upperCaseKeywords: false }),
-        ),
+        langComp.reconfigure(makeSqlLangExtension("duckdb", schema)),
         completionComp.reconfigure(
-          autocompletion({
-            override: [
-              createSqlCompletionSource(completionSchema, {
-                dialect: "duckdb",
-              }),
-            ],
-          }),
+          makeSqlAutocompletionExtension(completionSchema, "duckdb"),
         ),
       ],
     });

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -88,7 +88,6 @@ import {
   X,
   FolderTree,
 } from "lucide-react";
-import { format as sqlFormat } from "sql-formatter";
 import { FaInfo } from "react-icons/fa";
 import React, {
   Fragment,
@@ -103,7 +102,15 @@ import React, {
 import { flushSync } from "react-dom";
 import "../playground.css";
 import "../sqlPlayground.css";
-import { ErDiagramPane } from "../ErDiagramPane";
+import dynamic from "next/dynamic";
+
+// ErDiagramPane pulls in @xyflow/react and elkjs/lib/elk.bundled.js
+// (~hundreds of KB of layout-algorithm code). It only renders when
+// the user opens the ER-diagram tab, so defer the chunk until then.
+const ErDiagramPane = dynamic(
+  () => import("../ErDiagramPane").then((m) => m.ErDiagramPane),
+  { ssr: false },
+);
 import {
   LANGUAGE_ICONS as PLAYGROUND_ICONS,
   LANGUAGE_ICON_SIZE_FACTOR as PLAYGROUND_ICON_SIZE_FACTOR,
@@ -2636,13 +2643,14 @@ function DuckDbPlaygroundInner() {
     window.location.reload();
   }, []);
 
-  const handleFormatCode = useCallback(() => {
+  const handleFormatCode = useCallback(async () => {
     const view = editorRef.current;
     if (!view) return;
     const code = view.state.doc.toString();
     if (!code.trim()) return;
     setIsFormatting(true);
     try {
+      const { format: sqlFormat } = await import("sql-formatter");
       const formatted = sqlFormat(code, { language: "sql" });
       view.dispatch({
         changes: { from: 0, to: view.state.doc.length, insert: formatted },

--- a/app/_components/duckdb/duckdbImport.ts
+++ b/app/_components/duckdb/duckdbImport.ts
@@ -1,105 +1,12 @@
 "use client";
 
-import type { QueryExecResult, SqlValue } from "sql.js";
 import { sanitizeImportColName } from "../sql/utils/importUtils";
 import type { DuckDbEngine } from "../runtime/duckdb";
 
+export { parseCsv, tableNameFromFilename, readParquetFile } from "../sql/utils/importUtils";
+
 function quoteIdent(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
-}
-
-/** Parse CSV text into headers and rows. Mirrors the SQLite/Postgres
- *  parsers byte-for-byte so the import preview behaves identically
- *  across all three playgrounds. */
-export function parseCsv(text: string): { headers: string[]; rows: string[][] } {
-  const parseLine = (line: string): string[] => {
-    const fields: string[] = [];
-    let cur = "";
-    let inQuotes = false;
-    for (let i = 0; i < line.length; i++) {
-      const ch = line[i];
-      if (inQuotes) {
-        if (ch === '"') {
-          if (i + 1 < line.length && line[i + 1] === '"') {
-            cur += '"';
-            i += 1;
-          } else {
-            inQuotes = false;
-          }
-        } else {
-          cur += ch;
-        }
-      } else if (ch === '"') {
-        inQuotes = true;
-      } else if (ch === ",") {
-        fields.push(cur);
-        cur = "";
-      } else {
-        cur += ch;
-      }
-    }
-    fields.push(cur);
-    return fields;
-  };
-  const lines = text.split(/\r?\n/);
-  const nonEmpty = lines.filter((l) => l.trim() !== "");
-  if (nonEmpty.length === 0) return { headers: [], rows: [] };
-  const headers = parseLine(nonEmpty[0]);
-  const rows = nonEmpty.slice(1).map((l) => {
-    const vals = parseLine(l);
-    while (vals.length < headers.length) vals.push("");
-    return vals.slice(0, headers.length);
-  });
-  return { headers, rows };
-}
-
-export function tableNameFromFilename(filename: string): string {
-  const base = filename
-    .replace(/\.[^.]+$/, "")
-    .replace(/[^a-zA-Z0-9_]/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .replace(/_+/g, "_");
-  return base || "imported_table";
-}
-
-let _parquetWasmInit:
-  | Promise<typeof import("parquet-wasm/esm")>
-  | null = null;
-async function initParquetWasm(): Promise<typeof import("parquet-wasm/esm")> {
-  if (!_parquetWasmInit) {
-    _parquetWasmInit = (async () => {
-      const m = await import("parquet-wasm/esm");
-      await m.default(
-        "https://cdn.jsdelivr.net/npm/parquet-wasm@0.7.1/esm/parquet_wasm_bg.wasm",
-      );
-      return m;
-    })();
-  }
-  return _parquetWasmInit;
-}
-
-export async function readParquetFile(
-  file: File,
-): Promise<{ columns: string[]; rows: QueryExecResult["values"] }> {
-  const mod = await initParquetWasm();
-  const { tableFromIPC } = await import("apache-arrow");
-  const bytes = await file.arrayBuffer();
-  const wasmTable = mod.readParquet(new Uint8Array(bytes));
-  const ipcBytes = wasmTable.intoIPCStream();
-  const arrowTable = tableFromIPC(ipcBytes);
-  const columns = arrowTable.schema.fields.map((f) => f.name);
-  const rows: QueryExecResult["values"] = [];
-  for (const batch of arrowTable.batches) {
-    for (let r = 0; r < batch.numRows; r++) {
-      const row: SqlValue[] = [];
-      for (let c = 0; c < columns.length; c++) {
-        const val = batch.getChildAt(c)?.get(r);
-        row.push(val === undefined ? null : (val as SqlValue));
-      }
-      rows.push(row);
-    }
-  }
-  return { columns, rows };
 }
 
 /** Insert a batch of rows into a (new or existing) DuckDB table.

--- a/app/_components/duckdb/stores/useDuckDbSettingsStore.ts
+++ b/app/_components/duckdb/stores/useDuckDbSettingsStore.ts
@@ -1,46 +1,15 @@
 "use client";
 
-import { create } from "zustand";
-import { DEFAULT_PLAYGROUND_SETTINGS } from "../../playgroundShared";
+import { createSchemaSettingsStore } from "../../sql/stores/createSchemaSettingsStore";
 
-// DuckDB settings store. Mirrors `usePostgresSettingsStore`: the
-// general appearance settings (font size, theme, word wrap, clear
-// before run) are universal. The DuckDB playground intentionally has
-// no SQLite-style PRAGMA tab — DuckDB exposes runtime knobs through
-// SET statements (`SET threads = N`, `SET memory_limit = '512MB'`,
+// DuckDB settings store. The general appearance settings (font size,
+// theme, word wrap, clear before run) plus a system-schemas toggle
+// are universal across the schema-aware SQL playgrounds, so the
+// implementation lives in `sql/stores/createSchemaSettingsStore`. The
+// DuckDB playground intentionally has no SQLite-style PRAGMA tab —
+// DuckDB exposes runtime knobs through SET statements
+// (`SET threads = N`, `SET memory_limit = '512MB'`,
 // `SET TimeZone = 'UTC'`) that users can run from any query tab.
+export const useDuckDbSettingsStore = createSchemaSettingsStore();
 
-interface DuckDbSettingsState {
-  fontSize: number;
-  outputFontSizeEnabled: boolean;
-  outputFontSize: number;
-  editorTheme: string;
-  wordWrap: boolean;
-  clearBeforeRun: boolean;
-  showSystemSchemas: boolean;
-  setFontSize: (fontSize: number) => void;
-  setOutputFontSizeEnabled: (enabled: boolean) => void;
-  setOutputFontSize: (fontSize: number) => void;
-  setEditorTheme: (theme: string) => void;
-  setWordWrap: (wordWrap: boolean) => void;
-  setClearBeforeRun: (clearBeforeRun: boolean) => void;
-  setShowSystemSchemas: (showSystemSchemas: boolean) => void;
-}
-
-export const useDuckDbSettingsStore = create<DuckDbSettingsState>((set) => ({
-  fontSize: DEFAULT_PLAYGROUND_SETTINGS.fontSize,
-  outputFontSizeEnabled: DEFAULT_PLAYGROUND_SETTINGS.outputFontSizeEnabled,
-  outputFontSize: DEFAULT_PLAYGROUND_SETTINGS.outputFontSize,
-  editorTheme: DEFAULT_PLAYGROUND_SETTINGS.editorTheme,
-  wordWrap: DEFAULT_PLAYGROUND_SETTINGS.wordWrap,
-  clearBeforeRun: DEFAULT_PLAYGROUND_SETTINGS.clearBeforeRun,
-  showSystemSchemas: true,
-  setFontSize: (fontSize) => set({ fontSize }),
-  setOutputFontSizeEnabled: (outputFontSizeEnabled) =>
-    set({ outputFontSizeEnabled }),
-  setOutputFontSize: (outputFontSize) => set({ outputFontSize }),
-  setEditorTheme: (editorTheme) => set({ editorTheme }),
-  setWordWrap: (wordWrap) => set({ wordWrap }),
-  setClearBeforeRun: (clearBeforeRun) => set({ clearBeforeRun }),
-  setShowSystemSchemas: (showSystemSchemas) => set({ showSystemSchemas }),
-}));
+export type { SchemaSettingsState as DuckDbSettingsState } from "../../sql/stores/createSchemaSettingsStore";

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -20,40 +20,14 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS as DndCSS } from "@dnd-kit/utilities";
+import type { Compartment } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
 import {
-  autocompletion,
-  closeBrackets,
-  closeBracketsKeymap,
-  completionKeymap,
-  startCompletion,
-  acceptCompletion,
-} from "@codemirror/autocomplete";
-import {
-  defaultKeymap,
-  history,
-  historyKeymap,
-  indentWithTab,
-} from "@codemirror/commands";
-import {
-  bracketMatching,
-  indentOnInput,
-  indentUnit,
-} from "@codemirror/language";
-import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
-import { EditorState, Compartment } from "@codemirror/state";
-import {
-  EditorView,
-  crosshairCursor,
-  drawSelection,
-  dropCursor,
-  highlightActiveLine,
-  highlightActiveLineGutter,
-  keymap,
-  lineNumbers,
-  rectangularSelection,
-  tooltips,
-} from "@codemirror/view";
-import { sql as sqlLang, PostgreSQL } from "@codemirror/lang-sql";
+  createSqlEditorExtensions,
+  makeSqlAutocompletionExtension,
+  makeSqlEditorCompartments,
+  makeSqlLangExtension,
+} from "../sql/shared/editorSetup";
 import { AlertDialog } from "@base-ui-components/react/alert-dialog";
 import { Combobox } from "@base-ui-components/react/combobox";
 import { Dialog } from "@base-ui-components/react/dialog";
@@ -181,10 +155,7 @@ import type {
   ResultSetExportSnapshot,
 } from "../sql/types";
 import type { RuntimeInfo } from "../types";
-import {
-  createSqlCompletionSource,
-  type SqlCompletionSchema,
-} from "../sql/sqlCompletion";
+import type { SqlCompletionSchema } from "../sql/sqlCompletion";
 import { usePostgresSettingsStore } from "./stores/usePostgresSettingsStore";
 import {
   importRowsIntoPostgres,
@@ -1659,10 +1630,7 @@ function PostgresPlaygroundInner() {
   useEffect(() => {
     let cancelled = false;
     if (editorHostRef.current && !editorRef.current) {
-      const langComp = new Compartment();
-      const completionComp = new Compartment();
-      const themeComp = new Compartment();
-      const wrapComp = new Compartment();
+      const compartments = makeSqlEditorCompartments();
       const initialTheme =
         getStoredEditorTheme(storageKey("editortheme")) ??
         DEFAULT_PLAYGROUND_SETTINGS.editorTheme;
@@ -1673,96 +1641,30 @@ function PostgresPlaygroundInner() {
       const view = new EditorView({
         doc: activeTab?.code ?? "",
         parent: editorHostRef.current,
-        extensions: [
-          history(),
-          drawSelection(),
-          dropCursor(),
-          EditorState.allowMultipleSelections.of(true),
-          indentOnInput(),
-          bracketMatching(),
-          closeBrackets(),
-          rectangularSelection(),
-          tooltips({ parent: document.body }),
-          lineNumbers(),
-          highlightActiveLineGutter(),
-          highlightActiveLine(),
-          highlightSelectionMatches(),
-          crosshairCursor(),
-          EditorState.tabSize.of(2),
-          indentUnit.of("  "),
-          langComp.of(
-            sqlLang({ dialect: PostgreSQL, upperCaseKeywords: false }),
-          ),
-          completionComp.of(
-            autocompletion({
-              override: [
-                createSqlCompletionSource(
-                  { entities: [] },
-                  { dialect: "postgres" },
-                ),
-              ],
-            }),
-          ),
-          themeComp.of(themeFor(initialTheme)),
-          wrapComp.of(initialWordWrap ? EditorView.lineWrapping : []),
-          EditorView.updateListener.of((update) => {
-            if (update.selectionSet) {
-              const sel = update.state.selection.main;
-              setHasEditorSelectionRef.current(!sel.empty);
-            }
-            if (!update.docChanged) return;
+        extensions: createSqlEditorExtensions({
+          dialect: "postgres",
+          compartments,
+          initialTheme,
+          initialWordWrap,
+          onSelectionChange: (hasSelection) => {
+            setHasEditorSelectionRef.current(hasSelection);
+          },
+          onDocChange: (code) => {
             const id = activeTabIdRef.current;
-            const code = update.state.doc.toString();
             const next = tabsRef.current.map((tab) =>
               tab.id === id ? { ...tab, code } : tab,
             );
             persistTabs(next);
-          }),
-          keymap.of([
-            {
-              // Run selection if text is selected, otherwise run all.
-              key: "Mod-Enter",
-              run: (v) => {
-                const sel = v.state.selection.main;
-                if (!sel.empty) {
-                  const selected = v.state.sliceDoc(sel.from, sel.to);
-                  runSelectionRef.current(selected);
-                } else {
-                  runActiveTabRef.current();
-                }
-                return true;
-              },
-            },
-            {
-              // Always run all queries (ignores any selection).
-              key: "Mod-Shift-Enter",
-              run: () => {
-                runActiveTabRef.current();
-                return true;
-              },
-            },
-            {
-              key: "Ctrl-Space",
-              run: (v) => {
-                startCompletion(v);
-                return true;
-              },
-            },
-            ...closeBracketsKeymap,
-            ...defaultKeymap,
-            ...searchKeymap,
-            ...historyKeymap,
-            ...completionKeymap.filter((b) => b.key !== "Enter"),
-            { key: "Tab", run: acceptCompletion },
-            indentWithTab,
-          ]),
-        ],
+          },
+          onRunSelection: (text) => runSelectionRef.current(text),
+          onRunAll: () => runActiveTabRef.current(),
+        }),
       });
       editorRef.current = view;
-      langCompRef.current = langComp;
-      completionCompRef.current = completionComp;
-      themeCompRef.current = themeComp;
-      wrapCompRef.current = wrapComp;
+      langCompRef.current = compartments.lang;
+      completionCompRef.current = compartments.completion;
+      themeCompRef.current = compartments.theme;
+      wrapCompRef.current = compartments.wrap;
     }
     (async () => {
       try {
@@ -1894,17 +1796,9 @@ function PostgresPlaygroundInner() {
     }
     view.dispatch({
       effects: [
-        langComp.reconfigure(
-          sqlLang({ dialect: PostgreSQL, schema, upperCaseKeywords: false }),
-        ),
+        langComp.reconfigure(makeSqlLangExtension("postgres", schema)),
         completionComp.reconfigure(
-          autocompletion({
-            override: [
-              createSqlCompletionSource(completionSchema, {
-                dialect: "postgres",
-              }),
-            ],
-          }),
+          makeSqlAutocompletionExtension(completionSchema, "postgres"),
         ),
       ],
     });

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -87,7 +87,6 @@ import {
   Wand2,
   X,
 } from "lucide-react";
-import { format as sqlFormat } from "sql-formatter";
 import { FaInfo } from "react-icons/fa";
 import React, {
   Fragment,
@@ -102,7 +101,15 @@ import React, {
 import { flushSync } from "react-dom";
 import "../playground.css";
 import "../sqlPlayground.css";
-import { ErDiagramPane } from "../ErDiagramPane";
+import dynamic from "next/dynamic";
+
+// ErDiagramPane pulls in @xyflow/react and elkjs/lib/elk.bundled.js
+// (~hundreds of KB of layout-algorithm code). It only renders when
+// the user opens the ER-diagram tab, so defer the chunk until then.
+const ErDiagramPane = dynamic(
+  () => import("../ErDiagramPane").then((m) => m.ErDiagramPane),
+  { ssr: false },
+);
 import {
   LANGUAGE_ICONS as PLAYGROUND_ICONS,
   LANGUAGE_ICON_SIZE_FACTOR as PLAYGROUND_ICON_SIZE_FACTOR,
@@ -2238,13 +2245,14 @@ function PostgresPlaygroundInner() {
     window.location.reload();
   }, []);
 
-  const handleFormatCode = useCallback(() => {
+  const handleFormatCode = useCallback(async () => {
     const view = editorRef.current;
     if (!view) return;
     const code = view.state.doc.toString();
     if (!code.trim()) return;
     setIsFormatting(true);
     try {
+      const { format: sqlFormat } = await import("sql-formatter");
       const formatted = sqlFormat(code, { language: "postgresql" });
       view.dispatch({
         changes: { from: 0, to: view.state.doc.length, insert: formatted },

--- a/app/_components/postgres/postgresImport.ts
+++ b/app/_components/postgres/postgresImport.ts
@@ -1,106 +1,12 @@
 "use client";
 
-import type { QueryExecResult, SqlValue } from "sql.js";
 import { sanitizeImportColName } from "../sql/utils/importUtils";
 import type { PostgresEngine } from "../runtime/postgres";
 
+export { parseCsv, tableNameFromFilename, readParquetFile } from "../sql/utils/importUtils";
+
 function quoteIdent(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
-}
-
-/** Parse a CSV text into headers and rows. Mirrors the SQLite playground's
- *  parser so the two import flows behave identically. */
-export function parseCsv(text: string): { headers: string[]; rows: string[][] } {
-  const parseLine = (line: string): string[] => {
-    const fields: string[] = [];
-    let cur = "";
-    let inQuotes = false;
-    for (let i = 0; i < line.length; i++) {
-      const ch = line[i];
-      if (inQuotes) {
-        if (ch === '"') {
-          if (i + 1 < line.length && line[i + 1] === '"') {
-            cur += '"';
-            i += 1;
-          } else {
-            inQuotes = false;
-          }
-        } else {
-          cur += ch;
-        }
-      } else if (ch === '"') {
-        inQuotes = true;
-      } else if (ch === ",") {
-        fields.push(cur);
-        cur = "";
-      } else {
-        cur += ch;
-      }
-    }
-    fields.push(cur);
-    return fields;
-  };
-  const lines = text.split(/\r?\n/);
-  const nonEmpty = lines.filter((l) => l.trim() !== "");
-  if (nonEmpty.length === 0) return { headers: [], rows: [] };
-  const headers = parseLine(nonEmpty[0]);
-  const rows = nonEmpty.slice(1).map((l) => {
-    const vals = parseLine(l);
-    while (vals.length < headers.length) vals.push("");
-    return vals.slice(0, headers.length);
-  });
-  return { headers, rows };
-}
-
-export function tableNameFromFilename(filename: string): string {
-  const base = filename
-    .replace(/\.[^.]+$/, "")
-    .replace(/[^a-zA-Z0-9_]/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .replace(/_+/g, "_");
-  return base || "imported_table";
-}
-
-/** Lazy-loaded parquet decoder shared with the SQLite import path. The
- *  WASM binary is fetched from jsDelivr on first use and cached. */
-let _parquetWasmInit:
-  | Promise<typeof import("parquet-wasm/esm")>
-  | null = null;
-async function initParquetWasm(): Promise<typeof import("parquet-wasm/esm")> {
-  if (!_parquetWasmInit) {
-    _parquetWasmInit = (async () => {
-      const m = await import("parquet-wasm/esm");
-      await m.default(
-        "https://cdn.jsdelivr.net/npm/parquet-wasm@0.7.1/esm/parquet_wasm_bg.wasm",
-      );
-      return m;
-    })();
-  }
-  return _parquetWasmInit;
-}
-
-export async function readParquetFile(
-  file: File,
-): Promise<{ columns: string[]; rows: QueryExecResult["values"] }> {
-  const mod = await initParquetWasm();
-  const { tableFromIPC } = await import("apache-arrow");
-  const bytes = await file.arrayBuffer();
-  const wasmTable = mod.readParquet(new Uint8Array(bytes));
-  const ipcBytes = wasmTable.intoIPCStream();
-  const arrowTable = tableFromIPC(ipcBytes);
-  const columns = arrowTable.schema.fields.map((f) => f.name);
-  const rows: QueryExecResult["values"] = [];
-  for (const batch of arrowTable.batches) {
-    for (let r = 0; r < batch.numRows; r++) {
-      const row: SqlValue[] = [];
-      for (let c = 0; c < columns.length; c++) {
-        const val = batch.getChildAt(c)?.get(r);
-        row.push(val === undefined ? null : (val as SqlValue));
-      }
-      rows.push(row);
-    }
-  }
-  return { columns, rows };
 }
 
 /** Insert a batch of rows into a (new or existing) Postgres table.

--- a/app/_components/postgres/stores/usePostgresSettingsStore.ts
+++ b/app/_components/postgres/stores/usePostgresSettingsStore.ts
@@ -1,39 +1,7 @@
 "use client";
 
-import { create } from "zustand";
-import { DEFAULT_PLAYGROUND_SETTINGS } from "../../playgroundShared";
+import { createSchemaSettingsStore } from "../../sql/stores/createSchemaSettingsStore";
 
-interface PostgresSettingsState {
-  fontSize: number;
-  outputFontSizeEnabled: boolean;
-  outputFontSize: number;
-  editorTheme: string;
-  wordWrap: boolean;
-  clearBeforeRun: boolean;
-  showSystemSchemas: boolean;
-  setFontSize: (fontSize: number) => void;
-  setOutputFontSizeEnabled: (enabled: boolean) => void;
-  setOutputFontSize: (fontSize: number) => void;
-  setEditorTheme: (theme: string) => void;
-  setWordWrap: (wordWrap: boolean) => void;
-  setClearBeforeRun: (clearBeforeRun: boolean) => void;
-  setShowSystemSchemas: (showSystemSchemas: boolean) => void;
-}
+export const usePostgresSettingsStore = createSchemaSettingsStore();
 
-export const usePostgresSettingsStore = create<PostgresSettingsState>((set) => ({
-  fontSize: DEFAULT_PLAYGROUND_SETTINGS.fontSize,
-  outputFontSizeEnabled: DEFAULT_PLAYGROUND_SETTINGS.outputFontSizeEnabled,
-  outputFontSize: DEFAULT_PLAYGROUND_SETTINGS.outputFontSize,
-  editorTheme: DEFAULT_PLAYGROUND_SETTINGS.editorTheme,
-  wordWrap: DEFAULT_PLAYGROUND_SETTINGS.wordWrap,
-  clearBeforeRun: DEFAULT_PLAYGROUND_SETTINGS.clearBeforeRun,
-  showSystemSchemas: true,
-  setFontSize: (fontSize) => set({ fontSize }),
-  setOutputFontSizeEnabled: (outputFontSizeEnabled) =>
-    set({ outputFontSizeEnabled }),
-  setOutputFontSize: (outputFontSize) => set({ outputFontSize }),
-  setEditorTheme: (editorTheme) => set({ editorTheme }),
-  setWordWrap: (wordWrap) => set({ wordWrap }),
-  setClearBeforeRun: (clearBeforeRun) => set({ clearBeforeRun }),
-  setShowSystemSchemas: (showSystemSchemas) => set({ showSystemSchemas }),
-}));
+export type { SchemaSettingsState as PostgresSettingsState } from "../../sql/stores/createSchemaSettingsStore";

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -44,40 +44,14 @@ import React, {
 } from "react";
 import "../playground.css";
 import "../sqlPlayground.css";
-import { EditorState, Compartment } from "@codemirror/state";
+import type { Compartment } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
 import {
-  EditorView,
-  keymap,
-  lineNumbers as lineNumbersExt,
-  highlightActiveLineGutter,
-  highlightActiveLine,
-  drawSelection,
-  dropCursor,
-  rectangularSelection,
-  crosshairCursor,
-  tooltips,
-} from "@codemirror/view";
-import {
-  defaultKeymap,
-  history,
-  historyKeymap,
-  indentWithTab,
-} from "@codemirror/commands";
-import {
-  bracketMatching,
-  indentOnInput,
-  indentUnit,
-} from "@codemirror/language";
-import {
-  autocompletion,
-  closeBrackets,
-  closeBracketsKeymap,
-  completionKeymap,
-  startCompletion,
-  acceptCompletion,
-} from "@codemirror/autocomplete";
-import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
-import { sql as sqlLang, SQLite } from "@codemirror/lang-sql";
+  createSqlEditorExtensions,
+  makeSqlAutocompletionExtension,
+  makeSqlEditorCompartments,
+  makeSqlLangExtension,
+} from "./shared/editorSetup";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Popover } from "@base-ui-components/react/popover";
@@ -169,7 +143,7 @@ import {
   type SqliteEngine,
   type TableColumnInfo,
 } from "../runtime/sqlite";
-import type { QueryExecResult, SqlValue } from "sql.js";
+import type { QueryExecResult } from "sql.js";
 import dynamic from "next/dynamic";
 
 // ErDiagramPane pulls in @xyflow/react and elkjs/lib/elk.bundled.js
@@ -182,10 +156,7 @@ const ErDiagramPane = dynamic(
 import { ToastList } from "./components/ToastList";
 import { SqlTab, SqlTabDragOverlay } from "./components/SqlTab";
 import { QueryHistoryPane } from "./components/QueryHistoryPane";
-import {
-  createSqlCompletionSource,
-  type SqlCompletionSchema,
-} from "./sqlCompletion";
+import type { SqlCompletionSchema } from "./sqlCompletion";
 import { useSettingsStore } from "./stores/useSettingsStore";
 import { usePragmaStore } from "./stores/usePragmaStore";
 import { useSqlPlaygroundStore } from "./stores/useSqlPlaygroundStore";
@@ -224,19 +195,6 @@ function replaceDoc(view: EditorView, value: string): void {
   });
 }
 
-// CodeMirror's default is 100ms; 75ms keeps local schema suggestions feeling
-// immediate while still coalescing rapid typing before recomputing completions.
-const AUTOCOMPLETE_DELAY_MS = 75;
-
-function sqlAutocompletion(schema: SqlCompletionSchema) {
-  const source = createSqlCompletionSource(schema, { dialect: "sqlite" });
-  return autocompletion({
-    activateOnTyping: true,
-    activateOnTypingDelay: AUTOCOMPLETE_DELAY_MS,
-    closeOnBlur: true,
-    override: [source],
-  });
-}
 
 const PLAYGROUND_ID = "sqlite";
 
@@ -252,249 +210,6 @@ const RUNTIME_INFO: RuntimeInfo = {
     "Pure-JS build of SQLite compiled to WebAssembly. Each sample database is rebuilt in memory on every page load.",
 };
 
-
-
-// ────────────────────────────────────────────────────────────────────────
-// CSV export helper
-// ────────────────────────────────────────────────────────────────────────
-
-function escapeCsvCell(val: unknown): string {
-  if (val === null || val === undefined) return "";
-  const s = String(val);
-  if (
-    s.includes(",") ||
-    s.includes("\n") ||
-    s.includes("\r") ||
-    s.includes('"')
-  ) {
-    return `"${s.replace(/"/g, '""')}"`;
-  }
-  return s;
-}
-
-function toFileSafeName(title: string): string {
-  return title.replace(/[/\\:*?"<>|\x00-\x1f]/g, "_").trim() || "result_set";
-}
-
-function triggerDownload(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  a.click();
-  setTimeout(() => URL.revokeObjectURL(url), 60_000);
-}
-
-function exportResultToCsv(
-  columns: string[],
-  rows: QueryExecResult["values"],
-  filename: string,
-): void {
-  const lines = [
-    columns.map(escapeCsvCell).join(","),
-    ...rows.map((row) => row.map(escapeCsvCell).join(",")),
-  ];
-  triggerDownload(
-    new Blob([lines.join("\r\n")], { type: "text/csv;charset=utf-8" }),
-    filename,
-  );
-}
-
-function exportResultToJson(
-  columns: string[],
-  rows: QueryExecResult["values"],
-  filename: string,
-): void {
-  const data = rows.map((row) => {
-    const obj: Record<string, unknown> = {};
-    columns.forEach((col, i) => {
-      obj[col] = row[i] ?? null;
-    });
-    return obj;
-  });
-  triggerDownload(
-    new Blob([JSON.stringify(data, null, 2)], { type: "application/json" }),
-    filename,
-  );
-}
-
-function exportResultToSql(
-  columns: string[],
-  rows: QueryExecResult["values"],
-  filename: string,
-): void {
-  const quotedCols = columns
-    .map((c) => `"${c.replace(/"/g, '""')}"`)
-    .join(", ");
-  const lines = rows.map((row) => {
-    const vals = row
-      .map((v) => {
-        if (v === null || v === undefined) return "NULL";
-        if (typeof v === "number") return String(v);
-        return `'${String(v).replace(/'/g, "''")}'`;
-      })
-      .join(", ");
-    return `INSERT INTO result_set (${quotedCols}) VALUES (${vals});`;
-  });
-  triggerDownload(
-    new Blob([lines.join("\n")], { type: "text/plain;charset=utf-8" }),
-    filename,
-  );
-}
-
-// ─── Parquet helpers ─────────────────────────────────────────────────────
-//
-// Loaded lazily on first use via dynamic imports so the WASM binary is
-// not bundled into the initial page chunk. The WASM is fetched from the
-// jsDelivr CDN, loaded once, and cached thereafter.
-
-let _parquetWasmInit: Promise<typeof import("parquet-wasm/esm")> | null = null;
-
-async function initParquetWasm(): Promise<typeof import("parquet-wasm/esm")> {
-  if (!_parquetWasmInit) {
-    _parquetWasmInit = (async () => {
-      const mod = await import("parquet-wasm/esm");
-      await mod.default(
-        "https://cdn.jsdelivr.net/npm/parquet-wasm@0.7.1/esm/parquet_wasm_bg.wasm",
-      );
-      return mod;
-    })();
-  }
-  return _parquetWasmInit;
-}
-
-async function exportResultToParquet(
-  columns: string[],
-  rows: QueryExecResult["values"],
-  filename: string,
-): Promise<void> {
-  const [
-    { tableToIPC, tableFromArrays, Utf8, Float64, vectorFromArray },
-    { Table: WasmParquetTable, writeParquet },
-  ] = await Promise.all([import("apache-arrow"), initParquetWasm()]);
-
-  // Build per-column value arrays, preserving nulls.
-  const colArrays: Record<string, unknown[]> = {};
-  for (const col of columns) colArrays[col] = [];
-  for (const row of rows) {
-    for (let i = 0; i < columns.length; i++) {
-      const v = row[i];
-      colArrays[columns[i]].push(v === undefined ? null : v);
-    }
-  }
-
-  // Detect column types: if every non-null value is a number treat as
-  // Float64, otherwise treat as Utf8 (string).
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const fields: Record<string, any> = {};
-  for (const col of columns) {
-    const vals = colArrays[col];
-    const isNumeric = vals.every((v) => v === null || typeof v === "number");
-    if (isNumeric) {
-      fields[col] = vectorFromArray(vals as (number | null)[], new Float64());
-    } else {
-      fields[col] = vectorFromArray(
-        vals.map((v) => (v === null ? null : String(v))),
-        new Utf8(),
-      );
-    }
-  }
-
-  const arrowTable = tableFromArrays(
-    fields as Parameters<typeof tableFromArrays>[0],
-  );
-  const ipcBytes = tableToIPC(arrowTable, "stream");
-  const wasmTable = WasmParquetTable.fromIPCStream(ipcBytes);
-  const parquetBytes = writeParquet(wasmTable);
-  triggerDownload(
-    new Blob([parquetBytes], { type: "application/octet-stream" }),
-    filename,
-  );
-}
-
-async function importParquetFile(
-  file: File,
-): Promise<{ columns: string[]; rows: QueryExecResult["values"] }> {
-  const [{ tableFromIPC }, mod] = await Promise.all([
-    import("apache-arrow"),
-    initParquetWasm(),
-  ]);
-  const bytes = new Uint8Array(await file.arrayBuffer());
-  const wasmTable = mod.readParquet(bytes);
-  const arrowTable = tableFromIPC(wasmTable.intoIPCStream());
-
-  const columns = arrowTable.schema.fields.map((f) => f.name);
-  // Pre-build column index map to avoid O(n) findIndex inside the row loop.
-  const colIndexMap = new Map(columns.map((name, i) => [name, i]));
-  const colVectors = columns.map((_, i) => arrowTable.getChildAt(i));
-  const rows: QueryExecResult["values"] = [];
-  for (let r = 0; r < arrowTable.numRows; r++) {
-    const row: QueryExecResult["values"][number] = [];
-    for (let c = 0; c < columns.length; c++) {
-      const val = colVectors[colIndexMap.get(columns[c])!]?.get(r);
-      row.push((val === undefined ? null : val) as SqlValue);
-    }
-    rows.push(row);
-  }
-  return { columns, rows };
-}
-
-// ─── XLSX helpers (wasm-xlsxwriter) ─────────────────────────────────────────
-//
-// Loaded lazily on first use via dynamic imports so the WASM binary is
-// not bundled into the initial page chunk. The WASM is fetched from the
-// jsDelivr CDN, loaded once, and cached thereafter.
-
-let _xlsxWasmInit: Promise<typeof import("wasm-xlsxwriter/web")> | null = null;
-
-async function initXlsxWasm(): Promise<typeof import("wasm-xlsxwriter/web")> {
-  if (!_xlsxWasmInit) {
-    _xlsxWasmInit = (async () => {
-      const mod = await import("wasm-xlsxwriter/web");
-      await mod.default(
-        "https://cdn.jsdelivr.net/npm/wasm-xlsxwriter@0.13.0/web/wasm_xlsxwriter_bg.wasm",
-      );
-      return mod;
-    })();
-  }
-  return _xlsxWasmInit;
-}
-
-/** Convert a SQLite cell value to an ExcelData-compatible type. */
-function toExcelData(v: unknown): string | number | boolean | undefined {
-  if (v === null || v === undefined) return undefined;
-  if (typeof v === "number") return v;
-  if (typeof v === "boolean") return v;
-  if (v instanceof Uint8Array) return `[BLOB ${v.length} bytes]`;
-  return String(v);
-}
-
-/**
- * Export columns + rows to a single-sheet Excel (.xlsx) file.
- * The first row is the header row.
- */
-async function exportResultToXlsx(
-  columns: string[],
-  rows: QueryExecResult["values"],
-  filename: string,
-): Promise<void> {
-  const mod = await initXlsxWasm();
-  const workbook = new mod.Workbook();
-  const worksheet = workbook.addWorksheet();
-  // Header row
-  worksheet.writeRow(0, 0, columns);
-  // Data rows
-  for (let ri = 0; ri < rows.length; ri++) {
-    worksheet.writeRow(ri + 1, 0, rows[ri].map(toExcelData));
-  }
-  const bytes = workbook.saveToBufferSync();
-  triggerDownload(
-    new Blob([bytes], {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    }),
-    filename,
-  );
-}
 
 // ────────────────────────────────────────────────────────────────────────
 // Modify Structure drawer
@@ -1817,116 +1532,39 @@ function SqlPlaygroundInner() {
         getStoredEditorTheme(storageKey("editortheme")) ?? "lucario";
       const initialWordWrap =
         localStorage.getItem(storageKey("wordwrap")) !== "false";
-
-      const themeComp = new Compartment();
-      const wrapComp = new Compartment();
-      const completionComp = new Compartment();
-      const sqlLangComp = new Compartment();
-
-      // Persist whichever tab is currently active. Tab id + tab list are
-      // read from refs so this listener doesn't need to close over state.
-      const persistListener = EditorView.updateListener.of((update) => {
-        if (!update.docChanged) return;
-        const id = activeTabIdRef.current;
-        if (!id) return;
-        const value = update.state.doc.toString();
-        const next = tabsRef.current.map((t) =>
-          t.id === id ? { ...t, code: value } : t,
-        );
-        tabsRef.current = next;
-        setTabs(next);
-        saveTabs(activeDbIdRef.current, next);
-      });
-
-      // Track whether the editor has an active text selection so the
-      // Run button can switch between "Run" and "Run Selection" modes.
-      const selectionListener = EditorView.updateListener.of((update) => {
-        if (!update.selectionSet && !update.docChanged) return;
-        const sel = update.state.selection.main;
-        setHasEditorSelectionRef.current(!sel.empty);
-      });
+      const compartments = makeSqlEditorCompartments();
 
       const view = new EditorView({
         doc: "",
         parent: editorHostRef.current,
-        extensions: [
-          history(),
-          drawSelection(),
-          dropCursor(),
-          EditorState.allowMultipleSelections.of(true),
-          indentOnInput(),
-          bracketMatching(),
-          closeBrackets(),
-          lineNumbersExt(),
-          highlightActiveLineGutter(),
-          highlightActiveLine(),
-          highlightSelectionMatches(),
-          rectangularSelection(),
-          crosshairCursor(),
-          EditorState.tabSize.of(2),
-          indentUnit.of("  "),
-          completionComp.of(sqlAutocompletion({ entities: [] })),
-          tooltips({ parent: document.body }),
-          keymap.of([
-            {
-              // Run selection if text is selected, otherwise run all.
-              key: "Mod-Enter",
-              run: (v) => {
-                const sel = v.state.selection.main;
-                if (!sel.empty) {
-                  const selected = v.state.sliceDoc(sel.from, sel.to);
-                  runSelectionRef.current(selected);
-                } else {
-                  runRef.current();
-                }
-                return true;
-              },
-            },
-            {
-              // Always run all queries (ignores any selection).
-              key: "Mod-Shift-Enter",
-              run: () => {
-                runRef.current();
-                return true;
-              },
-            },
-            {
-              key: "Ctrl-Space",
-              run: (v) => {
-                startCompletion(v);
-                return true;
-              },
-            },
-            ...closeBracketsKeymap,
-            ...defaultKeymap,
-            ...searchKeymap,
-            ...historyKeymap,
-            // Remove Enter from the default completion keymap so that Enter
-            // always inserts a newline. Tab accepts the active completion
-            // instead, falling through to indentWithTab when no completion
-            // is shown.
-            ...completionKeymap.filter((b) => b.key !== "Enter"),
-            { key: "Tab", run: acceptCompletion },
-            indentWithTab,
-          ]),
-          // Initial language config — the schema-aware variant is swapped
-          // in via `sqlLangComp.reconfigure(...)` once the engine reports
-          // its tables.
-          sqlLangComp.of(
-            sqlLang({ dialect: SQLite, upperCaseKeywords: false }),
-          ),
-          themeComp.of(themeFor(initialTheme)),
-          wrapComp.of(initialWordWrap ? EditorView.lineWrapping : []),
-          persistListener,
-          selectionListener,
-        ],
+        extensions: createSqlEditorExtensions({
+          dialect: "sqlite",
+          compartments,
+          initialTheme,
+          initialWordWrap,
+          onSelectionChange: (hasSelection) => {
+            setHasEditorSelectionRef.current(hasSelection);
+          },
+          onDocChange: (code) => {
+            const id = activeTabIdRef.current;
+            if (!id) return;
+            const next = tabsRef.current.map((t) =>
+              t.id === id ? { ...t, code } : t,
+            );
+            tabsRef.current = next;
+            setTabs(next);
+            saveTabs(activeDbIdRef.current, next);
+          },
+          onRunSelection: (text) => runSelectionRef.current(text),
+          onRunAll: () => runRef.current(),
+        }),
       });
 
       editorRef.current = view;
-      themeCompRef.current = themeComp;
-      wrapCompRef.current = wrapComp;
-      completionCompRef.current = completionComp;
-      sqlLangCompRef.current = sqlLangComp;
+      themeCompRef.current = compartments.theme;
+      wrapCompRef.current = compartments.wrap;
+      completionCompRef.current = compartments.completion;
+      sqlLangCompRef.current = compartments.lang;
     }
 
     (async () => {
@@ -2052,10 +1690,10 @@ function SqlPlaygroundInner() {
       if (cancelled) return;
       view.dispatch({
         effects: [
-          sqlComp.reconfigure(
-            sqlLang({ dialect: SQLite, schema, upperCaseKeywords: false }),
+          sqlComp.reconfigure(makeSqlLangExtension("sqlite", schema)),
+          completionComp.reconfigure(
+            makeSqlAutocompletionExtension(completionSchema, "sqlite"),
           ),
-          completionComp.reconfigure(sqlAutocompletion(completionSchema)),
         ],
       });
     })();

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -131,7 +131,6 @@ import {
   X,
   Zap,
 } from "lucide-react";
-import { format as sqlFormat } from "sql-formatter";
 import { FaInfo } from "react-icons/fa";
 import { IoLink } from "react-icons/io5";
 import { MdOutlineKey } from "react-icons/md";
@@ -171,7 +170,15 @@ import {
   type TableColumnInfo,
 } from "../runtime/sqlite";
 import type { QueryExecResult, SqlValue } from "sql.js";
-import { ErDiagramPane } from "../ErDiagramPane";
+import dynamic from "next/dynamic";
+
+// ErDiagramPane pulls in @xyflow/react and elkjs/lib/elk.bundled.js
+// (~hundreds of KB of layout-algorithm code). It only renders when
+// the user opens the ER-diagram tab, so defer the chunk until then.
+const ErDiagramPane = dynamic(
+  () => import("../ErDiagramPane").then((m) => m.ErDiagramPane),
+  { ssr: false },
+);
 import { ToastList } from "./components/ToastList";
 import { SqlTab, SqlTabDragOverlay } from "./components/SqlTab";
 import { QueryHistoryPane } from "./components/QueryHistoryPane";
@@ -1670,13 +1677,14 @@ function SqlPlaygroundInner() {
     window.location.reload();
   }, []);
 
-  const handleFormatCode = useCallback(() => {
+  const handleFormatCode = useCallback(async () => {
     const view = editorRef.current;
     if (!view) return;
     const code = view.state.doc.toString();
     if (!code.trim()) return;
     setIsFormatting(true);
     try {
+      const { format: sqlFormat } = await import("sql-formatter");
       const formatted = sqlFormat(code, { language: "sqlite" });
       view.dispatch({
         changes: { from: 0, to: view.state.doc.length, insert: formatted },

--- a/app/_components/sql/hooks/useDatabaseActions.ts
+++ b/app/_components/sql/hooks/useDatabaseActions.ts
@@ -14,7 +14,12 @@ import {
 } from "../../sqlitePlaygroundTabs";
 import { findSampleDatabase, SQLITE_SAMPLE_DATABASES } from "../../runtime/sqliteSamples";
 import { replaceDoc } from "../utils/editorUtils";
-import { sanitizeImportColName } from "../utils/importUtils";
+import {
+  sanitizeImportColName,
+  parseCsv,
+  tableNameFromFilename,
+  readParquetFile,
+} from "../utils/importUtils";
 import {
   applyPragmasToEngine,
 } from "../utils/pragmaUtils";
@@ -36,36 +41,6 @@ export interface DatabaseActionsRefs {
   activeTabIdRef: React.MutableRefObject<string>;
   activeDbIdRef: React.MutableRefObject<string>;
   pragmaSettingsRef: React.MutableRefObject<PragmaSettings>;
-}
-
-async function importParquetFile(
-  file: File,
-): Promise<{ columns: string[]; rows: import("sql.js").QueryExecResult["values"] }> {
-  const mod = await (async () => {
-    const m = await import("parquet-wasm/esm");
-    await m.default(
-      "https://cdn.jsdelivr.net/npm/parquet-wasm@0.7.1/esm/parquet_wasm_bg.wasm",
-    );
-    return m;
-  })();
-  const { tableFromIPC } = await import("apache-arrow");
-  const bytes = await file.arrayBuffer();
-  const wasmTable = mod.readParquet(new Uint8Array(bytes));
-  const ipcBytes = wasmTable.intoIPCStream();
-  const arrowTable = tableFromIPC(ipcBytes);
-  const columns = arrowTable.schema.fields.map((f) => f.name);
-  const rows: import("sql.js").QueryExecResult["values"] = [];
-  for (const batch of arrowTable.batches) {
-    for (let r = 0; r < batch.numRows; r++) {
-      const row: import("sql.js").SqlValue[] = [];
-      for (let c = 0; c < columns.length; c++) {
-        const val = batch.getChildAt(c)?.get(r);
-        row.push(val === undefined ? null : val);
-      }
-      rows.push(row);
-    }
-  }
-  return { columns, rows };
 }
 
 export function useDatabaseActions(refs: DatabaseActionsRefs) {
@@ -332,60 +307,6 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
   }, [activeDbId, customFilenames, tables, quoteIdent, showToast, engineRef]);
 
   // ─── CSV parse helper ─────────────────────────────────────────────
-  const parseCsv = useCallback(
-    (text: string): { headers: string[]; rows: string[][] } => {
-      const parseLine = (line: string): string[] => {
-        const fields: string[] = [];
-        let cur = "";
-        let inQuotes = false;
-        for (let i = 0; i < line.length; i++) {
-          const ch = line[i];
-          if (inQuotes) {
-            if (ch === '"') {
-              if (i + 1 < line.length && line[i + 1] === '"') {
-                cur += '"';
-                i += 1;
-              } else {
-                inQuotes = false;
-              }
-            } else {
-              cur += ch;
-            }
-          } else if (ch === '"') {
-            inQuotes = true;
-          } else if (ch === ",") {
-            fields.push(cur);
-            cur = "";
-          } else {
-            cur += ch;
-          }
-        }
-        fields.push(cur);
-        return fields;
-      };
-      const lines = text.split(/\r?\n/);
-      const nonEmpty = lines.filter((l) => l.trim() !== "");
-      if (nonEmpty.length === 0) return { headers: [], rows: [] };
-      const headers = parseLine(nonEmpty[0]);
-      const rows = nonEmpty.slice(1).map((l) => {
-        const vals = parseLine(l);
-        while (vals.length < headers.length) vals.push("");
-        return vals.slice(0, headers.length);
-      });
-      return { headers, rows };
-    },
-    [],
-  );
-
-  const tableNameFromFilename = useCallback((filename: string): string => {
-    const base = filename
-      .replace(/\.[^.]+$/, "")
-      .replace(/[^a-zA-Z0-9_]/g, "_")
-      .replace(/^_+|_+$/g, "")
-      .replace(/_+/g, "_");
-    return base || "imported_table";
-  }, []);
-
   const handleCsvFile = useCallback(
     (file: File) => {
       const reader = new FileReader();
@@ -413,7 +334,7 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
       };
       reader.readAsText(file);
     },
-    [parseCsv, tableNameFromFilename, showToast, tables, setImportCsvState],
+    [showToast, tables, setImportCsvState],
   );
 
   const submitCsvImport = useCallback(() => {
@@ -529,7 +450,7 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
       };
       reader.readAsText(file);
     },
-    [tableNameFromFilename, showToast, tables, setImportJsonState],
+    [showToast, tables, setImportJsonState],
   );
 
   const submitJsonImport = useCallback(() => {
@@ -593,7 +514,7 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
     async (file: File) => {
       try {
         showToast("Reading parquet file…");
-        const { columns, rows } = await importParquetFile(file);
+        const { columns, rows } = await readParquetFile(file);
         if (columns.length === 0) {
           showToast("Parquet file appears to have no columns.", "warn");
           return;
@@ -611,7 +532,7 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
         showToast(`Parquet import failed: ${msg}`, "warn");
       }
     },
-    [tableNameFromFilename, showToast, tables, setImportParquetState],
+    [showToast, tables, setImportParquetState],
   );
 
   const submitParquetImport = useCallback(() => {

--- a/app/_components/sql/shared/editorSetup.ts
+++ b/app/_components/sql/shared/editorSetup.ts
@@ -1,0 +1,223 @@
+"use client";
+
+import {
+  acceptCompletion,
+  autocompletion,
+  closeBrackets,
+  closeBracketsKeymap,
+  completionKeymap,
+  startCompletion,
+} from "@codemirror/autocomplete";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab,
+} from "@codemirror/commands";
+import {
+  PostgreSQL,
+  SQLite,
+  sql as sqlLang,
+} from "@codemirror/lang-sql";
+import {
+  bracketMatching,
+  indentOnInput,
+  indentUnit,
+} from "@codemirror/language";
+import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
+import { Compartment, EditorState, type Extension } from "@codemirror/state";
+import {
+  EditorView,
+  crosshairCursor,
+  drawSelection,
+  dropCursor,
+  highlightActiveLine,
+  highlightActiveLineGutter,
+  keymap,
+  lineNumbers,
+  rectangularSelection,
+  tooltips,
+} from "@codemirror/view";
+import { themeFor } from "../../cmExtensions";
+import {
+  createSqlCompletionSource,
+  type SqlCompletionSchema,
+  type SqlDialect,
+} from "../sqlCompletion";
+
+// 75 ms keeps local schema suggestions feeling immediate while still
+// coalescing rapid typing before recomputing completions. CodeMirror's
+// default is 100 ms.
+const AUTOCOMPLETE_DELAY_MS = 75;
+
+export interface SqlEditorCompartments {
+  lang: Compartment;
+  completion: Compartment;
+  theme: Compartment;
+  wrap: Compartment;
+}
+
+export function makeSqlEditorCompartments(): SqlEditorCompartments {
+  return {
+    lang: new Compartment(),
+    completion: new Compartment(),
+    theme: new Compartment(),
+    wrap: new Compartment(),
+  };
+}
+
+export interface CreateSqlEditorExtensionsOptions {
+  dialect: SqlDialect;
+  compartments: SqlEditorCompartments;
+  initialSchema?: SqlCompletionSchema;
+  initialTheme: string;
+  initialWordWrap: boolean;
+  // The editor calls these on document / selection changes. The host
+  // typically wires them to refs that always reflect the freshest
+  // callbacks so the editor doesn't have to be torn down when a tab
+  // switch changes which "run" function should fire.
+  onDocChange: (code: string) => void;
+  onSelectionChange: (hasSelection: boolean) => void;
+  onRunSelection: (text: string) => void;
+  onRunAll: () => void;
+}
+
+/** Returns the dialect-specific argument for `@codemirror/lang-sql`'s
+ *  `sql({ dialect })` factory. DuckDB has no native dialect descriptor,
+ *  so we fall back to undefined (which lets lang-sql use its default
+ *  generic SQL grammar). */
+export function sqlLangDialect(dialect: SqlDialect) {
+  if (dialect === "postgres") return PostgreSQL;
+  if (dialect === "sqlite") return SQLite;
+  return undefined;
+}
+
+export function makeSqlAutocompletionExtension(
+  schema: SqlCompletionSchema,
+  dialect: SqlDialect,
+): Extension {
+  return autocompletion({
+    activateOnTyping: true,
+    activateOnTypingDelay: AUTOCOMPLETE_DELAY_MS,
+    closeOnBlur: true,
+    override: [createSqlCompletionSource(schema, { dialect })],
+  });
+}
+
+/** Build the `@codemirror/lang-sql` extension for a reconfigure
+ *  dispatch (when the schema or dialect changes after the editor is
+ *  mounted). The optional `schema` is the lang-sql shape used for
+ *  built-in completions — it's the same `Record<table, columns>`
+ *  the SQLite playground has always passed. */
+export function makeSqlLangExtension(
+  dialect: SqlDialect,
+  schema?: Record<string, string[]>,
+): Extension {
+  return sqlLang({
+    schema,
+    dialect: sqlLangDialect(dialect),
+    upperCaseKeywords: false,
+  });
+}
+
+/** Build the canonical extension list every SQL playground needs.
+ *
+ *  This consolidates ~80 lines that were duplicated across the SQLite,
+ *  Postgres, and DuckDB playgrounds. The four CodeMirror compartments
+ *  (lang / completion / theme / wrap) are passed in by the caller so
+ *  it can hold onto them for later `.reconfigure(...)` dispatches
+ *  (schema updates, theme toggles, word-wrap toggles). */
+export function createSqlEditorExtensions(
+  opts: CreateSqlEditorExtensionsOptions,
+): Extension[] {
+  const {
+    dialect,
+    compartments,
+    initialSchema = { entities: [] },
+    initialTheme,
+    initialWordWrap,
+    onDocChange,
+    onSelectionChange,
+    onRunSelection,
+    onRunAll,
+  } = opts;
+
+  return [
+    history(),
+    drawSelection(),
+    dropCursor(),
+    EditorState.allowMultipleSelections.of(true),
+    indentOnInput(),
+    bracketMatching(),
+    closeBrackets(),
+    rectangularSelection(),
+    tooltips({ parent: document.body }),
+    lineNumbers(),
+    highlightActiveLineGutter(),
+    highlightActiveLine(),
+    highlightSelectionMatches(),
+    crosshairCursor(),
+    EditorState.tabSize.of(2),
+    indentUnit.of("  "),
+    compartments.lang.of(
+      sqlLang({
+        dialect: sqlLangDialect(dialect),
+        upperCaseKeywords: false,
+      }),
+    ),
+    compartments.completion.of(
+      makeSqlAutocompletionExtension(initialSchema, dialect),
+    ),
+    compartments.theme.of(themeFor(initialTheme)),
+    compartments.wrap.of(initialWordWrap ? EditorView.lineWrapping : []),
+    EditorView.updateListener.of((update) => {
+      if (update.selectionSet) {
+        onSelectionChange(!update.state.selection.main.empty);
+      }
+      if (update.docChanged) {
+        onDocChange(update.state.doc.toString());
+      }
+    }),
+    keymap.of([
+      {
+        // Run selection if text is selected, otherwise run all.
+        key: "Mod-Enter",
+        run: (view) => {
+          const sel = view.state.selection.main;
+          if (!sel.empty) {
+            onRunSelection(view.state.sliceDoc(sel.from, sel.to));
+          } else {
+            onRunAll();
+          }
+          return true;
+        },
+      },
+      {
+        // Always run all queries (ignores any selection).
+        key: "Mod-Shift-Enter",
+        run: () => {
+          onRunAll();
+          return true;
+        },
+      },
+      {
+        key: "Ctrl-Space",
+        run: (view) => {
+          startCompletion(view);
+          return true;
+        },
+      },
+      ...closeBracketsKeymap,
+      ...defaultKeymap,
+      ...searchKeymap,
+      ...historyKeymap,
+      // Remove Enter from the default completion keymap so that Enter
+      // always inserts a newline. Tab accepts the active completion
+      // instead, falling through to indentWithTab when no completion is
+      // shown.
+      ...completionKeymap.filter((b) => b.key !== "Enter"),
+      { key: "Tab", run: acceptCompletion },
+      indentWithTab,
+    ]),
+  ];
+}

--- a/app/_components/sql/stores/createSchemaSettingsStore.ts
+++ b/app/_components/sql/stores/createSchemaSettingsStore.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { create } from "zustand";
+import { DEFAULT_PLAYGROUND_SETTINGS } from "../../playgroundShared";
+
+// Shape shared by the DuckDB and Postgres playground settings stores.
+// Both expose the same appearance toggles plus a `showSystemSchemas`
+// flag for the schema-selector dropdown. (The SQLite playground has
+// its own slightly different store because of distinct theme defaults
+// and a PRAGMA tab in place of system schemas.)
+export interface SchemaSettingsState {
+  fontSize: number;
+  outputFontSizeEnabled: boolean;
+  outputFontSize: number;
+  editorTheme: string;
+  wordWrap: boolean;
+  clearBeforeRun: boolean;
+  showSystemSchemas: boolean;
+  setFontSize: (fontSize: number) => void;
+  setOutputFontSizeEnabled: (enabled: boolean) => void;
+  setOutputFontSize: (fontSize: number) => void;
+  setEditorTheme: (theme: string) => void;
+  setWordWrap: (wordWrap: boolean) => void;
+  setClearBeforeRun: (clearBeforeRun: boolean) => void;
+  setShowSystemSchemas: (showSystemSchemas: boolean) => void;
+}
+
+export function createSchemaSettingsStore() {
+  return create<SchemaSettingsState>((set) => ({
+    fontSize: DEFAULT_PLAYGROUND_SETTINGS.fontSize,
+    outputFontSizeEnabled: DEFAULT_PLAYGROUND_SETTINGS.outputFontSizeEnabled,
+    outputFontSize: DEFAULT_PLAYGROUND_SETTINGS.outputFontSize,
+    editorTheme: DEFAULT_PLAYGROUND_SETTINGS.editorTheme,
+    wordWrap: DEFAULT_PLAYGROUND_SETTINGS.wordWrap,
+    clearBeforeRun: DEFAULT_PLAYGROUND_SETTINGS.clearBeforeRun,
+    showSystemSchemas: true,
+    setFontSize: (fontSize) => set({ fontSize }),
+    setOutputFontSizeEnabled: (outputFontSizeEnabled) =>
+      set({ outputFontSizeEnabled }),
+    setOutputFontSize: (outputFontSize) => set({ outputFontSize }),
+    setEditorTheme: (editorTheme) => set({ editorTheme }),
+    setWordWrap: (wordWrap) => set({ wordWrap }),
+    setClearBeforeRun: (clearBeforeRun) => set({ clearBeforeRun }),
+    setShowSystemSchemas: (showSystemSchemas) => set({ showSystemSchemas }),
+  }));
+}

--- a/app/_components/sql/utils/importUtils.ts
+++ b/app/_components/sql/utils/importUtils.ts
@@ -1,5 +1,112 @@
+import type { QueryExecResult, SqlValue } from "sql.js";
 import type { TableColumnInfo } from "../../runtime/sqlite";
 import type { ImportColComparison } from "../types";
+
+/** Parse CSV text into headers and rows. Used by every SQL playground
+ *  (sqlite, postgres, duckdb) so all three import flows behave
+ *  identically. Quoted fields, escaped double-quotes, and short rows
+ *  are handled per RFC 4180; trailing empty lines are skipped. */
+export function parseCsv(text: string): {
+  headers: string[];
+  rows: string[][];
+} {
+  const parseLine = (line: string): string[] => {
+    const fields: string[] = [];
+    let cur = "";
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (inQuotes) {
+        if (ch === '"') {
+          if (i + 1 < line.length && line[i + 1] === '"') {
+            cur += '"';
+            i += 1;
+          } else {
+            inQuotes = false;
+          }
+        } else {
+          cur += ch;
+        }
+      } else if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ",") {
+        fields.push(cur);
+        cur = "";
+      } else {
+        cur += ch;
+      }
+    }
+    fields.push(cur);
+    return fields;
+  };
+  const lines = text.split(/\r?\n/);
+  const nonEmpty = lines.filter((l) => l.trim() !== "");
+  if (nonEmpty.length === 0) return { headers: [], rows: [] };
+  const headers = parseLine(nonEmpty[0]);
+  const rows = nonEmpty.slice(1).map((l) => {
+    const vals = parseLine(l);
+    while (vals.length < headers.length) vals.push("");
+    return vals.slice(0, headers.length);
+  });
+  return { headers, rows };
+}
+
+/** Derive a SQL-safe table name from a filename, stripping the
+ *  extension and collapsing non-identifier runs to underscores. */
+export function tableNameFromFilename(filename: string): string {
+  const base = filename
+    .replace(/\.[^.]+$/, "")
+    .replace(/[^a-zA-Z0-9_]/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_");
+  return base || "imported_table";
+}
+
+let _parquetWasmInit:
+  | Promise<typeof import("parquet-wasm/esm")>
+  | null = null;
+/** Lazy-loaded parquet decoder shared across SQL playgrounds. The WASM
+ *  binary is fetched from jsDelivr on first use and cached for the
+ *  lifetime of the page. */
+async function initParquetWasm(): Promise<typeof import("parquet-wasm/esm")> {
+  if (!_parquetWasmInit) {
+    _parquetWasmInit = (async () => {
+      const m = await import("parquet-wasm/esm");
+      await m.default(
+        "https://cdn.jsdelivr.net/npm/parquet-wasm@0.7.1/esm/parquet_wasm_bg.wasm",
+      );
+      return m;
+    })();
+  }
+  return _parquetWasmInit;
+}
+
+/** Read a Parquet file and materialise it into the same column/row
+ *  shape parseCsv returns, so callers can hand the result off to a
+ *  shared import preview component. */
+export async function readParquetFile(
+  file: File,
+): Promise<{ columns: string[]; rows: QueryExecResult["values"] }> {
+  const mod = await initParquetWasm();
+  const { tableFromIPC } = await import("apache-arrow");
+  const bytes = await file.arrayBuffer();
+  const wasmTable = mod.readParquet(new Uint8Array(bytes));
+  const ipcBytes = wasmTable.intoIPCStream();
+  const arrowTable = tableFromIPC(ipcBytes);
+  const columns = arrowTable.schema.fields.map((f) => f.name);
+  const rows: QueryExecResult["values"] = [];
+  for (const batch of arrowTable.batches) {
+    for (let r = 0; r < batch.numRows; r++) {
+      const row: SqlValue[] = [];
+      for (let c = 0; c < columns.length; c++) {
+        const val = batch.getChildAt(c)?.get(r);
+        row.push(val === undefined ? null : (val as SqlValue));
+      }
+      rows.push(row);
+    }
+  }
+  return { columns, rows };
+}
 
 /** Sanitizes a raw header/column name to the SQL identifier used when
  *  building INSERT statements. Case is preserved so the created column

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,12 @@ import { CDN_BASE_URL } from "./app/_components/runtime/cdn";
 const nextConfig: NextConfig = {
   // Treat MDX files under content/ as page sources via fumadocs-mdx.
   pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
+  // Tell Next.js to rewrite barrel imports from these icon packages
+  // into deep specifier-level imports so we don't pull whole index
+  // graphs into every page's chunk.
+  experimental: {
+    optimizePackageImports: ["lucide-react", "react-icons"],
+  },
   // sql.js ships an Emscripten preamble that statically references the
   // Node-only `fs`/`path` modules. Those branches are dead code in the
   // browser (gated on `typeof process === "object"`), but Turbopack


### PR DESCRIPTION
## Context

Audit of the 12 in-browser playgrounds focused on (a) redundant code across the three SQL playgrounds (sqlite, postgres, duckdb), (b) DuckDB UX slowdowns during typing and scrolling — especially after a small CSV import — and (c) imports inflating the per-route bundle. This PR lands the highest-leverage findings; the larger SQL-shell refactor and sample-data consolidation are deferred to a follow-up.

## DuckDB performance hot-fixes

After importing a CSV, the DuckDB playground became noticeably laggy. Tracing the post-import path turned up three compounding causes — all addressed here:

1. **`saveTabs` ran synchronously on every keystroke.** The CodeMirror `updateListener` called `JSON.stringify(tabs)` + `localStorage.setItem(...)` per character. Now debounced (500 ms trailing edge), with explicit flushes on tab/db switch, `visibilitychange`, `pagehide`, and unmount.
2. **CodeMirror's SQL language + autocomplete were reconfigured on every schema update.** `refreshSchema()` always builds fresh `columnsByEntity` / `foreignKeysByEntity` objects, so the reference-keyed effect dispatched `langComp.reconfigure(sqlLang(...))` (forcing a full doc re-parse) after every query and CSV import — even when nothing visible had moved. Now compares a structural hash and skips the dispatch when unchanged.
3. **`refreshSchema` did a `SELECT COUNT(*)` per table.** With chinook loaded, importing one CSV fired ~36 queries on the DuckDB worker (3 per table × 12). Dropped the per-table COUNT; row counts now fetch lazily on first sidebar use with cached results and in-flight de-duplication. The `listColumns` / `listForeignKeys` fan-out is also bounded by a concurrency-6 pool so a 50-table catalog doesn't queue 100+ queries at once.

## Build-time / bundle wins

- `ErDiagramPane` → `next/dynamic`. It pulls in `@xyflow/react` and `elkjs/lib/elk.bundled.js` (a sizable layout-algorithm port), but only renders when the user opens the ER-diagram tab. The chunk now loads on demand. Applied across SQLite, Postgres, and DuckDB playgrounds.
- `sql-formatter` (~150 KB) was statically imported at module scope but only used on the Format button. Moved to a call-site `await import("sql-formatter")` in all three playgrounds.
- `next.config.ts`: enabled `experimental.optimizePackageImports` for `lucide-react` and `react-icons` so their named-export barrels don't drag whole index graphs into compilation.

## Dedup

- Three near-identical copies of the RFC-4180 CSV parser, the table-name-from-filename helper, and the parquet-wasm loader lived in the SQLite hook, the DuckDB import module, and the Postgres import module. Consolidated into `sql/utils/importUtils.ts`; dialect modules re-export so call sites are unchanged.
- The DuckDB and Postgres settings stores were byte-for-byte identical (different export/type names only). Moved the body into a new `sql/stores/createSchemaSettingsStore` factory; each dialect calls it. The SQLite store is left in place — its theme defaults and PRAGMA-tab integration differ.

Net: ~220 fewer lines, single source of truth for both areas.

## Out of scope (next PR)

- Decomposing the three ~5–6k-line SQL playground monoliths into a shared `SqlPlaygroundShell` parameterized by a dialect adapter (full Stage 3 of the audit plan).
- Consolidating `sqliteSamples` / `postgresSamples` / `duckdbSamples` into one template-driven module (Stage 4).
- Lazy-loading `@codemirror/lang-sql` and per-dialect dialect-data splitting (Stage 5, item 3).

## Test plan

- [x] `npm run lint` — same 5 pre-existing errors / 93 warnings as `main`; no new issues from this PR.
- [x] `tsc --noEmit` — clean.
- [x] `npx vitest run` — 175/175 passing.
- [x] `npm run build` — green across all routes (sqlite, postgres, duckdb, and 9 language playgrounds).
- [ ] Manual smoke in DevTools Performance: import a small CSV into DuckDB with chinook loaded; confirm post-import typing no longer shows long tasks > 50 ms per keystroke.
- [ ] Manual smoke: open the ER-diagram tab in each SQL playground and confirm it still renders (now via the dynamic chunk).
- [ ] Manual smoke: click Format in each SQL playground to verify the lazy `sql-formatter` import works.

https://claude.ai/code/session_011sG73DqcMQ6f62h11DMZix

---
_Generated by [Claude Code](https://claude.ai/code/session_011sG73DqcMQ6f62h11DMZix)_