### PR TITLE
Workspace follow-ups: DnD tab reorder, popover sizes, SQL lock notices, Clear all local data, DuckDB Files↔OPFS

### DIFF
--- a/agent-outputs/20260518-1306-opfs-workspaces-multi-tab-zustand-plan.md
+++ b/agent-outputs/20260518-1306-opfs-workspaces-multi-tab-zustand-plan.md
@@ -516,20 +516,38 @@ landed them on `claude/implement-workspace-features-nz1zP`:
 - **User add: Workspace tab files appear in the Files pane.**
   `Playground.tsx` now projects each `PlaygroundFile` (every entry
   in the tab strip) into the FilesPanel's `VirtualFile[]` so the
-  pane shows code files (e.g. `main.py`, `untitled_2.py`) alongside
-  uploaded data files. Code files always render at the root of the
-  tree — they cannot be moved into folders, since the entry-point
-  resolution assumes flat layout. Handlers are wrapped so a
-  `delete` on a code file closes the tab (`closeFileTab`, which
-  retains the "can't close the last file" guard), `rename`
-  forwards the bare filename to `renameFileTab` with a collision
-  check against existing code filenames, `download` serialises the
-  dirty buffer into a Blob, and `move` shows a toast. The merge
-  also filters data files whose path collides with a code
-  filename: code wins because it's the live editor target. New
-  memos: `codeFilenames`, `codeFileIdByName`,
+  pane shows code files (e.g. `main.py`, `src/utils.py`) alongside
+  uploaded data files. Handlers are wrapped so a `delete` on a
+  code file closes the tab (`closeFileTab`, which retains the
+  "can't close the last file" guard), `rename` forwards through
+  `renameFileTab`, `download` serialises the dirty buffer into a
+  Blob, and `move` relocates the file by routing through
+  `renameFileTab`. The merge also filters data files whose path
+  collides with a code filename: code wins because it's the live
+  editor target. New memos: `codeFilePaths`, `codeFileIdByPath`,
   `mergedVirtualFiles`; new wrapped handlers
   `mergedHandleFilesDownload` / `Delete` / `Rename` / `Move`.
+
+- **User add: code files can live at any path (not just root).**
+  `PlaygroundFile.filename` is now treated as a workspace-virtual
+  path that may include `/` segments (e.g. `src/utils.py`). Knock-on
+  changes:
+  - The tab strip label uses the leaf (basename) so tabs stay
+    compact regardless of nesting depth.
+  - Export-as-… uses the leaf when deriving the download filename.
+  - `renameFileTab` now distinguishes leaf-only renames (preserve
+    parent directory) from full-path renames (replace outright), so
+    a tab-strip rename of `src/foo.py` → `bar.py` produces
+    `src/bar.py` rather than dropping the `src/` prefix, while
+    typing `lib/bar.py` in the same dialog moves the file. It also
+    rejects renames that would collide with another tab.
+  - Files-pane Move on a code file relocates the file into the
+    destination folder by feeding `${destFolder}/${leaf}` back into
+    `renameFileTab`.
+
+  OPFS storage is keyed by the stable per-file `id`, so changing a
+  file's path costs nothing on disk — the manifest re-saves the new
+  path and the file content stays put.
 
 #### ⏳ Outstanding from the original plan
 

--- a/agent-outputs/20260518-1306-opfs-workspaces-multi-tab-zustand-plan.md
+++ b/agent-outputs/20260518-1306-opfs-workspaces-multi-tab-zustand-plan.md
@@ -447,47 +447,118 @@ app/_components/
 
 ### Where the next agent picks up
 
-**All six phases of the original plan are complete.** The remaining
-work falls into clearly-scoped follow-up tasks:
+**All six phases of the original plan are complete.** Follow-up
+session 2026-05-19 picked up items 3, 6, 7 + two user-driven
+additions ("Clear all local data" + DuckDB FilesPanel ↔ OPFS) and
+landed them on `claude/implement-workspace-features-nz1zP`:
+
+#### ✅ Done in 2026-05-19 follow-up session
+
+- **Item 3 — DnD tab reordering for non-SQL playgrounds.** The generic
+  `app/_components/tabs/TabBar.tsx` now accepts an optional
+  `onReorderTabs?: (next: TabDescriptor[]) => void` prop. When passed
+  the bar mounts a `DndContext` + horizontal `SortableContext` and
+  each `TabItem` is wired through `useSortable`. `Playground.tsx`
+  passes a `reorderFileTabs` callback that projects the new
+  descriptor order back onto `files` via id lookup, then commits via
+  the Zustand store's `setFiles`. `useSortable` is invoked
+  unconditionally with `{ disabled: !sortable }` so the bar stays a
+  single static call path. A `TabOverlay` clone is shown via
+  `DragOverlay` while dragging.
+
+- **Item 6 — Tab-isolation notice in SQL playgrounds.** Each SQL
+  playground bootstrap effect (`SqlPlayground.tsx`,
+  `PostgresPlayground.tsx`, `DuckDbPlayground.tsx`) now mirrors the
+  non-SQL `Playground.tsx` pattern: after `ensureActiveWorkspace`,
+  call `acquireWorkspaceLock(workspaceId)`, and if the lock is
+  unavailable show the one-time `pg_ws_warned_<id>` toast.
+
+- **Item 7 — Workspace size in popover.**
+  `WorkspaceBadge.tsx` now prefetches `estimateWorkspaceSize(id)` for
+  every workspace listed in the popover as soon as it opens.
+  The fetched sizes live in component state, so subsequent opens
+  render the cached value synchronously and update in place when the
+  fresh estimate lands. The "Last opened …" meta line now reads
+  "Last opened … · 12.4 KB".
+
+- **User add: "Clear all local data" action.** New helper
+  `app/_components/storage/clearAllData.ts` clears localStorage +
+  sessionStorage + OPFS (iterating `root.entries()` and
+  `removeEntry(name, { recursive: true })` on each) + IndexedDB (via
+  `indexedDB.databases()` where supported) + Cache Storage. The
+  `SettingsPanel` (`playgroundShared.tsx`) gained an optional
+  `onClearAllLocalData?` prop that renders an extra red action below
+  the existing "Clear all localStorage data" button. The SQL shell's
+  `SqlSettingsConfirmDialogs` gained matching optional
+  `clearAllDataOpen` / `onClearAllDataOpenChange` /
+  `onClearAllDataConfirm` props. All four playground shells
+  (Playground.tsx, SqlPlayground, PostgresPlayground, DuckDbPlayground)
+  now surface the new action, each with its own AlertDialog
+  confirmation. The shared SQL dialog store gained a
+  `confirmClearAllDataOpen` boolean.
+
+- **User add: DuckDB FilesPanel ↔ OPFS.** Previously DuckDB's
+  uploaded data files lived only in DuckDB-WASM's MEMFS and vanished
+  on reload. Now `DuckDbPlayground.tsx` mirrors every FilesPanel
+  operation into OPFS via the existing `opfsDataStorage` helpers:
+  - On bootstrap, after the engine and schemas are ready, walk the
+    manifest via `opfsLoadDataFiles`, re-register each file with the
+    engine, and seed `virtualFiles` + auto-expand ancestor folders.
+  - Upload writes to OPFS *before* `registerFileBuffer` (the worker
+    detaches the ArrayBuffer via transfer, so we must snapshot
+    first).
+  - Delete / Rename / Move / Create-Folder all call the matching
+    `opfs*DataEntry` / `opfs*Folder` helper after the engine
+    operation succeeds.
+  - A new `workspaceIdRef` mirrors `activeWorkspace.id` so the
+    handlers don't need to participate in dep arrays.
+
+#### ⏳ Outstanding from the original plan
 
 1. **Refactor `SqlTabBar` onto the generic `TabBar`** (§4.5). The
-   `app/_components/tabs/TabBar.tsx` component built in Phase 5 is
-   intentionally content-agnostic. `SqlTabBar` should adopt it as its
-   foundation. Two complications make this its own PR:
-   - The SQL tab's context menu has Duplicate / Close Others / Close
-     All entries — the generic bar currently exposes only Rename and
-     Close. Either generalise the context menu (preferred) via a
-     `contextMenuItems?: ContextMenuItem[]` prop on `TabDescriptor`,
-     or render the SQL menu separately and lift the rest of the bar.
-   - SQL tabs carry `kind: "view-data" | "er-diagram" |
-     "query-history"` with kind-specific icons. The generic
-     `TabDescriptor.icon` slot already covers this; the SQL bar's
-     special-case CSS classes (`.sql-tab-view-data` etc.) can map to
-     the generic `.pg-tab--kind-${kind}` classes.
+   generic `TabBar` now supports DnD so the bar is feature-compatible,
+   but `SqlTabBar`'s context menu still has Duplicate / Close Others /
+   Close All entries the generic bar lacks. Two paths forward:
+   - Generalise via a `contextMenuItems?: ContextMenuItem[]` prop on
+     `TabDescriptor` (preferred), OR
+   - Lift only the drag wrapper from `SqlTabBar` (it can now delegate
+     to the generic DnD strip we just added) and keep the SQL-specific
+     ContextMenu in `SqlTab.tsx`.
+
+   The SQL bar's kind-specific CSS (`.sql-tab-view-data` etc.) can map
+   straight onto the generic `.pg-tab--kind-${kind}` classes the
+   generic bar already emits.
 
 2. **Move Settings from a dialog to a tab** (§4.5, §8.2). The
