### PR TITLE
Fix remaining Mermaid sequenceDiagram syntax errors

### DIFF
--- a/content/learn/from-zero-to-cpp/how-computers-execute.mdx
+++ b/content/learn/from-zero-to-cpp/how-computers-execute.mdx
@@ -125,7 +125,7 @@ sequenceDiagram
     OS->>CPU: Set instruction pointer to main
     CPU->>Mem: Fetch instruction, run it, repeat
     CPU-->>U: Output to screen, files, network
-    CPU->>OS: main returns; please clean up
+    CPU->>OS: main returns, please clean up
     OS->>Mem: Reclaim memory
 ```
 

--- a/content/learn/intro-modern-csharp/how-programs-execute.mdx
+++ b/content/learn/intro-modern-csharp/how-programs-execute.mdx
@@ -103,7 +103,7 @@ sequenceDiagram
     CLR->>JIT: please compile Main to native
     JIT-->>CLR: returns machine code
     CLR->>CPU: jump to Main machine code
-    CPU->>CPU: executes; produces output
+    CPU->>CPU: executes, produces output
 ```
 
 This is why your *first* run might feel slightly slow: the JIT is

--- a/content/learn/java-programming-for-beginners/inheritance-and-polymorphism.mdx
+++ b/content/learn/java-programming-for-beginners/inheritance-and-polymorphism.mdx
@@ -127,19 +127,19 @@ the variable) and dispatches to *that* class's `area`. This is
 
 ```mermaid
 sequenceDiagram
-    participant Loop as for loop
+    participant Iter as for loop
     participant JVM
     participant C as Circle area
     participant R as Rectangle area
-    Loop->>JVM: s.area() — s is a Circle
+    Iter->>JVM: s.area() — s is a Circle
     JVM->>C: invoke Circle.area
     C-->>JVM: 12.566
-    JVM-->>Loop: 12.566
+    JVM-->>Iter: 12.566
 
-    Loop->>JVM: s.area() — s is a Rectangle
+    Iter->>JVM: s.area() — s is a Rectangle
     JVM->>R: invoke Rectangle.area
     R-->>JVM: 12.0
-    JVM-->>Loop: 12.0
+    JVM-->>Iter: 12.0
 ```
 
 This is the mechanism that lets *new* shape classes be added later


### PR DESCRIPTION
## Summary

Follow-up to #405. Three `/learn` lesson pages still rendered Mermaid's "Syntax error in text mermaid version 11.15.0" bomb. In each case the culprit was a single `sequenceDiagram` block whose message text or participant id collided with Mermaid grammar.

| Page | Root cause | Fix |
| --- | --- | --- |
| `java-programming-for-beginners/inheritance-and-polymorphism` | Participant id `Loop` collides with the reserved `loop` keyword | Rename id to `Iter` (display alias `for loop` unchanged) |
| `from-zero-to-cpp/how-computers-execute` | `;` in message `main returns; please clean up` is parsed as a statement separator | Replace `;` with `,` |
| `intro-modern-csharp/how-programs-execute` | `;` in message `executes; produces output` is parsed as a statement separator | Replace `;` with `,` |

The other flowchart/classDiagram blocks on these pages were already valid and are untouched.

## Verification

Parsed **every** Mermaid block on all three pages with the `mermaid@11.15.0` parser (DOM-backed via jsdom). Before: the three sequence diagrams threw `Parse error`. After: all 14 blocks across the three pages parse cleanly.

https://claude.ai/code/session_01RTTVU8Lg4wXuqfGWB24XXm

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTVU8Lg4wXuqfGWB24XXm)_