### PR TITLE
Fix popover text color and SQL toolbar hover-only tooltips

### DIFF
--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -2736,6 +2736,7 @@ input[type="range"].fs-slider:disabled {
   box-shadow: 0 8px 32px #0008;
   overflow: hidden;
   z-index: 9999;
+  color: var(--text);
   transform-origin: var(--transform-origin, top center);
   transition:
     opacity 0.16s ease,
@@ -2770,7 +2771,6 @@ input[type="range"].fs-slider:disabled {
   padding: 4px 8px;
   font-family: var(--font-ui);
   font-size: 11px;
-  color: var(--text-muted);
   white-space: nowrap;
   pointer-events: none;
 }

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -2402,13 +2402,21 @@ function SqlPlaygroundInner() {
             )}
             <Popover.Root>
               <Popover.Trigger
-                className="header-btn icon-only"
-                title="Query history"
-                aria-label="Query history"
-                onClick={openQueryHistoryTab}
-              >
-                <History size={14} aria-hidden="true" />
-              </Popover.Trigger>
+                openOnHover
+                delay={150}
+                closeDelay={400}
+                render={(triggerProps) => (
+                  <button
+                    {...triggerProps}
+                    type="button"
+                    className="header-btn icon-only"
+                    aria-label="Query history"
+                    onClick={openQueryHistoryTab}
+                  >
+                    <History size={14} aria-hidden="true" />
+                  </button>
+                )}
+              />
               <Popover.Portal>
                 <Popover.Positioner sideOffset={6} align="end">
                   <Popover.Popup className="bui-popup pane-btn-popover">
@@ -2419,13 +2427,21 @@ function SqlPlaygroundInner() {
             </Popover.Root>
             <Popover.Root>
               <Popover.Trigger
-                className="header-btn icon-only"
-                title="ER diagram"
-                aria-label="ER diagram"
-                onClick={openErDiagramTab}
-              >
-                <Network size={14} aria-hidden="true" />
-              </Popover.Trigger>
+                openOnHover
+                delay={150}
+                closeDelay={400}
+                render={(triggerProps) => (
+                  <button
+                    {...triggerProps}
+                    type="button"
+                    className="header-btn icon-only"
+                    aria-label="ER diagram"
+                    onClick={openErDiagramTab}
+                  >
+                    <Network size={14} aria-hidden="true" />
+                  </button>
+                )}
+              />
               <Popover.Portal>
                 <Popover.Positioner sideOffset={6} align="end">
                   <Popover.Popup className="bui-popup pane-btn-popover">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Set `color: var(--text)` on `.bui-popup` so all Base UI popovers across all playgrounds use the primary text color; removes the now-redundant `var(--text-muted)` override from `.pane-btn-popover`
- Convert the query history and ER diagram icon-button popovers in `SqlPlayground` to `openOnHover` (150ms open delay, 400ms close delay) so they behave as tooltips instead of click-toggled popovers; clicking still fires `openQueryHistoryTab` / `openErDiagramTab`

## Test plan

- [ ] Open any playground — verify popover text is readable (primary text color, not muted)
- [ ] In the SQL playground, hover the History icon button — tooltip appears after ~150ms and disappears ~400ms after moving away; no popover on click
- [ ] Click the History icon button — query history tab opens, no popover stays open
- [ ] Same for the ER Diagram icon button

https://claude.ai/code/session_01UNws8XiLL8hHig6zXpwgTY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNws8XiLL8hHig6zXpwgTY)_