### PR TITLE
fix: support top-level await in Python runtime

### DIFF
--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -175,22 +175,31 @@ def _patched_show(*args, **kwargs):
     plt.close("all")
 plt.show = _patched_show
 
-def _execute_with_last_display(code):
+import asyncio as _asyncio
+
+async def _execute_with_last_display(code):
     """Execute user code, auto-displaying the last expression like Jupyter."""
     _globals = globals()
+    _flags = _ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
     tree = _ast.parse(code)
     if tree.body and isinstance(tree.body[-1], _ast.Expr):
         last_expr = tree.body.pop()
         if tree.body:
             _ast.fix_missing_locations(tree)
-            exec(compile(tree, "<string>", "exec"), _globals)
+            result = eval(compile(tree, "<string>", "exec", flags=_flags), _globals)
+            if _asyncio.iscoroutine(result):
+                await result
         expr_tree = _ast.Expression(body=last_expr.value)
         _ast.fix_missing_locations(expr_tree)
-        result = eval(compile(expr_tree, "<string>", "eval"), _globals)
+        result = eval(compile(expr_tree, "<string>", "eval", flags=_flags), _globals)
+        if _asyncio.iscoroutine(result):
+            result = await result
         if result is not None:
             display(result)
     else:
-        exec(compile(tree, "<string>", "exec"), _globals)
+        result = eval(compile(tree, "<string>", "exec", flags=_flags), _globals)
+        if _asyncio.iscoroutine(result):
+            await result
 
 # ─── Autocomplete via stdlib rlcompleter ─────────────────────────────
 import re as _re
@@ -319,7 +328,7 @@ try:
     _go.Figure.show = _patched_go_show
 except: pass
 
-_execute_with_last_display(_user_code_str)
+await _execute_with_last_display(_user_code_str)
 
 # Auto-flush any matplotlib figures that the user did not explicitly show.
 # This handles patterns like df.x.plot.density() which create a figure


### PR DESCRIPTION
## Summary

- `_execute_with_last_display` used `exec()`/`eval()` without `PyCF_ALLOW_TOP_LEVEL_AWAIT`, causing `SyntaxError: 'await' outside function` for any top-level `await` (e.g. `await micropip.install(...)`)
- Made the function `async` and compile with `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`
- Added `asyncio.iscoroutine()` checks to await any coroutines returned by `eval()`
- Updated the `wrappedCode` call site to `await _execute_with_last_display(...)`

## Test plan

- [ ] Run a cell with `await micropip.install("polars")` followed by `import polars as pl` — should install and import without error
- [ ] Verify normal (non-async) code still executes correctly
- [ ] Verify last-expression auto-display still works (e.g. a cell ending with a DataFrame)
- [ ] Verify `await`-returning last expressions are awaited and displayed correctly

https://claude.ai/code/session_01LaNbut2cDWNrCnwhmpzv23

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaNbut2cDWNrCnwhmpzv23)_