### PR TITLE
feat: replace JS/TS playground runtimes with almostnode (multi-file + Node.js shims)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ script-runner-src/__pycache__/
 
 # fumadocs-mdx generated source (rebuilt on every build/dev start)
 .source/
+
+# Pre-bundled almostnode JS/TS workers (rebuilt by
+# `scripts/build-almostnode-workers.mjs` on postinstall + build + dev).
+/public/_workers/

--- a/agent-outputs/20260519-1959-almostnode-feasibility-research.md
+++ b/agent-outputs/20260519-1959-almostnode-feasibility-research.md
@@ -2,8 +2,14 @@
 ## Replacing the JS/TS Playground Runtimes with almostnode for Multi-File Module Resolution
 
 **Date:** 2026-05-19  
-**Status:** Research Complete — Implementation-Ready  
+**Status:** Phases 1–2 implemented (multi-file JS/TS runtime swap landed)  
 **Repo context:** `dataslope/dataslope`
+
+> **Update 2026-05-21:** The JavaScript and TypeScript playgrounds have
+> been migrated to almostnode in-place (no separate `*-v2` IDs). See
+> §8 *Implementation Notes (2026-05-21)* at the bottom of this document
+> for what shipped, the gotchas encountered, and the remaining
+> follow-ups for the next coding agent.
 
 ---
 
@@ -841,3 +847,245 @@ No conflicts between service workers exist as long as all routing logic is co-lo
 The basic JS/TS runtime replacement (Phases 1–3) is low-risk, high-value, and directly enables multi-file module resolution and npm package support that the current `AsyncFunction`-based workers fundamentally cannot provide. Phases 5–6 (dev server playgrounds) should be treated as separate feature work once the core runtime migration is proven stable.
 
 The most important prerequisite before Phase 1 begins is: **deploy the cross-origin sandbox** (`generateSandboxFiles()` → Vercel or equivalent). This is a one-time infrastructure task that unblocks the secure execution path for all future phases.
