### PR TITLE
UI polish: 13 updates across MCQ and challenge card components

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -2079,9 +2079,27 @@
   background: #222222;
 }
 
+:global(html.dark) .testPill[data-state="pass"] {
+  background: color-mix(in srgb, var(--ch-green-500) 12%, transparent);
+  border-color: color-mix(in srgb, var(--ch-green-500) 28%, transparent);
+}
+
+:global(html.dark) .testPill[data-state="fail"] {
+  background: color-mix(in srgb, var(--ch-red-500) 12%, transparent);
+  border-color: color-mix(in srgb, var(--ch-red-500) 28%, transparent);
+}
+
 :global(html.dark) .testPill[data-state="pending"] {
   background: #252525;
   border-color: #333333;
+}
+
+:global(html.dark) .banner[data-state="pass"] {
+  border-top-color: color-mix(in srgb, var(--ch-green-500) 28%, transparent);
+}
+
+:global(html.dark) .banner[data-state="fail"] {
+  border-top-color: color-mix(in srgb, var(--ch-red-500) 28%, transparent);
 }
 
 :global(html.dark) .banner[data-state="pass"] .bannerIcon {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1201,6 +1201,13 @@
   fill: none !important;
 }
 
+.utilSpinner {
+  width: 12px;
+  height: 12px;
+  animation: ch-spin 0.75s linear infinite;
+  fill: none !important;
+}
+
 @keyframes ch-spin {
   to {
     transform: rotate(360deg);
@@ -2032,6 +2039,16 @@
   background: #252525;
   color: #b8b8b8;
   box-shadow: 0 1px 0 #0d0d0d;
+}
+
+/* Keep the dropdown menu's kbd chips as semi-transparent white on blue
+   even in dark mode — the general .kbd dark rule would otherwise make them
+   gray (#252525) which clashes with the blue popup background. */
+:global(html.dark) .runMenuKbd .kbd {
+  background: color-mix(in srgb, #ffffff 16%, transparent);
+  border-color: color-mix(in srgb, #ffffff 28%, transparent);
+  color: color-mix(in srgb, #ffffff 88%, transparent);
+  box-shadow: none;
 }
 
 :global(html.dark) .testItem {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -116,7 +116,7 @@
   overflow: hidden;
   font-family: var(--ch-font-ui);
   color: var(--ch-text);
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.5;
   margin: 1rem 0;
   position: relative;
@@ -163,7 +163,7 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-text-secondary);
 }
 
@@ -177,7 +177,7 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 10.5px;
+  font-size: 11.5px;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -221,7 +221,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--ch-green);
 }
@@ -230,7 +230,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-text-secondary);
 }
 
@@ -281,7 +281,7 @@
 }
 
 .modalTitle {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
   color: var(--ch-text);
   line-height: 1.3;
@@ -291,7 +291,7 @@
 }
 
 .modalSubtitle {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-text-muted);
   white-space: nowrap;
   overflow: hidden;
@@ -346,7 +346,7 @@
   align-items: center;
   gap: 6px;
   padding: 7px 14px;
-  font-size: 12px;
+  font-size: 13px;
   font-family: var(--ch-font-mono);
   color: var(--ch-text-muted);
   background: transparent;
@@ -380,7 +380,7 @@
 
 .modalTabHint {
   color: var(--ch-text-muted);
-  font-size: 14px;
+  font-size: 15px;
   line-height: 1;
 }
 
@@ -565,7 +565,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-accent);
   cursor: pointer;
   background: none;
@@ -589,7 +589,7 @@
   border: 1px solid var(--ch-blue-200);
   border-radius: 6px;
   padding: 10px 12px;
-  font-size: 12.5px;
+  font-size: 13.5px;
   color: var(--ch-blue-800);
   line-height: 1.6;
 }
@@ -599,7 +599,7 @@
   border: 1px solid var(--ch-blue-200);
   color: var(--ch-blue-900);
   font-family: var(--ch-font-mono);
-  font-size: 11.5px;
+  font-size: 12.5px;
   border-radius: 3px;
   padding: 1px 5px;
 }
@@ -619,7 +619,7 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-text-muted);
   font-family: var(--ch-font-mono);
 }
@@ -639,7 +639,7 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-text-secondary);
 }
 
@@ -774,7 +774,7 @@
   border: none;
   color: var(--ch-text-muted);
   font-family: var(--ch-font-ui);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   cursor: pointer;
   text-align: left;
@@ -913,7 +913,7 @@
   left: 50%;
   transform: translateX(-50%);
   font-family: var(--ch-font-ui);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   color: var(--ch-text-muted);
   pointer-events: none;
@@ -946,7 +946,7 @@
   border: none;
   border-top: 1px solid var(--ch-border-light);
   font-family: var(--ch-font-ui);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   color: var(--ch-text-muted);
   cursor: pointer;
@@ -985,7 +985,7 @@
   border: none;
   border-right: 1px solid var(--ch-border-light);
   font-family: var(--ch-font-mono);
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-text-muted);
   cursor: pointer;
   white-space: nowrap;
@@ -1113,7 +1113,7 @@
   border: none;
   border-radius: 5px;
   color: var(--ch-white);
-  font-size: 13px;
+  font-size: 14px;
   cursor: pointer;
   text-align: left;
   font-family: inherit;
@@ -1150,7 +1150,7 @@
   color: color-mix(in srgb, var(--ch-white) 88%, transparent);
   box-shadow: none;
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
-  font-size: 10.5px;
+  font-size: 11.5px;
   padding: 2px 5px;
   border-radius: 4px;
   line-height: 1;
@@ -1159,7 +1159,7 @@
 
 .runMenuKbd .kbdSep {
   color: color-mix(in srgb, var(--ch-white) 50%, transparent);
-  font-size: 11px;
+  font-size: 12px;
 }
 
 .runBtn {
@@ -1167,7 +1167,7 @@
   color: var(--ch-white);
   border: none;
   padding: 6px 12px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   cursor: pointer;
   display: inline-flex;
@@ -1219,7 +1219,7 @@
   background: transparent;
   border: none;
   padding: 6px 11px;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--ch-accent);
   cursor: pointer;
@@ -1249,7 +1249,7 @@
 }
 
 .btnKbd .kbdSep {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ch-text-muted);
 }
 
