### PR TITLE
Sync package-lock.json so npm ci succeeds on Vercel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3542,6 +3542,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3558,6 +3559,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3574,6 +3576,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3590,6 +3593,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3606,6 +3610,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3622,6 +3627,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3638,6 +3644,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3654,6 +3661,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3670,6 +3678,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3694,6 +3703,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3715,6 +3725,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3731,6 +3742,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5171,6 +5183,17 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/almostnode/node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/almostnode/node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5185,6 +5208,14 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/almostnode/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/almostnode/node_modules/uuid": {
       "version": "10.0.0",
@@ -8158,6 +8189,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Context

Investigated why production builds take ~7 minutes on Vercel's Hobby plan. I reproduced the build locally and timed each phase.

### Measured phase breakdown (4-vCPU container)

| Phase | Time |
|---|---|
| `fumadocs-mdx` codegen | ~30 ms |
| `build-almostnode-workers` (esbuild) | ~2–3 s |
| **Turbopack "Creating an optimized production build"** | **3.1 min** ← dominant |
| TypeScript check | 11.9 s |
| Static generation of 523 pages (incl. 503 `/learn` MDX) | 13.4 s |

The bottleneck is the **Turbopack compile/bundle phase**, not the MDX content (13.4 s) or TypeScript (12 s). On Vercel Hobby's slower ~2-vCPU builders, this CPU-bound phase roughly doubles → ~7 min total, which matches the reported number.

### Audit: code-splitting is already in good shape

The codebase already aggressively code-splits the heavy dependency graph, so there was no static-import bottleneck to fix:

- All WASM runtimes use dynamic `import()` or type-only imports: `pyodide`, `webr`, `plotly.js-dist-min`, `mermaid`, `parquet-wasm`, `@electric-sql/pglite`, `php-wasm`, `apache-arrow`, `wasm-xlsxwriter`, DuckDB.
- Every CodeMirror language pack and `@wasm-fmt/*` formatter is lazy-loaded (`cmExtensions.ts`); only `@codemirror/lang-sql` is static (and only in SQL-specific components).
- `ErDiagramPane` (pulls in `elkjs` + `@xyflow/react`) is `dynamic()`-loaded in all three playgrounds.
- `react-icons` is already imported via subpath barrels; since the package ships only ~5 MB per-set barrels (no per-icon modules), `experimental.optimizePackageImports` is the correct tool and is kept.

## Change in this PR

The only concrete code-level fix: **`package-lock.json` was out of sync with `package.json`.** Two nested dependencies of `almostnode` (`@types/node@25.9.1`, `undici-types@7.24.6`) were missing from the lockfile, so `npm ci` failed:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json ... are in sync.
npm error Missing: @types/node@25.9.1 from lock file
npm error Missing: undici-types@7.24.6 from lock file
```

Vercel uses a clean/frozen install, so this forced a slower, non-deterministic `npm install` fallback. Regenerated the lockfile (32-line addition) so `npm ci` succeeds again.

## Remaining levers (no code change)

- **Ensure Vercel build cache is hitting** — `.next/cache` is preserved between Hobby builds; a warm cache should cut the cold 3.1-min compile substantially. Confirm the build log shows "Restored build cache".
- The ~3.1-min compile is largely inherent to the app's breadth (three very large playground client components + many lazy chunks Turbopack must still compile). Materially reducing it would require splitting those components — a larger refactor, not done here. Upgrading off Hobby to a faster builder is the other option.

https://claude.ai/code/session_0136VJs3QabfYQpvNJHvyaQW

---
_Generated by [Claude Code](https://claude.ai/code/session_0136VJs3QabfYQpvNJHvyaQW)_