### PR TITLE
Polish dark mode and challenge card UI (4 updates)

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -423,11 +423,10 @@
 .instructionsBody code {
   font-family: var(--ch-font-mono);
   font-size: 12px;
-  background: var(--ch-slate-100);
-  border: 1px solid var(--ch-slate-200);
+  background: var(--ch-gray-100);
   border-radius: 4px;
   padding: 1px 5px;
-  color: var(--ch-slate-900);
+  color: var(--ch-gray-900);
 }
 
 .instructionsBody ul,
@@ -707,7 +706,24 @@
 /* Init code wrapper — collapsible read-only init panel. */
 .initWrap {
   background: var(--ch-bg-muted);
-  border-bottom: 1px solid var(--ch-border-light);
+  /* bottom edge is the striped divider rendered via ::after */
+}
+
+/* Diagonal-stripe separator between the read-only init panel and the
+   editable editor below. */
+.initWrap::after {
+  content: "";
+  display: block;
+  height: 8px;
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--ch-border-light) 0,
+    var(--ch-border-light) 1px,
+    var(--ch-bg-muted) 1px,
+    var(--ch-bg-muted) 6px
+  );
+  border-top: 1px solid var(--ch-border);
+  border-bottom: 1px solid var(--ch-border);
 }
 
 .initToggle {
@@ -719,7 +735,7 @@
   background: transparent;
   border: none;
   color: var(--ch-text-muted);
-  font-family: var(--ch-font-mono);
+  font-family: var(--ch-font-ui);
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -831,16 +847,26 @@
 /* "Click to expand" label centred at the bottom of the fade overlay. */
 .initFadeLabel {
   position: absolute;
-  bottom: 6px;
+  bottom: 4px;
   left: 50%;
   transform: translateX(-50%);
-  font-family: var(--ch-font-mono);
+  font-family: var(--ch-font-ui);
   font-size: 11px;
   font-weight: 500;
   color: var(--ch-text-muted);
   letter-spacing: 0.03em;
   pointer-events: none;
   white-space: nowrap;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+}
+
+.initFadeLabel::after {
+  content: "⌄";
+  font-size: 13px;
+  line-height: 1;
 }
 
 .initFade:hover .initFadeLabel {
@@ -1847,10 +1873,18 @@
     0 1px 3px color-mix(in srgb, var(--ch-black) 40%, transparent);
 }
 
+/* Match CodeMirror editor background to page background in dark mode —
+   the default dark theme sets #0d1117 which doesn't match #121212. */
+:global(html.dark) .editor :global(.cm-editor),
+:global(html.dark) .editor :global(.cm-scroller),
+:global(html.dark) .initEditor :global(.cm-editor),
+:global(html.dark) .initEditor :global(.cm-scroller) {
+  background-color: var(--ch-bg) !important;
+}
+
 :global(html.dark) .instructionsBody code {
   background: #1f2937;
-  border-color: #374151;
-  color: var(--ch-slate-200);
+  color: #e5e7eb;
 }
 
 :global(html.dark) .hintBox {
@@ -2022,17 +2056,15 @@
 }
 
 .tableViewerEmpty code {
-  background: var(--ch-slate-100);
-  border: 1px solid var(--ch-slate-200);
+  background: var(--ch-gray-100);
   border-radius: 3px;
   padding: 1px 5px;
-  color: var(--ch-slate-900);
+  color: var(--ch-gray-900);
 }
 
 :global(html.dark) .tableViewerEmpty code {
-  background: var(--ch-slate-800);
-  border-color: var(--ch-slate-700);
-  color: var(--ch-slate-200);
+  background: var(--ch-gray-800);
+  color: #e5e7eb;
 }
 
 .tableViewerFootnote {

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -182,11 +182,10 @@
 .bodyMd code {
   font-family: var(--mc-font-mono);
   font-size: 13.5px;
-  background: var(--mc-slate-100);
-  border: 1px solid var(--mc-slate-200);
+  background: var(--mc-gray-100);
   border-radius: 4px;
   padding: 1px 5px;
-  color: var(--mc-slate-900);
+  color: var(--mc-gray-900);
 }
 
 .bodyMd ul,
@@ -325,11 +324,10 @@
 .choiceLabel code {
   font-family: var(--mc-font-mono);
   font-size: 13.5px;
-  background: var(--mc-slate-100);
-  border: 1px solid var(--mc-slate-200);
+  background: var(--mc-gray-100);
   border-radius: 4px;
   padding: 1px 5px;
-  color: var(--mc-slate-900);
+  color: var(--mc-gray-900);
 }
 
 /* Code blocks inside choice labels (multi-line code answers). */
@@ -574,11 +572,10 @@
 .overallBody code {
   font-family: var(--mc-font-mono);
   font-size: 13.5px;
-  background: var(--mc-slate-100);
-  border: 1px solid var(--mc-slate-200);
+  background: var(--mc-gray-100);
   border-radius: 4px;
   padding: 1px 5px;
-  color: var(--mc-slate-900);
+  color: var(--mc-gray-900);
 }
 
 /* ─── Dark mode ───────────────────────────────────────────────────── */
@@ -641,12 +638,65 @@
 :global(html.dark) .bodyMd code,
 :global(html.dark) .overallBody code {
   background: #1f2937;
-  border-color: #374151;
-  color: #e2e8f0;
+  color: #e5e7eb;
 }
 
 :global(html.dark) .bodyMd pre,
 :global(html.dark) .choiceLabel pre {
   background: #1f2937;
   border-color: #374151;
+}
+
+/* Choice explanation boxes inside verdict choices use explicit white in
+   light mode — override to a translucent tinted dark surface. */
+:global(html.dark) .choice[data-verdict="correct-selected"] .choiceExplanation,
+:global(html.dark) .choice[data-verdict="correct-missed"] .choiceExplanation {
+  background: rgba(22, 163, 74, 0.08);
+}
+
+:global(html.dark) .choice[data-verdict="wrong-selected"] .choiceExplanation {
+  background: rgba(220, 38, 38, 0.08);
+}
+
+/* Choice mark icons — replace light green/red fill with translucent dark tints. */
+:global(html.dark) .choice[data-verdict="correct-selected"] .choiceMark,
+:global(html.dark) .choice[data-verdict="correct-missed"] .choiceMark {
+  background: rgba(22, 163, 74, 0.2);
+  color: #86efac;
+}
+
+:global(html.dark) .choice[data-verdict="wrong-selected"] .choiceMark {
+  background: rgba(220, 38, 38, 0.2);
+  color: #fca5a5;
+}
+
+/* Banner icon circles — light green/red fills need dark-mode tints. */
+:global(html.dark) .banner[data-state="pass"] .bannerIcon {
+  background: rgba(22, 163, 74, 0.2);
+}
+
+:global(html.dark) .banner[data-state="fail"] .bannerIcon {
+  background: rgba(220, 38, 38, 0.2);
+}
+
+:global(html.dark) .banner[data-state="partial"] .bannerIcon {
+  background: rgba(217, 119, 6, 0.2);
+}
+
+/* Retry button uses an explicit white background in light mode. */
+:global(html.dark) .retryBtn {
+  background: var(--mc-bg-subtle);
+  border-color: var(--mc-border);
+  color: var(--mc-text);
+}
+
+:global(html.dark) .retryBtn:hover {
+  background: var(--mc-bg-hover);
+  border-color: #4b5563;
+}
+
+/* Locked-selected choice hover should stay at the dark translucent blue,
+   not flash back to the light mc-blue-50. */
+:global(html.dark) .choice[data-locked="true"][data-selected="true"]:hover {
+  background: rgba(37, 99, 235, 0.18);
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Update 1** — Dark mode CodeMirror background: override `.cm-editor`/`.cm-scroller` background to `var(--ch-bg)` so it matches the page background (`#121212`) instead of the theme-default `#0d1117`.

- **Update 2** — Init code section polish:
  - Replace `initWrap` `border-bottom` with a diagonal-stripe pseudo-element divider (`::after`) using `repeating-linear-gradient`.
  - Change `initToggle` and `initFadeLabel` font family from mono (`--ch-font-mono`) to Inter (`--ch-font-ui`).
  - Add a downward chevron (`⌄`) below "Click to expand" via `CSS ::after` on `initFadeLabel`.

- **Update 3** — Inline `<code>` element cleanup in both ChallengeCard and MultipleChoiceQuestion: remove borders, switch background from blue-tinted `slate-100` to neutral `gray-100`.

- **Update 4** — MCQ dark mode whites fixed: `choiceExplanation` verdict backgrounds, `choiceMark` fill colours, `bannerIcon` backgrounds, `retryBtn` background, and locked-selected hover state.

## Test plan

- [ ] Toggle dark mode on a Learn page with a challenge card — editor background should match page background
- [ ] Challenge card with init code: verify diagonal stripe divider, Inter font on toggle + fade label, and chevron below "Click to expand"
- [ ] Inline `<code>` in challenge instructions and MCQ bodies: no border, neutral gray background
- [ ] MCQ in dark mode: submit an answer (correct and incorrect) — verify no white boxes in choice explanations, retry button is dark-styled, verdict mark icons use translucent tints

https://claude.ai/code/session_019FcrKUgmWSid9hkJo3JDYX
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019FcrKUgmWSid9hkJo3JDYX)_