### PR TITLE
Customize fumadocs sidebar styles

### DIFF
--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -41,6 +41,25 @@
   --color-fd-card: hsl(0, 0%, 100%);
 }
 
+/* Item 1: Light mode active sidebar item — subtler highlight than the default
+   bg-fd-primary/10 (10% of near-black). Non-layered rules beat @layer utilities. */
+:root:not(.dark) #nd-sidebar [data-active="true"] {
+  background-color: hsl(0, 0%, 95%);
+}
+
+/* Item 2: Sidebar footer bar (GitHub icon + theme toggle) — remove the
+   input-like border and secondary background so it looks like plain icons. */
+#nd-sidebar div.border.rounded-lg {
+  background-color: transparent;
+  border: none;
+}
+
+/* Item 3: Dark mode — make the sidebar use the same background as the content
+   area (#121212) instead of the default card color (#191919). */
+.dark {
+  --color-fd-card: var(--color-fd-background);
+}
+
 body {
   font-family:
     "Inter", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",


### PR DESCRIPTION
## Summary

- **Light mode active item**: Replaces the default `bg-fd-primary/10` (10% of near-black) with `hsl(0, 0%, 95%)` — a subtler gray that's perceptible but not heavy
- **Sidebar footer bar**: Removes the `border` and `bg-fd-secondary/50` background from the GitHub icon + theme toggle container, so it renders as plain icons instead of an input-like box
- **Dark mode sidebar**: Sets `--color-fd-card` to `var(--color-fd-background)` so the sidebar background matches the content area (`#121212`) instead of the default card value (`#191919`)

## Test plan

- [ ] Light mode: click a sidebar item and confirm the active highlight is visibly lighter/subtler than before
- [ ] Check the sidebar footer — GitHub icon and light/dark toggle should appear without a surrounding border or background
- [ ] Switch to dark mode and confirm the sidebar blends with the content area (no visible background difference)

https://claude.ai/code/session_01ENPTq9F56rdU5u56EoXhHx

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENPTq9F56rdU5u56EoXhHx)_