### PR TITLE
Wire SqlPlaygroundShell to all three SQL playground pages

### DIFF
--- a/__tests__/sqlAdaptersAndSamples.test.ts
+++ b/__tests__/sqlAdaptersAndSamples.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { createDuckDbAdapter } from "../app/_components/duckdb/duckdbAdapter";
+import { createPostgresAdapter } from "../app/_components/postgres/postgresAdapter";
+import { createBlankSqlSample, findSqlSample } from "../app/_components/runtime/sqlSamples";
+import { createSqliteAdapter } from "../app/_components/sql/sqliteAdapter";
+
+describe("shared SQL sample helpers", () => {
+  const samples = [
+    {
+      id: "one",
+      label: "One",
+      filename: "one.db",
+      description: "First",
+      defaultTabs: [{ title: "Query 1", code: "SELECT 1;" }],
+    },
+    {
+      id: "two",
+      label: "Two",
+      filename: "two.db",
+      description: "Second",
+      defaultTabs: [{ title: "Query 1", code: "SELECT 2;" }],
+    },
+  ];
+
+  it("finds samples by id and falls back to the first sample", () => {
+    expect(findSqlSample(samples, null, "two").id).toBe("two");
+    expect(findSqlSample(samples, null, "missing").id).toBe("one");
+  });
+
+  it("returns the blank sample before searching the regular catalog", () => {
+    const blank = createBlankSqlSample({
+      id: "blank",
+      label: "Blank",
+      filename: "untitled.db",
+      description: "Empty",
+    });
+
+    expect(findSqlSample(samples, blank, "blank")).toBe(blank);
+    expect(blank.defaultTabs).toEqual([{ title: "Query 1", code: "" }]);
+  });
+});
+
+describe("SQL engine adapters", () => {
+  it("exposes dialect identity and storage prefixes", () => {
+    expect(createSqliteAdapter()).toMatchObject({
+      dialect: "sqlite",
+      displayName: "SQLite",
+      storagePrefix: "pg_sqlite_",
+      supportsSchemas: false,
+      supportsPragmas: true,
+    });
+    expect(createPostgresAdapter()).toMatchObject({
+      dialect: "postgres",
+      displayName: "PostgreSQL",
+      storagePrefix: "pgplayground_",
+      supportsSchemas: true,
+      supportsPragmas: false,
+    });
+    expect(createDuckDbAdapter()).toMatchObject({
+      dialect: "duckdb",
+      displayName: "DuckDB",
+      storagePrefix: "duckdb_",
+      supportsSchemas: true,
+      supportsPragmas: false,
+    });
+  });
+
+  it("quotes identifiers by doubling embedded quotes", () => {
+    expect(createSqliteAdapter().quoteIdent('a"b')).toBe('"a""b"');
+    expect(createPostgresAdapter().quoteIdent('a"b')).toBe('"a""b"');
+    expect(createDuckDbAdapter().quoteIdent('a"b')).toBe('"a""b"');
+  });
+
+  it("includes blank samples for engines that support creating databases", () => {
+    expect(createPostgresAdapter().findSample("blank")?.filename).toBe(
+      "untitled.pg",
+    );
+    expect(createDuckDbAdapter().findSample("blank")?.filename).toBe(
+      "untitled.duckdb",
+    );
+  });
+});

--- a/__tests__/sqlPlaygroundShell.test.tsx
+++ b/__tests__/sqlPlaygroundShell.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  addSqlShellTab,
+  loadSqlShellState,
+  saveSqlShellState,
+  sqlShellStorageKey,
+  updateSqlShellTabCode,
+  type SqlShellState,
+} from "../app/_components/sql/shared/SqlPlaygroundShell";
+import type { SqlSample } from "../app/_components/sql/shared/SqlEngineAdapter";
+
+class MemoryStorage {
+  private readonly items = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value);
+  }
+}
+
+const sample: SqlSample = {
+  id: "chinook",
+  label: "Chinook",
+  filename: "chinook.sql",
+  defaultTabs: [
+    { title: "Artists", code: "SELECT * FROM artists;" },
+    { title: "Albums", code: "SELECT * FROM albums;" },
+  ],
+};
+
+describe("SqlPlaygroundShell tab persistence", () => {
+  it("builds storage keys from adapter prefix and sample id", () => {
+    expect(sqlShellStorageKey("pg_sqlite", "chinook")).toBe(
+      "pg_sqlite:shell:chinook:tabs",
+    );
+  });
+
+  it("creates default tabs from sample tab seeds", () => {
+    const state = loadSqlShellState(null, "pg_sqlite", sample);
+
+    expect(state.tabs).toHaveLength(2);
+    expect(state.activeTabId).toBe(state.tabs[0].id);
+    expect(state.tabs[0]).toMatchObject({
+      title: "Artists",
+      code: "SELECT * FROM artists;",
+      pristineCode: "SELECT * FROM artists;",
+    });
+  });
+
+  it("loads valid persisted tabs and keeps a valid active tab", () => {
+    const storage = new MemoryStorage();
+    const persisted: SqlShellState = {
+      activeTabId: "tab_2",
+      tabs: [
+        {
+          id: "tab_1",
+          title: "One",
+          code: "SELECT 1;",
+          pristineCode: "SELECT 1;",
+        },
+        {
+          id: "tab_2",
+          title: "Two",
+          code: "SELECT 2;",
+          pristineCode: "SELECT 2;",
+        },
+      ],
+    };
+
+    saveSqlShellState(storage, "duckdb", sample.id, persisted);
+
+    expect(loadSqlShellState(storage, "duckdb", sample)).toEqual(persisted);
+  });
+
+  it("falls back to the first persisted tab when active tab is stale", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      sqlShellStorageKey("postgres", sample.id),
+      JSON.stringify({
+        activeTabId: "missing",
+        tabs: [{ id: "tab_1", title: "One", code: "SELECT 1;" }],
+      }),
+    );
+
+    const state = loadSqlShellState(storage, "postgres", sample);
+
+    expect(state.activeTabId).toBe("tab_1");
+    expect(state.tabs[0].pristineCode).toBe("SELECT 1;");
+  });
+
+  it("adds a new tab and makes it active", () => {
+    const state = loadSqlShellState(null, "pg_sqlite", sample);
+    const next = addSqlShellTab(state);
+
+    expect(next.tabs).toHaveLength(3);
+    expect(next.activeTabId).toBe(next.tabs[2].id);
+    expect(next.tabs[2]).toMatchObject({
+      title: "Query 3",
+      code: "",
+      pristineCode: "",
+    });
+  });
+
+  it("updates the requested tab code without changing pristine code", () => {
+    const state = loadSqlShellState(null, "pg_sqlite", sample);
+    const next = updateSqlShellTabCode(
+      state,
+      state.tabs[1].id,
+      "SELECT count(*) FROM albums;",
+    );
+
+    expect(next.tabs[0].code).toBe("SELECT * FROM artists;");
+    expect(next.tabs[1].code).toBe("SELECT count(*) FROM albums;");
+    expect(next.tabs[1].pristineCode).toBe("SELECT * FROM albums;");
+  });
+});

--- a/app/_components/duckdb/duckdbAdapter.ts
+++ b/app/_components/duckdb/duckdbAdapter.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { createDuckDbEngine } from "../runtime/duckdb";
+import {
+  DUCKDB_BLANK_DATABASE,
+  DUCKDB_SAMPLE_DATABASES,
+  findDuckDbSampleDatabase,
+} from "../runtime/duckdbSamples";
+import type {
+  SqlColumnInfo,
+  SqlEngineAdapter,
+  SqlEngineHandle,
+  SqlForeignKeyInfo,
+} from "../sql/shared/SqlEngineAdapter";
+
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+export function createDuckDbAdapter(): SqlEngineAdapter {
+  return {
+    dialect: "duckdb",
+    displayName: "DuckDB",
+    storagePrefix: "duckdb_",
+    defaultPageSize: 50,
+    supportsSchemas: true,
+    supportsPragmas: false,
+    createEngine: async (sampleId) => {
+      const engine = await createDuckDbEngine(sampleId);
+      return {
+        exec: (sql) => engine.exec(sql),
+        execParams: (sql, params) => engine.execParams(sql, [...params]),
+        listTables: (schema) => engine.listTables(schema),
+        listViews: (schema) => engine.listViews(schema),
+        listIndexes: (schema) => engine.listIndexes(schema),
+        listTriggers: () => engine.listTriggers(),
+        listSchemas: (showSystem) => engine.listSchemas(showSystem),
+        listColumns: async (name, schema) =>
+          (await engine.listColumns(name, schema)).map(
+            (column): SqlColumnInfo => ({
+              name: column.name,
+              type: column.type,
+              notNull: column.notNull,
+              defaultValue: column.defaultValue,
+              pk: column.pk,
+            }),
+          ),
+        listForeignKeys: async (name, schema) =>
+          (await engine.listForeignKeys(name, schema)).map(
+            (fk): SqlForeignKeyInfo => ({
+              from: fk.from,
+              to_table: fk.table,
+              to_column: fk.to,
+              on_delete: fk.onDelete,
+              on_update: fk.onUpdate,
+            }),
+          ),
+        destroy: () => engine.destroy(),
+      } satisfies SqlEngineHandle;
+    },
+    listSamples: () => [...DUCKDB_SAMPLE_DATABASES, DUCKDB_BLANK_DATABASE],
+    findSample: findDuckDbSampleDatabase,
+    quoteIdent,
+  };
+}

--- a/app/_components/postgres/postgresAdapter.ts
+++ b/app/_components/postgres/postgresAdapter.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { createPostgresEngine } from "../runtime/postgres";
+import {
+  findPostgresSampleDatabase,
+  POSTGRES_BLANK_DATABASE,
+  POSTGRES_SAMPLE_DATABASES,
+} from "../runtime/postgresSamples";
+import type {
+  SqlColumnInfo,
+  SqlEngineAdapter,
+  SqlEngineHandle,
+  SqlForeignKeyInfo,
+} from "../sql/shared/SqlEngineAdapter";
+
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+export function createPostgresAdapter(): SqlEngineAdapter {
+  return {
+    dialect: "postgres",
+    displayName: "PostgreSQL",
+    storagePrefix: "pgplayground_",
+    defaultPageSize: 50,
+    supportsSchemas: true,
+    supportsPragmas: false,
+    createEngine: async (sampleId) => {
+      const engine = await createPostgresEngine(sampleId);
+      return {
+        exec: (sql) => engine.exec(sql),
+        execParams: (sql, params) => engine.execParams(sql, [...params]),
+        listTables: (schema) => engine.listTables(schema),
+        listViews: (schema) => engine.listViews(schema),
+        listIndexes: (schema) => engine.listIndexes(schema),
+        listTriggers: (schema) => engine.listTriggers(schema),
+        listSchemas: (showSystem) => engine.listSchemas(showSystem),
+        listColumns: async (name, schema) =>
+          (await engine.listColumns(name, schema)).map(
+            (column): SqlColumnInfo => ({
+              name: column.name,
+              type: column.type,
+              notNull: column.notNull,
+              defaultValue: column.defaultValue,
+              pk: column.pk,
+            }),
+          ),
+        listForeignKeys: async (name, schema) =>
+          (await engine.listForeignKeys(name, schema)).map(
+            (fk): SqlForeignKeyInfo => ({
+              from: fk.from,
+              to_table: fk.table,
+              to_column: fk.to,
+              on_delete: fk.onDelete,
+              on_update: fk.onUpdate,
+            }),
+          ),
+        destroy: () => engine.close(),
+      } satisfies SqlEngineHandle;
+    },
+    listSamples: () => [...POSTGRES_SAMPLE_DATABASES, POSTGRES_BLANK_DATABASE],
+    findSample: findPostgresSampleDatabase,
+    quoteIdent,
+  };
+}

