### PR TITLE
Fix Mermaid fullscreen fit positioning and zoom pixelation

### DIFF
--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -122,14 +122,12 @@
 }
 
 .viewport {
+  position: relative;
   flex: 1;
   overflow: hidden;
   cursor: grab;
   touch-action: none;
   user-select: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .viewport.dragging {
@@ -137,6 +135,9 @@
 }
 
 .stage {
+  position: absolute;
+  top: 0;
+  left: 0;
   transform-origin: 0 0;
   will-change: transform;
 }

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { use, useCallback, useEffect, useId, useRef, useState } from "react";
+import {
+  use,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { useTheme } from "next-themes";
 import { Maximize2, Minus, Plus, RotateCcw, X } from "lucide-react";
 import styles from "./mermaid.module.css";
@@ -146,7 +154,7 @@ function MermaidFullscreen({
       const vw = viewport.clientWidth - pad;
       const vh = viewport.clientHeight - pad;
       const next = clamp(
-        Math.min(vw / naturalW, vh / naturalH, 1),
+        Math.min(vw / naturalW, vh / naturalH),
         ZOOM_MIN,
         ZOOM_MAX,
       );
@@ -162,7 +170,11 @@ function MermaidFullscreen({
   // gets rasterized once at 1× and GPU-upscaled, which blurs text and
   // shapes; setting width/height re-renders the vector crisply at every
   // zoom level. The transform is left to pure translation for panning.
-  useEffect(() => {
+  //
+  // Runs after every commit (not just on scale change) and via a layout
+  // effect so the size is reasserted before paint — pan re-renders must
+  // never leave the SVG at its natural size while `scale` says otherwise.
+  useLayoutEffect(() => {
     const stage = stageRef.current;
     const natural = naturalSizeRef.current;
     if (!stage || !natural) return;
@@ -170,7 +182,7 @@ function MermaidFullscreen({
     if (!svgEl) return;
     svgEl.style.width = `${natural.w * scale}px`;
     svgEl.style.height = `${natural.h * scale}px`;
-  }, [scale]);
+  });
 
   // Lock background scroll while the modal is open, and wire Esc-close.
   useEffect(() => {
@@ -319,13 +331,13 @@ function MermaidFullscreen({
           onPointerCancel={onPointerUp}
         >
           <div
-            ref={stageRef}
             className={styles.stage}
             style={{
               transform: `translate(${tx}px, ${ty}px)`,
             }}
-            dangerouslySetInnerHTML={{ __html: svg }}
-          />
+          >
+            <div ref={stageRef} dangerouslySetInnerHTML={{ __html: svg }} />
+          </div>
         </div>
       </div>
     </div>

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -157,6 +157,21 @@ function MermaidFullscreen({
     return () => cancelAnimationFrame(raf);
   }, []);
 
+  // Apply zoom by resizing the SVG's intrinsic dimensions rather than a
+  // CSS `transform: scale()`. A scaled transform on a composited layer
+  // gets rasterized once at 1× and GPU-upscaled, which blurs text and
+  // shapes; setting width/height re-renders the vector crisply at every
+  // zoom level. The transform is left to pure translation for panning.
+  useEffect(() => {
+    const stage = stageRef.current;
+    const natural = naturalSizeRef.current;
+    if (!stage || !natural) return;
+    const svgEl = stage.querySelector("svg");
+    if (!svgEl) return;
+    svgEl.style.width = `${natural.w * scale}px`;
+    svgEl.style.height = `${natural.h * scale}px`;
+  }, [scale]);
+
   // Lock background scroll while the modal is open, and wire Esc-close.
   useEffect(() => {
     const prevOverflow = document.body.style.overflow;
@@ -307,7 +322,7 @@ function MermaidFullscreen({
             ref={stageRef}
             className={styles.stage}
             style={{
-              transform: `translate(${tx}px, ${ty}px) scale(${scale})`,
+              transform: `translate(${tx}px, ${ty}px)`,
             }}
             dangerouslySetInnerHTML={{ __html: svg }}
           />


### PR DESCRIPTION
## Summary

Fixes two issues with the Mermaid diagram "Expand to Full Page" modal:

1. **Diagram opened in the bottom-right corner instead of fitting/centering.** The `.viewport` flex-centered the stage, but the `fit()` math computed `tx`/`ty` assuming the stage's origin was the viewport's top-left `(0,0)`. The two compounded: flexbox centered the (small) stage, then the translate pushed it ~half a viewport further, landing it in the corner. Fixed by removing the flex centering and anchoring the stage at top-left (`position: absolute; top/left: 0`) so the fit transform lands correctly.

2. **Diagram pixelated when zooming in (text and shapes).** The stage was promoted to a composited layer (`will-change: transform`) and zoomed via `transform: scale()`, so the GPU upscaled a 1× bitmap. Zoom now resizes the SVG's intrinsic `width`/`height` instead, re-rendering the vector crisply at every zoom level; the transform is left to pure translation for panning.

## Test plan

- [ ] Open a learn page with a Mermaid diagram (e.g. `/learn/mermaid-test`), click "Expand to full page"
- [ ] Verify the diagram is centered and scaled to fit the viewport on open
- [ ] Zoom in via the `+` button / scroll wheel and confirm text and shapes stay crisp (no pixelation)
- [ ] Verify pan (drag) and the reset/fit button still work

---
_Generated by [Claude Code](https://claude.ai/code/session_01Df8B6itwAswfkim4faPdiJ)_