### PR TITLE
Phase 5 + Phase 6: Multi-tab editing, OPFS persistence, and the Workspace Manager UI

### DIFF
--- a/agent-outputs/20260518-1306-opfs-workspaces-multi-tab-zustand-plan.md
+++ b/agent-outputs/20260518-1306-opfs-workspaces-multi-tab-zustand-plan.md
@@ -14,8 +14,8 @@
 | **Phase 2: SQLite Engine Migration** | ✅ **COMPLETE** | Rewritten on top of `@sqlite.org/sqlite-wasm` 3.53.0-build1; `sql.js` removed |
 | **Phase 3: SQLite OPFS Persistence** | ✅ **COMPLETE** | SAH Pool VFS, workspace-aware engine, first-open detection |
 | **Phase 4: PostgreSQL & DuckDB OPFS** | ✅ **COMPLETE** | PGlite `opfs-ahp://` dataDir; DuckDB snapshot-and-restore via `databaseStorage` |
-| Phase 5: Non-SQL Multi-Tab + OPFS | ⬜ Not started | |
-| Phase 6: Workspace Manager UI | ⬜ Not started | |
+| **Phase 5: Non-SQL Multi-Tab + OPFS** | ✅ **COMPLETE** | Generic `TabBar`, per-adapter Zustand store, OPFS-backed file tabs with per-tab editor + output history; legacy single-file `localStorage` content auto-migrates into the first tab |
+| **Phase 6: Workspace Manager UI** | ✅ **COMPLETE** | Header workspace badge + popover + manager drawer with rename/duplicate/delete + byte size; surfaces on all four playground shells; tab-isolation toast wired via existing Web Locks helper |
 
 ### Phase 1 — Files Created
 
@@ -193,6 +193,202 @@ swaps so the on-disk file always reflects the active sample.
 - `DuckDbPlayground.tsx` resolves the active workspace via
   `ensureActiveWorkspace("duckdb")` and forwards the ID.
 
