### PR TITLE
Stage 3 playground refactor: adapters, shared utilities, and leaf component extraction

### DIFF
--- a/agent-outputs/2026-05-16-stage3-refactor-handover.md
+++ b/agent-outputs/2026-05-16-stage3-refactor-handover.md
@@ -1,0 +1,250 @@
+# Stage 3 Refactor Handover — 2026-05-16
+
+Branch: `claude/five-stage-playground-refactor-6jEAd` → merged to `main` via PR #309
+
+## Context
+
+This document tracks the four remaining tasks from the Stage 3 bottom-up playground refactor. The three SQL playground monoliths are:
+
+- `app/_components/sql/SqlPlayground.tsx` (~4,091 lines — SQLite)
+- `app/_components/postgres/PostgresPlayground.tsx` (~5,305 lines — PostgreSQL/PGlite)
+- `app/_components/duckdb/DuckDbPlayground.tsx` (~5,785 lines — DuckDB-Wasm)
+
+### What has already been extracted (merged in PR #309)
+
+All files live under `app/_components/sql/components/` unless otherwise noted.
+
+| Artifact | Type | Notes |
+|---|---|---|
+| `DatabaseSelector` | Component | DB picker dropdown, dialect-agnostic |
+| `SqlSettingsPanel` | Component | Settings panel wrapper |
+| `SqlSettingsConfirmDialogs` | Component | Restore-defaults + clear-storage dialogs |
+| `DdlViewerDialog` | Component | DDL popup with copy-to-clipboard |
+| `SwitchDatabaseDialog` | Component | "Switch databases?" confirmation |
+| `SchemaActionDialogs` | Component | Drop entity + truncate table dialogs |
+| `ImportSqlDumpDialog` | Component | SQL text import with drag-and-drop |
+| `RenameDatabaseDialog` | Component | Rename with configurable extension picker |
+| `ImportBinaryFileDialog` | Component | Binary file import dropzone |
+| `SqlEditorToolbar` | Component | Run/run-selection split button |
+| `SqlTabBar` | Component | Full DnD tab bar (DnDContext + tabs + add button) |
+| `sql/shared/tabStorageUtils.ts` | Utility | `createTabStorage(prefix)` factory, `tabsAreDirty` |
+| `sql/shared/engineAdapter.ts` | Interface | `SqlEngineAdapter` + concrete adapters |
+| Import-safety patches | Bug fix | Postgres sandbox worker, DuckDB restore-on-failure, SQLite safe binary load |
+
+---
+
+## All Four Remaining Tasks (Single Agent Session)
+
+All four tasks below are intended to be completed in **one agent session**. They are ordered by dependency: Tasks 1 and 2 are prerequisites for Task 4. Task 3 is independent but reduces Task 4's scope. Completing all four in sequence is feasible in a single long-running session.
+
+---
+
+## Task 1 — Tab Management Hook (`useSqlTabManagement`)
+
+### Status
+Not started.
+
+### Problem
+`PostgresPlayground.tsx` and `DuckDbPlayground.tsx` each contain ~150 lines of near-identical tab management logic:
+
+- `addTab` (~22 lines each) — identical in both
+- `closeTab` (~22 lines each) — identical in both
+- `openTabAndRun` (~12 lines each) — identical in both
+- `handleTabDragStart` / `handleTabDragEnd` / `handleTabDragCancel` (~19 lines each) — identical in both
+- `resetTabsForCurrentDb` (~8 lines each) — differs only in `findPostgresSampleDatabase` vs `findDuckDbSampleDatabase`
+- `persistTabs` — **key difference**: Postgres saves synchronously; DuckDB uses a 500 ms trailing-edge debounce with `pendingSaveRef` + `saveTimerRef` + `flushPendingSave` flushed on `visibilitychange`/`pagehide`/unmount
+
+### Files to touch
+- Create: `app/_components/sql/hooks/useSqlTabManagement.ts`
+- Modify: `app/_components/postgres/PostgresPlayground.tsx`
+- Modify: `app/_components/duckdb/DuckDbPlayground.tsx`
+
+### Recommended design
+Accept a caller-supplied `persistTabs` callback so the hook stays free of save-strategy knowledge:
+
+```typescript
+export function useSqlTabManagement(options: {
+  dbId: string;
+  samples: readonly SqlSampleDatabase[];
+  storageUtils: TabStorageUtils;
+  persistTabs: (nextTabs: QueryTab[], dbId?: string) => void;
+}) { ... }
+```
+
+Postgres passes a synchronous `persistTabs`; DuckDB passes its debounced version. The debounce logic itself stays in `DuckDbPlayground.tsx` (or a tiny helper) and is passed in.
+
+### DuckDB debounced `persistTabs` (preserve exactly)
+```typescript
+const pendingSaveRef = useRef<{ dbId: string; tabs: QueryTab[] } | null>(null);
+const saveTimerRef = useRef<number | null>(null);
+const flushPendingSave = useCallback(() => {
+  if (saveTimerRef.current !== null) {
+    window.clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = null;
+  }
+  const pending = pendingSaveRef.current;
+  if (pending) {
+    pendingSaveRef.current = null;
+    saveTabs(pending.dbId, pending.tabs);
+  }
+}, []);
+useEffect(() => {
+  const handler = () => flushPendingSave();
+  window.addEventListener("visibilitychange", handler);
+  window.addEventListener("pagehide", handler);
+  return () => {
+    window.removeEventListener("visibilitychange", handler);
+    window.removeEventListener("pagehide", handler);
+    flushPendingSave();
+  };
+}, [flushPendingSave]);
+
+const persistTabs = useCallback(
+  (nextTabs: QueryTab[], dbId = activeDbIdRef.current) => {
+    tabsRef.current = nextTabs;
+    setTabs(nextTabs);
+    pendingSaveRef.current = { dbId, tabs: nextTabs };
+    if (saveTimerRef.current === null) {
+      saveTimerRef.current = window.setTimeout(() => {
+        saveTimerRef.current = null;
+        const pending = pendingSaveRef.current;
+        if (pending) {
+          pendingSaveRef.current = null;
+          saveTabs(pending.dbId, pending.tabs);
+        }
+      }, 500);
+    }
+  },
+  [],
+);
+```
+
+### Postgres synchronous `persistTabs`
+```typescript
+const persistTabs = useCallback(
+  (nextTabs: QueryTab[], dbId = activeDbIdRef.current) => {
+    tabsRef.current = nextTabs;
+    setTabs(nextTabs);
+    saveTabs(dbId, nextTabs);
+  },
+  [],
+);
+```
+
+### Reference: existing SQLite hook
+`app/_components/sql/hooks/useTabManagement.ts` — already exists for SQLite. Use it as a structural template for the new hook.
+
+---
+
+## Task 2 — Schema Sidebar Orchestration Hook (`useSchemaTree`)
+
+### Status
+Not started.
+
+### Problem
+Both `PostgresPlayground.tsx` and `DuckDbPlayground.tsx` contain ~200–300 lines each of near-identical schema-tree wiring around the already-extracted `SchemaSection` / `SchemaItem` / `SchemaLeafItem` components. `SqlPlayground.tsx` also has this code but without the multi-schema dimension.
+
+### Key structural difference
+- **SQLite**: no schema namespace; tables live in one flat namespace
+- **Postgres & DuckDB**: `selectedSchema` / `schemas` / `schemaLoading` + `refreshSchemas()` + `handleSchemaChange()`; supports multiple pg schemas (`public`, `private`, `information_schema`, etc.)
+
+A shared hook needs an `supportsSchemas: boolean` (or `multiSchema`) flag, or the schema-selector UI stays dialect-specific and only the rest of the state is shared.
+
+### State to extract (Postgres/DuckDB)
+```typescript
+const [selectedSchema, setSelectedSchema] = useState("public");
+const [schemas, setSchemas] = useState<string[]>(["public"]);
+const [schemaLoading, setSchemaLoading] = useState(false);
+const [tables, setTables] = useState<string[]>([]);
+const [views, setViews] = useState<string[]>([]);
+const [indexes, setIndexes] = useState<string[]>([]);
+const [triggers, setTriggers] = useState<string[]>([]);
+const [columnsByEntity, setColumnsByEntity] = useState<Record<string, TableColumnInfo[]>>({});
+const [foreignKeysByEntity, setForeignKeysByEntity] = useState<Record<string, ForeignKeyInfo[]>>({});
+const [expandedEntities, setExpandedEntities] = useState<Set<string>>(new Set());
+const [rowCountByTable, setRowCountByTable] = useState<Record<string, number>>({});
+```
+
+### Files to touch
+- Create: `app/_components/sql/hooks/useSchemaTree.ts`
+- Modify: `app/_components/postgres/PostgresPlayground.tsx`
+- Modify: `app/_components/duckdb/DuckDbPlayground.tsx`
+- Possibly modify: `app/_components/sql/SqlPlayground.tsx`
+
+---
+
+## Task 3 — Structure Drawers Extraction
+
+### Status
+Not started. **Lower priority** — only ~40–50% overlap between dialects. Can be done after Tasks 1 and 2, or skipped until Task 4 if time is limited.
+
+### What can be shared
+- Drawer layout / form chrome (labels, button placement)
+- `ModifyStructureForm` is already extracted
+- Basic column name / nullability inputs
+- Add Row dialog (row insertion logic is nearly identical between dialects)
+
+### What stays dialect-specific
+- Column type pickers (pg type list vs DuckDB type list)
+- Structure validation functions (`validatePgStructure` vs `validateDuckDbStructure`)
+- Constraint definitions (DuckDB has limited FK support compared to Postgres)
+- Generated column semantics (DuckDB has no VIRTUAL generated columns)
+
+### Files to touch
+- Potentially create: `app/_components/sql/components/AddRowDialog.tsx`
+- Potentially create: `app/_components/sql/components/AddTableDialog.tsx`
+- Modify: `app/_components/postgres/PostgresPlayground.tsx`
+- Modify: `app/_components/duckdb/DuckDbPlayground.tsx`
+
+---
+
+## Task 4 — `SqlPlaygroundShell` + Dialect Migrations
+
+### Status
+Not started. **Largest effort** — requires Tasks 1 and 2 to be done first. Completing all four tasks in sequence in the same session is the intended approach.
+
+### Goal
+A unified `SqlPlaygroundShell` component that all three dialects plug into via the `SqlEngineAdapter` interface. This eliminates all three monoliths.
+
+### The `SqlEngineAdapter` interface (already defined)
+```typescript
+// app/_components/sql/shared/engineAdapter.ts
+export interface SqlEngineAdapter<
+  TSample extends SqlSampleDatabase,
+  TEngine,
+> {
+  playgroundId: string;
+  storagePrefix: SqlPlaygroundStoragePrefix;
+  samples: readonly TSample[];
+  blankSample?: TSample;
+  // ... engine factory, import methods, etc.
+}
+```
+
+### Migration sequence (within the session)
+1. **SQLite first** (smallest; most hook infrastructure already in `sql/hooks/`) — migrate `SqlPlayground.tsx` → `SqlPlaygroundShell` + SQLite adapter config
+2. **Postgres second** — wire `SqlPlaygroundShell` with `postgresAdapter`; handle multi-schema UI
+3. **DuckDB last** — wire `SqlPlaygroundShell` with `duckdbAdapter`; handle DuckDB-specific features (Files panel, parquet/json import, schema browser)
+
+### Prerequisites within this session
+- Tasks 1, 2, and 3 reduce the delta between what `SqlPlaygroundShell` must absorb and what's already shared. Complete them first before starting Task 4.
+- Any remaining dialect-specific code in the shell should be gated via adapter flags or render props.
+
+### Files to create
+- `app/_components/sql/SqlPlaygroundShell.tsx` — the unified shell
+- `app/_components/sql/stores/` — shared Zustand stores (tab state, engine state, dialog state already exist for SQLite; Postgres/DuckDB adopt them)
+
+### Files to delete (after migration verified)
+- `app/_components/postgres/PostgresPlayground.tsx`
+- `app/_components/duckdb/DuckDbPlayground.tsx`
+- (SQLite's `SqlPlayground.tsx` becomes `SqlPlaygroundShell` itself or a thin wrapper)
+
+---
+
+## Branch / PR Conventions
+
+- Develop on a feature branch named `claude/<description>-<id>`
+- Stack commits; do not squash until merge
+- Run `npx tsc --noEmit && npm test` before pushing — all 175 tests must pass
+- PR target: `main` in `subwaymatch/dataslope-playground`
+- After pushing, always open a PR (ready for review, not draft)

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -105,6 +105,7 @@ import {
 } from "../playgroundShared";
 import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmDialogs";
+import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { type DuckDbEngine } from "../runtime/duckdb";
@@ -125,7 +126,6 @@ import {
   type DatabaseSelectorAction,
 } from "../sql/components/DatabaseSelector";
 import { ToastList } from "../sql/components/ToastList";
-import { DdlViewer } from "../sql/components/DdlViewer";
 import { GenExprEditor } from "../sql/components/GenExprEditor";
 import { ColumnFlag } from "../sql/components/ModifyStructureForm";
 import { QueryHistoryPane } from "../sql/components/QueryHistoryPane";
@@ -4102,55 +4102,16 @@ function DuckDbPlaygroundInner() {
           ]}
         />
 
-        <Dialog.Root
+        <DdlViewerDialog
           open={ddlDialog !== null}
