### PR TITLE
Improve SQL challenge card & code block UX

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -784,6 +784,28 @@
   background: var(--ch-bg-hover);
 }
 
+/* Static label for short (non-collapsible) init code. Mirrors
+   `.initToggle` but isn't interactive — just identifies the block as
+   read-only initialization code. */
+.initHeaderStatic {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  padding: 6px 14px;
+  background: var(--ch-bg);
+  color: var(--ch-gray-700);
+  font-family: var(--ch-font-ui);
+  font-size: 12px;
+  font-weight: 400;
+  text-align: left;
+}
+
+.initLockIcon {
+  flex-shrink: 0;
+  color: var(--ch-text-muted);
+}
+
 .initCaret {
   display: inline-block;
   font-size: 9px;
@@ -909,7 +931,10 @@
   outline-offset: -2px;
 }
 
-/* "Click to expand" label centred at the bottom of the fade overlay. */
+/* "Click to expand" label centred at the bottom of the fade overlay.
+   Sits on a solid rounded pill with a soft shadow so the text + chevron
+   stay legible even when code lines show through the gradient behind
+   them. */
 .initFadeLabel {
   position: absolute;
   bottom: 4px;
@@ -918,14 +943,22 @@
   font-family: var(--ch-font-ui);
   font-size: 12px;
   font-weight: 500;
-  color: var(--ch-text-muted);
+  color: var(--ch-text-secondary);
   pointer-events: none;
   white-space: nowrap;
   display: inline-flex;
   flex-direction: column;
   align-items: center;
   gap: 0px;
-  padding-bottom: 3px;
+  padding: 3px 12px 4px;
+  background: var(--ch-bg);
+  border: 1px solid var(--ch-border-light);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
+}
+
+:global(html.dark) .initFadeLabel {
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
 }
 
 .initFadeLabel svg {
@@ -934,6 +967,7 @@
 
 .initFade:hover .initFadeLabel {
   color: var(--ch-text);
+  border-color: var(--ch-border);
 }
 
 /* "Click to collapse" button shown at the bottom of the expanded init panel. */
@@ -1863,12 +1897,15 @@
   font-family: var(--ch-font-mono);
 }
 
+/* Full-bleed: no horizontal margin so the table spans the whole card
+   width (up to the container). Top/bottom borders only — the card's own
+   border supplies the left/right edges, so a boxed border + radius here
+   would just inset the table needlessly. */
 .sqlResultScroll {
   max-height: 320px;
   overflow: auto;
-  margin: 0 14px 14px;
-  border: 1px solid var(--ch-border-light);
-  border-radius: 6px;
+  border-top: 1px solid var(--ch-border-light);
+  border-bottom: 1px solid var(--ch-border-light);
 }
 
 .sqlResultTable {
@@ -1891,6 +1928,12 @@
   position: sticky;
   top: 0;
   z-index: 1;
+  /* Clip overlong column names so one verbose header can't stretch the
+     table wider than the card. The full name stays available via the
+     cell's `title` tooltip. */
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .sqlResultTable th:last-child {
@@ -1904,6 +1947,11 @@
   text-align: left;
   white-space: nowrap;
   color: var(--ch-text);
+  /* Same clipping as headers — long string values get an ellipsis
+     rather than blowing out the column width. */
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .sqlResultTable td:last-child {
@@ -1921,6 +1969,21 @@
 .sqlNullValue {
   color: var(--ch-text-muted);
   font-style: italic;
+}
+
+/* "Loading more rows…" row appended to the table viewer while the next
+   page streams in via infinite scroll. */
+.sqlResultLoadingRow td {
+  text-align: center;
+  color: var(--ch-text-muted);
+  font-size: 12px;
+  font-style: italic;
+  padding: 6px 12px;
+  background: var(--ch-bg-subtle);
+}
+
+.sqlResultLoadingRow td:hover {
+  background: var(--ch-bg-subtle);
 }
 
 .sqlEmptyResult {
@@ -2026,7 +2089,8 @@
   color: var(--ch-blue-100);
 }
 
-:global(html.dark) .initToggle {
+:global(html.dark) .initToggle,
+:global(html.dark) .initHeaderStatic {
   color: var(--ch-gray-300);
 }
 
@@ -2136,26 +2200,16 @@
   border-bottom: 1px solid var(--ch-border-light);
 }
 
+/* Static label row — the panel is no longer collapsible, so this is a
+   plain header (not a button) showing the table count / loading state. */
 .tableViewerHeader {
   display: flex;
   align-items: center;
   padding: 8px 14px;
   gap: 10px;
-  background: none;
-  border: none;
   width: 100%;
-  text-align: left;
-  cursor: pointer;
   font-family: var(--ch-font-ui);
   user-select: none;
-}
-
-.tableViewerHeader:hover {
-  background: var(--ch-bg-hover);
-}
-
-:global(html.dark) .tableViewerHeader:hover {
-  background: #222222;
 }
 
 .tableViewerLabel {
@@ -2173,40 +2227,168 @@
   color: var(--ch-text-muted);
 }
 
+/* Table tabs are styled to match the non-SQL code block file tab bar
+   (`.fileTabBar` / `.fileTab`): a flat, full-width strip of tabs with
+   right-border separators and an accent underline on the active tab,
+   rather than the previous free-floating pills. */
 .tableViewerTabs {
   display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 0 14px 6px;
-  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0;
+  background: var(--ch-bg-subtle);
+  border-top: 1px solid var(--ch-border-light);
+  border-bottom: 1px solid var(--ch-border-light);
+  overflow-x: auto;
+  scrollbar-width: none;
+  user-select: none;
+}
+
+.tableViewerTabs::-webkit-scrollbar {
+  display: none;
 }
 
 .tableViewerTab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--ch-border-light);
   font-family: var(--ch-font-mono);
-  font-size: 12.5px;
-  padding: 3px 9px;
-  border-radius: 4px;
-  border: 1px solid var(--ch-border-light);
-  background: var(--ch-bg);
-  color: var(--ch-text-secondary);
+  font-size: 13px;
+  color: var(--ch-text-muted);
   cursor: pointer;
-  transition: all 0.15s;
+  white-space: nowrap;
+  position: relative;
+  transition: background 0.12s, color 0.12s;
 }
 
 .tableViewerTab:hover {
-  border-color: var(--ch-border);
+  background: var(--ch-bg-hover);
   color: var(--ch-text);
 }
 
 .tableViewerTabActive {
-  background: var(--ch-badge-bg);
-  border-color: var(--ch-badge-border);
-  color: var(--ch-badge-color);
+  background: var(--ch-bg);
+  color: var(--ch-text);
+}
+
+.tableViewerTabActive::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--ch-accent);
 }
 
 .tableViewerSchema {
   color: var(--ch-text-muted);
   font-weight: 400;
+}
+
+/* ─── Table viewer loading skeleton ─────────────────────────────────── */
+
+.tableViewerSpinner {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  margin-right: 5px;
+  vertical-align: -1px;
+  border: 1.5px solid var(--ch-border);
+  border-top-color: var(--ch-accent);
+  border-radius: 50%;
+  animation: tableViewerSpin 0.7s linear infinite;
+}
+
+@keyframes tableViewerSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.tableViewerSkeleton {
+  margin: 0 14px 12px;
+  border: 1px solid var(--ch-border-light);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.skeletonRow {
+  display: flex;
+  gap: 10px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--ch-border-light);
+}
+
+.skeletonRow:last-child {
+  border-bottom: none;
+}
+
+.skeletonCell {
+  flex: 1;
+  height: 10px;
+  border-radius: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--ch-bg-subtle) 0%,
+    var(--ch-bg-hover) 50%,
+    var(--ch-bg-subtle) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeletonShimmer 1.3s ease-in-out infinite;
+}
+
+@keyframes skeletonShimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tableViewerSpinner,
+  .skeletonCell {
+    animation-duration: 0s;
+  }
+}
+
+/* ─── Table viewer resize bar ───────────────────────────────────────── */
+
+/* Drag handle at the bottom of the (non-collapsible) tables panel. Drag
+   vertically to grow/shrink the visible table area. */
+.tableViewerResizer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 12px;
+  cursor: ns-resize;
+  background: var(--ch-bg-subtle);
+  border-top: 1px solid var(--ch-border-light);
+  touch-action: none;
+}
+
+.tableViewerResizer:hover,
+.tableViewerResizer:focus-visible {
+  background: var(--ch-bg-hover);
+  outline: none;
+}
+
+.tableViewerResizerGrip {
+  width: 28px;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--ch-border);
+  transition: background 0.12s;
+}
+
+.tableViewerResizer:hover .tableViewerResizerGrip,
+.tableViewerResizer:focus-visible .tableViewerResizerGrip {
+  background: var(--ch-accent);
 }
 
 .tableViewerScroll {
@@ -2241,11 +2423,12 @@
 }
 
 .tableViewerFootnote {
-  padding: 4px 10px;
+  padding: 4px 14px;
   font-family: var(--ch-font-mono);
   font-size: 12px;
   color: var(--ch-text-muted);
-  border-top: 1px solid var(--ch-border-light);
+  /* The result scroll above already draws a bottom border, so no
+     border-top here (avoids a doubled 2px line). */
   background: var(--ch-bg-subtle);
 }
 

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -62,7 +62,6 @@ import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
 import { loadLanguage, themeFor, noActiveLine } from "./cmExtensions";
 import {
   LANGUAGE_ICONS,
-  LANGUAGE_ICON_COLORS,
   LANGUAGE_ICON_SIZE_FACTOR,
 } from "./languageIcons";
 import type {

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -10,11 +10,10 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { ChevronDown, ChevronUp, Play, RotateCcw } from "lucide-react";
+import { ChevronDown, ChevronUp, Lock, Play, RotateCcw } from "lucide-react";
 import { Toast } from "@base-ui-components/react/toast";
 import {
   LANGUAGE_ICONS,
-  LANGUAGE_ICON_COLORS,
   LANGUAGE_ICON_SIZE_FACTOR,
 } from "./languageIcons";
 import { FormatIcon, PlayIcon } from "./challengeShared";
@@ -189,20 +188,21 @@ function CopyIcon() {
   );
 }
 