-   `SettingsPanel` component currently uses Base UI's `Dialog`. To
-   render inline as a tab, extract its body into a `<SettingsContent>`
-   component that does not assume a dialog wrapper. Then add a
+   `SettingsPanel` component still uses Base UI's `Dialog`. To render
+   inline as a tab, extract its body (the `Tabs.Root` with General /
+   Themes / `extraTabs` panels) into a `<SettingsContent>` component
+   that does not assume a dialog wrapper. Then add a
    `kind: "settings"` tab in `Playground.tsx` (and the SQL shells),
    gated on `settingsTabOpen` in the existing Phase-5 store (the
    field is already in the store — the toggle just needs the click
    handler to switch tabs and add the descriptor). The gear icon
-   button in the sidebar then opens the settings tab instead of the
-   dialog.
-
-3. **Drag-and-drop tab reordering for non-SQL playgrounds.** The
-   generic `TabBar` does not yet wrap `@dnd-kit`. Lift the
-   `SortableContext` + sensor setup from `SqlTabBar.tsx` into
-   `TabBar.tsx` behind an `onReorderTabs?` prop, and wire it through
-   `Playground.tsx` to update `files` in the Zustand store.
+   button then opens the settings tab instead of the dialog. Watch
+   out for the `.settings-panel` CSS (~line 1463 of `playground.css`)
+   — it positions the dialog as a fixed top-right popup; the inline
+   version needs to inherit the editor pane's layout instead. The
+   close-button affordance becomes the tab's own X.
 
 4. **Multi-file execution per language** (§4.4). Phase 5 ships
    active-file-only execution. To support cross-file imports, each
-   runtime needs to receive a file map `{ filename: code }`:
-   - **Python / R / PHP**: write all workspace files to the
-     respective VFS (`pyodide.FS.writeFile`, WebR VFS, php-wasm VFS)
-     before running the entry point.
+   runtime needs to receive a file map `{ filename: code }`. Audited
+   in 2026-05-19 follow-up: *none* of the existing non-SQL adapters
+   (`runtime/python.tsx`, `r.tsx`, `php.tsx`, `javascript.tsx`,
+   `typescript.tsx`, `c.tsx`, `cpp.tsx`, `java.tsx`, `csharp.tsx`)
+   touch a VFS at all today — the `LanguageRuntime` interface only
+   has `run(code, emit)`. To unlock multi-file:
+   - Extend `LanguageRuntime` with an optional
+     `writeFile(path: string, content: string | Uint8Array)` method
+     and an optional `entryPoint?: string` argument to `run`.
+   - **Python / R / PHP**: write all workspace files (and the
+     FilesPanel data files — see follow-up #8 below) to the
+     respective VFS (`pyodide.FS.writeFile` from inside the worker,
+     WebR VFS, php-wasm VFS) before running the entry point.
    - **TypeScript**: the TS compiler already accepts multiple
      sources; thread the file map through `typescript-worker.ts`.
    - **C / C++ / Java / C#**: their respective WASM compilers accept
@@ -502,28 +573,68 @@ work falls into clearly-scoped follow-up tasks:
    dependency via several packages; if not, a small DEFLATE-only
    implementation suffices.
 
-6. **Tab-isolation notice in SQL playgrounds.** Phase 6 wired the
-   one-time `acquireWorkspaceLock` toast only into `Playground.tsx`
-   (non-SQL). Add the same pattern after `ensureActiveWorkspace` in
-   each of the three SQL playground bootstrap effects.
+#### 🚨 Newly-discovered gaps (audit, 2026-05-19)
 
-7. **Workspace size in the popover.** The drawer shows byte sizes; the
-   popover currently shows only "last opened". The async
-   `estimateWorkspaceSize` can be prefetched on popover open and
-   cached in a ref so the size renders without flicker.
+8. **FilesPanel data files are NOT exposed to non-SQL runtimes.** In
+   `Playground.tsx` the FilesPanel persists uploads to OPFS
+   correctly, *but* none of the non-SQL language adapters wire the
+   resulting `virtualFiles` array into the runtime's filesystem.
+   `LanguageRuntime.run` only receives the active-tab code string —
+   there's no path for Python's `open("data.csv")` (or R, PHP, JS,
+   TS, …) to ever reach a user-uploaded file. The DuckDB FilesPanel
+   *is* functional because DuckDB-WASM registers buffers directly.
+   This is essentially a prerequisite for follow-up #4: extend
+   `LanguageRuntime` with `writeFile` and have `Playground.tsx`
+   flush every `VirtualFile` into the runtime's VFS before invoking
+   `run`. Each adapter then needs to implement `writeFile`:
+   - **Python**: route through `pyodide-worker.ts` →
+     `pyodide.FS.writeFile`
+   - **R**: route through WebR's `evalRString`-driven VFS shim (R
+     doesn't have a stable FS API yet — may need a wrapper)
+   - **PHP**: `php-worker.ts` → `php.writeFile`
+   - **JavaScript / TypeScript**: synthetic `import.meta.fs` shim
+     or expose via `globalThis.__playgroundFs` for code to read
+   - **C / C++ / Java / C#**: pass into the compile step's source set
+
+   Without this, the FilesPanel in non-SQL playgrounds is purely
+   decorative (uploads persist across reloads but can't be read by
+   user code).
+
+9. **SQL playground query tabs are workspace-agnostic.** Tabs are
+   stored at `pg_<dialect>_db_<dbId>_tabs` in localStorage — keyed
+   by *database id*, not by workspace id. Switching workspaces in
+   SQL playgrounds keeps the same tab set per database, which is
+   probably the intended behaviour (the database itself is
+   workspace-scoped in OPFS), but it does mean `clearAllLocalStorage`
+   in one playground wipes another playground's tab state. The
+   stronger "Clear all local data" action makes this less of an
+   issue, but if cross-workspace tab isolation is ever needed the
+   key shape needs to change to `pg_<dialect>_<wsId>_<dbId>_tabs`.
+
+#### Still relevant from earlier list
+
+6. *(Done — see above.)*
+7. *(Done — see above.)*
 
 Key files for any follow-up agent:
-- `app/_components/tabs/TabBar.tsx` — generic tab strip
+- `app/_components/tabs/TabBar.tsx` — generic tab strip (now with
+  optional DnD reorder)
 - `app/_components/playgroundTabs.ts` — `PlaygroundFile` type +
   manifest helpers
 - `app/_components/stores/createPlaygroundStore.ts` — Zustand factory
   (already has a `settingsTabOpen` flag wired up but not yet
   rendered)
 - `app/_components/workspace/WorkspaceBadge.tsx` — reference for
-  popover + drawer patterns
+  popover + drawer patterns (now prefetches sizes)
+- `app/_components/storage/clearAllData.ts` — the "wipe everything"
+  helper; reuse for any other "factory reset" UX
+- `app/_components/files/opfsDataStorage.ts` — OPFS helpers for the
+  FilesPanel data files; DuckDB now also uses these
 - `app/_components/Playground.tsx` — reference non-SQL shell
 - `app/_components/sql/components/SqlTabBar.tsx` — the bar to
-  generalise
+  generalise (item 1 above)
+- `app/_components/playgroundShared.tsx` — shared `SettingsPanel`
+  (still dialog-based; see item 2 above)
 
 ---
 

--- a/agent-outputs/20260518-1306-opfs-workspaces-multi-tab-zustand-plan.md
+++ b/agent-outputs/20260518-1306-opfs-workspaces-multi-tab-zustand-plan.md
@@ -513,6 +513,24 @@ landed them on `claude/implement-workspace-features-nz1zP`:
   - A new `workspaceIdRef` mirrors `activeWorkspace.id` so the
     handlers don't need to participate in dep arrays.
 
+- **User add: Workspace tab files appear in the Files pane.**
+  `Playground.tsx` now projects each `PlaygroundFile` (every entry
+  in the tab strip) into the FilesPanel's `VirtualFile[]` so the
+  pane shows code files (e.g. `main.py`, `untitled_2.py`) alongside
+  uploaded data files. Code files always render at the root of the
+  tree — they cannot be moved into folders, since the entry-point
+  resolution assumes flat layout. Handlers are wrapped so a
+  `delete` on a code file closes the tab (`closeFileTab`, which
+  retains the "can't close the last file" guard), `rename`
+  forwards the bare filename to `renameFileTab` with a collision
+  check against existing code filenames, `download` serialises the
+  dirty buffer into a Blob, and `move` shows a toast. The merge
+  also filters data files whose path collides with a code
+  filename: code wins because it's the live editor target. New
+  memos: `codeFilenames`, `codeFileIdByName`,
+  `mergedVirtualFiles`; new wrapped handlers
+  `mergedHandleFilesDownload` / `Delete` / `Rename` / `Move`.
+
 #### ⏳ Outstanding from the original plan
 
 1. **Refactor `SqlTabBar` onto the generic `TabBar`** (§4.5). The

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -1559,6 +1559,141 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     [setFiles],
   );
 
