### PR TITLE
Fix CORS proxy Content-Encoding mismatch + Pyodide HTTP patching + proxy hardening

### DIFF
--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -118,11 +118,22 @@ async function initPyodide(): Promise<void> {
   await pyodide.loadPackage("micropip", pkgCallbacks);
   const micropip = pyodide.pyimport("micropip");
   await micropip.install("plotly");
+  // pyodide_http reroutes urllib/requests through the browser's fetch/XHR so
+  // that `requests.get(...)`, `pd.read_csv(url)`, etc. work in the worker.
+  // It does NOT bypass CORS — cross-origin hosts still need the CORS proxy.
+  await micropip.install("pyodide_http");
 
   // Set up display() and a matplotlib show() patch that captures figures
   // as base64 PNGs into _display_outputs.
   await pyodide.runPythonAsync(`
 import sys, io, base64, json, ast as _ast
+
+# Patch urllib/requests once so user code can make HTTP(S) calls (subject to
+# CORS — cross-origin hosts still need the CORS proxy). Called a single time
+# at init; re-patching already-patched modules is unnecessary.
+import pyodide_http
+pyodide_http.patch_all()
+
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt

--- a/cloudflare-cors-proxy/src/index.ts
+++ b/cloudflare-cors-proxy/src/index.ts
@@ -59,6 +59,10 @@ const PRIVATE_IP_PATTERNS = [
   /^10\./,
   /^192\.168\./,
   /^172\.(1[6-9]|2\d|3[01])\./,
+  // IPv4 link-local (169.254.0.0/16) — also covers the cloud metadata
+  // endpoint 169.254.169.254. The IPv6 link-local equivalent (fe80:) is
+  // already blocked below.
+  /^169\.254\./,
   /^::1$/,
   /^fc00:/i,
   /^fe80:/i,
@@ -278,6 +282,15 @@ export default {
     for (const [key, value] of Object.entries(corsHeaders)) {
       responseHeaders.set(key, value);
     }
+
+    // The Workers runtime transparently decompresses gzip/brotli upstream
+    // bodies, so `upstreamResponse.body` is already decoded. The upstream
+    // Content-Encoding/Content-Length no longer describe the bytes we return —
+    // leaving them in place makes clients (e.g. pandas read_csv, which trusts
+    // Content-Encoding over its own `compression=` argument) try to gunzip
+    // already-decompressed data, or truncate on a stale length. Drop them.
+    responseHeaders.delete("content-encoding");
+    responseHeaders.delete("content-length");
 
     return new Response(upstreamResponse.body, {
       status: upstreamResponse.status,

--- a/cloudflare-cors-proxy/src/index.ts
+++ b/cloudflare-cors-proxy/src/index.ts
@@ -10,13 +10,14 @@
  * 1. Only requests from allowed Origins may use the proxy
  *    (ALLOWED_ORIGINS env var, comma-separated).
  * 2. Only http:// and https:// target URLs are accepted.
- * 3. Private/loopback IP addresses are never proxied.
+ * 3. Private/loopback IP addresses are never proxied, including on every
+ *    redirect hop (redirect: "manual" + per-hop re-validation).
  * 4. Hop-by-hop headers are stripped from both the forwarded request and the
  *    upstream response to prevent header smuggling.
- * 5. Credentials (cookies, Authorization) sent by the browser to THIS worker
- *    are NOT forwarded upstream unless the caller explicitly sets them in the
- *    target request body/headers — the worker only mirrors what the runtime
- *    explicitly passes as query parameters or JSON body fields.
+ * 5. The browser's ambient Cookie header is stripped before forwarding — it is
+ *    never relevant to third-party upstream APIs. Explicitly-set Authorization
+ *    headers are kept so authenticated API calls work.
+ * 6. Requests are rate-limited per client IP (RATE_LIMITER binding).
  */
 
 export interface Env {
@@ -28,6 +29,15 @@ export interface Env {
    * `wrangler secret put ALLOWED_ORIGINS` / Cloudflare dashboard for production.
    */
   ALLOWED_ORIGINS: string;
+  /**
+   * Cloudflare Rate Limiting binding (Workers Paid plan required).
+   * Configure via [[unsafe.bindings]] in wrangler.toml.
+   * When absent (e.g. during `wrangler dev` without the binding), rate limiting
+   * is silently skipped so local development works without a paid plan.
+   */
+  RATE_LIMITER?: {
+    limit(options: { key: string }): Promise<{ success: boolean }>;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -68,6 +78,9 @@ const PRIVATE_IP_PATTERNS = [
   /^fe80:/i,
   /^0\.0\.0\.0$/,
 ];
+
+/** Maximum number of redirects the proxy will follow before giving up. */
+const MAX_REDIRECTS = 5;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -110,9 +123,41 @@ function parseAllowedOrigins(raw: string): Set<string> {
 /**
  * Returns true when the hostname looks like a private / loopback address that
  * should never be reachable via the proxy.
+ *
+ * Handles the common bypass vectors beyond the regex list:
+ *  - IPv6 bracket syntax (`URL.hostname` returns "[::1]", not "::1")
+ *  - IPv4-mapped IPv6 (::ffff:127.0.0.1)
+ *  - Decimal-encoded IPv4 (2130706433 == 127.0.0.1)
+ *  - Hex-encoded IPv4 (0x7f000001 == 127.0.0.1)
+ *
+ * Note: DNS rebinding (a public hostname that later resolves to a private IP)
+ * is not detectable at this layer. On Cloudflare Workers the risk is reduced
+ * because the runtime restricts outbound routing and there is no privileged
+ * internal metadata service reachable via the same private IP ranges available
+ * on typical cloud VMs.
  */
 function isPrivateHostname(hostname: string): boolean {
-  return PRIVATE_IP_PATTERNS.some((re) => re.test(hostname));
+  // URL.hostname wraps IPv6 addresses in brackets: "[::1]". Strip them so
+  // patterns match the raw address string.
+  const h = /^\[.+]$/.test(hostname) ? hostname.slice(1, -1) : hostname;
+
+  if (PRIVATE_IP_PATTERNS.some((re) => re.test(h))) return true;
+
+  // IPv4-mapped IPv6: ::ffff:127.0.0.1, ::ffff:192.168.0.1, etc.
+  const v4Mapped = h.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i);
+  if (v4Mapped && PRIVATE_IP_PATTERNS.some((re) => re.test(v4Mapped[1]))) {
+    return true;
+  }
+
+  // Decimal-encoded IPv4 (e.g. 2130706433 == 127.0.0.1). No valid public
+  // hostname is a bare integer, so any pure-numeric hostname is treated as
+  // private.
+  if (/^\d+$/.test(h)) return true;
+
+  // Hex-encoded IPv4 (e.g. 0x7f000001 == 127.0.0.1).
+  if (/^0x[0-9a-f]+$/i.test(h)) return true;
+
+  return false;
 }
 
 /**
@@ -193,7 +238,31 @@ export default {
     }
 
     // ------------------------------------------------------------------
-    // 4. Parse and validate the target URL
+    // 4. Rate limit per client IP
+    //    Preflights (handled above) are intentionally excluded so browsers
+    //    are not penalised for the automatic preflight they send.
+    //    Falls through silently when RATE_LIMITER is not bound (local dev).
+    // ------------------------------------------------------------------
+    if (env.RATE_LIMITER) {
+      const clientIp = request.headers.get("CF-Connecting-IP") ?? "unknown";
+      const { success } = await env.RATE_LIMITER.limit({ key: clientIp });
+      if (!success) {
+        return new Response(
+          JSON.stringify({ error: "Rate limit exceeded — please try again shortly" }),
+          {
+            status: 429,
+            headers: {
+              "Content-Type": "application/json",
+              "Retry-After": "60",
+              ...corsHeaders,
+            },
+          },
+        );
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // 5. Parse and validate the target URL
     // ------------------------------------------------------------------
     const { searchParams } = new URL(request.url);
     const targetUrlRaw = searchParams.get("url");
@@ -232,47 +301,99 @@ export default {
     }
 
     // ------------------------------------------------------------------
-    // 5. Forward the request to the upstream server
+    // 6. Forward the request to the upstream server, following redirects
+    //    manually so that each hop is re-validated against the private-IP
+    //    list. Using redirect: "follow" would skip that check for hops
+    //    after the first.
     // ------------------------------------------------------------------
     const upstreamHeaders = new Headers(
       stripHopByHopHeaders(request.headers),
     );
 
-    // Remove the Origin header sent to upstream — the caller's origin is
-    // irrelevant to the target server, and leaking it could expose the
-    // requester's identity unnecessarily.
+    // Remove the Origin header — the caller's origin is irrelevant to the
+    // target server, and leaking it could expose the requester's identity.
     upstreamHeaders.delete("origin");
     upstreamHeaders.delete("referer");
+    // Strip ambient browser cookies — never relevant to third-party upstream
+    // APIs and must not be leaked to arbitrary hosts. Explicitly-set
+    // Authorization headers are kept so authenticated API calls work.
+    upstreamHeaders.delete("cookie");
 
     // Tag requests so upstream servers can identify the proxy.
     upstreamHeaders.set("User-Agent", "dataslope-cors-proxy/1.0");
     upstreamHeaders.set("X-Forwarded-By", "dataslope-cors-proxy");
 
-    const upstreamInit: RequestInit = {
-      method: request.method,
-      headers: upstreamHeaders,
-      // Follow redirects server-side so the final response is returned to the
-      // browser. Returning a 3xx redirect to the browser would trigger a new
-      // cross-origin request that bypasses the proxy and hits CORS again.
-      redirect: "follow",
-    };
+    let currentUrl = targetUrl.toString();
+    let upstreamResponse: Response | null = null;
+    let redirectCount = 0;
 
-    // Attach a body for methods that allow one.
-    if (!["GET", "HEAD"].includes(request.method)) {
-      upstreamInit.body = request.body;
+    while (true) {
+      const init: RequestInit = {
+        method: request.method,
+        headers: upstreamHeaders,
+        redirect: "manual",
+      };
+      // Only attach a body for methods that allow one, and only on the first
+      // hop — the request body stream is consumed after the initial read.
+      if (!["GET", "HEAD"].includes(request.method) && redirectCount === 0) {
+        init.body = request.body;
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(currentUrl, init);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Upstream request failed";
+        return errorResponse(502, `Upstream error: ${message}`, corsHeaders);
+      }
+
+      // Not a redirect — use this response.
+      if (response.status < 300 || response.status >= 400) {
+        upstreamResponse = response;
+        break;
+      }
+
+      const location = response.headers.get("Location");
+      if (!location) {
+        // 3xx with no Location — return as-is.
+        upstreamResponse = response;
+        break;
+      }
+
+      if (redirectCount >= MAX_REDIRECTS) {
+        return errorResponse(502, "Too many redirects", corsHeaders);
+      }
+
+      let nextUrl: URL;
+      try {
+        nextUrl = new URL(location, currentUrl);
+      } catch {
+        return errorResponse(502, "Invalid redirect URL", corsHeaders);
+      }
+
+      if (nextUrl.protocol !== "http:" && nextUrl.protocol !== "https:") {
+        return errorResponse(400, "Redirect to disallowed scheme", corsHeaders);
+      }
+
+      if (isPrivateHostname(nextUrl.hostname)) {
+        return errorResponse(
+          400,
+          "Redirect to private or loopback address not allowed",
+          corsHeaders,
+        );
+      }
+
+      currentUrl = nextUrl.toString();
+      redirectCount++;
     }
 
-    let upstreamResponse: Response;
-    try {
-      upstreamResponse = await fetch(targetUrl.toString(), upstreamInit);
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Upstream request failed";
-      return errorResponse(502, `Upstream error: ${message}`, corsHeaders);
+    if (!upstreamResponse) {
+      return errorResponse(502, "Upstream request failed", corsHeaders);
     }
 
     // ------------------------------------------------------------------
-    // 6. Build and return the proxied response
+    // 7. Build and return the proxied response
     // ------------------------------------------------------------------
     const responseHeaders = new Headers(
       stripHopByHopHeaders(upstreamResponse.headers),

--- a/cloudflare-cors-proxy/wrangler.toml
+++ b/cloudflare-cors-proxy/wrangler.toml
@@ -8,3 +8,23 @@ compatibility_flags = ["nodejs_compat"]
 # Override via `wrangler secret put ALLOWED_ORIGINS` or in your Cloudflare dashboard
 # for production secrets, or set them here for non-sensitive defaults.
 ALLOWED_ORIGINS = "http://localhost:3000,https://dataslope.com,https://www.dataslope.com,https://dataslope.vercel.app"
+
+# ---------------------------------------------------------------------------
+# Rate limiting — Workers Paid plan required.
+#
+# namespace_id is an arbitrary integer that scopes the rate-limit counters for
+# this worker. Any stable integer works; just keep it the same across deploys.
+#
+# Current limits (adjust to taste):
+#   60 requests per 60 seconds per client IP
+#   ≈ 1 req/s average with burst tolerance — fits a learning/playground
+#   session without throttling a student running code actively.
+#
+# The binding is declared optional in TypeScript (RATE_LIMITER?), so the
+# worker falls back gracefully to no rate limiting during `wrangler dev`.
+# ---------------------------------------------------------------------------
+[[unsafe.bindings]]
+name = "RATE_LIMITER"
+type = "ratelimit"
+namespace_id = 1001
+simple = { limit = 60, period = 60 }


### PR DESCRIPTION
## Background

Debugging a `gzip.BadGzipFile: Not a gzipped file` error when calling `pd.read_csv(proxy_url)` through the CORS proxy in the Pyodide playground. Root cause: the Cloudflare Workers runtime transparently decompresses gzip/brotli upstream bodies, but the proxy was forwarding the now-inaccurate `Content-Encoding: gzip` header unchanged. pandas, when reading from a URL, trusts `Content-Encoding` over its own `compression=` argument and tried to gunzip already-decoded plaintext.

## Changes

### `cloudflare-cors-proxy/src/index.ts` + `wrangler.toml`

**1. Strip stale `Content-Encoding` / `Content-Length` headers**
After the Workers runtime decompresses the upstream body, `Content-Encoding` and `Content-Length` no longer describe the bytes being returned. Both are now deleted from the proxied response so clients receive headers that match the actual body.

**2. Rate limiting — 60 requests / 60 seconds per client IP**
Added a Cloudflare Rate Limiting binding (`RATE_LIMITER`). Returns 429 with `Retry-After: 60` when the limit is exceeded. Preflight OPTIONS requests are excluded (browsers send them automatically). The binding is declared optional in TypeScript so `wrangler dev` works without a paid plan — rate limiting silently skips when the binding is absent. Configured in `wrangler.toml` under `[[unsafe.bindings]]` (Workers Paid plan required to deploy).

**3. Redirect SSRF fix — per-hop private-IP validation**
Replaced `redirect: "follow"` with a manual redirect loop (max 5 hops). Each `Location` header is parsed and re-validated against `isPrivateHostname` before following, so a public URL cannot 302 to an internal address to bypass the SSRF check. The request body is only forwarded on the first hop since the stream is consumed after the initial read.

**4. Cookie stripping**
`Cookie` is now deleted from upstream request headers. Ambient browser cookies are never relevant to third-party upstream APIs and must not be leaked to arbitrary hosts. `Authorization` is intentionally kept so users can proxy authenticated API calls from playground code. The security-model comment is updated to match actual behaviour.

**5. IP encoding bypass hardening**
Extended `isPrivateHostname` to handle four additional bypass vectors the regex list didn't cover:
- **IPv6 bracket syntax** — `URL.hostname` returns `"[::1]"` not `"::1"`, so the existing IPv6 patterns never matched. Brackets are now stripped before pattern matching, fixing a pre-existing bug.
- **IPv4-mapped IPv6** — `::ffff:127.0.0.1`, `::ffff:192.168.x.x`, etc.
- **Decimal-encoded IPv4** — `2130706433` (== `127.0.0.1`). No valid public hostname is a bare integer.
- **Hex-encoded IPv4** — `0x7f000001` (== `127.0.0.1`).

**6. IPv4 link-local / metadata range**
Added `169.254.0.0/16` to `PRIVATE_IP_PATTERNS`. This covers the cloud metadata endpoint `169.254.169.254`. The IPv6 link-local equivalent (`fe80:`) was already blocked.

### `app/_components/runtime/pyodide-worker.ts`

**7. Auto-run `pyodide_http.patch_all()` at Pyodide worker init**
Installs `pyodide_http` via micropip and calls `patch_all()` once during worker initialisation. This reroutes `urllib`/`requests` through the browser's fetch/XHR so user code can use `requests.get(...)`, `pd.read_csv(url)`, etc. without boilerplate. CORS still applies — cross-origin hosts still need the proxy.

## Deployment notes

- **Worker**: `cd cloudflare-cors-proxy && wrangler deploy`
- **Rate limiting** requires the Workers Paid plan. On the free plan the binding is absent and the worker falls back to no rate limiting without erroring.
- The `namespace_id = 1001` in `wrangler.toml` is an arbitrary stable integer used to scope rate-limit counters for this worker. Change it if you have a naming convention, but keep it stable across deploys.

## Remaining known limitation

**DNS rebinding** (a public hostname that resolves to a private IP at fetch time) is not detectable at the Worker layer since DNS resolution happens inside the runtime after our hostname check. The risk is reduced on Cloudflare Workers — there is no privileged internal metadata service reachable via the same private IP ranges available on cloud VMs — but it cannot be fully mitigated without IP-level inspection after resolution.

## Test plan
- [ ] Deploy the worker via `wrangler deploy`.
- [ ] Run `pd.read_csv(proxy_url)` against a gzip-served GitHub raw CSV — confirm no `BadGzipFile` error.
- [ ] Confirm `import requests; requests.get(url)` works in the playground without a manual `patch_all()` call.
- [ ] Confirm a request to `169.254.169.254` is rejected with 400.
- [ ] Confirm a redirect to a private IP (e.g. `127.0.0.1`) is rejected with 400.
- [ ] Confirm rapid repeated requests from the same IP return 429 after 60 requests within a minute.

https://claude.ai/code/session_014MqQGnYaonzpU5NVhmxpGp