-// Brand-coloured glyph for the adapter's language. Uses the shared
-// `languageIcons` registry so the playground header, the /playground
-// index, and embedded code blocks all render the same icons + brand
-// colours. Falls back to the adapter's two-character monogram so future
+// Glyph for the adapter's language. Uses the shared `languageIcons`
+// registry so the embedded code blocks render the same icons as the
+// rest of the app. The colour is intentionally NOT the brand colour
+// here: code blocks share the challenge card's `.headerRuntimeLabel`
+// chrome, so the glyph inherits that label's two-tone (light/dark)
+// icon colour to stay visually consistent with the challenge cards.
+// Falls back to the adapter's two-character monogram so future
 // adapters render reasonably without having to update the registry first.
 function LanguageGlyph({ adapter }: { adapter: LanguageAdapter }) {
   const Icon = LANGUAGE_ICONS[adapter.id];
-  const color = LANGUAGE_ICON_COLORS[adapter.id];
   const factor = LANGUAGE_ICON_SIZE_FACTOR[adapter.id] ?? 1;
   if (!Icon) return <span aria-hidden>{adapter.logoText}</span>;
   return (
     <Icon
       style={{
-        color,
         width: `${Math.round(14 * factor)}px`,
         height: `${Math.round(14 * factor)}px`,
       }}
@@ -928,7 +928,7 @@ function CodeBlockInner({
 
       {hasInit && (
         <div className={challengeStyles.initWrap}>
-          {initLineCount > 3 && (
+          {initLineCount > 3 ? (
             <button
               type="button"
               className={challengeStyles.initToggle}
@@ -951,6 +951,22 @@ function CodeBlockInner({
                 {initLineCount} line{initLineCount === 1 ? "" : "s"} · read-only
               </span>
             </button>
+          ) : (
+            // Short init code isn't collapsible, but it still needs a
+            // label so the learner knows the first block is read-only
+            // setup code rather than part of the editable snippet.
+            <div className={challengeStyles.initHeaderStatic}>
+              <Lock
+                size={11}
+                strokeWidth={2}
+                aria-hidden
+                className={challengeStyles.initLockIcon}
+              />
+              <span className={challengeStyles.initLabel}>
+                Initialization code ({adapter.runtimeInfo.language})
+              </span>
+              <span className={challengeStyles.initMeta}>read-only</span>
+            </div>
           )}
           <div
             className={`${challengeStyles.initEditorWrap} ${

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -46,7 +46,6 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   LANGUAGE_ICONS,
-  LANGUAGE_ICON_COLORS,
   LANGUAGE_ICON_SIZE_FACTOR,
 } from "./languageIcons";
 import {
@@ -175,13 +174,19 @@ export interface SqlChallengeCardProps {
   tests: SqlChallengeTest[];
 }
 
-/** One table entry in the viewer panel. */
+/** One table entry in the viewer panel. Rows are loaded a page at a
+ *  time: `result.values` holds everything fetched so far, `hasMore`
+ *  records whether another page exists (so the viewer can keep
+ *  scroll-loading), and `loadingMore` guards/labels an in-flight fetch. */
 export interface TableViewerEntry {
   schema: string | null;
   table: string;
   result: SqlResult | null;
   error: string | null;
-  truncated: boolean;
+  /** True when at least one more row exists beyond what's loaded. */
+  hasMore: boolean;
+  /** True while the next page is being fetched (drives the spinner). */
+  loadingMore: boolean;
 }
 
 // ─── Engine adapter ───────────────────────────────────────────────────
@@ -588,6 +593,205 @@ export function sqlFormatterLanguage(d: SqlDialect): "sqlite" | "postgresql" | "
   return "postgresql";
 }
 
+// ─── Table viewer hook ────────────────────────────────────────────────
+
+/** Fetch a single page of a table's rows. Asks for `pageSize + 1` rows
+ *  so the caller can tell — without a second COUNT(*) round-trip —
+ *  whether more rows remain past this page. Works for every dialect
+ *  because `LIMIT … OFFSET …` is supported by SQLite, DuckDB, and
+ *  Postgres alike. Errors are returned, not thrown, so one broken table
+ *  can't blank the whole viewer. */
+export async function fetchTablePage(
+  engine: SqlEngineLike,
+  dialect: SqlDialect,
+  schema: string | null,
+  table: string,
+  pageSize: number,
+  offset: number,
+): Promise<{ result: SqlResult | null; hasMore: boolean; error: string | null }> {
+  if (!table) return { result: null, hasMore: false, error: "Empty table name." };
+  try {
+    const ref = qualifiedTable(dialect, schema, table);
+    const out = await engine.exec(
+      `SELECT * FROM ${ref} LIMIT ${pageSize + 1} OFFSET ${offset};`,
+    );
+    const last =
+      out.findLast?.((r) => r.columns.length > 0) ??
+      [...out].reverse().find((r) => r.columns.length > 0) ??
+      null;
+    if (!last) return { result: null, hasMore: false, error: null };
+    const hasMore = last.values.length > pageSize;
+    const result: SqlResult = hasMore
+      ? { columns: last.columns, values: last.values.slice(0, pageSize) }
+      : last;
+    return { result, hasMore, error: null };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { result: null, hasMore: false, error: msg };
+  }
+}
+
+export interface UseSqlTableViewerOptions {
+  dialect: SqlDialect;
+  tables: SqlTableViewerSpec[] | false | undefined;
+  /** Rows fetched per page. The viewer scroll-loads further pages on
+   *  demand, so this is a page size rather than a hard cap. */
+  tableRowLimit: number;
+  ensureEngine: () => Promise<SqlEngineLike>;
+}
+
+/** Shared table-viewer state machine for `<SqlChallengeCard>` and
+ *  `<SqlCodeBlock>`. Owns the list of tables, the active tab, the
+ *  open/closed state, the first-load "initializing" flag (which drives
+ *  the skeleton animation while the WASM engine boots and seeds), and
+ *  the per-table infinite-scroll paging. Living here keeps the two
+ *  card components byte-for-byte consistent. */
+export function useSqlTableViewer({
+  dialect,
+  tables,
+  tableRowLimit,
+  ensureEngine,
+}: UseSqlTableViewerOptions) {
+  const enabled = tables !== false;
+  const pageSize = Math.max(1, Math.floor(tableRowLimit));
+
+  const [entries, setEntries] = useState<TableViewerEntry[]>([]);
+  const [activeIdx, setActiveIdx] = useState(0);
+  // True from mount until the first table list has been fetched (or the
+  // boot failed). Drives the loading skeleton. Subsequent refreshes
+  // don't re-raise it, so re-running a query updates rows in place
+  // rather than flashing the skeleton.
+  const [initializing, setInitializing] = useState(enabled);
+
+  // Mirror of `entries` for stale-free reads inside async callbacks.
+  const entriesRef = useRef(entries);
+  useEffect(() => {
+    entriesRef.current = entries;
+  });
+  // Guards against firing a duplicate page fetch for the same table
+  // while one is already in flight (the scroll handler can fire many
+  // times before React commits the `loadingMore` flag).
+  const inFlightRef = useRef<Set<number>>(new Set());
+
+  const refresh = useCallback(
+    async (engine: SqlEngineLike) => {
+      if (!enabled) return;
+      const defaultSchema = defaultSchemaFor(dialect);
+      let plan: { schema: string | null; table: string }[];
+      if (Array.isArray(tables)) {
+        plan = tables.map((t) =>
+          typeof t === "string"
+            ? { schema: defaultSchema, table: t }
+            : { schema: t.schema ?? defaultSchema, table: t.table },
+        );
+      } else {
+        try {
+          const listed = await engine.exec(listTablesSqlFor(dialect));
+          const row = listed.find((r) => r.columns.length > 0);
+          plan = (row?.values ?? []).map((r) => ({
+            schema: String(r[0] ?? defaultSchema),
+            table: String(r[1] ?? ""),
+          }));
+        } catch {
+          plan = [];
+        }
+      }
+      inFlightRef.current.clear();
+      const next: TableViewerEntry[] = await Promise.all(
+        plan.map(async ({ schema, table }) => {
+          const page = await fetchTablePage(engine, dialect, schema, table, pageSize, 0);
+          return {
+            schema,
+            table,
+            result: page.result,
+            error: page.error,
+            hasMore: page.hasMore,
+            loadingMore: false,
+          };
+        }),
+      );
+      setEntries(next);
+      setActiveIdx((idx) => (next.length === 0 ? 0 : Math.min(idx, next.length - 1)));
+      setInitializing(false);
+    },
+    [dialect, enabled, pageSize, tables],
+  );
+
+  /** Append the next page of rows to the table at `idx`. No-op when the
+   *  table has no more rows, errored, or already has a fetch in flight. */
+  const loadMore = useCallback(
+    async (idx: number) => {
+      const entry = entriesRef.current[idx];
+      if (!entry || !entry.hasMore || entry.error || !entry.result) return;
+      if (inFlightRef.current.has(idx)) return;
+      inFlightRef.current.add(idx);
+      setEntries((prev) =>
+        prev.map((e, i) => (i === idx ? { ...e, loadingMore: true } : e)),
+      );
+      try {
+        const engine = await ensureEngine();
+        const offset = entry.result.values.length;
+        const page = await fetchTablePage(
+          engine,
+          dialect,
+          entry.schema,
+          entry.table,
+          pageSize,
+          offset,
+        );
+        setEntries((prev) =>
+          prev.map((e, i) => {
+            if (i !== idx) return e;
+            const added = page.result?.values ?? [];
+            const mergedResult: SqlResult | null = e.result
+              ? { columns: e.result.columns, values: [...e.result.values, ...added] }
+              : page.result;
+            return {
+              ...e,
+              result: mergedResult,
+              hasMore: page.error ? false : page.hasMore,
+              loadingMore: false,
+            };
+          }),
+        );
+      } catch {
+        setEntries((prev) =>
+          prev.map((e, i) =>
+            i === idx ? { ...e, hasMore: false, loadingMore: false } : e,
+          ),
+        );
+      } finally {
+        inFlightRef.current.delete(idx);
+      }
+    },
+    [dialect, ensureEngine, pageSize],
+  );
+
+  /** Clear all entries and re-arm the loading skeleton — used by Reset,
+   *  which destroys and re-seeds the engine. */
+  const clear = useCallback(() => {
+    inFlightRef.current.clear();
+    setEntries([]);
+    setInitializing(enabled);
+  }, [enabled]);
+
+  /** Lower the skeleton without populating tables — used when engine
+   *  bootstrap fails so the skeleton doesn't spin forever. */
+  const markInitDone = useCallback(() => setInitializing(false), []);
+
+  return {
+    enabled,
+    entries,
+    activeIdx,
+    setActiveIdx,
+    initializing,
+    refresh,
+    loadMore,
+    clear,
+    markInitDone,
+  };
+}
+
 export default function SqlChallengeCard({
   dialect,
   title,
@@ -645,9 +849,6 @@ export default function SqlChallengeCard({
   const [resultError, setResultError] = useState<string>("");
   const [elapsed, setElapsed] = useState<string>("");
   const [solutionOpen, setSolutionOpen] = useState(false);
-  const [tableEntries, setTableEntries] = useState<TableViewerEntry[]>([]);
-  const [tableViewerOpen, setTableViewerOpen] = useState(true);
-  const [activeTableIdx, setActiveTableIdx] = useState(0);
   const [testResults, setTestResults] = useState<DisplayedTest[]>([]);
   const [testListOpen, setTestListOpen] = useState(true);
   const [bannerState, setBannerState] = useState<"pass" | "fail" | null>(null);
@@ -854,76 +1055,6 @@ export default function SqlChallengeCard({
     };
   }, []);
 
-  // ─── Table viewer ───────────────────────────────────────────────────
-  const tableViewerEnabled = tables !== false;
-
-  /** Refresh the table viewer's contents. Lists tables (either the
-   *  hand-picked subset or every user table in the default schema),
-   *  then runs `SELECT ... LIMIT N` against each. Errors per table are
-   *  isolated so one broken entry doesn't blank the panel. */
-  const refreshTableViewer = useCallback(
-    async (engine: SqlEngineLike) => {
-      if (!tableViewerEnabled) return;
-      const defaultSchema = defaultSchemaFor(dialect);
-      let plan: { schema: string | null; table: string }[];
-      if (Array.isArray(tables)) {
-        plan = tables.map((t) =>
-          typeof t === "string"
-            ? { schema: defaultSchema, table: t }
-            : { schema: t.schema ?? defaultSchema, table: t.table },
-        );
-      } else {
-        try {
-          const listed = await engine.exec(listTablesSqlFor(dialect));
-          const row = listed.find((r) => r.columns.length > 0);
-          plan = (row?.values ?? []).map((r) => ({
-            schema: String(r[0] ?? defaultSchema),
-            table: String(r[1] ?? ""),
-          }));
-        } catch {
-          plan = [];
-        }
-      }
-      const limit = Math.max(1, Math.floor(tableRowLimit));
-      const fetchLimit = limit + 1;
-      const entries: TableViewerEntry[] = await Promise.all(
-        plan.map(async ({ schema, table }) => {
-          if (!table) {
-            return {
-              schema,
-              table,
-              result: null,
-              error: "Empty table name.",
-              truncated: false,
-            };
-          }
-          try {
-            const ref = qualifiedTable(dialect, schema, table);
-            const out = await engine.exec(`SELECT * FROM ${ref} LIMIT ${fetchLimit};`);
-            const last = out.findLast?.((r) => r.columns.length > 0) ??
-              [...out].reverse().find((r) => r.columns.length > 0) ?? null;
-            if (!last) {
-              return { schema, table, result: null, error: null, truncated: false };
-            }
-            const truncated = last.values.length > limit;
-            const trimmed: SqlResult = truncated
-              ? { columns: last.columns, values: last.values.slice(0, limit) }
-              : last;
-            return { schema, table, result: trimmed, error: null, truncated };
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            return { schema, table, result: null, error: msg, truncated: false };
-          }
-        }),
-      );
-      setTableEntries(entries);
-      setActiveTableIdx((idx) =>
-        entries.length === 0 ? 0 : Math.min(idx, entries.length - 1),
-      );
-    },
-    [dialect, tableViewerEnabled, tableRowLimit, tables],
-  );
-
   // ─── Engine bootstrap ───────────────────────────────────────────────
   // Seeding (running `initSql`) is folded INTO the cached promise so
   // every caller awaits the same fully-seeded engine. A previous design
@@ -953,6 +1084,26 @@ export default function SqlChallengeCard({
     return enginePromiseRef.current;
   }, [dialect, initSql]);
 
+  // ─── Table viewer ───────────────────────────────────────────────────
+  // All table-list / paging / loading state lives in the shared hook so
+  // this card and `<SqlCodeBlock>` behave identically.
+  const {
+    enabled: tableViewerEnabled,
+    entries: tableEntries,
+    activeIdx: activeTableIdx,
+    setActiveIdx: setActiveTableIdx,
+    initializing: tablesInitializing,
+    refresh: refreshTableViewer,
+    loadMore: loadMoreTable,
+    clear: clearTableViewer,
+    markInitDone: markTablesInitDone,
+  } = useSqlTableViewer({ dialect, tables, tableRowLimit, ensureEngine });
+
+  const loadMoreActiveTable = useCallback(
+    () => void loadMoreTable(activeTableIdx),
+    [loadMoreTable, activeTableIdx],
+  );
+
   // Eagerly boot the engine on mount so the table viewer can populate
   // before the learner clicks Run. The engine is per-card and isolated,
   // so doing this once per mount is safe.
@@ -961,9 +1112,11 @@ export default function SqlChallengeCard({
     void ensureEngine()
       .then((engine) => refreshTableViewer(engine))
       .catch(() => {
-        /* surface errors via the per-table error column instead of blocking mount */
+        // Lower the skeleton so it doesn't spin forever; per-table
+        // errors surface in their own column once a run succeeds.
+        markTablesInitDone();
       });
-  }, [ensureEngine, refreshTableViewer, tableViewerEnabled]);
+  }, [ensureEngine, refreshTableViewer, tableViewerEnabled, markTablesInitDone]);
 
   // ─── Execution ──────────────────────────────────────────────────────
   /**
@@ -1280,7 +1433,7 @@ export default function SqlChallengeCard({
     setStatusMessage("");
     setTestResults([]);
     setBannerState(null);
-    setTableEntries([]);
+    clearTableViewer();
     if (tableViewerEnabled) {
       void ensureEngine()
         .then((engine) => refreshTableViewer(engine))
@@ -1289,7 +1442,7 @@ export default function SqlChallengeCard({
         });
     }
     toasts.show("Reset to starter SQL.");
-  }, [initialCode, persistedKey, ensureEngine, refreshTableViewer, tableViewerEnabled, toasts]);
+  }, [initialCode, persistedKey, ensureEngine, refreshTableViewer, clearTableViewer, tableViewerEnabled, toasts]);
 
   const copyCode = useCallback(async () => {
     const code = editorRef.current?.state.doc.toString() ?? "";
@@ -1405,60 +1558,15 @@ export default function SqlChallengeCard({
       </div>
 
       {/* ── Table viewer ── */}
-      {tableViewerEnabled && tableEntries.length > 0 && (
-        <div className={styles.tableViewer}>
-          <button
-            type="button"
-            className={styles.tableViewerHeader}
-            onClick={() => setTableViewerOpen((v) => !v)}
-            aria-expanded={tableViewerOpen}
-          >
-            <span className={styles.tableViewerLabel}>Tables</span>
-            <span className={styles.tableViewerCount}>
-              {tableEntries.length} {tableEntries.length === 1 ? "table" : "tables"}
-            </span>
-            <ChevronDown
-              size={14}
-              aria-hidden
-              className={`${styles.testChevron} ${
-                tableViewerOpen ? styles.testChevronOpen : ""
-              }`}
-            />
-          </button>
-          {tableViewerOpen && (
-            <>
-              <div className={styles.tableViewerTabs} role="tablist">
-                {tableEntries.map((entry, idx) => (
-                  <button
-                    key={`${entry.schema ?? ""}.${entry.table}`}
-                    type="button"
-                    role="tab"
-                    aria-selected={idx === activeTableIdx}
-                    className={`${styles.tableViewerTab} ${
-                      idx === activeTableIdx ? styles.tableViewerTabActive : ""
-                    }`}
-                    onClick={() => setActiveTableIdx(idx)}
-                  >
-                    {entry.schema && entry.schema !== defaultSchemaFor(dialect) ? (
-                      <>
-                        <span className={styles.tableViewerSchema}>{entry.schema}.</span>
-                        {entry.table}
-                      </>
-                    ) : (
-                      entry.table
-                    )}
-                  </button>
-                ))}
-              </div>
-              {tableEntries[activeTableIdx] && (
-                <TableViewerPane
-                  entry={tableEntries[activeTableIdx]}
-                  limit={tableRowLimit}
-                />
-              )}
-            </>
-          )}
-        </div>
+      {tableViewerEnabled && (
+        <TableViewer
+          dialect={dialect}
+          entries={tableEntries}
+          activeIdx={activeTableIdx}
+          setActiveIdx={setActiveTableIdx}
+          initializing={tablesInitializing}
+          onLoadMore={loadMoreActiveTable}
+        />
       )}
 
       {/* ── Editor ── */}
@@ -1930,25 +2038,47 @@ function SolutionModal({
   );
 }
 
-/** Renders a single table's contents inside the table viewer panel.
+/** Human-readable form of a cell value, used both for the visible text
+ *  (where applicable) and the `title` tooltip so a value clipped by the
+ *  column's max-width is still fully readable on hover. */
+function cellText(v: unknown): string {
+  if (v === null || v === undefined) return "NULL";
+  if (v instanceof Uint8Array) return `<${v.byteLength} bytes>`;
+  return String(v);
+}
+
 /** Virtualised SQL result table — used both by the main result pane
- *  and the per-table viewer at the bottom of the card. The result
- *  set is in memory by the time we render (executeSql returns the
- *  full Promise<SqlResult>), so there's no per-page load — we just
- *  render only the rows currently in the viewport via
- *  `@tanstack/react-virtual` + a TanStack table for the column
- *  definitions. For very wide tables the inner row is still a
- *  regular `<tr>` so column auto-widths just work. */
+ *  and the per-table viewer at the bottom of the card. The query
+ *  result set is in memory by the time we render (executeSql returns
+ *  the full Promise<SqlResult>), so we just render the rows currently
+ *  in the viewport via `@tanstack/react-virtual` + a TanStack table for
+ *  the column definitions.
+ *
+ *  The table viewer passes `onLoadMore`/`hasMore` so browsing a large
+ *  seeded table scroll-loads further pages on demand (infinite scroll);
+ *  the main result pane omits them (the whole result is already here).
+ *  Long column names / values are clipped with an ellipsis via CSS and
+ *  carry a `title` so the full text stays available on hover. */
 export function VirtualizedResultTable({
   columns,
   values,
   maxHeight,
+  onLoadMore,
+  hasMore = false,
+  loadingMore = false,
 }: {
   columns: string[];
   values: unknown[][];
   /** CSS max-height of the scroll container. Defaults to 320px so a
    *  giant result set doesn't push the whole page below the fold. */
   maxHeight?: number;
+  /** Called when the viewport nears the bottom and `hasMore` is true.
+   *  Omit for fully-in-memory result sets (no paging). */
+  onLoadMore?: () => void;
+  /** Whether another page of rows exists past what's rendered. */
+  hasMore?: boolean;
+  /** Whether the next page is currently being fetched. */
+  loadingMore?: boolean;
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // Stable row identity — TanStack Table keys rows by index when no
@@ -1973,10 +2103,7 @@ export function VirtualizedResultTable({
             if (v === null || v === undefined) {
               return <span className={styles.sqlNullValue}>NULL</span>;
             }
-            if (v instanceof Uint8Array) {
-              return `<${v.byteLength} bytes>`;
-            }
-            return String(v);
+            return cellText(v);
           },
         }),
       ),
@@ -2006,6 +2133,20 @@ export function VirtualizedResultTable({
       : 0;
   const colSpan = tableColumns.length;
 
+  // Infinite scroll: when the last virtualised row gets within a short
+  // distance of the end of what's loaded, ask the owner for the next
+  // page. The owner guards against duplicate fetches, so a few extra
+  // calls during fast scrolling are harmless.
+  const lastIndex =
+    virtualRows.length > 0 ? virtualRows[virtualRows.length - 1].index : -1;
+  useEffect(() => {
+    if (!onLoadMore || !hasMore || loadingMore) return;
+    if (lastIndex < 0) return;
+    if (lastIndex >= tableRows.length - 1 - 8) {
+      onLoadMore();
+    }
+  }, [lastIndex, hasMore, loadingMore, tableRows.length, onLoadMore]);
+
   return (
     <div
       ref={scrollRef}
@@ -2017,7 +2158,7 @@ export function VirtualizedResultTable({
           {table.getHeaderGroups().map((hg) => (
             <tr key={hg.id}>
               {hg.headers.map((h) => (
-                <th key={h.id}>
+                <th key={h.id} title={columns[Number(h.column.id)]}>
                   {h.isPlaceholder
                     ? null
                     : flexRender(h.column.columnDef.header, h.getContext())}
@@ -2041,7 +2182,7 @@ export function VirtualizedResultTable({
                 ref={rowVirtualizer.measureElement}
               >
                 {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id}>
+                  <td key={cell.id} title={cellText(row.original.row[Number(cell.column.id)])}>
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
                 ))}
@@ -2053,6 +2194,13 @@ export function VirtualizedResultTable({
               <td colSpan={colSpan} />
             </tr>
           )}
+          {loadingMore && (
+            <tr aria-hidden className={styles.sqlResultLoadingRow}>
+              <td colSpan={colSpan}>
+                <span className={styles.tableViewerSpinner} /> Loading more rows…
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
     </div>
@@ -2061,13 +2209,18 @@ export function VirtualizedResultTable({
 
 /** Renders a single table's contents inside the table viewer panel.
  *  Errors and empty-table cases produce a contextual message rather
- *  than a blank pane. */
+ *  than a blank pane. Wires the result table's infinite scroll so more
+ *  rows stream in as the learner scrolls. */
 export function TableViewerPane({
   entry,
-  limit,
+  height = 220,
+  onLoadMore,
 }: {
   entry: TableViewerEntry;
-  limit: number;
+  /** Height (px) of the table's scroll area — driven by the viewer's
+   *  drag-to-resize bar. */
+  height?: number;
+  onLoadMore?: () => void;
 }) {
   if (entry.error) {
     return (
@@ -2092,12 +2245,175 @@ export function TableViewerPane({
       <VirtualizedResultTable
         columns={r.columns}
         values={r.values}
-        maxHeight={220}
+        maxHeight={height}
+        onLoadMore={onLoadMore}
+        hasMore={entry.hasMore}
+        loadingMore={entry.loadingMore}
       />
-      {entry.truncated && (
-        <div className={styles.tableViewerFootnote}>
-          Showing first {limit} row{limit === 1 ? "" : "s"}.
+      <div className={styles.tableViewerFootnote}>
+        {entry.loadingMore
+          ? "Loading more rows…"
+          : entry.hasMore
+            ? `${r.values.length} rows loaded — scroll for more`
+            : `${r.values.length} row${r.values.length === 1 ? "" : "s"}`}
+      </div>
+    </div>
+  );
+}
+
+/** Shimmering placeholder rows shown while the WASM engine boots and
+ *  seeds, before the first table list is available. */
+export function TableViewerSkeleton() {
+  return (
+    <div className={styles.tableViewerSkeleton} aria-hidden>
+      {Array.from({ length: 4 }).map((_, r) => (
+        <div key={r} className={styles.skeletonRow}>
+          {Array.from({ length: 4 }).map((_, c) => (
+            <div key={c} className={styles.skeletonCell} />
+          ))}
         </div>
+      ))}
+    </div>
+  );
+}
+
+// Drag-to-resize bounds for the table viewer's contents (px).
+const TABLE_VIEWER_MIN_HEIGHT = 120;
+const TABLE_VIEWER_MAX_HEIGHT = 640;
+const TABLE_VIEWER_DEFAULT_HEIGHT = 240;
+
+/** The always-visible "Tables" panel shared by `<SqlChallengeCard>` and
+ *  `<SqlCodeBlock>`. Shows a loading skeleton until the first table
+ *  list is fetched, then a tab bar (styled to match the non-SQL code
+ *  block file tabs) plus the active table's paginated contents. The
+ *  panel is not collapsible; instead a drag bar at the bottom lets the
+ *  learner resize the visible table area. */
+export function TableViewer({
+  dialect,
+  entries,
+  activeIdx,
+  setActiveIdx,
+  initializing,
+  onLoadMore,
+}: {
+  dialect: SqlDialect;
+  entries: TableViewerEntry[];
+  activeIdx: number;
+  setActiveIdx: React.Dispatch<React.SetStateAction<number>>;
+  initializing: boolean;
+  onLoadMore: () => void;
+}) {
+  const [paneHeight, setPaneHeight] = useState(TABLE_VIEWER_DEFAULT_HEIGHT);
+  // Live drag origin; null when not dragging. Stored in a ref so the
+  // window-level move/up listeners read fresh values without re-binding.
+  const dragRef = useRef<{ startY: number; startH: number } | null>(null);
+
+  const onResizeStart = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      dragRef.current = { startY: e.clientY, startH: paneHeight };
+      const onMove = (ev: PointerEvent) => {
+        if (!dragRef.current) return;
+        const dy = ev.clientY - dragRef.current.startY;
+        const next = Math.min(
+          TABLE_VIEWER_MAX_HEIGHT,
+          Math.max(TABLE_VIEWER_MIN_HEIGHT, dragRef.current.startH + dy),
+        );
+        setPaneHeight(next);
+      };
+      const onUp = () => {
+        dragRef.current = null;
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        document.body.style.userSelect = "";
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      // Suppress text selection while dragging the bar.
+      document.body.style.userSelect = "none";
+    },
+    [paneHeight],
+  );
+
+  // Keyboard resize for accessibility (focus the bar, use arrow keys).
+  const onResizeKey = useCallback((e: React.KeyboardEvent) => {
+    const step = e.shiftKey ? 48 : 16;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setPaneHeight((h) => Math.min(TABLE_VIEWER_MAX_HEIGHT, h + step));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setPaneHeight((h) => Math.max(TABLE_VIEWER_MIN_HEIGHT, h - step));
+    }
+  }, []);
+
+  const showSkeleton = initializing && entries.length === 0;
+  // Nothing to show: not initializing and no tables were found.
+  if (!showSkeleton && entries.length === 0) return null;
+  const active = entries[activeIdx];
+  return (
+    <div className={styles.tableViewer}>
+      <div className={styles.tableViewerHeader}>
+        <span className={styles.tableViewerLabel}>Tables</span>
+        {showSkeleton ? (
+          <span className={styles.tableViewerCount}>
+            <span className={styles.tableViewerSpinner} aria-hidden /> Initializing…
+          </span>
+        ) : (
+          <span className={styles.tableViewerCount}>
+            {entries.length} {entries.length === 1 ? "table" : "tables"}
+          </span>
+        )}
+      </div>
+      {showSkeleton ? (
+        <TableViewerSkeleton />
+      ) : (
+        <>
+          <div className={styles.tableViewerTabs} role="tablist">
+            {entries.map((entry, idx) => (
+              <button
+                key={`${entry.schema ?? ""}.${entry.table}`}
+                type="button"
+                role="tab"
+                aria-selected={idx === activeIdx}
+                className={`${styles.tableViewerTab} ${
+                  idx === activeIdx ? styles.tableViewerTabActive : ""
+                }`}
+                onClick={() => setActiveIdx(idx)}
+              >
+                {entry.schema && entry.schema !== defaultSchemaFor(dialect) ? (
+                  <>
+                    <span className={styles.tableViewerSchema}>{entry.schema}.</span>
+                    {entry.table}
+                  </>
+                ) : (
+                  entry.table
+                )}
+              </button>
+            ))}
+          </div>
+          {active && (
+            <TableViewerPane
+              // Re-key per table so switching tabs resets scroll to the
+              // top instead of inheriting the previous table's offset.
+              key={`${active.schema ?? ""}.${active.table}`}
+              entry={active}
+              height={paneHeight}
+              onLoadMore={onLoadMore}
+            />
+          )}
+          <div
+            className={styles.tableViewerResizer}
+            onPointerDown={onResizeStart}
+            onKeyDown={onResizeKey}
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Drag to resize the tables panel"
+            tabIndex={0}
+          >
+            <span className={styles.tableViewerResizerGrip} aria-hidden />
+          </div>
+        </>
       )}
     </div>
   );

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -2279,8 +2279,21 @@ export function TableViewerSkeleton() {
 
 // Drag-to-resize bounds for the table viewer's contents (px).
 const TABLE_VIEWER_MIN_HEIGHT = 120;
-const TABLE_VIEWER_MAX_HEIGHT = 640;
+const TABLE_VIEWER_MAX_HEIGHT = 520;
 const TABLE_VIEWER_DEFAULT_HEIGHT = 240;
+
+/** Effective maximum height for the resizable table area. Capped at
+ *  `TABLE_VIEWER_MAX_HEIGHT`, but also never more than ~70% of the
+ *  viewport so the panel can't swallow the whole screen on short
+ *  windows. Recomputed per drag/keystroke so it tracks window resizes. */
+function tableViewerMaxHeight(): number {
+  const vh = typeof window !== "undefined" ? window.innerHeight : 0;
+  const viewportCap = vh > 0 ? Math.round(vh * 0.7) : TABLE_VIEWER_MAX_HEIGHT;
+  return Math.max(
+    TABLE_VIEWER_MIN_HEIGHT,
+    Math.min(TABLE_VIEWER_MAX_HEIGHT, viewportCap),
+  );
+}
 
 /** The always-visible "Tables" panel shared by `<SqlChallengeCard>` and
  *  `<SqlCodeBlock>`. Shows a loading skeleton until the first table
@@ -2316,7 +2329,7 @@ export function TableViewer({
         if (!dragRef.current) return;
         const dy = ev.clientY - dragRef.current.startY;
         const next = Math.min(
-          TABLE_VIEWER_MAX_HEIGHT,
+          tableViewerMaxHeight(),
           Math.max(TABLE_VIEWER_MIN_HEIGHT, dragRef.current.startH + dy),
         );
         setPaneHeight(next);
@@ -2340,7 +2353,7 @@ export function TableViewer({
     const step = e.shiftKey ? 48 : 16;
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setPaneHeight((h) => Math.min(TABLE_VIEWER_MAX_HEIGHT, h + step));
+      setPaneHeight((h) => Math.min(tableViewerMaxHeight(), h + step));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setPaneHeight((h) => Math.max(TABLE_VIEWER_MIN_HEIGHT, h - step));

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -24,7 +24,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, ChevronDown, Database } from "lucide-react";
+import { RotateCcw, Database } from "lucide-react";
 import {
   CopyIcon,
   FormatIcon,
@@ -58,19 +58,16 @@ import {
 import styles from "./ChallengeCard.module.css";
 import {
   createEngineForDialect,
-  defaultSchemaFor,
   DialectGlyph,
-  listTablesSqlFor,
-  qualifiedTable,
   RunOverlay,
   sqlFormatterLanguage,
-  TableViewerPane,
+  TableViewer,
+  useSqlTableViewer,
   VirtualizedResultTable,
   type SqlDialect,
   type SqlEngineLike,
   type SqlResult,
   type SqlTableViewerSpec,
-  type TableViewerEntry,
 } from "./SqlChallengeCard";
 
 export type { SqlDialect } from "./SqlChallengeCard";
@@ -145,9 +142,6 @@ export default function SqlCodeBlock({
   const [resultMessage, setResultMessage] = useState<string>("");
   const [resultError, setResultError] = useState<string>("");
   const [elapsed, setElapsed] = useState<string>("");
-  const [tableEntries, setTableEntries] = useState<TableViewerEntry[]>([]);
-  const [tableViewerOpen, setTableViewerOpen] = useState(true);
-  const [activeTableIdx, setActiveTableIdx] = useState(0);
   const [isFormatting, setIsFormatting] = useState(false);
   const toasts = useChallengeToasts();
   const [engineLabel, setEngineLabel] = useState<string>(
@@ -278,74 +272,6 @@ export default function SqlCodeBlock({
     };
   }, []);
 
-  // ─── Table viewer ───────────────────────────────────────────────────
-  const tableViewerEnabled = tables !== false;
-
-  const refreshTableViewer = useCallback(
-    async (engine: SqlEngineLike) => {
-      if (!tableViewerEnabled) return;
-      const defaultSchema = defaultSchemaFor(dialect);
-      let plan: { schema: string | null; table: string }[];
-      if (Array.isArray(tables)) {
-        plan = tables.map((t) =>
-          typeof t === "string"
-            ? { schema: defaultSchema, table: t }
-            : { schema: t.schema ?? defaultSchema, table: t.table },
-        );
-      } else {
-        try {
-          const listed = await engine.exec(listTablesSqlFor(dialect));
-          const row = listed.find((r) => r.columns.length > 0);
-          plan = (row?.values ?? []).map((r) => ({
-            schema: String(r[0] ?? defaultSchema),
-            table: String(r[1] ?? ""),
-          }));
-        } catch {
-          plan = [];
-        }
-      }
-      const limit = Math.max(1, Math.floor(tableRowLimit));
-      const fetchLimit = limit + 1;
-      const entries: TableViewerEntry[] = await Promise.all(
-        plan.map(async ({ schema, table }) => {
-          if (!table) {
-            return {
-              schema,
-              table,
-              result: null,
-              error: "Empty table name.",
-              truncated: false,
-            };
-          }
-          try {
-            const ref = qualifiedTable(dialect, schema, table);
-            const out = await engine.exec(`SELECT * FROM ${ref} LIMIT ${fetchLimit};`);
-            const last =
-              out.findLast?.((r) => r.columns.length > 0) ??
-              [...out].reverse().find((r) => r.columns.length > 0) ??
-              null;
-            if (!last) {
-              return { schema, table, result: null, error: null, truncated: false };
-            }
-            const truncated = last.values.length > limit;
-            const trimmed: SqlResult = truncated
-              ? { columns: last.columns, values: last.values.slice(0, limit) }
-              : last;
-            return { schema, table, result: trimmed, error: null, truncated };
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            return { schema, table, result: null, error: msg, truncated: false };
-          }
-        }),
-      );
-      setTableEntries(entries);
-      setActiveTableIdx((idx) =>
-        entries.length === 0 ? 0 : Math.min(idx, entries.length - 1),
-      );
-    },
-    [dialect, tableViewerEnabled, tableRowLimit, tables],
-  );
-
   // ─── Engine bootstrap ───────────────────────────────────────────────
   // Seeding (running `initSql`) is folded INTO the cached promise so
   // every caller awaits the same fully-seeded engine. A previous design
@@ -374,6 +300,25 @@ export default function SqlCodeBlock({
     return enginePromiseRef.current;
   }, [dialect, initSql]);
 
+  // ─── Table viewer ───────────────────────────────────────────────────
+  // Shared with `<SqlChallengeCard>` so both stay consistent.
+  const {
+    enabled: tableViewerEnabled,
+    entries: tableEntries,
+    activeIdx: activeTableIdx,
+    setActiveIdx: setActiveTableIdx,
+    initializing: tablesInitializing,
+    refresh: refreshTableViewer,
+    loadMore: loadMoreTable,
+    clear: clearTableViewer,
+    markInitDone: markTablesInitDone,
+  } = useSqlTableViewer({ dialect, tables, tableRowLimit, ensureEngine });
+
+  const loadMoreActiveTable = useCallback(
+    () => void loadMoreTable(activeTableIdx),
+    [loadMoreTable, activeTableIdx],
+  );
+
   // Eagerly boot the engine on mount so the table viewer can populate
   // before the learner clicks Run.
   useEffect(() => {
@@ -381,10 +326,10 @@ export default function SqlCodeBlock({
     void ensureEngine()
       .then((engine) => refreshTableViewer(engine))
       .catch(() => {
-        /* surface errors via the per-table error column / result panel
-           instead of blocking mount */
+        // Lower the skeleton so it doesn't spin forever.
+        markTablesInitDone();
       });
-  }, [ensureEngine, refreshTableViewer, tableViewerEnabled]);
+  }, [ensureEngine, refreshTableViewer, tableViewerEnabled, markTablesInitDone]);
 
   // ─── Execution ──────────────────────────────────────────────────────
   const executeSql = useCallback(
@@ -501,16 +446,16 @@ export default function SqlCodeBlock({
     setElapsed("");
     setStatus("idle");
     setStatusMessage("");
-    setTableEntries([]);
+    clearTableViewer();
     if (tableViewerEnabled) {
       void ensureEngine()
         .then((engine) => refreshTableViewer(engine))
         .catch(() => {
-          /* see mount-time bootstrap */
+          markTablesInitDone();
         });
     }
     toasts.show("Reset to starter SQL.");
-  }, [initialCode, persistedKey, ensureEngine, refreshTableViewer, tableViewerEnabled, toasts]);
+  }, [initialCode, persistedKey, ensureEngine, refreshTableViewer, clearTableViewer, markTablesInitDone, tableViewerEnabled, toasts]);
 
   const copyCode = useCallback(async () => {
     const code = editorRef.current?.state.doc.toString() ?? "";
@@ -592,60 +537,15 @@ export default function SqlCodeBlock({
       </div>
 
       {/* ── Table viewer ── */}
-      {tableViewerEnabled && tableEntries.length > 0 && (
-        <div className={styles.tableViewer}>
-          <button
-            type="button"
-            className={styles.tableViewerHeader}
-            onClick={() => setTableViewerOpen((v) => !v)}
-            aria-expanded={tableViewerOpen}
-          >
-            <span className={styles.tableViewerLabel}>Tables</span>
-            <span className={styles.tableViewerCount}>
-              {tableEntries.length} {tableEntries.length === 1 ? "table" : "tables"}
-            </span>
-            <ChevronDown
-              size={14}
-              aria-hidden
-              className={`${styles.testChevron} ${
-                tableViewerOpen ? styles.testChevronOpen : ""
-              }`}
-            />
-          </button>
-          {tableViewerOpen && (
-            <>
-              <div className={styles.tableViewerTabs} role="tablist">
-                {tableEntries.map((entry, idx) => (
-                  <button
-                    key={`${entry.schema ?? ""}.${entry.table}`}
-                    type="button"
-                    role="tab"
-                    aria-selected={idx === activeTableIdx}
-                    className={`${styles.tableViewerTab} ${
-                      idx === activeTableIdx ? styles.tableViewerTabActive : ""
-                    }`}
-                    onClick={() => setActiveTableIdx(idx)}
-                  >
-                    {entry.schema && entry.schema !== defaultSchemaFor(dialect) ? (
-                      <>
-                        <span className={styles.tableViewerSchema}>{entry.schema}.</span>
-                        {entry.table}
-                      </>
-                    ) : (
-                      entry.table
-                    )}
-                  </button>
-                ))}
-              </div>
-              {tableEntries[activeTableIdx] && (
-                <TableViewerPane
-                  entry={tableEntries[activeTableIdx]}
-                  limit={tableRowLimit}
-                />
-              )}
-            </>
-          )}
-        </div>
+      {tableViewerEnabled && (
+        <TableViewer
+          dialect={dialect}
+          entries={tableEntries}
+          activeIdx={activeTableIdx}
+          setActiveIdx={setActiveTableIdx}
+          initializing={tablesInitializing}
+          onLoadMore={loadMoreActiveTable}
+        />
       )}
 
       {/* ── Editor ── */}

--- a/content/learn/challenge-cards/duckdb.mdx
+++ b/content/learn/challenge-cards/duckdb.mdx
@@ -262,14 +262,14 @@ ORDER BY avg_rating DESC;`}
 
 The result pane virtualises its rows so a `SELECT *` against a 10k-row
 table stays responsive — only the rows actually inside the viewport
-are rendered.
+are rendered. The **Tables** viewer above the editor pages its rows
+in on scroll (infinite scroll) rather than loading all 10,000 up front.
 
 <SqlChallengeCard
   dialect="duckdb"
   title="Bucket 10,000 rows by score"
   instructions={`A 10,000-row table \`big\` is preloaded with a numeric \`score\` in [0, 100). Write a query that bins the rows into buckets of 10 (so \`bucket\` is \`0\`, \`10\`, \`20\`, …, \`90\`) and returns the bucket plus the row count, sorted by \`bucket\`.`}
 
-  tableRowLimit={10000}
   initSql={`CREATE TABLE big AS
 SELECT
   i AS id,

--- a/content/learn/challenge-cards/postgres.mdx
+++ b/content/learn/challenge-cards/postgres.mdx
@@ -295,14 +295,14 @@ INSERT INTO orders (amount) VALUES (120.00), (80.00), (200.00), (50.00), (150.00
 
 The result pane virtualises its rows so a `SELECT *` against a 10k-row
 table stays responsive — only the rows actually inside the viewport
-are rendered.
+are rendered. The **Tables** viewer above the editor pages its rows
+in on scroll (infinite scroll) rather than loading all 10,000 up front.
 
 <SqlChallengeCard
   dialect="postgres"
   title="Bucket 10,000 rows by score"
   instructions={`A 10,000-row table \`big\` is preloaded with a numeric \`score\` in [0, 100). Write a query that bins the rows into buckets of 10 (so \`bucket\` is \`0\`, \`10\`, \`20\`, …, \`90\`) and returns the bucket plus the row count, sorted by \`bucket\`.`}
 
-  tableRowLimit={10000}
   initSql={`CREATE TABLE big AS
 SELECT
   s.i AS id,

--- a/content/learn/challenge-cards/sqlite.mdx
+++ b/content/learn/challenge-cards/sqlite.mdx
@@ -283,14 +283,14 @@ INSERT INTO users (name, email) VALUES
 
 The result pane virtualises its rows so a `SELECT *` against a 10k-row
 table stays responsive — only the rows actually inside the viewport
-are rendered.
+are rendered. The **Tables** viewer above the editor pages its rows
+in on scroll (infinite scroll) rather than loading all 10,000 up front.
 
 <SqlChallengeCard
   dialect="sqlite"
   title="Bucket 10,000 rows by score"
   instructions={`A 10,000-row table \`big\` is preloaded with a numeric \`score\` in [0, 100). Write a query that bins the rows into buckets of 10 (so \`bucket\` is \`0\`, \`10\`, \`20\`, …, \`90\`) and returns the bucket plus the row count, sorted by \`bucket\`.`}
 
-  tableRowLimit={10000}
   initSql={`CREATE TABLE big (id INTEGER, name TEXT, score INTEGER);
 WITH RECURSIVE n(i) AS (
   SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < 10000

--- a/content/learn/sql-code-blocks/duckdb.mdx
+++ b/content/learn/sql-code-blocks/duckdb.mdx
@@ -176,3 +176,39 @@ GROUP BY ALL
 ORDER BY total_spent DESC;`}
 />
 ```
+
+## 5. Infinite scroll (10,000 rows)
+
+Seed a three-column table with 10,000 rows using `range()`. The
+**Tables** viewer loads the first page, then streams in more rows as you
+scroll. Drag the bar at the bottom of the panel to resize it.
+
+<SqlCodeBlock
+  dialect="duckdb"
+  title="Scroll through 10,000 metrics"
+  initSql={`CREATE TABLE metrics AS
+SELECT
+  i              AS id,
+  'row-' || i    AS label,
+  ROUND(i * 1.5, 2) AS value
+FROM range(1, 10001) AS t(i);`}
+  initialCode={`SELECT id, label, value
+FROM metrics
+ORDER BY id;`}
+/>
+
+```jsx
+<SqlCodeBlock
+  dialect="duckdb"
+  title="Scroll through 10,000 metrics"
+  initSql={`CREATE TABLE metrics AS
+SELECT
+  i              AS id,
+  'row-' || i    AS label,
+  ROUND(i * 1.5, 2) AS value
+FROM range(1, 10001) AS t(i);`}
+  initialCode={`SELECT id, label, value
+FROM metrics
+ORDER BY id;`}
+/>
+```

--- a/content/learn/sql-code-blocks/postgres.mdx
+++ b/content/learn/sql-code-blocks/postgres.mdx
@@ -178,3 +178,39 @@ GROUP BY d.name
 ORDER BY avg_salary DESC;`}
 />
 ```
+
+## 5. Infinite scroll (10,000 rows)
+
+Seed a three-column table with 10,000 rows using `generate_series`. The
+**Tables** viewer loads the first page, then streams in more rows as you
+scroll. Drag the bar at the bottom of the panel to resize it.
+
+<SqlCodeBlock
+  dialect="postgres"
+  title="Scroll through 10,000 metrics"
+  initSql={`CREATE TABLE metrics AS
+SELECT
+  g                 AS id,
+  'row-' || g       AS label,
+  ROUND(g * 1.5, 2) AS value
+FROM generate_series(1, 10000) AS g;`}
+  initialCode={`SELECT id, label, value
+FROM metrics
+ORDER BY id;`}
+/>
+
+```jsx
+<SqlCodeBlock
+  dialect="postgres"
+  title="Scroll through 10,000 metrics"
+  initSql={`CREATE TABLE metrics AS
+SELECT
+  g                 AS id,
+  'row-' || g       AS label,
+  ROUND(g * 1.5, 2) AS value
+FROM generate_series(1, 10000) AS g;`}
+  initialCode={`SELECT id, label, value
+FROM metrics
+ORDER BY id;`}
+/>
+```

--- a/content/learn/sql-code-blocks/sqlite.mdx
+++ b/content/learn/sql-code-blocks/sqlite.mdx
@@ -201,3 +201,51 @@ JOIN authors a ON a.id = b.author_id
 ORDER BY a.name, b.year;`}
 />
 ```
+
+## 5. Infinite scroll (10,000 rows)
+
+Seed a three-column table with 10,000 rows. The **Tables** viewer loads
+the first page, then streams in more rows as you scroll. Drag the bar at
+the bottom of the panel to resize it.
+
+<SqlCodeBlock
+  dialect="sqlite"
+  title="Scroll through 10,000 metrics"
+  initSql={`CREATE TABLE metrics (
+  id    INTEGER PRIMARY KEY,
+  label TEXT,
+  value REAL
+);
+WITH RECURSIVE seq(n) AS (
+  SELECT 1
+  UNION ALL
+  SELECT n + 1 FROM seq WHERE n < 10000
+)
+INSERT INTO metrics (id, label, value)
+SELECT n, 'row-' || n, ROUND(n * 1.5, 2) FROM seq;`}
+  initialCode={`SELECT id, label, value
+FROM metrics
+ORDER BY id;`}
+/>
+
+```jsx
+<SqlCodeBlock
+  dialect="sqlite"
+  title="Scroll through 10,000 metrics"
+  initSql={`CREATE TABLE metrics (
+  id    INTEGER PRIMARY KEY,
+  label TEXT,
+  value REAL
+);
+WITH RECURSIVE seq(n) AS (
+  SELECT 1
+  UNION ALL
+  SELECT n + 1 FROM seq WHERE n < 10000
+)
+INSERT INTO metrics (id, label, value)
+SELECT n, 'row-' || n, ROUND(n * 1.5, 2) FROM seq;`}
+  initialCode={`SELECT id, label, value
+FROM metrics
+ORDER BY id;`}
+/>
+```


### PR DESCRIPTION
## Summary

Polishes the SQL challenge card, SQL code blocks, and the surrounding code-block chrome. The table-viewer logic for `SqlChallengeCard` and `SqlCodeBlock` is now centralized in a shared `useSqlTableViewer` hook + `TableViewer` component so the two stay byte-for-byte consistent.

### Table viewer (SQL challenge card + SQL code block)
- **Loading animation** — a shimmer skeleton + spinner shows while the WASM engine boots and seeds, so the panel clearly signals "initializing" until tables are populated.
- **Tab bar restyled** to match the non-SQL code block file tab bar (`.fileTabBar`/`.fileTab`): a flat full-width strip with right-border separators and an accent underline on the active tab, replacing the floating pills.
- **Long values handled** — column names and cell values are clipped with an ellipsis (`max-width`) and carry a `title` tooltip with the full text, so one verbose column can't blow out the table width.
- **Infinite scroll** — tables page in more rows on scroll via `LIMIT … OFFSET …`, which works across **SQLite, DuckDB, and Postgres**. A guard prevents duplicate in-flight fetches.
- **Non-collapsible + drag-to-resize** — the panel is no longer collapsible; instead a drag bar at the bottom resizes the visible table area (pointer drag + arrow-key support).
- **Full-bleed tables** — removed the horizontal margin on the result scroll so tables span the full card width (top/bottom borders only).

### Code blocks (SQL + non-SQL)
- **Language icon color** now inherits the challenge card's two-tone (light/dark) header icon color instead of per-language brand colors, so embedded code blocks match the challenge cards. (The `/playground` surface keeps its brand colors.)
- **"Click to expand" legibility** — the label now sits on a solid rounded pill with a soft shadow so it stays readable over the code showing through the fade.
- **Short init code label** — when initialization code is ≤3 lines (no expand/collapse affordance), a read-only "Initialization code (<lang>)" label with a lock icon is shown so it isn't mistaken for editable code.

### Docs
- Added a **3-column / 10,000-row** infinite-scroll example to each SQL code block dialect page (`sqlite`, `duckdb`, `postgres`), with the raw JSX shown beneath each, matching the existing page convention.

## Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on touched components — clean
- `npx next build` — succeeds (all 500+ learn pages + playground routes prerender)

https://claude.ai/code/session_01H8NWftVk5s7pYvAunKDQrG

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8NWftVk5s7pYvAunKDQrG)_