### PR TITLE
UI polish: MCQ/challenge card styling, editor fonts, home page courses, R harness fix

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -424,6 +424,7 @@
 
 .instructionsBody p {
   margin: 0 0 8px;
+  color: var(--tw-prose-body);
 }
 
 .instructionsBody p:last-child {
@@ -454,7 +455,7 @@
 }
 
 .instructionsBody li {
-  color: var(--ch-text-secondary);
+  color: var(--tw-prose-body);
 }
 
 .instructionsBody em {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -694,7 +694,7 @@
   min-height: 120px;
   max-height: 480px;
   font-family: var(--ch-font-mono);
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.7;
   font-variant-ligatures: none;
   font-feature-settings: "calt" 0, "liga" 0, "dlig" 0, "clig" 0;
@@ -838,13 +838,16 @@
   min-height: 30px;
   max-height: 280px;
   font-family: var(--ch-font-mono);
-  font-size: 12.5px;
+  font-size: 14px;
   line-height: 1.7;
   font-variant-ligatures: none;
   cursor: default;
 }
 
 .initEditor :global(.cm-editor .cm-scroller) {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
   overflow: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--ch-scrollbar-thumb) transparent;

--- a/app/_components/challengeHarness.ts
+++ b/app/_components/challengeHarness.ts
@@ -384,7 +384,7 @@ const buildRHarness: HarnessBuilder = (tests) => {
   lines.push("  }, error = function(e) {");
   lines.push("    msg <- conditionMessage(e)");
   lines.push(
-    `    cat(paste0("${HARNESS_RESULT_PREFIX}", tid, ":FAIL:", jsonlite::toJSON(msg, auto_unbox = TRUE), "\\n"))`,
+    `    cat(paste0("${HARNESS_RESULT_PREFIX}", tid, ":FAIL:", deparse(as.character(msg)), "\\n"))`,
   );
   lines.push("  })");
   lines.push("}");

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -397,6 +397,31 @@
   background: var(--mc-white);
 }
 
+/* In light mode, `code` elements inside green/red choice rows need
+   a tinted background so they don't look out of place on the coloured
+   surface. */
+.choice[data-verdict="correct-selected"] .choiceLabel code,
+.choice[data-verdict="correct-missed"] .choiceLabel code {
+  background: var(--mc-green-200);
+  color: var(--mc-green-700);
+}
+
+.choice[data-verdict="wrong-selected"] .choiceLabel code {
+  background: var(--mc-red-200);
+  color: var(--mc-red-700);
+}
+
+.choice[data-verdict="correct-selected"] .choiceExplanation code,
+.choice[data-verdict="correct-missed"] .choiceExplanation code {
+  background: var(--mc-green-100);
+  color: var(--mc-green-700);
+}
+
+.choice[data-verdict="wrong-selected"] .choiceExplanation code {
+  background: var(--mc-red-100);
+  color: var(--mc-red-700);
+}
+
 /* The explanation block hangs off to the right of the input + glyph.
    We render it inside the choice body, after the label, so when the
    author writes a multi-line choice the explanation always lines up

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -200,14 +200,9 @@ export default function MultipleChoiceQuestion({
         {parsed.choices.map((choice) => {
           const isSelected = selected.has(choice.id);
           const verdict = computeVerdict(choice, isSelected, submitted);
-          // Whether to surface this choice's authored explanation.
-          // Authors typically put the explanation on the wrong/correct
-          // pivot — show it for any choice that was selected and any
-          // correct choice the learner missed.
-          const showExplanation =
-            submitted &&
-            choice.explanation &&
-            (isSelected || (choice.correct && !isSelected));
+          // Show explanations for all choices after submit so learners
+          // can understand why each option is right or wrong.
+          const showExplanation = submitted && choice.explanation;
           return (
             <div key={choice.id} className={styles.choiceItem}>
               {/* Use <div> rather than <label> so that block-level

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -16,7 +16,7 @@
    must precede the tailwind/fumadocs imports below — `@import` rules
    are required to come before any non-`@import`/`@layer`/`@charset`
    at-rule, including the inlined CSS pulled in by tailwindcss. */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
 @import "tailwindcss";
 @source "../../node_modules/fumadocs-ui/dist/**/*.js";