+
+---
+
+## 8. Implementation Notes (2026-05-21)
+
+This section documents the actual migration that landed in commit on
+branch `claude/almostnode-playground-runtime-rZD9D`. The task was to
+**replace** the existing JS/TS playground runtimes with almostnode
+in-place (no `*-v2` IDs) and ship multi-file support with shimmed
+Node.js modules. Phases 0 (CORS proxy SW), 4 (cross-origin sandbox), 5
+(dev servers), and 6 (legacy cleanup of files that were already removed)
+remain untouched and are described in §6.6.
+
+### 8.1 What shipped
+
+| File | Change |
+|---|---|
+| `package.json` | Added `almostnode@^0.2.14` to `dependencies`; chained `node scripts/patch-almostnode.mjs` onto the `postinstall` script after `fumadocs-mdx`. |
+| `scripts/patch-almostnode.mjs` | New — see §8.3. Rewrites a hard-coded server-absolute asset URL inside `almostnode/dist/index.{mjs,cjs}` so Next.js / Turbopack can resolve it. |
+| `app/_components/runtime/almostnode-worker-shared.ts` | New — shared helpers (`stageFiles`, `wrapEntryAsAsyncIIFE`, `runEntry`, `formatArg`, `normalizeVfsPath`) used by both worker bundles. |
+| `app/_components/runtime/javascript-worker.ts` | **Replaced** in place. Drops `AsyncFunction`; spawns an almostnode `VirtualFS` + `Runtime`, stages files via a `prepare-fs` message, executes the entry file via `runFileAsync`. |
+| `app/_components/runtime/typescript-worker.ts` | **Replaced** in place. Transpiles every staged `.ts`/`.tsx`/`.mts`/`.cts` file to `.js` with the bundled TypeScript compiler (CJS emit), then hands the staged JS off to the same almostnode runner. |
+| `app/_components/runtime/javascript.tsx` | Adapter now implements `prepareFileSystem` and posts `prepare-fs` before `run`. Updated `runtimeInfo`, `packagesFooter`, and `importSnippet` (`const x = require("x");`). New `node_modules` and `multi_file` examples were added; the rest of the canonical examples are preserved. |
+| `app/_components/runtime/typescript.tsx` | Same shape as `javascript.tsx`; uses ESM-style `importSnippet` (`import * as x from "x";`) but `hasImport` accepts either ESM or CJS forms so duplicate-insert detection stays robust. New `node_modules` and `multi_file` examples added. |
+
+The public `LanguageAdapter` IDs remain `"javascript"` and `"typescript"`
+— routes (`/playground/javascript`, `/playground/typescript`) and
+workspace localStorage keys are untouched.
+
+### 8.2 Architecture as it landed
+
+```
+LanguageAdapter (javascript.tsx | typescript.tsx)
+    │  init() ─────────► new Worker(new URL("./{javascript|typescript}-worker.ts", import.meta.url))
+    │  prepareFileSystem(files) ─► postMessage("prepare-fs")
+    │  run(code, emit)            ─► postMessage("run", entryPath)
+    ▼
+Worker (javascript-worker.ts | typescript-worker.ts)
+    │  on "prepare-fs": vfs = stageFiles(files [+ transpile .ts→.js])
+    │  on "run":
+    │    1. read entry file from VFS (fallback: inline `code` arg)
+    │    2. wrap in `module.exports = (async () => { ... })()`
+    │    3. new Runtime(vfs, { onConsole: stream-out })
+    │    4. await runtime.runFileAsync(entryVfsPath)
+    │    5. await module.exports (the wrapper promise) so top-level
+    │       `await` resolves before "done" is posted
+    ▼
+almostnode { VirtualFS, Runtime } (loaded via the same-origin Web Worker)
+```
+
+Console output is captured by passing `onConsole: (method, args) => …`
+to the `Runtime` constructor. `warn`/`error` are routed to stderr cells;
+everything else (`log`/`info`/`debug`/`dir`/`table`) lands on stdout —
+matching the legacy worker's mapping exactly.
+
+### 8.3 Build-time gotcha: hard-coded asset URL in `almostnode/dist/index.mjs`
+
+`almostnode@0.2.14` ships a bundled `index.mjs` whose internal
+`WorkerRuntime` constructor reads:
+
+```js
+this.worker = new Worker(
+  new URL("/assets/runtime-worker-D6Dmsis4.js", import.meta.url),
+  { type: "module" },
+);
+```
+
+The leading-slash URL assumes the bundle is served from an HTTP origin
+that exposes `node_modules` at root — the Vite dev-server setup the
+library was authored against. Under Next.js 16 / Turbopack, the URL
+resolves to the filesystem root and the build aborts with
+`Module not found: Can't resolve '/assets/runtime-worker-D6Dmsis4.js'`.
+
+The migrated playground never instantiates `WorkerRuntime` (the
+LanguageAdapter contract already provides its own dedicated Web Worker,
+and almostnode's `Runtime` runs inside that worker on the main JS
+thread). But Turbopack performs static URL analysis on every
+`new URL(…, import.meta.url)` in `index.mjs` regardless of dead-code,
+so the bad string had to disappear from the bundle.
+
+**Fix:** A small post-install patch (`scripts/patch-almostnode.mjs`)
+rewrites the URL from `"/assets/runtime-worker-…"` → `"./assets/runtime-
+worker-…"`. The asset itself lives at
+`node_modules/almostnode/dist/assets/runtime-worker-D6Dmsis4.js`, which
+is exactly what the corrected relative URL resolves to. The patch is
+idempotent (regex skips already-rewritten files) and runs on every
+`npm install`, so fresh CI checkouts get a working build automatically.
+
+Upstream fix: filed as a follow-up in §8.6.
+
+### 8.4 Top-level `await` and the IIFE wrapper
+
+The legacy runtime executed user code via `new AsyncFunction(code)`, so
+top-level `await` (used by the canonical async examples) just worked.
+almostnode's `Runtime`, in contrast, wraps each module in a synchronous
+CommonJS shell, so top-level `await` is a hard syntax error.
+
+To preserve the existing semantics without forcing users to learn a new
+contract, **the entry file is rewritten before execution** so its body
+runs inside an async IIFE assigned to `module.exports`:
+
+```js
+module.exports = (async () => {
+  <user code>
+})();
+```
+
+The runner then `await`s `result.exports` (the IIFE's promise) before
+posting `done` — guaranteeing async work flushes its console output and
+that thrown errors reach stderr before the cell is marked complete.
+
+This transform applies **only to the entry file**, not to `require()`d
+modules. A user `require("./utils.js")` still gets the original CJS
+semantics of `utils.js`. The transform is a no-op for synchronous
+entry-file code.
+
+### 8.5 TypeScript: pre-transpile to `.js` before staging
+
+almostnode's resolver tries the file extensions `.js`, `.json`, and
+`.node` only — it has no `.ts` awareness. The library mentions
+TypeScript support in its README ("First-class TypeScript/TSX
+transformation via esbuild-wasm"), but inspection of `dist/runtime.mjs`
+shows the esbuild path is only wired into the *npm install* transformer
+(`src/transform.ts`) and depends on `typeof window !== 'undefined'`,
+which is false in a dedicated Web Worker.
+
+To keep the worker self-contained (no `window` polyfill, no
+network-fetched WASM at run time) the TypeScript adapter transpiles
+every `.ts`/`.tsx`/`.mts`/`.cts` file with the already-bundled
+`typescript` package, then writes the result to its `.js`-suffixed
+sibling path in VFS. The original `.ts` path is **not** also written,
+which avoids two competing copies of the same module under different
+extensions confusing the resolver.
+
+`require("./utils")` (no extension) resolves to `./utils.js` exactly as
+it would in Node. `require("./utils.ts")` (with extension) will **not**
+resolve — a small papercut documented in the new `multi_file` example
+in `typescript.tsx`.
+
+Diagnostics emitted by `ts.transpileModule` are buffered during
+`prepare-fs` and replayed as stderr cells at the start of the next
+`run`, so users see compile errors next to the failed execution.
+
+### 8.6 Remaining work / follow-ups for the next coding agent
+
+The scope of this task was strictly the runtime swap. Several items
+from §6 of the original research remain on the table — they were either
+called out explicitly as out-of-scope or are *enabled by* the swap but
+not part of it:
+
+1. **npm package installation in the packages drawer.** Both adapters
+   ship `PACKAGES: PackageInfo[] = []`, so the Packages button is
+   still hidden (the existing e2e tests assert this). Wiring the
+   drawer to `container.npm.install(name)` and persisting the resulting
+   `node_modules/` tree via `vfs.toSnapshot()` → OPFS is Phase 3 of
+   §6.6.
+
+2. **VFS snapshot persistence.** The current implementation creates a
+   fresh `VirtualFS` on every `prepare-fs` call. That's intentional for
+   correctness (deletions in the file pane propagate cleanly) but it
+   means any installed npm packages would be discarded between runs.
+   Phase 3 must persist the snapshot per workspace before npm install
+   is usable.
+
+3. **CORS proxy service worker (Phase 0 in §6.6).** Independent of
+   almostnode. The Cloudflare Worker already exists at
+   `cloudflare-cors-proxy/` and is deploy-ready. The remaining bullets
+   under §6.6's *Phase 0* checklist (deploying it, wiring
+   `NEXT_PUBLIC_CORS_PROXY_URL`, adding the root-scope `__sw__.js`,
+   monkey-patching `fetch` inside each runtime worker) still need to
+   land for outbound HTTP requests from playground code to reach
+   non-CORS-friendly APIs.
+
+4. **Cross-origin sandbox deployment.** The current implementation
+   runs almostnode's `Runtime` directly inside the existing same-origin
+   Web Worker (`new Runtime(vfs, …)`, *not* `createRuntime(vfs, {
+   sandbox: … })`). This matches the prior security level of the legacy
+   `AsyncFunction` worker, but does not improve it. For user-supplied
+   code, deploying the sandbox to a separate origin (Phase 4) and
+   switching the adapter to `createRuntime({ sandbox: "https://…" })`
+   is the right next step.
+
+5. **Unit tests for the new runtime.**
+   `__tests__/javascript.test.ts` and `__tests__/typescript.test.ts`
+   still verify the *legacy* `AsyncFunction`-based execution model by
+   re-implementing it inline — they don't exercise the new worker code
+   path. The tests are passing as legacy-semantics reference checks
+   but no longer test the production runtime. Either:
+   - mock the `almostnode` module and write integration tests that
+     drive `JavaScriptWorkerRuntime.prepareFileSystem` +
+     `JavaScriptWorkerRuntime.run` through a fake `Worker`; or
+   - rely on the Playwright e2e suite at `e2e/playgrounds.spec.ts`
+     (which exercises the real adapter end-to-end) and drop the
+     vitest re-implementations as historical artefacts.
+
+6. **Upstream fix for the asset URL bug.** The post-install patch in
+   `scripts/patch-almostnode.mjs` is a workaround. Filing a PR against
+   [macaly/almostnode](https://github.com/macaly/almostnode) to ship
+   relative asset URLs (`./assets/...`) in the prebuilt bundle is the
+   permanent fix. Once a patched almostnode release is consumed, the
+   post-install hook can be removed.
+
+7. **Dynamic `require(variable)` of `.ts` paths.** Documented gotcha:
+   `require("./utils.ts")` (explicit `.ts`) will not resolve in the TS
+   playground because the staged file is `./utils.js`. A future
+   refinement could double-stage each TS file under both its `.ts` and
+   `.js` paths so explicit-extension requires keep working.
+
+### 8.7 Validation performed
+
+| Check | Command | Result |
+|---|---|---|
+| TypeScript compile | `npx tsc --noEmit` | ✅ clean (0 errors) |
+| Unit tests | `npm run test` | ✅ 221 passed across 9 files |
+| Lint (new files) | `npm run lint` | ✅ no new errors (one pre-existing `no-assign-module-variable` in `php-worker.ts` is unrelated) |
+| Production build | `npm run build` | ✅ compiles in ~3 min, all 29 static pages generated, including `/playground/javascript` and `/playground/typescript` |
+| E2E suite | `npm run test:e2e` | ⚠️ not executed in this environment — see §8.6 item 5. The Playwright suite at `e2e/playgrounds.spec.ts` is the authoritative end-to-end check and should be run before merging. |
+
+### 8.8 Known regressions / behavioural changes for users
+
+These are intentional consequences of the runtime swap that users may
+notice:
+
+- **`import`/`export` syntax at the top of the entry file** now goes
+  through the wrapping IIFE. In the TypeScript playground, the TS
+  compiler downlevels ES module syntax to `require()`/`module.exports`
+  before wrapping — so `import lodash from "lodash"` Just Works. In the
+  raw JavaScript playground, top-level `import` is *not* available
+  (the entry file is plain CJS); users should write
+  `const lodash = require("lodash")` instead. The JS adapter's
+  `importSnippet` now generates the `require` form to nudge users in
+  the right direction.
+- **Module-level `module.exports = X` in the entry file is
+  overwritten** by the IIFE wrapper. The entry file is a script, not a
+  library — this matters in practice for nobody.
+- **`console.log`/`info`/`debug` output now batches per-call.** The
+  legacy runtime buffered all output until the run finished, then
+  flushed it as a single stdout cell. almostnode's `onConsole` fires
+  per-call, so a long-running script with many `console.log`s now
+  produces many small cells. This is closer to a real-Node interactive
+  REPL feel; if the old batched-output behaviour is preferred, the
+  worker's `runEntry` helper can buffer with a debounced flush.

--- a/agent-outputs/20260519-1959-almostnode-feasibility-research.md
+++ b/agent-outputs/20260519-1959-almostnode-feasibility-research.md
@@ -990,6 +990,67 @@ Diagnostics emitted by `ts.transpileModule` are buffered during
 `prepare-fs` and replayed as stderr cells at the start of the next
 `run`, so users see compile errors next to the failed execution.
 
+### 8.6a Build-time gotcha #2: Turbopack chunks the worker via `importScripts` (2026-05-21)
+
+After the initial migration shipped, both playgrounds threw at worker
+startup:
+
+```
+Failed to load: Uncaught SyntaxError: Failed to execute 'importScripts'
+on 'WorkerGlobalScope': Identifier 'e1' has already been declared
+```
+
+Source: Turbopack's worker runtime contains this line:
+
+```js
+new e(u, i ? {...i, type: void 0} : void 0)
+```
+
+`type: void 0` **overrides any `type` option passed to the Worker
+constructor**, forcing classic-worker mode. Its bootstrap script then
+does `importScripts.apply(self, chunks)` to load every chunk of the
+almostnode bundle. Two chunks happen to mint the same minified
+top-level identifier (`e1`), and the worker aborts before our handlers
+attach.
+
+**Why we didn't catch it in the e2e suite initially:** my Playwright
+run after deleting `.next/cache` produced a chunk graph that *didn't*
+collide on `e1`; the next clean build did. The collision is sensitive
+to the global chunk-minifier state.
+
+**Fix shipped:** route around Turbopack's worker bundler entirely.
+`scripts/build-almostnode-workers.mjs` runs esbuild over the two
+worker source files, producing self-contained ES modules at
+`public/_workers/javascript-worker.js` and `public/_workers/typescript-
+worker.js`. The adapters now do:
+
+```ts
+new Worker("/_workers/javascript-worker.js", { type: "module" })
+```
+
+— a static URL Turbopack treats as opaque (no static analysis, no
+chunking, no `importScripts`). Module-worker semantics are honoured by
+the browser directly.
+
+The script:
+
+- Runs from `postinstall`, `prebuild`, and `predev` (chained into
+  `dev` and `build` for clarity).
+- Stubs every `node:*` specifier to a no-op CJS proxy because
+  `just-bash`'s browser bundle (transitively pulled in by almostnode)
+  still references `node:zlib`, `node:async_hooks`, `node:dns` in dead
+  code branches that esbuild's resolver otherwise complains about.
+- Outputs to `public/_workers/`, which is `.gitignore`d.
+
+This keeps the rest of the app on Turbopack (no build-speed
+regression) while making the almostnode workers a deterministic
+single-file bundle.
+
+Validated against both `next dev` and `next start` via Playwright (the
+ad-hoc prod smoke test was deleted after passing; the regression guard
+remaining in `e2e/playgrounds.spec.ts` asserts no `importScripts`
+error appears during runtime init).
+
 ### 8.6 Remaining work / follow-ups for the next coding agent
 
 The scope of this task was strictly the runtime swap. Several items

--- a/app/_components/runtime/almostnode-worker-shared.ts
+++ b/app/_components/runtime/almostnode-worker-shared.ts
@@ -1,0 +1,152 @@
+/// <reference lib="webworker" />
+
+// Helpers shared by the JavaScript and TypeScript almostnode-backed
+// workers. Both spawn their own Worker instance via `new Worker(new
+// URL(...))`, so this file is imported once into each worker bundle.
+//
+// almostnode provides:
+//   - VirtualFS: in-memory POSIX-style filesystem
+//   - Runtime  : CommonJS executor with 40+ shimmed Node.js modules
+//
+// We use almostnode directly (not `createRuntime`) because we're already
+// inside a same-origin Web Worker — the existing security model — so
+// adding another layer of isolation (worker-inside-worker or a cross-
+// origin sandbox) buys nothing here.
+
+import { VirtualFS, Runtime } from "almostnode";
+
+// ─── Console arg formatting ─────────────────────────────────────────
+//
+// Mirrors the formatter from the legacy javascript-worker.ts so output
+// in the playground UI is byte-compatible with the previous runtime —
+// no migration surprises for existing snippets.
+
+function jsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") return `${value.toString()}n`;
+  if (typeof value === "function")
+    return `[Function: ${value.name || "anonymous"}]`;
+  if (typeof value === "undefined") return "undefined";
+  return value;
+}
+
+export function formatArg(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "function") return value.toString();
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value, jsonReplacer, 2);
+    } catch {
+      try {
+        return String(value);
+      } catch {
+        return "[object]";
+      }
+    }
+  }
+  if (typeof value === "bigint") return `${value.toString()}n`;
+  return String(value);
+}
+
+// ─── VFS path helpers ───────────────────────────────────────────────
+
+/** Convert a workspace-relative path (e.g. `index.js`, `data/sales.csv`)
+ *  into an absolute VFS path (`/index.js`). almostnode's resolver works
+ *  exclusively in absolute terms. */
+export function normalizeVfsPath(p: string): string {
+  return p.startsWith("/") ? p : `/${p}`;
+}
+
+/** Stage the given files into a freshly-created VirtualFS, returning the
+ *  new VFS. Recreating per `prepare-fs` cleanly mirrors deletions and
+ *  renames that happened in the UI — no stale entries linger. */
+export function stageFiles(
+  files: Array<[string, Uint8Array]>,
+  transformFile?: (
+    path: string,
+    bytes: Uint8Array,
+  ) => Array<[string, Uint8Array]>,
+): VirtualFS {
+  const vfs = new VirtualFS();
+  const write = (path: string, bytes: Uint8Array) => {
+    const vfsPath = normalizeVfsPath(path);
+    const lastSlash = vfsPath.lastIndexOf("/");
+    if (lastSlash > 0) {
+      vfs.mkdirSync(vfsPath.slice(0, lastSlash), { recursive: true });
+    }
+    vfs.writeFileSync(vfsPath, bytes);
+  };
+  for (const [path, bytes] of files) {
+    const outputs = transformFile ? transformFile(path, bytes) : [[path, bytes] as [string, Uint8Array]];
+    for (const [outPath, outBytes] of outputs) write(outPath, outBytes);
+  }
+  return vfs;
+}
+
+// ─── Entry-file wrapping ────────────────────────────────────────────
+//
+// almostnode wraps each module in a CommonJS shell, so top-level `await`
+// (which the previous AsyncFunction-based runtime supported and which
+// several of the canonical examples rely on) is a syntax error.
+//
+// We solve this by rewriting the *entry* file so its body executes
+// inside an async IIFE assigned to `module.exports`. The runtime then
+// returns the promise via `result.exports`, which the caller awaits
+// before reporting `done` — guaranteeing console writes flush in order.
+
+const WRAP_PROLOGUE = "module.exports = (async () => {\n";
+const WRAP_EPILOGUE = "\n})();";
+
+export function wrapEntryAsAsyncIIFE(source: string): string {
+  return WRAP_PROLOGUE + source + WRAP_EPILOGUE;
+}
+
+// ─── Runtime execution ──────────────────────────────────────────────
+
+export interface ConsoleSink {
+  stdout(content: string): void;
+  stderr(content: string): void;
+}
+
+/** Run the entry file in a fresh almostnode Runtime tied to the given
+ *  console sink, awaiting the wrapper IIFE's promise so async work
+ *  completes before this function resolves. */
+export async function runEntry(
+  vfs: VirtualFS,
+  entryVfsPath: string,
+  sink: ConsoleSink,
+): Promise<void> {
+  const runtime = new Runtime(vfs, {
+    onConsole: (method, args) => {
+      const text = args.map(formatArg).join(" ");
+      const isErr = method === "error" || method === "warn";
+      if (isErr) sink.stderr(text);
+      else sink.stdout(text);
+    },
+  });
+
+  try {
+    const result = await runtime.runFileAsync(entryVfsPath);
+    const exp = result.exports;
+    // The wrapper assigns `(async () => {...})()` to module.exports.
+    // Await the resulting promise so user-level top-level `await` is
+    // observed by the host, and so any thrown error surfaces here
+    // rather than going unhandled in the worker.
+    if (
+      exp !== null &&
+      typeof exp === "object" &&
+      typeof (exp as { then?: unknown }).then === "function"
+    ) {
+      await exp;
+    }
+  } catch (err) {
+    const message =
+      err instanceof Error
+        ? err.stack || `${err.name}: ${err.message}`
+        : String(err);
+    sink.stderr(message);
+  } finally {
+    runtime.clearCache();
+  }
+}