@@ -1269,7 +1269,7 @@
   border: 1px solid var(--ch-border);
   border-radius: 4px;
   padding: 2px 5px;
-  font-size: 10.5px;
+  font-size: 11.5px;
   font-family: var(--ch-font-mono);
   color: var(--ch-text-muted);
   box-shadow: 0 1px 0 var(--ch-border);
@@ -1279,7 +1279,7 @@
 
 .kbdSep {
   color: var(--ch-text-muted);
-  font-size: 11px;
+  font-size: 12px;
 }
 
 /* Utility-button group on the right side of the toolbar. */
@@ -1298,7 +1298,7 @@
    don't push the Reset / Solution / Copy buttons off-screen. */
 .actionBarStatus {
   font-family: var(--ch-font-mono);
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ch-text-secondary);
   white-space: nowrap;
   overflow: hidden;
@@ -1326,7 +1326,7 @@
   background: transparent;
   border: none;
   color: var(--ch-text-muted);
-  font-size: 12.5px;
+  font-size: 13.5px;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -1410,7 +1410,7 @@
 }
 
 .outputLabel {
-  font-size: 10.5px;
+  font-size: 11.5px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1419,7 +1419,7 @@
 
 .outputTime {
   margin-left: auto;
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: var(--ch-text-muted);
   font-family: var(--ch-font-mono);
 }
@@ -1427,7 +1427,7 @@
 .outputBody {
   padding: 10px 14px 14px 27px;
   font-family: var(--ch-font-mono);
-  font-size: 12.5px;
+  font-size: 13.5px;
   line-height: 1.8;
   color: var(--ch-text);
   white-space: pre-wrap;
@@ -1461,7 +1461,7 @@
 .outputEmpty {
   padding: 4px 14px 14px 27px;
   color: var(--ch-text-muted);
-  font-size: 12px;
+  font-size: 13px;
   font-style: italic;
 }
 
@@ -1485,7 +1485,7 @@
 .outCellHtml :global(table) {
   border-collapse: collapse;
   font-family: var(--ch-font-mono);
-  font-size: 12px;
+  font-size: 13px;
 }
 
 .outCellHtml :global(th) {
@@ -1493,7 +1493,7 @@
   border: 1px solid var(--ch-slate-200);
   padding: 5px 12px;
   text-align: right;
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: var(--ch-text-muted);
   font-weight: 600;
   white-space: nowrap;
@@ -1655,7 +1655,7 @@
 }
 
 .testLabel {
-  font-size: 10.5px;
+  font-size: 11.5px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1670,7 +1670,7 @@
 }
 
 .testPill {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   border-radius: 4px;
   padding: 2px 8px;
@@ -1756,21 +1756,21 @@
 
 .testItemName {
   font-family: var(--ch-font-mono);
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: var(--ch-text);
   font-weight: 500;
   line-height: 1.4;
 }
 
 .testItemDesc {
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: var(--ch-text-muted);
   margin-top: 2px;
 }
 
 .testItemDetail {
   margin-top: 4px;
-  font-size: 11.5px;
+  font-size: 12.5px;
   font-family: var(--ch-font-mono);
   color: var(--ch-red);
   background: var(--ch-red-bg);
@@ -1788,7 +1788,7 @@
   gap: 12px;
   padding: 12px 20px;
   border-top: 1px solid var(--ch-border-light);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
 }
 
@@ -1823,7 +1823,7 @@
 }
 
 .bannerSub {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 400;
   opacity: 0.8;
   margin-left: 2px;
@@ -1849,7 +1849,7 @@
 }
 
 .sqlResultLabel {
-  font-size: 10.5px;
+  font-size: 11.5px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1858,7 +1858,7 @@
 
 .sqlResultCount {
   margin-left: auto;
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: var(--ch-text-muted);
   font-family: var(--ch-font-mono);
 }
@@ -1874,7 +1874,7 @@
 .sqlResultTable {
   border-collapse: collapse;
   font-family: var(--ch-font-mono);
-  font-size: 12px;
+  font-size: 13px;
   width: 100%;
 }
 
@@ -1884,7 +1884,7 @@
   border-right: 1px solid var(--ch-border-light);
   padding: 6px 12px;
   text-align: left;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ch-text-muted);
   font-weight: 600;
   white-space: nowrap;
@@ -1925,7 +1925,7 @@
 
 .sqlEmptyResult {
   padding: 14px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-text-muted);
   font-style: italic;
   text-align: center;
@@ -1933,7 +1933,7 @@
 
 .sqlMessage {
   padding: 10px 14px 14px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-text-muted);
   font-family: var(--ch-font-mono);
 }
@@ -2119,7 +2119,7 @@
 }
 
 .tableViewerLabel {
-  font-size: 10.5px;
+  font-size: 11.5px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2129,7 +2129,7 @@
 .tableViewerCount {
   margin-left: auto;
   font-family: var(--ch-font-mono);
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: var(--ch-text-muted);
 }
 
@@ -2143,7 +2143,7 @@
 
 .tableViewerTab {
   font-family: var(--ch-font-mono);
-  font-size: 11.5px;
+  font-size: 12.5px;
   padding: 3px 9px;
   border-radius: 4px;
   border: 1px solid var(--ch-border-light);
@@ -2183,7 +2183,7 @@
   background: var(--ch-bg);
   border: 1px solid var(--ch-border-light);
   border-radius: 6px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ch-text-muted);
   font-family: var(--ch-font-mono);
 }
@@ -2203,7 +2203,7 @@
 .tableViewerFootnote {
   padding: 4px 10px;
   font-family: var(--ch-font-mono);
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ch-text-muted);
   border-top: 1px solid var(--ch-border-light);
   background: var(--ch-bg-subtle);
@@ -2232,7 +2232,7 @@
   padding: 6px 8px 6px 12px;
   background: #1e1e1e;
   color: #e8e8e8;
-  font-size: 12px;
+  font-size: 13px;
   font-family: var(--ch-font-ui);
   border-radius: 6px;
   box-shadow:

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -203,7 +203,7 @@
 }
 
 .title {
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 600;
   color: var(--ch-text);
   line-height: 1.4;
@@ -420,7 +420,7 @@
 }
 
 .instructionsBody {
-  font-size: 13px;
+  font-size: 15px;
   line-height: 1.65;
   color: var(--ch-text-secondary);
 }

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -183,9 +183,6 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--ch-badge-color);
-  background: var(--ch-badge-bg);
-  border-radius: 5px;
-  padding: 4px 8px;
   flex-shrink: 0;
   white-space: nowrap;
 }
