### PR TITLE
Add C# LINQ and Functional Patterns course link to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -93,6 +93,12 @@ export default function Home() {
               </span>
               <span className={styles.courseArrow} aria-hidden="true">→</span>
             </Link>
+            <Link href="/learn/csharp-linq-functional" className={styles.courseCard}>
+              <span className={styles.courseTitle}>
+                C# LINQ and Functional Patterns
+              </span>
+              <span className={styles.courseArrow} aria-hidden="true">→</span>
+            </Link>
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary

- Adds a link to the `learn/csharp-linq-functional` course on the home page under the "Courses" section
- Follows the same card pattern used by all other course links

## Test plan

- [ ] Visit the home page and confirm "C# LINQ and Functional Patterns" appears in the Courses list
- [ ] Click the card and verify it navigates to `/learn/csharp-linq-functional`

https://claude.ai/code/session_01XjoBE8SgxXddeBtZdQWDxf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjoBE8SgxXddeBtZdQWDxf)_