### PR TITLE
Fix plotly ndarray JSON serialization error in Pyodide runtime

### DIFF
--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -333,21 +333,20 @@ async function runCode(id: number, code: string): Promise<void> {
   // executed via _execute_with_last_display so that the last expression is
   // auto-displayed (Jupyter-style) when it evaluates to a non-None value.
   const wrappedCode = `
-import json as _json
 import plotly as _plotly
 
 _plotly_json_outputs = []
 _orig_plotly_show = _plotly.io.show
 
 def _patched_plotly_show(fig, *args, **kwargs):
-    _plotly_json_outputs.append(_json.dumps(fig.to_dict()))
+    _plotly_json_outputs.append(fig.to_json())
 
 _plotly.io.show = _patched_plotly_show
 try:
     import plotly.graph_objects as _go
     _orig_go_show = _go.Figure.show
     def _patched_go_show(self, *args, **kwargs):
-        _plotly_json_outputs.append(_json.dumps(self.to_dict()))
+        _plotly_json_outputs.append(self.to_json())
     _go.Figure.show = _patched_go_show
 except: pass
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Plotly's `fig.to_dict()` can leave numpy `ndarray` values unconverted, causing Python's standard `json.dumps()` to raise `TypeError: Object of type ndarray is not JSON serializable`
- Switched the Plotly show patches to use `fig.to_json()` / `self.to_json()`, which is Plotly's own serializer and correctly handles numpy arrays
- Removed the now-unused `import json as _json` line from the injected wrapper code

## Test plan

- [ ] Run a Plotly bar chart using a pandas DataFrame (as in the reported example) — chart should render without error
- [ ] Verify other Plotly chart types (scatter, line, pie) still render correctly
- [ ] Confirm non-Plotly code paths (matplotlib, plain output) are unaffected

https://claude.ai/code/session_01PsjFB5Spqr2KxZHbgrQdw2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsjFB5Spqr2KxZHbgrQdw2)_