### PR TITLE
Add intro-data-viz-plotly course link to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -150,6 +150,12 @@ export default function Home() {
               </span>
               <span className={styles.courseArrow} aria-hidden="true">→</span>
             </Link>
+            <Link href="/learn/intro-data-viz-plotly" className={styles.courseCard}>
+              <span className={styles.courseTitle}>
+                Introduction to Data Visualization with Plotly
+              </span>
+              <span className={styles.courseArrow} aria-hidden="true">→</span>
+            </Link>
             <Link href="/learn/c-programming-for-beginners" className={styles.courseCard}>
               <span className={styles.courseTitle}>
                 C Programming for Beginners


### PR DESCRIPTION
## Summary

- Added a link to `/learn/intro-data-viz-plotly` in the Courses section on the home page (`/`)
- The new card follows the same pattern as existing course cards with title and arrow

## Test plan

- [ ] Visit the home page and verify the "Introduction to Data Visualization with Plotly" course card appears in the Courses section
- [ ] Click the card and confirm it navigates to `/learn/intro-data-viz-plotly`

https://claude.ai/code/session_01Nh3vH1GUJDNNWcJYRz25cL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nh3vH1GUJDNNWcJYRz25cL)_