### PR TITLE
Fix CORS proxy headers, mermaid syntax errors, and add systems-programming-c course link

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,6 +72,12 @@ export default function Home() {
               </span>
               <span className={styles.courseArrow} aria-hidden="true">→</span>
             </Link>
+            <Link href="/learn/systems-programming-c" className={styles.courseCard}>
+              <span className={styles.courseTitle}>
+                Systems Programming with C
+              </span>
+              <span className={styles.courseArrow} aria-hidden="true">→</span>
+            </Link>
           </div>
         </section>
       </div>

--- a/cloudflare-cors-proxy/src/index.ts
+++ b/cloudflare-cors-proxy/src/index.ts
@@ -76,6 +76,7 @@ function buildCorsHeaders(origin: string): HeadersInit {
     "Access-Control-Allow-Headers": "*",
     "Access-Control-Expose-Headers": "*",
     "Access-Control-Max-Age": "86400",
+    "Cross-Origin-Resource-Policy": "cross-origin",
   };
 }
 

--- a/content/learn/oop-blueprint-java/constructors-and-state.mdx
+++ b/content/learn/oop-blueprint-java/constructors-and-state.mdx
@@ -24,7 +24,7 @@ sequenceDiagram
     participant Caller
     participant JVM
     participant Heap
-    participant Constructor as Person(...)
+    participant Constructor as "Person(...)"
 
     Caller->>JVM: new Person("Ada", 30)
     JVM->>Heap: allocate Person

--- a/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -27,7 +27,7 @@ They all live in `<stdlib.h>`.
 flowchart LR
     A[Program] -->|"malloc(n)"| B[Allocator]
     B -->|"void *"| A
-    A -->|"writes / reads"| C[Heap block<br/>(n bytes)]
+    A -->|"writes / reads"| C["Heap block<br/>(n bytes)"]
     A -->|"free(p)"| B
     B -->|"block reclaimed"| D[Free list / arena]
 ```


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **CORS proxy**: Add `Cross-Origin-Resource-Policy: cross-origin` to all responses (required for SharedArrayBuffer / WebR under COOP/COEP). `Access-Control-Allow-Credentials` is intentionally absent — it conflicts with wildcard `Access-Control-Allow-Headers: *`.
- **Mermaid fix (constructors-and-state)**: Quote the participant alias `Person(...)` in the sequenceDiagram — bare parentheses in an alias cause a syntax error in Mermaid 11.
- **Mermaid fix (heap-and-dynamic-allocation)**: Quote the node label `Heap block<br/>(n bytes)` in the flowchart — bare parentheses in an unquoted `[]` label cause a syntax error in Mermaid 11.
- **Home page**: Add a link to `/learn/systems-programming-c` under the Courses section.

## Test plan

- [ ] Verify CORS proxy responses include `Cross-Origin-Resource-Policy: cross-origin` and no `Access-Control-Allow-Credentials` header
- [ ] Confirm `/learn/oop-blueprint-java/constructors-and-state` renders all three mermaid diagrams without error
- [ ] Confirm `/learn/systems-programming-c/heap-and-dynamic-allocation` renders its mermaid diagram without error
- [ ] Confirm home page Courses section shows the Systems Programming with C link

https://claude.ai/code/session_01QxyDZT6W3VzFgZZbh98c6k
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxyDZT6W3VzFgZZbh98c6k)_