--- a/app/_components/runtime/duckdbSamples.ts
+++ b/app/_components/runtime/duckdbSamples.ts
@@ -1,14 +1,14 @@
 "use client";
 
-import type { QueryTabSeed } from "./sqliteSamples";
+import {
+  createBlankSqlSample,
+  findSqlSample,
+  type QueryTabSeed,
+  type SqlSampleCatalogEntry,
+} from "./sqlSamples";
 
-export interface DuckDbSampleDatabase {
-  id: string;
-  label: string;
-  filename: string;
-  description: string;
+export interface DuckDbSampleDatabase extends SqlSampleCatalogEntry {
   sql: string;
-  defaultTabs: QueryTabSeed[];
 }
 
 // ─── E-Commerce sample ───────────────────────────────────────────────
@@ -235,19 +235,14 @@ export const DUCKDB_SAMPLE_DATABASES: DuckDbSampleDatabase[] = [
   },
 ];
 
-export const DUCKDB_BLANK_DATABASE: DuckDbSampleDatabase = {
+export const DUCKDB_BLANK_DATABASE = createBlankSqlSample<DuckDbSampleDatabase>({
   id: "blank",
   label: "New Database",
   filename: "untitled.duckdb",
   description: "Empty DuckDB database — start from scratch.",
   sql: "",
-  defaultTabs: [{ title: "Query 1", code: "" }],
-};
+});
 
 export function findDuckDbSampleDatabase(id: string): DuckDbSampleDatabase {
-  if (id === DUCKDB_BLANK_DATABASE.id) return DUCKDB_BLANK_DATABASE;
-  return (
-    DUCKDB_SAMPLE_DATABASES.find((sample) => sample.id === id) ??
-    DUCKDB_SAMPLE_DATABASES[0]
-  );
+  return findSqlSample(DUCKDB_SAMPLE_DATABASES, DUCKDB_BLANK_DATABASE, id);
 }

--- a/app/_components/runtime/postgresSamples.ts
+++ b/app/_components/runtime/postgresSamples.ts
@@ -1,14 +1,14 @@
 "use client";
 
-import type { QueryTabSeed } from "./sqliteSamples";
+import {
+  createBlankSqlSample,
+  findSqlSample,
+  type QueryTabSeed,
+  type SqlSampleCatalogEntry,
+} from "./sqlSamples";
 
-export interface PostgresSampleDatabase {
-  id: string;
-  label: string;
-  filename: string;
-  description: string;
+export interface PostgresSampleDatabase extends SqlSampleCatalogEntry {
   sql: string;
-  defaultTabs: QueryTabSeed[];
 }
 
 const CREDIT_CARD_SQL = `
@@ -726,19 +726,14 @@ export const POSTGRES_SAMPLE_DATABASES: PostgresSampleDatabase[] = [
   },
 ];
 
-export const POSTGRES_BLANK_DATABASE: PostgresSampleDatabase = {
+export const POSTGRES_BLANK_DATABASE = createBlankSqlSample<PostgresSampleDatabase>({
   id: "blank",
   label: "New Database",
   filename: "untitled.pg",
   description: "Empty database — start from scratch.",
   sql: "",
-  defaultTabs: [{ title: "Query 1", code: "" }],
-};
+});
 
 export function findPostgresSampleDatabase(id: string): PostgresSampleDatabase {
-  if (id === POSTGRES_BLANK_DATABASE.id) return POSTGRES_BLANK_DATABASE;
-  return (
-    POSTGRES_SAMPLE_DATABASES.find((sample) => sample.id === id) ??
-    POSTGRES_SAMPLE_DATABASES[0]
-  );
+  return findSqlSample(POSTGRES_SAMPLE_DATABASES, POSTGRES_BLANK_DATABASE, id);
 }

--- a/app/_components/runtime/sqlSamples.ts
+++ b/app/_components/runtime/sqlSamples.ts
@@ -23,7 +23,9 @@ export function findSqlSample<T extends SqlSampleCatalogEntry>(
   if (blankSample && id === blankSample.id) return blankSample;
   const sample = samples.find((entry) => entry.id === id) ?? samples[0];
   if (!sample) {
-    throw new Error("SQL sample catalog must contain at least one sample.");
+    throw new Error(
+      "SQL sample catalog must contain at least one sample. Check the samples array passed to findSqlSample.",
+    );
   }
   return sample;
 }

--- a/app/_components/runtime/sqlSamples.ts
+++ b/app/_components/runtime/sqlSamples.ts
@@ -21,7 +21,11 @@ export function findSqlSample<T extends SqlSampleCatalogEntry>(
   id: string,
 ): T {
   if (blankSample && id === blankSample.id) return blankSample;
-  return samples.find((sample) => sample.id === id) ?? samples[0];
+  const sample = samples.find((entry) => entry.id === id) ?? samples[0];
+  if (!sample) {
+    throw new Error("SQL sample catalog must contain at least one sample.");
+  }
+  return sample;
 }
 
 export function createBlankSqlSample<T extends SqlSampleCatalogEntry>(

--- a/app/_components/runtime/sqlSamples.ts
+++ b/app/_components/runtime/sqlSamples.ts
@@ -21,13 +21,12 @@ export function findSqlSample<T extends SqlSampleCatalogEntry>(
   id: string,
 ): T {
   if (blankSample && id === blankSample.id) return blankSample;
-  const sample = samples.find((entry) => entry.id === id) ?? samples[0];
-  if (!sample) {
+  if (samples.length === 0) {
     throw new Error(
       "SQL sample catalog must contain at least one sample. Check the samples array passed to findSqlSample.",
     );
   }
-  return sample;
+  return samples.find((entry) => entry.id === id) ?? samples[0];
 }
 
 export function createBlankSqlSample<T extends SqlSampleCatalogEntry>(

--- a/app/_components/runtime/sqlSamples.ts
+++ b/app/_components/runtime/sqlSamples.ts
@@ -1,0 +1,34 @@
+"use client";
+
+export interface QueryTabSeed {
+  /** Human-readable title shown in the tab strip. */
+  title: string;
+  /** Initial SQL contents of the tab. */
+  code: string;
+}
+
+export interface SqlSampleCatalogEntry {
+  id: string;
+  label: string;
+  filename: string;
+  description: string;
+  defaultTabs: QueryTabSeed[];
+}
+
+export function findSqlSample<T extends SqlSampleCatalogEntry>(
+  samples: readonly T[],
+  blankSample: T | null,
+  id: string,
+): T {
+  if (blankSample && id === blankSample.id) return blankSample;
+  return samples.find((sample) => sample.id === id) ?? samples[0];
+}
+
+export function createBlankSqlSample<T extends SqlSampleCatalogEntry>(
+  sample: Omit<T, "defaultTabs"> & { defaultTabs?: QueryTabSeed[] },
+): T {
+  return {
+    ...sample,
+    defaultTabs: sample.defaultTabs ?? [{ title: "Query 1", code: "" }],
+  } as T;
+}

--- a/app/_components/runtime/sqliteSamples.ts
+++ b/app/_components/runtime/sqliteSamples.ts
@@ -5,15 +5,11 @@
 // loading a binary `.sqlite` file) is a one-entry change.
 
 import type { Database } from "sql.js";
+import { findSqlSample, type QueryTabSeed, type SqlSampleCatalogEntry } from "./sqlSamples";
 
-export interface QueryTabSeed {
-  /** Human-readable title shown in the tab strip. */
-  title: string;
-  /** Initial SQL contents of the tab. */
-  code: string;
-}
+export type { QueryTabSeed } from "./sqlSamples";
 
-export interface SqliteSampleDatabase {
+export interface SqliteSampleDatabase extends SqlSampleCatalogEntry {
   /** Stable id used in localStorage keys and the selector value. */
   id: string;
   /** Human-readable name shown in the selector trigger and dropdown. */
@@ -882,8 +878,5 @@ export const SQLITE_SAMPLE_DATABASES: SqliteSampleDatabase[] = [
  *  state even after the user deletes a sample we shipped in a previous
  *  release. */
 export function findSampleDatabase(id: string): SqliteSampleDatabase {
-  return (
-    SQLITE_SAMPLE_DATABASES.find((s) => s.id === id) ??
-    SQLITE_SAMPLE_DATABASES[0]
-  );
+  return findSqlSample(SQLITE_SAMPLE_DATABASES, null, id);
 }

--- a/app/_components/sql/components/ResultView.tsx
+++ b/app/_components/sql/components/ResultView.tsx
@@ -381,6 +381,7 @@ export function queryResultsIdentical(
 export function ResultView({
   result,
   loading,
+  loadingLabel,
   keyHints,
   sourceTable,
   constraintInfo,
@@ -397,6 +398,7 @@ export function ResultView({
 }: {
   result: QueryRunResult | null;
   loading: boolean;
+  loadingLabel?: string;
   keyHints?: ColumnKeyHints;
   sourceTable?: string;
   constraintInfo?: ColumnConstraintInfo[];
@@ -877,7 +879,7 @@ export function ResultView({
     return (
       <div className="welcome">
         <div className="welcome-icon">⌬</div>
-        <h3>Loading SQLite engine…</h3>
+        <h3>{loadingLabel ?? "Loading SQL engine…"}</h3>
       </div>
     );
   }

--- a/app/_components/sql/shared/SqlEngineAdapter.ts
+++ b/app/_components/sql/shared/SqlEngineAdapter.ts
@@ -1,0 +1,96 @@
+import type { Extension } from "@codemirror/state";
+import type { QueryExecResult } from "sql.js";
+import type { ComponentType, ReactNode } from "react";
+import type {
+  SqlCompletionSchema,
+  SqlDialect,
+} from "../sqlCompletion";
+
+export interface SqlSampleTab {
+  title: string;
+  code: string;
+}
+
+export interface SqlSample {
+  id: string;
+  label: string;
+  filename: string;
+  defaultTabs?: readonly SqlSampleTab[];
+  description?: string;
+}
+
+export interface SqlColumnInfo {
+  name: string;
+  type: string;
+  notNull?: boolean;
+  defaultValue?: string | null;
+  pk?: number;
+}
+
+export interface SqlForeignKeyInfo {
+  from: string;
+  to_table: string;
+  to_column: string;
+  on_delete?: string;
+  on_update?: string;
+}
+
+export interface SqlRunResult {
+  sets: (QueryExecResult | null)[];
+  elapsedMs: number;
+  error?: string;
+}
+
+export interface SqlEntityRef {
+  name: string;
+  kind: "table" | "view" | "index" | "trigger";
+  schema?: string;
+}
+
+export interface SqlEngineHandle {
+  exec(sql: string): Promise<(QueryExecResult | null)[]>;
+  execParams?(
+    sql: string,
+    params: readonly unknown[],
+  ): Promise<(QueryExecResult | null)[]>;
+  listTables(schema?: string): Promise<string[]>;
+  listViews(schema?: string): Promise<string[]>;
+  listIndexes(schema?: string): Promise<string[]>;
+  listTriggers(schema?: string): Promise<string[]>;
+  listColumns(name: string, schema?: string): Promise<SqlColumnInfo[]>;
+  listForeignKeys(
+    name: string,
+    schema?: string,
+  ): Promise<SqlForeignKeyInfo[]>;
+  listSchemas?(showSystem: boolean): Promise<string[]>;
+  destroy(): Promise<void> | void;
+}
+
+export interface SqlStructureDialogProps {
+  engine: SqlEngineHandle | null;
+  schema?: string;
+  onClose: () => void;
+  onChanged: () => void;
+}
+
+export interface SqlEngineAdapter {
+  dialect: SqlDialect;
+  displayName: string;
+  storagePrefix: string;
+  defaultPageSize: number;
+
+  createEngine(sampleId: string): Promise<SqlEngineHandle>;
+  listSamples(): readonly SqlSample[];
+  findSample(id: string): SqlSample | undefined;
+
+  quoteIdent(name: string): string;
+  supportsSchemas: boolean;
+  supportsPragmas: boolean;
+
+  initialCompletionSchema?: SqlCompletionSchema;
+  editorExtensions?: readonly Extension[];
+  extraSettingsItems?: ReactNode;
+  afterEngineCreated?(engine: SqlEngineHandle): Promise<void> | void;
+  renderAddTableDialog?: ComponentType<SqlStructureDialogProps>;
+  renderModifyStructureDrawer?: ComponentType<SqlStructureDialogProps>;
+}

--- a/app/_components/sql/shared/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/shared/SqlPlaygroundShell.tsx
@@ -380,10 +380,10 @@ function SqlPlaygroundShellInner({ adapter, sampleId }: SqlPlaygroundShellProps)
   const result = activeTab ? (resultsByTab[activeTab.id] ?? null) : null;
 
   // ─── Settings ─────────────────────────────────────────────────────
-  const [fontSize, setFontSize] = useState(DEFAULT_PLAYGROUND_SETTINGS.fontSize);
-  const [wordWrap, setWordWrap] = useState(DEFAULT_PLAYGROUND_SETTINGS.wordWrap);
-  const [clearBeforeRun, setClearBeforeRun] = useState(DEFAULT_PLAYGROUND_SETTINGS.clearBeforeRun);
-  const [editorTheme, setEditorTheme] = useState(DEFAULT_PLAYGROUND_SETTINGS.editorTheme);
+  const [fontSize, setFontSize] = useState<number>(DEFAULT_PLAYGROUND_SETTINGS.fontSize);
+  const [wordWrap, setWordWrap] = useState<boolean>(DEFAULT_PLAYGROUND_SETTINGS.wordWrap);
+  const [clearBeforeRun, setClearBeforeRun] = useState<boolean>(DEFAULT_PLAYGROUND_SETTINGS.clearBeforeRun);
+  const [editorTheme, setEditorTheme] = useState<string>(DEFAULT_PLAYGROUND_SETTINGS.editorTheme);
 
   const clearBeforeRunRef = useRef(clearBeforeRun);
   useEffect(() => { clearBeforeRunRef.current = clearBeforeRun; }, [clearBeforeRun]);

--- a/app/_components/sql/shared/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/shared/SqlPlaygroundShell.tsx
@@ -1,7 +1,44 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
-import type { SqlEngineAdapter, SqlSample } from "./SqlEngineAdapter";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { EditorView } from "@codemirror/view";
+import type { Compartment } from "@codemirror/state";
+import { Select } from "@base-ui-components/react/select";
+import { Toast } from "@base-ui-components/react/toast";
+import { Database, ChevronDown, ChevronRight, Hash } from "lucide-react";
+import { IoLink } from "react-icons/io5";
+import "../../playground.css";
+import "../../sqlPlayground.css";
+import type { SqlEngineAdapter, SqlEngineHandle, SqlColumnInfo, SqlForeignKeyInfo, SqlSample } from "./SqlEngineAdapter";
+import {
+  createSqlEditorExtensions,
+  makeSqlEditorCompartments,
+} from "./editorSetup";
+import { SqlRunControls } from "./SqlRunControls";
+import { useSqlPlaygroundSettingsHydration } from "./useSqlPlaygroundSettings";
+import { ResultView } from "../components/ResultView";
+import { SchemaSection } from "../components/SchemaSection";
+import type { QueryRunResult } from "../types";
+import {
+  DEFAULT_PLAYGROUND_SETTINGS,
+  DataslopeRunOverlay,
+  detectIsMac,
+} from "../../playgroundShared";
+import {
+  applyMode,
+  applyThemePalette,
+  clearThemePalette,
+  LIGHT_THEMES,
+} from "../../playgroundTheme";
+import { ToastList } from "../components/ToastList";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface SqlShellTab {
   id: string;
@@ -20,6 +57,8 @@ export interface SqlPlaygroundShellProps {
   sampleId?: string;
 }
 
+// ─── Storage helpers (kept for external use in tests etc.) ───────────────────
+
 interface ShellStorage {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
@@ -31,14 +70,10 @@ export function createSqlShellTabId(): string {
   if (typeof crypto !== "undefined" && crypto.randomUUID) {
     return `shell_${crypto.randomUUID()}`;
   }
-
   return `shell_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
-export function sqlShellStorageKey(
-  storagePrefix: string,
-  sampleId: string,
-): string {
+export function sqlShellStorageKey(storagePrefix: string, sampleId: string): string {
   return `${storagePrefix}:shell:${sampleId}:tabs`;
 }
 
@@ -57,7 +92,6 @@ export function defaultSqlShellTabs(sample: SqlSample): SqlShellTab[] {
 
 function normalizeTabs(value: unknown): SqlShellTab[] | null {
   if (!Array.isArray(value) || value.length === 0) return null;
-
   const tabs = value.flatMap((tab): SqlShellTab[] => {
     if (typeof tab !== "object" || tab === null) return [];
     const candidate = tab as Partial<SqlShellTab>;
@@ -65,23 +99,17 @@ function normalizeTabs(value: unknown): SqlShellTab[] | null {
       typeof candidate.id !== "string" ||
       typeof candidate.title !== "string" ||
       typeof candidate.code !== "string"
-    ) {
-      return [];
-    }
-
-    return [
-      {
-        id: candidate.id,
-        title: candidate.title,
-        code: candidate.code,
-        pristineCode:
-          typeof candidate.pristineCode === "string"
-            ? candidate.pristineCode
-            : candidate.code,
-      },
-    ];
+    ) return [];
+    return [{
+      id: candidate.id,
+      title: candidate.title,
+      code: candidate.code,
+      pristineCode:
+        typeof candidate.pristineCode === "string"
+          ? candidate.pristineCode
+          : candidate.code,
+    }];
   });
-
   return tabs.length > 0 ? tabs : null;
 }
 
@@ -99,21 +127,19 @@ export function loadSqlShellState(
         const tabs = normalizeTabs(parsed.tabs);
         const activeTabId =
           typeof parsed.activeTabId === "string" ? parsed.activeTabId : "";
-
         if (tabs) {
           return {
             tabs,
-            activeTabId: tabs.some((tab) => tab.id === activeTabId)
+            activeTabId: tabs.some((t) => t.id === activeTabId)
               ? activeTabId
               : tabs[0].id,
           };
         }
       }
     } catch {
-      // Corrupt persisted shell state falls back to sample defaults.
+      // Corrupt persisted state – fall through to defaults.
     }
   }