@@ -771,9 +768,9 @@
   gap: 8px;
   width: 100%;
   padding: 6px 14px;
-  background: transparent;
+  background: var(--ch-bg);
   border: none;
-  color: var(--ch-text-muted);
+  color: var(--ch-gray-700);
   font-family: var(--ch-font-ui);
   font-size: 12px;
   font-weight: 400;
@@ -782,7 +779,7 @@
 }
 
 .initToggle:hover {
-  color: var(--ch-text);
+  color: var(--ch-gray-900);
   background: var(--ch-bg-hover);
 }
 
@@ -800,6 +797,7 @@
 .initLabel {
   flex: 1;
   letter-spacing: 0;
+  color: var(--ch-gray-700);
 }
 
 .initMeta {
@@ -811,7 +809,6 @@
 
 .initEditorWrap {
   position: relative;
-  border-top: 1px solid var(--ch-border-light);
   background: var(--ch-bg);
   /* Animate the height change so collapse/expand isn't a snap. The
      wrapper has `overflow: hidden` while collapsed, so the gradient
@@ -944,19 +941,18 @@
   width: 100%;
   padding: 5px 8px;
   gap: 4px;
-  background: transparent;
+  background: var(--ch-bg);
   border: none;
-  border-top: 1px solid var(--ch-border-light);
   font-family: var(--ch-font-ui);
   font-size: 12px;
   font-weight: 500;
-  color: var(--ch-text-muted);
+  color: var(--ch-gray-700);
   cursor: pointer;
   transition: color 0.12s, background 0.12s;
 }
 
 .initCollapseBtn:hover {
-  color: var(--ch-text);
+  color: var(--ch-gray-900);
   background: var(--ch-bg-hover);
 }
 
@@ -1021,9 +1017,7 @@
   display: flex;
   align-items: center;
   padding: 8px 14px;
-  border-top: 1px solid var(--ch-border-light);
   border-bottom: 1px solid var(--ch-border-light);
-  background: var(--ch-bg-subtle);
   gap: 0;
   position: relative;
 }
@@ -2028,7 +2022,25 @@
   color: var(--ch-blue-100);
 }
 
+:global(html.dark) .initToggle {
+  color: var(--ch-gray-300);
+}
+
 :global(html.dark) .initToggle:hover {
+  color: #ffffff;
+  background: var(--ch-bg-hover);
+}
+
+:global(html.dark) .initLabel {
+  color: var(--ch-gray-300);
+}
+
+:global(html.dark) .initCollapseBtn {
+  color: var(--ch-gray-300);
+}
+
+:global(html.dark) .initCollapseBtn:hover {
+  color: #ffffff;
   background: var(--ch-bg-hover);
 }
 

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -171,6 +171,7 @@
   width: 13px;
   height: 13px;
   flex-shrink: 0;
+  color: var(--ch-gray-900);
 }
 
 .badge {
@@ -2004,6 +2005,10 @@
 :global(html.dark) .modalEditor :global(.cm-editor),
 :global(html.dark) .modalEditor :global(.cm-scroller) {
   background-color: var(--ch-bg) !important;
+}
+
+:global(html.dark) .headerRuntimeLabel svg {
+  color: #ffffff;
 }
 
 :global(html.dark) .instructionsBody code {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -775,7 +775,7 @@
   color: var(--ch-text-muted);
   font-family: var(--ch-font-ui);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 400;
   cursor: pointer;
   text-align: left;
 }
@@ -798,6 +798,7 @@
 
 .initLabel {
   flex: 1;
+  letter-spacing: 0;
 }
 
 .initMeta {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -921,7 +921,8 @@
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
+  gap: 0px;
+  padding-bottom: 3px;
 }
 
 .initFadeLabel svg {
@@ -935,12 +936,12 @@
 /* "Click to collapse" button shown at the bottom of the expanded init panel. */
 .initCollapseBtn {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
   width: 100%;
   padding: 5px 8px;
-  gap: 2px;
+  gap: 4px;
   background: transparent;
   border: none;
   border-top: 1px solid var(--ch-border-light);

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -256,13 +256,11 @@ function RunOverlay({ active }: { active: boolean }) {
 
 function LanguageGlyph({ adapter }: { adapter: LanguageAdapter }) {
   const Icon = LANGUAGE_ICONS[adapter.id];
-  const color = LANGUAGE_ICON_COLORS[adapter.id];
   const factor = LANGUAGE_ICON_SIZE_FACTOR[adapter.id] ?? 1;
   if (!Icon) return <span aria-hidden>{adapter.logoText}</span>;
   return (
     <Icon
       style={{
-        color,
         width: `${Math.round(14 * factor)}px`,
         height: `${Math.round(14 * factor)}px`,
       }}

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -95,7 +95,7 @@ type TestState = "pending" | "pass" | "fail";
 interface DisplayedTest {
   id: string;
   name: string;
-  description: string;
+  description?: string;
   state: TestState;
   detail: string | null;
 }
@@ -1782,7 +1782,7 @@ export default function ChallengeCard({
                   </div>
                   <div className={styles.testItemBody}>
                     <div className={styles.testItemName}>{t.name}</div>
-                    <div className={styles.testItemDesc}>{t.description}</div>
+                    {t.description && <div className={styles.testItemDesc}>{t.description}</div>}
                     {t.state === "fail" && t.detail && (
                       <div className={styles.testItemDetail}>{t.detail}</div>
                     )}

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -1411,8 +1411,8 @@ export default function ChallengeCard({
                 aria-label="Collapse initialization code"
                 onClick={() => setInitExpanded(false)}
               >
-                Click to collapse
                 <ChevronUp size={13} strokeWidth={2} aria-hidden />
+                Click to collapse
               </button>
             )}
           </div>

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -30,7 +30,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, ChevronUp, Eye, Play } from "lucide-react";
+import { RotateCcw, Check, X, ChevronDown, ChevronUp, Eye, Play, Terminal } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   CopyIcon,
@@ -431,6 +431,7 @@ export default function ChallengeCard({
   const [testResults, setTestResults] = useState<DisplayedTest[]>([]);
   const [testListOpen, setTestListOpen] = useState(true);
   const [bannerState, setBannerState] = useState<"pass" | "fail" | null>(null);
+  const [isFormatting, setIsFormatting] = useState(false);
   const toasts = useChallengeToasts();
 
   // ─── Multi-file workspace state ─────────────────────────────────────
@@ -1230,24 +1231,34 @@ export default function ChallengeCard({
     }
   }, [toasts]);
 
+  const MIN_FORMAT_MS = 300;
+
   const formatCode = useCallback(async () => {
     if (!adapter.formatCode) return;
     const view = editorRef.current;
     if (!view) return;
     const code = view.state.doc.toString();
     if (!code.trim()) return;
+    setIsFormatting(true);
+    const startedAt = performance.now();
     try {
       const formatted = await adapter.formatCode(code);
+      const wait = MIN_FORMAT_MS - (performance.now() - startedAt);
+      if (wait > 0) await new Promise<void>((r) => setTimeout(r, wait));
       if (formatted === code) {
         toasts.show("Already formatted — nothing to change.");
-        return;
+      } else {
+        view.dispatch({
+          changes: { from: 0, to: view.state.doc.length, insert: formatted },
+        });
+        toasts.show("Code formatted.");
       }
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: formatted },
-      });
-      toasts.show("Code formatted.");
     } catch {
+      const wait = MIN_FORMAT_MS - (performance.now() - startedAt);
+      if (wait > 0) await new Promise<void>((r) => setTimeout(r, wait));
       toasts.show("Couldn't format — code may have a syntax error.", "warn");
+    } finally {
+      setIsFormatting(false);
     }
   }, [adapter, toasts]);
 
@@ -1291,7 +1302,7 @@ export default function ChallengeCard({
       <div className={styles.header}>
         <div className={styles.headerRow}>
           <div className={styles.badge}>
-            <span className={styles.badgeDot} /> {badge}
+            <Terminal size={9} aria-hidden /> {badge}
           </div>
           <div className={styles.headerMeta}>
             <span className={styles.headerRuntimeLabel}>
@@ -1655,11 +1666,17 @@ export default function ChallengeCard({
                 type="button"
                 className={styles.utilBtn}
                 onClick={() => void formatCode()}
-                disabled={isBusy}
+                disabled={isBusy || isFormatting}
                 title="Format code"
                 aria-label="Format code"
               >
-                <FormatIcon />
+                {isFormatting ? (
+                  <svg viewBox="0 0 12 12" className={styles.utilSpinner} aria-hidden>
+                    <circle cx="6" cy="6" r="4.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeDasharray="14 8" />
+                  </svg>
+                ) : (
+                  <FormatIcon />
+                )}
                 <span className={styles.utilBtnLabel}>Format</span>
               </button>
             </>
@@ -1876,7 +1893,7 @@ function SolutionModal({
       >
         <div className={styles.modalHeader}>
           <div className={styles.badge}>
-            <span className={styles.badgeDot} /> Solution
+            <Terminal size={9} aria-hidden /> Solution
           </div>
           <div className={styles.modalTitleArea}>
             <div className={styles.modalTitle}>Reference solution</div>

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -35,7 +35,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, Eye, Play } from "lucide-react";
+import { RotateCcw, Check, X, ChevronDown, Eye, Play, Database } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   createColumnHelper,
@@ -654,6 +654,7 @@ export default function SqlChallengeCard({
   const [testResults, setTestResults] = useState<DisplayedTest[]>([]);
   const [testListOpen, setTestListOpen] = useState(true);
   const [bannerState, setBannerState] = useState<"pass" | "fail" | null>(null);
+  const [isFormatting, setIsFormatting] = useState(false);
   const toasts = useChallengeToasts();
   const [engineLabel, setEngineLabel] = useState<string>(
     dialect === "sqlite"
@@ -1297,26 +1298,36 @@ export default function SqlChallengeCard({
     }
   }, [toasts]);
 
+  const MIN_FORMAT_MS = 300;
+
   const formatCode = useCallback(async () => {
     const view = editorRef.current;
     if (!view) return;
     const code = view.state.doc.toString();
     if (!code.trim()) return;
+    setIsFormatting(true);
+    const startedAt = performance.now();
     try {
       const { format: sqlFormat } = await import("sql-formatter");
       const formatted = sqlFormat(code, {
         language: sqlFormatterLanguage(dialect),
       });
+      const wait = MIN_FORMAT_MS - (performance.now() - startedAt);
+      if (wait > 0) await new Promise<void>((r) => setTimeout(r, wait));
       if (formatted === code) {
         toasts.show("Already formatted — nothing to change.");
-        return;
+      } else {
+        view.dispatch({
+          changes: { from: 0, to: view.state.doc.length, insert: formatted },
+        });
+        toasts.show("SQL formatted.");
       }
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: formatted },
-      });
-      toasts.show("SQL formatted.");
     } catch {
+      const wait = MIN_FORMAT_MS - (performance.now() - startedAt);
+      if (wait > 0) await new Promise<void>((r) => setTimeout(r, wait));
       toasts.show("Couldn't format — SQL may have a syntax error.", "warn");
+    } finally {
+      setIsFormatting(false);
     }
   }, [dialect, toasts]);
 
@@ -1342,7 +1353,7 @@ export default function SqlChallengeCard({
       <div className={styles.header}>
         <div className={styles.headerRow}>
           <div className={styles.badge}>
-            <span className={styles.badgeDot} /> {badge}
+            <Database size={9} aria-hidden /> {badge}
           </div>
           <div className={styles.headerMeta}>
             <span className={styles.headerRuntimeLabel}>
@@ -1644,11 +1655,17 @@ export default function SqlChallengeCard({
             type="button"
             className={styles.utilBtn}
             onClick={() => void formatCode()}
-            disabled={isBusy}
+            disabled={isBusy || isFormatting}
             title="Format SQL"
             aria-label="Format SQL"
           >
-            <FormatIcon />
+            {isFormatting ? (
+              <svg viewBox="0 0 12 12" className={styles.utilSpinner} aria-hidden>
+                <circle cx="6" cy="6" r="4.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeDasharray="14 8" />
+              </svg>
+            ) : (
+              <FormatIcon />
+            )}
             <span className={styles.utilBtnLabel}>Format</span>
           </button>
           <div className={styles.btnGroupUtilSep} aria-hidden />
@@ -1867,7 +1884,7 @@ function SolutionModal({
       >
         <div className={styles.modalHeader}>
           <div className={styles.badge}>
-            <span className={styles.badgeDot} /> Solution
+            <Database size={9} aria-hidden /> Solution
           </div>
           <div className={styles.modalTitleArea}>
             <div className={styles.modalTitle}>Reference solution</div>

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -566,13 +566,11 @@ function RunOverlay({ active }: { active: boolean }) {
 function DialectGlyph({ dialect }: { dialect: SqlDialect }) {
   const key = languageIconKeyForDialect(dialect);
   const Icon = LANGUAGE_ICONS[key];
-  const color = LANGUAGE_ICON_COLORS[key];
   const factor = LANGUAGE_ICON_SIZE_FACTOR[key] ?? 1;
   if (!Icon) return null;
   return (
     <Icon
       style={{
-        color,
         width: `${Math.round(14 * factor)}px`,
         height: `${Math.round(14 * factor)}px`,
       }}

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -104,7 +104,7 @@ export interface SqlResult {
 export interface SqlChallengeTest {
   id: string;
   name: string;
-  description: string;
+  description?: string;
   /** Expected row count of the learner's final result set. */
   expectedRowCount?: number;
   /** Minimum row count of the learner's final result set. */
@@ -508,7 +508,7 @@ type TestState = "pending" | "pass" | "fail";
 interface DisplayedTest {
   id: string;
   name: string;
-  description: string;
+  description?: string;
   state: TestState;
   detail: string | null;
 }
@@ -1788,7 +1788,7 @@ export default function SqlChallengeCard({
                   </div>
                   <div className={styles.testItemBody}>
                     <div className={styles.testItemName}>{t.name}</div>
-                    <div className={styles.testItemDesc}>{t.description}</div>
+                    {t.description && <div className={styles.testItemDesc}>{t.description}</div>}
                     {t.state === "fail" && t.detail && (
                       <div className={styles.testItemDetail}>{t.detail}</div>
                     )}

--- a/app/_components/challengeHarness.ts
+++ b/app/_components/challengeHarness.ts
@@ -68,7 +68,7 @@ export interface StdoutExpect {
 export interface ChallengeTestBase {
   id: string;
   name: string;
-  description: string;
+  description?: string;
 }
 
 /** A test that injects code into the runtime alongside the learner's

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -446,17 +446,15 @@
   font-size: 13.5px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s;
+  transition: background 0.12s;
 }
 
 .submitBtn:hover:not(:disabled) {
   background: var(--mc-accent-hover);
-  border-color: var(--mc-accent-hover);
 }
 
 .submitBtn:disabled {
   background: var(--mc-accent-disabled);
-  border-color: var(--mc-accent-disabled);
   cursor: not-allowed;
 }
 
@@ -718,7 +716,6 @@
    down to a dim translucent blue so it reads as inactive. */
 :global(html.dark) .submitBtn:disabled {
   background: rgba(59, 130, 246, 0.5);
-  border-color: rgba(59, 130, 246, 0.55);
   color: rgba(255, 255, 255, 0.5);
   cursor: not-allowed;
 }

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -152,7 +152,7 @@
 /* ─── Question body (markdown-rendered) ───────────────────────────── */
 
 .body {
-  padding: 4px 20px 14px;
+  padding: 10px 20px 14px;
 }
 
 .bodyMd {
@@ -717,9 +717,9 @@
 /* Disabled submit button is too vivid (blue-300) in dark mode — tone it
    down to a dim translucent blue so it reads as inactive. */
 :global(html.dark) .submitBtn:disabled {
-  background: rgba(59, 130, 246, 0.18);
-  border-color: rgba(59, 130, 246, 0.22);
-  color: rgba(255, 255, 255, 0.3);
+  background: rgba(59, 130, 246, 0.28);
+  border-color: rgba(59, 130, 246, 0.35);
+  color: rgba(255, 255, 255, 0.5);
   cursor: not-allowed;
 }
 

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -389,7 +389,7 @@
   border-radius: 4px;
   font-size: 13.5px;
   line-height: 1.6;
-  color: var(--mc-text-secondary);
+  color: var(--mc-gray-700);
 }
 
 .choiceExplanation p {

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -109,9 +109,6 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--mc-badge-color);
-  background: var(--mc-badge-bg);
-  border-radius: 5px;
-  padding: 4px 8px;
   flex-shrink: 0;
   white-space: nowrap;
 }
@@ -129,6 +126,7 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
+  margin-left: auto;
 }
 
 .modeLabel svg {
@@ -136,18 +134,6 @@
   height: 13px;
 }
 
-.headerStatus {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: var(--mc-text-secondary);
-}
-
-.attemptCount {
-  font-variant-numeric: tabular-nums;
-}
 
 /* ─── Question body (markdown-rendered) ───────────────────────────── */
 

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -251,7 +251,7 @@
 }
 
 .choice[data-selected="true"] {
-  background: var(--mc-gray-100);
+  /* no background highlight — selection is indicated by the input alone */
 }
 
 .choice[data-locked="true"] {
@@ -310,6 +310,7 @@
   background-repeat: no-repeat;
   background-position: center;
   background-size: 9px;
+  box-shadow: none;
 }
 
 .choiceLabel {
@@ -607,7 +608,7 @@
 }
 
 :global(html.dark) .choice[data-selected="true"] {
-  background: rgba(255, 255, 255, 0.07);
+  /* no background highlight in dark mode either */
 }
 
 :global(html.dark) .choice[data-verdict="correct-selected"],
@@ -740,6 +741,27 @@
 :global(html.dark) .choiceInput[type="radio"]:checked {
   background: radial-gradient(circle, white 30%, #fff6 31%);
   box-shadow: none;
+}
+
+/* In dark mode, checked checkboxes flip to a white box with a dark
+   checkmark so they read as clearly "on" against any dark background. */
+:global(html.dark) .choiceInput[type="checkbox"]:checked {
+  background-color: #ffffff;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M2 5l2.5 2.5L8 3' stroke='%231a1a1a' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  box-shadow: none;
+}
+
+/* Inline code inside verdict choice explanations: use a tinted background
+   that blends with the dark green / dark red surface instead of gray. */
+:global(html.dark) .choice[data-verdict="correct-selected"] .choiceExplanation code,
+:global(html.dark) .choice[data-verdict="correct-missed"] .choiceExplanation code {
+  background: rgba(22, 163, 74, 0.3);
+  color: #bbf7d0;
+}
+
+:global(html.dark) .choice[data-verdict="wrong-selected"] .choiceExplanation code {
+  background: rgba(220, 38, 38, 0.3);
+  color: #fecaca;
 }
 
 /* Overall explanation paragraph text is white in dark mode. */

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -717,8 +717,8 @@
 /* Disabled submit button is too vivid (blue-300) in dark mode — tone it
    down to a dim translucent blue so it reads as inactive. */
 :global(html.dark) .submitBtn:disabled {
-  background: rgba(59, 130, 246, 0.28);
-  border-color: rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.5);
+  border-color: rgba(59, 130, 246, 0.55);
   color: rgba(255, 255, 255, 0.5);
   cursor: not-allowed;
 }

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -153,7 +153,6 @@
 
 .body {
   padding: 4px 20px 14px;
-  border-bottom: 1px solid var(--mc-border-light);
 }
 
 .bodyMd {
@@ -225,7 +224,7 @@
 
 .choiceList {
   margin: 0;
-  padding: 14px 20px 4px;
+  padding: 14px 20px 14px;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -297,12 +296,13 @@
 }
 
 .choiceInput:checked {
-  background: var(--mc-gray-500);
+  background: var(--mc-gray-900);
   box-shadow: 0 0 0 1.5px var(--mc-gray-400);
 }
 
 .choiceInput[type="radio"]:checked {
-  background: radial-gradient(circle, #fff 35%, var(--mc-gray-500) 36%);
+  background: radial-gradient(circle, #fff 30%, var(--mc-gray-900) 31%);
+  box-shadow: none;
 }
 
 .choiceInput[type="checkbox"]:checked {
@@ -561,7 +561,7 @@
 .overallBody {
   font-size: 14px;
   line-height: 1.7;
-  color: var(--mc-text-secondary);
+  color: var(--mc-gray-700);
 }
 
 .overallBody p {
@@ -729,13 +729,21 @@
   color: #ffffff;
 }
 
-/* Neutral (gray) checked state for radio/checkbox inputs in dark mode. */
+/* Neutral checked state for radio/checkbox inputs in dark mode.
+   Use background-color (not the background shorthand) so it doesn't
+   reset background-image, which would hide the checkbox checkmark. */
 :global(html.dark) .choiceInput:checked {
-  background: rgba(255, 255, 255, 0.4);
+  background-color: var(--mc-gray-900);
   box-shadow: 0 0 0 1.5px rgba(255, 255, 255, 0.25);
 }
 
 :global(html.dark) .choiceInput[type="radio"]:checked {
-  background: radial-gradient(circle, var(--mc-bg) 35%, rgba(255, 255, 255, 0.4) 36%);
+  background: radial-gradient(circle, white 30%, #fff6 31%);
+  box-shadow: none;
+}
+
+/* Overall explanation paragraph text is white in dark mode. */
+:global(html.dark) .overallBody {
+  color: #ffffff;
 }
 

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -253,7 +253,6 @@
 
 .choice[data-selected="true"] {
   background: var(--mc-gray-100);
-  box-shadow: 0 0 0 1px var(--mc-gray-400) inset;
 }
 
 .choice[data-locked="true"] {
@@ -263,24 +262,13 @@
 /* Post-submit verdicts. */
 .choice[data-verdict="correct-selected"],
 .choice[data-verdict="correct-missed"] {
-  border-color: var(--mc-green-500);
   background: var(--mc-green-50);
-  box-shadow: 0 0 0 1px var(--mc-green-500) inset;
+  box-shadow: none;
 }
 
 .choice[data-verdict="wrong-selected"] {
-  border-color: var(--mc-red-600);
   background: var(--mc-red-50);
-  box-shadow: 0 0 0 1px var(--mc-red-600) inset;
-}
-
-.choice[data-verdict="correct-missed"] {
-  /* Highlight unselected correct answers with a more subdued border so
-     the learner can distinguish "I missed this" from "I picked this and
-     it was correct". */
-  box-shadow: 0 0 0 1px var(--mc-green-500) inset;
-  background: var(--mc-green-50);
-  border-style: dashed;
+  box-shadow: none;
 }
 
 /* Native input controls — we keep them visible (rather than hiding
@@ -309,12 +297,12 @@
 }
 
 .choiceInput:checked {
-  background: var(--mc-accent);
-  box-shadow: 0 0 0 1.5px var(--mc-accent);
+  background: var(--mc-gray-500);
+  box-shadow: 0 0 0 1.5px var(--mc-gray-400);
 }
 
 .choiceInput[type="radio"]:checked {
-  background: radial-gradient(circle, #fff 35%, var(--mc-accent) 36%);
+  background: radial-gradient(circle, #fff 35%, var(--mc-gray-500) 36%);
 }
 
 .choiceInput[type="checkbox"]:checked {
@@ -506,7 +494,6 @@
   align-items: center;
   gap: 12px;
   padding: 12px 20px;
-  border-top: 1px solid var(--mc-border-light);
   font-size: 14px;
   font-weight: 500;
 }
@@ -514,19 +501,16 @@
 .banner[data-state="pass"] {
   background: var(--mc-green-50);
   color: var(--mc-green-700);
-  border-top-color: var(--mc-green-200);
 }
 
 .banner[data-state="fail"] {
   background: var(--mc-red-50);
   color: var(--mc-red-700);
-  border-top-color: var(--mc-red-200);
 }
 
 .banner[data-state="partial"] {
   background: var(--mc-amber-50);
   color: var(--mc-amber-700);
-  border-top-color: var(--mc-amber-200);
 }
 
 .bannerIcon {
@@ -562,7 +546,6 @@
 
 .overall {
   padding: 14px 20px 16px;
-  border-top: 1px solid var(--mc-border-light);
   background: var(--mc-bg);
 }
 
@@ -625,7 +608,6 @@
 
 :global(html.dark) .choice[data-selected="true"] {
   background: rgba(255, 255, 255, 0.07);
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.15) inset;
 }
 
 :global(html.dark) .choice[data-verdict="correct-selected"],
@@ -640,19 +622,16 @@
 :global(html.dark) .banner[data-state="pass"] {
   background: rgba(22, 163, 74, 0.12);
   color: #86efac;
-  border-top-color: rgba(22, 163, 74, 0.35);
 }
 
 :global(html.dark) .banner[data-state="fail"] {
   background: rgba(220, 38, 38, 0.12);
   color: #fca5a5;
-  border-top-color: rgba(220, 38, 38, 0.35);
 }
 
 :global(html.dark) .banner[data-state="partial"] {
   background: rgba(217, 119, 6, 0.12);
   color: #fcd34d;
-  border-top-color: rgba(217, 119, 6, 0.35);
 }
 
 :global(html.dark) .choiceLabel code,
@@ -741,5 +720,22 @@
   border-color: rgba(59, 130, 246, 0.22);
   color: rgba(255, 255, 255, 0.3);
   cursor: not-allowed;
+}
+
+/* White explanation text on dark red/green verdict backgrounds. */
+:global(html.dark) .choice[data-verdict="correct-selected"] .choiceExplanation,
+:global(html.dark) .choice[data-verdict="correct-missed"] .choiceExplanation,
+:global(html.dark) .choice[data-verdict="wrong-selected"] .choiceExplanation {
+  color: #ffffff;
+}
+
+/* Neutral (gray) checked state for radio/checkbox inputs in dark mode. */
+:global(html.dark) .choiceInput:checked {
+  background: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 0 0 1.5px rgba(255, 255, 255, 0.25);
+}
+
+:global(html.dark) .choiceInput[type="radio"]:checked {
+  background: radial-gradient(circle, var(--mc-bg) 35%, rgba(255, 255, 255, 0.4) 36%);
 }
 

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -108,7 +108,7 @@
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--mc-badge-color);
+  color: var(--mc-blue-500);
   flex-shrink: 0;
   white-space: nowrap;
 }

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -179,7 +179,6 @@ export default function MultipleChoiceQuestion({
             </>
           )}
         </span>
-        <span className={styles.headerStatus} />
       </header>
 
       {parsed.body ? (

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -28,7 +28,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import rehypeHighlight from "rehype-highlight";
-import { Check, X, RotateCcw, ListChecks, Pen } from "lucide-react";
+import { Check, X, RotateCcw, ListChecks, MousePointerClick, ScrollText } from "lucide-react";
 import {
   parseQuestion,
   type ParsedChoice,
@@ -133,6 +133,10 @@ export default function MultipleChoiceQuestion({
       }
       return next;
     });
+    if (!parsed.multiAnswer) {
+      setSubmitted(true);
+      setAttempts((n) => n + 1);
+    }
   };
 
   const onSubmit = () => {
@@ -159,7 +163,7 @@ export default function MultipleChoiceQuestion({
     <section className={styles.card} aria-label="Multiple choice question">
       <header className={styles.header}>
         <span className={styles.badge}>
-          <span className={styles.badgeDot} aria-hidden />
+          <ScrollText size={10} aria-hidden />
           {badge}
         </span>
         <span className={styles.modeLabel}>
@@ -170,18 +174,12 @@ export default function MultipleChoiceQuestion({
             </>
           ) : (
             <>
-              <Pen aria-hidden />
+              <MousePointerClick aria-hidden />
               Select one
             </>
           )}
         </span>
-        <span className={styles.headerStatus}>
-          {attempts > 0 ? (
-            <span className={styles.attemptCount}>
-              {attempts} {attempts === 1 ? "attempt" : "attempts"}
-            </span>
-          ) : null}
-        </span>
+        <span className={styles.headerStatus} />
       </header>
 
       {parsed.body ? (
@@ -268,28 +266,30 @@ export default function MultipleChoiceQuestion({
         })}
       </div>
 
-      <div className={styles.actionBar}>
-        {!submitted ? (
-          <button
-            type="button"
-            className={styles.submitBtn}
-            onClick={onSubmit}
-            disabled={selected.size === 0}
-          >
-            Submit
-          </button>
-        ) : (
-          <button type="button" className={styles.retryBtn} onClick={onRetry}>
-            <RotateCcw size={13} aria-hidden />
-            Try again
-          </button>
-        )}
-        {!submitted && parsed.multiAnswer ? (
-          <span className={styles.actionHint}>
-            Pick every option that applies, then submit.
-          </span>
-        ) : null}
-      </div>
+      {((!submitted && parsed.multiAnswer) || submitted) ? (
+        <div className={styles.actionBar}>
+          {!submitted ? (
+            <button
+              type="button"
+              className={styles.submitBtn}
+              onClick={onSubmit}
+              disabled={selected.size === 0}
+            >
+              Submit
+            </button>
+          ) : (
+            <button type="button" className={styles.retryBtn} onClick={onRetry}>
+              <RotateCcw size={13} aria-hidden />
+              Try again
+            </button>
+          )}
+          {!submitted && parsed.multiAnswer ? (
+            <span className={styles.actionHint}>
+              Pick every option that applies, then submit.
+            </span>
+          ) : null}
+        </div>
+      ) : null}
 
       {result ? (
         <div className={styles.banner} data-state={result}>


### PR DESCRIPTION
## Summary

### MCQ component (`MultipleChoiceQuestion.tsx` / `.module.css`)

**Visual / interaction**
- Auto-submit on choice selection for single-answer questions; action bar is hidden until submitted, then shows Try Again
- Remove background highlight from selected choices `[data-selected=true]` in both light and dark mode — selection is indicated by the input control alone
- Remove top borders from result banner and overall explanation sections
- Remove bottom border from question body section
- Increase `choiceList` bottom padding to 14px (matches top)
- Remove attempt counter display
- `choiceExplanation` text color in light mode changed from `var(--mc-text-secondary)` to `var(--mc-gray-700)` for better contrast
- Question body top padding increased (4px → 10px) for more breathing room above the choices
- Dark mode disabled Submit button: background opacity raised to 0.5, text opacity to 0.5; removed redundant `border-color` properties (button has `border: none`)

**Header**
- Badge: removed background, border-radius, and padding — color only, no pill chrome
- `modeLabel` pushed to the far right of the header via `margin-left: auto`
- Removed unused empty `headerStatus` span from JSX and its dead CSS rule

**Input controls**
- Neutral dark (`var(--mc-gray-900)`) background for checked inputs in light mode (was blue accent)
- Radio: `radial-gradient(circle, #fff 30%, gray-900 31%)` in light; `white 30% / #fff6 31%` in dark; no box-shadow
- Checkbox: `box-shadow: none`; in dark mode flips to a white box with a dark gray (`#1a1a1a`) checkmark so it reads clearly on any background
- Fixed missing checkmark in dark mode: the dark-mode `:checked` override used the `background` shorthand which reset `background-image: none` at higher specificity (0,3,1) than the checkbox rule (0,3,0); switched to `background-color` to leave `background-image` intact

**Verdict choices (post-submit)**
- Remove box-shadow and border from verdict choices; keep background colour only
- Inline `<code>` inside verdict explanations in dark mode: replace generic gray (`#252525`) background with a tinted overlay matching the green/red surface (`rgba green 0.3 / #bbf7d0` for correct; `rgba red 0.3 / #fecaca` for wrong)
- White font colour for all choice explanation text in dark mode

**Banner & explanation**
- Overall explanation body: darker text in light mode (`gray-700`); white in dark mode

**Icons**
- `Pen` → `MousePointerClick` for single-answer mode label
- Badge dot → `ScrollText` icon

### Challenge cards (`ChallengeCard.tsx` / `SqlChallengeCard.tsx` / `.module.css`)

- **Font sizes**: all text elements bumped +1px except `.title`, the instructions block, and CodeMirror editors — base card font goes from 13 → 14px, badges 10.5 → 11.5px, run/submit buttons 13 → 14px, test item names/desc 11.5 → 12.5px, etc.
- **Title font size**: 16px → 18px
- **Instructions body font size**: 13px → 15px
- **Badge**: removed `background` and `padding` from `.badge` in `headerRow` — color only, no pill chrome
- **Badge icons**: SQL card uses `Database`; non-SQL card uses `Terminal` (replaces the dot in both header and solution modal)
- **Format button spinner**: shows a spinner and disables during formatting with a 300 ms minimum duration to prevent blinking on fast formatters
- **Dark mode dropdown kbd fix**: `kbd` chips inside the "Run without Submitting" dropdown were turning dark gray (`#252525`) because the global dark-mode `.kbd` override outranked the menu-scoped rule; added a higher-specificity override to keep them semi-transparent white on blue, matching the Submit button
- **Dark mode testPill borders**: pass/fail pills now use tinted green/red (`color-mix` at 28%) instead of the light-mode `green-200`/`red-200` chip border colors
- **Dark mode banner borders**: pass/fail banner `border-top-color` now uses matching tinted green/red instead of `green-200`/`red-200`
- **Init panel legibility**: `initToggle`, `initLabel`, and `initCollapseBtn` use `gray-700` in light mode and `gray-300` in dark mode; hover lifts to `gray-900` / white respectively
- **Init panel "Click to expand"**: close the gap between the text and down chevron; add bottom padding so the chevron sits slightly higher from the overlay edge
- **Init panel "Click to collapse"**: switch from column to row layout, place the up chevron before the text, tighten the gap to 4px, remove top border, background → `var(--ch-bg)`
- **Init toggle**: `font-weight` reduced from 600 to 400 (normal); `initLabel` gets `letter-spacing: 0` to reset any tightening; background → `var(--ch-bg)`
- **Init editor wrap**: removed top border
- **Action bar**: removed top border and background (`var(--ch-bg-subtle)`)
- **Optional `description` on tests**: `description` field on `ChallengeTest` (via `ChallengeTestBase`) and `SqlChallengeTest` is now optional (`description?`); the desc row in the test list is only rendered when a value is present
- **Header runtime label icon**: color set to `var(--ch-gray-900)` in light mode and `#ffffff` in dark mode; removed inline `color` style from `LanguageGlyph`/`DialectGlyph` so CSS controls the icon color instead of being overridden by `element.style`

## Test plan

- [ ] MCQ single-answer: clicking a choice immediately shows verdict; Try Again appears after; no Submit button shown before selecting
- [ ] MCQ multi-answer: Submit button present; Try Again appears after submit
- [ ] MCQ: badge shows color only — no background pill or padding
- [ ] MCQ: modeLabel is flush to the right of the header
- [ ] MCQ: selecting a choice shows no background highlight — only the input changes appearance
- [ ] MCQ: no blue on radio/checkbox when selected — dark gray ring / fill
- [ ] MCQ: checkbox has no box-shadow ring; dark mode checkbox is white with dark checkmark
- [ ] MCQ: verdict choices have no border or box-shadow, only background colour
- [ ] MCQ dark mode: inline `<code>` inside correct explanations has green tint; inside wrong has red tint
- [ ] MCQ dark mode: explanation text is white
- [ ] MCQ: no top border on banner or overall explanation; no bottom border on body section
- [ ] MCQ: attempt counter no longer shown
- [ ] MCQ badge: ScrollText icon; single-answer shows MousePointerClick
- [ ] MCQ light mode: choice explanation text is `gray-700` (darker than before)
- [ ] MCQ: question body has visible top spacing above the choice list
- [ ] MCQ dark mode: disabled Submit button background is clearly visible at ~0.5 opacity
- [ ] Challenge card: badge shows color only, no background pill or padding
- [ ] Challenge card: all non-title, non-instructions, non-editor text is 1px larger
- [ ] Challenge card: title is 18px; instructions body is 15px
- [ ] Challenge card dark mode: dropdown kbd chips are white/transparent on blue, not dark gray
- [ ] Challenge card dark mode: testPill pass/fail borders are tinted green/red, not light-mode green-200/red-200
- [ ] Challenge card dark mode: banner top border is tinted green/red, not light-mode green-200/red-200
- [ ] Challenge card: Format button shows spinner for ≥300 ms, disabled during formatting
- [ ] Challenge card init panel: toggle and collapse button text is gray-700 (light) / gray-300 (dark); hover is darker
- [ ] Challenge card: "Click to expand" label — chevron sits close to text with extra space below
- [ ] Challenge card: "Click to collapse" shows ↑ chevron to the left of the text in a row, no top border
- [ ] Challenge card: init editor wrap has no top border
- [ ] Challenge card: action bar has no top border and no background tint
- [ ] SQL challenge card badge: Database icon
- [ ] Non-SQL challenge card badge: Terminal icon
- [ ] Challenge with no `description` on tests: no empty row rendered under test name
- [ ] Challenge card: header runtime label icon is dark gray in light mode, white in dark mode

https://claude.ai/code/session_013PRVdoakkkCj7WwXmaBA7Q