--- a/app/_components/runtime/javascript-worker.ts
+++ b/app/_components/runtime/javascript-worker.ts
@@ -1,129 +1,110 @@
 /// <reference lib="webworker" />
 
-// Web Worker that executes JavaScript code via AsyncFunction so that
-// user-code execution is off the main thread and can't block the UI.
+// Web Worker that executes JavaScript code via almostnode — a browser-
+// native Node.js runtime. The worker accepts multi-file workspaces,
+// stages them into almostnode's VirtualFS, and runs the entry file with
+// CommonJS semantics (`require()`, `module.exports`, 40+ Node module
+// shims like `fs`, `path`, `http`, `events`).
 //
 // Protocol
-//   Main → Worker  { kind: "run"; id: number; code: string }
+//   Main → Worker  { kind: "prepare-fs"; id: number;
+//                    files: Array<[path, Uint8Array]> }
+//                  { kind: "run"; id: number; code: string;
+//                    entryPath: string }
 //   Worker → Main  { kind: "ready" }
+//                  { kind: "prepare-fs-done"; id: number }
+//                  { kind: "prepare-fs-error"; id: number; message: string }
 //                  { kind: "stdout"; id: number; content: string }
 //                  { kind: "stderr"; id: number; content: string }
-//                  { kind: "done";   id: number }
+//                  { kind: "done"; id: number }
 
-type InMessage = { kind: "run"; id: number; code: string };
+import { VirtualFS } from "almostnode";
+import {
+  normalizeVfsPath,
+  runEntry,
+  stageFiles,
+  wrapEntryAsAsyncIIFE,
+} from "./almostnode-worker-shared";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+type InMessage =
+  | { kind: "prepare-fs"; id: number; files: Array<[string, Uint8Array]> }
+  | { kind: "run"; id: number; code: string; entryPath: string };
 
 type OutMessage =
   | { kind: "ready" }
+  | { kind: "prepare-fs-done"; id: number }
+  | { kind: "prepare-fs-error"; id: number; message: string }
   | { kind: "stdout"; id: number; content: string }
   | { kind: "stderr"; id: number; content: string }
   | { kind: "done"; id: number };
 
-function post(msg: OutMessage) {
+function post(msg: OutMessage): void {
   self.postMessage(msg);
 }
 
-function formatArg(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value === null) return "null";
-  if (value === undefined) return "undefined";
-  if (typeof value === "function") return value.toString();
-  if (typeof value === "object") {
-    try {
-      return JSON.stringify(value, jsonReplacer, 2);
-    } catch {
-      try {
-        return String(value);
-      } catch {
-        return "[object]";
-      }
-    }
-  }
-  if (typeof value === "bigint") return `${value.toString()}n`;
-  return String(value);
-}
+// Module-scope VFS so `prepare-fs` and `run` see the same state across
+// messages. Recreated on every `prepare-fs` call so deletions/renames
+// from the editor flow through cleanly.
+let vfs: VirtualFS = new VirtualFS();
 