@@ -32,6 +32,18 @@
 :root {
   --font-sans: "Inter", system-ui, -apple-system, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", ui-monospace,
+    monospace;
+}
+
+/* Ensure inline and block <code> elements pick up the JetBrains Mono
+   stack regardless of whether they're inside a .prose block or not. */
+code,
+pre,
+kbd,
+samp {
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", ui-monospace,
+    monospace;
 }
 
 /* Use pure white for the body and sidebar backgrounds in light mode only.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,6 +52,16 @@ export default function Home() {
             GitHub
           </a>
         </div>
+
+        <section className={styles.courses}>
+          <h2 className={styles.coursesHeading}>Courses</h2>
+          <div className={styles.courseList}>
+            <Link href="/learn/python-basics" className={styles.courseCard}>
+              <span className={styles.courseTitle}>Python Basics</span>
+              <span className={styles.courseArrow} aria-hidden="true">→</span>
+            </Link>
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/app/root.module.css
+++ b/app/root.module.css
@@ -84,3 +84,57 @@
   color: #e2e8f0;
   background: #1b2230;
 }
+
+/* ─── Courses section ─────────────────────────────────────────────── */
+
+.courses {
+  margin-top: 2.5rem;
+  text-align: left;
+}
+
+.coursesHeading {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4f8ef7;
+  margin: 0 0 0.75rem;
+}
+
+.courseList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.courseCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border: 1px solid #2a3347;
+  border-radius: 8px;
+  background: #161b27;
+  color: #e2e8f0;
+  text-decoration: none;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.courseCard:hover {
+  border-color: #4f8ef7;
+  background: #1b2230;
+}
+
+.courseTitle {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.courseArrow {
+  color: #4f8ef7;
+  transition: transform 0.15s;
+}
+
+.courseCard:hover .courseArrow {
+  transform: translateX(3px);
+}


### PR DESCRIPTION
## Summary

### MCQ component
- **Code element styling on verdict backgrounds** — `<code>` spans inside green (`correct-missed` / `correct-selected`) and red (`wrong-selected`) choice rows now use tinted green/red backgrounds and matching text colors in light mode instead of the default gray that clashed with the highlighted surface.
- **Show all explanations on submit** — Previously only the selected choice and any missed-correct choice showed their explanation. All choices with authored explanations are now revealed after submit so learners can understand every option.

### Challenge card component
- **Editor font size** — Both the user solution editor and the initialization code editor bumped from 13 px / 12.5 px to 14 px.
- **Init editor font family** — Added `font-family: inherit` (plus `font-size` and `line-height`) to `.initEditor .cm-scroller` so it inherits the JetBrains Mono stack from the parent `.cm-editor` rule instead of falling back to the CodeMirror theme's generic monospace stack.
- **instructionsBody text color** — `instructionsBody p` and `instructionsBody li` now use `var(--tw-prose-body)` instead of `var(--ch-text-secondary)` to match the surrounding prose color.

### Fumadocs learn pages
- **Monospace font** — Set `--font-mono` to `"JetBrains Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace` in `:root` and added a direct `code, pre, kbd, samp` rule in `learn.css` so all inline and block code on `/learn` pages uses JetBrains Mono instead of the Tailwind default `ui-monospace / SFMono-Regular` stack. Added JetBrains Mono to the Google Fonts import.

### Home page
- **Courses section** — Added a "Courses" section below the CTA buttons with a Python Basics card linking to `/learn/python-basics`. Left-aligned with a small blue uppercase label; each course card matches the dark chrome of the existing buttons (hover border highlight + sliding arrow).

### R challenge harness
- **Fix `jsonlite` missing error** — The R harness was calling `jsonlite::toJSON()` to encode error messages, but `jsonlite` is not installed in the R sandbox, causing every R challenge to throw `"there is no package called 'jsonlite'"` before any test could run. Replaced with `deparse(as.character(msg))`, which is base R and produces an identically valid JSON-quoted string.

## Test plan
- [ ] Open an MCQ card and submit an answer; confirm `<code>` spans inside green and red choice rows render with tinted backgrounds (not gray) in both light and dark mode.
- [ ] Confirm explanations appear for every choice that has one after submit, not only the selected/missed ones.
- [ ] Open a challenge card and verify both the init code panel and the user solution editor render at 14 px in JetBrains Mono.
- [ ] Confirm `instructionsBody` paragraph and list text matches the surrounding prose color.
- [ ] Open a `/learn` page and confirm inline `<code>` and `<pre>` blocks use JetBrains Mono.
- [ ] Visit the home page and confirm the Courses section appears with a Python Basics link.
- [ ] Open an R challenge card and confirm it no longer throws the `jsonlite` error; tests should run normally.

https://claude.ai/code/session_01TZNJFmVDzq3qtDXTR4sjeg