+  // ─── Merge workspace tabs into the Files pane ─────────────────────────
+  //
+  // The Files pane shows two distinct kinds of entries:
+  //   1. Workspace code files — one per tab in the tab strip
+  //      (e.g. `main.py`, `untitled_2.py`). Their content lives in
+  //      the per-file dirty buffer + OPFS.
+  //   2. User data files — anything uploaded via the panel
+  //      (e.g. `data.csv`, `images/cat.png`). Their content lives in
+  //      OPFS under `data/`.
+  //
+  // Code files always render at the root of the tree. If a data file
+  // collides with a code file's filename, the code file wins (it's
+  // the live editor target) and the data file is hidden — uploads
+  // already enforce uniqueness within `data/` so this only matters
+  // for the cross-namespace edge case.
+
+  const codeFilenames = useMemo(
+    () => new Set(files.map((f) => f.filename)),
+    [files],
+  );
+
+  const codeFileIdByName = useMemo(
+    () => new Map(files.map((f) => [f.filename, f.id])),
+    [files],
+  );
+
+  const mergedVirtualFiles = useMemo<VirtualFile[]>(() => {
+    const codeEntries: VirtualFile[] = files.map((f) => ({
+      path: f.filename,
+      // Byte-size estimate from the dirty buffer. Approximate (string
+      // length, not UTF-8 byte length) but accurate enough for the
+      // pane's size column — the same approximation FilesPanel uses
+      // everywhere else.
+      size: dirtyBuffers.get(f.id)?.length ?? 0,
+      isFolder: false,
+    }));
+    const filteredData = virtualFiles.filter(
+      (f) => !codeFilenames.has(f.path),
+    );
+    return [...codeEntries, ...filteredData];
+  }, [files, dirtyBuffers, virtualFiles, codeFilenames]);
+
+  /** Resolves the workspace tab id for a Files-pane path, if any. */
+  const tabIdForFilesPath = useCallback(
+    (path: string): string | null => codeFileIdByName.get(path) ?? null,
+    [codeFileIdByName],
+  );
+
+  const mergedHandleFilesDownload = useCallback(
+    (path: string) => {
+      const tabId = tabIdForFilesPath(path);
+      if (tabId) {
+        // Code file download: serialise the (possibly unsaved) dirty
+        // buffer into a Blob. Falls back to an empty file when the
+        // buffer hasn't been populated yet.
+        const content = dirtyBuffersRef.current.get(tabId) ?? "";
+        try {
+          const blob = new Blob([content], { type: "text/plain" });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = path.split("/").pop() ?? path;
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+          URL.revokeObjectURL(url);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          showToast(`Download failed: ${msg}`, "warn");
+        }
+        return;
+      }
+      handleFilesDownload(path);
+    },
+    [handleFilesDownload, showToast, tabIdForFilesPath],
+  );
+
+  const mergedHandleFilesDelete = useCallback(
+    (path: string) => {
+      const tabId = tabIdForFilesPath(path);
+      if (tabId) {
+        // Delete-from-Files-pane on a code file maps to "close the
+        // tab". `closeFileTab` already refuses to drop the last
+        // remaining file (the editor needs at least one target) and
+        // surfaces its own toast.
+        closeFileTab(tabId);
+        return;
+      }
+      handleFilesDelete(path);
+    },
+    [closeFileTab, handleFilesDelete, tabIdForFilesPath],
+  );
+
+  const mergedHandleFilesRename = useCallback(
+    (oldPath: string, newPath: string) => {
+      const tabId = tabIdForFilesPath(oldPath);
+      if (tabId) {
+        // Code file rename → bare filename only (paths must stay at
+        // the root of the tree).
+        const leaf = newPath.split("/").pop() ?? newPath;
+        if (codeFilenames.has(leaf) && leaf !== oldPath) {
+          showToast(
+            `A file named "${leaf}" already exists in this workspace.`,
+            "warn",
+          );
+          return;
+        }
+        renameFileTab(tabId, leaf);
+        return;
+      }
+      handleFilesRename(oldPath, newPath);
+    },
+    [
+      codeFilenames,
+      handleFilesRename,
+      renameFileTab,
+      showToast,
+      tabIdForFilesPath,
+    ],
+  );
+
+  const mergedHandleFilesMove = useCallback(
+    (sourcePath: string, destFolderPath: string) => {
+      if (tabIdForFilesPath(sourcePath) !== null) {
+        // Code files always live at the root of the Files tree —
+        // moving them into a folder would invalidate the
+        // language-specific entry-point resolution.
+        showToast("Code files can't be moved into folders.", "warn");
+        return;
+      }
+      handleFilesMove(sourcePath, destFolderPath);
+    },
+    [handleFilesMove, showToast, tabIdForFilesPath],
+  );
+
   // Apply an example to the editor immediately. Use `requestExample` for
   // user-initiated picks so we can prompt before discarding work.
   const applyExample = useCallback(
@@ -2596,15 +2731,15 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                 </button>
               </div>
               <FilesPanel
-                files={virtualFiles}
+                files={mergedVirtualFiles}
                 expandedFolders={expandedFolders}
                 onToggleFolder={handleFilesToggleFolder}
                 onUpload={handleFilesUpload}
-                onDownload={handleFilesDownload}
-                onDelete={handleFilesDelete}
-                onRename={handleFilesRename}
+                onDownload={mergedHandleFilesDownload}
+                onDelete={mergedHandleFilesDelete}
+                onRename={mergedHandleFilesRename}
                 onCreateFolder={handleFilesCreateFolder}
-                onMove={handleFilesMove}
+                onMove={mergedHandleFilesMove}
               />
             </div>
           )}

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -499,6 +499,8 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   const [confirmRestoreOpen, setConfirmRestoreOpen] = useState(false);
   const [confirmClearStorageOpen, setConfirmClearStorageOpen] =
     useState(false);
+  const [confirmClearAllDataOpen, setConfirmClearAllDataOpen] =
+    useState(false);
 
   // ─── Files pane (OPFS-backed virtual filesystem) ─────────────────────
   const [filesPaneOpen, setFilesPaneOpen] = useState(false);
@@ -1324,6 +1326,23 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     window.location.reload();
   }, []);
 
+  // Nuclear wipe: clears every storage surface (localStorage, OPFS,
+  // IndexedDB, caches) before reloading. Backed by the shared
+  // `clearAllLocalData` helper so every playground gets the same
+  // behaviour. Best-effort: failures inside one surface don't block
+  // the others, and we always reload.
+  const clearAllLocalData = useCallback(() => {
+    void (async () => {
+      try {
+        const mod = await import("./storage/clearAllData");
+        await mod.clearAllLocalData();
+      } catch {
+        /* fall through to reload regardless */
+      }
+      window.location.reload();
+    })();
+  }, []);
+
   // ─── Actions ────────────────────────────────────────────────────────────
   const runCode = useCallback(async () => {
     const editor = editorRef.current;
@@ -1513,6 +1532,27 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       const next = filesRef.current.map((f) =>
         f.id === fileId ? { ...f, filename: trimmed } : f,
       );
+      filesRef.current = next;
+      setFiles(next);
+    },
+    [setFiles],
+  );
+
+  /** Reorder the file tabs after a drag-and-drop drop. The generic
+   *  TabBar hands us the new tab order (TabDescriptors); we project it
+   *  back onto the `files` array via id lookup so the manifest stays
+   *  authoritative. */
+  const reorderFileTabs = useCallback(
+    (nextDescriptors: TabDescriptor[]) => {
+      const byId = new Map(filesRef.current.map((f) => [f.id, f]));
+      const next: PlaygroundFile[] = [];
+      for (const d of nextDescriptors) {
+        const f = byId.get(d.id);
+        if (f) next.push(f);
+      }
+      // Defensive: ensure we didn't drop any files (e.g. a transient
+      // mismatch between descriptors and the file list).
+      if (next.length !== filesRef.current.length) return;
       filesRef.current = next;
       setFiles(next);
     },
@@ -2295,6 +2335,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
           onClose={() => setSettingsOpen(false)}
           onRestoreDefaults={() => setConfirmRestoreOpen(true)}
           onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
+          onClearAllLocalData={() => setConfirmClearAllDataOpen(true)}
         />
 
         <PackagesDrawer
@@ -2406,6 +2447,46 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                   className="confirm-btn confirm-btn-danger"
                   onClick={() => {
                     clearAllLocalStorage();
+                  }}
+                >
+                  Clear &amp; reload
+                </AlertDialog.Close>
+              </div>
+            </AlertDialog.Popup>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>
+
+        {/* Nuclear wipe: drops localStorage AND OPFS AND IndexedDB AND
+            caches. Mirrors the lighter "Clear all localStorage" dialog
+            but with stronger language so the user understands they're
+            also losing every workspace, database, and uploaded file. */}
+        <AlertDialog.Root
+          open={confirmClearAllDataOpen}
+          onOpenChange={setConfirmClearAllDataOpen}
+        >
+          <AlertDialog.Portal>
+            <AlertDialog.Backdrop className="confirm-backdrop" />
+            <AlertDialog.Popup className="confirm-popup">
+              <AlertDialog.Title className="confirm-title">
+                Clear all local data?
+              </AlertDialog.Title>
+              <AlertDialog.Description className="confirm-desc">
+                This will permanently delete every saved setting, code
+                snippet, <strong>workspace</strong>, persisted{" "}
+                <strong>database</strong>, and uploaded{" "}
+                <strong>data file</strong> across{" "}
+                <strong>all playgrounds</strong> — including localStorage,
+                OPFS, IndexedDB, and any cached assets. The page will
+                reload immediately. This can&rsquo;t be undone.
+              </AlertDialog.Description>
+              <div className="confirm-actions">
+                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
+                  Cancel
+                </AlertDialog.Close>
+                <AlertDialog.Close
+                  className="confirm-btn confirm-btn-danger"
+                  onClick={() => {
+                    clearAllLocalData();
                   }}
                 >
                   Clear &amp; reload
@@ -2540,6 +2621,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
             onCloseTab={files.length > 1 ? closeFileTab : undefined}
             onAddTab={addNewFile}
             onRenameTab={renameFileTab}
+            onReorderTabs={files.length > 1 ? reorderFileTabs : undefined}
             className="pg-file-tabbar"
           />
         )}

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -1529,13 +1529,44 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     (fileId: string, newName: string) => {
       const trimmed = newName.trim();
       if (!trimmed) return;
+      const target = filesRef.current.find((f) => f.id === fileId);
+      if (!target) return;
+      // Two input shapes converge here:
+      //  - Full path (contains "/") — replace the workspace path
+      //    outright (e.g. user types `src/utils.py` to move the
+      //    file).
+      //  - Leaf only (no "/") — preserve the file's existing parent
+      //    directory so a tab-strip rename of `src/foo.py` to
+      //    `bar.py` becomes `src/bar.py`, not `bar.py` at the root.
+      let nextPath: string;
+      if (trimmed.includes("/")) {
+        nextPath = trimmed;
+      } else {
+        const lastSlash = target.filename.lastIndexOf("/");
+        const parentDir =
+          lastSlash >= 0 ? target.filename.slice(0, lastSlash + 1) : "";
+        nextPath = `${parentDir}${trimmed}`;
+      }
+      if (nextPath === target.filename) return;
+      // Refuse to overwrite another tab at the same path.
+      if (
+        filesRef.current.some(
+          (f) => f.id !== fileId && f.filename === nextPath,
+        )
+      ) {
+        showToast(
+          `A file at "${nextPath}" already exists in this workspace.`,
+          "warn",
+        );
+        return;
+      }
       const next = filesRef.current.map((f) =>
-        f.id === fileId ? { ...f, filename: trimmed } : f,
+        f.id === fileId ? { ...f, filename: nextPath } : f,
       );
       filesRef.current = next;
       setFiles(next);
     },
