### PR TITLE
UI polish: borders, icons, spacing, and dark mode fixes across learn components

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -502,7 +502,6 @@
   margin: 6px 0 8px;
   padding: 8px 10px;
   background: var(--ch-bg-subtle);
-  border: 1px solid var(--ch-border-light);
   border-radius: 5px;
   font-family: var(--ch-font-mono);
   font-size: 12px;

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -331,7 +331,7 @@
   gap: 0;
   padding: 0 8px;
   border-bottom: 1px solid var(--ch-border-light);
-  background: var(--ch-tab-bg, var(--ch-neutral-50));
+  background: var(--ch-bg-subtle);
   overflow-x: auto;
   flex-shrink: 0;
 }

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -76,7 +76,7 @@
   --ch-bg: var(--ch-white);
   --ch-bg-muted: var(--ch-neutral-50);
   --ch-bg-subtle: var(--ch-gray-50);
-  --ch-bg-hover: var(--ch-zinc-100);
+  --ch-bg-hover: var(--ch-gray-100);
   --ch-border: var(--ch-gray-200);
   --ch-border-light: var(--ch-gray-100);
   --ch-text: var(--ch-gray-900);
@@ -1840,7 +1840,7 @@
   --ch-bg: var(--color-fd-background, var(--ch-slate-900));
   --ch-bg-muted: color-mix(in srgb, var(--color-fd-background, #111827) 70%, #000000);
   --ch-bg-subtle: color-mix(in srgb, var(--color-fd-background, #111827) 85%, #000000);
-  --ch-bg-hover: #1f2937;
+  --ch-bg-hover: #222222;
   --ch-border: #2e2e2e;
   --ch-border-light: #232323;
   --ch-text: var(--ch-gray-200);

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -677,6 +677,7 @@
 .editor :global(.cm-editor) {
   height: auto;
   min-height: 120px;
+  max-height: 480px;
   font-family: var(--ch-font-mono);
   font-size: 13px;
   line-height: 1.7;
@@ -688,6 +689,27 @@
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
+  overflow: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--ch-scrollbar-thumb) transparent;
+}
+
+.editor :global(.cm-editor .cm-scroller)::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.editor :global(.cm-editor .cm-scroller)::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.editor :global(.cm-editor .cm-scroller)::-webkit-scrollbar-thumb {
+  background: var(--ch-scrollbar-thumb);
+  border-radius: 3px;
+}
+
+.editor :global(.cm-editor .cm-scroller)::-webkit-scrollbar-thumb:hover {
+  background: var(--ch-scrollbar-thumb-hover);
 }
 
 /* Suppress CodeMirror's default dotted focus outline — the surrounding
@@ -798,11 +820,36 @@
 .initEditor :global(.cm-editor) {
   height: auto;
   min-height: 30px;
+  max-height: 280px;
   font-family: var(--ch-font-mono);
   font-size: 12.5px;
   line-height: 1.7;
   font-variant-ligatures: none;
   cursor: default;
+}
+
+.initEditor :global(.cm-editor .cm-scroller) {
+  overflow: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--ch-scrollbar-thumb) transparent;
+}
+
+.initEditor :global(.cm-editor .cm-scroller)::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.initEditor :global(.cm-editor .cm-scroller)::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.initEditor :global(.cm-editor .cm-scroller)::-webkit-scrollbar-thumb {
+  background: var(--ch-scrollbar-thumb);
+  border-radius: 3px;
+}
+
+.initEditor :global(.cm-editor .cm-scroller)::-webkit-scrollbar-thumb:hover {
+  background: var(--ch-scrollbar-thumb-hover);
 }
 
 .initEditor :global(.cm-editor .cm-cursor) {
@@ -855,9 +902,9 @@
   pointer-events: none;
   white-space: nowrap;
   display: inline-flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
-  gap: 3px;
+  gap: 2px;
 }
 
 .initFadeLabel svg {
@@ -866,6 +913,31 @@
 
 .initFade:hover .initFadeLabel {
   color: var(--ch-text);
+}
+
+/* "Click to collapse" button shown at the bottom of the expanded init panel. */
+.initCollapseBtn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 5px 8px;
+  gap: 2px;
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--ch-border-light);
+  font-family: var(--ch-font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ch-text-muted);
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s;
+}
+
+.initCollapseBtn:hover {
+  color: var(--ch-text);
+  background: var(--ch-bg-hover);
 }
 
 /* ─── File tab bar (multi-file workspaces) ────────────────────────── */
@@ -1333,6 +1405,27 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  max-height: 360px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--ch-scrollbar-thumb) transparent;
+}
+
+.outputBody::-webkit-scrollbar {
+  width: 6px;
+}
+
+.outputBody::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.outputBody::-webkit-scrollbar-thumb {
+  background: var(--ch-scrollbar-thumb);
+  border-radius: 3px;
+}
+
+.outputBody::-webkit-scrollbar-thumb:hover {
+  background: var(--ch-scrollbar-thumb-hover);
 }
 
 .outputEmpty {
@@ -1841,11 +1934,15 @@
   --ch-bg-muted: color-mix(in srgb, var(--color-fd-background, #111827) 70%, #000000);
   --ch-bg-subtle: color-mix(in srgb, var(--color-fd-background, #111827) 85%, #000000);
   --ch-bg-hover: #222222;
+  --ch-bg-subtle: color-mix(in srgb, var(--color-fd-background, #121212) 85%, #000000);
+  --ch-bg-muted: color-mix(in srgb, var(--color-fd-background, #121212) 70%, #000000);
   --ch-border: #2e2e2e;
   --ch-border-light: #232323;
-  --ch-text: var(--ch-gray-200);
-  --ch-text-secondary: var(--ch-slate-300);
-  --ch-text-muted: var(--ch-slate-400);
+  --ch-text: #e0e0e0;
+  --ch-text-secondary: #b0b0b0;
+  --ch-text-muted: #808080;
+  --ch-scrollbar-thumb: rgba(255, 255, 255, 0.15);
+  --ch-scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
   --ch-accent: var(--ch-blue-500);
   --ch-accent-hover: var(--ch-blue-400);
   --ch-accent-disabled: var(--ch-blue-700);
@@ -1877,8 +1974,8 @@
 }
 
 :global(html.dark) .instructionsBody code {
-  background: #1f2937;
-  color: #e5e7eb;
+  background: #252525;
+  color: var(--ch-text);
 }
 
 :global(html.dark) .hintBox {
@@ -1894,12 +1991,12 @@
 }
 
 :global(html.dark) .initToggle:hover {
-  background: #1f2937;
+  background: var(--ch-bg-hover);
 }
 
 :global(html.dark) .utilBtn:hover:not(:disabled),
 :global(html.dark) .copyBtn:hover {
-  background: #1f2937;
+  background: var(--ch-bg-hover);
   color: var(--ch-text);
 }
 

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -329,36 +329,53 @@
   display: flex;
   align-items: stretch;
   gap: 0;
-  padding: 0 8px;
-  border-bottom: 1px solid var(--ch-border-light);
   background: var(--ch-bg-subtle);
+  border-bottom: 1px solid var(--ch-border-light);
   overflow-x: auto;
+  scrollbar-width: none;
   flex-shrink: 0;
+  user-select: none;
+}
+
+.modalTabBar::-webkit-scrollbar {
+  display: none;
 }
 
 .modalTab {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 12px;
+  padding: 7px 14px;
   font-size: 12px;
   font-family: var(--ch-font-mono);
-  color: var(--ch-text-secondary);
+  color: var(--ch-text-muted);
   background: transparent;
   border: none;
-  border-bottom: 2px solid transparent;
+  border-right: 1px solid var(--ch-border-light);
   cursor: pointer;
   white-space: nowrap;
-  transition: color 0.12s, border-color 0.12s;
+  position: relative;
+  transition: background 0.12s, color 0.12s;
 }
 
 .modalTab:hover {
+  background: var(--ch-bg-hover);
   color: var(--ch-text);
 }
 
 .modalTabActive {
+  background: var(--ch-bg);
   color: var(--ch-text);
-  border-bottom-color: var(--ch-accent, var(--ch-blue-600));
+}
+
+.modalTabActive::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--ch-accent);
 }
 
 .modalTabHint {
@@ -950,7 +967,12 @@
   border-top: 1px solid var(--ch-border-light);
   border-bottom: 1px solid var(--ch-border-light);
   overflow-x: auto;
+  scrollbar-width: none;
   user-select: none;
+}
+
+.fileTabBar::-webkit-scrollbar {
+  display: none;
 }
 
 .fileTab {
@@ -978,7 +1000,6 @@
 .fileTabActive {
   background: var(--ch-bg);
   color: var(--ch-text);
-  font-weight: 600;
 }
 
 .fileTabActive::after {
@@ -1969,7 +1990,9 @@
 :global(html.dark) .editor :global(.cm-editor),
 :global(html.dark) .editor :global(.cm-scroller),
 :global(html.dark) .initEditor :global(.cm-editor),
-:global(html.dark) .initEditor :global(.cm-scroller) {
+:global(html.dark) .initEditor :global(.cm-scroller),
+:global(html.dark) .modalEditor :global(.cm-editor),
+:global(html.dark) .modalEditor :global(.cm-scroller) {
   background-color: var(--ch-bg) !important;
 }
 

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -737,7 +737,6 @@
   font-family: var(--ch-font-ui);
   font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.04em;
   cursor: pointer;
   text-align: left;
 }
@@ -853,13 +852,12 @@
   font-size: 11px;
   font-weight: 500;
   color: var(--ch-text-muted);
-  letter-spacing: 0.03em;
   pointer-events: none;
   white-space: nowrap;
   display: inline-flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  gap: 1px;
+  gap: 3px;
 }
 
 .initFadeLabel svg {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -863,10 +863,8 @@
   gap: 1px;
 }
 
-.initFadeLabel::after {
-  content: "⌄";
-  font-size: 13px;
-  line-height: 1;
+.initFadeLabel svg {
+  display: block;
 }
 
 .initFade:hover .initFadeLabel {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1003,7 +1003,6 @@
   box-shadow:
     0 1px 2px color-mix(in srgb, var(--ch-black) 12%, transparent),
     0 8px 24px color-mix(in srgb, var(--ch-black) 22%, transparent);
-  padding: 4px;
   min-width: 240px;
   font-family: "Inter", system-ui, -apple-system, sans-serif;
   outline: none;
@@ -1842,8 +1841,8 @@
   --ch-bg-muted: color-mix(in srgb, var(--color-fd-background, #111827) 70%, #000000);
   --ch-bg-subtle: color-mix(in srgb, var(--color-fd-background, #111827) 85%, #000000);
   --ch-bg-hover: #1f2937;
-  --ch-border: var(--ch-gray-800);
-  --ch-border-light: #1f2937;
+  --ch-border: #2e2e2e;
+  --ch-border-light: #232323;
   --ch-text: var(--ch-gray-200);
   --ch-text-secondary: var(--ch-slate-300);
   --ch-text-muted: var(--ch-slate-400);

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1022,6 +1022,7 @@
   border-bottom: 1px solid var(--ch-border-light);
   background: var(--ch-bg-subtle);
   gap: 0;
+  position: relative;
 }
 
 /* Primary group: Run + Submit attached, borderless with overflow clip. */
@@ -2028,23 +2029,23 @@
 }
 
 :global(html.dark) .kbd {
-  background: var(--ch-gray-800);
-  color: var(--ch-slate-300);
-  box-shadow: 0 1px 0 var(--ch-slate-950);
+  background: #252525;
+  color: #b8b8b8;
+  box-shadow: 0 1px 0 #0d0d0d;
 }
 
 :global(html.dark) .testItem {
-  background: var(--ch-slate-950);
-  border-color: var(--ch-slate-800);
+  background: #0d0d0d;
+  border-color: #2a2a2a;
 }
 
 :global(html.dark) .testPanelHeader:hover {
-  background: var(--ch-slate-800);
+  background: #222222;
 }
 
 :global(html.dark) .testPill[data-state="pending"] {
-  background: var(--ch-gray-800);
-  border-color: var(--ch-slate-700);
+  background: #252525;
+  border-color: #333333;
 }
 
 :global(html.dark) .banner[data-state="pass"] .bannerIcon {
@@ -2056,18 +2057,18 @@
 }
 
 :global(html.dark) .outCellHtml :global(th) {
-  background: var(--ch-gray-900);
-  border-color: var(--ch-gray-800);
-  color: var(--ch-slate-400);
+  background: #1a1a1a;
+  border-color: #252525;
+  color: #909090;
 }
 
 :global(html.dark) .outCellHtml :global(td) {
-  border-color: var(--ch-slate-800);
+  border-color: #2a2a2a;
   color: var(--ch-text);
 }
 
 :global(html.dark) .outCellHtml :global(tr:hover td) {
-  background: var(--ch-gray-900);
+  background: #1a1a1a;
 }
 
 /* ─── Table viewer (SQL) ────────────────────────────────────────────── */
@@ -2096,7 +2097,7 @@
 }
 
 :global(html.dark) .tableViewerHeader:hover {
-  background: var(--ch-slate-800);
+  background: #222222;
 }
 
 .tableViewerLabel {
@@ -2177,8 +2178,8 @@
 }
 
 :global(html.dark) .tableViewerEmpty code {
-  background: var(--ch-gray-800);
-  color: #e5e7eb;
+  background: #252525;
+  color: #e0e0e0;
 }
 
 .tableViewerFootnote {
@@ -2196,8 +2197,8 @@
    rather than floating at the page level. */
 .toastViewport {
   position: absolute;
-  right: 12px;
-  bottom: 12px;
+  right: 0;
+  bottom: calc(100% + 4px);
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -2211,8 +2212,8 @@
   align-items: center;
   gap: 10px;
   padding: 6px 8px 6px 12px;
-  background: var(--ch-gray-900);
-  color: var(--ch-gray-50);
+  background: #1e1e1e;
+  color: #e8e8e8;
   font-size: 12px;
   font-family: var(--ch-font-ui);
   border-radius: 6px;
@@ -2293,7 +2294,3 @@
   scrollbar-color: var(--ch-scrollbar-thumb) transparent;
 }
 
-:global(html.dark) .card {
-  --ch-scrollbar-thumb: #334155;
-  --ch-scrollbar-thumb-hover: #475569;
-}

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -1387,7 +1387,10 @@ export default function ChallengeCard({
                 title="Expand initialization code"
                 onClick={() => setInitExpanded(true)}
               >
-                <span className={styles.initFadeLabel}>Click to expand</span>
+                <span className={styles.initFadeLabel}>
+                  Click to expand
+                  <ChevronDown size={13} strokeWidth={2} aria-hidden />
+                </span>
               </button>
             )}
           </div>

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -30,7 +30,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, Eye, Play } from "lucide-react";
+import { RotateCcw, Check, X, ChevronDown, ChevronUp, Eye, Play } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   CopyIcon,
@@ -1391,6 +1391,17 @@ export default function ChallengeCard({
                   Click to expand
                   <ChevronDown size={13} strokeWidth={2} aria-hidden />
                 </span>
+              </button>
+            )}
+            {initExpanded && initLineCount > 3 && (
+              <button
+                type="button"
+                className={styles.initCollapseBtn}
+                aria-label="Collapse initialization code"
+                onClick={() => setInitExpanded(false)}
+              >
+                Click to collapse
+                <ChevronUp size={13} strokeWidth={2} aria-hidden />
               </button>
             )}
           </div>

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -1675,6 +1675,12 @@ export default function ChallengeCard({
             <CopyIcon />
           </button>
         </div>
+        <ChallengeToastViewport
+          toasts={toasts.toasts}
+          onDismiss={toasts.dismiss}
+          className={styles.toastViewport}
+          itemClassName={styles.toast}
+        />
       </div>
 
       {/* ── Output panel ── */}
@@ -1817,12 +1823,6 @@ export default function ChallengeCard({
         />
       )}
 
-      <ChallengeToastViewport
-        toasts={toasts.toasts}
-        onDismiss={toasts.dismiss}
-        className={styles.toastViewport}
-        itemClassName={styles.toast}
-      />
     </div>
   );
 }

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -1662,6 +1662,12 @@ export default function SqlChallengeCard({
             <CopyIcon />
           </button>
         </div>
+        <ChallengeToastViewport
+          toasts={toasts.toasts}
+          onDismiss={toasts.dismiss}
+          className={styles.toastViewport}
+          itemClassName={styles.toast}
+        />
       </div>
 
       {/* ── Result panel ── */}
@@ -1815,12 +1821,6 @@ export default function SqlChallengeCard({
         />
       )}
 
-      <ChallengeToastViewport
-        toasts={toasts.toasts}
-        onDismiss={toasts.dismiss}
-        className={styles.toastViewport}
-        itemClassName={styles.toast}
-      />
     </div>
   );
 }

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -706,7 +706,7 @@
 
 :global(html.dark) .retryBtn:hover {
   background: var(--mc-bg-hover);
-  border-color: #4b5563;
+  border-color: #3a3a3a;
 }
 
 /* Choice hover in dark mode — use the dark bg-hover token instead of the

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -295,8 +295,8 @@
   flex-shrink: 0;
   margin-top: 3px;
   cursor: inherit;
-  background: transparent;
-  box-shadow: 0 0 0 1.5px var(--mc-gray-400);
+  background: var(--mc-gray-100);
+  box-shadow: none;
   transition: box-shadow 0.12s, background 0.12s;
 }
 
@@ -354,6 +354,12 @@
   font-family: var(--mc-font-mono);
   font-size: 13.5px;
   overflow-x: auto;
+}
+
+/* Remove top margin when the pre is the very first element in the choice
+   label — no preceding paragraph means no spacing is needed above it. */
+.choiceLabel pre:first-child {
+  margin-top: 0;
 }
 
 .choiceLabel pre code,
@@ -659,6 +665,19 @@
 :global(html.dark) .bodyMd pre,
 :global(html.dark) .choiceLabel pre {
   background: #1a1a1a;
+}
+
+/* Force code inside pre to be transparent so it doesn't show a lighter
+   background (#252525) on top of the pre's #1a1a1a — the higher specificity
+   here beats the general dark-mode code background rule. */
+:global(html.dark) .bodyMd pre code,
+:global(html.dark) .choiceLabel pre code {
+  background: transparent;
+}
+
+/* Unselected radio/checkbox: no ring, subtle fill close to the page bg. */
+:global(html.dark) .choiceInput:not(:checked) {
+  background: rgba(255, 255, 255, 0.05);
 }
 
 /* Choice explanation boxes inside verdict choices use explicit white in

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -248,9 +248,8 @@
   position: relative;
 }
 
-.choice:hover {
-  background: var(--mc-bg-hover);
-  border-color: var(--mc-gray-300);
+.choice:not([data-locked="true"]):hover {
+  background: var(--mc-gray-50);
 }
 
 .choice[data-selected="true"] {
@@ -261,16 +260,6 @@
 
 .choice[data-locked="true"] {
   cursor: default;
-}
-
-.choice[data-locked="true"]:hover {
-  background: var(--mc-bg);
-  border-color: var(--mc-border);
-}
-
-.choice[data-locked="true"][data-selected="true"]:hover {
-  background: var(--mc-blue-50);
-  border-color: var(--mc-accent);
 }
 
 /* Post-submit verdicts. */
@@ -695,8 +684,3 @@
   border-color: #4b5563;
 }
 
-/* Locked-selected choice hover should stay at the dark translucent blue,
-   not flash back to the light mc-blue-50. */
-:global(html.dark) .choice[data-locked="true"][data-selected="true"]:hover {
-  background: rgba(37, 99, 235, 0.18);
-}

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -207,7 +207,6 @@
   margin: 8px 0;
   padding: 12px 14px;
   background: var(--mc-bg-subtle);
-  border: 1px solid var(--mc-border-light);
   border-radius: 5px;
   font-family: var(--mc-font-mono);
   font-size: 13.5px;
@@ -290,12 +289,14 @@
    focus ring + accent-color does most of the heavy lifting and looks
    consistent with form controls elsewhere in fumadocs. */
 .choiceInput {
-  margin-top: 3px;
-  width: 14px;
-  height: 14px;
-  accent-color: var(--mc-accent);
-  flex-shrink: 0;
-  cursor: inherit;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .choiceLabel {
@@ -324,7 +325,6 @@
   margin: 8px 0 0;
   padding: 12px 14px;
   background: var(--mc-bg-subtle);
-  border: 1px solid var(--mc-border-light);
   border-radius: 5px;
   font-family: var(--mc-font-mono);
   font-size: 13.5px;
@@ -682,5 +682,20 @@
 :global(html.dark) .retryBtn:hover {
   background: var(--mc-bg-hover);
   border-color: #4b5563;
+}
+
+/* Choice hover in dark mode — use the dark bg-hover token instead of the
+   light gray-50 that the base rule references directly. */
+:global(html.dark) .choice:not([data-locked="true"]):hover {
+  background: var(--mc-bg-hover);
+}
+
+/* Disabled submit button is too vivid (blue-300) in dark mode — tone it
+   down to a dim translucent blue so it reads as inactive. */
+:global(html.dark) .submitBtn:disabled {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.22);
+  color: rgba(255, 255, 255, 0.3);
+  cursor: not-allowed;
 }
 

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -252,9 +252,8 @@
 }
 
 .choice[data-selected="true"] {
-  border-color: var(--mc-accent);
-  background: var(--mc-blue-50);
-  box-shadow: 0 0 0 1px var(--mc-accent) inset;
+  background: var(--mc-gray-100);
+  box-shadow: 0 0 0 1px var(--mc-gray-400) inset;
 }
 
 .choice[data-locked="true"] {
@@ -289,14 +288,40 @@
    focus ring + accent-color does most of the heavy lifting and looks
    consistent with form controls elsewhere in fumadocs. */
 .choiceInput {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  margin-top: 3px;
+  cursor: inherit;
+  background: transparent;
+  box-shadow: 0 0 0 1.5px var(--mc-gray-400);
+  transition: box-shadow 0.12s, background 0.12s;
+}
+
+.choiceInput[type="radio"] {
+  border-radius: 50%;
+}
+
+.choiceInput[type="checkbox"] {
+  border-radius: 3px;
+}
+
+.choiceInput:checked {
+  background: var(--mc-accent);
+  box-shadow: 0 0 0 1.5px var(--mc-accent);
+}
+
+.choiceInput[type="radio"]:checked {
+  background: radial-gradient(circle, #fff 35%, var(--mc-accent) 36%);
+}
+
+.choiceInput[type="checkbox"]:checked {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M2 5l2.5 2.5L8 3' stroke='white' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 9px;
 }
 
 .choiceLabel {
@@ -578,22 +603,23 @@
      are not present (e.g. isolated Storybook / unit-test environments).
      All surface tokens use black-based colour-mix so they stay neutral
      — no blue-tinted slate values. */
-  --mc-bg: var(--color-fd-background, #111827);
-  --mc-bg-muted: color-mix(in srgb, var(--color-fd-background, #111827) 70%, #000000);
-  --mc-bg-subtle: color-mix(in srgb, var(--color-fd-background, #111827) 85%, #000000);
+  --mc-bg: var(--color-fd-background, #121212);
+  --mc-bg-muted: color-mix(in srgb, var(--color-fd-background, #121212) 70%, #000000);
+  --mc-bg-subtle: color-mix(in srgb, var(--color-fd-background, #121212) 85%, #000000);
   --mc-bg-hover: #222222;
   --mc-border: #2e2e2e;
   --mc-border-light: #232323;
-  --mc-text: #e5e7eb;
-  --mc-text-secondary: #9ca3af;
-  --mc-text-muted: #6b7280;
+  --mc-text: #e0e0e0;
+  --mc-text-secondary: #b0b0b0;
+  --mc-text-muted: #808080;
   --mc-badge-bg: color-mix(in srgb, var(--mc-blue-500) 14%, transparent);
   --mc-badge-border: color-mix(in srgb, var(--mc-blue-500) 32%, transparent);
   --mc-badge-color: #93c5fd;
 }
 
 :global(html.dark) .choice[data-selected="true"] {
-  background: rgba(37, 99, 235, 0.18);
+  background: rgba(255, 255, 255, 0.07);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.15) inset;
 }
 
 :global(html.dark) .choice[data-verdict="correct-selected"],
@@ -626,14 +652,13 @@
 :global(html.dark) .choiceLabel code,
 :global(html.dark) .bodyMd code,
 :global(html.dark) .overallBody code {
-  background: #1f2937;
-  color: #e5e7eb;
+  background: #252525;
+  color: var(--mc-text);
 }
 
 :global(html.dark) .bodyMd pre,
 :global(html.dark) .choiceLabel pre {
-  background: #1f2937;
-  border-color: #374151;
+  background: #1a1a1a;
 }
 
 /* Choice explanation boxes inside verdict choices use explicit white in

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -57,7 +57,7 @@
   --mc-bg: var(--mc-white);
   --mc-bg-muted: var(--mc-neutral-50);
   --mc-bg-subtle: var(--mc-gray-50);
-  --mc-bg-hover: var(--mc-zinc-100);
+  --mc-bg-hover: var(--mc-gray-100);
   --mc-border: var(--mc-gray-200);
   --mc-border-light: var(--mc-gray-100);
   --mc-text: var(--mc-gray-900);
@@ -581,7 +581,7 @@
   --mc-bg: var(--color-fd-background, #111827);
   --mc-bg-muted: color-mix(in srgb, var(--color-fd-background, #111827) 70%, #000000);
   --mc-bg-subtle: color-mix(in srgb, var(--color-fd-background, #111827) 85%, #000000);
-  --mc-bg-hover: #1f2937;
+  --mc-bg-hover: #222222;
   --mc-border: #2e2e2e;
   --mc-border-light: #232323;
   --mc-text: #e5e7eb;

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -419,7 +419,7 @@
   gap: 6px;
   background: var(--mc-accent);
   color: var(--mc-white);
-  border: 1px solid var(--mc-accent);
+  border: none;
   border-radius: 6px;
   padding: 7px 14px;
   font-family: var(--mc-font-ui);
@@ -582,8 +582,8 @@
   --mc-bg-muted: color-mix(in srgb, var(--color-fd-background, #111827) 70%, #000000);
   --mc-bg-subtle: color-mix(in srgb, var(--color-fd-background, #111827) 85%, #000000);
   --mc-bg-hover: #1f2937;
-  --mc-border: #374151;
-  --mc-border-light: #1f2937;
+  --mc-border: #2e2e2e;
+  --mc-border-light: #232323;
   --mc-text: #e5e7eb;
   --mc-text-secondary: #9ca3af;
   --mc-text-muted: #6b7280;

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -28,7 +28,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import rehypeHighlight from "rehype-highlight";
-import { Check, X, RotateCcw, ListChecks, CircleDot } from "lucide-react";
+import { Check, X, RotateCcw, ListChecks, Pen } from "lucide-react";
 import {
   parseQuestion,
   type ParsedChoice,
@@ -170,7 +170,7 @@ export default function MultipleChoiceQuestion({
             </>
           ) : (
             <>
-              <CircleDot aria-hidden />
+              <Pen aria-hidden />
               Select one
             </>
           )}

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -242,6 +242,14 @@ h6 {
   background-color: #67060c;
 }
 
+/* Remove the default vertical margins Tailwind Typography adds to <li>
+   elements — the .5em top/bottom spacing is too loose for tightly-packed
+   instruction lists inside challenge and quiz cards. */
+.prose :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 /* Suppress the default hljs padding/background — our <pre> handles both. */
 pre code.hljs {
   display: block;

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -250,6 +250,11 @@ h6 {
   margin-bottom: 0;
 }
 
+/* Remove the border Tailwind Typography adds to inline <code> elements. */
+.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border: none;
+}
+
 /* Suppress the default hljs padding/background — our <pre> handles both. */
 pre code.hljs {
   display: block;

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -42,10 +42,30 @@
   --color-fd-card: hsl(0, 0%, 100%);
 }
 
-/* Item 1: Light mode active sidebar item — subtler highlight than the default
-   bg-fd-primary/10 (10% of near-black). Non-layered rules beat @layer utilities. */
+/* Sidebar active + hover overrides — fumadocs defaults use blue-tinted
+   accent tokens that stand out too much. Non-layered rules beat Tailwind's
+   @layer utilities so these reliably win without !important. */
+
+/* Light mode active */
 :root:not(.dark) #nd-sidebar [data-active="true"] {
-  background-color: hsl(0, 0%, 95%);
+  background-color: hsl(0, 0%, 94%);
+}
+
+/* Light mode hover (non-active items) */
+:root:not(.dark) #nd-sidebar a:hover:not([data-active="true"]),
+:root:not(.dark) #nd-sidebar button:hover:not([data-active="true"]) {
+  background-color: hsl(0, 0%, 97%);
+}
+
+/* Dark mode active — very subtle white overlay on the #121212 background */
+.dark #nd-sidebar [data-active="true"] {
+  background-color: rgba(255, 255, 255, 0.07);
+}
+
+/* Dark mode hover (non-active items) */
+.dark #nd-sidebar a:hover:not([data-active="true"]),
+.dark #nd-sidebar button:hover:not([data-active="true"]) {
+  background-color: rgba(255, 255, 255, 0.04);
 }
 
 /* Item 2: Sidebar footer bar (GitHub icon + theme toggle) — remove the


### PR DESCRIPTION
## Summary

### Challenge card (SQL and non-SQL)

- **Init expand icon**: `<ChevronDown>` rendered inline in JSX; `initFadeLabel` now column-layout so the chevron sits centred below "Click to expand".
- **Init collapse button**: When the init panel is expanded a "Click to collapse" button with `<ChevronUp>` appears at the bottom of the panel.
- **initFadeLabel / initToggle**: Removed `letter-spacing` from both.
- **`<pre>` border**: Removed from `.instructionsBody pre`.
- **Editor max-height + scrollbar**: Main editor capped at 480 px, init editor at 280 px, output body at 360 px. All three get a 6 px neutral styled scrollbar (neutral gray in light mode, `rgba(255,255,255,0.15)` in dark mode).
- **runMenuPopup**: Removed `4px` padding.
- **Solution modal tab bar dark mode**: Switched to `--ch-bg-subtle` so it adapts correctly in dark mode.
- **Dark mode tokens (neutral)**: `--ch-text` → `#e0e0e0`, `--ch-text-secondary` → `#b0b0b0`, `--ch-text-muted` → `#808080`; `bg-subtle`/`bg-muted` fallback changed from blue-tinted `#111827` to `#121212`; scrollbar thumb tokens set to translucent white.
- **Dark mode borders**: `--ch-border` / `--ch-border-light` → `#2e2e2e` / `#232323`.
- **Dark mode hover colors**: `--ch-bg-hover` → `#222222`; hardcoded `#1f2937` in `initToggle:hover`, `utilBtn:hover`, `copyBtn:hover` replaced with `var(--ch-bg-hover)`.
- **Dark mode `<code>` background**: `#1f2937` → `#252525`.

### Multiple choice question (MCQ)

- **Radio/checkbox inputs**: Restored as fully custom styled controls (`appearance: none`). Neutral ring (`box-shadow 1.5px gray-400`, no border); filled with accent colour when checked. Radio uses a radial-gradient dot; checkbox uses an SVG checkmark.
- **Selected choice**: Blue background/ring replaced with neutral `gray-100` + `gray-400` inset ring (light) and `rgba(255,255,255,0.07)` + white inset ring (dark).
- **`<pre>` borders**: Removed; dark mode pre background `#1f2937` → `#1a1a1a` (neutral).
- **Dark mode `<code>` background**: `#1f2937` → `#252525`.
- **Dark mode tokens**: fallback `#111827` → `#121212`; `--mc-text` → `#e0e0e0`, `--mc-text-secondary` → `#b0b0b0`, `--mc-text-muted` → `#808080`.
- **Dark mode borders**: `--mc-border` / `--mc-border-light` → `#2e2e2e` / `#232323`.
- **Dark mode hover**: `--mc-bg-hover` → `#222222`.
- **Submit button border**: Removed. Disabled state dimmed in dark mode.
- **Native inputs hidden → restored**: Previous sr-only approach replaced with visible custom-styled inputs.

### Fumadocs sidebar

- **Hover and active colors**: Neutral alpha values — dark active `rgba(255,255,255,0.07)`, dark hover `rgba(255,255,255,0.04)`, light active `hsl(0,0%,94%)`, light hover `hsl(0,0%,97%)`.

### Learn pages (global prose)

- **`<li>` margins**: Zeroed out.
- **`<code>` borders**: Removed.

## Test plan

- [ ] Challenge card init panel: chevron is below "Click to expand"; clicking expands; "Click to collapse" + ChevronUp appears at bottom; clicking collapses
- [ ] Editor, init editor, output body each cap at their max-height and scroll with a neutral 6 px scrollbar
- [ ] All hover backgrounds in challenge card are neutral gray (no blue tint) in dark mode
- [ ] Dark mode text colours are neutral (no slate/blue-gray tint)
- [ ] Dark mode `<code>` background is neutral dark gray
- [ ] MCQ radio (single) and checkbox (multi) inputs visible — neutral ring, filled on check, no border
- [ ] MCQ selected choice row uses neutral gray background + ring (no blue)
- [ ] MCQ dark mode selected row is subtle white tint
- [ ] MCQ `<pre>` blocks have no border and neutral dark background in dark mode
- [ ] Sidebar hover/active very subtle in both modes
- [ ] Prose `<li>` no gap; prose `<code>` no border

https://claude.ai/code/session_016fLXGtBNvjBXFjazTkvDe3