### PR TITLE
Challenge card overhaul: multi-file solutions, action-bar parity, solution sweep, R-harness fix

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -485,10 +485,57 @@
   font-size: 12.5px;
   line-height: 1.7;
   font-variant-ligatures: none;
-  cursor: not-allowed;
+  cursor: default;
 }
 .initEditor :global(.cm-editor .cm-cursor) {
   display: none !important;
+}
+
+/* ─── File tab bar (multi-file workspaces) ────────────────────────── */
+
+.fileTabBar {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  background: var(--ch-bg-subtle);
+  border-top: 1px solid var(--ch-border-light);
+  border-bottom: 1px solid var(--ch-border-light);
+  overflow-x: auto;
+  user-select: none;
+}
+.fileTab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--ch-border-light);
+  font-family: var(--ch-font-mono);
+  font-size: 12px;
+  color: var(--ch-text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  position: relative;
+  transition: background 0.12s, color 0.12s;
+}
+.fileTab:hover {
+  background: #f4f4f5;
+  color: var(--ch-text);
+}
+.fileTabActive {
+  background: var(--ch-bg);
+  color: var(--ch-text);
+  font-weight: 600;
+}
+.fileTabActive::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--ch-accent);
 }
 
 /* ─── Toolbar ─────────────────────────────────────────────────────── */
@@ -671,6 +718,7 @@
 
 .outputPanel {
   background: var(--ch-bg);
+  position: relative;
 }
 .outputHeader {
   display: flex;
@@ -755,6 +803,90 @@
 }
 .outCellHtml :global(tr:hover td) {
   background: #f8fafc;
+}
+
+/* ─── Running overlay (sine-wave animation) ──────────────────────────
+   Mirrors `<CodeBlock>`'s `.runOverlay` so a busy state in a challenge
+   card shows the same blue-wave hint. The overlay sits at the bottom
+   of the output panel and fades in/out to avoid blinking. Uses
+   `--ch-accent` so the colour tracks the card's theme token. */
+
+.runOverlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 36px;
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+  z-index: 0;
+  -webkit-mask-image: linear-gradient(to top, #000 35%, transparent 100%);
+  mask-image: linear-gradient(to top, #000 35%, transparent 100%);
+}
+.runOverlay.runOverlayActive {
+  opacity: 1;
+}
+.runWaves {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  overflow: visible;
+}
+.runWaveBack {
+  fill: color-mix(in oklab, var(--ch-accent) 22%, transparent);
+  animation: cc-waveBack 2.4s linear infinite;
+}
+.runWaveFront {
+  fill: color-mix(in oklab, var(--ch-accent) 45%, transparent);
+  animation: cc-waveFront 1.4s linear infinite;
+}
+.runGlow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    120% 80% at 50% 110%,
+    color-mix(in oklab, var(--ch-accent) 40%, transparent) 0%,
+    transparent 70%
+  );
+  animation: cc-glowPulse 0.9s ease-in-out infinite alternate;
+}
+.runStream {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 8px;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in oklab, var(--ch-accent) 80%, white 20%) 50%,
+    transparent 100%
+  );
+  filter: blur(0.5px);
+  transform: translateX(-100%);
+  animation: cc-stream 1.1s cubic-bezier(0.45, 0, 0.2, 1) infinite;
+}
+@keyframes cc-waveBack {
+  from { transform: translateX(0); }
+  to { transform: translateX(-240px); }
+}
+@keyframes cc-waveFront {
+  from { transform: translateX(0); }
+  to { transform: translateX(-240px); }
+}
+@keyframes cc-glowPulse {
+  from { opacity: 0.45; }
+  to { opacity: 0.85; }
+}
+@keyframes cc-stream {
+  0% { transform: translateX(-100%); opacity: 0; }
+  15% { opacity: 1; }
+  85% { opacity: 1; }
+  100% { transform: translateX(100%); opacity: 0; }
 }
 
 /* ─── Test panel ──────────────────────────────────────────────────── */
@@ -929,6 +1061,7 @@
 .sqlResultPanel {
   background: var(--ch-bg);
   border-top: 1px solid var(--ch-border-light);
+  position: relative;
 }
 .sqlResultHeader {
   display: flex;

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -664,9 +664,9 @@
   background: var(--ch-accent);
 }
 
-/* ─── Toolbar ─────────────────────────────────────────────────────── */
+/* ─── Action bar ──────────────────────────────────────────────────── */
 