+### Phase 5 — Non-SQL Multi-Tab + OPFS
+
+**What changed**
+
+- **New file `app/_components/tabs/tabTypes.ts`** — `TabKind` union and
+  the generic `TabDescriptor` interface (id, kind, label, icon,
+  closeable, renameable, pinned). Open-ended `kind` so future phases
+  can add new tab types without churning the type.
+- **New file `app/_components/tabs/TabBar.tsx`** — reusable
+  content-agnostic tab strip with rename / close / add affordances and
+  a context menu. Uses Base UI's `Dialog` for rename and
+  `ContextMenu` for right-click — both match the SQL playground's
+  existing patterns visually.
+- **New file `app/_components/playgroundTabs.ts`** — `PlaygroundFile`
+  shape (id, filename, pristineFilename), `newFileId()`,
+  `defaultFiles(adapter)`, `suggestNextFilename(adapter, existing)`,
+  and the localStorage-backed manifest `loadManifest` /
+  `saveManifest`. Manifest is metadata only; file contents live in
+  OPFS via Phase-1's `fileStorage`.
+- **New file `app/_components/stores/createPlaygroundStore.ts`** —
+  Zustand store factory holding workspace + files + activeTabId +
+  activeFileId + per-file dirty buffers (`Map<fileId, string>`) +
+  per-file output history (`Map<fileId, OutputCell[]>`) + status. The
+  module also exposes `getPlaygroundStore(adapterId)` so all callers
+  reach the same store instance per route.
+- **`LanguageAdapter` extension** — added `defaultFileExtension`
+  (required) and optional `entryPoint`. All nine non-SQL adapters
+  (Python, R, JavaScript, TypeScript, PHP, C, C++, Java, C#) declare
+  both.
+- **`Playground.tsx` rewired**:
+  - Bootstraps the active workspace asynchronously via
+    `ensureActiveWorkspace(adapter.id)`, hydrates the manifest, then
+    reads each file's content from OPFS into the dirty buffer.
+  - On first run with no manifest, seeds a single default file
+    (`<exportBaseFilename>.<defaultFileExtension>`) and migrates the
+    pre-Phase-5 single-file `localStorage[storageKey("code")]` into
+    it so existing users don't lose work.
+  - Persist listener now writes the active file's content into the
+    Zustand dirty buffer + `fileStorage.writeFile(wsId, fileId, …)`
+    (which already debounces + flushes on `pagehide`).
+  - Editor doc is replaced via `dispatch({ changes })` on tab switch;
+    a `suppressPersistRef` flag prevents the replacement from being
+    echoed back into the destination file's buffer.
+  - Runtime output cells route into `outputsByFile.get(activeFileId)`;
+    each tab has its own output history (the user's explicit ask:
+    "each per-language playground tab should contain both an editor
+    for the file, and the output pane").
+  - The editor's `clearBeforeRun`, `clearOutput`, copy/format
+    actions, and the export dropdown all respect the active file
+    (renaming a file changes the download base name).
+  - `TabBar` is rendered above the panes and is wired to add (`+`,
+    via `suggestNextFilename`), close (with a "can't close last
+    file" guard), rename (double-click + context menu), and select.
+- **CSS additions** in `playground.css` for `.pg-tabbar`, `.pg-tab`,
+  `.pg-tab-add` etc. Visually mirrors the SQL playground's existing
+  tab styling so language and SQL playgrounds feel uniform.
+
+**Files created / modified**
+
+```
+app/_components/
+  tabs/
+    tabTypes.ts                ← NEW
+    TabBar.tsx                 ← NEW
+  stores/
+    createPlaygroundStore.ts   ← NEW
+  playgroundTabs.ts            ← NEW
+  Playground.tsx               ← MODIFIED (workspace bootstrap, tab UI,
+                                            persist listener rewire,
+                                            per-tab outputs, export
+                                            filename inheritance)
+  playground.css               ← MODIFIED (.pg-tabbar / .pg-tab styles)
+  types.ts                     ← MODIFIED (LanguageAdapter +
+                                            defaultFileExtension /
+                                            entryPoint)
+  runtime/{python,r,javascript,typescript,php,c,cpp,java,csharp}.tsx
+                               ← MODIFIED (declare new adapter fields)
+```
+
+**Out-of-scope (deliberate)**
+
+- **Multi-file execution.** Only the active file is sent to the
+  runtime; full multi-file compilation / module resolution stays a
+  follow-up per §4.4 of the plan.
+- **Drag-and-drop reordering.** SqlTabBar uses `@dnd-kit`; the
+  generic `TabBar` does not yet. Reordering can be added by lifting
+  the SqlTabBar dnd setup into the generic component.
+- **Refactor of `SqlTabBar` onto the generic `TabBar`** (§4.5). The
+  SQL bar's context menu (Duplicate, Close Others, Close All) plus
+  the view-data/er-diagram/query-history kinds make this a separate
+  surgery — recommended for the agent picking up after Phase 6.
+- **Settings-as-a-tab migration** (§4.5, §8.2). The existing settings
+  *dialog* is preserved unchanged. Moving it inline as a tab requires
+  decoupling `SettingsPanel` from Base UI's `Dialog`, which is a
+  larger refactor.
+
+### Phase 6 — Workspace Manager UI
+
+**What changed**
+
+- **`opfs/workspace.ts` additions**:
+  - `renameWorkspace(id, newName)` — updates the registry entry and
+    rewrites `meta.json` in OPFS. Registry is the authoritative name
+    source, so an OPFS write failure does not roll the rename back.
+  - `duplicateWorkspace(sourceId, newName)` — creates a fresh
+    workspace via `createWorkspace`, then recursively copies the
+    source workspace's OPFS directory (skipping `meta.json`).
+    Internal `copyDirectoryHandle(src, dst)` handles nested
+    sub-trees so both `files/` and `db/` round-trip.
+- **`opfs/fileStorage.ts` addition**:
+  - `estimateWorkspaceSize(workspaceId)` — recursively sums every
+    file size under `workspaces/<id>/`. Used to surface byte counts
+    in the manager drawer.
+- **`opfs/activeWorkspace.ts` addition**:
+  - `switchActiveWorkspace(playgroundId, workspaceId)` — writes the
+    sessionStorage pointer and triggers `window.location.reload()`.
+    A reload is simpler and indistinguishable to the user from a
+    full engine + editor tear-down + re-bootstrap.
+- **New file `app/_components/workspace/WorkspaceBadge.tsx`** — the
+  user-facing workspace UI for every playground. Three layered
+  components:
+  - **`WorkspaceBadge`** — a pill-shaped header button showing the
+    folder icon + workspace name. Clicking opens the popover.
+  - **Workspace popover** — lists the playground's `RECENT_LIMIT`
+    most-recent workspaces (sorted by `lastUsedAt` desc) with an
+    active checkmark, plus "New workspace" and "Manage…" footer
+    actions.
+  - **`WorkspaceManagerDrawer`** — full list of workspaces with
+    per-row Rename / Duplicate / Delete actions and a byte-size
+    estimate. Delete is blocked on the last remaining workspace; if
+    the active workspace is deleted, the drawer automatically
+    switches to a surviving sibling.
+  - Inline `RenameDialog`, `DuplicateDialog`, `DeleteDialog` (all
+    Base UI `Dialog` / `AlertDialog`).
+- **`playground.css` additions** for `.workspace-badge`,
+  `.workspace-popover`, `.workspace-manager-*`. Reuses
+  `.pkg-drawer-*` and `.confirm-*` from the existing palette so the
+  manager visually slots in with the packages drawer and other
+  confirmation dialogs.
+- **Tab-isolation toast** in `Playground.tsx`: after
+  `ensureActiveWorkspace` resolves, the bootstrap effect attempts
+  `acquireWorkspaceLock(ws.id)`. If the lock is unavailable (another
+  tab already holds this workspace) it surfaces a one-time toast,
+  guarded by a `sessionStorage` key so it never repeats within a
+  session.
+- **Wiring into all four playground shells**:
+  - `Playground.tsx` renders the badge between the
+    language-switcher and the desktop action group.
+  - `SqlPlayground.tsx`, `PostgresPlayground.tsx`,
+    `DuckDbPlayground.tsx` each add `activeWorkspace`
+    `useState<{id,name}|null>`, capture it from the existing
+    `ensureActiveWorkspace` call in their bootstrap effect, and
+    render `<WorkspaceBadge>` as the first child of their
+    `headerActions` slot.
+
+**Files created / modified**
+
+```
+app/_components/
+  workspace/
+    WorkspaceBadge.tsx         ← NEW
+  opfs/
+    workspace.ts               ← MODIFIED (renameWorkspace,
+                                            duplicateWorkspace,
+                                            copyDirectoryHandle)
+    fileStorage.ts             ← MODIFIED (estimateWorkspaceSize)
+    activeWorkspace.ts         ← MODIFIED (switchActiveWorkspace)
+  Playground.tsx               ← MODIFIED (workspaceBadge in header,
+                                            tab-isolation toast)
+  playground.css               ← MODIFIED (.workspace-badge,
+                                            .workspace-popover,
+                                            .workspace-manager-*)
+  sql/SqlPlayground.tsx        ← MODIFIED (activeWorkspace state,
+                                            badge in headerActions)
+  postgres/PostgresPlayground.tsx
+                               ← MODIFIED (same)
+  duckdb/DuckDbPlayground.tsx  ← MODIFIED (same)
+```
+
+**Out-of-scope (deliberate)**
+
+- **Tab-isolation notice for SQL playgrounds.** The toast is only
+  wired into the non-SQL `Playground.tsx`. The SQL shells already
+  rely on `acquireWorkspaceLock` indirectly via the SAH Pool VFS
+  (which fails open if locked); adding a UI-level toast there is
+  straightforward but was kept to one playground in this pass to
+  avoid disturbing the SQL bootstraps.
+- **Workspace export / import.** Mentioned in §3.5 of the plan as
+  "Export workspace as ZIP". Not implemented; the duplicate action
+  satisfies the in-browser duplicate use case.
+- **Workspace size displayed in the popover.** Currently only the
+  drawer shows byte sizes (popover rows show only "last opened").
+  Adding the size estimate to the popover would require resolving
+  the async sum before the popover renders, which would either
+  delay the popover or flicker the size in late.
+
 ### Caveats & Follow-ups
 
 - **DuckDB persistence is best-effort.** `exportAsBinary` is async and
@@ -222,31 +418,112 @@ swaps so the on-disk file always reflects the active sample.
   OPFS file exists even before the user has made any changes. If the
   sample seed itself is expensive, consider deferring the first
   snapshot until after the user's first mutation.
-- **No new tests yet** for Phases 2-4. The existing 221-test suite
-  passes (covers Postgres, DuckDB, OPFS Phase-1 helpers, and shared
-  SQL utils). Integration-level OPFS persistence tests will need a
-  browser-level harness (Playwright) and were deferred — record an
-  issue when prioritising Phase 5.
+- **No new tests yet** for Phases 2-6. The existing 221-test suite
+  passes after each phase (covers Postgres, DuckDB, OPFS Phase-1
+  helpers, and shared SQL utils). Integration-level OPFS persistence
+  + tab-switch + workspace-management tests need a browser-level
+  harness (Playwright) and remain deferred — Phase 5 and Phase 6 were
+  smoke-tested via short headless Playwright scripts (tab add /
+  switch / persist / close; badge popover / manager rename + size
+  estimate). A proper e2e suite over those flows is the next obvious
+  testing investment.
+- **`renameWorkspace` is registry-authoritative.** If the OPFS
+  `meta.json` rewrite fails the registry entry still updates, so the
+  badge / popover reflect the new name. This is fine because
+  `meta.json` is currently informational only — every read path
+  consumes the registry. If that ever changes, the rename helper
+  must roll back on OPFS failure.
+- **`duplicateWorkspace` skips `meta.json`** when copying so the
+  destination's freshly-written `meta.json` is preserved. Any future
+  workspace metadata must follow the same pattern (or be merged
+  explicitly during duplication).
+- **Workspace switch reloads the page.** `switchActiveWorkspace`
+  writes `sessionStorage` and calls `window.location.reload()`. This
+  is a deliberate simplification (engines + editor rebuild as a side
+  effect) but it does mean unsaved edits in the *current* tab need to
+  be flushed first. The non-SQL `Playground.tsx` flushes the active
+  file's dirty buffer on every keystroke via `opfsWriteFile`, so the
+  worst case is the last few hundred ms of typing.
 
 ### Where the next agent picks up
 
-**Continue with Phase 5 — Non-SQL Multi-Tab + OPFS.** Phases 2-4 leave
-the SQLite / Postgres / DuckDB playgrounds workspace-aware and
-OPFS-persistent. The next agent should:
+**All six phases of the original plan are complete.** The remaining
+work falls into clearly-scoped follow-up tasks:
 
-1. Generalise the SQL playground's tab model to non-SQL playgrounds
-   (Python, JavaScript, etc.) per §4 of this plan.
-2. Persist editor file contents to OPFS via the existing
-   `fileStorage.ts` helpers, keyed by workspace ID.
-3. Reuse `ensureActiveWorkspace(playgroundId)` from
-   `app/_components/opfs/activeWorkspace.ts`.
+1. **Refactor `SqlTabBar` onto the generic `TabBar`** (§4.5). The
+   `app/_components/tabs/TabBar.tsx` component built in Phase 5 is
+   intentionally content-agnostic. `SqlTabBar` should adopt it as its
+   foundation. Two complications make this its own PR:
+   - The SQL tab's context menu has Duplicate / Close Others / Close
+     All entries — the generic bar currently exposes only Rename and
+     Close. Either generalise the context menu (preferred) via a
+     `contextMenuItems?: ContextMenuItem[]` prop on `TabDescriptor`,
+     or render the SQL menu separately and lift the rest of the bar.
+   - SQL tabs carry `kind: "view-data" | "er-diagram" |
+     "query-history"` with kind-specific icons. The generic
+     `TabDescriptor.icon` slot already covers this; the SQL bar's
+     special-case CSS classes (`.sql-tab-view-data` etc.) can map to
+     the generic `.pg-tab--kind-${kind}` classes.
 
-Key files the Phase 5 agent should study first:
-- `app/_components/opfs/activeWorkspace.ts` — workspace bootstrap
-- `app/_components/opfs/fileStorage.ts` — file persistence helpers
-- `app/_components/sql/SqlPlayground.tsx` — reference shell with tabs
-- `app/_components/python/PythonPlayground.tsx` (and siblings) —
-  current single-file shells that need multi-tab support
+2. **Move Settings from a dialog to a tab** (§4.5, §8.2). The
+   `SettingsPanel` component currently uses Base UI's `Dialog`. To
+   render inline as a tab, extract its body into a `<SettingsContent>`
+   component that does not assume a dialog wrapper. Then add a
+   `kind: "settings"` tab in `Playground.tsx` (and the SQL shells),
+   gated on `settingsTabOpen` in the existing Phase-5 store (the
+   field is already in the store — the toggle just needs the click
+   handler to switch tabs and add the descriptor). The gear icon
+   button in the sidebar then opens the settings tab instead of the
+   dialog.
+
+3. **Drag-and-drop tab reordering for non-SQL playgrounds.** The
+   generic `TabBar` does not yet wrap `@dnd-kit`. Lift the
+   `SortableContext` + sensor setup from `SqlTabBar.tsx` into
+   `TabBar.tsx` behind an `onReorderTabs?` prop, and wire it through
+   `Playground.tsx` to update `files` in the Zustand store.
+
+4. **Multi-file execution per language** (§4.4). Phase 5 ships
+   active-file-only execution. To support cross-file imports, each
+   runtime needs to receive a file map `{ filename: code }`:
+   - **Python / R / PHP**: write all workspace files to the
+     respective VFS (`pyodide.FS.writeFile`, WebR VFS, php-wasm VFS)
+     before running the entry point.
+   - **TypeScript**: the TS compiler already accepts multiple
+     sources; thread the file map through `typescript-worker.ts`.
+   - **C / C++ / Java / C#**: their respective WASM compilers accept
+     multiple source files; thread through `browsercc-worker.ts` and
+     `cheerpj.ts` / `dotnet.ts`.
+   The `LanguageAdapter.entryPoint` field (added in Phase 5) tells the
+   runtime which file to invoke when more than one is present.
+
+5. **Workspace export / import as ZIP** (§3.5). The duplicate action
+   already covers in-browser cloning; sharing a workspace with another
+   browser / user needs an export path. JSZip is already an indirect
+   dependency via several packages; if not, a small DEFLATE-only
+   implementation suffices.
+
+6. **Tab-isolation notice in SQL playgrounds.** Phase 6 wired the
+   one-time `acquireWorkspaceLock` toast only into `Playground.tsx`
+   (non-SQL). Add the same pattern after `ensureActiveWorkspace` in
+   each of the three SQL playground bootstrap effects.
+
+7. **Workspace size in the popover.** The drawer shows byte sizes; the
+   popover currently shows only "last opened". The async
+   `estimateWorkspaceSize` can be prefetched on popover open and
+   cached in a ref so the size renders without flicker.
+
+Key files for any follow-up agent:
+- `app/_components/tabs/TabBar.tsx` — generic tab strip
+- `app/_components/playgroundTabs.ts` — `PlaygroundFile` type +
+  manifest helpers
+- `app/_components/stores/createPlaygroundStore.ts` — Zustand factory
+  (already has a `settingsTabOpen` flag wired up but not yet
+  rendered)
+- `app/_components/workspace/WorkspaceBadge.tsx` — reference for
+  popover + drawer patterns
+- `app/_components/Playground.tsx` — reference non-SQL shell
+- `app/_components/sql/components/SqlTabBar.tsx` — the bar to
+  generalise
 
 ---
 

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -100,6 +100,25 @@ import {
   SettingsPanel,
   detectIsMac,
 } from "./playgroundShared";
+import { TabBar } from "./tabs/TabBar";
+import type { TabDescriptor } from "./tabs/tabTypes";
+import {
+  SETTINGS_TAB_ID,
+  defaultFiles,
+  loadManifest,
+  newFileId,
+  saveManifest,
+  suggestNextFilename,
+  type PlaygroundFile,
+} from "./playgroundTabs";
+import { getPlaygroundStore } from "./stores/createPlaygroundStore";
+import {
+  deleteFile as opfsDeleteFile,
+  readFile as opfsReadFile,
+  writeFile as opfsWriteFile,
+} from "./opfs/fileStorage";
+import { ensureActiveWorkspace } from "./opfs/activeWorkspace";
+import { FileCode2 } from "lucide-react";
 
 const MOBILE_EDITOR_TAB = "editor" as const;
 // Minimum time (ms) the "running" overlay is shown so the 180ms CSS
@@ -512,7 +531,60 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   const [statusState, setStatusState] = useState<
     "loading" | "ready" | "running" | "error"
   >("loading");
-  const [outputs, setOutputs] = useState<OutputCell[]>([]);
+
+  // ─── Per-adapter playground store ───────────────────────────────────────
+  // Workspaces, files (tabs), per-file dirty buffers and per-file output
+  // history all live in a Zustand store keyed by adapter id so the state
+  // survives navigation between unrelated UI surfaces.
+  const useStore = getPlaygroundStore(adapter.id);
+  const workspaceId = useStore((s) => s.workspaceId);
+  const files = useStore((s) => s.files);
+  const activeFileId = useStore((s) => s.activeFileId);
+  const activeTabId = useStore((s) => s.activeTabId);
+  const dirtyBuffers = useStore((s) => s.dirtyBuffers);
+  const outputsByFile = useStore((s) => s.outputsByFile);
+  const setWorkspace = useStore((s) => s.setWorkspace);
+  const setFiles = useStore((s) => s.setFiles);
+  const setActiveFileId = useStore((s) => s.setActiveFileId);
+  const setActiveTabId = useStore((s) => s.setActiveTabId);
+  const updateDirtyBuffer = useStore((s) => s.updateDirtyBuffer);
+  const clearDirtyBuffer = useStore((s) => s.clearDirtyBuffer);
+  const setOutputsForFile = useStore((s) => s.setOutputsForFile);
+  const clearOutputsForFile = useStore((s) => s.clearOutputsForFile);
+
+  // Derived: the active file's outputs (the output pane is per-tab).
+  const outputs = useMemo(
+    () => outputsByFile.get(activeFileId) ?? [],
+    [outputsByFile, activeFileId],
+  );
+
+  // Refs let stale closures (CodeMirror persist listener, async run loop)
+  // read the latest workspace + file ids without being rebuilt.
+  const activeFileIdRef = useRef("");
+  const workspaceIdRef = useRef("");
+  const filesRef = useRef<PlaygroundFile[]>([]);
+  const dirtyBuffersRef = useRef(dirtyBuffers);
+  useEffect(() => {
+    activeFileIdRef.current = activeFileId;
+  }, [activeFileId]);
+  useEffect(() => {
+    workspaceIdRef.current = workspaceId ?? "";
+  }, [workspaceId]);
+  useEffect(() => {
+    filesRef.current = files;
+  }, [files]);
+  useEffect(() => {
+    dirtyBuffersRef.current = dirtyBuffers;
+  }, [dirtyBuffers]);
+
+  // Suppress the persist listener while we programmatically replace the
+  // editor doc (tab switches, example loads). Without this every doc
+  // replacement would write the *previous* file's content into the
+  // *new* file's dirty buffer.
+  const suppressPersistRef = useRef(false);
+
+  const [workspaceReady, setWorkspaceReady] = useState(false);
+
   const [isFormatting, setIsFormatting] = useState(false);
   const [formatPopoverOpen, setFormatPopoverOpen] = useState(false);
   const outputCounter = useRef(0);
@@ -604,6 +676,103 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [adapter.id]);
 
+  // ─── Workspace + file manifest bootstrap ────────────────────────────────
+  // Resolves (or auto-creates) the active workspace for this language,
+  // hydrates the file manifest from localStorage, and seeds the
+  // in-memory dirty buffer by reading each file's contents from OPFS.
+  // Once complete, the editor mount effect can dispatch a doc
+  // replacement so the user lands on their saved code.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const ws = await ensureActiveWorkspace(adapter.id);
+        if (cancelled) return;
+
+        const manifest = loadManifest(adapter.id, ws.id);
+        let files: PlaygroundFile[];
+        let activeId: string;
+        if (manifest) {
+          files = manifest.files;
+          activeId = manifest.activeFileId;
+        } else {
+          files = defaultFiles(adapter);
+          activeId = files[0].id;
+          // Seed the file with the legacy single-file code (if any) so
+          // users migrating from Phase-4 don't lose their work.
+          const legacy = localStorage.getItem(storageKey("code"));
+          if (legacy && legacy.length > 0) {
+            opfsWriteFile(ws.id, files[0].id, legacy);
+          }
+          saveManifest(adapter.id, ws.id, files, activeId);
+        }
+
+        // Read each file's content from OPFS into the dirty buffer.
+        // Files without OPFS content fall back to the first example as
+        // a sensible starter (matches the single-file behaviour from
+        // before Phase 5).
+        for (const f of files) {
+          const stored = await opfsReadFile(ws.id, f.id);
+          if (cancelled) return;
+          if (stored != null) {
+            updateDirtyBuffer(f.id, stored);
+          } else if (f.id === activeId) {
+            const legacy = localStorage.getItem(storageKey("code"));
+            const seed = legacy ?? adapter.examples[0]?.code ?? "";
+            updateDirtyBuffer(f.id, seed);
+            if (seed) opfsWriteFile(ws.id, f.id, seed);
+          } else {
+            updateDirtyBuffer(f.id, "");
+          }
+        }
+
+        if (cancelled) return;
+        setWorkspace(ws.id, ws.name);
+        setFiles(files);
+        setActiveFileId(activeId);
+        setActiveTabId(activeId);
+        // Sync refs eagerly so the editor's persist listener can use them
+        // immediately on the next dispatch.
+        workspaceIdRef.current = ws.id;
+        activeFileIdRef.current = activeId;
+        filesRef.current = files;
+        setWorkspaceReady(true);
+      } catch {
+        // Workspace bootstrap failed (OPFS down, lock contention, etc.);
+        // fall back to a single in-memory file so the playground still
+        // works.
+        if (cancelled) return;
+        const files = defaultFiles(adapter);
+        const activeId = files[0].id;
+        const legacy =
+          typeof window !== "undefined"
+            ? localStorage.getItem(storageKey("code"))
+            : null;
+        const seed = legacy ?? adapter.examples[0]?.code ?? "";
+        updateDirtyBuffer(activeId, seed);
+        setFiles(files);
+        setActiveFileId(activeId);
+        setActiveTabId(activeId);
+        activeFileIdRef.current = activeId;
+        filesRef.current = files;
+        setWorkspaceReady(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [adapter.id]);
+
+  // Persist the manifest whenever files or active file change. Skipped
+  // until the workspace has finished bootstrapping so the initial
+  // hydration doesn't immediately overwrite a freshly-loaded manifest.
+  useEffect(() => {
+    if (!workspaceReady || !workspaceId) return;
+    saveManifest(adapter.id, workspaceId, files, activeFileId);
+  }, [adapter.id, workspaceId, files, activeFileId, workspaceReady]);
+
   // Boot the runtime + mount the editor.
   useEffect(() => {
     let cancelled = false;
@@ -648,15 +817,21 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
 
       // Listen for doc changes to persist + auto-trigger completion on `.`,
       // matching the v5 inputRead "type a dot" UX.
+      // The persist target is the *currently active file*: contents
+      // land in the file's in-memory dirty buffer (synchronous) and in
+      // OPFS via an async queue. We deliberately read the active file
+      // and workspace ids from refs so tab switches don't require
+      // rebuilding the editor extensions.
       const persistListener = EditorView.updateListener.of((update) => {
         if (!update.docChanged) return;
-        try {
-          localStorage.setItem(
-            storageKey("code"),
-            update.state.doc.toString(),
-          );
-        } catch {
-          // Quota exceeded / private mode — ignore.
+        if (!suppressPersistRef.current) {
+          const fileId = activeFileIdRef.current;
+          const wsId = workspaceIdRef.current;
+          if (fileId) {
+            const content = update.state.doc.toString();
+            updateDirtyBuffer(fileId, content);
+            if (wsId) opfsWriteFile(wsId, fileId, content);
+          }
         }
         for (const tr of update.transactions) {
           if (!tr.isUserEvent("input.type")) continue;
@@ -671,6 +846,10 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       });
 
       const view = new EditorView({
+        // The editor mounts before the workspace bootstrap resolves; we
+        // start with the legacy localStorage entry (if any) for a
+        // zero-flash first paint, then the workspace effect dispatches
+        // a doc replacement with whatever the OPFS read returned.
         doc:
           localStorage.getItem(storageKey("code")) ??
           adapter.examples[0]?.code ??
@@ -775,6 +954,30 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     applyThemePalette(editorTheme);
     applyMode(editorTheme);
   }, [editorTheme]);
+
+  // Sync the CodeMirror document to the active file's dirty buffer.
+  // Runs whenever the active file id changes (tab switch) or the
+  // workspace finishes bootstrapping. The persist listener is suppressed
+  // during the replacement so the change isn't echoed back as a "save".
+  useEffect(() => {
+    if (!workspaceReady) return;
+    if (activeTabId === SETTINGS_TAB_ID) return;
+    const view = editorRef.current;
+    if (!view) return;
+    if (!activeFileId) return;
+    const target = dirtyBuffersRef.current.get(activeFileId) ?? "";
+    if (view.state.doc.toString() === target) return;
+    suppressPersistRef.current = true;
+    try {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: target },
+        // Drop selection to the start so it's never out of range.
+        selection: { anchor: 0 },
+      });
+    } finally {
+      suppressPersistRef.current = false;
+    }
+  }, [activeFileId, activeTabId, workspaceReady]);
 
   // Push word-wrap changes into CodeMirror after init.
   useEffect(() => {
@@ -907,12 +1110,16 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     if (!editor || !rt) return;
     const code = editor.state.doc.toString().trim();
     if (!code) return;
+    // Snapshot the active file id at run start: even if the user
+    // switches tabs mid-run, the outputs should be routed to the file
+    // whose code we actually executed.
+    const targetFileId = activeFileIdRef.current;
+    if (!targetFileId) return;
 
     setStatusState("running");
 
     if (clearBeforeRun) {
-      setOutputs([]);
-      outputCounter.current = 0;
+      setOutputsForFile(targetFileId, []);
     }
 
     const t0 = performance.now();
@@ -922,7 +1129,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     try {
       await rt.run(code, (cell) => collected.push(cell));
       const elapsed = `${((performance.now() - t0) / 1000).toFixed(2)}s`;
-      setOutputs((prev) => [
+      setOutputsForFile(targetFileId, (prev) => [
         ...prev,
         ...collected.map((c) => ({
           ...c,
@@ -941,7 +1148,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     } catch (err) {
       const elapsed = `${((performance.now() - t0) / 1000).toFixed(2)}s`;
       const msg = err instanceof Error ? err.message : String(err);
-      setOutputs((prev) => [
+      setOutputsForFile(targetFileId, (prev) => [
         ...prev,
         ...collected.map((c) => ({
           ...c,
@@ -965,7 +1172,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       // user doesn't have to swipe back themselves.
       setMobileTab("output");
     }
-  }, [clearBeforeRun, showToast]);
+  }, [clearBeforeRun, setOutputsForFile, showToast]);
 
   // Keep a fresh closure available for the CodeMirror keymap.
   useEffect(() => {
@@ -975,12 +1182,121 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   }, [runCode]);
 
   const clearOutput = useCallback(() => {
-    setOutputs([]);
-    outputCounter.current = 0;
+    const fileId = activeFileIdRef.current;
+    if (fileId) clearOutputsForFile(fileId);
     if (loaded) {
       setStatusState("ready");
     }
-  }, [loaded]);
+  }, [clearOutputsForFile, loaded]);
+
+  // ─── File tab management ────────────────────────────────────────────────
+
+  /** Flush the current editor doc into the active file's dirty buffer
+   *  + OPFS, so the contents survive a tab switch. */
+  const flushActiveFileToBuffer = useCallback(() => {
+    const view = editorRef.current;
+    const fileId = activeFileIdRef.current;
+    const wsId = workspaceIdRef.current;
+    if (!view || !fileId) return;
+    const content = view.state.doc.toString();
+    updateDirtyBuffer(fileId, content);
+    if (wsId) opfsWriteFile(wsId, fileId, content);
+  }, [updateDirtyBuffer]);
+
+  const selectTab = useCallback(
+    (tabId: string) => {
+      if (tabId === activeTabId) return;
+      flushActiveFileToBuffer();
+      if (tabId === SETTINGS_TAB_ID) {
+        setActiveTabId(SETTINGS_TAB_ID);
+        return;
+      }
+      setActiveTabId(tabId);
+      setActiveFileId(tabId);
+      activeFileIdRef.current = tabId;
+    },
+    [activeTabId, flushActiveFileToBuffer, setActiveFileId, setActiveTabId],
+  );
+
+  const addNewFile = useCallback(() => {
+    flushActiveFileToBuffer();
+    const wsId = workspaceIdRef.current;
+    const id = newFileId();
+    const filename = suggestNextFilename(adapter, filesRef.current);
+    const newFile: PlaygroundFile = {
+      id,
+      filename,
+      pristineFilename: filename,
+    };
+    const next = [...filesRef.current, newFile];
+    filesRef.current = next;
+    setFiles(next);
+    updateDirtyBuffer(id, "");
+    if (wsId) opfsWriteFile(wsId, id, "");
+    activeFileIdRef.current = id;
+    setActiveFileId(id);
+    setActiveTabId(id);
+  }, [
+    adapter,
+    flushActiveFileToBuffer,
+    setActiveFileId,
+    setActiveTabId,
+    setFiles,
+    updateDirtyBuffer,
+  ]);
+
+  const closeFileTab = useCallback(
+    (fileId: string) => {
+      const current = filesRef.current;
+      if (current.length <= 1) {
+        // Refuse to close the last file — the playground needs at
+        // least one editor target. Could be relaxed later by recreating
+        // a default file on close.
+        showToast("Can't close the last file.", "warn");
+        return;
+      }
+      const wsId = workspaceIdRef.current;
+      const remaining = current.filter((f) => f.id !== fileId);
+      filesRef.current = remaining;
+      setFiles(remaining);
+      clearDirtyBuffer(fileId);
+      clearOutputsForFile(fileId);
+      if (wsId) void opfsDeleteFile(wsId, fileId);
+      if (activeFileIdRef.current === fileId) {
+        // Pick a neighbour: prefer the tab that visually replaces the
+        // closed one — i.e. the previous tab in tab order, falling back
+        // to the first remaining tab.
+        const closedIdx = current.findIndex((f) => f.id === fileId);
+        const next =
+          remaining[Math.max(0, Math.min(closedIdx - 1, remaining.length - 1))]
+            ?.id ?? remaining[0].id;
+        activeFileIdRef.current = next;
+        setActiveFileId(next);
+        setActiveTabId(next);
+      }
+    },
+    [
+      clearDirtyBuffer,
+      clearOutputsForFile,
+      setActiveFileId,
+      setActiveTabId,
+      setFiles,
+      showToast,
+    ],
+  );
+
+  const renameFileTab = useCallback(
+    (fileId: string, newName: string) => {
+      const trimmed = newName.trim();
+      if (!trimmed) return;
+      const next = filesRef.current.map((f) =>
+        f.id === fileId ? { ...f, filename: trimmed } : f,
+      );
+      filesRef.current = next;
+      setFiles(next);
+    },
+    [setFiles],
+  );
 
   // Apply an example to the editor immediately. Use `requestExample` for
   // user-initiated picks so we can prompt before discarding work.
@@ -1068,7 +1384,16 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `${adapter.exportBaseFilename}.${format.extension}`;
+      // When the active file has been renamed, prefer its filename
+      // base over the adapter's generic export name so a user who
+      // edited "utils.py" downloads "utils.py" rather than "script.py".
+      const active = filesRef.current.find(
+        (f) => f.id === activeFileIdRef.current,
+      );
+      const base = active
+        ? active.filename.replace(/\.[^.]+$/, "")
+        : adapter.exportBaseFilename;
+      a.download = `${base || adapter.exportBaseFilename}.${format.extension}`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
@@ -1262,6 +1587,19 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       window.clearInterval(id);
     };
   }, [loaded, statusState]);
+
+  const fileTabDescriptors = useMemo<TabDescriptor[]>(
+    () =>
+      files.map((f) => ({
+        id: f.id,
+        kind: "code" as const,
+        label: f.filename,
+        icon: <FileCode2 size={11} aria-hidden="true" />,
+        closeable: files.length > 1,
+        renameable: true,
+      })),
+    [files],
+  );
 
   const capabilitiesBlurb = useMemo(
     () => buildCapabilitiesBlurb(adapter.outputCapabilities),
@@ -1932,6 +2270,21 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
             </div>
           </nav>
           <div className="pg-body-content">
+        {/* File tabs: one tab per workspace file. The active tab's
+            editor + output pane appear directly below — switching tabs
+            swaps both the editor doc and the output history so each
+            file feels like its own self-contained workspace. */}
+        {files.length > 0 && (
+          <TabBar
+            tabs={fileTabDescriptors}
+            activeTabId={activeTabId || activeFileId}
+            onSelectTab={selectTab}
+            onCloseTab={files.length > 1 ? closeFileTab : undefined}
+            onAddTab={addNewFile}
+            onRenameTab={renameFileTab}
+            className="pg-file-tabbar"
+          />
+        )}
         <div className="mobile-tabs" role="tablist" aria-label="Pane">
           <button
             type="button"

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -118,6 +118,8 @@ import {
   writeFile as opfsWriteFile,
 } from "./opfs/fileStorage";
 import { ensureActiveWorkspace } from "./opfs/activeWorkspace";
+import { acquireWorkspaceLock } from "./opfs/workspace";
+import { WorkspaceBadge } from "./workspace/WorkspaceBadge";
 import { FileCode2 } from "lucide-react";
 
 const MOBILE_EDITOR_TAB = "editor" as const;
@@ -538,6 +540,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   // survives navigation between unrelated UI surfaces.
   const useStore = getPlaygroundStore(adapter.id);
   const workspaceId = useStore((s) => s.workspaceId);
+  const workspaceName = useStore((s) => s.workspaceName);
   const files = useStore((s) => s.files);
   const activeFileId = useStore((s) => s.activeFileId);
   const activeTabId = useStore((s) => s.activeTabId);
@@ -738,6 +741,26 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
         activeFileIdRef.current = activeId;
         filesRef.current = files;
         setWorkspaceReady(true);
+
+        // Tab-isolation notice: if another tab already holds the lock
+        // for this workspace, surface a one-time toast so the user
+        // knows their edits in this tab are unsafe. Shown at most once
+        // per (workspace × session) via sessionStorage.
+        const noticeKey = `pg_ws_warned_${ws.id}`;
+        try {
+          if (window.sessionStorage.getItem(noticeKey) !== "1") {
+            const hasLock = await acquireWorkspaceLock(ws.id);
+            if (!cancelled && !hasLock) {
+              window.sessionStorage.setItem(noticeKey, "1");
+              showToast(
+                "This workspace is already open in another tab. Edits here may conflict — switch workspaces via the badge in the header.",
+                "warn",
+              );
+            }
+          }
+        } catch {
+          /* sessionStorage / Locks unavailable — ignore. */
+        }
       } catch {
         // Workspace bootstrap failed (OPFS down, lock contention, etc.);
         // fall back to a single in-memory file so the playground still
@@ -1727,6 +1750,17 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
             </Select.Root>
           </div>
           <div className="header-sep" />
+
+          {/* Workspace badge: visible on every breakpoint. Clicking opens
+              a popover with this playground's recent workspaces and a
+              "Manage" entry into the full workspace drawer. */}
+          {workspaceReady && (
+            <WorkspaceBadge
+              playgroundId={adapter.id}
+              activeWorkspaceId={workspaceId}
+              activeWorkspaceName={workspaceName}
+            />
+          )}
 
           {/* Desktop action group — hidden on narrow viewports in favour
               of the consolidated mobile menu below. */}

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -105,6 +105,7 @@ import { SqlEditorToolbar } from "../sql/components/SqlEditorToolbar";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { ensureActiveWorkspace } from "../opfs/activeWorkspace";
+import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
 import { type DuckDbEngine } from "../runtime/duckdb";
 
 const DUCKDB_SAMPLE_DATABASES = duckdbAdapter.samples;
@@ -974,6 +975,10 @@ function DuckDbPlaygroundInner() {
   const [loadingMessage, setLoadingMessage] = useState(
     "Loading DuckDB engine…",
   );
+  const [activeWorkspace, setActiveWorkspace] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
   const [indexesExpanded, setIndexesExpanded] = useState(true);
   const [viewsExpanded, setViewsExpanded] = useState(true);
   const [tablesExpanded, setTablesExpanded] = useState(true);
@@ -1642,6 +1647,7 @@ function DuckDbPlaygroundInner() {
         try {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
+          setActiveWorkspace({ id: workspace.id, name: workspace.name });
         } catch {
           /* proceed in-memory */
         }
@@ -3559,6 +3565,13 @@ function DuckDbPlaygroundInner() {
       loadingCaption={loadingMessage}
       headerActions={
         <>
+          {activeWorkspace && (
+            <WorkspaceBadge
+              playgroundId={PLAYGROUND_ID}
+              activeWorkspaceId={activeWorkspace.id}
+              activeWorkspaceName={activeWorkspace.name}
+            />
+          )}
           <div className="header-actions desktop-only">
             <Menu.Root>
               <Menu.Trigger

--- a/app/_components/opfs/activeWorkspace.ts
+++ b/app/_components/opfs/activeWorkspace.ts
@@ -67,6 +67,24 @@ export function setActiveWorkspaceId(
 }
 
 /**
+ * Switches the active workspace for a playground and reloads the page.
+ * Uses a reload (rather than tearing down + re-bootstrapping the engine
+ * and editor in place) because every workspace switch needs to rebuild
+ * the runtime / database state from scratch — a reload is both simpler
+ * and indistinguishable from an in-place re-bootstrap from the user's
+ * perspective.
+ */
+export function switchActiveWorkspace(
+  playgroundId: string,
+  workspaceId: string,
+): void {
+  setActiveWorkspaceId(playgroundId, workspaceId);
+  if (typeof window !== "undefined") {
+    window.location.reload();
+  }
+}
+
+/**
  * Resolve (or create) the active workspace for a playground.
  *
  * Returns the full `WorkspaceEntry` (id, name, createdAt, etc.) so

--- a/app/_components/opfs/fileStorage.ts
+++ b/app/_components/opfs/fileStorage.ts
@@ -201,3 +201,42 @@ export async function listFiles(workspaceId: string): Promise<string[]> {
 export async function flushFileWrites(): Promise<void> {
   await flush();
 }
+
+/**
+ * Recursively sums every file size under a workspace's OPFS directory.
+ * Returns a byte count suitable for display in the Workspace Manager UI.
+ * Returns `0` when OPFS is unavailable or the workspace has no backing
+ * directory.
+ */
+export async function estimateWorkspaceSize(
+  workspaceId: string,
+): Promise<number> {
+  if (!isOpfsSupported()) return 0;
+  try {
+    const root = await navigator.storage.getDirectory();
+    const wsDir = await root.getDirectoryHandle("workspaces", {
+      create: false,
+    });
+    const wDir = await wsDir.getDirectoryHandle(workspaceId, { create: false });
+    return await sumDirectory(wDir);
+  } catch {
+    return 0;
+  }
+}
+
+async function sumDirectory(dir: FileSystemDirectoryHandle): Promise<number> {
+  let total = 0;
+  for await (const [, handle] of dir as unknown as IterableDir) {
+    if (handle.kind === "directory") {
+      total += await sumDirectory(handle as FileSystemDirectoryHandle);
+    } else {
+      try {
+        const file = await (handle as FileSystemFileHandle).getFile();
+        total += file.size;
+      } catch {
+        // Unreadable file — skip.
+      }
+    }
+  }
+  return total;
+}

--- a/app/_components/opfs/workspace.ts
+++ b/app/_components/opfs/workspace.ts
@@ -209,6 +209,107 @@ export async function deleteWorkspace(id: string): Promise<void> {
   updateWorkspaceRegistry(registry);
 }
 
+/**
+ * Renames a workspace in-place. Updates both `meta.json` (best-effort) and the
+ * registry entry. Returns the updated entry, or `null` if the workspace was
+ * not in the registry.
+ */
+export async function renameWorkspace(
+  id: string,
+  newName: string,
+): Promise<WorkspaceEntry | null> {
+  const trimmed = newName.trim();
+  if (!trimmed) return null;
+  const registry = getWorkspaceRegistry();
+  const idx = registry.findIndex((e) => e.id === id);
+  if (idx === -1) return null;
+  const updated: WorkspaceEntry = { ...registry[idx], name: trimmed };
+  registry[idx] = updated;
+  updateWorkspaceRegistry(registry);
+
+  if (isOpfsSupported()) {
+    try {
+      const dir = await getWorkspaceDir(id, false);
+      const meta: WorkspaceMeta = {
+        name: trimmed,
+        playground: updated.playground,
+        createdAt: updated.createdAt,
+      };
+      const metaFh = await dir.getFileHandle("meta.json", { create: true });
+      const writable = await metaFh.createWritable();
+      await writable.write(JSON.stringify(meta));
+      await writable.close();
+    } catch {
+      // Meta write failed — registry is the authoritative name source, so the
+      // rename is still effective.
+    }
+  }
+
+  return updated;
+}
+
+/**
+ * Duplicates a workspace's OPFS directory tree into a freshly-created
+ * workspace. Both top-level subdirectories (`files/`, `db/`) and their
+ * contents are copied. Returns the new workspace entry, or `null` when the
+ * source workspace is not in the registry.
+ *
+ * When OPFS is unavailable, the new workspace is registered with no backing
+ * data — callers fall back to the in-memory path just like `createWorkspace`.
+ */
+export async function duplicateWorkspace(
+  sourceId: string,
+  newName: string,
+): Promise<WorkspaceEntry | null> {
+  const registry = getWorkspaceRegistry();
+  const source = registry.find((e) => e.id === sourceId);
+  if (!source) return null;
+
+  const created = await createWorkspace(newName, source.playground);
+
+  if (isOpfsSupported()) {
+    try {
+      const wsDir = await getWorkspacesDir();
+      const srcDir = await wsDir.getDirectoryHandle(sourceId, {
+        create: false,
+      });
+      const dstDir = await wsDir.getDirectoryHandle(created.id, {
+        create: true,
+      });
+      await copyDirectoryHandle(srcDir, dstDir);
+    } catch {
+      // Source directory missing or unreadable — leave the new workspace
+      // empty (the registry entry is still valid).
+    }
+  }
+
+  return created;
+}
+
+/** Recursively copies the contents of `src` into `dst`. Skips `meta.json`
+ *  since the destination already has its own. */
+async function copyDirectoryHandle(
+  src: FileSystemDirectoryHandle,
+  dst: FileSystemDirectoryHandle,
+): Promise<void> {
+  type IterableDir = AsyncIterable<[string, FileSystemHandle]>;
+  for await (const [name, handle] of src as unknown as IterableDir) {
+    if (name === "meta.json") continue;
+    if (handle.kind === "directory") {
+      const child = handle as FileSystemDirectoryHandle;
+      const dstChild = await dst.getDirectoryHandle(name, { create: true });
+      await copyDirectoryHandle(child, dstChild);
+    } else {
+      const fileHandle = handle as FileSystemFileHandle;
+      const file = await fileHandle.getFile();
+      const dstFh = await dst.getFileHandle(name, { create: true });
+      const writable = await dstFh.createWritable();
+      await writable.write(await file.arrayBuffer());
+      await writable.close();
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Web Locks — cross-tab workspace exclusivity
 // ---------------------------------------------------------------------------

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -3290,3 +3290,147 @@ html[data-pg-theme="dark"] .welcome h3 {
   opacity: 0.35;
   cursor: not-allowed;
 }
+
+/* ───────────────────────────────────────────────────────────────────────
+   Generic playground tab bar (used for file tabs in non-SQL playgrounds).
+   Visually mirrors the SQL playground's existing tab bar so language and
+   SQL playgrounds feel uniform.
+   ─────────────────────────────────────────────────────────────────────── */
+
+.pg-tabbar {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  min-height: 34px;
+  padding-top: 4px;
+  padding-left: 6px;
+  padding-right: 6px;
+  min-width: 0;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.pg-tabs {
+  display: flex;
+  align-items: stretch;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  gap: 2px;
+}
+
+.pg-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px 6px 12px;
+  background: transparent;
+  color: var(--text-dim);
+  border: 0;
+  border-radius: 0;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  cursor: pointer;
+  position: relative;
+  flex: 0 1 auto;
+  min-width: 60px;
+  max-width: 240px;
+  overflow: hidden;
+  margin-bottom: -1px;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+  animation: pg-tab-appear 0.15s ease backwards;
+}
+
+@keyframes pg-tab-appear {
+  from { opacity: 0; max-width: 0; }
+  to   { opacity: 1; max-width: 240px; }
+}
+
+.pg-tab--closing {
+  animation: pg-tab-close 0.15s ease both;
+  pointer-events: none;
+}
+
+@keyframes pg-tab-close {
+  from { opacity: 1; transform: scaleX(1); max-width: 240px; }
+  to   { opacity: 0; transform: scaleX(0.7); max-width: 0; }
+}
+
+.pg-tab:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--bg) 90%, transparent);
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+}
+
+.pg-tab.active {
+  background: var(--bg);
+  color: var(--text);
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+  box-shadow: inset 0 2px 0 0 var(--primary);
+}
+
+.pg-tab-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.pg-tab.active .pg-tab-icon {
+  color: var(--text);
+}
+
+.pg-tab-title {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+  pointer-events: none;
+}
+
+.pg-tab-close {
+  background: transparent;
+  border: 0;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+  flex-shrink: 0;
+}
+
+.pg-tab-close:hover {
+  background: var(--border);
+  color: var(--text);
+}
+
+.pg-tab-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  color: var(--text);
+  width: 28px;
+  height: 28px;
+  margin: auto 4px -1px 4px;
+  border-radius: 6px 6px 0 0;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.pg-tab-add:hover {
+  background: color-mix(in srgb, var(--bg) 90%, transparent);
+}

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -3434,3 +3434,289 @@ html[data-pg-theme="dark"] .welcome h3 {
 .pg-tab-add:hover {
   background: color-mix(in srgb, var(--bg) 90%, transparent);
 }
+
+/* ───────────────────────────────────────────────────────────────────────
+   Workspace badge + popover + manager drawer (Phase 6).
+   ─────────────────────────────────────────────────────────────────────── */
+
+.workspace-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: color-mix(in srgb, var(--bg) 75%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  max-width: 220px;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.workspace-badge:hover {
+  background: var(--bg);
+  border-color: color-mix(in srgb, var(--primary) 40%, var(--border));
+}
+
+.workspace-badge-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-popover {
+  min-width: 260px;
+  max-width: 320px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.workspace-popover-header {
+  padding: 8px 12px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+}
+
+.workspace-popover-body {
+  display: flex;
+  flex-direction: column;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.workspace-popover-empty {
+  padding: 16px 12px;
+  font-size: 12px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
+.workspace-popover-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  color: var(--text);
+  width: 100%;
+  font-family: var(--font-ui);
+  font-size: 12px;
+}
+
+.workspace-popover-item:hover {
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+}
+
+.workspace-popover-item.active {
+  background: color-mix(in srgb, var(--primary) 18%, transparent);
+}
+
+.workspace-popover-item-check {
+  width: 14px;
+  flex-shrink: 0;
+  color: var(--primary);
+}
+
+.workspace-popover-item-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.workspace-popover-item-name {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.workspace-popover-item-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.workspace-popover-footer {
+  display: flex;
+  border-top: 1px solid var(--border);
+}
+
+.workspace-popover-action {
+  flex: 1 1 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px;
+  background: transparent;
+  border: 0;
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.workspace-popover-action + .workspace-popover-action {
+  border-left: 1px solid var(--border);
+}
+
+.workspace-popover-action:hover {
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+}
+
+/* Manager drawer ──────────────────────────────────────────────────────── */
+
+.workspace-manager-drawer {
+  /* The drawer reuses the packages-drawer base styles; this just gives
+     it a sensible minimum height on tall screens. */
+  min-height: 60vh;
+}
+
+.workspace-manager-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.workspace-manager-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: color-mix(in srgb, var(--primary) 18%, transparent);
+  border: 1px dashed
+    color-mix(in srgb, var(--primary) 50%, var(--border));
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  margin-bottom: 8px;
+  align-self: flex-start;
+}
+
+.workspace-manager-new:hover {
+  background: color-mix(in srgb, var(--primary) 28%, transparent);
+}
+
+.workspace-manager-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+}
+
+.workspace-manager-item.active {
+  border-color: color-mix(in srgb, var(--primary) 55%, var(--border));
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+}
+
+.workspace-manager-item-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.workspace-manager-item-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: var(--text);
+  text-align: left;
+  min-width: 0;
+}
+
+.workspace-manager-item-name {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.workspace-manager-active-pill {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  background: color-mix(in srgb, var(--primary) 25%, transparent);
+  color: var(--text);
+  font-size: 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  vertical-align: 2px;
+}
+
+.workspace-manager-item-meta {
+  display: flex;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+}
+
+.workspace-manager-item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.workspace-manager-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: color-mix(in srgb, var(--bg) 75%, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.workspace-manager-action:hover:not(:disabled) {
+  background: var(--bg);
+  border-color: color-mix(in srgb, var(--primary) 40%, var(--border));
+}
+
+.workspace-manager-action.danger {
+  color: var(--danger, #e57373);
+}
+
+.workspace-manager-action.danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger, #e57373) 14%, transparent);
+  border-color: color-mix(in srgb, var(--danger, #e57373) 50%, var(--border));
+}
+
+.workspace-manager-action:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/app/_components/playgroundTabs.ts
+++ b/app/_components/playgroundTabs.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import type { LanguageAdapter } from "./types";
+
+/** Reserved tab id used to render the Settings panel as a tab. Lives
+ *  alongside the file tabs in the generic TabBar so users can switch
+ *  between code and settings without losing their place. */
+export const SETTINGS_TAB_ID = "__settings__";
+
+/** A file slot rendered as a tab in the non-SQL playgrounds. The file
+ *  contents are NOT stored here — code lives in OPFS under
+ *  `workspaces/<wsId>/files/<id>` and is shadowed by an in-memory
+ *  dirty buffer in the Zustand store. */
+export interface PlaygroundFile {
+  /** Stable tab id. Doubles as the OPFS filename — never derive it from
+   *  `filename` since renames must not touch OPFS. */
+  id: string;
+  /** User-visible filename (e.g. "main.py", "utils.py"). */
+  filename: string;
+  /** Filename at creation, used to detect rename. */
+  pristineFilename: string;
+}
+
+export function newFileId(): string {
+  return `f_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/** Default initial file set for a freshly-created workspace. */
+export function defaultFiles(adapter: LanguageAdapter): PlaygroundFile[] {
+  const base = adapter.exportBaseFilename || "main";
+  const ext = adapter.defaultFileExtension || "txt";
+  const filename = `${base}.${ext}`;
+  return [
+    { id: newFileId(), filename, pristineFilename: filename },
+  ];
+}
+
+/** Suggest a fresh, non-colliding filename for a new tab. */
+export function suggestNextFilename(
+  adapter: LanguageAdapter,
+  existing: PlaygroundFile[],
+): string {
+  const ext = adapter.defaultFileExtension || "txt";
+  const taken = new Set(existing.map((f) => f.filename.toLowerCase()));
+  let i = existing.length + 1;
+  // Cap the search so a runaway loop is impossible.
+  for (let attempt = 0; attempt < 1000; attempt += 1) {
+    const candidate = `untitled_${i}.${ext}`;
+    if (!taken.has(candidate.toLowerCase())) return candidate;
+    i += 1;
+  }
+  return `untitled_${Date.now()}.${ext}`;
+}
+
+// ---------------------------------------------------------------------------
+// Manifest persistence (small, synchronous → localStorage)
+// ---------------------------------------------------------------------------
+//
+// Per (adapter, workspace) we keep a JSON list of `PlaygroundFile`
+// records plus the active file id. File CONTENT lives in OPFS via
+// `fileStorage.ts`; the manifest is metadata only.
+
+interface ManifestPayload {
+  files: PlaygroundFile[];
+  activeFileId: string;
+}
+
+function manifestKey(adapterId: string, workspaceId: string): string {
+  return `pg_files_${adapterId}_${workspaceId}`;
+}
+
+export function loadManifest(
+  adapterId: string,
+  workspaceId: string,
+): ManifestPayload | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(manifestKey(adapterId, workspaceId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as ManifestPayload;
+    if (!Array.isArray(parsed.files) || parsed.files.length === 0) return null;
+    const cleaned: PlaygroundFile[] = parsed.files
+      .filter(
+        (f): f is PlaygroundFile =>
+          typeof f?.id === "string" && typeof f?.filename === "string",
+      )
+      .map((f) => ({
+        id: f.id,
+        filename: f.filename,
+        pristineFilename:
+          typeof f.pristineFilename === "string"
+            ? f.pristineFilename
+            : f.filename,
+      }));
+    if (cleaned.length === 0) return null;
+    const activeFileId =
+      typeof parsed.activeFileId === "string" &&
+      cleaned.some((f) => f.id === parsed.activeFileId)
+        ? parsed.activeFileId
+        : cleaned[0].id;
+    return { files: cleaned, activeFileId };
+  } catch {
+    return null;
+  }
+}
+
+export function saveManifest(
+  adapterId: string,
+  workspaceId: string,
+  files: PlaygroundFile[],
+  activeFileId: string,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: ManifestPayload = { files, activeFileId };
+    window.localStorage.setItem(
+      manifestKey(adapterId, workspaceId),
+      JSON.stringify(payload),
+    );
+  } catch {
+    /* quota / private mode — ignore. */
+  }
+}

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -106,6 +106,7 @@ import { RenameDatabaseDialog } from "../sql/components/RenameDatabaseDialog";
 import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
 import { ensureActiveWorkspace } from "../opfs/activeWorkspace";
+import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
 import { type PostgresEngine } from "../runtime/postgres";
 
 const POSTGRES_SAMPLE_DATABASES = postgresAdapter.samples;
@@ -951,6 +952,10 @@ function PostgresPlaygroundInner() {
   const [loadingMessage, setLoadingMessage] = useState(
     "Loading PostgreSQL engine…",
   );
+  const [activeWorkspace, setActiveWorkspace] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
   const [indexesExpanded, setIndexesExpanded] = useState(true);
   const [viewsExpanded, setViewsExpanded] = useState(true);
   const [tablesExpanded, setTablesExpanded] = useState(true);
@@ -1596,6 +1601,7 @@ function PostgresPlaygroundInner() {
         try {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
+          setActiveWorkspace({ id: workspace.id, name: workspace.name });
         } catch {
           /* proceed in-memory */
         }
@@ -3075,6 +3081,13 @@ function PostgresPlaygroundInner() {
       loadingCaption={loadingMessage}
       headerActions={
         <>
+          {activeWorkspace && (
+            <WorkspaceBadge
+              playgroundId={PLAYGROUND_ID}
+              activeWorkspaceId={activeWorkspace.id}
+              activeWorkspaceName={activeWorkspace.name}
+            />
+          )}
           <div className="header-actions desktop-only">
             <Menu.Root>
               <Menu.Trigger

--- a/app/_components/runtime/c.tsx
+++ b/app/_components/runtime/c.tsx
@@ -449,6 +449,8 @@ export const cAdapter: LanguageAdapter = {
     { extension: "h", label: "C header (.h)", mimeType: "text/x-chdr" },
   ],
   exportBaseFilename: "main",
+  defaultFileExtension: "c",
+  entryPoint: "main.c",
   packagesFooter: (
     <>
       Headers above are part of the{" "}

--- a/app/_components/runtime/cpp.tsx
+++ b/app/_components/runtime/cpp.tsx
@@ -514,6 +514,8 @@ export const cppAdapter: LanguageAdapter = {
     { extension: "hpp", label: "C++ header (.hpp)", mimeType: "text/x-c++hdr" },
   ],
   exportBaseFilename: "main",
+  defaultFileExtension: "cpp",
+  entryPoint: "main.cpp",
   packagesFooter: (
     <>
       Headers above are part of the{" "}

--- a/app/_components/runtime/csharp.tsx
+++ b/app/_components/runtime/csharp.tsx
@@ -338,6 +338,8 @@ export const csharpAdapter: LanguageAdapter = {
     { extension: "cs",  label: "C# source (.cs)",  mimeType: "text/x-csharp" },
   ],
   exportBaseFilename: "script",
+  defaultFileExtension: "cs",
+  entryPoint: "Program.cs",
   packagesFooter: (
     <>
       Namespaces above are part of the{" "}

--- a/app/_components/runtime/java.tsx
+++ b/app/_components/runtime/java.tsx
@@ -582,6 +582,8 @@ export const javaAdapter: LanguageAdapter = {
     },
   ],
   exportBaseFilename: "Main",
+  defaultFileExtension: "java",
+  entryPoint: "Main.java",
   packagesFooter: (
     <>
       Packages above are part of the{" "}

--- a/app/_components/runtime/javascript.tsx
+++ b/app/_components/runtime/javascript.tsx
@@ -197,6 +197,8 @@ export const javascriptAdapter: LanguageAdapter = {
     { extension: "mjs", label: "ES Module (.mjs)", mimeType: "text/javascript" },
   ],
   exportBaseFilename: "script",
+  defaultFileExtension: "js",
+  entryPoint: "index.js",
   packagesFooter: (
     <>
       JavaScript runs natively in your browser — there&apos;s no extra

--- a/app/_components/runtime/php.tsx
+++ b/app/_components/runtime/php.tsx
@@ -217,6 +217,8 @@ export const phpAdapter: LanguageAdapter = {
     { extension: "php", label: "PHP (.php)", mimeType: "application/x-php" },
   ],
   exportBaseFilename: "script",
+  defaultFileExtension: "php",
+  entryPoint: "index.php",
   packagesFooter: (
     <>
       Functions above are part of the{" "}

--- a/app/_components/runtime/python.tsx
+++ b/app/_components/runtime/python.tsx
@@ -706,6 +706,8 @@ export const pythonAdapter: LanguageAdapter = {
     { extension: "py", label: "Python (.py)", mimeType: "text/x-python" },
   ],
   exportBaseFilename: "script",
+  defaultFileExtension: "py",
+  entryPoint: "main.py",
   packagesFooter: (
     <>
       Packages run in WebAssembly via{" "}

--- a/app/_components/runtime/r.tsx
+++ b/app/_components/runtime/r.tsx
@@ -711,6 +711,8 @@ export const rAdapter: LanguageAdapter = {
     { extension: "r", label: "R (.r)", mimeType: "text/x-r-source" },
   ],
   exportBaseFilename: "script",
+  defaultFileExtension: "R",
+  entryPoint: "script.R",
   packagesFooter: (
     <>
       Packages run in WebAssembly via{" "}

--- a/app/_components/runtime/typescript.tsx
+++ b/app/_components/runtime/typescript.tsx
@@ -240,6 +240,8 @@ export const typescriptAdapter: LanguageAdapter = {
     { extension: "ts", label: "TypeScript (.ts)", mimeType: "text/typescript" },
   ],
   exportBaseFilename: "script",
+  defaultFileExtension: "ts",
+  entryPoint: "index.ts",
   packagesFooter: (
     <>
       Code is transpiled in-browser by the official{" "}

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -126,6 +126,7 @@ import { SqlEditorToolbar } from "./components/SqlEditorToolbar";
 import { findSampleDatabase } from "../runtime/sqliteSamples";
 import { sqliteAdapter } from "./sqliteAdapter";
 import { ensureActiveWorkspace } from "../opfs/activeWorkspace";
+import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
 import {
   type ColumnConstraintInfo,
   type ColumnSpec,
@@ -1188,6 +1189,12 @@ function SqlPlaygroundInner() {
     null,
   );
   const [quipIndex, setQuipIndex] = useState<number>(0);
+  // Active workspace surfaced in the header WorkspaceBadge. Resolved
+  // asynchronously by the bootstrap effect below.
+  const [activeWorkspace, setActiveWorkspace] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
 
   // ─── Derived values ──────────────────────────────────────────────────
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
@@ -1629,6 +1636,7 @@ function SqlPlaygroundInner() {
         try {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
+          setActiveWorkspace({ id: workspace.id, name: workspace.name });
         } catch {
           // Workspace bootstrap is best-effort — proceed in-memory.
         }
@@ -2148,6 +2156,13 @@ function SqlPlaygroundInner() {
       }
       headerActions={
         <>
+          {activeWorkspace && (
+            <WorkspaceBadge
+              playgroundId={PLAYGROUND_ID}
+              activeWorkspaceId={activeWorkspace.id}
+              activeWorkspaceName={activeWorkspace.name}
+            />
+          )}
           <div className="header-actions desktop-only">
             <Menu.Root>
               <Menu.Trigger

--- a/app/_components/stores/createPlaygroundStore.ts
+++ b/app/_components/stores/createPlaygroundStore.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { create, type UseBoundStore, type StoreApi } from "zustand";
+import type { OutputCell } from "../types";
+import type { PlaygroundFile } from "../playgroundTabs";
+
+type StatusState = "loading" | "ready" | "running" | "error";
+
+export interface PlaygroundState {
+  // Workspace
+  workspaceId: string | null;
+  workspaceName: string;
+
+  // Files (tabs)
+  files: PlaygroundFile[];
+  /** The currently-active tab. Can be a file id or `SETTINGS_TAB_ID`. */
+  activeTabId: string;
+  /** The most recently active *file* — used when the user closes the
+   *  Settings tab so we can return to a sensible code tab. */
+  activeFileId: string;
+  /** Per-file in-memory editor contents. Persisted to OPFS via
+   *  `fileStorage.writeFile` whenever an entry is updated. */
+  dirtyBuffers: Map<string, string>;
+  /** Per-file output history. Switching tabs swaps this in/out of the
+   *  output pane. */
+  outputsByFile: Map<string, OutputCell[]>;
+  /** Whether the Settings tab is currently mounted in the tab strip. */
+  settingsTabOpen: boolean;
+
+  // Status
+  statusState: StatusState;
+
+  // Setters
+  setWorkspace: (id: string, name: string) => void;
+  setFiles: (files: PlaygroundFile[]) => void;
+  setActiveTabId: (id: string) => void;
+  setActiveFileId: (id: string) => void;
+  updateDirtyBuffer: (fileId: string, code: string) => void;
+  clearDirtyBuffer: (fileId: string) => void;
+  setOutputsForFile: (
+    fileId: string,
+    updater: OutputCell[] | ((prev: OutputCell[]) => OutputCell[]),
+  ) => void;
+  clearOutputsForFile: (fileId: string) => void;
+  setSettingsTabOpen: (open: boolean) => void;
+  setStatusState: (s: StatusState) => void;
+}
+
+export type PlaygroundStore = UseBoundStore<StoreApi<PlaygroundState>>;
+
+export function createPlaygroundStore(): PlaygroundStore {
+  return create<PlaygroundState>((set) => ({
+    workspaceId: null,
+    workspaceName: "",
+    files: [],
+    activeTabId: "",
+    activeFileId: "",
+    dirtyBuffers: new Map(),
+    outputsByFile: new Map(),
+    settingsTabOpen: false,
+    statusState: "loading",
+
+    setWorkspace: (workspaceId, workspaceName) =>
+      set({ workspaceId, workspaceName }),
+    setFiles: (files) => set({ files }),
+    setActiveTabId: (activeTabId) => set({ activeTabId }),
+    setActiveFileId: (activeFileId) => set({ activeFileId }),
+    updateDirtyBuffer: (fileId, code) =>
+      set((state) => {
+        if (state.dirtyBuffers.get(fileId) === code) return state;
+        const next = new Map(state.dirtyBuffers);
+        next.set(fileId, code);
+        return { dirtyBuffers: next };
+      }),
+    clearDirtyBuffer: (fileId) =>
+      set((state) => {
+        if (!state.dirtyBuffers.has(fileId)) return state;
+        const next = new Map(state.dirtyBuffers);
+        next.delete(fileId);
+        return { dirtyBuffers: next };
+      }),
+    setOutputsForFile: (fileId, updater) =>
+      set((state) => {
+        const prev = state.outputsByFile.get(fileId) ?? [];
+        const nextOutputs =
+          typeof updater === "function" ? updater(prev) : updater;
+        const next = new Map(state.outputsByFile);
+        next.set(fileId, nextOutputs);
+        return { outputsByFile: next };
+      }),
+    clearOutputsForFile: (fileId) =>
+      set((state) => {
+        if (!state.outputsByFile.has(fileId)) return state;
+        const next = new Map(state.outputsByFile);
+        next.delete(fileId);
+        return { outputsByFile: next };
+      }),
+    setSettingsTabOpen: (settingsTabOpen) => set({ settingsTabOpen }),
+    setStatusState: (statusState) => set({ statusState }),
+  }));
+}
+
+// Module-level registry of per-adapter stores so that any component that
+// asks for "the python playground store" reaches the same instance.
+// Each non-SQL playground occupies its own route → component → adapter,
+// so this map is effectively keyed by route.
+const stores = new Map<string, PlaygroundStore>();
+
+export function getPlaygroundStore(adapterId: string): PlaygroundStore {
+  let s = stores.get(adapterId);
+  if (!s) {
+    s = createPlaygroundStore();
+    stores.set(adapterId, s);
+  }
+  return s;
+}

--- a/app/_components/tabs/TabBar.tsx
+++ b/app/_components/tabs/TabBar.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import { Dialog } from "@base-ui-components/react/dialog";
+import { ContextMenu } from "@base-ui-components/react/context-menu";
+import { Plus, X } from "lucide-react";
+import type { TabDescriptor } from "./tabTypes";
+
+export interface TabBarProps {
+  tabs: TabDescriptor[];
+  activeTabId: string;
+  onSelectTab: (id: string) => void;
+  onCloseTab?: (id: string) => void;
+  onAddTab?: () => void;
+  onRenameTab?: (id: string, newLabel: string) => void;
+  /** Optional className appended to the root tabbar element. */
+  className?: string;
+}
+
+/**
+ * Generic, content-agnostic tab strip. The bar renders only the strip
+ * and "+" button — the surrounding component is responsible for
+ * rendering the active tab's content.
+ */
+export function TabBar({
+  tabs,
+  activeTabId,
+  onSelectTab,
+  onCloseTab,
+  onAddTab,
+  onRenameTab,
+  className,
+}: TabBarProps) {
+  const cls = ["pg-tabbar", className].filter(Boolean).join(" ");
+  return (
+    <div className={cls}>
+      <div className="pg-tabs" role="tablist">
+        {tabs.map((tab) => (
+          <TabItem
+            key={tab.id}
+            tab={tab}
+            active={tab.id === activeTabId}
+            onSelect={() => onSelectTab(tab.id)}
+            onClose={onCloseTab ? () => onCloseTab(tab.id) : undefined}
+            onRename={
+              onRenameTab
+                ? (label) => onRenameTab(tab.id, label)
+                : undefined
+            }
+          />
+        ))}
+      </div>
+      {onAddTab && (
+        <button
+          type="button"
+          className="pg-tab-add"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={onAddTab}
+          aria-label="New tab"
+        >
+          <Plus size={12} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface TabItemProps {
+  tab: TabDescriptor;
+  active: boolean;
+  onSelect: () => void;
+  onClose?: () => void;
+  onRename?: (label: string) => void;
+}
+
+const TabItem = memo(function TabItem({
+  tab,
+  active,
+  onSelect,
+  onClose,
+  onRename,
+}: TabItemProps) {
+  const closeable = tab.closeable !== false;
+  const renameable = tab.renameable === true && !!onRename;
+
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [draftLabel, setDraftLabel] = useState(tab.label);
+  const [isClosing, setIsClosing] = useState(false);
+  const closedRef = useRef(false);
+
+  const openRename = useCallback(() => {
+    if (!renameable) return;
+    setDraftLabel(tab.label);
+    setRenameOpen(true);
+  }, [renameable, tab.label]);
+
+  const submitRename = useCallback(() => {
+    if (onRename) onRename(draftLabel.trim() || tab.label);
+    setRenameOpen(false);
+  }, [draftLabel, onRename, tab.label]);
+
+  const handleClose = useCallback(() => {
+    if (!onClose) return;
+    setIsClosing(true);
+    setTimeout(() => {
+      if (!closedRef.current) {
+        closedRef.current = true;
+        onClose();
+      }
+    }, 200);
+  }, [onClose]);
+
+  const handleAnimationEnd = useCallback(() => {
+    if (isClosing && !closedRef.current && onClose) {
+      closedRef.current = true;
+      onClose();
+    }
+  }, [isClosing, onClose]);
+
+  // Reset closing flag when tab id changes (e.g. component reused).
+  useEffect(() => {
+    closedRef.current = false;
+  }, [tab.id]);
+
+  return (
+    <>
+      {renameable && (
+        <Dialog.Root open={renameOpen} onOpenChange={setRenameOpen}>
+          <Dialog.Portal>
+            <Dialog.Backdrop className="confirm-backdrop" />
+            <Dialog.Popup className="confirm-popup sql-rename-popup">
+              <Dialog.Title className="confirm-title">Rename tab</Dialog.Title>
+              <Dialog.Description className="confirm-desc">
+                Choose a name for this tab.
+              </Dialog.Description>
+              <form
+                className="sql-rename-form"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  submitRename();
+                }}
+              >
+                <input
+                  className="sql-rename-input"
+                  value={draftLabel}
+                  onChange={(e) => setDraftLabel(e.target.value)}
+                  autoFocus
+                />
+                <div className="confirm-actions">
+                  <Dialog.Close className="confirm-btn confirm-btn-secondary">
+                    Cancel
+                  </Dialog.Close>
+                  <button
+                    type="submit"
+                    className="confirm-btn confirm-btn-primary"
+                  >
+                    Rename
+                  </button>
+                </div>
+              </form>
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>
+      )}
+
+      <ContextMenu.Root>
+        <ContextMenu.Trigger
+          render={(props) => (
+            <button
+              type="button"
+              {...props}
+              className={`pg-tab${active ? " active" : ""} pg-tab--kind-${tab.kind}${isClosing ? " pg-tab--closing" : ""}`}
+              onClick={onSelect}
+              onDoubleClick={openRename}
+              onAnimationEnd={handleAnimationEnd}
+              aria-selected={active}
+              role="tab"
+              data-tab-id={tab.id}
+            >
+              {tab.icon && (
+                <span className="pg-tab-icon" aria-hidden="true">
+                  {tab.icon}
+                </span>
+              )}
+              <span className="pg-tab-title">{tab.label}</span>
+              {closeable && (
+                <span
+                  role="button"
+                  tabIndex={-1}
+                  className="pg-tab-close"
+                  aria-label={`Close ${tab.label}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleClose();
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleClose();
+                    }
+                  }}
+                >
+                  <X size={10} aria-hidden="true" />
+                </span>
+              )}
+            </button>
+          )}
+        />
+        <ContextMenu.Portal>
+          <ContextMenu.Positioner sideOffset={6}>
+            <ContextMenu.Popup className="bui-popup">
+              {renameable && (
+                <ContextMenu.Item
+                  className="example-item"
+                  onClick={openRename}
+                >
+                  <div className="ex-title">Rename</div>
+                </ContextMenu.Item>
+              )}
+              {closeable && (
+                <ContextMenu.Item
+                  className="example-item"
+                  onClick={handleClose}
+                >
+                  <div className="ex-title">Close</div>
+                </ContextMenu.Item>
+              )}
+            </ContextMenu.Popup>
+          </ContextMenu.Positioner>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>
+    </>
+  );
+});

--- a/app/_components/tabs/tabTypes.ts
+++ b/app/_components/tabs/tabTypes.ts
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+/** Open-ended set of tab kinds. The string fallback lets callers
+ *  introduce new kinds (e.g. "terminal") without churning this file. */
+export type TabKind =
+  | "code"
+  | "settings"
+  | "er-diagram"
+  | "query-history"
+  | "terminal"
+  | (string & {});
+
+export interface TabDescriptor {
+  id: string;
+  kind: TabKind;
+  /** Visible label shown in the tab strip. */
+  label: string;
+  /** Optional icon rendered left of the label. */
+  icon?: ReactNode;
+  /** False to hide the close affordance. Defaults to true. */
+  closeable?: boolean;
+  /** True to allow rename via context menu / dblclick. Defaults to false. */
+  renameable?: boolean;
+  /** True to pin to the leftmost position (and skip reorder). */
+  pinned?: boolean;
+}

--- a/app/_components/types.ts
+++ b/app/_components/types.ts
@@ -107,6 +107,13 @@ export interface LanguageAdapter {
   exportFormats: ExportFormat[];
   /** Base filename (without extension) used when exporting, e.g. "script". */
   exportBaseFilename: string;
+  /** Default file extension (no dot) for new tabs in this playground —
+   *  e.g. "py", "js", "cpp". Used to seed the initial workspace file
+   *  and to suggest names for "+" new tabs. */
+  defaultFileExtension: string;
+  /** Filename treated as the entry point for multi-file runs. When
+   *  unset, the active tab's file is the entry point. */
+  entryPoint?: string;
   /** Render-only: footer note shown at the bottom of the packages drawer. */
   packagesFooter: React.ReactNode;
   /** Build the snippet inserted at the top of the editor when the user

--- a/app/_components/workspace/WorkspaceBadge.tsx
+++ b/app/_components/workspace/WorkspaceBadge.tsx
@@ -1,0 +1,687 @@
+"use client";
+
+/**
+ * Workspace badge + popover + manager drawer used by every playground
+ * header. Renders the current workspace name as a pill button; clicking
+ * opens a popover listing recent workspaces for this playground with
+ * "New" and "Manage" affordances. The Manage button promotes the popover
+ * into a Drawer-backed full manager (rename / delete / duplicate +
+ * per-workspace size estimate).
+ *
+ * Workspace switching is implemented as `setActiveWorkspaceId` followed
+ * by `window.location.reload()` — engines and editor state rebuild from
+ * scratch as a side effect of the reload, which is both simpler and
+ * indistinguishable from an in-place tear-down to the user.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { Popover } from "@base-ui-components/react/popover";
+import { Dialog } from "@base-ui-components/react/dialog";
+import { AlertDialog } from "@base-ui-components/react/alert-dialog";
+import { Drawer } from "@base-ui/react/drawer";
+import {
+  Check,
+  Copy as CopyIcon,
+  Folder,
+  HardDrive,
+  Pencil,
+  Plus,
+  Settings2,
+  Trash2,
+} from "lucide-react";
+import {
+  createWorkspace,
+  deleteWorkspace,
+  duplicateWorkspace,
+  getWorkspaceRegistry,
+  renameWorkspace,
+  type WorkspaceEntry,
+} from "../opfs/workspace";
+import { switchActiveWorkspace } from "../opfs/activeWorkspace";
+import { estimateWorkspaceSize } from "../opfs/fileStorage";
+
+const RECENT_LIMIT = 6;
+
+export interface WorkspaceBadgeProps {
+  /** The playground this badge belongs to ("python", "sqlite", …). */
+  playgroundId: string;
+  /** Currently-active workspace id (from `ensureActiveWorkspace`). */
+  activeWorkspaceId: string | null;
+  /** Currently-active workspace display name. */
+  activeWorkspaceName: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let i = 0;
+  let n = bytes;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i += 1;
+  }
+  return `${n.toFixed(n >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function formatRelative(timestamp: number): string {
+  const now = Date.now();
+  const diff = Math.max(0, now - timestamp);
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+export function WorkspaceBadge({
+  playgroundId,
+  activeWorkspaceId,
+  activeWorkspaceName,
+}: WorkspaceBadgeProps) {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [managerOpen, setManagerOpen] = useState(false);
+  const [registry, setRegistry] = useState<WorkspaceEntry[]>([]);
+
+  // Hydrate registry on the client only — `getWorkspaceRegistry` reads
+  // localStorage which is undefined on the server. Re-read whenever the
+  // popover or manager is opened so we always reflect deletions from
+  // other tabs.
+  const refreshRegistry = useCallback(() => {
+    setRegistry(getWorkspaceRegistry());
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    refreshRegistry();
+  }, [refreshRegistry, activeWorkspaceId]);
+
+  // Recent = workspaces for this playground sorted by lastUsedAt desc.
+  const recent = useMemo(
+    () =>
+      registry
+        .filter((e) => e.playground === playgroundId)
+        .sort((a, b) => b.lastUsedAt - a.lastUsedAt)
+        .slice(0, RECENT_LIMIT),
+    [registry, playgroundId],
+  );
+
+  const handleSwitch = useCallback(
+    (workspaceId: string) => {
+      if (workspaceId === activeWorkspaceId) {
+        setPopoverOpen(false);
+        return;
+      }
+      switchActiveWorkspace(playgroundId, workspaceId);
+    },
+    [playgroundId, activeWorkspaceId],
+  );
+
+  const handleCreateNew = useCallback(async () => {
+    const defaultName = `Workspace ${new Date().toLocaleString()}`;
+    const created = await createWorkspace(defaultName, playgroundId);
+    switchActiveWorkspace(playgroundId, created.id);
+  }, [playgroundId]);
+
+  const openManager = useCallback(() => {
+    refreshRegistry();
+    setPopoverOpen(false);
+    setManagerOpen(true);
+  }, [refreshRegistry]);
+
+  return (
+    <>
+      <Popover.Root open={popoverOpen} onOpenChange={setPopoverOpen}>
+        <Popover.Trigger
+          className="workspace-badge"
+          title={`Active workspace: ${activeWorkspaceName || "(unnamed)"}`}
+          aria-label="Active workspace"
+        >
+          <Folder size={12} aria-hidden="true" />
+          <span className="workspace-badge-name">
+            {activeWorkspaceName || "Workspace"}
+          </span>
+          <svg viewBox="0 0 12 12" width={9} height={9} aria-hidden="true">
+            <polyline
+              points="2,4 6,8 10,4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            />
+          </svg>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Positioner sideOffset={6} align="start">
+            <Popover.Popup className="bui-popup workspace-popover">
+              <div className="workspace-popover-header">
+                Workspaces for {playgroundLabel(playgroundId)}
+              </div>
+              <div className="workspace-popover-body">
+                {recent.length === 0 && (
+                  <div className="workspace-popover-empty">
+                    No workspaces yet.
+                  </div>
+                )}
+                {recent.map((ws) => {
+                  const active = ws.id === activeWorkspaceId;
+                  return (
+                    <button
+                      type="button"
+                      key={ws.id}
+                      className={`workspace-popover-item${active ? " active" : ""}`}
+                      onClick={() => handleSwitch(ws.id)}
+                    >
+                      <span className="workspace-popover-item-check">
+                        {active ? <Check size={12} aria-hidden="true" /> : null}
+                      </span>
+                      <span className="workspace-popover-item-text">
+                        <span className="workspace-popover-item-name">
+                          {ws.name}
+                        </span>
+                        <span className="workspace-popover-item-meta">
+                          Last opened {formatRelative(ws.lastUsedAt)}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="workspace-popover-footer">
+                <button
+                  type="button"
+                  className="workspace-popover-action"
+                  onClick={() => {
+                    void handleCreateNew();
+                  }}
+                >
+                  <Plus size={12} aria-hidden="true" />
+                  <span>New workspace</span>
+                </button>
+                <button
+                  type="button"
+                  className="workspace-popover-action"
+                  onClick={openManager}
+                >
+                  <Settings2 size={12} aria-hidden="true" />
+                  <span>Manage…</span>
+                </button>
+              </div>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+
+      <WorkspaceManagerDrawer
+        open={managerOpen}
+        onOpenChange={setManagerOpen}
+        playgroundId={playgroundId}
+        activeWorkspaceId={activeWorkspaceId}
+        registry={registry}
+        onRegistryChange={refreshRegistry}
+      />
+    </>
+  );
+}
+
+function playgroundLabel(id: string): string {
+  return id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+// ---------------------------------------------------------------------------
+// Manager Drawer
+// ---------------------------------------------------------------------------
+
+interface WorkspaceManagerDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  playgroundId: string;
+  activeWorkspaceId: string | null;
+  registry: WorkspaceEntry[];
+  onRegistryChange: () => void;
+}
+
+function WorkspaceManagerDrawer({
+  open,
+  onOpenChange,
+  playgroundId,
+  activeWorkspaceId,
+  registry,
+  onRegistryChange,
+}: WorkspaceManagerDrawerProps) {
+  const list = useMemo(
+    () =>
+      registry
+        .filter((e) => e.playground === playgroundId)
+        .sort((a, b) => b.lastUsedAt - a.lastUsedAt),
+    [registry, playgroundId],
+  );
+
+  const [sizes, setSizes] = useState<Map<string, number>>(() => new Map());
+  const [renameTarget, setRenameTarget] = useState<WorkspaceEntry | null>(null);
+  const [duplicateTarget, setDuplicateTarget] = useState<WorkspaceEntry | null>(
+    null,
+  );
+  const [deleteTarget, setDeleteTarget] = useState<WorkspaceEntry | null>(null);
+
+  // Recompute byte sizes whenever the drawer opens or the workspace list
+  // changes. We rebuild the full map rather than diffing because the
+  // recalculation is cheap (one async pass per workspace, no UI block).
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const next = new Map<string, number>();
+      for (const ws of list) {
+        const bytes = await estimateWorkspaceSize(ws.id);
+        if (cancelled) return;
+        next.set(ws.id, bytes);
+      }
+      if (!cancelled) setSizes(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, list]);
+
+  const handleCreateNew = useCallback(async () => {
+    const defaultName = `Workspace ${new Date().toLocaleString()}`;
+    const created = await createWorkspace(defaultName, playgroundId);
+    switchActiveWorkspace(playgroundId, created.id);
+  }, [playgroundId]);
+
+  return (
+    <>
+      <Drawer.Root
+        open={open}
+        onOpenChange={onOpenChange}
+        swipeDirection="down"
+      >
+        <Drawer.Portal>
+          <Drawer.Backdrop className="pkg-overlay" />
+          <Drawer.Viewport className="mobile-drawer-viewport pkg-drawer-viewport">
+            <Drawer.Popup
+              className="pkg-drawer workspace-manager-drawer"
+              aria-label="Workspace manager"
+            >
+              <Drawer.Content className="pkg-drawer-content">
+                <div className="mobile-menu-handle" aria-hidden="true" />
+                <div className="pkg-drawer-header">
+                  <div>
+                    <Drawer.Title className="pkg-drawer-title">
+                      Workspaces
+                      <span className="pkg-count-badge">{list.length}</span>
+                    </Drawer.Title>
+                    <Drawer.Description className="pkg-drawer-hint">
+                      Isolated, OPFS-backed copies of this playground&apos;s
+                      files and database state.
+                    </Drawer.Description>
+                  </div>
+                  <Drawer.Close
+                    className="settings-close"
+                    aria-label="Close workspaces"
+                  >
+                    ✕
+                  </Drawer.Close>
+                </div>
+
+                <div className="pkg-body workspace-manager-body">
+                  <button
+                    type="button"
+                    className="workspace-manager-new"
+                    onClick={() => {
+                      void handleCreateNew();
+                    }}
+                  >
+                    <Plus size={14} aria-hidden="true" />
+                    <span>Create new workspace</span>
+                  </button>
+
+                  {list.length === 0 && (
+                    <div
+                      style={{
+                        padding: 32,
+                        textAlign: "center",
+                        color: "var(--text-dim)",
+                        fontSize: 13,
+                      }}
+                    >
+                      No workspaces yet.
+                    </div>
+                  )}
+
+                  {list.map((ws) => {
+                    const active = ws.id === activeWorkspaceId;
+                    const bytes = sizes.get(ws.id) ?? 0;
+                    return (
+                      <div
+                        key={ws.id}
+                        className={`workspace-manager-item${active ? " active" : ""}`}
+                      >
+                        <div className="workspace-manager-item-main">
+                          <button
+                            type="button"
+                            className="workspace-manager-item-switch"
+                            onClick={() => {
+                              if (active) return;
+                              switchActiveWorkspace(playgroundId, ws.id);
+                            }}
+                            aria-label={
+                              active
+                                ? `${ws.name} (active)`
+                                : `Switch to ${ws.name}`
+                            }
+                          >
+                            <Folder size={14} aria-hidden="true" />
+                            <span className="workspace-manager-item-name">
+                              {ws.name}
+                              {active && (
+                                <span className="workspace-manager-active-pill">
+                                  Active
+                                </span>
+                              )}
+                            </span>
+                          </button>
+                          <div className="workspace-manager-item-meta">
+                            <span title="Approximate storage used by this workspace in OPFS">
+                              <HardDrive
+                                size={11}
+                                aria-hidden="true"
+                                style={{ verticalAlign: "-1px" }}
+                              />{" "}
+                              {formatBytes(bytes)}
+                            </span>
+                            <span>·</span>
+                            <span>Last opened {formatRelative(ws.lastUsedAt)}</span>
+                          </div>
+                        </div>
+                        <div className="workspace-manager-item-actions">
+                          <ActionButton
+                            label="Rename"
+                            onClick={() => setRenameTarget(ws)}
+                            icon={<Pencil size={12} aria-hidden="true" />}
+                          />
+                          <ActionButton
+                            label="Duplicate"
+                            onClick={() => setDuplicateTarget(ws)}
+                            icon={<CopyIcon size={12} aria-hidden="true" />}
+                          />
+                          <ActionButton
+                            label="Delete"
+                            onClick={() => setDeleteTarget(ws)}
+                            icon={<Trash2 size={12} aria-hidden="true" />}
+                            danger
+                            disabled={active && list.length <= 1}
+                            disabledTitle={
+                              active && list.length <= 1
+                                ? "Can't delete the last workspace."
+                                : undefined
+                            }
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </Drawer.Content>
+            </Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>
+
+      <RenameDialog
+        target={renameTarget}
+        onClose={() => setRenameTarget(null)}
+        onConfirm={async (name) => {
+          const t = renameTarget;
+          setRenameTarget(null);
+          if (!t) return;
+          await renameWorkspace(t.id, name);
+          onRegistryChange();
+        }}
+      />
+
+      <DuplicateDialog
+        target={duplicateTarget}
+        onClose={() => setDuplicateTarget(null)}
+        onConfirm={async (name) => {
+          const t = duplicateTarget;
+          setDuplicateTarget(null);
+          if (!t) return;
+          await duplicateWorkspace(t.id, name);
+          onRegistryChange();
+        }}
+      />
+
+      <DeleteDialog
+        target={deleteTarget}
+        isActive={deleteTarget?.id === activeWorkspaceId}
+        siblings={list.filter((e) => e.id !== deleteTarget?.id)}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={async () => {
+          const t = deleteTarget;
+          setDeleteTarget(null);
+          if (!t) return;
+          await deleteWorkspace(t.id);
+          onRegistryChange();
+          // If we just deleted the active workspace, we have to switch
+          // to a surviving one (or auto-create on next visit).
+          if (t.id === activeWorkspaceId) {
+            const next = list.find((e) => e.id !== t.id);
+            if (next) {
+              switchActiveWorkspace(playgroundId, next.id);
+            } else if (typeof window !== "undefined") {
+              window.location.reload();
+            }
+          }
+        }}
+      />
+    </>
+  );
+}
+
+interface ActionButtonProps {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+  danger?: boolean;
+  disabled?: boolean;
+  disabledTitle?: string;
+}
+
+function ActionButton({
+  label,
+  icon,
+  onClick,
+  danger,
+  disabled,
+  disabledTitle,
+}: ActionButtonProps) {
+  return (
+    <button
+      type="button"
+      className={`workspace-manager-action${danger ? " danger" : ""}`}
+      onClick={onClick}
+      disabled={disabled}
+      title={disabled ? disabledTitle : label}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rename / Duplicate / Delete dialogs
+// ---------------------------------------------------------------------------
+
+function RenameDialog({
+  target,
+  onClose,
+  onConfirm,
+}: {
+  target: WorkspaceEntry | null;
+  onClose: () => void;
+  onConfirm: (name: string) => void | Promise<void>;
+}) {
+  const [draft, setDraft] = useState("");
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (target) setDraft(target.name);
+  }, [target]);
+  return (
+    <Dialog.Root open={target !== null} onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="confirm-backdrop" />
+        <Dialog.Popup className="confirm-popup sql-rename-popup">
+          <Dialog.Title className="confirm-title">Rename workspace</Dialog.Title>
+          <Dialog.Description className="confirm-desc">
+            Workspaces are scoped per playground; renaming only affects this
+            list.
+          </Dialog.Description>
+          <form
+            className="sql-rename-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void onConfirm(draft);
+            }}
+          >
+            <input
+              className="sql-rename-input"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              autoFocus
+            />
+            <div className="confirm-actions">
+              <Dialog.Close className="confirm-btn confirm-btn-secondary">
+                Cancel
+              </Dialog.Close>
+              <button type="submit" className="confirm-btn confirm-btn-primary">
+                Rename
+              </button>
+            </div>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function DuplicateDialog({
+  target,
+  onClose,
+  onConfirm,
+}: {
+  target: WorkspaceEntry | null;
+  onClose: () => void;
+  onConfirm: (name: string) => void | Promise<void>;
+}) {
+  const [draft, setDraft] = useState("");
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (target) setDraft(`${target.name} (copy)`);
+  }, [target]);
+  return (
+    <Dialog.Root open={target !== null} onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="confirm-backdrop" />
+        <Dialog.Popup className="confirm-popup sql-rename-popup">
+          <Dialog.Title className="confirm-title">
+            Duplicate workspace
+          </Dialog.Title>
+          <Dialog.Description className="confirm-desc">
+            Creates a new workspace with a fresh copy of every file and
+            database snapshot.
+          </Dialog.Description>
+          <form
+            className="sql-rename-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void onConfirm(draft);
+            }}
+          >
+            <input
+              className="sql-rename-input"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              autoFocus
+            />
+            <div className="confirm-actions">
+              <Dialog.Close className="confirm-btn confirm-btn-secondary">
+                Cancel
+              </Dialog.Close>
+              <button type="submit" className="confirm-btn confirm-btn-primary">
+                Duplicate
+              </button>
+            </div>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function DeleteDialog({
+  target,
+  isActive,
+  siblings,
+  onClose,
+  onConfirm,
+}: {
+  target: WorkspaceEntry | null;
+  isActive: boolean;
+  siblings: WorkspaceEntry[];
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+}) {
+  return (
+    <AlertDialog.Root
+      open={target !== null}
+      onOpenChange={(o) => !o && onClose()}
+    >
+      <AlertDialog.Portal>
+        <AlertDialog.Backdrop className="confirm-backdrop" />
+        <AlertDialog.Popup className="confirm-popup">
+          <AlertDialog.Title className="confirm-title">
+            Delete workspace?
+          </AlertDialog.Title>
+          <AlertDialog.Description className="confirm-desc">
+            <strong>“{target?.name}”</strong> and all of its files
+            {target?.playground === "sqlite" ||
+            target?.playground === "postgres" ||
+            target?.playground === "duckdb"
+              ? " and database state"
+              : ""}{" "}
+            will be permanently removed from OPFS. This can&rsquo;t be undone.
+            {isActive && siblings.length > 0 && (
+              <>
+                {" "}
+                You&apos;ll be switched to
+                <strong> {siblings[0].name}</strong>.
+              </>
+            )}
+          </AlertDialog.Description>
+          <div className="confirm-actions">
+            <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
+              Cancel
+            </AlertDialog.Close>
+            <AlertDialog.Close
+              className="confirm-btn confirm-btn-danger"
+              onClick={() => void onConfirm()}
+            >
+              Delete
+            </AlertDialog.Close>
+          </div>
+        </AlertDialog.Popup>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
+}


### PR DESCRIPTION
Implements Phases 5 **and** 6 of `agent-outputs/20260518-1306-opfs-workspaces-multi-tab-zustand-plan.md`. The plan markdown is updated in-tree to mark both phases complete, document every file touched, and rewrite the "Where the next agent picks up" section as a punch list of remaining follow-ups (SqlTabBar refactor, Settings-as-tab, drag-reorder, multi-file execution, ZIP export, …).

## Phase 5 — Non-SQL Multi-Tab + OPFS

Every non-SQL playground (Python, R, JavaScript, TypeScript, PHP, C, C++, Java, C#) now has multiple file tabs. Each tab contains both an editor for the file **and** its own output history — switching a tab swaps editor doc and output pane together.

Highlights:
- `app/_components/tabs/{tabTypes,TabBar}` — content-agnostic, reusable tab strip with rename / close / add.
- `app/_components/playgroundTabs.ts` — `PlaygroundFile`, `newFileId`, `defaultFiles`, `suggestNextFilename`, and the localStorage-backed manifest.
- `app/_components/stores/createPlaygroundStore.ts` — Zustand factory keyed by adapter id; holds workspace + files + per-file dirty buffers + per-file output history.
- `LanguageAdapter.defaultFileExtension` (required) and `entryPoint` (optional) added — all nine non-SQL adapters declare them.
- `Playground.tsx` rewired: workspace bootstrap → OPFS-backed dirty buffers → tabbed editor with per-tab output. Legacy single-file `localStorage` code is auto-migrated into the first tab.

## Phase 6 — Workspace Manager UI

Adds the workspace switcher / manager across all four playground shells.

Highlights:
- `app/_components/workspace/WorkspaceBadge.tsx` — pill-shaped header badge → popover with recent workspaces, "New", "Manage…" → full drawer with rename / duplicate / delete + per-workspace OPFS byte-size estimate.
- `opfs/workspace.ts`: `renameWorkspace`, `duplicateWorkspace` (recursive directory copy).
- `opfs/fileStorage.ts`: `estimateWorkspaceSize(workspaceId)`.
- `opfs/activeWorkspace.ts`: `switchActiveWorkspace` (writes the session pointer + reloads — engines and editor rebuild as a side effect, simpler than in-place teardown).
- Non-SQL `Playground.tsx` now also raises a one-time, per-session tab-isolation toast when `acquireWorkspaceLock` reports another tab is already holding the workspace.
- `SqlPlayground`, `PostgresPlayground`, `DuckDbPlayground` each add a small `activeWorkspace` state and render `<WorkspaceBadge>` as the first child of their existing `headerActions` slot.

## Verification

- `npx tsc --noEmit` — clean.
- `npm test` — 221/221 pass (unchanged from main).
- `npm run lint` — 0 errors, 131 pre-existing warnings (no new ones from this PR).
- `npm run build` — succeeds.
- Headless Playwright smoke against `next start` confirmed:
  - File-tab add / switch / persist-across-reload / close (Phase 5).
  - Badge popover lists workspaces; "New workspace" creates + switches; manager drawer renames; size column shows byte counts (Phase 6).

## Out of scope (documented in the plan as follow-ups)

- Refactor `SqlTabBar` onto the new generic `TabBar`.
- Migrate `SettingsPanel` from Dialog to an inline Settings tab.
- Multi-file execution per language.
- Drag-and-drop tab reordering for non-SQL playgrounds.
- "Export workspace as ZIP".
- Tab-isolation toast in the SQL shells (only wired into the non-SQL `Playground.tsx` in this PR).

## Test plan

**Phase 5**
- [ ] Open `/playground/python`, type code, reload — code persists.
- [ ] Add a second tab; run code on it; switch tabs and verify outputs are per-tab.
- [ ] Close a tab — its OPFS file is deleted; "can't close the last file" guard fires when only one remains.
- [ ] Rename a tab via double-click or context menu — name persists across reload.
- [ ] Repeat for `/playground/{r,javascript,typescript,php,c,cpp,java,csharp}`.

**Phase 6**
- [ ] Click the workspace badge on every playground; popover lists this playground's workspaces only.
- [ ] "New workspace" creates + switches + reloads; the badge name updates.
- [ ] Manager drawer renames / duplicates / deletes; Delete is blocked when only one workspace remains for the playground.
- [ ] Open the same playground in two browser tabs — the second tab should surface the one-time tab-isolation toast.
- [ ] Confirm the badge appears on `/playground/{sqlite,postgres,duckdb}` and that switching workspace there rebuilds the engine cleanly.

https://claude.ai/code/session_01ShnpXxJVjXPiYoWCU6DqSb