-    [setFiles],
+    [setFiles, showToast],
   );
 
   /** Reorder the file tabs after a drag-and-drop drop. The generic
@@ -1563,24 +1594,25 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   //
   // The Files pane shows two distinct kinds of entries:
   //   1. Workspace code files — one per tab in the tab strip
-  //      (e.g. `main.py`, `untitled_2.py`). Their content lives in
+  //      (e.g. `main.py`, `src/utils.py`). Their content lives in
   //      the per-file dirty buffer + OPFS.
   //   2. User data files — anything uploaded via the panel
   //      (e.g. `data.csv`, `images/cat.png`). Their content lives in
   //      OPFS under `data/`.
   //
-  // Code files always render at the root of the tree. If a data file
-  // collides with a code file's filename, the code file wins (it's
-  // the live editor target) and the data file is hidden — uploads
-  // already enforce uniqueness within `data/` so this only matters
-  // for the cross-namespace edge case.
+  // Code files may live at any path (root or inside folders) — the
+  // tab strip just shows the leaf. If a data file's path collides
+  // with a code file's path, the code file wins (it's the live
+  // editor target) and the data file is hidden — uploads already
+  // enforce uniqueness within `data/` so this only matters for the
+  // cross-namespace edge case.
 
-  const codeFilenames = useMemo(
+  const codeFilePaths = useMemo(
     () => new Set(files.map((f) => f.filename)),
     [files],
   );
 
-  const codeFileIdByName = useMemo(
+  const codeFileIdByPath = useMemo(
     () => new Map(files.map((f) => [f.filename, f.id])),
     [files],
   );
@@ -1596,15 +1628,15 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       isFolder: false,
     }));
     const filteredData = virtualFiles.filter(
-      (f) => !codeFilenames.has(f.path),
+      (f) => !codeFilePaths.has(f.path),
     );
     return [...codeEntries, ...filteredData];
-  }, [files, dirtyBuffers, virtualFiles, codeFilenames]);
+  }, [files, dirtyBuffers, virtualFiles, codeFilePaths]);
 
   /** Resolves the workspace tab id for a Files-pane path, if any. */
   const tabIdForFilesPath = useCallback(
-    (path: string): string | null => codeFileIdByName.get(path) ?? null,
-    [codeFileIdByName],
+    (path: string): string | null => codeFileIdByPath.get(path) ?? null,
+    [codeFileIdByPath],
   );
 
   const mergedHandleFilesDownload = useCallback(
@@ -1656,42 +1688,40 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     (oldPath: string, newPath: string) => {
       const tabId = tabIdForFilesPath(oldPath);
       if (tabId) {
-        // Code file rename → bare filename only (paths must stay at
-        // the root of the tree).
-        const leaf = newPath.split("/").pop() ?? newPath;
-        if (codeFilenames.has(leaf) && leaf !== oldPath) {
-          showToast(
-            `A file named "${leaf}" already exists in this workspace.`,
-            "warn",
-          );
-          return;
-        }
-        renameFileTab(tabId, leaf);
+        // FilesPanel hands us the already-reconstructed full path
+        // (parent dir + new leaf). `renameFileTab` enforces collision
+        // detection across the workspace.
+        renameFileTab(tabId, newPath);
         return;
       }
       handleFilesRename(oldPath, newPath);
     },
-    [
-      codeFilenames,
-      handleFilesRename,
-      renameFileTab,
-      showToast,
-      tabIdForFilesPath,
-    ],
+    [handleFilesRename, renameFileTab, tabIdForFilesPath],
   );
 
   const mergedHandleFilesMove = useCallback(
     (sourcePath: string, destFolderPath: string) => {
-      if (tabIdForFilesPath(sourcePath) !== null) {
-        // Code files always live at the root of the Files tree —
-        // moving them into a folder would invalidate the
-        // language-specific entry-point resolution.
-        showToast("Code files can't be moved into folders.", "warn");
+      const tabId = tabIdForFilesPath(sourcePath);
+      if (tabId) {
+        // Code file move: relocate to the destination folder while
+        // preserving the leaf filename. `renameFileTab` handles the
+        // collision check.
+        const leaf = sourcePath.split("/").pop() ?? sourcePath;
+        const newPath = destFolderPath ? `${destFolderPath}/${leaf}` : leaf;
+        if (newPath === sourcePath) return;
+        renameFileTab(tabId, newPath);
+        if (destFolderPath) {
+          setExpandedFolders((prev) => {
+            const next = new Set(prev);
+            next.add(destFolderPath);
+            return next;
+          });
+        }
         return;
       }
       handleFilesMove(sourcePath, destFolderPath);
     },
-    [handleFilesMove, showToast, tabIdForFilesPath],
+    [handleFilesMove, renameFileTab, tabIdForFilesPath],
   );
 
   // Apply an example to the editor immediately. Use `requestExample` for
@@ -1786,8 +1816,14 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       const active = filesRef.current.find(
         (f) => f.id === activeFileIdRef.current,
       );
-      const base = active
-        ? active.filename.replace(/\.[^.]+$/, "")
+      // Use the leaf of the workspace path (`"src/main.py"` →
+      // `"main"`) so an export of `src/utils.py` downloads
+      // `utils.<ext>` rather than `src/utils.<ext>`.
+      const activeLeaf = active
+        ? active.filename.split("/").pop() ?? active.filename
+        : "";
+      const base = activeLeaf
+        ? activeLeaf.replace(/\.[^.]+$/, "")
         : adapter.exportBaseFilename;
       a.download = `${base || adapter.exportBaseFilename}.${format.extension}`;
       document.body.appendChild(a);
@@ -1986,14 +2022,21 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
 
   const fileTabDescriptors = useMemo<TabDescriptor[]>(
     () =>
-      files.map((f) => ({
-        id: f.id,
-        kind: "code" as const,
-        label: f.filename,
-        icon: <FileCode2 size={11} aria-hidden="true" />,
-        closeable: files.length > 1,
-        renameable: true,
-      })),
+      files.map((f) => {
+        // PlaygroundFile.filename may be a multi-segment path
+        // (e.g. "src/utils.py"); the tab strip is too narrow for the
+        // full path, so we show only the leaf and let the Files pane
+        // expose the rest.
+        const leaf = f.filename.split("/").pop() ?? f.filename;
+        return {
+          id: f.id,
+          kind: "code" as const,
+          label: leaf,
+          icon: <FileCode2 size={11} aria-hidden="true" />,
+          closeable: files.length > 1,
+          renameable: true,
+        };
+      }),
     [files],
   );
 

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -105,6 +105,15 @@ import { SqlEditorToolbar } from "../sql/components/SqlEditorToolbar";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
 import { ensureActiveWorkspace } from "../opfs/activeWorkspace";
+import { acquireWorkspaceLock } from "../opfs/workspace";
+import {
+  deleteDataEntry as opfsDeleteDataEntry,
+  loadDataFiles as opfsLoadDataFiles,
+  readDataFile as opfsReadDataFile,
+  renameDataEntry as opfsRenameDataEntry,
+  upsertDataFolder as opfsUpsertDataFolder,
+  writeDataFile as opfsWriteDataFile,
+} from "../files/opfsDataStorage";
 import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
 import { type DuckDbEngine } from "../runtime/duckdb";
 
@@ -979,6 +988,14 @@ function DuckDbPlaygroundInner() {
     id: string;
     name: string;
   } | null>(null);
+  // Mirror activeWorkspace.id in a ref so the file-pane handlers can
+  // read the current workspace synchronously without participating in
+  // useCallback dep arrays (which would force them to rebuild every
+  // time the workspace switches).
+  const workspaceIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    workspaceIdRef.current = activeWorkspace?.id ?? null;
+  }, [activeWorkspace]);
   const [indexesExpanded, setIndexesExpanded] = useState(true);
   const [viewsExpanded, setViewsExpanded] = useState(true);
   const [tablesExpanded, setTablesExpanded] = useState(true);
@@ -1045,6 +1062,7 @@ function DuckDbPlaygroundInner() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [confirmRestoreOpen, setConfirmRestoreOpen] = useState(false);
   const [confirmClearStorageOpen, setConfirmClearStorageOpen] = useState(false);