-          onOpenChange={(next) => {
-            if (!next) setDdlDialog(null);
-          }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-ddl-popup">
-              <Dialog.Title className="confirm-title">
-                DDL: {ddlDialog?.title ?? ""}
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Read-only view of the reconstructed <code>CREATE</code>{" "}
-                statement(s).
-              </Dialog.Description>
-              <DdlViewer
-                sql={ddlDialog?.sql ?? ""}
-                theme={editorTheme}
-                isPostgres
-              />
-              <div className="confirm-actions">
-                <button
-                  type="button"
-                  className="confirm-btn confirm-btn-secondary"
-                  onClick={() => {
-                    if (
-                      ddlDialog &&
-                      typeof navigator !== "undefined" &&
-                      navigator.clipboard
-                    ) {
-                      navigator.clipboard
-                        .writeText(ddlDialog.sql)
-                        .then(() => showToast("Copied DDL to clipboard."))
-                        .catch(() =>
-                          showToast("Couldn't copy to clipboard.", "warn"),
-                        );
-                    }
-                  }}
-                >
-                  Copy
-                </button>
-                <Dialog.Close className="confirm-btn confirm-btn-primary">
-                  Close
-                </Dialog.Close>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+          onOpenChange={(next) => { if (!next) setDdlDialog(null); }}
+          title={ddlDialog?.title ?? ""}
+          sql={ddlDialog?.sql ?? ""}
+          theme={editorTheme}
+          isPostgres
+          onCopied={() => showToast("Copied DDL to clipboard.")}
+          onCopyFailed={() => showToast("Couldn't copy to clipboard.", "warn")}
+        />
 
         {/* ── Import SQL dump dialog ── */}
         <Dialog.Root

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -144,6 +144,10 @@ import {
   stripSqlComments,
 } from "../sql/utils/sqlAnalysis";
 import { computeImportColComparison } from "../sql/utils/importUtils";
+import {
+  ensurePersistUnloadFlush,
+  persistAsync,
+} from "../sql/utils/persistedStorage";
 import { pickFallbackTab, pushTabHistory } from "../sql/utils/tabUtils";
 import type {
   AddRowDialogState,
@@ -905,6 +909,11 @@ type ImportFlavor = "csv" | "json" | "parquet";
 
 function DuckDbPlaygroundInner() {
   const router = useRouter();
+  // Coalesced localStorage writer for settings — install the
+  // pagehide/visibilitychange flush listener once per playground mount.
+  useEffect(() => {
+    ensurePersistUnloadFlush();
+  }, []);
   const toastManager = Toast.useToastManager();
   const showToast = useCallback(
     (title: string, kind: "info" | "warn" = "info") => {
@@ -944,33 +953,21 @@ function DuckDbPlaygroundInner() {
   const setFontSize = useCallback(
     (n: number) => {
       setFontSizeState(n);
-      try {
-        localStorage.setItem(storageKey("fontsize"), String(n));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("fontsize"), String(n));
     },
     [setFontSizeState],
   );
   const setOutputFontSizeEnabled = useCallback(
     (b: boolean) => {
       setOutputFontSizeEnabledState(b);
-      try {
-        localStorage.setItem(storageKey("outputfontsize_enabled"), String(b));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("outputfontsize_enabled"), String(b));
     },
     [setOutputFontSizeEnabledState],
   );
   const setOutputFontSize = useCallback(
     (n: number) => {
       setOutputFontSizeState(n);
-      try {
-        localStorage.setItem(storageKey("outputfontsize"), String(n));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("outputfontsize"), String(n));
     },
     [setOutputFontSizeState],
   );
@@ -984,22 +981,14 @@ function DuckDbPlaygroundInner() {
   const setWordWrap = useCallback(
     (b: boolean) => {
       setWordWrapState(b);
-      try {
-        localStorage.setItem(storageKey("wordwrap"), String(b));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("wordwrap"), String(b));
     },
     [setWordWrapState],
   );
   const setClearBeforeRun = useCallback(
     (b: boolean) => {
       setClearBeforeRunState(b);
-      try {
-        localStorage.setItem(storageKey("clearbeforerun"), String(b));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("clearbeforerun"), String(b));
     },
     [setClearBeforeRunState],
   );
@@ -1824,9 +1813,8 @@ function DuckDbPlaygroundInner() {
   const lastReconfigureKeyRef = useRef<string>("");
   useEffect(() => {
     const view = editorRef.current;
-    const langComp = langCompRef.current;
     const completionComp = completionCompRef.current;
-    if (!view || !langComp || !completionComp) return;
+    if (!view || !langCompRef.current || !completionComp) return;
     const schema: Record<string, string[]> = {};
     const completionSchema: SqlCompletionSchema = { entities: [] };
     for (const name of tables) {
@@ -1841,15 +1829,36 @@ function DuckDbPlaygroundInner() {
     }
     const key = JSON.stringify(completionSchema.entities);
     if (key === lastReconfigureKeyRef.current) return;
-    lastReconfigureKeyRef.current = key;
+    // Dispatch the completion reconfigure immediately so user-defined
+    // tables/views show up in autocomplete the moment the schema lands.
     view.dispatch({
       effects: [
-        langComp.reconfigure(makeSqlLangExtension("duckdb", schema)),
         completionComp.reconfigure(
           makeSqlAutocompletionExtension(completionSchema, "duckdb"),
         ),
       ],
     });
+    // `@codemirror/lang-sql` is lazy-loaded (Stage 5.3) so the lang
+    // compartment reconfigure has to await the chunk. The view + key
+    // checks below guard against stale dispatches if the user typed,
+    // imported, or destroyed the editor before the chunk resolved.
+    // We only mark `lastReconfigureKeyRef` as up-to-date once the lang
+    // dispatch actually fires — that way a StrictMode-cancelled effect
+    // won't make the next run incorrectly skip the lang reconfigure.
+    let cancelled = false;
+    void makeSqlLangExtension("duckdb", schema).then((langExt) => {
+      if (cancelled) return;
+      const currentView = editorRef.current;
+      const currentLangComp = langCompRef.current;
+      if (!currentView || !currentLangComp) return;
+      currentView.dispatch({
+        effects: [currentLangComp.reconfigure(langExt)],
+      });
+      lastReconfigureKeyRef.current = key;
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [tables, views, columnsByEntity]);
 
   // Drop result entries whose owning tab no longer exists.

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -111,6 +111,7 @@ import { SchemaActionDialogs } from "../sql/components/SchemaActionDialogs";
 import { ImportSqlDumpDialog } from "../sql/components/ImportSqlDumpDialog";
 import { RenameDatabaseDialog } from "../sql/components/RenameDatabaseDialog";
 import { ImportBinaryFileDialog } from "../sql/components/ImportBinaryFileDialog";
+import { SqlEditorToolbar } from "../sql/components/SqlEditorToolbar";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { type DuckDbEngine } from "../runtime/duckdb";
@@ -5396,126 +5397,14 @@ function DuckDbPlaygroundInner() {
                   </Popover.Portal>
                 </Popover.Root>
               </div>
-              <div className="sql-toolbar">
-                <div className="sql-toolbar-shortcuts">
-                  <span
-                    className="kbd-group"
-                    title={
-                      isMac
-                        ? "Cmd + Enter — run selection or all"
-                        : "Ctrl + Enter — run selection or all"
-                    }
-                  >
-                    <kbd className="kbd">{isMac ? "⌘" : "Ctrl"}</kbd>
-                    <span className="kbd-plus" aria-hidden="true">
-                      +
-                    </span>
-                    <kbd className="kbd">Enter</kbd>
-                  </span>
-                </div>
-                <div className="sql-toolbar-actions">
-                  {hasEditorSelection ? (
-                    <div
-                      className={`run-btn-split${statusState === "running" ? " running" : ""}`}
-                    >
-                      <button
-                        type="button"
-                        className="run-btn-split-main"
-                        disabled={!loaded || statusState === "running"}
-                        onClick={runCurrentSelection}
-                      >
-                        {statusState === "running" ? (
-                          <svg viewBox="0 0 12 12" className="run-btn-spinner">
-                            <circle
-                              cx="6"
-                              cy="6"
-                              r="4.5"
-                              fill="none"
-                              stroke="white"
-                              strokeWidth="1.5"
-                              strokeLinecap="round"
-                              strokeDasharray="14 8"
-                            />
-                          </svg>
-                        ) : (
-                          <Play size={10} aria-hidden="true" />
-                        )}
-                        {statusState === "running"
-                          ? "Running…"
-                          : "Run Selection"}
-                      </button>
-                      <span
-                        className="run-btn-split-divider"
-                        aria-hidden="true"
-                      />
-                      <Menu.Root>
-                        <Menu.Trigger
-                          className="run-btn-split-chevron"
-                          disabled={!loaded || statusState === "running"}
-                          aria-label="Run options"
-                        >
-                          <ChevronDown size={11} aria-hidden="true" />
-                        </Menu.Trigger>
-                        <Menu.Portal>
-                          <Menu.Positioner sideOffset={6} align="end">
-                            <Menu.Popup className="bui-popup run-split-dropdown">
-                              <Menu.Item
-                                className="run-split-item"
-                                onClick={runCurrentSelection}
-                                disabled={!loaded || statusState === "running"}
-                              >
-                                <span className="run-split-item-label">
-                                  Run Selection
-                                </span>
-                                <span className="run-split-item-kbd">
-                                  {isMac ? "⌘Enter" : "Ctrl+Enter"}
-                                </span>
-                              </Menu.Item>
-                              <Menu.Item
-                                className="run-split-item"
-                                onClick={runActiveTab}
-                                disabled={!loaded || statusState === "running"}
-                              >
-                                <span className="run-split-item-label">
-                                  Run All
-                                </span>
-                                <span className="run-split-item-kbd">
-                                  {isMac ? "⌘⇧Enter" : "Ctrl+Shift+Enter"}
-                                </span>
-                              </Menu.Item>
-                            </Menu.Popup>
-                          </Menu.Positioner>
-                        </Menu.Portal>
-                      </Menu.Root>
-                    </div>
-                  ) : (
-                    <button
-                      type="button"
-                      className={`run-btn${statusState === "running" ? " running" : ""}`}
-                      disabled={!loaded || statusState === "running"}
-                      onClick={runActiveTab}
-                    >
-                      {statusState === "running" ? (
-                        <svg viewBox="0 0 12 12" className="run-btn-spinner">
-                          <circle
-                            cx="6"
-                            cy="6"
-                            r="4.5"
-                            fill="none"
-                            stroke="white"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeDasharray="14 8"
-                          />
-                        </svg>
-                      ) : (
-                        <Play size={10} aria-hidden="true" />
-                      )}
-                      {statusState === "running" ? "Running…" : "Run"}
-                    </button>
-                  )}
-                </div>
-              </div>
+              <SqlEditorToolbar
+                loaded={loaded}
+                running={statusState === "running"}
+                hasEditorSelection={hasEditorSelection}
+                isMac={isMac}
+                onRunSelection={runCurrentSelection}
+                onRunAll={runActiveTab}
+              />
             </div>
             {activeTab?.kind === "er-diagram" ? (
               <ErDiagramPane

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -2273,17 +2273,19 @@ function DuckDbPlaygroundInner() {
       const engine = engineRef.current;
       if (!engine) return;
       setStatusState("loading");
-      setTables([]);
-      setViews([]);
-      setIndexes([]);
-      setTriggers([]);
-      setColumnsByEntity({});
-      setForeignKeysByEntity({});
-      setRowCountByTable({});
-      setExpandedEntities(new Set());
       try {
-        await engine.loadBlankDatabase();
-        await engine.exec(sqlText);
+        // importSqlDump bootstraps a blank schema, runs the SQL there, and
+        // restores the previous sample on failure so the user is never
+        // stranded on a wiped database.
+        await engine.importSqlDump(sqlText);
+        setTables([]);
+        setViews([]);
+        setIndexes([]);
+        setTriggers([]);
+        setColumnsByEntity({});
+        setForeignKeysByEntity({});
+        setRowCountByTable({});
+        setExpandedEntities(new Set());
         setActiveDbId(DUCKDB_BLANK_DATABASE.id);
         setCustomDbFilename(filename);
         try {
@@ -2311,6 +2313,13 @@ function DuckDbPlaygroundInner() {
         setStatusState("ready");
         showToast(`Loaded "${filename}".`);
       } catch (err) {
+        // importSqlDump restored the previous sample on failure; re-read
+        // the schema so the sidebar reflects the restored state.
+        try {
+          await refreshSchema();
+        } catch {
+          /* ignore */
+        }
         showToast(
           `Import failed: ${err instanceof Error ? err.message : String(err)}`,
           "warn",
@@ -2326,16 +2335,19 @@ function DuckDbPlaygroundInner() {
       const engine = engineRef.current;
       if (!engine) return;
       setStatusState("loading");
-      setTables([]);
-      setViews([]);
-      setIndexes([]);
-      setTriggers([]);
-      setColumnsByEntity({});
-      setForeignKeysByEntity({});
-      setRowCountByTable({});
-      setExpandedEntities(new Set());
       try {
+        // importFromBinary wipes the schema before attaching; on failure it
+        // restores the previous sample internally so the user database is
+        // not left empty. Only clear UI state once import has succeeded.
         await engine.importFromBinary(bytes);
+        setTables([]);
+        setViews([]);
+        setIndexes([]);
+        setTriggers([]);
+        setColumnsByEntity({});
+        setForeignKeysByEntity({});
+        setRowCountByTable({});
+        setExpandedEntities(new Set());
         setActiveDbId(DUCKDB_BLANK_DATABASE.id);
         setCustomDbFilename(filename);
         try {
@@ -2366,6 +2378,14 @@ function DuckDbPlaygroundInner() {
         setStatusState("ready");
         showToast(`Loaded "${filename}".`);
       } catch (err) {
+        // importFromBinary restored the previous sample on failure; reread
+        // the schema so the sidebar reflects the restored state.
+        try {
+          await refreshSchemas();
+          await refreshSchema();
+        } catch {
+          /* ignore */
+        }
         showToast(
           `Import failed: ${err instanceof Error ? err.message : String(err)}`,
           "warn",

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -107,6 +107,7 @@ import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmDialogs";
 import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
 import { SwitchDatabaseDialog } from "../sql/components/SwitchDatabaseDialog";
+import { SchemaActionDialogs } from "../sql/components/SchemaActionDialogs";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { type DuckDbEngine } from "../runtime/duckdb";
@@ -4415,69 +4416,14 @@ function DuckDbPlaygroundInner() {
           }}
         />
 
-        <AlertDialog.Root
-          open={pendingDropEntity !== null}
-          onOpenChange={(next) => {
-            if (!next) setPendingDropEntity(null);
-          }}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Drop {pendingDropEntity?.kind ?? "entity"}?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                This will permanently drop{" "}
-                <strong>{pendingDropEntity?.name ?? ""}</strong> from the
-                in-memory database. Reload the page to restore the sample.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => void performDropEntity()}
-                >
-                  Drop
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
-
-        <AlertDialog.Root
-          open={pendingTruncate !== null}
-          onOpenChange={(next) => {
-            if (!next) setPendingTruncate(null);
-          }}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Truncate table?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                Truncate table <strong>{pendingTruncate}</strong>? This deletes
-                every row but keeps the schema. The change is in-memory only and
-                will be undone next page load.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => void confirmTruncate()}
-                >
-                  Truncate
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
+        <SchemaActionDialogs
+          dropEntityPending={pendingDropEntity}
+          onDropEntityOpenChange={(next) => { if (!next) setPendingDropEntity(null); }}
+          onDropEntityConfirm={() => void performDropEntity()}
+          truncatePending={pendingTruncate}
+          onTruncateOpenChange={(next) => { if (!next) setPendingTruncate(null); }}
+          onTruncateConfirm={() => void confirmTruncate()}
+        />
 
         <SqlSettingsConfirmDialogs
           dialectDisplayName="DuckDB"

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -53,7 +53,6 @@ import {
   Pencil,
   Play,
   Plus,
-  RotateCcw,
   Table,
   Trash2,
   TriangleAlert,
@@ -102,9 +101,9 @@ import {
   DataslopeRunOverlay,
   DEFAULT_PLAYGROUND_SETTINGS,
   RuntimeInfoContent,
-  SettingsPanel,
   detectIsMac,
 } from "../playgroundShared";
+import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { type DuckDbEngine } from "../runtime/duckdb";
@@ -4046,7 +4045,7 @@ function DuckDbPlaygroundInner() {
           </div>
         </header>
 
-        <SettingsPanel
+        <SqlSettingsPanel
           open={settingsOpen}
           fontSize={fontSize}
           setFontSize={setFontSize}
@@ -4061,23 +4060,11 @@ function DuckDbPlaygroundInner() {
           clearBeforeRun={clearBeforeRun}
           setClearBeforeRun={setClearBeforeRun}
           language={PLAYGROUND_ID}
-          showOutputFontSizeControls={false}
-          clearBeforeRunLabel="Clear Results Before Running"
-          showClearBeforeRunRow={false}
           onClose={() => setSettingsOpen(false)}
           onRestoreDefaults={() => setConfirmRestoreOpen(true)}
           onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
-          extraGeneralRows={null}
-          extraActionRows={
-            <button
-              type="button"
-              className="settings-action-btn"
-              onClick={resetTabsForCurrentDb}
-            >
-              <RotateCcw size={14} aria-hidden="true" />
-              <span>Reset query tabs for {activeSample.label}</span>
-            </button>
-          }
+          resetTabsLabel={`Reset query tabs for ${activeSample.label}`}
+          onResetTabs={resetTabsForCurrentDb}
           extraTabs={[
             {
               value: "database",

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -120,6 +120,10 @@ import { ResultView } from "../sql/components/ResultView";
 import { SchemaItem } from "../sql/components/SchemaItem";
 import { SchemaLeafItem } from "../sql/components/SchemaLeafItem";
 import { SchemaSection } from "../sql/components/SchemaSection";
+import {
+  DatabaseSelector,
+  type DatabaseSelectorAction,
+} from "../sql/components/DatabaseSelector";
 import { ToastList } from "../sql/components/ToastList";
 import { DdlViewer } from "../sql/components/DdlViewer";
 import { GenExprEditor } from "../sql/components/GenExprEditor";
@@ -173,6 +177,27 @@ import { FK_ACTIONS } from "../sql/constants";
 
 const PLAYGROUND_ID = duckdbAdapter.playgroundId;
 const STORAGE_PREFIX = duckdbAdapter.storagePrefix;
+
+const DUCKDB_DB_ACTIONS: readonly DatabaseSelectorAction[] = [
+  {
+    id: "__new_db__",
+    icon: <FilePlus size={14} />,
+    label: "New Database",
+    description: "Create a blank database",
+  },
+  {
+    id: "__import_sql_dump__",
+    icon: <Upload size={14} />,
+    label: "Import SQL Dump",
+    description: "Open a SQL dump file",
+  },
+  {
+    id: "__rename_db__",
+    icon: <Pencil size={14} />,
+    label: "Rename Current Database",
+    description: "Change the display name",
+  },
+];
 const MAX_EXCEL_SHEET_NAME_LENGTH = 31;
 const INFINITE_SCROLL_PAGE_SIZE = 500;
 // Minimum time (ms) the "running" overlay is shown so the 180ms CSS
@@ -5247,9 +5272,13 @@ function DuckDbPlaygroundInner() {
         <div className="sql-shell duckdb-shell" ref={shellRef}>
           <aside className="sql-sidebar" aria-label="Database explorer">
             <div className="sql-db-selector-wrap">
-              <Select.Root
+              <DatabaseSelector
                 value={activeDbId}
-                onValueChange={(value) => {
+                displayFilename={displayFilename}
+                samples={DUCKDB_SAMPLE_DATABASES}
+                actions={DUCKDB_DB_ACTIONS}
+                chevron={<ChevronDown size={12} />}
+                onChange={(value) => {
                   if (value === "__new_db__") {
                     void performDbSwitch(DUCKDB_BLANK_DATABASE.id);
                     return;
@@ -5271,117 +5300,9 @@ function DuckDbPlaygroundInner() {
                     setRenameDbOpen(true);
                     return;
                   }
-                  requestDbSwitch(String(value));
+                  requestDbSwitch(value);
                 }}
-              >
-                <Select.Trigger
-                  className="sql-db-selector"
-                  aria-label="Select sample database"
-                >
-                  <Database
-                    size={14}
-                    className="sql-db-selector-icon"
-                    aria-hidden="true"
-                  />
-                  <Select.Value className="sql-db-selector-value">
-                    {displayFilename}
-                  </Select.Value>
-                  <Select.Icon className="playground-switcher-icon">
-                    <ChevronDown size={12} />
-                  </Select.Icon>
-                </Select.Trigger>
-                <Select.Portal>
-                  <Select.Positioner
-                    className="sql-db-positioner"
-                    sideOffset={6}
-                    alignItemWithTrigger={false}
-                  >
-                    <Select.Popup className="bui-select-popup sql-db-popup">
-                      <Select.Item
-                        value="__new_db__"
-                        className="bui-select-item sql-db-item"
-                      >
-                        <span
-                          className="bui-select-item-icon"
-                          aria-hidden="true"
-                        >
-                          <FilePlus size={14} />
-                        </span>
-                        <span className="sql-db-item-text">
-                          <Select.ItemText>New Database</Select.ItemText>
-                          <span className="sql-db-item-desc">
-                            Create a blank database
-                          </span>
-                        </span>
-                      </Select.Item>
-                      <Select.Item
-                        value="__import_sql_dump__"
-                        className="bui-select-item sql-db-item"
-                      >
-                        <span
-                          className="bui-select-item-icon"
-                          aria-hidden="true"
-                        >
-                          <Upload size={14} />
-                        </span>
-                        <span className="sql-db-item-text">
-                          <Select.ItemText>Import SQL Dump</Select.ItemText>
-                          <span className="sql-db-item-desc">
-                            Open a SQL dump file
-                          </span>
-                        </span>
-                      </Select.Item>
-                      <Select.Item
-                        value="__rename_db__"
-                        className="bui-select-item sql-db-item"
-                      >
-                        <span
-                          className="bui-select-item-icon"
-                          aria-hidden="true"
-                        >
-                          <Pencil size={14} />
-                        </span>
-                        <span className="sql-db-item-text">
-                          <Select.ItemText>
-                            Rename Current Database
-                          </Select.ItemText>
-                          <span className="sql-db-item-desc">
-                            Change the display name
-                          </span>
-                        </span>
-                      </Select.Item>
-                      <div
-                        role="separator"
-                        aria-orientation="horizontal"
-                        className="sql-db-popup-sep"
-                      />
-                      <div className="sql-db-popup-group-label">
-                        Sample databases
-                      </div>
-                      {DUCKDB_SAMPLE_DATABASES.map((sample) => (
-                        <Select.Item
-                          key={sample.id}
-                          value={sample.id}
-                          className="bui-select-item sql-db-item"
-                        >
-                          <span
-                            className="bui-select-item-icon"
-                            aria-hidden="true"
-                          >
-                            <Database size={14} />
-                          </span>
-                          <span className="sql-db-item-text">
-                            <Select.ItemText>{sample.filename}</Select.ItemText>
-                            <span className="sql-db-item-desc">
-                              {sample.description}
-                            </span>
-                          </span>
-                        </Select.Item>
-                      ))}
-                    </Select.Popup>
-                  </Select.Positioner>
-                </Select.Portal>
-              </Select.Root>
+              />
             </div>
             <div className="sql-schema-selector-wrap">
               <div className="sql-db-selector-row">

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -110,6 +110,7 @@ import { SwitchDatabaseDialog } from "../sql/components/SwitchDatabaseDialog";
 import { SchemaActionDialogs } from "../sql/components/SchemaActionDialogs";
 import { ImportSqlDumpDialog } from "../sql/components/ImportSqlDumpDialog";
 import { RenameDatabaseDialog } from "../sql/components/RenameDatabaseDialog";
+import { ImportBinaryFileDialog } from "../sql/components/ImportBinaryFileDialog";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { type DuckDbEngine } from "../runtime/duckdb";
@@ -4125,95 +4126,32 @@ function DuckDbPlaygroundInner() {
           onImport={(sql, filename) => void performImportSqlDump(sql, filename)}
         />
 
-        {/* ── Import DuckDB binary dialog ── */}
-        <Dialog.Root
+        <ImportBinaryFileDialog
           open={importDuckDbOpen}
-          onOpenChange={(next) => {
-            if (!next) {
-              setImportDuckDbOpen(false);
-              setImportDuckDbDragging(false);
-            }
-          }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-import-popup">
-              <Dialog.Title className="confirm-title">
-                Import DuckDB File
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Open a local <code>.duckdb</code> file as a new in-memory
-                database.
-              </Dialog.Description>
-              <div className="sql-import-warning">
-                <TriangleAlert
-                  size={14}
-                  className="sql-import-warning-icon"
-                  aria-hidden="true"
-                />
-                <span>
-                  This will replace the current database with the contents of
-                  the file. Your file will <strong>not</strong> be uploaded or
-                  persisted — it is only loaded into browser memory and will be
-                  gone on reload.
-                </span>
-              </div>
-              <div
-                className={`sql-dropzone${importDuckDbDragging ? " dragging" : ""}`}
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  setImportDuckDbDragging(true);
-                }}
-                onDragLeave={() => setImportDuckDbDragging(false)}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  setImportDuckDbDragging(false);
-                  const file = e.dataTransfer.files[0];
-                  if (!file) return;
-                  const reader = new FileReader();
-                  reader.onload = (ev) => {
-                    const buf = ev.target?.result;
-                    if (!(buf instanceof ArrayBuffer)) return;
-                    void performImportDuckDb(new Uint8Array(buf), file.name);
-                  };
-                  reader.readAsArrayBuffer(file);
-                }}
-              >
-                <Upload
-                  size={28}
-                  className="sql-dropzone-icon"
-                  aria-hidden="true"
-                />
-                <span>Drop a DuckDB file here</span>
-                <span className="sql-dropzone-hint">
-                  or click to browse — .duckdb
-                </span>
-                <input
-                  type="file"
-                  accept=".duckdb"
-                  aria-label="Choose DuckDB file"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (!file) return;
-                    const reader = new FileReader();
-                    reader.onload = (ev) => {
-                      const buf = ev.target?.result;
-                      if (!(buf instanceof ArrayBuffer)) return;
-                      void performImportDuckDb(new Uint8Array(buf), file.name);
-                    };
-                    reader.readAsArrayBuffer(file);
-                    e.target.value = "";
-                  }}
-                />
-              </div>
-              <div className="confirm-actions" style={{ marginTop: 16 }}>
-                <Dialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </Dialog.Close>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+          dragging={importDuckDbDragging}
+          onClose={() => setImportDuckDbOpen(false)}
+          onDraggingChange={setImportDuckDbDragging}
+          onImport={(data, filename) => void performImportDuckDb(data, filename)}
+          title="Import DuckDB File"
+          description={
+            <>
+              Open a local <code>.duckdb</code> file as a new in-memory
+              database.
+            </>
+          }
+          warningText={
+            <>
+              This will replace the current database with the contents of the
+              file. Your file will <strong>not</strong> be uploaded or persisted
+              — it is only loaded into browser memory and will be gone on
+              reload.
+            </>
+          }
+          dropText="Drop a DuckDB file here"
+          browseHint="or click to browse — .duckdb"
+          accept=".duckdb"
+          inputAriaLabel="Choose DuckDB file"
+        />
 
         {/* ── Create Schema popover ── */}
         <Popover.Root

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -105,12 +105,12 @@ import {
   SettingsPanel,
   detectIsMac,
 } from "../playgroundShared";
-import {
-  DUCKDB_SAMPLE_DATABASES,
-  DUCKDB_BLANK_DATABASE,
-  findDuckDbSampleDatabase,
-} from "../runtime/duckdbSamples";
-import { createDuckDbEngine, type DuckDbEngine } from "../runtime/duckdb";
+import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
+import { duckdbAdapter } from "./duckdbAdapter";
+import { type DuckDbEngine } from "../runtime/duckdb";
+
+const DUCKDB_SAMPLE_DATABASES = duckdbAdapter.samples;
+const DUCKDB_BLANK_DATABASE = duckdbAdapter.blankSample!;
 import type { ForeignKeyInfo, TableColumnInfo } from "../runtime/sqlite";
 import type { QueryExecResult } from "sql.js";
 import type { QueryTab } from "../sqlitePlaygroundTabs";
@@ -171,8 +171,8 @@ import {
 } from "./duckdbImport";
 import { FK_ACTIONS } from "../sql/constants";
 
-const PLAYGROUND_ID = "duckdb";
-const STORAGE_PREFIX = "duckdb_";
+const PLAYGROUND_ID = duckdbAdapter.playgroundId;
+const STORAGE_PREFIX = duckdbAdapter.storagePrefix;
 const MAX_EXCEL_SHEET_NAME_LENGTH = 31;
 const INFINITE_SCROLL_PAGE_SIZE = 500;
 // Minimum time (ms) the "running" overlay is shown so the 180ms CSS
@@ -1694,7 +1694,7 @@ function DuckDbPlaygroundInner() {
     (async () => {
       try {
         setLoadingMessage("Loading DuckDB engine…");
-        const engine = await createDuckDbEngine(initialDbId);
+        const engine = await duckdbAdapter.createEngine(initialDbId);
         if (cancelled) {
           // The component already unmounted while bootstrap was in flight.
           // The engine never reaches engineRef, so the unmount cleanup

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -2,7 +2,6 @@
 
 import {
   DndContext,
-  DragOverlay,
   KeyboardSensor,
   PointerSensor,
   closestCenter,
@@ -14,7 +13,6 @@ import {
 import {
   SortableContext,
   arrayMove,
-  horizontalListSortingStrategy,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
@@ -122,7 +120,11 @@ import type { ForeignKeyInfo, TableColumnInfo } from "../runtime/sqlite";
 import type { QueryExecResult } from "sql.js";
 import type { QueryTab } from "../sqlitePlaygroundTabs";
 import { newTabId } from "../sqlitePlaygroundTabs";
-import { SqlTab, SqlTabDragOverlay } from "../sql/components/SqlTab";
+import {
+  createTabStorage,
+  tabsAreDirty,
+} from "../sql/shared/tabStorageUtils";
+import { SqlTabBar } from "../sql/components/SqlTabBar";
 import { ResultView } from "../sql/components/ResultView";
 import { SchemaItem } from "../sql/components/SchemaItem";
 import { SchemaLeafItem } from "../sql/components/SchemaLeafItem";
@@ -183,6 +185,7 @@ import { FK_ACTIONS } from "../sql/constants";
 
 const PLAYGROUND_ID = duckdbAdapter.playgroundId;
 const STORAGE_PREFIX = duckdbAdapter.storagePrefix;
+const { dbScopedKey, loadTabs, saveTabs } = createTabStorage(STORAGE_PREFIX);
 
 const DUCKDB_DB_ACTIONS: readonly DatabaseSelectorAction[] = [
   {
@@ -845,8 +848,6 @@ function PgGeneratedColumnRow({
 }
 
 const storageKey = (key: string) => `${STORAGE_PREFIX}${key}`;
-const dbScopedKey = (dbId: string, key: string) =>
-  `${STORAGE_PREFIX}db_${dbId}_${key}`;
 const DEFAULT_PAGE_SIZE = 50;
 
 const RUNTIME_INFO: RuntimeInfo = {
@@ -867,73 +868,6 @@ const IMPORT_COL_STATUS_LABEL: Record<ImportColComparison["status"], string> = {
 
 function quoteIdent(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
-}
-
-function makeTabs(defaults: { title: string; code: string }[]): QueryTab[] {
-  return defaults.map((seed) => ({
-    ...seed,
-    id: newTabId(),
-    pristineCode: seed.code,
-  }));
-}
-
-function loadTabs(dbId: string): QueryTab[] {
-  const sample = findDuckDbSampleDatabase(dbId);
-  if (typeof window === "undefined") return makeTabs(sample.defaultTabs);
-  try {
-    const raw = localStorage.getItem(dbScopedKey(dbId, "tabs"));
-    if (raw) {
-      const parsed = JSON.parse(raw) as QueryTab[];
-      if (Array.isArray(parsed) && parsed.length > 0) {
-        return parsed.map((tab) => ({
-          id: typeof tab.id === "string" ? tab.id : newTabId(),
-          title: typeof tab.title === "string" ? tab.title : "Query",
-          code: typeof tab.code === "string" ? tab.code : "",
-          pristineCode:
-            typeof tab.pristineCode === "string"
-              ? tab.pristineCode
-              : typeof tab.code === "string"
-                ? tab.code
-                : "",
-          kind: tab.kind === "view-data" ? "view-data" : undefined,
-        }));
-      }
-    }
-  } catch {
-    // Fall back to defaults.
-  }
-  return makeTabs(sample.defaultTabs);
-}
-
-function saveTabs(dbId: string, tabs: QueryTab[]): void {
-  try {
-    localStorage.setItem(
-      dbScopedKey(dbId, "tabs"),
-      JSON.stringify(
-        tabs.filter(
-          (tab) => tab.kind !== "er-diagram" && tab.kind !== "query-history",
-        ),
-      ),
-    );
-  } catch {
-    // Ignore storage quota / private-mode errors.
-  }
-}
-
-function tabsAreDirty(
-  tabs: QueryTab[],
-  defaults: { title: string; code: string }[],
-): boolean {
-  if (tabs.length !== defaults.length) return true;
-  for (let i = 0; i < tabs.length; i += 1) {
-    if (
-      tabs[i].title !== defaults[i].title ||
-      tabs[i].code !== defaults[i].code
-    ) {
-      return true;
-    }
-  }
-  return false;
 }
 
 type ImportFlavor = "csv" | "json" | "parquet";
@@ -1031,7 +965,9 @@ function DuckDbPlaygroundInner() {
       : (localStorage.getItem(storageKey("db")) ??
         DUCKDB_SAMPLE_DATABASES[0].id);
   const [activeDbId, setActiveDbId] = useState(initialDbId);
-  const [tabs, setTabs] = useState<QueryTab[]>(() => loadTabs(initialDbId));
+  const [tabs, setTabs] = useState<QueryTab[]>(() =>
+    loadTabs(initialDbId, findDuckDbSampleDatabase(initialDbId).defaultTabs),
+  );
   const [activeTabId, setActiveTabId] = useState(() => tabs[0]?.id ?? "");
   const [resultsByTab, setResultsByTab] = useState<
     Record<string, QueryRunResult | null>
@@ -1262,7 +1198,6 @@ function DuckDbPlaygroundInner() {
     activeDbId === DUCKDB_BLANK_DATABASE.id && customDbFilename !== null
       ? customDbFilename
       : activeSample.filename;
-  const tabIds = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
   const tabDragSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   );
@@ -1947,7 +1882,7 @@ function DuckDbPlaygroundInner() {
         } catch {
           /* ignore */
         }
-        const nextTabs = loadTabs(sample.id);
+        const nextTabs = loadTabs(sample.id, sample.defaultTabs);
         persistTabs(nextTabs, sample.id);
         // Try to restore active tab id for this DB.
         let nextActive = nextTabs[0]?.id ?? "";
@@ -2293,7 +2228,10 @@ function DuckDbPlaygroundInner() {
         } catch {
           /* ignore */
         }
-        const nextTabs = loadTabs(DUCKDB_BLANK_DATABASE.id);
+        const nextTabs = loadTabs(
+          DUCKDB_BLANK_DATABASE.id,
+          DUCKDB_BLANK_DATABASE.defaultTabs,
+        );
         persistTabs(nextTabs, DUCKDB_BLANK_DATABASE.id);
         let nextActive = nextTabs[0]?.id ?? "";
         try {
@@ -2355,7 +2293,10 @@ function DuckDbPlaygroundInner() {
         } catch {
           /* ignore */
         }
-        const nextTabs = loadTabs(DUCKDB_BLANK_DATABASE.id);
+        const nextTabs = loadTabs(
+          DUCKDB_BLANK_DATABASE.id,
+          DUCKDB_BLANK_DATABASE.defaultTabs,
+        );
         persistTabs(nextTabs, DUCKDB_BLANK_DATABASE.id);
         let nextActive = nextTabs[0]?.id ?? "";
         try {
@@ -2460,7 +2401,11 @@ function DuckDbPlaygroundInner() {
 
   const resetTabsForCurrentDb = useCallback(() => {
     const sample = findDuckDbSampleDatabase(activeDbIdRef.current);
-    const fresh = makeTabs(sample.defaultTabs);
+    const fresh = sample.defaultTabs.map((seed) => ({
+      ...seed,
+      id: newTabId(),
+      pristineCode: seed.code,
+    }));
     tabHistoryRef.current = [];
     persistTabs(fresh);
     setActiveTabId(fresh[0]?.id ?? "");
@@ -5229,93 +5174,65 @@ function DuckDbPlaygroundInner() {
             ref={panesRef}
             className={`sql-panes duckdb-panes${activeTab?.kind === "view-data" ? " sql-panes--view-data" : ""}${activeTab?.kind === "er-diagram" ? " sql-panes--er-diagram" : ""}${activeTab?.kind === "query-history" ? " sql-panes--query-history" : ""}`}
           >
-            <div className="sql-tabbar">
-              <DndContext
-                sensors={tabDragSensors}
-                collisionDetection={closestCenter}
-                onDragStart={handleTabDragStart}
-                onDragEnd={handleTabDragEnd}
-                onDragCancel={handleTabDragCancel}
-              >
-                <SortableContext
-                  items={tabIds}
-                  strategy={horizontalListSortingStrategy}
-                >
-                  <div className="sql-tabs" role="tablist">
-                    {tabs.map((tab) => (
-                      <SqlTab
-                        key={tab.id}
-                        tab={tab}
-                        active={tab.id === activeTabId}
-                        onActivate={() => {
-                          const prevId = activeTabIdRef.current;
-                          if (prevId !== tab.id) {
-                            tabHistoryRef.current = pushTabHistory(tabHistoryRef.current, prevId, tab.id);
-                          }
-                          setActiveTabId(tab.id);
-                        }}
-                        onClose={() => closeTab(tab.id)}
-                        onRename={(title) =>
-                          persistTabs(
-                            tabsRef.current.map((candidate) =>
-                              candidate.id === tab.id
-                                ? { ...candidate, title }
-                                : candidate,
-                            ),
-                          )
-                        }
-                        onDuplicate={() => {
-                          const dup = {
-                            ...tab,
-                            id: newTabId(),
-                            title: `${tab.title} copy`,
-                          };
-                          tabHistoryRef.current = pushTabHistory(tabHistoryRef.current, activeTabIdRef.current, dup.id);
-                          persistTabs([...tabsRef.current, dup]);
-                          setActiveTabId(dup.id);
-                        }}
-                        onCloseOthers={() => {
-                          tabHistoryRef.current = [];
-                          persistTabs([tab]);
-                        }}
-                        onCloseAll={() => {
-                          const fresh = {
-                            id: newTabId(),
-                            title: "Query 1",
-                            code: "",
-                            pristineCode: "",
-                          };
-                          tabHistoryRef.current = [];
-                          persistTabs([fresh]);
-                          setActiveTabId(fresh.id);
-                          window.setTimeout(
-                            () => editorRef.current?.focus(),
-                            0,
-                          );
-                        }}
-                      />
-                    ))}
-                  </div>
-                </SortableContext>
-                <DragOverlay dropAnimation={null}>
-                  {draggingTab ? (
-                    <SqlTabDragOverlay tab={draggingTab} active={draggingTab.id === activeTabId} />
-                  ) : null}
-                </DragOverlay>
-              </DndContext>
-              <button
-                type="button"
-                className="sql-tab-add"
-                // Prevent the button from stealing focus on mouse-down so
-                // focus stays wherever it was.  The editor focus is
-                // handled synchronously inside addTab.
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={addTab}
-                aria-label="New query tab"
-              >
-                <Plus size={12} aria-hidden="true" />
-              </button>
-            </div>
+            <SqlTabBar
+              tabs={tabs}
+              activeTabId={activeTabId}
+              draggingTab={draggingTab}
+              tabDragSensors={tabDragSensors}
+              onDragStart={handleTabDragStart}
+              onDragEnd={handleTabDragEnd}
+              onDragCancel={handleTabDragCancel}
+              onTabActivate={(tabId) => {
+                const prevId = activeTabIdRef.current;
+                if (prevId !== tabId) {
+                  tabHistoryRef.current = pushTabHistory(
+                    tabHistoryRef.current,
+                    prevId,
+                    tabId,
+                  );
+                }
+                setActiveTabId(tabId);
+              }}
+              onTabClose={closeTab}
+              onTabRename={(tabId, title) =>
+                persistTabs(
+                  tabsRef.current.map((t) =>
+                    t.id === tabId ? { ...t, title } : t,
+                  ),
+                )
+              }
+              onTabDuplicate={(tabId) => {
+                const tab = tabsRef.current.find((t) => t.id === tabId);
+                if (!tab) return;
+                const dup = { ...tab, id: newTabId(), title: `${tab.title} copy` };
+                tabHistoryRef.current = pushTabHistory(
+                  tabHistoryRef.current,
+                  activeTabIdRef.current,
+                  dup.id,
+                );
+                persistTabs([...tabsRef.current, dup]);
+                setActiveTabId(dup.id);
+              }}
+              onTabCloseOthers={(tabId) => {
+                const tab = tabsRef.current.find((t) => t.id === tabId);
+                if (!tab) return;
+                tabHistoryRef.current = [];
+                persistTabs([tab]);
+              }}
+              onTabCloseAll={() => {
+                const fresh = {
+                  id: newTabId(),
+                  title: "Query 1",
+                  code: "",
+                  pristineCode: "",
+                };
+                tabHistoryRef.current = [];
+                persistTabs([fresh]);
+                setActiveTabId(fresh.id);
+                window.setTimeout(() => editorRef.current?.focus(), 0);
+              }}
+              onAddTab={addTab}
+            />
             <div
               className="sql-editor-pane"
               ref={editorPaneRef}

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -104,6 +104,7 @@ import {
   detectIsMac,
 } from "../playgroundShared";
 import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
+import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmDialogs";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { type DuckDbEngine } from "../runtime/duckdb";
@@ -4542,68 +4543,15 @@ function DuckDbPlaygroundInner() {
           </AlertDialog.Portal>
         </AlertDialog.Root>
 
-        <AlertDialog.Root
-          open={confirmRestoreOpen}
-          onOpenChange={setConfirmRestoreOpen}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Restore default settings?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                This will reset DuckDB&apos;s editor font size, word wrap,
-                run/result preferences, and the shared editor theme to their
-                built-in defaults. Your saved queries are not affected.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => {
-                    restoreDefaultSettings();
-                    setConfirmRestoreOpen(false);
-                  }}
-                >
-                  Restore
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
-
-        <AlertDialog.Root
-          open={confirmClearStorageOpen}
-          onOpenChange={setConfirmClearStorageOpen}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Clear all localStorage data?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                Settings, saved queries, and per-database state for every
-                Dataslope playground will be erased. This action cannot be
-                undone — the page will reload immediately afterwards.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={clearAllLocalStorage}
-                >
-                  Clear &amp; reload
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
+        <SqlSettingsConfirmDialogs
+          dialectDisplayName="DuckDB"
+          restoreOpen={confirmRestoreOpen}
+          onRestoreOpenChange={setConfirmRestoreOpen}
+          onRestoreConfirm={restoreDefaultSettings}
+          clearStorageOpen={confirmClearStorageOpen}
+          onClearStorageOpenChange={setConfirmClearStorageOpen}
+          onClearStorageConfirm={clearAllLocalStorage}
+        />
 
         {/* ── View/Edit Structure drawer ── */}
         <Dialog.Root

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -108,6 +108,8 @@ import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmD
 import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
 import { SwitchDatabaseDialog } from "../sql/components/SwitchDatabaseDialog";
 import { SchemaActionDialogs } from "../sql/components/SchemaActionDialogs";
+import { ImportSqlDumpDialog } from "../sql/components/ImportSqlDumpDialog";
+import { RenameDatabaseDialog } from "../sql/components/RenameDatabaseDialog";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { type DuckDbEngine } from "../runtime/duckdb";
@@ -4115,95 +4117,13 @@ function DuckDbPlaygroundInner() {
           onCopyFailed={() => showToast("Couldn't copy to clipboard.", "warn")}
         />
 
-        {/* ── Import SQL dump dialog ── */}
-        <Dialog.Root
+        <ImportSqlDumpDialog
           open={importSqlDumpOpen}
-          onOpenChange={(next) => {
-            if (!next) {
-              setImportSqlDumpOpen(false);
-              setImportSqlDumpDragging(false);
-            }
-          }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-import-popup">
-              <Dialog.Title className="confirm-title">
-                Import SQL Dump
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Open a local <code>.sql</code> dump file as a new in-memory
-                database.
-              </Dialog.Description>
-              <div className="sql-import-warning">
-                <TriangleAlert
-                  size={14}
-                  className="sql-import-warning-icon"
-                  aria-hidden="true"
-                />
-                <span>
-                  This will replace the current database with the contents of
-                  the file. Your file will <strong>not</strong> be uploaded or
-                  persisted — it is only loaded into browser memory and will be
-                  gone on reload.
-                </span>
-              </div>
-              <div
-                className={`sql-dropzone${importSqlDumpDragging ? " dragging" : ""}`}
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  setImportSqlDumpDragging(true);
-                }}
-                onDragLeave={() => setImportSqlDumpDragging(false)}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  setImportSqlDumpDragging(false);
-                  const file = e.dataTransfer.files[0];
-                  if (!file) return;
-                  const reader = new FileReader();
-                  reader.onload = (ev) => {
-                    const text = ev.target?.result as string | null;
-                    if (text == null) return;
-                    void performImportSqlDump(text, file.name);
-                  };
-                  reader.readAsText(file);
-                }}
-              >
-                <Upload
-                  size={28}
-                  className="sql-dropzone-icon"
-                  aria-hidden="true"
-                />
-                <span>Drop a SQL file here</span>
-                <span className="sql-dropzone-hint">
-                  or click to browse — .sql
-                </span>
-                <input
-                  type="file"
-                  accept=".sql"
-                  aria-label="Choose SQL dump file"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (!file) return;
-                    const reader = new FileReader();
-                    reader.onload = (ev) => {
-                      const text = ev.target?.result as string | null;
-                      if (text == null) return;
-                      void performImportSqlDump(text, file.name);
-                    };
-                    reader.readAsText(file);
-                    e.target.value = "";
-                  }}
-                />
-              </div>
-              <div className="confirm-actions" style={{ marginTop: 16 }}>
-                <Dialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </Dialog.Close>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+          dragging={importSqlDumpDragging}
+          onClose={() => setImportSqlDumpOpen(false)}
+          onDraggingChange={setImportSqlDumpDragging}
+          onImport={(sql, filename) => void performImportSqlDump(sql, filename)}
+        />
 
         {/* ── Import DuckDB binary dialog ── */}
         <Dialog.Root
@@ -4346,65 +4266,20 @@ function DuckDbPlaygroundInner() {
           </Popover.Portal>
         </Popover.Root>
 
-        {/* ── Rename Database dialog ── */}
-        <Dialog.Root
+        <RenameDatabaseDialog
           open={renameDbOpen}
-          onOpenChange={(next) => {
-            if (!next) setRenameDbOpen(false);
+          name={renameDbName}
+          ext={renameDbExt}
+          extensionOptions={[".duckdb", ".sql", ".db"]}
+          onNameChange={setRenameDbName}
+          onExtChange={setRenameDbExt}
+          onClose={() => setRenameDbOpen(false)}
+          onConfirm={(newFilename) => {
+            setCustomDbFilename(newFilename);
+            showToast(`Renamed to "${newFilename}".`);
+            setRenameDbOpen(false);
           }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-rename-db-popup">
-              <Dialog.Title className="confirm-title">
-                Rename Database
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Choose a new display name for the current database.
-              </Dialog.Description>
-              <div className="sql-rename-db-form">
-                <div className="sql-rename-db-name-row">
-                  <input
-                    className="sql-rename-input sql-rename-db-name-input"
-                    value={renameDbName}
-                    onChange={(e) => setRenameDbName(e.target.value)}
-                    placeholder="database name"
-                    aria-label="Database name"
-                    autoFocus
-                  />
-                  <select
-                    className="sql-rename-db-ext-select"
-                    value={renameDbExt}
-                    onChange={(e) => setRenameDbExt(e.target.value)}
-                    aria-label="File extension"
-                  >
-                    <option value=".duckdb">.duckdb</option>
-                    <option value=".sql">.sql</option>
-                    <option value=".db">.db</option>
-                  </select>
-                </div>
-              </div>
-              <div className="confirm-actions">
-                <Dialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </Dialog.Close>
-                <button
-                  type="button"
-                  className="confirm-btn confirm-btn-primary"
-                  disabled={!renameDbName.trim()}
-                  onClick={() => {
-                    const newFilename = `${renameDbName.trim()}${renameDbExt}`;
-                    setCustomDbFilename(newFilename);
-                    showToast(`Renamed to "${newFilename}".`);
-                    setRenameDbOpen(false);
-                  }}
-                >
-                  Rename
-                </button>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+        />
 
         <SwitchDatabaseDialog
           open={pendingDbId !== null}

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -106,6 +106,7 @@ import {
 import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmDialogs";
 import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
+import { SwitchDatabaseDialog } from "../sql/components/SwitchDatabaseDialog";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { type DuckDbEngine } from "../runtime/duckdb";
@@ -4404,41 +4405,15 @@ function DuckDbPlaygroundInner() {
           </Dialog.Portal>
         </Dialog.Root>
 
-        <AlertDialog.Root
+        <SwitchDatabaseDialog
           open={pendingDbId !== null}
-          onOpenChange={(next) => {
-            if (!next) setPendingDbId(null);
+          onOpenChange={(next) => { if (!next) setPendingDbId(null); }}
+          currentDbFilename={displayFilename}
+          onConfirm={() => {
+            if (pendingDbId) void performDbSwitch(pendingDbId);
+            setPendingDbId(null);
           }}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Switch databases?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                You have unsaved edits in the query tabs for{" "}
-                <strong>{displayFilename}</strong>. They will be saved and
-                restored when you switch back, but loading another database will
-                replace what&rsquo;s currently in the editor.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => {
-                    if (pendingDbId) void performDbSwitch(pendingDbId);
-                    setPendingDbId(null);
-                  }}
-                >
-                  Switch database
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
+        />
 
         <AlertDialog.Root
           open={pendingDropEntity !== null}

--- a/app/_components/duckdb/duckdbAdapter.ts
+++ b/app/_components/duckdb/duckdbAdapter.ts
@@ -1,0 +1,27 @@
+"use client";
+
+// Concrete DuckDB implementation of `SqlEngineAdapter`. The DuckDB
+// playground imports this and routes its engine factory / identity
+// constants through it so the per-dialect surface lives in one place
+// (Stage 3 scaffolding from the playground refactor plan).
+
+import type { SqlEngineAdapter } from "../sql/shared/engineAdapter";
+import { createDuckDbEngine, type DuckDbEngine } from "../runtime/duckdb";
+import {
+  DUCKDB_BLANK_DATABASE,
+  DUCKDB_SAMPLE_DATABASES,
+  type DuckDbSampleDatabase,
+} from "../runtime/duckdbSamples";
+
+export const duckdbAdapter: SqlEngineAdapter<
+  DuckDbEngine,
+  DuckDbSampleDatabase
+> = {
+  dialect: "duckdb",
+  playgroundId: "duckdb",
+  storagePrefix: "duckdb_",
+  createEngine: (sampleId) => createDuckDbEngine(sampleId),
+  samples: DUCKDB_SAMPLE_DATABASES,
+  blankSample: DUCKDB_BLANK_DATABASE,
+  defaultTabsFor: (sample) => sample.defaultTabs,
+};

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -1936,8 +1936,9 @@ function PostgresPlaygroundInner() {
       if (!engine) return;
       setStatusState("loading");
       try {
-        await engine.loadBlankDatabase();
-        await engine.exec(sqlText);
+        // Imports into a sandbox worker first; only swaps in on success,
+        // so a failed import leaves the existing database intact.
+        await engine.importSqlDump(sqlText);
         setActiveDbId(POSTGRES_BLANK_DATABASE.id);
         setCustomDbFilename(filename);
         try {

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -104,6 +104,7 @@ import {
 } from "../playgroundShared";
 import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmDialogs";
+import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
 import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
 import { type PostgresEngine } from "../runtime/postgres";
@@ -124,7 +125,6 @@ import {
   type DatabaseSelectorAction,
 } from "../sql/components/DatabaseSelector";
 import { ToastList } from "../sql/components/ToastList";
-import { DdlViewer } from "../sql/components/DdlViewer";
 import { GenExprEditor } from "../sql/components/GenExprEditor";
 import { ColumnFlag } from "../sql/components/ModifyStructureForm";
 import { QueryHistoryPane } from "../sql/components/QueryHistoryPane";
@@ -3629,55 +3629,16 @@ function PostgresPlaygroundInner() {
           ]}
         />
 
-        <Dialog.Root
+        <DdlViewerDialog
           open={ddlDialog !== null}
-          onOpenChange={(next) => {
-            if (!next) setDdlDialog(null);
-          }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-ddl-popup">
-              <Dialog.Title className="confirm-title">
-                DDL: {ddlDialog?.title ?? ""}
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Read-only view of the reconstructed <code>CREATE</code>{" "}
-                statement(s).
-              </Dialog.Description>
-              <DdlViewer
-                sql={ddlDialog?.sql ?? ""}
-                theme={editorTheme}
-                isPostgres
-              />
-              <div className="confirm-actions">
-                <button
-                  type="button"
-                  className="confirm-btn confirm-btn-secondary"
-                  onClick={() => {
-                    if (
-                      ddlDialog &&
-                      typeof navigator !== "undefined" &&
-                      navigator.clipboard
-                    ) {
-                      navigator.clipboard
-                        .writeText(ddlDialog.sql)
-                        .then(() => showToast("Copied DDL to clipboard."))
-                        .catch(() =>
-                          showToast("Couldn't copy to clipboard.", "warn"),
-                        );
-                    }
-                  }}
-                >
-                  Copy
-                </button>
-                <Dialog.Close className="confirm-btn confirm-btn-primary">
-                  Close
-                </Dialog.Close>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+          onOpenChange={(next) => { if (!next) setDdlDialog(null); }}
+          title={ddlDialog?.title ?? ""}
+          sql={ddlDialog?.sql ?? ""}
+          theme={editorTheme}
+          isPostgres
+          onCopied={() => showToast("Copied DDL to clipboard.")}
+          onCopyFailed={() => showToast("Couldn't copy to clipboard.", "warn")}
+        />
 
         {/* ── Import SQL dump dialog ── */}
         <Dialog.Root

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -119,6 +119,10 @@ import { ResultView } from "../sql/components/ResultView";
 import { SchemaItem } from "../sql/components/SchemaItem";
 import { SchemaLeafItem } from "../sql/components/SchemaLeafItem";
 import { SchemaSection } from "../sql/components/SchemaSection";
+import {
+  DatabaseSelector,
+  type DatabaseSelectorAction,
+} from "../sql/components/DatabaseSelector";
 import { ToastList } from "../sql/components/ToastList";
 import { DdlViewer } from "../sql/components/DdlViewer";
 import { GenExprEditor } from "../sql/components/GenExprEditor";
@@ -171,6 +175,27 @@ import { FK_ACTIONS } from "../sql/constants";
 
 const PLAYGROUND_ID = postgresAdapter.playgroundId;
 const STORAGE_PREFIX = postgresAdapter.storagePrefix;
+
+const POSTGRES_DB_ACTIONS: readonly DatabaseSelectorAction[] = [
+  {
+    id: "__new_db__",
+    icon: <FilePlus size={14} />,
+    label: "New Database",
+    description: "Create a blank database",
+  },
+  {
+    id: "__import_sql_dump__",
+    icon: <Upload size={14} />,
+    label: "Import SQL Dump",
+    description: "Open a SQL dump file",
+  },
+  {
+    id: "__rename_db__",
+    icon: <Pencil size={14} />,
+    label: "Rename Current Database",
+    description: "Change the display name",
+  },
+];
 const MAX_EXCEL_SHEET_NAME_LENGTH = 31;
 const INFINITE_SCROLL_PAGE_SIZE = 500;
 // Minimum time (ms) the "running" overlay is shown so the 180ms CSS
@@ -4641,9 +4666,14 @@ function PostgresPlaygroundInner() {
         <div className="sql-shell postgres-shell" ref={shellRef}>
           <aside className="sql-sidebar" aria-label="Database explorer">
             <div className="sql-db-selector-wrap">
-              <Select.Root
+              <DatabaseSelector
                 value={activeDbId}
-                onValueChange={(value) => {
+                displayFilename={displayFilename}
+                samples={POSTGRES_SAMPLE_DATABASES}
+                actions={POSTGRES_DB_ACTIONS}
+                triggerClassName="sql-database-selector"
+                chevron={<ChevronDown size={12} />}
+                onChange={(value) => {
                   if (value === "__new_db__") {
                     void performDbSwitch(POSTGRES_BLANK_DATABASE.id);
                     return;
@@ -4665,117 +4695,9 @@ function PostgresPlaygroundInner() {
                     setRenameDbOpen(true);
                     return;
                   }
-                  requestDbSwitch(String(value));
+                  requestDbSwitch(value);
                 }}
-              >
-                <Select.Trigger
-                  className="sql-db-selector sql-database-selector"
-                  aria-label="Select sample database"
-                >
-                  <Database
-                    size={14}
-                    className="sql-db-selector-icon"
-                    aria-hidden="true"
-                  />
-                  <Select.Value className="sql-db-selector-value">
-                    {displayFilename}
-                  </Select.Value>
-                  <Select.Icon className="playground-switcher-icon">
-                    <ChevronDown size={12} />
-                  </Select.Icon>
-                </Select.Trigger>
-                <Select.Portal>
-                  <Select.Positioner
-                    className="sql-db-positioner"
-                    sideOffset={6}
-                    alignItemWithTrigger={false}
-                  >
-                    <Select.Popup className="bui-select-popup sql-db-popup">
-                      <Select.Item
-                        value="__new_db__"
-                        className="bui-select-item sql-db-item"
-                      >
-                        <span
-                          className="bui-select-item-icon"
-                          aria-hidden="true"
-                        >
-                          <FilePlus size={14} />
-                        </span>
-                        <span className="sql-db-item-text">
-                          <Select.ItemText>New Database</Select.ItemText>
-                          <span className="sql-db-item-desc">
-                            Create a blank database
-                          </span>
-                        </span>
-                      </Select.Item>
-                      <Select.Item
-                        value="__import_sql_dump__"
-                        className="bui-select-item sql-db-item"
-                      >
-                        <span
-                          className="bui-select-item-icon"
-                          aria-hidden="true"
-                        >
-                          <Upload size={14} />
-                        </span>
-                        <span className="sql-db-item-text">
-                          <Select.ItemText>Import SQL Dump</Select.ItemText>
-                          <span className="sql-db-item-desc">
-                            Open a SQL dump file
-                          </span>
-                        </span>
-                      </Select.Item>
-                      <Select.Item
-                        value="__rename_db__"
-                        className="bui-select-item sql-db-item"
-                      >
-                        <span
-                          className="bui-select-item-icon"
-                          aria-hidden="true"
-                        >
-                          <Pencil size={14} />
-                        </span>
-                        <span className="sql-db-item-text">
-                          <Select.ItemText>
-                            Rename Current Database
-                          </Select.ItemText>
-                          <span className="sql-db-item-desc">
-                            Change the display name
-                          </span>
-                        </span>
-                      </Select.Item>
-                      <div
-                        role="separator"
-                        aria-orientation="horizontal"
-                        className="sql-db-popup-sep"
-                      />
-                      <div className="sql-db-popup-group-label">
-                        Sample databases
-                      </div>
-                      {POSTGRES_SAMPLE_DATABASES.map((sample) => (
-                        <Select.Item
-                          key={sample.id}
-                          value={sample.id}
-                          className="bui-select-item sql-db-item"
-                        >
-                          <span
-                            className="bui-select-item-icon"
-                            aria-hidden="true"
-                          >
-                            <Database size={14} />
-                          </span>
-                          <span className="sql-db-item-text">
-                            <Select.ItemText>{sample.filename}</Select.ItemText>
-                            <span className="sql-db-item-desc">
-                              {sample.description}
-                            </span>
-                          </span>
-                        </Select.Item>
-                      ))}
-                    </Select.Popup>
-                  </Select.Positioner>
-                </Select.Portal>
-              </Select.Root>
+              />
             </div>
             <div className="sql-schema-selector-wrap">
               <div className="sql-db-selector-row">

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -103,6 +103,7 @@ import {
   detectIsMac,
 } from "../playgroundShared";
 import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
+import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmDialogs";
 import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
 import { type PostgresEngine } from "../runtime/postgres";
@@ -3928,68 +3929,15 @@ function PostgresPlaygroundInner() {
           </AlertDialog.Portal>
         </AlertDialog.Root>
 
-        <AlertDialog.Root
-          open={confirmRestoreOpen}
-          onOpenChange={setConfirmRestoreOpen}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Restore default settings?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                This will reset PostgreSQL&apos;s editor font size, word wrap,
-                run/result preferences, and the shared editor theme to their
-                built-in defaults. Your saved queries are not affected.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => {
-                    restoreDefaultSettings();
-                    setConfirmRestoreOpen(false);
-                  }}
-                >
-                  Restore
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
-
-        <AlertDialog.Root
-          open={confirmClearStorageOpen}
-          onOpenChange={setConfirmClearStorageOpen}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Clear all localStorage data?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                Settings, saved queries, and per-database state for every
-                Dataslope playground will be erased. This action cannot be
-                undone — the page will reload immediately afterwards.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={clearAllLocalStorage}
-                >
-                  Clear &amp; reload
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
+        <SqlSettingsConfirmDialogs
+          dialectDisplayName="PostgreSQL"
+          restoreOpen={confirmRestoreOpen}
+          onRestoreOpenChange={setConfirmRestoreOpen}
+          onRestoreConfirm={restoreDefaultSettings}
+          clearStorageOpen={confirmClearStorageOpen}
+          onClearStorageOpenChange={setConfirmClearStorageOpen}
+          onClearStorageConfirm={clearAllLocalStorage}
+        />
 
         {/* ── View/Edit Structure drawer ── */}
         <Dialog.Root

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -106,6 +106,7 @@ import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmDialogs";
 import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
 import { SwitchDatabaseDialog } from "../sql/components/SwitchDatabaseDialog";
+import { SchemaActionDialogs } from "../sql/components/SchemaActionDialogs";
 import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
 import { type PostgresEngine } from "../runtime/postgres";
@@ -3801,69 +3802,14 @@ function PostgresPlaygroundInner() {
           }}
         />
 
-        <AlertDialog.Root
-          open={pendingDropEntity !== null}
-          onOpenChange={(next) => {
-            if (!next) setPendingDropEntity(null);
-          }}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Drop {pendingDropEntity?.kind ?? "entity"}?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                This will permanently drop{" "}
-                <strong>{pendingDropEntity?.name ?? ""}</strong> from the
-                in-memory database. Reload the page to restore the sample.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => void performDropEntity()}
-                >
-                  Drop
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
-
-        <AlertDialog.Root
-          open={pendingTruncate !== null}
-          onOpenChange={(next) => {
-            if (!next) setPendingTruncate(null);
-          }}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Truncate table?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                Truncate table <strong>{pendingTruncate}</strong>? This deletes
-                every row but keeps the schema. The change is in-memory only and
-                will be undone next page load.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => void confirmTruncate()}
-                >
-                  Truncate
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
+        <SchemaActionDialogs
+          dropEntityPending={pendingDropEntity}
+          onDropEntityOpenChange={(next) => { if (!next) setPendingDropEntity(null); }}
+          onDropEntityConfirm={() => void performDropEntity()}
+          truncatePending={pendingTruncate}
+          onTruncateOpenChange={(next) => { if (!next) setPendingTruncate(null); }}
+          onTruncateConfirm={() => void confirmTruncate()}
+        />
 
         <SqlSettingsConfirmDialogs
           dialectDisplayName="PostgreSQL"

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -104,12 +104,12 @@ import {
   SettingsPanel,
   detectIsMac,
 } from "../playgroundShared";
-import {
-  POSTGRES_SAMPLE_DATABASES,
-  POSTGRES_BLANK_DATABASE,
-  findPostgresSampleDatabase,
-} from "../runtime/postgresSamples";
-import { createPostgresEngine, type PostgresEngine } from "../runtime/postgres";
+import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
+import { postgresAdapter } from "./postgresAdapter";
+import { type PostgresEngine } from "../runtime/postgres";
+
+const POSTGRES_SAMPLE_DATABASES = postgresAdapter.samples;
+const POSTGRES_BLANK_DATABASE = postgresAdapter.blankSample!;
 import type { ForeignKeyInfo, TableColumnInfo } from "../runtime/sqlite";
 import type { QueryExecResult } from "sql.js";
 import type { QueryTab } from "../sqlitePlaygroundTabs";
@@ -169,8 +169,8 @@ import {
 } from "./postgresImport";
 import { FK_ACTIONS } from "../sql/constants";
 
-const PLAYGROUND_ID = "postgres";
-const STORAGE_PREFIX = "pg_postgres_";
+const PLAYGROUND_ID = postgresAdapter.playgroundId;
+const STORAGE_PREFIX = postgresAdapter.storagePrefix;
 const MAX_EXCEL_SHEET_NAME_LENGTH = 31;
 const INFINITE_SCROLL_PAGE_SIZE = 500;
 // Minimum time (ms) the "running" overlay is shown so the 180ms CSS
@@ -1656,7 +1656,7 @@ function PostgresPlaygroundInner() {
     (async () => {
       try {
         setLoadingMessage("Loading PostgreSQL engine…");
-        const engine = await createPostgresEngine(initialDbId);
+        const engine = await postgresAdapter.createEngine(initialDbId);
         if (cancelled) {
           // Component unmounted while the engine was being created; close it
           // immediately so the worker is terminated and its leader-election

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -107,6 +107,8 @@ import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmD
 import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
 import { SwitchDatabaseDialog } from "../sql/components/SwitchDatabaseDialog";
 import { SchemaActionDialogs } from "../sql/components/SchemaActionDialogs";
+import { ImportSqlDumpDialog } from "../sql/components/ImportSqlDumpDialog";
+import { RenameDatabaseDialog } from "../sql/components/RenameDatabaseDialog";
 import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
 import { type PostgresEngine } from "../runtime/postgres";
@@ -3642,155 +3644,28 @@ function PostgresPlaygroundInner() {
           onCopyFailed={() => showToast("Couldn't copy to clipboard.", "warn")}
         />
 
-        {/* ── Import SQL dump dialog ── */}
-        <Dialog.Root
+        <ImportSqlDumpDialog
           open={importSqlDumpOpen}
-          onOpenChange={(next) => {
-            if (!next) {
-              setImportSqlDumpOpen(false);
-              setImportSqlDumpDragging(false);
-            }
-          }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-import-popup">
-              <Dialog.Title className="confirm-title">
-                Import SQL Dump
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Open a local <code>.sql</code> dump file as a new in-memory
-                database.
-              </Dialog.Description>
-              <div className="sql-import-warning">
-                <TriangleAlert
-                  size={14}
-                  className="sql-import-warning-icon"
-                  aria-hidden="true"
-                />
-                <span>
-                  This will replace the current database with the contents of
-                  the file. Your file will <strong>not</strong> be uploaded or
-                  persisted — it is only loaded into browser memory and will be
-                  gone on reload.
-                </span>
-              </div>
-              <div
-                className={`sql-dropzone${importSqlDumpDragging ? " dragging" : ""}`}
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  setImportSqlDumpDragging(true);
-                }}
-                onDragLeave={() => setImportSqlDumpDragging(false)}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  setImportSqlDumpDragging(false);
-                  const file = e.dataTransfer.files[0];
-                  if (!file) return;
-                  const reader = new FileReader();
-                  reader.onload = (ev) => {
-                    const text = ev.target?.result as string | null;
-                    if (text == null) return;
-                    void performImportSqlDump(text, file.name);
-                  };
-                  reader.readAsText(file);
-                }}
-              >
-                <Upload
-                  size={28}
-                  className="sql-dropzone-icon"
-                  aria-hidden="true"
-                />
-                <span>Drop a SQL file here</span>
-                <span className="sql-dropzone-hint">
-                  or click to browse — .sql
-                </span>
-                <input
-                  type="file"
-                  accept=".sql"
-                  aria-label="Choose SQL dump file"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (!file) return;
-                    const reader = new FileReader();
-                    reader.onload = (ev) => {
-                      const text = ev.target?.result as string | null;
-                      if (text == null) return;
-                      void performImportSqlDump(text, file.name);
-                    };
-                    reader.readAsText(file);
-                    e.target.value = "";
-                  }}
-                />
-              </div>
-              <div className="confirm-actions" style={{ marginTop: 16 }}>
-                <Dialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </Dialog.Close>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+          dragging={importSqlDumpDragging}
+          onClose={() => setImportSqlDumpOpen(false)}
+          onDraggingChange={setImportSqlDumpDragging}
+          onImport={(sql, filename) => void performImportSqlDump(sql, filename)}
+        />
 
-        {/* ── Rename Database dialog ── */}
-        <Dialog.Root
+        <RenameDatabaseDialog
           open={renameDbOpen}
-          onOpenChange={(next) => {
-            if (!next) setRenameDbOpen(false);
+          name={renameDbName}
+          ext={renameDbExt}
+          extensionOptions={[".pg", ".sql", ".dump"]}
+          onNameChange={setRenameDbName}
+          onExtChange={setRenameDbExt}
+          onClose={() => setRenameDbOpen(false)}
+          onConfirm={(newFilename) => {
+            setCustomDbFilename(newFilename);
+            showToast(`Renamed to "${newFilename}".`);
+            setRenameDbOpen(false);
           }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-rename-db-popup">
-              <Dialog.Title className="confirm-title">
-                Rename Database
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Choose a new display name for the current database.
-              </Dialog.Description>
-              <div className="sql-rename-db-form">
-                <div className="sql-rename-db-name-row">
-                  <input
-                    className="sql-rename-input sql-rename-db-name-input"
-                    value={renameDbName}
-                    onChange={(e) => setRenameDbName(e.target.value)}
-                    placeholder="database name"
-                    aria-label="Database name"
-                    autoFocus
-                  />
-                  <select
-                    className="sql-rename-db-ext-select"
-                    value={renameDbExt}
-                    onChange={(e) => setRenameDbExt(e.target.value)}
-                    aria-label="File extension"
-                  >
-                    <option value=".pg">.pg</option>
-                    <option value=".sql">.sql</option>
-                    <option value=".dump">.dump</option>
-                  </select>
-                </div>
-              </div>
-              <div className="confirm-actions">
-                <Dialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </Dialog.Close>
-                <button
-                  type="button"
-                  className="confirm-btn confirm-btn-primary"
-                  disabled={!renameDbName.trim()}
-                  onClick={() => {
-                    const newFilename = `${renameDbName.trim()}${renameDbExt}`;
-                    setCustomDbFilename(newFilename);
-                    showToast(`Renamed to "${newFilename}".`);
-                    setRenameDbOpen(false);
-                  }}
-                >
-                  Rename
-                </button>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+        />
 
         <SwitchDatabaseDialog
           open={pendingDbId !== null}

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -53,7 +53,6 @@ import {
   Pencil,
   Play,
   Plus,
-  RotateCcw,
   Table,
   Trash2,
   TriangleAlert,
@@ -101,9 +100,9 @@ import {
   DataslopeRunOverlay,
   DEFAULT_PLAYGROUND_SETTINGS,
   RuntimeInfoContent,
-  SettingsPanel,
   detectIsMac,
 } from "../playgroundShared";
+import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
 import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
 import { type PostgresEngine } from "../runtime/postgres";
@@ -3573,7 +3572,7 @@ function PostgresPlaygroundInner() {
           </div>
         </header>
 
-        <SettingsPanel
+        <SqlSettingsPanel
           open={settingsOpen}
           fontSize={fontSize}
           setFontSize={setFontSize}
@@ -3588,23 +3587,11 @@ function PostgresPlaygroundInner() {
           clearBeforeRun={clearBeforeRun}
           setClearBeforeRun={setClearBeforeRun}
           language={PLAYGROUND_ID}
-          showOutputFontSizeControls={false}
-          clearBeforeRunLabel="Clear Results Before Running"
-          showClearBeforeRunRow={false}
           onClose={() => setSettingsOpen(false)}
           onRestoreDefaults={() => setConfirmRestoreOpen(true)}
           onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
-          extraGeneralRows={null}
-          extraActionRows={
-            <button
-              type="button"
-              className="settings-action-btn"
-              onClick={resetTabsForCurrentDb}
-            >
-              <RotateCcw size={14} aria-hidden="true" />
-              <span>Reset query tabs for {activeSample.label}</span>
-            </button>
-          }
+          resetTabsLabel={`Reset query tabs for ${activeSample.label}`}
+          onResetTabs={resetTabsForCurrentDb}
           extraTabs={[
             {
               value: "database",

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -108,6 +108,7 @@ import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
 import { SwitchDatabaseDialog } from "../sql/components/SwitchDatabaseDialog";
 import { SchemaActionDialogs } from "../sql/components/SchemaActionDialogs";
 import { ImportSqlDumpDialog } from "../sql/components/ImportSqlDumpDialog";
+import { SqlEditorToolbar } from "../sql/components/SqlEditorToolbar";
 import { RenameDatabaseDialog } from "../sql/components/RenameDatabaseDialog";
 import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
@@ -4936,126 +4937,14 @@ function PostgresPlaygroundInner() {
                   </Popover.Portal>
                 </Popover.Root>
               </div>
-              <div className="sql-toolbar">
-                <div className="sql-toolbar-shortcuts">
-                  <span
-                    className="kbd-group"
-                    title={
-                      isMac
-                        ? "Cmd + Enter — run selection or all"
-                        : "Ctrl + Enter — run selection or all"
-                    }
-                  >
-                    <kbd className="kbd">{isMac ? "⌘" : "Ctrl"}</kbd>
-                    <span className="kbd-plus" aria-hidden="true">
-                      +
-                    </span>
-                    <kbd className="kbd">Enter</kbd>
-                  </span>
-                </div>
-                <div className="sql-toolbar-actions">
-                  {hasEditorSelection ? (
-                    <div
-                      className={`run-btn-split${statusState === "running" ? " running" : ""}`}
-                    >
-                      <button
-                        type="button"
-                        className="run-btn-split-main"
-                        disabled={!loaded || statusState === "running"}
-                        onClick={runCurrentSelection}
-                      >
-                        {statusState === "running" ? (
-                          <svg viewBox="0 0 12 12" className="run-btn-spinner">
-                            <circle
-                              cx="6"
-                              cy="6"
-                              r="4.5"
-                              fill="none"
-                              stroke="white"
-                              strokeWidth="1.5"
-                              strokeLinecap="round"
-                              strokeDasharray="14 8"
-                            />
-                          </svg>
-                        ) : (
-                          <Play size={10} aria-hidden="true" />
-                        )}
-                        {statusState === "running"
-                          ? "Running…"
-                          : "Run Selection"}
-                      </button>
-                      <span
-                        className="run-btn-split-divider"
-                        aria-hidden="true"
-                      />
-                      <Menu.Root>
-                        <Menu.Trigger
-                          className="run-btn-split-chevron"
-                          disabled={!loaded || statusState === "running"}
-                          aria-label="Run options"
-                        >
-                          <ChevronDown size={11} aria-hidden="true" />
-                        </Menu.Trigger>
-                        <Menu.Portal>
-                          <Menu.Positioner sideOffset={6} align="end">
-                            <Menu.Popup className="bui-popup run-split-dropdown">
-                              <Menu.Item
-                                className="run-split-item"
-                                onClick={runCurrentSelection}
-                                disabled={!loaded || statusState === "running"}
-                              >
-                                <span className="run-split-item-label">
-                                  Run Selection
-                                </span>
-                                <span className="run-split-item-kbd">
-                                  {isMac ? "⌘Enter" : "Ctrl+Enter"}
-                                </span>
-                              </Menu.Item>
-                              <Menu.Item
-                                className="run-split-item"
-                                onClick={runActiveTab}
-                                disabled={!loaded || statusState === "running"}
-                              >
-                                <span className="run-split-item-label">
-                                  Run All
-                                </span>
-                                <span className="run-split-item-kbd">
-                                  {isMac ? "⌘⇧Enter" : "Ctrl+Shift+Enter"}
-                                </span>
-                              </Menu.Item>
-                            </Menu.Popup>
-                          </Menu.Positioner>
-                        </Menu.Portal>
-                      </Menu.Root>
-                    </div>
-                  ) : (
-                    <button
-                      type="button"
-                      className={`run-btn${statusState === "running" ? " running" : ""}`}
-                      disabled={!loaded || statusState === "running"}
-                      onClick={runActiveTab}
-                    >
-                      {statusState === "running" ? (
-                        <svg viewBox="0 0 12 12" className="run-btn-spinner">
-                          <circle
-                            cx="6"
-                            cy="6"
-                            r="4.5"
-                            fill="none"
-                            stroke="white"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeDasharray="14 8"
-                          />
-                        </svg>
-                      ) : (
-                        <Play size={10} aria-hidden="true" />
-                      )}
-                      {statusState === "running" ? "Running…" : "Run"}
-                    </button>
-                  )}
-                </div>
-              </div>
+              <SqlEditorToolbar
+                loaded={loaded}
+                running={statusState === "running"}
+                hasEditorSelection={hasEditorSelection}
+                isMac={isMac}
+                onRunSelection={runCurrentSelection}
+                onRunAll={runActiveTab}
+              />
             </div>
             {activeTab?.kind === "er-diagram" ? (
               <ErDiagramPane

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -142,6 +142,10 @@ import {
   stripSqlComments,
 } from "../sql/utils/sqlAnalysis";
 import { computeImportColComparison } from "../sql/utils/importUtils";
+import {
+  ensurePersistUnloadFlush,
+  persistAsync,
+} from "../sql/utils/persistedStorage";
 import { pickFallbackTab, pushTabHistory } from "../sql/utils/tabUtils";
 import type {
   AddRowDialogState,
@@ -882,6 +886,9 @@ type ImportFlavor = "csv" | "json" | "parquet";
 
 function PostgresPlaygroundInner() {
   const router = useRouter();
+  useEffect(() => {
+    ensurePersistUnloadFlush();
+  }, []);
   const toastManager = Toast.useToastManager();
   const showToast = useCallback(
     (title: string, kind: "info" | "warn" = "info") => {
@@ -921,33 +928,21 @@ function PostgresPlaygroundInner() {
   const setFontSize = useCallback(
     (n: number) => {
       setFontSizeState(n);
-      try {
-        localStorage.setItem(storageKey("fontsize"), String(n));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("fontsize"), String(n));
     },
     [setFontSizeState],
   );
   const setOutputFontSizeEnabled = useCallback(
     (b: boolean) => {
       setOutputFontSizeEnabledState(b);
-      try {
-        localStorage.setItem(storageKey("outputfontsize_enabled"), String(b));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("outputfontsize_enabled"), String(b));
     },
     [setOutputFontSizeEnabledState],
   );
   const setOutputFontSize = useCallback(
     (n: number) => {
       setOutputFontSizeState(n);
-      try {
-        localStorage.setItem(storageKey("outputfontsize"), String(n));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("outputfontsize"), String(n));
     },
     [setOutputFontSizeState],
   );
@@ -961,22 +956,14 @@ function PostgresPlaygroundInner() {
   const setWordWrap = useCallback(
     (b: boolean) => {
       setWordWrapState(b);
-      try {
-        localStorage.setItem(storageKey("wordwrap"), String(b));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("wordwrap"), String(b));
     },
     [setWordWrapState],
   );
   const setClearBeforeRun = useCallback(
     (b: boolean) => {
       setClearBeforeRunState(b);
-      try {
-        localStorage.setItem(storageKey("clearbeforerun"), String(b));
-      } catch {
-        /* ignore */
-      }
+      persistAsync(storageKey("clearbeforerun"), String(b));
     },
     [setClearBeforeRunState],
   );
@@ -1776,12 +1763,15 @@ function PostgresPlaygroundInner() {
     void refreshSchemas();
   }, [showSystemSchemas, refreshSchemas]);
 
-  // Keep autocomplete schema in sync with current tables/views.
+  // Keep autocomplete schema in sync with current tables/views. The
+  // reconfigure key memoization mirrors the DuckDB playground's
+  // Stage 1.2 fix so a query / CSV import that doesn't change the
+  // visible schema doesn't trigger a full editor re-parse.
+  const lastReconfigureKeyRef = useRef<string>("");
   useEffect(() => {
     const view = editorRef.current;
-    const langComp = langCompRef.current;
     const completionComp = completionCompRef.current;
-    if (!view || !langComp || !completionComp) return;
+    if (!view || !langCompRef.current || !completionComp) return;
     const schema: Record<string, string[]> = {};
     const completionSchema: SqlCompletionSchema = { entities: [] };
     for (const name of tables) {
@@ -1794,14 +1784,34 @@ function PostgresPlaygroundInner() {
       schema[name] = cols;
       completionSchema.entities.push({ name, columns: cols, kind: "view" });
     }
+    const key = JSON.stringify(completionSchema.entities);
+    if (key === lastReconfigureKeyRef.current) return;
     view.dispatch({
       effects: [
-        langComp.reconfigure(makeSqlLangExtension("postgres", schema)),
         completionComp.reconfigure(
           makeSqlAutocompletionExtension(completionSchema, "postgres"),
         ),
       ],
     });
+    // Lazy-load `@codemirror/lang-sql` (Stage 5.3) and apply the lang
+    // reconfigure once the chunk lands. Only commit
+    // `lastReconfigureKeyRef` after the dispatch fires so a
+    // StrictMode-cancelled effect can't make the next run skip the
+    // lang reconfigure for the current schema.
+    let cancelled = false;
+    void makeSqlLangExtension("postgres", schema).then((langExt) => {
+      if (cancelled) return;
+      const currentView = editorRef.current;
+      const currentLangComp = langCompRef.current;
+      if (!currentView || !currentLangComp) return;
+      currentView.dispatch({
+        effects: [currentLangComp.reconfigure(langExt)],
+      });
+      lastReconfigureKeyRef.current = key;
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [tables, views, columnsByEntity]);
 
   // Drop result entries whose owning tab no longer exists.

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -105,6 +105,7 @@ import {
 import { SqlSettingsPanel } from "../sql/components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmDialogs";
 import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
+import { SwitchDatabaseDialog } from "../sql/components/SwitchDatabaseDialog";
 import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
 import { type PostgresEngine } from "../runtime/postgres";
@@ -3790,41 +3791,15 @@ function PostgresPlaygroundInner() {
           </Dialog.Portal>
         </Dialog.Root>
 
-        <AlertDialog.Root
+        <SwitchDatabaseDialog
           open={pendingDbId !== null}
-          onOpenChange={(next) => {
-            if (!next) setPendingDbId(null);
+          onOpenChange={(next) => { if (!next) setPendingDbId(null); }}
+          currentDbFilename={displayFilename}
+          onConfirm={() => {
+            if (pendingDbId) void performDbSwitch(pendingDbId);
+            setPendingDbId(null);
           }}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Switch databases?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                You have unsaved edits in the query tabs for{" "}
-                <strong>{displayFilename}</strong>. They will be saved and
-                restored when you switch back, but loading another database will
-                replace what&rsquo;s currently in the editor.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => {
-                    if (pendingDbId) void performDbSwitch(pendingDbId);
-                    setPendingDbId(null);
-                  }}
-                >
-                  Switch database
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
+        />
 
         <AlertDialog.Root
           open={pendingDropEntity !== null}

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -2,7 +2,6 @@
 
 import {
   DndContext,
-  DragOverlay,
   KeyboardSensor,
   PointerSensor,
   closestCenter,
@@ -14,7 +13,6 @@ import {
 import {
   SortableContext,
   arrayMove,
-  horizontalListSortingStrategy,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
@@ -120,7 +118,11 @@ import type { ForeignKeyInfo, TableColumnInfo } from "../runtime/sqlite";
 import type { QueryExecResult } from "sql.js";
 import type { QueryTab } from "../sqlitePlaygroundTabs";
 import { newTabId } from "../sqlitePlaygroundTabs";
-import { SqlTab, SqlTabDragOverlay } from "../sql/components/SqlTab";
+import {
+  createTabStorage,
+  tabsAreDirty,
+} from "../sql/shared/tabStorageUtils";
+import { SqlTabBar } from "../sql/components/SqlTabBar";
 import { ResultView } from "../sql/components/ResultView";
 import { SchemaItem } from "../sql/components/SchemaItem";
 import { SchemaLeafItem } from "../sql/components/SchemaLeafItem";
@@ -180,6 +182,7 @@ import { FK_ACTIONS } from "../sql/constants";
 
 const PLAYGROUND_ID = postgresAdapter.playgroundId;
 const STORAGE_PREFIX = postgresAdapter.storagePrefix;
+const { dbScopedKey, loadTabs, saveTabs } = createTabStorage(STORAGE_PREFIX);
 
 const POSTGRES_DB_ACTIONS: readonly DatabaseSelectorAction[] = [
   {
@@ -821,8 +824,6 @@ function PgGeneratedColumnRow({
 }
 
 const storageKey = (key: string) => `${STORAGE_PREFIX}${key}`;
-const dbScopedKey = (dbId: string, key: string) =>
-  `${STORAGE_PREFIX}db_${dbId}_${key}`;
 const DEFAULT_PAGE_SIZE = 50;
 
 const RUNTIME_INFO: RuntimeInfo = {
@@ -843,73 +844,6 @@ const IMPORT_COL_STATUS_LABEL: Record<ImportColComparison["status"], string> = {
 
 function quoteIdent(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
-}
-
-function makeTabs(defaults: { title: string; code: string }[]): QueryTab[] {
-  return defaults.map((seed) => ({
-    ...seed,
-    id: newTabId(),
-    pristineCode: seed.code,
-  }));
-}
-
-function loadTabs(dbId: string): QueryTab[] {
-  const sample = findPostgresSampleDatabase(dbId);
-  if (typeof window === "undefined") return makeTabs(sample.defaultTabs);
-  try {
-    const raw = localStorage.getItem(dbScopedKey(dbId, "tabs"));
-    if (raw) {
-      const parsed = JSON.parse(raw) as QueryTab[];
-      if (Array.isArray(parsed) && parsed.length > 0) {
-        return parsed.map((tab) => ({
-          id: typeof tab.id === "string" ? tab.id : newTabId(),
-          title: typeof tab.title === "string" ? tab.title : "Query",
-          code: typeof tab.code === "string" ? tab.code : "",
-          pristineCode:
-            typeof tab.pristineCode === "string"
-              ? tab.pristineCode
-              : typeof tab.code === "string"
-                ? tab.code
-                : "",
-          kind: tab.kind === "view-data" ? "view-data" : undefined,
-        }));
-      }
-    }
-  } catch {
-    // Fall back to defaults.
-  }
-  return makeTabs(sample.defaultTabs);
-}
-
-function saveTabs(dbId: string, tabs: QueryTab[]): void {
-  try {
-    localStorage.setItem(
-      dbScopedKey(dbId, "tabs"),
-      JSON.stringify(
-        tabs.filter(
-          (tab) => tab.kind !== "er-diagram" && tab.kind !== "query-history",
-        ),
-      ),
-    );
-  } catch {
-    // Ignore storage quota / private-mode errors.
-  }
-}
-
-function tabsAreDirty(
-  tabs: QueryTab[],
-  defaults: { title: string; code: string }[],
-): boolean {
-  if (tabs.length !== defaults.length) return true;
-  for (let i = 0; i < tabs.length; i += 1) {
-    if (
-      tabs[i].title !== defaults[i].title ||
-      tabs[i].code !== defaults[i].code
-    ) {
-      return true;
-    }
-  }
-  return false;
 }
 
 type ImportFlavor = "csv" | "json" | "parquet";
@@ -1005,7 +939,9 @@ function PostgresPlaygroundInner() {
       : (localStorage.getItem(storageKey("db")) ??
         POSTGRES_SAMPLE_DATABASES[0].id);
   const [activeDbId, setActiveDbId] = useState(initialDbId);
-  const [tabs, setTabs] = useState<QueryTab[]>(() => loadTabs(initialDbId));
+  const [tabs, setTabs] = useState<QueryTab[]>(() =>
+    loadTabs(initialDbId, findPostgresSampleDatabase(initialDbId).defaultTabs),
+  );
   const [activeTabId, setActiveTabId] = useState(() => tabs[0]?.id ?? "");
   const [resultsByTab, setResultsByTab] = useState<
     Record<string, QueryRunResult | null>
@@ -1226,7 +1162,6 @@ function PostgresPlaygroundInner() {
     activeDbId === POSTGRES_BLANK_DATABASE.id && customDbFilename !== null
       ? customDbFilename
       : activeSample.filename;
-  const tabIds = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
   const tabDragSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   );
@@ -1879,7 +1814,7 @@ function PostgresPlaygroundInner() {
         } catch {
           /* ignore */
         }
-        const nextTabs = loadTabs(sample.id);
+        const nextTabs = loadTabs(sample.id, sample.defaultTabs);
         persistTabs(nextTabs, sample.id);
         // Try to restore active tab id for this DB.
         let nextActive = nextTabs[0]?.id ?? "";
@@ -1946,7 +1881,10 @@ function PostgresPlaygroundInner() {
         } catch {
           /* ignore */
         }
-        const nextTabs = loadTabs(POSTGRES_BLANK_DATABASE.id);
+        const nextTabs = loadTabs(
+          POSTGRES_BLANK_DATABASE.id,
+          POSTGRES_BLANK_DATABASE.defaultTabs,
+        );
         persistTabs(nextTabs, POSTGRES_BLANK_DATABASE.id);
         let nextActive = nextTabs[0]?.id ?? "";
         try {
@@ -2043,7 +1981,11 @@ function PostgresPlaygroundInner() {
 
   const resetTabsForCurrentDb = useCallback(() => {
     const sample = findPostgresSampleDatabase(activeDbIdRef.current);
-    const fresh = makeTabs(sample.defaultTabs);
+    const fresh = sample.defaultTabs.map((seed) => ({
+      ...seed,
+      id: newTabId(),
+      pristineCode: seed.code,
+    }));
     tabHistoryRef.current = [];
     persistTabs(fresh);
     setActiveTabId(fresh[0]?.id ?? "");
@@ -4750,93 +4692,65 @@ function PostgresPlaygroundInner() {
             ref={panesRef}
             className={`sql-panes postgres-panes${activeTab?.kind === "view-data" ? " sql-panes--view-data" : ""}${activeTab?.kind === "er-diagram" ? " sql-panes--er-diagram" : ""}${activeTab?.kind === "query-history" ? " sql-panes--query-history" : ""}`}
           >
-            <div className="sql-tabbar">
-              <DndContext
-                sensors={tabDragSensors}
-                collisionDetection={closestCenter}
-                onDragStart={handleTabDragStart}
-                onDragEnd={handleTabDragEnd}
-                onDragCancel={handleTabDragCancel}
-              >
-                <SortableContext
-                  items={tabIds}
-                  strategy={horizontalListSortingStrategy}
-                >
-                  <div className="sql-tabs" role="tablist">
-                    {tabs.map((tab) => (
-                      <SqlTab
-                        key={tab.id}
-                        tab={tab}
-                        active={tab.id === activeTabId}
-                        onActivate={() => {
-                          const prevId = activeTabIdRef.current;
-                          if (prevId !== tab.id) {
-                            tabHistoryRef.current = pushTabHistory(tabHistoryRef.current, prevId, tab.id);
-                          }
-                          setActiveTabId(tab.id);
-                        }}
-                        onClose={() => closeTab(tab.id)}
-                        onRename={(title) =>
-                          persistTabs(
-                            tabsRef.current.map((candidate) =>
-                              candidate.id === tab.id
-                                ? { ...candidate, title }
-                                : candidate,
-                            ),
-                          )
-                        }
-                        onDuplicate={() => {
-                          const dup = {
-                            ...tab,
-                            id: newTabId(),
-                            title: `${tab.title} copy`,
-                          };
-                          tabHistoryRef.current = pushTabHistory(tabHistoryRef.current, activeTabIdRef.current, dup.id);
-                          persistTabs([...tabsRef.current, dup]);
-                          setActiveTabId(dup.id);
-                        }}
-                        onCloseOthers={() => {
-                          tabHistoryRef.current = [];
-                          persistTabs([tab]);
-                        }}
-                        onCloseAll={() => {
-                          const fresh = {
-                            id: newTabId(),
-                            title: "Query 1",
-                            code: "",
-                            pristineCode: "",
-                          };
-                          tabHistoryRef.current = [];
-                          persistTabs([fresh]);
-                          setActiveTabId(fresh.id);
-                          window.setTimeout(
-                            () => editorRef.current?.focus(),
-                            0,
-                          );
-                        }}
-                      />
-                    ))}
-                  </div>
-                </SortableContext>
-                <DragOverlay dropAnimation={null}>
-                  {draggingTab ? (
-                    <SqlTabDragOverlay tab={draggingTab} active={draggingTab.id === activeTabId} />
-                  ) : null}
-                </DragOverlay>
-              </DndContext>
-              <button
-                type="button"
-                className="sql-tab-add"
-                // Prevent the button from stealing focus on mouse-down so
-                // focus stays wherever it was.  The editor focus is
-                // handled synchronously inside addTab.
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={addTab}
-                aria-label="New query tab"
-              >
-                <Plus size={12} aria-hidden="true" />
-              </button>
-            </div>
+            <SqlTabBar
+              tabs={tabs}
+              activeTabId={activeTabId}
+              draggingTab={draggingTab}
+              tabDragSensors={tabDragSensors}
+              onDragStart={handleTabDragStart}
+              onDragEnd={handleTabDragEnd}
+              onDragCancel={handleTabDragCancel}
+              onTabActivate={(tabId) => {
+                const prevId = activeTabIdRef.current;
+                if (prevId !== tabId) {
+                  tabHistoryRef.current = pushTabHistory(
+                    tabHistoryRef.current,
+                    prevId,
+                    tabId,
+                  );
+                }
+                setActiveTabId(tabId);
+              }}
+              onTabClose={closeTab}
+              onTabRename={(tabId, title) =>
+                persistTabs(
+                  tabsRef.current.map((t) =>
+                    t.id === tabId ? { ...t, title } : t,
+                  ),
+                )
+              }
+              onTabDuplicate={(tabId) => {
+                const tab = tabsRef.current.find((t) => t.id === tabId);
+                if (!tab) return;
+                const dup = { ...tab, id: newTabId(), title: `${tab.title} copy` };
+                tabHistoryRef.current = pushTabHistory(
+                  tabHistoryRef.current,
+                  activeTabIdRef.current,
+                  dup.id,
+                );
+                persistTabs([...tabsRef.current, dup]);
+                setActiveTabId(dup.id);
+              }}
+              onTabCloseOthers={(tabId) => {
+                const tab = tabsRef.current.find((t) => t.id === tabId);
+                if (!tab) return;
+                tabHistoryRef.current = [];
+                persistTabs([tab]);
+              }}
+              onTabCloseAll={() => {
+                const fresh = {
+                  id: newTabId(),
+                  title: "Query 1",
+                  code: "",
+                  pristineCode: "",
+                };
+                tabHistoryRef.current = [];
+                persistTabs([fresh]);
+                setActiveTabId(fresh.id);
+                window.setTimeout(() => editorRef.current?.focus(), 0);
+              }}
+              onAddTab={addTab}
+            />
             <div
               className="sql-editor-pane"
               ref={editorPaneRef}

--- a/app/_components/postgres/postgresAdapter.ts
+++ b/app/_components/postgres/postgresAdapter.ts
@@ -1,0 +1,27 @@
+"use client";
+
+// Concrete Postgres implementation of `SqlEngineAdapter`. The Postgres
+// playground imports this and routes its engine factory / identity
+// constants through it so the per-dialect surface lives in one place
+// (Stage 3 scaffolding from the playground refactor plan).
+
+import type { SqlEngineAdapter } from "../sql/shared/engineAdapter";
+import { createPostgresEngine, type PostgresEngine } from "../runtime/postgres";
+import {
+  POSTGRES_BLANK_DATABASE,
+  POSTGRES_SAMPLE_DATABASES,
+  type PostgresSampleDatabase,
+} from "../runtime/postgresSamples";
+
+export const postgresAdapter: SqlEngineAdapter<
+  PostgresEngine,
+  PostgresSampleDatabase
+> = {
+  dialect: "postgres",
+  playgroundId: "postgres",
+  storagePrefix: "pg_postgres_",
+  createEngine: (sampleId) => createPostgresEngine(sampleId),
+  samples: POSTGRES_SAMPLE_DATABASES,
+  blankSample: POSTGRES_BLANK_DATABASE,
+  defaultTabsFor: (sample) => sample.defaultTabs,
+};

--- a/app/_components/runtime/duckdb.ts
+++ b/app/_components/runtime/duckdb.ts
@@ -471,6 +471,11 @@ export interface DuckDbEngine {
    *  Registers the bytes in the virtual filesystem, cleans the live
    *  schema, ATTACHes the file read-only, and copies via `COPY FROM DATABASE`. */
   importFromBinary: (bytes: Uint8Array) => Promise<void>;
+  /** Try to import a SQL dump as a new blank database. If any statement
+   *  fails partway through, restores the previously active sample so the
+   *  user's database is never left in a half-populated state. Throws the
+   *  underlying SQL error after a successful restore. */
+  importSqlDump: (sql: string) => Promise<DuckDbSampleDatabase>;
   /** Best-effort whole-database export. Falls back to a multi-statement
    *  SQL script when binary export isn't available in the in-memory
    *  build (the common case in WASM). */
@@ -722,6 +727,44 @@ export async function createDuckDbEngine(
         /* ignore */
       }
       conn = next;
+      return sample;
+    },
+
+    async importSqlDump(sql) {
+      // DuckDB-Wasm shares a single underlying instance across connections,
+      // so any "fresh" connection sees the same schema. We can't sandbox
+      // the import; the best we can do is bootstrap a blank schema, try
+      // the SQL there, and restore the previous sample if it fails.
+      const previousSample = sample;
+      const next = await bootstrapDatabase(DUCKDB_BLANK_DATABASE);
+      try {
+        const stmts = splitDuckDbStatements(sql);
+        for (const stmt of stmts) {
+          await next.query(stmt);
+        }
+      } catch (err) {
+        try {
+          await next.close();
+        } catch {
+          /* ignore */
+        }
+        const restored = await bootstrapDatabase(previousSample);
+        try {
+          await conn.close();
+        } catch {
+          /* ignore */
+        }
+        conn = restored;
+        sample = previousSample;
+        throw err;
+      }
+      try {
+        await conn.close();
+      } catch {
+        /* ignore */
+      }
+      conn = next;
+      sample = DUCKDB_BLANK_DATABASE;
       return sample;
     },
 
@@ -1291,6 +1334,8 @@ export async function createDuckDbEngine(
       const importFile = "_playground_import_tmp.duckdb";
       const alias = "_playground_import_alias";
       await db.registerFileBuffer(importFile, bytes);
+      const previousSample = sample;
+      let importFailed = false;
       try {
         // cleanDuckDbSchema wipes the main schema; then we copy from the
         // attached file database into the now-empty memory catalog.
@@ -1321,11 +1366,26 @@ export async function createDuckDbEngine(
           `COPY FROM DATABASE ${quoteIdent(alias)} TO memory`,
         );
         await conn.query(`DETACH ${quoteIdent(alias)}`);
-      } finally {
+      } catch (err) {
+        importFailed = true;
+        // Schema was wiped before the failing step; restore the previous
+        // sample so the user is never stranded on an empty database.
+        const restored = await bootstrapDatabase(previousSample);
         try {
-          await conn.query(`DETACH ${quoteIdent(alias)}`);
+          await conn.close();
         } catch {
-          /* already detached — ignore */
+          /* ignore */
+        }
+        conn = restored;
+        sample = previousSample;
+        throw err;
+      } finally {
+        if (!importFailed) {
+          try {
+            await conn.query(`DETACH ${quoteIdent(alias)}`);
+          } catch {
+            /* already detached — ignore */
+          }
         }
         try {
           await db.dropFile?.(importFile);

--- a/app/_components/runtime/duckdbSamples.ts
+++ b/app/_components/runtime/duckdbSamples.ts
@@ -1,12 +1,12 @@
 "use client";
 
-import type { QueryTabSeed } from "./sqliteSamples";
+import {
+  findSqlSampleById,
+  type QueryTabSeed,
+  type SqlSampleDatabaseBase,
+} from "./sqlSamples";
 
-export interface DuckDbSampleDatabase {
-  id: string;
-  label: string;
-  filename: string;
-  description: string;
+export interface DuckDbSampleDatabase extends SqlSampleDatabaseBase {
   sql: string;
   defaultTabs: QueryTabSeed[];
 }
@@ -245,9 +245,5 @@ export const DUCKDB_BLANK_DATABASE: DuckDbSampleDatabase = {
 };
 
 export function findDuckDbSampleDatabase(id: string): DuckDbSampleDatabase {
-  if (id === DUCKDB_BLANK_DATABASE.id) return DUCKDB_BLANK_DATABASE;
-  return (
-    DUCKDB_SAMPLE_DATABASES.find((sample) => sample.id === id) ??
-    DUCKDB_SAMPLE_DATABASES[0]
-  );
+  return findSqlSampleById(id, DUCKDB_SAMPLE_DATABASES, DUCKDB_BLANK_DATABASE);
 }

--- a/app/_components/runtime/postgres.ts
+++ b/app/_components/runtime/postgres.ts
@@ -196,6 +196,10 @@ export interface PostgresEngine {
     schema?: string,
   ) => Promise<void>;
   activeSample: () => PostgresSampleDatabase;
+  /** Try to import a SQL dump into a fresh sandbox worker. If the SQL
+   *  executes cleanly, swap the engine over to it. If it throws, the
+   *  sandbox is discarded and the existing database stays intact. */
+  importSqlDump: (sql: string) => Promise<PostgresSampleDatabase>;
   close: () => Promise<void>;
 }
 
@@ -729,6 +733,29 @@ export async function createPostgresEngine(
     },
 
     activeSample() {
+      return sample;
+    },
+
+    async importSqlDump(sql) {
+      const next = createFreshWorker();
+      await next.waitReady;
+      try {
+        await next.exec(sql);
+      } catch (err) {
+        try {
+          await next.close();
+        } catch {
+          /* ignore */
+        }
+        throw err;
+      }
+      try {
+        await db.close();
+      } catch {
+        /* ignore */
+      }
+      db = next;
+      sample = POSTGRES_BLANK_DATABASE;
       return sample;
     },
 

--- a/app/_components/runtime/postgresSamples.ts
+++ b/app/_components/runtime/postgresSamples.ts
@@ -1,12 +1,12 @@
 "use client";
 
-import type { QueryTabSeed } from "./sqliteSamples";
+import {
+  findSqlSampleById,
+  type QueryTabSeed,
+  type SqlSampleDatabaseBase,
+} from "./sqlSamples";
 
-export interface PostgresSampleDatabase {
-  id: string;
-  label: string;
-  filename: string;
-  description: string;
+export interface PostgresSampleDatabase extends SqlSampleDatabaseBase {
   sql: string;
   defaultTabs: QueryTabSeed[];
 }
@@ -736,9 +736,9 @@ export const POSTGRES_BLANK_DATABASE: PostgresSampleDatabase = {
 };
 
 export function findPostgresSampleDatabase(id: string): PostgresSampleDatabase {
-  if (id === POSTGRES_BLANK_DATABASE.id) return POSTGRES_BLANK_DATABASE;
-  return (
-    POSTGRES_SAMPLE_DATABASES.find((sample) => sample.id === id) ??
-    POSTGRES_SAMPLE_DATABASES[0]
+  return findSqlSampleById(
+    id,
+    POSTGRES_SAMPLE_DATABASES,
+    POSTGRES_BLANK_DATABASE,
   );
 }

--- a/app/_components/runtime/sqlSamples.ts
+++ b/app/_components/runtime/sqlSamples.ts
@@ -1,0 +1,45 @@
+// Shared types and helpers used by the three SQL playground sample
+// catalogues (sqliteSamples.ts / postgresSamples.ts / duckdbSamples.ts).
+// The dialect-specific DDL/seed payloads stay in their per-dialect
+// files because the SQL itself is what differs between SQLite,
+// Postgres and DuckDB — consolidating it behind a synthetic emitter
+// layer added complexity without value during the Stage 4 audit.
+
+export interface QueryTabSeed {
+  /** Human-readable title shown in the tab strip. */
+  title: string;
+  /** Initial SQL contents of the tab. */
+  code: string;
+}
+
+/** Fields every dialect's sample-database entry exposes. Per-dialect
+ *  modules extend this with their own payload (e.g. SQLite ships a
+ *  `seed(db)` callback, Postgres/DuckDB inline the SQL as a `sql`
+ *  string). */
+export interface SqlSampleDatabaseBase {
+  /** Stable id used in localStorage keys and the selector value. */
+  id: string;
+  /** Human-readable name shown in the selector trigger and dropdown. */
+  label: string;
+  /** Display filename (e.g. `chinook.db`) shown next to the selector
+   *  trigger so the user sees the same on-disk metaphor used by other
+   *  tools. */
+  filename: string;
+  /** Short description shown under the label in the selector dropdown. */
+  description: string;
+  /** Default editor tabs opened on the first visit to this database. */
+  defaultTabs: QueryTabSeed[];
+}
+
+/** Look a sample up by id, falling back to the first registered
+ *  sample (or, if provided, a "blank" entry) so the playground always
+ *  boots into a usable state even after the user deletes a sample we
+ *  shipped in a previous release. Shared between every dialect. */
+export function findSqlSampleById<T extends SqlSampleDatabaseBase>(
+  id: string,
+  samples: readonly T[],
+  blank?: T,
+): T {
+  if (blank && id === blank.id) return blank;
+  return samples.find((s) => s.id === id) ?? samples[0];
+}

--- a/app/_components/runtime/sqlite-core.ts
+++ b/app/_components/runtime/sqlite-core.ts
@@ -1181,6 +1181,20 @@ export async function createSqliteEngineInProcess(
       return meta;
     },
     loadFromBytes(bytes: Uint8Array, filename: string) {
+      // Build the new database first so a corrupt or unsupported file
+      // throws before we tear down the live one — keeps the playground
+      // in a working state if the bytes turn out to be invalid.
+      const next = new SQL.Database(bytes);
+      try {
+        next.run("PRAGMA foreign_keys = ON;");
+      } catch (err) {
+        try {
+          next.close();
+        } catch {
+          /* ignore */
+        }
+        throw err;
+      }
       if (db) {
         try {
           db.close();
@@ -1188,8 +1202,7 @@ export async function createSqliteEngineInProcess(
           // Ignore close errors.
         }
       }
-      db = new SQL.Database(bytes);
-      db.run("PRAGMA foreign_keys = ON;");
+      db = next;
       // Derive a stable-ish id from the filename so the UI can
       // distinguish this from the blank placeholder.
       const basename = filename

--- a/app/_components/runtime/sqliteSamples.ts
+++ b/app/_components/runtime/sqliteSamples.ts
@@ -5,25 +5,15 @@
 // loading a binary `.sqlite` file) is a one-entry change.
 
 import type { Database } from "sql.js";
+import {
+  findSqlSampleById,
+  type QueryTabSeed,
+  type SqlSampleDatabaseBase,
+} from "./sqlSamples";
 
-export interface QueryTabSeed {
-  /** Human-readable title shown in the tab strip. */
-  title: string;
-  /** Initial SQL contents of the tab. */
-  code: string;
-}
+export type { QueryTabSeed } from "./sqlSamples";
 
-export interface SqliteSampleDatabase {
-  /** Stable id used in localStorage keys and the selector value. */
-  id: string;
-  /** Human-readable name shown in the selector trigger and dropdown. */
-  label: string;
-  /** Display filename (e.g. `chinook.db`) shown next to the selector
-   *  trigger so the user sees the same on-disk metaphor used by other
-   *  SQLite tools. */
-  filename: string;
-  /** Short description shown under the label in the selector dropdown. */
-  description: string;
+export interface SqliteSampleDatabase extends SqlSampleDatabaseBase {
   /** Multi-statement DDL string. Run as one batch via `db.run`. */
   schema: string;
   /** Populates the database tables created by `schema`. Receives a fresh
@@ -882,8 +872,5 @@ export const SQLITE_SAMPLE_DATABASES: SqliteSampleDatabase[] = [
  *  state even after the user deletes a sample we shipped in a previous
  *  release. */
 export function findSampleDatabase(id: string): SqliteSampleDatabase {
-  return (
-    SQLITE_SAMPLE_DATABASES.find((s) => s.id === id) ??
-    SQLITE_SAMPLE_DATABASES[0]
-  );
+  return findSqlSampleById(id, SQLITE_SAMPLE_DATABASES);
 }

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -131,6 +131,7 @@ import {
   detectIsMac,
 } from "../playgroundShared";
 import { SqlSettingsPanel } from "./components/SqlSettingsPanel";
+import { SqlSettingsConfirmDialogs } from "./components/SqlSettingsConfirmDialogs";
 import { findSampleDatabase } from "../runtime/sqliteSamples";
 import { sqliteAdapter } from "./sqliteAdapter";
 import {
@@ -2528,68 +2529,15 @@ function SqlPlaygroundInner() {
           </AlertDialog.Portal>
         </AlertDialog.Root>
 
-        <AlertDialog.Root
-          open={confirmRestoreOpen}
-          onOpenChange={setConfirmRestoreOpen}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Restore default settings?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                This will reset SQLite&apos;s editor font size, word wrap,
-                run/result preferences, and the shared editor theme to their
-                built-in defaults. Your saved queries are not affected.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => {
-                    restoreDefaultSettings();
-                    setConfirmRestoreOpen(false);
-                  }}
-                >
-                  Restore defaults
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
-
-        <AlertDialog.Root
-          open={confirmClearStorageOpen}
-          onOpenChange={setConfirmClearStorageOpen}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Clear all localStorage data?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                This will permanently delete every saved setting and query
-                across <strong>all playgrounds</strong>. The page will reload
-                immediately. This can&rsquo;t be undone.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={clearAllLocalStorage}
-                >
-                  Clear &amp; reload
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
+        <SqlSettingsConfirmDialogs
+          dialectDisplayName="SQLite"
+          restoreOpen={confirmRestoreOpen}
+          onRestoreOpenChange={setConfirmRestoreOpen}
+          onRestoreConfirm={restoreDefaultSettings}
+          clearStorageOpen={confirmClearStorageOpen}
+          onClearStorageOpenChange={setConfirmClearStorageOpen}
+          onClearStorageConfirm={clearAllLocalStorage}
+        />
 
         <AlertDialog.Root
           open={truncateConfirm !== null}

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -134,6 +134,8 @@ import { SqlSettingsPanel } from "./components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "./components/SqlSettingsConfirmDialogs";
 import { DdlViewerDialog } from "./components/DdlViewerDialog";
 import { SwitchDatabaseDialog } from "./components/SwitchDatabaseDialog";
+import { ImportBinaryFileDialog } from "./components/ImportBinaryFileDialog";
+import { RenameDatabaseDialog } from "./components/RenameDatabaseDialog";
 import { findSampleDatabase } from "../runtime/sqliteSamples";
 import { sqliteAdapter } from "./sqliteAdapter";
 import {
@@ -2586,164 +2588,60 @@ function SqlPlaygroundInner() {
           </AlertDialog.Portal>
         </AlertDialog.Root>
 
-        {/* ── Import SQLite dialog ── */}
-        <Dialog.Root
+        <ImportBinaryFileDialog
           open={importSqliteOpen}
-          onOpenChange={(next) => {
-            if (!next) {
-              setImportSqliteOpen(false);
-              setImportSqliteDragging(false);
-            }
-          }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-import-popup">
-              <Dialog.Title className="confirm-title">
-                Import SQLite File
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Open a local <code>.sqlite</code> or <code>.db</code> file as a
-                new in-memory database.
-              </Dialog.Description>
-              <div className="sql-import-warning">
-                <TriangleAlert
-                  size={14}
-                  className="sql-import-warning-icon"
-                  aria-hidden="true"
-                />
-                <span>
-                  This is a playground environment. Your file will{" "}
-                  <strong>not</strong> be uploaded or persisted — it is only
-                  loaded into browser memory and will be gone on reload.
-                </span>
-              </div>
-              <div
-                className={`sql-dropzone${importSqliteDragging ? " dragging" : ""}`}
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  setImportSqliteDragging(true);
-                }}
-                onDragLeave={() => setImportSqliteDragging(false)}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  setImportSqliteDragging(false);
-                  const file = e.dataTransfer.files[0];
-                  if (!file) return;
-                  const reader = new FileReader();
-                  reader.onload = (ev) => {
-                    const buf = ev.target?.result as ArrayBuffer | null;
-                    if (!buf) return;
-                    performImportSqlite(new Uint8Array(buf), file.name);
-                  };
-                  reader.readAsArrayBuffer(file);
-                }}
-              >
-                <Upload
-                  size={28}
-                  className="sql-dropzone-icon"
-                  aria-hidden="true"
-                />
-                <span>Drop a SQLite file here</span>
-                <span className="sql-dropzone-hint">
-                  or click to browse — .sqlite, .db
-                </span>
-                <input
-                  type="file"
-                  accept=".sqlite,.db,.sqlite3"
-                  aria-label="Choose SQLite file"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (!file) return;
-                    const reader = new FileReader();
-                    reader.onload = (ev) => {
-                      const buf = ev.target?.result as ArrayBuffer | null;
-                      if (!buf) return;
-                      performImportSqlite(new Uint8Array(buf), file.name);
-                    };
-                    reader.readAsArrayBuffer(file);
-                    // Reset the input so the same file can be re-selected.
-                    e.target.value = "";
-                  }}
-                />
-              </div>
-              <div className="confirm-actions" style={{ marginTop: 16 }}>
-                <Dialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </Dialog.Close>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+          dragging={importSqliteDragging}
+          onClose={() => setImportSqliteOpen(false)}
+          onDraggingChange={setImportSqliteDragging}
+          onImport={(data, filename) => performImportSqlite(data, filename)}
+          title="Import SQLite File"
+          description={
+            <>
+              Open a local <code>.sqlite</code> or <code>.db</code> file as a
+              new in-memory database.
+            </>
+          }
+          warningText={
+            <>
+              This is a playground environment. Your file will{" "}
+              <strong>not</strong> be uploaded or persisted — it is only loaded
+              into browser memory and will be gone on reload.
+            </>
+          }
+          dropText="Drop a SQLite file here"
+          browseHint="or click to browse — .sqlite, .db"
+          accept=".sqlite,.db,.sqlite3"
+          inputAriaLabel="Choose SQLite file"
+        />
 
-        {/* ── Rename Database dialog ── */}
-        <Dialog.Root
+        <RenameDatabaseDialog
           open={renameDbOpen}
-          onOpenChange={(next) => {
-            if (!next) setRenameDbOpen(false);
+          name={renameDbBaseName}
+          ext={renameDbExt}
+          extensionOptions={[
+            { value: ".sqlite", label: ".sqlite (most common)" },
+            ".db",
+            ".sqlite3",
+            ".db3",
+          ]}
+          onNameChange={setRenameDbBaseName}
+          onExtChange={setRenameDbExt}
+          onClose={() => setRenameDbOpen(false)}
+          description="Choose a new filename for the current database."
+          onConfirm={(newFilename) => {
+            setCustomFilenames((prev) => ({
+              ...prev,
+              [activeDbId]: newFilename,
+            }));
+            if (customDb?.id === activeDbId) {
+              setCustomDb((prev) =>
+                prev ? { ...prev, filename: newFilename } : prev,
+              );
+            }
+            showToast(`Renamed to "${newFilename}".`);
+            setRenameDbOpen(false);
           }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-rename-db-popup">
-              <Dialog.Title className="confirm-title">
-                Rename Database
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Choose a new filename for the current database.
-              </Dialog.Description>
-              <div className="sql-rename-db-form">
-                <div className="sql-rename-db-name-row">
-                  <input
-                    className="sql-rename-input sql-rename-db-name-input"
-                    value={renameDbBaseName}
-                    onChange={(e) => setRenameDbBaseName(e.target.value)}
-                    placeholder="database name"
-                    aria-label="Database name"
-                    autoFocus
-                  />
-                  <select
-                    className="sql-rename-db-ext-select"
-                    value={renameDbExt}
-                    onChange={(e) => setRenameDbExt(e.target.value)}
-                    aria-label="File extension"
-                  >
-                    <option value=".sqlite">.sqlite (most common)</option>
-                    <option value=".db">.db</option>
-                    <option value=".sqlite3">.sqlite3</option>
-                    <option value=".db3">.db3</option>
-                  </select>
-                </div>
-              </div>
-              <div className="confirm-actions">
-                <Dialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </Dialog.Close>
-                <button
-                  type="button"
-                  className="confirm-btn confirm-btn-primary"
-                  disabled={!renameDbBaseName.trim()}
-                  onClick={() => {
-                    const newFilename = `${renameDbBaseName.trim()}${renameDbExt}`;
-                    setCustomFilenames((prev) => ({
-                      ...prev,
-                      [activeDbId]: newFilename,
-                    }));
-                    if (customDb?.id === activeDbId) {
-                      setCustomDb((prev) =>
-                        prev ? { ...prev, filename: newFilename } : prev,
-                      );
-                    }
-                    showToast(`Renamed to "${newFilename}".`);
-                    setRenameDbOpen(false);
-                  }}
-                >
-                  Rename
-                </button>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+        />
 
         {/* ── Import CSV dialog ── */}
         <Dialog.Root

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -19,19 +19,11 @@
 // user picks a different editor theme.
 
 import {
-  DndContext,
-  DragOverlay,
-  closestCenter,
   PointerSensor,
   useSensor,
   useSensors,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import {
-  SortableContext,
-  horizontalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS as DndCSS } from "@dnd-kit/utilities";
 import React, {
   startTransition,
   useCallback,
@@ -94,7 +86,6 @@ import {
   Network,
   Pencil,
   Play,
-  Plus,
   RotateCcw,
   Settings2,
   Table,
@@ -159,7 +150,7 @@ const ErDiagramPane = dynamic(
   { ssr: false },
 );
 import { ToastList } from "./components/ToastList";
-import { SqlTab, SqlTabDragOverlay } from "./components/SqlTab";
+import { SqlTabBar } from "./components/SqlTabBar";
 import { QueryHistoryPane } from "./components/QueryHistoryPane";
 import type { SqlCompletionSchema } from "./sqlCompletion";
 import { useSettingsStore } from "./stores/useSettingsStore";
@@ -1187,7 +1178,6 @@ function SqlPlaygroundInner() {
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
   const result = activeTabId ? (resultsByTab[activeTabId] ?? null) : null;
   const loadingFading = loaded && showLoadingOverlay;
-  const tabIds = useMemo(() => tabs.map((t) => t.id), [tabs]);
 
   // ─── Refs ────────────────────────────────────────────────────────────
   const engineRef = useRef<SqliteEngine | null>(null);
@@ -3863,80 +3853,44 @@ function SqlPlaygroundInner() {
             className={`sql-panes${activeTab?.kind === "view-data" ? " sql-panes--view-data" : ""}${activeTab?.kind === "er-diagram" ? " sql-panes--er-diagram" : ""}${activeTab?.kind === "query-history" ? " sql-panes--query-history" : ""}`}
             ref={panesRef}
           >
-            <div className="sql-tabbar">
-              <DndContext
-                sensors={tabDragSensors}
-                collisionDetection={closestCenter}
-                onDragStart={onTabDragStart}
-                onDragEnd={onTabDragEnd}
-                onDragCancel={onTabDragCancel}
-              >
-                <SortableContext
-                  items={tabIds}
-                  strategy={horizontalListSortingStrategy}
-                >
-                  <div className="sql-tabs" role="tablist">
-                    {tabs.map((t) => (
-                      <SqlTab
-                        key={t.id}
-                        tab={t}
-                        active={t.id === activeTabId}
-                        onActivate={() => {
-                          const prevId = activeTabIdRef.current;
-                          if (prevId !== t.id) {
-                            tabHistoryRef.current = pushTabHistory(tabHistoryRef.current, prevId, t.id);
-                          }
-                          activeTabIdRef.current = t.id;
-                          setActiveTabId(t.id);
-                          // When the user re-clicks the already-active tab the
-                          // useEffect that focuses the editor won't re-run
-                          // (activeTabId hasn't changed).  Focus it explicitly
-                          // so typing works immediately without a second click.
-                          if (
-                            prevId === t.id &&
-                            t.kind !== "er-diagram" &&
-                            t.kind !== "view-data" &&
-                            t.kind !== "query-history"
-                          ) {
-                            editorRef.current?.focus();
-                          }
-                        }}
-                        onClose={() => closeTab(t.id)}
-                        onRename={(name) => renameTab(t.id, name)}
-                        onDuplicate={() => duplicateTab(t.id)}
-                        onCloseOthers={() => closeOtherTabs(t.id)}
-                        onCloseAll={closeAllTabs}
-                      />
-                    ))}
-                  </div>
-                </SortableContext>
-                <DragOverlay dropAnimation={null}>
-                  {draggingTab ? (
-                    <SqlTabDragOverlay tab={draggingTab} active={draggingTab.id === activeTabId} />
-                  ) : null}
-                </DragOverlay>
-              </DndContext>
-              {/* The "new tab" (+) button sits outside the scrollable
-                  .sql-tabs container so it remains pinned at the right
-                  edge of the tab bar when tabs overflow horizontally.
-                  When the strip isn't full it naturally appears next
-                  to the last tab because both are flex children of
-                  .sql-tabbar. */}
-              <button
-                type="button"
-                className="sql-tab-add"
-                // Prevent the button from stealing focus on mouse-down so
-                // focus stays wherever it was during the click.  The
-                // addTab hook commits the new tab and focuses the editor
-                // synchronously before the click handler returns.
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={addTab}
-                title="New query tab"
-                aria-label="New query tab"
-              >
-                <Plus size={12} aria-hidden="true" />
-              </button>
-            </div>
+            <SqlTabBar
+              tabs={tabs}
+              activeTabId={activeTabId}
+              draggingTab={draggingTab}
+              tabDragSensors={tabDragSensors}
+              onDragStart={onTabDragStart}
+              onDragEnd={onTabDragEnd}
+              onDragCancel={onTabDragCancel}
+              onTabActivate={(tabId) => {
+                const prevId = activeTabIdRef.current;
+                if (prevId !== tabId) {
+                  tabHistoryRef.current = pushTabHistory(
+                    tabHistoryRef.current,
+                    prevId,
+                    tabId,
+                  );
+                }
+                activeTabIdRef.current = tabId;
+                setActiveTabId(tabId);
+                // Re-click the already-active tab: focus the editor so
+                // typing works immediately without a second click.
+                const tab = tabs.find((t) => t.id === tabId);
+                if (
+                  prevId === tabId &&
+                  tab?.kind !== "er-diagram" &&
+                  tab?.kind !== "view-data" &&
+                  tab?.kind !== "query-history"
+                ) {
+                  editorRef.current?.focus();
+                }
+              }}
+              onTabClose={closeTab}
+              onTabRename={renameTab}
+              onTabDuplicate={duplicateTab}
+              onTabCloseOthers={closeOtherTabs}
+              onTabCloseAll={closeAllTabs}
+              onAddTab={addTab}
+            />
 
             <div
               className="sql-editor-pane"

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -133,6 +133,7 @@ import {
 import { SqlSettingsPanel } from "./components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "./components/SqlSettingsConfirmDialogs";
 import { DdlViewerDialog } from "./components/DdlViewerDialog";
+import { SwitchDatabaseDialog } from "./components/SwitchDatabaseDialog";
 import { findSampleDatabase } from "../runtime/sqliteSamples";
 import { sqliteAdapter } from "./sqliteAdapter";
 import {
@@ -2462,41 +2463,15 @@ function SqlPlaygroundInner() {
           ]}
         />
 
-        <AlertDialog.Root
+        <SwitchDatabaseDialog
           open={pendingDbId !== null}
-          onOpenChange={(next) => {
-            if (!next) setPendingDbId(null);
+          onOpenChange={(next) => { if (!next) setPendingDbId(null); }}
+          currentDbFilename={activeSample.filename}
+          onConfirm={() => {
+            if (pendingDbId) performDbSwitch(pendingDbId);
+            setPendingDbId(null);
           }}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Backdrop className="confirm-backdrop" />
-            <AlertDialog.Popup className="confirm-popup">
-              <AlertDialog.Title className="confirm-title">
-                Switch databases?
-              </AlertDialog.Title>
-              <AlertDialog.Description className="confirm-desc">
-                You have unsaved edits in the query tabs for{" "}
-                <strong>{activeSample.filename}</strong>. They will be saved and
-                restored when you switch back, but loading another database will
-                replace what&rsquo;s currently in the editor.
-              </AlertDialog.Description>
-              <div className="confirm-actions">
-                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
-                  Cancel
-                </AlertDialog.Close>
-                <AlertDialog.Close
-                  className="confirm-btn confirm-btn-danger"
-                  onClick={() => {
-                    if (pendingDbId) performDbSwitch(pendingDbId);
-                    setPendingDbId(null);
-                  }}
-                >
-                  Switch database
-                </AlertDialog.Close>
-              </div>
-            </AlertDialog.Popup>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
+        />
 
         <AlertDialog.Root
           open={confirmCloseTabId !== null}

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -166,6 +166,10 @@ import { useDialogStore } from "./stores/useDialogStore";
 import { useQueryRunner } from "./hooks/useQueryRunner";
 import { useTabManagement } from "./hooks/useTabManagement";
 import { pushTabHistory } from "./utils/tabUtils";
+import {
+  ensurePersistUnloadFlush,
+  persistAsync,
+} from "./utils/persistedStorage";
 import { useSidebarActions } from "./hooks/useSidebarActions";
 import { useDatabaseActions } from "./hooks/useDatabaseActions";
 import { useQueryHistory } from "./hooks/useQueryHistory";
@@ -953,6 +957,9 @@ function PragmaSettingsTab({
 
 function SqlPlaygroundInner() {
   const router = useRouter();
+  useEffect(() => {
+    ensurePersistUnloadFlush();
+  }, []);
 
   // ─── Settings store ──────────────────────────────────────────────────
   const fontSize = useSettingsStore((s) => s.fontSize);
@@ -1293,21 +1300,21 @@ function SqlPlaygroundInner() {
   const setFontSize = useCallback(
     (n: number) => {
       setFontSizeState(n);
-      localStorage.setItem(storageKey("fontsize"), String(n));
+      persistAsync(storageKey("fontsize"), String(n));
     },
     [setFontSizeState],
   );
   const setOutputFontSizeEnabled = useCallback(
     (b: boolean) => {
       setOutputFontSizeEnabledState(b);
-      localStorage.setItem(storageKey("outputfontsize_enabled"), String(b));
+      persistAsync(storageKey("outputfontsize_enabled"), String(b));
     },
     [setOutputFontSizeEnabledState],
   );
   const setOutputFontSize = useCallback(
     (n: number) => {
       setOutputFontSizeState(n);
-      localStorage.setItem(storageKey("outputfontsize"), String(n));
+      persistAsync(storageKey("outputfontsize"), String(n));
     },
     [setOutputFontSizeState],
   );
@@ -1321,14 +1328,14 @@ function SqlPlaygroundInner() {
   const setWordWrap = useCallback(
     (b: boolean) => {
       setWordWrapState(b);
-      localStorage.setItem(storageKey("wordwrap"), String(b));
+      persistAsync(storageKey("wordwrap"), String(b));
     },
     [setWordWrapState],
   );
   const setClearBeforeRun = useCallback(
     (b: boolean) => {
       setClearBeforeRunState(b);
-      localStorage.setItem(storageKey("clearbeforerun"), String(b));
+      persistAsync(storageKey("clearbeforerun"), String(b));
     },
     [setClearBeforeRunState],
   );
@@ -1688,9 +1695,11 @@ function SqlPlaygroundInner() {
         });
       }
       if (cancelled) return;
+      const langExt = await makeSqlLangExtension("sqlite", schema);
+      if (cancelled) return;
       view.dispatch({
         effects: [
-          sqlComp.reconfigure(makeSqlLangExtension("sqlite", schema)),
+          sqlComp.reconfigure(langExt),
           completionComp.reconfigure(
             makeSqlAutocompletionExtension(completionSchema, "sqlite"),
           ),

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -136,6 +136,7 @@ import { DdlViewerDialog } from "./components/DdlViewerDialog";
 import { SwitchDatabaseDialog } from "./components/SwitchDatabaseDialog";
 import { ImportBinaryFileDialog } from "./components/ImportBinaryFileDialog";
 import { RenameDatabaseDialog } from "./components/RenameDatabaseDialog";
+import { SqlEditorToolbar } from "./components/SqlEditorToolbar";
 import { findSampleDatabase } from "../runtime/sqliteSamples";
 import { sqliteAdapter } from "./sqliteAdapter";
 import {
@@ -4038,124 +4039,14 @@ function SqlPlaygroundInner() {
                   </Popover.Portal>
                 </Popover.Root>
               </div>
-              <div className="sql-toolbar">
-                <div className="sql-toolbar-shortcuts">
-                  <span
-                    className="kbd-group"
-                    title={
-                      isMac
-                        ? "Cmd + Enter — run selection or all"
-                        : "Ctrl + Enter — run selection or all"
-                    }
-                  >
-                    <kbd className="kbd">{isMac ? "⌘" : "Ctrl"}</kbd>
-                    <span className="kbd-plus" aria-hidden="true">
-                      +
-                    </span>
-                    <kbd className="kbd">Enter</kbd>
-                  </span>
-                </div>
-                <div className="sql-toolbar-actions">
-                {hasEditorSelection ? (
-                  <div
-                    className={`run-btn-split${statusState === "running" ? " running" : ""}`}
-                  >
-                    <button
-                      type="button"
-                      className="run-btn-split-main"
-                      disabled={!loaded || statusState === "running"}
-                      onClick={runCurrentSelection}
-                    >
-                      {statusState === "running" ? (
-                        <svg viewBox="0 0 12 12" className="run-btn-spinner">
-                          <circle
-                            cx="6"
-                            cy="6"
-                            r="4.5"
-                            fill="none"
-                            stroke="white"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeDasharray="14 8"
-                          />
-                        </svg>
-                      ) : (
-                        <Play size={10} aria-hidden="true" />
-                      )}
-                      {statusState === "running" ? "Running…" : "Run Selection"}
-                    </button>
-                    <span
-                      className="run-btn-split-divider"
-                      aria-hidden="true"
-                    />
-                    <Menu.Root>
-                      <Menu.Trigger
-                        className="run-btn-split-chevron"
-                        disabled={!loaded || statusState === "running"}
-                        aria-label="Run options"
-                      >
-                        <ChevronDown size={11} aria-hidden="true" />
-                      </Menu.Trigger>
-                      <Menu.Portal>
-                        <Menu.Positioner sideOffset={6} align="end">
-                          <Menu.Popup className="bui-popup run-split-dropdown">
-                            <Menu.Item
-                              className="run-split-item"
-                              onClick={runCurrentSelection}
-                              disabled={!loaded || statusState === "running"}
-                            >
-                              <span className="run-split-item-label">
-                                Run Selection
-                              </span>
-                              <span className="run-split-item-kbd">
-                                {isMac ? "⌘Enter" : "Ctrl+Enter"}
-                              </span>
-                            </Menu.Item>
-                            <Menu.Item
-                              className="run-split-item"
-                              onClick={runActiveTab}
-                              disabled={!loaded || statusState === "running"}
-                            >
-                              <span className="run-split-item-label">
-                                Run All
-                              </span>
-                              <span className="run-split-item-kbd">
-                                {isMac ? "⌘⇧Enter" : "Ctrl+Shift+Enter"}
-                              </span>
-                            </Menu.Item>
-                          </Menu.Popup>
-                        </Menu.Positioner>
-                      </Menu.Portal>
-                    </Menu.Root>
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    className={`run-btn${statusState === "running" ? " running" : ""}`}
-                    disabled={!loaded || statusState === "running"}
-                    onClick={runActiveTab}
-                  >
-                    {statusState === "running" ? (
-                      <svg viewBox="0 0 12 12" className="run-btn-spinner">
-                        <circle
-                          cx="6"
-                          cy="6"
-                          r="4.5"
-                          fill="none"
-                          stroke="white"
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeDasharray="14 8"
-                        />
-                      </svg>
-                    ) : (
-                      <Play size={10} aria-hidden="true" />
-                    )}
-                    {statusState === "running" ? "Running…" : "Run"}
-                  </button>
-                )}
-                </div>
-              </div>
+              <SqlEditorToolbar
+                loaded={loaded}
+                running={statusState === "running"}
+                hasEditorSelection={hasEditorSelection}
+                isMac={isMac}
+                onRunSelection={runCurrentSelection}
+                onRunAll={runActiveTab}
+              />
             </div>
 
             <div

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -131,18 +131,17 @@ import {
   SettingsPanel,
   detectIsMac,
 } from "../playgroundShared";
+import { findSampleDatabase } from "../runtime/sqliteSamples";
+import { sqliteAdapter } from "./sqliteAdapter";
 import {
-  SQLITE_SAMPLE_DATABASES,
-  findSampleDatabase,
-} from "../runtime/sqliteSamples";
-import {
-  createSqliteEngine,
   type ColumnConstraintInfo,
   type ColumnSpec,
   type ForeignKeyInfo,
   type SqliteEngine,
   type TableColumnInfo,
 } from "../runtime/sqlite";
+
+const SQLITE_SAMPLE_DATABASES = sqliteAdapter.samples;
 import type { QueryExecResult } from "sql.js";
 import dynamic from "next/dynamic";
 
@@ -200,7 +199,7 @@ function replaceDoc(view: EditorView, value: string): void {
 }
 
 
-const PLAYGROUND_ID = "sqlite";
+const PLAYGROUND_ID = sqliteAdapter.playgroundId;
 
 const DROP_KIND_LABELS: Record<"table" | "view" | "index" | "trigger", string> =
   { table: "Table", view: "View", index: "Index", trigger: "Trigger" };
@@ -1580,7 +1579,7 @@ function SqlPlaygroundInner() {
         const initialSampleId =
           localStorage.getItem(storageKey("db")) ??
           SQLITE_SAMPLE_DATABASES[0].id;
-        const engine = await createSqliteEngine(initialSampleId);
+        const engine = await sqliteAdapter.createEngine(initialSampleId);
         if (cancelled) return;
         engineRef.current = engine;
         setEngineForRender(engine);

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -128,9 +128,9 @@ import {
   DataslopeRunOverlay,
   LOADING_QUIPS,
   RuntimeInfoContent,
-  SettingsPanel,
   detectIsMac,
 } from "../playgroundShared";
+import { SqlSettingsPanel } from "./components/SqlSettingsPanel";
 import { findSampleDatabase } from "../runtime/sqliteSamples";
 import { sqliteAdapter } from "./sqliteAdapter";
 import {
@@ -2421,7 +2421,7 @@ function SqlPlaygroundInner() {
           </div>
         </header>
 
-        <SettingsPanel
+        <SqlSettingsPanel
           open={settingsOpen}
           fontSize={fontSize}
           setFontSize={setFontSize}
@@ -2436,23 +2436,11 @@ function SqlPlaygroundInner() {
           clearBeforeRun={clearBeforeRun}
           setClearBeforeRun={setClearBeforeRun}
           language={PLAYGROUND_ID}
-          showOutputFontSizeControls={false}
-          clearBeforeRunLabel="Clear Results Before Running"
-          showClearBeforeRunRow={false}
           onClose={() => setSettingsOpen(false)}
           onRestoreDefaults={() => setConfirmRestoreOpen(true)}
           onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
-          extraGeneralRows={null}
-          extraActionRows={
-            <button
-              type="button"
-              className="settings-action-btn"
-              onClick={resetTabsForCurrentDb}
-            >
-              <RotateCcw size={14} aria-hidden="true" />
-              <span>Reset query tabs for {activeSample.label}</span>
-            </button>
-          }
+          resetTabsLabel={`Reset query tabs for ${activeSample.label}`}
+          onResetTabs={resetTabsForCurrentDb}
           extraTabs={[
             {
               value: "pragmas",

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -132,6 +132,7 @@ import {
 } from "../playgroundShared";
 import { SqlSettingsPanel } from "./components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "./components/SqlSettingsConfirmDialogs";
+import { DdlViewerDialog } from "./components/DdlViewerDialog";
 import { findSampleDatabase } from "../runtime/sqliteSamples";
 import { sqliteAdapter } from "./sqliteAdapter";
 import {
@@ -173,7 +174,6 @@ import {
 import { useSidebarActions } from "./hooks/useSidebarActions";
 import { useDatabaseActions } from "./hooks/useDatabaseActions";
 import { useQueryHistory } from "./hooks/useQueryHistory";
-import { DdlViewer } from "./components/DdlViewer";
 import { ModifyStructureForm } from "./components/ModifyStructureForm";
 import { ResultView } from "./components/ResultView";
 import { SchemaItem } from "./components/SchemaItem";
@@ -3498,52 +3498,21 @@ function SqlPlaygroundInner() {
           </Dialog.Portal>
         </Dialog.Root>
 
-        <Dialog.Root
+        <DdlViewerDialog
           open={ddlDialog !== null}
-          onOpenChange={(next) => {
-            if (!next) setDdlDialog(null);
-          }}
-        >
-          <Dialog.Portal>
-            <Dialog.Backdrop className="confirm-backdrop" />
-            <Dialog.Popup className="confirm-popup sql-ddl-popup">
-              <Dialog.Title className="confirm-title">
-                DDL: {ddlDialog?.title ?? ""}
-              </Dialog.Title>
-              <Dialog.Description className="confirm-desc">
-                Read-only view of the original <code>CREATE</code> statement(s)
-                recorded in
-                <code> sqlite_master</code>.
-              </Dialog.Description>
-              <DdlViewer sql={ddlDialog?.sql ?? ""} theme={editorTheme} />
-              <div className="confirm-actions">
-                <button
-                  type="button"
-                  className="confirm-btn confirm-btn-secondary"
-                  onClick={() => {
-                    if (
-                      ddlDialog &&
-                      typeof navigator !== "undefined" &&
-                      navigator.clipboard
-                    ) {
-                      navigator.clipboard
-                        .writeText(ddlDialog.sql)
-                        .then(() => showToast("Copied DDL to clipboard."))
-                        .catch(() =>
-                          showToast("Couldn't copy to clipboard.", "warn"),
-                        );
-                    }
-                  }}
-                >
-                  Copy
-                </button>
-                <Dialog.Close className="confirm-btn confirm-btn-primary">
-                  Close
-                </Dialog.Close>
-              </div>
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
+          onOpenChange={(next) => { if (!next) setDdlDialog(null); }}
+          title={ddlDialog?.title ?? ""}
+          sql={ddlDialog?.sql ?? ""}
+          theme={editorTheme}
+          description={
+            <>
+              Read-only view of the original <code>CREATE</code> statement(s)
+              recorded in <code>sqlite_master</code>.
+            </>
+          }
+          onCopied={() => showToast("Copied DDL to clipboard.")}
+          onCopyFailed={() => showToast("Couldn't copy to clipboard.", "warn")}
+        />
 
         <Dialog.Root
           open={modifyDialog !== null}

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -179,6 +179,10 @@ import { SchemaItem } from "./components/SchemaItem";
 import { SchemaLeafItem } from "./components/SchemaLeafItem";
 import { SchemaSection } from "./components/SchemaSection";
 import {
+  DatabaseSelector,
+  type DatabaseSelectorAction,
+} from "./components/DatabaseSelector";
+import {
   dbScopedKey,
   loadActiveTabId,
   loadTabs,
@@ -200,6 +204,27 @@ function replaceDoc(view: EditorView, value: string): void {
 
 
 const PLAYGROUND_ID = sqliteAdapter.playgroundId;
+
+const SQLITE_DB_ACTIONS: readonly DatabaseSelectorAction[] = [
+  {
+    id: "__new_db__",
+    icon: <FilePlus size={14} />,
+    label: "New Database",
+    description: "Create a blank database",
+  },
+  {
+    id: "__import_sqlite__",
+    icon: <Upload size={14} />,
+    label: "Import SQLite File",
+    description: "Open a .sqlite or .db file",
+  },
+  {
+    id: "__rename_db__",
+    icon: <Pencil size={14} />,
+    label: "Rename Current Database",
+    description: "Change filename and extension",
+  },
+];
 
 const DROP_KIND_LABELS: Record<"table" | "view" | "index" | "trigger", string> =
   { table: "Table", view: "View", index: "Index", trigger: "Trigger" };
@@ -3859,9 +3884,12 @@ function SqlPlaygroundInner() {
           <aside className="sql-sidebar" aria-label="Database explorer">
             <div className="sql-db-selector-wrap">
               <div className="sql-db-selector-row">
-                <Select.Root
+                <DatabaseSelector
                   value={activeDbId}
-                  onValueChange={(value) => {
+                  displayFilename={activeSample.filename}
+                  samples={SQLITE_SAMPLE_DATABASES}
+                  actions={SQLITE_DB_ACTIONS}
+                  onChange={(value) => {
                     if (value === "__new_db__") {
                       performBlankLoad();
                       return;
@@ -3893,126 +3921,9 @@ function SqlPlaygroundInner() {
                       setRenameDbOpen(true);
                       return;
                     }
-                    requestDbSwitch(String(value));
+                    requestDbSwitch(value);
                   }}
-                >
-                  <Select.Trigger
-                    className="sql-db-selector"
-                    aria-label="Select sample database"
-                  >
-                    <Database
-                      size={14}
-                      className="sql-db-selector-icon"
-                      aria-hidden="true"
-                    />
-                    <Select.Value className="sql-db-selector-value">
-                      {activeSample.filename}
-                    </Select.Value>
-                    <Select.Icon className="playground-switcher-icon">
-                      <svg viewBox="0 0 12 12" width={10} height={10}>
-                        <polyline
-                          points="2,4 6,8 10,4"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        />
-                      </svg>
-                    </Select.Icon>
-                  </Select.Trigger>
-                  <Select.Portal>
-                    <Select.Positioner
-                      className="sql-db-positioner"
-                      sideOffset={6}
-                      alignItemWithTrigger={false}
-                    >
-                      <Select.Popup className="bui-select-popup sql-db-popup">
-                        <Select.Item
-                          value="__new_db__"
-                          className="bui-select-item sql-db-item"
-                        >
-                          <span
-                            className="bui-select-item-icon"
-                            aria-hidden="true"
-                          >
-                            <FilePlus size={14} />
-                          </span>
-                          <span className="sql-db-item-text">
-                            <Select.ItemText>New Database</Select.ItemText>
-                            <span className="sql-db-item-desc">
-                              Create a blank database
-                            </span>
-                          </span>
-                        </Select.Item>
-                        <Select.Item
-                          value="__import_sqlite__"
-                          className="bui-select-item sql-db-item"
-                        >
-                          <span
-                            className="bui-select-item-icon"
-                            aria-hidden="true"
-                          >
-                            <Upload size={14} />
-                          </span>
-                          <span className="sql-db-item-text">
-                            <Select.ItemText>
-                              Import SQLite File
-                            </Select.ItemText>
-                            <span className="sql-db-item-desc">
-                              Open a .sqlite or .db file
-                            </span>
-                          </span>
-                        </Select.Item>
-                        <Select.Item
-                          value="__rename_db__"
-                          className="bui-select-item sql-db-item"
-                        >
-                          <span
-                            className="bui-select-item-icon"
-                            aria-hidden="true"
-                          >
-                            <Pencil size={14} />
-                          </span>
-                          <span className="sql-db-item-text">
-                            <Select.ItemText>
-                              Rename Current Database
-                            </Select.ItemText>
-                            <span className="sql-db-item-desc">
-                              Change filename and extension
-                            </span>
-                          </span>
-                        </Select.Item>
-                        <div
-                          role="separator"
-                          aria-orientation="horizontal"
-                          className="sql-db-popup-sep"
-                        />
-                        <div className="sql-db-popup-group-label">
-                          Sample databases
-                        </div>
-                        {SQLITE_SAMPLE_DATABASES.map((s) => (
-                          <Select.Item
-                            key={s.id}
-                            value={s.id}
-                            className="bui-select-item sql-db-item"
-                          >
-                            <span
-                              className="bui-select-item-icon"
-                              aria-hidden="true"
-                            >
-                              <Database size={14} />
-                            </span>
-                            <span className="sql-db-item-text">
-                              <Select.ItemText>{s.filename}</Select.ItemText>
-                              <span className="sql-db-item-desc">
-                                {s.description}
-                              </span>
-                            </span>
-                          </Select.Item>
-                        ))}
-                      </Select.Popup>
-                    </Select.Positioner>
-                  </Select.Portal>
-                </Select.Root>
+                />
               </div>
             </div>
 

--- a/app/_components/sql/components/DatabaseSelector.tsx
+++ b/app/_components/sql/components/DatabaseSelector.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+// Sample-database selector rendered in the left sidebar of every SQL
+// playground. The trigger displays the active database filename; the
+// popup lists dialect-specific action items (new / import / rename)
+// followed by the registered sample databases.
+//
+// Extracted as part of Stage 3 of the playground refactor. Each
+// playground supplies its own action list (the import sentinel differs
+// per dialect, the rename copy varies, etc.) and the component renders
+// the Base UI Select markup all three were duplicating identically.
+
+import { Select } from "@base-ui-components/react/select";
+import { Database } from "lucide-react";
+import type { ReactNode } from "react";
+
+export interface DatabaseSelectorAction {
+  /** Sentinel id reported back to `onChange` when this item is picked. */
+  id: string;
+  /** Leading icon node (e.g. `<FilePlus size={14}/>`). */
+  icon: ReactNode;
+  /** Primary label (e.g. "New Database"). */
+  label: string;
+  /** Sub-label rendered under the primary label. */
+  description: string;
+}
+
+export interface DatabaseSelectorSample {
+  id: string;
+  filename: string;
+  description: string;
+}
+
+export interface DatabaseSelectorProps {
+  /** Currently selected id — either a sample id or one of the
+   *  blank-database / sentinel ids the host wires up. */
+  value: string;
+  /** Text rendered inside the trigger. Usually the active sample's
+   *  filename, or a user-renamed filename for the blank database. */
+  displayFilename: string;
+  /** Sample databases shown beneath the action items. */
+  samples: readonly DatabaseSelectorSample[];
+  /** Action items shown at the top of the popup. Each fires
+   *  `onChange(action.id)` when selected; the host decides how to
+   *  handle each sentinel. */
+  actions: readonly DatabaseSelectorAction[];
+  /** Called with either an `action.id` sentinel or a `sample.id`. */
+  onChange: (value: string) => void;
+  /** Extra class names appended to the default `sql-db-selector` on
+   *  the trigger. Used by the Postgres playground for a vestigial
+   *  `sql-database-selector` class. */
+  triggerClassName?: string;
+  /** Override for the chevron icon. Defaults to a 10x10 inline SVG
+   *  matching the SQLite playground's historical rendering. */
+  chevron?: ReactNode;
+}
+
+const DEFAULT_CHEVRON = (
+  <svg viewBox="0 0 12 12" width={10} height={10}>
+    <polyline
+      points="2,4 6,8 10,4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
+export function DatabaseSelector({
+  value,
+  displayFilename,
+  samples,
+  actions,
+  onChange,
+  triggerClassName,
+  chevron = DEFAULT_CHEVRON,
+}: DatabaseSelectorProps) {
+  return (
+    <Select.Root
+      value={value}
+      onValueChange={(v) => onChange(String(v))}
+    >
+      <Select.Trigger
+        className={
+          triggerClassName
+            ? `sql-db-selector ${triggerClassName}`
+            : "sql-db-selector"
+        }
+        aria-label="Select sample database"
+      >
+        <Database
+          size={14}
+          className="sql-db-selector-icon"
+          aria-hidden="true"
+        />
+        <Select.Value className="sql-db-selector-value">
+          {displayFilename}
+        </Select.Value>
+        <Select.Icon className="playground-switcher-icon">{chevron}</Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Positioner
+          className="sql-db-positioner"
+          sideOffset={6}
+          alignItemWithTrigger={false}
+        >
+          <Select.Popup className="bui-select-popup sql-db-popup">
+            {actions.map((action) => (
+              <Select.Item
+                key={action.id}
+                value={action.id}
+                className="bui-select-item sql-db-item"
+              >
+                <span className="bui-select-item-icon" aria-hidden="true">
+                  {action.icon}
+                </span>
+                <span className="sql-db-item-text">
+                  <Select.ItemText>{action.label}</Select.ItemText>
+                  <span className="sql-db-item-desc">{action.description}</span>
+                </span>
+              </Select.Item>
+            ))}
+            {actions.length > 0 && samples.length > 0 && (
+              <>
+                <div
+                  role="separator"
+                  aria-orientation="horizontal"
+                  className="sql-db-popup-sep"
+                />
+                <div className="sql-db-popup-group-label">Sample databases</div>
+              </>
+            )}
+            {samples.map((sample) => (
+              <Select.Item
+                key={sample.id}
+                value={sample.id}
+                className="bui-select-item sql-db-item"
+              >
+                <span className="bui-select-item-icon" aria-hidden="true">
+                  <Database size={14} />
+                </span>
+                <span className="sql-db-item-text">
+                  <Select.ItemText>{sample.filename}</Select.ItemText>
+                  <span className="sql-db-item-desc">{sample.description}</span>
+                </span>
+              </Select.Item>
+            ))}
+          </Select.Popup>
+        </Select.Positioner>
+      </Select.Portal>
+    </Select.Root>
+  );
+}

--- a/app/_components/sql/components/DdlViewerDialog.tsx
+++ b/app/_components/sql/components/DdlViewerDialog.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Dialog } from "@base-ui-components/react/dialog";
+import type { ReactNode } from "react";
+import { DdlViewer } from "./DdlViewer";
+
+export interface DdlViewerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  sql: string;
+  theme: string;
+  isPostgres?: boolean;
+  /** Overrides the default description rendered under the title. */
+  description?: ReactNode;
+  onCopied: () => void;
+  onCopyFailed: () => void;
+}
+
+export function DdlViewerDialog({
+  open,
+  onOpenChange,
+  title,
+  sql,
+  theme,
+  isPostgres,
+  description = (
+    <>
+      Read-only view of the reconstructed <code>CREATE</code> statement(s).
+    </>
+  ),
+  onCopied,
+  onCopyFailed,
+}: DdlViewerDialogProps) {
+  function handleCopy() {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      navigator.clipboard.writeText(sql).then(onCopied).catch(onCopyFailed);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="confirm-backdrop" />
+        <Dialog.Popup className="confirm-popup sql-ddl-popup">
+          <Dialog.Title className="confirm-title">DDL: {title}</Dialog.Title>
+          <Dialog.Description className="confirm-desc">
+            {description}
+          </Dialog.Description>
+          <DdlViewer sql={sql} theme={theme} isPostgres={isPostgres} />
+          <div className="confirm-actions">
+            <button
+              type="button"
+              className="confirm-btn confirm-btn-secondary"
+              onClick={handleCopy}
+            >
+              Copy
+            </button>
+            <Dialog.Close className="confirm-btn confirm-btn-primary">
+              Close
+            </Dialog.Close>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/app/_components/sql/components/ImportBinaryFileDialog.tsx
+++ b/app/_components/sql/components/ImportBinaryFileDialog.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Dialog } from "@base-ui-components/react/dialog";
+import { TriangleAlert, Upload } from "lucide-react";
+import type { ReactNode } from "react";
+
+export interface ImportBinaryFileDialogProps {
+  open: boolean;
+  dragging: boolean;
+  onClose: () => void;
+  onDraggingChange: (dragging: boolean) => void;
+  /** Called with file bytes and the original filename. */
+  onImport: (data: Uint8Array, filename: string) => void;
+  title: string;
+  /** JSX rendered in the description slot (e.g. file extensions). */
+  description: ReactNode;
+  /** Warning body text (sentence explaining persistence behaviour). */
+  warningText: ReactNode;
+  /** Primary label inside the drop zone ("Drop a SQLite file here"). */
+  dropText: string;
+  /** Secondary hint inside the drop zone ("or click to browse — .sqlite, .db"). */
+  browseHint: string;
+  /** `accept` attribute on the hidden file input. */
+  accept: string;
+  /** `aria-label` for the hidden file input. */
+  inputAriaLabel: string;
+}
+
+function readFileAsUint8Array(
+  file: File,
+  onLoad: (data: Uint8Array) => void,
+): void {
+  const reader = new FileReader();
+  reader.onload = (ev) => {
+    const buf = ev.target?.result;
+    if (buf instanceof ArrayBuffer) onLoad(new Uint8Array(buf));
+  };
+  reader.readAsArrayBuffer(file);
+}
+
+export function ImportBinaryFileDialog({
+  open,
+  dragging,
+  onClose,
+  onDraggingChange,
+  onImport,
+  title,
+  description,
+  warningText,
+  dropText,
+  browseHint,
+  accept,
+  inputAriaLabel,
+}: ImportBinaryFileDialogProps) {
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          onClose();
+          onDraggingChange(false);
+        }
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className="confirm-backdrop" />
+        <Dialog.Popup className="confirm-popup sql-import-popup">
+          <Dialog.Title className="confirm-title">{title}</Dialog.Title>
+          <Dialog.Description className="confirm-desc">
+            {description}
+          </Dialog.Description>
+          <div className="sql-import-warning">
+            <TriangleAlert
+              size={14}
+              className="sql-import-warning-icon"
+              aria-hidden="true"
+            />
+            <span>{warningText}</span>
+          </div>
+          <div
+            className={`sql-dropzone${dragging ? " dragging" : ""}`}
+            onDragOver={(e) => {
+              e.preventDefault();
+              onDraggingChange(true);
+            }}
+            onDragLeave={() => onDraggingChange(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              onDraggingChange(false);
+              const file = e.dataTransfer.files[0];
+              if (!file) return;
+              readFileAsUint8Array(file, (data) => onImport(data, file.name));
+            }}
+          >
+            <Upload size={28} className="sql-dropzone-icon" aria-hidden="true" />
+            <span>{dropText}</span>
+            <span className="sql-dropzone-hint">{browseHint}</span>
+            <input
+              type="file"
+              accept={accept}
+              aria-label={inputAriaLabel}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (!file) return;
+                readFileAsUint8Array(file, (data) => onImport(data, file.name));
+                e.target.value = "";
+              }}
+            />
+          </div>
+          <div className="confirm-actions" style={{ marginTop: 16 }}>
+            <Dialog.Close className="confirm-btn confirm-btn-secondary">
+              Cancel
+            </Dialog.Close>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/app/_components/sql/components/ImportSqlDumpDialog.tsx
+++ b/app/_components/sql/components/ImportSqlDumpDialog.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Dialog } from "@base-ui-components/react/dialog";
+import { TriangleAlert, Upload } from "lucide-react";
+
+export interface ImportSqlDumpDialogProps {
+  open: boolean;
+  dragging: boolean;
+  onClose: () => void;
+  onDraggingChange: (dragging: boolean) => void;
+  /** Called with the file's text content and its original filename. */
+  onImport: (sql: string, filename: string) => void;
+}
+
+function readFileAsText(
+  file: File,
+  onLoad: (text: string) => void,
+): void {
+  const reader = new FileReader();
+  reader.onload = (ev) => {
+    const text = ev.target?.result as string | null;
+    if (text != null) onLoad(text);
+  };
+  reader.readAsText(file);
+}
+
+export function ImportSqlDumpDialog({
+  open,
+  dragging,
+  onClose,
+  onDraggingChange,
+  onImport,
+}: ImportSqlDumpDialogProps) {
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          onClose();
+          onDraggingChange(false);
+        }
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className="confirm-backdrop" />
+        <Dialog.Popup className="confirm-popup sql-import-popup">
+          <Dialog.Title className="confirm-title">Import SQL Dump</Dialog.Title>
+          <Dialog.Description className="confirm-desc">
+            Open a local <code>.sql</code> dump file as a new in-memory
+            database.
+          </Dialog.Description>
+          <div className="sql-import-warning">
+            <TriangleAlert
+              size={14}
+              className="sql-import-warning-icon"
+              aria-hidden="true"
+            />
+            <span>
+              This will replace the current database with the contents of the
+              file. Your file will <strong>not</strong> be uploaded or persisted
+              — it is only loaded into browser memory and will be gone on
+              reload.
+            </span>
+          </div>
+          <div
+            className={`sql-dropzone${dragging ? " dragging" : ""}`}
+            onDragOver={(e) => {
+              e.preventDefault();
+              onDraggingChange(true);
+            }}
+            onDragLeave={() => onDraggingChange(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              onDraggingChange(false);
+              const file = e.dataTransfer.files[0];
+              if (!file) return;
+              readFileAsText(file, (text) => onImport(text, file.name));
+            }}
+          >
+            <Upload size={28} className="sql-dropzone-icon" aria-hidden="true" />
+            <span>Drop a SQL file here</span>
+            <span className="sql-dropzone-hint">or click to browse — .sql</span>
+            <input
+              type="file"
+              accept=".sql"
+              aria-label="Choose SQL dump file"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (!file) return;
+                readFileAsText(file, (text) => onImport(text, file.name));
+                e.target.value = "";
+              }}
+            />
+          </div>
+          <div className="confirm-actions" style={{ marginTop: 16 }}>
+            <Dialog.Close className="confirm-btn confirm-btn-secondary">
+              Cancel
+            </Dialog.Close>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/app/_components/sql/components/RenameDatabaseDialog.tsx
+++ b/app/_components/sql/components/RenameDatabaseDialog.tsx
@@ -2,17 +2,25 @@
 
 import { Dialog } from "@base-ui-components/react/dialog";
 
+export interface ExtensionOption {
+  value: string;
+  /** Displayed in the dropdown. Defaults to `value` if omitted. */
+  label?: string;
+}
+
 export interface RenameDatabaseDialogProps {
   open: boolean;
   name: string;
   ext: string;
-  /** Extension `<option>` values, e.g. `[".pg", ".sql", ".dump"]`. */
-  extensionOptions: string[];
+  /** Extension options for the dropdown. Pass strings or `{ value, label }` pairs. */
+  extensionOptions: Array<string | ExtensionOption>;
   onNameChange: (name: string) => void;
   onExtChange: (ext: string) => void;
   onClose: () => void;
   /** Called with the assembled filename: `${name.trim()}${ext}`. */
   onConfirm: (newFilename: string) => void;
+  /** Overrides the default description text. */
+  description?: string;
 }
 
 export function RenameDatabaseDialog({
@@ -24,6 +32,7 @@ export function RenameDatabaseDialog({
   onExtChange,
   onClose,
   onConfirm,
+  description = "Choose a new display name for the current database.",
 }: RenameDatabaseDialogProps) {
   return (
     <Dialog.Root
@@ -37,7 +46,7 @@ export function RenameDatabaseDialog({
         <Dialog.Popup className="confirm-popup sql-rename-db-popup">
           <Dialog.Title className="confirm-title">Rename Database</Dialog.Title>
           <Dialog.Description className="confirm-desc">
-            Choose a new display name for the current database.
+            {description}
           </Dialog.Description>
           <div className="sql-rename-db-form">
             <div className="sql-rename-db-name-row">
@@ -55,11 +64,15 @@ export function RenameDatabaseDialog({
                 onChange={(e) => onExtChange(e.target.value)}
                 aria-label="File extension"
               >
-                {extensionOptions.map((o) => (
-                  <option key={o} value={o}>
-                    {o}
-                  </option>
-                ))}
+                {extensionOptions.map((o) => {
+                  const val = typeof o === "string" ? o : o.value;
+                  const label = typeof o === "string" ? o : (o.label ?? o.value);
+                  return (
+                    <option key={val} value={val}>
+                      {label}
+                    </option>
+                  );
+                })}
               </select>
             </div>
           </div>

--- a/app/_components/sql/components/RenameDatabaseDialog.tsx
+++ b/app/_components/sql/components/RenameDatabaseDialog.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Dialog } from "@base-ui-components/react/dialog";
+
+export interface RenameDatabaseDialogProps {
+  open: boolean;
+  name: string;
+  ext: string;
+  /** Extension `<option>` values, e.g. `[".pg", ".sql", ".dump"]`. */
+  extensionOptions: string[];
+  onNameChange: (name: string) => void;
+  onExtChange: (ext: string) => void;
+  onClose: () => void;
+  /** Called with the assembled filename: `${name.trim()}${ext}`. */
+  onConfirm: (newFilename: string) => void;
+}
+
+export function RenameDatabaseDialog({
+  open,
+  name,
+  ext,
+  extensionOptions,
+  onNameChange,
+  onExtChange,
+  onClose,
+  onConfirm,
+}: RenameDatabaseDialogProps) {
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className="confirm-backdrop" />
+        <Dialog.Popup className="confirm-popup sql-rename-db-popup">
+          <Dialog.Title className="confirm-title">Rename Database</Dialog.Title>
+          <Dialog.Description className="confirm-desc">
+            Choose a new display name for the current database.
+          </Dialog.Description>
+          <div className="sql-rename-db-form">
+            <div className="sql-rename-db-name-row">
+              <input
+                className="sql-rename-input sql-rename-db-name-input"
+                value={name}
+                onChange={(e) => onNameChange(e.target.value)}
+                placeholder="database name"
+                aria-label="Database name"
+                autoFocus
+              />
+              <select
+                className="sql-rename-db-ext-select"
+                value={ext}
+                onChange={(e) => onExtChange(e.target.value)}
+                aria-label="File extension"
+              >
+                {extensionOptions.map((o) => (
+                  <option key={o} value={o}>
+                    {o}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="confirm-actions">
+            <Dialog.Close className="confirm-btn confirm-btn-secondary">
+              Cancel
+            </Dialog.Close>
+            <button
+              type="button"
+              className="confirm-btn confirm-btn-primary"
+              disabled={!name.trim()}
+              onClick={() => onConfirm(`${name.trim()}${ext}`)}
+            >
+              Rename
+            </button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/app/_components/sql/components/ResultView.tsx
+++ b/app/_components/sql/components/ResultView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { memo, useState, useCallback, useEffect, useRef, useMemo } from "react";
 import React from "react";
 import {
   flexRender,
@@ -186,6 +186,12 @@ const PAGE_SIZE_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
 
 const VIRTUAL_ROW_HEIGHT_ESTIMATE = 30;
 const LOAD_MORE_THRESHOLD_ROWS = 25;
+// Stage 1 (DuckDB perf): when a paged result still contains more than
+// this many DOM rows (e.g. the user disabled pagination, or chose a
+// very large page size), switch the rendering path to the same
+// virtualizer infinite scroll uses so we don't push thousands of
+// <tr> elements into the DOM.
+const VIRTUALIZE_ROW_THRESHOLD = 200;
 
 // ─── Result set export button + tooltip ──────────────────────────────────
 // Encapsulated so it can track menu-open state with a hook and suppress
@@ -378,7 +384,9 @@ export function queryResultsIdentical(
   return true;
 }
 
-export function ResultView({
+export const ResultView = memo(ResultViewImpl);
+
+function ResultViewImpl({
   result,
   loading,
   keyHints,
@@ -1122,7 +1130,15 @@ export function ResultView({
                           onDuplicateRow(sourceTable, columnNames, values)
                       : undefined
                   }
-                  virtualized={isInfiniteAll}
+                  // Always virtualize when rendering more than
+                  // VIRTUALIZE_ROW_THRESHOLD rows (covers the
+                  // "no page limit" + large result-set case the
+                  // Stage 1 audit flagged). Infinite-scroll mode
+                  // always needs virtualization.
+                  virtualized={
+                    isInfiniteAll ||
+                    visibleRows.length > VIRTUALIZE_ROW_THRESHOLD
+                  }
                   scrollParentRef={resultSetsScrollRef}
                   hasMoreRows={hasMoreRows}
                   onLoadMoreRows={

--- a/app/_components/sql/components/SchemaActionDialogs.tsx
+++ b/app/_components/sql/components/SchemaActionDialogs.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { AlertDialog } from "@base-ui-components/react/alert-dialog";
+
+export interface SchemaActionDialogsProps {
+  dropEntityPending: { kind: string; name: string } | null;
+  onDropEntityOpenChange: (open: boolean) => void;
+  onDropEntityConfirm: () => void;
+  truncatePending: string | null;
+  onTruncateOpenChange: (open: boolean) => void;
+  onTruncateConfirm: () => void;
+}
+
+export function SchemaActionDialogs({
+  dropEntityPending,
+  onDropEntityOpenChange,
+  onDropEntityConfirm,
+  truncatePending,
+  onTruncateOpenChange,
+  onTruncateConfirm,
+}: SchemaActionDialogsProps) {
+  return (
+    <>
+      <AlertDialog.Root
+        open={dropEntityPending !== null}
+        onOpenChange={onDropEntityOpenChange}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Backdrop className="confirm-backdrop" />
+          <AlertDialog.Popup className="confirm-popup">
+            <AlertDialog.Title className="confirm-title">
+              Drop {dropEntityPending?.kind ?? "entity"}?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="confirm-desc">
+              This will permanently drop{" "}
+              <strong>{dropEntityPending?.name ?? ""}</strong> from the
+              in-memory database. Reload the page to restore the sample.
+            </AlertDialog.Description>
+            <div className="confirm-actions">
+              <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
+                Cancel
+              </AlertDialog.Close>
+              <AlertDialog.Close
+                className="confirm-btn confirm-btn-danger"
+                onClick={onDropEntityConfirm}
+              >
+                Drop
+              </AlertDialog.Close>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+
+      <AlertDialog.Root
+        open={truncatePending !== null}
+        onOpenChange={onTruncateOpenChange}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Backdrop className="confirm-backdrop" />
+          <AlertDialog.Popup className="confirm-popup">
+            <AlertDialog.Title className="confirm-title">
+              Truncate table?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="confirm-desc">
+              Truncate table <strong>{truncatePending}</strong>? This deletes
+              every row but keeps the schema. The change is in-memory only and
+              will be undone next page load.
+            </AlertDialog.Description>
+            <div className="confirm-actions">
+              <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
+                Cancel
+              </AlertDialog.Close>
+              <AlertDialog.Close
+                className="confirm-btn confirm-btn-danger"
+                onClick={onTruncateConfirm}
+              >
+                Truncate
+              </AlertDialog.Close>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+    </>
+  );
+}

--- a/app/_components/sql/components/SchemaItem.tsx
+++ b/app/_components/sql/components/SchemaItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import { memo, useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { Popover } from "@base-ui-components/react/popover";
 import { ContextMenu } from "@base-ui-components/react/context-menu";
 import { Menu } from "@base-ui-components/react/menu";
@@ -117,7 +117,9 @@ export interface SchemaItemProps {
   onGetRowCount: (name: string) => number | Promise<number>;
 }
 
-export function SchemaItem({
+export const SchemaItem = memo(SchemaItemImpl);
+
+function SchemaItemImpl({
   name,
   kind,
   expanded,

--- a/app/_components/sql/components/SchemaLeafItem.tsx
+++ b/app/_components/sql/components/SchemaLeafItem.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { Popover } from "@base-ui-components/react/popover";
 import { ContextMenu } from "@base-ui-components/react/context-menu";
 import { Hash, Zap } from "lucide-react";
@@ -18,7 +19,9 @@ export interface SchemaLeafItemProps {
   onDrop: (name: string, kind: "index" | "trigger") => void;
 }
 
-export function SchemaLeafItem({
+export const SchemaLeafItem = memo(SchemaLeafItemImpl);
+
+function SchemaLeafItemImpl({
   name,
   kind,
   onCopy,

--- a/app/_components/sql/components/SchemaSection.tsx
+++ b/app/_components/sql/components/SchemaSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { ContextMenu } from "@base-ui-components/react/context-menu";
 import { Popover } from "@base-ui-components/react/popover";
 import {
@@ -28,7 +28,9 @@ export interface SchemaSectionProps {
   onCollapseAll?: () => void;
 }
 
-export function SchemaSection({
+export const SchemaSection = memo(SchemaSectionImpl);
+
+function SchemaSectionImpl({
   label,
   count,
   expanded,

--- a/app/_components/sql/components/SqlEditorToolbar.tsx
+++ b/app/_components/sql/components/SqlEditorToolbar.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Menu } from "@base-ui-components/react/menu";
+import { ChevronDown, Play } from "lucide-react";
+
+export interface SqlEditorToolbarProps {
+  loaded: boolean;
+  running: boolean;
+  hasEditorSelection: boolean;
+  isMac: boolean;
+  onRunSelection: () => void;
+  onRunAll: () => void;
+}
+
+const SPINNER = (
+  <svg viewBox="0 0 12 12" className="run-btn-spinner">
+    <circle
+      cx="6"
+      cy="6"
+      r="4.5"
+      fill="none"
+      stroke="white"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeDasharray="14 8"
+    />
+  </svg>
+);
+
+export function SqlEditorToolbar({
+  loaded,
+  running,
+  hasEditorSelection,
+  isMac,
+  onRunSelection,
+  onRunAll,
+}: SqlEditorToolbarProps) {
+  const disabled = !loaded || running;
+
+  return (
+    <div className="sql-toolbar">
+      <div className="sql-toolbar-shortcuts">
+        <span
+          className="kbd-group"
+          title={
+            isMac
+              ? "Cmd + Enter — run selection or all"
+              : "Ctrl + Enter — run selection or all"
+          }
+        >
+          <kbd className="kbd">{isMac ? "⌘" : "Ctrl"}</kbd>
+          <span className="kbd-plus" aria-hidden="true">
+            +
+          </span>
+          <kbd className="kbd">Enter</kbd>
+        </span>
+      </div>
+      <div className="sql-toolbar-actions">
+        {hasEditorSelection ? (
+          <div className={`run-btn-split${running ? " running" : ""}`}>
+            <button
+              type="button"
+              className="run-btn-split-main"
+              disabled={disabled}
+              onClick={onRunSelection}
+            >
+              {running ? SPINNER : <Play size={10} aria-hidden="true" />}
+              {running ? "Running…" : "Run Selection"}
+            </button>
+            <span className="run-btn-split-divider" aria-hidden="true" />
+            <Menu.Root>
+              <Menu.Trigger
+                className="run-btn-split-chevron"
+                disabled={disabled}
+                aria-label="Run options"
+              >
+                <ChevronDown size={11} aria-hidden="true" />
+              </Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner sideOffset={6} align="end">
+                  <Menu.Popup className="bui-popup run-split-dropdown">
+                    <Menu.Item
+                      className="run-split-item"
+                      onClick={onRunSelection}
+                      disabled={disabled}
+                    >
+                      <span className="run-split-item-label">Run Selection</span>
+                      <span className="run-split-item-kbd">
+                        {isMac ? "⌘Enter" : "Ctrl+Enter"}
+                      </span>
+                    </Menu.Item>
+                    <Menu.Item
+                      className="run-split-item"
+                      onClick={onRunAll}
+                      disabled={disabled}
+                    >
+                      <span className="run-split-item-label">Run All</span>
+                      <span className="run-split-item-kbd">
+                        {isMac ? "⌘⇧Enter" : "Ctrl+Shift+Enter"}
+                      </span>
+                    </Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={`run-btn${running ? " running" : ""}`}
+            disabled={disabled}
+            onClick={onRunAll}
+          >
+            {running ? SPINNER : <Play size={10} aria-hidden="true" />}
+            {running ? "Running…" : "Run"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/_components/sql/components/SqlSettingsConfirmDialogs.tsx
+++ b/app/_components/sql/components/SqlSettingsConfirmDialogs.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { AlertDialog } from "@base-ui-components/react/alert-dialog";
+
+export interface SqlSettingsConfirmDialogsProps {
+  dialectDisplayName: string;
+  restoreOpen: boolean;
+  onRestoreOpenChange: (open: boolean) => void;
+  onRestoreConfirm: () => void;
+  clearStorageOpen: boolean;
+  onClearStorageOpenChange: (open: boolean) => void;
+  onClearStorageConfirm: () => void;
+}
+
+export function SqlSettingsConfirmDialogs({
+  dialectDisplayName,
+  restoreOpen,
+  onRestoreOpenChange,
+  onRestoreConfirm,
+  clearStorageOpen,
+  onClearStorageOpenChange,
+  onClearStorageConfirm,
+}: SqlSettingsConfirmDialogsProps) {
+  return (
+    <>
+      <AlertDialog.Root open={restoreOpen} onOpenChange={onRestoreOpenChange}>
+        <AlertDialog.Portal>
+          <AlertDialog.Backdrop className="confirm-backdrop" />
+          <AlertDialog.Popup className="confirm-popup">
+            <AlertDialog.Title className="confirm-title">
+              Restore default settings?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="confirm-desc">
+              This will reset {dialectDisplayName}&apos;s editor font size, word
+              wrap, run/result preferences, and the shared editor theme to their
+              built-in defaults. Your saved queries are not affected.
+            </AlertDialog.Description>
+            <div className="confirm-actions">
+              <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
+                Cancel
+              </AlertDialog.Close>
+              <AlertDialog.Close
+                className="confirm-btn confirm-btn-danger"
+                onClick={() => {
+                  onRestoreConfirm();
+                  onRestoreOpenChange(false);
+                }}
+              >
+                Restore defaults
+              </AlertDialog.Close>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+
+      <AlertDialog.Root
+        open={clearStorageOpen}
+        onOpenChange={onClearStorageOpenChange}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Backdrop className="confirm-backdrop" />
+          <AlertDialog.Popup className="confirm-popup">
+            <AlertDialog.Title className="confirm-title">
+              Clear all localStorage data?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="confirm-desc">
+              Settings, saved queries, and per-database state for every
+              Dataslope playground will be erased. This action cannot be undone
+              — the page will reload immediately afterwards.
+            </AlertDialog.Description>
+            <div className="confirm-actions">
+              <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
+                Cancel
+              </AlertDialog.Close>
+              <AlertDialog.Close
+                className="confirm-btn confirm-btn-danger"
+                onClick={onClearStorageConfirm}
+              >
+                Clear &amp; reload
+              </AlertDialog.Close>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+    </>
+  );
+}

--- a/app/_components/sql/components/SqlSettingsPanel.tsx
+++ b/app/_components/sql/components/SqlSettingsPanel.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { RotateCcw } from "lucide-react";
+import type { ReactNode } from "react";
+import {
+  SettingsPanel,
+  type SettingsPanelProps,
+} from "../../playgroundShared";
+
+export interface SqlSettingsPanelProps {
+  open: boolean;
+  fontSize: number;
+  setFontSize: (n: number) => void;
+  outputFontSizeEnabled: boolean;
+  setOutputFontSizeEnabled: (b: boolean) => void;
+  outputFontSize: number;
+  setOutputFontSize: (n: number) => void;
+  editorTheme: string;
+  setEditorTheme: (t: string) => void;
+  wordWrap: boolean;
+  setWordWrap: (b: boolean) => void;
+  clearBeforeRun: boolean;
+  setClearBeforeRun: (b: boolean) => void;
+  language: string;
+  onClose: () => void;
+  onRestoreDefaults: () => void;
+  onClearLocalStorage: () => void;
+  /** Text for the "Reset query tabs for …" action button. */
+  resetTabsLabel: string;
+  /** Called when the user clicks the reset-tabs button. */
+  onResetTabs: () => void;
+  /** Dialect-specific extra tabs (e.g. Pragmas for SQLite, Database for
+   *  Postgres/DuckDB). Forwarded verbatim to SettingsPanel. */
+  extraTabs?: SettingsPanelProps["extraTabs"];
+}
+
+export function SqlSettingsPanel({
+  open,
+  fontSize,
+  setFontSize,
+  outputFontSizeEnabled,
+  setOutputFontSizeEnabled,
+  outputFontSize,
+  setOutputFontSize,
+  editorTheme,
+  setEditorTheme,
+  wordWrap,
+  setWordWrap,
+  clearBeforeRun,
+  setClearBeforeRun,
+  language,
+  onClose,
+  onRestoreDefaults,
+  onClearLocalStorage,
+  resetTabsLabel,
+  onResetTabs,
+  extraTabs,
+}: SqlSettingsPanelProps) {
+  return (
+    <SettingsPanel
+      open={open}
+      fontSize={fontSize}
+      setFontSize={setFontSize}
+      outputFontSizeEnabled={outputFontSizeEnabled}
+      setOutputFontSizeEnabled={setOutputFontSizeEnabled}
+      outputFontSize={outputFontSize}
+      setOutputFontSize={setOutputFontSize}
+      editorTheme={editorTheme}
+      setEditorTheme={setEditorTheme}
+      wordWrap={wordWrap}
+      setWordWrap={setWordWrap}
+      clearBeforeRun={clearBeforeRun}
+      setClearBeforeRun={setClearBeforeRun}
+      language={language}
+      showOutputFontSizeControls={false}
+      clearBeforeRunLabel="Clear Results Before Running"
+      showClearBeforeRunRow={false}
+      onClose={onClose}
+      onRestoreDefaults={onRestoreDefaults}
+      onClearLocalStorage={onClearLocalStorage}
+      extraGeneralRows={null}
+      extraActionRows={
+        <button
+          type="button"
+          className="settings-action-btn"
+          onClick={onResetTabs}
+        >
+          <RotateCcw size={14} aria-hidden="true" />
+          <span>{resetTabsLabel}</span>
+        </button>
+      }
+      extraTabs={extraTabs}
+    />
+  );
+}

--- a/app/_components/sql/components/SqlTab.tsx
+++ b/app/_components/sql/components/SqlTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS as DndCSS } from "@dnd-kit/utilities";
 import { Dialog } from "@base-ui-components/react/dialog";
@@ -20,7 +20,9 @@ export interface SqlTabProps {
   onCloseAll: () => void;
 }
 
-export function SqlTab({
+export const SqlTab = memo(SqlTabImpl);
+
+function SqlTabImpl({
   tab,
   active,
   onActivate,

--- a/app/_components/sql/components/SqlTabBar.tsx
+++ b/app/_components/sql/components/SqlTabBar.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import React, { useMemo } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  type DragEndEvent,
+  type DragStartEvent,
+  type SensorDescriptor,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Plus } from "lucide-react";
+import type { QueryTab } from "../../sqlitePlaygroundTabs";
+import { SqlTab, SqlTabDragOverlay } from "./SqlTab";
+
+export interface SqlTabBarProps {
+  tabs: QueryTab[];
+  activeTabId: string;
+  draggingTab: QueryTab | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tabDragSensors: SensorDescriptor<any>[];
+  onDragStart: (event: DragStartEvent) => void;
+  onDragEnd: (event: DragEndEvent) => void;
+  onDragCancel: () => void;
+  onTabActivate: (tabId: string) => void;
+  onTabClose: (tabId: string) => void;
+  onTabRename: (tabId: string, title: string) => void;
+  onTabDuplicate: (tabId: string) => void;
+  onTabCloseOthers: (tabId: string) => void;
+  onTabCloseAll: () => void;
+  onAddTab: () => void;
+}
+
+export function SqlTabBar({
+  tabs,
+  activeTabId,
+  draggingTab,
+  tabDragSensors,
+  onDragStart,
+  onDragEnd,
+  onDragCancel,
+  onTabActivate,
+  onTabClose,
+  onTabRename,
+  onTabDuplicate,
+  onTabCloseOthers,
+  onTabCloseAll,
+  onAddTab,
+}: SqlTabBarProps) {
+  const tabIds = useMemo(() => tabs.map((t) => t.id), [tabs]);
+
+  return (
+    <div className="sql-tabbar">
+      <DndContext
+        sensors={tabDragSensors}
+        collisionDetection={closestCenter}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onDragCancel={onDragCancel}
+      >
+        <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
+          <div className="sql-tabs" role="tablist">
+            {tabs.map((tab) => (
+              <SqlTab
+                key={tab.id}
+                tab={tab}
+                active={tab.id === activeTabId}
+                onActivate={() => onTabActivate(tab.id)}
+                onClose={() => onTabClose(tab.id)}
+                onRename={(title) => onTabRename(tab.id, title)}
+                onDuplicate={() => onTabDuplicate(tab.id)}
+                onCloseOthers={() => onTabCloseOthers(tab.id)}
+                onCloseAll={onTabCloseAll}
+              />
+            ))}
+          </div>
+        </SortableContext>
+        <DragOverlay dropAnimation={null}>
+          {draggingTab ? (
+            <SqlTabDragOverlay
+              tab={draggingTab}
+              active={draggingTab.id === activeTabId}
+            />
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+      <button
+        type="button"
+        className="sql-tab-add"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onAddTab}
+        aria-label="New query tab"
+      >
+        <Plus size={12} aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/app/_components/sql/components/SwitchDatabaseDialog.tsx
+++ b/app/_components/sql/components/SwitchDatabaseDialog.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { AlertDialog } from "@base-ui-components/react/alert-dialog";
+
+export interface SwitchDatabaseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Filename of the database the user is switching away from. */
+  currentDbFilename: string;
+  /** Called when the user confirms the switch. */
+  onConfirm: () => void;
+}
+
+export function SwitchDatabaseDialog({
+  open,
+  onOpenChange,
+  currentDbFilename,
+  onConfirm,
+}: SwitchDatabaseDialogProps) {
+  return (
+    <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
+      <AlertDialog.Portal>
+        <AlertDialog.Backdrop className="confirm-backdrop" />
+        <AlertDialog.Popup className="confirm-popup">
+          <AlertDialog.Title className="confirm-title">
+            Switch databases?
+          </AlertDialog.Title>
+          <AlertDialog.Description className="confirm-desc">
+            You have unsaved edits in the query tabs for{" "}
+            <strong>{currentDbFilename}</strong>. They will be saved and
+            restored when you switch back, but loading another database will
+            replace what&rsquo;s currently in the editor.
+          </AlertDialog.Description>
+          <div className="confirm-actions">
+            <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
+              Cancel
+            </AlertDialog.Close>
+            <AlertDialog.Close
+              className="confirm-btn confirm-btn-danger"
+              onClick={onConfirm}
+            >
+              Switch database
+            </AlertDialog.Close>
+          </div>
+        </AlertDialog.Popup>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
+}

--- a/app/_components/sql/shared/editorSetup.ts
+++ b/app/_components/sql/shared/editorSetup.ts
@@ -15,11 +15,6 @@ import {
   indentWithTab,
 } from "@codemirror/commands";
 import {
-  PostgreSQL,
-  SQLite,
-  sql as sqlLang,
-} from "@codemirror/lang-sql";
-import {
   bracketMatching,
   indentOnInput,
   indentUnit,
@@ -82,13 +77,34 @@ export interface CreateSqlEditorExtensionsOptions {
   onRunAll: () => void;
 }
 
+// Stage 5.3 — `@codemirror/lang-sql` is loaded on demand so it lives in
+// its own chunk instead of bloating each SQL playground's main bundle.
+// The chunk is small enough that fetching it in parallel with engine
+// boot keeps the user-visible editor mount instant: the editor renders
+// immediately with no syntax highlighting / lang-aware completions and
+// the lang compartment is reconfigured as soon as the dynamic import
+// resolves (typically before the user even finishes the database boot).
+type LangSqlModule = typeof import("@codemirror/lang-sql");
+let _langSqlPromise: Promise<LangSqlModule> | null = null;
+function loadLangSql(): Promise<LangSqlModule> {
+  if (!_langSqlPromise) {
+    _langSqlPromise = import("@codemirror/lang-sql");
+  }
+  return _langSqlPromise;
+}
+/** Returns a Promise that resolves to the `@codemirror/lang-sql`
+ *  module. Cached so concurrent callers share one fetch. */
+export function ensureLangSqlLoaded(): Promise<LangSqlModule> {
+  return loadLangSql();
+}
+
 /** Returns the dialect-specific argument for `@codemirror/lang-sql`'s
  *  `sql({ dialect })` factory. DuckDB has no native dialect descriptor,
  *  so we fall back to undefined (which lets lang-sql use its default
  *  generic SQL grammar). */
-export function sqlLangDialect(dialect: SqlDialect) {
-  if (dialect === "postgres") return PostgreSQL;
-  if (dialect === "sqlite") return SQLite;
+function pickLangDialect(mod: LangSqlModule, dialect: SqlDialect) {
+  if (dialect === "postgres") return mod.PostgreSQL;
+  if (dialect === "sqlite") return mod.SQLite;
   return undefined;
 }
 
@@ -108,14 +124,19 @@ export function makeSqlAutocompletionExtension(
  *  dispatch (when the schema or dialect changes after the editor is
  *  mounted). The optional `schema` is the lang-sql shape used for
  *  built-in completions — it's the same `Record<table, columns>`
- *  the SQLite playground has always passed. */
-export function makeSqlLangExtension(
+ *  the SQLite playground has always passed.
+ *
+ *  Returns a Promise so callers can re-use the lazy-loaded chunk
+ *  without re-importing it. Each playground caches the resolved
+ *  module via the shared `loadLangSql` promise above. */
+export async function makeSqlLangExtension(
   dialect: SqlDialect,
   schema?: Record<string, string[]>,
-): Extension {
-  return sqlLang({
+): Promise<Extension> {
+  const mod = await loadLangSql();
+  return mod.sql({
     schema,
-    dialect: sqlLangDialect(dialect),
+    dialect: pickLangDialect(mod, dialect),
     upperCaseKeywords: false,
   });
 }
@@ -126,7 +147,12 @@ export function makeSqlLangExtension(
  *  Postgres, and DuckDB playgrounds. The four CodeMirror compartments
  *  (lang / completion / theme / wrap) are passed in by the caller so
  *  it can hold onto them for later `.reconfigure(...)` dispatches
- *  (schema updates, theme toggles, word-wrap toggles). */
+ *  (schema updates, theme toggles, word-wrap toggles).
+ *
+ *  The `lang` compartment is intentionally seeded with an empty
+ *  extension. The caller is expected to dispatch a reconfigure with
+ *  the resolved `makeSqlLangExtension(...)` once it lands — this lets
+ *  us defer the lang-sql chunk without blocking editor mount. */
 export function createSqlEditorExtensions(
   opts: CreateSqlEditorExtensionsOptions,
 ): Extension[] {
@@ -159,12 +185,9 @@ export function createSqlEditorExtensions(
     crosshairCursor(),
     EditorState.tabSize.of(2),
     indentUnit.of("  "),
-    compartments.lang.of(
-      sqlLang({
-        dialect: sqlLangDialect(dialect),
-        upperCaseKeywords: false,
-      }),
-    ),
+    // Lang compartment seeded empty; reconfigured once the lazy-loaded
+    // `@codemirror/lang-sql` chunk resolves (see `makeSqlLangExtension`).
+    compartments.lang.of([]),
     compartments.completion.of(
       makeSqlAutocompletionExtension(initialSchema, dialect),
     ),
@@ -221,3 +244,4 @@ export function createSqlEditorExtensions(
     ]),
   ];
 }
+

--- a/app/_components/sql/shared/engineAdapter.ts
+++ b/app/_components/sql/shared/engineAdapter.ts
@@ -1,0 +1,68 @@
+"use client";
+
+// Stage 3 (Decompose) — engine adapter contract shared by the three
+// SQL playground shells (SQLite / Postgres / DuckDB).
+//
+// The full Stage 3 plan is to migrate the three ~5–6 kLOC playground
+// monoliths onto a single `SqlPlaygroundShell` that owns the tab bar,
+// schema sidebar, results pane, editor and dialogs, and only the
+// dialect-specific surface (engine factory, sample catalogue, CSV /
+// Parquet importer, settings store) lives in a per-dialect adapter
+// behind this interface.
+//
+// The audit report explicitly gates the actual code migration as the
+// "largest, riskiest stage" with a staged rollout (SQLite first, then
+// Postgres, then DuckDB), and our hard constraint here is that the
+// three playgrounds remain visually and functionally identical to
+// users. Codifying the contract here unblocks that incremental
+// migration without forcing a single-pass rewrite of 16 kLOC.
+
+import type { SqlDialect } from "../sqlCompletion";
+import type {
+  QueryTabSeed,
+  SqlSampleDatabaseBase,
+} from "../../runtime/sqlSamples";
+
+/** A storage namespace each playground uses for `localStorage` keys
+ *  (e.g. `"duckdb_"`, `"pg_postgres_"`, `"sqlite:"`). The shell uses
+ *  it for tab/settings persistence so per-dialect state never
+ *  collides. */
+export type SqlPlaygroundStoragePrefix = string;
+
+/** Bare-minimum SQL engine surface the shell needs in order to run a
+ *  query and refresh the schema sidebar. Each per-dialect engine
+ *  (`SqliteEngine`, `PostgresEngine`, `DuckDbEngine`) already exposes
+ *  these, plus a much larger dialect-specific API used by structure
+ *  drawers and importers. */
+export interface SqlEngineLike {
+  /** Execute one or more statements, returning the result sets. */
+  exec(sql: string): unknown;
+  /** Free the underlying database handle. */
+  close?(): void | Promise<void>;
+}
+
+/** Adapter for one of the three SQL flavors. Plug into the shell to
+ *  obtain dialect-specific behaviour. */
+export interface SqlEngineAdapter<
+  TEngine extends SqlEngineLike = SqlEngineLike,
+  TSample extends SqlSampleDatabaseBase = SqlSampleDatabaseBase,
+> {
+  /** Dialect id used by the editor / completion / formatter wiring. */
+  dialect: SqlDialect;
+  /** Display id (`"sqlite" | "postgres" | "duckdb"`) used for stable
+   *  per-playground references (icons, tab routes, runtime info). */
+  playgroundId: "sqlite" | "postgres" | "duckdb";
+  /** Prefix for any `localStorage` keys the shell writes (tabs,
+   *  settings, sidebar widths). */
+  storagePrefix: SqlPlaygroundStoragePrefix;
+  /** Construct a fresh engine bound to a given sample database id. */
+  createEngine(sampleId: string): Promise<TEngine>;
+  /** Catalogue of sample databases the database-selector renders. */
+  samples: readonly TSample[];
+  /** Optional "empty" / "blank" entry. Postgres and DuckDB expose
+   *  this; SQLite currently doesn't because the credit-card sample is
+   *  always loaded fresh. */
+  blankSample?: TSample;
+  /** Default editor tabs opened on the first visit to a sample. */
+  defaultTabsFor(sample: TSample): QueryTabSeed[];
+}

--- a/app/_components/sql/shared/tabStorageUtils.ts
+++ b/app/_components/sql/shared/tabStorageUtils.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { newTabId } from "../../sqlitePlaygroundTabs";
+import type { QueryTab } from "../../sqlitePlaygroundTabs";
+
+export interface TabStorageUtils {
+  dbScopedKey: (dbId: string, k: string) => string;
+  loadTabs: (dbId: string, defaults: { title: string; code: string }[]) => QueryTab[];
+  saveTabs: (dbId: string, tabs: QueryTab[]) => void;
+}
+
+/**
+ * Creates tab-storage helpers bound to a specific localStorage namespace.
+ * Each SQL dialect uses a distinct prefix so their keys never collide.
+ */
+export function createTabStorage(storagePrefix: string): TabStorageUtils {
+  function dbScopedKey(dbId: string, k: string): string {
+    return `${storagePrefix}db_${dbId}_${k}`;
+  }
+
+  function loadTabs(
+    dbId: string,
+    defaults: { title: string; code: string }[],
+  ): QueryTab[] {
+    const fallback = (): QueryTab[] =>
+      defaults.map((seed) => ({
+        ...seed,
+        id: newTabId(),
+        pristineCode: seed.code,
+      }));
+
+    if (typeof window === "undefined") return fallback();
+    try {
+      const raw = localStorage.getItem(dbScopedKey(dbId, "tabs"));
+      if (raw) {
+        const parsed = JSON.parse(raw) as QueryTab[];
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          return parsed.map((tab) => ({
+            id: typeof tab.id === "string" ? tab.id : newTabId(),
+            title: typeof tab.title === "string" ? tab.title : "Query",
+            code: typeof tab.code === "string" ? tab.code : "",
+            pristineCode:
+              typeof tab.pristineCode === "string"
+                ? tab.pristineCode
+                : typeof tab.code === "string"
+                  ? tab.code
+                  : "",
+            kind: tab.kind === "view-data" ? "view-data" : undefined,
+          }));
+        }
+      }
+    } catch {
+      // Fall back to defaults.
+    }
+    return fallback();
+  }
+
+  function saveTabs(dbId: string, tabs: QueryTab[]): void {
+    try {
+      localStorage.setItem(
+        dbScopedKey(dbId, "tabs"),
+        JSON.stringify(
+          tabs.filter(
+            (tab) => tab.kind !== "er-diagram" && tab.kind !== "query-history",
+          ),
+        ),
+      );
+    } catch {
+      // Ignore storage quota / private-mode errors.
+    }
+  }
+
+  return { dbScopedKey, loadTabs, saveTabs };
+}
+
+/** Pure helper: true when tabs differ from the defaults (title, code, or count). */
+export function tabsAreDirty(
+  tabs: QueryTab[],
+  defaults: { title: string; code: string }[],
+): boolean {
+  if (tabs.length !== defaults.length) return true;
+  for (let i = 0; i < tabs.length; i += 1) {
+    if (tabs[i].title !== defaults[i].title || tabs[i].code !== defaults[i].code)
+      return true;
+  }
+  return false;
+}

--- a/app/_components/sql/sqliteAdapter.ts
+++ b/app/_components/sql/sqliteAdapter.ts
@@ -1,0 +1,27 @@
+"use client";
+
+// Concrete SQLite implementation of `SqlEngineAdapter`. The SQLite
+// playground imports this and routes its engine factory / identity
+// constants through it so the per-dialect surface lives in one place
+// (Stage 3 scaffolding from the playground refactor plan).
+
+import type { SqlEngineAdapter } from "./shared/engineAdapter";
+import { createSqliteEngine, type SqliteEngine } from "../runtime/sqlite";
+import {
+  SQLITE_SAMPLE_DATABASES,
+  type SqliteSampleDatabase,
+} from "../runtime/sqliteSamples";
+
+export const sqliteAdapter: SqlEngineAdapter<
+  SqliteEngine,
+  SqliteSampleDatabase
+> = {
+  dialect: "sqlite",
+  playgroundId: "sqlite",
+  // Legacy storage prefix kept verbatim so users' existing
+  // localStorage state (tabs, settings, page sizes) is preserved.
+  storagePrefix: "pg_sqlite_",
+  createEngine: (sampleId) => createSqliteEngine(sampleId),
+  samples: SQLITE_SAMPLE_DATABASES,
+  defaultTabsFor: (sample) => sample.defaultTabs,
+};

--- a/app/_components/sql/utils/exportUtils.ts
+++ b/app/_components/sql/utils/exportUtils.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { QueryExecResult } from "sql.js";
+import { ensureParquetWasm } from "./parquetWasm";
 
 export function triggerDownload(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
@@ -112,21 +113,6 @@ export function exportResultToSql(
   );
 }
 
-let _parquetWasmInit: Promise<typeof import("parquet-wasm/esm")> | null = null;
-
-async function initParquetWasm(): Promise<typeof import("parquet-wasm/esm")> {
-  if (!_parquetWasmInit) {
-    _parquetWasmInit = (async () => {
-      const mod = await import("parquet-wasm/esm");
-      await mod.default(
-        "https://cdn.jsdelivr.net/npm/parquet-wasm@0.7.1/esm/parquet_wasm_bg.wasm",
-      );
-      return mod;
-    })();
-  }
-  return _parquetWasmInit;
-}
-
 export async function exportResultToParquet(
   columns: string[],
   rows: QueryExecResult["values"],
@@ -135,7 +121,7 @@ export async function exportResultToParquet(
   const [
     { tableToIPC, tableFromArrays, Utf8, Float64, vectorFromArray },
     { Table: WasmParquetTable, writeParquet },
-  ] = await Promise.all([import("apache-arrow"), initParquetWasm()]);
+  ] = await Promise.all([import("apache-arrow"), ensureParquetWasm()]);
 
   const colArrays: Record<string, unknown[]> = {};
   for (const col of columns) colArrays[col] = [];

--- a/app/_components/sql/utils/importUtils.ts
+++ b/app/_components/sql/utils/importUtils.ts
@@ -1,6 +1,7 @@
 import type { QueryExecResult, SqlValue } from "sql.js";
 import type { TableColumnInfo } from "../../runtime/sqlite";
 import type { ImportColComparison } from "../types";
+import { ensureParquetWasm } from "./parquetWasm";
 
 /** Parse CSV text into headers and rows. Used by every SQL playground
  *  (sqlite, postgres, duckdb) so all three import flows behave
@@ -62,32 +63,13 @@ export function tableNameFromFilename(filename: string): string {
   return base || "imported_table";
 }
 
-let _parquetWasmInit:
-  | Promise<typeof import("parquet-wasm/esm")>
-  | null = null;
-/** Lazy-loaded parquet decoder shared across SQL playgrounds. The WASM
- *  binary is fetched from jsDelivr on first use and cached for the
- *  lifetime of the page. */
-async function initParquetWasm(): Promise<typeof import("parquet-wasm/esm")> {
-  if (!_parquetWasmInit) {
-    _parquetWasmInit = (async () => {
-      const m = await import("parquet-wasm/esm");
-      await m.default(
-        "https://cdn.jsdelivr.net/npm/parquet-wasm@0.7.1/esm/parquet_wasm_bg.wasm",
-      );
-      return m;
-    })();
-  }
-  return _parquetWasmInit;
-}
-
 /** Read a Parquet file and materialise it into the same column/row
  *  shape parseCsv returns, so callers can hand the result off to a
  *  shared import preview component. */
 export async function readParquetFile(
   file: File,
 ): Promise<{ columns: string[]; rows: QueryExecResult["values"] }> {
-  const mod = await initParquetWasm();
+  const mod = await ensureParquetWasm();
   const { tableFromIPC } = await import("apache-arrow");
   const bytes = await file.arrayBuffer();
   const wasmTable = mod.readParquet(new Uint8Array(bytes));

--- a/app/_components/sql/utils/parquetWasm.ts
+++ b/app/_components/sql/utils/parquetWasm.ts
@@ -1,0 +1,18 @@
+// Shared parquet-wasm singleton — guarantees the WASM binary is
+// fetched from CDN at most once per page load regardless of whether
+// the first caller is an import or an export operation.
+
+let _init: Promise<typeof import("parquet-wasm/esm")> | null = null;
+
+export function ensureParquetWasm(): Promise<typeof import("parquet-wasm/esm")> {
+  if (!_init) {
+    _init = (async () => {
+      const mod = await import("parquet-wasm/esm");
+      await mod.default(
+        "https://cdn.jsdelivr.net/npm/parquet-wasm@0.7.1/esm/parquet_wasm_bg.wasm",
+      );
+      return mod;
+    })();
+  }
+  return _init;
+}

--- a/app/_components/sql/utils/persistedStorage.ts
+++ b/app/_components/sql/utils/persistedStorage.ts
@@ -1,0 +1,74 @@
+"use client";
+
+// Coalesced, idle-deferred localStorage writer. Settings toggles like
+// font size / word wrap / clear-before-run fire on user input and the
+// previous implementation wrote to localStorage synchronously, which
+// can contend with rendering on lower-end devices. We instead keep the
+// latest value per key in memory and flush all pending writes inside a
+// `requestIdleCallback` (falling back to `setTimeout`). Writes are
+// still flushed eagerly on `pagehide` / `visibilitychange` via the
+// listener installed below so nothing is lost on tab close.
+
+type PendingMap = Map<string, string>;
+
+const pending: PendingMap = new Map();
+let scheduled = false;
+
+type IdleCallback = (deadline: { didTimeout: boolean; timeRemaining: () => number }) => void;
+interface IdleWindow {
+  requestIdleCallback?: (cb: IdleCallback, opts?: { timeout?: number }) => number;
+}
+
+function flush(): void {
+  scheduled = false;
+  if (pending.size === 0) return;
+  for (const [key, value] of pending) {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Ignore storage quota / private-mode errors.
+    }
+  }
+  pending.clear();
+}
+
+function schedule(): void {
+  if (scheduled) return;
+  scheduled = true;
+  const w = (typeof window !== "undefined" ? window : undefined) as
+    | (Window & IdleWindow)
+    | undefined;
+  if (w?.requestIdleCallback) {
+    w.requestIdleCallback(() => flush(), { timeout: 500 });
+  } else if (typeof setTimeout !== "undefined") {
+    setTimeout(flush, 100);
+  } else {
+    flush();
+  }
+}
+
+/** Queue a localStorage write, coalescing with any other pending
+ *  writes for the same key and deferring the actual `setItem` until
+ *  the browser is idle. Returns immediately. */
+export function persistAsync(key: string, value: string): void {
+  pending.set(key, value);
+  schedule();
+}
+
+/** Force-flush any queued writes. Safe to call on navigation or unload. */
+export function flushPersistedStorage(): void {
+  flush();
+}
+
+let unloadListenerAttached = false;
+/** Install pagehide/visibilitychange listeners so queued writes are
+ *  not lost if the user closes the tab between an idle callback being
+ *  scheduled and firing. Idempotent. */
+export function ensurePersistUnloadFlush(): void {
+  if (unloadListenerAttached) return;
+  if (typeof window === "undefined") return;
+  unloadListenerAttached = true;
+  const handler = () => flush();
+  window.addEventListener("pagehide", handler);
+  window.addEventListener("visibilitychange", handler);
+}


### PR DESCRIPTION
## Summary

Stage 3 bottom-up leaf extraction: adapters, shared utilities, import-safety bug fixes, and leaf component extraction — reducing the three SQL playground monoliths before the full `SqlPlaygroundShell` migration.

### Components extracted (`sql/components/`)

| Component | What it encapsulates |
|---|---|
| `SqlSettingsPanel` | Settings panel wrapper with SQL-specific defaults |
| `SqlSettingsConfirmDialogs` | Restore-defaults + clear-storage confirm dialogs |
| `DdlViewerDialog` | DDL viewer popup with copy-to-clipboard |
| `SwitchDatabaseDialog` | "Switch databases?" confirmation |
| `SchemaActionDialogs` | Drop entity + truncate table confirmations |
| `ImportSqlDumpDialog` | Text SQL dump import with drag-and-drop |
| `RenameDatabaseDialog` | Rename form with configurable extension options |
| `ImportBinaryFileDialog` | Binary file import dropzone |
| `SqlEditorToolbar` | Run/run-selection split button with keyboard shortcut |
| `DatabaseSelector` | Database picker dropdown |
| `SqlTabBar` | DnD tab bar (DnDContext + SortableContext + add button) |

### Shared utilities (`sql/shared/`)

| Module | What it provides |
|---|---|
| `engineAdapter.ts` | `SqlEngineAdapter` interface + concrete adapters for SQLite, Postgres, DuckDB |
| `tabStorageUtils.ts` | `createTabStorage(prefix)` factory — `loadTabs`, `saveTabs`, `dbScopedKey` bound to any dialect's localStorage namespace; `tabsAreDirty` pure helper |

### Bug fixes

- **Postgres import safety**: `importSqlDump` now creates a sandbox PGlite worker and only swaps in the new database on success — failed imports leave the original database completely intact.
- **DuckDB import safety**: `importSqlDump` and `importFromBinary` now capture the previous sample and restore it on failure (DuckDB-Wasm shared instance prevents true sandboxing, so restore-on-failure is used instead).
- **SQLite binary import safety**: `loadFromBytes` now constructs the new database before closing the old one, so a corrupt file never destroys existing data.

### Metrics

| File | Before | After | Δ |
|---|---|---|---|
| `SqlPlayground.tsx` | ~4,800 | 4,091 | −709 |
| `PostgresPlayground.tsx` | ~6,200 | 5,305 | −895 |
| `DuckDbPlayground.tsx` | ~6,800 | 5,785 | −1,015 |
| **Total monolith lines** | **~17,800** | **15,181** | **−2,619** |

All 175 tests pass. TypeScript clean.
