### PR TITLE
Fix CORS proxy gzip error by not forwarding Accept-Encoding upstream

### DIFF
--- a/cloudflare-cors-proxy/src/index.ts
+++ b/cloudflare-cors-proxy/src/index.ts
@@ -286,6 +286,16 @@ export default {
     // Authorization headers are kept so authenticated API calls work.
     upstreamHeaders.delete("cookie");
 
+    // Let the Workers runtime negotiate content encoding itself. If we forward
+    // the client's Accept-Encoding, fetch() switches to pass-through mode where
+    // the returned body and Content-Encoding header can disagree (the runtime
+    // may hand back a decompressed body while still reporting the upstream
+    // Content-Encoding). Clients that trust that header — e.g. pandas read_csv
+    // in Pyodide — then try to gunzip already-decoded bytes and fail with
+    // "Not a gzipped file". Removing it lets Cloudflare transparently
+    // decompress and return a clean, identity-encoded body.
+    upstreamHeaders.delete("accept-encoding");
+
     // Tag requests so upstream servers can identify the proxy.
     upstreamHeaders.set("User-Agent", "dataslope-cors-proxy/1.0");
     upstreamHeaders.set("X-Forwarded-By", "dataslope-cors-proxy");


### PR DESCRIPTION
## Problem

Reading a gzip-compressed CSV (e.g. GitHub raw) through the CORS proxy fails in Pyodide:

```
gzip.BadGzipFile: Not a gzipped file (b'\xef\xbb')
```

`\xef\xbb` is the start of a UTF-8 BOM — i.e. the body is already-decompressed plain text, but a `Content-Encoding: gzip` header still reached the client, so pandas `read_csv` tried to gunzip it a second time.

## Root cause

The proxy forwarded the **client's `Accept-Encoding`** header upstream (visible in the reporter's httpbin test, which echoed `"Accept-Encoding": "gzip, br"`). This puts the Workers `fetch()` into pass-through mode where the decompressed body and the upstream `Content-Encoding` header can disagree.

- `httpbin.org/get` works because it returns uncompressed JSON regardless of `Accept-Encoding`.
- `raw.githubusercontent.com` honors `Accept-Encoding` and returns gzip-compressed CSV with a `Content-Encoding: gzip` header → triggers the double-decompress failure.

PR #376 already deletes `Content-Encoding`/`Content-Length` on the response as a defensive measure, but the reliable fix is to stop forwarding `Accept-Encoding` so Cloudflare negotiates encoding itself and transparently decompresses to a clean, identity-encoded body.

## Change

- Strip `Accept-Encoding` from the headers forwarded to the upstream server.

The existing response-side deletion of `Content-Encoding`/`Content-Length` is kept as defense-in-depth.

## Test plan

- [ ] Deploy and confirm `pd.read_csv` through the proxy succeeds for `https://github.com/bdi475/datasets/raw/refs/heads/main/HR-dataset-v14.csv`
- [ ] Confirm `requests.get` against `httpbin.org/get` through the proxy still works

https://claude.ai/code/session_01FW2oh3wXQXWxYrTCUzFT7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01FW2oh3wXQXWxYrTCUzFT7B)_