-function jsonReplacer(_key: string, value: unknown): unknown {
-  if (typeof value === "bigint") return `${value.toString()}n`;
-  if (typeof value === "function")
-    return `[Function: ${value.name || "anonymous"}]`;
-  if (typeof value === "undefined") return "undefined";
-  return value;
-}
-
-function formatArgs(args: unknown[]): string {
-  return args.map(formatArg).join(" ");
-}
-
-async function runCode(id: number, code: string): Promise<void> {
-  let stdoutBuf = "";
-  let stderrBuf = "";
-
-  const sandboxConsole = {
-    log: (...args: unknown[]) => {
-      stdoutBuf += formatArgs(args) + "\n";
-    },
-    info: (...args: unknown[]) => {
-      stdoutBuf += formatArgs(args) + "\n";
-    },
-    debug: (...args: unknown[]) => {
-      stdoutBuf += formatArgs(args) + "\n";
-    },
-    warn: (...args: unknown[]) => {
-      stderrBuf += formatArgs(args) + "\n";
-    },
-    error: (...args: unknown[]) => {
-      stderrBuf += formatArgs(args) + "\n";
-    },
-    table: (value: unknown) => {
-      stdoutBuf += formatArg(value) + "\n";
-    },
-    dir: (value: unknown) => {
-      stdoutBuf += formatArg(value) + "\n";
-    },
-  };
-
-  const AsyncFunction = Object.getPrototypeOf(
-    async function () {},
-  ).constructor as new (...args: string[]) => (
-    console: typeof sandboxConsole,
-  ) => Promise<unknown>;
-
+async function handlePrepareFs(
+  id: number,
+  files: Array<[string, Uint8Array]>,
+): Promise<void> {
   try {
-    const fn = new AsyncFunction("console", `"use strict";\n${code}`);
-    const result = await fn(sandboxConsole);
-    if (stdoutBuf)
-      post({ kind: "stdout", id, content: stdoutBuf.replace(/\n$/, "") });
-    if (stderrBuf)
-      post({ kind: "stderr", id, content: stderrBuf.replace(/\n$/, "") });
-    if (result !== undefined) {
-      post({ kind: "stdout", id, content: formatArg(result) });
-    }
+    vfs = stageFiles(files);
+    post({ kind: "prepare-fs-done", id });
   } catch (err) {
-    if (stdoutBuf)
-      post({ kind: "stdout", id, content: stdoutBuf.replace(/\n$/, "") });
-    if (stderrBuf)
-      post({ kind: "stderr", id, content: stderrBuf.replace(/\n$/, "") });
-    const message =
-      err instanceof Error
-        ? err.stack || `${err.name}: ${err.message}`
-        : String(err);
-    post({ kind: "stderr", id, content: message });
+    const message = err instanceof Error ? err.message : String(err);
+    post({ kind: "prepare-fs-error", id, message });
   }
+}
+
+async function handleRun(
+  id: number,
+  code: string,
+  entryPath: string,
+): Promise<void> {
+  const entryVfsPath = normalizeVfsPath(entryPath);
+
+  // Prefer the staged copy of the entry file (Playground passes it via
+  // prepare-fs whenever multi-file mode is in use). If the worker is
+  // invoked single-file — no prepare-fs — fall back to the inline
+  // `code` argument. This lets the worker work for both flows without
+  // a separate code path on the caller side.
+  const decoder = new TextDecoder();
+  const entrySource = vfs.existsSync(entryVfsPath)
+    ? decoder.decode(vfs.readFileSync(entryVfsPath))
+    : code;
+
+  // Rewrite the entry file so top-level `await` is legal. See the wrap
+  // helper for the precise transform.
+  vfs.writeFileSync(entryVfsPath, wrapEntryAsAsyncIIFE(entrySource));
+
+  await runEntry(vfs, entryVfsPath, {
+    stdout: (content) => post({ kind: "stdout", id, content }),
+    stderr: (content) => post({ kind: "stderr", id, content }),
+  });
+
   post({ kind: "done", id });
 }
 
-// Serialise concurrent run requests so async user code can't interleave.
-let workQueue: Promise<unknown> = Promise.resolve();
+// Serialise concurrent run requests so async user code can't interleave
+// across runs — matches the behaviour of the legacy worker.
+let queue: Promise<unknown> = Promise.resolve();
 function enqueue(task: () => Promise<void>): void {
-  workQueue = workQueue.then(task, task).catch(() => {});
+  queue = queue.then(task, task).catch(() => {});
 }
 
-// No async init — JS runs natively, signal readiness immediately.
 post({ kind: "ready" });
 
 self.addEventListener("message", (ev: MessageEvent<InMessage>) => {
-  if (ev.data.kind === "run") {
-    const { id, code } = ev.data;
-    enqueue(() => runCode(id, code));
+  const data = ev.data;
+  if (data.kind === "prepare-fs") {
+    enqueue(() => handlePrepareFs(data.id, data.files));
+  } else if (data.kind === "run") {
+    enqueue(() => handleRun(data.id, data.code, data.entryPath));
   }
 });

--- a/app/_components/runtime/javascript.tsx
+++ b/app/_components/runtime/javascript.tsx
@@ -296,17 +296,20 @@ export const javascriptAdapter: LanguageAdapter = {
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
     setLoadingMessage("Starting almostnode runtime…");
-    // Module worker (`type: "module"`) — required because almostnode's
-    // bundle is large enough that Turbopack splits it into multiple
-    // chunks. A classic worker would load each chunk via
-    // `importScripts()`, and two chunks have colliding minified
-    // top-level identifiers, throwing
-    // `SyntaxError: Identifier 'e1' has already been declared`.
-    // Module workers use native ESM imports and avoid the clash.
-    const worker = new Worker(
-      new URL("./javascript-worker.ts", import.meta.url),
-      { type: "module" },
-    );
+    // The worker is pre-bundled by `scripts/build-almostnode-workers
+    // .mjs` to `public/_workers/javascript-worker.js`. We point the
+    // Worker constructor at the resulting static URL (not at
+    // `new URL("./javascript-worker.ts", import.meta.url)`) so
+    // Turbopack never sees the import — Turbopack's worker bundler
+    // splits almostnode's ~16 MB tree across many chunks loaded via
+    // `importScripts`, where colliding minified top-level identifiers
+    // throw `Identifier 'e1' has already been declared` at startup.
+    // The pre-bundled file is a single self-contained ES module, so
+    // no chunking, no collision, and `{ type: "module" }` is honoured
+    // by the browser directly.
+    const worker = new Worker("/_workers/javascript-worker.js", {
+      type: "module",
+    });
     return new Promise<LanguageRuntime>((resolve, reject) => {
       const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
         if (ev.data.kind === "ready") {

--- a/app/_components/runtime/javascript.tsx
+++ b/app/_components/runtime/javascript.tsx
@@ -296,8 +296,16 @@ export const javascriptAdapter: LanguageAdapter = {
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
     setLoadingMessage("Starting almostnode runtime…");
+    // Module worker (`type: "module"`) — required because almostnode's
+    // bundle is large enough that Turbopack splits it into multiple
+    // chunks. A classic worker would load each chunk via
+    // `importScripts()`, and two chunks have colliding minified
+    // top-level identifiers, throwing
+    // `SyntaxError: Identifier 'e1' has already been declared`.
+    // Module workers use native ESM imports and avoid the clash.
     const worker = new Worker(
       new URL("./javascript-worker.ts", import.meta.url),
+      { type: "module" },
     );
     return new Promise<LanguageRuntime>((resolve, reject) => {
       const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {

--- a/app/_components/runtime/javascript.tsx
+++ b/app/_components/runtime/javascript.tsx
@@ -7,10 +7,12 @@ import type {
 } from "../types";
 import { getWebFmt } from "./webFmt";
 
-// JavaScript runs in a dedicated Web Worker via the AsyncFunction constructor
-// so that user code (including top-level `await`) never blocks the UI.
-// The worker handles console.* interception and streams stdout/stderr back
-// to the main thread via postMessage.
+// JavaScript runs in a dedicated Web Worker backed by almostnode — a
+// browser-native Node.js runtime. The worker stages every open file
+// (code tabs + uploaded data) into almostnode's VirtualFS, then
+// executes the entry file with CommonJS semantics. `require()` works,
+// 40+ Node.js modules are shimmed (`fs`, `path`, `http`, `events`,
+// `crypto`, …), and multi-file imports resolve from VirtualFS.
 
 const EXAMPLES: ExampleSnippet[] = [
   {
@@ -18,7 +20,7 @@ const EXAMPLES: ExampleSnippet[] = [
     title: "Hello World",
     desc: "Basic console output, math & strings",
     code: `// Hello, JavaScript Playground!
-console.log("Node-like environment? No — this runs in your browser.");
+console.log("Node-like environment in your browser, powered by almostnode.");
 console.log("π ≈", Math.PI);
 console.log("e ≈", Math.E);
 
@@ -92,6 +94,42 @@ console.log(\`\\nTotal wall time: \${elapsed}ms (parallel)\`);
 `,
   },
   {
+    key: "node_modules",
+    title: "Node.js Modules",
+    desc: "require('path'), require('crypto'), require('os')",
+    code: `// almostnode shims Node.js core modules — require() them just
+// like in a Node script.
+const path = require("node:path");
+const crypto = require("node:crypto");
+const os = require("node:os");
+
+console.log("path.join =>", path.join("/users", "ada", "notes.txt"));
+console.log("path.basename =>", path.basename("/users/ada/notes.txt"));
+
+const hash = crypto.createHash("sha256").update("hello").digest("hex");
+console.log("sha256('hello') =>", hash);
+
+console.log("platform =>", os.platform());
+console.log("EOL bytes =>", JSON.stringify(os.EOL));
+`,
+  },
+  {
+    key: "multi_file",
+    title: "Multi-File Modules",
+    desc: "Split logic across files with require()",
+    code: `// Add another tab named "utils.js" with the contents:
+//
+//   exports.greet = (name) => \`Hello, \${name}!\`;
+//   exports.shout = (s) => s.toUpperCase() + "!";
+//
+// then run this file — \`require\` resolves from the workspace VFS.
+const utils = require("./utils");
+
+console.log(utils.greet("almostnode"));
+console.log(utils.shout("multi-file modules just work"));
+`,
+  },
+  {
     key: "classes",
     title: "Classes & Iterators",
     desc: "Generator-based iteration",
@@ -140,13 +178,17 @@ console.log(\`\\nAverage score: \${avg.toFixed(1)}\`);
 ];
 
 const PACKAGES: PackageInfo[] = [
-  // JavaScript runs natively in the browser — all standard globals
-  // (console, Math, Date, Promise, fetch, etc.) are always available
-  // without any import statement, so there are no packages to list here.
+  // No installable packages are surfaced yet — npm package install in
+  // the packages drawer is a future feature (see the integration plan
+  // in agent-outputs/). almostnode's bundled Node.js shims (`fs`,
+  // `path`, `crypto`, …) are always available via require() without
+  // any UI plumbing.
 ];
 
 type WorkerOutMessage =
   | { kind: "ready" }
+  | { kind: "prepare-fs-done"; id: number }
+  | { kind: "prepare-fs-error"; id: number; message: string }
   | { kind: "stdout"; id: number; content: string }
   | { kind: "stderr"; id: number; content: string }
   | { kind: "done"; id: number };
@@ -154,6 +196,26 @@ type WorkerOutMessage =
 class JavaScriptWorkerRuntime implements LanguageRuntime {
   private nextId = 0;
   constructor(private worker: Worker) {}
+
+  async prepareFileSystem(files: Map<string, Uint8Array>): Promise<void> {
+    const id = ++this.nextId;
+    const payload: Array<[string, Uint8Array]> = [];
+    for (const [path, bytes] of files) payload.push([path, bytes]);
+    return new Promise<void>((resolve, reject) => {
+      const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
+        const msg = ev.data;
+        if (msg.kind !== "prepare-fs-done" && msg.kind !== "prepare-fs-error") {
+          return;
+        }
+        if (msg.id !== id) return;
+        this.worker.removeEventListener("message", onMessage);
+        if (msg.kind === "prepare-fs-done") resolve();
+        else reject(new Error(msg.message));
+      };
+      this.worker.addEventListener("message", onMessage);
+      this.worker.postMessage({ kind: "prepare-fs", id, files: payload });
+    });
+  }
 
   async run(code: string, emit: EmitOutput): Promise<void> {
     const id = ++this.nextId;
@@ -170,7 +232,12 @@ class JavaScriptWorkerRuntime implements LanguageRuntime {
         }
       };
       this.worker.addEventListener("message", onMessage);
-      this.worker.postMessage({ kind: "run", id, code });
+      this.worker.postMessage({
+        kind: "run",
+        id,
+        code,
+        entryPath: "index.js",
+      });
     });
   }
 }
@@ -184,10 +251,10 @@ export const javascriptAdapter: LanguageAdapter = {
   runtimeInfo: {
     language: "JavaScript",
     version: "ES2023+",
-    engine: "Native browser",
-    engineUrl: "https://developer.mozilla.org/docs/Web/JavaScript",
+    engine: "almostnode (browser-native Node.js)",
+    engineUrl: "https://almostnode.dev/",
     notes:
-      "Runs in a Web Worker via the AsyncFunction constructor — top-level await is supported and the UI stays responsive while your code executes.",
+      "Runs in a Web Worker on top of almostnode — multi-file projects, require(), and 40+ shimmed Node.js modules (fs, path, http, crypto, …) work in the browser.",
   },
   codeMirrorMode: "javascript",
   examples: EXAMPLES,
@@ -201,36 +268,34 @@ export const javascriptAdapter: LanguageAdapter = {
   entryPoint: "index.js",
   packagesFooter: (
     <>
-      JavaScript runs natively in your browser — there&apos;s no extra
-      runtime to load. The entries above are{" "}
-      <a
-        href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects"
-        target="_blank"
-        rel="noreferrer"
-      >
-        built-in globals
-      </a>
-      , so they&apos;re always available.
+      JavaScript runs via{" "}
+      <a href="https://almostnode.dev/" target="_blank" rel="noreferrer">
+        almostnode
+      </a>{" "}
+      in a Web Worker. Built-in browser globals (console, fetch, Promise,
+      …) are always available, and Node.js core modules can be brought in
+      with{" "}
+      <code style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>
+        require(&apos;node:fs&apos;)
+      </code>{" "}
+      style imports.
     </>
   ),
-  // The "import" affordance doesn't really apply to a sandboxed JS
-  // environment with no module loader, so we just drop in a pointer to
-  // the global. This keeps the packages-drawer click consistent with
-  // the other playgrounds.
-  importSnippet: (name) => `// ${name} is a built-in global — no import needed.`,
+  importSnippet: (name) => `const ${name} = require("${name}");`,
   hasImport(code, name) {
-    // Treat the snippet as "already inserted" if the same hint comment
-    // is present, so clicking the package twice doesn't duplicate it.
-    return code.includes(
-      `// ${name} is a built-in global — no import needed.`,
-    );
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Match `require("name")` or `require('name')` anywhere in the file.
+    // We don't require the const/let binding so users who write
+    // `require("x").doThing()` aren't pestered to insert again.
+    const re = new RegExp(`require\\(\\s*["'\`]${escapedName}["'\`]\\s*\\)`);
+    return re.test(code);
   },
   async formatCode(code: string): Promise<string> {
     const { format } = await getWebFmt();
     return format(code, "script.js");
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Starting JavaScript worker…");
+    setLoadingMessage("Starting almostnode runtime…");
     const worker = new Worker(
       new URL("./javascript-worker.ts", import.meta.url),
     );

--- a/app/_components/runtime/typescript-worker.ts
+++ b/app/_components/runtime/typescript-worker.ts
@@ -1,176 +1,174 @@
 /// <reference lib="webworker" />
 
-// Web Worker that transpiles TypeScript → JavaScript (via the official
-// TypeScript compiler) then executes the result via AsyncFunction — keeping
-// both the compilation and the execution off the main thread so the UI
-// stays responsive.
+// Web Worker that executes TypeScript code via almostnode. .ts/.tsx
+// files are first transpiled to JavaScript with the official TypeScript
+// compiler (already a build dependency), then staged into almostnode's
+// VirtualFS under .js paths so CommonJS resolution picks them up
+// (almostnode's resolver tries .js/.json/.node — not .ts).
 //
-// Protocol (mirrors javascript-worker.ts)
-//   Main → Worker  { kind: "run"; id: number; code: string }  (code is TS source)
-//   Worker → Main  { kind: "loading"; message: string }       (while loading ts pkg)
-//                  { kind: "ready" }
-//                  { kind: "stdout"; id: number; content: string }
-//                  { kind: "stderr"; id: number; content: string }
-//                  { kind: "done";   id: number }
+// Protocol mirrors javascript-worker.ts exactly so the adapter code can
+// share the same message shapes.
 
 import * as ts from "typescript";
+import { VirtualFS } from "almostnode";
+import {
+  normalizeVfsPath,
+  runEntry,
+  stageFiles,
+  wrapEntryAsAsyncIIFE,
+} from "./almostnode-worker-shared";
 
 declare const self: DedicatedWorkerGlobalScope;
 
-type InMessage = { kind: "run"; id: number; code: string };
+type InMessage =
+  | { kind: "prepare-fs"; id: number; files: Array<[string, Uint8Array]> }
+  | { kind: "run"; id: number; code: string; entryPath: string };
 
 type OutMessage =
   | { kind: "loading"; message: string }
   | { kind: "ready" }
+  | { kind: "prepare-fs-done"; id: number }
+  | { kind: "prepare-fs-error"; id: number; message: string }
   | { kind: "stdout"; id: number; content: string }
   | { kind: "stderr"; id: number; content: string }
   | { kind: "done"; id: number };
 
-function post(msg: OutMessage) {
+function post(msg: OutMessage): void {
   self.postMessage(msg);
 }
 
-function formatArg(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value === null) return "null";
-  if (value === undefined) return "undefined";
-  if (typeof value === "function") return value.toString();
-  if (typeof value === "object") {
-    try {
-      return JSON.stringify(value, jsonReplacer, 2);
-    } catch {
-      try {
-        return String(value);
-      } catch {
-        return "[object]";
-      }
-    }
+const TS_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
+
+function isTsPath(p: string): boolean {
+  return TS_EXTENSIONS.some((ext) => p.endsWith(ext));
+}
+
+/** Replace a `.ts`/`.tsx`/`.mts`/`.cts` suffix with `.js`. Leaves any
+ *  other suffix untouched. */
+function tsToJsPath(p: string): string {
+  for (const ext of TS_EXTENSIONS) {
+    if (p.endsWith(ext)) return p.slice(0, -ext.length) + ".js";
   }
-  if (typeof value === "bigint") return `${value.toString()}n`;
-  return String(value);
+  return p;
 }
 
-function jsonReplacer(_key: string, value: unknown): unknown {
-  if (typeof value === "bigint") return `${value.toString()}n`;
-  if (typeof value === "function")
-    return `[Function: ${value.name || "anonymous"}]`;
-  if (typeof value === "undefined") return "undefined";
-  return value;
+/** Transpile TS source → JS. Diagnostics are returned alongside the
+ *  output text so the caller can surface them as stderr cells without
+ *  aborting the run (the legacy adapter behaved the same way). */
+function transpileTs(
+  source: string,
+  fileName: string,
+): { outputText: string; diagnostics: string[] } {
+  const result = ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      // CommonJS so almostnode's `require()` resolves modules from
+      // VirtualFS. Top-level `import`/`export` statements in user code
+      // are downleveled to `require()`/`module.exports` automatically.
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+      allowJs: true,
+      isolatedModules: true,
+      strict: false,
+      removeComments: false,
+    },
+    reportDiagnostics: true,
+    fileName,
+  });
+  const diagnostics = (result.diagnostics ?? [])
+    .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+    .filter(Boolean);
+  return { outputText: result.outputText, diagnostics };
 }
 
-function formatArgs(args: unknown[]): string {
-  return args.map(formatArg).join(" ");
-}
+let vfs: VirtualFS = new VirtualFS();
+// Pending diagnostics from the most recent prepare-fs, replayed as
+// stderr on the next run so the user sees compile errors next to the
+// failed execution rather than in a void.
+let pendingDiagnostics: string[] = [];
 
-async function runCode(id: number, tsSource: string): Promise<void> {
-  // Step 1: Transpile TS → JS (syntactic-only, same settings as before).
-  let outputText: string;
+async function handlePrepareFs(
+  id: number,
+  files: Array<[string, Uint8Array]>,
+): Promise<void> {
   try {
-    const result = ts.transpileModule(tsSource, {
-      compilerOptions: {
-        target: ts.ScriptTarget.ES2022,
-        module: ts.ModuleKind.ESNext,
-        isolatedModules: true,
-        esModuleInterop: true,
-        allowJs: true,
-        strict: false,
-        removeComments: false,
-      },
-      reportDiagnostics: true,
-      fileName: "playground.ts",
+    pendingDiagnostics = [];
+    const decoder = new TextDecoder();
+    const encoder = new TextEncoder();
+    vfs = stageFiles(files, (path, bytes) => {
+      if (!isTsPath(path)) return [[path, bytes]];
+      const source = decoder.decode(bytes);
+      const { outputText, diagnostics } = transpileTs(source, path);
+      if (diagnostics.length > 0) {
+        for (const d of diagnostics) pendingDiagnostics.push(`TS (${path}): ${d}`);
+      }
+      // Write the transpiled JS under the .js-suffixed path. Keep the
+      // original .ts file out of the VFS — almostnode's resolver
+      // wouldn't use it anyway, and dropping it avoids two competing
+      // copies of the same module under different extensions.
+      return [[tsToJsPath(path), encoder.encode(outputText)]];
     });
-
-    const errors = (result.diagnostics ?? [])
-      .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
-      .filter(Boolean);
-    if (errors.length > 0) {
-      post({
-        kind: "stderr",
-        id,
-        content: errors.map((m) => `TS: ${m}`).join("\n"),
-      });
-    }
-    outputText = result.outputText;
+    post({ kind: "prepare-fs-done", id });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    post({
-      kind: "stderr",
-      id,
-      content: `TypeScript transpile error: ${message}`,
-    });
-    post({ kind: "done", id });
-    return;
+    post({ kind: "prepare-fs-error", id, message });
   }
+}
 
-  // Step 2: Execute transpiled JS via AsyncFunction.
-  let stdoutBuf = "";
-  let stderrBuf = "";
+async function handleRun(
+  id: number,
+  code: string,
+  entryPath: string,
+): Promise<void> {
+  // Translate the workspace-relative entry path (e.g. "index.ts") to
+  // the on-disk VFS path of the transpiled output (e.g. "/index.js").
+  const entryVfsPath = normalizeVfsPath(
+    isTsPath(entryPath) ? tsToJsPath(entryPath) : entryPath,
+  );
 
-  const sandboxConsole = {
-    log: (...args: unknown[]) => {
-      stdoutBuf += formatArgs(args) + "\n";
-    },
-    info: (...args: unknown[]) => {
-      stdoutBuf += formatArgs(args) + "\n";
-    },
-    debug: (...args: unknown[]) => {
-      stdoutBuf += formatArgs(args) + "\n";
-    },
-    warn: (...args: unknown[]) => {
-      stderrBuf += formatArgs(args) + "\n";
-    },
-    error: (...args: unknown[]) => {
-      stderrBuf += formatArgs(args) + "\n";
-    },
-    table: (value: unknown) => {
-      stdoutBuf += formatArg(value) + "\n";
-    },
-    dir: (value: unknown) => {
-      stdoutBuf += formatArg(value) + "\n";
-    },
-  };
+  // Flush any diagnostics gathered during prepare-fs first so the user
+  // sees them alongside (and before) the run's runtime output.
+  for (const msg of pendingDiagnostics) {
+    post({ kind: "stderr", id, content: msg });
+  }
+  pendingDiagnostics = [];
 
-  const AsyncFunction = Object.getPrototypeOf(
-    async function () {},
-  ).constructor as new (...args: string[]) => (
-    console: typeof sandboxConsole,
-  ) => Promise<unknown>;
-
-  try {
-    const fn = new AsyncFunction("console", `"use strict";\n${outputText}`);
-    const result = await fn(sandboxConsole);
-    if (stdoutBuf)
-      post({ kind: "stdout", id, content: stdoutBuf.replace(/\n$/, "") });
-    if (stderrBuf)
-      post({ kind: "stderr", id, content: stderrBuf.replace(/\n$/, "") });
-    if (result !== undefined) {
-      post({ kind: "stdout", id, content: formatArg(result) });
+  // Prefer the staged + transpiled copy of the entry file. Fall back
+  // to transpiling `code` inline if prepare-fs wasn't called (single-
+  // file mode).
+  let entrySource: string;
+  if (vfs.existsSync(entryVfsPath)) {
+    entrySource = new TextDecoder().decode(vfs.readFileSync(entryVfsPath));
+  } else {
+    const { outputText, diagnostics } = transpileTs(code, entryPath);
+    for (const d of diagnostics) {
+      post({ kind: "stderr", id, content: `TS: ${d}` });
     }
-  } catch (err) {
-    if (stdoutBuf)
-      post({ kind: "stdout", id, content: stdoutBuf.replace(/\n$/, "") });
-    if (stderrBuf)
-      post({ kind: "stderr", id, content: stderrBuf.replace(/\n$/, "") });
-    const message =
-      err instanceof Error
-        ? err.stack || `${err.name}: ${err.message}`
-        : String(err);
-    post({ kind: "stderr", id, content: message });
+    entrySource = outputText;
   }
+
+  vfs.writeFileSync(entryVfsPath, wrapEntryAsAsyncIIFE(entrySource));
+
+  await runEntry(vfs, entryVfsPath, {
+    stdout: (content) => post({ kind: "stdout", id, content }),
+    stderr: (content) => post({ kind: "stderr", id, content }),
+  });
+
   post({ kind: "done", id });
 }
 
-// Serialise concurrent run requests.
-let workQueue: Promise<unknown> = Promise.resolve();
+let queue: Promise<unknown> = Promise.resolve();
 function enqueue(task: () => Promise<void>): void {
-  workQueue = workQueue.then(task, task).catch(() => {});
+  queue = queue.then(task, task).catch(() => {});
 }
 
 post({ kind: "ready" });
 
 self.addEventListener("message", (ev: MessageEvent<InMessage>) => {
-  if (ev.data.kind === "run") {
-    const { id, code } = ev.data;
-    enqueue(() => runCode(id, code));
+  const data = ev.data;
+  if (data.kind === "prepare-fs") {
+    enqueue(() => handlePrepareFs(data.id, data.files));
+  } else if (data.kind === "run") {
+    enqueue(() => handleRun(data.id, data.code, data.entryPath));
   }
 });

--- a/app/_components/runtime/typescript.tsx
+++ b/app/_components/runtime/typescript.tsx
@@ -343,8 +343,14 @@ export const typescriptAdapter: LanguageAdapter = {
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
     setLoadingMessage("Starting TypeScript worker…");
+    // Module worker (`type: "module"`) — see javascript.tsx for the
+    // rationale: a classic worker tries to load almostnode's split
+    // chunks via `importScripts()`, which throws
+    // `SyntaxError: Identifier 'e1' has already been declared` from
+    // colliding minified top-level bindings in two chunks.
     const worker = new Worker(
       new URL("./typescript-worker.ts", import.meta.url),
+      { type: "module" },
     );
     return new Promise<LanguageRuntime>((resolve, reject) => {
       const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {

--- a/app/_components/runtime/typescript.tsx
+++ b/app/_components/runtime/typescript.tsx
@@ -343,15 +343,13 @@ export const typescriptAdapter: LanguageAdapter = {
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
     setLoadingMessage("Starting TypeScript worker…");
-    // Module worker (`type: "module"`) — see javascript.tsx for the
-    // rationale: a classic worker tries to load almostnode's split
-    // chunks via `importScripts()`, which throws
-    // `SyntaxError: Identifier 'e1' has already been declared` from
-    // colliding minified top-level bindings in two chunks.
-    const worker = new Worker(
-      new URL("./typescript-worker.ts", import.meta.url),
-      { type: "module" },
-    );
+    // Pre-bundled by `scripts/build-almostnode-workers.mjs`; see
+    // javascript.tsx for the rationale (Turbopack's worker bundler
+    // chunks almostnode's tree and load-collides on minified
+    // identifiers, so we route around it with a static URL).
+    const worker = new Worker("/_workers/typescript-worker.js", {
+      type: "module",
+    });
     return new Promise<LanguageRuntime>((resolve, reject) => {
       const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
         const msg = ev.data;

--- a/app/_components/runtime/typescript.tsx
+++ b/app/_components/runtime/typescript.tsx
@@ -7,13 +7,16 @@ import type {
 } from "../types";
 import { getWebFmt } from "./webFmt";
 
-// TypeScript runs in a dedicated Web Worker (typescript-worker.ts) that:
-//   1. Imports the official TypeScript compiler and transpiles the user's
-//      source to ES2022 JavaScript via `transpileModule`.
-//   2. Executes the resulting JS via `AsyncFunction` (top-level await works).
+// TypeScript runs in a dedicated Web Worker (typescript-worker.ts):
+//   1. Every .ts/.tsx file in the workspace is transpiled to JavaScript
+//      via the official TypeScript compiler.
+//   2. The transpiled .js files are staged into almostnode's VirtualFS.
+//   3. almostnode's Runtime executes the entry file with CommonJS
+//      semantics, so require()/module.exports across files Just Works.
 //
-// Moving both steps to a worker keeps the ~10MB compiler bundle off the
-// main thread and ensures heavy transpilation / execution never blocks the UI.
+// almostnode's resolver doesn't recognise .ts paths, so we do the
+// transpile-then-stage dance ourselves rather than handing raw .ts to
+// the runtime.
 
 const EXAMPLES: ExampleSnippet[] = [
   {
@@ -143,6 +146,43 @@ console.log(\`\\nTotal wall time: \${elapsed}ms (parallel)\`);
 `,
   },
   {
+    key: "node_modules",
+    title: "Node.js Modules",
+    desc: "Typed access to crypto, path, os",
+    code: `// almostnode shims Node.js core modules. We import via require()
+// so types come from declaration merging at runtime — the TS compiler
+// emits this exactly as written.
+const path: typeof import("node:path") = require("node:path");
+const crypto: typeof import("node:crypto") = require("node:crypto");
+const os: typeof import("node:os") = require("node:os");
+
+console.log("join =>", path.join("/users", "ada", "notes.txt"));
+console.log("basename =>", path.basename("/users/ada/notes.txt"));
+
+const hash: string = crypto.createHash("sha256").update("hello").digest("hex");
+console.log("sha256('hello') =>", hash);
+
+console.log("platform =>", os.platform());
+`,
+  },
+  {
+    key: "multi_file",
+    title: "Multi-File Modules",
+    desc: "Split logic across .ts files",
+    code: `// Add another tab named "utils.ts" with the contents:
+//
+//   export const greet = (name: string): string => \`Hello, \${name}!\`;
+//   export const shout = (s: string): string => s.toUpperCase() + "!";
+//
+// then run this file — TypeScript's CommonJS emit resolves the import
+// through almostnode's VirtualFS.
+import { greet, shout } from "./utils";
+
+console.log(greet("almostnode"));
+console.log(shout("multi-file TypeScript just works"));
+`,
+  },
+  {
     key: "utility_types",
     title: "Utility Types",
     desc: "Pick / Omit / Record in action",
@@ -180,15 +220,16 @@ console.log(JSON.stringify(safe[1], null, 2));
 ];
 
 const PACKAGES: PackageInfo[] = [
-  // TypeScript is transpiled in-browser by the official TypeScript
-  // compiler, then executed natively. All standard browser globals
-  // (console, Math, Date, Promise, fetch, etc.) are always available
-  // without any import statement, so there are no packages to list here.
+  // npm package installation through the packages drawer is a future
+  // feature. Node.js core modules (fs, path, crypto, …) are reachable
+  // via require() out of the box thanks to almostnode's shims.
 ];
 
 type WorkerOutMessage =
   | { kind: "loading"; message: string }
   | { kind: "ready" }
+  | { kind: "prepare-fs-done"; id: number }
+  | { kind: "prepare-fs-error"; id: number; message: string }
   | { kind: "stdout"; id: number; content: string }
   | { kind: "stderr"; id: number; content: string }
   | { kind: "done"; id: number };
@@ -196,6 +237,26 @@ type WorkerOutMessage =
 class TypeScriptWorkerRuntime implements LanguageRuntime {
   private nextId = 0;
   constructor(private worker: Worker) {}
+
+  async prepareFileSystem(files: Map<string, Uint8Array>): Promise<void> {
+    const id = ++this.nextId;
+    const payload: Array<[string, Uint8Array]> = [];
+    for (const [path, bytes] of files) payload.push([path, bytes]);
+    return new Promise<void>((resolve, reject) => {
+      const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
+        const msg = ev.data;
+        if (msg.kind !== "prepare-fs-done" && msg.kind !== "prepare-fs-error") {
+          return;
+        }
+        if (msg.id !== id) return;
+        this.worker.removeEventListener("message", onMessage);
+        if (msg.kind === "prepare-fs-done") resolve();
+        else reject(new Error(msg.message));
+      };
+      this.worker.addEventListener("message", onMessage);
+      this.worker.postMessage({ kind: "prepare-fs", id, files: payload });
+    });
+  }
 
   async run(code: string, emit: EmitOutput): Promise<void> {
     const id = ++this.nextId;
@@ -212,7 +273,12 @@ class TypeScriptWorkerRuntime implements LanguageRuntime {
         }
       };
       this.worker.addEventListener("message", onMessage);
-      this.worker.postMessage({ kind: "run", id, code });
+      this.worker.postMessage({
+        kind: "run",
+        id,
+        code,
+        entryPath: "index.ts",
+      });
     });
   }
 }
@@ -226,13 +292,12 @@ export const typescriptAdapter: LanguageAdapter = {
   runtimeInfo: {
     language: "TypeScript",
     version: "5.7",
-    engine: "TypeScript compiler (in-browser) + native JS",
-    engineUrl: "https://www.typescriptlang.org/",
+    engine: "TypeScript 5.7 → almostnode (browser-native Node.js)",
+    engineUrl: "https://almostnode.dev/",
     notes:
-      "Your code is transpiled and executed in a Web Worker using the official TypeScript compiler — the UI stays responsive while your code runs.",
+      "Code is transpiled in a Web Worker by the official TypeScript compiler, then executed by almostnode. Multi-file projects, require(), and 40+ shimmed Node.js modules (fs, path, http, crypto, …) work in the browser.",
   },
-  // The JS CodeMirror mode handles TypeScript via a typescript flag —
-  // CodeMirror v5 exposes that as the `text/typescript` MIME alias.
+  // CodeMirror v5 exposes TypeScript via the `text/typescript` MIME alias.
   codeMirrorMode: "text/typescript",
   examples: EXAMPLES,
   packages: PACKAGES,
@@ -247,20 +312,30 @@ export const typescriptAdapter: LanguageAdapter = {
       Code is transpiled in-browser by the official{" "}
       <a href="https://www.typescriptlang.org/" target="_blank" rel="noreferrer">
         TypeScript compiler
+      </a>{" "}
+      and executed by{" "}
+      <a href="https://almostnode.dev/" target="_blank" rel="noreferrer">
+        almostnode
       </a>
-      , then executed natively. Type-checking is{" "}
-      <em>syntactic-only</em> (the equivalent of{" "}
+      . Type-checking is <em>syntactic-only</em> (the equivalent of{" "}
       <code style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>
         tsc --isolatedModules
       </code>
       ), so cross-file type errors aren&apos;t reported.
     </>
   ),
-  importSnippet: (name) => `// ${name} is a built-in global — no import needed.`,
+  importSnippet: (name) => `import * as ${name} from "${name}";`,
   hasImport(code, name) {
-    return code.includes(
-      `// ${name} is a built-in global — no import needed.`,
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Match either an ES `import ... from "name"` or a CJS
+    // `require("name")` so users with either style aren't pestered.
+    const importRe = new RegExp(
+      `(^|\\n)\\s*import[^;]*from\\s*["'\`]${escapedName}["'\`]`,
     );
+    const requireRe = new RegExp(
+      `require\\(\\s*["'\`]${escapedName}["'\`]\\s*\\)`,
+    );
+    return importRe.test(code) || requireRe.test(code);
   },
   async formatCode(code: string): Promise<string> {
     const { format } = await getWebFmt();

--- a/e2e/playgrounds.spec.ts
+++ b/e2e/playgrounds.spec.ts
@@ -62,8 +62,25 @@ async function runAndCollectOutput(page: Page) {
 
 test.describe("Playgrounds (fast)", () => {
   test("JavaScript runs the default example", async ({ page }) => {
+    // Regression guard: almostnode's bundle is large enough that Turbopack
+    // splits the worker into multiple chunks. A classic Worker would load
+    // them via importScripts() and throw "Identifier 'e1' has already been
+    // declared" before our adapter ever wires up. The fix is `type:
+    // "module"` in the Worker constructor — catch any regression here.
+    const initErrors: string[] = [];
+    page.on("pageerror", (err) => initErrors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") initErrors.push(msg.text());
+    });
+
     await page.goto("/playground/javascript");
     await waitForRuntimeReady(page);
+
+    expect(
+      initErrors.find((m) => m.includes("importScripts")),
+      `expected no importScripts error during worker init, got:\n${initErrors.join("\n")}`,
+    ).toBeUndefined();
+
     const cells = await runAndCollectOutput(page);
     const stdout = cells.find((c) => c.type === "stdout");
     expect(stdout, "expected a stdout cell").toBeTruthy();
@@ -72,8 +89,19 @@ test.describe("Playgrounds (fast)", () => {
   });
 
   test("TypeScript runs the default example", async ({ page }) => {
+    const initErrors: string[] = [];
+    page.on("pageerror", (err) => initErrors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") initErrors.push(msg.text());
+    });
+
     await page.goto("/playground/typescript");
     await waitForRuntimeReady(page);
+
+    expect(
+      initErrors.find((m) => m.includes("importScripts")),
+      `expected no importScripts error during worker init, got:\n${initErrors.join("\n")}`,
+    ).toBeUndefined();
     const cells = await runAndCollectOutput(page);
     const stdout = cells.find((c) => c.type === "stdout");
     expect(stdout, "expected a stdout cell").toBeTruthy();

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@wasm-fmt/ruff_fmt": "^0.15.12",
         "@wasm-fmt/web_fmt": "^0.2.9",
         "@xyflow/react": "^12.10.2",
+        "almostnode": "^0.2.14",
         "apache-arrow": "^21.1.0",
         "elkjs": "^0.11.1",
         "fumadocs-core": "^16.8.5",
@@ -74,6 +75,86 @@
         "tailwindcss": "^4.2.4",
         "typescript": "5.7.3",
         "vitest": "^4.1.5"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.118",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.118.tgz",
+      "integrity": "sha512-XYPbVoDo1TDMVLe5Eg42gIjdOyxaizh9H0kiSSnTXr+AdrqZvutk/ypLOiqBXPV3D1K3+BSm/sbFeomZJlM64A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.64.tgz",
+      "integrity": "sha512-epO4iS6QwktaY2PF6uBcPnDTJ3BxPOfsGS7/OEtBe3GtNj7C8h8gMDVtIe5K8W16HNDbn0tbR4dcQfpfs+XVFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.190",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.190.tgz",
+      "integrity": "sha512-ee8bZ3ZCC/PZDfCIX0LNvoPezo1v+jHp85pW6ct6B3qddsSp4SoFvapGuhK1gHRMLR6rKq0D5Gjii/+rgLzb9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.27",
+        "ai": "6.0.188",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -500,6 +581,16 @@
         }
       }
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
@@ -784,7 +875,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -806,7 +896,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2040,6 +2129,48 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jitl/quickjs-ffi-types": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.32.0.tgz",
+      "integrity": "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==",
+      "license": "MIT"
+    },
+    "node_modules/@jitl/quickjs-wasmfile-debug-asyncify": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-asyncify/-/quickjs-wasmfile-debug-asyncify-0.32.0.tgz",
+      "integrity": "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-debug-sync": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-sync/-/quickjs-wasmfile-debug-sync-0.32.0.tgz",
+      "integrity": "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-release-asyncify": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-asyncify/-/quickjs-wasmfile-release-asyncify-0.32.0.tgz",
+      "integrity": "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-release-sync": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-sync/-/quickjs-wasmfile-release-sync-0.32.0.tgz",
+      "integrity": "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2254,6 +2385,27 @@
         "@chevrotain/types": "~11.1.1"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mongodb-js/zstd": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd/-/zstd-7.0.0.tgz",
+      "integrity": "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      }
+    },
     "node_modules/@msgpack/msgpack": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
@@ -2420,6 +2572,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2466,6 +2630,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@orama/orama": {
@@ -3036,6 +3209,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-virtual": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
+      "integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3161,6 +3351,204 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.33.tgz",
+      "integrity": "sha512-N+L0uXhuO7FIfzqwgxmzv0zIpV0qEp8wPX3QQs2p4atjMoywup2JTeDlXPw+z9pWJGCae3JjM+tZ6myclI+2gA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.33.tgz",
+      "integrity": "sha512-/Il4QHSOhV4FekbsDtkrNmKbsX26oSysvgrRswa/RYOHXAkwXDbB4jaeKq6PsJLSPkzJ2KzQ061gtBnk0vNHfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.33.tgz",
+      "integrity": "sha512-C64hBnBxq4viOPQ8hlx+2lJ23bzZBGnjw7ryALmS+0Q3zHmwO8lw1/DArLENw4Q18/0w5wdEO1k3m1wWNtKGqQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.33.tgz",
+      "integrity": "sha512-TRJfnJbX3jqpxRDRoieMzRiCBS5jOmXNb3iQXmcgjFEHKLnAgK1RZRU8Cq1MsPqO4jAJp/ld1G4O3fXuxv85uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.33.tgz",
+      "integrity": "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.33.tgz",
+      "integrity": "sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.33.tgz",
+      "integrity": "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.33.tgz",
+      "integrity": "sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.33.tgz",
+      "integrity": "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.33.tgz",
+      "integrity": "sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.33.tgz",
+      "integrity": "sha512-gtyvzSNR8DHKfFEA2uqb8Ld1myqi6uEg2jyeUq3ikn5ytYs7H8RpZYC8mdy4NXr8hfcdJfCLXPlYaqqfBXpoEQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.33.tgz",
+      "integrity": "sha512-d6fRqQSkJI+kmMEBWaDQ7TMl8+YjLYbwRUPZQ9DY0ORBJeTzOrG0twvfvlZ2xgw6jA0ScQKgfBm4vHLSLl5Hqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -3169,6 +3557,21 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@swc/wasm": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.15.33.tgz",
+      "integrity": "sha512-uZPBvYMwjvTtyNm018KFV6ino5ZL4z9riN/tBsfTSgbfONW9Jn+ca88+UeEIdMOZY5Dm+y2OBf6o0kxa1wfD0A==",
+      "license": "Apache-2.0"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
@@ -3530,11 +3933,33 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4462,6 +4887,15 @@
         "d3-transition": "^3.0.1"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -4648,6 +5082,24 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/ai": {
+      "version": "6.0.188",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.188.tgz",
+      "integrity": "sha512-kNwIl1MM4ESzeOPDYuN+FidJ2QY5kGWHLtTMru6HHPW/JJ6nPuvHRhJ8tMX/Y2Tijx9DCiv2W7y5IBouuB712g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.118",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -4663,6 +5115,604 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/almostnode": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/almostnode/-/almostnode-0.2.14.tgz",
+      "integrity": "sha512-Sp+S0JYToYP2g5A6MoIZQpzDIuRrNiU13FLJ9kRbB7c6DqS/7sG3rDG8qqhsijbQDSZKp02Y2pH9tlnM+s8NIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/openai": "^3.0.28",
+        "@ai-sdk/react": "^3.0.87",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "ai": "^6.0.85",
+        "brotli": "^1.3.3",
+        "brotli-wasm": "^3.0.1",
+        "comlink": "^4.4.2",
+        "css-tree": "^3.1.0",
+        "just-bash": "^2.7.0",
+        "pako": "^2.1.0",
+        "resolve.exports": "^2.0.3",
+        "vite-plugin-top-level-await": "^1.6.0",
+        "vite-plugin-wasm": "^3.5.0",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/almostnode/node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/almostnode/node_modules/@swc/core": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.33.tgz",
+      "integrity": "sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.33",
+        "@swc/core-darwin-x64": "1.15.33",
+        "@swc/core-linux-arm-gnueabihf": "1.15.33",
+        "@swc/core-linux-arm64-gnu": "1.15.33",
+        "@swc/core-linux-arm64-musl": "1.15.33",
+        "@swc/core-linux-ppc64-gnu": "1.15.33",
+        "@swc/core-linux-s390x-gnu": "1.15.33",
+        "@swc/core-linux-x64-gnu": "1.15.33",
+        "@swc/core-linux-x64-musl": "1.15.33",
+        "@swc/core-win32-arm64-msvc": "1.15.33",
+        "@swc/core-win32-ia32-msvc": "1.15.33",
+        "@swc/core-win32-x64-msvc": "1.15.33"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/almostnode/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/almostnode/node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/almostnode/node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/almostnode/node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
+    "node_modules/almostnode/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/almostnode/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/almostnode/node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+      }
+    },
+    "node_modules/almostnode/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/almostnode/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/almostnode/node_modules/vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/almostnode/node_modules/vite-plugin-top-level-await": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.6.0.tgz",
+      "integrity": "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-virtual": "^3.0.2",
+        "@swc/core": "^1.12.14",
+        "@swc/wasm": "^1.12.14",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.8"
+      }
+    },
+    "node_modules/almostnode/node_modules/vite-plugin-wasm": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.6.0.tgz",
+      "integrity": "sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/ansi-regex": {
@@ -5007,11 +6057,30 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.21",
@@ -5025,11 +6094,37 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5049,6 +6144,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/brotli-wasm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-3.0.1.tgz",
+      "integrity": "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=v18.0.0"
       }
     },
     "node_modules/browserslist": {
@@ -5083,6 +6196,31 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/call-bind": {
@@ -5271,6 +6409,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -5347,6 +6492,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -5456,6 +6607,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/csstype": {
@@ -6070,6 +7234,32 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6159,6 +7349,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/discontinuous-range": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
@@ -6221,6 +7420,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
@@ -7145,6 +8354,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -7212,6 +8440,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -7233,6 +8499,24 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -7351,6 +8635,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -9096,6 +10387,13 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -9488,6 +10786,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9546,6 +10864,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -10080,7 +11407,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -10131,6 +11458,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -10192,6 +11525,37 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/just-bash": {
+      "version": "2.14.5",
+      "resolved": "https://registry.npmjs.org/just-bash/-/just-bash-2.14.5.tgz",
+      "integrity": "sha512-MCBGnRlDeZ/MM7mcw+ZuSGFMBsggajrmKz6e/hrOAN7syvVZkjiY+Vh2wyCwN/CdcnAX5SxbiQB51n5nrQuX+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "diff": "^8.0.2",
+        "fast-xml-parser": "^5.7.3",
+        "file-type": "^21.2.0",
+        "ini": "^6.0.0",
+        "minimatch": "^10.1.1",
+        "modern-tar": "^0.7.3",
+        "papaparse": "^5.5.3",
+        "quickjs-emscripten": "^0.32.0",
+        "re2js": "^1.2.1",
+        "seek-bzip": "^2.0.0",
+        "smol-toml": "^1.6.0",
+        "sprintf-js": "^1.1.3",
+        "sql.js": "^1.13.0",
+        "turndown": "^7.2.2",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "just-bash": "dist/bin/just-bash.js",
+        "just-bash-shell": "dist/bin/shell/shell.js"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/zstd": "^7.0.0",
+        "node-liblzma": "^2.0.3"
+      }
     },
     "node_modules/katex": {
       "version": "0.16.46",
@@ -10970,6 +12334,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -11740,11 +13110,23 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -11760,10 +13142,26 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/moo": {
@@ -11820,9 +13218,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -11836,6 +13234,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -11945,6 +13350,29 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -11972,6 +13400,40 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-liblzma": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-liblzma/-/node-liblzma-2.2.0.tgz",
+      "integrity": "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g==",
+      "hasInstallScript": true,
+      "license": "LGPL-3.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "bin": {
+        "nxz": "lib/cli/nxz.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/oorabona"
       }
     },
     "node_modules/node-releases": {
@@ -12114,6 +13576,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
@@ -12211,6 +13683,12 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12281,6 +13759,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -12439,6 +13932,34 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12474,6 +13995,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -12520,6 +14052,31 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quickjs-emscripten": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.32.0.tgz",
+      "integrity": "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0",
+        "@jitl/quickjs-wasmfile-debug-sync": "0.32.0",
+        "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0",
+        "@jitl/quickjs-wasmfile-release-sync": "0.32.0",
+        "quickjs-emscripten-core": "0.32.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/quickjs-emscripten-core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten-core/-/quickjs-emscripten-core-0.32.0.tgz",
+      "integrity": "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -12538,6 +14095,45 @@
       "engines": {
         "node": ">=0.12"
       }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/re2js": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-1.3.3.tgz",
+      "integrity": "sha512-s/I5zEAo79SUK0Qw4dpZKpiMwbQ6Gz0KU2NRr7eaO4x/p2g7Vvmn3hdeXDg8VsaUjfj/ora+e9oi27LX/C9+mw==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.5",
@@ -13010,6 +14606,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -13192,6 +14797,28 @@
       "license": "MIT",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
+      }
+    },
+    "node_modules/seek-bzip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
+      "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^6.0.0"
+      },
+      "bin": {
+        "seek-bunzip": "bin/seek-bunzip",
+        "seek-table": "bin/seek-bzip-table"
+      }
+    },
+    "node_modules/seek-bzip/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/semver": {
@@ -13432,6 +15059,65 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -13460,6 +15146,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/sql-formatter": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.7.4.tgz",
@@ -13472,6 +15164,12 @@
       "bin": {
         "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -13699,6 +15397,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/style-mod": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
@@ -13777,6 +15503,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -13825,6 +15564,63 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -13911,6 +15707,24 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -13989,6 +15803,32 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
       }
     },
     "node_modules/type-check": {
@@ -14127,6 +15967,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbox-primitive": {
@@ -14961,6 +16813,13 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -14980,6 +16839,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlhttprequest-ssl": {
@@ -15008,6 +16882,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "fumadocs-mdx && next dev",
-    "build": "fumadocs-mdx && next build",
-    "postinstall": "fumadocs-mdx && node scripts/patch-almostnode.mjs",
+    "dev": "fumadocs-mdx && node scripts/build-almostnode-workers.mjs && next dev",
+    "build": "fumadocs-mdx && node scripts/build-almostnode-workers.mjs && next build",
+    "build:workers": "node scripts/build-almostnode-workers.mjs",
+    "postinstall": "fumadocs-mdx && node scripts/patch-almostnode.mjs && node scripts/build-almostnode-workers.mjs",
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "fumadocs-mdx && next dev",
     "build": "fumadocs-mdx && next build",
-    "postinstall": "fumadocs-mdx",
+    "postinstall": "fumadocs-mdx && node scripts/patch-almostnode.mjs",
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",
@@ -43,6 +43,7 @@
     "@wasm-fmt/ruff_fmt": "^0.15.12",
     "@wasm-fmt/web_fmt": "^0.2.9",
     "@xyflow/react": "^12.10.2",
+    "almostnode": "^0.2.14",
     "apache-arrow": "^21.1.0",
     "elkjs": "^0.11.1",
     "fumadocs-core": "^16.8.5",

--- a/scripts/build-almostnode-workers.mjs
+++ b/scripts/build-almostnode-workers.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Pre-bundle the almostnode-backed JS/TS playground workers as
+ * standalone ES module files served from `/public/_workers/`.
+ *
+ * Why this exists:
+ *
+ * Turbopack's worker bundler emits a bootstrap script that loads its
+ * dependency chunks with `importScripts.apply(self, chunks)` — and
+ * explicitly strips the `type` option from the Worker constructor
+ * (see `new e(u, i ? {...i, type: void 0} : void 0)` in Turbopack's
+ * runtime). Two consequences for the almostnode worker:
+ *
+ *   1. `{ type: "module" }` on `new Worker(...)` is ignored — the
+ *      worker is always classic.
+ *   2. almostnode's ~16 MB bundle is split into many chunks, all
+ *      concatenated via `importScripts`. Two chunks happen to declare
+ *      the same minified top-level identifier (`e1`), and the worker
+ *      aborts at startup with
+ *      `SyntaxError: Failed to execute 'importScripts' on
+ *       'WorkerGlobalScope': Identifier 'e1' has already been declared`.
+ *
+ * Switching the whole app to Webpack would fix it but would also slow
+ * `next build`/`next dev` substantially. Pre-bundling only the two
+ * worker files with esbuild keeps Turbopack for everything else while
+ * producing a single self-contained worker module that has zero chunk
+ * collisions to worry about.
+ *
+ * The output goes under `public/_workers/` so Next.js serves it as a
+ * plain static asset at `/_workers/...`. The adapters spawn:
+ *
+ *     new Worker("/_workers/javascript-worker.js", { type: "module" })
+ *
+ * which Turbopack treats as a regular URL string (no static analysis,
+ * no bundling).
+ *
+ * Idempotent. Safe to run from `postinstall`, `prebuild`, and `predev`.
+ */
+
+import { build } from "esbuild";
+import { mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const OUT_DIR = join(ROOT, "public", "_workers");
+const SRC_DIR = join(ROOT, "app", "_components", "runtime");
+
+await rm(OUT_DIR, { recursive: true, force: true });
+await mkdir(OUT_DIR, { recursive: true });
+
+/**
+ * almostnode pulls in `just-bash`'s browser bundle (`vercel-labs/just-
+ * bash`), which has straggler `import "node:zlib"` / `"node:async_hooks"`
+ * / `"node:dns"` references that aren't actually called at runtime but
+ * still trip esbuild's resolver. Stub every `node:*` specifier to an
+ * empty module so the bundle resolves cleanly. almostnode ships its own
+ * shims for the Node modules our user code actually touches (fs, path,
+ * crypto, …) inside `dist/index.mjs`, so the empty stubs are only used
+ * by dead-code branches.
+ */
+const stubNodeBuiltins = {
+  name: "stub-node-builtins",
+  setup(buildContext) {
+    buildContext.onResolve({ filter: /^node:/ }, (args) => ({
+      path: args.path,
+      namespace: "node-stub",
+    }));
+    buildContext.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
+      // CommonJS loader so any `import { foo } from "node:zlib"`
+      // resolves at runtime through property access on the stub
+      // object — esbuild interops ESM↔CJS by reading properties
+      // dynamically. just-bash's browser bundle imports things like
+      // `{ gunzipSync, gzipSync, constants }` from `node:zlib` in dead
+      // code paths; this stub returns `undefined` for any name so the
+      // bundle resolves cleanly. If any of these are actually called,
+      // they'll throw `TypeError: undefined is not a function`, which
+      // is the right behaviour for code that was never meant to run in
+      // a browser.
+      contents:
+        "module.exports = new Proxy({}, { get() { return undefined; } });",
+      loader: "js",
+    }));
+  },
+};
+
+/** @type {import("esbuild").BuildOptions} */
+const common = {
+  bundle: true,
+  format: "esm",
+  target: "es2022",
+  platform: "browser",
+  // Workers don't have a DOM and we don't ship sourcemaps for them to
+  // browsers — keeping the file small matters more than debuggability
+  // here (the original .ts source is still in /app/_components/runtime).
+  minify: true,
+  legalComments: "none",
+  // Tell esbuild we're targeting a worker so any conditional
+  // browser-vs-worker package exports pick the right entry.
+  conditions: ["worker", "browser", "import", "default"],
+  plugins: [stubNodeBuiltins],
+  // almostnode's bundle pulls in `comlink` which references
+  // `MessageChannel` etc. — all worker-safe globals.
+};
+
+const targets = [
+  {
+    entry: join(SRC_DIR, "javascript-worker.ts"),
+    out: join(OUT_DIR, "javascript-worker.js"),
+  },
+  {
+    entry: join(SRC_DIR, "typescript-worker.ts"),
+    out: join(OUT_DIR, "typescript-worker.js"),
+  },
+];
+
+for (const { entry, out } of targets) {
+  await build({
+    ...common,
+    entryPoints: [entry],
+    outfile: out,
+  });
+  console.log(`[build-almostnode-workers] wrote ${out}`);
+}

--- a/scripts/patch-almostnode.mjs
+++ b/scripts/patch-almostnode.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Post-install patch for almostnode.
+ *
+ * `almostnode`'s prebuilt bundle (`dist/index.mjs`) constructs its
+ * internal `WorkerRuntime` with a server-absolute asset URL:
+ *
+ *   new Worker(new URL("/assets/runtime-worker-XYZ.js", import.meta.url), …);
+ *
+ * The leading slash assumes the bundle is loaded from an HTTP origin
+ * that serves `node_modules` at the root (the Vite dev-server model the
+ * library was authored against). Under Next.js / Turbopack, the URL
+ * resolves to a filesystem path that does not exist and the build
+ * aborts with `Module not found: Can't resolve '/assets/runtime-...'`.
+ *
+ * We don't use `WorkerRuntime` (the playground spawns its own dedicated
+ * Web Worker via the LanguageAdapter contract) — only `VirtualFS` and
+ * `Runtime`. But Turbopack still statically analyses every `new URL(...,
+ * import.meta.url)` in `index.mjs`, so the bad string has to go away
+ * even if the surrounding class is dead code at runtime.
+ *
+ * The fix: rewrite `/assets/runtime-worker-...` → `./assets/runtime-
+ * worker-...` so the URL resolves relative to `dist/index.mjs`, where
+ * the asset actually lives (`dist/assets/runtime-worker-*.js`).
+ *
+ * Idempotent: re-running the script is a no-op once the patch is
+ * applied. Safe to invoke from `npm install` lifecycle hooks.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const TARGETS = [
+  join(ROOT, "node_modules", "almostnode", "dist", "index.mjs"),
+  join(ROOT, "node_modules", "almostnode", "dist", "index.cjs"),
+];
+
+// Match the leading-slash form but not the already-patched relative
+// form, so the patch is naturally idempotent.
+const BAD_URL_RE = /(["'`])\/assets\/runtime-worker-/g;
+
+let patchedAny = false;
+
+for (const target of TARGETS) {
+  if (!existsSync(target)) {
+    // almostnode not installed (yet); nothing to do.
+    continue;
+  }
+  const src = readFileSync(target, "utf8");
+  if (!BAD_URL_RE.test(src)) {
+    // Already patched — or future almostnode versions may have fixed
+    // it upstream. Either way, nothing to do.
+    continue;
+  }
+  // Reset the regex's lastIndex after the test() above and replace.
+  BAD_URL_RE.lastIndex = 0;
+  const next = src.replace(BAD_URL_RE, (_match, quote) => `${quote}./assets/runtime-worker-`);
+  writeFileSync(target, next);
+  console.log(`[patch-almostnode] rewrote asset URL in ${target}`);
+  patchedAny = true;
+}
+
+if (!patchedAny) {
+  console.log("[patch-almostnode] no patch needed");
+}


### PR DESCRIPTION
## Summary

Replaces the JavaScript and TypeScript playground runtimes with [almostnode](https://github.com/macaly/almostnode) — a browser-native Node.js runtime — in place. The `LanguageAdapter` ids (`"javascript"` / `"typescript"`) and routes (`/playground/javascript`, `/playground/typescript`) are unchanged; existing workspaces keep working.

What this unlocks:
- **Multi-file workspaces**: `require()` resolves across open tabs through almostnode's `VirtualFS`.
- **Shimmed Node.js modules**: `require("node:fs")`, `require("node:path")`, `require("node:crypto")`, `require("node:http")`, and ~40 more.
- **Foundation for future npm install UI** (Phase 3 of the integration plan).

## What changed

| Area | Change |
|---|---|
| `app/_components/runtime/javascript-worker.ts` | Replaced. Drops `AsyncFunction`; spawns an almostnode `VirtualFS` + `Runtime`, stages files via `prepare-fs`, executes entry via `runFileAsync`. |
| `app/_components/runtime/typescript-worker.ts` | Replaced. Pre-transpiles `.ts`/`.tsx`/`.mts`/`.cts` → `.js` with the bundled TypeScript compiler (CJS emit), then hands off to the same almostnode runner. |
| `app/_components/runtime/javascript.tsx` / `typescript.tsx` | Adapters now implement `prepareFileSystem`. Updated `runtimeInfo`, `packagesFooter`, `importSnippet`. New `node_modules` + `multi_file` examples added. |
| `app/_components/runtime/almostnode-worker-shared.ts` | New — shared helpers (`stageFiles`, `wrapEntryAsAsyncIIFE`, `runEntry`, `formatArg`). |
| `scripts/patch-almostnode.mjs` | New — postinstall patch (see below). |
| `package.json` | Adds `almostnode@^0.2.14`; chains the patch script onto `postinstall`. |

## Two design decisions worth flagging

**1. Top-level `await` is preserved via an IIFE wrapper.** almostnode's `Runtime` wraps each module in a synchronous CommonJS shell, so top-level `await` is a syntax error. The entry file is rewritten to `module.exports = (async () => { <user code> })();` and the runner awaits the resulting promise before posting `done`. This keeps the existing async example working without forcing users into a new contract. Documented in §8.4 of the research doc.

**2. TypeScript files are pre-transpiled, not handed raw to almostnode.** almostnode's resolver only tries `.js`/`.json`/`.node` extensions. The TS worker transpiles every `.ts*` file to its `.js` sibling path in `VirtualFS` so `require("./utils")` resolves naturally. Diagnostics from `ts.transpileModule` are buffered and replayed as stderr on the next run. Documented in §8.5.

## Build-time gotcha (and the patch script)

`almostnode@0.2.14`'s prebuilt `dist/index.mjs` has a hard-coded server-absolute asset URL inside its (unused-by-us) `WorkerRuntime` class:

```js
new Worker(new URL("/assets/runtime-worker-D6Dmsis4.js", import.meta.url), …)
```

Turbopack does eager static analysis on every `new URL(…, import.meta.url)` and aborts with `Module not found`. We never instantiate `WorkerRuntime` (the `LanguageAdapter` contract already provides its own Worker), but the static string had to disappear.

`scripts/patch-almostnode.mjs` rewrites `/assets/runtime-worker-…` → `./assets/runtime-worker-…` so the URL resolves to the file that actually exists at `node_modules/almostnode/dist/assets/`. The patch is idempotent and runs from `postinstall`, so CI checkouts pick it up automatically. An upstream PR is tracked in §8.6 as a follow-up.

## Validation

| Check | Result |
|---|---|
| `npx tsc --noEmit` | ✅ 0 errors |
| `npm run test` | ✅ 221 passed across 9 files |
| `npm run lint` | ✅ no new errors (one pre-existing unrelated error in `php-worker.ts`) |
| `npm run build` | ✅ Turbopack compiles in ~3 min, all 29 static pages generated including `/playground/javascript` and `/playground/typescript` |
| `npm run test:e2e` | ⚠️ not executed in this sandbox — the Playwright suite at `e2e/playgrounds.spec.ts` should be run before merging |

## Test plan

- [ ] Open `/playground/javascript`, run the default `Hello World` example — expect ordered stdout with `π`, `e`, and the 5 star lines.
- [ ] Run the new `Node.js Modules` example — expect `sha256`, `path.join`, and `os.platform()` to all print.
- [ ] Add a `utils.js` tab containing `exports.greet = (n) => ...` and run the new `Multi-File Modules` example from `index.js` — expect `Hello, almostnode!`.
- [ ] Run the `Async / Await` example — expect 3 parallel "loaded in Xms" lines and the total wall time (top-level await still works).
- [ ] Repeat all of the above on `/playground/typescript`, including the new TS `Multi-File Modules` example with `import { greet, shout } from "./utils"`.
- [ ] Confirm the Packages button stays hidden on both playgrounds (no npm install UI yet — that's the next phase).
- [ ] Run `npm run test:e2e` and inspect `e2e/playgrounds.spec.ts` results (the suite exercises the default examples on both playgrounds end-to-end).

## Follow-ups (out of scope here — listed in the research doc §8.6)

1. npm package install UI in the packages drawer.
2. VFS snapshot persistence to OPFS so installed packages survive reload.
3. CORS proxy service worker (Phase 0 in the plan — independent of almostnode).
4. Cross-origin sandbox deployment + switching to `createRuntime({ sandbox: ... })`.
5. New unit tests against the production runtime (the existing vitest tests now exercise the legacy `AsyncFunction` semantics as a reference check rather than the live runtime).
6. Upstream PR for the asset URL bug in almostnode, after which the postinstall patch can be removed.

See `agent-outputs/20260519-1959-almostnode-feasibility-research.md` §8 for the full implementation write-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_011Y36M4PgcTV4tLH2R8GRSG)_