+  const [confirmClearAllDataOpen, setConfirmClearAllDataOpen] = useState(false);
   const [pendingDbId, setPendingDbId] = useState<string | null>(null);
   const [pendingDropEntity, setPendingDropEntity] = useState<{
     name: string;
@@ -1648,6 +1666,21 @@ function DuckDbPlaygroundInner() {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
+          const noticeKey = `pg_ws_warned_${workspace.id}`;
+          try {
+            if (window.sessionStorage.getItem(noticeKey) !== "1") {
+              const hasLock = await acquireWorkspaceLock(workspace.id);
+              if (!cancelled && !hasLock) {
+                window.sessionStorage.setItem(noticeKey, "1");
+                showToast(
+                  "This workspace is already open in another tab. Edits here may conflict — switch workspaces via the badge in the header.",
+                  "warn",
+                );
+              }
+            }
+          } catch {
+            /* sessionStorage / Locks unavailable — ignore. */
+          }
         } catch {
           /* proceed in-memory */
         }
@@ -1668,6 +1701,44 @@ function DuckDbPlaygroundInner() {
         await refreshSchema();
         setLoaded(true);
         setStatusState("ready");
+
+        // Rehydrate user-uploaded data files from OPFS into DuckDB's
+        // virtual filesystem so previously-uploaded CSV / JSON /
+        // Parquet remain queryable across reloads. Best-effort: an
+        // unavailable OPFS just leaves the panel empty.
+        if (workspaceId) {
+          try {
+            const persisted = await opfsLoadDataFiles(workspaceId);
+            if (cancelled) return;
+            for (const entry of persisted) {
+              if (entry.isFolder) continue;
+              const bytes = await opfsReadDataFile(workspaceId, entry.path);
+              if (cancelled) return;
+              if (!bytes) continue;
+              try {
+                await engine.registerFileBuffer(entry.path, bytes);
+              } catch {
+                /* skip unreadable entry — UI still shows it as available */
+              }
+            }
+            if (!cancelled && persisted.length > 0) {
+              setVirtualFiles(persisted);
+              const folders = new Set<string>();
+              for (const e of persisted) {
+                const segments = e.path.split("/");
+                segments.pop();
+                let cur = "";
+                for (const s of segments) {
+                  cur = cur ? `${cur}/${s}` : s;
+                  folders.add(cur);
+                }
+              }
+              setExpandedFolders((prev) => new Set([...prev, ...folders]));
+            }
+          } catch {
+            /* OPFS rehydrate best-effort */
+          }
+        }
       } catch (err) {
         if (cancelled) return;
         setLoadingMessage(
@@ -1990,6 +2061,18 @@ function DuckDbPlaygroundInner() {
             const buf = await file.arrayBuffer();
             const bytes = new Uint8Array(buf);
             const path = parentPath ? `${parentPath}/${file.name}` : file.name;
+            // Persist a copy to OPFS *before* handing the buffer to the
+            // DuckDB-WASM worker — the worker detaches the underlying
+            // ArrayBuffer via postMessage transfer, so we can't rely on
+            // the bytes still being readable after `registerFileBuffer`.
+            const wsId = workspaceIdRef.current;
+            if (wsId) {
+              try {
+                await opfsWriteDataFile(wsId, path, bytes);
+              } catch {
+                /* OPFS write best-effort */
+              }
+            }
             await registerVirtualFile(path, bytes);
             showToast(`Uploaded "${path}".`);
           } catch (err) {
@@ -2048,6 +2131,16 @@ function DuckDbPlaygroundInner() {
             await engine.dropFile(entry.path);
           }
         }
+        // Also drop the OPFS copy so the file doesn't reappear on the
+        // next page load.
+        const wsId = workspaceIdRef.current;
+        if (wsId) {
+          try {
+            await opfsDeleteDataEntry(wsId, path);
+          } catch {
+            /* OPFS delete best-effort */
+          }
+        }
         setVirtualFiles((prev) =>
           prev.filter(
             (f) => f.path !== path && !f.path.startsWith(prefix),
@@ -2081,6 +2174,16 @@ function DuckDbPlaygroundInner() {
               : `${newPrefix}${entry.path.slice(oldPrefix.length)}`;
             await engine.dropFile(entry.path);
             await engine.registerFileBuffer(dest, bytes);
+          }
+          // Mirror the rename inside OPFS so the on-disk copy follows
+          // the new path.
+          const wsId = workspaceIdRef.current;
+          if (wsId) {
+            try {
+              await opfsRenameDataEntry(wsId, oldPath, newPath);
+            } catch {
+              /* OPFS rename best-effort */
+            }
           }
           setVirtualFiles((prev) =>
             prev.map((f) => {
@@ -2117,6 +2220,11 @@ function DuckDbPlaygroundInner() {
         if (parentPath) next.add(parentPath);
         return next;
       });
+      // Persist the folder marker so empty folders survive reloads.
+      const wsId = workspaceIdRef.current;
+      if (wsId) {
+        void opfsUpsertDataFolder(wsId, path);
+      }
     },
     [],
   );
@@ -2159,6 +2267,16 @@ function DuckDbPlaygroundInner() {
                 : `${newPrefix}${entry.path.slice(oldPrefix.length)}`;
             await engine.dropFile(entry.path);
             await engine.registerFileBuffer(dest, bytes);
+          }
+          // Mirror the move inside OPFS (also renames children of a
+          // moved folder).
+          const wsId = workspaceIdRef.current;
+          if (wsId) {
+            try {
+              await opfsRenameDataEntry(wsId, sourcePath, newPath);
+            } catch {
+              /* OPFS rename best-effort */
+            }
           }
           setVirtualFiles((prev) =>
             prev.map((f) => {
@@ -2419,6 +2537,20 @@ function DuckDbPlaygroundInner() {
       /* ignore */
     }
     window.location.reload();
+  }, []);
+
+  // Nuclear wipe: clears every storage surface (localStorage, OPFS,
+  // IndexedDB, caches) before reloading.
+  const clearAllLocalData = useCallback(() => {
+    void (async () => {
+      try {
+        const mod = await import("../storage/clearAllData");
+        await mod.clearAllLocalData();
+      } catch {
+        /* fall through to reload regardless */
+      }
+      window.location.reload();
+    })();
   }, []);
 
   const handleFormatCode = useCallback(async () => {
@@ -3840,6 +3972,7 @@ function DuckDbPlaygroundInner() {
           onClose={() => setSettingsOpen(false)}
           onRestoreDefaults={() => setConfirmRestoreOpen(true)}
           onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
+          onClearAllLocalData={() => setConfirmClearAllDataOpen(true)}
           resetTabsLabel={`Reset query tabs for ${activeSample.label}`}
           onResetTabs={resetTabsForCurrentDb}
           extraTabs={[
@@ -4017,6 +4150,9 @@ function DuckDbPlaygroundInner() {
           clearStorageOpen={confirmClearStorageOpen}
           onClearStorageOpenChange={setConfirmClearStorageOpen}
           onClearStorageConfirm={clearAllLocalStorage}
+          clearAllDataOpen={confirmClearAllDataOpen}
+          onClearAllDataOpenChange={setConfirmClearAllDataOpen}
+          onClearAllDataConfirm={clearAllLocalData}
         />
 
         {/* ── View/Edit Structure drawer ── */}

--- a/app/_components/playgroundShared.tsx
+++ b/app/_components/playgroundShared.tsx
@@ -302,6 +302,12 @@ export interface SettingsPanelProps {
   onClose: () => void;
   onRestoreDefaults: () => void;
   onClearLocalStorage: () => void;
+  /** Wipe every browser-side storage surface this app uses
+   *  (localStorage + sessionStorage + OPFS + IndexedDB + caches) and
+   *  reload. More thorough than `onClearLocalStorage`. Optional so
+   *  callers can opt into surfacing the action — when omitted the row
+   *  is hidden. */
+  onClearAllLocalData?: () => void;
   /** Optional extra rows appended inside the General tab — used by the
    *  SQL playground to surface a per-DB "Reset query tabs" action. */
   extraGeneralRows?: ReactNode;
@@ -343,6 +349,7 @@ export function SettingsPanel({
   onClose,
   onRestoreDefaults,
   onClearLocalStorage,
+  onClearAllLocalData,
   extraGeneralRows,
   extraActionRows,
   extraTabs,
@@ -506,6 +513,16 @@ export function SettingsPanel({
                     <Trash2 size={14} aria-hidden="true" />
                     <span>Clear all localStorage data</span>
                   </button>
+                  {onClearAllLocalData && (
+                    <button
+                      type="button"
+                      className="settings-action-btn settings-action-danger"
+                      onClick={onClearAllLocalData}
+                    >
+                      <Trash2 size={14} aria-hidden="true" />
+                      <span>Clear all local data (storage + OPFS)</span>
+                    </button>
+                  )}
                 </div>
               </div>
             </Tabs.Panel>

--- a/app/_components/playgroundTabs.ts
+++ b/app/_components/playgroundTabs.ts
@@ -15,7 +15,10 @@ export interface PlaygroundFile {
   /** Stable tab id. Doubles as the OPFS filename — never derive it from
    *  `filename` since renames must not touch OPFS. */
   id: string;
-  /** User-visible filename (e.g. "main.py", "utils.py"). */
+  /** User-visible path inside the workspace's virtual filesystem
+   *  (e.g. `"main.py"`, `"src/utils.py"`). May include `/` to nest
+   *  files inside folders; the tab strip displays only the leaf name
+   *  (basename). */
   filename: string;
   /** Filename at creation, used to detect rename. */
   pristineFilename: string;

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -106,6 +106,7 @@ import { RenameDatabaseDialog } from "../sql/components/RenameDatabaseDialog";
 import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
 import { ensureActiveWorkspace } from "../opfs/activeWorkspace";
+import { acquireWorkspaceLock } from "../opfs/workspace";
 import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
 import { type PostgresEngine } from "../runtime/postgres";
 
@@ -1015,6 +1016,7 @@ function PostgresPlaygroundInner() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [confirmRestoreOpen, setConfirmRestoreOpen] = useState(false);
   const [confirmClearStorageOpen, setConfirmClearStorageOpen] = useState(false);
+  const [confirmClearAllDataOpen, setConfirmClearAllDataOpen] = useState(false);
   const [pendingDbId, setPendingDbId] = useState<string | null>(null);
   const [pendingDropEntity, setPendingDropEntity] = useState<{
     name: string;
@@ -1602,6 +1604,21 @@ function PostgresPlaygroundInner() {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
+          const noticeKey = `pg_ws_warned_${workspace.id}`;
+          try {
+            if (window.sessionStorage.getItem(noticeKey) !== "1") {
+              const hasLock = await acquireWorkspaceLock(workspace.id);
+              if (!cancelled && !hasLock) {
+                window.sessionStorage.setItem(noticeKey, "1");
+                showToast(
+                  "This workspace is already open in another tab. Edits here may conflict — switch workspaces via the badge in the header.",
+                  "warn",
+                );
+              }
+            }
+          } catch {
+            /* sessionStorage / Locks unavailable — ignore. */
+          }
         } catch {
           /* proceed in-memory */
         }
@@ -1983,6 +2000,20 @@ function PostgresPlaygroundInner() {
       /* ignore */
     }
     window.location.reload();
+  }, []);
+
+  // Nuclear wipe: clears every storage surface (localStorage, OPFS,
+  // IndexedDB, caches) before reloading.
+  const clearAllLocalData = useCallback(() => {
+    void (async () => {
+      try {
+        const mod = await import("../storage/clearAllData");
+        await mod.clearAllLocalData();
+      } catch {
+        /* fall through to reload regardless */
+      }
+      window.location.reload();
+    })();
   }, []);
 
   const handleFormatCode = useCallback(async () => {
@@ -3328,6 +3359,7 @@ function PostgresPlaygroundInner() {
           onClose={() => setSettingsOpen(false)}
           onRestoreDefaults={() => setConfirmRestoreOpen(true)}
           onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
+          onClearAllLocalData={() => setConfirmClearAllDataOpen(true)}
           resetTabsLabel={`Reset query tabs for ${activeSample.label}`}
           onResetTabs={resetTabsForCurrentDb}
           extraTabs={[
@@ -3427,6 +3459,9 @@ function PostgresPlaygroundInner() {
           clearStorageOpen={confirmClearStorageOpen}
           onClearStorageOpenChange={setConfirmClearStorageOpen}
           onClearStorageConfirm={clearAllLocalStorage}
+          clearAllDataOpen={confirmClearAllDataOpen}
+          onClearAllDataOpenChange={setConfirmClearAllDataOpen}
+          onClearAllDataConfirm={clearAllLocalData}
         />
 
         {/* ── View/Edit Structure drawer ── */}

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -126,6 +126,7 @@ import { SqlEditorToolbar } from "./components/SqlEditorToolbar";
 import { findSampleDatabase } from "../runtime/sqliteSamples";
 import { sqliteAdapter } from "./sqliteAdapter";
 import { ensureActiveWorkspace } from "../opfs/activeWorkspace";
+import { acquireWorkspaceLock } from "../opfs/workspace";
 import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
 import {
   type ColumnConstraintInfo,
@@ -1102,6 +1103,12 @@ function SqlPlaygroundInner() {
   const setConfirmClearStorageOpen = useDialogStore(
     (s) => s.setConfirmClearStorageOpen,
   );
+  const confirmClearAllDataOpen = useDialogStore(
+    (s) => s.confirmClearAllDataOpen,
+  );
+  const setConfirmClearAllDataOpen = useDialogStore(
+    (s) => s.setConfirmClearAllDataOpen,
+  );
   const confirmCloseTabId = useDialogStore((s) => s.confirmCloseTabId);
   const setConfirmCloseTabId = useDialogStore((s) => s.setConfirmCloseTabId);
   const pendingDbId = useDialogStore((s) => s.pendingDbId);
@@ -1442,6 +1449,22 @@ function SqlPlaygroundInner() {
     window.location.reload();
   }, []);
 
+  // Nuclear wipe: clears localStorage, OPFS, IndexedDB, and caches.
+  // Backed by the shared `clearAllLocalData` helper so every playground
+  // gets the same behaviour. Best-effort: failures inside one surface
+  // don't block the others, and we always reload.
+  const clearAllLocalData = useCallback(() => {
+    void (async () => {
+      try {
+        const mod = await import("../storage/clearAllData");
+        await mod.clearAllLocalData();
+      } catch {
+        /* fall through to reload regardless */
+      }
+      window.location.reload();
+    })();
+  }, []);
+
   const handleFormatCode = useCallback(async () => {
     const view = editorRef.current;
     if (!view) return;
@@ -1637,6 +1660,24 @@ function SqlPlaygroundInner() {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
+          // Tab-isolation notice: warn once per (workspace × session)
+          // when another tab already holds the OPFS lock for this
+          // workspace, so the user knows edits here can conflict.
+          const noticeKey = `pg_ws_warned_${workspace.id}`;
+          try {
+            if (window.sessionStorage.getItem(noticeKey) !== "1") {
+              const hasLock = await acquireWorkspaceLock(workspace.id);
+              if (!cancelled && !hasLock) {
+                window.sessionStorage.setItem(noticeKey, "1");
+                showToast(
+                  "This workspace is already open in another tab. Edits here may conflict — switch workspaces via the badge in the header.",
+                  "warn",
+                );
+              }
+            }
+          } catch {
+            /* sessionStorage / Locks unavailable — ignore. */
+          }
         } catch {
           // Workspace bootstrap is best-effort — proceed in-memory.
         }
@@ -2427,6 +2468,7 @@ function SqlPlaygroundInner() {
           onClose={() => setSettingsOpen(false)}
           onRestoreDefaults={() => setConfirmRestoreOpen(true)}
           onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
+          onClearAllLocalData={() => setConfirmClearAllDataOpen(true)}
           resetTabsLabel={`Reset query tabs for ${activeSample.label}`}
           onResetTabs={resetTabsForCurrentDb}
           extraTabs={[
@@ -2498,6 +2540,9 @@ function SqlPlaygroundInner() {
           clearStorageOpen={confirmClearStorageOpen}
           onClearStorageOpenChange={setConfirmClearStorageOpen}
           onClearStorageConfirm={clearAllLocalStorage}
+          clearAllDataOpen={confirmClearAllDataOpen}
+          onClearAllDataOpenChange={setConfirmClearAllDataOpen}
+          onClearAllDataConfirm={clearAllLocalData}
         />
 
         <AlertDialog.Root

--- a/app/_components/sql/components/SqlSettingsConfirmDialogs.tsx
+++ b/app/_components/sql/components/SqlSettingsConfirmDialogs.tsx
@@ -10,6 +10,11 @@ export interface SqlSettingsConfirmDialogsProps {
   clearStorageOpen: boolean;
   onClearStorageOpenChange: (open: boolean) => void;
   onClearStorageConfirm: () => void;
+  /** Confirm dialog for the nuclear "Clear all local data" action.
+   *  Optional so callers can opt in. */
+  clearAllDataOpen?: boolean;
+  onClearAllDataOpenChange?: (open: boolean) => void;
+  onClearAllDataConfirm?: () => void;
 }
 
 export function SqlSettingsConfirmDialogs({
@@ -20,6 +25,9 @@ export function SqlSettingsConfirmDialogs({
   clearStorageOpen,
   onClearStorageOpenChange,
   onClearStorageConfirm,
+  clearAllDataOpen,
+  onClearAllDataOpenChange,
+  onClearAllDataConfirm,
 }: SqlSettingsConfirmDialogsProps) {
   return (
     <>
@@ -52,6 +60,42 @@ export function SqlSettingsConfirmDialogs({
           </AlertDialog.Popup>
         </AlertDialog.Portal>
       </AlertDialog.Root>
+
+      {onClearAllDataConfirm && onClearAllDataOpenChange && (
+        <AlertDialog.Root
+          open={!!clearAllDataOpen}
+          onOpenChange={onClearAllDataOpenChange}
+        >
+          <AlertDialog.Portal>
+            <AlertDialog.Backdrop className="confirm-backdrop" />
+            <AlertDialog.Popup className="confirm-popup">
+              <AlertDialog.Title className="confirm-title">
+                Clear all local data?
+              </AlertDialog.Title>
+              <AlertDialog.Description className="confirm-desc">
+                This will permanently delete every saved setting, query,
+                {" "}<strong>workspace</strong>, persisted{" "}
+                <strong>database</strong>, and uploaded{" "}
+                <strong>data file</strong> across{" "}
+                <strong>all Dataslope playgrounds</strong> — including
+                localStorage, OPFS, IndexedDB, and any cached assets. The
+                page will reload immediately. This cannot be undone.
+              </AlertDialog.Description>
+              <div className="confirm-actions">
+                <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
+                  Cancel
+                </AlertDialog.Close>
+                <AlertDialog.Close
+                  className="confirm-btn confirm-btn-danger"
+                  onClick={onClearAllDataConfirm}
+                >
+                  Clear &amp; reload
+                </AlertDialog.Close>
+              </div>
+            </AlertDialog.Popup>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>
+      )}
 
       <AlertDialog.Root
         open={clearStorageOpen}

--- a/app/_components/sql/components/SqlSettingsPanel.tsx
+++ b/app/_components/sql/components/SqlSettingsPanel.tsx
@@ -25,6 +25,9 @@ export interface SqlSettingsPanelProps {
   onClose: () => void;
   onRestoreDefaults: () => void;
   onClearLocalStorage: () => void;
+  /** Optional — when provided, surfaces a "Clear all local data" action
+   *  alongside the localStorage clear. */
+  onClearAllLocalData?: () => void;
   /** Text for the "Reset query tabs for …" action button. */
   resetTabsLabel: string;
   /** Called when the user clicks the reset-tabs button. */
@@ -52,6 +55,7 @@ export function SqlSettingsPanel({
   onClose,
   onRestoreDefaults,
   onClearLocalStorage,
+  onClearAllLocalData,
   resetTabsLabel,
   onResetTabs,
   extraTabs,
@@ -78,6 +82,7 @@ export function SqlSettingsPanel({
       onClose={onClose}
       onRestoreDefaults={onRestoreDefaults}
       onClearLocalStorage={onClearLocalStorage}
+      onClearAllLocalData={onClearAllLocalData}
       extraGeneralRows={null}
       extraActionRows={
         <button

--- a/app/_components/sql/stores/useDialogStore.ts
+++ b/app/_components/sql/stores/useDialogStore.ts
@@ -44,6 +44,7 @@ interface DialogState {
   confirmCloseTabId: string | null;
   confirmRestoreOpen: boolean;
   confirmClearStorageOpen: boolean;
+  confirmClearAllDataOpen: boolean;
   exportNoTabsHover: boolean;
   // Setters
   setSettingsOpen: (open: boolean) => void;
@@ -108,6 +109,7 @@ interface DialogState {
   setConfirmCloseTabId: (id: string | null) => void;
   setConfirmRestoreOpen: (open: boolean) => void;
   setConfirmClearStorageOpen: (open: boolean) => void;
+  setConfirmClearAllDataOpen: (open: boolean) => void;
   setExportNoTabsHover: (hover: boolean) => void;
 }
 
@@ -143,6 +145,7 @@ export const useDialogStore = create<DialogState>((set) => ({
   confirmCloseTabId: null,
   confirmRestoreOpen: false,
   confirmClearStorageOpen: false,
+  confirmClearAllDataOpen: false,
   exportNoTabsHover: false,
   setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
   setDdlDialog: (ddlDialog) => set({ ddlDialog }),
@@ -213,6 +216,8 @@ export const useDialogStore = create<DialogState>((set) => ({
   setPendingDbId: (pendingDbId) => set({ pendingDbId }),
   setConfirmCloseTabId: (confirmCloseTabId) => set({ confirmCloseTabId }),
   setConfirmRestoreOpen: (confirmRestoreOpen) => set({ confirmRestoreOpen }),
+  setConfirmClearAllDataOpen: (confirmClearAllDataOpen) =>
+    set({ confirmClearAllDataOpen }),
   setConfirmClearStorageOpen: (confirmClearStorageOpen) =>
     set({ confirmClearStorageOpen }),
   setExportNoTabsHover: (exportNoTabsHover) => set({ exportNoTabsHover }),

--- a/app/_components/storage/clearAllData.ts
+++ b/app/_components/storage/clearAllData.ts
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * Nuclear "Clear all local data" helper. Wipes every browser-side storage
+ * surface this app touches:
+ *   - localStorage (settings, manifests, examples, workspace registry)
+ *   - sessionStorage (per-session toast suppression flags, etc.)
+ *   - OPFS (workspaces/, including code files, uploaded data files, and
+ *     persisted SQLite / PGlite / DuckDB databases)
+ *   - IndexedDB (best-effort — used by some pyodide / DuckDB-WASM caches)
+ *   - Cache Storage (best-effort — service worker caches if present)
+ *
+ * Each step is independently best-effort: a failure in one surface (e.g.
+ * private mode disables OPFS) does not abort the others. After all surfaces
+ * have been visited, the caller should reload the page so freshly-mounted
+ * components can re-bootstrap from a clean state.
+ */
+
+import { isOpfsSupported } from "../opfs/featureDetect";
+
+async function clearOpfs(): Promise<void> {
+  if (!isOpfsSupported()) return;
+  try {
+    const root = await navigator.storage.getDirectory();
+    // Walk the top level and remove every entry recursively. We can't
+    // delete the root itself — only its children — so this is the
+    // closest we get to "wipe OPFS".
+    const entries = root as unknown as {
+      entries(): AsyncIterable<[string, FileSystemHandle]>;
+    };
+    for await (const [name] of entries.entries()) {
+      try {
+        await root.removeEntry(name, { recursive: true });
+      } catch {
+        // Skip handles we can't remove (e.g. locked by an open SyncAccessHandle
+        // in another tab). The remaining entries still get cleared.
+      }
+    }
+  } catch {
+    /* OPFS access denied or unavailable — nothing more to do. */
+  }
+}
+
+async function clearIndexedDb(): Promise<void> {
+  if (typeof indexedDB === "undefined") return;
+  try {
+    // `databases()` is unsupported in Firefox / Safari; in that case the
+    // catch falls through and we just leave IDB alone.
+    const dbs = await (indexedDB as unknown as {
+      databases?: () => Promise<{ name?: string }[]>;
+    }).databases?.();
+    if (!dbs) return;
+    await Promise.allSettled(
+      dbs
+        .filter((d) => typeof d.name === "string" && d.name.length > 0)
+        .map(
+          (d) =>
+            new Promise<void>((resolve) => {
+              const req = indexedDB.deleteDatabase(d.name as string);
+              req.onsuccess = () => resolve();
+              req.onerror = () => resolve();
+              req.onblocked = () => resolve();
+            }),
+        ),
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+async function clearCacheStorage(): Promise<void> {
+  if (typeof caches === "undefined") return;
+  try {
+    const keys = await caches.keys();
+    await Promise.allSettled(keys.map((k) => caches.delete(k)));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Clears every local storage surface used by the app. Returns when
+ *  every best-effort pass has run — does NOT reload the page itself
+ *  (the caller decides whether to reload). */
+export async function clearAllLocalData(): Promise<void> {
+  try {
+    localStorage.clear();
+  } catch {
+    /* private mode — ignore */
+  }
+  try {
+    sessionStorage.clear();
+  } catch {
+    /* ignore */
+  }
+  await Promise.all([clearOpfs(), clearIndexedDb(), clearCacheStorage()]);
+}

--- a/app/_components/tabs/TabBar.tsx
+++ b/app/_components/tabs/TabBar.tsx
@@ -1,8 +1,25 @@
 "use client";
 
-import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Dialog } from "@base-ui-components/react/dialog";
 import { ContextMenu } from "@base-ui-components/react/context-menu";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  horizontalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS as DndCSS } from "@dnd-kit/utilities";
 import { Plus, X } from "lucide-react";
 import type { TabDescriptor } from "./tabTypes";
 
@@ -13,6 +30,13 @@ export interface TabBarProps {
   onCloseTab?: (id: string) => void;
   onAddTab?: () => void;
   onRenameTab?: (id: string, newLabel: string) => void;
+  /**
+   * Optional handler that receives the post-drop tab order. When
+   * provided, the bar mounts a `DndContext` + horizontal
+   * `SortableContext` so users can drag tabs to reorder them. Pass
+   * `undefined` to keep the bar non-draggable (cheaper render path).
+   */
+  onReorderTabs?: (nextTabs: TabDescriptor[]) => void;
   /** Optional className appended to the root tabbar element. */
   className?: string;
 }
@@ -29,27 +53,45 @@ export function TabBar({
   onCloseTab,
   onAddTab,
   onRenameTab,
+  onReorderTabs,
   className,
 }: TabBarProps) {
   const cls = ["pg-tabbar", className].filter(Boolean).join(" ");
+  const sortable = !!onReorderTabs;
+
+  const strip = (
+    <div className="pg-tabs" role="tablist">
+      {tabs.map((tab) => (
+        <TabItem
+          key={tab.id}
+          tab={tab}
+          active={tab.id === activeTabId}
+          sortable={sortable}
+          onSelect={() => onSelectTab(tab.id)}
+          onClose={onCloseTab ? () => onCloseTab(tab.id) : undefined}
+          onRename={
+            onRenameTab
+              ? (label) => onRenameTab(tab.id, label)
+              : undefined
+          }
+        />
+      ))}
+    </div>
+  );
+
   return (
     <div className={cls}>
-      <div className="pg-tabs" role="tablist">
-        {tabs.map((tab) => (
-          <TabItem
-            key={tab.id}
-            tab={tab}
-            active={tab.id === activeTabId}
-            onSelect={() => onSelectTab(tab.id)}
-            onClose={onCloseTab ? () => onCloseTab(tab.id) : undefined}
-            onRename={
-              onRenameTab
-                ? (label) => onRenameTab(tab.id, label)
-                : undefined
-            }
-          />
-        ))}
-      </div>
+      {sortable ? (
+        <DndStrip
+          tabs={tabs}
+          activeTabId={activeTabId}
+          onReorderTabs={onReorderTabs!}
+        >
+          {strip}
+        </DndStrip>
+      ) : (
+        strip
+      )}
       {onAddTab && (
         <button
           type="button"
@@ -65,9 +107,75 @@ export function TabBar({
   );
 }
 
+interface DndStripProps {
+  tabs: TabDescriptor[];
+  activeTabId: string;
+  onReorderTabs: (next: TabDescriptor[]) => void;
+  children: React.ReactNode;
+}
+
+function DndStrip({
+  tabs,
+  activeTabId,
+  onReorderTabs,
+  children,
+}: DndStripProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+  const tabIds = useMemo(() => tabs.map((t) => t.id), [tabs]);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const draggingTab = useMemo(
+    () => (draggingId ? tabs.find((t) => t.id === draggingId) ?? null : null),
+    [draggingId, tabs],
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setDraggingId(String(event.active.id));
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setDraggingId(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const from = tabs.findIndex((t) => t.id === active.id);
+      const to = tabs.findIndex((t) => t.id === over.id);
+      if (from === -1 || to === -1) return;
+      onReorderTabs(arrayMove(tabs, from, to));
+    },
+    [onReorderTabs, tabs],
+  );
+
+  const handleDragCancel = useCallback(() => setDraggingId(null), []);
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
+        {children}
+      </SortableContext>
+      <DragOverlay dropAnimation={null}>
+        {draggingTab ? (
+          <TabOverlay
+            tab={draggingTab}
+            active={draggingTab.id === activeTabId}
+          />
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+
 interface TabItemProps {
   tab: TabDescriptor;
   active: boolean;
+  sortable: boolean;
   onSelect: () => void;
   onClose?: () => void;
   onRename?: (label: string) => void;
@@ -76,6 +184,7 @@ interface TabItemProps {
 const TabItem = memo(function TabItem({
   tab,
   active,
+  sortable,
   onSelect,
   onClose,
   onRename,
@@ -87,6 +196,19 @@ const TabItem = memo(function TabItem({
   const [draftLabel, setDraftLabel] = useState(tab.label);
   const [isClosing, setIsClosing] = useState(false);
   const closedRef = useRef(false);
+
+  // useSortable must be called unconditionally; when `sortable` is
+  // false we just don't apply its props/refs, so the tab renders as a
+  // static button.
+  const sortableState = useSortable({ id: tab.id, disabled: !sortable });
+  const dragStyle: React.CSSProperties = sortable
+    ? {
+        transform: DndCSS.Transform.toString(sortableState.transform),
+        transition: sortableState.transition,
+        opacity: sortableState.isDragging ? 0 : undefined,
+        zIndex: sortableState.isDragging ? 10 : undefined,
+      }
+    : {};
 
   const openRename = useCallback(() => {
     if (!renameable) return;
@@ -169,6 +291,10 @@ const TabItem = memo(function TabItem({
             <button
               type="button"
               {...props}
+              {...(sortable ? sortableState.attributes : {})}
+              {...(sortable ? sortableState.listeners : {})}
+              ref={sortable ? sortableState.setNodeRef : undefined}
+              style={dragStyle}
               className={`pg-tab${active ? " active" : ""} pg-tab--kind-${tab.kind}${isClosing ? " pg-tab--closing" : ""}`}
               onClick={onSelect}
               onDoubleClick={openRename}
@@ -233,3 +359,32 @@ const TabItem = memo(function TabItem({
     </>
   );
 });
+
+/** Lightweight clone rendered inside `DragOverlay` while a tab is
+ *  being dragged. No interactive affordances — DnD-kit handles the
+ *  drop animation. */
+function TabOverlay({
+  tab,
+  active,
+}: {
+  tab: TabDescriptor;
+  active: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={`pg-tab${active ? " active" : ""} pg-tab--kind-${tab.kind}`}
+      style={{ opacity: 0.85, cursor: "grabbing" }}
+    >
+      {tab.icon && (
+        <span className="pg-tab-icon" aria-hidden="true">
+          {tab.icon}
+        </span>
+      )}
+      <span className="pg-tab-title">{tab.label}</span>
+      <span className="pg-tab-close">
+        <X size={10} aria-hidden="true" />
+      </span>
+    </button>
+  );
+}

--- a/app/_components/workspace/WorkspaceBadge.tsx
+++ b/app/_components/workspace/WorkspaceBadge.tsx
@@ -91,6 +91,13 @@ export function WorkspaceBadge({
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [managerOpen, setManagerOpen] = useState(false);
   const [registry, setRegistry] = useState<WorkspaceEntry[]>([]);
+  // Cached byte-size estimates for the recent workspaces, prefetched
+  // whenever the popover opens. State is retained between opens so
+  // subsequent opens render the previous size synchronously and update
+  // in place when the fresh estimate lands.
+  const [popoverSizes, setPopoverSizes] = useState<Map<string, number>>(
+    () => new Map(),
+  );
 
   // Hydrate registry on the client only — `getWorkspaceRegistry` reads
   // localStorage which is undefined on the server. Re-read whenever the
@@ -114,6 +121,31 @@ export function WorkspaceBadge({
         .slice(0, RECENT_LIMIT),
     [registry, playgroundId],
   );
+
+  // Prefetch sizes when the popover opens. Each `estimateWorkspaceSize`
+  // call is independent so we fire them in parallel and stream results
+  // into the size map as they land — no flicker on subsequent opens
+  // because the previous map is retained between renders.
+  useEffect(() => {
+    if (!popoverOpen) return;
+    let cancelled = false;
+    const ids = recent.map((ws) => ws.id);
+    void Promise.all(
+      ids.map(async (id) => {
+        const bytes = await estimateWorkspaceSize(id);
+        if (cancelled) return;
+        setPopoverSizes((prev) => {
+          if (prev.get(id) === bytes) return prev;
+          const next = new Map(prev);
+          next.set(id, bytes);
+          return next;
+        });
+      }),
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [popoverOpen, recent]);
 
   const handleSwitch = useCallback(
     (workspaceId: string) => {
@@ -189,6 +221,12 @@ export function WorkspaceBadge({
                         </span>
                         <span className="workspace-popover-item-meta">
                           Last opened {formatRelative(ws.lastUsedAt)}
+                          {popoverSizes.has(ws.id) && (
+                            <>
+                              {" · "}
+                              {formatBytes(popoverSizes.get(ws.id) ?? 0)}
+                            </>
+                          )}
                         </span>
                       </span>
                     </button>


### PR DESCRIPTION
## Summary

Picks up the plan doc's "Where the next agent picks up" follow-ups
(items 3, 6, 7) plus two user-driven additions made during the session.

### From the plan
- **Item 3 — DnD tab reorder for non-SQL playgrounds.** Generic
  `TabBar` gained an optional `onReorderTabs?` prop that wraps the
  strip in `DndContext` + horizontal `SortableContext`. Each
  `TabItem` is wired through `useSortable` (called unconditionally
  with `{ disabled: !sortable }` so the bar stays a single static
  call path). `Playground.tsx` projects the dropped order back onto
  `files` via id lookup, then commits to the Zustand store.
- **Item 6 — Tab-isolation notice in SQL playgrounds.** Each SQL
  bootstrap effect (SQLite, Postgres, DuckDB) now calls
  `acquireWorkspaceLock(workspaceId)` after `ensureActiveWorkspace`
  and emits the one-time `pg_ws_warned_<id>` toast when another tab
  already holds the workspace, mirroring the non-SQL pattern.
- **Item 7 — Workspace size in popover.** `WorkspaceBadge`
  prefetches `estimateWorkspaceSize` for every recent workspace as
  soon as the popover opens, caches the result in component state,
  and renders it inline under each item ("Last opened … · 12.4 KB").
  Subsequent opens render synchronously from cache and update in
  place when fresh estimates land.

### Two user-driven additions
- **"Clear all local data" action in Settings.** New
  `storage/clearAllData.ts` helper iterates `navigator.storage
  .getDirectory().entries()` and removes each top-level entry
  recursively (the closest equivalent to wiping OPFS), plus drops
  every IndexedDB database via `databases()` (where supported),
  clears Cache Storage keys, and finally calls `localStorage.clear()`
  + `sessionStorage.clear()`. All four playground shells (non-SQL +
  3× SQL) surface this as a second red action below the existing
  "Clear all localStorage data" button, each with its own
  AlertDialog confirm. The lighter localStorage-only action is kept
  for the cheap case.
- **DuckDB FilesPanel ↔ OPFS.** Previously DuckDB's uploaded data
  files lived only in DuckDB-WASM's MEMFS and vanished on reload.
  `DuckDbPlayground.tsx` now mirrors every FilesPanel op into OPFS
  via the existing `opfsDataStorage` helpers (`writeDataFile`,
  `deleteDataEntry`, `renameDataEntry`, `upsertDataFolder`,
  `loadDataFiles` / `readDataFile`). On bootstrap, files are
  loaded from OPFS and re-registered with the engine; ancestor
  folders auto-expand so they're visible. Upload writes to OPFS
  *before* `registerFileBuffer` because the worker detaches the
  transferred ArrayBuffer.

### Plan doc updates
- Marked items 3, 6, 7 done; rewrote the handoff to describe what
  the next agent inherits.
- Documented two newly-discovered audit gaps:
  - **#8** FilesPanel data files aren't exposed to any non-SQL
    runtime (`LanguageRuntime` only has `run(code, emit)` — no
    `writeFile`); the FilesPanel currently persists to OPFS but
    nothing is loaded into Pyodide/WebR/php-wasm/etc.
  - **#9** SQL query tabs are workspace-agnostic — keyed by db id
    in localStorage rather than `(wsId, dbId)`. Likely intentional
    given the DB itself is workspace-scoped, but flagged.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (133 pre-existing warnings unchanged)
- [x] `npm run test` — 221/221 passing
- [x] `npm run build` — succeeds (29 static routes generated)
- [ ] Manual: drag a non-SQL tab to reorder; reload; order
      persists via the manifest
- [ ] Manual: open a workspace in two browser tabs; the second tab
      shows the lock-busy toast once per session
- [ ] Manual: open the workspace popover; sizes appear within ~1
      frame, stay visible on subsequent opens without flicker
- [ ] Manual: in DuckDB, upload a CSV; reload; the file is still in
      the FilesPanel and `SELECT * FROM 'foo.csv'` still works
- [ ] Manual: click "Clear all local data" in Settings; confirm;
      the page reloads with empty workspaces, no saved tabs, no
      persisted DBs

https://claude.ai/code/session_01GBqJhVXnt2d4CBgCXLVCyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBqJhVXnt2d4CBgCXLVCyT)_