-.toolbar {
+.actionBar {
   display: flex;
   align-items: center;
   padding: 8px 14px;

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -245,6 +245,43 @@
   color: var(--ch-text);
   border-color: var(--ch-border-light);
 }
+.modalTabBar {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--ch-border-light);
+  background: var(--ch-tab-bg, #fafafa);
+  overflow-x: auto;
+  flex-shrink: 0;
+}
+.modalTab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-family: var(--ch-font-mono);
+  color: var(--ch-text-secondary);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.12s, border-color 0.12s;
+}
+.modalTab:hover {
+  color: var(--ch-text);
+}
+.modalTabActive {
+  color: var(--ch-text);
+  border-bottom-color: var(--ch-accent, #2563eb);
+}
+.modalTabHint {
+  color: var(--ch-text-muted);
+  font-size: 14px;
+  line-height: 1;
+}
 .modalEditor {
   flex: 1;
   overflow: auto;

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -13,41 +13,101 @@
 .card {
   /* Light, paper-style chrome distinct from the dark-by-default
      CodeBlock — challenges are meant to feel like a worksheet, not a
-     console. Tokens duplicated locally so the card works even when
-     dropped into a page that doesn't load other DataSlope stylesheets. */
-  --ch-bg: #ffffff;
-  --ch-bg-muted: #fafafa;
-  --ch-bg-subtle: #f9fafb;
-  --ch-border: #e5e7eb;
-  --ch-border-light: #f0f1f3;
-  --ch-text: #111827;
-  --ch-text-secondary: #6b7280;
-  --ch-text-muted: #9ca3af;
-  --ch-accent: #2563eb;
-  --ch-accent-hover: #1d4ed8;
-  --ch-green: #16a34a;
-  --ch-green-dot: #22c55e;
-  --ch-green-bg: #f0fdf4;
-  --ch-red: #dc2626;
-  --ch-red-bg: #fef2f2;
-  --ch-purple: #7c3aed;
-  --ch-purple-bg: #f5f3ff;
-  --ch-purple-border: #ede9fe;
-  /* Badge accent — tracks --ch-accent so the pill matches the card's
-     primary accent everywhere it appears (badge, table-viewer active
-     tab, etc.). */
+     console.
+
+     Color tokens come straight from the Tailwind v4 palette
+     (https://tailwindcss.com/docs/colors). Palette tokens live in
+     the first block; the semantic aliases (--ch-bg, --ch-text…)
+     that the rest of the module references are derived from them.
+     We duplicate the palette locally rather than reading Tailwind's
+     own `--color-…` vars because Tailwind's preflight is only
+     imported on /learn; this module is also used by /playground. */
+
+  /* Tailwind palette tokens */
+  --ch-white: #ffffff;
+  --ch-black: #000000;
+  --ch-slate-50: #f8fafc;
+  --ch-slate-100: #f1f5f9;
+  --ch-slate-200: #e2e8f0;
+  --ch-slate-300: #cbd5e1;
+  --ch-slate-400: #94a3b8;
+  --ch-slate-700: #334155;
+  --ch-slate-800: #1e293b;
+  --ch-slate-900: #0f172a;
+  --ch-slate-950: #020617;
+  --ch-gray-50: #f9fafb;
+  --ch-gray-100: #f3f4f6;
+  --ch-gray-200: #e5e7eb;
+  --ch-gray-300: #d1d5db;
+  --ch-gray-400: #9ca3af;
+  --ch-gray-500: #6b7280;
+  --ch-gray-700: #374151;
+  --ch-gray-800: #1f2937;
+  --ch-gray-900: #111827;
+  --ch-zinc-100: #f4f4f5;
+  --ch-neutral-50: #fafafa;
+  --ch-blue-50: #eff6ff;
+  --ch-blue-100: #dbeafe;
+  --ch-blue-200: #bfdbfe;
+  --ch-blue-300: #93c5fd;
+  --ch-blue-500: #3b82f6;
+  --ch-blue-600: #2563eb;
+  --ch-blue-700: #1d4ed8;
+  --ch-blue-800: #1e40af;
+  --ch-blue-900: #1e3a8a;
+  --ch-green-50: #f0fdf4;
+  --ch-green-100: #dcfce7;
+  --ch-green-200: #bbf7d0;
+  --ch-green-500: #22c55e;
+  --ch-green-600: #16a34a;
+  --ch-red-50: #fef2f2;
+  --ch-red-100: #fee2e2;
+  --ch-red-200: #fecaca;
+  --ch-red-500: #ef4444;
+  --ch-red-600: #dc2626;
+  --ch-red-900: #7f1d1d;
+  --ch-violet-50: #f5f3ff;
+  --ch-violet-100: #ede9fe;
+  --ch-violet-500: #8b5cf6;
+  --ch-violet-600: #7c3aed;
+  --ch-amber-500: #f59e0b;
+
+  /* Semantic aliases */
+  --ch-bg: var(--ch-white);
+  --ch-bg-muted: var(--ch-neutral-50);
+  --ch-bg-subtle: var(--ch-gray-50);
+  --ch-bg-hover: var(--ch-zinc-100);
+  --ch-border: var(--ch-gray-200);
+  --ch-border-light: var(--ch-gray-100);
+  --ch-text: var(--ch-gray-900);
+  --ch-text-secondary: var(--ch-gray-500);
+  --ch-text-muted: var(--ch-gray-400);
+  --ch-accent: var(--ch-blue-600);
+  --ch-accent-hover: var(--ch-blue-700);
+  --ch-accent-disabled: var(--ch-blue-300);
+  --ch-green: var(--ch-green-600);
+  --ch-green-dot: var(--ch-green-500);
+  --ch-green-bg: var(--ch-green-50);
+  --ch-red: var(--ch-red-600);
+  --ch-red-bg: var(--ch-red-50);
+  --ch-purple: var(--ch-violet-600);
+  --ch-purple-bg: var(--ch-violet-50);
+  --ch-purple-border: var(--ch-violet-100);
   --ch-badge-color: var(--ch-accent);
-  --ch-badge-bg: #eff6ff;
-  --ch-badge-border: #dbeafe;
-  --ch-scrollbar-thumb: #d1d5db;
-  --ch-scrollbar-thumb-hover: #9ca3af;
+  --ch-badge-bg: var(--ch-blue-50);
+  --ch-badge-border: var(--ch-blue-100);
+  --ch-scrollbar-thumb: var(--ch-gray-300);
+  --ch-scrollbar-thumb-hover: var(--ch-gray-400);
+  /* Modal backdrop: slate-900 at 55% opacity. */
+  --ch-overlay: color-mix(in srgb, var(--ch-slate-900) 55%, transparent);
+
   --ch-font-ui: "Inter", system-ui, -apple-system, sans-serif;
   --ch-font-mono:
     "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   --ch-radius: 8px;
   --ch-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.08),
-    0 1px 2px rgba(0, 0, 0, 0.05);
+    0 1px 3px color-mix(in srgb, var(--ch-black) 8%, transparent),
+    0 1px 2px color-mix(in srgb, var(--ch-black) 5%, transparent);
 
   background: var(--ch-bg);
   border: 1px solid var(--ch-border);
@@ -176,7 +236,7 @@
 .modalBackdrop {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.55);
+  background: var(--ch-overlay);
   z-index: 1000;
   display: flex;
   align-items: center;
@@ -241,7 +301,7 @@
   transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 .modalIconBtn:hover {
-  background: #f4f4f5;
+  background: var(--ch-bg-hover);
   color: var(--ch-text);
   border-color: var(--ch-border-light);
 }
@@ -251,7 +311,7 @@
   gap: 0;
   padding: 0 8px;
   border-bottom: 1px solid var(--ch-border-light);
-  background: var(--ch-tab-bg, #fafafa);
+  background: var(--ch-tab-bg, var(--ch-neutral-50));
   overflow-x: auto;
   flex-shrink: 0;
 }
@@ -275,7 +335,7 @@
 }
 .modalTabActive {
   color: var(--ch-text);
-  border-bottom-color: var(--ch-accent, #2563eb);
+  border-bottom-color: var(--ch-accent, var(--ch-blue-600));
 }
 .modalTabHint {
   color: var(--ch-text-muted);
@@ -330,11 +390,11 @@
 .instructionsBody code {
   font-family: var(--ch-font-mono);
   font-size: 12px;
-  background: #f1f5f9;
-  border: 1px solid #e2e8f0;
+  background: var(--ch-slate-100);
+  border: 1px solid var(--ch-slate-200);
   border-radius: 4px;
   padding: 1px 5px;
-  color: #0f172a;
+  color: var(--ch-slate-900);
 }
 .instructionsBody ul,
 .instructionsBody ol {
@@ -445,18 +505,18 @@
 }
 .hintBox {
   margin-top: 10px;
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
+  background: var(--ch-blue-50);
+  border: 1px solid var(--ch-blue-200);
   border-radius: 6px;
   padding: 10px 12px;
   font-size: 12.5px;
-  color: #1e40af;
+  color: var(--ch-blue-800);
   line-height: 1.6;
 }
 .hintBox code {
-  background: #dbeafe;
-  border: 1px solid #bfdbfe;
-  color: #1e3a8a;
+  background: var(--ch-blue-100);
+  border: 1px solid var(--ch-blue-200);
+  color: var(--ch-blue-900);
   font-family: var(--ch-font-mono);
   font-size: 11.5px;
   border-radius: 3px;
@@ -515,7 +575,7 @@
 }
 .statusDot[data-status="loading"],
 .statusDot[data-status="running"] {
-  background: #f59e0b;
+  background: var(--ch-amber-500);
   animation: ch-pulse 1s ease-in-out infinite;
 }
 .statusDot[data-status="error"] {
@@ -580,7 +640,7 @@
 }
 .initToggle:hover {
   color: var(--ch-text);
-  background: #f4f4f5;
+  background: var(--ch-bg-hover);
 }
 .initCaret {
   display: inline-block;
@@ -600,8 +660,27 @@
   text-transform: none;
   letter-spacing: 0;
 }
-.initEditor {
+.initEditorWrap {
+  position: relative;
   border-top: 1px solid var(--ch-border-light);
+  background: var(--ch-bg);
+  /* Animate the height change so collapse/expand isn't a snap. The
+     wrapper has `overflow: hidden` while collapsed, so the gradient
+     reveals progressively more of the editor as it expands. */
+  transition: max-height 0.18s ease;
+}
+/* Show roughly the first 3 lines (3 × 12.5px × 1.7 + ~4px slack)
+   when collapsed. The exact value just has to land partway through
+   line 3 so the gradient has something to fade out. */
+.initEditorWrapCollapsed {
+  max-height: 68px;
+  overflow: hidden;
+}
+.initEditorWrapOpen {
+  max-height: none;
+  overflow: visible;
+}
+.initEditor {
   background: var(--ch-bg);
 }
 .initEditor :global(.cm-editor) {
@@ -615,6 +694,41 @@
 }
 .initEditor :global(.cm-editor .cm-cursor) {
   display: none !important;
+}
+
+/* Gradient fade overlay rendered over the bottom half of the
+   collapsed init editor. Clicking it expands the panel. We render it
+   as an actual <button> so it inherits keyboard focus + activation
+   semantics for free. */
+.initFade {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    transparent 35%,
+    color-mix(in srgb, var(--ch-bg) 70%, transparent) 60%,
+    var(--ch-bg) 100%
+  );
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: backdrop-filter 0.15s ease;
+}
+.initFade:hover {
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    transparent 25%,
+    color-mix(in srgb, var(--ch-bg) 70%, transparent) 55%,
+    var(--ch-bg) 100%
+  );
+}
+.initFade:focus-visible {
+  outline: 2px solid var(--ch-accent);
+  outline-offset: -2px;
 }
 
 /* ─── File tab bar (multi-file workspaces) ────────────────────────── */
@@ -646,7 +760,7 @@
   transition: background 0.12s, color 0.12s;
 }
 .fileTab:hover {
-  background: #f4f4f5;
+  background: var(--ch-bg-hover);
   color: var(--ch-text);
 }
 .fileTabActive {
@@ -684,13 +798,95 @@
   border: 1px solid var(--ch-accent);
   flex-shrink: 0;
 }
-/* Divider between Run and Submit, only when both are present. */
+/* Hairline divider between the main Submit/Run pill and the chevron
+   that opens the dropdown — only when both halves are present. */
 .btnGroupPrimary .runBtn:not(:last-child) {
-  border-right: 1px solid rgba(255, 255, 255, 0.22);
+  border-right: 1px solid color-mix(in srgb, var(--ch-white) 22%, transparent);
+}
+
+/* Chevron half of the split button — same accent fill as the main
+   Run pill, but a thinner column reserved just for the disclosure
+   arrow. Anchored to the right of `.btnGroupPrimary`. */
+.runBtnChevron {
+  background: var(--ch-accent);
+  color: var(--ch-white);
+  border: none;
+  padding: 0 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+.runBtnChevron:hover:not(:disabled) {
+  background: var(--ch-accent-hover);
+}
+.runBtnChevron:disabled {
+  background: var(--ch-accent-disabled);
+  cursor: not-allowed;
+}
+.runBtnChevron[data-popup-open] {
+  background: var(--ch-accent-hover);
+}
+.runBtnChevron svg {
+  display: block;
+}
+
+/* Dropdown menu opened from the chevron half of the split button.
+   Match base-ui's `Menu.Popup` conventions used by the playground
+   so focus / dismiss behaviour is consistent. */
+.runMenuPositioner {
+  z-index: 1100;
+  outline: none;
+}
+.runMenuPopup {
+  background: var(--ch-white);
+  border: 1px solid var(--ch-border);
+  border-radius: 8px;
+  box-shadow:
+    0 1px 2px color-mix(in srgb, var(--ch-slate-900) 4%, transparent),
+    0 8px 24px color-mix(in srgb, var(--ch-slate-900) 10%, transparent);
+  padding: 4px;
+  min-width: 240px;
+  font-family: var(--ch-font-ui);
+  outline: none;
+}
+.runMenuItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  color: var(--ch-text);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+}
+.runMenuItem:hover,
+.runMenuItem[data-highlighted] {
+  background: var(--ch-bg-subtle);
+}
+.runMenuItem svg {
+  flex-shrink: 0;
+  color: var(--ch-accent);
+}
+.runMenuLabel {
+  flex: 1;
+  min-width: 0;
+}
+.runMenuKbd {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
 }
 .runBtn {
   background: var(--ch-accent);
-  color: #fff;
+  color: var(--ch-white);
   border: none;
   padding: 6px 12px;
   font-size: 13px;
@@ -706,7 +902,7 @@
   background: var(--ch-accent-hover);
 }
 .runBtn:disabled {
-  background: #93c5fd;
+  background: var(--ch-accent-disabled);
   cursor: not-allowed;
 }
 .runBtn svg {
@@ -738,7 +934,7 @@
   transition: background 0.15s, color 0.15s;
 }
 .checkBtn:hover:not(:disabled) {
-  background: rgba(37, 99, 235, 0.07);
+  background: color-mix(in srgb, var(--ch-blue-600) 7%, transparent);
   color: var(--ch-accent-hover);
 }
 .checkBtn:disabled {
@@ -758,16 +954,16 @@
   color: var(--ch-text-muted);
 }
 .runBtn .btnKbd .kbd {
-  background: rgba(255, 255, 255, 0.16);
-  border-color: rgba(255, 255, 255, 0.28);
-  color: rgba(255, 255, 255, 0.88);
+  background: color-mix(in srgb, var(--ch-white) 16%, transparent);
+  border-color: color-mix(in srgb, var(--ch-white) 28%, transparent);
+  color: color-mix(in srgb, var(--ch-white) 88%, transparent);
   box-shadow: none;
 }
 .runBtn .btnKbd .kbdSep {
-  color: rgba(255, 255, 255, 0.5);
+  color: color-mix(in srgb, var(--ch-white) 50%, transparent);
 }
 .kbd {
-  background: #fff;
+  background: var(--ch-white);
   border: 1px solid var(--ch-border);
   border-radius: 4px;
   padding: 2px 5px;
@@ -813,7 +1009,7 @@
 }
 .utilBtn:hover:not(:disabled) {
   color: var(--ch-text);
-  background: #f0f1f3;
+  background: var(--ch-border-light);
 }
 .utilBtn:disabled {
   opacity: 0.45;
@@ -833,7 +1029,7 @@
 }
 .copyBtn:hover {
   color: var(--ch-text);
-  background: #f0f1f3;
+  background: var(--ch-border-light);
 }
 
 @media (max-width: 480px) {
@@ -911,8 +1107,8 @@
   font-size: 12px;
 }
 .outCellHtml :global(th) {
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
+  background: var(--ch-slate-50);
+  border: 1px solid var(--ch-slate-200);
   padding: 5px 12px;
   text-align: right;
   font-size: 11.5px;
@@ -921,14 +1117,14 @@
   white-space: nowrap;
 }
 .outCellHtml :global(td) {
-  border: 1px solid #f1f5f9;
+  border: 1px solid var(--ch-slate-100);
   padding: 4px 12px;
   text-align: right;
   white-space: nowrap;
   color: var(--ch-text);
 }
 .outCellHtml :global(tr:hover td) {
-  background: #f8fafc;
+  background: var(--ch-slate-50);
 }
 
 /* ─── Running overlay (sine-wave animation) ──────────────────────────
@@ -948,8 +1144,8 @@
   opacity: 0;
   transition: opacity 0.18s ease;
   z-index: 0;
-  -webkit-mask-image: linear-gradient(to top, #000 35%, transparent 100%);
-  mask-image: linear-gradient(to top, #000 35%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to top, var(--ch-black) 35%, transparent 100%);
+  mask-image: linear-gradient(to top, var(--ch-black) 35%, transparent 100%);
 }
 .runOverlay.runOverlayActive {
   opacity: 1;
@@ -1035,7 +1231,7 @@
   font-family: var(--ch-font-ui);
 }
 .testPanelHeader:hover {
-  background: #f4f4f5;
+  background: var(--ch-bg-hover);
 }
 .testLabel {
   font-size: 10.5px;
@@ -1062,17 +1258,17 @@
 .testPill[data-state="pass"] {
   background: var(--ch-green-bg);
   color: var(--ch-green);
-  border: 1px solid #bbf7d0;
+  border: 1px solid var(--ch-green-200);
 }
 .testPill[data-state="fail"] {
   background: var(--ch-red-bg);
   color: var(--ch-red);
-  border: 1px solid #fecaca;
+  border: 1px solid var(--ch-red-200);
 }
 .testPill[data-state="pending"] {
-  background: #f3f4f6;
+  background: var(--ch-gray-100);
   color: var(--ch-text-muted);
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--ch-gray-200);
 }
 .testChevron {
   color: var(--ch-text-muted);
@@ -1094,7 +1290,7 @@
   gap: 8px;
   padding: 8px 10px;
   border-radius: 6px;
-  background: #fff;
+  background: var(--ch-white);
   border: 1px solid var(--ch-border-light);
 }
 .testIcon {
@@ -1109,7 +1305,7 @@
 }
 .testIcon[data-state="pass"] { background: var(--ch-green-bg); color: var(--ch-green); }
 .testIcon[data-state="fail"] { background: var(--ch-red-bg); color: var(--ch-red); }
-.testIcon[data-state="pending"] { background: #f3f4f6; color: var(--ch-text-muted); }
+.testIcon[data-state="pending"] { background: var(--ch-gray-100); color: var(--ch-text-muted); }
 
 .testItemBody {
   flex: 1;
@@ -1153,12 +1349,12 @@
 .banner[data-state="pass"] {
   background: var(--ch-green-bg);
   color: var(--ch-green);
-  border-top-color: #bbf7d0;
+  border-top-color: var(--ch-green-200);
 }
 .banner[data-state="fail"] {
   background: var(--ch-red-bg);
   color: var(--ch-red);
-  border-top-color: #fecaca;
+  border-top-color: var(--ch-red-200);
 }
 .bannerIcon {
   width: 22px;
@@ -1169,8 +1365,8 @@
   justify-content: center;
   flex-shrink: 0;
 }
-.banner[data-state="pass"] .bannerIcon { background: #dcfce7; }
-.banner[data-state="fail"] .bannerIcon { background: #fee2e2; }
+.banner[data-state="pass"] .bannerIcon { background: var(--ch-green-100); }
+.banner[data-state="fail"] .bannerIcon { background: var(--ch-red-100); }
 .bannerSub {
   font-size: 12px;
   font-weight: 400;
@@ -1271,92 +1467,108 @@
    slate-tinted surface, soft borders, slightly desaturated semantic
    colours so accents don't burn next to body text. */
 :global(html.dark) .card {
-  --ch-bg: #0f172a;
-  --ch-bg-muted: #111827;
-  --ch-bg-subtle: #0b1220;
-  --ch-border: #1f2937;
-  --ch-border-light: #1a2433;
-  --ch-text: #e5e7eb;
-  --ch-text-secondary: #c7cdd6;
-  --ch-text-muted: #8a93a3;
-  --ch-accent: #3b82f6;
-  --ch-accent-hover: #60a5fa;
-  --ch-green: #4ade80;
-  --ch-green-dot: #22c55e;
-  --ch-green-bg: rgba(34, 197, 94, 0.12);
-  --ch-red: #f87171;
-  --ch-red-bg: rgba(239, 68, 68, 0.12);
-  --ch-purple: #c4b5fd;
-  --ch-purple-bg: rgba(139, 92, 246, 0.14);
-  --ch-purple-border: rgba(139, 92, 246, 0.32);
+  /* Dark-theme additions to the Tailwind palette (the light tokens
+     above are still available). All values come from the Tailwind
+     palette so a future colour audit only has to look at these
+     palette aliases. */
+  --ch-slate-950: #020617;
+  --ch-blue-400: #60a5fa;
+  --ch-green-400: #4ade80;
+  --ch-red-400: #f87171;
+  --ch-red-500: #ef4444;
+  --ch-violet-300: #c4b5fd;
+  --ch-violet-500: #8b5cf6;
+
+  /* Semantic aliases re-pointed at darker tones. */
+  --ch-bg: var(--ch-slate-900);
+  --ch-bg-muted: var(--ch-gray-900);
+  --ch-bg-subtle: var(--ch-slate-950);
+  --ch-bg-hover: var(--ch-slate-800);
+  --ch-border: var(--ch-gray-800);
+  --ch-border-light: var(--ch-slate-800);
+  --ch-text: var(--ch-gray-200);
+  --ch-text-secondary: var(--ch-slate-300);
+  --ch-text-muted: var(--ch-slate-400);
+  --ch-accent: var(--ch-blue-500);
+  --ch-accent-hover: var(--ch-blue-400);
+  --ch-accent-disabled: var(--ch-blue-700);
+  --ch-green: var(--ch-green-400);
+  --ch-green-dot: var(--ch-green-500);
+  --ch-green-bg: color-mix(in srgb, var(--ch-green-500) 12%, transparent);
+  --ch-red: var(--ch-red-400);
+  --ch-red-bg: color-mix(in srgb, var(--ch-red-500) 12%, transparent);
+  --ch-purple: var(--ch-violet-300);
+  --ch-purple-bg: color-mix(in srgb, var(--ch-violet-500) 14%, transparent);
+  --ch-purple-border: color-mix(in srgb, var(--ch-violet-500) 32%, transparent);
   /* Badge inherits the dark-mode accent (the var() declared above
      auto-tracks --ch-accent), but bg/border need explicit dark tints. */
-  --ch-badge-bg: rgba(59, 130, 246, 0.14);
-  --ch-badge-border: rgba(59, 130, 246, 0.32);
+  --ch-badge-bg: color-mix(in srgb, var(--ch-blue-500) 14%, transparent);
+  --ch-badge-border: color-mix(in srgb, var(--ch-blue-500) 32%, transparent);
+  --ch-overlay: color-mix(in srgb, var(--ch-black) 65%, transparent);
   --ch-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 1px 3px rgba(0, 0, 0, 0.4);
+    0 1px 2px color-mix(in srgb, var(--ch-black) 50%, transparent),
+    0 1px 3px color-mix(in srgb, var(--ch-black) 40%, transparent);
 }
 
 :global(html.dark) .instructionsBody code {
-  background: #1e293b;
-  border-color: #334155;
-  color: #e2e8f0;
+  background: var(--ch-slate-800);
+  border-color: var(--ch-slate-700);
+  color: var(--ch-slate-200);
 }
 :global(html.dark) .hintBox {
-  background: rgba(59, 130, 246, 0.10);
-  border-color: rgba(59, 130, 246, 0.35);
-  color: #bfdbfe;
+  background: color-mix(in srgb, var(--ch-blue-500) 10%, transparent);
+  border-color: color-mix(in srgb, var(--ch-blue-500) 35%, transparent);
+  color: var(--ch-blue-200);
 }
 :global(html.dark) .hintBox code {
-  background: rgba(59, 130, 246, 0.18);
-  border-color: rgba(59, 130, 246, 0.4);
-  color: #dbeafe;
+  background: color-mix(in srgb, var(--ch-blue-500) 18%, transparent);
+  border-color: color-mix(in srgb, var(--ch-blue-500) 40%, transparent);
+  color: var(--ch-blue-100);
 }
 :global(html.dark) .initToggle:hover {
-  background: #1a2433;
+  background: var(--ch-slate-800);
 }
 :global(html.dark) .utilBtn:hover:not(:disabled),
 :global(html.dark) .copyBtn:hover {
-  background: #1a2433;
+  background: var(--ch-slate-800);
   color: var(--ch-text);
 }
 :global(html.dark) .checkBtn:hover:not(:disabled) {
-  background: rgba(59, 130, 246, 0.15);
+  background: color-mix(in srgb, var(--ch-blue-500) 15%, transparent);
 }
 :global(html.dark) .kbd {
-  background: #1f2937;
-  color: #cbd5e1;
-  box-shadow: 0 1px 0 #0b1220;
+  background: var(--ch-gray-800);
+  color: var(--ch-slate-300);
+  box-shadow: 0 1px 0 var(--ch-slate-950);
 }
 :global(html.dark) .testItem {
-  background: #0b1220;
-  border-color: #1a2433;
+  background: var(--ch-slate-950);
+  border-color: var(--ch-slate-800);
 }
 :global(html.dark) .testPanelHeader:hover {
-  background: #1a2433;
+  background: var(--ch-slate-800);
 }
 :global(html.dark) .testPill[data-state="pending"] {
-  background: #1f2937;
-  border-color: #334155;
+  background: var(--ch-gray-800);
+  border-color: var(--ch-slate-700);
 }
 :global(html.dark) .banner[data-state="pass"] .bannerIcon {
-  background: rgba(34, 197, 94, 0.22);
+  background: color-mix(in srgb, var(--ch-green-500) 22%, transparent);
 }
 :global(html.dark) .banner[data-state="fail"] .bannerIcon {
-  background: rgba(239, 68, 68, 0.22);
+  background: color-mix(in srgb, var(--ch-red-500) 22%, transparent);
 }
 :global(html.dark) .outCellHtml :global(th) {
-  background: #111827;
-  border-color: #1f2937;
-  color: #94a3b8;
+  background: var(--ch-gray-900);
+  border-color: var(--ch-gray-800);
+  color: var(--ch-slate-400);
 }
 :global(html.dark) .outCellHtml :global(td) {
-  border-color: #1a2433;
+  border-color: var(--ch-slate-800);
   color: var(--ch-text);
 }
 :global(html.dark) .outCellHtml :global(tr:hover td) {
-  background: #111827;
+  background: var(--ch-gray-900);
 }
 
 /* ─── Table viewer (SQL) ────────────────────────────────────────────── */
@@ -1379,10 +1591,10 @@
   user-select: none;
 }
 .tableViewerHeader:hover {
-  background: #f4f4f5;
+  background: var(--ch-bg-hover);
 }
 :global(html.dark) .tableViewerHeader:hover {
-  background: #1a2433;
+  background: var(--ch-slate-800);
 }
 .tableViewerLabel {
   font-size: 10.5px;
@@ -1446,16 +1658,16 @@
   font-family: var(--ch-font-mono);
 }
 .tableViewerEmpty code {
-  background: #f1f5f9;
-  border: 1px solid #e2e8f0;
+  background: var(--ch-slate-100);
+  border: 1px solid var(--ch-slate-200);
   border-radius: 3px;
   padding: 1px 5px;
-  color: #0f172a;
+  color: var(--ch-slate-900);
 }
 :global(html.dark) .tableViewerEmpty code {
-  background: #1e293b;
-  border-color: #334155;
-  color: #e2e8f0;
+  background: var(--ch-slate-800);
+  border-color: var(--ch-slate-700);
+  color: var(--ch-slate-200);
 }
 .tableViewerFootnote {
   padding: 4px 10px;
@@ -1486,19 +1698,19 @@
   align-items: center;
   gap: 10px;
   padding: 6px 8px 6px 12px;
-  background: #111827;
-  color: #f9fafb;
+  background: var(--ch-gray-900);
+  color: var(--ch-gray-50);
   font-size: 12px;
   font-family: var(--ch-font-ui);
   border-radius: 6px;
   box-shadow:
-    0 10px 25px rgba(0, 0, 0, 0.15),
-    0 4px 10px rgba(0, 0, 0, 0.10);
+    0 10px 25px color-mix(in srgb, var(--ch-black) 15%, transparent),
+    0 4px 10px color-mix(in srgb, var(--ch-black) 10%, transparent);
   animation: ch-toast-in 0.16s ease-out;
   max-width: 320px;
 }
 .toast[data-kind="warn"] {
-  background: #7f1d1d;
+  background: var(--ch-red-900);
 }
 .toast > button {
   display: inline-flex;
@@ -1506,15 +1718,15 @@
   justify-content: center;
   background: transparent;
   border: none;
-  color: rgba(249, 250, 251, 0.7);
+  color: color-mix(in srgb, var(--ch-gray-50) 70%, transparent);
   padding: 2px;
   border-radius: 3px;
   cursor: pointer;
   transition: color 0.12s, background 0.12s;
 }
 .toast > button:hover {
-  color: #fff;
-  background: rgba(255, 255, 255, 0.12);
+  color: var(--ch-white);
+  background: color-mix(in srgb, var(--ch-white) 12%, transparent);
 }
 @keyframes ch-toast-in {
   from { opacity: 0; transform: translateY(6px); }

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -171,6 +171,95 @@
   color: var(--ch-text-muted);
 }
 
+/* ─── Solution modal ──────────────────────────────────────────────── */
+
+.modalBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.modalCard {
+  max-width: 720px;
+  width: 100%;
+  max-height: 80vh;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+.modalHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--ch-border-light);
+}
+.modalTitleArea {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.modalTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ch-text);
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.modalSubtitle {
+  font-size: 12px;
+  color: var(--ch-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.modalActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.modalIconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: var(--ch-text-muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.modalIconBtn:hover {
+  background: #f4f4f5;
+  color: var(--ch-text);
+  border-color: var(--ch-border-light);
+}
+.modalEditor {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+.modalEditor :global(.cm-editor) {
+  height: 100%;
+  font-family: var(--ch-font-mono);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.modalEditor :global(.cm-scroller) {
+  font-family: inherit;
+}
+
 /* ─── Instructions ────────────────────────────────────────────────── */
 
 .instructions {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -839,16 +839,27 @@
   z-index: 1100;
   outline: none;
 }
+/* The menu lives in a portal outside `.card`, so the --ch-* tokens
+   defined on `.card` don't reach it via inheritance. Inline the few
+   Tailwind palette + semantic tokens the menu actually needs here so
+   the popup renders with the same blue chrome as the Submit button. */
 .runMenuPopup {
-  background: var(--ch-white);
-  border: 1px solid var(--ch-border);
+  --ch-white: #ffffff;
+  --ch-black: #000000;
+  --ch-blue-500: #3b82f6;
+  --ch-blue-600: #2563eb;
+  --ch-blue-700: #1d4ed8;
+  --ch-blue-900: #1e3a8a;
+
+  background: var(--ch-blue-600);
+  border: 1px solid var(--ch-blue-700);
   border-radius: 8px;
   box-shadow:
-    0 1px 2px color-mix(in srgb, var(--ch-slate-900) 4%, transparent),
-    0 8px 24px color-mix(in srgb, var(--ch-slate-900) 10%, transparent);
+    0 1px 2px color-mix(in srgb, var(--ch-black) 12%, transparent),
+    0 8px 24px color-mix(in srgb, var(--ch-black) 22%, transparent);
   padding: 4px;
   min-width: 240px;
-  font-family: var(--ch-font-ui);
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
   outline: none;
 }
 .runMenuItem {
@@ -860,7 +871,7 @@
   background: transparent;
   border: none;
   border-radius: 5px;
-  color: var(--ch-text);
+  color: var(--ch-white);
   font-size: 13px;
   cursor: pointer;
   text-align: left;
@@ -868,11 +879,12 @@
 }
 .runMenuItem:hover,
 .runMenuItem[data-highlighted] {
-  background: var(--ch-bg-subtle);
+  background: var(--ch-blue-700);
 }
 .runMenuItem svg {
   flex-shrink: 0;
-  color: var(--ch-accent);
+  width: 12px;
+  height: 12px;
 }
 .runMenuLabel {
   flex: 1;
@@ -883,6 +895,24 @@
   align-items: center;
   gap: 3px;
   flex-shrink: 0;
+}
+/* Kbd chips inside the menu mirror the embedded kbd inside the Run
+   button — semi-transparent white pill on the accent background. */
+.runMenuKbd .kbd {
+  background: color-mix(in srgb, var(--ch-white) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ch-white) 28%, transparent);
+  color: color-mix(in srgb, var(--ch-white) 88%, transparent);
+  box-shadow: none;
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+  font-size: 10.5px;
+  padding: 2px 5px;
+  border-radius: 4px;
+  line-height: 1;
+  font-weight: 500;
+}
+.runMenuKbd .kbdSep {
+  color: color-mix(in srgb, var(--ch-white) 50%, transparent);
+  font-size: 11px;
 }
 .runBtn {
   background: var(--ch-accent);
@@ -906,10 +936,14 @@
   cursor: not-allowed;
 }
 .runBtn svg {
-  width: 11px;
-  height: 11px;
-  fill: white;
-  stroke: white;
+  /* Use the surrounding currentColor (white) for both fill and stroke
+     by default so the custom PlayIcon (filled triangle) renders
+     filled while Lucide icons (which set fill="none" on the root and
+     stroke="currentColor") still draw their strokes. Explicit
+     `fill: white` would paint the inside of Lucide stroke paths and
+     turn the Check tick into a blob. */
+  width: 12px;
+  height: 12px;
 }
 .runBtnSpinner {
   animation: ch-spin 0.75s linear infinite;
@@ -985,6 +1019,28 @@
   align-items: center;
   flex-shrink: 0;
   margin-left: auto;
+  gap: 0;
+  min-width: 0;
+}
+/* Runtime status text shown next to the utility buttons while a run
+   is in flight. Truncates rather than wrapping so long messages
+   ("Loading browsercc clang toolchain (this can take a moment)…")
+   don't push the Reset / Solution / Copy buttons off-screen. */
+.actionBarStatus {
+  font-family: var(--ch-font-mono);
+  font-size: 11px;
+  color: var(--ch-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+  margin-right: 6px;
+  padding: 0 4px;
+  flex-shrink: 1;
+  min-width: 0;
+}
+.actionBarStatus[data-status="error"] {
+  color: var(--ch-red);
 }
 .btnGroupUtilSep {
   width: 1px;

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -97,6 +97,18 @@ interface DisplayedTest {
   detail: string | null;
 }
 
+/** One file in a multi-file challenge workspace. Authors who only need
+ *  a single editable file should pass `initialCode` instead — `files`
+ *  is for cases where the learner edits more than one file (e.g. a
+ *  Java challenge with both `Main.java` and `Dog.java`). */
+export interface ChallengeFile {
+  /** Workspace-relative filename, e.g. `"Dog.java"`. */
+  filename: string;
+  /** Starter content shown in the editor for this file. Reset restores
+   *  this exact text. */
+  initialContent: string;
+}
+
 export interface ChallengeCardProps {
   /** Language adapter used for both running the code and building the
    *  test harness. Pass the same instance as a CodeBlock would. */
@@ -114,8 +126,19 @@ export interface ChallengeCardProps {
    *  panel above the editor, mirroring `<CodeBlock>`'s `initCode`. */
   initCode?: string;
   /** Starting source loaded into the editor. The Reset button restores
-   *  this exact text. */
-  initialCode: string;
+   *  this exact text. Ignored when `files` is supplied. */
+  initialCode?: string;
+  /** Multi-file workspace. When set, takes precedence over
+   *  `initialCode`. A non-sortable, non-closeable tab bar appears above
+   *  the editor so the learner can switch between files. Tests still
+   *  run against `entryFilename` (or the first file when omitted) —
+   *  every other file is staged into the runtime's virtual file system
+   *  via `prepareFileSystem` so multi-file `import`s / `include`s /
+   *  cross-class references resolve. */
+  files?: ChallengeFile[];
+  /** When `files` is set, the filename whose content is passed to
+   *  `runtime.run()` as the entry. Defaults to the first file. */
+  entryFilename?: string;
   /** Canonical reference solution. When provided, a "Show Solution"
    *  button appears in the toolbar that opens a read-only modal. */
   solutionCode?: string;
@@ -137,6 +160,34 @@ function detectIsMac(): boolean {
 // card rather than a console. We always render the IntelliJ IDEA
 // CodeMirror theme so the editor matches the card chrome.
 const CM_EDITOR_THEME = "idea";
+
+// Sine-wave running overlay — mirrors `<CodeBlock>`'s RunOverlay so the
+// challenge card shows the same blue-wave hint while running/submitting.
+function RunOverlay({ active }: { active: boolean }) {
+  return (
+    <div
+      className={`${styles.runOverlay}${active ? ` ${styles.runOverlayActive}` : ""}`}
+      aria-hidden="true"
+    >
+      <div className={styles.runGlow} />
+      <svg
+        className={styles.runWaves}
+        viewBox="0 0 240 28"
+        preserveAspectRatio="none"
+      >
+        <path
+          className={styles.runWaveBack}
+          d="M0 18 C 20 14, 40 14, 60 18 S 100 22, 120 18 S 160 14, 180 18 S 220 22, 240 18 S 280 14, 300 18 S 340 22, 360 18 S 400 14, 420 18 S 460 22, 480 18 L 480 28 L 0 28 Z"
+        />
+        <path
+          className={styles.runWaveFront}
+          d="M0 21 C 20 17, 40 17, 60 21 S 100 25, 120 21 S 160 17, 180 21 S 220 25, 240 21 S 280 17, 300 21 S 340 25, 360 21 S 400 17, 420 21 S 460 25, 480 21 L 480 28 L 0 28 Z"
+        />
+      </svg>
+      <div className={styles.runStream} />
+    </div>
+  );
+}
 
 function LanguageGlyph({ adapter }: { adapter: LanguageAdapter }) {
   const Icon = LANGUAGE_ICONS[adapter.id];
@@ -177,6 +228,8 @@ export default function ChallengeCard({
   instructions,
   initCode,
   initialCode,
+  files,
+  entryFilename,
   solutionCode,
   tests,
 }: ChallengeCardProps) {
@@ -185,6 +238,21 @@ export default function ChallengeCard({
   const hasInit = trimmedInit.length > 0;
   const initLineCount = hasInit ? trimmedInit.split("\n").length : 0;
   const initPanelId = `${blockId}-init`;
+
+  // Normalize prop shape into a list of files. Single-file authors pass
+  // `initialCode`; multi-file authors pass `files`. We always work with
+  // the array internally so the rest of the component is uniform.
+  const workspaceFiles: ChallengeFile[] = useMemo(() => {
+    if (files && files.length > 0) return files;
+    const defaultName = `main.${adapter.defaultFileExtension || "txt"}`;
+    return [{ filename: defaultName, initialContent: initialCode ?? "" }];
+  }, [files, initialCode, adapter.defaultFileExtension]);
+
+  const isMultiFile = workspaceFiles.length > 1;
+  const resolvedEntryFilename =
+    (entryFilename && workspaceFiles.find((f) => f.filename === entryFilename)
+      ? entryFilename
+      : workspaceFiles[0].filename) ?? workspaceFiles[0].filename;
 
   const editorHostRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<EditorView | null>(null);
@@ -196,14 +264,28 @@ export default function ChallengeCard({
   // buffer. See `persistedKey` below.
   const persistSaveTimerRef = useRef<number | null>(null);
 
-  // Stable localStorage key for this challenge's editor buffer. The
-  // fingerprint includes the starter source so editing the MDX
-  // `initialCode` retires any saved attempts against the old prompt.
-  // `title` is in the fingerprint too so a challenge whose starter code
-  // happens to be identical to another's (e.g. both start with
-  // `// TODO`) doesn't collide.
+  // Stable per-file localStorage keys. The workspace fingerprint
+  // includes every starter so editing the MDX retires saved attempts
+  // against the old prompt; the filename is appended per file so each
+  // tab persists independently.
+  const workspaceFingerprint = useMemo(
+    () =>
+      workspaceFiles.map((f) => `${f.filename}:${f.initialContent}`).join("|"),
+    [workspaceFiles],
+  );
+  const persistedKeyForFile = useCallback(
+    (filename: string) =>
+      persistKey(
+        "challenge",
+        `${adapter.id}|${title}|${workspaceFingerprint}|${filename}`,
+      ),
+    [adapter.id, title, workspaceFingerprint],
+  );
+  // Legacy single-file key retained so existing challenges don't lose
+  // their saved buffers when this multi-file support shipped.
   const persistedKey = useMemo(
-    () => persistKey("challenge", `${adapter.id}|${title}|${initialCode}`),
+    () =>
+      persistKey("challenge", `${adapter.id}|${title}|${initialCode ?? ""}`),
     [adapter.id, title, initialCode],
   );
   // Shared per-adapter runtime, scoped to the fumadocs surface: every
@@ -232,6 +314,35 @@ export default function ChallengeCard({
   const [bannerState, setBannerState] = useState<"pass" | "fail" | null>(null);
   const toasts = useChallengeToasts();
 
+  // ─── Multi-file workspace state ─────────────────────────────────────
+  // Each file has its own buffer + persisted copy. The single editor
+  // view shows the active file; swapping tabs rewrites the doc with the
+  // saved buffer for the newly-active file.
+  const [activeFilename, setActiveFilename] = useState<string>(
+    workspaceFiles[0].filename,
+  );
+  // Initialise once from props + persisted localStorage. Subsequent
+  // edits drive this via the editor's update listener; tab switches
+  // read it to repopulate the doc.
+  const fileBuffersRef = useRef<Map<string, string>>(
+    new Map(
+      workspaceFiles.map((f) => {
+        if (isMultiFile) {
+          const persisted = loadPersistedCode(persistedKeyForFile(f.filename));
+          return [f.filename, persisted ?? f.initialContent];
+        }
+        // Single-file mode honours the legacy persistedKey so existing
+        // saved attempts survive.
+        const persisted = loadPersistedCode(persistedKey);
+        return [f.filename, persisted ?? f.initialContent];
+      }),
+    ),
+  );
+  const activeFilenameRef = useRef(activeFilename);
+  useEffect(() => {
+    activeFilenameRef.current = activeFilename;
+  }, [activeFilename]);
+
   const isMac = useSyncExternalStore(
     () => () => {},
     () => detectIsMac(),
@@ -240,6 +351,19 @@ export default function ChallengeCard({
 
   const canCheck = canRunTests(adapter.id, tests);
 
+  // Persist the active file's current doc content to its localStorage
+  // key. Used by both the debounced editor listener and tab-switch /
+  // unmount flushes.
+  const persistActiveFile = useCallback(
+    (filename: string, content: string) => {
+      const key = isMultiFile
+        ? persistedKeyForFile(filename)
+        : persistedKey;
+      savePersistedCode(key, content);
+    },
+    [isMultiFile, persistedKey, persistedKeyForFile],
+  );
+
   // ─── Editor mount ───────────────────────────────────────────────────
   useEffect(() => {
     if (!editorHostRef.current || editorRef.current) return;
@@ -247,10 +371,8 @@ export default function ChallengeCard({
     const languageComp = new Compartment();
     const lineOffset = hasInit ? initLineCount : 0;
 
-    // Restore the user's previously-saved buffer for this challenge,
-    // falling back to the MDX starter when there isn't one.
-    const persisted = loadPersistedCode(persistedKey);
-    const initialDoc = persisted ?? initialCode;
+    const initialDoc =
+      fileBuffersRef.current.get(activeFilenameRef.current) ?? "";
 
     const view = new EditorView({
       doc: initialDoc,
@@ -291,11 +413,14 @@ export default function ChallengeCard({
         // navigation away and back restore their in-progress attempt.
         EditorView.updateListener.of((update) => {
           if (!update.docChanged) return;
+          const filename = activeFilenameRef.current;
+          const content = update.state.doc.toString();
+          fileBuffersRef.current.set(filename, content);
           if (persistSaveTimerRef.current !== null)
             window.clearTimeout(persistSaveTimerRef.current);
           persistSaveTimerRef.current = window.setTimeout(() => {
             persistSaveTimerRef.current = null;
-            savePersistedCode(persistedKey, update.state.doc.toString());
+            persistActiveFile(filename, content);
           }, 400);
         }),
       ],
@@ -313,13 +438,42 @@ export default function ChallengeCard({
       if (persistSaveTimerRef.current !== null) {
         window.clearTimeout(persistSaveTimerRef.current);
         persistSaveTimerRef.current = null;
-        savePersistedCode(persistedKey, view.state.doc.toString());
+        const filename = activeFilenameRef.current;
+        persistActiveFile(filename, view.state.doc.toString());
       }
       view.destroy();
       editorRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Tab switch: flush any pending debounced save for the previously
+  // active file, snapshot the current editor doc into the file
+  // buffers Map, and load the newly-active file's buffer.
+  const previousActiveRef = useRef(activeFilename);
+  useEffect(() => {
+    const view = editorRef.current;
+    if (!view) {
+      previousActiveRef.current = activeFilename;
+      return;
+    }
+    const previousFilename = previousActiveRef.current;
+    if (previousFilename === activeFilename) return;
+    // Snapshot the outgoing file's buffer and flush its persisted copy.
+    const outgoingContent = view.state.doc.toString();
+    fileBuffersRef.current.set(previousFilename, outgoingContent);
+    if (persistSaveTimerRef.current !== null) {
+      window.clearTimeout(persistSaveTimerRef.current);
+      persistSaveTimerRef.current = null;
+    }
+    persistActiveFile(previousFilename, outgoingContent);
+    // Load the incoming file's buffer into the editor.
+    const incoming = fileBuffersRef.current.get(activeFilename) ?? "";
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: incoming },
+    });
+    previousActiveRef.current = activeFilename;
+  }, [activeFilename, persistActiveFile]);
 
   // Mount the read-only solution editor lazily when the modal opens.
   useEffect(() => {
@@ -389,15 +543,38 @@ export default function ChallengeCard({
 
   // ─── Execution helpers ─────────────────────────────────────────────
 
-  /** Execute a single combined snippet against the shared runtime,
-   *  capturing output cells via the streaming emitter. Returns the
-   *  collected cells and total elapsed milliseconds.
+  /** Snapshot every file's current content. Reads the active file from
+   *  the live editor (so unsaved edits propagate) and the rest from the
+   *  in-memory buffers Map. */
+  const snapshotAllFiles = useCallback((): Map<string, string> => {
+    const out = new Map<string, string>();
+    const view = editorRef.current;
+    const active = activeFilenameRef.current;
+    for (const f of workspaceFiles) {
+      if (view && f.filename === active) {
+        out.set(f.filename, view.state.doc.toString());
+      } else {
+        out.set(f.filename, fileBuffersRef.current.get(f.filename) ?? "");
+      }
+    }
+    return out;
+  }, [workspaceFiles]);
+
+  /** Execute the entry file's code against the shared runtime. Before
+   *  invoking `run()`, stage every workspace file into the runtime's
+   *  virtual file system (so multi-file `import`s / `include`s /
+   *  cross-class references resolve) via `prepareFileSystem`. The
+   *  caller passes a precomputed entry source so it can prepend the
+   *  init/harness blocks without us having to know about either.
    *
    *  Sentinel-line filtering for the test harness is handled by the
    *  caller (so plain Run can stream raw output, but Check can post-
    *  process the stdout to peel off `__DSTEST__:…` lines). */
   const execute = useCallback(
-    async (code: string): Promise<{ cells: OutputCell[]; elapsedMs: number }> => {
+    async (
+      entrySource: string,
+      filesSnapshot: Map<string, string>,
+    ): Promise<{ cells: OutputCell[]; elapsedMs: number }> => {
       const mySeq = ++runSeqRef.current;
       setOutputs([]);
       setStatus("loading");
@@ -430,25 +607,58 @@ export default function ChallengeCard({
       let nextOutputId = 0;
       const cells: OutputCell[] = [];
 
-      await runtime.run(code, (cell) => {
-        if (runSeqRef.current !== mySeq) return;
-        const elapsedMs = performance.now() - startedAt;
-        const fmt =
-          elapsedMs < 1000
-            ? `${elapsedMs.toFixed(0)}ms`
-            : `${(elapsedMs / 1000).toFixed(2)}s`;
-        const full: OutputCell = {
-          id: ++nextOutputId,
-          elapsed: fmt,
-          ...cell,
-        };
-        cells.push(full);
-      });
+      // Multi-file workspaces: stage every file into the runtime VFS so
+      // imports resolve. The entry file's bytes mirror what we pass to
+      // `run()` below, including any init prelude / harness suffix the
+      // caller bolted on. Adapters that don't support multi-file omit
+      // `prepareFileSystem` entirely — the call is a no-op there.
+      if (runtime.prepareFileSystem) {
+        const fileMap = new Map<string, Uint8Array>();
+        const encoder = new TextEncoder();
+        for (const [name, content] of filesSnapshot) {
+          fileMap.set(
+            name,
+            encoder.encode(
+              name === resolvedEntryFilename ? entrySource : content,
+            ),
+          );
+        }
+        try {
+          await runtime.prepareFileSystem(fileMap);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          cells.push({
+            id: ++nextOutputId,
+            type: "stderr",
+            content: `Failed to stage workspace files: ${message}`,
+            elapsed: "",
+          });
+        }
+      }
+
+      await runtime.run(
+        entrySource,
+        (cell) => {
+          if (runSeqRef.current !== mySeq) return;
+          const elapsedMs = performance.now() - startedAt;
+          const fmt =
+            elapsedMs < 1000
+              ? `${elapsedMs.toFixed(0)}ms`
+              : `${(elapsedMs / 1000).toFixed(2)}s`;
+          const full: OutputCell = {
+            id: ++nextOutputId,
+            elapsed: fmt,
+            ...cell,
+          };
+          cells.push(full);
+        },
+        isMultiFile ? { entryFilename: resolvedEntryFilename } : undefined,
+      );
 
       const elapsedMs = performance.now() - startedAt;
       return { cells, elapsedMs };
     },
-    [adapter],
+    [adapter, isMultiFile, resolvedEntryFilename],
   );
 
   const formatElapsed = (ms: number) =>
@@ -456,10 +666,11 @@ export default function ChallengeCard({
 
   // ─── Run (no tests) ────────────────────────────────────────────────
   const run = useCallback(async () => {
-    const userCode = editorRef.current?.state.doc.toString() ?? "";
-    const combined = hasInit ? `${trimmedInit}\n${userCode}` : userCode;
+    const snapshot = snapshotAllFiles();
+    const entryCode = snapshot.get(resolvedEntryFilename) ?? "";
+    const combined = hasInit ? `${trimmedInit}\n${entryCode}` : entryCode;
     try {
-      const { cells, elapsedMs } = await execute(combined);
+      const { cells, elapsedMs } = await execute(combined, snapshot);
       setOutputs(cells);
       setElapsed(formatElapsed(elapsedMs));
       const erred = cells.some((c) => c.type === "stderr");
@@ -478,13 +689,14 @@ export default function ChallengeCard({
       setStatus("error");
       setStatusMessage(message);
     }
-  }, [execute, hasInit, trimmedInit]);
+  }, [execute, hasInit, resolvedEntryFilename, snapshotAllFiles, trimmedInit]);
 
   // ─── Check Answer (run + tests) ─────────────────────────────────────
   const check = useCallback(async () => {
     if (!canCheck) return;
-    const userCode = editorRef.current?.state.doc.toString() ?? "";
-    const userPart = hasInit ? `${trimmedInit}\n${userCode}` : userCode;
+    const snapshot = snapshotAllFiles();
+    const entryCode = snapshot.get(resolvedEntryFilename) ?? "";
+    const userPart = hasInit ? `${trimmedInit}\n${entryCode}` : entryCode;
     // Build a native harness for the subset of tests that have a `code`
     // field. Stdout-based tests are evaluated separately after the run.
     const harness = buildHarness(adapter.id, tests);
@@ -505,7 +717,7 @@ export default function ChallengeCard({
     setTestListOpen(true);
 
     try {
-      const { cells, elapsedMs } = await execute(combined);
+      const { cells, elapsedMs } = await execute(combined, snapshot);
 
       // Split stdout cells into "user-visible" + parsed harness results.
       // Non-stdout cells (html / image / plot / stderr) pass through
@@ -586,7 +798,16 @@ export default function ChallengeCard({
       );
       setBannerState("fail");
     }
-  }, [adapter.id, canCheck, execute, hasInit, tests, trimmedInit]);
+  }, [
+    adapter.id,
+    canCheck,
+    execute,
+    hasInit,
+    resolvedEntryFilename,
+    snapshotAllFiles,
+    tests,
+    trimmedInit,
+  ]);
 
   // Keep the keymap closure pointing at the latest `run` handler.
   useEffect(() => {
@@ -596,20 +817,28 @@ export default function ChallengeCard({
   // ─── Reset ─────────────────────────────────────────────────────────
   const reset = useCallback(() => {
     runSeqRef.current++;
+    // Restore every file's buffer to its MDX starter, drop the active
+    // file's saved copy from localStorage so the next mount picks up
+    // the starter cleanly, and reload the active doc into the editor.
+    for (const f of workspaceFiles) {
+      fileBuffersRef.current.set(f.filename, f.initialContent);
+      const key = isMultiFile
+        ? persistedKeyForFile(f.filename)
+        : persistedKey;
+      clearPersistedCode(key);
+    }
     const view = editorRef.current;
     if (view) {
+      const active = activeFilenameRef.current;
+      const incoming = fileBuffersRef.current.get(active) ?? "";
       view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: initialCode },
+        changes: { from: 0, to: view.state.doc.length, insert: incoming },
       });
     }
-    // The dispatch above schedules a persist write of the starter; drop
-    // the debounce and the localStorage entry so the next mount picks up
-    // the MDX starter cleanly.
     if (persistSaveTimerRef.current !== null) {
       window.clearTimeout(persistSaveTimerRef.current);
       persistSaveTimerRef.current = null;
     }
-    clearPersistedCode(persistedKey);
     setOutputs([]);
     setElapsed("");
     setStatus("idle");
@@ -617,7 +846,13 @@ export default function ChallengeCard({
     setTestResults([]);
     setBannerState(null);
     toasts.show("Reset to starter code.");
-  }, [initialCode, persistedKey, toasts]);
+  }, [
+    isMultiFile,
+    persistedKey,
+    persistedKeyForFile,
+    toasts,
+    workspaceFiles,
+  ]);
 
   const copyCode = useCallback(async () => {
     const code = editorRef.current?.state.doc.toString() ?? "";
@@ -752,6 +987,38 @@ export default function ChallengeCard({
               aria-label="Initialization code (read-only)"
             />
           )}
+        </div>
+      )}
+
+      {/* ── File tab bar (multi-file workspaces only) ── */}
+      {isMultiFile && (
+        <div
+          className={styles.fileTabBar}
+          role="tablist"
+          aria-label="Workspace files"
+        >
+          {workspaceFiles.map((f) => {
+            const isActive = f.filename === activeFilename;
+            return (
+              <button
+                key={f.filename}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={`${styles.fileTab} ${
+                  isActive ? styles.fileTabActive : ""
+                }`}
+                onClick={() => setActiveFilename(f.filename)}
+                title={
+                  f.filename === resolvedEntryFilename
+                    ? `${f.filename} (entry)`
+                    : f.filename
+                }
+              >
+                {f.filename}
+              </button>
+            );
+          })}
         </div>
       )}
 
@@ -892,6 +1159,7 @@ export default function ChallengeCard({
               ))}
             </div>
           )}
+          <RunOverlay active={isBusy} />
         </div>
       )}
 

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -30,7 +30,8 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, Eye } from "lucide-react";
+import { RotateCcw, Check, X, ChevronDown, Eye, Play } from "lucide-react";
+import { Menu } from "@base-ui-components/react/menu";
 import {
   CopyIcon,
   PlayIcon,
@@ -396,6 +397,11 @@ export default function ChallengeCard({
   // Latest run handler — keeps the CodeMirror keymap closure
   // (registered once at mount) wired to the current function.
   const runRef = useRef<() => void>(() => {});
+  // Latest submit handler. Bound to Mod-Enter from the editor's
+  // keymap and to the split-button's default click. Falls back to
+  // `run` for challenges that don't supply tests, so Mod-Enter
+  // always does *something* sensible.
+  const submitRef = useRef<() => void>(() => {});
 
   const [status, setStatus] = useState<Status>("idle");
   const [statusMessage, setStatusMessage] = useState<string>("");
@@ -497,7 +503,22 @@ export default function ChallengeCard({
         EditorView.lineWrapping,
         keymap.of([
           {
+            // Default keyboard action mirrors the split button's
+            // default button: Submit (i.e. run + check tests). For
+            // challenges with no tests (`canCheck` false), the
+            // submit handler short-circuits to run + display output
+            // without ever flipping the pass/fail banner.
             key: "Mod-Enter",
+            run: () => {
+              submitRef.current();
+              return true;
+            },
+          },
+          {
+            // Dropdown action: run the code without grading it.
+            // Matches the dropdown menu item visible from the
+            // chevron on the Submit button.
+            key: "Mod-Shift-Enter",
             run: () => {
               runRef.current();
               return true;
@@ -650,9 +671,13 @@ export default function ChallengeCard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [solutionOpen, activeSolutionFile, activeSolutionSource]);
 
-  // Mount the read-only init editor lazily when expanded.
+  // Mount the read-only init editor once whenever `hasInit` becomes
+  // true. We keep the editor mounted even in the collapsed state so
+  // the learner can see the first few lines of context through the
+  // gradient fade — clicking the fade or the toggle expands the
+  // panel to the full height.
   useEffect(() => {
-    if (!hasInit || !initExpanded) return;
+    if (!hasInit) return;
     if (!initEditorHostRef.current || initEditorRef.current) return;
     const languageComp = new Compartment();
     const view = new EditorView({
@@ -681,7 +706,7 @@ export default function ChallengeCard({
       initEditorRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasInit, initExpanded]);
+  }, [hasInit]);
 
   // ─── Execution helpers ─────────────────────────────────────────────
 
@@ -990,6 +1015,13 @@ export default function ChallengeCard({
     checkRef.current = check;
   }, [check]);
 
+  // The split button's default action (and Mod-Enter) is "Submit"
+  // when the challenge actually has tests; otherwise it falls back
+  // to a plain Run so the keystroke isn't a dead key.
+  useEffect(() => {
+    submitRef.current = canCheck ? () => void check() : () => void run();
+  }, [canCheck, check, run]);
+
   // ─── Reset ─────────────────────────────────────────────────────────
   const reset = useCallback(() => {
     runSeqRef.current++;
@@ -1251,7 +1283,9 @@ export default function ChallengeCard({
         </div>
       </div>
 
-      {/* ── Init code (collapsed by default) ── */}
+      {/* ── Init code (collapsed by default — preview the first
+            ~3 lines under a gradient fade; click the fade or the
+            toggle to expand) ── */}
       {hasInit && (
         <div className={styles.initWrap}>
           <button
@@ -1276,14 +1310,29 @@ export default function ChallengeCard({
               {initLineCount} line{initLineCount === 1 ? "" : "s"} · read-only
             </span>
           </button>
-          {initExpanded && (
+          <div
+            className={`${styles.initEditorWrap} ${
+              initExpanded
+                ? styles.initEditorWrapOpen
+                : styles.initEditorWrapCollapsed
+            }`}
+          >
             <div
               id={initPanelId}
               className={styles.initEditor}
               ref={initEditorHostRef}
               aria-label="Initialization code (read-only)"
             />
-          )}
+            {!initExpanded && initLineCount > 3 && (
+              <button
+                type="button"
+                className={styles.initFade}
+                aria-label="Expand initialization code"
+                title="Expand initialization code"
+                onClick={() => setInitExpanded(true)}
+              />
+            )}
+          </div>
         </div>
       )}
 
@@ -1331,59 +1380,150 @@ export default function ChallengeCard({
       {/* ── Action bar ── */}
       <div className={styles.actionBar} role="toolbar" aria-label="Challenge controls">
         <div className={styles.btnGroupPrimary}>
-          <button
-            type="button"
-            className={styles.runBtn}
-            onClick={() => void run()}
-            disabled={isBusy}
-          >
-            {isBusy ? (
-              <svg
-                viewBox="0 0 12 12"
-                className={styles.runBtnSpinner}
-                aria-hidden
+          {canCheck ? (
+            <>
+              <button
+                type="button"
+                className={styles.runBtn}
+                onClick={() => void check()}
+                disabled={isBusy}
+                data-testid="challenge-submit"
               >
-                <circle
-                  cx="6"
-                  cy="6"
-                  r="4.5"
-                  fill="none"
-                  stroke="white"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeDasharray="14 8"
-                />
-              </svg>
-            ) : (
-              <PlayIcon />
-            )}
-            <span>{isBusy ? "Running…" : "Run"}</span>
-            {!isBusy && (
-              <span
-                className={styles.btnKbd}
-                title={isMac ? "Cmd + Enter" : "Ctrl + Enter"}
-              >
-                <kbd className={styles.kbd}>{isMac ? "⌘" : "Ctrl"}</kbd>
-                <span className={styles.kbdSep} aria-hidden>+</span>
-                <kbd className={styles.kbd}>↵</kbd>
-              </span>
-            )}
-          </button>
-          {canCheck && (
+                {isBusy ? (
+                  <svg
+                    viewBox="0 0 12 12"
+                    className={styles.runBtnSpinner}
+                    aria-hidden
+                  >
+                    <circle
+                      cx="6"
+                      cy="6"
+                      r="4.5"
+                      fill="none"
+                      stroke="white"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeDasharray="14 8"
+                    />
+                  </svg>
+                ) : (
+                  <Check size={12} strokeWidth={2.6} aria-hidden />
+                )}
+                <span>{isBusy ? "Submitting…" : "Submit"}</span>
+                {!isBusy && (
+                  <span
+                    className={styles.btnKbd}
+                    title={isMac ? "Cmd + Enter" : "Ctrl + Enter"}
+                  >
+                    <kbd className={styles.kbd}>{isMac ? "⌘" : "Ctrl"}</kbd>
+                    <span className={styles.kbdSep} aria-hidden>+</span>
+                    <kbd className={styles.kbd}>↵</kbd>
+                  </span>
+                )}
+              </button>
+              <Menu.Root>
+                <Menu.Trigger
+                  className={styles.runBtnChevron}
+                  disabled={isBusy}
+                  aria-label="More run options"
+                  title="More run options"
+                >
+                  <ChevronDown size={14} strokeWidth={2.4} aria-hidden />
+                </Menu.Trigger>
+                <Menu.Portal>
+                  <Menu.Positioner
+                    sideOffset={6}
+                    align="end"
+                    className={styles.runMenuPositioner}
+                  >
+                    <Menu.Popup className={styles.runMenuPopup}>
+                      <Menu.Item
+                        className={styles.runMenuItem}
+                        onClick={() => void run()}
+                      >
+                        <Play
+                          size={12}
+                          strokeWidth={2.4}
+                          fill="currentColor"
+                          aria-hidden
+                        />
+                        <span className={styles.runMenuLabel}>
+                          Run without Submitting
+                        </span>
+                        <span
+                          className={styles.runMenuKbd}
+                          title={
+                            isMac
+                              ? "Cmd + Shift + Enter"
+                              : "Ctrl + Shift + Enter"
+                          }
+                        >
+                          <kbd className={styles.kbd}>
+                            {isMac ? "⌘" : "Ctrl"}
+                          </kbd>
+                          <span
+                            className={styles.kbdSep}
+                            aria-hidden
+                          >
+                            +
+                          </span>
+                          <kbd className={styles.kbd}>⇧</kbd>
+                          <span
+                            className={styles.kbdSep}
+                            aria-hidden
+                          >
+                            +
+                          </span>
+                          <kbd className={styles.kbd}>↵</kbd>
+                        </span>
+                      </Menu.Item>
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
+            </>
+          ) : (
+            // Challenges without tests still get a plain Run pill —
+            // no menu, no dropdown — since there's nothing to
+            // submit. The keymap above falls back to `run` for the
+            // same reason.
             <button
               type="button"
-              className={styles.checkBtn}
-              onClick={() => void check()}
+              className={styles.runBtn}
+              onClick={() => void run()}
               disabled={isBusy}
-              data-testid="challenge-submit"
             >
-              <Check size={12} strokeWidth={2.5} aria-hidden />
-              <span>Submit</span>
-              <span className={styles.btnKbd} title="Shift + Enter">
-                <kbd className={styles.kbd}>⇧</kbd>
-                <span className={styles.kbdSep} aria-hidden>+</span>
-                <kbd className={styles.kbd}>↵</kbd>
-              </span>
+              {isBusy ? (
+                <svg
+                  viewBox="0 0 12 12"
+                  className={styles.runBtnSpinner}
+                  aria-hidden
+                >
+                  <circle
+                    cx="6"
+                    cy="6"
+                    r="4.5"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeDasharray="14 8"
+                  />
+                </svg>
+              ) : (
+                <PlayIcon />
+              )}
+              <span>{isBusy ? "Running…" : "Run"}</span>
+              {!isBusy && (
+                <span
+                  className={styles.btnKbd}
+                  title={isMac ? "Cmd + Enter" : "Ctrl + Enter"}
+                >
+                  <kbd className={styles.kbd}>{isMac ? "⌘" : "Ctrl"}</kbd>
+                  <span className={styles.kbdSep} aria-hidden>+</span>
+                  <kbd className={styles.kbd}>↵</kbd>
+                </span>
+              )}
             </button>
           )}
         </div>

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -49,7 +49,7 @@ import {
   drawSelection,
   dropCursor,
 } from "@codemirror/view";
-import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import {
   bracketMatching,
   indentOnInput,
@@ -107,6 +107,25 @@ export interface ChallengeFile {
   /** Starter content shown in the editor for this file. Reset restores
    *  this exact text. */
   initialContent: string;
+  /** Optional reference solution for this file. When at least one file
+   *  in a multi-file challenge supplies `solutionContent`, the
+   *  Solution modal renders the same file tab bar (non-sortable,
+   *  non-closeable) so the learner can flip between files; files that
+   *  omit `solutionContent` are shown with their `initialContent` (the
+   *  scaffold the learner does not need to modify). */
+  solutionContent?: string;
+}
+
+interface SolutionFile {
+  filename: string;
+  source: string;
+  /** True when the author supplied a real solution for this file
+   *  (single-file `solutionCode`, or multi-file `solutionContent`).
+   *  False when we are echoing back the file's `initialContent`
+   *  because the file is part of the scaffold the learner is not
+   *  expected to modify. The modal labels these "(unchanged)" so
+   *  the learner can tell the file apart from one they should edit. */
+  hasSolution: boolean;
 }
 
 export interface ChallengeCardProps {
@@ -153,6 +172,22 @@ function detectIsMac(): boolean {
   const platform = navigator.platform || "";
   const ua = navigator.userAgent || "";
   return /Mac|iPhone|iPod/.test(platform) || /Macintosh/.test(ua);
+}
+
+// Pick a line-comment prefix for the language. Used only to prepend a
+// human-readable "init code runs first" notice at the top of solution
+// files — the comment must parse as a no-op in the target language so
+// the displayed solution still pastes back as valid source.
+function lineCommentFor(codeMirrorMode: string): string {
+  switch (codeMirrorMode) {
+    case "python":
+    case "r":
+      return "#";
+    case "sql":
+      return "--";
+    default:
+      return "//";
+  }
 }
 
 // The challenge card is intentionally light-themed even when the
@@ -254,6 +289,37 @@ export default function ChallengeCard({
       ? entryFilename
       : workspaceFiles[0].filename) ?? workspaceFiles[0].filename;
 
+  // ─── Solution files ─────────────────────────────────────────────────
+  // Build the per-file solution view the modal renders. For single-file
+  // challenges the legacy `solutionCode` prop becomes the synthetic
+  // entry file's solution. For multi-file challenges, every file
+  // appears in the tab bar — files that supplied `solutionContent`
+  // show that text; files that did not are shown with their
+  // `initialContent` (the scaffold the learner is not expected to
+  // change). The modal opens iff at least one file actually has a
+  // solution.
+  const solutionFiles: SolutionFile[] = useMemo(() => {
+    const out: SolutionFile[] = [];
+    for (const file of workspaceFiles) {
+      const explicit = file.solutionContent;
+      if (isMultiFile) {
+        out.push({
+          filename: file.filename,
+          source: explicit ?? file.initialContent,
+          hasSolution: explicit !== undefined,
+        });
+      } else if (solutionCode !== undefined) {
+        out.push({
+          filename: file.filename,
+          source: solutionCode,
+          hasSolution: true,
+        });
+      }
+    }
+    return out;
+  }, [workspaceFiles, isMultiFile, solutionCode]);
+  const hasSolution = solutionFiles.some((f) => f.hasSolution);
+
   const editorHostRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<EditorView | null>(null);
   const initEditorHostRef = useRef<HTMLDivElement | null>(null);
@@ -309,6 +375,12 @@ export default function ChallengeCard({
   const [elapsed, setElapsed] = useState<string>("");
   const [initExpanded, setInitExpanded] = useState(false);
   const [solutionOpen, setSolutionOpen] = useState(false);
+  // Active file inside the solution modal. Independent of the
+  // workspace's active tab so opening the modal doesn't disturb where
+  // the learner was editing.
+  const [solutionActiveFilename, setSolutionActiveFilename] = useState<
+    string | null
+  >(null);
   const [testResults, setTestResults] = useState<DisplayedTest[]>([]);
   const [testListOpen, setTestListOpen] = useState(true);
   const [bannerState, setBannerState] = useState<"pass" | "fail" | null>(null);
@@ -406,6 +478,7 @@ export default function ChallengeCard({
           ...closeBracketsKeymap,
           ...defaultKeymap,
           ...historyKeymap,
+          indentWithTab,
         ]),
         languageComp.of([]),
         themeComp.of(themeFor(CM_EDITOR_THEME)),
@@ -475,18 +548,52 @@ export default function ChallengeCard({
     previousActiveRef.current = activeFilename;
   }, [activeFilename, persistActiveFile]);
 
-  // Mount the read-only solution editor lazily when the modal opens.
-  // We keep the doc editable at the contenteditable level (relying on
-  // `readOnly` to block insertions) so the user can click into the
-  // editor, move the caret, and select text — including Mod-A
-  // select-all, which is wired explicitly below since `editable.of(false)`
-  // would otherwise drop keyboard focus and disable the default keymap.
+  // Resolve which file the modal should display. Prefer the user's
+  // explicit click; otherwise default to the first file that actually
+  // has a real `solutionContent` so the modal lands on something the
+  // learner is supposed to read. Derived rather than stored so we
+  // don't need a `useEffect` to keep the selection in sync with
+  // `solutionFiles` (which would trigger react-hooks/set-state-in-effect).
+  const activeSolutionFile = useMemo(() => {
+    if (solutionFiles.length === 0) return null;
+    if (solutionActiveFilename) {
+      const match = solutionFiles.find(
+        (f) => f.filename === solutionActiveFilename,
+      );
+      if (match) return match;
+    }
+    return solutionFiles.find((f) => f.hasSolution) ?? solutionFiles[0];
+  }, [solutionFiles, solutionActiveFilename]);
+
+  // What text the modal actually displays for the active file. When
+  // `initCode` is set we prepend a single-line comment header so the
+  // learner knows there's read-only setup that runs before this code.
+  const activeSolutionSource = useMemo(() => {
+    if (!activeSolutionFile) return "";
+    if (!hasInit) return activeSolutionFile.source;
+    const prefix = lineCommentFor(adapter.codeMirrorMode);
+    const header = `${prefix} Initialization code (read-only) runs before this file. Solution begins below.\n\n`;
+    return header + activeSolutionFile.source;
+  }, [activeSolutionFile, hasInit, adapter.codeMirrorMode]);
+
+  // Mount / re-mount the read-only solution editor whenever the modal
+  // opens or the active solution file changes. We keep the doc
+  // editable at the contenteditable level (relying on `readOnly` to
+  // block insertions) so the user can click into the editor, move the
+  // caret, and select text — including Mod-A select-all, which is
+  // wired explicitly below since `editable.of(false)` would otherwise
+  // drop keyboard focus and disable the default keymap.
   useEffect(() => {
-    if (!solutionOpen || !solutionCode) return;
-    if (!solutionEditorHostRef.current || solutionEditorRef.current) return;
+    if (!solutionOpen || !activeSolutionFile) return;
+    if (!solutionEditorHostRef.current) return;
+    // Tear down a prior view so switching tabs rebuilds with the new doc.
+    if (solutionEditorRef.current) {
+      solutionEditorRef.current.destroy();
+      solutionEditorRef.current = null;
+    }
     const languageComp = new Compartment();
     const view = new EditorView({
-      doc: solutionCode,
+      doc: activeSolutionSource,
       parent: solutionEditorHostRef.current,
       extensions: [
         EditorState.readOnly.of(true),
@@ -508,10 +615,12 @@ export default function ChallengeCard({
     });
     return () => {
       view.destroy();
-      solutionEditorRef.current = null;
+      if (solutionEditorRef.current === view) {
+        solutionEditorRef.current = null;
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [solutionOpen]);
+  }, [solutionOpen, activeSolutionFile, activeSolutionSource]);
 
   // Mount the read-only init editor lazily when expanded.
   useEffect(() => {
@@ -1102,7 +1211,7 @@ export default function ChallengeCard({
             <RotateCcw size={12} strokeWidth={2.4} aria-hidden />
             Reset
           </button>
-          {solutionCode && (
+          {hasSolution && (
             <>
               <div className={styles.btnGroupUtilSep} aria-hidden />
               <button
@@ -1268,11 +1377,15 @@ export default function ChallengeCard({
       )}
 
       {/* ── Solution modal ── */}
-      {solutionOpen && solutionCode && (
+      {solutionOpen && hasSolution && activeSolutionFile && (
         <SolutionModal
           onClose={() => setSolutionOpen(false)}
           editorHostRef={solutionEditorHostRef}
-          source={solutionCode}
+          source={activeSolutionSource}
+          files={solutionFiles}
+          activeFilename={activeSolutionFile.filename}
+          onSelectFile={setSolutionActiveFilename}
+          showTabs={isMultiFile}
         />
       )}
 
@@ -1290,10 +1403,18 @@ function SolutionModal({
   onClose,
   editorHostRef,
   source,
+  files,
+  activeFilename,
+  onSelectFile,
+  showTabs,
 }: {
   onClose: () => void;
   editorHostRef: React.RefObject<HTMLDivElement | null>;
   source: string;
+  files: SolutionFile[];
+  activeFilename: string;
+  onSelectFile: (filename: string) => void;
+  showTabs: boolean;
 }) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -1356,6 +1477,43 @@ function SolutionModal({
             </button>
           </div>
         </div>
+        {showTabs && (
+          <div
+            className={styles.modalTabBar}
+            role="tablist"
+            aria-label="Solution files"
+          >
+            {files.map((f) => {
+              const isActive = f.filename === activeFilename;
+              return (
+                <button
+                  key={f.filename}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  className={
+                    isActive
+                      ? `${styles.modalTab} ${styles.modalTabActive}`
+                      : styles.modalTab
+                  }
+                  onClick={() => onSelectFile(f.filename)}
+                  title={
+                    f.hasSolution
+                      ? f.filename
+                      : `${f.filename} (unchanged from starter)`
+                  }
+                >
+                  {f.filename}
+                  {!f.hasSolution && (
+                    <span className={styles.modalTabHint} aria-hidden>
+                      ·
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
         <div
           ref={editorHostRef}
           className={styles.modalEditor}

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -404,6 +404,13 @@ export default function ChallengeCard({
   const submitRef = useRef<() => void>(() => {});
 
   const [status, setStatus] = useState<Status>("idle");
+  // Tracks which action triggered the in-flight run so the Submit
+  // pill can show the correct "Submitting…" vs "Running…" label
+  // (the dropdown's "Run without Submitting" item should *not* read
+  // as "Submitting…" while it's executing).
+  const [activeAction, setActiveAction] = useState<"submit" | "run" | null>(
+    null,
+  );
   const [statusMessage, setStatusMessage] = useState<string>("");
   const [outputs, setOutputs] = useState<OutputCell[]>([]);
   const [elapsed, setElapsed] = useState<string>("");
@@ -862,6 +869,7 @@ export default function ChallengeCard({
 
   // ─── Run (no tests) ────────────────────────────────────────────────
   const run = useCallback(async () => {
+    setActiveAction("run");
     const snapshot = snapshotAllFiles();
     const entryCode = snapshot.get(resolvedEntryFilename) ?? "";
     const combined = hasInit ? `${trimmedInit}\n${entryCode}` : entryCode;
@@ -884,12 +892,15 @@ export default function ChallengeCard({
       ]);
       setStatus("error");
       setStatusMessage(message);
+    } finally {
+      setActiveAction(null);
     }
   }, [execute, hasInit, resolvedEntryFilename, snapshotAllFiles, trimmedInit]);
 
   // ─── Check Answer (run + tests) ─────────────────────────────────────
   const check = useCallback(async () => {
     if (!canCheck) return;
+    setActiveAction("submit");
     const snapshot = snapshotAllFiles();
     const entryCode = snapshot.get(resolvedEntryFilename) ?? "";
     const userPart = hasInit ? `${trimmedInit}\n${entryCode}` : entryCode;
@@ -993,6 +1004,8 @@ export default function ChallengeCard({
         })),
       );
       setBannerState("fail");
+    } finally {
+      setActiveAction(null);
     }
   }, [
     adapter.id,
@@ -1409,7 +1422,13 @@ export default function ChallengeCard({
                 ) : (
                   <Check size={12} strokeWidth={2.6} aria-hidden />
                 )}
-                <span>{isBusy ? "Submitting…" : "Submit"}</span>
+                <span>
+                  {isBusy
+                    ? activeAction === "run"
+                      ? "Running…"
+                      : "Submitting…"
+                    : "Submit"}
+                </span>
                 {!isBusy && (
                   <span
                     className={styles.btnKbd}
@@ -1528,6 +1547,21 @@ export default function ChallengeCard({
           )}
         </div>
         <div className={styles.btnGroupUtil}>
+          {/* Runtime status / loading message — mirrors the executable
+              code block's status text. While the runtime is fetching
+              its WASM toolchain on first run, this surfaces "Loading
+              Pyodide", "Loading browsercc clang toolchain (this can
+              take a moment)…" etc. instead of leaving the user
+              staring at a spinning button with no context. */}
+          {isBusy && statusMessage && (
+            <span
+              className={styles.actionBarStatus}
+              data-status={status}
+              title={statusMessage}
+            >
+              {statusMessage}
+            </span>
+          )}
           <button
             type="button"
             className={styles.utilBtn}

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -116,6 +116,28 @@ export interface ChallengeFile {
   solutionContent?: string;
 }
 
+/** Imperative driver exposed on `window.__dsChallenges[adapter::title]`
+ *  so the Playwright solution sweep can load a card's reference
+ *  solution and trigger the test run without driving every keystroke
+ *  through the DOM. Production code must not depend on this — it is
+ *  a test surface and may change shape across releases. */
+export interface ChallengeTestHandle {
+  adapterId: string;
+  title: string;
+  entryFilename: string;
+  filenames: string[];
+  setFileContent(filename: string, content: string): boolean;
+  submit(): Promise<void>;
+  getStatus(): Status;
+  getBannerState(): "pass" | "fail" | null;
+  getTestResults(): {
+    id: string;
+    name: string;
+    state: TestState;
+    detail: string | null;
+  }[];
+}
+
 interface SolutionFile {
   filename: string;
   source: string;
@@ -928,6 +950,11 @@ export default function ChallengeCard({
     runRef.current = run;
   }, [run]);
 
+  // Keep the test driver's submit hook pointing at the latest `check`.
+  useEffect(() => {
+    checkRef.current = check;
+  }, [check]);
+
   // ─── Reset ─────────────────────────────────────────────────────────
   const reset = useCallback(() => {
     runSeqRef.current++;
@@ -966,6 +993,108 @@ export default function ChallengeCard({
     persistedKeyForFile,
     toasts,
     workspaceFiles,
+  ]);
+
+  // ─── Test hook ─────────────────────────────────────────────────────
+  // Expose an imperative driver on `window.__dsChallenges` so the
+  // Playwright solution sweep (e2e/challenge-solutions.spec.ts) can
+  // load a card's reference solution into its buffers and run the
+  // tests without round-tripping every keystroke through the DOM.
+  // The registry key is a (adapter.id, title) tuple — stable across
+  // page reloads, so the test can lock onto a card via the same
+  // identifier the data attributes expose.
+  const checkRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const testResultsRef = useRef(testResults);
+  const bannerStateRef = useRef(bannerState);
+  const statusRef = useRef<Status>(status);
+  useEffect(() => {
+    testResultsRef.current = testResults;
+  }, [testResults]);
+  useEffect(() => {
+    bannerStateRef.current = bannerState;
+  }, [bannerState]);
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const registry = (window as unknown as {
+      __dsChallenges?: Record<string, ChallengeTestHandle>;
+    }).__dsChallenges ?? {};
+    const key = `${adapter.id}::${title}`;
+    const handle: ChallengeTestHandle = {
+      adapterId: adapter.id,
+      title,
+      entryFilename: resolvedEntryFilename,
+      filenames: workspaceFiles.map((f) => f.filename),
+      setFileContent(filename, content) {
+        if (!fileBuffersRef.current.has(filename)) return false;
+        fileBuffersRef.current.set(filename, content);
+        if (activeFilenameRef.current === filename) {
+          const view = editorRef.current;
+          if (view) {
+            view.dispatch({
+              changes: {
+                from: 0,
+                to: view.state.doc.length,
+                insert: content,
+              },
+            });
+          }
+        } else {
+          // Persist so a later tab-switch picks up the new buffer.
+          const persisted = isMultiFile
+            ? persistedKeyForFile(filename)
+            : persistedKey;
+          try {
+            window.localStorage.setItem(persisted, content);
+          } catch {
+            /* quota / private mode — ignore, in-memory buffer still updated */
+          }
+        }
+        return true;
+      },
+      submit() {
+        return checkRef.current();
+      },
+      getStatus() {
+        return statusRef.current;
+      },
+      getBannerState() {
+        return bannerStateRef.current;
+      },
+      getTestResults() {
+        return testResultsRef.current.map((t) => ({
+          id: t.id,
+          name: t.name,
+          state: t.state,
+          detail: t.detail,
+        }));
+      },
+    };
+    (window as unknown as {
+      __dsChallenges: Record<string, ChallengeTestHandle>;
+    }).__dsChallenges = { ...registry, [key]: handle };
+    return () => {
+      const current = (window as unknown as {
+        __dsChallenges?: Record<string, ChallengeTestHandle>;
+      }).__dsChallenges;
+      if (current && current[key] === handle) {
+        const next = { ...current };
+        delete next[key];
+        (window as unknown as {
+          __dsChallenges: Record<string, ChallengeTestHandle>;
+        }).__dsChallenges = next;
+      }
+    };
+  }, [
+    adapter.id,
+    title,
+    resolvedEntryFilename,
+    workspaceFiles,
+    isMultiFile,
+    persistedKey,
+    persistedKeyForFile,
   ]);
 
   const copyCode = useCallback(async () => {
@@ -1015,10 +1144,29 @@ export default function ChallengeCard({
         ? "fail"
         : "pending";
 
+  // Test-only solution payload. Stamped onto the card as a JSON-encoded
+  // list of { filename, source } pairs so the Playwright solution
+  // runner (e2e/challenge-solutions.spec.ts) can drive each card
+  // without us having to parse MDX outside of next. Only files with
+  // an actual solution are included — scaffold files the learner is
+  // not expected to modify are omitted.
+  const solutionTestPayload = useMemo(() => {
+    const real = solutionFiles.filter((f) => f.hasSolution);
+    if (real.length === 0) return null;
+    return JSON.stringify(
+      real.map((f) => ({ filename: f.filename, source: f.source })),
+    );
+  }, [solutionFiles]);
+
   return (
     <div
       className={styles.card}
       aria-label={`${adapter.runtimeInfo.language} coding challenge: ${title}`}
+      data-testid="challenge-card"
+      data-adapter-id={adapter.id}
+      data-challenge-title={title}
+      data-entry-filename={resolvedEntryFilename}
+      data-solution-files={solutionTestPayload ?? undefined}
     >
       {/* ── Header ── */}
       <div className={styles.header}>
@@ -1128,6 +1276,8 @@ export default function ChallengeCard({
                     ? `${f.filename} (entry)`
                     : f.filename
                 }
+                data-testid="challenge-file-tab"
+                data-filename={f.filename}
               >
                 {f.filename}
               </button>
@@ -1190,6 +1340,7 @@ export default function ChallengeCard({
               className={styles.checkBtn}
               onClick={() => void check()}
               disabled={isBusy}
+              data-testid="challenge-submit"
             >
               <Check size={12} strokeWidth={2.5} aria-hidden />
               <span>Submit</span>
@@ -1349,7 +1500,11 @@ export default function ChallengeCard({
 
       {/* ── Banner ── */}
       {bannerState && (
-        <div className={styles.banner} data-state={bannerState}>
+        <div
+          className={styles.banner}
+          data-state={bannerState}
+          data-testid="challenge-banner"
+        >
           <div className={styles.bannerIcon}>
             {bannerState === "pass" ? (
               <Check size={14} strokeWidth={2.5} aria-hidden />

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -218,6 +218,12 @@ function lineCommentFor(codeMirrorMode: string): string {
 // CodeMirror theme so the editor matches the card chrome.
 const CM_EDITOR_THEME = "idea";
 
+// Minimum time (ms) the "running" overlay is held visible after a run
+// completes. Matches the playground's MIN_ANIMATION_MS so a fast run
+// (e.g. a few-line JS challenge that finishes in 20ms) doesn't blink
+// the wave animation in and back out within a single frame.
+const MIN_RUN_OVERLAY_MS = 300;
+
 // Sine-wave running overlay — mirrors `<CodeBlock>`'s RunOverlay so the
 // challenge card shows the same blue-wave hint while running/submitting.
 function RunOverlay({ active }: { active: boolean }) {
@@ -772,24 +778,53 @@ export default function ChallengeCard({
         }
       }
 
-      await runtime.run(
-        entrySource,
-        (cell) => {
-          if (runSeqRef.current !== mySeq) return;
-          const elapsedMs = performance.now() - startedAt;
-          const fmt =
-            elapsedMs < 1000
-              ? `${elapsedMs.toFixed(0)}ms`
-              : `${(elapsedMs / 1000).toFixed(2)}s`;
-          const full: OutputCell = {
-            id: ++nextOutputId,
-            elapsed: fmt,
-            ...cell,
-          };
-          cells.push(full);
-        },
-        isMultiFile ? { entryFilename: resolvedEntryFilename } : undefined,
-      );
+      try {
+        await runtime.run(
+          entrySource,
+          (cell) => {
+            if (runSeqRef.current !== mySeq) return;
+            const elapsedMs = performance.now() - startedAt;
+            const fmt =
+              elapsedMs < 1000
+                ? `${elapsedMs.toFixed(0)}ms`
+                : `${(elapsedMs / 1000).toFixed(2)}s`;
+            // Collapse consecutive stdout cells into a single block
+            // (matches the JS/TS/PHP playground behaviour where one
+            // console.log per cell would otherwise produce a noisy
+            // stack of one-line cells).
+            const last = cells[cells.length - 1];
+            if (
+              cell.type === "stdout" &&
+              last &&
+              last.type === "stdout"
+            ) {
+              cells[cells.length - 1] = {
+                ...last,
+                content: last.content + "\n" + cell.content,
+                elapsed: fmt,
+              };
+            } else {
+              const full: OutputCell = {
+                id: ++nextOutputId,
+                elapsed: fmt,
+                ...cell,
+              };
+              cells.push(full);
+            }
+          },
+          isMultiFile ? { entryFilename: resolvedEntryFilename } : undefined,
+        );
+      } finally {
+        // Hold the running overlay for at least MIN_RUN_OVERLAY_MS so
+        // the wave animation doesn't blink in/out on sub-frame runs.
+        // The `finally` covers the throw path so error states also
+        // get the same minimum visible duration; the thrown exception
+        // still propagates to the caller's catch.
+        const wait = MIN_RUN_OVERLAY_MS - (performance.now() - startedAt);
+        if (wait > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, wait));
+        }
+      }
 
       const elapsedMs = performance.now() - startedAt;
       return { cells, elapsedMs };
@@ -1293,8 +1328,8 @@ export default function ChallengeCard({
         aria-label={`${adapter.runtimeInfo.language} solution editor`}
       />
 
-      {/* ── Toolbar ── */}
-      <div className={styles.toolbar} role="toolbar" aria-label="Challenge controls">
+      {/* ── Action bar ── */}
+      <div className={styles.actionBar} role="toolbar" aria-label="Challenge controls">
         <div className={styles.btnGroupPrimary}>
           <button
             type="button"

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -476,6 +476,11 @@ export default function ChallengeCard({
   }, [activeFilename, persistActiveFile]);
 
   // Mount the read-only solution editor lazily when the modal opens.
+  // We keep the doc editable at the contenteditable level (relying on
+  // `readOnly` to block insertions) so the user can click into the
+  // editor, move the caret, and select text — including Mod-A
+  // select-all, which is wired explicitly below since `editable.of(false)`
+  // would otherwise drop keyboard focus and disable the default keymap.
   useEffect(() => {
     if (!solutionOpen || !solutionCode) return;
     if (!solutionEditorHostRef.current || solutionEditorRef.current) return;
@@ -485,12 +490,12 @@ export default function ChallengeCard({
       parent: solutionEditorHostRef.current,
       extensions: [
         EditorState.readOnly.of(true),
-        EditorView.editable.of(false),
         drawSelection(),
         lineNumbersExt(),
         EditorState.tabSize.of(4),
         indentUnit.of("    "),
         EditorView.lineWrapping,
+        keymap.of(defaultKeymap),
         languageComp.of([]),
         themeFor(CM_EDITOR_THEME),
       ],
@@ -1314,62 +1319,46 @@ function SolutionModal({
       aria-modal="true"
       aria-label="Reference solution"
       onClick={onClose}
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(15, 23, 42, 0.55)",
-        zIndex: 1000,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "24px",
-      }}
+      className={styles.modalBackdrop}
     >
       <div
-        className={styles.card}
+        className={`${styles.card} ${styles.modalCard}`}
         onClick={(e) => e.stopPropagation()}
-        style={{
-          maxWidth: "720px",
-          width: "100%",
-          maxHeight: "80vh",
-          margin: 0,
-          display: "flex",
-          flexDirection: "column",
-        }}
       >
-        <div className={styles.header} style={{ borderBottom: "1px solid var(--ch-border-light)" }}>
+        <div className={styles.modalHeader}>
           <div className={styles.badge}>
             <span className={styles.badgeDot} /> Solution
           </div>
-          <div className={styles.titleArea}>
-            <div className={styles.title}>Reference solution</div>
-            <div className={styles.meta}>
-              <span>One valid answer — there may be others.</span>
+          <div className={styles.modalTitleArea}>
+            <div className={styles.modalTitle}>Reference solution</div>
+            <div className={styles.modalSubtitle}>
+              One valid answer — there may be others.
             </div>
           </div>
-          <button
-            type="button"
-            onClick={() => void copySolution()}
-            aria-label="Copy solution"
-            title="Copy solution"
-            className={styles.copyBtn}
-            style={{ marginLeft: "auto" }}
-          >
-            <CopyIcon />
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            className={styles.copyBtn}
-          >
-            <X size={14} strokeWidth={2.4} aria-hidden />
-          </button>
+          <div className={styles.modalActions}>
+            <button
+              type="button"
+              onClick={() => void copySolution()}
+              aria-label="Copy solution"
+              title="Copy solution"
+              className={styles.modalIconBtn}
+            >
+              <CopyIcon />
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className={styles.modalIconBtn}
+            >
+              <X size={14} strokeWidth={2.4} aria-hidden />
+            </button>
+          </div>
         </div>
         <div
           ref={editorHostRef}
-          className={styles.editor}
-          style={{ flex: 1, overflow: "auto" }}
+          className={styles.modalEditor}
           aria-label="Solution editor (read-only)"
         />
       </div>

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -21,17 +21,59 @@
      so it doesn't leak onto the surrounding learning page. Dark mode
      values match the Dracula editor theme; light mode values match the
      IntelliJ IDEA editor theme (see overrides below). */
-  --cb-bg: #0f1117;
-  --cb-bg2: #161b27;
-  --cb-bg3: #1e2535;
-  --cb-border: #2a3347;
-  --cb-text: #e2e8f0;
-  --cb-text-dim: #64748b;
-  --cb-text-muted: #94a3b8;
-  --cb-accent: oklch(68% 0.18 250);
-  --cb-green: oklch(68% 0.18 145);
-  --cb-red: oklch(62% 0.18 15);
-  --cb-yellow: oklch(78% 0.16 85);
+  /* Tailwind palette tokens
+     (https://tailwindcss.com/docs/colors). The Dracula-flavoured
+     dark theme below maps onto the nearest Tailwind shades; the
+     light override at `[data-cb-theme="light"]` repoints them at
+     the lighter shades. */
+  --cb-white: #ffffff;
+  --cb-black: #000000;
+  --cb-slate-50: #f8fafc;
+  --cb-slate-200: #e2e8f0;
+  --cb-slate-300: #cbd5e1;
+  --cb-slate-400: #94a3b8;
+  --cb-slate-500: #64748b;
+  --cb-slate-600: #475569;
+  --cb-slate-700: #334155;
+  --cb-slate-800: #1e293b;
+  --cb-slate-900: #0f172a;
+  --cb-slate-950: #020617;
+  --cb-gray-100: #f3f4f6;
+  --cb-gray-200: #e5e7eb;
+  --cb-neutral-100: #f5f5f5;
+  --cb-neutral-300: #d4d4d4;
+  --cb-gray-500: #6b7280;
+  --cb-gray-600: #4b5563;
+  --cb-gray-700: #374151;
+  --cb-gray-800: #1f2937;
+  --cb-gray-900: #111827;
+  --cb-blue-50: #eff6ff;
+  --cb-blue-200: #bfdbfe;
+  --cb-blue-500: #3b82f6;
+  --cb-blue-600: #2563eb;
+  --cb-blue-700: #1d4ed8;
+  --cb-green-200: #bbf7d0;
+  --cb-green-500: #22c55e;
+  --cb-green-700: #15803d;
+  --cb-red-200: #fecaca;
+  --cb-red-500: #ef4444;
+  --cb-red-700: #b91c1c;
+  --cb-yellow-200: #fef08a;
+  --cb-yellow-400: #facc15;
+  --cb-yellow-700: #a16207;
+
+  /* Semantic aliases — dark variant. Light override below. */
+  --cb-bg: var(--cb-slate-950);
+  --cb-bg2: var(--cb-slate-900);
+  --cb-bg3: var(--cb-slate-800);
+  --cb-border: var(--cb-slate-700);
+  --cb-text: var(--cb-slate-200);
+  --cb-text-dim: var(--cb-slate-500);
+  --cb-text-muted: var(--cb-slate-400);
+  --cb-accent: var(--cb-blue-500);
+  --cb-green: var(--cb-green-500);
+  --cb-red: var(--cb-red-500);
+  --cb-yellow: var(--cb-yellow-400);
   --cb-font-ui: "Inter", system-ui, -apple-system, sans-serif;
   --cb-font-mono:
     "JetBrains Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace;
@@ -58,14 +100,14 @@
    blends into the surrounding pane bars instead of looking like a dark
    inset on a light page. */
 .codeBlock[data-cb-theme="light"] {
-  --cb-bg: #ffffff;
-  --cb-bg2: #f7f8fa;
-  --cb-bg3: #ebecf0;
-  --cb-border: #ebecf0;
-  --cb-text: #000000;
-  --cb-text-dim: #6c707e;
-  --cb-text-muted: #4f5258;
-  --cb-accent: oklch(58% 0.2 250);
+  --cb-bg: var(--cb-white);
+  --cb-bg2: var(--cb-slate-50);
+  --cb-bg3: var(--cb-gray-200);
+  --cb-border: var(--cb-gray-200);
+  --cb-text: var(--cb-black);
+  --cb-text-dim: var(--cb-slate-500);
+  --cb-text-muted: var(--cb-slate-600);
+  --cb-accent: var(--cb-blue-600);
 }
 
 /* ─── Header (id, language, status dot) ───────────────────────────── */
@@ -245,7 +287,7 @@
 
 .runBtn {
   background: var(--cb-accent);
-  color: #fff;
+  color: var(--cb-white);
   border: none;
   padding: 6px 12px;
   font-size: 13px;
@@ -294,12 +336,12 @@
 }
 .btnKbd .kbdSep {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.5);
+  color: color-mix(in srgb, var(--cb-white) 50%, transparent);
 }
 .runBtn .btnKbd .kbd {
-  background: rgba(255, 255, 255, 0.16);
-  border-color: rgba(255, 255, 255, 0.28);
-  color: rgba(255, 255, 255, 0.88);
+  background: color-mix(in srgb, var(--cb-white) 16%, transparent);
+  border-color: color-mix(in srgb, var(--cb-white) 28%, transparent);
+  color: color-mix(in srgb, var(--cb-white) 88%, transparent);
   box-shadow: none;
 }
 .kbd {
@@ -631,8 +673,24 @@
   text-transform: none;
   letter-spacing: 0;
 }
-.initEditor {
+/* Init editor wrapper — animates max-height between the collapsed
+   preview (~3 lines) and the fully expanded state. The gradient
+   .initFade overlays the bottom while collapsed. */
+.initEditorWrap {
+  position: relative;
   border-top: 1px solid var(--cb-border);
+  background: var(--cb-bg);
+  transition: max-height 0.18s ease;
+}
+.initEditorWrapCollapsed {
+  max-height: 68px;
+  overflow: hidden;
+}
+.initEditorWrapOpen {
+  max-height: none;
+  overflow: visible;
+}
+.initEditor {
   background: var(--cb-bg);
 }
 .initEditor :global(.cm-editor) {
@@ -643,7 +701,39 @@
   line-height: 1.7;
   font-variant-ligatures: none;
   font-feature-settings: "calt" 0, "liga" 0, "dlig" 0, "clig" 0;
-  cursor: not-allowed;
+  cursor: default;
+}
+
+/* Gradient fade rendered over the bottom of the collapsed init
+   editor. It's a real <button> so it picks up keyboard activation. */
+.initFade {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    transparent 35%,
+    color-mix(in srgb, var(--cb-bg) 70%, transparent) 60%,
+    var(--cb-bg) 100%
+  );
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+.initFade:hover {
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    transparent 25%,
+    color-mix(in srgb, var(--cb-bg) 70%, transparent) 55%,
+    var(--cb-bg) 100%
+  );
+}
+.initFade:focus-visible {
+  outline: 2px solid var(--cb-accent);
+  outline-offset: -2px;
 }
 .initEditor :global(.cm-editor .cm-scroller) {
   font-family: inherit;
@@ -689,8 +779,8 @@
   z-index: 0;
   /* Vertical alpha mask: opaque at the bottom, transparent at the top
      so the band blends into the action bar without a hard seam. */
-  -webkit-mask-image: linear-gradient(to top, #000 35%, transparent 100%);
-  mask-image: linear-gradient(to top, #000 35%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to top, var(--cb-black) 35%, transparent 100%);
+  mask-image: linear-gradient(to top, var(--cb-black) 35%, transparent 100%);
 }
 .runOverlay.runOverlayActive {
   opacity: 1;
@@ -821,13 +911,14 @@
   box-sizing: border-box;
   padding: 0.75rem 2.25rem 0.75rem 0.875rem;
   border-radius: 8px;
-  /* Dark (Dracula) values — matching --cb-bg2 / --cb-text / --cb-border */
-  background: #161b27;
-  color: #e2e8f0;
-  border: 1px solid #2a3347;
+  /* Dark theme — pulls from the same Tailwind tokens as the rest of
+     the block. */
+  background: var(--cb-slate-900);
+  color: var(--cb-slate-200);
+  border: 1px solid var(--cb-slate-700);
   box-shadow:
-    0 4px 16px rgb(0 0 0 / 0.18),
-    0 1px 4px rgb(0 0 0 / 0.08);
+    0 4px 16px color-mix(in srgb, var(--cb-black) 18%, transparent),
+    0 1px 4px color-mix(in srgb, var(--cb-black) 8%, transparent);
   background-clip: padding-box;
   font-family:
     "Inter",
@@ -857,21 +948,21 @@
 
 /* Light mode: IntelliJ IDEA token values */
 :global(html[data-theme="light"]) .toastRoot {
-  background: #f5f5f5;
-  color: #1f2937;
-  border-color: #d8d8d8;
+  background: var(--cb-neutral-100);
+  color: var(--cb-gray-800);
+  border-color: var(--cb-neutral-300);
   box-shadow:
-    0 4px 16px rgb(0 0 0 / 0.1),
-    0 1px 4px rgb(0 0 0 / 0.06);
+    0 4px 16px color-mix(in srgb, var(--cb-black) 10%, transparent),
+    0 1px 4px color-mix(in srgb, var(--cb-black) 6%, transparent);
 }
 /* Docs pages using next-themes class-based switching */
 :global(html.light) .toastRoot {
-  background: #f5f5f5;
-  color: #1f2937;
-  border-color: #d8d8d8;
+  background: var(--cb-neutral-100);
+  color: var(--cb-gray-800);
+  border-color: var(--cb-neutral-300);
   box-shadow:
-    0 4px 16px rgb(0 0 0 / 0.1),
-    0 1px 4px rgb(0 0 0 / 0.06);
+    0 4px 16px color-mix(in srgb, var(--cb-black) 10%, transparent),
+    0 1px 4px color-mix(in srgb, var(--cb-black) 6%, transparent);
 }
 
 .toastRoot[data-expanded] {
@@ -947,7 +1038,7 @@
   background: transparent;
   border: none;
   border-radius: 4px;
-  color: #64748b;
+  color: var(--cb-slate-500);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -955,11 +1046,11 @@
   line-height: 1;
 }
 .toastClose:hover {
-  color: #e2e8f0;
-  background: #1e2535;
+  color: var(--cb-slate-200);
+  background: var(--cb-slate-800);
 }
 :global(html[data-theme="light"]) .toastClose:hover,
 :global(html.light) .toastClose:hover {
-  color: #1f2937;
-  background: #ebebeb;
+  color: var(--cb-gray-800);
+  background: var(--cb-gray-200);
 }

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -206,11 +206,19 @@
 }
 
 /* ─── Action bar ──────────────────────────────────────────────────── */
+/* Visual styling mirrors `ChallengeCard.module.css`'s `.actionBar`
+   so the executable code block and the challenge card present the
+   same control row. Theme-sensitive colors come from `--cb-…`
+   variables so the dark (Dracula) theme still works — the
+   challenge-card variant is permanently light themed. */
 
 .actionBar {
-  padding: 8px 12px;
-  background: var(--cb-bg2);
+  display: flex;
+  align-items: center;
+  padding: 8px 14px;
   border-top: 1px solid var(--cb-border);
+  background: var(--cb-bg2);
+  gap: 0;
   flex-shrink: 0;
   position: relative;
 }
@@ -219,43 +227,51 @@
 .actionBarButtons {
   display: flex;
   align-items: center;
-  gap: 8px;
+  width: 100%;
+  gap: 0;
   position: relative;
   z-index: 1;
 }
 
-.runBtn {
+/* Primary group: just Run here (the challenge card variant adds a
+   Submit button alongside; the code block doesn't have one). */
+.btnGroupPrimary {
   display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 3px 14px;
-  border-radius: 4px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--cb-accent);
+  flex-shrink: 0;
+}
+
+.runBtn {
   background: var(--cb-accent);
+  color: #fff;
   border: none;
-  color: white;
-  font-family: var(--cb-font-ui);
+  padding: 6px 12px;
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  transition: background 0.15s, filter 0.15s;
+  font-family: var(--cb-font-ui);
 }
 .runBtn:hover:not(:disabled) {
   filter: brightness(1.1);
 }
 .runBtn:disabled {
-  opacity: 0.45;
+  opacity: 0.65;
   cursor: not-allowed;
   filter: none;
 }
 .runBtn svg {
-  width: 12px;
-  height: 12px;
-  flex-shrink: 0;
+  width: 11px;
+  height: 11px;
   fill: white;
   stroke: white;
 }
 .runBtnRunning {
-  opacity: 0.75;
   cursor: not-allowed;
 }
 .runBtnSpinner {
@@ -268,91 +284,94 @@
   }
 }
 
-.resetBtn {
+/* Inline kbd shortcut hint rendered inside the Run button — matches
+   the challenge card's `.btnKbd`. */
+.btnKbd {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 4px;
+}
+.btnKbd .kbdSep {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+}
+.runBtn .btnKbd .kbd {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.28);
+  color: rgba(255, 255, 255, 0.88);
+  box-shadow: none;
+}
+.kbd {
+  background: var(--cb-bg);
+  border: 1px solid var(--cb-border);
+  border-radius: 4px;
+  padding: 2px 5px;
+  font-size: 10.5px;
+  font-family: var(--cb-font-mono);
+  color: var(--cb-text-dim);
+  box-shadow: 0 1px 0 var(--cb-border);
+  line-height: 1;
+  font-weight: 500;
+}
+.kbdSep {
+  color: var(--cb-text-dim);
+  font-size: 11px;
+}
+
+/* Utility-button group on the right side of the action bar. Same
+   shape and treatment as the challenge card's `.btnGroupUtil`. */
+.btnGroupUtil {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+.btnGroupUtilSep {
+  width: 1px;
+  height: 16px;
+  background: var(--cb-border);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+.utilBtn {
+  background: transparent;
+  border: none;
+  color: var(--cb-text-dim);
+  font-size: 12.5px;
+  cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 3px 10px;
-  background: transparent;
-  border: 1px solid var(--cb-border);
-  border-radius: 4px;
-  color: var(--cb-text-dim);
+  padding: 5px 8px;
+  border-radius: 5px;
   font-family: var(--cb-font-ui);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition:
-    background 0.15s,
-    color 0.15s,
-    border-color 0.15s;
+  transition: color 0.15s, background 0.15s;
 }
-.resetBtn:hover:not(:disabled) {
-  background: var(--cb-bg3);
+.utilBtn:hover:not(:disabled) {
   color: var(--cb-text);
+  background: var(--cb-bg3);
 }
-.resetBtn:disabled {
+.utilBtn:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }
 
-/* Keyboard-shortcut hint — same look as the main playground's
-   `.kbd`/`.kbd-group`/`.kbd-plus` so the action bar reads as the
-   playground in miniature. */
-.kbdGroup {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.kbd {
-  font-family: var(--cb-font-mono);
-  font-size: 10px;
-  color: var(--cb-text-dim);
-  padding: 2px 6px;
-  border: 1px solid var(--cb-border);
-  border-radius: 4px;
-  background: var(--cb-bg);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  /* Reset browser UA stylesheet defaults for <kbd> — some browsers
-     (Firefox, Safari) render a raised/inset appearance with box-shadow
-     that looks out of place in the Dracula / IntelliJ IDEA chrome. */
-  box-shadow: none;
-  line-height: 1.4;
-  display: inline-flex;
-  align-items: center;
-}
-
-.kbdPlus {
-  font-family: var(--cb-font-mono);
-  font-size: 10px;
-  color: var(--cb-text-dim);
-  font-weight: 600;
-}
-
 /* Icon-only buttons (copy code, copy output) — sized to match the
-   surrounding action-bar / cell-header text controls. Mirrors the main
-   playground's `.icon-btn`. */
+   surrounding action-bar / cell-header text controls. */
 .iconBtn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
   background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--cb-radius);
+  border: none;
   color: var(--cb-text-dim);
   cursor: pointer;
-  padding: 0;
-  transition:
-    color 0.15s,
-    border-color 0.15s,
-    background 0.15s;
+  padding: 5px 7px;
+  border-radius: 5px;
+  display: inline-flex;
+  align-items: center;
+  transition: color 0.15s, background 0.15s;
 }
 .iconBtn:hover {
   color: var(--cb-text);
-  border-color: var(--cb-border);
   background: var(--cb-bg3);
 }
 .iconBtn:focus-visible {
@@ -363,8 +382,8 @@
   display: block;
 }
 
-.actionBarSpacer {
-  flex: 1 1 auto;
+@media (max-width: 480px) {
+  .btnKbd { display: none; }
 }
 
 .statusText {

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -255,6 +255,12 @@ function ToastList() {
   ));
 }
 
+// Minimum time (ms) the "running" overlay is held visible after a run
+// completes. Mirrors the playground's MIN_ANIMATION_MS so a fast
+// snippet (a few-line JS expression that finishes in 20ms) doesn't
+// blink the wave animation in and back out within a single frame.
+const MIN_RUN_OVERLAY_MS = 300;
+
 // Sine-wave running overlay — anchored to the bottom of the code block
 // and shorter (28 px) than the full playground variant (44 px).
 function RunOverlay({ active }: { active: boolean }) {
@@ -546,20 +552,50 @@ function CodeBlockInner({
 
       let nextOutputId = 0;
       const startedAt = performance.now();
-      await runtimeRef.current.run(code, (cell) => {
-        if (runSeqRef.current !== mySeq) return;
-        const elapsedMs = performance.now() - startedAt;
-        const elapsed =
-          elapsedMs < 1000
-            ? `${elapsedMs.toFixed(0)}ms`
-            : `${(elapsedMs / 1000).toFixed(2)}s`;
-        const fullCell: OutputCell = {
-          id: ++nextOutputId,
-          elapsed,
-          ...cell,
-        };
-        setOutputs((prev) => [...prev, fullCell]);
-      });
+      try {
+        await runtimeRef.current.run(code, (cell) => {
+          if (runSeqRef.current !== mySeq) return;
+          const elapsedMs = performance.now() - startedAt;
+          const elapsed =
+            elapsedMs < 1000
+              ? `${elapsedMs.toFixed(0)}ms`
+              : `${(elapsedMs / 1000).toFixed(2)}s`;
+          setOutputs((prev) => {
+            // Collapse consecutive stdout cells into a single block
+            // (matches the JS/TS/PHP playground behaviour where one
+            // console.log per cell would otherwise produce a noisy
+            // stack of one-line cells).
+            const last = prev[prev.length - 1];
+            if (
+              cell.type === "stdout" &&
+              last &&
+              last.type === "stdout"
+            ) {
+              const merged: OutputCell = {
+                ...last,
+                content: last.content + "\n" + cell.content,
+                elapsed,
+              };
+              return [...prev.slice(0, -1), merged];
+            }
+            const fullCell: OutputCell = {
+              id: ++nextOutputId,
+              elapsed,
+              ...cell,
+            };
+            return [...prev, fullCell];
+          });
+        });
+      } finally {
+        // Hold the running overlay for at least MIN_RUN_OVERLAY_MS so
+        // the wave animation doesn't blink in/out on sub-frame runs.
+        // Covers the throw path too so error states get the same
+        // minimum visible duration.
+        const wait = MIN_RUN_OVERLAY_MS - (performance.now() - startedAt);
+        if (wait > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, wait));
+        }
+      }
       if (runSeqRef.current !== mySeq) return;
       setStatus("ready");
       setStatusMessage("Done");
@@ -713,7 +749,7 @@ function CodeBlockInner({
         role="toolbar"
         aria-label="Code block actions"
       >
-        <div className={styles.actionBarButtons}>
+        <div className={styles.btnGroupPrimary}>
           <button
             type="button"
             className={`${styles.runBtn}${isBusy ? ` ${styles.runBtnRunning}` : ""}`}
@@ -741,27 +777,27 @@ function CodeBlockInner({
               <PlayIcon />
             )}
             <span>{isBusy ? "Running…" : "Run"}</span>
-          </button>
-          {!isBusy && (
-            <span
-              className={styles.kbdGroup}
-              title={isMac ? "Cmd + Enter" : "Ctrl + Enter"}
-            >
-              <kbd className={styles.kbd}>{isMac ? "⌘" : "Ctrl"}</kbd>
-              <span className={styles.kbdPlus} aria-hidden="true">
-                +
+            {!isBusy && (
+              <span
+                className={styles.btnKbd}
+                title={isMac ? "Cmd + Enter" : "Ctrl + Enter"}
+              >
+                <kbd className={styles.kbd}>{isMac ? "⌘" : "Ctrl"}</kbd>
+                <span className={styles.kbdSep} aria-hidden>+</span>
+                <kbd className={styles.kbd}>↵</kbd>
               </span>
-              <kbd className={styles.kbd}>Enter</kbd>
-            </span>
-          )}
+            )}
+          </button>
+        </div>
+        <div className={styles.btnGroupUtil}>
           <button
             type="button"
-            className={styles.resetBtn}
+            className={styles.utilBtn}
             onClick={reset}
             disabled={isBusy}
           >
-            <RotateCcw size={13} strokeWidth={2.4} aria-hidden />
-            <span>Reset</span>
+            <RotateCcw size={12} strokeWidth={2.4} aria-hidden />
+            Reset
           </button>
           <button
             type="button"
@@ -774,11 +810,13 @@ function CodeBlockInner({
           >
             <CopyIcon />
           </button>
-          <span className={styles.actionBarSpacer} />
           {statusMessage && (
-            <span className={styles.statusText} data-status={status}>
-              {statusMessage}
-            </span>
+            <>
+              <div className={styles.btnGroupUtilSep} aria-hidden />
+              <span className={styles.statusText} data-status={status}>
+                {statusMessage}
+              </span>
+            </>
           )}
         </div>
       </div>

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -478,10 +478,11 @@ function CodeBlockInner({
 
   // Mount the read-only init editor lazily, the first time the panel is
   // expanded — keeps the cost zero for collapsed init blocks. The cleanup
-  // destroys the EditorView when the panel collapses so React can safely
-  // unmount the host element.
+  // mounts once when `hasInit` becomes true so the collapsed preview
+  // can show the first few lines through the gradient fade. The
+  // EditorView lives until the surrounding component unmounts.
   useEffect(() => {
-    if (!hasInit || !initExpanded) return;
+    if (!hasInit) return;
     if (!initEditorHostRef.current || initEditorRef.current) return;
 
     const themeComp = new Compartment();
@@ -518,7 +519,7 @@ function CodeBlockInner({
       initThemeCompRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasInit, initExpanded]);
+  }, [hasInit]);
 
   // ─── Run / Reset ───────────────────────────────────────────────────────
   const run = useCallback(async () => {
@@ -727,14 +728,29 @@ function CodeBlockInner({
               {initLineCount} line{initLineCount === 1 ? "" : "s"} · read-only
             </span>
           </button>
-          {initExpanded && (
+          <div
+            className={`${styles.initEditorWrap} ${
+              initExpanded
+                ? styles.initEditorWrapOpen
+                : styles.initEditorWrapCollapsed
+            }`}
+          >
             <div
               id={initPanelId}
               className={styles.initEditor}
               aria-label={`${adapter.runtimeInfo.language} initialization code (read-only)`}
               ref={initEditorHostRef}
             />
-          )}
+            {!initExpanded && initLineCount > 3 && (
+              <button
+                type="button"
+                className={styles.initFade}
+                aria-label="Expand initialization code"
+                title="Expand initialization code"
+                onClick={() => setInitExpanded(true)}
+              />
+            )}
+          </div>
         </div>
       )}
 

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -27,7 +27,7 @@ import {
   drawSelection,
   dropCursor,
 } from "@codemirror/view";
-import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import {
   bracketMatching,
   indentOnInput,
@@ -411,6 +411,7 @@ function CodeBlockInner({
           ...closeBracketsKeymap,
           ...defaultKeymap,
           ...historyKeymap,
+          indentWithTab,
         ]),
         languageComp.of([]),
         themeComp.of(themeFor(cmThemeNameFor(detectIsDark()))),

--- a/app/_components/MdxChallengeCard.tsx
+++ b/app/_components/MdxChallengeCard.tsx
@@ -41,6 +41,8 @@ interface MdxChallengeCardProps
   tests: ChallengeTest[];
 }
 
+export type { ChallengeFile } from "./ChallengeCard";
+
 export default function MdxChallengeCard({
   adapter,
   ...rest

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -512,6 +512,12 @@ function detectIsMac(): boolean {
 
 const CM_EDITOR_THEME = "idea";
 
+// Minimum time (ms) the "running" overlay is held visible after a run
+// completes. Mirrors the playground's MIN_ANIMATION_MS so a fast
+// query doesn't blink the wave animation in and back out within a
+// single frame.
+const MIN_RUN_OVERLAY_MS = 300;
+
 /** Map a SQL dialect to the corresponding key in the shared
  *  `LANGUAGE_ICONS` registry so the SqlChallengeCard's runtime label
  *  uses the same brand glyph as the playground language switcher. */
@@ -912,7 +918,20 @@ export default function SqlChallengeCard({
       setStatus("running");
       setStatusMessage("Running…");
       const startedAt = performance.now();
-      const results = await engine.exec(sql);
+      let results: SqlResult[];
+      try {
+        results = await engine.exec(sql);
+      } finally {
+        // Hold the running overlay for at least MIN_RUN_OVERLAY_MS so
+        // the wave animation doesn't blink in/out on sub-frame runs.
+        // The throw path is covered here too so error states get the
+        // same minimum visible duration before the caller's catch
+        // swaps status to "error".
+        const wait = MIN_RUN_OVERLAY_MS - (performance.now() - startedAt);
+        if (wait > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, wait));
+        }
+      }
       const elapsedMs = performance.now() - startedAt;
       // The "last meaningful result" is the last result set with
       // columns. DML statements come back with empty columns so they
@@ -1351,8 +1370,8 @@ export default function SqlChallengeCard({
         aria-label="SQL solution editor"
       />
 
-      {/* ── Toolbar ── */}
-      <div className={styles.toolbar} role="toolbar" aria-label="Challenge controls">
+      {/* ── Action bar ── */}
+      <div className={styles.actionBar} role="toolbar" aria-label="Challenge controls">
         <div className={styles.btnGroupPrimary}>
           <button
             type="button"

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -67,6 +67,7 @@ import {
 } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
 import { themeFor } from "./cmExtensions";
+import { DUCKDB_VERSION } from "./runtime/duckdb";
 import {
   clearPersistedCode,
   loadPersistedCode,
@@ -200,7 +201,7 @@ async function createSqliteChallengeEngine(): Promise<SqlEngineLike> {
       );
     },
     label: "SQLite",
-    version: "3.x",
+    version: "3.53",
   };
 }
 
@@ -231,7 +232,7 @@ async function createPostgresChallengeEngine(): Promise<SqlEngineLike> {
       );
     },
     label: "PostgreSQL",
-    version: "via PGlite",
+    version: "17",
   };
 }
 
@@ -518,6 +519,34 @@ function languageIconKeyForDialect(d: SqlDialect): string {
   return d;
 }
 
+// Sine-wave running overlay — mirrors `<CodeBlock>`'s RunOverlay so the
+// SQL challenge card shows the same blue-wave hint while running/submitting.
+function RunOverlay({ active }: { active: boolean }) {
+  return (
+    <div
+      className={`${styles.runOverlay}${active ? ` ${styles.runOverlayActive}` : ""}`}
+      aria-hidden="true"
+    >
+      <div className={styles.runGlow} />
+      <svg
+        className={styles.runWaves}
+        viewBox="0 0 240 28"
+        preserveAspectRatio="none"
+      >
+        <path
+          className={styles.runWaveBack}
+          d="M0 18 C 20 14, 40 14, 60 18 S 100 22, 120 18 S 160 14, 180 18 S 220 22, 240 18 S 280 14, 300 18 S 340 22, 360 18 S 400 14, 420 18 S 460 22, 480 18 L 480 28 L 0 28 Z"
+        />
+        <path
+          className={styles.runWaveFront}
+          d="M0 21 C 20 17, 40 17, 60 21 S 100 25, 120 21 S 160 17, 180 21 S 220 25, 240 21 S 280 17, 300 21 S 340 25, 360 21 S 400 17, 420 21 S 460 25, 480 21 L 480 28 L 0 28 Z"
+        />
+      </svg>
+      <div className={styles.runStream} />
+    </div>
+  );
+}
+
 function DialectGlyph({ dialect }: { dialect: SqlDialect }) {
   const key = languageIconKeyForDialect(dialect);
   const Icon = LANGUAGE_ICONS[key];
@@ -599,10 +628,10 @@ export default function SqlChallengeCard({
   const toasts = useChallengeToasts();
   const [engineLabel, setEngineLabel] = useState<string>(
     dialect === "sqlite"
-      ? "SQLite"
+      ? "SQLite 3.53"
       : dialect === "duckdb"
-        ? "DuckDB"
-        : "PostgreSQL",
+        ? `DuckDB ${DUCKDB_VERSION}`
+        : "PostgreSQL 17",
   );
 
   const isMac = useSyncExternalStore(
@@ -1485,6 +1514,7 @@ export default function SqlChallengeCard({
           ) : (
             <div className={styles.sqlMessage}>Running…</div>
           )}
+          <RunOverlay active={isBusy} />
         </div>
       )}
 

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -623,6 +623,12 @@ export default function SqlChallengeCard({
   const submitRef = useRef<() => void>(() => {});
 
   const [status, setStatus] = useState<Status>("idle");
+  // Tracks which action triggered the in-flight run so the Submit
+  // pill can show "Submitting…" vs "Running…" correctly when the
+  // dropdown's "Run without Submitting" item is the trigger.
+  const [activeAction, setActiveAction] = useState<"submit" | "run" | null>(
+    null,
+  );
   const [statusMessage, setStatusMessage] = useState<string>("");
   const [resultSet, setResultSet] = useState<SqlResult | null>(null);
   const [resultMessage, setResultMessage] = useState<string>("");
@@ -970,6 +976,7 @@ export default function SqlChallengeCard({
 
   // ─── Run (no tests) ─────────────────────────────────────────────────
   const run = useCallback(async () => {
+    setActiveAction("run");
     const userSql = editorRef.current?.state.doc.toString() ?? "";
     setTestResults([]);
     setBannerState(null);
@@ -1005,12 +1012,16 @@ export default function SqlChallengeCard({
       setResultError(message);
       setStatus("error");
       setStatusMessage(message);
+    } finally {
+      setActiveAction(null);
     }
   }, [executeSql, ensureEngine, refreshTableViewer, tableViewerEnabled]);
 
   // ─── Check Answer (run + tests) ─────────────────────────────────────
   const check = useCallback(async () => {
     if (!canCheck) return;
+    setActiveAction("submit");
+    try {
     const userSql = editorRef.current?.state.doc.toString() ?? "";
 
     setTestResults(
@@ -1169,6 +1180,9 @@ export default function SqlChallengeCard({
       } catch {
         /* viewer refresh failure shouldn't mask the run's outcome */
       }
+    }
+    } finally {
+      setActiveAction(null);
     }
   }, [canCheck, ensureEngine, executeSql, refreshTableViewer, solutionSql, tableViewerEnabled, tests]);
 
@@ -1426,7 +1440,13 @@ export default function SqlChallengeCard({
                 ) : (
                   <Check size={12} strokeWidth={2.6} aria-hidden />
                 )}
-                <span>{isBusy ? "Submitting…" : "Submit"}</span>
+                <span>
+                  {isBusy
+                    ? activeAction === "run"
+                      ? "Running…"
+                      : "Submitting…"
+                    : "Submit"}
+                </span>
                 {!isBusy && (
                   <span
                     className={styles.btnKbd}
@@ -1538,6 +1558,19 @@ export default function SqlChallengeCard({
           )}
         </div>
         <div className={styles.btnGroupUtil}>
+          {/* Runtime status — shows "Loading PGlite", "Loading
+              DuckDB-WASM", etc. while the SQL engine is fetching its
+              WASM bundle on first run. Once the engine is warm this
+              stays hidden. */}
+          {isBusy && statusMessage && (
+            <span
+              className={styles.actionBarStatus}
+              data-status={status}
+              title={statusMessage}
+            >
+              {statusMessage}
+            </span>
+          )}
           <button
             type="button"
             className={styles.utilBtn}

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -59,7 +59,7 @@ import {
   drawSelection,
   dropCursor,
 } from "@codemirror/view";
-import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import {
   bracketMatching,
   indentOnInput,
@@ -681,6 +681,7 @@ export default function SqlChallengeCard({
           ...closeBracketsKeymap,
           ...defaultKeymap,
           ...historyKeymap,
+          indentWithTab,
         ]),
         languageComp.of([]),
         themeComp.of(themeFor(CM_EDITOR_THEME)),

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -38,6 +38,13 @@ import {
 import { RotateCcw, Check, X, ChevronDown, Eye, Play } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
   LANGUAGE_ICONS,
   LANGUAGE_ICON_COLORS,
   LANGUAGE_ICON_SIZE_FACTOR,
@@ -1647,34 +1654,10 @@ export default function SqlChallengeCard({
                 Query returned no rows.
               </div>
             ) : (
-              <div className={styles.sqlResultScroll}>
-                <table className={styles.sqlResultTable}>
-                  <thead>
-                    <tr>
-                      {resultSet.columns.map((c, i) => (
-                        <th key={i}>{c}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {resultSet.values.map((row, ri) => (
-                      <tr key={ri}>
-                        {row.map((cell, ci) => (
-                          <td key={ci}>
-                            {cell === null || cell === undefined ? (
-                              <span className={styles.sqlNullValue}>NULL</span>
-                            ) : cell instanceof Uint8Array ? (
-                              `<${cell.byteLength} bytes>`
-                            ) : (
-                              String(cell)
-                            )}
-                          </td>
-                        ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              <VirtualizedResultTable
+                columns={resultSet.columns}
+                values={resultSet.values}
+              />
             )
           ) : resultMessage ? (
             <div className={styles.sqlMessage}>{resultMessage}</div>
@@ -1885,6 +1868,135 @@ function SolutionModal({
 }
 
 /** Renders a single table's contents inside the table viewer panel.
+/** Virtualised SQL result table — used both by the main result pane
+ *  and the per-table viewer at the bottom of the card. The result
+ *  set is in memory by the time we render (executeSql returns the
+ *  full Promise<SqlResult>), so there's no per-page load — we just
+ *  render only the rows currently in the viewport via
+ *  `@tanstack/react-virtual` + a TanStack table for the column
+ *  definitions. For very wide tables the inner row is still a
+ *  regular `<tr>` so column auto-widths just work. */
+function VirtualizedResultTable({
+  columns,
+  values,
+  maxHeight,
+}: {
+  columns: string[];
+  values: unknown[][];
+  /** CSS max-height of the scroll container. Defaults to 320px so a
+   *  giant result set doesn't push the whole page below the fold. */
+  maxHeight?: number;
+}) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Stable row identity — TanStack Table keys rows by index when no
+  // explicit id is supplied, which is fine here since the result set
+  // never re-sorts in this component.
+  const data = useMemo(
+    () => values.map((row, i) => ({ __idx: i, row })),
+    [values],
+  );
+  const columnHelper = useMemo(
+    () => createColumnHelper<{ __idx: number; row: unknown[] }>(),
+    [],
+  );
+  const tableColumns = useMemo(
+    () =>
+      columns.map((c, i) =>
+        columnHelper.accessor((d) => d.row[i], {
+          id: `${i}`,
+          header: c,
+          cell: (info) => {
+            const v = info.getValue();
+            if (v === null || v === undefined) {
+              return <span className={styles.sqlNullValue}>NULL</span>;
+            }
+            if (v instanceof Uint8Array) {
+              return `<${v.byteLength} bytes>`;
+            }
+            return String(v);
+          },
+        }),
+      ),
+    [columns, columnHelper],
+  );
+  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table is required for the column / cell model.
+  const table = useReactTable({
+    data,
+    columns: tableColumns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+  const tableRows = table.getRowModel().rows;
+  const rowVirtualizer = useVirtualizer({
+    count: tableRows.length,
+    getScrollElement: () => scrollRef.current,
+    // Matches the playground's VIRTUAL_ROW_HEIGHT_ESTIMATE so the
+    // table feels identical to the playground's result pane.
+    estimateSize: () => 30,
+    overscan: 20,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const paddingTop = virtualRows.length > 0 ? (virtualRows[0]?.start ?? 0) : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? rowVirtualizer.getTotalSize() -
+        (virtualRows[virtualRows.length - 1]?.end ?? 0)
+      : 0;
+  const colSpan = tableColumns.length;
+
+  return (
+    <div
+      ref={scrollRef}
+      className={styles.sqlResultScroll}
+      style={{ maxHeight: maxHeight ?? 320 }}
+    >
+      <table className={styles.sqlResultTable}>
+        <thead>
+          {table.getHeaderGroups().map((hg) => (
+            <tr key={hg.id}>
+              {hg.headers.map((h) => (
+                <th key={h.id}>
+                  {h.isPlaceholder
+                    ? null
+                    : flexRender(h.column.columnDef.header, h.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {paddingTop > 0 && (
+            <tr aria-hidden style={{ height: paddingTop }}>
+              <td colSpan={colSpan} />
+            </tr>
+          )}
+          {virtualRows.map((vr) => {
+            const row = tableRows[vr.index];
+            return (
+              <tr
+                key={row.id}
+                data-index={vr.index}
+                ref={rowVirtualizer.measureElement}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+          {paddingBottom > 0 && (
+            <tr aria-hidden style={{ height: paddingBottom }}>
+              <td colSpan={colSpan} />
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Renders a single table's contents inside the table viewer panel.
  *  Errors and empty-table cases produce a contextual message rather
  *  than a blank pane. */
 function TableViewerPane({
@@ -1913,33 +2025,12 @@ function TableViewerPane({
     );
   }
   return (
-    <div className={styles.tableViewerScroll}>
-      <table className={styles.sqlResultTable}>
-        <thead>
-          <tr>
-            {r.columns.map((c, i) => (
-              <th key={i}>{c}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {r.values.map((row, ri) => (
-            <tr key={ri}>
-              {row.map((cell, ci) => (
-                <td key={ci}>
-                  {cell === null || cell === undefined ? (
-                    <span className={styles.sqlNullValue}>NULL</span>
-                  ) : cell instanceof Uint8Array ? (
-                    `<${cell.byteLength} bytes>`
-                  ) : (
-                    String(cell)
-                  )}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div>
+      <VirtualizedResultTable
+        columns={r.columns}
+        values={r.values}
+        maxHeight={220}
+      />
       {entry.truncated && (
         <div className={styles.tableViewerFootnote}>
           Showing first {limit} row{limit === 1 ? "" : "s"}.

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -725,6 +725,11 @@ export default function SqlChallengeCard({
   }, []);
 
   // Mount the read-only solution editor lazily when the modal opens.
+  // We keep the doc editable at the contenteditable level (relying on
+  // `readOnly` to block insertions) so the user can click into the
+  // editor and select text — including Mod-A select-all, wired via
+  // the default keymap below since `editable.of(false)` would
+  // otherwise disable keyboard focus and shortcuts.
   useEffect(() => {
     if (!solutionOpen || !solutionSql) return;
     if (!solutionEditorHostRef.current || solutionEditorRef.current) return;
@@ -734,12 +739,12 @@ export default function SqlChallengeCard({
       parent: solutionEditorHostRef.current,
       extensions: [
         EditorState.readOnly.of(true),
-        EditorView.editable.of(false),
         drawSelection(),
         lineNumbersExt(),
         EditorState.tabSize.of(2),
         indentUnit.of("  "),
         EditorView.lineWrapping,
+        keymap.of(defaultKeymap),
         languageComp.of([]),
         themeFor(CM_EDITOR_THEME),
       ],
@@ -1670,62 +1675,46 @@ function SolutionModal({
       aria-modal="true"
       aria-label="Reference solution"
       onClick={onClose}
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(15, 23, 42, 0.55)",
-        zIndex: 1000,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "24px",
-      }}
+      className={styles.modalBackdrop}
     >
       <div
-        className={styles.card}
+        className={`${styles.card} ${styles.modalCard}`}
         onClick={(e) => e.stopPropagation()}
-        style={{
-          maxWidth: "720px",
-          width: "100%",
-          maxHeight: "80vh",
-          margin: 0,
-          display: "flex",
-          flexDirection: "column",
-        }}
       >
-        <div className={styles.header} style={{ borderBottom: "1px solid var(--ch-border-light)" }}>
+        <div className={styles.modalHeader}>
           <div className={styles.badge}>
             <span className={styles.badgeDot} /> Solution
           </div>
-          <div className={styles.titleArea}>
-            <div className={styles.title}>Reference solution</div>
-            <div className={styles.meta}>
-              <span>One valid answer — there may be others.</span>
+          <div className={styles.modalTitleArea}>
+            <div className={styles.modalTitle}>Reference solution</div>
+            <div className={styles.modalSubtitle}>
+              One valid answer — there may be others.
             </div>
           </div>
-          <button
-            type="button"
-            onClick={() => void copySolution()}
-            aria-label="Copy solution"
-            title="Copy solution"
-            className={styles.copyBtn}
-            style={{ marginLeft: "auto" }}
-          >
-            <CopyIcon />
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            className={styles.copyBtn}
-          >
-            <X size={14} strokeWidth={2.4} aria-hidden />
-          </button>
+          <div className={styles.modalActions}>
+            <button
+              type="button"
+              onClick={() => void copySolution()}
+              aria-label="Copy solution"
+              title="Copy solution"
+              className={styles.modalIconBtn}
+            >
+              <CopyIcon />
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className={styles.modalIconBtn}
+            >
+              <X size={14} strokeWidth={2.4} aria-hidden />
+            </button>
+          </div>
         </div>
         <div
           ref={editorHostRef}
-          className={styles.editor}
-          style={{ flex: 1, overflow: "auto" }}
+          className={styles.modalEditor}
           aria-label="Solution editor (read-only)"
         />
       </div>

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -35,7 +35,8 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, Eye } from "lucide-react";
+import { RotateCcw, Check, X, ChevronDown, Eye, Play } from "lucide-react";
+import { Menu } from "@base-ui-components/react/menu";
 import {
   LANGUAGE_ICONS,
   LANGUAGE_ICON_COLORS,
@@ -617,6 +618,9 @@ export default function SqlChallengeCard({
   const engineSeededRef = useRef(false);
   const runSeqRef = useRef(0);
   const runRef = useRef<() => void>(() => {});
+  // Default action of the split button (Submit when canCheck,
+  // otherwise plain Run). Bound to Mod-Enter from the editor's keymap.
+  const submitRef = useRef<() => void>(() => {});
 
   const [status, setStatus] = useState<Status>("idle");
   const [statusMessage, setStatusMessage] = useState<string>("");
@@ -678,7 +682,21 @@ export default function SqlChallengeCard({
         EditorView.lineWrapping,
         keymap.of([
           {
+            // Default keyboard action mirrors the split button:
+            // Submit (run + grade against tests). For challenges
+            // with no tests, the submit handler short-circuits to a
+            // plain Run so the keystroke isn't a dead key.
             key: "Mod-Enter",
+            run: () => {
+              submitRef.current();
+              return true;
+            },
+          },
+          {
+            // Dropdown action: run the query without grading it,
+            // matching the menu item visible from the Submit
+            // button's chevron.
+            key: "Mod-Shift-Enter",
             run: () => {
               runRef.current();
               return true;
@@ -1159,6 +1177,13 @@ export default function SqlChallengeCard({
     runRef.current = run;
   }, [run]);
 
+  // The split button's default action (and Mod-Enter) is "Submit"
+  // when the challenge actually has tests; otherwise it falls back
+  // to a plain Run so the keystroke still does something useful.
+  useEffect(() => {
+    submitRef.current = canCheck ? () => void check() : () => void run();
+  }, [canCheck, check, run]);
+
   // ─── Reset ──────────────────────────────────────────────────────────
   // Reset restores the starter code AND re-seeds the database so
   // INSERT/UPDATE/DELETE exercises can be retried from a clean slate.
@@ -1373,58 +1398,142 @@ export default function SqlChallengeCard({
       {/* ── Action bar ── */}
       <div className={styles.actionBar} role="toolbar" aria-label="Challenge controls">
         <div className={styles.btnGroupPrimary}>
-          <button
-            type="button"
-            className={styles.runBtn}
-            onClick={() => void run()}
-            disabled={isBusy}
-          >
-            {isBusy ? (
-              <svg
-                viewBox="0 0 12 12"
-                className={styles.runBtnSpinner}
-                aria-hidden
+          {canCheck ? (
+            <>
+              <button
+                type="button"
+                className={styles.runBtn}
+                onClick={() => void check()}
+                disabled={isBusy}
               >
-                <circle
-                  cx="6"
-                  cy="6"
-                  r="4.5"
-                  fill="none"
-                  stroke="white"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeDasharray="14 8"
-                />
-              </svg>
-            ) : (
-              <PlayIcon />
-            )}
-            <span>{isBusy ? "Running…" : "Run"}</span>
-            {!isBusy && (
-              <span
-                className={styles.btnKbd}
-                title={isMac ? "Cmd + Enter" : "Ctrl + Enter"}
-              >
-                <kbd className={styles.kbd}>{isMac ? "⌘" : "Ctrl"}</kbd>
-                <span className={styles.kbdSep} aria-hidden>+</span>
-                <kbd className={styles.kbd}>↵</kbd>
-              </span>
-            )}
-          </button>
-          {canCheck && (
+                {isBusy ? (
+                  <svg
+                    viewBox="0 0 12 12"
+                    className={styles.runBtnSpinner}
+                    aria-hidden
+                  >
+                    <circle
+                      cx="6"
+                      cy="6"
+                      r="4.5"
+                      fill="none"
+                      stroke="white"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeDasharray="14 8"
+                    />
+                  </svg>
+                ) : (
+                  <Check size={12} strokeWidth={2.6} aria-hidden />
+                )}
+                <span>{isBusy ? "Submitting…" : "Submit"}</span>
+                {!isBusy && (
+                  <span
+                    className={styles.btnKbd}
+                    title={isMac ? "Cmd + Enter" : "Ctrl + Enter"}
+                  >
+                    <kbd className={styles.kbd}>{isMac ? "⌘" : "Ctrl"}</kbd>
+                    <span className={styles.kbdSep} aria-hidden>+</span>
+                    <kbd className={styles.kbd}>↵</kbd>
+                  </span>
+                )}
+              </button>
+              <Menu.Root>
+                <Menu.Trigger
+                  className={styles.runBtnChevron}
+                  disabled={isBusy}
+                  aria-label="More run options"
+                  title="More run options"
+                >
+                  <ChevronDown size={14} strokeWidth={2.4} aria-hidden />
+                </Menu.Trigger>
+                <Menu.Portal>
+                  <Menu.Positioner
+                    sideOffset={6}
+                    align="end"
+                    className={styles.runMenuPositioner}
+                  >
+                    <Menu.Popup className={styles.runMenuPopup}>
+                      <Menu.Item
+                        className={styles.runMenuItem}
+                        onClick={() => void run()}
+                      >
+                        <Play
+                          size={12}
+                          strokeWidth={2.4}
+                          fill="currentColor"
+                          aria-hidden
+                        />
+                        <span className={styles.runMenuLabel}>
+                          Run without Submitting
+                        </span>
+                        <span
+                          className={styles.runMenuKbd}
+                          title={
+                            isMac
+                              ? "Cmd + Shift + Enter"
+                              : "Ctrl + Shift + Enter"
+                          }
+                        >
+                          <kbd className={styles.kbd}>
+                            {isMac ? "⌘" : "Ctrl"}
+                          </kbd>
+                          <span className={styles.kbdSep} aria-hidden>
+                            +
+                          </span>
+                          <kbd className={styles.kbd}>⇧</kbd>
+                          <span className={styles.kbdSep} aria-hidden>
+                            +
+                          </span>
+                          <kbd className={styles.kbd}>↵</kbd>
+                        </span>
+                      </Menu.Item>
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
+            </>
+          ) : (
+            // No tests on this challenge: render a plain Run pill,
+            // no menu. Mod-Enter falls back to `run` for the same
+            // reason.
             <button
               type="button"
-              className={styles.checkBtn}
-              onClick={() => void check()}
+              className={styles.runBtn}
+              onClick={() => void run()}
               disabled={isBusy}
             >
-              <Check size={12} strokeWidth={2.5} aria-hidden />
-              <span>Submit</span>
-              <span className={styles.btnKbd} title="Shift + Enter">
-                <kbd className={styles.kbd}>⇧</kbd>
-                <span className={styles.kbdSep} aria-hidden>+</span>
-                <kbd className={styles.kbd}>↵</kbd>
-              </span>
+              {isBusy ? (
+                <svg
+                  viewBox="0 0 12 12"
+                  className={styles.runBtnSpinner}
+                  aria-hidden
+                >
+                  <circle
+                    cx="6"
+                    cy="6"
+                    r="4.5"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeDasharray="14 8"
+                  />
+                </svg>
+              ) : (
+                <PlayIcon />
+              )}
+              <span>{isBusy ? "Running…" : "Run"}</span>
+              {!isBusy && (
+                <span
+                  className={styles.btnKbd}
+                  title={isMac ? "Cmd + Enter" : "Ctrl + Enter"}
+                >
+                  <kbd className={styles.kbd}>{isMac ? "⌘" : "Ctrl"}</kbd>
+                  <span className={styles.kbdSep} aria-hidden>+</span>
+                  <kbd className={styles.kbd}>↵</kbd>
+                </span>
+              )}
             </button>
           )}
         </div>

--- a/app/_components/challengeHarness.ts
+++ b/app/_components/challengeHarness.ts
@@ -366,11 +366,17 @@ const buildJsHarness: HarnessBuilder = (tests) => {
  * R harness — same shape as the Python one, using `tryCatch` for the
  * pass / fail framing. Test bodies should call `stop("…")` (or any
  * function that calls it, e.g. `stopifnot()`) to signal failure.
+ *
+ * Note: R identifiers cannot begin with `_`, so the helper names use
+ * a leading `.` (which is conventional for "hidden" R variables) —
+ * `.dstest_run`, `.dstest_t0`, etc. Using the `__dstest…` form the
+ * other harnesses share would cause R's parser to fail with
+ * "unexpected input" on line 1 of the snippet.
  */
 const buildRHarness: HarnessBuilder = (tests) => {
   const lines: string[] = [];
   lines.push(`cat("${HARNESS_BEGIN}\\n")`);
-  lines.push("__dstest_run <- function(tid, fn) {");
+  lines.push(".dstest_run <- function(tid, fn) {");
   lines.push("  tryCatch({ fn();");
   lines.push(
     `    cat(paste0("${HARNESS_RESULT_PREFIX}", tid, ":PASS\\n"))`,
@@ -384,13 +390,13 @@ const buildRHarness: HarnessBuilder = (tests) => {
   lines.push("}");
   lines.push("");
   tests.forEach((t, i) => {
-    const fnName = `__dstest_t${i}`;
+    const fnName = `.dstest_t${i}`;
     const body = t.code.trim() || "invisible(NULL)";
     lines.push(`${fnName} <- function() {`);
     for (const raw of body.split("\n")) lines.push("  " + raw);
     lines.push("}");
     lines.push(
-      `__dstest_run(${JSON.stringify(t.id)}, ${fnName})`,
+      `.dstest_run(${JSON.stringify(t.id)}, ${fnName})`,
     );
     lines.push("");
   });

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -115,7 +115,7 @@ import {
   writeDataFile as opfsWriteDataFile,
 } from "../files/opfsDataStorage";
 import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
-import { type DuckDbEngine } from "../runtime/duckdb";
+import { type DuckDbEngine, DUCKDB_VERSION } from "../runtime/duckdb";
 
 const DUCKDB_SAMPLE_DATABASES = duckdbAdapter.samples;
 const DUCKDB_BLANK_DATABASE = duckdbAdapter.blankSample!;
@@ -860,8 +860,8 @@ const DEFAULT_PAGE_SIZE = 50;
 
 const RUNTIME_INFO: RuntimeInfo = {
   language: "DuckDB",
-  version: "1.30",
-  engine: "duckdb-wasm 1.30",
+  version: DUCKDB_VERSION,
+  engine: `duckdb-wasm ${DUCKDB_VERSION}`,
   engineUrl: "https://duckdb.org/docs/api/wasm/overview",
   notes:
     "Pure-WASM build of DuckDB that runs entirely in your browser. Each sample database is rebuilt in memory on every page load. DuckDB does not support triggers or VIRTUAL generated columns; STORED generated columns are supported.",

--- a/app/_components/runtime/duckdb.ts
+++ b/app/_components/runtime/duckdb.ts
@@ -86,7 +86,7 @@ interface DuckDbModule {
 // and cached by the browser. The promise is memoized so navigating
 // away and back doesn't re-fetch the module.
 
-const DUCKDB_VERSION = "1.32.0";
+export const DUCKDB_VERSION = "1.32.0";
 const DUCKDB_CDN = `https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@${DUCKDB_VERSION}/+esm`;
 
 let _duckdbModulePromise: Promise<DuckDbModule> | null = null;

--- a/content/learn/challenge-cards/c.mdx
+++ b/content/learn/challenge-cards/c.mdx
@@ -284,3 +284,35 @@ filesystem before each run, so the entry translation unit can
     },
   ]}
 />
+
+```jsx
+<ChallengeCard
+  adapter="c"
+  title="Implement greet() in utils.c"
+  instructions={`Open utils.c and implement greet() ...`}
+  entryFilename="main.c"
+  files={[
+    {
+      filename: "main.c",
+      initialContent: `#include "utils.h"\n\nint main(void) {\n    greet();\n    return 0;\n}\n`,
+    },
+    {
+      filename: "utils.h",
+      initialContent: `#ifndef UTILS_H\n#define UTILS_H\nvoid greet(void);\n#endif\n`,
+    },
+    {
+      filename: "utils.c",
+      initialContent: `#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n}\n`,
+      solutionContent: `#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n    printf("Hello, World!\\n");\n}\n`,
+    },
+  ]}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "Exact stdout match",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/c.mdx
+++ b/content/learn/challenge-cards/c.mdx
@@ -272,9 +272,9 @@ filesystem before each run, so the entry translation unit can
     {
       filename: "utils.c",
       initialContent: `#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n    // your code here\n}\n`,
+      solutionContent: `#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n    printf("Hello, World!\\n");\n}\n`,
     },
   ]}
-  solutionCode={`#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n    printf("Hello, World!\\n");\n}\n`}
   tests={[
     {
       id: "greets",

--- a/content/learn/challenge-cards/c.mdx
+++ b/content/learn/challenge-cards/c.mdx
@@ -247,3 +247,40 @@ int main(void) {
   ]}
 />
 ```
+
+## Multi-file challenge
+
+Multi-file challenges open with a non-sortable, non-closeable tab bar
+above the editor. Every file is staged into browsercc's virtual
+filesystem before each run, so the entry translation unit can
+`#include` sibling headers.
+
+<ChallengeCard
+  adapter="c"
+  title="Implement greet() in utils.c"
+  instructions={`Open \`utils.c\` and implement \`greet()\` so that it prints \`Hello, World!\` followed by a newline. \`main.c\` is provided — it calls \`greet()\` once.`}
+  entryFilename="main.c"
+  files={[
+    {
+      filename: "main.c",
+      initialContent: `#include "utils.h"\n\nint main(void) {\n    greet();\n    return 0;\n}\n`,
+    },
+    {
+      filename: "utils.h",
+      initialContent: `#ifndef UTILS_H\n#define UTILS_H\nvoid greet(void);\n#endif\n`,
+    },
+    {
+      filename: "utils.c",
+      initialContent: `#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n    // your code here\n}\n`,
+    },
+  ]}
+  solutionCode={`#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n    printf("Hello, World!\\n");\n}\n`}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "Exact stdout match",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>

--- a/content/learn/challenge-cards/cpp.mdx
+++ b/content/learn/challenge-cards/cpp.mdx
@@ -288,3 +288,35 @@ filesystem before each run, so the entry translation unit can
     },
   ]}
 />
+
+```jsx
+<ChallengeCard
+  adapter="cpp"
+  title="Implement Greeter::greet()"
+  instructions={`Open greeter.cpp and implement Greeter::greet() ...`}
+  entryFilename="main.cpp"
+  files={[
+    {
+      filename: "main.cpp",
+      initialContent: `#include "greeter.h"\n\nint main() {\n    Greeter g;\n    g.greet();\n    return 0;\n}\n`,
+    },
+    {
+      filename: "greeter.h",
+      initialContent: `#pragma once\nclass Greeter {\npublic:\n    void greet();\n};\n`,
+    },
+    {
+      filename: "greeter.cpp",
+      initialContent: `#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n}\n`,
+      solutionContent: `#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n    std::cout << "Hello, World!\\n";\n}\n`,
+    },
+  ]}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "Exact stdout match",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/cpp.mdx
+++ b/content/learn/challenge-cards/cpp.mdx
@@ -276,9 +276,9 @@ filesystem before each run, so the entry translation unit can
     {
       filename: "greeter.cpp",
       initialContent: `#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n    // your code here\n}\n`,
+      solutionContent: `#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n    std::cout << "Hello, World!\\n";\n}\n`,
     },
   ]}
-  solutionCode={`#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n    std::cout << "Hello, World!\\n";\n}\n`}
   tests={[
     {
       id: "greets",

--- a/content/learn/challenge-cards/cpp.mdx
+++ b/content/learn/challenge-cards/cpp.mdx
@@ -251,3 +251,40 @@ int main() {
   ]}
 />
 ```
+
+## Multi-file challenge
+
+Multi-file challenges open with a non-sortable, non-closeable tab bar
+above the editor. Every file is staged into browsercc's virtual
+filesystem before each run, so the entry translation unit can
+`#include` sibling headers.
+
+<ChallengeCard
+  adapter="cpp"
+  title="Implement Greeter::greet()"
+  instructions={`Open \`greeter.cpp\` and implement \`Greeter::greet()\` so that it prints \`Hello, World!\` followed by a newline. \`main.cpp\` is provided — it constructs a \`Greeter\` and calls \`greet()\`.`}
+  entryFilename="main.cpp"
+  files={[
+    {
+      filename: "main.cpp",
+      initialContent: `#include "greeter.h"\n\nint main() {\n    Greeter g;\n    g.greet();\n    return 0;\n}\n`,
+    },
+    {
+      filename: "greeter.h",
+      initialContent: `#pragma once\nclass Greeter {\npublic:\n    void greet();\n};\n`,
+    },
+    {
+      filename: "greeter.cpp",
+      initialContent: `#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n    // your code here\n}\n`,
+    },
+  ]}
+  solutionCode={`#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n    std::cout << "Hello, World!\\n";\n}\n`}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "Exact stdout match",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>

--- a/content/learn/challenge-cards/csharp.mdx
+++ b/content/learn/challenge-cards/csharp.mdx
@@ -292,9 +292,9 @@ types defined in sibling files.
     {
       filename: "Greeter.cs",
       initialContent: `public class Greeter\n{\n    public string Greet()\n    {\n        // your code here\n        return "";\n    }\n}\n`,
+      solutionContent: `public class Greeter\n{\n    public string Greet()\n    {\n        return "Hello, World!";\n    }\n}\n`,
     },
   ]}
-  solutionCode={`public class Greeter\n{\n    public string Greet()\n    {\n        return "Hello, World!";\n    }\n}\n`}
   tests={[
     {
       id: "greets",

--- a/content/learn/challenge-cards/csharp.mdx
+++ b/content/learn/challenge-cards/csharp.mdx
@@ -271,3 +271,36 @@ class Program {
   ]}
 />
 ```
+
+## Multi-file challenge
+
+Multi-file challenges open with a non-sortable, non-closeable tab bar
+above the editor. Every `.cs` file is staged into Roslyn's
+compilation unit before each run, so the entry script can reference
+types defined in sibling files.
+
+<ChallengeCard
+  adapter="csharp"
+  title="Implement Greeter.Greet()"
+  instructions={`Open \`Greeter.cs\` and implement \`Greet()\` so that it returns the string \`"Hello, World!"\`. The entry script \`Main.cs\` already constructs a \`Greeter\` and prints the result.`}
+  entryFilename="Main.cs"
+  files={[
+    {
+      filename: "Main.cs",
+      initialContent: `var g = new Greeter();\nSystem.Console.WriteLine(g.Greet());\n`,
+    },
+    {
+      filename: "Greeter.cs",
+      initialContent: `public class Greeter\n{\n    public string Greet()\n    {\n        // your code here\n        return "";\n    }\n}\n`,
+    },
+  ]}
+  solutionCode={`public class Greeter\n{\n    public string Greet()\n    {\n        return "Hello, World!";\n    }\n}\n`}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "Exact stdout match",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>

--- a/content/learn/challenge-cards/csharp.mdx
+++ b/content/learn/challenge-cards/csharp.mdx
@@ -304,3 +304,31 @@ types defined in sibling files.
     },
   ]}
 />
+
+```jsx
+<ChallengeCard
+  adapter="csharp"
+  title="Implement Greeter.Greet()"
+  instructions={`Open Greeter.cs and implement Greet() ...`}
+  entryFilename="Main.cs"
+  files={[
+    {
+      filename: "Main.cs",
+      initialContent: `var g = new Greeter();\nSystem.Console.WriteLine(g.Greet());\n`,
+    },
+    {
+      filename: "Greeter.cs",
+      initialContent: `public class Greeter\n{\n    public string Greet()\n    {\n        return "";\n    }\n}\n`,
+      solutionContent: `public class Greeter\n{\n    public string Greet()\n    {\n        return "Hello, World!";\n    }\n}\n`,
+    },
+  ]}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "Exact stdout match",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/duckdb.mdx
+++ b/content/learn/challenge-cards/duckdb.mdx
@@ -269,6 +269,7 @@ are rendered.
   title="Bucket 10,000 rows by score"
   instructions={`A 10,000-row table \`big\` is preloaded with a numeric \`score\` in [0, 100). Write a query that bins the rows into buckets of 10 (so \`bucket\` is \`0\`, \`10\`, \`20\`, …, \`90\`) and returns the bucket plus the row count, sorted by \`bucket\`.`}
 
+  tableRowLimit={10000}
   initSql={`CREATE TABLE big AS
 SELECT
   i AS id,

--- a/content/learn/challenge-cards/duckdb.mdx
+++ b/content/learn/challenge-cards/duckdb.mdx
@@ -257,3 +257,63 @@ ORDER BY avg_rating DESC;`}
   ]}
 />
 ```
+
+## 4. Large result sets (infinite scroll)
+
+The result pane virtualises its rows so a `SELECT *` against a 10k-row
+table stays responsive — only the rows actually inside the viewport
+are rendered.
+
+<SqlChallengeCard
+  dialect="duckdb"
+  title="Bucket 10,000 rows by score"
+  instructions={`A 10,000-row table \`big\` is preloaded with a numeric \`score\` in [0, 100). Write a query that bins the rows into buckets of 10 (so \`bucket\` is \`0\`, \`10\`, \`20\`, …, \`90\`) and returns the bucket plus the row count, sorted by \`bucket\`.`}
+
+  initSql={`CREATE TABLE big AS
+SELECT
+  i AS id,
+  ('user_' || i) AS name,
+  (i * 37 % 100) AS score
+FROM range(1, 10001) t(i);
+`}
+  initialCode={`SELECT * FROM big LIMIT 5;`}
+  solutionSql={`SELECT (score / 10) * 10 AS bucket, COUNT(*) AS n
+FROM big
+GROUP BY bucket
+ORDER BY bucket;`}
+  tests={[
+    {
+      id: "row_count",
+      name: "10 buckets",
+      description: "score in [0, 100) divided by 10",
+      expectedRowCount: 10,
+    },
+    {
+      id: "matches",
+      name: "Matches the reference solution",
+      description: "Same buckets, same counts, same order",
+      matchesSolution: true,
+      ordered: true,
+    },
+  ]}
+/>
+
+```jsx
+<SqlChallengeCard
+  dialect="duckdb"
+  title="Bucket 10,000 rows by score"
+  instructions={`A 10,000-row table big is preloaded ...`}
+
+  initSql={`CREATE TABLE big AS
+SELECT i AS id, ('user_' || i) AS name, (i * 37 % 100) AS score
+FROM range(1, 10001) t(i);
+`}
+  initialCode={`SELECT * FROM big LIMIT 5;`}
+  solutionSql={`SELECT (score / 10) * 10 AS bucket, COUNT(*) AS n
+FROM big GROUP BY bucket ORDER BY bucket;`}
+  tests={[
+    { id: "row_count", name: "10 buckets", expectedRowCount: 10 },
+    { id: "matches", matchesSolution: true, ordered: true },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/java.mdx
+++ b/content/learn/challenge-cards/java.mdx
@@ -203,8 +203,13 @@ so `Main` can reference `Dog` directly without any imports.
       filename: "Dog.java",
       initialContent: `public class Dog {
     public String bark() {
-        // your code here
         return "";
+    }
+}
+`,
+      solutionContent: `public class Dog {
+    public String bark() {
+        return "Woof!";
     }
 }
 `,

--- a/content/learn/challenge-cards/java.mdx
+++ b/content/learn/challenge-cards/java.mdx
@@ -164,14 +164,14 @@ so `Main` can reference `Dog` directly without any imports.
     }
 }
 `,
-    },
-  ]}
-  solutionCode={`public class Dog {
+      solutionContent: `public class Dog {
     public String bark() {
         return "Woof!";
     }
 }
-`}
+`,
+    },
+  ]}
   tests={[
     {
       id: "barks",

--- a/content/learn/challenge-cards/java.mdx
+++ b/content/learn/challenge-cards/java.mdx
@@ -132,7 +132,96 @@ from it. Keep the class named `Main` for these exercises.
 />
 ```
 
-## 3. Loops and conditionals
+## 3. Multi-file challenge
+
+Multi-file challenges open with a non-sortable, non-closeable tab bar
+above the editor. Click a filename to switch buffers. Every file in the
+workspace is staged into CheerpJ's virtual filesystem before each run,
+so `Main` can reference `Dog` directly without any imports.
+
+<ChallengeCard
+  adapter="java"
+  title="Implement Dog.bark()"
+  instructions={`Open \`Dog.java\` and implement the \`bark()\` method so that it returns the string \`"Woof!"\`. \`Main.java\` is provided — it constructs a \`Dog\` and prints the result of \`bark()\`.`}
+  entryFilename="Main.java"
+  files={[
+    {
+      filename: "Main.java",
+      initialContent: `public class Main {
+    public static void main(String[] args) {
+        Dog d = new Dog();
+        System.out.println(d.bark());
+    }
+}
+`,
+    },
+    {
+      filename: "Dog.java",
+      initialContent: `public class Dog {
+    public String bark() {
+        // your code here
+        return "";
+    }
+}
+`,
+    },
+  ]}
+  solutionCode={`public class Dog {
+    public String bark() {
+        return "Woof!";
+    }
+}
+`}
+  tests={[
+    {
+      id: "barks",
+      name: "Prints `Woof!`",
+      description: "Main runs and bark() returns the expected value",
+      expect: { stdoutEquals: "Woof!" },
+    },
+  ]}
+/>
+
+```jsx
+<ChallengeCard
+  adapter="java"
+  title="Implement Dog.bark()"
+  instructions={`Open Dog.java and implement the bark() method ...`}
+  entryFilename="Main.java"
+  files={[
+    {
+      filename: "Main.java",
+      initialContent: `public class Main {
+    public static void main(String[] args) {
+        Dog d = new Dog();
+        System.out.println(d.bark());
+    }
+}
+`,
+    },
+    {
+      filename: "Dog.java",
+      initialContent: `public class Dog {
+    public String bark() {
+        // your code here
+        return "";
+    }
+}
+`,
+    },
+  ]}
+  tests={[
+    {
+      id: "barks",
+      name: "Prints `Woof!`",
+      description: "Main runs and bark() returns the expected value",
+      expect: { stdoutEquals: "Woof!" },
+    },
+  ]}
+/>
+```
+
+## 4. Loops and conditionals
 
 <ChallengeCard
   adapter="java"

--- a/content/learn/challenge-cards/javascript.mdx
+++ b/content/learn/challenge-cards/javascript.mdx
@@ -295,3 +295,31 @@ entry module can `require()` sibling files.
     },
   ]}
 />
+
+```jsx
+<ChallengeCard
+  adapter="javascript"
+  title="Implement greet() in utils.js"
+  instructions={`Open utils.js and implement greet(name) ...`}
+  entryFilename="main.js"
+  files={[
+    {
+      filename: "main.js",
+      initialContent: `const { greet } = require("./utils");\nconsole.log(greet("World"));\n`,
+    },
+    {
+      filename: "utils.js",
+      initialContent: `function greet(name) {\n  return "";\n}\n\nmodule.exports = { greet };\n`,
+      solutionContent: `function greet(name) {\n  return \`Hello, \${name}!\`;\n}\n\nmodule.exports = { greet };\n`,
+    },
+  ]}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/javascript.mdx
+++ b/content/learn/challenge-cards/javascript.mdx
@@ -107,20 +107,12 @@ console.log(sumArray([1, 2, 3, 4, 5]));
 
 console.log(byCustomer);
 `}
-  solutionCode={`function groupByCustomer(orders) {
-  const out = {};
-  for (const o of orders) {
-    out[o.customer] = (out[o.customer] || 0) + o.amount;
-  }
-  return out;
+  solutionCode={`let byCustomer = {};
+for (const o of orders) {
+  byCustomer[o.customer] = (byCustomer[o.customer] || 0) + o.amount;
 }
 
-const result = groupByCustomer([
-  { customer: "Ada",   amount: 100 },
-  { customer: "Linus", amount: 80 },
-  { customer: "Ada",   amount: 50 },
-]);
-console.log(result);
+console.log(byCustomer);
 `}
   tests={[
     {
@@ -167,20 +159,12 @@ console.log(result);
 
 console.log(byCustomer);
 `}
-  solutionCode={`function groupByCustomer(orders) {
-  const out = {};
-  for (const o of orders) {
-    out[o.customer] = (out[o.customer] || 0) + o.amount;
-  }
-  return out;
+  solutionCode={`let byCustomer = {};
+for (const o of orders) {
+  byCustomer[o.customer] = (byCustomer[o.customer] || 0) + o.amount;
 }
 
-const result = groupByCustomer([
-  { customer: "Ada",   amount: 100 },
-  { customer: "Linus", amount: 80 },
-  { customer: "Ada",   amount: 50 },
-]);
-console.log(result);
+console.log(byCustomer);
 `}
   tests={[
     {
@@ -223,11 +207,11 @@ console.log(result);
 
 delay(10).then((v) => console.log(v));
 `}
-  solutionCode={`function delayed(value, ms) {
-  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
+  solutionCode={`function delay(ms) {
+  return new Promise((resolve) => setTimeout(() => resolve("done"), ms));
 }
 
-delayed("done", 10).then((v) => console.log(v));
+delay(10).then((v) => console.log(v));
 `}
   tests={[
     {
@@ -256,11 +240,11 @@ delayed("done", 10).then((v) => console.log(v));
 
 delay(10).then((v) => console.log(v));
 `}
-  solutionCode={`function delayed(value, ms) {
-  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
+  solutionCode={`function delay(ms) {
+  return new Promise((resolve) => setTimeout(() => resolve("done"), ms));
 }
 
-delayed("done", 10).then((v) => console.log(v));
+delay(10).then((v) => console.log(v));
 `}
   tests={[
     {
@@ -299,9 +283,9 @@ entry module can `require()` sibling files.
     {
       filename: "utils.js",
       initialContent: `function greet(name) {\n  // your code here\n  return "";\n}\n\nmodule.exports = { greet };\n`,
+      solutionContent: `function greet(name) {\n  return \`Hello, \${name}!\`;\n}\n\nmodule.exports = { greet };\n`,
     },
   ]}
-  solutionCode={`function greet(name) {\n  return \`Hello, \${name}!\`;\n}\n\nmodule.exports = { greet };\n`}
   tests={[
     {
       id: "greets",

--- a/content/learn/challenge-cards/javascript.mdx
+++ b/content/learn/challenge-cards/javascript.mdx
@@ -278,3 +278,36 @@ delayed("done", 10).then((v) => console.log(v));
   ]}
 />
 ```
+
+## Multi-file challenge
+
+Multi-file challenges open with a non-sortable, non-closeable tab bar
+above the editor. Click a filename to switch buffers. Every file is
+staged into almostnode's virtual filesystem before each run, so the
+entry module can `require()` sibling files.
+
+<ChallengeCard
+  adapter="javascript"
+  title="Implement greet() in utils.js"
+  instructions={`Open \`utils.js\` and implement \`greet(name)\` so that it returns the string \`"Hello, <name>!"\`. The entry script \`main.js\` already requires your function and prints the result.`}
+  entryFilename="main.js"
+  files={[
+    {
+      filename: "main.js",
+      initialContent: `const { greet } = require("./utils");\nconsole.log(greet("World"));\n`,
+    },
+    {
+      filename: "utils.js",
+      initialContent: `function greet(name) {\n  // your code here\n  return "";\n}\n\nmodule.exports = { greet };\n`,
+    },
+  ]}
+  solutionCode={`function greet(name) {\n  return \`Hello, \${name}!\`;\n}\n\nmodule.exports = { greet };\n`}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>

--- a/content/learn/challenge-cards/php.mdx
+++ b/content/learn/challenge-cards/php.mdx
@@ -103,16 +103,11 @@ $total = 0; // TODO
 echo $total;
 `}
   solutionCode={`<?php
-$items = [
-    ["name" => "Apple",  "price" => 1.20, "in_stock" => true],
-    ["name" => "Bread",  "price" => 3.50, "in_stock" => false],
-    ["name" => "Cheese", "price" => 5.00, "in_stock" => true],
-];
-
 $total = 0.0;
 foreach ($items as $item) {
     if ($item["in_stock"]) $total += $item["price"];
 }
+
 echo $total;
 `}
   tests={[
@@ -150,16 +145,11 @@ $total = 0; // TODO
 echo $total;
 `}
   solutionCode={`<?php
-$items = [
-    ["name" => "Apple",  "price" => 1.20, "in_stock" => true],
-    ["name" => "Bread",  "price" => 3.50, "in_stock" => false],
-    ["name" => "Cheese", "price" => 5.00, "in_stock" => true],
-];
-
 $total = 0.0;
 foreach ($items as $item) {
     if ($item["in_stock"]) $total += $item["price"];
 }
+
 echo $total;
 `}
   tests={[
@@ -265,9 +255,9 @@ sibling files.
     {
       filename: "utils.php",
       initialContent: `<?php\nfunction greet($name) {\n    // your code here\n    return "";\n}\n`,
+      solutionContent: `<?php\nfunction greet($name) {\n    return "Hello, {$name}!";\n}\n`,
     },
   ]}
-  solutionCode={`<?php\nfunction greet($name) {\n    return "Hello, {$name}!";\n}\n`}
   tests={[
     {
       id: "greets",

--- a/content/learn/challenge-cards/php.mdx
+++ b/content/learn/challenge-cards/php.mdx
@@ -244,3 +244,36 @@ for ($i = 1; $i <= 10; $i++) {
   ]}
 />
 ```
+
+## Multi-file challenge
+
+Multi-file challenges open with a non-sortable, non-closeable tab bar
+above the editor. Every file is staged into php-wasm's virtual
+filesystem before each run, so the entry script can `require_once`
+sibling files.
+
+<ChallengeCard
+  adapter="php"
+  title="Implement greet() in utils.php"
+  instructions={`Open \`utils.php\` and implement \`greet($name)\` so that it returns the string \`"Hello, <name>!"\`. The entry script \`main.php\` already requires your file and echoes the result.`}
+  entryFilename="main.php"
+  files={[
+    {
+      filename: "main.php",
+      initialContent: `<?php\nrequire_once "utils.php";\necho greet("World");\n`,
+    },
+    {
+      filename: "utils.php",
+      initialContent: `<?php\nfunction greet($name) {\n    // your code here\n    return "";\n}\n`,
+    },
+  ]}
+  solutionCode={`<?php\nfunction greet($name) {\n    return "Hello, {$name}!";\n}\n`}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>

--- a/content/learn/challenge-cards/php.mdx
+++ b/content/learn/challenge-cards/php.mdx
@@ -267,3 +267,31 @@ sibling files.
     },
   ]}
 />
+
+```jsx
+<ChallengeCard
+  adapter="php"
+  title="Implement greet() in utils.php"
+  instructions={`Open utils.php and implement greet($name) ...`}
+  entryFilename="main.php"
+  files={[
+    {
+      filename: "main.php",
+      initialContent: `<?php\nrequire_once "utils.php";\necho greet("World");\n`,
+    },
+    {
+      filename: "utils.php",
+      initialContent: `<?php\nfunction greet($name) {\n    return "";\n}\n`,
+      solutionContent: `<?php\nfunction greet($name) {\n    return "Hello, {$name}!";\n}\n`,
+    },
+  ]}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/postgres.mdx
+++ b/content/learn/challenge-cards/postgres.mdx
@@ -289,3 +289,64 @@ INSERT INTO orders (amount) VALUES (120.00), (80.00), (200.00), (50.00), (150.00
   ]}
 />
 ```
+
+
+## 4. Large result sets (infinite scroll)
+
+The result pane virtualises its rows so a `SELECT *` against a 10k-row
+table stays responsive — only the rows actually inside the viewport
+are rendered.
+
+<SqlChallengeCard
+  dialect="postgres"
+  title="Bucket 10,000 rows by score"
+  instructions={`A 10,000-row table \`big\` is preloaded with a numeric \`score\` in [0, 100). Write a query that bins the rows into buckets of 10 (so \`bucket\` is \`0\`, \`10\`, \`20\`, …, \`90\`) and returns the bucket plus the row count, sorted by \`bucket\`.`}
+
+  initSql={`CREATE TABLE big AS
+SELECT
+  s.i AS id,
+  (user_ || s.i) AS name,
+  (s.i * 37 % 100) AS score
+FROM generate_series(1, 10000) AS s(i);
+`}
+  initialCode={`SELECT * FROM big LIMIT 5;`}
+  solutionSql={`SELECT (score / 10) * 10 AS bucket, COUNT(*)::int AS n
+FROM big
+GROUP BY bucket
+ORDER BY bucket;`}
+  tests={[
+    {
+      id: "row_count",
+      name: "10 buckets",
+      description: "score in [0, 100) divided by 10",
+      expectedRowCount: 10,
+    },
+    {
+      id: "matches",
+      name: "Matches the reference solution",
+      description: "Same buckets, same counts, same order",
+      matchesSolution: true,
+      ordered: true,
+    },
+  ]}
+/>
+
+```jsx
+<SqlChallengeCard
+  dialect="postgres"
+  title="Bucket 10,000 rows by score"
+  instructions={`A 10,000-row table big is preloaded ...`}
+
+  initSql={`CREATE TABLE big AS
+SELECT s.i AS id, ('user_' || s.i) AS name, (s.i * 37 % 100) AS score
+FROM generate_series(1, 10000) AS s(i);
+`}
+  initialCode={`SELECT * FROM big LIMIT 5;`}
+  solutionSql={`SELECT (score / 10) * 10 AS bucket, COUNT(*)::int AS n
+FROM big GROUP BY bucket ORDER BY bucket;`}
+  tests={[
+    { id: "row_count", name: "10 buckets", expectedRowCount: 10 },
+    { id: "matches", matchesSolution: true, ordered: true },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/postgres.mdx
+++ b/content/learn/challenge-cards/postgres.mdx
@@ -302,10 +302,11 @@ are rendered.
   title="Bucket 10,000 rows by score"
   instructions={`A 10,000-row table \`big\` is preloaded with a numeric \`score\` in [0, 100). Write a query that bins the rows into buckets of 10 (so \`bucket\` is \`0\`, \`10\`, \`20\`, …, \`90\`) and returns the bucket plus the row count, sorted by \`bucket\`.`}
 
+  tableRowLimit={10000}
   initSql={`CREATE TABLE big AS
 SELECT
   s.i AS id,
-  (user_ || s.i) AS name,
+  ('user_' || s.i) AS name,
   (s.i * 37 % 100) AS score
 FROM generate_series(1, 10000) AS s(i);
 `}

--- a/content/learn/challenge-cards/python.mdx
+++ b/content/learn/challenge-cards/python.mdx
@@ -462,3 +462,63 @@ print(reverse_words("hello world"))
   ]}
 />
 ```
+
+## Multi-file challenge
+
+Multi-file challenges open with a non-sortable, non-closeable tab bar
+above the editor. Click a filename to switch buffers. Every file is
+staged into Pyodide's virtual filesystem before each run, so the entry
+module can `import` from sibling files.
+
+<ChallengeCard
+  adapter="python"
+  title="Implement greet() in utils.py"
+  instructions={`Open \`utils.py\` and implement \`greet(name)\` so that it returns the string \`"Hello, <name>!"\`. The entry script \`main.py\` already imports your function and prints the result.`}
+  entryFilename="main.py"
+  files={[
+    {
+      filename: "main.py",
+      initialContent: `from utils import greet\n\nprint(greet("World"))\n`,
+    },
+    {
+      filename: "utils.py",
+      initialContent: `def greet(name):\n    # your code here\n    return ""\n`,
+    },
+  ]}
+  solutionCode={`def greet(name):\n    return f"Hello, {name}!"\n`}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      code: `from utils import greet\nassert greet("World") == "Hello, World!"`,
+    },
+  ]}
+/>
+
+```jsx
+<ChallengeCard
+  adapter="python"
+  title="Implement greet() in utils.py"
+  instructions={`Open utils.py and implement greet(name) ...`}
+  entryFilename="main.py"
+  files={[
+    {
+      filename: "main.py",
+      initialContent: `from utils import greet\n\nprint(greet("World"))\n`,
+    },
+    {
+      filename: "utils.py",
+      initialContent: `def greet(name):\n    return ""\n`,
+    },
+  ]}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      code: `from utils import greet\nassert greet("World") == "Hello, World!"`,
+    },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/python.mdx
+++ b/content/learn/challenge-cards/python.mdx
@@ -510,6 +510,7 @@ module can `import` from sibling files.
     {
       filename: "utils.py",
       initialContent: `def greet(name):\n    return ""\n`,
+      solutionContent: `def greet(name):\n    return f"Hello, {name}!"\n`,
     },
   ]}
   tests={[

--- a/content/learn/challenge-cards/python.mdx
+++ b/content/learn/challenge-cards/python.mdx
@@ -483,9 +483,9 @@ module can `import` from sibling files.
     {
       filename: "utils.py",
       initialContent: `def greet(name):\n    # your code here\n    return ""\n`,
+      solutionContent: `def greet(name):\n    return f"Hello, {name}!"\n`,
     },
   ]}
-  solutionCode={`def greet(name):\n    return f"Hello, {name}!"\n`}
   tests={[
     {
       id: "greets",

--- a/content/learn/challenge-cards/r.mdx
+++ b/content/learn/challenge-cards/r.mdx
@@ -20,10 +20,11 @@ s  <- NA
 
 cat("mean:", m, "median:", md, "sd:", s, "\\n")
 `}
-  solutionCode={`x <- c(2, 4, 4, 4, 5, 5, 7, 9)
-cat("mean:",   mean(x),   "\\n")
-cat("median:", median(x), "\\n")
-cat("sd:",     sd(x),     "\\n")
+  solutionCode={`m  <- mean(x)
+md <- median(x)
+s  <- sd(x)
+
+cat("mean:", m, "median:", md, "sd:", s, "\\n")
 `}
   tests={[
     {
@@ -59,10 +60,11 @@ s  <- NA
 
 cat("mean:", m, "median:", md, "sd:", s, "\\n")
 `}
-  solutionCode={`x <- c(2, 4, 4, 4, 5, 5, 7, 9)
-cat("mean:",   mean(x),   "\\n")
-cat("median:", median(x), "\\n")
-cat("sd:",     sd(x),     "\\n")
+  solutionCode={`m  <- mean(x)
+md <- median(x)
+s  <- sd(x)
+
+cat("mean:", m, "median:", md, "sd:", s, "\\n")
 `}
   tests={[
     {
@@ -102,12 +104,9 @@ cat("sd:",     sd(x),     "\\n")
 
 print(filtered)
 `}
-  solutionCode={`df <- data.frame(
-  name  = c("Ada", "Linus", "Grace", "Alan"),
-  score = c(95, 70, 88, 60)
-)
-high <- df[df$score >= 80, ]
-print(high)
+  solutionCode={`filtered <- df[df$score >= 80, ]
+
+print(filtered)
 `}
   tests={[
     {
@@ -145,12 +144,9 @@ print(high)
 
 print(filtered)
 `}
-  solutionCode={`df <- data.frame(
-  name  = c("Ada", "Linus", "Grace", "Alan"),
-  score = c(95, 70, 88, 60)
-)
-high <- df[df$score >= 80, ]
-print(high)
+  solutionCode={`filtered <- df[df$score >= 80, ]
+
+print(filtered)
 `}
   tests={[
     {
@@ -242,9 +238,9 @@ before each run, so the entry script can `source()` sibling files.
     {
       filename: "utils.R",
       initialContent: `greet <- function(name) {\n  # your code here\n  ""\n}\n`,
+      solutionContent: `greet <- function(name) {\n  paste0("Hello, ", name, "!")\n}\n`,
     },
   ]}
-  solutionCode={`greet <- function(name) {\n  paste0("Hello, ", name, "!")\n}\n`}
   tests={[
     {
       id: "greets",

--- a/content/learn/challenge-cards/r.mdx
+++ b/content/learn/challenge-cards/r.mdx
@@ -222,3 +222,35 @@ print(high)
   ]}
 />
 ```
+
+## Multi-file challenge
+
+Multi-file challenges open with a non-sortable, non-closeable tab bar
+above the editor. Every file is staged into WebR's virtual filesystem
+before each run, so the entry script can `source()` sibling files.
+
+<ChallengeCard
+  adapter="r"
+  title="Implement greet() in utils.R"
+  instructions={`Open \`utils.R\` and implement \`greet(name)\` so that it returns the string \`"Hello, <name>!"\`. The entry script \`main.R\` already sources your file and prints the result.`}
+  entryFilename="main.R"
+  files={[
+    {
+      filename: "main.R",
+      initialContent: `source("utils.R")\ncat(greet("World"))\n`,
+    },
+    {
+      filename: "utils.R",
+      initialContent: `greet <- function(name) {\n  # your code here\n  ""\n}\n`,
+    },
+  ]}
+  solutionCode={`greet <- function(name) {\n  paste0("Hello, ", name, "!")\n}\n`}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      code: `stopifnot(greet("World") == "Hello, World!")`,
+    },
+  ]}
+/>

--- a/content/learn/challenge-cards/r.mdx
+++ b/content/learn/challenge-cards/r.mdx
@@ -250,3 +250,31 @@ before each run, so the entry script can `source()` sibling files.
     },
   ]}
 />
+
+```jsx
+<ChallengeCard
+  adapter="r"
+  title="Implement greet() in utils.R"
+  instructions={`Open utils.R and implement greet(name) ...`}
+  entryFilename="main.R"
+  files={[
+    {
+      filename: "main.R",
+      initialContent: `source("utils.R")\ncat(greet("World"))\n`,
+    },
+    {
+      filename: "utils.R",
+      initialContent: `greet <- function(name) {\n  ""\n}\n`,
+      solutionContent: `greet <- function(name) {\n  paste0("Hello, ", name, "!")\n}\n`,
+    },
+  ]}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      code: `stopifnot(greet("World") == "Hello, World!")`,
+    },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/sqlite.mdx
+++ b/content/learn/challenge-cards/sqlite.mdx
@@ -277,3 +277,67 @@ INSERT INTO users (name, email) VALUES
   ]}
 />
 ```
+
+
+## 4. Large result sets (infinite scroll)
+
+The result pane virtualises its rows so a `SELECT *` against a 10k-row
+table stays responsive — only the rows actually inside the viewport
+are rendered.
+
+<SqlChallengeCard
+  dialect="sqlite"
+  title="Bucket 10,000 rows by score"
+  instructions={`A 10,000-row table \`big\` is preloaded with a numeric \`score\` in [0, 100). Write a query that bins the rows into buckets of 10 (so \`bucket\` is \`0\`, \`10\`, \`20\`, …, \`90\`) and returns the bucket plus the row count, sorted by \`bucket\`.`}
+
+  initSql={`CREATE TABLE big (id INTEGER, name TEXT, score INTEGER);
+WITH RECURSIVE n(i) AS (
+  SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < 10000
+)
+INSERT INTO big
+SELECT i, 'user_' || i, (i * 37 % 100) FROM n;
+`}
+  initialCode={`SELECT * FROM big LIMIT 5;`}
+  solutionSql={`SELECT (score / 10) * 10 AS bucket, COUNT(*) AS n
+FROM big
+GROUP BY bucket
+ORDER BY bucket;`}
+  tests={[
+    {
+      id: "row_count",
+      name: "10 buckets",
+      description: "score in [0, 100) divided by 10",
+      expectedRowCount: 10,
+    },
+    {
+      id: "matches",
+      name: "Matches the reference solution",
+      description: "Same buckets, same counts, same order",
+      matchesSolution: true,
+      ordered: true,
+    },
+  ]}
+/>
+
+```jsx
+<SqlChallengeCard
+  dialect="sqlite"
+  title="Bucket 10,000 rows by score"
+  instructions={`A 10,000-row table big is preloaded ...`}
+
+  initSql={`CREATE TABLE big (id INTEGER, name TEXT, score INTEGER);
+WITH RECURSIVE n(i) AS (
+  SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < 10000
+)
+INSERT INTO big
+SELECT i, 'user_' || i, (i * 37 % 100) FROM n;
+`}
+  initialCode={`SELECT * FROM big LIMIT 5;`}
+  solutionSql={`SELECT (score / 10) * 10 AS bucket, COUNT(*) AS n
+FROM big GROUP BY bucket ORDER BY bucket;`}
+  tests={[
+    { id: "row_count", name: "10 buckets", expectedRowCount: 10 },
+    { id: "matches", matchesSolution: true, ordered: true },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/sqlite.mdx
+++ b/content/learn/challenge-cards/sqlite.mdx
@@ -290,6 +290,7 @@ are rendered.
   title="Bucket 10,000 rows by score"
   instructions={`A 10,000-row table \`big\` is preloaded with a numeric \`score\` in [0, 100). Write a query that bins the rows into buckets of 10 (so \`bucket\` is \`0\`, \`10\`, \`20\`, …, \`90\`) and returns the bucket plus the row count, sorted by \`bucket\`.`}
 
+  tableRowLimit={10000}
   initSql={`CREATE TABLE big (id INTEGER, name TEXT, score INTEGER);
 WITH RECURSIVE n(i) AS (
   SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < 10000

--- a/content/learn/challenge-cards/typescript.mdx
+++ b/content/learn/challenge-cards/typescript.mdx
@@ -116,19 +116,17 @@ console.log(area({ kind: "circle", radius: 1 }));
 console.log(area({ kind: "square", side: 4 }));
 console.log(area({ kind: "rect", width: 3, height: 5 }));
 `}
-  solutionCode={`type Shape =
-  | { kind: "circle"; radius: number }
-  | { kind: "rectangle"; width: number; height: number };
-
-function area(s: Shape): number {
-  switch (s.kind) {
-    case "circle":    return Math.PI * s.radius * s.radius;
-    case "rectangle": return s.width * s.height;
+  solutionCode={`function area(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle": return Math.PI * shape.radius * shape.radius;
+    case "square": return shape.side * shape.side;
+    case "rect":   return shape.width * shape.height;
   }
 }
 
-console.log(area({ kind: "rectangle", width: 3, height: 4 }));
-console.log(area({ kind: "circle", radius: 1 }).toFixed(4));
+console.log(area({ kind: "circle", radius: 1 }));
+console.log(area({ kind: "square", side: 4 }));
+console.log(area({ kind: "rect", width: 3, height: 5 }));
 `}
   tests={[
     {
@@ -175,19 +173,17 @@ console.log(area({ kind: "circle", radius: 1 }));
 console.log(area({ kind: "square", side: 4 }));
 console.log(area({ kind: "rect", width: 3, height: 5 }));
 `}
-  solutionCode={`type Shape =
-  | { kind: "circle"; radius: number }
-  | { kind: "rectangle"; width: number; height: number };
-
-function area(s: Shape): number {
-  switch (s.kind) {
-    case "circle":    return Math.PI * s.radius * s.radius;
-    case "rectangle": return s.width * s.height;
+  solutionCode={`function area(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle": return Math.PI * shape.radius * shape.radius;
+    case "square": return shape.side * shape.side;
+    case "rect":   return shape.width * shape.height;
   }
 }
 
-console.log(area({ kind: "rectangle", width: 3, height: 4 }));
-console.log(area({ kind: "circle", radius: 1 }).toFixed(4));
+console.log(area({ kind: "circle", radius: 1 }));
+console.log(area({ kind: "square", side: 4 }));
+console.log(area({ kind: "rect", width: 3, height: 5 }));
 `}
   tests={[
     {
@@ -274,9 +270,9 @@ sibling files.
     {
       filename: "utils.ts",
       initialContent: `export function greet(name: string): string {\n  // your code here\n  return "";\n}\n`,
+      solutionContent: `export function greet(name: string): string {\n  return \`Hello, \${name}!\`;\n}\n`,
     },
   ]}
-  solutionCode={`export function greet(name: string): string {\n  return \`Hello, \${name}!\`;\n}\n`}
   tests={[
     {
       id: "greets",

--- a/content/learn/challenge-cards/typescript.mdx
+++ b/content/learn/challenge-cards/typescript.mdx
@@ -282,3 +282,31 @@ sibling files.
     },
   ]}
 />
+
+```jsx
+<ChallengeCard
+  adapter="typescript"
+  title="Implement greet() in utils.ts"
+  instructions={`Open utils.ts and implement greet(name) ...`}
+  entryFilename="main.ts"
+  files={[
+    {
+      filename: "main.ts",
+      initialContent: `import { greet } from "./utils";\nconsole.log(greet("World"));\n`,
+    },
+    {
+      filename: "utils.ts",
+      initialContent: `export function greet(name: string): string {\n  return "";\n}\n`,
+      solutionContent: `export function greet(name: string): string {\n  return \`Hello, \${name}!\`;\n}\n`,
+    },
+  ]}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>
+```

--- a/content/learn/challenge-cards/typescript.mdx
+++ b/content/learn/challenge-cards/typescript.mdx
@@ -253,3 +253,36 @@ console.log(message);
   ]}
 />
 ```
+
+## Multi-file challenge
+
+Multi-file challenges open with a non-sortable, non-closeable tab bar
+above the editor. Every file is staged into almostnode's virtual
+filesystem before each run, so the entry module can `import` from
+sibling files.
+
+<ChallengeCard
+  adapter="typescript"
+  title="Implement greet() in utils.ts"
+  instructions={`Open \`utils.ts\` and implement \`greet(name)\` so that it returns the string \`"Hello, <name>!"\`. The entry script \`main.ts\` already imports your function and prints the result.`}
+  entryFilename="main.ts"
+  files={[
+    {
+      filename: "main.ts",
+      initialContent: `import { greet } from "./utils";\nconsole.log(greet("World"));\n`,
+    },
+    {
+      filename: "utils.ts",
+      initialContent: `export function greet(name: string): string {\n  // your code here\n  return "";\n}\n`,
+    },
+  ]}
+  solutionCode={`export function greet(name: string): string {\n  return \`Hello, \${name}!\`;\n}\n`}
+  tests={[
+    {
+      id: "greets",
+      name: "Prints `Hello, World!`",
+      description: "main runs and greet returns the expected value",
+      expect: { stdoutEquals: "Hello, World!" },
+    },
+  ]}
+/>

--- a/e2e/challenge-solutions.spec.ts
+++ b/e2e/challenge-solutions.spec.ts
@@ -1,0 +1,228 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Drives every <ChallengeCard> on every /learn/challenge-cards/<lang>
+// page, loads its reference solution into the editor buffers, clicks
+// Submit, and asserts that all of the card's declared tests pass.
+//
+// Each card exposes a test driver via:
+//   - DOM:    [data-testid="challenge-card"][data-adapter-id][data-challenge-title][data-solution-files]
+//   - window: window.__dsChallenges["<adapter>::<title>"]
+//
+// `data-solution-files` carries the per-file solution payload as JSON
+// so the spec doesn't have to re-parse MDX. `window.__dsChallenges`
+// hands us a programmatic setFileContent/submit/getTestResults trio
+// so we don't have to round-trip every character through CodeMirror's
+// contenteditable — that pathway is fragile against IME / paste /
+// indent extensions.
+//
+// Pages and per-card runs are slow because each runtime fetches its
+// WASM toolchain from a CDN on first load (browsercc, Pyodide, WebR,
+// php-wasm, pglite, sqlite-wasm). The per-test timeouts in
+// playwright.config.ts already allow for that — we don't need extra
+// retry logic here.
+
+type SolutionFilePayload = { filename: string; source: string };
+
+interface TestResultLite {
+  id: string;
+  name: string;
+  state: "idle" | "pending" | "pass" | "fail";
+  detail: string | null;
+}
+
+interface ChallengeTestHandleLite {
+  adapterId: string;
+  title: string;
+  entryFilename: string;
+  filenames: string[];
+  setFileContent(filename: string, content: string): boolean;
+  submit(): Promise<void>;
+  getBannerState(): "pass" | "fail" | null;
+  getTestResults(): TestResultLite[];
+}
+
+declare global {
+  interface Window {
+    __dsChallenges?: Record<string, ChallengeTestHandleLite>;
+  }
+}
+
+const CHALLENGE_PAGES: { slug: string; label: string }[] = [
+  { slug: "javascript", label: "JavaScript" },
+  { slug: "typescript", label: "TypeScript" },
+  { slug: "python", label: "Python" },
+  { slug: "r", label: "R" },
+  { slug: "java", label: "Java" },
+  { slug: "c", label: "C" },
+  { slug: "cpp", label: "C++" },
+  { slug: "csharp", label: "C#" },
+  { slug: "php", label: "PHP" },
+];
+
+async function readCardsOnPage(page: Page): Promise<
+  {
+    key: string;
+    adapterId: string;
+    title: string;
+    solutionFiles: SolutionFilePayload[];
+  }[]
+> {
+  return await page.evaluate(() => {
+    const out: {
+      key: string;
+      adapterId: string;
+      title: string;
+      solutionFiles: SolutionFilePayload[];
+    }[] = [];
+    const nodes = document.querySelectorAll<HTMLElement>(
+      '[data-testid="challenge-card"]',
+    );
+    nodes.forEach((node) => {
+      const adapterId = node.getAttribute("data-adapter-id") ?? "";
+      const title = node.getAttribute("data-challenge-title") ?? "";
+      const raw = node.getAttribute("data-solution-files");
+      if (!raw) return;
+      let files: SolutionFilePayload[] = [];
+      try {
+        files = JSON.parse(raw) as SolutionFilePayload[];
+      } catch {
+        return;
+      }
+      if (files.length === 0) return;
+      out.push({
+        key: `${adapterId}::${title}`,
+        adapterId,
+        title,
+        solutionFiles: files,
+      });
+    });
+    return out;
+  });
+}
+
+async function waitForChallengeHandle(
+  page: Page,
+  key: string,
+  timeoutMs: number,
+): Promise<void> {
+  await page.waitForFunction(
+    (k) => {
+      const reg = window.__dsChallenges;
+      return !!(reg && reg[k]);
+    },
+    key,
+    { timeout: timeoutMs },
+  );
+}
+
+async function runOneCard(
+  page: Page,
+  card: {
+    key: string;
+    adapterId: string;
+    title: string;
+    solutionFiles: SolutionFilePayload[];
+  },
+): Promise<{ ok: boolean; detail: string }> {
+  await waitForChallengeHandle(page, card.key, 60_000);
+
+  // Stage every file's solution into the card's buffers.
+  const staged = await page.evaluate(
+    ([key, files]) => {
+      const handle = window.__dsChallenges?.[key as string];
+      if (!handle) return { ok: false, missing: "handle" };
+      for (const f of files as SolutionFilePayload[]) {
+        const written = handle.setFileContent(f.filename, f.source);
+        if (!written) return { ok: false, missing: f.filename };
+      }
+      return { ok: true, missing: "" };
+    },
+    [card.key, card.solutionFiles] as const,
+  );
+  if (!staged.ok) {
+    return {
+      ok: false,
+      detail: `Failed to set file content (${staged.missing})`,
+    };
+  }
+
+  // Submit the run and wait for the banner to flip to pass/fail.
+  // The runtime may take a while on first run per language because
+  // packages are still warming up.
+  await page.evaluate((key) => {
+    const handle = window.__dsChallenges?.[key];
+    return handle?.submit();
+  }, card.key);
+
+  await page.waitForFunction(
+    (key) => window.__dsChallenges?.[key]?.getBannerState() !== null,
+    card.key,
+    { timeout: 150_000 },
+  );
+
+  const result = await page.evaluate((key) => {
+    const handle = window.__dsChallenges?.[key];
+    return {
+      banner: handle?.getBannerState() ?? null,
+      tests: handle?.getTestResults() ?? [],
+    };
+  }, card.key);
+
+  if (result.banner === "pass") {
+    return { ok: true, detail: `${result.tests.length} tests passed` };
+  }
+  const failed = result.tests
+    .filter((t) => t.state !== "pass")
+    .map((t) => `  - ${t.name} [${t.state}] ${t.detail ?? ""}`.trimEnd())
+    .join("\n");
+  return {
+    ok: false,
+    detail: `Banner=${result.banner ?? "null"}\n${failed || "(no per-test detail)"}`,
+  };
+}
+
+test.describe("Challenge solutions", () => {
+  for (const { slug, label } of CHALLENGE_PAGES) {
+    test(`${label} — every challenge solution passes`, async ({ page }) => {
+      const pageErrors: string[] = [];
+      page.on("pageerror", (err) => pageErrors.push(err.message));
+
+      await page.goto(`/learn/challenge-cards/${slug}`);
+      // Cards register on `window.__dsChallenges` from a `useEffect`
+      // that fires once the React tree commits — wait until at least
+      // one card has registered before reading the manifest, so we
+      // don't race the initial render.
+      await page.waitForFunction(
+        () => {
+          const reg = window.__dsChallenges;
+          return !!reg && Object.keys(reg).length > 0;
+        },
+        null,
+        { timeout: 60_000 },
+      );
+
+      const cards = await readCardsOnPage(page);
+      expect(cards.length, "page should contain at least one challenge card").toBeGreaterThan(0);
+
+      const failures: { key: string; detail: string }[] = [];
+      for (const card of cards) {
+        const r = await runOneCard(page, card);
+        if (!r.ok) failures.push({ key: card.key, detail: r.detail });
+      }
+
+      if (failures.length > 0) {
+        const summary = failures
+          .map((f) => `❌ ${f.key}\n${f.detail}`)
+          .join("\n\n");
+        throw new Error(
+          `${failures.length}/${cards.length} challenges failed on ${slug}:\n\n${summary}`,
+        );
+      }
+
+      // Anything thrown into pageerror during the sweep is worth
+      // surfacing — it usually means a runtime crashed before its
+      // banner could settle.
+      expect(pageErrors, "no uncaught page errors during run").toEqual([]);
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "test:solutions": "playwright test e2e/challenge-solutions.spec.ts"
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-rc.0",


### PR DESCRIPTION
## Summary

This branch grew from a small set of tweaks into a wider sweep of the challenge-card / code-block surface. Grouped by area:

### Runtime metadata + display
1. **DuckDB version is now read dynamically.** `DUCKDB_VERSION` is exported from `app/_components/runtime/duckdb.ts` (the same constant that determines the jsDelivr WASM URL) and consumed by `DuckDbPlayground`'s `RUNTIME_INFO`, so the playground popup, the engine label, and the CDN URL stay in sync.
2. **Language/version labels on every challenge card.** `SqlChallengeCard`'s engine label now reads "SQLite 3.53", "DuckDB &lt;version&gt;", "PostgreSQL 17" instead of leaking the runtime library (e.g. the old "PostgreSQL via PGlite"). The non-SQL `ChallengeCard` was already correct.

### Multi-file challenges
3. **Multi-file challenge cards.** New optional `files: ChallengeFile[]` + `entryFilename?: string` props on `ChallengeCard`. A non-sortable, non-closeable tab bar appears above the editor; the active tab swaps the editor doc and each tab persists its own buffer. On every run/check every file is staged into the runtime VFS via `runtime.prepareFileSystem(…)` and the entry filename is forwarded through `RunOptions`, so the existing multi-file adapters (Java, C, C++, C#, Python, R, PHP, JS, TS) all work. A multi-file example exists on every non-SQL challenge-card page (the Java page now has the explicit `Dog.java` / `Main.java` example the brief called for).
4. **Multi-file reference solutions.** `ChallengeFile` gains an optional `solutionContent`; the Solution modal renders the same file tab bar (non-sortable, non-closeable) so the learner can flip between files. Files that don't supply a `solutionContent` (scaffold the learner is not expected to modify) are shown with their starter content and labelled `(unchanged)`. Every existing multi-file challenge was migrated from the single-string `solutionCode` prop to per-file `solutionContent` so the modal lands on the file that's actually edited. Each multi-file challenge now has a matching ```jsx preview fence below it.
5. **Solutions are scoped to the editable portion.** Previously some solutions redeclared the read-only `initCode` (orders array, Shape union, vector `x`, df, `$items`) and a few solved a renamed variant of the function under test (JS `delayed`/`delay`, `groupByCustomer`). Those wouldn't even pass the harness if pasted back. Rewrote them to be exactly what should go into the editable buffer. When a challenge has `initCode`, the modal now prepends a single-line comment ("Initialization code (read-only) runs before this file. Solution begins below.") in the language's native syntax (`#`, `--`, `//`) so the displayed source still pastes back as valid code.

### Editor / action bar
6. **Tab-to-indent inside editable CodeMirror editors.** ChallengeCard, SqlChallengeCard, and CodeBlock registered `defaultKeymap` but not `indentWithTab`, so Tab moved focus out of the editor. Added `indentWithTab` to each keymap; read-only editors are unaffected.
7. **Default cursor on the read-only init editor** (was `not-allowed`).
8. **Solution-modal layout fix.** The modal was reusing the card's `.header` (`flex-direction: column`), which stretched the badge / title / copy / close to full width. Replaced with a dedicated row-flex `.modalHeader` so the badge sits inline, the title grows, and the icon buttons hug the right edge.
9. **Cmd/Ctrl+A inside the Solution modal.** The solution editor was already a CodeMirror `EditorView`, but `EditorView.editable.of(false)` set `contenteditable=false` and disabled the default keymap. Dropped `editable.of(false)` (`readOnly` still blocks edits) and wired up `defaultKeymap` so click-then-Cmd-A select-all works.
10. **`.toolbar` → `.actionBar` rename + CodeBlock parity.** The ChallengeCard module's `.toolbar` class is now `.actionBar`, matching CodeBlock's naming. CodeBlock's action bar was restyled to match the challenge card visually — same primary/utility grouping, same `.runBtn` / `.utilBtn` / `.iconBtn` shapes, keyboard-shortcut chip is now embedded inside the Run button. CodeBlock keeps Run / Reset / Copy with the shared styling; Submit and Solution remain challenge-only. The Dracula-dark variant is preserved via `--cb-…` variables.

### Run / output behaviour
11. **Wave-animation min duration.** CodeBlock, ChallengeCard, and SqlChallengeCard now hold the running overlay for at least 300 ms (`MIN_RUN_OVERLAY_MS`) before flipping back to ready/error, matching the playground's `MIN_ANIMATION_MS`. The delay sits in a `finally` so the error path gets the same minimum-visible duration as the happy path.
12. **Blue wave running overlay on challenge cards.** Ported the `runOverlay` / `runWaves` / `runStream` / `runGlow` styles from `CodeBlock.module.css` into `ChallengeCard.module.css` and dropped a `&lt;RunOverlay&gt;` into both `ChallengeCard`'s output panel and `SqlChallengeCard`'s SQL result panel.
13. **JS/TS code blocks group consecutive stdout cells.** Matches the JS/TS playground — adjacent stdout cells coalesce at append time so the streaming UI still shows output as it arrives but doesn't produce a noisy stack of one-line cells.

### R-harness fix
14. **R challenge harness no longer crashes on Submit.** R identifiers cannot begin with `_`, so the shared `__dstest_run` / `__dstest_t0` names lifted from the Python/JS harness made R's parser bail with "unexpected input" on every R challenge. Renamed to `.dstest_run` / `.dstest_t0` — leading `.` is the conventional "hidden variable" prefix in R and parses cleanly.

### Test infrastructure
15. **`npm run test:solutions`** (or `npx playwright test e2e/challenge-solutions.spec.ts`). ChallengeCard stamps `data-testid="challenge-card"` + a `data-solution-files` JSON payload + a programmatic `window.__dsChallenges["&lt;adapter&gt;::&lt;title&gt;"]` handle exposing `setFileContent` / `submit` / `getBannerState` / `getTestResults`. The spec visits every `/learn/challenge-cards/&lt;lang&gt;` page, iterates every card on it, stages the reference solution through the handle, clicks Submit, and asserts the green banner — failures report per-test detail. SQL challenge cards use a different harness shape and are out of scope for this sweep.

### Not pursued
- **Mermaid build-time pre-render.** Would require a Puppeteer/Playwright dep (~150 MB) and a custom remark plugin that drives the renderer against a headless DOM. Honoring the "if too complex, don't worry about it" guidance.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint app/_components/{ChallengeCard,SqlChallengeCard,CodeBlock}.tsx e2e/` — clean
- [ ] `npm run test:solutions` against a live dev server (slow — every runtime fetches its WASM toolchain from CDN; 10–30 minutes end-to-end)
- [ ] Manually visit `/learn/challenge-cards/r` and confirm Submit no longer throws `parse(text = expr) ... unexpected input`
- [ ] Run a fast JS challenge and confirm the Run button + wave animation stay visible for ≥300 ms (no blink)
- [ ] Open the Solution modal on a multi-file challenge (e.g. Java `Dog.bark()`); confirm the file tab bar appears and switching tabs shows the per-file solution
- [ ] In a JS code block, run `console.log` several times in a row and confirm the outputs render as a single grouped cell
- [ ] Confirm the CodeBlock action bar matches the ChallengeCard action bar visually (Run pill with embedded kbd hint, utility-style Reset, icon-only Copy)

https://claude.ai/code/session_01TpgMRKNdjUcbZjFxNwT56A

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpgMRKNdjUcbZjFxNwT56A)_