-
   const tabs = defaultSqlShellTabs(sample);
   return { tabs, activeTabId: tabs[0].id };
 }
@@ -125,14 +151,10 @@ export function saveSqlShellState(
   state: SqlShellState,
 ): void {
   if (!storage) return;
-
   try {
-    storage.setItem(
-      sqlShellStorageKey(storagePrefix, sampleId),
-      JSON.stringify(state),
-    );
+    storage.setItem(sqlShellStorageKey(storagePrefix, sampleId), JSON.stringify(state));
   } catch {
-    // Quota exceeded / private mode — ignore just like the existing playgrounds.
+    // Quota exceeded / private mode.
   }
 }
 
@@ -144,11 +166,7 @@ export function addSqlShellTab(state: SqlShellState): SqlShellState {
     code: "",
     pristineCode: "",
   };
-
-  return {
-    tabs: [...state.tabs, nextTab],
-    activeTabId: nextTab.id,
-  };
+  return { tabs: [...state.tabs, nextTab], activeTabId: nextTab.id };
 }
 
 export function updateSqlShellTabCode(
@@ -169,94 +187,803 @@ function getBrowserStorage(): ShellStorage | null {
   return window.localStorage;
 }
 
-export function SqlPlaygroundShell({
-  adapter,
-  sampleId,
-}: SqlPlaygroundShellProps) {
-  const sample = useMemo(() => {
-    const samples = adapter.listSamples();
+// ─── Schema sidebar ───────────────────────────────────────────────────────────
+
+function SchemaColumnList({
+  name,
+  columns,
+  foreignKeys,
+}: {
+  name: string;
+  columns: SqlColumnInfo[] | undefined;
+  foreignKeys: SqlForeignKeyInfo[] | undefined;
+}) {
+  if (!columns) {
     return (
-      (sampleId ? adapter.findSample(sampleId) : undefined) ??
-      samples[0] ?? {
-        id: "default",
-        label: adapter.displayName,
-        filename: "",
-      }
+      <ul className="sql-tree-columns" aria-label={`Columns of ${name}`}>
+        <li className="sql-tree-column" style={{ opacity: 0.5 }}>Loading…</li>
+      </ul>
     );
-  }, [adapter, sampleId]);
-
-  const storage = getBrowserStorage();
-  const [state, setState] = useState<SqlShellState>(() =>
-    loadSqlShellState(storage, adapter.storagePrefix, sample),
-  );
-
-  const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
-
-  const persist = useCallback(
-    (next: SqlShellState) => {
-      saveSqlShellState(storage, adapter.storagePrefix, sample.id, next);
-      return next;
-    },
-    [adapter.storagePrefix, sample.id, storage],
-  );
-
-  const handleAddTab = useCallback(() => {
-    setState((current) => persist(addSqlShellTab(current)));
-  }, [persist]);
-
-  const handleCodeChange = useCallback(
-    (code: string) => {
-      if (!activeTab) return;
-      setState((current) =>
-        persist(updateSqlShellTabCode(current, activeTab.id, code)),
-      );
-    },
-    [activeTab, persist],
-  );
-
+  }
+  if (columns.length === 0) {
+    return (
+      <ul className="sql-tree-columns" aria-label={`Columns of ${name}`}>
+        <li className="sql-tree-column" style={{ opacity: 0.5 }}>No columns</li>
+      </ul>
+    );
+  }
+  const fkMap = new Map<string, SqlForeignKeyInfo>();
+  for (const fk of foreignKeys ?? []) {
+    fkMap.set(fk.from, fk);
+  }
   return (
-    <section
-      aria-label={`${adapter.displayName} SQL playground shell scaffold`}
-      className="flex h-full min-h-0 flex-col gap-3"
-    >
-      <div className="flex items-center gap-2">
-        {state.tabs.map((tab) => (
-          <button
-            className={tab.id === activeTab?.id ? "font-semibold" : undefined}
-            key={tab.id}
-            onClick={() =>
-              setState((current) =>
-                persist({ ...current, activeTabId: tab.id }),
-              )
-            }
-            type="button"
-          >
-            {tab.title}
-          </button>
-        ))}
-        <button onClick={handleAddTab} type="button">
-          Add tab
+    <ul className="sql-tree-columns" aria-label={`Columns of ${name}`}>
+      {columns.map((col) => {
+        const isPk = (col.pk ?? 0) > 0;
+        const fk = fkMap.get(col.name);
+        return (
+          <li key={col.name} className="sql-tree-column">
+            <span className="sql-tree-column-icons">
+              {isPk && (
+                <span className="sql-tree-column-pk" title="Primary key">
+                  <Hash size={9} aria-label="Primary key" />
+                </span>
+              )}
+              {fk && !isPk && (
+                <span className="sql-tree-column-fk" title={`Foreign key → ${fk.to_table}.${fk.to_column}`}>
+                  <IoLink size={9} aria-label="Foreign key" />
+                </span>
+              )}
+            </span>
+            <span className="sql-tree-column-name">{col.name}</span>
+            {col.type && (
+              <span className="sql-tree-column-type" style={{ opacity: 0.55, fontSize: 10 }}>
+                {col.type}
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function SchemaEntityRow({
+  name,
+  kind,
+  expanded,
+  columns,
+  foreignKeys,
+  onToggle,
+  onPreview,
+}: {
+  name: string;
+  kind: "table" | "view";
+  expanded: boolean;
+  columns: SqlColumnInfo[] | undefined;
+  foreignKeys: SqlForeignKeyInfo[] | undefined;
+  onToggle: () => void;
+  onPreview: (name: string, kind: "table" | "view") => void;
+}) {
+  return (
+    <div className="sql-tree-entity">
+      <div className="sql-tree-item-row">
+        <button
+          type="button"
+          className="sql-tree-entity-trigger sql-tree-item"
+          onClick={onToggle}
+          aria-expanded={expanded}
+        >
+          <span className="sql-tree-chevron" aria-hidden="true">
+            {expanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+          </span>
+          {kind === "table" ? (
+            <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true" style={{ flexShrink: 0 }}>
+              <rect x="1" y="1" width="12" height="12" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.2" />
+              <line x1="1" y1="4.5" x2="13" y2="4.5" stroke="currentColor" strokeWidth="1.2" />
+              <line x1="5" y1="4.5" x2="5" y2="13" stroke="currentColor" strokeWidth="1.2" />
+            </svg>
+          ) : (
+            <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true" style={{ flexShrink: 0 }}>
+              <circle cx="7" cy="7" r="5.5" fill="none" stroke="currentColor" strokeWidth="1.2" />
+              <circle cx="7" cy="7" r="2" fill="currentColor" opacity="0.5" />
+            </svg>
+          )}
+          <span className="sql-tree-item-name">{name}</span>
+        </button>
+        <button
+          type="button"
+          className="sql-tree-entity-action-btn"
+          title={`Preview ${name}`}
+          onClick={() => onPreview(name, kind)}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-label="Preview" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+            <circle cx="12" cy="12" r="3" />
+          </svg>
         </button>
       </div>
+      {expanded && (
+        <SchemaColumnList name={name} columns={columns} foreignKeys={foreignKeys} />
+      )}
+    </div>
+  );
+}
 
-      <textarea
-        aria-label="SQL editor scaffold"
-        className="min-h-48 w-full flex-1 rounded border p-3 font-mono text-sm"
-        onChange={(event) => handleCodeChange(event.target.value)}
-        value={activeTab?.code ?? ""}
-      />
+// ─── Main shell ───────────────────────────────────────────────────────────────
 
-      <pre className="overflow-auto rounded bg-neutral-950 p-3 text-xs text-neutral-100">
-        {JSON.stringify(
-          {
-            dialect: adapter.dialect,
-            sampleId: sample.id,
-            activeTabCode: activeTab?.code ?? "",
-          },
-          null,
-          2,
+function SqlPlaygroundShellInner({ adapter, sampleId }: SqlPlaygroundShellProps) {
+  const samples = useMemo(() => adapter.listSamples(), [adapter]);
+  const isMac = useMemo(() => detectIsMac(), []);
+
+  // ─── Active sample ────────────────────────────────────────────────
+  const [activeSampleId, setActiveSampleId] = useState<string>(() => {
+    if (sampleId) {
+      const found = adapter.findSample(sampleId);
+      if (found) return found.id;
+    }
+    return samples[0]?.id ?? "blank";
+  });
+
+  const activeSample = useMemo(
+    () => adapter.findSample(activeSampleId) ?? samples[0] ?? { id: "blank", label: adapter.displayName, filename: "" },
+    [adapter, activeSampleId, samples],
+  );
+
+  const storage = getBrowserStorage();
+
+  // ─── Tab state ────────────────────────────────────────────────────
+  const [shellState, setShellState] = useState<SqlShellState>(() =>
+    loadSqlShellState(storage, adapter.storagePrefix, activeSample),
+  );
+
+  const activeTab = shellState.tabs.find((t) => t.id === shellState.activeTabId);
+
+  const persistState = useCallback(
+    (next: SqlShellState) => {
+      saveSqlShellState(storage, adapter.storagePrefix, activeSampleId, next);
+      return next;
+    },
+    [adapter.storagePrefix, activeSampleId, storage],
+  );
+
+  // ─── Engine / status state ────────────────────────────────────────
+  type Status = "booting" | "ready" | "running" | "error";
+  const [status, setStatus] = useState<Status>("booting");
+  const [loaded, setLoaded] = useState(false);
+  const [loadingMessage, setLoadingMessage] = useState("Loading engine…");
+
+  const engineRef = useRef<SqlEngineHandle | null>(null);
+  const activeTabIdRef = useRef<string>(shellState.activeTabId);
+  const activeSampleIdRef = useRef<string>(activeSampleId);
+  useEffect(() => { activeSampleIdRef.current = activeSampleId; }, [activeSampleId]);
+
+  // Keep ref in sync
+  useEffect(() => {
+    activeTabIdRef.current = shellState.activeTabId;
+  }, [shellState.activeTabId]);
+
+  // ─── Schema state ─────────────────────────────────────────────────
+  const [tables, setTables] = useState<string[]>([]);
+  const [views, setViews] = useState<string[]>([]);
+  const [columnsByEntity, setColumnsByEntity] = useState<Record<string, SqlColumnInfo[]>>({});
+  const [fksByEntity, setFksByEntity] = useState<Record<string, SqlForeignKeyInfo[]>>({});
+  const [expandedEntities, setExpandedEntities] = useState<Set<string>>(new Set());
+  const [tablesSectionExpanded, setTablesSectionExpanded] = useState(true);
+  const [viewsSectionExpanded, setViewsSectionExpanded] = useState(true);
+
+  // ─── Results state ────────────────────────────────────────────────
+  const [resultsByTab, setResultsByTab] = useState<Record<string, QueryRunResult | null>>({});
+  const [globalPageSize, setGlobalPageSize] = useState(50);
+  const [hasSelection, setHasSelection] = useState(false);
+
+  const result = activeTab ? (resultsByTab[activeTab.id] ?? null) : null;
+
+  // ─── Settings ─────────────────────────────────────────────────────
+  const [fontSize, setFontSize] = useState(DEFAULT_PLAYGROUND_SETTINGS.fontSize);
+  const [wordWrap, setWordWrap] = useState(DEFAULT_PLAYGROUND_SETTINGS.wordWrap);
+  const [clearBeforeRun, setClearBeforeRun] = useState(DEFAULT_PLAYGROUND_SETTINGS.clearBeforeRun);
+  const [editorTheme, setEditorTheme] = useState(DEFAULT_PLAYGROUND_SETTINGS.editorTheme);
+
+  const clearBeforeRunRef = useRef(clearBeforeRun);
+  useEffect(() => { clearBeforeRunRef.current = clearBeforeRun; }, [clearBeforeRun]);
+
+  useSqlPlaygroundSettingsHydration(
+    adapter.storagePrefix,
+    { fontSize, wordWrap, clearBeforeRun, editorTheme },
+    { setFontSize, setWordWrap, setClearBeforeRun, setEditorTheme },
+  );
+
+  // ─── Editor refs ──────────────────────────────────────────────────
+  const editorHostRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<EditorView | null>(null);
+  const themeCompRef = useRef<Compartment | null>(null);
+  const wrapCompRef = useRef<Compartment | null>(null);
+  const completionCompRef = useRef<Compartment | null>(null);
+  const runRef = useRef<() => void>(() => undefined);
+  const runSelectionRef = useRef<(sql: string) => void>(() => undefined);
+  const shellStateRef = useRef<SqlShellState>(shellState);
+  useEffect(() => { shellStateRef.current = shellState; }, [shellState]);
+
+  // ─── Toast helper ─────────────────────────────────────────────────
+  const toastManager = Toast.useToastManager();
+  const showToast = useCallback(
+    (msg: string) => {
+      toastManager.add({ title: msg, data: { kind: "info" } });
+    },
+    [toastManager],
+  );
+
+  // ─── Schema refresh ───────────────────────────────────────────────
+  const refreshSchema = useCallback(async (engine: SqlEngineHandle) => {
+    const [newTables, newViews] = await Promise.all([
+      engine.listTables(),
+      engine.listViews(),
+    ]);
+    setTables(newTables);
+    setViews(newViews);
+    // Purge column cache for dropped entities.
+    const entitySet = new Set([...newTables, ...newViews]);
+    setColumnsByEntity((prev) => {
+      const dropped = Object.keys(prev).filter((n) => !entitySet.has(n));
+      if (dropped.length === 0) return prev;
+      const next = { ...prev };
+      for (const d of dropped) delete next[d];
+      return next;
+    });
+    setFksByEntity((prev) => {
+      const dropped = Object.keys(prev).filter((n) => !entitySet.has(n));
+      if (dropped.length === 0) return prev;
+      const next = { ...prev };
+      for (const d of dropped) delete next[d];
+      return next;
+    });
+  }, []);
+
+  // ─── Mount editor once ────────────────────────────────────────────
+  useEffect(() => {
+    if (!editorHostRef.current || editorRef.current) return;
+
+    const compartments = makeSqlEditorCompartments();
+    themeCompRef.current = compartments.theme;
+    wrapCompRef.current = compartments.wrap;
+    completionCompRef.current = compartments.completion;
+
+    const view = new EditorView({
+      doc: activeTab?.code ?? "",
+      parent: editorHostRef.current,
+      extensions: createSqlEditorExtensions({
+        dialect: adapter.dialect,
+        compartments,
+        initialTheme: editorTheme,
+        initialWordWrap: wordWrap,
+        onSelectionChange: setHasSelection,
+        onDocChange: (code) => {
+          const tabId = activeTabIdRef.current;
+          const sampleId = activeSampleIdRef.current;
+          setShellState((prev) => {
+            const next = updateSqlShellTabCode(prev, tabId, code);
+            // Defer persistence to an idle callback so typing stays snappy.
+            if (typeof requestIdleCallback !== "undefined") {
+              requestIdleCallback(() => {
+                saveSqlShellState(storage, adapter.storagePrefix, sampleId, next);
+              });
+            } else {
+              saveSqlShellState(storage, adapter.storagePrefix, sampleId, next);
+            }
+            return next;
+          });
+        },
+        onRunSelection: (sql) => runSelectionRef.current(sql),
+        onRunAll: () => runRef.current(),
+      }),
+    });
+
+    editorRef.current = view;
+    return () => {
+      view.destroy();
+      editorRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ─── Boot / reload engine when sample changes ─────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    setLoaded(false);
+    setStatus("booting");
+    setLoadingMessage(`Loading ${adapter.displayName} engine…`);
+    setTables([]);
+    setViews([]);
+    setColumnsByEntity({});
+    setFksByEntity({});
+    setExpandedEntities(new Set());
+
+    const prevEngine = engineRef.current;
+    engineRef.current = null;
+    if (prevEngine) prevEngine.destroy();
+
+    (async () => {
+      try {
+        const engine = await adapter.createEngine(activeSampleId);
+        if (cancelled) { engine.destroy(); return; }
+        engineRef.current = engine;
+
+        if (adapter.afterEngineCreated) {
+          await adapter.afterEngineCreated(engine);
+        }
+
+        await refreshSchema(engine);
+
+        // Load tab state for this sample and sync editor.
+        const newState = loadSqlShellState(storage, adapter.storagePrefix, activeSample);
+        setShellState(newState);
+        activeTabIdRef.current = newState.activeTabId;
+
+        const tab = newState.tabs.find((t) => t.id === newState.activeTabId);
+        const view = editorRef.current;
+        if (view) {
+          view.dispatch({
+            changes: { from: 0, to: view.state.doc.length, insert: tab?.code ?? "" },
+          });
+        }
+
+        setLoaded(true);
+        setStatus("ready");
+      } catch (err) {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        setLoadingMessage(`Failed to load: ${msg}`);
+        setStatus("error");
+      }
+    })();
+
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeSampleId]);
+
+  // Cleanup engine on unmount.
+  useEffect(() => {
+    return () => { engineRef.current?.destroy(); };
+  }, []);
+
+  // ─── Theme / wrap reconfigure ─────────────────────────────────────
+  useEffect(() => {
+    const view = editorRef.current;
+    const comp = themeCompRef.current;
+    if (!view || !comp) return;
+    import("../../cmExtensions").then(({ themeFor }) => {
+      view.dispatch({ effects: comp.reconfigure(themeFor(editorTheme)) });
+    });
+    applyThemePalette(editorTheme);
+    applyMode(editorTheme);
+  }, [editorTheme]);
+
+  useEffect(() => {
+    const view = editorRef.current;
+    const comp = wrapCompRef.current;
+    if (!view || !comp) return;
+    view.dispatch({ effects: comp.reconfigure(wordWrap ? EditorView.lineWrapping : []) });
+  }, [wordWrap]);
+
+  useEffect(() => {
+    return () => { clearThemePalette(); };
+  }, []);
+
+  // ─── Sync editor when active tab changes ─────────────────────────
+  useEffect(() => {
+    const view = editorRef.current;
+    if (!view || !activeTab) return;
+    const editorDoc = view.state.doc.toString();
+    if (editorDoc !== activeTab.code) {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: activeTab.code },
+      });
+    }
+    view.focus();
+  }, [activeTab?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ─── Query runner ─────────────────────────────────────────────────
+  const runSql = useCallback(
+    (sql: string, tabId: string, source: string) => {
+      const engine = engineRef.current;
+      if (!engine) return;
+      const trimmed = sql.trim();
+      if (!trimmed) return;
+
+      if (clearBeforeRunRef.current) {
+        setResultsByTab((prev) => ({ ...prev, [tabId]: null }));
+      }
+      setStatus("running");
+      const t0 = performance.now();
+
+      void (async () => {
+        try {
+          const sets = await engine.exec(trimmed);
+          const elapsedMs = performance.now() - t0;
+          setResultsByTab((prev) => ({
+            ...prev,
+            [tabId]: { sets, elapsedMs, source },
+          }));
+          await refreshSchema(engine);
+          const MIN_MS = 300;
+          const wait = MIN_MS - (performance.now() - t0);
+          if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+          setStatus("ready");
+        } catch (err) {
+          const elapsedMs = performance.now() - t0;
+          const msg = err instanceof Error ? err.message : String(err);
+          setResultsByTab((prev) => ({
+            ...prev,
+            [tabId]: { sets: [], elapsedMs, error: msg, source },
+          }));
+          setStatus("error");
+          window.setTimeout(() => setStatus("ready"), 3000);
+        }
+      })();
+    },
+    [refreshSchema],
+  );
+
+  const runActiveTab = useCallback(() => {
+    const id = activeTabIdRef.current;
+    const state = shellStateRef.current;
+    const tab = state.tabs.find((t) => t.id === id);
+    if (!tab) return;
+    const sql = editorRef.current?.state.doc.toString() ?? tab.code;
+    runSql(sql, tab.id, tab.title);
+  }, [runSql]);
+
+  const runSelection = useCallback(
+    (sql: string) => {
+      const id = activeTabIdRef.current;
+      const state = shellStateRef.current;
+      const tab = state.tabs.find((t) => t.id === id);
+      if (!tab) return;
+      runSql(sql, tab.id, tab.title);
+    },
+    [runSql],
+  );
+
+  // Keep stable refs so the CodeMirror keymap callbacks never go stale.
+  useEffect(() => { runRef.current = runActiveTab; }, [runActiveTab]);
+  useEffect(() => { runSelectionRef.current = runSelection; }, [runSelection]);
+
+  // ─── Tab management ───────────────────────────────────────────────
+  const handleAddTab = useCallback(() => {
+    setShellState((prev) => persistState(addSqlShellTab(prev)));
+  }, [persistState]);
+
+  const handleActivateTab = useCallback(
+    (tabId: string) => {
+      setShellState((prev) => {
+        const next = { ...prev, activeTabId: tabId };
+        return persistState(next);
+      });
+      activeTabIdRef.current = tabId;
+    },
+    [persistState],
+  );
+
+  const handleCloseTab = useCallback(
+    (tabId: string) => {
+      setShellState((prev) => {
+        if (prev.tabs.length <= 1) return prev;
+        const idx = prev.tabs.findIndex((t) => t.id === tabId);
+        const nextTabs = prev.tabs.filter((t) => t.id !== tabId);
+        const nextActiveId =
+          prev.activeTabId === tabId
+            ? (nextTabs[Math.max(0, idx - 1)]?.id ?? nextTabs[0]?.id ?? "")
+            : prev.activeTabId;
+        return persistState({ tabs: nextTabs, activeTabId: nextActiveId });
+      });
+    },
+    [persistState],
+  );
+
+  // ─── Schema: lazy column load ─────────────────────────────────────
+  const handleToggleEntity = useCallback(
+    (name: string) => {
+      setExpandedEntities((prev) => {
+        const next = new Set(prev);
+        if (next.has(name)) {
+          next.delete(name);
+        } else {
+          next.add(name);
+          // Lazy load columns if not yet cached.
+          if (!columnsByEntity[name]) {
+            const engine = engineRef.current;
+            if (engine) {
+              void (async () => {
+                const [cols, fks] = await Promise.all([
+                  engine.listColumns(name),
+                  engine.listForeignKeys(name),
+                ]);
+                setColumnsByEntity((p) => ({ ...p, [name]: cols }));
+                setFksByEntity((p) => ({ ...p, [name]: fks }));
+              })();
+            }
+          }
+        }
+        return next;
+      });
+    },
+    [columnsByEntity],
+  );
+
+  // ─── Preview table ────────────────────────────────────────────────
+  const previewTable = useCallback(
+    (name: string, kind: "table" | "view") => {
+      const sql = `SELECT * FROM ${adapter.quoteIdent(name)};`;
+      const newTab: SqlShellTab = {
+        id: createSqlShellTabId(),
+        title: name,
+        code: sql,
+        pristineCode: sql,
+      };
+      setShellState((prev) => {
+        const next = persistState({
+          tabs: [...prev.tabs, newTab],
+          activeTabId: newTab.id,
+        });
+        return next;
+      });
+      activeTabIdRef.current = newTab.id;
+      const view = editorRef.current;
+      if (view) {
+        view.dispatch({
+          changes: { from: 0, to: view.state.doc.length, insert: sql },
+        });
+      }
+      runSql(sql, newTab.id, `${kind === "table" ? "Table" : "View"}: ${name}`);
+    },
+    [adapter, persistState, runSql],
+  );
+
+  // ─── Open tab and run ─────────────────────────────────────────────
+  const openTabAndRun = useCallback(
+    (title: string, sql: string) => {
+      const newTab: SqlShellTab = {
+        id: createSqlShellTabId(),
+        title,
+        code: sql,
+        pristineCode: sql,
+      };
+      setShellState((prev) => persistState({ tabs: [...prev.tabs, newTab], activeTabId: newTab.id }));
+      activeTabIdRef.current = newTab.id;
+      const view = editorRef.current;
+      if (view) {
+        view.dispatch({
+          changes: { from: 0, to: view.state.doc.length, insert: sql },
+        });
+      }
+      runSql(sql, newTab.id, title);
+    },
+    [persistState, runSql],
+  );
+
+  // ─── Sample switch ────────────────────────────────────────────────
+  const handleSampleSelect = useCallback(
+    (value: string) => {
+      if (!value || value === activeSampleId) return;
+      // Persist current tab state before leaving.
+      saveSqlShellState(storage, adapter.storagePrefix, activeSampleId, shellStateRef.current);
+      setResultsByTab({});
+      setActiveSampleId(value);
+    },
+    [activeSampleId, adapter.storagePrefix, storage],
+  );
+
+  // ─── Render ───────────────────────────────────────────────────────
+  const isDark = !LIGHT_THEMES.has(editorTheme);
+
+  return (
+    <div
+      className="sql-shell"
+      style={{ fontSize }}
+      aria-label={`${adapter.displayName} SQL playground`}
+    >
+      {/* Sidebar */}
+      <aside className="sql-sidebar">
+        <div className="sql-db-selector-wrap">
+          <div className="sql-db-selector-row">
+            <Select.Root value={activeSampleId} onValueChange={handleSampleSelect}>
+              <Select.Trigger className="sql-db-selector" aria-label="Select database">
+                <Database size={13} aria-hidden="true" className="sql-db-selector-icon" />
+                <Select.Value className="sql-db-selector-value">
+                  {activeSample.filename || activeSample.label}
+                </Select.Value>
+                <Select.Icon className="playground-switcher-icon">
+                  <svg viewBox="0 0 12 12" width={10} height={10}>
+                    <polyline points="2,4 6,8 10,4" fill="none" stroke="currentColor" strokeWidth="2" />
+                  </svg>
+                </Select.Icon>
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner className="sql-db-positioner" sideOffset={6} alignItemWithTrigger={false}>
+                  <Select.Popup className="bui-select-popup sql-db-popup">
+                    <div className="sql-db-popup-group-label">Sample databases</div>
+                    {samples.map((s) => (
+                      <Select.Item key={s.id} value={s.id} className="bui-select-item sql-db-item">
+                        <span className="bui-select-item-icon" aria-hidden="true">
+                          <Database size={14} />
+                        </span>
+                        <span className="sql-db-item-text">
+                          <Select.ItemText>{s.filename || s.label}</Select.ItemText>
+                          {s.description && (
+                            <span className="sql-db-item-desc">{s.description}</span>
+                          )}
+                        </span>
+                      </Select.Item>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </div>
+        </div>
+
+        <div className="sql-tree">
+          {!loaded && (
+            <div className="sql-tree-loading-overlay" aria-live="polite">
+              <span className="sql-tree-loading-label">{loadingMessage}</span>
+            </div>
+          )}
+          <SchemaSection
+            label="Tables"
+            count={tables.length}
+            expanded={tablesSectionExpanded}
+            onToggle={() => setTablesSectionExpanded((v) => !v)}
+            emptyMessage="No tables."
+          >
+            {tables.map((name) => (
+              <SchemaEntityRow
+                key={name}
+                name={name}
+                kind="table"
+                expanded={expandedEntities.has(name)}
+                columns={columnsByEntity[name]}
+                foreignKeys={fksByEntity[name]}
+                onToggle={() => handleToggleEntity(name)}
+                onPreview={previewTable}
+              />
+            ))}
+          </SchemaSection>
+          <SchemaSection
+            label="Views"
+            count={views.length}
+            expanded={viewsSectionExpanded}
+            onToggle={() => setViewsSectionExpanded((v) => !v)}
+            emptyMessage="No views."
+          >
+            {views.map((name) => (
+              <SchemaEntityRow
+                key={name}
+                name={name}
+                kind="view"
+                expanded={expandedEntities.has(name)}
+                columns={columnsByEntity[name]}
+                foreignKeys={fksByEntity[name]}
+                onToggle={() => handleToggleEntity(name)}
+                onPreview={previewTable}
+              />
+            ))}
+          </SchemaSection>
+        </div>
+
+        {adapter.extraSettingsItems && (
+          <div className="sql-sidebar-footer">
+            {adapter.extraSettingsItems}
+          </div>
         )}
-      </pre>
-    </section>
+      </aside>
+
+      <div className="sql-sidebar-resizer" role="separator" aria-orientation="vertical" aria-label="Drag to resize" />
+
+      {/* Main panes */}
+      <div className="sql-panes">
+        {/* Tab bar */}
+        <div className="sql-tabbar">
+          <div className="sql-tabs" role="tablist">
+            {shellState.tabs.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={tab.id === shellState.activeTabId}
+                className={`sql-tab${tab.id === shellState.activeTabId ? " sql-tab--active" : ""}`}
+                onClick={() => handleActivateTab(tab.id)}
+              >
+                <span className="sql-tab-title">{tab.title}</span>
+                {shellState.tabs.length > 1 && (
+                  <span
+                    className="sql-tab-close"
+                    role="button"
+                    aria-label={`Close ${tab.title}`}
+                    onClick={(e) => { e.stopPropagation(); handleCloseTab(tab.id); }}
+                  >
+                    ×
+                  </span>
+                )}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="sql-tab-add"
+              onClick={handleAddTab}
+              aria-label="Add query tab"
+              title="Add query tab"
+            >
+              +
+            </button>
+          </div>
+
+          {/* Toolbar */}
+          <div className="sql-toolbar">
+            <div className="sql-toolbar-hint">
+              <kbd className="kbd">{isMac ? "⌘" : "Ctrl"}</kbd>
+              <span className="kbd-plus" aria-hidden="true">+</span>
+              <kbd className="kbd">Enter</kbd>
+            </div>
+            <div className="sql-toolbar-actions">
+              <SqlRunControls
+                statusState={status}
+                hasSelection={hasSelection}
+                loaded={loaded}
+                isMac={isMac}
+                onRun={runActiveTab}
+                onRunSelection={() => {
+                  const view = editorRef.current;
+                  if (!view) return;
+                  const sel = view.state.selection.main;
+                  if (sel.empty) return;
+                  runSelection(view.state.sliceDoc(sel.from, sel.to));
+                }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Editor */}
+        <div className="sql-editor-pane">
+          <div className="sql-editor-wrap" ref={editorHostRef} />
+        </div>
+
+        <div className="sql-resizer" role="separator" aria-orientation="horizontal" aria-label="Drag to resize editor and results" />
+
+        {/* Results */}
+        <div className="sql-results-pane">
+          <div className="sql-results-body">
+            <ResultView
+              result={result}
+              loading={!loaded}
+              globalPageSize={globalPageSize}
+              onSetGlobalPageSize={setGlobalPageSize}
+              onLoadPage={(sql, page, explicitPageSize) => {
+                const id = activeTabIdRef.current;
+                const tab = shellStateRef.current.tabs.find((t) => t.id === id);
+                if (!tab) return;
+                runSql(sql, tab.id, tab.title);
+              }}
+              onOpenQueryTab={openTabAndRun}
+            />
+          </div>
+          <DataslopeRunOverlay running={status === "running"} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SqlPlaygroundShell(props: SqlPlaygroundShellProps) {
+  return (
+    <Toast.Provider timeout={2400}>
+      <SqlPlaygroundShellInner {...props} />
+      <Toast.Portal>
+        <Toast.Viewport className="toast-viewport">
+          <ToastList />
+        </Toast.Viewport>
+      </Toast.Portal>
+    </Toast.Provider>
   );
 }

--- a/app/_components/sql/shared/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/shared/SqlPlaygroundShell.tsx
@@ -764,7 +764,7 @@ function SqlPlaygroundShellInner({ adapter, sampleId }: SqlPlaygroundShellProps)
 
   // ─── Sample switch ────────────────────────────────────────────────
   const handleSampleSelect = useCallback(
-    (value: string) => {
+    (value: string | null) => {
       if (!value || value === activeSampleId) return;
       // Persist current tab state before leaving.
       saveSqlShellState(storage, adapter.storagePrefix, activeSampleId, shellStateRef.current);

--- a/app/_components/sql/shared/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/shared/SqlPlaygroundShell.tsx
@@ -39,10 +39,9 @@ export function sqlShellStorageKey(
 }
 
 export function defaultSqlShellTabs(sample: SqlSample): SqlShellTab[] {
-  const seeds =
-    sample.defaultTabs && sample.defaultTabs.length > 0
-      ? sample.defaultTabs
-      : [{ title: "Query 1", code: DEFAULT_SQL }];
+  const seeds = sample.defaultTabs?.length
+    ? sample.defaultTabs
+    : [{ title: "Query 1", code: DEFAULT_SQL }];
 
   return seeds.map((seed) => ({
     id: createSqlShellTabId(),
@@ -112,7 +111,7 @@ export function loadSqlShellState(
   }
 
   const tabs = defaultSqlShellTabs(sample);
-  return { tabs, activeTabId: tabs[0]?.id ?? "" };
+  return { tabs, activeTabId: tabs[0].id };
 }
 
 export function saveSqlShellState(

--- a/app/_components/sql/shared/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/shared/SqlPlaygroundShell.tsx
@@ -11,8 +11,10 @@ import { EditorView } from "@codemirror/view";
 import type { Compartment } from "@codemirror/state";
 import { Select } from "@base-ui-components/react/select";
 import { Toast } from "@base-ui-components/react/toast";
-import { Database, ChevronDown, ChevronRight, Hash } from "lucide-react";
+import { Database, ChevronDown, ChevronRight, Hash, Settings2 } from "lucide-react";
 import { IoLink } from "react-icons/io5";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import "../../playground.css";
 import "../../sqlPlayground.css";
 import type { SqlEngineAdapter, SqlEngineHandle, SqlColumnInfo, SqlForeignKeyInfo, SqlSample } from "./SqlEngineAdapter";
@@ -29,14 +31,21 @@ import {
   DEFAULT_PLAYGROUND_SETTINGS,
   DataslopeRunOverlay,
   detectIsMac,
+  SettingsPanel,
 } from "../../playgroundShared";
 import {
   applyMode,
   applyThemePalette,
   clearThemePalette,
   LIGHT_THEMES,
+  setStoredEditorTheme,
 } from "../../playgroundTheme";
 import { ToastList } from "../components/ToastList";
+import { PLAYGROUNDS } from "../../playgrounds";
+import {
+  LANGUAGE_ICONS as PLAYGROUND_ICONS,
+  LANGUAGE_ICON_SIZE_FACTOR as PLAYGROUND_ICON_SIZE_FACTOR,
+} from "../../languageIcons";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -313,6 +322,7 @@ function SchemaEntityRow({
 // ─── Main shell ───────────────────────────────────────────────────────────────
 
 function SqlPlaygroundShellInner({ adapter, sampleId }: SqlPlaygroundShellProps) {
+  const router = useRouter();
   const samples = useMemo(() => adapter.listSamples(), [adapter]);
   const isMac = useMemo(() => detectIsMac(), []);
 
@@ -384,6 +394,19 @@ function SqlPlaygroundShellInner({ adapter, sampleId }: SqlPlaygroundShellProps)
   const [wordWrap, setWordWrap] = useState<boolean>(DEFAULT_PLAYGROUND_SETTINGS.wordWrap);
   const [clearBeforeRun, setClearBeforeRun] = useState<boolean>(DEFAULT_PLAYGROUND_SETTINGS.clearBeforeRun);
   const [editorTheme, setEditorTheme] = useState<string>(DEFAULT_PLAYGROUND_SETTINGS.editorTheme);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const handleSetEditorTheme = useCallback((t: string) => {
+    setEditorTheme(t);
+    setStoredEditorTheme(t);
+  }, []);
+
+  const handleRestoreDefaults = useCallback(() => {
+    setFontSize(DEFAULT_PLAYGROUND_SETTINGS.fontSize);
+    setWordWrap(DEFAULT_PLAYGROUND_SETTINGS.wordWrap);
+    setClearBeforeRun(DEFAULT_PLAYGROUND_SETTINGS.clearBeforeRun);
+    handleSetEditorTheme(DEFAULT_PLAYGROUND_SETTINGS.editorTheme);
+  }, [handleSetEditorTheme]);
 
   const clearBeforeRunRef = useRef(clearBeforeRun);
   useEffect(() => { clearBeforeRunRef.current = clearBeforeRun; }, [clearBeforeRun]);
@@ -777,10 +800,107 @@ function SqlPlaygroundShellInner({ adapter, sampleId }: SqlPlaygroundShellProps)
   // ─── Render ───────────────────────────────────────────────────────
   const isDark = !LIGHT_THEMES.has(editorTheme);
 
+  const playgroundId = adapter.dialect === "postgres" ? "postgres" : adapter.dialect === "duckdb" ? "duckdb" : "sqlite";
+
   return (
+    <div className="pg-app" style={{ fontSize }}>
+      {/* ─── Top navigation bar ─── */}
+      <header className="pg-header">
+        <div className="logo">
+          <Link href="/" aria-label="Dataslope home">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/dataslope-logo-blue.svg" alt="Dataslope logo" className="brand-logo" />
+          </Link>
+          <Link href="/" className="brand-name">Dataslope</Link>
+          <Select.Root
+            value={playgroundId}
+            onValueChange={(value) => {
+              if (!value) return;
+              const next = PLAYGROUNDS.find((p) => p.id === value);
+              if (next && next.id !== playgroundId) router.push(next.href);
+            }}
+          >
+            <Select.Trigger className="playground-switcher" aria-label="Switch playground">
+              {(() => {
+                const Icon = PLAYGROUND_ICONS[playgroundId];
+                const factor = PLAYGROUND_ICON_SIZE_FACTOR[playgroundId] ?? 1;
+                return Icon ? (
+                  <span className="playground-switcher-lang-icon" style={{ color: "var(--text)" }} aria-hidden="true">
+                    <Icon size={Math.round(16 * factor)} />
+                  </span>
+                ) : null;
+              })()}
+              <Select.Value />
+              <Select.Icon className="playground-switcher-icon">
+                <svg viewBox="0 0 12 12" width={10} height={10}>
+                  <polyline points="2,4 6,8 10,4" fill="none" stroke="currentColor" strokeWidth="2" />
+                </svg>
+              </Select.Icon>
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner className="pg-lang-switcher-positioner" sideOffset={6} alignItemWithTrigger={false}>
+                <Select.Popup className="bui-select-popup pg-lang-switcher-popup">
+                  {PLAYGROUNDS.map((p) => {
+                    const Icon = PLAYGROUND_ICONS[p.id];
+                    const factor = PLAYGROUND_ICON_SIZE_FACTOR[p.id] ?? 1;
+                    return (
+                      <Select.Item key={p.id} value={p.id} className="bui-select-item">
+                        {Icon && (
+                          <span className="bui-select-item-icon" aria-hidden="true">
+                            <Icon size={Math.round(16 * factor)} />
+                          </span>
+                        )}
+                        <Select.ItemText>{p.label}</Select.ItemText>
+                      </Select.Item>
+                    );
+                  })}
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        </div>
+        <div className="header-sep" />
+        <div className="header-actions">
+          <button
+            type="button"
+            className="header-btn"
+            title="Settings"
+            aria-label="Settings"
+            onClick={() => setSettingsOpen(true)}
+          >
+            <Settings2 size={14} aria-hidden="true" />
+            <span className="btn-label">Settings</span>
+          </button>
+        </div>
+      </header>
+
+      {/* ─── Settings panel ─── */}
+      <SettingsPanel
+        open={settingsOpen}
+        fontSize={fontSize}
+        setFontSize={setFontSize}
+        outputFontSizeEnabled={false}
+        setOutputFontSizeEnabled={() => undefined}
+        outputFontSize={DEFAULT_PLAYGROUND_SETTINGS.fontSize}
+        setOutputFontSize={() => undefined}
+        showOutputFontSizeControls={false}
+        editorTheme={editorTheme}
+        setEditorTheme={handleSetEditorTheme}
+        wordWrap={wordWrap}
+        setWordWrap={setWordWrap}
+        clearBeforeRun={clearBeforeRun}
+        setClearBeforeRun={setClearBeforeRun}
+        showClearBeforeRunRow={false}
+        language={playgroundId}
+        onClose={() => setSettingsOpen(false)}
+        onRestoreDefaults={handleRestoreDefaults}
+        onClearLocalStorage={() => {
+          try { localStorage.clear(); } catch { /* ignore */ }
+        }}
+      />
+
     <div
       className="sql-shell"
-      style={{ fontSize }}
       aria-label={`${adapter.displayName} SQL playground`}
     >
       {/* Sidebar */}
@@ -957,6 +1077,7 @@ function SqlPlaygroundShellInner({ adapter, sampleId }: SqlPlaygroundShellProps)
             <ResultView
               result={result}
               loading={!loaded}
+              loadingLabel={`Loading ${adapter.displayName} engine…`}
               globalPageSize={globalPageSize}
               onSetGlobalPageSize={setGlobalPageSize}
               onLoadPage={(sql, page, explicitPageSize) => {
@@ -971,6 +1092,7 @@ function SqlPlaygroundShellInner({ adapter, sampleId }: SqlPlaygroundShellProps)
           <DataslopeRunOverlay running={status === "running"} />
         </div>
       </div>
+    </div>
     </div>
   );
 }

--- a/app/_components/sql/shared/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/shared/SqlPlaygroundShell.tsx
@@ -28,6 +28,10 @@ interface ShellStorage {
 const DEFAULT_SQL = "-- Start writing SQL here\nSELECT 1;";
 
 export function createSqlShellTabId(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return `shell_${crypto.randomUUID()}`;
+  }
+
   return `shell_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
@@ -133,10 +137,10 @@ export function saveSqlShellState(
 }
 
 export function addSqlShellTab(state: SqlShellState): SqlShellState {
-  const nextIndex = state.tabs.length + 1;
+  const nextTabNumber = state.tabs.length + 1;
   const nextTab: SqlShellTab = {
     id: createSqlShellTabId(),
-    title: `Query ${nextIndex}`,
+    title: `Query ${nextTabNumber}`,
     code: "",
     pristineCode: "",
   };
@@ -186,8 +190,7 @@ export function SqlPlaygroundShell({
     loadSqlShellState(storage, adapter.storagePrefix, sample),
   );
 
-  const activeTab =
-    state.tabs.find((tab) => tab.id === state.activeTabId) ?? state.tabs[0];
+  const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
 
   const persist = useCallback(
     (next: SqlShellState) => {

--- a/app/_components/sql/shared/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/shared/SqlPlaygroundShell.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import type { SqlEngineAdapter, SqlSample } from "./SqlEngineAdapter";
+
+export interface SqlShellTab {
+  id: string;
+  title: string;
+  code: string;
+  pristineCode: string;
+}
+
+export interface SqlShellState {
+  tabs: SqlShellTab[];
+  activeTabId: string;
+}
+
+export interface SqlPlaygroundShellProps {
+  adapter: SqlEngineAdapter;
+  sampleId?: string;
+}
+
+interface ShellStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+const DEFAULT_SQL = "-- Start writing SQL here\nSELECT 1;";
+
+export function createSqlShellTabId(): string {
+  return `shell_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function sqlShellStorageKey(
+  storagePrefix: string,
+  sampleId: string,
+): string {
+  return `${storagePrefix}:shell:${sampleId}:tabs`;
+}
+
+export function defaultSqlShellTabs(sample: SqlSample): SqlShellTab[] {
+  const seeds =
+    sample.defaultTabs && sample.defaultTabs.length > 0
+      ? sample.defaultTabs
+      : [{ title: "Query 1", code: DEFAULT_SQL }];
+
+  return seeds.map((seed) => ({
+    id: createSqlShellTabId(),
+    title: seed.title,
+    code: seed.code,
+    pristineCode: seed.code,
+  }));
+}
+
+function normalizeTabs(value: unknown): SqlShellTab[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+
+  const tabs = value.flatMap((tab): SqlShellTab[] => {
+    if (typeof tab !== "object" || tab === null) return [];
+    const candidate = tab as Partial<SqlShellTab>;
+    if (
+      typeof candidate.id !== "string" ||
+      typeof candidate.title !== "string" ||
+      typeof candidate.code !== "string"
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        id: candidate.id,
+        title: candidate.title,
+        code: candidate.code,
+        pristineCode:
+          typeof candidate.pristineCode === "string"
+            ? candidate.pristineCode
+            : candidate.code,
+      },
+    ];
+  });
+
+  return tabs.length > 0 ? tabs : null;
+}
+
+export function loadSqlShellState(
+  storage: ShellStorage | null,
+  storagePrefix: string,
+  sample: SqlSample,
+): SqlShellState {
+  const key = sqlShellStorageKey(storagePrefix, sample.id);
+  if (storage) {
+    try {
+      const raw = storage.getItem(key);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<SqlShellState>;
+        const tabs = normalizeTabs(parsed.tabs);
+        const activeTabId =
+          typeof parsed.activeTabId === "string" ? parsed.activeTabId : "";
+
+        if (tabs) {
+          return {
+            tabs,
+            activeTabId: tabs.some((tab) => tab.id === activeTabId)
+              ? activeTabId
+              : tabs[0].id,
+          };
+        }
+      }
+    } catch {
+      // Corrupt persisted shell state falls back to sample defaults.
+    }
+  }
+
+  const tabs = defaultSqlShellTabs(sample);
+  return { tabs, activeTabId: tabs[0]?.id ?? "" };
+}
+
+export function saveSqlShellState(
+  storage: ShellStorage | null,
+  storagePrefix: string,
+  sampleId: string,
+  state: SqlShellState,
+): void {
+  if (!storage) return;
+
+  try {
+    storage.setItem(
+      sqlShellStorageKey(storagePrefix, sampleId),
+      JSON.stringify(state),
+    );
+  } catch {
+    // Quota exceeded / private mode — ignore just like the existing playgrounds.
+  }
+}
+
+export function addSqlShellTab(state: SqlShellState): SqlShellState {
+  const nextIndex = state.tabs.length + 1;
+  const nextTab: SqlShellTab = {
+    id: createSqlShellTabId(),
+    title: `Query ${nextIndex}`,
+    code: "",
+    pristineCode: "",
+  };
+
+  return {
+    tabs: [...state.tabs, nextTab],
+    activeTabId: nextTab.id,
+  };
+}
+
+export function updateSqlShellTabCode(
+  state: SqlShellState,
+  tabId: string,
+  code: string,
+): SqlShellState {
+  return {
+    ...state,
+    tabs: state.tabs.map((tab) =>
+      tab.id === tabId ? { ...tab, code } : tab,
+    ),
+  };
+}
+
+function getBrowserStorage(): ShellStorage | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+export function SqlPlaygroundShell({
+  adapter,
+  sampleId,
+}: SqlPlaygroundShellProps) {
+  const sample = useMemo(() => {
+    const samples = adapter.listSamples();
+    return (
+      (sampleId ? adapter.findSample(sampleId) : undefined) ??
+      samples[0] ?? {
+        id: "default",
+        label: adapter.displayName,
+        filename: "",
+      }
+    );
+  }, [adapter, sampleId]);
+
+  const storage = getBrowserStorage();
+  const [state, setState] = useState<SqlShellState>(() =>
+    loadSqlShellState(storage, adapter.storagePrefix, sample),
+  );
+
+  const activeTab =
+    state.tabs.find((tab) => tab.id === state.activeTabId) ?? state.tabs[0];
+
+  const persist = useCallback(
+    (next: SqlShellState) => {
+      saveSqlShellState(storage, adapter.storagePrefix, sample.id, next);
+      return next;
+    },
+    [adapter.storagePrefix, sample.id, storage],
+  );
+
+  const handleAddTab = useCallback(() => {
+    setState((current) => persist(addSqlShellTab(current)));
+  }, [persist]);
+
+  const handleCodeChange = useCallback(
+    (code: string) => {
+      if (!activeTab) return;
+      setState((current) =>
+        persist(updateSqlShellTabCode(current, activeTab.id, code)),
+      );
+    },
+    [activeTab, persist],
+  );
+
+  return (
+    <section
+      aria-label={`${adapter.displayName} SQL playground shell scaffold`}
+      className="flex h-full min-h-0 flex-col gap-3"
+    >
+      <div className="flex items-center gap-2">
+        {state.tabs.map((tab) => (
+          <button
+            className={tab.id === activeTab?.id ? "font-semibold" : undefined}
+            key={tab.id}
+            onClick={() =>
+              setState((current) =>
+                persist({ ...current, activeTabId: tab.id }),
+              )
+            }
+            type="button"
+          >
+            {tab.title}
+          </button>
+        ))}
+        <button onClick={handleAddTab} type="button">
+          Add tab
+        </button>
+      </div>
+
+      <textarea
+        aria-label="SQL editor scaffold"
+        className="min-h-48 w-full flex-1 rounded border p-3 font-mono text-sm"
+        onChange={(event) => handleCodeChange(event.target.value)}
+        value={activeTab?.code ?? ""}
+      />
+
+      <pre className="overflow-auto rounded bg-neutral-950 p-3 text-xs text-neutral-100">
+        {JSON.stringify(
+          {
+            dialect: adapter.dialect,
+            sampleId: sample.id,
+            activeTabCode: activeTab?.code ?? "",
+          },
+          null,
+          2,
+        )}
+      </pre>
+    </section>
+  );
+}

--- a/app/_components/sql/shared/SqlRunControls.tsx
+++ b/app/_components/sql/shared/SqlRunControls.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Menu } from "@base-ui-components/react/menu";
+import { ChevronDown, Play } from "lucide-react";
+
+export type SqlRunStatus = "idle" | "loading" | "running" | "success" | "error";
+
+export interface SqlRunControlsProps {
+  statusState: SqlRunStatus | string;
+  hasSelection: boolean;
+  loaded: boolean;
+  isMac: boolean;
+  onRun: () => void;
+  onRunSelection: () => void;
+}
+
+function RunSpinner() {
+  return (
+    <svg viewBox="0 0 12 12" className="run-btn-spinner">
+      <circle
+        cx="6"
+        cy="6"
+        r="4.5"
+        fill="none"
+        stroke="white"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeDasharray="14 8"
+      />
+    </svg>
+  );
+}
+
+export function SqlRunControls({
+  statusState,
+  hasSelection,
+  loaded,
+  isMac,
+  onRun,
+  onRunSelection,
+}: SqlRunControlsProps) {
+  const running = statusState === "running";
+  const disabled = !loaded || running;
+
+  if (hasSelection) {
+    return (
+      <div className={`run-btn-split${running ? " running" : ""}`}>
+        <button
+          type="button"
+          className="run-btn-split-main"
+          disabled={disabled}
+          onClick={onRunSelection}
+        >
+          {running ? <RunSpinner /> : <Play size={10} aria-hidden="true" />}
+          {running ? "Running…" : "Run Selection"}
+        </button>
+        <span className="run-btn-split-divider" aria-hidden="true" />
+        <Menu.Root>
+          <Menu.Trigger
+            className="run-btn-split-chevron"
+            disabled={disabled}
+            aria-label="Run options"
+          >
+            <ChevronDown size={11} aria-hidden="true" />
+          </Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner sideOffset={6} align="end">
+              <Menu.Popup className="bui-popup run-split-dropdown">
+                <Menu.Item
+                  className="run-split-item"
+                  onClick={onRunSelection}
+                  disabled={disabled}
+                >
+                  <span className="run-split-item-label">Run Selection</span>
+                  <span className="run-split-item-kbd">
+                    {isMac ? "⌘Enter" : "Ctrl+Enter"}
+                  </span>
+                </Menu.Item>
+                <Menu.Item
+                  className="run-split-item"
+                  onClick={onRun}
+                  disabled={disabled}
+                >
+                  <span className="run-split-item-label">Run All</span>
+                  <span className="run-split-item-kbd">
+                    {isMac ? "⌘⇧Enter" : "Ctrl+Shift+Enter"}
+                  </span>
+                </Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={`run-btn${running ? " running" : ""}`}
+      disabled={disabled}
+      onClick={onRun}
+    >
+      {running ? <RunSpinner /> : <Play size={10} aria-hidden="true" />}
+      {running ? "Running…" : "Run"}
+    </button>
+  );
+}

--- a/app/_components/sql/shared/useSqlPlaygroundSettings.ts
+++ b/app/_components/sql/shared/useSqlPlaygroundSettings.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  applyMode,
+  applyThemePalette,
+  getStoredEditorTheme,
+} from "../../playgroundTheme";
+
+export interface SqlPlaygroundSettingsState {
+  fontSize: number;
+  wordWrap: boolean;
+  clearBeforeRun: boolean;
+  editorTheme: string;
+}
+
+export interface SqlPlaygroundSettingsSetters {
+  setFontSize: (value: number) => void;
+  setWordWrap: (value: boolean) => void;
+  setClearBeforeRun: (value: boolean) => void;
+  setEditorTheme: (value: string) => void;
+}
+
+function boolFromStorage(key: string, fallback: boolean): boolean {
+  if (typeof window === "undefined") return fallback;
+  const raw = window.localStorage.getItem(key);
+  if (raw === null) return fallback;
+  return raw === "1" || raw === "true";
+}
+
+function numberFromStorage(key: string, fallback: number): number {
+  if (typeof window === "undefined") return fallback;
+  const raw = Number(window.localStorage.getItem(key));
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}
+
+export function hydrateSqlPlaygroundSettings(
+  storagePrefix: string,
+  fallback: SqlPlaygroundSettingsState,
+): SqlPlaygroundSettingsState {
+  return {
+    fontSize: numberFromStorage(`${storagePrefix}font_size`, fallback.fontSize),
+    wordWrap: boolFromStorage(`${storagePrefix}word_wrap`, fallback.wordWrap),
+    clearBeforeRun: boolFromStorage(
+      `${storagePrefix}clear_before_run`,
+      fallback.clearBeforeRun,
+    ),
+    editorTheme:
+      getStoredEditorTheme(`${storagePrefix}editor_theme`) ??
+      fallback.editorTheme,
+  };
+}
+
+export function useSqlPlaygroundSettingsHydration(
+  storagePrefix: string,
+  fallback: SqlPlaygroundSettingsState,
+  setters: SqlPlaygroundSettingsSetters,
+) {
+  useEffect(() => {
+    const hydrated = hydrateSqlPlaygroundSettings(storagePrefix, fallback);
+    setters.setFontSize(hydrated.fontSize);
+    setters.setWordWrap(hydrated.wordWrap);
+    setters.setClearBeforeRun(hydrated.clearBeforeRun);
+    setters.setEditorTheme(hydrated.editorTheme);
+    applyThemePalette(hydrated.editorTheme);
+    applyMode(hydrated.editorTheme);
+  }, [fallback, setters, storagePrefix]);
+}

--- a/app/_components/sql/shared/useSqlPlaygroundSettings.ts
+++ b/app/_components/sql/shared/useSqlPlaygroundSettings.ts
@@ -56,13 +56,32 @@ export function useSqlPlaygroundSettingsHydration(
   fallback: SqlPlaygroundSettingsState,
   setters: SqlPlaygroundSettingsSetters,
 ) {
+  const { fontSize, wordWrap, clearBeforeRun, editorTheme } = fallback;
+  const { setFontSize, setWordWrap, setClearBeforeRun, setEditorTheme } =
+    setters;
+
   useEffect(() => {
-    const hydrated = hydrateSqlPlaygroundSettings(storagePrefix, fallback);
-    setters.setFontSize(hydrated.fontSize);
-    setters.setWordWrap(hydrated.wordWrap);
-    setters.setClearBeforeRun(hydrated.clearBeforeRun);
-    setters.setEditorTheme(hydrated.editorTheme);
+    const hydrated = hydrateSqlPlaygroundSettings(storagePrefix, {
+      fontSize,
+      wordWrap,
+      clearBeforeRun,
+      editorTheme,
+    });
+    setFontSize(hydrated.fontSize);
+    setWordWrap(hydrated.wordWrap);
+    setClearBeforeRun(hydrated.clearBeforeRun);
+    setEditorTheme(hydrated.editorTheme);
     applyThemePalette(hydrated.editorTheme);
     applyMode(hydrated.editorTheme);
-  }, [fallback, setters, storagePrefix]);
+  }, [
+    clearBeforeRun,
+    editorTheme,
+    fontSize,
+    setClearBeforeRun,
+    setEditorTheme,
+    setFontSize,
+    setWordWrap,
+    storagePrefix,
+    wordWrap,
+  ]);
 }

--- a/app/_components/sql/sqliteAdapter.ts
+++ b/app/_components/sql/sqliteAdapter.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { createSqliteEngine } from "../runtime/sqlite";
+import {
+  findSampleDatabase,
+  SQLITE_SAMPLE_DATABASES,
+} from "../runtime/sqliteSamples";
+import type {
+  SqlColumnInfo,
+  SqlEngineAdapter,
+  SqlEngineHandle,
+  SqlForeignKeyInfo,
+} from "./shared/SqlEngineAdapter";
+
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+export function createSqliteAdapter(): SqlEngineAdapter {
+  return {
+    dialect: "sqlite",
+    displayName: "SQLite",
+    storagePrefix: "pg_sqlite_",
+    defaultPageSize: 50,
+    supportsSchemas: false,
+    supportsPragmas: true,
+    createEngine: async (sampleId) => {
+      const engine = await createSqliteEngine(sampleId);
+      return {
+        exec: (sql) => engine.execAll(sql),
+        listTables: () => engine.listTables(),
+        listViews: () => engine.listViews(),
+        listIndexes: () => engine.listIndexes(),
+        listTriggers: () => engine.listTriggers(),
+        listColumns: async (name) =>
+          (await engine.listColumns(name)).map(
+            (column): SqlColumnInfo => ({
+              name: column.name,
+              type: column.type,
+              notNull: column.notNull,
+              defaultValue: column.defaultValue,
+              pk: column.pk,
+            }),
+          ),
+        listForeignKeys: async (name) =>
+          (await engine.listForeignKeys(name)).map(
+            (fk): SqlForeignKeyInfo => ({
+              from: fk.from,
+              to_table: fk.table,
+              to_column: fk.to,
+              on_delete: fk.onDelete,
+              on_update: fk.onUpdate,
+            }),
+          ),
+        destroy: () => {
+          // The current SQLite worker facade has no close primitive.
+        },
+      } satisfies SqlEngineHandle;
+    },
+    listSamples: () => SQLITE_SAMPLE_DATABASES,
+    findSample: findSampleDatabase,
+    quoteIdent,
+  };
+}

--- a/app/_components/sql/sqliteAdapter.ts
+++ b/app/_components/sql/sqliteAdapter.ts
@@ -20,6 +20,7 @@ export function createSqliteAdapter(): SqlEngineAdapter {
   return {
     dialect: "sqlite",
     displayName: "SQLite",
+    // Preserve the existing SQLite tab/settings namespace from sqlitePlaygroundTabs.ts.
     storagePrefix: "pg_sqlite_",
     defaultPageSize: 50,
     supportsSchemas: false,

--- a/app/playground/duckdb/page.tsx
+++ b/app/playground/duckdb/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import DuckDbPlayground from "../../_components/duckdb/DuckDbPlayground";
+import { SqlPlaygroundShell } from "../../_components/sql/shared/SqlPlaygroundShell";
+import { createDuckDbAdapter } from "../../_components/duckdb/duckdbAdapter";
+
+const adapter = createDuckDbAdapter();
 
 export default function DuckDbPage() {
-  return <DuckDbPlayground />;
+  return <SqlPlaygroundShell adapter={adapter} />;
 }

--- a/app/playground/postgres/page.tsx
+++ b/app/playground/postgres/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import PostgresPlayground from "../../_components/postgres/PostgresPlayground";
+import { SqlPlaygroundShell } from "../../_components/sql/shared/SqlPlaygroundShell";
+import { createPostgresAdapter } from "../../_components/postgres/postgresAdapter";
+
+const adapter = createPostgresAdapter();
 
 export default function PostgresPage() {
-  return <PostgresPlayground />;
+  return <SqlPlaygroundShell adapter={adapter} />;
 }

--- a/app/playground/sqlite/page.tsx
+++ b/app/playground/sqlite/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import SqlPlayground from "../../_components/SqlPlayground";
+import { SqlPlaygroundShell } from "../../_components/sql/shared/SqlPlaygroundShell";
+import { createSqliteAdapter } from "../../_components/sql/sqliteAdapter";
+
+const adapter = createSqliteAdapter();
 
 export default function SqlitePage() {
-  return <SqlPlayground />;
+  return <SqlPlaygroundShell adapter={adapter} />;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Replaces the textarea scaffold** in `SqlPlaygroundShell` with a complete working playground: CodeMirror editor (via shared `editorSetup`), engine lifecycle (boot/teardown keyed on sample ID), query execution via `adapter.exec`, lazy schema column loading on expand, `ResultView` for tabular results, and sample-switching via `Select`.
- **Wires all three page files** (`playground/sqlite/page.tsx`, `playground/duckdb/page.tsx`, `playground/postgres/page.tsx`) to pass their respective adapters (`createSqliteAdapter` / `createDuckDbAdapter` / `createPostgresAdapter`) to `SqlPlaygroundShell`, removing the last direct imports of the three ~5–6k-line monolith components from the page layer.
- **Fixes a stale-closure bug** in the `onDocChange` handler where `prev.activeTabId` was incorrectly used as the localStorage key for persistence; now uses `activeSampleIdRef` so the idle-callback write always targets the correct sample key.

## What the shell now does

| Feature | Notes |
|---|---|
| Multi-tab editor | CodeMirror via `createSqlEditorExtensions`; Ctrl/Cmd+Enter to run |
| Engine lifecycle | Boot on mount + on sample switch; destroy on unmount/switch |
| Query execution | `adapter.exec(sql)` → `ResultView`; 300 ms minimum animation |
| Schema sidebar | Tables + Views with lazy column/FK load on expand |
| Sample switching | `Select` dropdown populated from `adapter.listSamples()` |
| Tab persistence | `localStorage` via idle callback (debounced, per-sample keyed) |
| Settings hydration | Font size, word wrap, clear-before-run, editor theme via `useSqlPlaygroundSettingsHydration` |
| Theme / wrap sync | Reconfigures CodeMirror compartments on settings change |
| Adapter extensions | `adapter.extraSettingsItems` rendered in sidebar footer |

## What's deferred

Row editing (delete/update/duplicate), import dialogs (CSV/JSON/Parquet/SQLite), schema-modification dialogs, ER diagram tab, query history tab, and DnD tab reordering. These can be wired in via the adapter's extension points (`renderAddTableDialog`, `renderModifyStructureDrawer`, `extraSettingsItems`).

## Test plan

- [ ] Open `/playground/sqlite` — engine boots, chinook schema appears, `SELECT * FROM albums LIMIT 10` returns results
- [ ] Open `/playground/duckdb` — DuckDB-Wasm loads, sample data appears, query runs
- [ ] Open `/playground/postgres` — PGlite boots, schema appears, query runs
- [ ] Switch sample database on each playground — schema clears and reloads, tab state restores from localStorage
- [ ] Add/close tabs; reload page — tab state persists per sample
- [ ] Expand a table in the schema sidebar — columns load lazily
- [ ] Click the preview (eye) icon on a table — opens a new tab and runs `SELECT *`
- [ ] `npm run lint` passes
- [ ] `npm test` (Vitest) passes

https://claude.ai/code/session_0168hbUJshmMbeqBHigtg6YP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0168hbUJshmMbeqBHigtg6YP)_