### PR TITLE
Remove "Correct!" prefixes from correct-answer explanations in multiple choice questions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+# Agent Guidelines
+
+Rules and patterns for AI coding agents working in this repository.
+
+---
+
+## Multiple-choice question explanations
+
+Choice explanations in `<MultipleChoice>` blocks are shown to **all** learners after they submit, regardless of which choice they selected. This means the correct choice's explanation is also shown to learners who picked a wrong answer.
+
+**Never start a choice explanation with an affirmative word or phrase.** This includes:
+
+- `Correct!`, `Correct.`, `Correct —`, `Correct:`
+- `Right!`, `Right.`
+- `Exactly.`, `Exactly!`
+- `Yes!`, `Yes.`
+- `Perfect!`, `Great!`, `Well done!`
+
+Write the explanation as a neutral statement that stands on its own.
+
+```markdown
+<!-- Bad -->
+- [o] Tableau
+  > Correct! Tableau is widely used for creating interactive dashboards.
+
+<!-- Good -->
+- [o] Tableau
+  > Tableau is widely used for creating interactive dashboards.
+```
+
+---
+
+## Mermaid diagram syntax
+
+Mermaid is strict about special characters. The following rules prevent the most common parse errors.
+
+### 1. Quote node labels that contain special characters
+
+Any label inside `[ ]`, `( )`, `[( )]`, or `{ }` that contains `<br/>`, `:`, `/`, `.`, `(`, `)`, `"`, `,`, `|`, `<`, `>`, `%`, or `#` **must** be wrapped in double quotes.
+
+```
+<!-- Bad -->
+flowchart LR
+    A[hello.c<br/>source text] --> B[Preprocessor]
+    C{Solve A x = b?}
+
+<!-- Good -->
+flowchart LR
+    A["hello.c<br/>source text"] --> B[Preprocessor]
+    C{"Solve A x = b?"}
+```
+
+### 2. Quote edge labels that contain special characters
+
+Edge labels written as `-->|label|` or `-- label -->` need quotes when the label contains `,`, `:`, `(`, `)`, `/`, or other special characters.
+
+```
+<!-- Bad -->
+A -->|apply: mean(sales)| B
+A -- 1-D, bracketed --> B
+
+<!-- Good -->
+A -->|"apply: mean(sales)"| B
+A -- "1-D, bracketed" --> B
+```
+
+### 3. Dotted edges with labels need spaces around the label
+
+```
+<!-- Bad (parse error) -->
+A -.label.-> B
+
+<!-- Good -->
+A -. label .-> B
+```
+
+### 4. sequenceDiagram: no quotes around message text
+
+Message text in `sequenceDiagram` (the part after `->>`/`-->>`/`->`) must **not** be wrapped in quotes.
+
+```
+<!-- Bad -->
+U->>OS: "Run hello.exe"
+
+<!-- Good -->
+U->>OS: Run hello.exe
+```
+
+### 5. sequenceDiagram: no semicolons in message text
+
+Semicolons terminate a statement in Mermaid. Use a comma instead.
+
+```
+<!-- Bad -->
+CPU->>CPU: executes; produces output
+
+<!-- Good -->
+CPU->>CPU: executes, produces output
+```
+
+### 6. sequenceDiagram participant aliases: no special characters
+
+Participant `as` aliases cannot contain `.`, `(`, `)`, `"`, or other special characters.
+
+```
+<!-- Bad -->
+participant CLR as .NET runtime
+participant Main as "(top level)"
+
+<!-- Good -->
+participant CLR as NET runtime
+participant Main as top level
+```
+
+### 7. subgraph labels: no extra spaces around the label
+
+```
+<!-- Bad -->
+subgraph Hand[ "By hand" ]
+
+<!-- Good -->
+subgraph Hand["By hand"]
+```
+
+### Quick checklist before committing a Mermaid block
+
+- [ ] Every node label with special chars is quoted
+- [ ] Every edge label with special chars is quoted
+- [ ] No semicolons in `sequenceDiagram` message text
+- [ ] No quoted strings in `sequenceDiagram` message text
+- [ ] Participant aliases contain only plain words
+- [ ] Dotted edge labels have spaces: `-. label .->`
+- [ ] `subgraph` labels have no extra spaces inside the brackets

--- a/content/learn/beginners-javascript/arrays.mdx
+++ b/content/learn/beginners-javascript/arrays.mdx
@@ -457,7 +457,7 @@ if (JSON.stringify(original) !== "[1,2,3,4,5]") throw new Error("original array 
 
 - \`[1, 2, 3]\` — \`a\` is independent of \`b\`
 - [o] \`[1, 2, 3, 99]\` — \`a\` and \`b\` reference the *same* array, so changes through one are visible through the other
-  > Correct. Arrays (and all objects) in JavaScript are passed by reference. Assigning \`b = a\` makes \`b\` refer to the same array, not a copy. To get a real copy, use \`[...a]\` or \`a.slice()\`.
+  > Arrays (and all objects) in JavaScript are passed by reference. Assigning \`b = a\` makes \`b\` refer to the same array, not a copy. To get a real copy, use \`[...a]\` or \`a.slice()\`.
 - \`undefined\` — pushing through \`b\` clears \`a\`
 - A \`TypeError\` is thrown
 

--- a/content/learn/beginners-javascript/asynchronous-thinking.mdx
+++ b/content/learn/beginners-javascript/asynchronous-thinking.mdx
@@ -455,7 +455,7 @@ runSequentially(tasks, (err, results) => {
 - Because it makes code faster on multi-core CPUs
 - Because the language standard requires it
 - [o] Because it lets the single thread stay busy on other work while waiting for slow operations, instead of blocking
-  > Correct. Async is about *concurrency*, not parallelism. While the host is doing something slow (timers, network, disk), the JS thread is free to handle other code. Without async, every slow operation would freeze the entire program — including, in a browser, the UI.
+  > Async is about *concurrency*, not parallelism. While the host is doing something slow (timers, network, disk), the JS thread is free to handle other code. Without async, every slow operation would freeze the entire program — including, in a browser, the UI.
 - Because asynchronous code is always easier to read
 
 JavaScript still runs one piece of code at a time — async simply lets it *choose* what to run instead of being stuck waiting.`}

--- a/content/learn/beginners-javascript/birth-of-javascript.mdx
+++ b/content/learn/beginners-javascript/birth-of-javascript.mdx
@@ -251,7 +251,7 @@ is the next part of our story.
 
 - He had several years to design and refine the language carefully
 - [o] He had about ten days to ship a working prototype, with rigid constraints (look like Java, embed in HTML, never crash the browser, be friendly to beginners)
-  > Correct. JavaScript was designed under extreme time pressure with externally imposed constraints. Many of the language's quirks — and its great strengths, like first-class functions and forgiving runtime behaviour — come directly from those conditions.
+  > JavaScript was designed under extreme time pressure with externally imposed constraints. Many of the language's quirks — and its great strengths, like first-class functions and forgiving runtime behaviour — come directly from those conditions.
 - He copied the language directly from an existing language called LiveScript
 - He designed it as a pure functional language modelled on Haskell
 

--- a/content/learn/beginners-javascript/booleans-and-logic.mdx
+++ b/content/learn/beginners-javascript/booleans-and-logic.mdx
@@ -383,7 +383,7 @@ console.log(isLeapYear(2023));
 
 - Both sides are always evaluated, but only the first matters
 - [o] The right side is evaluated **only** if the left side is truthy; otherwise the left side is returned without ever touching the right
-  > Correct. \`a && b\` first looks at \`a\`. If \`a\` is falsy, the whole expression is \`a\` — \`b\` is not evaluated at all. This is how patterns like \`user && user.notify()\` safely call a method only when the object exists.
+  > \`a && b\` first looks at \`a\`. If \`a\` is falsy, the whole expression is \`a\` — \`b\` is not evaluated at all. This is how patterns like \`user && user.notify()\` safely call a method only when the object exists.
 - It produces a shorter machine-code instruction
 - It only works for boolean values, not truthy/falsy ones
 

--- a/content/learn/beginners-javascript/closures.mdx
+++ b/content/learn/beginners-javascript/closures.mdx
@@ -409,7 +409,7 @@ if (b.value() !== 99) throw new Error("b should be 99");`,
 - A way to close (terminate) a function early
 - A keyword that hides a variable from the outside world
 - [o] A function that "remembers" the variables from the scope where it was defined, even after that scope has finished
-  > Correct. When an inner function refers to a variable from its enclosing scope, JavaScript keeps that variable alive for as long as the inner function exists. This lets us create private state, configurable functions, memoisation caches, modules, and many other powerful patterns — all built on the same underlying mechanism.
+  > When an inner function refers to a variable from its enclosing scope, JavaScript keeps that variable alive for as long as the inner function exists. This lets us create private state, configurable functions, memoisation caches, modules, and many other powerful patterns — all built on the same underlying mechanism.
 - A way to copy values into a function
 
 Closures are arguably the single most important idea to understand in JavaScript. Once you see them clearly, an enormous amount of "magic" in libraries and frameworks turns into ordinary code.`}

--- a/content/learn/beginners-javascript/computational-thinking.mdx
+++ b/content/learn/beginners-javascript/computational-thinking.mdx
@@ -387,7 +387,7 @@ console.log(countWords("   spaced   out   "));
   markdown={`Which of the four computational-thinking moves is most directly responsible for turning a vague task like "split a restaurant bill fairly" into something you can actually code?
 
 - [o] Decomposition — breaking the big task into small, well-defined sub-problems
-  > Correct. The first move on any unfamiliar problem is almost always decomposition: turning a fuzzy goal into a list of concrete questions you can each answer with a few lines of code.
+  > The first move on any unfamiliar problem is almost always decomposition: turning a fuzzy goal into a list of concrete questions you can each answer with a few lines of code.
 - Pattern matching — noticing that this looks like a previous problem
 - Abstraction — hiding details behind names
 - Algorithmic thinking — writing precise step-by-step recipes

--- a/content/learn/beginners-javascript/conditionals.mdx
+++ b/content/learn/beginners-javascript/conditionals.mdx
@@ -390,7 +390,7 @@ if (action("") !== "unknown signal") throw new Error("empty string should also b
 - Guard clauses run faster
 - Guard clauses use less memory
 - [o] Guard clauses keep the main logic at the top indent level, making the function easier to read and easier to extend
-  > Correct. Each guard clause handles an edge case and exits, so the "happy path" stays flat and obvious. Deeply nested \`if\` blocks hide the main logic inside a pyramid and make it painful to add new conditions later.
+  > Each guard clause handles an edge case and exits, so the "happy path" stays flat and obvious. Deeply nested \`if\` blocks hide the main logic inside a pyramid and make it painful to add new conditions later.
 - Guard clauses are the only way to return from a function
 
 Guard clauses are a style choice that consistently makes code more readable in practice, with no performance trade-off.`}

--- a/content/learn/beginners-javascript/debugging-and-reasoning.mdx
+++ b/content/learn/beginners-javascript/debugging-and-reasoning.mdx
@@ -408,7 +408,7 @@ if (a.length !== 3 || a[0] !== 1) throw new Error("must not mutate input");`,
 - Rewrite the function from scratch and hope the new version is correct
 - Search the web for "JavaScript function wrong number"
 - [o] Add logs that print your inputs, intermediate values, and assumptions — then re-run to see *where* the actual values diverge from what you expected
-  > Correct. Bugs are gaps between your mental model and reality. The fastest way to close that gap is to print what you *think* is happening at each step and compare with what's actually happening. Rewriting blindly often reintroduces the same bug; reasoning from data tells you *where* the wrong value first appeared.
+  > Bugs are gaps between your mental model and reality. The fastest way to close that gap is to print what you *think* is happening at each step and compare with what's actually happening. Rewriting blindly often reintroduces the same bug; reasoning from data tells you *where* the wrong value first appeared.
 - Add try/catch around the call to suppress the error
 
 Debugging is investigation, not vandalism. Don't change code until you know what's wrong.`}

--- a/content/learn/beginners-javascript/ecosystem-explosion.mdx
+++ b/content/learn/beginners-javascript/ecosystem-explosion.mdx
@@ -266,7 +266,7 @@ much more pleasant language than the one Brendan Eich shipped in
 - It made JavaScript faster inside the browser
 - It replaced the JavaScript language with a new one
 - [o] It let JavaScript run outside the browser, turning it into a general-purpose programming language used on servers, command lines, and build tools
-  > Correct. By packaging the V8 engine outside the browser, Node.js opened up entirely new domains for JavaScript — servers, scripts, build tools, desktop apps. Combined with npm, it transformed JavaScript from a "browser thing" into the most widely used language on the planet.
+  > By packaging the V8 engine outside the browser, Node.js opened up entirely new domains for JavaScript — servers, scripts, build tools, desktop apps. Combined with npm, it transformed JavaScript from a "browser thing" into the most widely used language on the planet.
 - It removed the need for HTML and CSS on the web
 
 Before Node.js, JavaScript was tied to the browser. After Node.js, you could legitimately call yourself a "JavaScript developer" without writing a single line of HTML.`}

--- a/content/learn/beginners-javascript/functional-intuition.mdx
+++ b/content/learn/beginners-javascript/functional-intuition.mdx
@@ -443,7 +443,7 @@ if (r[0].score !== 90) throw new Error("should not change unrelated entries");`,
 - always returns the same type
 - uses arrow-function syntax
 - [o] returns the same output for the same input and has no side effects
-  > Correct. Purity is about *behavior*, not syntax: a pure function depends only on its arguments and changes nothing outside itself (no I/O, no mutation of inputs, no reliance on hidden state).
+  > Purity is about *behavior*, not syntax: a pure function depends only on its arguments and changes nothing outside itself (no I/O, no mutation of inputs, no reliance on hidden state).
 - doesn't use any \`if\` statements
 
 Purity is what makes functions easy to test, easy to combine, and easy to reason about. It's a property of *what* a function does, not *how* it's written.`}

--- a/content/learn/beginners-javascript/functions-basics.mdx
+++ b/content/learn/beginners-javascript/functions-basics.mdx
@@ -461,7 +461,7 @@ console.log(bmi(70, 1.75), bmiCategory(bmi(70, 1.75)));
 - Functions can only be called once
 - Functions cannot be assigned to variables
 - [o] Functions are *first-class values*: they can be stored in variables, passed as arguments, and returned from other functions
-  > Correct. This is one of JavaScript's most powerful features (inherited from languages like Scheme). It makes idioms like \`array.map(fn)\`, \`array.filter(fn)\`, callbacks, event handlers, and higher-order functions natural. Without it, the entire modern JavaScript style would be impossible.
+  > This is one of JavaScript's most powerful features (inherited from languages like Scheme). It makes idioms like \`array.map(fn)\`, \`array.filter(fn)\`, callbacks, event handlers, and higher-order functions natural. Without it, the entire modern JavaScript style would be impossible.
 - Functions must always be declared before they're called
 
 First-class functions are what set the stage for closures, callbacks, functional programming, and most of modern JavaScript.`}

--- a/content/learn/beginners-javascript/how-computers-execute-programs.mdx
+++ b/content/learn/beginners-javascript/how-computers-execute-programs.mdx
@@ -252,7 +252,7 @@ because when we wrote `let y = x;`, the value `10` was copied into
 
 - Memorising all of JavaScript's built-in functions
 - [o] "Pretending to be the runtime" — walking through the program one line at a time, writing down the value of each variable after each step
-  > Correct. When a program does something unexpected, the fastest way to figure out why is to simulate the runtime yourself, step by step. Most bugs reveal themselves the moment you do this carefully.
+  > When a program does something unexpected, the fastest way to figure out why is to simulate the runtime yourself, step by step. Most bugs reveal themselves the moment you do this carefully.
 - Restarting your computer
 - Adding more \`console.log\` statements until the bug fixes itself
 

--- a/content/learn/beginners-javascript/how-javascript-runs.mdx
+++ b/content/learn/beginners-javascript/how-javascript-runs.mdx
@@ -400,7 +400,7 @@ What does it print?
 - A B C D
 - A D B C
 - [o] A D C B
-  > Correct. \`A\` and \`D\` are synchronous and run first. When the stack empties, the event loop drains *microtasks* before tasks, so the promise callback \`C\` runs before the \`setTimeout\` callback \`B\`. Even though \`setTimeout\` is scheduled before the promise, microtasks always win against macrotasks.
+  > \`A\` and \`D\` are synchronous and run first. When the stack empties, the event loop drains *microtasks* before tasks, so the promise callback \`C\` runs before the \`setTimeout\` callback \`B\`. Even though \`setTimeout\` is scheduled before the promise, microtasks always win against macrotasks.
 - A C D B
 
 The crucial rule: microtasks (promises, \`queueMicrotask\`) run between every task. \`setTimeout(..., 0)\` is a *task*, so it has to wait its turn.`}

--- a/content/learn/beginners-javascript/internet-and-interactivity.mdx
+++ b/content/learn/beginners-javascript/internet-and-interactivity.mdx
@@ -201,7 +201,7 @@ revolution.
 - Because HTML could not display images
 - Because servers were unable to validate user input
 - [o] Because every interaction had to round-trip to the server, which was slow and clunky — the browser needed to run small programs locally to respond immediately
-  > Correct. Without an in-browser language, every form check, every menu, every reactive behaviour required a full request/response cycle. A scripting language let the browser handle small interactions on its own, instantly.
+  > Without an in-browser language, every form check, every menu, every reactive behaviour required a full request/response cycle. A scripting language let the browser handle small interactions on its own, instantly.
 - Because Java applets were faster than native code
 
 Embedding a small scripting language in the browser meant interactions could happen in milliseconds, not seconds, without involving the server at all.`}

--- a/content/learn/beginners-javascript/javascript-beyond-the-browser.mdx
+++ b/content/learn/beginners-javascript/javascript-beyond-the-browser.mdx
@@ -264,7 +264,7 @@ world.
 - Because frameworks like React change every year
 - Because browsers will eventually stop supporting old JavaScript
 - [o] Because that core works identically across every JavaScript runtime — browsers, Node.js, mobile, desktop, IoT — so the skill is broadly reusable
-  > Correct. Built-in APIs and frameworks differ between runtimes, but the language itself is shared. Mastering the language pays off in every environment you will ever encounter.
+  > Built-in APIs and frameworks differ between runtimes, but the language itself is shared. Mastering the language pays off in every environment you will ever encounter.
 - Because runtimes are too slow to handle anything else
 
 Browser APIs, Node APIs, and frameworks come and go. The language stays. That's why this course focuses on it.`}

--- a/content/learn/beginners-javascript/javascript-today.mdx
+++ b/content/learn/beginners-javascript/javascript-today.mdx
@@ -232,7 +232,7 @@ to run a program?*
 - The difference between Java and JavaScript
 - The difference between Chrome and Firefox
 - [o] The difference between the JavaScript *language* (stable, portable, this course's focus) and the *frameworks and tools* built on top of it (which change every few years)
-  > Correct. The language itself is the durable, transferable skill. Frameworks like React, build tools like Webpack, and even runtime APIs like \`fetch\` come and go or differ between runtimes — but \`let\`, \`const\`, \`function\`, \`if\`, \`for\`, arrays, objects, closures, and \`async\`/\`await\` will be exactly the same a decade from now.
+  > The language itself is the durable, transferable skill. Frameworks like React, build tools like Webpack, and even runtime APIs like \`fetch\` come and go or differ between runtimes — but \`let\`, \`const\`, \`function\`, \`if\`, \`for\`, arrays, objects, closures, and \`async\`/\`await\` will be exactly the same a decade from now.
 - The difference between \`==\` and \`===\`
 
 The language is the bedrock. Once you know it well, picking up any framework or runtime API is a matter of reading documentation.`}

--- a/content/learn/beginners-javascript/loops-and-iteration.mdx
+++ b/content/learn/beginners-javascript/loops-and-iteration.mdx
@@ -426,7 +426,7 @@ for (let i = 0; i < expected.length; i++) {
 - A \`for (let i = 0; i < arr.length; i++)\` loop
 - A \`for...in\` loop
 - [o] A \`for...of\` loop: \`for (const item of arr) { ... }\`
-  > Correct. \`for...of\` walks each element directly, with no index arithmetic to get wrong. Use it whenever you don't need the index. If you do need the index, either fall back to the classic \`for (let i ...)\` loop or use \`arr.entries()\` for destructured \`[index, item]\` pairs.
+  > \`for...of\` walks each element directly, with no index arithmetic to get wrong. Use it whenever you don't need the index. If you do need the index, either fall back to the classic \`for (let i ...)\` loop or use \`arr.entries()\` for destructured \`[index, item]\` pairs.
 
 The other forms work, but \`for...of\` expresses the intent most clearly. (And \`for...in\` is for object keys, not array elements — using it on arrays is a common bug.)`}
 />

--- a/content/learn/beginners-javascript/maintainable-code.mdx
+++ b/content/learn/beginners-javascript/maintainable-code.mdx
@@ -490,7 +490,7 @@ console.log(enrollStudent(null));
 - It is more than 10 lines long
 - It uses both \`if\` and \`for\`
 - [o] You can't describe its purpose in a single short sentence without using the word "and"
-  > Correct. Length is a rough proxy, not the real signal. The real signal is *cohesion*: a function should do one thing. If you need an "and" to describe it ("fetches data AND formats AND sends an email"), that's two or three functions packed into one. Splitting them makes each piece testable, nameable, and reusable.
+  > Length is a rough proxy, not the real signal. The real signal is *cohesion*: a function should do one thing. If you need an "and" to describe it ("fetches data AND formats AND sends an email"), that's two or three functions packed into one. Splitting them makes each piece testable, nameable, and reusable.
 - It uses arrow function syntax
 
 A clear, single-sentence purpose is the gold standard for whether a function is the right size.`}

--- a/content/learn/beginners-javascript/map-filter-reduce.mdx
+++ b/content/learn/beginners-javascript/map-filter-reduce.mdx
@@ -408,7 +408,7 @@ if (r.length !== 1 || typeof r[0] !== "string") throw new Error("must return an 
 - A \`for\` loop that pushes into a new array
 - A \`for...of\` loop with manual indexing
 - [o] \`users.map((u) => ({ ...u, name: u.name.toUpperCase() }))\`
-  > Correct. \`map\` precisely expresses "transform every element". The transformation describes the result without spelling out the mechanics of the loop. Using object spread together with \`map\` is the standard idiom for "produce a new array of updated objects".
+  > \`map\` precisely expresses "transform every element". The transformation describes the result without spelling out the mechanics of the loop. Using object spread together with \`map\` is the standard idiom for "produce a new array of updated objects".
 - A \`while\` loop that builds a new array index-by-index
 
 \`map\` makes the *intent* obvious. Hand-written loops do the same work but force the reader to figure out what you're trying to express.`}

--- a/content/learn/beginners-javascript/modular-organization.mdx
+++ b/content/learn/beginners-javascript/modular-organization.mdx
@@ -494,7 +494,7 @@ if (!threw) throw new Error("must throw for negative amount");`,
 - Smaller exports make the program run faster
 - Files with fewer exports use less memory
 - [o] Anything you export becomes a commitment — callers can rely on it, so the more you expose, the less freedom you have to change the internals later
-  > Correct. Module exports define a *contract*. Once other code starts using \`pad\` or \`SYMBOLS\`, renaming or removing them risks breaking callers. Keeping internals private leaves you free to refactor without breaking anyone, which is one of the biggest long-term wins of good modular design.
+  > Module exports define a *contract*. Once other code starts using \`pad\` or \`SYMBOLS\`, renaming or removing them risks breaking callers. Keeping internals private leaves you free to refactor without breaking anyone, which is one of the biggest long-term wins of good modular design.
 - Smaller exports look nicer in editors
 
 Modules are about *information hiding*. The less you expose, the easier the code is to evolve.`}

--- a/content/learn/beginners-javascript/nested-data.mdx
+++ b/content/learn/beginners-javascript/nested-data.mdx
@@ -439,7 +439,7 @@ console.log(getPath({}, "x", "n/a"));
 - It runs faster than ordinary property access
 - It automatically creates missing properties
 - [o] It safely returns \`undefined\` if any link in the chain is \`null\` or \`undefined\`, instead of throwing a \`TypeError\` and crashing the program
-  > Correct. Real-world data is often partial — some fields are missing, optional, or not yet loaded. \`?.\` lets you write \`user?.address?.city\` and get back \`undefined\` for any missing link, instead of an exception. Combined with \`??\` for defaults, it replaces many lines of defensive \`if\` checks.
+  > Real-world data is often partial — some fields are missing, optional, or not yet loaded. \`?.\` lets you write \`user?.address?.city\` and get back \`undefined\` for any missing link, instead of an exception. Combined with \`??\` for defaults, it replaces many lines of defensive \`if\` checks.
 - It is a faster form of array indexing
 
 Optional chaining is one of the most quietly useful additions to modern JavaScript. Once you've used it, going back to nested \`&&\` checks feels archaic.`}

--- a/content/learn/beginners-javascript/next-steps.mdx
+++ b/content/learn/beginners-javascript/next-steps.mdx
@@ -178,7 +178,7 @@ Now stop reading, and go build something. Good luck. 🚀
 - Watch as many video tutorials as possible
 - Read several JavaScript books cover to cover before writing more code
 - [o] Pick a small project you'd actually use, build the smallest possible version that works, then add one feature at a time
-  > Correct. Programming is a *practice*. Tutorials and books are scaffolding, but real skill is built by writing, debugging, and shipping small things — especially things you'll use yourself, because then you naturally notice what's missing or wrong. The "start small, grow by one feature" loop is exactly how working developers learn the rest of their careers.
+  > Programming is a *practice*. Tutorials and books are scaffolding, but real skill is built by writing, debugging, and shipping small things — especially things you'll use yourself, because then you naturally notice what's missing or wrong. The "start small, grow by one feature" loop is exactly how working developers learn the rest of their careers.
 - Memorise every method on \`Array.prototype\` and \`String.prototype\`
 
 You don't grow into a strong developer by accumulating facts. You grow by repeatedly building, breaking, and fixing real things.`}

--- a/content/learn/beginners-javascript/numbers-and-arithmetic.mdx
+++ b/content/learn/beginners-javascript/numbers-and-arithmetic.mdx
@@ -361,7 +361,7 @@ if (typeof toFahrenheit(50) !== "number") throw new Error("toFahrenheit must ret
 
 - Because JavaScript has a bug in its addition operator
 - [o] Because JavaScript numbers are 64-bit floating-point, and decimals like 0.1 cannot be represented exactly in binary — tiny rounding errors are unavoidable
-  > Correct. This behaviour is built into the IEEE 754 floating-point standard used by almost every modern language. When you need to compare decimals, compare with a small tolerance (\`Math.abs(a - b) < 1e-9\`), or for money, work in integer cents and only format for display.
+  > This behaviour is built into the IEEE 754 floating-point standard used by almost every modern language. When you need to compare decimals, compare with a small tolerance (\`Math.abs(a - b) < 1e-9\`), or for money, work in integer cents and only format for display.
 - Because \`0.3\` is actually \`null\` under the hood
 - Because \`===\` always returns false for decimals
 

--- a/content/learn/beginners-javascript/objects.mdx
+++ b/content/learn/beginners-javascript/objects.mdx
@@ -463,7 +463,7 @@ if (JSON.stringify(updates) !== '{"age":29}') throw new Error("updates was mutat
 - It creates a deep clone of \`base\` and \`updates\`
 - It throws an error because objects can't be spread
 - [o] It creates a new object combining the properties of \`base\` and \`updates\`. Where both objects have the same key, the later one (\`updates\`) wins.
-  > Correct. Object spread is one of the most useful features of modern JavaScript: it makes "produce a new object based on an existing one" a one-liner. Note that the merge is *shallow* — nested objects and arrays are still shared by reference.
+  > Object spread is one of the most useful features of modern JavaScript: it makes "produce a new object based on an existing one" a one-liner. Note that the merge is *shallow* — nested objects and arrays are still shared by reference.
 - It modifies \`base\` in place by adding the properties of \`updates\`
 
 This pattern is the foundation of immutable-update code style: produce new objects instead of mutating existing ones.`}

--- a/content/learn/beginners-javascript/parameters-and-returns.mdx
+++ b/content/learn/beginners-javascript/parameters-and-returns.mdx
@@ -373,7 +373,7 @@ if (JSON.stringify(r) !== "[2,5]") throw new Error("expected [2,5], got " + JSON
 - A \`TypeError\` is thrown immediately
 - The missing arguments are filled in with \`null\`
 - [o] The missing parameters are bound to \`undefined\`; the call still proceeds. (If you want a different default, use \`= defaultValue\` in the parameter list.)
-  > Correct. JavaScript is forgiving about argument counts — missing parameters become \`undefined\` and the function runs anyway. This is why default parameter values (\`function f(x = 10)\`) are so useful: they make missing arguments behave the way you actually want.
+  > JavaScript is forgiving about argument counts — missing parameters become \`undefined\` and the function runs anyway. This is why default parameter values (\`function f(x = 10)\`) are so useful: they make missing arguments behave the way you actually want.
 - The first argument is duplicated to fill the slots
 
 JavaScript's tolerance of mismatched argument counts is convenient but can hide bugs. Default values make your intent explicit.`}

--- a/content/learn/beginners-javascript/problem-solving.mdx
+++ b/content/learn/beginners-javascript/problem-solving.mdx
@@ -398,7 +398,7 @@ if (finalTotal([{ price: 2, quantity: 1 }], "FLAT5") !== 0) throw new Error("exp
 
 - They use the wrong text editor
 - [o] They sit down and try to write the complete answer in one shot, instead of working in small understand → plan → implement → test → refine cycles
-  > Correct. Trying to write the answer in one go almost always leads to confusion and frustration. Taking small, deliberate steps — and *running* after each one — is dramatically more productive.
+  > Trying to write the answer in one go almost always leads to confusion and frustration. Taking small, deliberate steps — and *running* after each one — is dramatically more productive.
 - They use too many functions
 - They write too many tests
 

--- a/content/learn/beginners-javascript/promises-and-async-await.mdx
+++ b/content/learn/beginners-javascript/promises-and-async-await.mdx
@@ -546,7 +546,7 @@ retry(flaky, 5)
   const pb = fetchB();
   const [a, b] = await Promise.all([pa, pb]);
   \`\`\`
-  > Correct. Both \`fetchA()\` and \`fetchB()\` are *called* before any \`await\` runs, so the host kicks off both right away. \`Promise.all\` then waits for both to settle. The first snippet, by contrast, only starts \`fetchB()\` after \`fetchA()\` has fully fulfilled — that's sequential, not concurrent.
+  > Both \`fetchA()\` and \`fetchB()\` are *called* before any \`await\` runs, so the host kicks off both right away. \`Promise.all\` then waits for both to settle. The first snippet, by contrast, only starts \`fetchB()\` after \`fetchA()\` has fully fulfilled — that's sequential, not concurrent.
 - 
   \`\`\`javascript
   await fetchA();

--- a/content/learn/beginners-javascript/rise-of-scripting-languages.mdx
+++ b/content/learn/beginners-javascript/rise-of-scripting-languages.mdx
@@ -224,7 +224,7 @@ That is the next stop on our story.
 
 - They run faster than compiled languages
 - [o] They let people write small, useful programs and "glue" larger systems together without a heavy compile/link cycle
-  > Correct. Scripting languages are designed for fast iteration, simple syntax, and embedding inside larger systems. They rarely *replace* compiled languages — they sit on top of them, letting people automate, customise, and extend large systems with relatively little code.
+  > Scripting languages are designed for fast iteration, simple syntax, and embedding inside larger systems. They rarely *replace* compiled languages — they sit on top of them, letting people automate, customise, and extend large systems with relatively little code.
 - They produce smaller machine code than compiled languages
 - They are the only languages that support functions
 

--- a/content/learn/beginners-javascript/scope-and-scope-chain.mdx
+++ b/content/learn/beginners-javascript/scope-and-scope-chain.mdx
@@ -352,7 +352,7 @@ console.log(compute());
 - Only in the current function's scope
 - Only in the global scope
 - [o] First in the current scope, then in the enclosing scope, and so on outward through the *scope chain* until either it finds the name or reaches the global scope
-  > Correct. JavaScript uses *lexical* scoping: the chain of scopes is determined by where the code is written. Each scope contains its own declarations, and unresolved names fall through to the enclosing scope. The first match wins.
+  > JavaScript uses *lexical* scoping: the chain of scopes is determined by where the code is written. Each scope contains its own declarations, and unresolved names fall through to the enclosing scope. The first match wins.
 - Wherever the function was called from (dynamic scoping)
 
 Lexical scoping makes the meaning of a name predictable from the source code — you don't need to know who called a function to know which variable it sees.`}

--- a/content/learn/beginners-javascript/story-of-programming.mdx
+++ b/content/learn/beginners-javascript/story-of-programming.mdx
@@ -194,7 +194,7 @@ from "what is a value".
 
 - To make programs run faster than assembly
 - [o] To let humans express ideas closer to how they think, and let a translator turn those ideas into machine code
-  > Correct. High-level languages exist so people can describe *what they want* in a way humans can read, write, and maintain. A compiler or interpreter does the tedious work of turning those descriptions into machine code the CPU can execute.
+  > High-level languages exist so people can describe *what they want* in a way humans can read, write, and maintain. A compiler or interpreter does the tedious work of turning those descriptions into machine code the CPU can execute.
 - To make every CPU support the same set of instructions
 - To replace mathematics in programming
 

--- a/content/learn/beginners-javascript/strings-and-text.mdx
+++ b/content/learn/beginners-javascript/strings-and-text.mdx
@@ -355,7 +355,7 @@ console.log(titleCase(""));
 - Single quotes with string concatenation: \`'Hello, ' + name + '!'\`
 - Double quotes with string concatenation: \`"Hello, " + name + "!"\`
 - [o] Backticks (template literals): \`\` \`Hello, \${name}!\` \`\`
-  > Correct. Template literals (\`\`backticks\`\`) let you interpolate variables directly with \`\${...}\`, and also span multiple lines without escape characters. They're the modern default for any non-trivial string.
+  > Template literals (\`\`backticks\`\`) let you interpolate variables directly with \`\${...}\`, and also span multiple lines without escape characters. They're the modern default for any non-trivial string.
 - Triple quotes: \`'''Hello, name!'''\`
 
 Template literals are clearer to read, easier to maintain, and avoid the visual noise of multiple \`+\` operators.`}

--- a/content/learn/beginners-javascript/values-and-types.mdx
+++ b/content/learn/beginners-javascript/values-and-types.mdx
@@ -370,7 +370,7 @@ core mental model of programming.**
 
 - \`==\` because it is more forgiving and converts types automatically
 - [o] \`===\` because it compares values *and* types, giving predictable behaviour without surprising conversions
-  > Correct. \`===\` (and \`!==\`) avoid the long list of historic, surprising rules built into \`==\`. They give you exactly what most programmers actually want: "true if these two values are the same kind of thing and equal in value".
+  > \`===\` (and \`!==\`) avoid the long list of historic, surprising rules built into \`==\`. They give you exactly what most programmers actually want: "true if these two values are the same kind of thing and equal in value".
 - \`=\` because it is the assignment operator and works for everything
 - It doesn't matter — they behave identically
 

--- a/content/learn/beginners-javascript/variables-and-state.mdx
+++ b/content/learn/beginners-javascript/variables-and-state.mdx
@@ -357,7 +357,7 @@ console.log({ balance, deposits, withdrawals });
 - Always use \`var\` for backwards compatibility
 - Use \`let\` for everything to keep things flexible
 - [o] Use \`const\` by default; switch to \`let\` only when you actually need to reassign; avoid \`var\`
-  > Correct. \`const\` documents that the binding won't change, which makes code easier to read and reason about. \`let\` is reserved for the cases where you really do reassign. \`var\` is kept only for legacy reasons.
+  > \`const\` documents that the binding won't change, which makes code easier to read and reason about. \`let\` is reserved for the cases where you really do reassign. \`var\` is kept only for legacy reasons.
 - Use \`const\` for primitives and \`let\` for objects
 
 The right rule has nothing to do with the value's type — it's about whether you intend to reassign the variable.`}

--- a/content/learn/c-programming-for-beginners/arrays.mdx
+++ b/content/learn/c-programming-for-beginners/arrays.mdx
@@ -349,7 +349,7 @@ a[2] = a[0] + a[4];
 - 30
 - 50
 - [o] 60
-  > Correct! \`a[0]\` is \`10\`, \`a[4]\` is \`50\`. \`10 + 50 = 60\`, written back into \`a[2]\`.
+  > \`a[0]\` is \`10\`, \`a[4]\` is \`50\`. \`10 + 50 = 60\`, written back into \`a[2]\`.
 - 100
 
 C arrays are zero-indexed: the first element is at index \`0\`, the last element of an array of size \`n\` is at index \`n - 1\`.`}
@@ -369,7 +369,7 @@ for (int i = 0; i <= 10; i++) {
   > It compiles cleanly. The danger is at runtime.
 - It runs an infinite loop.
 - [o] It writes one element past the end of the array (\`data[10]\`), which is undefined behavior and may corrupt other memory.
-  > Correct! Valid indices are \`0..9\`. Writing \`data[10]\` clobbers whatever happens to live in the next 4 bytes — possibly another variable, possibly internal bookkeeping. This is the classic off-by-one bug.
+  > Valid indices are \`0..9\`. Writing \`data[10]\` clobbers whatever happens to live in the next 4 bytes — possibly another variable, possibly internal bookkeeping. This is the classic off-by-one bug.
 - It runs correctly because C will resize the array.
   > C arrays do **not** resize. The size is fixed at declaration.
 

--- a/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
@@ -295,7 +295,7 @@ void say_goodbye(const char *name) {
   markdown={`Which stage of the C toolchain replaces \`#include\` directives with the contents of header files?
 
 - [o] The preprocessor.
-  > Correct! \`#include\` is handled before the compiler proper ever sees your code.
+  > \`#include\` is handled before the compiler proper ever sees your code.
 - The compiler.
 - The assembler.
 - The linker.
@@ -310,7 +310,7 @@ The preprocessor is a text-only stage. It handles \`#include\`, \`#define\`, con
 - A compiler error about an unknown function.
   > The compiler is happy: it has the declaration from \`util.h\`. The problem appears later.
 - [o] A linker error: \`undefined reference to \`compute'\`.
-  > Correct! The header gave the compiler the declaration, so the call type-checks. But the linker has no \`.o\` file containing the definition of \`compute\`, so it can't resolve the symbol.
+  > The header gave the compiler the declaration, so the call type-checks. But the linker has no \`.o\` file containing the definition of \`compute\`, so it can't resolve the symbol.
 - A runtime error when \`compute()\` is first called.
 
 Remember: declarations satisfy the compiler; *definitions* are what the linker needs.`}

--- a/content/learn/c-programming-for-beginners/computational-thinking.mdx
+++ b/content/learn/c-programming-for-beginners/computational-thinking.mdx
@@ -222,7 +222,7 @@ table. The bug usually exposes itself by row three.
 - Removing all comments from a program to make it run faster.
 - Renaming variables so the code is easier to read.
 - [o] Breaking a large problem into smaller, more manageable sub-problems.
-  > Correct! Decomposition is exactly this: chopping a big, fuzzy goal into small concrete steps that you can solve and combine.
+  > Decomposition is exactly this: chopping a big, fuzzy goal into small concrete steps that you can solve and combine.
 - Writing the same code in multiple languages to compare them.
 
 Decomposition is the first habit of computational thinking, because *you cannot tell a computer how to do something until you have first told yourself how to do it*.`}
@@ -243,7 +243,7 @@ What does this algorithm compute?
 - The largest number in the list.
 - The number of items in the list.
 - [o] The sum of all numbers in the list.
-  > Correct! The variable \`total\` starts at zero and accumulates each value it sees.
+  > The variable \`total\` starts at zero and accumulates each value it sees.
 - The average of the numbers in the list.
   > To get an average, you would also need to divide by the count after the loop.
 

--- a/content/learn/c-programming-for-beginners/conditionals.mdx
+++ b/content/learn/c-programming-for-beginners/conditionals.mdx
@@ -347,7 +347,7 @@ int main(void) {
 - Nothing, because \`if (x = 10)\` is a compile error.
 - \`x = 5\`, because the assignment doesn't take effect.
 - [o] \`hello\` followed by \`x = 10\`.
-  > Correct! \`x = 10\` is an assignment expression whose value is \`10\` (non-zero, therefore true). The body of the \`if\` runs, and \`x\` is now \`10\`.
+  > \`x = 10\` is an assignment expression whose value is \`10\` (non-zero, therefore true). The body of the \`if\` runs, and \`x\` is now \`10\`.
 - \`hello\` followed by \`x = 5\`.
 
 A single \`=\` is assignment; a double \`==\` is comparison. Most modern compilers will warn you when an assignment appears as an \`if\` condition.`}
@@ -370,7 +370,7 @@ What does the program print when \`n\` is \`1\`?
   > Without an explicit \`break\` after case 1, execution **falls through** to the next case.
 - \`one other \`
 - [o] \`one two \`
-  > Correct! Execution falls through into \`case 2\`, prints \`two\`, then hits \`break\` and exits the switch.
+  > Execution falls through into \`case 2\`, prints \`two\`, then hits \`break\` and exits the switch.
 - A compile-time error.
 
 Switch fall-through is occasionally useful (when several cases share code), but it is a frequent source of bugs. Always write \`break\` unless you specifically want fall-through and you've commented why.`}

--- a/content/learn/c-programming-for-beginners/data-types.mdx
+++ b/content/learn/c-programming-for-beginners/data-types.mdx
@@ -303,7 +303,7 @@ int main(void) {
   > C's \`/\` between two \`int\`s does **integer** division — the result is itself an \`int\`, so there is no \`.5\`.
 - 4
 - [o] 3
-  > Correct! Integer division truncates toward zero: \`7 / 2\` yields \`3\`.
+  > Integer division truncates toward zero: \`7 / 2\` yields \`3\`.
 - A compile-time error.
 
 To get a fractional result, at least one of the operands must be a floating-point value: \`(double)a / b\` or \`a / 2.0\`.`}
@@ -317,7 +317,7 @@ To get a fractional result, at least one of the operands must be a floating-poin
 - \`char\` — temperatures fit in one byte.
   > \`char\` can only hold whole integers in a small range; the fractional part would be lost.
 - [o] \`double\` — for accurate fractional values.
-  > Correct! \`double\` is the standard choice for general-purpose fractional numbers in C.
+  > \`double\` is the standard choice for general-purpose fractional numbers in C.
 - \`unsigned int\` — temperatures are always positive.
   > Temperatures can be negative; \`unsigned\` types cannot hold negative values.
 

--- a/content/learn/c-programming-for-beginners/debugging-and-reasoning.mdx
+++ b/content/learn/c-programming-for-beginners/debugging-and-reasoning.mdx
@@ -264,7 +264,7 @@ int main(void) {
 - \`p\` points to memory that has already been \`free\`'d.
 - \`p\` was never initialized and points at a random address.
 - [o] The variable \`p\` is misspelled.
-  > Correct! A misspelling would be caught by the compiler, not produce a runtime segfault. Segfaults are runtime memory access errors and almost always come from one of the other three causes.
+  > A misspelling would be caught by the compiler, not produce a runtime segfault. Segfaults are runtime memory access errors and almost always come from one of the other three causes.
 
 The first instinct on a segfault should be: "I'm dereferencing a pointer that doesn't point at anything I own." Then ask: NULL? freed? uninitialized? out-of-bounds?`}
 />
@@ -276,7 +276,7 @@ The first instinct on a segfault should be: "I'm dereferencing a pointer that do
 - Rewrite the program from scratch.
 - Add \`printf\` statements throughout the code, then re-run with the full input.
 - [o] Try to reproduce the bug on a much smaller input — half the file, then half of that, etc.
-  > Correct! Minimizing the input is the single highest-leverage debugging move. A bug you can reproduce in 5 lines of input is many times easier to find than the same bug in 50MB.
+  > Minimizing the input is the single highest-leverage debugging move. A bug you can reproduce in 5 lines of input is many times easier to find than the same bug in 50MB.
 
 Once you have a tiny failing input, *then* it's worth reading the code carefully or adding prints. Trying to debug with the full input is like trying to find a needle in 50MB of hay.`}
 />

--- a/content/learn/c-programming-for-beginners/dynamic-memory.mdx
+++ b/content/learn/c-programming-for-beginners/dynamic-memory.mdx
@@ -357,7 +357,7 @@ printf("%d\\n", *p);
 - It will fail to compile.
 - The \`malloc\` will fail because 4 bytes is too small.
 - [o] \`*p\` is a use-after-free; the memory was returned to the heap and may now belong to something else.
-  > Correct! Reading or writing through a pointer after \`free\` is undefined behavior. It might appear to work today and crash tomorrow.
+  > Reading or writing through a pointer after \`free\` is undefined behavior. It might appear to work today and crash tomorrow.
 - The \`printf\` requires \`%p\`, not \`%d\`.
 
 The cure is to either not access the memory after \`free\`, or to set \`p = NULL;\` after the \`free\` so the bug crashes loudly rather than silently corrupting other data.`}
@@ -368,7 +368,7 @@ The cure is to either not access the memory after \`free\`, or to set \`p = NULL
 
 - \`malloc(n * sizeof(int))\`
 - [o] \`calloc(n, sizeof(int))\`
-  > Correct! \`calloc\` zero-fills the memory it returns. \`malloc\` does not; it gives you whatever happened to be in those bytes.
+  > \`calloc\` zero-fills the memory it returns. \`malloc\` does not; it gives you whatever happened to be in those bytes.
 - \`realloc(NULL, n * sizeof(int))\`
 - \`alloca(n * sizeof(int))\`
 

--- a/content/learn/c-programming-for-beginners/functions.mdx
+++ b/content/learn/c-programming-for-beginners/functions.mdx
@@ -360,7 +360,7 @@ int main(void) {
 - 6
 - 0
 - [o] 5
-  > Correct! Arguments in C are passed by value. \`increment\` receives a copy of \`n\`; modifying that copy does not affect \`n\` in \`main\`.
+  > Arguments in C are passed by value. \`increment\` receives a copy of \`n\`; modifying that copy does not affect \`n\` in \`main\`.
 - A compile-time error.
 
 To modify a caller's variable, the function would need to receive a *pointer* to it — \`void increment(int *x) { (*x)++; }\` — and the caller would pass \`&n\`. We'll meet pointers soon.`}
@@ -373,7 +373,7 @@ To modify a caller's variable, the function would need to receive a *pointer* to
   > Modern compilers can sometimes inline calls so there's no speed difference. The main benefit is for *humans*.
 - The C standard limits how many lines \`main\` may have.
 - [o] It lets a human reader understand the program one small piece at a time.
-  > Correct! Functions are an *abstraction tool*. They let you reason about *what* a chunk of code does without having to read every line.
+  > Functions are an *abstraction tool*. They let you reason about *what* a chunk of code does without having to read every line.
 - It is required by the compiler.
 
 Abstraction is the only sustainable defense against complexity. Every well-named function you extract is one less thing the next reader (often: future you) has to hold in their head.`}

--- a/content/learn/c-programming-for-beginners/how-computers-execute-programs.mdx
+++ b/content/learn/c-programming-for-beginners/how-computers-execute-programs.mdx
@@ -180,7 +180,7 @@ exactly why it's such a great teacher.
 
 - It counts how many programs are currently running on the computer.
 - [o] It holds the address of the next instruction the CPU will fetch.
-  > Correct! The PC is just a special register that points into memory at the next instruction. Jumps, function calls, and \`if\` statements all work by changing the PC.
+  > The PC is just a special register that points into memory at the next instruction. Jumps, function calls, and \`if\` statements all work by changing the PC.
 - It records how many instructions a program has executed in total.
 - It stores the result of the most recent arithmetic operation.
 
@@ -193,7 +193,7 @@ The CPU repeats: read the instruction at the address in PC, advance (or change) 
 - The CPU creates a brand-new memory chip labeled \`x\`.
 - The compiler stores \`x\` as the literal text \`"x"\` somewhere in memory.
 - [o] The compiler reserves a small region of memory (typically 4 bytes) to hold the value 42; the name \`x\` only exists in the source code.
-  > Correct! Variable names are a human convenience. At runtime, the CPU sees only addresses. The compiler is the bridge between the two views.
+  > Variable names are a human convenience. At runtime, the CPU sees only addresses. The compiler is the bridge between the two views.
 - The number 42 is sent to the CPU directly, not stored in memory.
 
 The hardware doesn't know variable names. The compiler maps each name to a specific memory location (or sometimes a register), and from then on the CPU just shuffles bits between addresses.`}

--- a/content/learn/c-programming-for-beginners/input-and-output.mdx
+++ b/content/learn/c-programming-for-beginners/input-and-output.mdx
@@ -275,7 +275,7 @@ int main(void) {
   > Close, but \`%f\` defaults to **6** digits.
 - \`%s\`
 - [o] \`%.3f\`
-  > Correct! The \`.3\` between \`%\` and \`f\` specifies the number of digits after the decimal point.
+  > The \`.3\` between \`%\` and \`f\` specifies the number of digits after the decimal point.
 
 \`printf\`'s format mini-language is small but expressive: you can control width, precision, padding, sign, and base all with a few characters between \`%\` and the conversion letter.`}
 />
@@ -285,7 +285,7 @@ int main(void) {
 
 - Because the C standard forbids passing values directly to \`scanf\`.
 - [o] Because \`scanf\` needs the *address* of \`n\` to write the parsed value back into it.
-  > Correct! C passes arguments by value. To modify the caller's variable, \`scanf\` needs a pointer (an address) so it can write the result into the right memory location.
+  > C passes arguments by value. To modify the caller's variable, \`scanf\` needs a pointer (an address) so it can write the result into the right memory location.
 - Because \`&\` converts \`n\` to a string suitable for parsing.
 - Because \`%d\` requires a special pointer type.
 

--- a/content/learn/c-programming-for-beginners/linked-lists.mdx
+++ b/content/learn/c-programming-for-beginners/linked-lists.mdx
@@ -340,7 +340,7 @@ for (Node *cur = head; cur != NULL; cur = cur->next) {
 - It will leak memory.
 - It runs forever.
 - [o] \`cur->next\` is read after \`cur\` has been freed — undefined behavior.
-  > Correct! By the time the loop step \`cur = cur->next\` runs, the memory at \`cur\` has already been returned to the heap. The fix is to save \`cur->next\` into a local before \`free(cur)\`.
+  > By the time the loop step \`cur = cur->next\` runs, the memory at \`cur\` has already been returned to the heap. The fix is to save \`cur->next\` into a local before \`free(cur)\`.
 - It frees one node too few.
 
 This bug often *appears* to work because the freed memory hasn't been overwritten yet. Such bugs are a nightmare to debug. Tools like AddressSanitizer flag them immediately.`}
@@ -352,7 +352,7 @@ This bug often *appears* to work because the freed memory hasn't been overwritte
 - uses less memory.
 - gives faster random access by index.
 - [o] gives O(1) insertion at the front, but O(n) access by index.
-  > Correct! That's the classic trade-off. Lists win when you insert and remove a lot, especially at the front. Arrays win when you index a lot.
+  > That's the classic trade-off. Lists win when you insert and remove a lot, especially at the front. Arrays win when you index a lot.
 - has cache-friendlier access patterns.
 
 In practice, modern hardware loves arrays — they're contiguous and the CPU cache prefetches the next elements. Linked lists are conceptually elegant but are slower than arrays for most real workloads. Use them when you specifically need their insertion characteristics or as a building block for more complex structures like trees and graphs.`}

--- a/content/learn/c-programming-for-beginners/loops.mdx
+++ b/content/learn/c-programming-for-beginners/loops.mdx
@@ -356,7 +356,7 @@ for (int i = 0; i < 10; i += 2) {
 
 - 10
 - [o] 5
-  > Correct! \`i\` takes the values 0, 2, 4, 6, 8 — five iterations. At \`i == 10\`, the condition is false and the loop exits.
+  > \`i\` takes the values 0, 2, 4, 6, 8 — five iterations. At \`i == 10\`, the condition is false and the loop exits.
 - 6
 - Infinite — the loop never stops.
 
@@ -367,7 +367,7 @@ To count iterations of a \`for\` loop, list the values of the loop counter that 
   markdown={`Which of the following describes the difference between \`break\` and \`continue\`?
 
 - [o] \`break\` exits the loop entirely; \`continue\` skips to the next iteration's condition check.
-  > Correct! \`break\` jumps past the closing \`}\` of the loop; \`continue\` jumps back up to the loop's condition / increment.
+  > \`break\` jumps past the closing \`}\` of the loop; \`continue\` jumps back up to the loop's condition / increment.
 - \`break\` skips the next iteration; \`continue\` exits the loop.
 - They behave identically.
 - \`break\` works only in \`switch\`; \`continue\` works only in loops.

--- a/content/learn/c-programming-for-beginners/next-steps.mdx
+++ b/content/learn/c-programming-for-beginners/next-steps.mdx
@@ -189,7 +189,7 @@ Welcome to the craft. There is a lot of code waiting for you.
 - A new IDE with prettier syntax highlighting.
 - A web search engine.
 - [o] AddressSanitizer (\`-fsanitize=address\`) or Valgrind, to catch memory bugs at the moment they happen.
-  > Correct! Memory bugs in C are infamous for crashing the program far from where the actual bug is. Sanitizers turn "mysterious crash an hour later" into "precise error message at the offending line". Nothing else comes close in productivity gain.
+  > Memory bugs in C are infamous for crashing the program far from where the actual bug is. Sanitizers turn "mysterious crash an hour later" into "precise error message at the offending line". Nothing else comes close in productivity gain.
 - A heavier build system.
 
 A close runner-up is the debugger (\`gdb\` / \`lldb\`), but sanitizers tend to win on raw bug-finding power, especially for beginners.`}
@@ -201,7 +201,7 @@ A close runner-up is the debugger (\`gdb\` / \`lldb\`), but sanitizers tend to w
 - Read every recommended book before writing more code.
 - Switch immediately to Rust or C++ to avoid C's pitfalls.
 - [o] Write more complete programs in C, end-to-end, and use tools (debugger, sanitizers) to deepen your understanding before chasing new languages.
-  > Correct! Skill comes from writing and finishing programs, not from collecting languages. C is an unusually honest place to practice computational thinking; staying with it for a while pays off no matter what you write next.
+  > Skill comes from writing and finishing programs, not from collecting languages. C is an unusually honest place to practice computational thinking; staying with it for a while pays off no matter what you write next.
 - Memorize the entire C standard library.
 
 There is nothing wrong with learning a new language soon — but the foundation you've built is the part that's hardest to acquire, and the most valuable to deepen first.`}

--- a/content/learn/c-programming-for-beginners/pointers-and-arrays.mdx
+++ b/content/learn/c-programming-for-beginners/pointers-and-arrays.mdx
@@ -316,7 +316,7 @@ int main(void) {
 - \`*(p + 3)\`
 - \`*(a + 3)\`
 - [o] \`a + 3\`
-  > Correct! \`a + 3\` is the **address** of the fourth element, not its value. To get the value you need \`*(a + 3)\` or \`a[3]\`.
+  > \`a + 3\` is the **address** of the fourth element, not its value. To get the value you need \`*(a + 3)\` or \`a[3]\`.
 
 The relationship \`a[i]\` ≡ \`*(a + i)\` is built into the C standard. Notice this also implies the bizarre legal expression \`3[a]\`, which evaluates to \`*(3 + a)\`, which is the same as \`a[3]\`. Just because something is legal doesn't mean it's a good idea.`}
 />
@@ -335,7 +335,7 @@ void show(int arr[]) {
 - The function should declare \`arr\` as \`int *arr\` instead.
   > Actually \`int arr[]\` and \`int *arr\` mean exactly the same thing in a function parameter.
 - [o] Inside the function, \`arr\` is a pointer, not an array. \`sizeof(arr)\` is the size of a pointer (typically 8), not the array's total size.
-  > Correct! When an array is passed to a function, it decays to a pointer to its first element, and the size information is lost.
+  > When an array is passed to a function, it decays to a pointer to its first element, and the size information is lost.
 - C functions cannot compute the length of an array under any circumstances.
   > Functions can — but only if the caller passes the length explicitly.
 

--- a/content/learn/c-programming-for-beginners/pointers.mdx
+++ b/content/learn/c-programming-for-beginners/pointers.mdx
@@ -330,7 +330,7 @@ What is the value of \`n\` afterwards?
 - 5
 - The address of \`n\`.
 - [o] 10
-  > Correct! \`*p = 10\` writes \`10\` into the memory location \`p\` points at, which is \`n\`'s memory.
+  > \`*p = 10\` writes \`10\` into the memory location \`p\` points at, which is \`n\`'s memory.
 - Undefined, because \`p\` was reassigned.
 
 \`p\` is just a sticky note with \`n\`'s address on it; \`*p = 10\` follows the sticky note to \`n\` and writes \`10\` there.`}
@@ -343,7 +343,7 @@ What is the value of \`n\` afterwards?
 - \`int *\`
 - \`void *\`
 - [o] \`double *\`
-  > Correct! The address-of operator yields a pointer whose target type is the same as the operand's type — so \`&x\` where \`x\` is a \`double\` is a \`double *\`.
+  > The address-of operator yields a pointer whose target type is the same as the operand's type — so \`&x\` where \`x\` is a \`double\` is a \`double *\`.
 
 The type of a pointer matters: a \`double *\` and an \`int *\` step through memory in different sized strides during pointer arithmetic, and reading or writing through them touches different numbers of bytes.`}
 />

--- a/content/learn/c-programming-for-beginners/reading-code.mdx
+++ b/content/learn/c-programming-for-beginners/reading-code.mdx
@@ -264,7 +264,7 @@ like a C programmer.
 - Line 1, and continue strictly in order.
 - The longest function in the file.
 - [o] The header file (\`.h\`) for the file, plus the names of all functions defined in the \`.c\` — to learn what the file does and exposes before diving in.
-  > Correct! Building a high-level mental model first means every subsequent detail has a place to live. Diving straight into line-by-line reading is the slowest way to understand a file.
+  > Building a high-level mental model first means every subsequent detail has a place to live. Diving straight into line-by-line reading is the slowest way to understand a file.
 - The bottom of the file (most files put \`main\` at the bottom).
 
 This isn't a hard rule — sometimes \`main\` is the right place to start, sometimes a key data structure is. The principle is "build the big picture first, fill in details on demand".`}
@@ -284,7 +284,7 @@ What should you immediately suspect?
 - That \`scanf\` will read multiple words by mistake.
   > Actually, \`%s\` stops at whitespace; reading multiple words is the opposite of what it does.
 - [o] That an input longer than 63 characters will overflow \`buf\` — \`scanf("%s", ...)\` has no length limit.
-  > Correct! This is a classic buffer overflow. The fix is \`scanf("%63s", buf)\` (note the explicit length) or, better, \`fgets(buf, sizeof buf, stdin)\`.
+  > This is a classic buffer overflow. The fix is \`scanf("%63s", buf)\` (note the explicit length) or, better, \`fgets(buf, sizeof buf, stdin)\`.
 - That \`buf\` should have been declared \`const\`.
 
 Memorize this pattern. Any unbounded read into a fixed-size buffer is a security bug waiting for the right input.`}

--- a/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
+++ b/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
@@ -326,7 +326,7 @@ int multiply(int a, int b) {
 - It makes the variable read-only.
 - It makes the variable visible to all functions in the file.
 - [o] It gives the variable a single, persistent storage location that retains its value across calls to the function.
-  > Correct! \`static\` inside a function changes the variable's *lifetime* (whole program) and *initialization rules* (initialized once), but its *scope* is still that one function.
+  > \`static\` inside a function changes the variable's *lifetime* (whole program) and *initialization rules* (initialized once), but its *scope* is still that one function.
 - It causes the variable to be initialized every time the function is called.
 
 Compare two ideas: \`static\` *inside* a function gives a long lifetime + local scope. \`static\` *outside* any function (at file scope) restricts the linkage to the current file.`}
@@ -339,7 +339,7 @@ Compare two ideas: \`static\` *inside* a function gives a long lifetime + local 
   > Most compilers warn, but it's syntactically valid.
 - It would be slower than returning the value directly.
 - [o] The local variable's memory is reclaimed when the function returns, so the pointer is left pointing at memory that may be overwritten at any time.
-  > Correct! Local variables live on the stack. Once the function returns, that stack space is reused by the next call. Reading or writing through the returned pointer is undefined behavior.
+  > Local variables live on the stack. Once the function returns, that stack space is reused by the next call. Reading or writing through the returned pointer is undefined behavior.
 - C functions cannot return any kind of pointer.
 
 Functions can absolutely return pointers — to globals, to data on the heap (\`malloc\`), to memory the caller supplied. They just can't safely return pointers to their own stack-allocated locals.`}

--- a/content/learn/c-programming-for-beginners/story-of-c.mdx
+++ b/content/learn/c-programming-for-beginners/story-of-c.mdx
@@ -188,7 +188,7 @@ when a program runs. Then, finally, we'll write some code.
 
 - To replace FORTRAN as the language of scientific computing.
 - [o] To make it possible to rewrite the UNIX operating system in a portable, high-level language.
-  > Correct! UNIX was originally written in assembly for the PDP-7 and PDP-11. C was designed to give Thompson and Ritchie a language high-level enough to be productive in, but low-level enough to write an operating system in.
+  > UNIX was originally written in assembly for the PDP-7 and PDP-11. C was designed to give Thompson and Ritchie a language high-level enough to be productive in, but low-level enough to write an operating system in.
 - To teach programming in universities.
 - To compete with Microsoft Windows.
   > Windows wouldn't exist for another decade. C predates the personal computer revolution.
@@ -203,7 +203,7 @@ C's first big customer was UNIX itself: rewriting the UNIX kernel in C in 1973 w
 - The reference Python interpreter (CPython).
 - The SQLite database engine.
 - [o] An HTML web page.
-  > Correct! HTML is a markup language for describing documents, not a programming language. The *browser* that renders HTML, on the other hand, is largely written in C++.
+  > HTML is a markup language for describing documents, not a programming language. The *browser* that renders HTML, on the other hand, is largely written in C++.
 
 C and C++ dominate the layer of software that other software is built on top of: operating systems, databases, browsers, and language runtimes.`}
 />

--- a/content/learn/c-programming-for-beginners/story-of-computers.mdx
+++ b/content/learn/c-programming-for-beginners/story-of-computers.mdx
@@ -191,7 +191,7 @@ them in the next chapter.
   > Machine code is literally what the CPU executes — speed of execution is not the issue. The issue is for humans, not the machine.
 - It used too much electricity.
 - [o] It was extremely difficult for humans to read, write, and debug.
-  > Correct! The machine doesn't care, but human beings can barely look at long sequences of 1s and 0s without making mistakes. This is why assembly language was invented.
+  > The machine doesn't care, but human beings can barely look at long sequences of 1s and 0s without making mistakes. This is why assembly language was invented.
 - It only worked on machines built after 1960.
 
 Machine code is the native language of the CPU, so it always runs at full speed. The pain is on the human side: writing and maintaining anything non-trivial in raw bits is essentially impossible.`}
@@ -205,7 +205,7 @@ Machine code is the native language of the CPU, so it always runs at full speed.
 - Assembly runs on any CPU regardless of architecture.
   > Assembly is tied to a specific CPU architecture, just like machine code.
 - [o] Each line of assembly typically corresponds to a single machine instruction; an assembler translates between them.
-  > Correct! Assembly is essentially a human-readable spelling of machine code, with mnemonics like \`MOV\` and \`ADD\` instead of raw bit patterns.
+  > Assembly is essentially a human-readable spelling of machine code, with mnemonics like \`MOV\` and \`ADD\` instead of raw bit patterns.
 - Assembly is a high-level language similar to FORTRAN.
 
 Assembly languages give us names for opcodes and registers, but they do not abstract away the machine. A compiler for a high-level language, on the other hand, can generate machine code for many different CPU architectures from the same source.`}

--- a/content/learn/c-programming-for-beginners/strings.mdx
+++ b/content/learn/c-programming-for-beginners/strings.mdx
@@ -271,7 +271,7 @@ int main(void) {
 
 - 4
 - [o] 5
-  > Correct! \`strlen\` counts the visible characters, **not** the trailing \`\\0\`.
+  > \`strlen\` counts the visible characters, **not** the trailing \`\\0\`.
 - 6
   > That would be the array's **storage size** (5 letters + 1 null). \`strlen\` excludes the terminator.
 - It depends on the system.
@@ -292,7 +292,7 @@ strcpy(buf, "This message is much longer than ten bytes.");
 - It runs but \`buf\` will silently be truncated to 10 bytes.
   > \`strcpy\` does **not** truncate. It just keeps writing.
 - [o] \`strcpy\` doesn't check the destination size, so it writes far past the end of \`buf\`, corrupting other memory.
-  > Correct! This is the classic *buffer overflow*. The runtime behavior is undefined: the program may crash, silently corrupt unrelated variables, or be exploitable by an attacker.
+  > This is the classic *buffer overflow*. The runtime behavior is undefined: the program may crash, silently corrupt unrelated variables, or be exploitable by an attacker.
 - The compiler will refuse to copy a string longer than \`buf\`.
 
 Safer alternatives: \`strncpy\` (with explicit size, but always null-terminate yourself), or \`snprintf\` (with size limit and truncation reporting). Or use a bigger buffer that you've sized to your data.`}

--- a/content/learn/c-programming-for-beginners/structs.mdx
+++ b/content/learn/c-programming-for-beginners/structs.mdx
@@ -313,7 +313,7 @@ int main(void) {
 - \`p.x\`
 - \`*p.x\`
 - [o] \`p->x\`
-  > Correct! When you have a pointer to a struct, the arrow operator dereferences and accesses the field in one step. Equivalent to \`(*p).x\`.
+  > When you have a pointer to a struct, the arrow operator dereferences and accesses the field in one step. Equivalent to \`(*p).x\`.
 - \`&p.x\`
 
 The arrow operator exists purely because \`(*p).x\` is so common — and because the parentheses are easy to forget. \`*p.x\` would be parsed as \`*(p.x)\`, which is almost never what you want.`}
@@ -333,7 +333,7 @@ printf("%d %d\\n", x.a, y.a);
 - \`99 99\`
 - \`99 1\`
 - [o] \`1 99\`
-  > Correct! Struct assignment makes a full copy. Modifying \`y.a\` doesn't touch \`x\`.
+  > Struct assignment makes a full copy. Modifying \`y.a\` doesn't touch \`x\`.
 - The code is invalid; you can't assign one struct to another.
 
 If \`S\` had contained a pointer field, only the pointer value (the address) would have been copied, not the data the pointer points at — that's known as a "shallow copy" and is something to watch out for once your structs start owning heap memory.`}

--- a/content/learn/c-programming-for-beginners/variables-and-memory.mdx
+++ b/content/learn/c-programming-for-beginners/variables-and-memory.mdx
@@ -288,7 +288,7 @@ int main(void) {
 - A keyword reserved by the compiler.
 - An object that grows and shrinks automatically based on the value assigned to it.
 - [o] A name bound to a fixed-size region of memory whose contents can be read or written.
-  > Correct! In C, variable size is fixed at declaration based on its type. The variable is essentially a labelled box at a specific address.
+  > In C, variable size is fixed at declaration based on its type. The variable is essentially a labelled box at a specific address.
 - A function that always returns the most recent value passed to it.
 
 C is a *statically typed* language: the size and layout of a variable are decided when you write \`int x;\`, not at runtime.`}
@@ -306,7 +306,7 @@ printf("%d\\n", y);
 - Nothing — \`y\` will always be \`1\`.
 - The compiler will refuse to build it.
 - [o] \`x\` is uninitialized, so reading it is undefined behavior; \`y\` could be anything.
-  > Correct! The compiler reserves memory for \`x\` but doesn't zero it out. Whatever bits happened to be there become its value.
+  > The compiler reserves memory for \`x\` but doesn't zero it out. Whatever bits happened to be there become its value.
 - \`y\` cannot be initialized from another variable.
 
 Always initialize your variables. Modern compilers will often emit a warning for uninitialized reads — turn warnings on and pay attention to them.`}

--- a/content/learn/c-programming-for-beginners/your-first-program.mdx
+++ b/content/learn/c-programming-for-beginners/your-first-program.mdx
@@ -232,7 +232,7 @@ int main(void) {
 - It runs first when the program starts.
 - It tells the operating system to use the standard input format.
 - [o] It instructs the preprocessor to insert the declarations from \`stdio.h\` so the compiler knows about functions like \`printf\`.
-  > Correct! \`#include\` is a textual paste handled before compilation. Without it, the compiler doesn't know what \`printf\` looks like.
+  > \`#include\` is a textual paste handled before compilation. Without it, the compiler doesn't know what \`printf\` looks like.
 - It compiles \`stdio.h\` into a separate executable.
 
 The preprocessor literally copies the contents of \`stdio.h\` into your translation unit before the compiler ever looks at your code.`}
@@ -244,7 +244,7 @@ The preprocessor literally copies the contents of \`stdio.h\` into your translat
 - A period \`.\`
 - A newline character
 - [o] A semicolon \`;\`
-  > Correct! C is *not* a whitespace-sensitive language; you can spread a statement across multiple lines or put many statements on one line, as long as each statement ends with a semicolon.
+  > C is *not* a whitespace-sensitive language; you can spread a statement across multiple lines or put many statements on one line, as long as each statement ends with a semicolon.
 - The closing brace \`}\`
 
 Forgetting semicolons is by far the most common syntax error for newcomers to C. Read your compiler's error messages carefully — they almost always point to the right line (or the line just after the missing semicolon).`}

--- a/content/learn/csharp-linq-functional/aggregations.mdx
+++ b/content/learn/csharp-linq-functional/aggregations.mdx
@@ -278,7 +278,7 @@ public static class Checksum
 - Returns \`null\`.
   > Returning \`null\` isn't possible for a non-nullable \`int\`, and even for nullable types the empty behavior depends on the overload.
 - [o] Throws \`InvalidOperationException\` because the sequence is empty.
-  > Correct. \`Min\` on an empty non-nullable \`IEnumerable<int>\` throws. Use \`DefaultIfEmpty\`, \`MinBy\`, or guard with \`Any()\` to handle the empty case.
+  > \`Min\` on an empty non-nullable \`IEnumerable<int>\` throws. Use \`DefaultIfEmpty\`, \`MinBy\`, or guard with \`Any()\` to handle the empty case.
 
 \`Sum\` and \`Count\` have natural answers for empty sequences (zero),
 but \`Min\`, \`Max\`, and \`Average\` do not. They throw. Always

--- a/content/learn/csharp-linq-functional/birth-of-linq.mdx
+++ b/content/learn/csharp-linq-functional/birth-of-linq.mdx
@@ -176,7 +176,7 @@ Rust `Iterator` pipeline.
 - Anonymous types
   > Anonymous types let you build ad-hoc shapes mid-pipeline, but they have nothing to do with how \`Where\` attaches to \`IEnumerable<T>\`.
 - [o] Extension methods
-  > Correct. Extension methods let \`Enumerable.Where(this IEnumerable<T> source, …)\` be invoked as if \`Where\` were a member of \`IEnumerable<T>\`, even though the interface itself is untouched.
+  > Extension methods let \`Enumerable.Where(this IEnumerable<T> source, …)\` be invoked as if \`Where\` were a member of \`IEnumerable<T>\`, even though the interface itself is untouched.
 - Expression trees
   > Expression trees are what let LINQ to Providers translate lambdas into SQL — they are not how \`Where\` is attached to a collection.
 

--- a/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
+++ b/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
@@ -351,7 +351,7 @@ This is the kind of muscle that needs reps.
 - It writes test logs internally that the test framework reads.
   > It has no logging or IO. That's the *point*.
 - [o] It is a pure function: it takes an \`IEnumerable<Txn>\` and returns \`IEnumerable<ProductSummary>\` with no IO or hidden state.
-  > Correct. Pure functions are trivially testable: hand-craft a few \`Txn\` records, call the function, assert on the returned values. No mocks, no fakes, no setup, no teardown — and the same input always produces the same output.
+  > Pure functions are trivially testable: hand-craft a few \`Txn\` records, call the function, assert on the returned values. No mocks, no fakes, no setup, no teardown — and the same input always produces the same output.
 - It uses inheritance to be mocked.
   > It is a plain \`static\` method. No mocking required *because* it is pure.
 

--- a/content/learn/csharp-linq-functional/composing-pipelines.mdx
+++ b/content/learn/csharp-linq-functional/composing-pipelines.mdx
@@ -316,7 +316,7 @@ not to abstract for abstraction's sake.
 - The compiler refuses to chain List-returning operators in LINQ.
   > Any \`IEnumerable<T>\`-returning method (including those returning \`List<T>\`) chains fine in LINQ.
 - [o] The \`yield\` version preserves laziness — downstream operators like \`Take(5)\` can stop the source early.
-  > Correct. With \`yield\`, elements flow one at a time and short-circuit operators terminate the source mid-stream. A list-based version forces the entire upstream to materialize before any downstream operator sees an element.
+  > With \`yield\`, elements flow one at a time and short-circuit operators terminate the source mid-stream. A list-based version forces the entire upstream to materialize before any downstream operator sees an element.
 - Lists cannot store generic types.
   > \`List<T>\` is generic by definition. This is simply false.
 

--- a/content/learn/csharp-linq-functional/deferred-execution.mdx
+++ b/content/learn/csharp-linq-functional/deferred-execution.mdx
@@ -278,7 +278,7 @@ foreach (var x in q) { ... }
 - A compile error, because you can't iterate a deferred sequence twice.
   > It compiles and runs fine, but it re-executes the pipeline on each iteration.
 - [o] The pipeline (and the underlying \`LoadFromDatabase\` call) runs *twice*, once per \`foreach\`.
-  > Correct. Deferred operators define a recipe, not a stored result. Each \`foreach\` walks the source again — re-running any side-effectful or expensive source method.
+  > Deferred operators define a recipe, not a stored result. Each \`foreach\` walks the source again — re-running any side-effectful or expensive source method.
 - The second \`foreach\` produces no output, because the enumerator is already at the end.
   > Each \`foreach\` calls \`GetEnumerator\` again, so it starts from the beginning each time.
 

--- a/content/learn/csharp-linq-functional/filtering-and-projection.mdx
+++ b/content/learn/csharp-linq-functional/filtering-and-projection.mdx
@@ -287,7 +287,7 @@ public static class PeopleFilter
 - The \`Select\` lambda runs for every element of \`nums\`, regardless of the filter.
   > Pipelined operators only invoke later steps for elements that survive earlier steps; \`Select\` does not run for elements that \`Where\` rejected.
 - [o] \`result\` is a deferred \`IEnumerable<int>\` — neither \`Where\` nor \`Select\` runs until something enumerates it (e.g. \`foreach\`, \`ToList\`, \`Sum\`).
-  > Correct. LINQ is *pull-based*: the lambdas execute only when a consumer asks for elements.
+  > LINQ is *pull-based*: the lambdas execute only when a consumer asks for elements.
 - \`Where\` and \`Select\` can only be used on \`List<T>\` and arrays.
   > They are extension methods on \`IEnumerable<T>\`, which is implemented by virtually every collection in .NET and by hand-written iterators.
 

--- a/content/learn/csharp-linq-functional/functional-design-patterns.mdx
+++ b/content/learn/csharp-linq-functional/functional-design-patterns.mdx
@@ -360,7 +360,7 @@ expressive *without* abandoning the strengths of the OO model.
 - It catches exceptions inside each step and converts them to errors.
   > A useful helper, but not what \`Bind\` itself does — it just propagates the existing \`Err\` value.
 - [o] It chains an operation that *returns* a \`Result\` onto a previous \`Result\`, automatically short-circuiting on the first error.
-  > Correct. \`Bind\` lets you write \`a.Bind(Step2).Bind(Step3)\` where each step may fail. As soon as one step returns \`Err\`, every subsequent \`Bind\` skips its function and threads the error to the end of the pipeline.
+  > \`Bind\` lets you write \`a.Bind(Step2).Bind(Step3)\` where each step may fail. As soon as one step returns \`Err\`, every subsequent \`Bind\` skips its function and threads the error to the end of the pipeline.
 - It converts a synchronous result into an async one.
   > That's a separate concern (lifting into a \`Task\` / \`ValueTask\`), not the purpose of \`Bind\`.
 

--- a/content/learn/csharp-linq-functional/functional-renaissance.mdx
+++ b/content/learn/csharp-linq-functional/functional-renaissance.mdx
@@ -190,7 +190,7 @@ underneath LINQ.
 - Use functional patterns only in greenfield F# projects.
   > Functional patterns belong in normal C# code, in normal OO codebases. This course is specifically about applying them in C#.
 - [o] Apply functional patterns — immutability, pure functions, pipelines — primarily to the data-processing layers, while keeping the rest of the OO design.
-  > Correct. The functional renaissance was additive: functional ideas mostly attack the place most bugs live (data transformation and state mutation), and coexist with OO services, interfaces, and classes.
+  > The functional renaissance was additive: functional ideas mostly attack the place most bugs live (data transformation and state mutation), and coexist with OO services, interfaces, and classes.
 - Avoid LINQ in production code because it is slower than imperative loops.
   > LINQ to Objects is competitive with hand loops in the vast majority of code paths, and the readability benefit is usually decisive.
 

--- a/content/learn/csharp-linq-functional/generic-abstractions.mdx
+++ b/content/learn/csharp-linq-functional/generic-abstractions.mdx
@@ -307,7 +307,7 @@ single ten-line interface.
 - The lambda parameter \`s\` is declared as \`string\`, which is how \`T\` is decided.
   > Close, but inverted. The compiler first infers \`T\` from the *source*, then types the lambda accordingly.
 - [o] The compiler infers \`T = string\` from the source array's element type, then specializes \`MyWhere\` for \`string\`.
-  > Correct. C# infers generic type arguments by looking at the call site — most importantly the type of the source expression — and then synthesizes a strongly typed specialization. No casting, no boxing, full IntelliSense.
+  > C# infers generic type arguments by looking at the call site — most importantly the type of the source expression — and then synthesizes a strongly typed specialization. No casting, no boxing, full IntelliSense.
 - \`T\` is resolved at runtime by reflection.
   > No — generic type resolution happens at compile time in C#. Reflection is not involved at the call site.
 

--- a/content/learn/csharp-linq-functional/higher-order-functions.mdx
+++ b/content/learn/csharp-linq-functional/higher-order-functions.mdx
@@ -315,7 +315,7 @@ public static class Filters
 - A "Multiplier" method that returns \`Func<int, int>\` for a given factor.
   > Returning a function makes a method higher-order, so this *is* higher-order.
 - [o] \`static int Add(int x, int y) => x + y;\`
-  > Correct. \`Add\` neither takes a function as a parameter nor returns one — it only operates on values. It is a perfectly ordinary first-order function.
+  > \`Add\` neither takes a function as a parameter nor returns one — it only operates on values. It is a perfectly ordinary first-order function.
 
 A higher-order function must either accept a function as an argument
 or return a function. Plain functions over plain values (like \`Add\`)

--- a/content/learn/csharp-linq-functional/ienumerable-and-iteration.mdx
+++ b/content/learn/csharp-linq-functional/ienumerable-and-iteration.mdx
@@ -285,7 +285,7 @@ you've locked your caller into one concrete type for no reason.
 - You can iterate the returned sequence multiple times and always get the same results.
   > The sequence might be backed by a \`yield\` method, a network stream, or a one-shot reader. Iterating twice can re-run the source — or fail.
 - [o] You can call \`foreach\` over the result and read elements one at a time.
-  > Correct. That is exactly what \`IEnumerable<T>\` promises: it gives you an enumerator that produces elements until it signals the end.
+  > That is exactly what \`IEnumerable<T>\` promises: it gives you an enumerator that produces elements until it signals the end.
 - The results are already in memory and indexing is O(1).
   > Indexing isn't part of \`IEnumerable<T>\` at all — that's \`IList<T>\` or arrays. And the elements may be computed on demand rather than stored.
 

--- a/content/learn/csharp-linq-functional/immutability.mdx
+++ b/content/learn/csharp-linq-functional/immutability.mdx
@@ -278,7 +278,7 @@ public record Money(decimal Amount, string Currency)
 - Immutability is mainly a matter of code style.
   > It looks like style, but it has direct consequences for correctness, threading, and reasoning. It is structural, not cosmetic.
 - [o] Immutable values cannot be aliased into incorrect states, because nothing can change them after construction.
-  > Correct. Aliasing only causes bugs when one of the aliases *mutates* the shared object. If the object is immutable, no aliased reference can ever observe an unexpected change.
+  > Aliasing only causes bugs when one of the aliases *mutates* the shared object. If the object is immutable, no aliased reference can ever observe an unexpected change.
 
 Immutability doesn't *forbid* sharing references — it makes shared
 references *safe*. Two pieces of code that both hold the same

--- a/content/learn/csharp-linq-functional/lambdas-and-delegates.mdx
+++ b/content/learn/csharp-linq-functional/lambdas-and-delegates.mdx
@@ -267,7 +267,7 @@ recompiling. That power comes from treating functions as values.
 - \`Func<int, bool>\` can only be created from a method, while \`Expression<Func<int, bool>>\` can be created from a lambda.
   > Both can be created from a lambda; the *compiler* decides which target type to produce based on the variable's declared type.
 - [o] \`Func<int, bool>\` compiles to executable code that can be invoked directly; \`Expression<Func<int, bool>>\` compiles to a data structure that describes the lambda and can be inspected or translated by a LINQ provider.
-  > Correct. The same lambda \`x => x > 30\` becomes a callable delegate when assigned to \`Func<int, bool>\`, and an inspectable tree when assigned to \`Expression<Func<int, bool>>\`. Providers like EF use the latter to translate to SQL.
+  > The same lambda \`x => x > 30\` becomes a callable delegate when assigned to \`Func<int, bool>\`, and an inspectable tree when assigned to \`Expression<Func<int, bool>>\`. Providers like EF use the latter to translate to SQL.
 - \`Expression<Func<int, bool>>\` is the async version of \`Func<int, bool>\`.
   > Async has nothing to do with expression trees; there is no asynchronous variant of either type implied by these names.
 

--- a/content/learn/csharp-linq-functional/modern-csharp-functional.mdx
+++ b/content/learn/csharp-linq-functional/modern-csharp-functional.mdx
@@ -294,7 +294,7 @@ with the most important idea of all: **pure functions**.
 - It mutates \`p\` so that its Age becomes 37 and returns \`p\`.
   > Records support non-destructive update; \`with\` never mutates the original. The original \`p\` is unchanged.
 - [o] It creates a new record value that is a copy of \`p\` but with \`Age\` set to 37, leaving \`p\` unchanged.
-  > Correct. \`with\` is the non-destructive update operator: it produces a brand-new record with selected fields replaced. The original record is immutable.
+  > \`with\` is the non-destructive update operator: it produces a brand-new record with selected fields replaced. The original record is immutable.
 - It throws a compile error because records do not support partial updates.
   > Records explicitly support \`with\` expressions for exactly this purpose.
 - It modifies \`p\` only if \`p\` is a mutable record (i.e. not declared with init-only properties).

--- a/content/learn/csharp-linq-functional/next-steps.mdx
+++ b/content/learn/csharp-linq-functional/next-steps.mdx
@@ -205,7 +205,7 @@ Happy querying.
 - They are unrelated — \`IQueryable<T>\` is a database-only type with its own API.
   > \`IQueryable<T>\` inherits from \`IEnumerable<T>\`. They share the LINQ method surface.
 - [o] \`IQueryable<T>\` captures a query as an *expression tree* that a provider (like EF Core) can translate, instead of executing the LINQ in process.
-  > Correct. The same \`.Where(...).Select(...)\` syntax that runs in-memory against \`IEnumerable<T>\` becomes a reified expression tree against \`IQueryable<T>\`, which providers translate (typically to SQL). This is the trick behind EF Core, LINQ to XML, LINQ to remote services, and more.
+  > The same \`.Where(...).Select(...)\` syntax that runs in-memory against \`IEnumerable<T>\` becomes a reified expression tree against \`IQueryable<T>\`, which providers translate (typically to SQL). This is the trick behind EF Core, LINQ to XML, LINQ to remote services, and more.
 - They are the same interface with different names for historical reasons.
   > They have different semantics: \`IEnumerable<T>\` runs delegates in-process; \`IQueryable<T>\` captures expressions for a provider.
 - \`IQueryable<T>\` is always faster because it runs on a server.

--- a/content/learn/csharp-linq-functional/ordering-and-grouping.mdx
+++ b/content/learn/csharp-linq-functional/ordering-and-grouping.mdx
@@ -314,7 +314,7 @@ public static class SalesReport
 - A sequence sorted by A, with ties in A broken by B.
   > That's what \`ThenBy\` does. Two consecutive \`OrderBy\` calls behave differently.
 - [o] A sequence sorted by B, with ties in B broken by A.
-  > Correct. The *second* \`OrderBy\` re-sorts everything by B; the first \`OrderBy\`'s ordering survives only within tied B values (because the sort is stable).
+  > The *second* \`OrderBy\` re-sorts everything by B; the first \`OrderBy\`'s ordering survives only within tied B values (because the sort is stable).
 - A compile error, because you can't apply \`OrderBy\` twice.
   > It compiles fine — every \`IEnumerable<T>\` has \`OrderBy\` available as an extension. But the *behavior* is usually not what people want.
 - A sequence in undefined order.

--- a/content/learn/csharp-linq-functional/pure-functions.mdx
+++ b/content/learn/csharp-linq-functional/pure-functions.mdx
@@ -277,7 +277,7 @@ public static class MathCore
 - \`static int RollDie() => new Random().Next(1, 7);\`
   > Not pure — it reads from a random number generator (hidden state), so two calls with no arguments can give different results.
 - [o] \`static int Triple(int x) => x * 3;\`
-  > Correct. Output depends only on the input, and the method has no side effects.
+  > Output depends only on the input, and the method has no side effects.
 - \`static int LogAndReturn(int x) { System.Console.WriteLine(x); return x; }\`
   > Not pure — it has the side effect of writing to standard output, even though the return value depends only on \`x\`.
 - \`static void Add(System.Collections.Generic.List<int> xs, int x) => xs.Add(x);\`

--- a/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
+++ b/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
@@ -353,7 +353,7 @@ There is no winner. They are the same LINQ. Pick whichever makes the
 - Query syntax always reads better when more than one operator is involved.
   > Often false. Short pipelines (\`Where\` + \`Select\` + \`Sum\`) usually read better in method syntax. Query syntax shines specifically for multiple \`from\`s, \`let\`, and \`join\`.
 - [o] They compile to identical method calls; the choice between them is purely about readability.
-  > Correct. Query syntax is a *sugar* over the same extension methods. Pick whichever conveys intent more clearly for a given query.
+  > Query syntax is a *sugar* over the same extension methods. Pick whichever conveys intent more clearly for a given query.
 
 This is the right mental model: there is one LINQ, with two faces.`}
 />

--- a/content/learn/csharp-linq-functional/rise-of-declarative.mdx
+++ b/content/learn/csharp-linq-functional/rise-of-declarative.mdx
@@ -172,7 +172,7 @@ across many modern languages.
 - It runs faster than imperative code.
   > Declarative code can be faster or slower, depending on the runtime. Performance is not the defining trait.
 - [o] It describes *what* result is wanted and leaves *how* to compute it to the runtime or library.
-  > Correct. Declarative code expresses the desired result; an imperative program describes the precise sequence of state changes to reach it.
+  > Declarative code expresses the desired result; an imperative program describes the precise sequence of state changes to reach it.
 - It must be written in a functional programming language.
   > Declarative styles exist in many paradigms, including SQL (relational), HTML (markup), and LINQ inside an OO language.
 

--- a/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
+++ b/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
@@ -293,7 +293,7 @@ public static class Reports
 - Doubling every element of an \`int[]\`.
   > That's a one-to-one transformation, so \`Select\` is the right operator. No nesting is involved.
 - [o] Producing a flat list of every tag across every blog post in a list of posts.
-  > Correct. Each post has *many* tags, and you want one flat sequence. That's exactly the flattening that \`SelectMany\` performs.
+  > Each post has *many* tags, and you want one flat sequence. That's exactly the flattening that \`SelectMany\` performs.
 - Filtering a list of orders to only those with \`Total > 100\`.
   > That's a filter, not a flattening — \`Where\` is the right operator.
 - Counting how many items are in a list.

--- a/content/learn/csharp-linq-functional/set-operations.mdx
+++ b/content/learn/csharp-linq-functional/set-operations.mdx
@@ -327,7 +327,7 @@ public static class Roster
 - \`Union\` always produces a longer sequence than \`Concat\`.
   > The opposite is often true — \`Union\` deduplicates and can be shorter than \`Concat\`.
 - [o] \`Concat\` preserves every element including duplicates between the two sequences; \`Union\` deduplicates so each value appears at most once.
-  > Correct. \`Concat\` is purely "append" semantics; \`Union\` is set semantics that removes duplicates across (and within) the inputs.
+  > \`Concat\` is purely "append" semantics; \`Union\` is set semantics that removes duplicates across (and within) the inputs.
 - \`Concat\` requires both sequences to have the same element type; \`Union\` does not.
   > Both require compatible element types (typically the same type or a common base type).
 

--- a/content/learn/csharp-linq-functional/side-effect-management.mdx
+++ b/content/learn/csharp-linq-functional/side-effect-management.mdx
@@ -337,7 +337,7 @@ can adopt.
 - Because static calls are forbidden inside LINQ lambdas.
   > Not true — you can call any method inside a lambda. The objection is about *purity*, not legality.
 - [o] To make the function deterministic and testable — the same inputs always produce the same output, and tests can supply any time/seed they want.
-  > Correct. Hidden environmental reads (clock, RNG, environment variables) make a function impure and untestable. Lifting those reads to parameters turns the function into a pure, predictable building block; the shell stays responsible for sourcing the real values.
+  > Hidden environmental reads (clock, RNG, environment variables) make a function impure and untestable. Lifting those reads to parameters turns the function into a pure, predictable building block; the shell stays responsible for sourcing the real values.
 - To improve thread safety.
   > A side benefit in some cases (avoiding shared \`Random\` instances, for example), but the primary motivation is testability and reasoning.
 

--- a/content/learn/data-analysis-python-pandas/aggregation-basics.mdx
+++ b/content/learn/data-analysis-python-pandas/aggregation-basics.mdx
@@ -248,7 +248,7 @@ Pair-report mean and median whenever distributions might be skewed.`}
 - The counts of unique values
 - A list of unique values
 - [o] The *proportions* (fractions of total) of each unique value
-  > Correct. \`normalize=True\` divides each count by the total, giving share-of-total — perfect for "what fraction of customers are in each tier" questions.
+  > \`normalize=True\` divides each count by the total, giving share-of-total — perfect for "what fraction of customers are in each tier" questions.
 - A sorted Series
 
 A small flag that saves a division — well worth knowing.`}

--- a/content/learn/data-analysis-python-pandas/birth-of-data-science.mdx
+++ b/content/learn/data-analysis-python-pandas/birth-of-data-science.mdx
@@ -223,7 +223,7 @@ roles.
 
 - Web designers, copywriters, and accountants
 - [o] Statisticians, computer scientists, and business analysts
-  > Correct. The Drew Conway Venn diagram (math/stats, hacking skills, substantive expertise) captures the same three-way intersection.
+  > The Drew Conway Venn diagram (math/stats, hacking skills, substantive expertise) captures the same three-way intersection.
 - Hardware engineers, mathematicians, and biologists
 - Sociologists, philosophers, and historians
 
@@ -248,7 +248,7 @@ Time spent cleaning is not wasted — it is the substrate that every later concl
 - NumPy
 - scikit-learn
 - [o] pandas
-  > Correct. Pandas was released by Wes McKinney in 2008 while he was at AQR Capital Management. Its history is the subject of the next chapter.
+  > Pandas was released by Wes McKinney in 2008 while he was at AQR Capital Management. Its history is the subject of the next chapter.
 - matplotlib
 
 NumPy and matplotlib are older; scikit-learn arrived in 2010. Pandas is the one we will build the course around.`}

--- a/content/learn/data-analysis-python-pandas/concat-vs-merge.mdx
+++ b/content/learn/data-analysis-python-pandas/concat-vs-merge.mdx
@@ -173,7 +173,7 @@ Whenever a *key* relates the two tables, merge.`}
 - It is slow
 - It does not work with strings
 - [o] It pairs rows by index/position rather than by a key — easy to silently mis-align rows if the two frames are in different orders
-  > Correct. Even if it works today, a future sort or reset on one frame breaks the pairing. Use merge when you have an ID.
+  > Even if it works today, a future sort or reset on one frame breaks the pairing. Use merge when you have an ID.
 - It is deprecated
 
 Position-based joins are dangerous in any data tool, not just Pandas.`}

--- a/content/learn/data-analysis-python-pandas/creating-new-columns.mdx
+++ b/content/learn/data-analysis-python-pandas/creating-new-columns.mdx
@@ -277,7 +277,7 @@ For grade letters, salary bands, customer tiers, etc., \`np.select\` keeps the l
 - Pandas does not support strings in maps
 - The map is corrupted
 - [o] \`.map\` returns NaN for any value not found in the mapping dict; "GBP" is missing so the result is NaN
-  > Correct. You can supply a default with \`.map(dict).fillna(...)\` or by using \`.replace\` instead.
+  > You can supply a default with \`.map(dict).fillna(...)\` or by using \`.replace\` instead.
 - The dict is read-only
 
 Always confirm your mapping is exhaustive (or explicitly handle the misses).`}

--- a/content/learn/data-analysis-python-pandas/dataframes-and-series.mdx
+++ b/content/learn/data-analysis-python-pandas/dataframes-and-series.mdx
@@ -253,7 +253,7 @@ Once you have used alignment in anger, you will not want to go back.`}
 - A single float
 - A DataFrame of means
 - [o] A Series with one entry per column
-  > Correct. A DataFrame reduction (\`mean\`, \`sum\`, \`std\`, ...) collapses one axis. Default \`axis=0\` collapses rows → Series indexed by column name.
+  > A DataFrame reduction (\`mean\`, \`sum\`, \`std\`, ...) collapses one axis. Default \`axis=0\` collapses rows → Series indexed by column name.
 - A NumPy array
 
 Knowing the shape of every operation's output is half the battle.`}

--- a/content/learn/data-analysis-python-pandas/dates-and-times.mdx
+++ b/content/learn/data-analysis-python-pandas/dates-and-times.mdx
@@ -337,7 +337,7 @@ When you have time-series data, almost always promote the timestamp to the index
 - A datetime
 - A float (days)
 - [o] A \`Timedelta\` — a duration value that you can convert to days, seconds, etc. via \`.dt.days\`, \`.dt.total_seconds()\`, etc.
-  > Correct. Always be explicit about the unit when converting Timedeltas to floats.
+  > Always be explicit about the unit when converting Timedeltas to floats.
 - An integer
 
 The Timedelta type keeps you safe — it would be much worse if Pandas guessed at days vs hours vs seconds.`}

--- a/content/learn/data-analysis-python-pandas/duplicates-and-inconsistencies.mdx
+++ b/content/learn/data-analysis-python-pandas/duplicates-and-inconsistencies.mdx
@@ -243,7 +243,7 @@ The order matters: stripping and case-normalizing before replacement gives the r
 - It causes the file to fail to open
 - It is too small
 - [o] Aggregations like \`mean\`, \`sum\`, comparisons, and rankings will mix incompatible numbers, producing meaningless results without any error
-  > Correct. There is no syntactic clue that 1500 cents and 10 USD are the same amount; convert to one unit early.
+  > There is no syntactic clue that 1500 cents and 10 USD are the same amount; convert to one unit early.
 - It uses too much memory
 
 Unit-normalize before any numeric operation. Always.`}

--- a/content/learn/data-analysis-python-pandas/filtering-data.mdx
+++ b/content/learn/data-analysis-python-pandas/filtering-data.mdx
@@ -340,7 +340,7 @@ Train your fingers: \`&\`, \`|\`, \`~\`, and parentheses around each condition.`
 - The two are equivalent
 - The second is shorter
 - [o] The chained form may silently operate on a *copy* and fail to update the original (the SettingWithCopyWarning); \`loc\` guarantees in-place update
-  > Correct. This is one of the most common silent bugs in Pandas. \`loc\` is the safe way.
+  > This is one of the most common silent bugs in Pandas. \`loc\` is the safe way.
 - The second is faster
 
 When in doubt, use \`loc\` for assignments.`}

--- a/content/learn/data-analysis-python-pandas/groupby-operations.mdx
+++ b/content/learn/data-analysis-python-pandas/groupby-operations.mdx
@@ -383,7 +383,7 @@ If you have ever been confused by MultiIndex columns coming out of groupby, swit
 - A flat RangeIndex
 - A column index
 - [o] A MultiIndex — one level for column \`a\`, one level for column \`b\`
-  > Correct. Multi-column groupbys naturally produce hierarchical indexes. Call \`.reset_index()\` if you want a flat DataFrame.
+  > Multi-column groupbys naturally produce hierarchical indexes. Call \`.reset_index()\` if you want a flat DataFrame.
 - A DatetimeIndex
 
 The MultiIndex is powerful but adds a learning curve. \`reset_index()\` is your friend.`}

--- a/content/learn/data-analysis-python-pandas/how-computers-see-data.mdx
+++ b/content/learn/data-analysis-python-pandas/how-computers-see-data.mdx
@@ -280,7 +280,7 @@ limitation (your dataset must fit).
 - A spreadsheet
 - A binary database table
 - [o] A sequence of bytes (typically interpreted as text) with rows separated by newlines and values separated by commas
-  > Correct. CSV is plain text. The "table-ness" is imposed by whatever reader (Excel, Pandas, etc.) interprets the bytes.
+  > CSV is plain text. The "table-ness" is imposed by whatever reader (Excel, Pandas, etc.) interprets the bytes.
 - A proprietary Pandas format
 
 This is why CSV files are portable across every OS, language, and tool.`}
@@ -316,7 +316,7 @@ Understanding column orientation explains why \`df["age"].mean()\` is fast and w
 - \`bool\`
 - \`int64\`
 - [o] \`object\` (Python strings)
-  > Correct. Pandas does not auto-recognize lowercase \`"true"\` / \`"false"\` as booleans (it has done so in some versions for \`True\`/\`False\`, but not reliably). You need to convert explicitly with \`df["col"].map({"true": True, "false": False})\` or \`astype("bool")\` after cleaning.
+  > Pandas does not auto-recognize lowercase \`"true"\` / \`"false"\` as booleans (it has done so in some versions for \`True\`/\`False\`, but not reliably). You need to convert explicitly with \`df["col"].map({"true": True, "false": False})\` or \`astype("bool")\` after cleaning.
 - \`category\`
 
 Booleans-as-strings are a common surprise; defensive type checking catches them.`}

--- a/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
+++ b/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
@@ -210,7 +210,7 @@ Always ask "what else could explain this?".`}
 - A 97% chance the result is real
 - A 3% chance the data is wrong
 - [o] If the null hypothesis (no real effect) were true, the chance of seeing a result this extreme by luck is 3%
-  > Correct. It's a statement about a hypothetical world, not directly about your actual hypothesis being "true".
+  > It's a statement about a hypothetical world, not directly about your actual hypothesis being "true".
 - A 30% chance of error
 
 Misinterpreting p-values is one of the most common errors in applied analytics.`}

--- a/content/learn/data-analysis-python-pandas/indexes-and-labels.mdx
+++ b/content/learn/data-analysis-python-pandas/indexes-and-labels.mdx
@@ -206,7 +206,7 @@ and demoting via `set_index` / `reset_index` is cheap.
 - A copy of the first column
 - All NaN
 - [o] A \`RangeIndex\` — integers 0, 1, 2, ... corresponding to row positions
-  > Correct. Unless you specify \`index=\`, Pandas gives you boring sequential integers.
+  > Unless you specify \`index=\`, Pandas gives you boring sequential integers.
 - A timestamp
 
 You can replace the default later with anything meaningful.`}

--- a/content/learn/data-analysis-python-pandas/loading-datasets.mdx
+++ b/content/learn/data-analysis-python-pandas/loading-datasets.mdx
@@ -342,7 +342,7 @@ For columns with millions of rows and only a handful of distinct values, the sav
 - Restart your computer
 - Convert to float
 - [o] Pass \`dtype={"phone": "string"}\` to \`pd.read_csv\` so the values are read as strings from the start
-  > Correct. Once a leading-zero phone or ZIP code has been parsed as int, the leading zeros are gone. Force the string type at read time.
+  > Once a leading-zero phone or ZIP code has been parsed as int, the leading zeros are gone. Force the string type at read time.
 - Use \`.astype("int64")\` afterwards
 
 Specifying \`dtype\` at read time is much safer than trying to recover later.`}

--- a/content/learn/data-analysis-python-pandas/loc-vs-iloc.mdx
+++ b/content/learn/data-analysis-python-pandas/loc-vs-iloc.mdx
@@ -196,7 +196,7 @@ This asymmetry surprises everyone the first time. Lock it in.`}
 - The first is shorter
 - They are equivalent
 - [o] The chained version may operate on a copy of the data and silently fail to update the original DataFrame (the *SettingWithCopyWarning*); \`loc\` guarantees in-place update on the original
-  > Correct. This is the single most common Pandas footgun. Always use \`loc\` for assignment.
+  > This is the single most common Pandas footgun. Always use \`loc\` for assignment.
 - Pandas does not support boolean masks
 
 Train your fingers to write \`df.loc[mask, "col"] = ...\` and you will save yourself many hours of debugging.`}

--- a/content/learn/data-analysis-python-pandas/merging-and-joining.mdx
+++ b/content/learn/data-analysis-python-pandas/merging-and-joining.mdx
@@ -319,7 +319,7 @@ Left joins are the workhorse of enrichment workflows.`}
 - copy=False
 - sort=True
 - [o] indicator=True — adds a \`_merge\` column showing which rows are left-only, right-only, or matched in both
-  > Correct. Always reach for this when row counts surprise you.
+  > Always reach for this when row counts surprise you.
 - on="*"
 
 \`indicator=True\` should be in every data analyst's debugging toolbox.`}

--- a/content/learn/data-analysis-python-pandas/messy-data-overview.mdx
+++ b/content/learn/data-analysis-python-pandas/messy-data-overview.mdx
@@ -217,7 +217,7 @@ A canonical mapping (\`"U.S."\` → \`"USA"\`, etc.) is the typical fix.`}
 - Removing the rows
 - Replacing the values with NaN
 - [o] Keeping the original values but adding a boolean column that marks them as suspicious, so reviewers can see your judgment without losing information
-  > Correct. Flagging is the least-destructive option — perfect when you are not 100% sure whether a value is wrong.
+  > Flagging is the least-destructive option — perfect when you are not 100% sure whether a value is wrong.
 - Coloring the cells
 
 Flagging preserves information while making your suspicions explicit and testable.`}

--- a/content/learn/data-analysis-python-pandas/missing-values.mdx
+++ b/content/learn/data-analysis-python-pandas/missing-values.mdx
@@ -326,7 +326,7 @@ Understanding *why* values are missing is essential before deciding how to handl
 - Replaces NaNs with 0
 - Removes NaNs from \`s\`
 - [o] Replaces NaNs with the median of the non-null values in \`s\`
-  > Correct. Median imputation is a robust default — it does not get pulled by outliers like the mean does.
+  > Median imputation is a robust default — it does not get pulled by outliers like the mean does.
 - Computes the median while ignoring NaNs
 
 For numeric columns where missingness is moderate and random, median imputation is a sensible default.`}

--- a/content/learn/data-analysis-python-pandas/notebooks-and-environments.mdx
+++ b/content/learn/data-analysis-python-pandas/notebooks-and-environments.mdx
@@ -234,7 +234,7 @@ The skills transfer directly.
 - To make Python run faster
 - To use more memory
 - [o] To isolate each project's package versions so that incompatible dependencies in different projects do not conflict
-  > Correct. Without virtual environments, two projects that need different versions of the same package will collide. Environments give each project its own package directory.
+  > Without virtual environments, two projects that need different versions of the same package will collide. Environments give each project its own package directory.
 - To prevent code from being copied
 
 Once you have been bitten by a version conflict, you become a virtual environment evangelist for life.`}

--- a/content/learn/data-analysis-python-pandas/pivot-tables.mdx
+++ b/content/learn/data-analysis-python-pandas/pivot-tables.mdx
@@ -294,7 +294,7 @@ Margins are a small but valuable feature when producing reports.`}
 - Convert to JSON instead
 - Delete the index manually
 - [o] Call \`.reset_index()\` (and optionally clear \`columns.name\`) to flatten the pivot back into a regular DataFrame
-  > Correct. CSV exports work best on flat, name-free DataFrames.
+  > CSV exports work best on flat, name-free DataFrames.
 - Use \`pivot\` instead of \`pivot_table\`
 
 Pivots are great for presentation but often need flattening before export or further joins.`}

--- a/content/learn/data-analysis-python-pandas/python-and-pandas-story.mdx
+++ b/content/learn/data-analysis-python-pandas/python-and-pandas-story.mdx
@@ -252,7 +252,7 @@ now used by millions every day.
 - The animal, because the logo is cute
 - A clever acronym
 - [o] "Panel data" — an econometrics term for multi-dimensional structured datasets, which is what McKinney was working with at AQR
-  > Correct. Pandas was originally designed for panel data in finance; the bear-themed branding came later as a happy coincidence.
+  > Pandas was originally designed for panel data in finance; the bear-themed branding came later as a happy coincidence.
 - "Python and dataframes"
 
 Knowing the origin helps explain why pandas takes labeled multi-dimensional data so seriously.`}

--- a/content/learn/data-analysis-python-pandas/python-for-analysis.mdx
+++ b/content/learn/data-analysis-python-pandas/python-for-analysis.mdx
@@ -349,7 +349,7 @@ for r, e in zip(results, expected):
 - \`0.075\`
 - \`7.5\`
 - [o] \`7.5%\`
-  > Correct. The \`.1%\` format multiplies by 100 and adds a percent sign, with one decimal place. Memorizing this format is worth the five seconds.
+  > The \`.1%\` format multiplies by 100 and adds a percent sign, with one decimal place. Memorizing this format is worth the five seconds.
 - \`75.0%\`
 
 Format specifiers like this make report-ready output trivial.`}

--- a/content/learn/data-analysis-python-pandas/rise-of-digital-datasets.mdx
+++ b/content/learn/data-analysis-python-pandas/rise-of-digital-datasets.mdx
@@ -178,7 +178,7 @@ This is the workflow we will use through the rest of the course.
 
 - Any dataset larger than 1,000 rows
 - [o] "Big data" is context-dependent — usually it means a dataset that does not fit on one machine's memory or disk, requiring distributed systems
-  > Correct. The chapter gives three rough tiers — bigger than a spreadsheet, bigger than memory, bigger than one machine — and notes that the third tier is what most practitioners mean by "big data".
+  > The chapter gives three rough tiers — bigger than a spreadsheet, bigger than memory, bigger than one machine — and notes that the third tier is what most practitioners mean by "big data".
 - Any dataset that contains numbers
 - Any dataset that requires Pandas
 

--- a/content/learn/data-analysis-python-pandas/rows-and-columns.mdx
+++ b/content/learn/data-analysis-python-pandas/rows-and-columns.mdx
@@ -301,7 +301,7 @@ A column is an attribute that applies to every row of the dataset.`}
 - The font used to display the data
 - The total size of the dataset in bytes
 - [o] The level of detail each row represents — for example "one row per customer" versus "one row per customer-month"
-  > Correct. Grain is one of the most under-discussed concepts in data work; getting it wrong leads to double-counting in joins and aggregations.
+  > Grain is one of the most under-discussed concepts in data work; getting it wrong leads to double-counting in joins and aggregations.
 - The color scheme of the table
 
 Always state the grain of a dataset before joining or aggregating it.`}

--- a/content/learn/data-analysis-python-pandas/selecting-data.mdx
+++ b/content/learn/data-analysis-python-pandas/selecting-data.mdx
@@ -286,7 +286,7 @@ Memorize: label-slice is inclusive; position-slice is exclusive.`}
 - An error
 - All rows of df
 - [o] The rows of df where status equals "active", keeping only the columns id and rev
-  > Correct. This is the canonical "filter rows AND project columns" pattern.
+  > This is the canonical "filter rows AND project columns" pattern.
 - The first row
 
 This pattern shows up many times per day in real analyst code.`}

--- a/content/learn/data-analysis-python-pandas/sorting-and-ranking.mdx
+++ b/content/learn/data-analysis-python-pandas/sorting-and-ranking.mdx
@@ -242,7 +242,7 @@ Either works; \`nlargest\` is the idiomatic choice.`}
 - It produces unique floating-point ranks
 - It removes ties
 - [o] Tied rows share a rank, and the *next distinct* rank value is one higher (no gaps), unlike \`"min"\` which leaves gaps
-  > Correct. With values \`[100, 80, 100, 60]\` sorted descending: \`"min"\` gives \`[1, 3, 1, 4]\`; \`"dense"\` gives \`[1, 2, 1, 3]\`.
+  > With values \`[100, 80, 100, 60]\` sorted descending: \`"min"\` gives \`[1, 3, 1, 4]\`; \`"dense"\` gives \`[1, 2, 1, 3]\`.
 - The result type is dense
 
 Choose the tie-breaking method that matches your business rule (Olympic-style, leaderboard, etc.).`}

--- a/content/learn/data-analysis-python-pandas/spreadsheets-and-business.mdx
+++ b/content/learn/data-analysis-python-pandas/spreadsheets-and-business.mdx
@@ -238,7 +238,7 @@ Reproducibility is the dominant reason organizations migrate analyses from Excel
 
 - Modern Excel allows infinite rows
 - [o] Even modern Excel caps a sheet at around one million rows, which is small by today's data standards — real-world tables routinely exceed that
-  > Correct. Modern \`.xlsx\` files cap at 1,048,576 rows (the classic \`.xls\` capped at 65,536). Web analytics, IoT, transaction logs, and many scientific datasets blow past this limit easily.
+  > Modern \`.xlsx\` files cap at 1,048,576 rows (the classic \`.xls\` capped at 65,536). Web analytics, IoT, transaction logs, and many scientific datasets blow past this limit easily.
 - The row limit is set by your operating system
 - The row limit only applies to text columns
 

--- a/content/learn/data-analysis-python-pandas/spreadsheets-vs-code.mdx
+++ b/content/learn/data-analysis-python-pandas/spreadsheets-vs-code.mdx
@@ -268,7 +268,7 @@ Speed and scale matter too, but the everyday win is reproducibility.`}
   markdown={`In the chapter's "recurring test," what is the heuristic for choosing between a spreadsheet and Pandas?
 
 - [o] If you will do this analysis more than twice, write it in code
-  > Correct. The upfront cost of code pays off as soon as you have to repeat the work. One-off analyses are still fine in a spreadsheet.
+  > The upfront cost of code pays off as soon as you have to repeat the work. One-off analyses are still fine in a spreadsheet.
 - If the dataset has more than 50 rows, use Pandas
 - If the analysis has more than 3 steps, use Excel
 - If you have meetings on Mondays, use Pandas

--- a/content/learn/data-analysis-python-pandas/string-operations.mdx
+++ b/content/learn/data-analysis-python-pandas/string-operations.mdx
@@ -339,7 +339,7 @@ Forgetting \`na=False\` is a classic gotcha when filtering string columns that c
 - It is faster than not expanding
 - It returns a Series of lists
 - [o] It returns a DataFrame, one column per split piece — perfect for splitting one column into many
-  > Correct. Useful for emails, names, addresses, anything with predictable delimiters.
+  > Useful for emails, names, addresses, anything with predictable delimiters.
 - It removes the @ sign
 
 The \`expand=True\` flag is the difference between a hard-to-use Series-of-lists and a friendly DataFrame.`}

--- a/content/learn/data-analysis-python-pandas/what-is-data-analysis.mdx
+++ b/content/learn/data-analysis-python-pandas/what-is-data-analysis.mdx
@@ -268,7 +268,7 @@ coming back to it.
 - Producing as many charts as possible
 - Memorizing Pandas function names
 - [o] A disciplined process of turning raw recorded observations into useful, defensible answers to questions humans care about
-  > Correct. Notice the three load-bearing words: *disciplined*, *useful*, *defensible*. None of them mentions a specific tool.
+  > Notice the three load-bearing words: *disciplined*, *useful*, *defensible*. None of them mentions a specific tool.
 - Building machine-learning models
 
 A useful definition is tool-independent.`}

--- a/content/learn/data-analysis-python-pandas/wide-vs-long.mdx
+++ b/content/learn/data-analysis-python-pandas/wide-vs-long.mdx
@@ -253,7 +253,7 @@ melt unpivots; pivot pivots.`}
 - They reject wide DataFrames
 - It uses less memory
 - [o] They map columns to plot aesthetics (x, y, color, facet) — a single tidy column for each variable plugs straight in
-  > Correct. Once you internalize the "one column per variable" rule, plotting becomes mechanical.
+  > Once you internalize the "one column per variable" rule, plotting becomes mechanical.
 - Wide format is deprecated
 
 The same principle underlies Seaborn, Plotly Express, and ggplot2.`}

--- a/content/learn/from-zero-to-cpp/a-brief-history.mdx
+++ b/content/learn/from-zero-to-cpp/a-brief-history.mdx
@@ -266,7 +266,7 @@ syntactic detail, is what this course will teach you.
 - Brian Kernighan, originally called "K&R++"
   > Kernighan co-wrote the famous C book but did not design C++.
 - [o] Bjarne Stroustrup, originally called "C with Classes"
-  > Correct. Stroustrup began the project at Bell Labs in 1979 and renamed it C++ in 1983.
+  > Stroustrup began the project at Bell Labs in 1979 and renamed it C++ in 1983.
 - Alan Kay, originally called "Smalltalk-C"
   > Kay designed Smalltalk, which influenced object-oriented programming but is not C++.`}
 />
@@ -279,7 +279,7 @@ syntactic detail, is what this course will teach you.
 - C++ is a strict subset of C, with fewer features.
   > It is the opposite — C++ adds many features on top of C.
 - [o] C++ began as an extension of C, and although most C programs still compile as C++, idiomatic modern C++ looks very different from idiomatic C.
-  > Correct. C++ grew classes, templates, RAII, and a large standard library on top of C's core model.
+  > C++ grew classes, templates, RAII, and a large standard library on top of C's core model.
 - C and C++ are competitors with no shared history.
   > They share decades of history and a great deal of syntax.`}
 />
@@ -292,7 +292,7 @@ syntactic detail, is what this course will teach you.
 - To replace C entirely in operating-system kernels.
   > Most kernels are still written in C; C++ adoption in kernels is partial and recent.
 - [o] To help programmers manage growing software complexity by bundling data with the functions that operate on it.
-  > Correct. As programs grew to hundreds of thousands of lines, encapsulation became essential.
+  > As programs grew to hundreds of thousands of lines, encapsulation became essential.
 - Because the C standard required it.
   > The C and C++ standards are independent of each other.`}
 />
@@ -307,7 +307,7 @@ syntactic detail, is what this course will teach you.
 - Procedural programming
   > C++ supports plain functions and procedural style; in fact, much C++ code is mostly procedural.
 - [o] Pure functional programming with strict immutability enforced by the compiler
-  > Correct. C++ supports a functional *style* with lambdas and algorithms, but the language does not enforce immutability the way Haskell does.`}
+  > C++ supports a functional *style* with lambdas and algorithms, but the language does not enforce immutability the way Haskell does.`}
 />
 
 Next, we'll zoom in on the machine itself: what actually happens

--- a/content/learn/from-zero-to-cpp/algorithms-intuition.mdx
+++ b/content/learn/from-zero-to-cpp/algorithms-intuition.mdx
@@ -192,7 +192,7 @@ int main() {
 - O(log n)
   > That would be repeatedly halving.
 - [o] O(n²)
-  > Correct. Each of the n outer iterations does n inner iterations.
+  > Each of the n outer iterations does n inner iterations.
 - O(n log n)
   > That is the cost of typical sorting algorithms.`}
 />
@@ -205,7 +205,6 @@ int main() {
 - It does not; it works on any range.
   > It works, but produces nonsense on unsorted input.
 - [o] It uses binary search internally; binary search is correct only if the elements are arranged in order.
-  > Correct.
 - It uses hashing.
   > It does not.`}
 />

--- a/content/learn/from-zero-to-cpp/arrays-and-strings.mdx
+++ b/content/learn/from-zero-to-cpp/arrays-and-strings.mdx
@@ -293,7 +293,7 @@ int main() {
 - Raw arrays are faster at runtime.
   > They are typically the same speed; \`std::array\` is a zero-cost wrapper.
 - [o] \`std::array\` knows its size, can be copied and returned by value, and works with standard algorithms, while raw arrays decay to pointers and forget their length.
-  > Correct. \`std::array\` removes most of the footguns without any runtime cost.
+  > \`std::array\` removes most of the footguns without any runtime cost.
 - They are interchangeable; the names are just different.
   > They differ in how they propagate type information.
 - Raw arrays live on the heap.
@@ -308,7 +308,7 @@ int main() {
 - It is O(n) every time.
   > That would make any vector-based algorithm slow; this isn't the case.
 - [o] Most pushes are O(1); when capacity is exceeded the vector reallocates and copies, but it grows geometrically, so the *average* cost per push is constant.
-  > Correct. This is the classic amortized-analysis argument.
+  > This is the classic amortized-analysis argument.
 - It is O(log n).
   > Logarithmic growth would make growth too slow; vectors double (or similar).`}
 />
@@ -319,7 +319,7 @@ int main() {
 - It allocates new storage.
   > Neither does.
 - [o] It checks the index against the vector's size and throws \`std::out_of_range\` if it is invalid; \`[]\` performs no such check.
-  > Correct. Use \`at\` when handling unvalidated input.
+  > Use \`at\` when handling unvalidated input.
 - It returns a copy instead of a reference.
   > Both return references.
 - It is significantly faster.

--- a/content/learn/from-zero-to-cpp/building-maintainable-software.mdx
+++ b/content/learn/from-zero-to-cpp/building-maintainable-software.mdx
@@ -180,7 +180,6 @@ that lasts from code that gets rewritten every two years.
 - It reduces the executable size.
   > Often the opposite, very slightly.
 - [o] Small functions with one responsibility are easier to read, name accurately, test in isolation, and reuse — which compounds into a much more maintainable codebase.
-  > Correct.
 - It is required by the C++ standard.
   > It is not.`}
 />
@@ -191,7 +190,6 @@ that lasts from code that gets rewritten every two years.
 - A comment that restates the next line of code in English.
   > Those tend to drift out of sync and add noise.
 - [o] A comment that captures *why* a non-obvious decision was made — context the reader cannot reconstruct from the code alone.
-  > Correct.
 - A header banner of equal signs.
   > Decoration is not insight.
 - A comment marking the end of every block.

--- a/content/learn/from-zero-to-cpp/classes-and-objects.mdx
+++ b/content/learn/from-zero-to-cpp/classes-and-objects.mdx
@@ -241,7 +241,7 @@ int main() {
 - They are the same thing.
   > They are distinct concepts.
 - [o] A class is a type — a blueprint describing data and operations. An object is an *instance* of that type, with its own copy of the data.
-  > Correct. Code creates many objects from one class.
+  > Code creates many objects from one class.
 - An object is a class with no methods.
   > That is incorrect.
 - A class can only exist once per program.
@@ -256,7 +256,7 @@ int main() {
 - It is required by the compiler.
   > It is optional.
 - [o] It documents and enforces that the method does not modify the object, allowing it to be called on \`const\` instances and helping readers reason about behaviour.
-  > Correct. Mark every observer method \`const\`.
+  > Mark every observer method \`const\`.
 - It hides the method from outside code.
   > That is what \`private:\` does.`}
 />

--- a/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
+++ b/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
@@ -296,7 +296,7 @@ implementation to the call from `main`.
   markdown={`Which stage of the pipeline expands \`#include\` directives?
 
 - [o] The preprocessor.
-  > Correct. The preprocessor pastes the entire contents of the included file before the compiler sees anything.
+  > The preprocessor pastes the entire contents of the included file before the compiler sees anything.
 - The compiler.
   > By the time the compiler runs, includes have already been expanded.
 - The assembler.
@@ -313,7 +313,7 @@ implementation to the call from `main`.
 - The compiler.
   > The compiler accepts a declaration of \`foo\`; it does not need a body.
 - [o] The linker.
-  > Correct. The linker tried to match a *use* of \`foo\` to a *definition* and could not find one.
+  > The linker tried to match a *use* of \`foo\` to a *definition* and could not find one.
 - The operating system at runtime.
   > By the time the OS runs the program, all references must already be resolved.`}
 />
@@ -326,7 +326,7 @@ implementation to the call from `main`.
 - Because compilers cannot read \`.cpp\` files.
   > Compilers absolutely can read \`.cpp\` files.
 - [o] To obey the One-Definition Rule: many \`.cpp\` files can share the same *declarations* (via \`#include\`) but the function must be *defined* in exactly one place.
-  > Correct. Putting definitions in headers would cause linker errors when the header is included by more than one source file.
+  > Putting definitions in headers would cause linker errors when the header is included by more than one source file.
 - Because headers run faster than source files.
   > Headers and source files do not "run"; they are just compiled.`}
 />
@@ -339,7 +339,7 @@ implementation to the call from `main`.
 - A source file with macros expanded.
   > That is the output of the preprocessor.
 - [o] An object file containing machine code plus tables of defined and required symbols.
-  > Correct. Object files are the puzzle pieces the linker assembles.
+  > Object files are the puzzle pieces the linker assembles.
 - An interpreter bytecode file.
   > C++ is not interpreted; it produces native machine code.`}
 />

--- a/content/learn/from-zero-to-cpp/computational-thinking.mdx
+++ b/content/learn/from-zero-to-cpp/computational-thinking.mdx
@@ -328,7 +328,7 @@ int main() {
 - Writing the answer in as few lines of code as possible.
   > Code golf is not decomposition.
 - [o] Breaking a large problem into smaller, more manageable sub-problems.
-  > Correct. Decomposition is the first step in turning a vague task into something programmable.
+  > Decomposition is the first step in turning a vague task into something programmable.
 - Memorizing the syntax of the language you are using.
   > Syntax knowledge is useful but unrelated to decomposition.
 - Deleting unnecessary features from a finished program.
@@ -341,7 +341,7 @@ int main() {
 - Bugs in your code.
   > Debugging is its own skill.
 - [o] Repetition that could be replaced by a single function or loop.
-  > Correct. Spotting repeated structure is the cue to abstract it.
+  > Spotting repeated structure is the cue to abstract it.
 - The fastest possible algorithm for a problem.
   > Selecting algorithms is more about analysis than pattern matching.
 - Which programming language to use.
@@ -354,7 +354,7 @@ int main() {
 - Pseudocode is faster to compile than C++.
   > Pseudocode is not compiled at all.
 - [o] It lets you reason about the algorithm without being distracted by syntax, and exposes flaws before you've committed to code.
-  > Correct. Many beginner bugs come from rushing into syntax before the algorithm is clear.
+  > Many beginner bugs come from rushing into syntax before the algorithm is clear.
 - The compiler will refuse C++ that wasn't preceded by pseudocode.
   > It will happily compile any valid C++.
 - Pseudocode automatically handles all edge cases.
@@ -371,7 +371,7 @@ int main() {
 - A list of all-equal elements.
   > Often a useful edge case.
 - [o] The exact list the interviewer happens to have in mind.
-  > Correct. Real programs do not know in advance what input they'll get; you must reason about *categories* of input, not specific cases.`}
+  > Real programs do not know in advance what input they'll get; you must reason about *categories* of input, not specific cases.`}
 />
 
 Next: variables and memory — what *is* a variable, really?

--- a/content/learn/from-zero-to-cpp/constructors-and-destructors.mdx
+++ b/content/learn/from-zero-to-cpp/constructors-and-destructors.mdx
@@ -223,7 +223,7 @@ int main() {
 - Whenever the compiler decides.
   > It runs deterministically.
 - [o] At the closing brace of the scope in which the object was created, in reverse order of construction.
-  > Correct. This is what makes RAII reliable.
+  > This is what makes RAII reliable.
 - When you explicitly call \`delete\` on it.
   > \`delete\` is only for objects created with \`new\`.`}
 />
@@ -236,7 +236,6 @@ int main() {
 - The body cannot reference members.
   > It can.
 - [o] The initializer list constructs each field directly with the right value, instead of default-constructing it first and then overwriting it. This is more efficient and required for \`const\` and reference members.
-  > Correct.
 - It causes the constructor to run twice.
   > It does not.`}
 />

--- a/content/learn/from-zero-to-cpp/control-flow.mdx
+++ b/content/learn/from-zero-to-cpp/control-flow.mdx
@@ -457,7 +457,7 @@ int main() {
 - They are interchangeable.
   > They are very different.
 - [o] \`==\` compares two values; \`=\` assigns the right-hand side to the left-hand side.
-  > Correct. \`if (x = 5)\` is almost certainly a bug.
+  > \`if (x = 5)\` is almost certainly a bug.
 - \`=\` compares; \`==\` assigns.
   > It is the other way around.
 - Both compare values, but \`==\` is faster.
@@ -470,7 +470,7 @@ int main() {
 - For backwards compatibility with Fortran.
   > That is not the reason.
 - [o] So the right-hand side is only evaluated when needed, which lets you write safe guards like \`p != nullptr && p->value > 0\`.
-  > Correct. Short-circuiting is essential for safe pointer access.
+  > Short-circuiting is essential for safe pointer access.
 - To make code run faster on multi-core CPUs.
   > Short-circuiting is unrelated to multi-core execution.
 - It is a quirk inherited from C with no real benefit.
@@ -485,7 +485,7 @@ int main() {
 - The case threw an exception that fell through to a handler.
   > \`switch\` is unrelated to exceptions.
 - [o] Without \`break\`, execution continues into the next case's body, running its code as well.
-  > Correct. Fall-through is occasionally useful but usually a bug; modern compilers warn about it.
+  > Fall-through is occasionally useful but usually a bug; modern compilers warn about it.
 - The compiler emitted a warning that the user can ignore.
   > Fall-through is a runtime behavior, not just a warning.`}
 />
@@ -498,7 +498,7 @@ int main() {
 - The current file.
   > Definitely not.
 - [o] Only inside the loop header and body; \`i\` ceases to exist after the loop ends.
-  > Correct. This is exactly the smallest-scope principle from the previous chapter.
+  > This is exactly the smallest-scope principle from the previous chapter.
 - All functions called from inside the loop.
   > A called function cannot see the caller's local variables.`}
 />

--- a/content/learn/from-zero-to-cpp/data-structures-intuition.mdx
+++ b/content/learn/from-zero-to-cpp/data-structures-intuition.mdx
@@ -171,7 +171,7 @@ almost always be slower than a vector.**
 - \`std::deque\`
   > Use it only when you really need double-ended push/pop.
 - [o] \`std::vector\`
-  > Correct. Contiguous storage is fast for iteration and most operations.
+  > Contiguous storage is fast for iteration and most operations.
 - \`std::map\`
   > That is a key/value container, not a plain sequence.`}
 />
@@ -184,7 +184,7 @@ almost always be slower than a vector.**
 - When the data fits in cache.
   > Both can.
 - [o] When you need to iterate keys in sorted order, or want bounded worst-case complexity instead of average-case.
-  > Correct. Otherwise \`unordered_map\` is usually faster.
+  > Otherwise \`unordered_map\` is usually faster.
 - Whenever performance matters.
   > \`unordered_map\` is generally faster for plain lookup.`}
 />

--- a/content/learn/from-zero-to-cpp/debugging-and-reasoning.mdx
+++ b/content/learn/from-zero-to-cpp/debugging-and-reasoning.mdx
@@ -167,7 +167,7 @@ A few standard tricks:
 - They are the only way to handle errors.
   > For real runtime errors, use \`if\` plus exceptions or status codes.
 - [o] They catch broken assumptions *near* the cause, by crashing immediately when an invariant is violated, instead of letting bad state propagate.
-  > Correct. They make bugs loud and local.
+  > They make bugs loud and local.
 - They throw a recoverable exception.
   > A failed assert typically calls \`abort()\`; it is not recoverable.`}
 />
@@ -180,7 +180,6 @@ A few standard tricks:
 - The compiler refuses to debug intermittent bugs.
   > Debuggers handle intermittent bugs; they're just harder.
 - [o] Until you can trigger the bug on demand, you cannot verify a fix or apply any debugging tool consistently; reproduction turns a mystery into a test case.
-  > Correct.
 - It is required by the C++ standard.
   > The standard says nothing about debugging methodology.`}
 />

--- a/content/learn/from-zero-to-cpp/dynamic-memory.mdx
+++ b/content/learn/from-zero-to-cpp/dynamic-memory.mdx
@@ -310,7 +310,7 @@ int main() {
 - Returns a copy of \`T\`.
   > It returns a *pointer* to a newly constructed object.
 - [o] Allocates enough memory for one \`T\` on the heap, constructs a \`T\` in it, and returns a pointer to it.
-  > Correct. Allocation + construction in one step.
+  > Allocation + construction in one step.
 - Frees existing memory and reallocates it.
   > That would be \`realloc\`, which is a C concept and not what \`new\` does.`}
 />
@@ -323,7 +323,7 @@ int main() {
 - The OS tracks them separately on disk.
   > The OS is not involved at that level of detail.
 - [o] \`new[]\` may record an element count alongside the allocation, and \`delete[]\` knows how to invoke each destructor and release the whole block; \`delete\` does not.
-  > Correct. Mixing them is undefined behavior.
+  > Mixing them is undefined behavior.
 - They are interchangeable in modern C++.
   > They are not.`}
 />
@@ -336,7 +336,7 @@ int main() {
 - It causes data corruption in unrelated objects.
   > That is *use-after-free* or buffer overflow, not a leak.
 - [o] Memory is allocated but never freed, so a long-running program can exhaust available memory over time.
-  > Correct. Leaks degrade reliability and performance of long-running services.
+  > Leaks degrade reliability and performance of long-running services.
 - It triggers a compile-time error.
   > Compilers don't track allocation/free pairs in general.`}
 />
@@ -349,7 +349,7 @@ int main() {
 - Use \`malloc\`/\`free\`.
   > Those are C functions; they don't construct C++ objects.
 - [o] Use \`std::unique_ptr\` (often via \`std::make_unique\`); its destructor frees the object automatically.
-  > Correct. This applies the RAII pattern and removes the need for manual \`delete\`.
+  > This applies the RAII pattern and removes the need for manual \`delete\`.
 - Allocate it on the stack with \`new\` followed by no \`delete\`.
   > \`new\` does not allocate on the stack.`}
 />

--- a/content/learn/from-zero-to-cpp/encapsulation-and-abstraction.mdx
+++ b/content/learn/from-zero-to-cpp/encapsulation-and-abstraction.mdx
@@ -146,7 +146,7 @@ Reach for `class` when you have something to protect.
 - A field whose value is fixed.
   > That would be a \`const\` member.
 - [o] A property of the object's state that must always hold whenever no method is in progress.
-  > Correct. The class's public methods are responsible for maintaining it.
+  > The class's public methods are responsible for maintaining it.
 - A type alias used by the class.
   > That is not the meaning here.`}
 />
@@ -159,7 +159,7 @@ Reach for `class` when you have something to protect.
 - It hides the field from the debugger.
   > It does not; debuggers can see private members.
 - [o] It prevents outside code from putting the object in an invalid state, letting the class defend its invariants.
-  > Correct. It also lets you change the storage without breaking callers.
+  > It also lets you change the storage without breaking callers.
 - It is required for inheritance.
   > It isn't.`}
 />

--- a/content/learn/from-zero-to-cpp/functions-and-modularity.mdx
+++ b/content/learn/from-zero-to-cpp/functions-and-modularity.mdx
@@ -458,7 +458,7 @@ int main() {
 - The function gets a pointer to the caller's string.
   > It gets a *reference*, which is similar in spirit but different in syntax and safety.
 - [o] The function gets an alias for the caller's string, with a promise not to modify it.
-  > Correct. This is the standard way to accept large read-only inputs without copying.
+  > This is the standard way to accept large read-only inputs without copying.
 - The function will compile only if the string is a literal.
   > Any string can be passed.`}
 />
@@ -469,7 +469,7 @@ int main() {
 - A loop inside the function.
   > A pure recursive function has no loop; the recursion *is* the repetition.
 - [o] A base case that returns without making another recursive call, and a recursive case that progresses toward the base case.
-  > Correct. Without both, you'll either never recurse or recurse forever.
+  > Without both, you'll either never recurse or recurse forever.
 - A maximum-depth guard set by the compiler.
   > The compiler does not insert such guards; you must design termination yourself.
 - A pointer parameter.
@@ -482,7 +482,7 @@ int main() {
 - A function call.
   > A call would have parentheses with arguments and no return type.
 - [o] A function **declaration**: it tells the compiler the signature without providing the body.
-  > Correct. The body (the *definition*) can appear later, or in another file.
+  > The body (the *definition*) can appear later, or in another file.
 - A typo — function bodies are mandatory.
   > Declarations without bodies are valid and common.
 - A way to make the function virtual.
@@ -495,7 +495,7 @@ int main() {
 - Because the linker can't sort by return type alone.
   > Linkers actually can encode types in symbol names; the rule is about *call resolution*.
 - [o] Because the compiler picks the right overload from the arguments at the call site, and arguments don't carry the call's expected return type.
-  > Correct. The compiler can't know which overload you meant if only the return type differs.
+  > The compiler can't know which overload you meant if only the return type differs.
 - For backwards compatibility with C.
   > C does not support overloading at all.
 - Because the standard does not allow two functions with the same name.

--- a/content/learn/from-zero-to-cpp/how-computers-execute.mdx
+++ b/content/learn/from-zero-to-cpp/how-computers-execute.mdx
@@ -244,7 +244,7 @@ detail to keep in mind for the next several chapters.
 - A bit
   > Bits are smaller, but most CPUs address memory in bytes, not bits.
 - [o] A byte
-  > Correct. Each byte has its own numeric address.
+  > Each byte has its own numeric address.
 - A word (4 or 8 bytes)
   > Words are read or written in groups, but the underlying addressing is by byte.
 - A page (typically 4096 bytes)
@@ -257,7 +257,7 @@ detail to keep in mind for the next several chapters.
 - It points to the start of the program file on disk.
   > Programs are loaded into memory before execution; the IP points within memory, not disk.
 - [o] It holds the memory address of the next instruction to execute.
-  > Correct. After each instruction it advances, except when a jump changes it.
+  > After each instruction it advances, except when a jump changes it.
 - It tells the operating system which process to schedule next.
   > Scheduling is done by the OS, not by the instruction pointer.
 - It stores the result of the most recent arithmetic operation.
@@ -270,7 +270,7 @@ detail to keep in mind for the next several chapters.
 - In CPU registers exclusively.
   > Some small variables may live in registers, but the model and the language describe them as living on the stack.
 - [o] In a new frame on the call stack.
-  > Correct. Each function call grows the stack; returning pops the frame.
+  > Each function call grows the stack; returning pops the frame.
 - On the heap, allocated by \`new\`.
   > Only variables explicitly allocated with \`new\` go on the heap.
 - In the data segment, alongside global variables.
@@ -285,7 +285,7 @@ detail to keep in mind for the next several chapters.
 - The stack is faster to read than the heap.
   > Allocation on the stack is much faster, but reads from either can be cached and equally fast.
 - [o] Because the lifetime, allocation cost, and management rules of stack and heap memory are different, and C++ exposes those differences so you can reason about them.
-  > Correct. C++ trades convenience for control on purpose.
+  > C++ trades convenience for control on purpose.
 - Only the heap can be freed; the stack lives forever.
   > It is the other way around — stack frames are freed automatically when functions return.`}
 />

--- a/content/learn/from-zero-to-cpp/inheritance-and-polymorphism.mdx
+++ b/content/learn/from-zero-to-cpp/inheritance-and-polymorphism.mdx
@@ -303,7 +303,7 @@ int main() {
 - It marks the function as faster to call.
   > Virtual functions are slightly *slower* due to the indirect call.
 - [o] It makes the function dispatched at runtime through the vtable, so calls via a base pointer/reference run the most-derived override.
-  > Correct. This is the mechanism for runtime polymorphism.
+  > This is the mechanism for runtime polymorphism.
 - It hides the function from derived classes.
   > That is what \`private\` does.
 - It is required for any inherited function.
@@ -318,7 +318,6 @@ int main() {
 - It makes destruction faster.
   > It is slightly slower.
 - [o] So that \`delete\` through a base-class pointer also calls the derived destructor and releases derived-class resources; otherwise you get a partial cleanup which is undefined behavior.
-  > Correct.
 - It is purely stylistic.
   > It has real semantic consequences.`}
 />

--- a/content/learn/from-zero-to-cpp/memory-model.mdx
+++ b/content/learn/from-zero-to-cpp/memory-model.mdx
@@ -293,7 +293,7 @@ container/pointer to do it for you.
 - On the heap, allocated by \`new\` each call.
   > They are allocated once for the whole program.
 - [o] In the data segment, alongside globals — its memory survives between calls.
-  > Correct. A \`static\` local is essentially a hidden global with restricted scope.
+  > A \`static\` local is essentially a hidden global with restricted scope.
 - In CPU registers.
   > Registers are too small and too temporary for this.`}
 />
@@ -306,7 +306,7 @@ container/pointer to do it for you.
 - The OS reclaims them at process exit.
   > That would happen eventually, but it would be a leak in the meantime.
 - [o] The vector's destructor runs automatically when the local goes out of scope, and it frees the heap memory for you.
-  > Correct. This is RAII: ownership is tied to a stack object.
+  > This is RAII: ownership is tied to a stack object.
 - The compiler issues a warning.
   > No warning is needed because there is no leak.`}
 />
@@ -317,7 +317,7 @@ container/pointer to do it for you.
 - \`new std::vector<int>(1000)\`
   > That allocates the vector handle on the heap AND the 1000-int buffer on the heap.
 - [o] \`int x = 0;\` inside a function.
-  > Correct. A stack allocation is essentially "advance the stack pointer by 4 bytes," which the CPU can do in a single instruction.
+  > A stack allocation is essentially "advance the stack pointer by 4 bytes," which the CPU can do in a single instruction.
 - \`int* p = new int[1000];\`
   > Heap allocation requires bookkeeping in the allocator.
 - A \`std::string\` of length 1000 declared as a local.
@@ -332,7 +332,7 @@ container/pointer to do it for you.
 - Scope is runtime, storage duration is compile-time.
   > It is the other way around in spirit: scope is a compile-time concept (about names), storage duration is a runtime concept (about memory).
 - [o] Scope is the region of source code where a name is visible; storage duration is how long the underlying memory lives at runtime.
-  > Correct. A \`static\` local is the textbook example: small scope, but long storage duration.
+  > A \`static\` local is the textbook example: small scope, but long storage duration.
 - Storage duration only applies to heap allocations.
   > It applies to every variable, in every region.`}
 />

--- a/content/learn/from-zero-to-cpp/move-semantics-intuition.mdx
+++ b/content/learn/from-zero-to-cpp/move-semantics-intuition.mdx
@@ -158,7 +158,7 @@ needs no special members*.
 - It moves \`x\` immediately and zeros it out.
   > It does not move anything by itself.
 - [o] It is a cast that lets \`x\` bind to an rvalue reference, enabling a move constructor or move assignment to transfer ownership from \`x\`.
-  > Correct. The actual move happens in the operation that consumes the rvalue.
+  > The actual move happens in the operation that consumes the rvalue.
 - It deletes \`x\`.
   > It does not delete anything.
 - It marks \`x\` as \`const\`.
@@ -173,7 +173,7 @@ needs no special members*.
 - The standard library uses a global pool.
   > It does not.
 - [o] The vector is either constructed directly into the caller's location (copy elision) or its internal pointer is moved instead of copying the elements.
-  > Correct. Both are pointer-level operations.
+  > Both are pointer-level operations.
 - Because \`std::vector\` is small.
   > A vector's *handle* is small (a few pointers/sizes); the heap buffer it owns can be huge.`}
 />

--- a/content/learn/from-zero-to-cpp/pointers-and-references.mdx
+++ b/content/learn/from-zero-to-cpp/pointers-and-references.mdx
@@ -381,7 +381,7 @@ int main() {
 - A copy of an object stored elsewhere.
   > Pointers do not copy the pointee; they refer to it.
 - [o] A variable whose value is the memory address of another object, paired with a type that describes what's at that address.
-  > Correct. The type lets the compiler dereference and step through memory correctly.
+  > The type lets the compiler dereference and step through memory correctly.
 - A type-erased reference to any value.
   > Pointers are *typed*; this is what \`void*\` would attempt to do.`}
 />
@@ -392,7 +392,7 @@ int main() {
 - They must be initialized when declared.
   > True; you cannot create an uninitialized reference.
 - [o] You can later make a reference refer to a different object by assigning to it.
-  > Correct. References cannot be rebound; assigning to a reference modifies the *referent*.
+  > References cannot be rebound; assigning to a reference modifies the *referent*.
 - They cannot be null.
   > True; the language guarantees a reference refers to a real object.
 - They are usually compiled to a hidden pointer.
@@ -407,7 +407,7 @@ int main() {
 - The OS will always send SIGSEGV.
   > Most modern OSes do, but the standard does not require any particular signal.
 - [o] Because \`nullptr\` does not point to any valid object, the language places no restrictions on what happens; the compiler is allowed to do anything.
-  > Correct. Always check or guarantee non-null before dereferencing.
+  > Always check or guarantee non-null before dereferencing.
 - It is well-defined; it always returns 0.
   > It does not; that is a common myth.`}
 />
@@ -420,7 +420,7 @@ int main() {
 - It allocates a new field \`x\` on \`p\`.
   > Members cannot be added at runtime in C++.
 - [o] It is shorthand for \`(*p).x\`: dereference the pointer, then access member \`x\`.
-  > Correct. The arrow is purely a convenience.
+  > The arrow is purely a convenience.
 - It is undefined behavior.
   > Only if \`p\` is invalid; for a valid pointer the syntax is perfectly well-defined.`}
 />

--- a/content/learn/from-zero-to-cpp/raii-and-resources.mdx
+++ b/content/learn/from-zero-to-cpp/raii-and-resources.mdx
@@ -176,7 +176,7 @@ RAII wrappers, where the language can enforce correctness.
 - Recursive Algorithm Implementation Interface.
   > Also not a real term.
 - [o] *Resource Acquisition Is Initialization*: acquire resources in constructors and release them in destructors, so that scope exit always cleans up correctly.
-  > Correct. It is the foundation of modern C++ resource management.
+  > It is the foundation of modern C++ resource management.
 - Read-After-Initialize Idiom; read fields after constructing.
   > That is not what RAII means.`}
 />
@@ -189,7 +189,7 @@ RAII wrappers, where the language can enforce correctness.
 - The runtime keeps a list of every \`new\` and calls \`delete\` for each.
   > It does not; you must arrange ownership yourself.
 - [o] During stack unwinding, the destructors of every fully-constructed object in scope run automatically, releasing their resources.
-  > Correct. This is why RAII makes exception safety practical.
+  > This is why RAII makes exception safety practical.
 - It does not; exceptions are unsafe and you should disable them.
   > Modern C++ relies on exception-safe RAII.`}
 />

--- a/content/learn/from-zero-to-cpp/smart-pointers.mdx
+++ b/content/learn/from-zero-to-cpp/smart-pointers.mdx
@@ -231,7 +231,6 @@ int main() {
 - It allows multiple owners.
   > That is what \`shared_ptr\` does.
 - [o] It applies RAII: the destructor runs on scope exit and reliably deletes the owned object, eliminating leaks, double-deletes, and use-after-free bugs on the *owner* side.
-  > Correct.
 - It is the only legal way to use the heap in modern C++.
   > Raw \`new\` is still legal; just usually unwise.`}
 />
@@ -244,7 +243,6 @@ int main() {
 - For all polymorphic objects.
   > Polymorphism does not by itself require shared ownership.
 - [o] When the lifetime of the object is genuinely shared across multiple owners that may release it in any order — and \`unique_ptr\` cannot capture that.
-  > Correct.
 - For any object larger than 64 bytes.
   > Size is unrelated to ownership shape.`}
 />

--- a/content/learn/from-zero-to-cpp/structs-and-aggregates.mdx
+++ b/content/learn/from-zero-to-cpp/structs-and-aggregates.mdx
@@ -234,7 +234,7 @@ int main() {
 - \`class\` is allocated on the heap, \`struct\` on the stack.
   > Storage location is independent of \`struct\` vs \`class\`.
 - [o] The default member access: \`struct\` members are public by default, \`class\` members are private by default.
-  > Correct. Conventions add more meaning, but the language only distinguishes default access.
+  > Conventions add more meaning, but the language only distinguishes default access.
 - \`struct\` does not support inheritance.
   > It does.`}
 />
@@ -245,7 +245,7 @@ int main() {
 - It allocates memory on the heap.
   > It does not; \`p\` is a local on the stack.
 - [o] The fields hold whatever bytes were already in that memory, so reading them is undefined behavior until you assign meaningful values.
-  > Correct. Prefer \`Point p{};\` or aggregate initialization with explicit values.
+  > Prefer \`Point p{};\` or aggregate initialization with explicit values.
 - It is forbidden by the C++ standard.
   > It is allowed; that's why it's a footgun.
 - It causes the compiler to emit a warning.

--- a/content/learn/from-zero-to-cpp/the-call-stack.mdx
+++ b/content/learn/from-zero-to-cpp/the-call-stack.mdx
@@ -288,7 +288,7 @@ The stack is the secret protagonist of every C++ program.
 - The visible part of the call stack in your debugger UI.
   > That is one way to *view* a frame, but the frame itself is a memory concept.
 - [o] A region of memory allocated on entry to a function that holds its parameters, locals, and bookkeeping such as the return address.
-  > Correct. Each function call creates a new frame; returning destroys it.
+  > Each function call creates a new frame; returning destroys it.
 - A shared region of memory used by all currently-running threads.
   > Each thread has its own stack; frames are per-call, not shared.
 - A backup copy of all global variables at the time of the call.
@@ -303,7 +303,7 @@ The stack is the secret protagonist of every C++ program.
 - The OS encrypts stack memory after a function returns.
   > It does not.
 - [o] When the function returns, its frame is popped and the memory may be reused; the pointer then refers to something that no longer exists, which is undefined behavior.
-  > Correct. Return by value, or return something heap-allocated.
+  > Return by value, or return something heap-allocated.
 - Local variables are read-only and cannot be addressed.
   > Local variables are perfectly addressable while they exist.`}
 />
@@ -316,7 +316,7 @@ The stack is the secret protagonist of every C++ program.
 - A loop that ran too many iterations.
   > A loop reuses the same stack space; it doesn't grow the stack.
 - [o] Unbounded recursion (or a missing base case) caused the call stack to outgrow the OS-imposed size limit.
-  > Correct. Either fix the base case, or convert the recursion to iteration.
+  > Either fix the base case, or convert the recursion to iteration.
 - The program tried to print too much to standard output.
   > Output is unrelated to the call stack.`}
 />
@@ -331,7 +331,7 @@ The stack is the secret protagonist of every C++ program.
 - In a separate "parameter segment" of memory.
   > C++ does not have such a thing; parameters live in the callee's frame.
 - [o] In the callee's stack frame, initialized from the caller's arguments at the moment of the call.
-  > Correct. Parameters are just local variables that the language sets up for you on entry.`}
+  > Parameters are just local variables that the language sets up for you on entry.`}
 />
 
 Up next: zoom out from the stack to the *whole* memory model — what

--- a/content/learn/from-zero-to-cpp/types-and-values.mdx
+++ b/content/learn/from-zero-to-cpp/types-and-values.mdx
@@ -351,7 +351,7 @@ int main() {
 - The compiler always emits a warning, so the operation is forbidden.
   > It is not forbidden — but the result is often surprising.
 - [o] Floating-point arithmetic is approximate; many decimal values cannot be represented exactly in binary, so the comparison may fail even for inputs that look mathematically equal.
-  > Correct. Use a tolerance (\`std::abs(a-b) < eps\`) for floating-point equality.
+  > Use a tolerance (\`std::abs(a-b) < eps\`) for floating-point equality.
 - It is dangerous only on 32-bit systems.
   > It is true everywhere; IEEE-754 behaves the same way on all platforms.`}
 />
@@ -362,7 +362,7 @@ int main() {
 - A reinterpret_cast.
   > That is for low-level pointer reinterpretation; using it for arithmetic is dangerous.
 - [o] A static_cast, e.g. \`static_cast<int>(3.9)\`.
-  > Correct. \`static_cast\` is the right tool for ordinary numeric conversions.
+  > \`static_cast\` is the right tool for ordinary numeric conversions.
 - A const_cast.
   > That is for removing \`const\`, not for type changes.
 - A dynamic_cast.
@@ -377,7 +377,7 @@ int main() {
 - It uses less memory.
   > The storage is typically the same.
 - [o] It gives the values a distinct type, so the compiler can prevent misuse like mixing colors with unrelated integers.
-  > Correct. \`enum class\` is a type-safety win.
+  > \`enum class\` is a type-safety win.
 - It is required by the C++ standard.
   > The language allows plain integers too; \`enum class\` is just better hygiene.`}
 />
@@ -390,7 +390,7 @@ int main() {
 - Whenever you want a variable that might change later.
   > Both \`const\` and \`constexpr\` forbid changes after initialization.
 - [o] When the value is genuinely known at compile time and you may need it in a context that requires a compile-time constant (array sizes, template arguments, etc.).
-  > Correct. \`constexpr\` is a compile-time promise; \`const\` is only a runtime "do not modify" promise.
+  > \`constexpr\` is a compile-time promise; \`const\` is only a runtime "do not modify" promise.
 - Only inside template metaprogramming code.
   > \`constexpr\` is useful in everyday code too.`}
 />

--- a/content/learn/from-zero-to-cpp/variables-and-memory.mdx
+++ b/content/learn/from-zero-to-cpp/variables-and-memory.mdx
@@ -345,7 +345,7 @@ int main() {
 - A copy of data stored in the CPU's registers permanently.
   > Variables can be cached in registers temporarily but they live in memory.
 - [o] A name bound to a region of memory of a known type and size.
-  > Correct. The compiler tracks the binding; the OS and CPU manage the memory.
+  > The compiler tracks the binding; the OS and CPU manage the memory.
 - A pointer to a row in a database table.
   > That is not what the C++ language means by "variable".`}
 />
@@ -358,7 +358,7 @@ int main() {
 - The compiler refuses to compile the program.
   > Compilers warn about this in many cases, but the standard does not require an error.
 - [o] You get **undefined behavior**: the bytes in that memory are whatever happened to be there, and any code that uses them may misbehave.
-  > Correct. Always initialize, ideally with \`int x{};\` or an explicit value.
+  > Always initialize, ideally with \`int x{};\` or an explicit value.
 - The runtime throws a NullVariableException.
   > C++ does not throw exceptions for uninitialized variables.`}
 />
@@ -371,7 +371,7 @@ int main() {
 - It guarantees the variable will be optimized away.
   > Optimization is the compiler's choice; \`const\` is a *contract*.
 - [o] It tells the compiler that this variable's value must not change after initialization, and prevents any code that tries to.
-  > Correct. \`const\` is one of the simplest ways to make code safer to read.
+  > \`const\` is one of the simplest ways to make code safer to read.
 - It exports the variable to other source files.
   > That role is filled by \`extern\`, not \`const\`.`}
 />
@@ -382,7 +382,7 @@ int main() {
 - Because \`auto\` makes the variable dynamically typed.
   > C++ remains statically typed; \`auto\` does not change that.
 - [o] Because the compiler still determines a single concrete type at compile time and locks it in; \`auto\` only saves you from spelling the type out.
-  > Correct. \`auto x = 42;\` makes \`x\` exactly an \`int\` and nothing else.
+  > \`auto x = 42;\` makes \`x\` exactly an \`int\` and nothing else.
 - Because \`auto\` only works in templates.
   > \`auto\` works in many places, including ordinary local variables.
 - Because the type is decided at runtime based on what you assign first.

--- a/content/learn/from-zero-to-cpp/your-first-program.mdx
+++ b/content/learn/from-zero-to-cpp/your-first-program.mdx
@@ -267,7 +267,7 @@ int main() {
 - It returns the number zero from the program to the caller of \`main\`.
   > Technically true, but the meaning of that number matters more than the number itself.
 - [o] It signals to the operating system that the program completed successfully.
-  > Correct. By convention, \`0\` means success and any other value means a particular kind of failure.
+  > By convention, \`0\` means success and any other value means a particular kind of failure.
 - It frees all memory used by the program.
   > Memory cleanup is performed automatically by the OS when the process ends.
 - It is required only in debug builds.
@@ -282,7 +282,7 @@ int main() {
 - Because C++ uses dollar signs to indicate variables.
   > C++ does not use dollar signs for that.
 - [o] Because \`cout\` lives in the standard-library namespace \`std\`, and \`std::cout\` fully qualifies which \`cout\` we mean.
-  > Correct. Namespaces prevent collisions between libraries that happen to share short names.
+  > Namespaces prevent collisions between libraries that happen to share short names.
 - Because \`std\` makes the program run faster.
   > Namespaces have no runtime cost.`}
 />
@@ -293,7 +293,7 @@ int main() {
 - The two characters backslash and \`n\`.
   > Only if it were written as \`\\\\n\`.
 - [o] A single newline character.
-  > Correct. \`\\n\` is shorthand for the newline byte.
+  > \`\\n\` is shorthand for the newline byte.
 - The end of the string.
   > Strings end with an implicit null byte in C++ string literals; \`\\n\` is just a newline.
 - A tab character.
@@ -306,7 +306,7 @@ int main() {
 - They are the same thing.
   > They have different *types* and different storage.
 - [o] \`'a'\` is a single \`char\` (1 byte), while \`"a"\` is a string literal of two characters (\`'a'\` followed by a hidden null terminator).
-  > Correct. The type of \`'a'\` is \`char\`; the type of \`"a"\` is \`const char[2]\`.
+  > The type of \`'a'\` is \`char\`; the type of \`"a"\` is \`const char[2]\`.
 - \`'a'\` is a string; \`"a"\` is a character.
   > It is the opposite.
 - \`"a"\` is invalid; only single quotes work.

--- a/content/learn/functional-programming-typescript/algebraic-data-types.mdx
+++ b/content/learn/functional-programming-typescript/algebraic-data-types.mdx
@@ -442,7 +442,7 @@ export function area(s: Shape): number {
 - Unions use less memory at runtime
   > Memory layout is essentially the same — both are plain objects.
 - [o] A discriminated union ties each piece of data to the variant that needs it, so impossible combinations of fields cannot exist
-  > Correct. With optional fields, the type permits nonsense like "active AND suspended". A union forbids that statically: each variant carries exactly the data it needs, no more.
+  > With optional fields, the type permits nonsense like "active AND suspended". A union forbids that statically: each variant carries exactly the data it needs, no more.
 - Unions don't need a "kind" tag
   > They do — the tag is what makes the union *discriminated* and what TypeScript narrows on.
 

--- a/content/learn/functional-programming-typescript/capstone-pipeline.mdx
+++ b/content/learn/functional-programming-typescript/capstone-pipeline.mdx
@@ -243,7 +243,7 @@ of building this way.
 - Every \`.ts\` file is small
   > Helpful, but not the structural reason.
 - [o] All business logic lives in pure functions that take data and return data, with side effects confined to a tiny shell — so each piece can be tested with plain inputs, and the parts you'll want to change live where you expect them
-  > Correct. The architectural choice of "pure core, imperative shell" is what turns a *style* (FP) into a *system property* (maintainability).
+  > The architectural choice of "pure core, imperative shell" is what turns a *style* (FP) into a *system property* (maintainability).
 - The program is short
   > Toy programs are easy to test for many reasons; the *real* benefit scales to large programs.
 

--- a/content/learn/functional-programming-typescript/category-theory-intuitions.mdx
+++ b/content/learn/functional-programming-typescript/category-theory-intuitions.mdx
@@ -341,7 +341,7 @@ export function map2<A, B, C>(
 - Whenever the operation might throw an error
   > Errors alone don't decide it; it depends on whether the *next step* itself returns a container.
 - [o] When the function you want to apply returns another value of the same container type — for example \`(a: A) => Option<B>\` — and you want a flat \`Option<B>\` instead of \`Option<Option<B>>\`
-  > Correct. \`flatMap\` is the operator that *flattens* one layer of container. \`map\` would leave you nested.
+  > \`flatMap\` is the operator that *flattens* one layer of container. \`map\` would leave you nested.
 - When you want to combine two independent containers
   > That's applicative (\`map2\`/\`ap\`), not monad.
 - When you want to discard the wrapper completely

--- a/content/learn/functional-programming-typescript/composable-architecture.mdx
+++ b/content/learn/functional-programming-typescript/composable-architecture.mdx
@@ -283,7 +283,7 @@ export function topSpender(orders: ReadonlyArray<Order>): string | null {
 - In the shell, because the shell knows where the data came from
   > The shell should be as dumb as possible: gather inputs, call the core, write outputs.
 - [o] In the pure core, as functions of \`(state, input) → output\` that depend on no I/O
-  > Correct. Centralizing decisions in pure code makes them inspectable, testable, replayable, and independent of infrastructure choices.
+  > Centralizing decisions in pure code makes them inspectable, testable, replayable, and independent of infrastructure choices.
 - Spread evenly throughout the codebase
   > That's the *anti*-pattern this architecture exists to avoid.
 

--- a/content/learn/functional-programming-typescript/declarative-thinking.mdx
+++ b/content/learn/functional-programming-typescript/declarative-thinking.mdx
@@ -364,7 +364,7 @@ export function avgPerCategory(sales: readonly Sale[]): ReadonlyMap<string, numb
 - Code that has no \`if\` statements
   > Conditionals are fine in declarative code (often as ternaries, pattern matches, or \`filter\` predicates).
 - [o] Code that describes *what* you want as an expression over data, rather than *how* to compute it as a sequence of mutating steps
-  > Correct. The defining shift is from "step-by-step procedure mutating state" to "expression that names the answer". Operators like \`map\`, \`filter\`, \`reduce\` give you the vocabulary; immutability and purity make it sound.
+  > The defining shift is from "step-by-step procedure mutating state" to "expression that names the answer". Operators like \`map\`, \`filter\`, \`reduce\` give you the vocabulary; immutability and purity make it sound.
 - Code that uses TypeScript classes
   > Classes are orthogonal to the imperative/declarative axis.
 

--- a/content/learn/functional-programming-typescript/effect-management.mdx
+++ b/content/learn/functional-programming-typescript/effect-management.mdx
@@ -210,7 +210,7 @@ like to happen.
 - It hides the side effect from the rest of the program
   > Actually, it makes it *visible* in the type signature.
 - [o] It separates *describing* an effect from *running* it, so descriptions can be composed, tested, retried, swapped, or interpreted differently without changing the rest of the code
-  > Correct. The pure core builds recipes; a small interpreter at the edge executes them. Tests can substitute a different interpreter.
+  > The pure core builds recipes; a small interpreter at the edge executes them. Tests can substitute a different interpreter.
 - It guarantees the effect will only run once
   > That's an idempotency guarantee, not what effect-as-value gives you.
 

--- a/content/learn/functional-programming-typescript/evolution-of-complexity.mdx
+++ b/content/learn/functional-programming-typescript/evolution-of-complexity.mdx
@@ -244,7 +244,7 @@ lambda calculus through Lisp and Haskell to the modern ecosystem.
 - It is always slower than immutable data
   > Performance is not the core problem. Mutable code can be very fast. The problem is comprehension and correctness, not speed.
 - [o] The behavior of a function depends on the entire history of every other function that touched the same state
-  > Correct. With mutable shared state, a function's outputs depend not just on its inputs but on *when* it ran and *who* ran before it. That coupling grows quadratically with the size of the codebase.
+  > With mutable shared state, a function's outputs depend not just on its inputs but on *when* it ran and *who* ran before it. That coupling grows quadratically with the size of the codebase.
 - TypeScript cannot type-check mutable variables
   > TypeScript does type-check mutable variables. The issue is not typing but reasoning: types describe shape, not history.
 - It always causes the program to crash

--- a/content/learn/functional-programming-typescript/function-composition.mdx
+++ b/content/learn/functional-programming-typescript/function-composition.mdx
@@ -388,7 +388,7 @@ export const slug = (s: string): string =>
 - \`compose\` curries its arguments; \`pipe\` does not
   > Currying is independent of composition direction.
 - [o] They express the same idea in different argument orders; \`compose(f, g)(x) = f(g(x))\`, while \`pipe(x, g, f)\` applies \`g\` first then \`f\`
-  > Correct. \`compose\` reads right-to-left (the math convention); \`pipe\` reads left-to-right, which usually matches data flow more naturally in TypeScript.
+  > \`compose\` reads right-to-left (the math convention); \`pipe\` reads left-to-right, which usually matches data flow more naturally in TypeScript.
 - \`compose\` can only combine two functions; \`pipe\` works for any number
   > Both can be variadic depending on the implementation.
 

--- a/content/learn/functional-programming-typescript/functional-async-workflows.mdx
+++ b/content/learn/functional-programming-typescript/functional-async-workflows.mdx
@@ -323,7 +323,7 @@ export function run(userId: string): TaskResult<string, string> {
 - Tasks can hold synchronous values, Promises can't
   > Both can hold synchronous values; \`Promise.resolve(x)\` is fine.
 - [o] A \`Task\` is *lazy* — building one does no work, so you can compose, retry, parallelize, or substitute it without accidentally kicking off the computation
-  > Correct. A \`Promise\` starts running the moment it's created; that's not always what you want when composing. A \`Task\` is a recipe you choose when to run.
+  > A \`Promise\` starts running the moment it's created; that's not always what you want when composing. A \`Task\` is a recipe you choose when to run.
 - Tasks cannot fail
   > They certainly can; you usually pair them with \`Result\` (as \`TaskResult<E, A>\`) for typed failure.
 

--- a/content/learn/functional-programming-typescript/functional-state-management.mdx
+++ b/content/learn/functional-programming-typescript/functional-state-management.mdx
@@ -352,7 +352,7 @@ export function reduce(state: State, action: Action): State {
 - Because reducers can be written without TypeScript
   > Irrelevant — most reducers in real codebases *do* use TypeScript.
 - [o] Because each transition is a pure function — same inputs give the same output — so state changes are predictable, replayable, and trivially testable
-  > Correct. Purity buys you predictability, replayability, time-travel debugging, and ordinary unit-testability for free.
+  > Purity buys you predictability, replayability, time-travel debugging, and ordinary unit-testability for free.
 - Because reducers can mutate the state in place for performance
   > That defeats almost every benefit listed above.
 - Because actions are usually classes

--- a/content/learn/functional-programming-typescript/generic-abstractions-and-type-classes.mdx
+++ b/content/learn/functional-programming-typescript/generic-abstractions-and-type-classes.mdx
@@ -306,7 +306,7 @@ export function combineAll<A>(s: Semigroup<A>, xs: ReadonlyArray<A>): A | undefi
 - It must work for some specific union of concrete types
   > Closer, but parametric means *every* type, not a chosen list.
 - [o] It works uniformly for every choice of \`A\` and makes no assumptions about \`A\`'s structure
-  > Correct. Parametric polymorphism gives the strongest guarantees: because the function knows *nothing* about \`A\`, very few behaviors are compatible with its type.
+  > Parametric polymorphism gives the strongest guarantees: because the function knows *nothing* about \`A\`, very few behaviors are compatible with its type.
 - It uses \`unknown\` everywhere and casts at the boundary
   > That defeats the purpose — \`unknown\` erases the polymorphism.
 

--- a/content/learn/functional-programming-typescript/higher-order-functions.mdx
+++ b/content/learn/functional-programming-typescript/higher-order-functions.mdx
@@ -403,7 +403,7 @@ export function mapInput<A, B>(f: (a: A) => B, v: Validator<B>): Validator<A> {
 - A function defined at the top level of a module
   > "Top-level" refers to scope, not behavior.
 - [o] A function that takes another function as an argument, returns a function, or both
-  > Correct. This is the literal definition. It is what makes \`map\`, \`filter\`, \`reduce\`, decorators, factories, and most FP abstractions possible.
+  > This is the literal definition. It is what makes \`map\`, \`filter\`, \`reduce\`, decorators, factories, and most FP abstractions possible.
 - A function annotated with TypeScript generics
   > Generic and higher-order are different concepts. A function can be one without the other (though they often appear together).
 

--- a/content/learn/functional-programming-typescript/immutability.mdx
+++ b/content/learn/functional-programming-typescript/immutability.mdx
@@ -434,7 +434,7 @@ export function totalQty(cart: Cart): number {
 - It removes the need for unit tests
   > It makes unit tests easier, but you still write them. Immutability isn't a replacement for testing.
 - [o] You can pass a value across modules and be certain nobody can change it behind your back
-  > Correct. The contract "this value will not change" is the single most useful guarantee for reasoning about cross-module behavior. It eliminates an entire class of bug ("who mutated my data?") without any runtime cost.
+  > The contract "this value will not change" is the single most useful guarantee for reasoning about cross-module behavior. It eliminates an entire class of bug ("who mutated my data?") without any runtime cost.
 - It makes \`==\` always work correctly
   > Equality in JavaScript is reference-based by default for objects, regardless of mutability. Immutability doesn't change that.
 

--- a/content/learn/functional-programming-typescript/next-steps.mdx
+++ b/content/learn/functional-programming-typescript/next-steps.mdx
@@ -142,7 +142,7 @@ Welcome to the club.
 - Switch immediately to Haskell
   > Haskell is a great teacher, but you'll learn far more by *applying* what you already know.
 - [o] Consistently apply the patterns you've learned in real code you maintain, until they become reflexive — and only then layer libraries on top
-  > Correct. The patterns are the durable part; libraries are conveniences. Internalize the patterns first, ship code with them, then adopt a library to remove the boilerplate.
+  > The patterns are the durable part; libraries are conveniences. Internalize the patterns first, ship code with them, then adopt a library to remove the boilerplate.
 - Read every paper on category theory
   > Wonderful when you're curious, but not the limiting factor.
 

--- a/content/learn/functional-programming-typescript/option-and-result.mdx
+++ b/content/learn/functional-programming-typescript/option-and-result.mdx
@@ -412,7 +412,7 @@ export function emailOfManagerOf(id: string): Option<string> {
 - It hides errors from the caller
   > The opposite — it makes errors *unhideable*.
 - [o] The error possibility appears in the function's return type, so the caller is forced by the compiler to handle it
-  > Correct. With exceptions, a function's failure modes are invisible in its type. With \`Result<E, A>\`, the failure is part of the signature; you literally cannot read \`.value\` without first checking \`.kind\`.
+  > With exceptions, a function's failure modes are invisible in its type. With \`Result<E, A>\`, the failure is part of the signature; you literally cannot read \`.value\` without first checking \`.kind\`.
 - It eliminates the need for the \`try\`/\`catch\` keyword
   > You can still use \`try\`/\`catch\` at boundaries (e.g. wrapping a throwing API). \`Result\` is about *what flows through your own code*, not what the language permits.
 

--- a/content/learn/functional-programming-typescript/pattern-matching.mdx
+++ b/content/learn/functional-programming-typescript/pattern-matching.mdx
@@ -334,7 +334,7 @@ export function apply(balance: number, e: Event): number {
 - It throws an error at runtime when an unhandled case occurs
   > Only as a secondary effect. The real value is at *compile* time.
 - [o] It causes a compile error if a new variant is added to the union and not handled, because the value would no longer be of type \`never\`
-  > Correct. The pattern turns "I forgot to handle this case" from a runtime surprise into a build-time error.
+  > The pattern turns "I forgot to handle this case" from a runtime surprise into a build-time error.
 - It improves runtime performance of the \`switch\`
   > No measurable effect.
 

--- a/content/learn/functional-programming-typescript/pure-functions.mdx
+++ b/content/learn/functional-programming-typescript/pure-functions.mdx
@@ -322,7 +322,7 @@ export function meanOfSquares(xs: readonly number[]): number {
 - \`const roll = (): number => Math.floor(Math.random() * 6) + 1;\`
   > Not pure — it reads from a random number generator, so two calls with no arguments can give different results.
 - [o] \`const triple = (x: number): number => x * 3;\`
-  > Correct. Output depends only on the input, and the function has no side effects.
+  > Output depends only on the input, and the function has no side effects.
 - \`const logAndReturn = (x: number): number => { console.log(x); return x; };\`
   > Not pure — it has the side effect of writing to standard output, even though the return value depends only on \`x\`.
 - \`const push = (xs: number[], x: number): void => { xs.push(x); };\`

--- a/content/learn/functional-programming-typescript/referential-transparency.mdx
+++ b/content/learn/functional-programming-typescript/referential-transparency.mdx
@@ -297,7 +297,7 @@ edge — exactly the same pattern as in [Pure Functions](./pure-functions).
 - It eliminates the need for unit tests
   > It makes tests easier and more reliable, but you still write them.
 - [o] It lets you replace an expression with its value anywhere it appears, enabling caching, parallelism, inlining, reordering, and equational reasoning
-  > Correct. The single property "this expression equals this value, everywhere" unlocks essentially every classical compiler optimization *and* every refactoring you'd want to do by hand.
+  > The single property "this expression equals this value, everywhere" unlocks essentially every classical compiler optimization *and* every refactoring you'd want to do by hand.
 - It makes pointer aliasing safe
   > Aliasing is mostly a non-issue in TypeScript, and it's not what referential transparency is about.
 

--- a/content/learn/functional-programming-typescript/roots-of-functional-thinking.mdx
+++ b/content/learn/functional-programming-typescript/roots-of-functional-thinking.mdx
@@ -292,7 +292,7 @@ third is the style we will spend the rest of the course mastering.
 - A library for working with mathematical functions in TypeScript
   > It is not a library. It is a formal system that predates computers.
 - [o] A 1936 formal system in which functions are the only primitive — Turing-complete and the foundation of functional programming
-  > Correct. The lambda calculus is where the *idea* "everything is a function" was first made rigorous. Every functional language is, at heart, a way of writing programs in that system.
+  > The lambda calculus is where the *idea* "everything is a function" was first made rigorous. Every functional language is, at heart, a way of writing programs in that system.
 - A type-inference algorithm used by Haskell and ML
   > Type inference (Hindley–Milner) is a *separate* invention from the lambda calculus, though it operates on lambda-calculus-like programs.
 

--- a/content/learn/functional-programming-typescript/type-driven-design.mdx
+++ b/content/learn/functional-programming-typescript/type-driven-design.mdx
@@ -346,7 +346,7 @@ export function next(state: Checkout, event: Event): Checkout {
 - Parsing happens at compile time; validation happens at runtime
   > Both run at runtime. The difference is what they *return*.
 - [o] Validation checks a constraint and returns the same type; parsing checks a constraint and returns a *stricter* type that carries the proof going forward
-  > Correct. Once you have a value of the stricter type, the rest of the program doesn't need to re-check the constraint — the type system does.
+  > Once you have a value of the stricter type, the rest of the program doesn't need to re-check the constraint — the type system does.
 - Validation is faster than parsing
   > No meaningful difference; both are typically a few CPU cycles.
 

--- a/content/learn/functional-programming-typescript/typescript-meets-fp.mdx
+++ b/content/learn/functional-programming-typescript/typescript-meets-fp.mdx
@@ -340,7 +340,7 @@ that has a `Foo.map` method".
 - The \`strict\` compiler flag
   > Strict mode enables many useful checks, but it doesn't itself model your domain. It's a *prerequisite*, not the mechanism.
 - [o] Discriminated unions with exhaustiveness checking
-  > Correct. By modeling "this is one of N possibilities" as a discriminated union and then handling every variant in a \`switch\`, you make impossible combinations *unrepresentable* in the types. The compiler enforces it.
+  > By modeling "this is one of N possibilities" as a discriminated union and then handling every variant in a \`switch\`, you make impossible combinations *unrepresentable* in the types. The compiler enforces it.
 - Interfaces
   > Interfaces model *product types* — a record with these fields. They cannot express "one of several alternatives", which is what we need to rule out illegal combinations.
 

--- a/content/learn/intro-data-viz-plotly/best-practices.mdx
+++ b/content/learn/intro-data-viz-plotly/best-practices.mdx
@@ -150,7 +150,7 @@ When in doubt about a "X vs Y" question with both numeric, reach for a scatter.`
 - Human-readable axis labels with units.
 - Y-axis starts at zero for bars.
 - [o] The chart uses at least three colors.
-  > Correct — this is the odd one out. Color count has nothing to do with chart quality; many of the best charts use a single color or grayscale. The other three (title, labels, honest axis) are essential.
+  > This is the odd one out. Color count has nothing to do with chart quality; many of the best charts use a single color or grayscale. The other three (title, labels, honest axis) are essential.
 
 Use color only when it encodes meaningful information.`}
 />

--- a/content/learn/intro-data-viz-plotly/ethics-and-accessibility.mdx
+++ b/content/learn/intro-data-viz-plotly/ethics-and-accessibility.mdx
@@ -181,7 +181,7 @@ This is one of the most common — and most reliably criticized — ways charts 
 - Adding meaningful alt text.
 - Using high-contrast text.
 - [o] Adding a 3-D effect to the bars.
-  > Correct — this is the odd one out. 3-D effects make charts *harder* to read for everyone, including users with vision impairments. The other three (colorblind palettes, alt text, contrast) all expand who can read your chart.
+  > This is the odd one out. 3-D effects make charts *harder* to read for everyone, including users with vision impairments. The other three (colorblind palettes, alt text, contrast) all expand who can read your chart.
 
 Accessibility is not "extra polish" — it's basic competence. ~8% of men can't reliably distinguish red from green.`}
 />

--- a/content/learn/intro-data-viz-plotly/histograms.mdx
+++ b/content/learn/intro-data-viz-plotly/histograms.mdx
@@ -221,7 +221,7 @@ Catching bimodality early can completely change your analysis. A summary statist
 - "What's the most common range of values?"
 - "Are there outliers far from the typical range?"
 - [o] "What's the correlation between income and education?"
-  > Correct — this is the odd one out. Correlation is a *two-variable* question, best answered with a scatter plot. Histograms are designed for *one* variable's distribution. The other three questions all concern the shape of a single variable, which is exactly what a histogram shows.
+  > This is the odd one out. Correlation is a *two-variable* question, best answered with a scatter plot. Histograms are designed for *one* variable's distribution. The other three questions all concern the shape of a single variable, which is exactly what a histogram shows.
 
 Match the chart type to the *number of variables* and the *kind of question* you're asking.`}
 />

--- a/content/learn/intro-data-viz-plotly/history-of-visual-communication.mdx
+++ b/content/learn/intro-data-viz-plotly/history-of-visual-communication.mdx
@@ -132,7 +132,7 @@ Van Langren's insight — that a picture of data can reveal a story numbers alon
   markdown={`Which chart types is **William Playfair** credited with inventing or popularizing?
 
 - [o] Line chart, bar chart, and pie chart.
-  > Correct. Playfair introduced the line chart and bar chart in his 1786 *Commercial and Political Atlas* and the pie chart in his later *Statistical Breviary* (1801). All three are still among the most-used chart types on Earth.
+  > Playfair introduced the line chart and bar chart in his 1786 *Commercial and Political Atlas* and the pie chart in his later *Statistical Breviary* (1801). All three are still among the most-used chart types on Earth.
 - Scatter plot and heatmap.
 - 3-D surface plot and treemap.
 - Histogram and box plot.

--- a/content/learn/intro-data-viz-plotly/how-humans-perceive-visuals.mdx
+++ b/content/learn/intro-data-viz-plotly/how-humans-perceive-visuals.mdx
@@ -190,7 +190,7 @@ If something is important, encode it with a pre-attentive feature so it pops out
 - Area.
 - Angle.
 - [o] Position along a common scale.
-  > Correct. Position along a shared axis (the x or y axis of a chart) is the most accurate visual encoding for quantitative comparison. This is why bar charts and scatter plots are so powerful — they use position for the things you want to compare precisely.
+  > Position along a shared axis (the x or y axis of a chart) is the most accurate visual encoding for quantitative comparison. This is why bar charts and scatter plots are so powerful — they use position for the things you want to compare precisely.
 
 Length is second. Color and area are far down the list. Plan your charts accordingly.`}
 />

--- a/content/learn/intro-data-viz-plotly/introducing-plotly-express.mdx
+++ b/content/learn/intro-data-viz-plotly/introducing-plotly-express.mdx
@@ -216,7 +216,7 @@ The fact that **fig** is a real Python object is what makes Plotly Express exten
 - Column names as the values of **x**, **y**, **color**, etc.
 - A **template=...** argument for visual styling.
 - [o] A function that runs the chart against a SQL database directly.
-  > Correct — this is the odd one out. Plotly Express does not query databases. You first load data into a pandas DataFrame (using SQL, CSV, Parquet, or whatever), and *then* you call Plotly Express. Keeping data loading separate from charting is a feature, not a limitation.
+  > This is the odd one out. Plotly Express does not query databases. You first load data into a pandas DataFrame (using SQL, CSV, Parquet, or whatever), and *then* you call Plotly Express. Keeping data loading separate from charting is a feature, not a limitation.
 
 Pandas does the loading and reshaping; Plotly Express does the visualization. Two tools, one workflow.`}
 />

--- a/content/learn/intro-data-viz-plotly/line-charts.mdx
+++ b/content/learn/intro-data-viz-plotly/line-charts.mdx
@@ -221,7 +221,7 @@ A common test: if reordering the x-axis would make the chart "say something diff
 - Facet into one mini-chart per country.
 - Highlight 3 countries in color and gray out the rest.
 - [o] Increase the line thickness for all 30 countries.
-  > Correct — this is the odd one out. Thicker lines just make the tangle *more visible*. The other three fixes (filtering, faceting, selective highlighting) all *reduce the cognitive load* the chart asks of the reader. Spaghetti is a structural problem; styling cannot rescue it.
+  > This is the odd one out. Thicker lines just make the tangle *more visible*. The other three fixes (filtering, faceting, selective highlighting) all *reduce the cognitive load* the chart asks of the reader. Spaghetti is a structural problem; styling cannot rescue it.
 
 A good rule: ~7 lines is the practical max for a single chart. Past that, you need a different structure.`}
 />

--- a/content/learn/intro-data-viz-plotly/python-for-analytics.mdx
+++ b/content/learn/intro-data-viz-plotly/python-for-analytics.mdx
@@ -195,7 +195,7 @@ Almost every page of this course starts with a **px.data.something()** call that
 - Python is faster than C++ for numerical code.
 - Python charts are prettier than R charts.
 - [o] Python is "good enough" at everything from data pipelines to ML to web apps, so analysts rarely have to leave it.
-  > Correct. Python is rarely the *best* language for any single task, but the cost of switching languages mid-project is high. By being adequate at everything, Python eliminated the friction of "which language do I write this next part in?"
+  > Python is rarely the *best* language for any single task, but the cost of switching languages mid-project is high. By being adequate at everything, Python eliminated the friction of "which language do I write this next part in?"
 - Python is the only language with notebooks.
 
 R, Julia, and even SQL have notebook-like environments — but the Python ecosystem became self-reinforcing first, and now leads by a wide margin.`}

--- a/content/learn/intro-data-viz-plotly/rise-of-business-intelligence.mdx
+++ b/content/learn/intro-data-viz-plotly/rise-of-business-intelligence.mdx
@@ -185,7 +185,7 @@ BI predates "data science" by about 30 years and is still, by revenue, far large
 - Code is always faster than dragging and dropping.
 - Tableau cannot produce interactive charts.
 - [o] Code makes analyses **reproducible**, **version-controllable**, **customizable**, and easy to embed alongside the reasoning that produced them.
-  > Correct. Dragging and dropping is great for fast exploration, but the moment you need to re-run an analysis in six months — or share *exactly* how you got a number — code wins. Both approaches have their place.
+  > Dragging and dropping is great for fast exploration, but the moment you need to re-run an analysis in six months — or share *exactly* how you got a number — code wins. Both approaches have their place.
 - Code is required by law for financial reporting.
 
 Many serious analytics teams use *both*: dashboards for stakeholders, code-based notebooks for the rigorous work behind them.`}

--- a/content/learn/intro-data-viz-plotly/spreadsheets-to-interactive.mdx
+++ b/content/learn/intro-data-viz-plotly/spreadsheets-to-interactive.mdx
@@ -188,7 +188,7 @@ If you remember one rule about interactive design, make it this one.`}
 - It makes charts look more professional.
 - It allows charts to animate.
 - [o] It lets the *viewer* ask follow-up questions — hover for detail, filter to subsets, zoom into regions — without re-running code.
-  > Correct. Interactivity changes the *cognitive workload* of analysis. A static chart can only answer the questions the author anticipated; an interactive chart can answer the questions the viewer discovers on the spot.
+  > Interactivity changes the *cognitive workload* of analysis. A static chart can only answer the questions the author anticipated; an interactive chart can answer the questions the viewer discovers on the spot.
 - It is required by web browsers.
 
 The exploratory loop "overview → zoom → filter → detail" is dramatically faster with interactive charts than with static ones.`}
@@ -213,7 +213,7 @@ Plotly Express in Python eventually compiles down to Plotly.js, which itself use
 - You can zoom into a region of interest.
 - You can filter series by clicking the legend.
 - [o] They guarantee that your conclusions are statistically valid.
-  > Correct — this is the odd one out. Interactive charts make exploration *faster* and *richer*, but they do **not** validate your statistics. You still need careful analysis behind the visualization. Pretty interactivity will not save a bad analysis.
+  > This is the odd one out. Interactive charts make exploration *faster* and *richer*, but they do **not** validate your statistics. You still need careful analysis behind the visualization. Pretty interactivity will not save a bad analysis.
 
 A chart, no matter how interactive, is a *tool for thinking*, not a substitute for thinking.`}
 />

--- a/content/learn/intro-data-viz-plotly/the-rise-of-plotly.mdx
+++ b/content/learn/intro-data-viz-plotly/the-rise-of-plotly.mdx
@@ -231,7 +231,7 @@ This three-layer stack (Plotly Express → plotly.py → Plotly.js) is invisible
 - It is faster than plotly.graph_objects.
 - It produces static images.
 - [o] It is a high-level wrapper that takes a DataFrame and column names, producing a complete chart in essentially one function call.
-  > Correct. Plotly Express trades fine-grained control for brevity. One line of **px.bar(df, x=..., y=...)** replaces nine lines of **graph_objects** code, and the chart is just as interactive.
+  > Plotly Express trades fine-grained control for brevity. One line of **px.bar(df, x=..., y=...)** replaces nine lines of **graph_objects** code, and the chart is just as interactive.
 - It requires a paid Plotly subscription.
 
 Both are free and open source. When you outgrow Plotly Express, you can always drop down to **graph_objects** for fine control.`}

--- a/content/learn/intro-data-viz-plotly/what-is-data-visualization.mdx
+++ b/content/learn/intro-data-viz-plotly/what-is-data-visualization.mdx
@@ -187,7 +187,7 @@ The bar chart is a textbook statistical visualization. The other three are visua
 - It applies a password to the chart file.
 - It uses statistical formulas internally.
 - [o] It maps columns of data to visual properties such as position, length, color, size, or shape.
-  > Correct. "Encoding" is the term for the *rules* of the map between data and image. **x="year"** is an encoding: it maps the **year** column to horizontal position. Every choice you make in **px.bar(...)** or **px.scatter(...)** is an encoding decision.
+  > "Encoding" is the term for the *rules* of the map between data and image. **x="year"** is an encoding: it maps the **year** column to horizontal position. Every choice you make in **px.bar(...)** or **px.scatter(...)** is an encoding decision.
 - It compresses the data.
 
 Encoding is the central design act of visualization. We'll devote a whole chapter to it shortly.`}

--- a/content/learn/intro-data-viz-plotly/why-charts-exist.mdx
+++ b/content/learn/intro-data-viz-plotly/why-charts-exist.mdx
@@ -190,7 +190,7 @@ Tables for look-up; charts for patterns. Many good reports use both.`}
 - Inviting over-interpretation of short trends.
 - Imposing the author's framing through axes and colors.
 - [o] Always being slower to read than tables.
-  > Correct — this is the odd one out. Charts are typically *much faster* to read than tables for pattern-finding tasks. The other three are real failure modes: charts can hide small differences, suggest spurious trends, and reflect the author's framing more strongly than a raw table.
+  > This is the odd one out. Charts are typically *much faster* to read than tables for pattern-finding tasks. The other three are real failure modes: charts can hide small differences, suggest spurious trends, and reflect the author's framing more strongly than a raw table.
 
 Being honest about the limits of each tool is what separates competent analysts from naïve ones.`}
 />

--- a/content/learn/intro-data-viz-plotly/why-interactivity-changed-everything.mdx
+++ b/content/learn/intro-data-viz-plotly/why-interactivity-changed-everything.mdx
@@ -167,7 +167,7 @@ The Plotly mode bar (zoom, pan, lasso, reset) and the hover tooltip together imp
 - Click-dragging to zoom into a region.
 - Clicking a legend item to hide a series.
 - [o] Editing the data values by clicking a bar and typing a new value.
-  > Correct — this is the odd one out. Plotly charts are read-only by design. You can hover, zoom, pan, filter via legend, and download — but you cannot edit the underlying data through the chart. If you want editable charts you need a dashboard framework like Plotly Dash with form widgets.
+  > This is the odd one out. Plotly charts are read-only by design. You can hover, zoom, pan, filter via legend, and download — but you cannot edit the underlying data through the chart. If you want editable charts you need a dashboard framework like Plotly Dash with form widgets.
 
 Read-only interactivity is enough for 95% of analytical work. The other 5% is what dashboard frameworks exist for.`}
 />

--- a/content/learn/intro-modern-csharp/anders-and-birth-of-csharp.mdx
+++ b/content/learn/intro-modern-csharp/anders-and-birth-of-csharp.mdx
@@ -195,7 +195,7 @@ software.
 - Minimalism — keep the language as small as possible
   > C# is the opposite — it has grown a lot of pragmatic features over time.
 - [o] Pragmatic productivity: strong static typing, but ergonomic syntax and great tooling support
-  > Correct. You can trace this philosophy from Turbo Pascal through Delphi, C#, and TypeScript.
+  > You can trace this philosophy from Turbo Pascal through Delphi, C#, and TypeScript.
 - Direct memory control, like C
   > C# leaves low-level memory control to the runtime, deliberately.`}
 />
@@ -206,7 +206,7 @@ software.
 - It declares a variable that has no type
   > Every C# variable has a type — including \`var\` ones.
 - [o] It tells the compiler to infer the variable's type from the expression on the right, while still treating the variable as statically typed
-  > Correct. \`var x = "hi";\` is exactly equivalent to \`string x = "hi";\` — the compiler figures it out.
+  > \`var x = "hi";\` is exactly equivalent to \`string x = "hi";\` — the compiler figures it out.
 - It declares a global variable
   > It has nothing to do with scope.
 - It's the same as \`dynamic\`

--- a/content/learn/intro-modern-csharp/classes-and-objects.mdx
+++ b/content/learn/intro-modern-csharp/classes-and-objects.mdx
@@ -327,7 +327,7 @@ Console.WriteLine($"perimeter={r.Perimeter()}");
 - A class is created at runtime; an object is created at compile time
   > It's the opposite — classes are described in source; objects are created at runtime.
 - [o] A class is a blueprint; an object is an actual instance built from that blueprint at runtime
-  > Correct. One class can have any number of objects.
+  > One class can have any number of objects.
 - A class is a value type; an object is a reference type
   > Classes are always reference types in C#, but that doesn't define the relationship.`}
 />
@@ -338,7 +338,6 @@ Console.WriteLine($"perimeter={r.Perimeter()}");
 - It destroys the object when it's no longer needed
   > That's the GC's job (and, conceptually, a finalizer).
 - [o] It runs once when the object is created, typically to initialize the object's data into a valid state
-  > Correct.
 - It runs every time a method on the object is called
   > It runs only at creation time.
 - It is required to return a value

--- a/content/learn/intro-modern-csharp/collections.mdx
+++ b/content/learn/intro-modern-csharp/collections.mdx
@@ -285,7 +285,7 @@ public static class WordCounter
 - \`string[]\`
   > Same problem — and arrays don't grow.
 - [o] \`HashSet<string>\`
-  > Correct. Sets are designed for fast membership tests and automatic de-duplication.
+  > Sets are designed for fast membership tests and automatic de-duplication.
 - \`Dictionary<string, string>\`
   > Possible, but wasteful: there's no value to associate with each key.`}
 />
@@ -298,7 +298,7 @@ public static class WordCounter
 - It returns a default value silently
   > It doesn't — \`TryGetValue\` is the safe alternative.
 - [o] It throws a \`KeyNotFoundException\`
-  > Correct. Use \`ContainsKey\` or \`TryGetValue\` to look up safely.
+  > Use \`ContainsKey\` or \`TryGetValue\` to look up safely.
 - It adds the key with a default value
   > That would be surprising; the indexer doesn't do that on read.`}
 />

--- a/content/learn/intro-modern-csharp/computational-thinking.mdx
+++ b/content/learn/intro-modern-csharp/computational-thinking.mdx
@@ -318,7 +318,7 @@ Console.WriteLine($"sum of evens = {sum}");
 - Using fewer comments
   > Comments are not the issue.
 - [o] Deciding that, for your task tracker, a task is just "title + due date + status", and ignoring colors, fonts, file formats, and disk layout
-  > Correct. Abstraction is choosing what to ignore so you can focus on what matters.
+  > Abstraction is choosing what to ignore so you can focus on what matters.
 - Always using \`var\` instead of a full type
   > That's a style choice; it has nothing to do with abstraction.`}
 />
@@ -331,7 +331,7 @@ Console.WriteLine($"sum of evens = {sum}");
 - Abstraction
   > Closely related, but not the precise name.
 - [o] Pattern recognition
-  > Correct. Both problems are the "find the maximum of a collection" pattern.
+  > Both problems are the "find the maximum of a collection" pattern.
 - Refactoring
   > Refactoring changes existing code without changing behavior; that's a different activity.`}
 />

--- a/content/learn/intro-modern-csharp/control-flow.mdx
+++ b/content/learn/intro-modern-csharp/control-flow.mdx
@@ -359,7 +359,6 @@ real test was watching the whole time.
 - All branches always run
   > Definitely not.
 - [o] Only the *first* matching branch runs; the rest are skipped
-  > Correct.
 - The compiler picks the branch with the shortest condition
   > It does not.`}
 />
@@ -374,7 +373,7 @@ real test was watching the whole time.
 - \`for\` with a counter
   > Possible, but \`foreach\` makes intent clearer for "every element."
 - [o] \`foreach\`
-  > Correct. \`foreach\` says "for every element" directly and avoids off-by-one errors.`}
+  > \`foreach\` says "for every element" directly and avoids off-by-one errors.`}
 />
 
 <MultipleChoice
@@ -385,7 +384,6 @@ real test was watching the whole time.
 - Restarts the entire loop from the beginning
   > It doesn't reset the loop variable; it just moves on to the next iteration.
 - [o] Skips the rest of the current iteration's body and goes on to the next iteration
-  > Correct.
 - Ends the program
   > It does not.`}
 />

--- a/content/learn/intro-modern-csharp/debugging-and-reasoning.mdx
+++ b/content/learn/intro-modern-csharp/debugging-and-reasoning.mdx
@@ -213,7 +213,7 @@ initial value of `max`. Initialize it to `xs[0]` and try again.
 - Run it a few times to see if the problem repeats
   > Sometimes useful, but secondary.
 - [o] Read the stack trace from the top — the exception type and the file/line tell you what went wrong and where
-  > Correct. Most bugs are visible right there.
+  > Most bugs are visible right there.
 - Reinstall the .NET SDK
   > Extremely unlikely to be the cause.`}
 />
@@ -224,7 +224,7 @@ initial value of `max`. Initialize it to `xs[0]` and try again.
 - It might break the build
   > Possible, but not the main problem.
 - [o] Even if the symptom goes away, you don't know *which* change fixed it, so you've learned nothing and may have introduced new bugs
-  > Correct. One controlled change at a time is how you actually make progress.
+  > One controlled change at a time is how you actually make progress.
 - The compiler refuses to compile multi-change files
   > It does not.
 - Git makes it impossible

--- a/content/learn/intro-modern-csharp/early-programming-complexity.mdx
+++ b/content/learn/intro-modern-csharp/early-programming-complexity.mdx
@@ -189,7 +189,7 @@ that is the next chapter of our story.
 - Assembly produced faster programs
   > Not really — assembly translates one-for-one into the same machine code, so it doesn't make the program faster.
 - [o] Assembly used readable mnemonics like \`MOV\` and labels instead of raw numbers, making programs easier to write and debug
-  > Correct. Assembly is essentially a human-friendly notation for the exact same instructions.
+  > Assembly is essentially a human-friendly notation for the exact same instructions.
 - Assembly programs could run on any CPU
   > No. Assembly is still CPU-specific.
 - Assembly removed the need for memory management
@@ -204,7 +204,7 @@ that is the next chapter of our story.
 - Programming languages were too high-level
   > The complaint was the opposite — that the tools and styles weren't *high-level enough* to manage big programs.
 - [o] As programs grew larger, the dominant style (procedural code with global state) became impossible to maintain reliably
-  > Correct. That motivated the search for better ways to *organize* large codebases — which led directly to OOP.
+  > That motivated the search for better ways to *organize* large codebases — which led directly to OOP.
 - Universities weren't training enough programmers
   > Workforce size was a separate concern; the crisis was about the *practice* of building software.`}
 />

--- a/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
+++ b/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
@@ -313,7 +313,7 @@ catch (ArgumentException)
 - It reduces the number of lines of code
   > Often it adds a few lines (properties, validation).
 - [o] It localizes the rules that govern a piece of data, so the rest of the program can't accidentally violate them
-  > Correct. Invariants are enforced in one place.
+  > Invariants are enforced in one place.
 - It makes classes immutable
   > Encapsulation does not require immutability.`}
 />
@@ -324,7 +324,7 @@ catch (ArgumentException)
 - A class with no fields
   > That's just an empty class.
 - [o] Hiding *how* something works behind a stable interface that says *what* it does
-  > Correct. Abstraction is about what callers see.
+  > Abstraction is about what callers see.
 - Making all members \`public\`
   > That's the opposite of abstraction.
 - Replacing classes with structs

--- a/content/learn/intro-modern-csharp/error-handling.mdx
+++ b/content/learn/intro-modern-csharp/error-handling.mdx
@@ -337,7 +337,7 @@ Console.WriteLine(SafeMath.SumNumbers(data));
 - Only when you want to crash the program
   > Exceptions are designed to be *caught*, not just to crash.
 - [o] When the failure is unusual or unexpected, and forcing every call site to check for it would be noisy
-  > Correct. Ordinary, expected failures should use return values like \`TryParse\`.
+  > Ordinary, expected failures should use return values like \`TryParse\`.
 - Whenever your method touches a file
   > Reaching for exceptions reflexively misses the real distinction.`}
 />
@@ -350,7 +350,7 @@ Console.WriteLine(SafeMath.SumNumbers(data));
 - The compiler removes it
   > It doesn't.
 - [o] It hides bugs by swallowing every exception, even ones you never anticipated
-  > Correct. The program continues with corrupt state and you have no idea anything went wrong.
+  > The program continues with corrupt state and you have no idea anything went wrong.
 - It uses too much memory
   > Memory isn't the issue.`}
 />

--- a/content/learn/intro-modern-csharp/evolution-of-dotnet.mdx
+++ b/content/learn/intro-modern-csharp/evolution-of-dotnet.mdx
@@ -217,7 +217,6 @@ runtime, so every example you see should run in your browser.
 - They are the same thing with different marketing
   > Not quite — they're separate codebases with different capabilities.
 - [o] .NET Framework is the original Windows-only, closed-source product (still maintained). Modern .NET (formerly .NET Core, now .NET 5/6/7/8+) is cross-platform, open-source, and where all new development happens.
-  > Correct.
 - .NET Framework is faster than modern .NET
   > In fact, modern .NET has had major performance improvements every release.
 - Modern .NET only runs on Linux
@@ -230,7 +229,7 @@ runtime, so every example you see should run in your browser.
 - Removing features to make the language smaller
   > C# has been *adding* features, not removing them.
 - [o] Adding ergonomic features that let you express the same ideas with less ceremony (top-level statements, records, pattern matching, etc.)
-  > Correct. The language has grown, but each addition is meant to *reduce* boilerplate around something you were already doing.
+  > The language has grown, but each addition is meant to *reduce* boilerplate around something you were already doing.
 - Replacing the runtime with the JVM
   > That has not happened and would not make sense.
 - Making C# look more like assembly

--- a/content/learn/intro-modern-csharp/how-programs-execute.mdx
+++ b/content/learn/intro-modern-csharp/how-programs-execute.mdx
@@ -270,7 +270,7 @@ picture.
 - A Word document
   > No.
 - [o] An assembly (a \`.dll\` or \`.exe\`) containing Intermediate Language (IL)
-  > Correct. IL is a portable lower-level representation that the .NET runtime knows how to execute.
+  > IL is a portable lower-level representation that the .NET runtime knows how to execute.
 - A pre-rendered video of your program running
   > No.`}
 />
@@ -283,7 +283,6 @@ picture.
 - They are the same thing
   > They are distinct memory regions with different lifetime rules.
 - [o] The stack holds short-lived bookkeeping for method calls (parameters, locals, return addresses). The heap holds longer-lived objects created with \`new\` and managed by the garbage collector.
-  > Correct.
 - The heap is faster than the stack
   > It's usually the other way around — stack access is extremely fast.`}
 />
@@ -296,7 +295,7 @@ picture.
 - Recompiles your code
   > That's the JIT.
 - [o] Finds heap objects that no living code can still reach, and reclaims their memory so it can be reused
-  > Correct. This is what makes C# a "memory-safe" language in everyday use.
+  > This is what makes C# a "memory-safe" language in everyday use.
 - Slows your program down on purpose
   > It does occasionally pause work to scan the heap, but its purpose is to *reclaim* memory, not to slow things down.`}
 />

--- a/content/learn/intro-modern-csharp/inheritance-and-polymorphism.mdx
+++ b/content/learn/intro-modern-csharp/inheritance-and-polymorphism.mdx
@@ -302,7 +302,7 @@ foreach (var s in shapes)
 - It eliminates the need for classes
   > It depends on classes.
 - [o] One call site (\`shape.Area()\`) automatically does the right thing for every subclass, so new subclasses don't require changes to existing code
-  > Correct. This is the "open for extension, closed for modification" idea.
+  > This is the "open for extension, closed for modification" idea.
 - It makes programs run faster
   > Performance is neutral to slightly worse than direct calls.
 - It allows multiple inheritance
@@ -319,7 +319,7 @@ foreach (var s in shapes)
 - Inheritance for unrelated types, composition for related types
   > That's backwards.
 - [o] Use inheritance for genuine "is-a" relationships; use composition for "has-a" relationships
-  > Correct. Many design problems get simpler when you reach for composition first.`}
+  > Many design problems get simpler when you reach for composition first.`}
 />
 
 <Callout type="success">

--- a/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
+++ b/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
@@ -205,7 +205,7 @@ ergonomics) has borrowed ideas from them.
 - A new kind of operating system
   > Managed runtimes run on top of normal operating systems.
 - [o] A piece of software that sits between your program and the hardware, automatically handling memory, type safety, and other low-level concerns
-  > Correct. The JVM and the .NET CLR are the two most famous examples.
+  > The JVM and the .NET CLR are the two most famous examples.
 - A type of database
   > Unrelated.`}
 />
@@ -216,7 +216,7 @@ ergonomics) has borrowed ideas from them.
 - Java was faster than any Microsoft language
   > Speed wasn't the primary issue.
 - [o] Java's "Write Once, Run Anywhere" model meant applications could leave Windows behind, undermining Microsoft's platform lock-in
-  > Correct. The threat was strategic, not just technical.
+  > The threat was strategic, not just technical.
 - Java had a nicer logo
   > Marketing helped Java's adoption, but the threat was about platform neutrality.
 - Microsoft was legally barred from using Java

--- a/content/learn/intro-modern-csharp/managed-runtimes.mdx
+++ b/content/learn/intro-modern-csharp/managed-runtimes.mdx
@@ -223,7 +223,7 @@ that's invisible. You just write C#.
 - Type safety checks at runtime
   > It does this.
 - [o] Choosing variable names for you automatically
-  > Correct — naming is your responsibility, not the runtime's.
+  > Naming is your responsibility, not the runtime's.
 - Exception unwinding
   > It does this.`}
 />
@@ -236,7 +236,7 @@ that's invisible. You just write C#.
 - Managed code can't use modern CPUs
   > It absolutely can.
 - [o] In exchange for the overhead, the runtime catches whole categories of bugs (memory leaks, dangling pointers, type confusion, buffer overruns) that you'd otherwise have to find yourself
-  > Correct. This trade is one of the best deals in programming.
+  > This trade is one of the best deals in programming.
 - C# files are larger
   > File size isn't the cost being paid.`}
 />

--- a/content/learn/intro-modern-csharp/methods-and-modularity.mdx
+++ b/content/learn/intro-modern-csharp/methods-and-modularity.mdx
@@ -391,7 +391,7 @@ Console.WriteLine($"max={Stats.Max(data)}");
 - The method has no parameters
   > A method can have parameters regardless of return type.
 - [o] The method returns no value to the caller
-  > Correct. You call it for its side effects, not for a returned value.
+  > You call it for its side effects, not for a returned value.
 - The method is private
   > Visibility is controlled by separate keywords like \`public\` and \`private\`.`}
 />
@@ -404,7 +404,7 @@ Console.WriteLine($"max={Stats.Max(data)}");
 - The language requires it
   > It doesn't.
 - [o] Small focused methods are easier to name, test, reuse, and reason about — and changes stay localized
-  > Correct. This is the central argument for modularity.
+  > This is the central argument for modularity.
 - Smaller methods use less memory
   > Method size has almost no impact on memory usage.`}
 />

--- a/content/learn/intro-modern-csharp/microsoft-dotnet-vision.mdx
+++ b/content/learn/intro-modern-csharp/microsoft-dotnet-vision.mdx
@@ -196,7 +196,7 @@ it does? On to **Anders Hejlsberg and the birth of C#**.
 - It is the editor used to write C# code
   > That's the IDE (Visual Studio, Rider, etc.).
 - [o] It is the managed runtime that loads, JIT-compiles, and runs all .NET programs, regardless of which .NET language they were written in
-  > Correct. CLR is to .NET what the JVM is to Java.
+  > CLR is to .NET what the JVM is to Java.
 - It is a database engine
   > Unrelated.`}
 />
@@ -207,7 +207,7 @@ it does? On to **Anders Hejlsberg and the birth of C#**.
 - To make C# files smaller
   > File size isn't the motivation.
 - [o] So that types defined in one .NET language (e.g., F#) can be used directly from another (e.g., C#) with no glue code
-  > Correct. The CTS is what makes the multi-language story actually work.
+  > The CTS is what makes the multi-language story actually work.
 - To enforce naming conventions
   > Naming is governed by style guides, not the CTS.
 - To make .NET incompatible with Java

--- a/content/learn/intro-modern-csharp/resource-management.mdx
+++ b/content/learn/intro-modern-csharp/resource-management.mdx
@@ -245,7 +245,6 @@ production bugs.
 - Memory, file handles, and network sockets
   > Just memory.
 - [o] Memory only — other resources still need to be released explicitly, typically via \`IDisposable\` / \`using\`
-  > Correct.
 - Only unmanaged memory
   > It collects managed objects on the .NET heap.
 - Variables on the stack
@@ -260,7 +259,6 @@ production bugs.
 - It doesn't actually call \`Dispose()\`
   > It does — that's the whole point.
 - [o] It guarantees \`Dispose()\` runs at the end of the block, even if an exception is thrown — so you can't forget cleanup
-  > Correct.
 - It hides what's happening
   > It makes the intent *clearer*, not more hidden.`}
 />

--- a/content/learn/intro-modern-csharp/rise-of-oop.mdx
+++ b/content/learn/intro-modern-csharp/rise-of-oop.mdx
@@ -236,7 +236,7 @@ spend a large part of this course learning to think in objects.
 - Computers can be replaced more often
   > Unrelated.
 - [o] Data and the operations that act on it are bundled together, with a boundary that prevents outsiders from changing the data directly
-  > Correct. That is the seed idea — every other OOP concept is built on top of it.
+  > That is the seed idea — every other OOP concept is built on top of it.
 - Programs no longer need variables
   > They very much do; OOP is about organizing them, not removing them.`}
 />
@@ -249,7 +249,7 @@ spend a large part of this course learning to think in objects.
 - Private fields take less memory
   > Visibility doesn't change memory size.
 - [o] So no code outside \`BankAccount\` can bypass the rules in \`Deposit\` and \`Withdraw\` and corrupt the balance
-  > Correct. \`private\` is what gives the class authority to enforce its own invariants.
+  > \`private\` is what gives the class authority to enforce its own invariants.
 - C# requires every field to be private
   > It doesn't — \`public\` and other modifiers are also allowed; you choose deliberately.`}
 />

--- a/content/learn/intro-modern-csharp/software-organization.mdx
+++ b/content/learn/intro-modern-csharp/software-organization.mdx
@@ -238,7 +238,6 @@ clearer place emerges.
 - A folder on disk
   > Folders and namespaces often mirror each other but they're different concepts.
 - [o] A logical label that groups types so they can be referenced without name collisions and organized by topic
-  > Correct.
 - A separate executable
   > That would be a project.
 - A reserved keyword for the main entry point
@@ -253,7 +252,7 @@ clearer place emerges.
 - The convention is purely aesthetic
   > The benefit is very concrete.
 - [o] Keeping dependencies pointing inward means the core business logic can be tested and reused without dragging the UI or database along
-  > Correct. This is the heart of "clean" architecture.
+  > This is the heart of "clean" architecture.
 - It makes the program start faster
   > Startup isn't really affected.`}
 />

--- a/content/learn/intro-modern-csharp/type-system.mdx
+++ b/content/learn/intro-modern-csharp/type-system.mdx
@@ -344,7 +344,6 @@ careful."
 - The runtime checks types as the program runs
   > That's dynamic typing.
 - [o] The compiler knows the type of every variable and refuses to compile code that uses values in a way that doesn't match their type
-  > Correct.
 - C# uses no types at all
   > C# is one of the most strongly typed mainstream languages.`}
 />
@@ -365,7 +364,7 @@ What is in \`a\`?
 - \`[3]\`
   > The original items are still there.
 - [o] \`[1, 2, 3]\`
-  > Correct. \`a\` and \`b\` reference the *same* list on the heap.
+  > \`a\` and \`b\` reference the *same* list on the heap.
 - Compile error
   > It compiles fine.`}
 />
@@ -378,7 +377,7 @@ What is in \`a\`?
 - \`int.Parse(userInput)\` and ignore the result
   > It throws on bad input — your program will crash.
 - [o] \`int.TryParse(userInput, out int n)\` and handle the \`false\` case
-  > Correct. \`TryParse\` returns \`false\` instead of throwing, so you can react gracefully.
+  > \`TryParse\` returns \`false\` instead of throwing, so you can react gracefully.
 - Convert it to \`double\` first and then to \`int\`
   > Doesn't solve the "what if it's not a number?" problem.`}
 />

--- a/content/learn/intro-modern-csharp/variables-and-memory.mdx
+++ b/content/learn/intro-modern-csharp/variables-and-memory.mdx
@@ -301,7 +301,7 @@ Console.WriteLine($"b = {b}");
 - It creates a variable whose type can change later
   > It cannot.
 - [o] It creates a statically typed \`int\` variable; the compiler infers the type from the literal \`42\`
-  > Correct. \`var\` is shorthand for "let the compiler write the type for me."
+  > \`var\` is shorthand for "let the compiler write the type for me."
 - It creates a runtime-only variable
   > That would be \`dynamic\`, which is a different feature.`}
 />
@@ -314,7 +314,6 @@ Console.WriteLine($"b = {b}");
 - \`decimal\` uses less memory
   > It uses more.
 - [o] \`double\` has small rounding errors for decimal fractions (e.g., \`0.1 + 0.2 != 0.3\`); \`decimal\` is exact for the decimal numbers humans care about
-  > Correct.
 - They're the same — pick either one
   > They're meaningfully different.`}
 />

--- a/content/learn/intro-modern-csharp/why-csharp-matters.mdx
+++ b/content/learn/intro-modern-csharp/why-csharp-matters.mdx
@@ -252,7 +252,7 @@ By the end of this course, every line above will feel obvious.
 - Modern C# is a purely functional language
   > It supports functional style, but it is not pure.
 - [o] Modern C# supports object-oriented, functional, imperative, and declarative styles in the same program, and you can mix and match as appropriate
-  > Correct. That flexibility is one of C#'s biggest strengths today.
+  > That flexibility is one of C#'s biggest strengths today.
 - Modern C# only supports declarative LINQ queries
   > LINQ is one important feature, but far from the whole language.`}
 />
@@ -265,7 +265,7 @@ By the end of this course, every line above will feel obvious.
 - It is the only language with a garbage collector
   > Many languages have garbage collectors.
 - [o] It forces you to be explicit about types, organization, and responsibilities — habits that transfer to every other modern language
-  > Correct. The mental model you build here applies to Java, Kotlin, TypeScript, Swift, and many others.
+  > The mental model you build here applies to Java, Kotlin, TypeScript, Swift, and many others.
 - It runs faster than every other language
   > Performance varies; that's not the educational argument.`}
 />

--- a/content/learn/intro-modern-csharp/windows-and-enterprise-software.mdx
+++ b/content/learn/intro-modern-csharp/windows-and-enterprise-software.mdx
@@ -162,7 +162,7 @@ the first place — **Java**.
 - Games and consumer apps
   > Those exist, but are a different category.
 - [o] Long-lived business software (payroll, CRM, inventory, line-of-business tools) with strong requirements around reliability, integration, and maintainability
-  > Correct. Those requirements drove most of the design choices in .NET and C#.
+  > Those requirements drove most of the design choices in .NET and C#.
 - Software written exclusively in C#
   > Enterprise software predates C# by decades.`}
 />
@@ -175,7 +175,7 @@ the first place — **Java**.
 - Windows wasn't popular enough to write software for
   > Windows was overwhelmingly dominant on business desktops.
 - [o] There was no single language that combined safety, productivity, and power, with deep Windows integration
-  > Correct. Each existing tool excelled at one dimension and was weak on another. That gap is exactly what C# was created to fill.
+  > Each existing tool excelled at one dimension and was weak on another. That gap is exactly what C# was created to fill.
 - C++ wasn't installed on enough machines
   > Compiler installation wasn't the bottleneck.`}
 />

--- a/content/learn/intro-modern-csharp/writing-maintainable-software.mdx
+++ b/content/learn/intro-modern-csharp/writing-maintainable-software.mdx
@@ -223,7 +223,7 @@ A short, rotating set of habits that compound massively:
 - Readability is required by the language spec
   > It isn't.
 - [o] Code is read far more often than it is written; readable code is cheaper to maintain and less likely to harbor bugs
-  > Correct. Reading time dwarfs writing time over a project's life.
+  > Reading time dwarfs writing time over a project's life.
 - Readable code uses less memory
   > Unrelated.`}
 />
@@ -236,7 +236,7 @@ A short, rotating set of habits that compound massively:
 - The author's initials and the current date
   > Source control already records this.
 - [o] An explanation of *why* the code is the way it is — context the code itself can't capture
-  > Correct. Comments earn their keep when they answer the questions code can't.
+  > Comments earn their keep when they answer the questions code can't.
 - Nothing — comments should always be removed
   > Sometimes a comment is exactly what saves the reader.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/birth-of-containers.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/birth-of-containers.mdx
@@ -273,7 +273,7 @@ Collections Framework.
 - Because \`Object\` is faster than other types
   > Speed is unrelated.
 - [o] Because \`Vector\` had no element-type parameter — the same class held any kind of element
-  > Correct. Without generics, a container had to be defined in terms of \`Object\`, and the cast was the price of mixing types.
+  > Without generics, a container had to be defined in terms of \`Object\`, and the cast was the price of mixing types.
 - Because \`Vector\` is an interface, not a class
   > \`Vector\` is a class.
 - Because Java compiles all collections to \`Object[]\` at runtime
@@ -286,7 +286,7 @@ Collections Framework.
 - It's not allowed by the compiler
   > It is allowed.
 - [o] It exposes Vector's index-based methods, breaking the LIFO abstraction a stack is supposed to provide
-  > Correct. Inheritance gives users of Stack access to the parent's API, so a "stack" suddenly supports indexing into the middle of itself.
+  > Inheritance gives users of Stack access to the parent's API, so a "stack" suddenly supports indexing into the middle of itself.
 - It causes a stack overflow at runtime
   > It does not.
 - It prevents Stack from being iterated
@@ -299,7 +299,7 @@ Collections Framework.
 - It only supports \`Integer\` keys
   > It accepts any \`Object\` as a key.
 - [o] Every method is synchronized, so it pays a locking cost even in single-threaded code
-  > Correct. The original design baked thread-safety in unconditionally; modern code uses \`HashMap\` and adds synchronization only where needed.
+  > The original design baked thread-safety in unconditionally; modern code uses \`HashMap\` and adds synchronization only where needed.
 - It cannot store more than 16 entries
   > It can grow arbitrarily.
 - It was removed in Java 9

--- a/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
@@ -402,7 +402,7 @@ public class Bag<T> {
 - Because \`Dog\` and \`Animal\` are different classes
   > They are — but that's true of subclass relationships generally.
 - [o] Because if it were, you could add a \`Cat\` to a \`List<Dog>\` via the wider reference, breaking type safety
-  > Correct. Java keeps generics invariant precisely to prevent that smuggling.
+  > Java keeps generics invariant precisely to prevent that smuggling.
 - Because Java doesn't support polymorphism for collections
   > It does support polymorphism — through wildcards.
 - Because \`Animal\` is abstract
@@ -415,7 +415,7 @@ public class Bag<T> {
 - "Public, Encapsulated, Composed, Shared" — for OO design
   > Made-up; PECS is about variance.
 - [o] "Producer Extends, Consumer Super" — use \`? extends T\` for parameters you only read from, \`? super T\` for parameters you only write into
-  > Correct. PECS is the standard mnemonic for choosing wildcard variance.
+  > PECS is the standard mnemonic for choosing wildcard variance.
 - "Performance, Encapsulation, Cohesion, Safety"
   > Made-up.
 - "Parameter Extends, Class Super" — applied to class declarations
@@ -428,7 +428,7 @@ public class Bag<T> {
 - It is forbidden by the compiler
   > It compiles.
 - [o] It pushes "I don't know the exact element type" onto every caller, while a concrete return type like \`List<Integer>\` is just as easy to produce
-  > Correct. Wildcards belong on inputs (where you want flexibility); outputs should be specific.
+  > Wildcards belong on inputs (where you want flexibility); outputs should be specific.
 - It causes runtime casts to fail
   > It does not cause runtime cast failures.
 - It is slower than \`List<Integer>\` at runtime

--- a/content/learn/java-collections-and-generics-deep-dive/capstone-music-library.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/capstone-music-library.mdx
@@ -230,7 +230,7 @@ That single class touches every major idea in the course:
 - It allows duplicates
   > It does not.
 - [o] It keeps insertion order, which makes the printed output deterministic and matches the user-visible "as encountered" order
-  > Correct. Determinism matters as soon as a human or a test reads the output.
+  > Determinism matters as soon as a human or a test reads the output.
 - It supports concurrent reads
   > It does not (no built-in synchronization).`}
 />
@@ -241,7 +241,7 @@ That single class touches every major idea in the course:
 - It is faster
   > It is not.
 - [o] Because sorting in place would permanently reorder the library, making "insertion order" queries (like \`byArtist\`) wrong on subsequent calls
-  > Correct. Never mutate state to compute a query result.
+  > Never mutate state to compute a query result.
 - The \`Comparator\` requires a fresh list
   > It does not.
 - The original list is unmodifiable

--- a/content/learn/java-collections-and-generics-deep-dive/collection-architecture.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/collection-architecture.mdx
@@ -322,7 +322,7 @@ public class Inbox {
 - \`HashMap<String,?>\`
   > Wrong kind altogether.
 - [o] \`Iterable<String>\` (or \`Collection<String>\` if you also need \`size()\`)
-  > Correct. Accept the widest interface that satisfies your needs.
+  > Accept the widest interface that satisfies your needs.
 - \`Object\`
   > Too wide; loses static type information.`}
 />
@@ -333,7 +333,7 @@ public class Inbox {
 - \`final\` is wrong here
   > \`final\` is fine; it refers to the reference, not the contents.
 - [o] The caller receives a reference to your live mutable state and can \`add\`, \`remove\`, or \`clear\` it, corrupting your invariants
-  > Correct. Return an unmodifiable view or an immutable copy instead.
+  > Return an unmodifiable view or an immutable copy instead.
 - It throws \`ConcurrentModificationException\`
   > Not by itself.
 - It causes a memory leak
@@ -348,7 +348,7 @@ public class Inbox {
 - \`Iterator<Item>\` exposed directly
   > Iterators are poor public API; they support \`remove\` and have no good way to be closed.
 - [o] \`Stream<Item>\` (or a paged result type), so the caller composes filters before materializing — and the repository can lazily fetch in batches
-  > Correct. Lazy, composable, and never materializes the whole set if the caller filters first.
+  > Lazy, composable, and never materializes the whole set if the caller filters first.
 - \`Set<Item>\` for "uniqueness"
   > Same memory problem and the wrong shape.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/comparable-and-comparator.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/comparable-and-comparator.mdx
@@ -332,7 +332,7 @@ public final class Leaderboard {
 - Always, just in case
   > Many types have no single meaningful order.
 - [o] When there is **one** obvious natural order that is consistent with \`equals\` and serves most callers
-  > Correct. Otherwise prefer a \`Comparator\`, which can have many flavors.
+  > Otherwise prefer a \`Comparator\`, which can have many flavors.
 - Only when the class will be stored in a \`TreeSet\`
   > That's one consumer; \`Comparator\` works there too.
 - Whenever the class has numeric fields
@@ -345,7 +345,7 @@ public final class Leaderboard {
 - It is slower than \`Integer.compare\`
   > Performance is not the concern; correctness is.
 - [o] It can **overflow** when \`a\` and \`b\` are far apart in sign or magnitude, returning a wrong sign
-  > Correct. Always use \`Integer.compare(a, b)\` for \`int\` and \`Long.compare\` for \`long\`.
+  > Always use \`Integer.compare(a, b)\` for \`int\` and \`Long.compare\` for \`long\`.
 - It does not compile
   > It compiles.
 - It returns a value outside \`{-1, 0, 1}\`
@@ -358,7 +358,7 @@ public final class Leaderboard {
 - Sorts by \`b\` and then by \`a\`
   > Reversed.
 - [o] Sorts by \`a\` ascending; uses \`b\` to break ties
-  > Correct. \`thenComparing\` only kicks in when the primary comparison returns 0.
+  > \`thenComparing\` only kicks in when the primary comparison returns 0.
 - Sums the two comparison results
   > Comparators are not added.
 - Sorts only by \`a\`

--- a/content/learn/java-collections-and-generics-deep-dive/data-modeling-with-collections.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/data-modeling-with-collections.mdx
@@ -324,7 +324,7 @@ public final class OrderIndex {
 - A \`Set<Message>\`
   > Loses order; doesn't index by user.
 - [o] A \`Map<UserId, List<Message>>\` updated on every arrival
-  > Correct. Lookup becomes \`O(1)\` and per-user order is preserved.
+  > Lookup becomes \`O(1)\` and per-user order is preserved.
 - A \`Map<UserId, Set<Message>>\`
   > Wrong if order matters; messages aren't naturally unique either.`}
 />
@@ -337,7 +337,7 @@ public final class OrderIndex {
 - One \`Map<TagId, List<PostId>>\`
   > Symmetric problem.
 - [o] Two indices: \`Map<PostId, Set<TagId>>\` and \`Map<TagId, Set<PostId>>\`, kept in sync on every change
-  > Correct. Each direction is \`O(1)\`; updates do a tiny bit more work.
+  > Each direction is \`O(1)\`; updates do a tiny bit more work.
 - A \`List<Pair<PostId, TagId>>\`
   > Both queries become \`O(n)\`.`}
 />
@@ -350,7 +350,7 @@ public final class OrderIndex {
 - It's faster
   > It is comparable.
 - [o] The compiler now refuses to mix up customer ids with other strings (order ids, emails, etc.), and you can put validation in the record's constructor
-  > Correct. Type-driven modeling shifts entire categories of bugs from runtime to compile time.
+  > Type-driven modeling shifts entire categories of bugs from runtime to compile time.
 - It's required by the Collections API
   > It is not.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
@@ -390,7 +390,7 @@ public class UniquenessTracker {
 - All collections stop working
   > Most things still work; the bug is specific to hash-based collections.
 - [o] Hash-based collections (\`HashSet\`, \`HashMap\`) can fail to find equal objects because they look in the wrong bucket
-  > Correct. The lookup uses \`hashCode\` to choose a bucket, so unequal hashcodes for equal values mean the element is invisible to lookup.
+  > The lookup uses \`hashCode\` to choose a bucket, so unequal hashcodes for equal values mean the element is invisible to lookup.
 - \`equals\` calls go into infinite recursion
   > They don't.`}
 />
@@ -403,7 +403,7 @@ public class UniquenessTracker {
 - They double the memory cost
   > They don't.
 - [o] If a field that participates in \`hashCode\` changes while the object is a key, the entry becomes unreachable
-  > Correct. The map indexed it in a bucket computed from the old hash; after mutation, it looks in a different bucket and reports "not present."
+  > The map indexed it in a bucket computed from the old hash; after mutation, it looks in a different bucket and reports "not present."
 - \`HashMap\` deep-copies keys, so the cost is performance
   > \`HashMap\` does not deep-copy.`}
 />
@@ -416,7 +416,7 @@ public class UniquenessTracker {
 - Inherit them from \`Object\`
   > That gives identity equality, which is rarely what you want.
 - [o] Declare the class as a \`record\`
-  > Correct. Records automatically generate \`equals\`, \`hashCode\`, and \`toString\` from the components.
+  > Records automatically generate \`equals\`, \`hashCode\`, and \`toString\` from the components.
 - Implement \`Comparable\`
   > \`Comparable\` is about ordering, not value equality.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
@@ -368,7 +368,7 @@ ada / 36
 - In the class header
   > That introduces type parameters scoped to the entire class, not just one method.
 - [o] Immediately before the return type, e.g. \`public static <T> T identity(T x)\`
-  > Correct. A method-scoped type parameter list goes right before the return type.
+  > A method-scoped type parameter list goes right before the return type.
 - In the calling code only
   > The declaration must appear on the method itself.`}
 />
@@ -379,7 +379,7 @@ ada / 36
 - Call any method of \`Object\` on \`T\`
   > Both forms allow that — every type is an \`Object\`.
 - [o] Call methods defined on \`Number\` (such as \`intValue()\`, \`doubleValue()\`) on any value of type \`T\`
-  > Correct. The bound is a *contract* telling the compiler what \`T\` is guaranteed to support.
+  > The bound is a *contract* telling the compiler what \`T\` is guaranteed to support.
 - Compare \`T\` values with \`<\` and \`>\`
   > Java does not overload \`<\` for objects, regardless of generics.
 - Construct new instances of \`T\`
@@ -392,7 +392,7 @@ ada / 36
 - It uses less memory
   > Memory use is similar.
 - [o] It composes a \`List\` instead of extending \`Vector\`, so its public API contains only the stack operations — not random list methods
-  > Correct. Composition contains the abstraction; inheritance would leak parent methods into the stack's surface.
+  > Composition contains the abstraction; inheritance would leak parent methods into the stack's surface.
 - It is faster on every operation
   > Performance is comparable; the win is API hygiene.
 - The legacy \`Stack\` does not compile in modern Java

--- a/content/learn/java-collections-and-generics-deep-dive/immutable-collections.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/immutable-collections.mdx
@@ -339,7 +339,7 @@ public final class Roster {
 - They are the same
   > They are not.
 - [o] \`List.of\` is truly immutable (no backing to mutate); \`Collections.unmodifiableList\` is an unmodifiable **view** over a list whose owner can still mutate it
-  > Correct. For a snapshot that nobody can change, use \`List.copyOf\` or \`List.of\`.
+  > For a snapshot that nobody can change, use \`List.copyOf\` or \`List.of\`.
 - \`Collections.unmodifiableList\` is faster
   > It's a thin wrapper, but mutability semantics are the issue.
 - \`List.of\` allows nulls
@@ -352,7 +352,7 @@ public final class Roster {
 - To save memory
   > It actually uses more.
 - [o] Because otherwise the caller still holds a reference to the same list and can mutate "your" state after construction
-  > Correct. Defensive copy at the boundary is what protects your invariants.
+  > Defensive copy at the boundary is what protects your invariants.
 - Because Java requires it
   > It does not.
 - Because lists are not serializable otherwise
@@ -367,7 +367,7 @@ public final class Roster {
 - It returns \`{a, b, a}\`
   > Sets cannot contain duplicates.
 - [o] It throws \`IllegalArgumentException\` at construction
-  > Correct. \`Set.of\` and \`Map.of\` are strict about duplicates.
+  > \`Set.of\` and \`Map.of\` are strict about duplicates.
 - It throws \`NullPointerException\`
   > That's for null elements/keys/values.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/iterables-and-iterators.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/iterables-and-iterators.mdx
@@ -420,7 +420,7 @@ public class Countdown implements Iterable<Integer> {
 - Because iterators are smaller in memory
   > Size isn't the design driver.
 - [o] So multiple independent walks of the same container can happen at once, each with its own cursor
-  > Correct. Nested loops over the same collection rely on each walk having its own state.
+  > Nested loops over the same collection rely on each walk having its own state.
 - Because \`Iterator\` is older than \`Iterable\`
   > Iterable was added in Java 5 specifically to support \`for-each\` over \`Iterator\`-producing types.
 - Because the JVM forbids state in interfaces
@@ -435,7 +435,7 @@ public class Countdown implements Iterable<Integer> {
 - \`NoSuchElementException\`
   > That is what \`next()\` throws past the end.
 - [o] \`ConcurrentModificationException\`
-  > Correct. JCF iterators are fail-fast: they detect concurrent mutation and throw immediately.
+  > JCF iterators are fail-fast: they detect concurrent mutation and throw immediately.
 - \`UnsupportedOperationException\`
   > That is what an immutable collection throws on a mutating call.`}
 />
@@ -448,7 +448,7 @@ public class Countdown implements Iterable<Integer> {
 - Iterate \`values()\`
   > That gives you values without keys.
 - [o] Iterate \`entrySet()\` and read \`getKey()\` / \`getValue()\` on each entry
-  > Correct. A single walk over the entry view yields both halves of each pair.
+  > A single walk over the entry view yields both halves of each pair.
 - Convert the map to a \`List\` and iterate that
   > Unnecessary copying; \`entrySet()\` already does what you need.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/iteration-patterns.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/iteration-patterns.mdx
@@ -366,7 +366,7 @@ for (Integer n : list) if (n % 2 == 0) list.remove(n);
 - Because \`list.remove(Object)\` is \`O(n)\`
   > That's a performance issue, not a correctness one.
 - [o] Because the enhanced-for uses an \`Iterator\`, and modifying the underlying list via \`list.remove\` invalidates the iterator's internal modCount
-  > Correct. Either use \`Iterator.remove()\` directly or call \`list.removeIf(...)\`.
+  > Either use \`Iterator.remove()\` directly or call \`list.removeIf(...)\`.
 - Because \`list\` is unmodifiable
   > It need not be; the exception fires on a mutable list too.
 - Because integers are autoboxed
@@ -383,7 +383,7 @@ for (Integer n : list) if (n % 2 == 0) list.remove(n);
 - Plain \`Iterator\`
   > Plain \`Iterator\` only supports \`remove\`, not \`add\`.
 - [o] \`ListIterator\`
-  > Correct. \`ListIterator.add(e)\` inserts at the current cursor position.`}
+  > \`ListIterator.add(e)\` inserts at the current cursor position.`}
 />
 
 <MultipleChoice
@@ -394,7 +394,7 @@ for (Integer n : list) if (n % 2 == 0) list.remove(n);
 - When the body needs \`break\` or \`return\`
   > Streams don't have \`break\`; a \`for\` loop is cleaner there.
 - [o] When the body is a straightforward pipeline of filter / transform / collect with no early exit
-  > Correct. Streams trade flexibility for declarative clarity in exactly that case.
+  > Streams trade flexibility for declarative clarity in exactly that case.
 - When you need to mutate the source collection
   > Streams must not mutate their source.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/lists.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/lists.mdx
@@ -349,7 +349,7 @@ public class RecentHistory<E> {
 - Appending at the end
   > Both are \`O(1)\` amortized at the end.
 - [o] \`get(i)\` for arbitrary \`i\`
-  > Correct. An \`ArrayList\` indexes by arithmetic; a \`LinkedList\` must walk.
+  > An \`ArrayList\` indexes by arithmetic; a \`LinkedList\` must walk.
 - \`contains(x)\`
   > Both are \`O(n)\` — they scan.
 - Removing the first element
@@ -362,7 +362,7 @@ public class RecentHistory<E> {
 - The JVM secretly stores \`LinkedList\` nodes contiguously
   > It does not.
 - [o] Contiguous array memory is far more cache-friendly than scattered linked-list nodes, so the CPU spends much less time waiting on memory
-  > Correct. Big-O hides the constant factors that cache misses dominate in modern hardware.
+  > Big-O hides the constant factors that cache misses dominate in modern hardware.
 - \`LinkedList\` was deprecated in Java 11
   > It is not deprecated.
 - \`ArrayList\` is implemented in native code
@@ -377,7 +377,7 @@ public class RecentHistory<E> {
 - A primitive \`int[]\`
   > It returns a \`List\`.
 - [o] A live *view* of the original list; mutations affect the backing list and structural changes to the backing list invalidate the view
-  > Correct. This is both powerful and a frequent source of surprise.
+  > This is both powerful and a frequent source of surprise.
 - An immutable list snapshot
   > Sublists are mutable views, not immutable snapshots.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/maps.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/maps.mdx
@@ -368,7 +368,7 @@ public class Grouper {
 - \`merge\`
   > Useful, but a bit awkward for the "map of lists" case.
 - [o] \`computeIfAbsent(key, k -> new ArrayList<>()).add(value)\`
-  > Correct. \`computeIfAbsent\` returns the (newly or previously) inserted list, on which you can immediately call \`add\`.
+  > \`computeIfAbsent\` returns the (newly or previously) inserted list, on which you can immediately call \`add\`.
 - \`putIfAbsent\`
   > It returns the *previous* value (or null), so chaining \`.add\` on it fails on first insertion.`}
 />
@@ -379,7 +379,7 @@ public class Grouper {
 - When you need higher throughput
   > \`HashMap\` is faster on average.
 - [o] When you need keys iterated in sorted order, range queries (\`subMap\`), or "next key after \`x\`" (\`ceilingKey\`, \`floorKey\`)
-  > Correct. The \`O(log n)\` price buys real ordering operations a hash table cannot provide.
+  > The \`O(log n)\` price buys real ordering operations a hash table cannot provide.
 - When the keys are strings
   > Both maps handle string keys; ordering is the deciding factor.
 - When values can be null
@@ -392,7 +392,7 @@ public class Grouper {
 - \`HashMap\` is forbidden for enum keys
   > It works fine.
 - [o] \`EnumMap\` is backed by a plain array indexed by the enum's \`ordinal\`, so it's faster and far more compact than a hash table
-  > Correct. When the key space is a fixed small enum, a direct-indexed array is unbeatable.
+  > When the key space is a fixed small enum, a direct-indexed array is unbeatable.
 - It throws on a missing key, which is desirable
   > It returns \`null\` like other maps.
 - It is automatically thread-safe

--- a/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
@@ -245,7 +245,7 @@ flowchart TD
 - \`ArrayList.iterator()\` is \`O(log n)\`
   > Both are \`O(n)\` per \`next()\`.
 - [o] \`ArrayList\` stores elements in a contiguous backing array, so a sequential walk is extremely cache-friendly; \`LinkedList\` follows pointers to scattered heap nodes
-  > Correct. Cache behavior dominates Big-O for in-memory walks at modern CPU speeds.
+  > Cache behavior dominates Big-O for in-memory walks at modern CPU speeds.
 - \`LinkedList.iterator()\` allocates per element
   > It does not.
 - \`ArrayList\` parallelizes by default
@@ -260,7 +260,7 @@ flowchart TD
 - The maximum number of entries
   > \`HashMap\` has no hard cap.
 - [o] The ratio of size to capacity at which the table doubles and rehashes
-  > Correct. Default 0.75: a 16-bucket map rehashes when it reaches 12 entries.
+  > Default 0.75: a 16-bucket map rehashes when it reaches 12 entries.
 - The hash function used for keys
   > That's determined by the key type's \`hashCode\`.`}
 />
@@ -273,7 +273,7 @@ flowchart TD
 - \`new ArrayList<>(10)\`, then call \`add\` 50k times
   > Worse: even more resizes.
 - [o] \`new ArrayList<>(50_000)\`, then call \`add\` 50k times
-  > Correct. One allocation, zero resizes.
+  > One allocation, zero resizes.
 - \`new LinkedList<>()\`
   > More memory and slower iteration in almost every scenario.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
@@ -365,7 +365,7 @@ public class SlidingWindow<E> {
 - \`LinkedList\`
   > It works, but \`ArrayDeque\` is faster and uses less memory.
 - [o] \`ArrayDeque\`
-  > Correct. Circular array, both ends \`O(1)\`, far better cache behavior than a linked list.
+  > Circular array, both ends \`O(1)\`, far better cache behavior than a linked list.
 - \`PriorityQueue\`
   > That gives you priority order, not FIFO.
 - \`Vector\`
@@ -380,7 +380,7 @@ public class SlidingWindow<E> {
 - The first inserted element
   > That would be FIFO, not priority.
 - [o] The smallest element according to natural order
-  > Correct. The heap is a min-heap by default; use \`Comparator.reverseOrder()\` for a max-heap.
+  > The heap is a min-heap by default; use \`Comparator.reverseOrder()\` for a max-heap.
 - A random element
   > Heap order is deterministic, not random.`}
 />
@@ -391,7 +391,7 @@ public class SlidingWindow<E> {
 - Iteration throws \`UnsupportedOperationException\`
   > It does not.
 - [o] Iteration walks the underlying heap array, which is *not* in sorted order — drain via \`poll()\` if you need sorted order
-  > Correct. Heap order only guarantees the *root* is the smallest; the rest is partially ordered.
+  > Heap order only guarantees the *root* is the smallest; the rest is partially ordered.
 - It is \`O(n²)\`
   > Iteration is \`O(n)\`.
 - It mutates the queue

--- a/content/learn/java-collections-and-generics-deep-dive/sets.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/sets.mdx
@@ -320,7 +320,7 @@ public class Distinct {
 - \`TreeSet\`
   > Sorted, not insertion order.
 - [o] \`LinkedHashSet\`
-  > Correct. It pays a small constant-factor cost for a linked list threaded through the entries.
+  > It pays a small constant-factor cost for a linked list threaded through the entries.
 - \`ArrayList\`
   > A list is not a set and allows duplicates.`}
 />
@@ -333,7 +333,7 @@ public class Distinct {
 - The size becomes 2
   > A correctly implemented \`User\` would have value equality, leading to dedup; using the same object instance is *definitely* a duplicate.
 - [o] The second \`add\` returns \`false\` and the set is unchanged
-  > Correct. \`add\` is the standard "have I seen this before?" primitive.
+  > \`add\` is the standard "have I seen this before?" primitive.
 - The first \`User\` is overwritten
   > \`Set\` does not overwrite — it ignores the duplicate.`}
 />
@@ -344,7 +344,7 @@ public class Distinct {
 - It triggers \`ConcurrentModificationException\`
   > Not by itself.
 - [o] The element's bucket was chosen from the old hash; after mutation the set looks for it in a different bucket and reports "not present"
-  > Correct. Treat set elements (and map keys) as immutable for this exact reason.
+  > Treat set elements (and map keys) as immutable for this exact reason.
 - It silently clears the set
   > It does not.
 - It throws \`UnsupportedOperationException\`

--- a/content/learn/java-collections-and-generics-deep-dive/the-collections-framework.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-collections-framework.mdx
@@ -421,7 +421,7 @@ public class Roster {
 - Faster sorting algorithms
   > Sorting got faster eventually, but speed wasn't the design idea.
 - [o] Separating *interfaces* that describe container shapes from *implementations* that realize them
-  > Correct. That separation is what lets one method body work for every present and future implementation.
+  > That separation is what lets one method body work for every present and future implementation.
 - Replacing arrays as the JVM's underlying storage
   > Arrays are still the substrate of most collections.
 - Adding network synchronization to data structures
@@ -434,7 +434,7 @@ public class Roster {
 - Because maps don't store data
   > Maps very much store data.
 - [o] Because maps fundamentally hold (key, value) pairs, not single elements, so the \`Collection\` operations (\`add(E)\`, \`contains(E)\`) don't fit
-  > Correct. The shape of a map is different enough that putting it under \`Collection\` would have meant either weaker types or awkward method signatures.
+  > The shape of a map is different enough that putting it under \`Collection\` would have meant either weaker types or awkward method signatures.
 - Because \`Map\` is older than \`Collection\`
   > Both arrived together in Java 1.2.
 - Because maps cannot be iterated
@@ -447,7 +447,7 @@ public class Roster {
 - It compiles faster
   > Compile time is unaffected.
 - [o] The variable is typed by what it represents (a list of strings), so the implementation can be swapped without touching the rest of the code
-  > Correct. Programming to the interface is what makes JCF code so refactor-friendly.
+  > Programming to the interface is what makes JCF code so refactor-friendly.
 - \`ArrayList\` does not exist in modern Java
   > It does and is widely used.
 - The garbage collector treats interfaces and classes differently

--- a/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
@@ -314,7 +314,7 @@ simple: **always provide the type argument.**
 - They made collections faster
   > Performance is largely unchanged by generics.
 - [o] They moved type checking of element types from runtime (\`ClassCastException\`) to compile time
-  > Correct. With generics, the compiler proves that a \`List<String>\` can only contain \`String\`s, so the cast in \`String s = list.get(0)\` cannot fail.
+  > With generics, the compiler proves that a \`List<String>\` can only contain \`String\`s, so the cast in \`String s = list.get(0)\` cannot fail.
 - They allowed multiple threads to share a \`List\` safely
   > Generics are unrelated to thread safety.
 - They eliminated the need for the \`Collection\` interface
@@ -327,7 +327,7 @@ simple: **always provide the type argument.**
 - Only that it returns some \`Object\`
   > That was the pre-generics behaviour.
 - [o] That it returns a \`Customer\` (or \`null\`)
-  > Correct. The second type parameter tells the compiler the value type, so no cast is needed at the call site.
+  > The second type parameter tells the compiler the value type, so no cast is needed at the call site.
 - That it returns a \`String\`
   > The first parameter is the *key* type, not the return type.
 - That it will throw if the key is missing
@@ -342,7 +342,7 @@ simple: **always provide the type argument.**
 - It is slower than \`List<String> list = new ArrayList<>();\`
   > Speed is unchanged.
 - [o] It uses a raw type, throwing away the compile-time guarantees generics give you
-  > Correct. Raw types exist only for backwards compatibility; using one effectively turns off generic type-checking for that variable.
+  > Raw types exist only for backwards compatibility; using one effectively turns off generic type-checking for that variable.
 - The JVM forbids it at runtime
   > It runs fine; the cost is in correctness, not compilation.`}
 />

--- a/content/learn/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
@@ -219,7 +219,7 @@ string.
 - They use too much memory
   > Memory use is rarely the dominant problem; arrays are actually quite memory-efficient.
 - [o] They have a fixed size and offer no built-in support for resizing, searching, uniqueness, or higher-level access patterns
-  > Correct. Arrays solve one job — O(1) indexed storage — and leave every other data-handling concern to the programmer.
+  > Arrays solve one job — O(1) indexed storage — and leave every other data-handling concern to the programmer.
 - They cannot be iterated
   > Arrays can be iterated; the issue is uniformity, not capability.
 - The Java compiler doesn't allow them in modern code
@@ -232,7 +232,7 @@ string.
 - Because hand-rolled code is always slower
   > A hand-rolled version can be just as fast; speed is not the main issue.
 - [o] Because each copy is slightly different and accumulates slightly different bugs over time
-  > Correct. Repeated reinvention guarantees inconsistency, and inconsistency is what makes large systems unmaintainable.
+  > Repeated reinvention guarantees inconsistency, and inconsistency is what makes large systems unmaintainable.
 - Because the JVM forbids more than one growing array per program
   > It does not.
 - Because arrays cannot be passed to methods
@@ -245,7 +245,7 @@ string.
 - That arrays were too slow to use directly
   > Arrays are very fast; speed isn't the lesson.
 - [o] That higher-level data-handling concerns were duplicated across modules, with no shared abstraction
-  > Correct. Without a standard library of containers, every team reinvents the same handful of patterns with their own quirks.
+  > Without a standard library of containers, every team reinvents the same handful of patterns with their own quirks.
 - That arrays could not be shared between modules
   > Arrays can be shared; sharing isn't the issue.
 - That Java forbids modules from owning their own data

--- a/content/learn/java-collections-and-generics-deep-dive/type-erasure.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/type-erasure.mdx
@@ -255,7 +255,7 @@ and many reflective APIs.
 - \`false\` — they are different parameterized types
   > That would be true if Java kept type parameters at runtime, but it doesn't.
 - [o] \`true\` — both share the same erasure (\`ArrayList\`)
-  > Correct. Generics are erased; the runtime class is the same regardless of the type parameter.
+  > Generics are erased; the runtime class is the same regardless of the type parameter.
 - A compile error
   > It compiles.
 - \`null\`
@@ -268,7 +268,7 @@ and many reflective APIs.
 - Arrays don't allow size 10
   > Arrays allow any non-negative size.
 - [o] Arrays carry their element type at runtime, but \`T\` is erased — the JVM can't enforce the element type, so the language forbids the construction
-  > Correct. Use \`List<T>\` (or a \`Class<T>\` token plus \`Array.newInstance\`) instead.
+  > Use \`List<T>\` (or a \`Class<T>\` token plus \`Array.newInstance\`) instead.
 - It would always throw \`ClassCastException\`
   > It would create *unsafe* arrays, which is precisely why it's banned at compile time.
 - The JVM only supports primitive arrays
@@ -283,7 +283,7 @@ and many reflective APIs.
 - Use \`instanceof List<X>\` checks
   > Such checks are forbidden by the language.
 - [o] Accept a \`Class<T>\` token as a constructor or method parameter and use it for \`isInstance\`, \`cast\`, or array creation
-  > Correct. This is the pattern used by \`Collections.checkedList\`, many reflective APIs, and most JSON libraries.
+  > This is the pattern used by \`Collections.checkedList\`, many reflective APIs, and most JSON libraries.
 - Switch to a different language
   > Unnecessary; the \`Class<T>\` idiom handles essentially every case.`}
 />

--- a/content/learn/java-programming-for-beginners/arrays-and-collections.mdx
+++ b/content/learn/java-programming-for-beginners/arrays-and-collections.mdx
@@ -244,7 +244,7 @@ more often than bare arrays.
 - Returns null
   > No.
 - [o] Throws \`ArrayIndexOutOfBoundsException\` at runtime
-  > Correct. Valid indices are 0..length-1.
+  > Valid indices are 0..length-1.
 - Grows the array by one
   > Arrays cannot grow; ArrayList can.`}
 />
@@ -255,7 +255,6 @@ more often than bare arrays.
 - It is faster
   > Arrays are slightly faster for primitives.
 - [o] It can grow and shrink, has a richer API, and integrates with the rest of the collections framework
-  > Correct.
 - It uses less memory
   > It actually uses more (boxing overhead).
 - The compiler refuses to use \`int[]\`
@@ -270,7 +269,6 @@ more often than bare arrays.
 - Nothing — that's the recommended pattern
   > Not recommended; it throws.
 - [o] It throws \`ConcurrentModificationException\` because the iterator detects the structural change
-  > Correct.
 - It silently loses one element
   > It throws; it does not silently corrupt.`}
 />

--- a/content/learn/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
+++ b/content/learn/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
@@ -230,7 +230,6 @@ But this table covers an *astonishing* fraction of day-to-day code.
 - The algorithm uses the index parity
   > It does not.
 - [o] Each step compares the target to the middle element and then *discards an entire half* of the remaining range based on the ordering; without an ordering, you cannot rule out a half
-  > Correct.
 - Java's binary search throws an exception on unsorted input
   > Behavior is *undefined*, but it doesn't necessarily throw — it can simply return wrong answers.`}
 />
@@ -243,7 +242,6 @@ But this table covers an *astonishing* fraction of day-to-day code.
 - The next-to-last to come out
   > No — it's the very next one.
 - [o] The first one to come out when you pop
-  > Correct.
 - Sorted to the bottom
   > Stacks do not sort.`}
 />
@@ -256,7 +254,6 @@ But this table covers an *astonishing* fraction of day-to-day code.
 - Sort the list first and keep using \`contains\`
   > \`contains\` does not benefit from sorting.
 - [o] Replace the ArrayList with a HashSet so each \`contains\` call runs in roughly constant time
-  > Correct.
 - Re-create the list with a smaller capacity
   > Does not change \`contains\`'s linear cost.`}
 />

--- a/content/learn/java-programming-for-beginners/birth-of-oop.mdx
+++ b/content/learn/java-programming-for-beginners/birth-of-oop.mdx
@@ -125,7 +125,7 @@ programs in the millions of lines without our heads exploding.
 - Smalltalk
   > Smalltalk popularized them, but they were invented earlier.
 - [o] Simula 67
-  > Correct. Simula, built for simulations, introduced classes and objects.
+  > Simula, built for simulations, introduced classes and objects.
 - Java
   > Java is a major adopter, not the inventor.`}
 />
@@ -136,7 +136,7 @@ programs in the millions of lines without our heads exploding.
 - Programs were too slow
   > Encapsulation is about correctness and maintainability, not speed.
 - [o] In large procedural programs, any code could change any data, making bugs nearly impossible to localize
-  > Correct. Encapsulation gives each piece of data a single owner.
+  > Encapsulation gives each piece of data a single owner.
 - Programmers wanted to type less
   > OOP usually adds typing, not removes it.
 - Computers did not have enough memory for procedures

--- a/content/learn/java-programming-for-beginners/classes-and-objects.mdx
+++ b/content/learn/java-programming-for-beginners/classes-and-objects.mdx
@@ -237,7 +237,7 @@ wasn't there*.
 - An object is the blueprint; a class is one specific instance
   > That's backwards.
 - [o] A class is a blueprint describing structure and behavior; an object is one specific instance created from that blueprint
-  > Correct. Many objects, one class.
+  > Many objects, one class.
 - A class is for primitives; an object is for reference types
   > Both classes and objects are reference-type concepts.`}
 />
@@ -250,7 +250,6 @@ wasn't there*.
 - The most recently created \`Dog\`
   > No, it refers to the specific receiver.
 - [o] The specific \`Dog\` object the method was called on — that is, \`rex\`
-  > Correct.
 - A reserved field automatically present on every object
   > It's a keyword, not a field.`}
 />

--- a/content/learn/java-programming-for-beginners/computational-thinking.mdx
+++ b/content/learn/java-programming-for-beginners/computational-thinking.mdx
@@ -170,7 +170,7 @@ part*. Translating into Java becomes a clerical task.
 - Pattern recognition
   > That's about *spotting* familiar sub-problems, not creating them.
 - [o] Decomposition
-  > Correct. Decomposition is breaking a problem down.
+  > Decomposition is breaking a problem down.
 - Abstraction
   > Abstraction hides details, but does not split the work.
 - Algorithm design
@@ -183,7 +183,7 @@ part*. Translating into Java becomes a clerical task.
 - It makes programs run faster
   > Abstraction is about *managing complexity*, not speed.
 - [o] It lets the caller use a piece of code without needing to understand its internals
-  > Correct. Hiding details lets each part of the program be understood on its own.
+  > Hiding details lets each part of the program be understood on its own.
 - It removes bugs from the program automatically
   > It does not.
 - It is required by the Java compiler

--- a/content/learn/java-programming-for-beginners/constructors-and-lifecycle.mdx
+++ b/content/learn/java-programming-for-beginners/constructors-and-lifecycle.mdx
@@ -223,7 +223,7 @@ chapter.
 - Because they return \`void\`
   > They don't even return \`void\` — the return type is omitted entirely.
 - [o] Because their "return value" is the newly created object, handed back by \`new\`, not by the constructor itself
-  > Correct. The constructor's job is to initialize, not to return.
+  > The constructor's job is to initialize, not to return.
 - Because Java's syntax does not allow return types in any method
   > Methods do have return types; constructors are the exception.
 - Because they always return \`null\`
@@ -236,7 +236,7 @@ chapter.
 - To free memory when an object dies
   > Java reclaims memory automatically.
 - [o] To run code that brings a new object into a valid initial state
-  > Correct. Construction = initialization + invariant enforcement.
+  > Construction = initialization + invariant enforcement.
 - To replace one object with another
   > It builds; it does not replace.
 - To print debug information

--- a/content/learn/java-programming-for-beginners/control-flow.mdx
+++ b/content/learn/java-programming-for-beginners/control-flow.mdx
@@ -228,7 +228,6 @@ beginner milestones.
 - \`while\` is faster than \`do-while\`
   > Speed is not the distinction.
 - [o] \`while\` checks the condition before the first iteration; \`do-while\` checks after, so its body always runs at least once
-  > Correct.
 - \`do-while\` cannot have a condition
   > It must have one — it's the trailing condition.`}
 />
@@ -241,7 +240,7 @@ beginner milestones.
 - Creates a new array \`x\` with the same contents as \`arr\`
   > It does not create an array.
 - [o] Iterates over each element of \`arr\` in order, binding the current element to \`x\`
-  > Correct. \`x\` is the *element*, not the index.
+  > \`x\` is the *element*, not the index.
 - Sorts the array
   > It does not sort.`}
 />

--- a/content/learn/java-programming-for-beginners/debugging-and-reasoning.mdx
+++ b/content/learn/java-programming-for-beginners/debugging-and-reasoning.mdx
@@ -238,7 +238,6 @@ difference is the bug.
 - A middle line, picked at random
   > Not useful.
 - [o] The top-most line — it points to the actual statement that threw the exception
-  > Correct.
 - The line that mentions \`Thread.run\`
   > That's framework plumbing, not your code.`}
 />
@@ -251,7 +250,6 @@ difference is the bug.
 - Invariants make code faster
   > That's not the point.
 - [o] By stating "X must be true at this point," you can bisect a long computation into parts that obey the invariant and parts that violate it, narrowing the bug
-  > Correct.
 - Invariants prevent all bugs by themselves
   > They help find bugs; they do not prevent them.`}
 />
@@ -264,7 +262,6 @@ difference is the bug.
 - It slows the programmer down enough for a coffee break
   > Funny but not the reason.
 - [o] Explaining the code line by line forces the programmer to articulate *what each step is supposed to do*, which often surfaces the line that doesn't match the explanation
-  > Correct.
 - It causes the compiler to recheck the code
   > It does not.`}
 />

--- a/content/learn/java-programming-for-beginners/early-programming.mdx
+++ b/content/learn/java-programming-for-beginners/early-programming.mdx
@@ -78,7 +78,7 @@ for a while.
 - It made programs run faster
   > Assembly translates to the same machine code; speed is unchanged.
 - [o] It gave instructions short readable names, so humans could write and debug them more easily
-  > Correct. Assembly was the first major step toward making programs human-readable.
+  > Assembly was the first major step toward making programs human-readable.
 - It allowed the same program to run on any CPU
   > That came later, with high-level languages.
 - It removed the need for an operator to load programs
@@ -124,7 +124,7 @@ the **software crisis**. That is the next page.
 - A type of machine instruction
   > Procedures are built *out of* machine instructions, but are higher-level.
 - [o] A named, reusable sequence of instructions that other parts of the program can call
-  > Correct. Procedures are the basic building block of procedural programming.
+  > Procedures are the basic building block of procedural programming.
 - A diagram explaining the program
   > Diagrams describe code, but a procedure is real code itself.`}
 />

--- a/content/learn/java-programming-for-beginners/encapsulation-and-abstraction.mdx
+++ b/content/learn/java-programming-for-beginners/encapsulation-and-abstraction.mdx
@@ -209,7 +209,7 @@ return an unmodifiable view, or expose specific operations like
 - It makes the class faster
   > Access modifiers do not change speed in any meaningful way.
 - [o] So the class itself is the only place that decides how its own data may change, allowing it to enforce its invariants
-  > Correct. Encapsulation gives the class ownership of its own rules.
+  > Encapsulation gives the class ownership of its own rules.
 - Because the Java compiler refuses to compile public fields
   > It compiles them fine — encapsulation is a design choice, not a language requirement.`}
 />
@@ -222,7 +222,7 @@ return an unmodifiable view, or expose specific operations like
 - It has a getter and setter for every field
   > That is often a sign of *bad* encapsulation — the API mirrors the storage.
 - [o] Its public methods are named for behaviors that callers actually need, and its fields are private
-  > Correct. The API talks about *behavior*, not storage.
+  > The API talks about *behavior*, not storage.
 - It uses the keyword \`final\` somewhere
   > \`final\` helps but is not the central criterion.`}
 />

--- a/content/learn/java-programming-for-beginners/enterprise-and-cross-platform.mdx
+++ b/content/learn/java-programming-for-beginners/enterprise-and-cross-platform.mdx
@@ -106,7 +106,7 @@ ten years, a single forgotten `delete` could ruin everyone's week.
 - Because computers were getting more expensive
   > The cost of hardware was actually falling.
 - [o] Because big organizations ran many different kinds of machines and could not afford to maintain a separate program for each one
-  > Correct. Enterprise environments were heterogeneous, and rewriting per platform was painful.
+  > Enterprise environments were heterogeneous, and rewriting per platform was painful.
 - Because users wanted programs to look identical everywhere
   > Visual consistency mattered but was not the main driver.
 - Because the internet did not yet exist
@@ -157,7 +157,7 @@ next page.
 - C++ did not support inheritance
   > It did, very early.
 - [o] C++ required the programmer to manually allocate and free memory, which became error-prone at large scale
-  > Correct. Manual memory management is powerful but fragile in big codebases.
+  > Manual memory management is powerful but fragile in big codebases.
 - C++ could not compile on Unix systems
   > C++ ran perfectly well on Unix.`}
 />
@@ -168,7 +168,7 @@ next page.
 - Browsers could not display text
   > They could.
 - [o] C++ compiled to a CPU-specific binary, but a browser could be running on any CPU on any operating system
-  > Correct. The browser ran on many platforms, and a single C++ build could not target all of them.
+  > The browser ran on many platforms, and a single C++ build could not target all of them.
 - C++ did not support graphics
   > It supported graphics through platform libraries.
 - Browsers did not support classes

--- a/content/learn/java-programming-for-beginners/evolution-of-java.mdx
+++ b/content/learn/java-programming-for-beginners/evolution-of-java.mdx
@@ -145,7 +145,7 @@ language running on the JVM.
 - It has been used mostly for graphical desktop applications
   > Briefly, but never primarily.
 - [o] It started as a small portable language for embedded and browser use, and became a major language for servers, mobile, and data infrastructure
-  > Correct. Java's center of gravity moved server-side and stayed there.
+  > Java's center of gravity moved server-side and stayed there.
 - It has been replaced by Kotlin in almost all use cases
   > Kotlin is popular for Android, but most server-side Java code is still Java.
 - It has not changed since 1996
@@ -158,7 +158,7 @@ language running on the JVM.
 - Because the JVM no longer supports them
   > The JVM still supports the relevant APIs; the issue is elsewhere.
 - [o] Because browsers stopped supporting browser plug-ins, and JavaScript took over interactive content in web pages
-  > Correct. The browser environment changed, and applets did not fit anymore.
+  > The browser environment changed, and applets did not fit anymore.
 - Because Java itself has been deprecated
   > Java is alive and well.
 - Because Sun never released them

--- a/content/learn/java-programming-for-beginners/exception-handling.mdx
+++ b/content/learn/java-programming-for-beginners/exception-handling.mdx
@@ -287,7 +287,6 @@ each problem is *recognized*, *named*, and *handled*.
 - Unchecked exceptions cannot be caught
   > They can be caught — the compiler just doesn't *require* it.
 - [o] Checked exceptions must be either caught or declared in a \`throws\` clause; unchecked exceptions (RuntimeException and its subclasses) have no such requirement
-  > Correct.
 - Unchecked exceptions are always fatal
   > They can be caught and recovered from.`}
 />
@@ -300,7 +299,6 @@ each problem is *recognized*, *named*, and *handled*.
 - The compiler refuses to compile it
   > It compiles fine.
 - [o] It silently swallows every failure, hiding bugs and making the program produce wrong answers without telling anyone
-  > Correct.
 - It always throws \`NullPointerException\`
   > It does nothing of the sort.`}
 />
@@ -313,7 +311,6 @@ each problem is *recognized*, *named*, and *handled*.
 - Only when an exception was thrown
   > It runs in both cases.
 - [o] Always — after the try (and any catch) finishes, whether or not an exception was thrown
-  > Correct.
 - Only when the JVM is shutting down
   > It runs at the end of every \`try\` block.`}
 />

--- a/content/learn/java-programming-for-beginners/gosling-and-java.mdx
+++ b/content/learn/java-programming-for-beginners/gosling-and-java.mdx
@@ -105,7 +105,7 @@ flowchart LR
 - Scientific computing
   > That was FORTRAN's strength.
 - [o] Programming consumer electronics devices like TVs and set-top boxes
-  > Correct. The Green project's original target was embedded devices.
+  > The Green project's original target was embedded devices.
 - Database servers
   > Java would later dominate this space, but it was not the original target.`}
 />
@@ -152,7 +152,7 @@ important idea in the rest of this course.
 - Functions
   > Java has methods, which are essentially functions inside classes.
 - [o] Manual memory management with explicit \`new\` and \`delete\`
-  > Correct. Java introduced automatic garbage collection.
+  > Java introduced automatic garbage collection.
 - Strong typing
   > Java has *stricter* typing than C++, not weaker.`}
 />
@@ -165,7 +165,7 @@ important idea in the rest of this course.
 - Because they are all interpreted languages
   > C and C++ are compiled to machine code, not interpreted.
 - [o] Because Gosling kept C-family syntax on purpose so existing C/C++ programmers would feel at home
-  > Correct. Surface familiarity was a deliberate adoption strategy.
+  > Surface familiarity was a deliberate adoption strategy.
 - Because all programming languages look the same
   > They very much do not.`}
 />

--- a/content/learn/java-programming-for-beginners/how-programs-execute.mdx
+++ b/content/learn/java-programming-for-beginners/how-programs-execute.mdx
@@ -161,7 +161,7 @@ flowchart LR
 - A native executable for your operating system
   > That's what C/C++ compilers produce, not \`javac\`.
 - [o] One or more \`.class\` files containing platform-independent bytecode
-  > Correct. Bytecode is the input to the JVM.
+  > Bytecode is the input to the JVM.
 - A new \`.java\` file
   > It reads \`.java\` and produces \`.class\`.
 - Machine code that only runs on the developer's CPU
@@ -176,7 +176,6 @@ flowchart LR
 - Because the JVM is faster than native execution
   > Generally the opposite, though the JIT closes much of the gap.
 - [o] Because bytecode is portable — the same \`.class\` files can run on any platform that has a JVM, fulfilling Java's "write once, run anywhere" promise
-  > Correct.
 - Because Java cannot be compiled directly
   > It could be, in principle — the design choice was portability.`}
 />
@@ -187,7 +186,7 @@ flowchart LR
 - The actual numeric value of an int variable
   > That depends on input or computation at run time.
 - [o] Whether a particular field is accessible from a particular call site, based on its access modifier
-  > Correct. Access checks are done by the compiler.
+  > Access checks are done by the compiler.
 - Which override of a method is dispatched to
   > That's a runtime decision (dynamic dispatch).
 - Whether a file actually exists on disk

--- a/content/learn/java-programming-for-beginners/inheritance-and-polymorphism.mdx
+++ b/content/learn/java-programming-for-beginners/inheritance-and-polymorphism.mdx
@@ -258,7 +258,7 @@ Common red flags that you should *not* be using inheritance:
 - Allocate less memory for subclasses
   > Memory layout is unrelated.
 - [o] Call the same method on different objects and have each respond in its own way, decided at runtime
-  > Correct. That's exactly dynamic dispatch.
+  > That's exactly dynamic dispatch.
 - Write a class without any methods
   > Not what polymorphism means.`}
 />
@@ -271,7 +271,7 @@ Common red flags that you should *not* be using inheritance:
 - They sound related in English
   > Too loose a criterion.
 - [o] Every instance of the child class genuinely *is a* legitimate instance of the parent and can be used wherever the parent is expected
-  > Correct — this is the Liskov substitution intuition.
+  > This is the Liskov substitution intuition.
 - The child wants to reuse one helper method from the parent
   > Reuse alone is not enough — use composition instead.`}
 />
@@ -282,7 +282,6 @@ Common red flags that you should *not* be using inheritance:
 - It makes the override happen
   > The override happens whether or not you annotate it.
 - [o] It tells the compiler "this method is supposed to override a parent's method," so a typo or signature mismatch becomes a compile error instead of a silently-new method
-  > Correct.
 - It marks the method as final
   > That's \`final\`, not \`@Override\`.
 - It improves runtime performance

--- a/content/learn/java-programming-for-beginners/interfaces.mdx
+++ b/content/learn/java-programming-for-beginners/interfaces.mdx
@@ -255,7 +255,6 @@ only cares that it can call `List` methods on the parameter.
 - Abstract classes are faster
   > Speed is unrelated.
 - [o] A class can implement many interfaces but extend only one class, so interfaces are the right way to mix in multiple independent capabilities
-  > Correct.
 - Interfaces support fields, abstract classes don't
   > It's the other way around.
 - Interfaces don't allow \`@Override\`
@@ -270,7 +269,6 @@ only cares that it can call `List` methods on the parameter.
 - ArrayList is deprecated
   > It is not.
 - [o] You ask only for the capability you actually need, so callers can pass any List implementation and you can change your own storage later
-  > Correct.
 - The compiler refuses concrete types in parameters
   > It accepts them just fine.`}
 />

--- a/content/learn/java-programming-for-beginners/java-becomes-dominant.mdx
+++ b/content/learn/java-programming-for-beginners/java-becomes-dominant.mdx
@@ -92,7 +92,7 @@ transfers cleanly.
 - Because it could be combined with COBOL in the same source file
   > It could not.
 - [o] Because it was portable across platforms, garbage-collected, strongly typed, and supported by a major hardware vendor
-  > Correct. Several pragmatic advantages combined to make Java a safe long-term bet.
+  > Several pragmatic advantages combined to make Java a safe long-term bet.
 - Because it was the cheapest language to license
   > It was free, but so were many others.`}
 />
@@ -103,7 +103,7 @@ transfers cleanly.
 - Because it is the simplest language to write small programs in
   > Languages like Python are arguably simpler for very small programs.
 - [o] Because its strict structure (mandatory classes, strong typing, simple memory model) forces students to learn programming concepts clearly without too many language footguns
-  > Correct. Java is *explicit*, which is pedagogically useful.
+  > Java is *explicit*, which is pedagogically useful.
 - Because the JVM is required for the AP exam
   > The AP exam uses Java, not the other way around.
 - Because Java is required by law in many countries

--- a/content/learn/java-programming-for-beginners/javas-influence.mdx
+++ b/content/learn/java-programming-for-beginners/javas-influence.mdx
@@ -150,7 +150,7 @@ lessons.
 - The use of carriage returns to end lines of source code
   > That predates Java by decades.
 - [o] Garbage collection in production-grade general-purpose programming
-  > Correct. GC existed (Lisp had it) but Java made it mainstream.
+  > GC existed (Lisp had it) but Java made it mainstream.
 - The notion of a function
   > Functions go back to the very beginning.
 - Storing strings in variables
@@ -165,7 +165,7 @@ lessons.
 - BASIC
   > BASIC is from the 1960s.
 - [o] C#, created by Microsoft as a Windows-friendly counterpart to Java
-  > Correct. C# borrowed extensively from Java's syntax and design.
+  > C# borrowed extensively from Java's syntax and design.
 - FORTRAN
   > FORTRAN is from the 1950s.`}
 />

--- a/content/learn/java-programming-for-beginners/jvm-conceptually.mdx
+++ b/content/learn/java-programming-for-beginners/jvm-conceptually.mdx
@@ -218,7 +218,6 @@ flat. You didn't write a single line of cleanup code.
 - It compiles everything to native code before running anything
   > That's "ahead-of-time" compilation, not the standard JVM model.
 - [o] It interprets bytecode at first, and uses a Just-In-Time compiler to translate frequently-used methods into native CPU instructions for speed
-  > Correct.
 - It runs Java code by translating it back to source first
   > It does not.`}
 />
@@ -229,7 +228,6 @@ flat. You didn't write a single line of cleanup code.
 - To make the JVM smaller
   > It actually makes the JVM larger and more complex.
 - [o] So programmers do not have to manually free memory; objects that become unreachable are reclaimed automatically
-  > Correct.
 - To prevent the program from creating any objects
   > It does not prevent allocation; it manages reclamation.
 - Because the JVM cannot create memory itself
@@ -244,7 +242,7 @@ flat. You didn't write a single line of cleanup code.
 - The method area
   > That stores class definitions, not instances.
 - [o] The heap
-  > Correct. Objects live in the shared heap.
+  > Objects live in the shared heap.
 - The class loader
   > A class loader loads classes; it isn't a memory region.`}
 />

--- a/content/learn/java-programming-for-beginners/maintainable-software.mdx
+++ b/content/learn/java-programming-for-beginners/maintainable-software.mdx
@@ -248,7 +248,6 @@ month the marketing team says "make shipping free above $40" or
 - The compiler inlines them automatically
   > It may, but that's not the maintainability reason.
 - [o] Each method reads like a sentence, can be understood in isolation, and can be changed without affecting unrelated logic
-  > Correct.
 - The JIT runs faster on small methods
   > That's a tiny detail at best, not the point.`}
 />
@@ -261,7 +260,7 @@ month the marketing team says "make shipping free above $40" or
 - The literal \`1\` used to add one to a counter
   > Usually fine.
 - [o] The literal \`0.07\` used to multiply a price for tax
-  > Correct — its meaning ("tax rate") is not obvious from the digits.
+  > Its meaning ("tax rate") is not obvious from the digits.
 - The literal \`"\\n"\` used in a print statement
   > Often fine inline.`}
 />
@@ -274,7 +273,6 @@ month the marketing team says "make shipping free above $40" or
 - It needs more methods
   > It needs fewer responsibilities, not more methods.
 - [o] It is doing too many unrelated things — the word "and" in its description hints that it should be split into several focused classes
-  > Correct.
 - It should be made \`abstract\`
   > Abstractness doesn't address the responsibility problem.`}
 />

--- a/content/learn/java-programming-for-beginners/maps-and-sets.mdx
+++ b/content/learn/java-programming-for-beginners/maps-and-sets.mdx
@@ -215,7 +215,6 @@ genuinely don't know in advance.
 - The second add throws an exception
   > It doesn't throw.
 - [o] The second add is silently ignored — the set still contains exactly one copy
-  > Correct.
 - The set now contains two copies
   > Sets enforce uniqueness.
 - The first copy is removed
@@ -230,7 +229,6 @@ genuinely don't know in advance.
 - It keeps the map sorted by key
   > It does not sort.
 - [o] It computes the key's hash code, picks a bucket directly, and looks only in that bucket
-  > Correct.
 - It uses a binary search across the keys
   > That's a TreeMap (and it's O(log n), not O(1)).`}
 />
@@ -243,7 +241,7 @@ genuinely don't know in advance.
 - HashMap with the ID as the value
   > Keys go in maps, not values.
 - [o] HashSet of IDs
-  > Correct. Constant-time \`contains\`.
+  > Constant-time \`contains\`.
 - A plain array
   > Same problem as ArrayList: linear search.`}
 />

--- a/content/learn/java-programming-for-beginners/methods-and-modularity.mdx
+++ b/content/learn/java-programming-for-beginners/methods-and-modularity.mdx
@@ -241,7 +241,7 @@ methods that conceptually do the same thing for different inputs.
 - Because Java requires more than one method per class
   > It doesn't.
 - [o] To give each chunk of logic a name, so the whole program reads as a story of small, named ideas
-  > Correct. Modularity helps humans, not the compiler.
+  > Modularity helps humans, not the compiler.
 - Because variables can only exist inside methods
   > They can exist in classes too (fields).`}
 />
@@ -252,7 +252,6 @@ methods that conceptually do the same thing for different inputs.
 - The maximum size of its body
   > No.
 - [o] The kind of value the method gives back to its caller (or \`void\` if none)
-  > Correct.
 - The number of parameters the method takes
   > That's the parameter list.
 - The name of the variable it stores its result in

--- a/content/learn/java-programming-for-beginners/problem-solving.mdx
+++ b/content/learn/java-programming-for-beginners/problem-solving.mdx
@@ -163,7 +163,7 @@ debugger.
 - Look up the fastest sorting algorithm
   > Premature — you don't yet know the problem.
 - [o] Ask clarifying questions: what does "sort" mean here? Sort by what? Where does the data come from? Where should the result go?
-  > Correct. Understanding the problem comes first.
+  > Understanding the problem comes first.
 - Buy a faster computer
   > No.`}
 />
@@ -239,7 +239,7 @@ o — nine of them.)
 - Using a debugger toy as a substitute for a real debugger
   > It's a technique, not a tool replacement.
 - [o] Explaining your code aloud (to a rubber duck or anyone) so that the act of forming sentences reveals what you missed
-  > Correct. Verbalizing forces clarity.
+  > Verbalizing forces clarity.
 - A way of testing programs by throwing a duck at the screen
   > No, please don't.
 - A formal Java debugger built into Eclipse

--- a/content/learn/java-programming-for-beginners/software-complexity-crisis.mdx
+++ b/content/learn/java-programming-for-beginners/software-complexity-crisis.mdx
@@ -85,7 +85,7 @@ This is sometimes called the **maintenance problem**: a program is
 - That computers were too slow to run real programs
   > Hardware was actually improving very quickly.
 - [o] That building large software systems was much harder than anyone had expected, and existing techniques did not scale
-  > Correct. Big programs were collapsing under their own weight.
+  > Big programs were collapsing under their own weight.
 - That programmers were not paid enough
   > Compensation was not the issue named at the conference.
 - That assembly language was about to disappear
@@ -151,7 +151,7 @@ That is the next page.
 - It uses too much memory
   > Memory usage is not the central issue.
 - [o] Any procedure anywhere can change it, so when something goes wrong it is very hard to know who is responsible
-  > Correct. The lack of ownership makes bugs nearly impossible to track down.
+  > The lack of ownership makes bugs nearly impossible to track down.
 - The compiler cannot generate code for global variables
   > Compilers handle global variables fine.
 - It cannot store strings, only numbers
@@ -164,7 +164,7 @@ That is the next page.
 - That programs always run more slowly the larger they get
   > Speed and complexity are separate concerns.
 - [o] That every new piece of code interacts with the existing code, so the effort to keep everything correct grows non-linearly
-  > Correct. This is why we need techniques that *limit* interactions, not just techniques that let us write more lines.
+  > This is why we need techniques that *limit* interactions, not just techniques that let us write more lines.
 - That long programs are impossible to write
   > They are possible, but they require deliberate techniques.
 - That you should never write more than 1000 lines of code

--- a/content/learn/java-programming-for-beginners/software-organization.mdx
+++ b/content/learn/java-programming-for-beginners/software-organization.mdx
@@ -187,7 +187,7 @@ That is the entire game.
 - "Write the fewest possible classes"
   > Smallness isn't the same as good structure.
 - [o] "When something needs to change, only a small, predictable part of the system needs to change"
-  > Correct. Sometimes called the "locality of change" principle.
+  > Sometimes called the "locality of change" principle.
 - "Make every class depend on every other class for flexibility"
   > That's the opposite of low coupling.`}
 />
@@ -200,7 +200,6 @@ That is the entire game.
 - The compiler refuses to allow it
   > It allows it; this is a design rule, not a compiler rule.
 - [o] It couples the core business rules to a specific technology choice, making the domain hard to test, hard to reuse, and hard to evolve as the infrastructure changes
-  > Correct.
 - It causes a stack overflow
   > It does not.`}
 />
@@ -213,7 +212,6 @@ That is the entire game.
 - "Many classes"
   > Not the summary.
 - [o] "High cohesion, low coupling"
-  > Correct.
 - "Latest framework"
   > Not the summary.`}
 />

--- a/content/learn/java-programming-for-beginners/stack-and-heap.mdx
+++ b/content/learn/java-programming-for-beginners/stack-and-heap.mdx
@@ -272,7 +272,6 @@ The fix: every recursion must reach a base case.
 - All objects the method has ever created
   > Objects live on the heap, not in stack frames.
 - [o] The method's parameters and local variables, including primitives by value and references that point to heap objects
-  > Correct.
 - A copy of every object passed to the method
   > Java does not deep-copy objects on call; it copies the reference.
 - The bytecode of the method
@@ -287,7 +286,7 @@ The fix: every recursion must reach a base case.
 - Zero — Java doesn't allocate a list yet
   > One was already allocated when \`a\` was created.
 - [o] One — \`a\` and \`b\` are two references pointing to the *same* list
-  > Correct. That's aliasing.
+  > That's aliasing.
 - One, but \`b\` is an immutable copy
   > It's not a copy at all.`}
 />
@@ -300,7 +299,6 @@ The fix: every recursion must reach a base case.
 - The original Order is silently destroyed
   > Other references may still hold it.
 - [o] Nothing — Java is pass-by-value; reassigning the parameter only changes the local reference inside the method, not the caller's variable
-  > Correct.
 - A compile error
   > It compiles fine.`}
 />

--- a/content/learn/java-programming-for-beginners/the-jvm-vision.mdx
+++ b/content/learn/java-programming-for-beginners/the-jvm-vision.mdx
@@ -118,7 +118,7 @@ classes soon.
 - A type of CPU made by Sun Microsystems
   > It's a *virtual* CPU, implemented in software.
 - [o] A program that pretends to be a computer, executes bytecode, manages memory, and shields your code from the real OS
-  > Correct. The JVM is the runtime environment for Java programs.
+  > The JVM is the runtime environment for Java programs.
 - A graphical environment for writing Java code
   > That would be an IDE.`}
 />
@@ -187,7 +187,7 @@ software that you can ask questions of.
 - Naming your classes
   > That's your job.
 - [o] Reclaiming memory used by objects that are no longer referenced
-  > Correct. The garbage collector is part of the JVM.
+  > The garbage collector is part of the JVM.
 - Choosing which fields a class has
   > That's your job.
 - Drawing windows on the screen
@@ -202,7 +202,7 @@ software that you can ask questions of.
 - Because the JVM auto-translates source code between languages
   > It does not.
 - [o] Because they all compile to JVM bytecode, which is a shared, language-agnostic format
-  > Correct. The JVM is the meeting point.
+  > The JVM is the meeting point.
 - Because Java libraries are written in those languages
   > Java libraries are written in Java.`}
 />

--- a/content/learn/java-programming-for-beginners/the-type-system.mdx
+++ b/content/learn/java-programming-for-beginners/the-type-system.mdx
@@ -222,7 +222,7 @@ compiler can see and check it.
 - To prevent the JVM from running too slowly
   > Type checks help safety, not raw speed.
 - [o] To catch type mistakes before the program runs, so an entire category of bugs is impossible in production
-  > Correct. Static typing trades upfront strictness for runtime safety.
+  > Static typing trades upfront strictness for runtime safety.
 - Because Java was designed before runtime type checking existed
   > Runtime type checking has existed forever; Java's choice is intentional.`}
 />
@@ -235,7 +235,7 @@ compiler can see and check it.
 - \`a.compareTo(b) == 1\`
   > That is true only for a specific ordering, not equality.
 - [o] \`a.equals(b)\`
-  > Correct. \`equals\` on String compares the actual character contents.
+  > \`equals\` on String compares the actual character contents.
 - \`a + b\`
   > That concatenates, it doesn't compare.`}
 />

--- a/content/learn/java-programming-for-beginners/variables-and-memory.mdx
+++ b/content/learn/java-programming-for-beginners/variables-and-memory.mdx
@@ -199,7 +199,7 @@ other across different parts of the program.
 - It creates a permanent constant called x
   > That would require \`final\`.
 - [o] It declares a variable x of type int and stores the value 5 in it
-  > Correct. Declaration + initial assignment.
+  > Declaration + initial assignment.
 - It defines a function called x
   > No — this is a variable declaration, not a function.`}
 />
@@ -212,7 +212,7 @@ other across different parts of the program.
 - They are stored identically
   > They are not.
 - [o] An int holds its value directly; a String variable holds a reference to a String object stored elsewhere in memory
-  > Correct. Primitives are inlined; reference types hold pointers.
+  > Primitives are inlined; reference types hold pointers.
 - A String cannot be declared without \`final\`
   > It can.`}
 />

--- a/content/learn/java-programming-for-beginners/what-is-a-program.mdx
+++ b/content/learn/java-programming-for-beginners/what-is-a-program.mdx
@@ -119,7 +119,7 @@ of every computational system in the world.
 - A set of guidelines the computer mostly follows
   > Programs are executed exactly, not "mostly."
 - [o] A precise, unambiguous sequence of instructions a machine can execute
-  > Correct. Precision and unambiguity are the defining features.
+  > Precision and unambiguity are the defining features.
 - A document written in English describing how to use software
   > That is documentation, not a program.`}
 />
@@ -207,7 +207,7 @@ about doing this with more and more sophistication.
 - It is a fixed list of facts about the world
   > That's a database, not a program.
 - [o] Input → Processing → Output
-  > Correct. Almost every program fits this picture at some level.
+  > Almost every program fits this picture at some level.
 - A sequence of jokes for the computer to enjoy
   > That sounds nice but is not accurate.
 - An advertisement shown to other programs

--- a/content/learn/java-programming-for-beginners/write-once-run-anywhere.mdx
+++ b/content/learn/java-programming-for-beginners/write-once-run-anywhere.mdx
@@ -145,7 +145,7 @@ platform-specific details.
 - An interpreted text file
   > Bytecode is binary, not text.
 - [o] A \`.class\` file containing JVM bytecode
-  > Correct. \`javac\` translates Java source to bytecode for the JVM.
+  > \`javac\` translates Java source to bytecode for the JVM.
 - An image of the source code
   > No, it's binary instructions for the JVM.`}
 />
@@ -156,7 +156,7 @@ platform-specific details.
 - Because the \`.class\` file contains separate code for each platform
   > It contains a single set of bytecode instructions.
 - [o] Because each platform has its own JVM that knows how to execute bytecode
-  > Correct. The platform-specific work is done by the JVM, not by your program.
+  > The platform-specific work is done by the JVM, not by your program.
 - Because operating systems can directly execute bytecode
   > They cannot — bytecode is not native machine code.
 - Because Java is interpreted in the browser

--- a/content/learn/java-programming-for-beginners/your-first-java-program.mdx
+++ b/content/learn/java-programming-for-beginners/your-first-java-program.mdx
@@ -123,7 +123,7 @@ the error message**. Java's compiler is wordy but rarely cryptic.
 - It is the only method that may print to the screen
   > Any method can print.
 - It is the method called automatically by the JVM when the program starts
-  > Correct. \`main\` is the agreed-upon entry point.
+  > \`main\` is the agreed-upon entry point.
 - It is required to be called \`Main\` like the class
   > It must be called \`main\` (lowercase), regardless of the class name.
 - It is optional — Java programs without a \`main\` method still run
@@ -138,7 +138,7 @@ the error message**. Java's compiler is wordy but rarely cryptic.
 - Because \`static\` means the same as \`public\`
   > They mean different things.
 - [o] Because the JVM needs to call \`main\` before any object of the class has been constructed
-  > Correct. \`static\` means "belongs to the class itself," so it can be called without an instance.
+  > \`static\` means "belongs to the class itself," so it can be called without an instance.
 - Because \`static\` is required for every method in Java
   > Most methods are *not* static.`}
 />

--- a/content/learn/mastering-dsa-cpp/arrays.mdx
+++ b/content/learn/mastering-dsa-cpp/arrays.mdx
@@ -329,7 +329,7 @@ int main() {
   markdown={`Why does iterating through a \`std::vector<int>\` often run faster than iterating through a linked list with the same number of integers?
 
 - [o] The vector stores elements contiguously, which improves cache locality.
-  > Correct. Nearby values are likely loaded into CPU cache together.
+  > Nearby values are likely loaded into CPU cache together.
 - A vector changes every operation to O(log n).
   > Vector iteration is O(n), but constants are often smaller.
 - A linked list cannot store integers.
@@ -344,7 +344,7 @@ int main() {
 - \`std::list\` has O(1) random access.
   > It does not. Random access in a list requires walking nodes.
 - [o] \`std::vector\` has compact storage, O(1) indexing, and excellent iteration performance.
-  > Correct. These properties make it the default sequence container.
+  > These properties make it the default sequence container.
 - \`std::vector\` can only store primitive types.
   > It can store objects too.
 - \`std::list\` is always asymptotically slower for every operation.
@@ -359,7 +359,7 @@ int main() {
 - \`v[i]\` checks bounds and throws if invalid.
   > That describes \`at\`, not \`operator[]\`.
 - [o] \`v.at(i)\` performs bounds checking and throws an exception when \`i\` is invalid.
-  > Correct. \`operator[]\` has undefined behavior for an invalid index.
+  > \`operator[]\` has undefined behavior for an invalid index.
 - \`v.at(i)\` inserts a new element if \`i\` is too large.
   > It does not insert; it reports an error.`}
 />

--- a/content/learn/mastering-dsa-cpp/backtracking.mdx
+++ b/content/learn/mastering-dsa-cpp/backtracking.mdx
@@ -235,7 +235,6 @@ int main() { std::vector<std::vector<char>> b = {{'A','B','C','E'}, {'S','F','C'
 - Sort -> scan -> stop.
   > Greedy style.
 - [o] Choose -> explore -> un-choose.
-  > Correct.
 - Hash -> lookup -> return.
   > Not the core pattern.
 - Push all nodes into a queue.
@@ -244,7 +243,6 @@ int main() { std::vector<std::vector<char>> b = {{'A','B','C','E'}, {'S','F','C'
 <MultipleChoice markdown={`What is pruning?
 
 - [o] Rejecting a partial solution before exploring all descendants.
-  > Correct.
 - Printing every solution twice.
   > No.
 - Removing all recursion.
@@ -255,7 +253,6 @@ int main() { std::vector<std::vector<char>> b = {{'A','B','C','E'}, {'S','F','C'
 <MultipleChoice markdown={`Why unmark a grid cell in word search?
 
 - [o] Other paths may need to use it later.
-  > Correct.
 - To sort the board.
   > No.
 - To make DFS iterative.

--- a/content/learn/mastering-dsa-cpp/binary-search-trees.mdx
+++ b/content/learn/mastering-dsa-cpp/binary-search-trees.mdx
@@ -441,7 +441,7 @@ int main() {
 - All descendants are greater than the node
   > Left descendants should be smaller.
 - [o] Values in the left subtree are smaller and values in the right subtree are larger.
-  > Correct. The rule applies recursively.
+  > The rule applies recursively.
 - Only immediate children must be sorted alphabetically
   > The invariant must hold through entire subtrees.
 - Every node has exactly two children
@@ -450,7 +450,7 @@ int main() {
 <MultipleChoice markdown={`What is the cost of search in a BST of height h?
 
 - [o] O(h)
-  > Correct. Search follows one path from the root.
+  > Search follows one path from the root.
 - O(1) always
   > Only the root can be checked in constant time.
 - O(n log n)
@@ -465,6 +465,6 @@ int main() {
 - To make recursion iterative
   > Bounds work in either recursive or iterative validation.
 - [o] A node can satisfy its parent but violate an ancestor.
-  > Correct. Ancestor constraints must be carried downward.
+  > Ancestor constraints must be carried downward.
 - Because leaf nodes are always invalid
   > Leaves can be perfectly valid.`} />

--- a/content/learn/mastering-dsa-cpp/complexity-analysis.mdx
+++ b/content/learn/mastering-dsa-cpp/complexity-analysis.mdx
@@ -250,7 +250,7 @@ int main() {
   markdown={`Which complexity grows more slowly for large \`n\`: O(n log n) or O(n^2)?
 
 - [o] O(n log n) grows more slowly
-  > Correct. \`n log n\` grows more slowly than \`n^2\` as \`n\` becomes large.
+  > \`n log n\` grows more slowly than \`n^2\` as \`n\` becomes large.
 - O(n^2) is asymptotically faster
   > Quadratic growth eventually dominates \`n log n\`.
 - They are the same because both contain \`n\`
@@ -265,7 +265,7 @@ int main() {
 - O(1)
   > It usually takes more than one comparison.
 - [o] O(log n)
-  > Correct. Each comparison halves the remaining search space.
+  > Each comparison halves the remaining search space.
 - O(n)
   > That describes a linear scan.
 - O(n^2)
@@ -280,7 +280,7 @@ int main() {
 - Every call is worst-case O(1), even when the vector reallocates
   > Reallocation can move existing elements, so one call can be O(n).
 - [o] A sequence of many pushes has constant average cost per push, even though occasional pushes are expensive
-  > Correct. Reallocations are spread across many cheap insertions.
+  > Reallocations are spread across many cheap insertions.
 - It means pushing is O(log n) but written differently
   > Amortized O(1) and O(log n) are different claims.`}
 />
@@ -289,7 +289,7 @@ int main() {
   markdown={`For a fixed input size \`n = 10\`, is an O(n!) algorithm always slower than an O(2^n) algorithm?
 
 - [o] No; asymptotic notation describes growth, and constants/implementation details can dominate at one fixed input size
-  > Correct. O(n!) grows faster eventually, but Big-O alone does not guarantee runtime for one fixed small input.
+  > O(n!) grows faster eventually, but Big-O alone does not guarantee runtime for one fixed small input.
 - Yes; Big-O gives exact runtimes for every \`n\`
   > Big-O is not an exact stopwatch.
 - Yes; Big-O rankings give exact runtime order at \`n = 10\`

--- a/content/learn/mastering-dsa-cpp/cpp-essentials.mdx
+++ b/content/learn/mastering-dsa-cpp/cpp-essentials.mdx
@@ -264,7 +264,7 @@ int main() {
 - When the argument may be missing and represented as null
   > That is a reason to use a pointer or another optional type.
 - [o] When the function requires a valid object and may modify it
-  > Correct. A non-const reference clearly means a valid object is required and can be changed.
+  > A non-const reference clearly means a valid object is required and can be changed.
 - When you need to allocate memory manually
   > References do not allocate memory.
 - When you want to store an address in a container
@@ -279,7 +279,7 @@ int main() {
 - It allows the function to delete elements faster
   > \`const\` prevents modification.
 - [o] It avoids copying the whole vector while preventing modification
-  > Correct. This is the standard pattern for read-only access to large objects.
+  > This is the standard pattern for read-only access to large objects.
 - It converts the vector into an array
   > No conversion happens.`}
 />
@@ -292,7 +292,7 @@ int main() {
 - \`<vector>\`
   > This provides \`std::vector\`, not sorting algorithms.
 - [o] \`<algorithm>\`
-  > Correct. Many general-purpose STL algorithms live in \`<algorithm>\`.
+  > Many general-purpose STL algorithms live in \`<algorithm>\`.
 - \`<queue>\`
   > This provides queue adapters such as \`std::queue\` and \`std::priority_queue\`.`}
 />

--- a/content/learn/mastering-dsa-cpp/doubly-linked-lists.mdx
+++ b/content/learn/mastering-dsa-cpp/doubly-linked-lists.mdx
@@ -326,7 +326,7 @@ int main() {
 - A pointer to the head of the whole program
   > Nodes do not point to the whole program.
 - [o] A pointer to the previous node
-  > Correct. The previous pointer enables backward traversal.
+  > The previous pointer enables backward traversal.
 - A copy of every earlier value
   > That would be wasteful and is not how lists work.
 - A random-access index table
@@ -337,7 +337,7 @@ int main() {
   markdown={`Which statement about \`std::list\` is true?
 
 - [o] It has stable iterators for elements not erased, but it does not support random access.
-  > Correct. You can insert without invalidating other iterators, but you cannot use \`list[i]\`.
+  > You can insert without invalidating other iterators, but you cannot use \`list[i]\`.
 - It is always faster than \`std::vector\` for iteration.
   > Usually the opposite is true because of cache locality.
 - It stores all values contiguously.
@@ -354,7 +354,7 @@ int main() {
 - When you want the best cache locality for scanning
   > Vector is usually better for scanning.
 - [o] When you rely on splice operations or stable iterators.
-  > Correct. These are the list's distinctive strengths.
+  > These are the list's distinctive strengths.
 - When values must be sorted automatically
   > A list does not automatically keep itself sorted.`}
 />

--- a/content/learn/mastering-dsa-cpp/dynamic-programming.mdx
+++ b/content/learn/mastering-dsa-cpp/dynamic-programming.mdx
@@ -310,7 +310,6 @@ int main() {
 - Every subproblem is unique.
   > That gives little reuse.
 - [o] The problem has optimal substructure and overlapping subproblems.
-  > Correct.
 - The input is always sorted.
   > Sorting is not required.
 - Only for graphs.
@@ -319,7 +318,6 @@ int main() {
 <MultipleChoice markdown={`What is top-down DP?
 
 - [o] Recursion plus a cache.
-  > Correct.
 - Iteration without storage.
   > Usually bottom-up uses iteration.
 - Sorting by value.
@@ -332,7 +330,6 @@ int main() {
 - O(n + m)
   > It checks pairs of prefixes.
 - [o] O(nm)
-  > Correct.
 - O(log n)
   > No halving.
 - O(2^n)
@@ -345,6 +342,5 @@ int main() {
 - C++ memoizes automatically.
   > It does not.
 - [o] Each state needs only the previous two values.
-  > Correct.
 - It only works for n=10.
   > The dependency pattern is general.`} />

--- a/content/learn/mastering-dsa-cpp/graph-traversal.mdx
+++ b/content/learn/mastering-dsa-cpp/graph-traversal.mdx
@@ -616,7 +616,7 @@ int main() {
   markdown={`Which data structure is the usual core of BFS?
 
 - [o] Queue
-  > Correct. BFS processes vertices in first-in, first-out order.
+  > BFS processes vertices in first-in, first-out order.
 - Stack
   > A stack is the usual core of iterative DFS.
 - Binary search tree
@@ -633,7 +633,7 @@ BFS uses a queue so all vertices at distance k are processed before distance k +
 - Queue only
   > A queue creates breadth-first behavior.
 - [o] Recursion or an explicit stack
-  > Correct. DFS follows one path deeply, which matches the call stack or a stack container.
+  > DFS follows one path deeply, which matches the call stack or a stack container.
 - Priority queue only
   > Priority queues order by priority, not depth.
 - Hash table only
@@ -650,7 +650,7 @@ Recursive DFS is concise; iterative DFS avoids recursion-depth limits.`}
 - Only in complete graphs
   > Completeness is not required.
 - [o] In unweighted graphs, where every edge has equal cost
-  > Correct. BFS minimizes number of edges.
+  > BFS minimizes number of edges.
 - Only in directed acyclic graphs
   > DAGs can be weighted; BFS is not generally enough there.
 

--- a/content/learn/mastering-dsa-cpp/graphs.mdx
+++ b/content/learn/mastering-dsa-cpp/graphs.mdx
@@ -338,7 +338,7 @@ int main() {
 - Adjacency matrix
   > A matrix needs O(V²) space, which is enormous for one million vertices.
 - [o] Adjacency list
-  > Correct. It stores only existing edges and uses O(V + E) space.
+  > It stores only existing edges and uses O(V + E) space.
 - A sorted array of vertices only
   > Vertices alone do not store connectivity.
 - A single stack
@@ -355,7 +355,7 @@ Sparse graphs usually favor adjacency lists because they avoid storing absent ed
 - A dense adjacency graph
   > Density describes how many edges exist, not whether cycles exist.
 - [o] A directed acyclic graph
-  > Correct. DAG stands for directed acyclic graph.
+  > DAG stands for directed acyclic graph.
 - A graph represented only by a matrix
   > Representation does not define whether a graph is a DAG.
 
@@ -366,7 +366,7 @@ DAGs are common in dependency graphs, build systems, and scheduling.`}
   markdown={`How does edge lookup \`hasEdge(u, v)\` compare between an adjacency matrix and an unsorted adjacency list?
 
 - [o] Matrix is O(1); list is O(degree(u))
-  > Correct. A matrix indexes directly, while a list scans neighbors of u.
+  > A matrix indexes directly, while a list scans neighbors of u.
 - Matrix is O(V²); list is O(1)
   > Matrix construction is O(V²), but lookup is direct.
 - Both are always O(1)

--- a/content/learn/mastering-dsa-cpp/greedy.mdx
+++ b/content/learn/mastering-dsa-cpp/greedy.mdx
@@ -235,7 +235,6 @@ int main() { for (int x : {30,41,99}) std::cout << minCoinsCanonical(x) << "\n";
 - Try all answers.
   > Exhaustive search.
 - [o] Make the locally best choice repeatedly.
-  > Correct.
 - Cache subproblems.
   > Dynamic programming.
 - Always use recursion.
@@ -244,7 +243,6 @@ int main() { for (int x : {30,41,99}) std::cout << minCoinsCanonical(x) << "\n";
 <MultipleChoice markdown={`Why does {1,3,4} fail for amount 6?
 
 - [o] Greedy takes 4+1+1, but 3+3 is better.
-  > Correct.
 - There is no 1 coin.
   > There is.
 - 6 is impossible.
@@ -255,7 +253,6 @@ int main() { for (int x : {30,41,99}) std::cout << minCoinsCanonical(x) << "\n";
 <MultipleChoice markdown={`What does an exchange argument show?
 
 - [o] An optimal solution can be transformed to include the greedy choice.
-  > Correct.
 - The code has no bugs.
   > No.
 - The input is sorted.

--- a/content/learn/mastering-dsa-cpp/hash-tables.mdx
+++ b/content/learn/mastering-dsa-cpp/hash-tables.mdx
@@ -459,7 +459,7 @@ int main() {
 - O(n)
   > This is possible in the worst case, but not the expected average for a healthy table.
 - [o] O(1)
-  > Correct. A good hash function and controlled load factor make lookup constant on average.
+  > A good hash function and controlled load factor make lookup constant on average.
 - O(log n)
   > This is typical of balanced binary search trees.
 - O(n log n)
@@ -472,14 +472,14 @@ int main() {
 - A stack
   > A stack only exposes the top element.
 - [o] A hash table with buckets
-  > Correct. Keys are hashed to choose buckets.
+  > Keys are hashed to choose buckets.
 - A linked list only
   > Some implementations use nodes, but the core idea is bucketed hashing.`} />
 
 <MultipleChoice markdown={`Why might std::map be preferred over std::unordered_map?
 
 - [o] It iterates keys in sorted order and supports ordered operations.
-  > Correct. The tree structure keeps keys ordered.
+  > The tree structure keeps keys ordered.
 - It always has O(1) lookup.
   > std::map lookup is O(log n), not O(1).
 - It uses no comparisons.
@@ -494,6 +494,6 @@ int main() {
 - One key is silently deleted.
   > Correct implementations preserve both keys.
 - [o] The table resolves the collision with chaining or probing.
-  > Correct. Collision resolution is part of hash-table design.
+  > Collision resolution is part of hash-table design.
 - The keys become equal.
   > Equal hash values do not imply equal keys.`} />

--- a/content/learn/mastering-dsa-cpp/heaps.mdx
+++ b/content/learn/mastering-dsa-cpp/heaps.mdx
@@ -409,7 +409,7 @@ int main() {
 - O(1) always
   > The new value may need to move up the tree.
 - [o] O(log n)
-  > Correct. Sift-up follows the tree height.
+  > Sift-up follows the tree height.
 - O(n)
   > A single push does not scan every element in a heap.
 - O(n log n)
@@ -418,7 +418,7 @@ int main() {
 <MultipleChoice markdown={`When might a heap be preferred over a BST?
 
 - [o] When you only need repeated access to the minimum or maximum item.
-  > Correct. Heaps optimize top, push, and pop for priority behavior.
+  > Heaps optimize top, push, and pop for priority behavior.
 - When you need sorted iteration over all keys at all times.
   > A BST is better for ordered traversal.
 - When you need fast search for any arbitrary value.
@@ -431,7 +431,7 @@ int main() {
 - It is a min-heap.
   > The smallest value is not on top by default.
 - [o] It is a max-heap.
-  > Correct. The largest value appears at top.
+  > The largest value appears at top.
 - It keeps all values sorted in ascending iteration.
   > Priority queues do not expose sorted iteration.
 - It removes elements in insertion order.

--- a/content/learn/mastering-dsa-cpp/linked-lists.mdx
+++ b/content/learn/mastering-dsa-cpp/linked-lists.mdx
@@ -358,7 +358,7 @@ int main() {
 - Accessing the element at index 900
   > You must walk node by node from the head.
 - [o] Prepending a new node to the front
-  > Correct. The new node points to the old head, then head changes.
+  > The new node points to the old head, then head changes.
 - Searching for a value
   > Search may inspect every node.
 - Sorting the list
@@ -369,7 +369,7 @@ int main() {
   markdown={`Why does a singly linked list not support efficient random access like a vector?
 
 - [o] Nodes are connected by pointers, so reaching position i requires following i links.
-  > Correct. There is no direct address calculation for an arbitrary index.
+  > There is no direct address calculation for an arbitrary index.
 - Each node stores too many integers.
   > A node can store one integer and still lack random access.
 - The compiler forbids indexing syntax for structs.
@@ -384,7 +384,7 @@ int main() {
 - Updating the head pointer
   > Updating head is often required after deleting the first node.
 - [o] Losing the only pointer to a node before calling \`delete\`
-  > Correct. That leaks memory because the allocation can no longer be freed.
+  > That leaks memory because the allocation can no longer be freed.
 - Traversing with a temporary pointer
   > Temporary traversal pointers are normal.
 - Comparing node values

--- a/content/learn/mastering-dsa-cpp/next-steps.mdx
+++ b/content/learn/mastering-dsa-cpp/next-steps.mdx
@@ -96,7 +96,7 @@ int main() {
 - Stop practicing algorithms forever.
   > Skills fade without use.
 - [o] Pick a roadmap topic and build or solve problems with it.
-  > Correct. Practice makes the ideas durable.
+  > Practice makes the ideas durable.
 - Only memorize code templates.
   > Understanding matters more.
 - Avoid modern C++ features.

--- a/content/learn/mastering-dsa-cpp/queues.mdx
+++ b/content/learn/mastering-dsa-cpp/queues.mdx
@@ -294,7 +294,7 @@ int main() {
 - Last in, first out
   > That describes a stack.
 - [o] First in, first out
-  > Correct. The oldest enqueued element is served first.
+  > The oldest enqueued element is served first.
 - Highest value, first out
   > That describes a priority queue pattern, not a normal queue.
 - Random element, first out
@@ -305,7 +305,7 @@ int main() {
   markdown={`Why is \`std::deque\` often preferred over \`std::list\` for queue-like work?
 
 - [o] It supports efficient end operations with better locality and fewer per-element allocations.
-  > Correct. Deque storage is usually friendlier to caches than linked nodes.
+  > Deque storage is usually friendlier to caches than linked nodes.
 - It makes every operation O(log n).
   > Queue end operations are constant time.
 - It automatically removes duplicates.
@@ -320,7 +320,7 @@ int main() {
 - Both are always O(1).
   > Vector must shift remaining elements.
 - [o] Vector front erase is O(n), while deque pop_front is O(1).
-  > Correct. This is why deque is a natural queue backing container.
+  > This is why deque is a natural queue backing container.
 - Vector front erase is O(log n), while deque pop_front is O(n).
   > These are not the usual complexities.
 - Both are O(n^2).

--- a/content/learn/mastering-dsa-cpp/recursion.mdx
+++ b/content/learn/mastering-dsa-cpp/recursion.mdx
@@ -247,7 +247,7 @@ int main() {
 - It makes the function run in O(1) time.
   > A base case does not guarantee constant time; it only defines when recursion stops.
 - [o] It stops recursive calls from continuing forever.
-  > Correct. Without a reachable base case, calls keep stacking until failure.
+  > Without a reachable base case, calls keep stacking until failure.
 - It stores all previous answers automatically.
   > That describes memoization, not a base case.
 - It lets C++ allocate variables on the heap.
@@ -264,7 +264,7 @@ A base case is the smallest input that can be answered directly.`}
 - O(n log n)
   > The branching recurrence is larger than this.
 - [o] Exponential, often written as O(2^n)
-  > Correct. Each call branches and repeats work.
+  > Each call branches and repeats work.
 - O(log n)
   > O(log n) fits fast exponentiation, not naive Fibonacci.
 
@@ -279,7 +279,7 @@ Repeated subproblems are what dynamic programming fixes.`}
 - A hash table
   > Hash tables help memoization but are not required for recursion itself.
 - [o] The call stack
-  > Correct. Each active call has its own stack frame.
+  > Each active call has its own stack frame.
 - A sorted vector
   > Sorting is unrelated to tracking recursive calls.
 

--- a/content/learn/mastering-dsa-cpp/searching.mdx
+++ b/content/learn/mastering-dsa-cpp/searching.mdx
@@ -246,7 +246,7 @@ int main() {
   markdown={`What is the worst-case time complexity of linear search over \`n\` elements?
 
 - [o] O(n)
-  > Correct. It may inspect every element.
+  > It may inspect every element.
 - O(log n)
   > That is binary search on sorted data.
 - O(1)
@@ -261,7 +261,7 @@ int main() {
 - The vector must have no duplicates.
   > Duplicates are allowed.
 - [o] The vector must be sorted according to the search comparison.
-  > Correct. Binary search relies on sorted order.
+  > Binary search relies on sorted order.
 - The vector must contain only positive integers.
   > It works for any comparable values.
 - The vector must be stored on the heap.
@@ -276,7 +276,7 @@ int main() {
 - A boolean indicating whether \`x\` exists.
   > That is \`std::binary_search\`.
 - [o] An iterator to the first element not less than \`x\`.
-  > Correct. It finds the first value \`>= x\`.
+  > It finds the first value \`>= x\`.
 - The last occurrence of \`x\`.
   > It returns the insertion position before equal values.`}
 />
@@ -289,7 +289,7 @@ int main() {
 - \`low = mid\`
   > This can repeat the same middle index forever.
 - [o] \`low = mid + 1\`
-  > Correct. Exclude the too-small middle value.
+  > Exclude the too-small middle value.
 - \`high = mid\`
   > This keeps the too-small middle in the interval.`}
 />

--- a/content/learn/mastering-dsa-cpp/shortest-paths.mdx
+++ b/content/learn/mastering-dsa-cpp/shortest-paths.mdx
@@ -463,7 +463,7 @@ int main() {
 - It uses recursion, which cannot handle negative numbers
   > Dijkstra is usually iterative, and C++ can store negative integers.
 - [o] A finalized smallest distance could later be improved by a negative edge
-  > Correct. Negative edges break the greedy guarantee.
+  > Negative edges break the greedy guarantee.
 - Priority queues cannot store negative values
   > Priority queues can store negative values just fine.
 - Weighted graphs are always acyclic
@@ -480,7 +480,7 @@ Use Bellman-Ford when negative edges are allowed.`}
 - O(log V)
   > A single heap operation is logarithmic, but the whole algorithm processes vertices and edges.
 - [o] O((V + E) log V)
-  > Correct. Heap operations occur as distances are pushed and popped while edges are scanned.
+  > Heap operations occur as distances are pushed and popped while edges are scanned.
 - O(1)
   > Shortest paths require examining graph structure.
 
@@ -493,7 +493,7 @@ The exact bound is often written O(E log V) for connected sparse graphs, but O((
 - To process the largest vertex id first
   > Vertex id is not the priority.
 - [o] To always expand the currently smallest known distance
-  > Correct. That is Dijkstra's greedy step.
+  > That is Dijkstra's greedy step.
 - To make all edges positive
   > A heap does not change edge weights.
 - To store the graph itself

--- a/content/learn/mastering-dsa-cpp/sorting-basic.mdx
+++ b/content/learn/mastering-dsa-cpp/sorting-basic.mdx
@@ -259,7 +259,7 @@ int main() {
   markdown={`Which basic sort can run in O(n) on already sorted input with an early-exit flag?
 
 - [o] Bubble sort
-  > Correct. A pass with no swaps proves the array is sorted.
+  > A pass with no swaps proves the array is sorted.
 - Selection sort
   > It still searches for a minimum each pass.
 - Merge sort
@@ -276,7 +276,7 @@ int main() {
 - It always runs in O(n log n).
   > Runtime and stability are separate properties.
 - [o] Equal elements keep their original relative order.
-  > Correct. This matters for records with multiple fields.
+  > This matters for records with multiple fields.
 - It never swaps elements.
   > Stable algorithms can move elements while preserving equal-key order.`}
 />
@@ -287,7 +287,7 @@ int main() {
 - Bubble sort
   > Bubble sort swaps adjacent out-of-order pairs.
 - [o] Selection sort
-  > Correct. It selects the next minimum for the sorted prefix.
+  > It selects the next minimum for the sorted prefix.
 - Insertion sort
   > It inserts a key into a sorted prefix.
 - Binary search

--- a/content/learn/mastering-dsa-cpp/sorting-efficient.mdx
+++ b/content/learn/mastering-dsa-cpp/sorting-efficient.mdx
@@ -265,7 +265,7 @@ int main() {
 - Merge sort can be O(n^2), while quicksort is always O(n log n).
   > This reverses the usual guarantee.
 - [o] Merge sort guarantees O(n log n), while naive quicksort can be O(n^2).
-  > Correct. Bad pivots make partitions unbalanced.
+  > Bad pivots make partitions unbalanced.
 - Both are always O(n^2).
   > Both are designed to be faster than quadratic on typical inputs.
 - Both require O(n) extra arrays in standard forms.
@@ -280,7 +280,7 @@ int main() {
 - Pure merge sort only
   > Merge-sort-like algorithms are more associated with stable sorting.
 - [o] Introsort: quicksort-style partitioning with safeguards and small-range optimizations
-  > Correct. It combines speed with fallback protection.
+  > It combines speed with fallback protection.
 - Linear search followed by insertion
   > Searching alone does not sort a range.`}
 />
@@ -293,7 +293,7 @@ int main() {
 - When sorting descending instead of ascending.
   > Direction does not determine stability.
 - [o] When equal keys should preserve their previous relative order.
-  > Correct. This is common with records and multiple fields.
+  > This is common with records and multiple fields.
 - When the vector is stored contiguously.
   > Contiguous storage is unrelated to stability.`}
 />

--- a/content/learn/mastering-dsa-cpp/stacks.mdx
+++ b/content/learn/mastering-dsa-cpp/stacks.mdx
@@ -336,7 +336,7 @@ int main() {
 - Lowest input, first output
   > LIFO is about insertion order, not numeric value.
 - [o] Last in, first out
-  > Correct. The newest pushed element is removed first.
+  > The newest pushed element is removed first.
 - Linear index, fast offset
   > That is not a stack term.
 - Linked item, fixed order
@@ -360,7 +360,7 @@ int main() {
   markdown={`Why is \`std::deque\` a good default underlying container for \`std::stack\`?
 
 - [o] It supports efficient insertion and removal at the back without requiring contiguous reallocation like a vector.
-  > Correct. It gives stable, efficient end operations.
+  > It gives stable, efficient end operations.
 - It sorts stack values automatically.
   > A stack preserves LIFO order; it does not sort.
 - It makes \`top\` O(n).

--- a/content/learn/mastering-dsa-cpp/strings.mdx
+++ b/content/learn/mastering-dsa-cpp/strings.mdx
@@ -316,7 +316,7 @@ int main() {
   markdown={`What is the time complexity of indexing a valid position in a \`std::string\` with \`s[i]\`?
 
 - [o] O(1)
-  > Correct. A string stores characters contiguously and computes the address directly.
+  > A string stores characters contiguously and computes the address directly.
 - O(log n)
   > There is no tree search involved.
 - O(n)
@@ -329,7 +329,7 @@ int main() {
   markdown={`Why might a function take \`std::string_view\` instead of \`const std::string&\`?
 
 - [o] It can accept strings, literals, and slices without owning or copying the characters.
-  > Correct. A view is just a pointer and a length.
+  > A view is just a pointer and a length.
 - It always extends the lifetime of temporary character data.
   > It does not own data, so lifetime must still be valid.
 - It allows mutation of the original string.
@@ -344,7 +344,7 @@ int main() {
 - A pointer into the original string that can mutate it.
   > \`substr\` returns a string object, not a mutable pointer.
 - [o] A new string containing up to \`count\` characters starting at \`pos\`.
-  > Correct. The result owns its copied characters.
+  > The result owns its copied characters.
 - The number of characters after \`pos\`.
   > That would be a length calculation, not \`substr\`.
 - A boolean indicating whether the substring exists.

--- a/content/learn/mastering-dsa-cpp/trees.mdx
+++ b/content/learn/mastering-dsa-cpp/trees.mdx
@@ -484,7 +484,7 @@ int main() {
 - The root node only
   > The root can be a leaf only when the tree has one node.
 - [o] A node with no children
-  > Correct. Leaves are endpoints in the rooted structure.
+  > Leaves are endpoints in the rooted structure.
 - Any node at depth one
   > Depth one nodes may have children.`} />
 
@@ -493,7 +493,7 @@ int main() {
 - 2 1 3
   > That is in-order for this small tree.
 - [o] 1 2 3
-  > Correct. Pre-order visits root before subtrees.
+  > Pre-order visits root before subtrees.
 - 2 3 1
   > That resembles post-order.
 - 3 1 2
@@ -504,7 +504,7 @@ int main() {
 - When the tree is very sparse
   > Sparse trees waste many array slots.
 - [o] When the tree is complete or nearly complete
-  > Correct. Complete trees map cleanly to parent and child formulas.
+  > Complete trees map cleanly to parent and child formulas.
 - When every node needs a parent pointer
   > Arrays can compute parents, but that is not the main reason.
 - When traversal must be recursive

--- a/content/learn/mastering-dsa-cpp/tries.mdx
+++ b/content/learn/mastering-dsa-cpp/tries.mdx
@@ -477,7 +477,7 @@ int main() {
 - O(1) always
   > Each character must be followed.
 - [o] O(L)
-  > Correct. One edge is followed per character.
+  > One edge is followed per character.
 - O(n log n)
   > The number of stored words is not directly multiplied this way.
 - O(26 to the power L)
@@ -486,7 +486,7 @@ int main() {
 <MultipleChoice markdown={`When can a trie beat a hash set of strings?
 
 - [o] When many prefix queries such as starts-with or autocomplete are needed.
-  > Correct. Prefix navigation is the trie specialty.
+  > Prefix navigation is the trie specialty.
 - When memory must always be minimized.
   > Tries often use more memory because of child links.
 - When only exact membership is needed and no prefixes matter.
@@ -499,7 +499,7 @@ int main() {
 - A whole independent hash table of all words
   > A node may store child links, but it represents a prefix position.
 - [o] A prefix formed by the path from the root to that node
-  > Correct. The end flag says whether that prefix is also a complete word.
+  > The end flag says whether that prefix is also a complete word.
 - Always exactly one complete word
   > Internal nodes can be prefixes for many words and may or may not end a word.
 - The sorted rank of a string

--- a/content/learn/mastering-dsa-cpp/union-find.mdx
+++ b/content/learn/mastering-dsa-cpp/union-find.mdx
@@ -524,7 +524,7 @@ int main() {
 - O(log n) exactly
   > The optimized bound is even tighter asymptotically.
 - [o] Near O(α(n)), practically constant
-  > Correct. α(n) is the inverse Ackermann function.
+  > α(n) is the inverse Ackermann function.
 - O(n²)
   > DSU operations are much faster than quadratic.
 
@@ -537,7 +537,7 @@ Tarjan's analysis gives the famous inverse-Ackermann amortized bound.`}
 - It sorts all elements in the set
   > DSU does not maintain sorted set contents.
 - [o] It makes nodes on the search path point directly to the root
-  > Correct. This flattens the tree for future finds.
+  > This flattens the tree for future finds.
 - It deletes the set containing x
   > Find is a query/update optimization, not deletion.
 - It always chooses the larger root
@@ -550,7 +550,7 @@ Path compression is why repeated finds become extremely fast.`}
   markdown={`Why is DSU often preferred over rerunning BFS for incremental connectivity queries where edges are only added?
 
 - [o] DSU updates connectivity with very fast unite operations
-  > Correct. Each added edge can be processed almost constantly.
+  > Each added edge can be processed almost constantly.
 - BFS cannot traverse graphs
   > BFS traverses graphs well, but rerunning it after every edge can be expensive.
 - DSU stores shortest paths

--- a/content/learn/mastering-dsa-cpp/why-cpp-for-dsa.mdx
+++ b/content/learn/mastering-dsa-cpp/why-cpp-for-dsa.mdx
@@ -276,7 +276,7 @@ int main() {
 - It automatically proves algorithms correct
   > C++ gives speed and libraries, but correctness is still your job.
 - [o] It combines high performance with strong standard containers and algorithms
-  > Correct. The combination of compiled speed and the STL is extremely useful under time limits.
+  > The combination of compiled speed and the STL is extremely useful under time limits.
 - It has no pointers or memory model to learn
   > C++ exposes pointers, references, and value semantics; that is part of its power and complexity.
 - It is the only language accepted by online judges
@@ -287,7 +287,7 @@ int main() {
   markdown={`Why can a \`std::vector<int>\` be faster to iterate than a \`std::list<int>\`, even though both traversals are O(n)?
 
 - [o] Vector stores elements contiguously, which is usually cache-friendly
-  > Correct. Contiguous memory helps the CPU fetch nearby elements efficiently.
+  > Contiguous memory helps the CPU fetch nearby elements efficiently.
 - List traversal is O(log n)
   > List traversal is O(n), not O(log n).
 - Vector always uses less memory than every other container

--- a/content/learn/multiple-choice.mdx
+++ b/content/learn/multiple-choice.mdx
@@ -41,7 +41,7 @@ with the prose.
 - Microsoft Word
   > Microsoft Word is primarily used for document creation, not interactive data visualization.
 - [o] Tableau
-  > Correct! Tableau is widely used for creating interactive dashboards and visual analytics.
+  > Tableau is widely used for creating interactive dashboards and visual analytics.
 - Adobe Photoshop
 - Notepad
 
@@ -56,7 +56,7 @@ Which tool is commonly used to create interactive business dashboards and data v
 - Microsoft Word
   > Microsoft Word is primarily used for document creation, not interactive data visualization.
 - [o] Tableau
-  > Correct! Tableau is widely used for creating interactive dashboards and visual analytics.
+  > Tableau is widely used for creating interactive dashboards and visual analytics.
 - Adobe Photoshop
 - Notepad
 
@@ -205,7 +205,7 @@ Blank lines inside the block are preserved exactly as authored.
 
   df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
   \`\`\`
-  > Correct! \`pd.DataFrame\` accepts a dict of column name → values.
+  > \`pd.DataFrame\` accepts a dict of column name → values.
 
 A \`DataFrame\` is pandas's primary 2-D data structure. Pass a plain dict
 where each key becomes a column label and each value is the column's data.`}
@@ -232,7 +232,7 @@ Which snippet correctly creates a pandas DataFrame with columns A and B?
 
   df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
   ```
-  > Correct! `pd.DataFrame` accepts a dict of column name → values.
+  > `pd.DataFrame` accepts a dict of column name → values.
 
 A `DataFrame` is pandas's primary 2-D data structure. Pass a plain dict
 where each key becomes a column label and each value is the column's data.
@@ -250,7 +250,7 @@ way to create a Python list.
 - [o] \`\`\`python
   my_list = [1, 2, 3]
   \`\`\`
-  > Correct — square-bracket literal syntax produces a \`list\`.
+  > Square-bracket literal syntax produces a \`list\`.
 - \`\`\`python
   my_list = (1, 2, 3)
   \`\`\`
@@ -258,7 +258,7 @@ way to create a Python list.
 - [o] \`\`\`python
   my_list = list(range(3))
   \`\`\`
-  > Correct — \`list()\` converts any iterable, including \`range\`, into a list.
+  > \`list()\` converts any iterable, including \`range\`, into a list.
 - \`\`\`python
   my_list = {1, 2, 3}
   \`\`\`
@@ -275,7 +275,7 @@ Which of the following create a Python **list**? Select all that apply.
 - [o] ```python
   my_list = [1, 2, 3]
   ```
-  > Correct — square-bracket literal syntax produces a `list`.
+  > Square-bracket literal syntax produces a `list`.
 - ```python
   my_list = (1, 2, 3)
   ```
@@ -283,7 +283,7 @@ Which of the following create a Python **list**? Select all that apply.
 - [o] ```python
   my_list = list(range(3))
   ```
-  > Correct — `list()` converts any iterable, including `range`, into a list.
+  > `list()` converts any iterable, including `range`, into a list.
 - ```python
   my_list = {1, 2, 3}
   ```

--- a/content/learn/oop-blueprint-java/abstract-classes.mdx
+++ b/content/learn/oop-blueprint-java/abstract-classes.mdx
@@ -359,7 +359,7 @@ To +1-555-0100: Your code is 1234
 - It is the same as an interface
   > Interfaces and abstract classes are related but different (next page).
 - [o] It can have both concrete and abstract methods, and cannot be instantiated with \`new\` directly
-  > Correct. Abstract classes are partial blueprints — useful when you want to share both code and a contract.
+  > Abstract classes are partial blueprints — useful when you want to share both code and a contract.
 - It can only have static methods
   > That would be a utility class.`}
 />
@@ -370,7 +370,7 @@ To +1-555-0100: Your code is 1234
 - To make it run faster
   > Performance isn't the motivation.
 - [o] To prevent subclasses from changing the overall shape of the algorithm; they may only fill in the marked steps
-  > Correct. The base class controls the *order* of work; subclasses choose only what each step does.
+  > The base class controls the *order* of work; subclasses choose only what each step does.
 - Because the JVM forbids overriding abstract methods
   > It doesn't — that's exactly what you *must* do.
 - To make the class implicitly abstract
@@ -383,7 +383,7 @@ To +1-555-0100: Your code is 1234
 - When you want many unrelated classes to share a tiny contract
   > That's a job for an interface.
 - [o] When you have genuine shared *state* and *concrete code* that all subclasses would otherwise duplicate
-  > Correct. Abstract classes earn their keep when there is real shared implementation to factor out.
+  > Abstract classes earn their keep when there is real shared implementation to factor out.
 - Whenever you have more than three methods
   > Method count is irrelevant.
 - When you don't want to use \`@Override\`

--- a/content/learn/oop-blueprint-java/aggregation-and-dependency.mdx
+++ b/content/learn/oop-blueprint-java/aggregation-and-dependency.mdx
@@ -389,7 +389,7 @@ public class Classroom {
 - Composition
   > That implies the members would cease to exist with the library.
 - [o] Aggregation
-  > Correct. The library holds references to things that live independently.
+  > The library holds references to things that live independently.
 - Dependency
   > Dependency is briefer — a method-scope collaborator.
 - Inheritance
@@ -404,7 +404,7 @@ public class Classroom {
 - Aggregation
   > Aggregation implies a held reference (a field).
 - [o] Dependency (uses-a)
-  > Correct. The collaborators are only used for the duration of the call.
+  > The collaborators are only used for the duration of the call.
 - Inheritance
   > No subclassing involved.`}
 />
@@ -417,7 +417,7 @@ public class Classroom {
 - It saves typing
   > Often it adds typing, not removes it.
 - [o] It keeps the class loosely coupled — the same class can work with different implementations or test stand-ins
-  > Correct. This is the heart of dependency injection and a major source of OOP flexibility.
+  > This is the heart of dependency injection and a major source of OOP flexibility.
 - It is required for the class to compile
   > It is not required by the compiler.`}
 />

--- a/content/learn/oop-blueprint-java/birth-of-oop.mdx
+++ b/content/learn/oop-blueprint-java/birth-of-oop.mdx
@@ -307,7 +307,7 @@ That is OOP. The rest of this course is just elaboration.
 - John Backus
   > Backus led the FORTRAN team; FORTRAN is procedural.
 - [o] Alan Kay (with Dan Ingalls and Adele Goldberg at Xerox PARC)
-  > Correct. Kay's team built Smalltalk and articulated the messaging-first view of OOP.
+  > Kay's team built Smalltalk and articulated the messaging-first view of OOP.
 - Linus Torvalds
   > Torvalds created Linux and Git, not Smalltalk.`}
 />
@@ -318,7 +318,7 @@ That is OOP. The rest of this course is just elaboration.
 - Writing the world's first operating system
   > Operating systems existed before Simula and were written in other languages.
 - [o] Writing simulations of real-world systems (ships, queues, traffic)
-  > Correct. Simulating things in the real world is exactly why Dahl and Nygaard introduced classes and objects.
+  > Simulating things in the real world is exactly why Dahl and Nygaard introduced classes and objects.
 - Compiling Lisp programs faster
   > Lisp's compilation has nothing to do with Simula's design goals.
 - Replacing assembly language for microcontrollers
@@ -333,7 +333,7 @@ That is OOP. The rest of this course is just elaboration.
 - Objects share a global mailbox where they leave notes
   > There is no shared mailbox in basic OOP.
 - [o] One object requests another to perform a behavior by calling one of its methods, and the receiver decides how to respond
-  > Correct. A method call is the message; the receiving object chooses how to handle it.
+  > A method call is the message; the receiving object chooses how to handle it.
 - Messages replace all uses of variables
   > Variables still exist; messages are how behavior is invoked across objects.`}
 />

--- a/content/learn/oop-blueprint-java/capstone-library-system.mdx
+++ b/content/learn/oop-blueprint-java/capstone-library-system.mdx
@@ -414,7 +414,7 @@ Each of those is a textbook responsibility-driven extension.
 - Because Java requires every \`Library\` to use one
   > Java requires nothing of the sort.
 - [o] So that different libraries can plug in different policies without modifying \`Library\`
-  > Correct. This is "program to an interface" and the Strategy pattern.
+  > This is "program to an interface" and the Strategy pattern.
 - Because Java forbids classes from holding boolean methods
   > It doesn't.
 - To save memory
@@ -429,7 +429,7 @@ Each of those is a textbook responsibility-driven extension.
 - Java forbids \`Library\` from having boolean methods
   > It doesn't.
 - [o] The relevant data (the due date) lives on \`Loan\`, so the *behavior* belongs there too — that's "tell, don't ask"
-  > Correct. Behavior follows data; this avoids feature envy.
+  > Behavior follows data; this avoids feature envy.
 - To make \`Loan\` extend \`Library\`
   > There is no inheritance between them in this design.`}
 />
@@ -442,7 +442,7 @@ Each of those is a textbook responsibility-driven extension.
 - Add a new field to \`Member\`
   > The change is about a rule, not about member state.
 - [o] Write a new class \`WeekendPolicy implements BorrowingPolicy\` and pass it into \`Library\`'s constructor — \`Library\` itself does not change
-  > Correct. This is the open-closed principle and polymorphism in action.
+  > This is the open-closed principle and polymorphism in action.
 - Modify \`LimitPolicy\` to know about weekends
   > That muddles two policies and breaks the single-responsibility idea.`}
 />

--- a/content/learn/oop-blueprint-java/composition.mdx
+++ b/content/learn/oop-blueprint-java/composition.mdx
@@ -391,7 +391,7 @@ Pride and Prejudice by Jane Austen
 - A \`PrintService\` *uses* a \`Logger\` it was handed temporarily
   > That is closer to *dependency* (uses).
 - [o] A \`House\` *has* \`Room\`s that are created and destroyed with the house
-  > Correct. Strong ownership of parts whose lifetime is bound to the whole.
+  > Strong ownership of parts whose lifetime is bound to the whole.
 - A \`Library\` keeps references to \`Book\`s borrowed from a national archive
   > Books that live outside the library are more like *aggregation* (weak has-a).`}
 />
@@ -404,7 +404,7 @@ Pride and Prejudice by Jane Austen
 - Polymorphism
   > No method overriding is happening here.
 - [o] Delegation — the \`Car\` asks its part (the engine) to do the work
-  > Correct. Composition + delegation is the workhorse of OOP.
+  > Composition + delegation is the workhorse of OOP.
 - Abstraction leak
   > It's the opposite — the engine details are hidden from callers.`}
 />
@@ -417,7 +417,7 @@ Pride and Prejudice by Jane Austen
 - Inheritance was deprecated in Java 17
   > It was not.
 - [o] Composition assembles small, swappable pieces, while inheritance locks classes into a rigid tree that's hard to change later
-  > Correct. The GoF principle "favor object composition over class inheritance" captures this.
+  > The GoF principle "favor object composition over class inheritance" captures this.
 - Composition methods always run faster
   > Speed is not the criterion.`}
 />

--- a/content/learn/oop-blueprint-java/constructors-and-state.mdx
+++ b/content/learn/oop-blueprint-java/constructors-and-state.mdx
@@ -330,7 +330,7 @@ bad: invalid email
 - To call all the other methods in the class
   > Constructors typically don't call public methods at all.
 - [o] To bring an object into existence in a valid state, enforcing its invariants
-  > Correct. After a constructor returns, every other method should be able to assume the object is valid.
+  > After a constructor returns, every other method should be able to assume the object is valid.
 - To print a debug message describing the new object
   > Side effects like logging don't belong in constructors.
 - To allocate memory for the object
@@ -345,7 +345,7 @@ bad: invalid email
 - It runs the two-argument constructor with \`null\` and \`0\`
   > Java does not invent argument values.
 - [o] It fails to compile — there is no matching constructor
-  > Correct. Once you declare any constructor, the implicit no-arg one disappears.
+  > Once you declare any constructor, the implicit no-arg one disappears.
 - It produces a \`NullPointerException\` at runtime
   > The problem is detected at compile time, not runtime.`}
 />
@@ -358,7 +358,7 @@ bad: invalid email
 - The JVM can compile them down to machine code more easily
   > That's not the design motivation.
 - [o] They cannot accidentally change underneath you, so they can be passed and shared freely without surprising mutations
-  > Correct. Immutability eliminates an entire class of bug.
+  > Immutability eliminates an entire class of bug.
 - They automatically run faster than mutable objects
   > Performance is not guaranteed; safety is the real benefit.`}
 />

--- a/content/learn/oop-blueprint-java/encapsulation.mdx
+++ b/content/learn/oop-blueprint-java/encapsulation.mdx
@@ -335,7 +335,7 @@ balance=20
 - Public fields cannot be read
   > They can be read and written from anywhere — that's the problem.
 - [o] Any code anywhere can modify the field, so the class cannot enforce its own invariants
-  > Correct. Encapsulation exists precisely so the *class* owns the rules about its data.
+  > Encapsulation exists precisely so the *class* owns the rules about its data.
 - The compiler refuses to compile a class with public fields
   > It compiles fine; the issue is design.`}
 />
@@ -348,7 +348,7 @@ balance=20
 - Its constructors throw exceptions on invalid input
   > Helpful, but only part of the picture.
 - [o] Its public methods are named for behaviors callers actually need, and its fields are \`private\`
-  > Correct. Encapsulation is about exposing *behavior*, not storage.
+  > Encapsulation is about exposing *behavior*, not storage.
 - It uses the keyword \`final\` somewhere
   > \`final\` helps but is not the central criterion.`}
 />
@@ -361,7 +361,7 @@ balance=20
 - Because \`private\` methods run faster
   > Performance is not why.
 - [o] Because it is internal plumbing that callers never need to see, and hiding it keeps the public API small and intentional
-  > Correct. Keeping helpers private prevents accidental coupling to internal details.
+  > Keeping helpers private prevents accidental coupling to internal details.
 - Because \`public\` methods cannot call \`private\` ones
   > Public methods *can* call private methods of the same class — that is normal.`}
 />

--- a/content/learn/oop-blueprint-java/enums.mdx
+++ b/content/learn/oop-blueprint-java/enums.mdx
@@ -326,7 +326,7 @@ SUNDAY weekend? true
 - Enums use less memory than strings
   > Memory difference is negligible and not the point.
 - [o] The compiler can guarantee at compile time that only valid values are passed; typos and made-up values are rejected
-  > Correct. Type safety is the headline win.
+  > Type safety is the headline win.
 - Strings cannot be \`switch\`-ed on
   > They can, since Java 7.
 - Enums automatically log their values to disk
@@ -343,7 +343,7 @@ SUNDAY weekend? true
 - Enums cannot have fields or methods
   > They can — they are a kind of class.
 - [o] Each enum constant is an object, and the enum type may have its own fields, constructor, and methods
-  > Correct. Enums are essentially classes with a closed list of instances.`}
+  > Enums are essentially classes with a closed list of instances.`}
 />
 
 <MultipleChoice
@@ -354,7 +354,7 @@ SUNDAY weekend? true
 - A \`Set\` of constants
   > It returns an array, not a set.
 - [o] An array containing every declared constant, in the order they were declared
-  > Correct. This is the standard way to iterate over an enum's constants.
+  > This is the standard way to iterate over an enum's constants.
 - The number of constants in the enum
   > That would be \`Operation.values().length\`.`}
 />

--- a/content/learn/oop-blueprint-java/gang-of-four.mdx
+++ b/content/learn/oop-blueprint-java/gang-of-four.mdx
@@ -252,7 +252,7 @@ We will return to this exercise more formally later in the course.
 - Four early Smalltalk designers at Xerox PARC
   > That team includes Kay, Ingalls, and Goldberg, but is not the Gang of Four.
 - [o] Erich Gamma, Richard Helm, Ralph Johnson, and John Vlissides — authors of *Design Patterns* (1994)
-  > Correct. They are the four authors of the book that named and cataloged the classic OOP design patterns.
+  > They are the four authors of the book that named and cataloged the classic OOP design patterns.
 - Four students who founded a software consultancy in the 1970s
   > No, the term refers specifically to the authors of *Design Patterns*.
 - Four engineers credited with creating the Java language
@@ -265,7 +265,7 @@ We will return to this exercise more formally later in the course.
 - "Always inherit from a base class instead of composing"
   > The GoF actually argue the opposite.
 - [o] "Favor object composition over class inheritance"
-  > Correct. This is one of the book's most famous and frequently cited principles.
+  > This is one of the book's most famous and frequently cited principles.
 - "Avoid interfaces — they add too much indirection"
   > GoF heavily favor programming to interfaces.
 - "Make every method static so it is easier to call"
@@ -280,7 +280,7 @@ We will return to this exercise more formally later in the course.
 - Because a new class always runs faster than a \`switch\`
   > Performance is not the point here; clarity and change-safety are.
 - [o] Because the new scheme is added by *creating a new class*, leaving the existing \`Checkout\` and other pricing classes untouched and re-testable
-  > Correct. This is the open–closed idea in practice: open for extension, closed for modification.
+  > This is the open–closed idea in practice: open for extension, closed for modification.
 - Because \`switch\` is not allowed in object-oriented languages
   > It is fully allowed; the issue is design quality at scale.`}
 />

--- a/content/learn/oop-blueprint-java/inheritance.mdx
+++ b/content/learn/oop-blueprint-java/inheritance.mdx
@@ -368,7 +368,7 @@ public class Main {
 - Calls a static method on the parent class
   > It calls the parent's *constructor*, not a static method.
 - [o] Invokes the parent class's constructor with the given arguments to initialize the parent part of the new object
-  > Correct. It must be the first statement of the subclass constructor.
+  > It must be the first statement of the subclass constructor.
 - Creates an entirely separate parent object
   > No second object is created — the subclass instance *is* also an instance of the parent.
 - Marks the constructor as overriding
@@ -383,7 +383,7 @@ public class Main {
 - It tells the JVM to skip the parent method entirely
   > That is what overriding does in general, regardless of the annotation.
 - [o] It asks the compiler to verify that you really are overriding an inherited method, catching typos and signature mismatches at compile time
-  > Correct. It's a cheap, valuable form of static checking.
+  > It's a cheap, valuable form of static checking.
 - It improves runtime performance of the method
   > It has no effect on performance.`}
 />
@@ -396,7 +396,7 @@ public class Main {
 - The other class has many methods
   > Method count is not a design criterion.
 - [o] The new class is genuinely a *kind of* the other class, and the parent was designed for extension
-  > Correct. True "is-a" relationships with extension-ready base classes are where inheritance shines.
+  > True "is-a" relationships with extension-ready base classes are where inheritance shines.
 - You want to avoid creating new files
   > File hygiene is not a design criterion.`}
 />

--- a/content/learn/oop-blueprint-java/interfaces.mdx
+++ b/content/learn/oop-blueprint-java/interfaces.mdx
@@ -469,7 +469,7 @@ name: 1
 - Implement many classes and extend many interfaces
   > The wording is reversed and both halves are inaccurate.
 - [o] Implement *many* interfaces but extend *at most one* class
-  > Correct. This is one of Java's defining design decisions.
+  > This is one of Java's defining design decisions.
 - Implement many interfaces and extend many classes
   > Java does not allow multiple class inheritance.`}
 />
@@ -482,7 +482,7 @@ name: 1
 - Never use concrete classes
   > Concrete classes are required to actually have an instance — somebody must implement the interface.
 - [o] When declaring variables, parameters, and return types, prefer the more general interface type so callers aren't locked to a specific implementation
-  > Correct. This is how interfaces unlock loose coupling.
+  > This is how interfaces unlock loose coupling.
 - Use only abstract classes
   > That's a separate idea and not the same principle.`}
 />
@@ -493,7 +493,7 @@ name: 1
 - An interface can have a constructor; an abstract class cannot
   > Reversed.
 - [o] An interface has no instance state; an abstract class may have fields, a constructor, and concrete methods
-  > Correct. Interfaces describe capabilities; abstract classes can also carry shared state.
+  > Interfaces describe capabilities; abstract classes can also carry shared state.
 - An interface can extend many other interfaces; an abstract class cannot extend anything
   > Abstract classes can extend a class and implement interfaces.
 - They are exactly the same since Java 8 added default methods

--- a/content/learn/oop-blueprint-java/methods-and-messages.mdx
+++ b/content/learn/oop-blueprint-java/methods-and-messages.mdx
@@ -388,7 +388,7 @@ Hello, Eve!
 - \`item\`
   > That is the argument.
 - [o] \`receipt\`
-  > Correct. The receiver is the object the message is sent to.
+  > The receiver is the object the message is sent to.
 - The return value
   > The return value is the *response*, not the receiver.`}
 />
@@ -399,7 +399,7 @@ Hello, Eve!
 - \`int compute()\` and \`double compute()\`
   > Return type alone does not differentiate overloads. This won't compile.
 - [o] \`void print(String s)\` and \`void print(int n)\`
-  > Correct. Different parameter types yield different signatures.
+  > Different parameter types yield different signatures.
 - \`public void run()\` and \`private void run()\`
   > Access modifiers don't differentiate overloads either.
 - \`void log(String s)\` and \`void log(String s)\`
@@ -414,7 +414,7 @@ Hello, Eve!
 - It makes the program use less memory
   > Memory use is unrelated.
 - [o] It reminds you that the *receiver* decides how to respond, so you focus on what each object should do rather than how callers should reach into it
-  > Correct. The "messaging" mindset is what produces well-encapsulated, swappable objects.
+  > The "messaging" mindset is what produces well-encapsulated, swappable objects.
 - It removes the need for return values
   > Methods can still return values.`}
 />

--- a/content/learn/oop-blueprint-java/objects-and-classes.mdx
+++ b/content/learn/oop-blueprint-java/objects-and-classes.mdx
@@ -346,7 +346,7 @@ a=3, b=1
 - An object is a description; a class is built from it
   > That's backwards.
 - [o] A class is a blueprint that describes structure and behavior; an object (instance) is an individual thing created from that blueprint
-  > Correct. You can have many objects of the same class, each with its own field values.
+  > You can have many objects of the same class, each with its own field values.
 - A class can have state but an object cannot
   > Objects are the things that *carry* state; classes are descriptions.`}
 />
@@ -359,7 +359,7 @@ a=3, b=1
 - It is set to 0
   > Not modified at all.
 - [o] It stays the same — each object has its own copy of the fields
-  > Correct. \`age\` belongs to each instance individually.
+  > \`age\` belongs to each instance individually.
 - The program raises an error
   > No error; instance fields are independent.`}
 />
@@ -372,7 +372,7 @@ a=3, b=1
 - A copy of every other object of the same class
   > No, \`this\` is a single reference.
 - [o] The specific object the method was called on
-  > Correct. If you call \`rex.describe()\`, then inside \`describe\`, \`this\` is \`rex\`.
+  > If you call \`rex.describe()\`, then inside \`describe\`, \`this\` is \`rex\`.
 - A field automatically named \`this\`
   > \`this\` is a keyword, not a user-defined field.`}
 />

--- a/content/learn/oop-blueprint-java/objects-in-memory.mdx
+++ b/content/learn/oop-blueprint-java/objects-in-memory.mdx
@@ -304,7 +304,7 @@ many of them.
 - Zero
   > \`new Dog(...)\` allocated one.
 - [o] One — both \`a\` and \`b\` are references to the same object
-  > Correct. Assigning one reference to another copies the reference, not the underlying object.
+  > Assigning one reference to another copies the reference, not the underlying object.
 - Two — Java duplicates on assignment
   > Java never silently duplicates objects.
 - It depends on the garbage collector
@@ -317,7 +317,7 @@ many of them.
 - An error from running out of heap memory
   > That is an \`OutOfMemoryError\`.
 - [o] An error from invoking a method or accessing a field on a reference whose value is \`null\`
-  > Correct. Dereferencing \`null\` is the cause.
+  > Dereferencing \`null\` is the cause.
 - An error from overflowing the call stack
   > That is a \`StackOverflowError\`.
 - An error from dividing by zero
@@ -332,7 +332,7 @@ many of them.
 - The original object is freed immediately
   > The GC decides when, not the language.
 - [o] The caller's variable still points at the original object — only the local parameter changed
-  > Correct. The parameter is a separate local variable holding its own copy of the reference.
+  > The parameter is a separate local variable holding its own copy of the reference.
 - The program throws a \`NullPointerException\`
   > No exception; reassignment is legal.`}
 />

--- a/content/learn/oop-blueprint-java/packages-and-architecture.mdx
+++ b/content/learn/oop-blueprint-java/packages-and-architecture.mdx
@@ -358,7 +358,7 @@ package. The domain doesn't move.
 - Make every member \`protected\` because it's "in the middle"
   > Protected is more permissive than you usually want.
 - [o] Make everything as restrictive as possible (\`private\` by default, package-private when needed) and widen only when there's a real reason
-  > Correct. Narrow visibility keeps refactoring safe.
+  > Narrow visibility keeps refactoring safe.
 - Always use \`package-private\` for everything
   > Sometimes you genuinely need \`public\` (the API) or \`private\` (internals).`}
 />
@@ -371,7 +371,7 @@ package. The domain doesn't move.
 - Domain should depend on the presentation layer
   > Definitely not; the domain is the most independent piece.
 - [o] From the outer layers (presentation, infrastructure) toward the inner core (application, domain) — the domain depends on nothing else of yours
-  > Correct. This is the "dependencies point inward" rule that keeps the core swappable.
+  > This is the "dependencies point inward" rule that keeps the core swappable.
 - All layers should depend on every other layer equally
   > That recreates the spaghetti you're trying to avoid.`}
 />
@@ -384,7 +384,7 @@ package. The domain doesn't move.
 - Combine all classes into one giant package so nothing has to import anything
   > That maximizes coupling and destroys cohesion.
 - [o] Classes within a package should belong together; packages should depend on each other as little as possible
-  > Correct. This is the classic measure of a healthy modular design.
+  > This is the classic measure of a healthy modular design.
 - Use the keyword \`public\` on as many members as possible
   > Visibility breadth and cohesion are unrelated.`}
 />

--- a/content/learn/oop-blueprint-java/polymorphism.mdx
+++ b/content/learn/oop-blueprint-java/polymorphism.mdx
@@ -386,7 +386,7 @@ public class Payroll {
 - Neither — the compiler rejects this code
   > It compiles fine; \`Animal\` declares \`speak()\`.
 - [o] \`Dog.speak()\` because the runtime type of the object \`a\` points to is \`Dog\`
-  > Correct. Java uses dynamic dispatch on instance methods.
+  > Java uses dynamic dispatch on instance methods.
 - It is undefined; the JVM picks at random
   > Behavior is fully deterministic.`}
 />
@@ -399,7 +399,7 @@ public class Payroll {
 - Because it removes the need for any interfaces or abstract classes
   > Polymorphism is *enabled by* interfaces and inheritance.
 - [o] Because one piece of generic code can handle any number of concrete types, including types that don't exist yet
-  > Correct. This is the open-closed principle in action.
+  > This is the open-closed principle in action.
 - Because it allows downcasting without checks
   > Downcasting is the *risky* operation polymorphism is supposed to let you avoid.`}
 />
@@ -412,7 +412,7 @@ public class Payroll {
 - You override \`equals\` and \`hashCode\` on your value classes
   > That's normal.
 - [o] Several methods in your code do \`if (x instanceof A) ... else if (x instanceof B) ...\` and call different code per branch
-  > Correct. That pattern usually points at a missing abstraction — give the parent a method and let each subtype override it.
+  > That pattern usually points at a missing abstraction — give the parent a method and let each subtype override it.
 - Your interfaces have only one method
   > Single-method interfaces are common and often fine.`}
 />

--- a/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
+++ b/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
@@ -453,7 +453,7 @@ balance: 60
 - Each class should have exactly one method
   > Method count isn't the criterion; coherence of responsibility is.
 - [o] Each class should have a small, coherent set of responsibilities, and those determine its behavior and its collaborators
-  > Correct — this is essentially the Wirfs-Brock formulation.
+  > This is essentially the Wirfs-Brock formulation.
 - All classes should inherit from a shared base class
   > Inheritance is unrelated to responsibility-driven design.
 - Behaviour should be split across as many classes as possible
@@ -468,7 +468,7 @@ balance: 60
 - Long parameter list
   > That's specifically about too many parameters of primitive types.
 - [o] Feature envy
-  > Correct. The method *envies* Bar's data; it likely belongs on Bar.
+  > The method *envies* Bar's data; it likely belongs on Bar.
 - Anemic model
   > That describes a *class* with only data and no behavior, not a single method.`}
 />
@@ -481,7 +481,7 @@ balance: 60
 - Always pass parameters by value
   > Java has its own parameter-passing rules independent of this guideline.
 - [o] Send the object a command to do the thing, rather than pulling out its data and doing the thing yourself
-  > Correct. This keeps the object in control of its own rules.
+  > This keeps the object in control of its own rules.
 - Don't write public methods at all
   > You absolutely need public methods to expose behavior.`}
 />

--- a/content/learn/oop-blueprint-java/software-crisis.mdx
+++ b/content/learn/oop-blueprint-java/software-crisis.mdx
@@ -187,7 +187,7 @@ that idea. That happens in the next page.
 - Because the compiler refuses to type-check global state
   > Most compilers happily check globals; the issue is not type-checking.
 - [o] Because *any* function in the program can modify the data, so the culprit could be anywhere
-  > Correct. With no ownership, every read and write site is a suspect, which makes debugging slow and frustrating.
+  > With no ownership, every read and write site is a suspect, which makes debugging slow and frustrating.
 - Because global variables are stored on the heap instead of the stack
   > The storage location of a variable doesn't make a bug harder to find.
 - Because procedural languages have no \`if\` statements
@@ -202,7 +202,7 @@ that idea. That happens in the next page.
 - A specific virus that destroyed mainframe systems
   > It was not a literal attack; it was a structural problem.
 - [o] A pattern of large software projects being late, over budget, buggy, and hard to change
-  > Correct. The crisis was about the difficulty of building and maintaining big systems with the tools of the time.
+  > The crisis was about the difficulty of building and maintaining big systems with the tools of the time.
 - The first appearance of open-source licensing disputes
   > Open-source licensing debates came much later and are unrelated.`}
 />
@@ -215,7 +215,7 @@ that idea. That happens in the next page.
 - A single global database that all functions share
   > That is closer to the problem than the solution.
 - [o] Units of code that own their data, enforce their own rules, and can be composed into larger systems
-  > Correct. This is essentially the definition of an object — which is where OOP enters the story.
+  > This is essentially the definition of an object — which is where OOP enters the story.
 - More clever \`GOTO\` statements
   > \`GOTO\`-heavy code was part of what made systems unmaintainable.`}
 />

--- a/content/learn/oop-blueprint-java/static-and-utility.mdx
+++ b/content/learn/oop-blueprint-java/static-and-utility.mdx
@@ -329,7 +329,7 @@ sum=15
 - Each instance, with one independent copy per instance
   > That describes *non-static* (instance) fields.
 - [o] The class itself; there is one copy shared by all instances
-  > Correct. \`static\` members belong to the class, not to any individual object.
+  > \`static\` members belong to the class, not to any individual object.
 - The first instance created
   > Static state is independent of any instance.
 - The package that contains the class
@@ -344,7 +344,7 @@ sum=15
 - \`@Constant\` annotation
   > No such annotation.
 - [o] \`public static final\` field, written in \`UPPER_SNAKE_CASE\`
-  > Correct. This is the standard idiom — class-wide, immutable, and easy to spot.
+  > This is the standard idiom — class-wide, immutable, and easy to spot.
 - \`private\` field with a getter
   > That makes a constant-ish *instance* value, but the canonical Java idiom is \`public static final\`.`}
 />
@@ -355,7 +355,7 @@ sum=15
 - Whenever you want to avoid writing constructors
   > Avoidance isn't a design reason.
 - [o] When the methods are genuinely stateless and don't naturally belong to any particular object
-  > Correct. Pure functions on a shared theme (like \`Math\`) fit this nicely.
+  > Pure functions on a shared theme (like \`Math\`) fit this nicely.
 - For all classes — it makes them easier to test
   > Heavy static use *hurts* testability and reuse. It also negates most OOP benefits.
 - For any class that has more than ten methods

--- a/content/learn/practical-r-for-beginners/data-frames.mdx
+++ b/content/learn/practical-r-for-beginners/data-frames.mdx
@@ -169,7 +169,7 @@ finding them.
 - A single multi-dimensional array
 - An Excel file
 - [o] A list of equal-length vectors (one per column), displayed as a table
-  > Correct! Each column is a vector — possibly of a different type — and they all share the same length.
+  > Each column is a vector — possibly of a different type — and they all share the same length.
 - A SQL table`}
 />
 
@@ -178,7 +178,7 @@ finding them.
 
 - \`mtcars[mpg]\`
 - [o] \`mtcars$mpg\`
-  > Correct! \`$\` extracts a single column by name and returns it as a vector. \`mtcars[["mpg"]]\` works too.
+  > \`$\` extracts a single column by name and returns it as a vector. \`mtcars[["mpg"]]\` works too.
 - \`mtcars.mpg\`
 - \`mtcars(mpg)\``}
 />
@@ -189,7 +189,7 @@ finding them.
 - The single value of \`mpg\` greater than 25
 - The column \`mpg\` filtered
 - [o] All rows of \`mtcars\` where \`mpg > 25\`, with all columns kept
-  > Correct! The logical vector \`mtcars$mpg > 25\` selects rows; the empty slot after the comma keeps all columns.
+  > The logical vector \`mtcars$mpg > 25\` selects rows; the empty slot after the comma keeps all columns.
 - An error`}
 />
 

--- a/content/learn/practical-r-for-beginners/dplyr-verbs.mdx
+++ b/content/learn/practical-r-for-beginners/dplyr-verbs.mdx
@@ -255,7 +255,7 @@ verbs, one sentence.
 - \`select()\`
   > \`select()\` is for columns, not rows.
 - [o] \`filter()\`
-  > Correct! \`filter()\` keeps rows matching a condition.
+  > \`filter()\` keeps rows matching a condition.
 - \`arrange()\`
 - \`mutate()\``}
 />
@@ -265,7 +265,7 @@ verbs, one sentence.
 
 - It runs two commands in parallel.
 - [o] It passes the value on the left as the first argument to the function on the right, letting you chain operations in reading order.
-  > Correct! \`x |> f()\` is the same as \`f(x)\`, but reads top to bottom when chained.
+  > \`x |> f()\` is the same as \`f(x)\`, but reads top to bottom when chained.
 - It compares two values for equality.
 - It declares a function.`}
 />
@@ -278,7 +278,7 @@ verbs, one sentence.
   > \`summarise()\` *collapses* rows; you want to add a derived column.
 - \`filter()\`
 - [o] \`mutate()\`
-  > Correct! \`mutate()\` adds or changes columns based on other columns.`}
+  > \`mutate()\` adds or changes columns based on other columns.`}
 />
 
 ## Mini challenge: top efficient cars

--- a/content/learn/practical-r-for-beginners/exploring-distributions.mdx
+++ b/content/learn/practical-r-for-beginners/exploring-distributions.mdx
@@ -199,7 +199,7 @@ par(mfrow = c(1, 1))
 
 - left-skewed
 - [o] right-skewed
-  > Correct! "Right-skewed" means the tail extends to the right (toward larger values). It is the most common shape for natural data like income or transaction sizes.
+  > "Right-skewed" means the tail extends to the right (toward larger values). It is the most common shape for natural data like income or transaction sizes.
 - bimodal
 - symmetric`}
 />
@@ -209,7 +209,7 @@ par(mfrow = c(1, 1))
 
 - The mean ± one standard deviation.
 - [o] The middle 50% of the data, from Q1 (25th percentile) to Q3 (75th percentile).
-  > Correct! The line inside is the median; the box edges are the quartiles.
+  > The line inside is the median; the box edges are the quartiles.
 - The full range of the data.
 - The confidence interval of the mean.`}
 />
@@ -219,7 +219,7 @@ par(mfrow = c(1, 1))
 
 - They have the fewest pixels.
 - [o] They compress each group's full distribution into a small, standardized picture that lines up nicely side-by-side.
-  > Correct! That makes shifts in center, spread, and outliers easy to spot across many groups at once.
+  > That makes shifts in center, spread, and outliers easy to spot across many groups at once.
 - They show every individual data point.
 - They are the only plot that handles NAs.`}
 />

--- a/content/learn/practical-r-for-beginners/from-s-to-r.mdx
+++ b/content/learn/practical-r-for-beginners/from-s-to-r.mdx
@@ -223,7 +223,7 @@ extraordinarily well-suited.
 - John Chambers and Rick Becker at Bell Labs.
   > Chambers and Becker created **S**, the language R is descended from. R itself was created by two other people.
 - [o] Ross Ihaka and Robert Gentleman at the University of Auckland.
-  > Correct! They started R as a teaching tool in 1991 and released it publicly in 1993.
+  > They started R as a teaching tool in 1991 and released it publicly in 1993.
 - Hadley Wickham as part of the tidyverse project.
   > Hadley Wickham is one of R's most influential contributors today, but R itself predates his work by many years.
 - The R Foundation as an institutional project.
@@ -236,7 +236,7 @@ extraordinarily well-suited.
 - The interactive R user interface.
 - A book series about R.
 - [o] The Comprehensive R Archive Network — a worldwide repository of R packages.
-  > Correct! CRAN launched in 1997 and is the place from which R packages are submitted, reviewed, and distributed.
+  > CRAN launched in 1997 and is the place from which R packages are submitted, reviewed, and distributed.
 - The compiler used to build the R interpreter.`}
 />
 
@@ -246,7 +246,7 @@ extraordinarily well-suited.
 - R is faster than any other language for numerical computing.
   > R is competitive in many cases, but raw speed is not where it shines — and other languages (Julia, C++, Python with NumPy) are often faster for pure number-crunching.
 - [o] It is free, extensible, and lets users contribute packages that the entire community can use.
-  > Correct. The combination of "free under the GPL" + "real programming language" + "CRAN as a central package archive" is what turned R into a true platform for the world's statisticians.
+  > The combination of "free under the GPL" + "real programming language" + "CRAN as a central package archive" is what turned R into a true platform for the world's statisticians.
 - R was bundled with university computer science textbooks.
 - R is the only language that supports the t-test.`}
 />

--- a/content/learn/practical-r-for-beginners/ggplot-grammar.mdx
+++ b/content/learn/practical-r-for-beginners/ggplot-grammar.mdx
@@ -245,7 +245,7 @@ flowchart TB
 - They are equivalent.
 - The first errors; only the second works.
 - [o] The first **sets** every point to red. The second **maps** the literal string "red" to color as if it were a category, and ggplot picks the default color for that category — usually not red — and adds a useless legend.
-  > Correct! Inside \`aes()\`, you map data to properties. Outside, you set properties to constant values.
+  > Inside \`aes()\`, you map data to properties. Outside, you set properties to constant values.
 - The second is faster.`}
 />
 
@@ -254,7 +254,7 @@ flowchart TB
 
 - \`ggplot(mtcars) + geom_point(hp, mpg)\`
 - [o] \`ggplot(mtcars, aes(x = hp, y = mpg)) + geom_point()\`
-  > Correct! Aesthetic mappings go in \`aes()\` inside \`ggplot()\` (or inside the geom).
+  > Aesthetic mappings go in \`aes()\` inside \`ggplot()\` (or inside the geom).
 - \`plot(mtcars$hp, mtcars$mpg)\`
 - \`ggplot(mtcars, hp, mpg) + scatter()\``}
 />
@@ -263,7 +263,7 @@ flowchart TB
   markdown={`To split a ggplot into one small panel per Species in \`iris\`, you add:
 
 - [o] \`facet_wrap(~ Species)\`
-  > Correct! \`facet_wrap()\` creates one panel per unique value, laid out in a wrapping grid.
+  > \`facet_wrap()\` creates one panel per unique value, laid out in a wrapping grid.
 - \`group_by(Species)\`
 - \`color = Species\`
 - \`split(Species)\``}

--- a/content/learn/practical-r-for-beginners/grouped-analysis.mdx
+++ b/content/learn/practical-r-for-beginners/grouped-analysis.mdx
@@ -292,7 +292,7 @@ if (!all(need %in% names(monthly))) stop(sprintf("missing: %s", paste(setdiff(ne
 
 - Filter-arrange-join
 - [o] Split-apply-combine
-  > Correct! Split the data into groups, apply a computation to each, combine the results into a single table.
+  > Split the data into groups, apply a computation to each, combine the results into a single table.
 - Map-reduce-filter
 - Sort-merge-deduplicate`}
 />
@@ -302,7 +302,7 @@ if (!all(need %in% names(monthly))) stop(sprintf("missing: %s", paste(setdiff(ne
 
 - Returns the number of columns.
 - [o] Returns the number of rows in the current (possibly grouped) data.
-  > Correct! Inside \`summarise()\` after a \`group_by()\`, \`n()\` gives the count per group.
+  > Inside \`summarise()\` after a \`group_by()\`, \`n()\` gives the count per group.
 - Returns the mean of the data.
 - Returns the row name.`}
 />
@@ -313,7 +313,7 @@ if (!all(need %in% names(monthly))) stop(sprintf("missing: %s", paste(setdiff(ne
 - They're the same.
 - \`summarise\` is slower than \`mutate\`.
 - [o] \`summarise\` returns one row per group (collapses); \`mutate\` keeps every row and broadcasts the group statistic into each row.
-  > Correct! Use \`summarise\` for a compact group table, \`mutate\` when you want a per-row column that depends on the group.
+  > Use \`summarise\` for a compact group table, \`mutate\` when you want a per-row column that depends on the group.
 - \`mutate\` cannot be used with \`group_by\`.`}
 />
 

--- a/content/learn/practical-r-for-beginners/inspecting-a-dataset.mdx
+++ b/content/learn/practical-r-for-beginners/inspecting-a-dataset.mdx
@@ -214,7 +214,7 @@ report("NAs per column", colSums(is.na(iris)))
 - \`summary()\`
 - \`head()\`
 - [o] \`str()\`
-  > Correct! \`str()\` is the structural summary — types and a sample, in one screen.
+  > \`str()\` is the structural summary — types and a sample, in one screen.
 - \`dim()\``}
 />
 
@@ -224,7 +224,7 @@ report("NAs per column", colSums(is.na(iris)))
 - It's required by R; the language won't compute without it.
   > Not true — R will happily compute on a dataset you've never looked at.
 - [o] Because real datasets contain surprises (missing values, wrong types, implausible values) that can silently corrupt every downstream analysis.
-  > Correct! Five minutes of inspection saves hours of debugging later.
+  > Five minutes of inspection saves hours of debugging later.
 - Because \`summary()\` is the only way to compute means.
 - Because it's a tradition.`}
 />
@@ -235,7 +235,7 @@ report("NAs per column", colSums(is.na(iris)))
 - The \`mean\` function is broken.
 - The dataset has fewer than 30 rows.
 - [o] The \`Ozone\` column contains \`NA\` values, and \`mean()\` returns \`NA\` unless told otherwise.
-  > Correct! Fix it with \`mean(airquality$Ozone, na.rm = TRUE)\`.
+  > Fix it with \`mean(airquality$Ozone, na.rm = TRUE)\`.
 - R refuses to compute means on built-in datasets.`}
 />
 

--- a/content/learn/practical-r-for-beginners/interpreting-plots.mdx
+++ b/content/learn/practical-r-for-beginners/interpreting-plots.mdx
@@ -191,7 +191,7 @@ shows us *associations*; causation requires more.
 
 - The legend
 - [o] The axes — their labels, units, scale, and starting values
-  > Correct! Without knowing what the axes are showing, the picture itself is uninterpretable. A y-axis starting at 85 vs. 0 can completely change the story.
+  > Without knowing what the axes are showing, the picture itself is uninterpretable. A y-axis starting at 85 vs. 0 can completely change the story.
 - The colors
 - The chart's title`}
 />
@@ -202,7 +202,7 @@ shows us *associations*; causation requires more.
 - R sometimes plots data incorrectly.
 - Correlation is always meaningless.
 - [o] Datasets with nearly identical summary statistics can have completely different shapes — so you must visualize, not just summarize.
-  > Correct! It is the canonical demonstration of why "plot first" is non-negotiable in EDA.
+  > It is the canonical demonstration of why "plot first" is non-negotiable in EDA.
 - Linear regression is always wrong.`}
 />
 
@@ -212,7 +212,7 @@ shows us *associations*; causation requires more.
 - Ice cream causes drowning.
 - Drowning causes ice cream sales.
 - [o] The two are associated; a likely cause is a confounding variable like summer weather, but the chart alone cannot establish causation.
-  > Correct! The chart describes an association. Causation requires either an experiment or careful reasoning about confounders.
+  > The chart describes an association. Causation requires either an experiment or careful reasoning about confounders.
 - The chart is wrong.`}
 />
 

--- a/content/learn/practical-r-for-beginners/intuition-for-inference.mdx
+++ b/content/learn/practical-r-for-beginners/intuition-for-inference.mdx
@@ -243,7 +243,7 @@ could plausibly be larger or smaller.
 - There is a 95% chance the true mean is between 45 and 55.
 - 95% of the data falls between 45 and 55.
 - [o] If we repeated the study many times and built CIs the same way each time, about 95% of those intervals would contain the true mean.
-  > Correct. The interval is what varies across hypothetical repetitions — the true value is fixed.
+  > The interval is what varies across hypothetical repetitions — the true value is fixed.
 - The mean is exactly 50.`}
 />
 
@@ -253,7 +253,7 @@ could plausibly be larger or smaller.
 - The probability the null hypothesis is true is 0.001.
 - The probability the finding is a fluke is 0.001.
 - [o] If there were no real difference between the groups, the chance of seeing a difference at least this extreme would be about 0.001.
-  > Correct! That's the actual definition of a p-value.
+  > That's the actual definition of a p-value.
 - The difference is definitely large.`}
 />
 
@@ -263,7 +263,7 @@ could plausibly be larger or smaller.
 - p-values are unreliable.
 - Effect size determines the p-value entirely.
 - [o] A result can be statistically significant (especially with large n) yet practically meaningless — effect size tells you whether it matters in the real world.
-  > Correct! Significance and importance are different questions.
+  > Significance and importance are different questions.
 - Confidence intervals are not used in practice.`}
 />
 

--- a/content/learn/practical-r-for-beginners/logical-and-character-vectors.mdx
+++ b/content/learn/practical-r-for-beginners/logical-and-character-vectors.mdx
@@ -249,7 +249,7 @@ vectors will do.
 
 - \`90\` (the sum of values greater than 15)
 - [o] \`3\`
-  > Correct! \`x > 15\` is \`c(FALSE, TRUE, TRUE, TRUE)\`. \`sum()\` treats \`TRUE\` as 1, so the count is 3.
+  > \`x > 15\` is \`c(FALSE, TRUE, TRUE, TRUE)\`. \`sum()\` treats \`TRUE\` as 1, so the count is 3.
 - \`TRUE\`
 - \`0.75\``}
 />
@@ -259,7 +259,7 @@ vectors will do.
 
 - \`3\`
 - [o] \`0.75\`
-  > Correct! \`mean()\` treats \`TRUE\` as 1 and \`FALSE\` as 0, so the mean is \`(1+1+0+1)/4 = 0.75\` — the *proportion* of \`TRUE\` values.
+  > \`mean()\` treats \`TRUE\` as 1 and \`FALSE\` as 0, so the mean is \`(1+1+0+1)/4 = 0.75\` — the *proportion* of \`TRUE\` values.
 - \`TRUE\`
 - An error`}
 />
@@ -270,7 +270,7 @@ vectors will do.
 - \`c(40, 33)\`
 - \`c(TRUE, FALSE, TRUE)\`
 - [o] \`c("Ana", "Cara")\`
-  > Correct! The logical \`ages > 30\` is \`c(TRUE, FALSE, TRUE)\`, used as an index into \`names\`, keeping positions 1 and 3.
+  > The logical \`ages > 30\` is \`c(TRUE, FALSE, TRUE)\`, used as an index into \`names\`, keeping positions 1 and 3.
 - An error`}
 />
 

--- a/content/learn/practical-r-for-beginners/mini-project-walkthrough.mdx
+++ b/content/learn/practical-r-for-beginners/mini-project-walkthrough.mdx
@@ -347,7 +347,7 @@ real analysis is a longer, deeper version of the same loop.
 - Run a regression.
 - Make a plot.
 - [o] Inspect it — \`dim()\`, \`head()\`, \`str()\`, \`summary()\` — so you understand what's actually there before assuming anything.
-  > Correct! Skipping inspection is the #1 cause of confidently-wrong analyses.
+  > Skipping inspection is the #1 cause of confidently-wrong analyses.
 - Compute the mean of every column.`}
 />
 
@@ -356,7 +356,7 @@ real analysis is a longer, deeper version of the same loop.
 
 - Temperature causes ozone.
 - [o] The two vary together strongly in this dataset — a real association, but correlation alone doesn't prove causation; other plausible factors (sunlight, emissions, weather patterns) are not ruled out.
-  > Correct! Stating associations carefully — and not over-claiming — is core craft.
+  > Stating associations carefully — and not over-claiming — is core craft.
 - The model is broken.
 - Ozone causes temperature.`}
 />
@@ -367,7 +367,7 @@ real analysis is a longer, deeper version of the same loop.
 - The raw data.
 - The R code.
 - [o] A clearly-written, honest interpretation of what was found, backed up by reproducible code and clear visualizations.
-  > Correct! Code and plots are means; communicating an honest finding is the end.
+  > Code and plots are means; communicating an honest finding is the end.
 - A p-value.`}
 />
 

--- a/content/learn/practical-r-for-beginners/missing-values.mdx
+++ b/content/learn/practical-r-for-beginners/missing-values.mdx
@@ -182,7 +182,7 @@ work with them constantly.
 
 - \`2\`
 - [o] \`NA\`
-  > Correct! By default, the presence of \`NA\` makes most summary functions return \`NA\`. Use \`na.rm = TRUE\` to ignore them.
+  > By default, the presence of \`NA\` makes most summary functions return \`NA\`. Use \`na.rm = TRUE\` to ignore them.
 - An error
 - \`0\``}
 />
@@ -195,7 +195,7 @@ work with them constantly.
 - \`x = NA\`
   > That's *assignment*, not a test.
 - [o] \`is.na(x)\`
-  > Correct! \`is.na()\` is the only reliable way to check for missingness.
+  > \`is.na()\` is the only reliable way to check for missingness.
 - \`x !== NA\``}
 />
 
@@ -204,7 +204,7 @@ work with them constantly.
 
 - \`NA\`
 - [o] \`30\`
-  > Correct! \`na.rm = TRUE\` removes the \`NA\` first, then sums the rest.
+  > \`na.rm = TRUE\` removes the \`NA\` first, then sums the rest.
 - \`10\`
 - \`20\``}
 />

--- a/content/learn/practical-r-for-beginners/next-steps.mdx
+++ b/content/learn/practical-r-for-beginners/next-steps.mdx
@@ -228,7 +228,7 @@ That loop is the entire job. Welcome to it.
 - Start over.
 - Memorize harder.
 - [o] Look it up — \`?function_name\`, the docs, a search — and move on. Looking things up is the work.
-  > Correct! Even very experienced R users look things up constantly.
+  > Even very experienced R users look things up constantly.
 - Switch tools.`}
 />
 

--- a/content/learn/practical-r-for-beginners/principles-of-visualization.mdx
+++ b/content/learn/practical-r-for-beginners/principles-of-visualization.mdx
@@ -206,7 +206,7 @@ The data is the same. The reader's experience is not.
 
 - Color hue
 - [o] Position along a common scale
-  > Correct! Position (and length to a common baseline) is the most accurate visual channel. Color and area are far coarser.
+  > Position (and length to a common baseline) is the most accurate visual channel. Color and area are far coarser.
 - Area
 - Shape`}
 />
@@ -217,7 +217,7 @@ The data is the same. The reader's experience is not.
 - They take more pixels.
 - They cannot show more than two categories.
 - [o] The eye reads angles and areas poorly — bar charts (which use position/length) are usually clearer and more accurate.
-  > Correct! Almost any time you'd reach for a pie chart, a sorted bar chart is better.
+  > Almost any time you'd reach for a pie chart, a sorted bar chart is better.
 - R does not support them.`}
 />
 
@@ -227,7 +227,7 @@ The data is the same. The reader's experience is not.
 - Sort alphabetically.
 - Sort by region ID.
 - [o] Sort by the value you're plotting, so the chart's order itself encodes a ranking.
-  > Correct! Sorting by value lets the reader see the ranking instantly with no conscious effort.
+  > Sorting by value lets the reader see the ranking instantly with no conscious effort.
 - Leave them in a random order.`}
 />
 

--- a/content/learn/practical-r-for-beginners/r-as-a-calculator.mdx
+++ b/content/learn/practical-r-for-beginners/r-as-a-calculator.mdx
@@ -288,7 +288,7 @@ calculator: numbers in, numbers / booleans out.
 - 3
   > That would be \`10 %/% 3\` — integer division.
 - [o] 1
-  > Correct! \`%%\` is the modulo operator: 10 divided by 3 leaves a remainder of 1.
+  > \`%%\` is the modulo operator: 10 divided by 3 leaves a remainder of 1.
 - 30`}
 />
 
@@ -299,7 +299,7 @@ calculator: numbers in, numbers / booleans out.
   > This returns \`FALSE\` because of floating-point representation issues.
 - \`(0.1 + 0.2) ~ 0.3\`
 - [o] \`all.equal(0.1 + 0.2, 0.3)\`
-  > Correct! \`all.equal()\` is R's idiom for "are these approximately equal within tolerance?"
+  > \`all.equal()\` is R's idiom for "are these approximately equal within tolerance?"
 - \`(0.1 + 0.2) === 0.3\`
   > R does not have a \`===\` operator — that's JavaScript.`}
 />
@@ -312,7 +312,7 @@ calculator: numbers in, numbers / booleans out.
 - 196
   > That would require \`((2 + 3) * 4) ^ 2 = 400\` — not this either.
 - [o] 50
-  > Correct! Apply exponentiation first: \`4 ^ 2 = 16\`. Then multiplication: \`3 * 16 = 48\`. Then addition: \`2 + 48 = 50\`.
+  > Apply exponentiation first: \`4 ^ 2 = 16\`. Then multiplication: \`3 * 16 = 48\`. Then addition: \`2 + 48 = 50\`.
 - 100`}
 />
 

--- a/content/learn/practical-r-for-beginners/relationships-between-variables.mdx
+++ b/content/learn/practical-r-for-beginners/relationships-between-variables.mdx
@@ -234,7 +234,7 @@ the natural next step.
 - They are unrelated.
 - One causes the other.
 - [o] They have a strong negative linear relationship — when one tends to go up, the other tends to go down.
-  > Correct! Correlation measures linear association strength and direction, on a scale from -1 to +1. It does *not* establish causation.
+  > Correlation measures linear association strength and direction, on a scale from -1 to +1. It does *not* establish causation.
 - One of the variables has more NAs than the other.`}
 />
 
@@ -244,7 +244,7 @@ the natural next step.
 - They are completely independent.
 - They have no relationship of any kind.
 - [o] They have no *linear* relationship. They might still have a curved or otherwise structured relationship — only a plot will tell you.
-  > Correct! Pearson correlation only sees linear association.
+  > Pearson correlation only sees linear association.
 - The dataset is too small.`}
 />
 
@@ -254,7 +254,7 @@ the natural next step.
 - Ice cream causes drowning.
 - Drowning causes ice cream sales (e.g., grieving families binge).
 - [o] A third variable — summer/hot weather — causes both. This is a *confounding* variable.
-  > Correct! This is the classic example of why correlation does not imply causation.
+  > This is the classic example of why correlation does not imply causation.
 - Pure coincidence.`}
 />
 

--- a/content/learn/practical-r-for-beginners/reproducible-analysis.mdx
+++ b/content/learn/practical-r-for-beginners/reproducible-analysis.mdx
@@ -256,7 +256,7 @@ institutionalized.
 - Scripts are always faster.
 - Scripts can analyze more data.
 - [o] The script *itself* is a precise record of every step, which means anyone (including future-you) can re-run the exact analysis.
-  > Correct! Reproducibility is fundamentally about leaving a trail. A script *is* the trail; a sequence of mouse clicks is not.
+  > Reproducibility is fundamentally about leaving a trail. A script *is* the trail; a sequence of mouse clicks is not.
 - Spreadsheets cannot do statistics.
   > Spreadsheets can perform statistical calculations; the issue is that the process is opaque and easily lost.`}
 />
@@ -267,7 +267,7 @@ institutionalized.
 - It runs R faster.
 - It eliminates the need to know R.
 - [o] It interleaves prose, code, and computed output into a single document that is regenerated from the data every time it is rendered.
-  > Correct! This means the narrative explanation and the actual numbers in your report are always in sync — there is no opportunity for a stale copy-pasted figure to disagree with the text.
+  > This means the narrative explanation and the actual numbers in your report are always in sync — there is no opportunity for a stale copy-pasted figure to disagree with the text.
 - It encrypts your data automatically.`}
 />
 
@@ -278,7 +278,7 @@ institutionalized.
   > That is *replication*, a separate concept.
 - An analysis that produces only one possible answer no matter the data.
 - [o] An analysis where another person, given the same raw data and the same code, can rerun the pipeline and obtain the same final numbers, tables, and figures.
-  > Correct! Reproducibility is about *given the same inputs, getting the same outputs*. Replication is a stricter and separate scientific practice.
+  > Reproducibility is about *given the same inputs, getting the same outputs*. Replication is a stricter and separate scientific practice.
 - An analysis whose findings have been confirmed by a peer-reviewed journal.`}
 />
 

--- a/content/learn/practical-r-for-beginners/reshaping-data.mdx
+++ b/content/learn/practical-r-for-beginners/reshaping-data.mdx
@@ -234,7 +234,7 @@ flowchart TB
 - \`pivot_wider()\`
 - \`group_by()\`
 - [o] \`pivot_longer()\`
-  > Correct! \`pivot_longer()\` folds multiple columns into a key column (year) and a value column (gdp).
+  > \`pivot_longer()\` folds multiple columns into a key column (year) and a value column (gdp).
 - \`select()\``}
 />
 
@@ -242,7 +242,7 @@ flowchart TB
   markdown={`A long table has columns \`country\`, \`year\`, \`gdp\`. To produce a display-friendly wide table with one column per year, you would use:
 
 - [o] \`pivot_wider(names_from = year, values_from = gdp)\`
-  > Correct! Year's *values* become the new column *names*; gdp's values fill them.
+  > Year's *values* become the new column *names*; gdp's values fill them.
 - \`pivot_longer(cols = year)\`
 - \`summarise(gdp = mean(gdp))\`
 - \`mutate(year = as.character(year))\``}
@@ -253,7 +253,7 @@ flowchart TB
 
 - Wide form, because plots need rectangles.
 - [o] Long form, because ggplot maps **columns** to visual properties (one column per variable).
-  > Correct! Long form is what makes \`aes(color = metric)\`-style mappings work cleanly.
+  > Long form is what makes \`aes(color = metric)\`-style mappings work cleanly.
 - Either — ggplot doesn't care.
 - A matrix, not a data frame.`}
 />

--- a/content/learn/practical-r-for-beginners/rise-of-statistical-computing.mdx
+++ b/content/learn/practical-r-for-beginners/rise-of-statistical-computing.mdx
@@ -201,7 +201,7 @@ What happened next surprised everyone, including them.
 - It was faster than SAS at large-scale data crunching.
 - It supported larger datasets than SAS.
 - [o] It treated data analysis as an *interactive, programmable* activity rather than a batch job.
-  > Correct! S was designed for interactive use at a terminal, with data as first-class objects and full programmability. This shaped the modern style of "exploratory data analysis as a conversation with the data."
+  > S was designed for interactive use at a terminal, with data as first-class objects and full programmability. This shaped the modern style of "exploratory data analysis as a conversation with the data."
 - It was the first statistical software to use the normal distribution.`}
 />
 
@@ -211,7 +211,7 @@ What happened next surprised everyone, including them.
 - Stanford University
 - North Carolina State University
 - [o] Bell Labs
-  > Correct! S was created at Bell Labs in Murray Hill, New Jersey, by a team led by John Chambers starting around 1976.
+  > S was created at Bell Labs in Murray Hill, New Jersey, by a team led by John Chambers starting around 1976.
 - IBM Research`}
 />
 
@@ -220,7 +220,7 @@ What happened next surprised everyone, including them.
 
 - Sitting at a terminal, typing one expression at a time and seeing immediate output.
 - [o] Writing a batch script of \`DATA\` and \`PROC\` steps, submitting it, and reading the printed output later.
-  > Correct. SAS was — and historically still is — primarily a batch language, in which an analyst writes a complete program of steps and submits it as a job.
+  > SAS was — and historically still is — primarily a batch language, in which an analyst writes a complete program of steps and submits it as a job.
 - Writing FORTRAN code that called SAS subroutines.
 - Editing data interactively in a spreadsheet-like grid.`}
 />

--- a/content/learn/practical-r-for-beginners/sampling-and-distributions.mdx
+++ b/content/learn/practical-r-for-beginners/sampling-and-distributions.mdx
@@ -231,7 +231,7 @@ next page.)
 
 - σ
 - [o] σ / √n
-  > Correct! Doubling sample size shrinks SE by √2, quadrupling shrinks it by 2, etc.
+  > Doubling sample size shrinks SE by √2, quadrupling shrinks it by 2, etc.
 - σ × n
 - σ² / n`}
 />
@@ -241,7 +241,7 @@ next page.)
 
 - All data is normally distributed if you collect enough.
 - [o] The distribution of the **sample mean** becomes approximately normal as n grows, regardless of the population shape.
-  > Correct! It's a statement about averages, not about individual data points.
+  > It's a statement about averages, not about individual data points.
 - Skewed data can be ignored.
 - p-values are always small.`}
 />
@@ -251,7 +251,7 @@ next page.)
 
 - It's never a problem if n is huge.
 - [o] Bias is a systematic offset that big sample size does **not** fix — you'll just be very precisely wrong.
-  > Correct! Sample size shrinks variance, but only sound sampling design eliminates bias.
+  > Sample size shrinks variance, but only sound sampling design eliminates bias.
 - p-values become unreliable.
 - The CLT stops applying.`}
 />

--- a/content/learn/practical-r-for-beginners/scripts-and-projects.mdx
+++ b/content/learn/practical-r-for-beginners/scripts-and-projects.mdx
@@ -239,7 +239,7 @@ can develop.
 
 - They're owned by the OS.
 - [o] Raw data is the immutable ground truth — preserving it means anyone can re-derive every cleaned output by re-running scripts, and accidental edits can't silently corrupt your analysis.
-  > Correct! Treat raw data as read-only.
+  > Treat raw data as read-only.
 - R can't write to that folder.
 - It's a tradition with no real reason.`}
 />
@@ -249,7 +249,7 @@ can develop.
 
 - It's longer to type.
 - [o] It won't work on anyone else's machine (or even yours, after you reorganize your files) — relative paths anchored to the project root are portable.
-  > Correct! Portability matters even if "anyone else" is just future-you.
+  > Portability matters even if "anyone else" is just future-you.
 - R can't read Windows paths.
 - It only works for CSV files.`}
 />
@@ -259,7 +259,7 @@ can develop.
 
 - They speed up script execution.
 - [o] They record the exact package versions a project uses, so the analysis can be reliably re-run later even after packages on CRAN have changed.
-  > Correct! Reproducibility doesn't end at code — it includes the environment around it.
+  > Reproducibility doesn't end at code — it includes the environment around it.
 - They replace base R.
 - They make scripts run in parallel.`}
 />

--- a/content/learn/practical-r-for-beginners/statistics-before-computers.mdx
+++ b/content/learn/practical-r-for-beginners/statistics-before-computers.mdx
@@ -215,7 +215,7 @@ but practically unreachable. We will see that next.
 
 - Larger samples are statistically invalid.
 - [o] Hand-computation made larger samples impractical at the time.
-  > Correct! Many famous methods (the t-test, ANOVA) were tuned to give useful answers from the kind of data a researcher could realistically analyze with paper, pencil, and a mechanical calculator.
+  > Many famous methods (the t-test, ANOVA) were tuned to give useful answers from the kind of data a researcher could realistically analyze with paper, pencil, and a mechanical calculator.
 - Statisticians had not yet discovered that more data is better.
 - The math was always intended for small n on philosophical grounds.
   > While there are interesting modern conversations about small data, the historical reason was very practical: arithmetic was expensive.`}
@@ -227,7 +227,7 @@ but practically unreachable. We will see that next.
 - A mainframe machine in a glass-walled room.
 - A research grant for computation.
 - [o] A person — often a woman — whose job was to do arithmetic.
-  > Correct! The word "computer" originally meant a person who performs calculations. Mechanical and then electronic computers eventually inherited the job title.
+  > The word "computer" originally meant a person who performs calculations. Mechanical and then electronic computers eventually inherited the job title.
 - A pocket calculator.`}
 />
 
@@ -237,7 +237,7 @@ but practically unreachable. We will see that next.
 - The math was too complicated to ever understand.
 - It was illegal to compute these values yourself.
 - [o] Computing those values from scratch was prohibitively expensive — so once computed, the answers were published once and reused everywhere.
-  > Correct. A table you can look up in five seconds replaces hours of hand computation.
+  > A table you can look up in five seconds replaces hours of hand computation.
 - They contained errors that statisticians could correct over time.`}
 />
 

--- a/content/learn/practical-r-for-beginners/subsetting-and-filtering.mdx
+++ b/content/learn/practical-r-for-beginners/subsetting-and-filtering.mdx
@@ -178,7 +178,7 @@ then use those positions as row indices.
 
 - \`df[cols, rows]\`
 - [o] \`df[rows, cols]\`
-  > Correct! Rows first, columns second — same convention as matrices in mathematics.
+  > Rows first, columns second — same convention as matrices in mathematics.
 - \`df[rows][cols]\`
 - \`df.rows.cols\``}
 />
@@ -188,7 +188,7 @@ then use those positions as row indices.
 
 - \`iris[iris$Species == "setosa" == "versicolor", ]\`
 - [o] \`iris[iris$Species %in% c("setosa", "versicolor"), ]\`
-  > Correct! \`%in%\` is the idiomatic way to match against a set of values.
+  > \`%in%\` is the idiomatic way to match against a set of values.
 - \`iris[iris$Species = "setosa" | "versicolor", ]\`
 - \`iris[in(iris$Species, "setosa", "versicolor"), ]\``}
 />
@@ -198,7 +198,7 @@ then use those positions as row indices.
 
 - It's not — it works perfectly.
 - [o] \`Ozone\` contains NAs, and \`NA > 100\` evaluates to NA, which produces rows of all NAs in the result.
-  > Correct! Always guard with \`!is.na(col) & ...\` (or use \`dplyr::filter()\`, which handles this for you).
+  > Always guard with \`!is.na(col) & ...\` (or use \`dplyr::filter()\`, which handles this for you).
 - It sorts the data instead of filtering it.
 - \`Ozone\` is character, so the comparison errors.`}
 />

--- a/content/learn/practical-r-for-beginners/summary-statistics.mdx
+++ b/content/learn/practical-r-for-beginners/summary-statistics.mdx
@@ -206,7 +206,7 @@ a plot.
 - mean
 - variance
 - [o] median
-  > Correct! The median only depends on the *position* of values, not their magnitude. A single extreme value can pull the mean a lot but barely move the median.
+  > The median only depends on the *position* of values, not their magnitude. A single extreme value can pull the mean a lot but barely move the median.
 - range`}
 />
 
@@ -216,7 +216,7 @@ a plot.
 - has more values
 - has higher values
 - [o] has values that are more spread out around 50
-  > Correct! Standard deviation measures typical distance from the mean — bigger sd means values are scattered farther from the center.
+  > Standard deviation measures typical distance from the mean — bigger sd means values are scattered farther from the center.
 - has fewer NAs`}
 />
 
@@ -225,7 +225,7 @@ a plot.
 
 - That R has poor numerical precision.
 - [o] Four very different datasets can share nearly identical summary statistics — proving you must visualize, not just summarize.
-  > Correct! It's the canonical reminder that summaries compress; plots reveal.
+  > It's the canonical reminder that summaries compress; plots reveal.
 - That correlation always implies causation.
 - That outliers should be removed.`}
 />

--- a/content/learn/practical-r-for-beginners/the-age-of-data.mdx
+++ b/content/learn/practical-r-for-beginners/the-age-of-data.mdx
@@ -147,7 +147,7 @@ when statistics was a craft practiced with paper and ink.
 
 - The bottleneck has stayed the same: people still mostly run out of data.
 - [o] The bottleneck has shifted from *collecting* data to *understanding* it.
-  > Correct! For most of history, gathering data was the hard part. Today, data is generated in huge volumes automatically; the challenge is interpreting it, separating signal from noise, and making decisions that are not fooled by spurious patterns.
+  > For most of history, gathering data was the hard part. Today, data is generated in huge volumes automatically; the challenge is interpreting it, separating signal from noise, and making decisions that are not fooled by spurious patterns.
 - The bottleneck is now purely hardware — we need faster computers.
   > Hardware matters, but the bigger constraint is human: turning data into reliable insight.
 - There is no longer any bottleneck because AI handles everything.
@@ -160,7 +160,7 @@ when statistics was a craft practiced with paper and ink.
 - Computers introduce rounding errors at scale.
 - Large datasets are always biased.
 - [o] When you test many hypotheses against a large dataset, some will look "statistically interesting" purely by chance.
-  > Correct! This is sometimes called the *multiple comparisons problem* — and it is one of the main reasons data analysts need disciplined statistical tools, not just spreadsheets.
+  > This is sometimes called the *multiple comparisons problem* — and it is one of the main reasons data analysts need disciplined statistical tools, not just spreadsheets.
 - Larger datasets cannot be visualized.`}
 />
 
@@ -171,7 +171,7 @@ when statistics was a craft practiced with paper and ink.
 - The risk of finding patterns that are not really there
 - The shift from hand calculation to programmatic analysis
 - [o] The disappearance of the need to understand basic arithmetic
-  > Correct — basic arithmetic is *more* important than ever, because you need to sanity-check what the computer is doing. Tools amplify both correct and incorrect reasoning.`}
+  > Basic arithmetic is *more* important than ever, because you need to sanity-check what the computer is doing. Tools amplify both correct and incorrect reasoning.`}
 />
 
 In the next page we will go back even further — to a time when

--- a/content/learn/practical-r-for-beginners/thinking-in-data.mdx
+++ b/content/learn/practical-r-for-beginners/thinking-in-data.mdx
@@ -262,7 +262,7 @@ expression first.**
 - "Computers are faster, but the way you think about a problem stays exactly the same."
 - "Computers think in numbers; humans think in patterns."
 - [o] "Hand arithmetic operates one number at a time; computational thinking operates on whole collections at a time."
-  > Correct! This is the central idea. The size of the data stops being a bottleneck because each *line of code* applies to as much data as you give it.
+  > This is the central idea. The size of the data stops being a bottleneck because each *line of code* applies to as much data as you give it.
 - "Computational thinking means avoiding statistics."`}
 />
 
@@ -271,7 +271,7 @@ expression first.**
 
 - R multiplies the lengths together to get 9.
 - [o] R multiplies the two vectors *elementwise* and returns a new vector of length 3.
-  > Correct! This is vectorization in action: matching positions are multiplied, and you get back a vector of the same length.
+  > This is vectorization in action: matching positions are multiplied, and you get back a vector of the same length.
 - R picks the first element of each and multiplies those.
 - R raises an error because you can't multiply two vectors.`}
 />
@@ -283,7 +283,7 @@ expression first.**
   > R does support loops; it just rarely needs them for data analysis.
 - Because loops always crash.
 - [o] Because most operations can be expressed more clearly and concisely with vectorized expressions on whole columns.
-  > Correct! Vectorization is shorter, easier to read, often faster, and matches the way R was designed to be used.
+  > Vectorization is shorter, easier to read, often faster, and matches the way R was designed to be used.
 - Because loops are illegal in statistical analysis.`}
 />
 

--- a/content/learn/practical-r-for-beginners/tidy-data-principles.mdx
+++ b/content/learn/practical-r-for-beginners/tidy-data-principles.mdx
@@ -203,7 +203,7 @@ further.
   markdown={`A dataset is *tidy* when:
 
 - [o] Each variable is a column, each observation is a row, and each observational unit is its own table.
-  > Correct! These are Hadley Wickham's three rules from the foundational "Tidy Data" paper.
+  > These are Hadley Wickham's three rules from the foundational "Tidy Data" paper.
 - Each value is rounded to two decimals.
 - Missing values have been removed.
 - The data has been sorted.`}
@@ -214,7 +214,7 @@ further.
 
 - Yes — every row is one country.
 - [o] No — "year" is hidden in the column names, so year is not a variable in its own right.
-  > Correct! The tidy form has columns \`country\`, \`year\`, \`gdp\` — one row per country-year combination.
+  > The tidy form has columns \`country\`, \`year\`, \`gdp\` — one row per country-year combination.
 - Yes — every column has a name.
 - It depends on how many countries there are.`}
 />
@@ -225,7 +225,7 @@ further.
 - It's mandatory in R.
 - It makes the file smaller.
 - [o] Modern tools (\`dplyr\`, \`ggplot2\`, modeling functions) all assume one row per observation and one column per variable, so tidy data "just works" with them.
-  > Correct! Once your data is tidy, the whole tidyverse and most statistical functions become straightforward.
+  > Once your data is tidy, the whole tidyverse and most statistical functions become straightforward.
 - It removes missing values.`}
 />
 

--- a/content/learn/practical-r-for-beginners/uncertainty-and-variability.mdx
+++ b/content/learn/practical-r-for-beginners/uncertainty-and-variability.mdx
@@ -224,7 +224,7 @@ expensive!
 
 - Exactly 5 heads every time.
 - [o] Around 5 heads on average, but individual experiments vary considerably — anywhere from 3 to 7 is unremarkable.
-  > Correct! Even when the true rate is exactly 0.5, small samples wiggle. That's variability.
+  > Even when the true rate is exactly 0.5, small samples wiggle. That's variability.
 - Always between 4 and 6 heads.
 - A different number every time, drawn uniformly from 0–10.`}
 />
@@ -234,7 +234,7 @@ expensive!
 
 - Larger numbers are more accurate.
 - [o] As your sample grows, the observed average converges to the true underlying value — variability of the mean shrinks.
-  > Correct! That's why a 10,000-flip coin is much closer to 50/50 than a 10-flip one.
+  > That's why a 10,000-flip coin is much closer to 50/50 than a 10-flip one.
 - The mean is always the right statistic.
 - The mean grows with sample size.`}
 />
@@ -244,7 +244,7 @@ expensive!
 
 - Roll it out immediately.
 - [o] Ask whether a "no real difference" world could plausibly produce a gap this big by chance — i.e., compare the observed effect to the noise floor for samples this size.
-  > Correct! That's the central question of statistical inference, and the intuition behind concepts like the p-value and confidence interval.
+  > That's the central question of statistical inference, and the intuition behind concepts like the p-value and confidence interval.
 - Run the test for one more day, then declare victory.
 - Average the two rates.`}
 />

--- a/content/learn/practical-r-for-beginners/variables-and-assignment.mdx
+++ b/content/learn/practical-r-for-beginners/variables-and-assignment.mdx
@@ -256,7 +256,7 @@ scripts it can be useful for cleaning up.
 - \`count == 7\`
   > That is a comparison, not an assignment. It returns \`TRUE\` or \`FALSE\`.
 - [o] \`count <- 7\`
-  > Correct! \`<-\` is R's assignment operator.
+  > \`<-\` is R's assignment operator.
 - \`count ~ 7\`
   > \`~\` is used in model formulas, not for assignment.
 - \`count := 7\`
@@ -277,7 +277,7 @@ What is the value of \`x\`?
 - \`6\`
   > That would be true if R had reference semantics, but it doesn't here.
 - [o] \`5\`
-  > Correct! When you wrote \`y <- x\`, R gave \`y\` its own independent copy. Modifying \`y\` leaves \`x\` alone.
+  > When you wrote \`y <- x\`, R gave \`y\` its own independent copy. Modifying \`y\` leaves \`x\` alone.
 - \`NA\`
 - An error`}
 />
@@ -289,7 +289,7 @@ What is the value of \`x\`?
 - \`avg.price\`
   > Dots are allowed inside R names — this is valid (though somewhat dated style).
 - [o] \`2nd_quarter\`
-  > Correct! R variable names cannot start with a digit.
+  > R variable names cannot start with a digit.
 - \`.hidden\``}
 />
 
@@ -299,7 +299,7 @@ What is the value of \`x\`?
 - \`=\` is forbidden in R.
   > It is not — \`=\` also works for assignment in most contexts.
 - [o] To keep assignment visually distinct from comparison (\`==\`) and from named function arguments (\`mean(x = 1:10)\`).
-  > Correct! The arrow leaves no doubt that what's happening is a write, not a read or a label.
+  > The arrow leaves no doubt that what's happening is a write, not a read or a label.
 - Because \`=\` is reserved for SQL.
 - Because R does not understand the \`=\` symbol.`}
 />

--- a/content/learn/practical-r-for-beginners/vectorized-computation.mdx
+++ b/content/learn/practical-r-for-beginners/vectorized-computation.mdx
@@ -212,7 +212,7 @@ this?" 95% of the time, there is.
 
 - \`60\` (the product of all elements times 10)
 - [o] \`10 20 30\`
-  > Correct! The \`10\` is recycled to match the length of the vector, then multiplied element-wise.
+  > The \`10\` is recycled to match the length of the vector, then multiplied element-wise.
 - An error — different lengths
 - \`c(10, 2, 3)\``}
 />
@@ -222,7 +222,7 @@ this?" 95% of the time, there is.
 
 - \`4\`
 - [o] \`5\`
-  > Correct! \`(2 + 4 + 6 + 8) / 4 = 20 / 4 = 5\`.
+  > \`(2 + 4 + 6 + 8) / 4 = 20 / 4 = 5\`.
 - \`6\`
 - \`20\``}
 />
@@ -232,7 +232,7 @@ this?" 95% of the time, there is.
 
 - Because \`for\` loops are forbidden in R.
 - [o] Because operations and most built-in functions are *vectorized* — they automatically apply to every element.
-  > Correct! This is R's signature design choice and is the reason R code for data work is so compact.
+  > This is R's signature design choice and is the reason R code for data work is so compact.
 - Because R secretly rewrites loops as parallel code.
 - Because R cannot iterate over vectors.`}
 />

--- a/content/learn/practical-r-for-beginners/vectors-everywhere.mdx
+++ b/content/learn/practical-r-for-beginners/vectors-everywhere.mdx
@@ -223,7 +223,7 @@ really starts to shine.
 - \`1\`
 - \`2\`
 - [o] \`3\`
-  > Correct! The vector has three character elements.
+  > The vector has three character elements.
 - \`"abc"\``}
 />
 
@@ -234,7 +234,7 @@ really starts to shine.
   > That would be \`list(1, "two", TRUE)\`, not \`c(...)\`.
 - An error
 - [o] A character vector: \`"1" "two" "TRUE"\`
-  > Correct! Mixing types with \`c()\` coerces everything to the most general type — in this case, character.
+  > Mixing types with \`c()\` coerces everything to the most general type — in this case, character.
 - A numeric vector: \`1 2 1\``}
 />
 
@@ -244,7 +244,7 @@ really starts to shine.
 - \`20\`
 - \`40\`
 - [o] \`10 30 40 50\`
-  > Correct! Negative indices in R mean *exclude this position*. \`x[-2]\` returns everything except the second element.
+  > Negative indices in R mean *exclude this position*. \`x[-2]\` returns everything except the second element.
 - \`50 40 30 10\` (reversed without the second)`}
 />
 

--- a/content/learn/practical-r-for-beginners/why-r-matters-today.mdx
+++ b/content/learn/practical-r-for-beginners/why-r-matters-today.mdx
@@ -240,7 +240,7 @@ it later.
 - You want to build a production-grade mobile app.
   > R is not suited to mobile development.
 - [o] You want to perform a careful statistical analysis and produce a reproducible report with charts.
-  > Correct! This is R's home turf — statistical analysis, visualization, and reproducible documents are exactly what R was designed for.
+  > This is R's home turf — statistical analysis, visualization, and reproducible documents are exactly what R was designed for.
 - You want to train a 10-billion-parameter language model.
   > That kind of work happens almost exclusively in Python + GPU kernels written in C++ or CUDA.
 - You want to build a high-frequency trading system.
@@ -254,7 +254,7 @@ it later.
 - Python has completely replaced R in academia.
   > Python has grown rapidly, but R remains dominant in many statistical fields, especially genomics, biostatistics, epidemiology, and parts of econometrics.
 - [o] They are complementary tools, often used together, with R typically stronger for statistics and visualization, and Python typically stronger for general programming and large-scale ML.
-  > Correct! Real data teams routinely use both languages and pick whichever fits the task.
+  > Real data teams routinely use both languages and pick whichever fits the task.
 - R has been deprecated in favor of Julia.
   > Julia is a promising language for numerical computing, but R is very much alive and growing.`}
 />
@@ -267,7 +267,7 @@ it later.
 - Because it does not support general programming constructs.
   > R supports functions, loops, conditionals, packages, and most general-purpose constructs.
 - [o] Because its syntax, conventions, and ecosystem were shaped around how statisticians actually think about and work with data.
-  > Correct! From model formulas (\`y ~ x1 + x2\`) to "data frames" to the way packages encapsulate statistical methods, R's design choices flow from a statistical worldview.
+  > From model formulas (\`y ~ x1 + x2\`) to "data frames" to the way packages encapsulate statistical methods, R's design choices flow from a statistical worldview.
 - Because it does not run on personal computers.
   > R runs on Windows, macOS, Linux, and even in the browser (which is how this very page runs it).`}
 />

--- a/content/learn/practical-r-for-beginners/writing-your-own-functions.mdx
+++ b/content/learn/practical-r-for-beginners/writing-your-own-functions.mdx
@@ -249,7 +249,7 @@ stays local.
 
 - Nothing — only \`return()\` returns.
 - [o] The value of its last expression by default, or an explicit \`return()\` value if you use one.
-  > Correct! Many idiomatic R functions just end with the value to return.
+  > Many idiomatic R functions just end with the value to return.
 - The first expression.
 - A list of all its expressions.`}
 />
@@ -259,7 +259,7 @@ stays local.
 
 - It saves typing.
 - [o] Every duplication is a place a bug can hide and a place you'll have to remember to update — lifting repeated logic into a function gives you one place to fix it and one place to test.
-  > Correct. Fewer redundant lines = fewer ways for the code to drift out of sync with itself.
+  > Fewer redundant lines = fewer ways for the code to drift out of sync with itself.
 - Functions run faster than inline code.
 - It makes scripts shorter.`}
 />
@@ -270,7 +270,7 @@ stays local.
 - \`f\`
 - \`do_thing\`
 - [o] \`standardize\`
-  > Correct! Function names should be verbs that describe what the function *does*.
+  > Function names should be verbs that describe what the function *does*.
 - \`x_value\``}
 />
 

--- a/content/learn/practical-r-for-beginners/your-first-r-program.mdx
+++ b/content/learn/practical-r-for-beginners/your-first-r-program.mdx
@@ -258,11 +258,11 @@ per-element behavior.
 - \`x <- 5\`
   > Assignment produces no automatic output — the result is stored, not printed.
 - [o] \`5 + 3\`
-  > Correct! An unassigned expression auto-prints its result.
+  > An unassigned expression auto-prints its result.
 - \`# print("hello")\`
   > That is a comment — everything after \`#\` is ignored.
 - [o] \`print(5)\`
-  > Correct! \`print()\` explicitly outputs its argument.`}
+  > \`print()\` explicitly outputs its argument.`}
 />
 
 <MultipleChoice
@@ -270,7 +270,7 @@ per-element behavior.
 
 - They are identical.
 - [o] \`print()\` formats values in R-style for inspection; \`cat()\` concatenates arguments into a plain string for building human-readable messages.
-  > Correct! Use \`print()\` to inspect a value, \`cat()\` to compose a sentence.
+  > Use \`print()\` to inspect a value, \`cat()\` to compose a sentence.
 - \`print()\` writes to a file; \`cat()\` writes to the screen.
 - \`cat()\` is the modern replacement for \`print()\`.`}
 />
@@ -284,7 +284,7 @@ result <- 2 + 2
 
 - Because R does not handle integer arithmetic.
 - [o] Because the result of the expression was assigned to the variable \`result\` instead of being printed.
-  > Correct! Assignment is silent. To see the value, add a separate line: \`print(result)\` or just \`result\`.
+  > Assignment is silent. To see the value, add a separate line: \`print(result)\` or just \`result\`.
 - Because of a parsing error.
 - Because R only prints character strings.`}
 />

--- a/content/learn/python-basics/booleans.mdx
+++ b/content/learn/python-basics/booleans.mdx
@@ -389,7 +389,7 @@ assert all_truthy(["a", "", "c"]) is False`,
 - \`None\`
   > \`None\` is falsy.
 - [o] \`[0]\`
-  > Correct. A list containing the number 0 is **non-empty**, so it is truthy. Only the empty list \`[]\` is falsy.`}
+  > A list containing the number 0 is **non-empty**, so it is truthy. Only the empty list \`[]\` is falsy.`}
 />
 
 <MultipleChoice
@@ -402,7 +402,7 @@ assert all_truthy(["a", "", "c"]) is False`,
 - \`""\`
   > Empty string is falsy, so \`or\` keeps looking.
 - [o] \`"x"\`
-  > Correct. The first three operands are falsy, so \`or\` keeps evaluating and lands on \`"x"\`, which is truthy.`}
+  > The first three operands are falsy, so \`or\` keeps evaluating and lands on \`"x"\`, which is truthy.`}
 />
 
 <MultipleChoice
@@ -413,7 +413,7 @@ assert all_truthy(["a", "", "c"]) is False`,
 - \`False\`
   > Close, but \`and\` returns the first falsy operand or the last operand, not necessarily \`False\`.
 - [o] \`[]\`
-  > Correct. \`and\` returns the first falsy operand. \`[]\` is falsy, so that's what it returns.
+  > \`and\` returns the first falsy operand. \`[]\` is falsy, so that's what it returns.
 - \`"hello"\`
   > \`and\` would return \`"hello"\` only if the first operand were truthy.`}
 />
@@ -424,7 +424,7 @@ assert all_truthy(["a", "", "c"]) is False`,
 - \`if len(items) > 0:\`
   > This works, but it's verbose. Pythonic code uses truthiness.
 - [o] \`if items:\`
-  > Correct. This is the idiomatic Pythonic way—concise and readable.
+  > This is the idiomatic Pythonic way—concise and readable.
 - \`if items is not None:\`
   > This checks whether \`items\` is \`None\`, not whether it's empty. An empty list \`[]\` would pass this check.
 - \`if items == True:\`

--- a/content/learn/python-basics/comprehensions.mdx
+++ b/content/learn/python-basics/comprehensions.mdx
@@ -334,7 +334,7 @@ For example, \`cartesian([1, 2], ["a", "b"])\` returns \`[(1, "a"), (1, "b"), (2
 - \`[0, 2, 4, 6]\`
   > That would be without the \`if\`.
 - [o] \`[2, 6]\`
-  > Correct. \`x % 2\` is truthy for odd \`x\` (1, 3), so we keep \`2*1\` and \`2*3\`.
+  > \`x % 2\` is truthy for odd \`x\` (1, 3), so we keep \`2*1\` and \`2*3\`.
 - \`[1, 3]\`
   > The expression is \`x * 2\`, not \`x\`.
 - \`[0, 4]\`
@@ -349,7 +349,7 @@ For example, \`cartesian([1, 2], ["a", "b"])\` returns \`[(1, "a"), (1, "b"), (2
 - \`{x*x for x in range(5)}\`
   > That is a set comprehension, not a list.
 - [o] \`list(x*x for x in range(5))\`
-  > Correct. Converting the generator to a list gives the same result.
+  > Converting the generator to a list gives the same result.
 - \`{x: x*x for x in range(5)}\`
   > That is a dict comprehension, not a list.`}
 />
@@ -360,7 +360,7 @@ For example, \`cartesian([1, 2], ["a", "b"])\` returns \`[(1, "a"), (1, "b"), (2
 - Generators are always faster.
   > Not always — list access is O(1), generator iteration has per-item overhead.
 - [o] Generators use O(1) memory regardless of input size.
-  > Correct. Generators produce items lazily, one at a time.
+  > Generators produce items lazily, one at a time.
 - Generators support slicing.
   > Generators do **not** support slicing; lists do.
 - Generators automatically deduplicate.
@@ -377,7 +377,7 @@ For example, \`cartesian([1, 2], ["a", "b"])\` returns \`[(1, "a"), (1, "b"), (2
 - \`[11, 21, 12, 22]\`
   > That is the correct order.
 - [o] \`[11, 21, 12, 22]\`
-  > Correct. The outer loop is \`x\`, the inner loop is \`y\`.
+  > The outer loop is \`x\`, the inner loop is \`y\`.
 - \`[11, 12, 21, 22]\`
   > That would be if \`y\` were the outer loop.
 - \`[30, 40]\`

--- a/content/learn/python-basics/control-flow.mdx
+++ b/content/learn/python-basics/control-flow.mdx
@@ -448,7 +448,7 @@ else:
 \`\`\`
 
 - [o] \`a\`
-  > Correct. Only the **first** matching branch runs, even though \`x > 5\` is also true.
+  > Only the **first** matching branch runs, even though \`x > 5\` is also true.
 - \`b\`
   > The first branch matches, so the \`elif\` is never evaluated.
 - \`a\` then \`b\`
@@ -463,7 +463,7 @@ else:
 - \`case x | y:\` at the start
   > \`|\` works for alternatives inside a pattern (e.g. \`case 1 | 2:\`), but the syntax error here is that you need a concrete value or wildcard first.
 - [o] \`case (x, y) if x == y:\`
-  > Correct. This matches a 2-tuple and adds a guard clause.
+  > This matches a 2-tuple and adds a guard clause.
 - \`case [x, y, z, *rest] if len(rest) > 0:\`
   > Guards can only reference bound variables, not call functions like \`len\` on them. This would raise a name error.
 - \`case x and y:\`
@@ -481,7 +481,7 @@ result = "big" if x > 10 else "small"
 - \`"big"\`
   > The condition \`x > 10\` is false.
 - [o] \`"small"\`
-  > Correct. When the condition is false, the \`else\` part is used.
+  > When the condition is false, the \`else\` part is used.
 - \`None\`
   > The conditional expression always evaluates to one of the two values.
 - A \`SyntaxError\`
@@ -494,7 +494,7 @@ result = "big" if x > 10 else "small"
 - \`(0 < x) < 10\`
   > This would compare a boolean to 10, which is not the same.
 - [o] \`0 < x and x < 10\`
-  > Correct. Chained comparisons are equivalent to combining with \`and\`.
+  > Chained comparisons are equivalent to combining with \`and\`.
 - \`0 < (x < 10)\`
   > Parentheses do not change the chaining behavior.
 - \`x in range(1, 10)\`

--- a/content/learn/python-basics/data-types.mdx
+++ b/content/learn/python-basics/data-types.mdx
@@ -306,7 +306,7 @@ print(safe_int("", -1))
 - \`dict\`
   > Dicts are mutable: \`d["key"] = value\` changes them in place.
 - [o] \`tuple\`
-  > Correct. Tuples are immutable sequences—you can't change their contents after creation.
+  > Tuples are immutable sequences—you can't change their contents after creation.
 - \`set\`
   > Sets are mutable: \`s.add(x)\` changes them in place.`}
 />
@@ -317,7 +317,7 @@ print(safe_int("", -1))
 - \`False\`
   > \`bool\` is a subclass of \`int\`, so \`isinstance\` returns \`True\`.
 - [o] \`True\`
-  > Correct. \`bool\` inherits from \`int\`, so \`isinstance(True, int)\` is \`True\`.
+  > \`bool\` inherits from \`int\`, so \`isinstance(True, int)\` is \`True\`.
 - A \`TypeError\`
   > \`isinstance\` is perfectly legal with \`int\` and \`bool\`.
 - \`None\`
@@ -335,7 +335,7 @@ x = int(x)
 - \`str\`
   > The second line rebinds \`x\` to an integer.
 - [o] \`int\`
-  > Correct. \`int("42")\` converts the string to the integer \`42\`, and the assignment rebinds \`x\` to that integer.
+  > \`int("42")\` converts the string to the integer \`42\`, and the assignment rebinds \`x\` to that integer.
 - \`float\`
   > We called \`int(x)\`, not \`float(x)\`.
 - A \`TypeError\`

--- a/content/learn/python-basics/decorators.mdx
+++ b/content/learn/python-basics/decorators.mdx
@@ -595,7 +595,7 @@ assert foo.__name__ == "foo"`,
 - It makes the wrapper run faster.
   > \`wraps\` has no effect on performance.
 - [o] It copies metadata (name, docstring, signature) from \`fn\` onto the wrapper.
-  > Correct. Without it, tools and tracebacks see the wrapper's name instead of the real function's.
+  > Without it, tools and tracebacks see the wrapper's name instead of the real function's.
 - It prevents the wrapper from accepting \`*args\` and \`**kwargs\`.
   > \`wraps\` does not change the wrapper's signature — you still need \`*args, **kwargs\`.
 - It is required syntax for the \`@\` decorator notation to work.
@@ -616,7 +616,7 @@ Which is equivalent?
 - \`f = a(b)(f)\`
   > This would be the case if \`a\` were a decorator factory, but here both \`a\` and \`b\` are decorators.
 - [o] \`f = a(b(f))\`
-  > Correct. Decorators apply bottom-up: \`b\` wraps \`f\` first, then \`a\` wraps the result.
+  > Decorators apply bottom-up: \`b\` wraps \`f\` first, then \`a\` wraps the result.
 - \`f = b(a(f))\`
   > This is top-down, which is not how stacking works.
 - \`f = a(f) + b(f)\`
@@ -629,7 +629,7 @@ Which is equivalent?
 - A function that creates multiple decorators at once.
   > A factory returns one decorator per call, not multiple.
 - [o] A function that takes arguments and returns a decorator.
-  > Correct. The pattern is \`factory(args) → decorator → wrapper\`. This is how \`@retry(3)\` or \`@app.route("/path")\` work.
+  > The pattern is \`factory(args) → decorator → wrapper\`. This is how \`@retry(3)\` or \`@app.route("/path")\` work.
 - A built-in Python module for generating decorators.
   > There is no such module. "Factory" refers to the three-layer nesting pattern.
 - A decorator that only works on factory functions.
@@ -642,7 +642,7 @@ Which is equivalent?
 - To make the wrapper run faster.
   > \`*args, **kwargs\` has no performance impact.
 - [o] To accept any arguments the wrapped function expects, without knowing them in advance.
-  > Correct. Decorators are generic — they should work on any function signature.
+  > Decorators are generic — they should work on any function signature.
 - It is required syntax for decorators to work.
   > You can write a decorator without \`*args, **kwargs\`, but it will only work on functions with a specific signature.
 - To prevent the function from being called with keyword arguments.
@@ -655,7 +655,7 @@ Which is equivalent?
 - The original function is called anyway.
   > No, if you don't call it explicitly, it is not called at all.
 - [o] The wrapped function always returns \`None\`, breaking its behavior.
-  > Correct. The wrapper implicitly returns \`None\` if you don't return the result of \`fn(*args, **kwargs)\`.
+  > The wrapper implicitly returns \`None\` if you don't return the result of \`fn(*args, **kwargs)\`.
 - Python raises a \`DecoratorError\`.
   > No such error exists. The code runs but behaves incorrectly.
 - The decorator is ignored and the original function is used.
@@ -668,7 +668,7 @@ Which is equivalent?
 - It is called when the decorator is applied to a function.
   > \`__init__\` is called when the decorator is applied. \`__call__\` is called when the wrapped function is invoked.
 - [o] It is called each time the wrapped function is invoked, making the instance callable.
-  > Correct. \`__call__\` lets the class instance act like a function.
+  > \`__call__\` lets the class instance act like a function.
 - It registers the class as a decorator in Python's internal registry.
   > No such registry exists. \`__call__\` is a standard dunder method for making objects callable.
 - It is required syntax for class decorators to work.

--- a/content/learn/python-basics/dictionaries.mdx
+++ b/content/learn/python-basics/dictionaries.mdx
@@ -419,7 +419,7 @@ Assume all values are numbers.`}
 - \`[1, 2, 3]\`
   > Lists are mutable and not hashable, so no.
 - [o] \`(1, 2, 3)\`
-  > Correct. Tuples of hashables are hashable.
+  > Tuples of hashables are hashable.
 - \`{"a": 1}\`
   > Dicts are mutable and not hashable, so no.`}
 />
@@ -437,7 +437,7 @@ print(d)
 - \`{"a": 99, "b": 2, "c": 3}\`
   > \`setdefault\` only writes when the key is missing.
 - [o] \`{"a": 1, "b": 2, "c": 3}\`
-  > Correct. \`a\` already exists so it is untouched; \`c\` is added.
+  > \`a\` already exists so it is untouched; \`c\` is added.
 - \`{"a": 1, "b": 2}\`
   > \`c\` is missing, so it is added.
 - A \`KeyError\`
@@ -448,7 +448,7 @@ print(d)
   markdown={`What is the time complexity of \`key in d\` where \`d\` is a dict?
 
 - [o] O(1) average case
-  > Correct. Dicts use hash tables, giving O(1) average-case lookup.
+  > Dicts use hash tables, giving O(1) average-case lookup.
 - O(n)
   > That would be true for a list, not a dict.
 - O(log n)
@@ -465,7 +465,7 @@ print(d)
 - Sorted by key alphabetically.
   > Dicts preserve insertion order, not sorted order.
 - [o] Insertion order is preserved.
-  > Correct. The first item inserted is the first one you see when iterating.
+  > The first item inserted is the first one you see when iterating.
 - Sorted by value.
   > Dicts do not sort by value automatically.`}
 />

--- a/content/learn/python-basics/hello-world.mdx
+++ b/content/learn/python-basics/hello-world.mdx
@@ -232,7 +232,7 @@ print("a", "b", "c", sep="-", end="!")
 - \`a-b-c\\n\`
   > \`end\` was overridden too, so there is no trailing newline.
 - [o] \`a-b-c!\`
-  > Correct. Items are joined by \`sep\` and \`end\` is appended after them.
+  > Items are joined by \`sep\` and \`end\` is appended after them.
 - \`a-b-c!\\n\`
   > The default \`end\` is \`"\\n"\`, but it was overridden to \`"!"\`.`}
 />
@@ -245,7 +245,7 @@ print("a", "b", "c", sep="-", end="!")
 - Any triple-quoted string in the code
   > Not quite. It must be the first statement in a module, function, or class.
 - [o] A string literal at the top of a module, function, or class, used for documentation
-  > Correct. Docstrings are stored in \`__doc__\` and read by \`help()\` and documentation tools.
+  > Docstrings are stored in \`__doc__\` and read by \`help()\` and documentation tools.
 - A string that is never executed
   > All string literals are evaluated, but docstrings are retained for introspection.`}
 />
@@ -258,7 +258,7 @@ print("a", "b", "c", sep="-", end="!")
 - \`print("Hello", end="")\`
   > This works! But there is another correct answer too.
 - [o] \`print("Hello", end="")\`
-  > Correct. Setting \`end=""\` removes the newline.
+  > Setting \`end=""\` removes the newline.
 - \`print("Hello", sep="")\`
   > \`sep\` controls how multiple arguments are joined, not the ending.`}
 />

--- a/content/learn/python-basics/installation.mdx
+++ b/content/learn/python-basics/installation.mdx
@@ -167,7 +167,7 @@ print("Platform:", sys.platform)
 - The python.org installer
   > This installs a single global version. It works, but switching versions is manual.
 - [o] pyenv
-  > Correct. pyenv lets you install multiple Python versions side-by-side and switch between them per-project with \`pyenv local\`.
+  > pyenv lets you install multiple Python versions side-by-side and switch between them per-project with \`pyenv local\`.
 - The Microsoft Store app
   > This is convenient for Windows users but only installs one version at a time.
 - Copying python.exe into your project folder
@@ -182,7 +182,7 @@ print("Platform:", sys.platform)
 - Installing Python 2 instead of Python 3
   > The default installer on python.org is Python 3.
 - [o] Forgetting to check "Add python.exe to PATH"
-  > Correct. Without this, the \`python\` command will not be found in the terminal.
+  > Without this, the \`python\` command will not be found in the terminal.
 - Installing to the wrong drive
   > The install location does not matter as long as the PATH is set correctly.`}
 />
@@ -195,7 +195,7 @@ print("Platform:", sys.platform)
 - Recursive Evaluation of Python Literals
   > That sounds impressive but is not a real term.
 - [o] Read, Eval, Print, Loop
-  > Correct. The REPL reads a line of code, evaluates it, prints the result, and loops back to read the next line.
+  > The REPL reads a line of code, evaluates it, prints the result, and loops back to read the next line.
 - Rapid Experimentation and Python Learning
   > This is a nice backronym but not the actual meaning.`}
 />

--- a/content/learn/python-basics/iterators-and-generators.mdx
+++ b/content/learn/python-basics/iterators-and-generators.mdx
@@ -481,7 +481,7 @@ from itertools import islice
 
 - The body runs immediately and returns the first value.
 - [o] No code in the body runs; you get back a generator object, and the body runs lazily as you iterate.
-  > Correct. \`yield\` makes the function lazy — nothing runs until you call \`next()\` or loop over it.
+  > \`yield\` makes the function lazy — nothing runs until you call \`next()\` or loop over it.
 - It raises \`StopIteration\` if the body is empty.
   > \`StopIteration\` is raised when iteration is exhausted, not when the generator is created.
 - It returns a list of every value the function yields.
@@ -494,7 +494,7 @@ from itertools import islice
 - Generators are stored in compressed form.
   > No compression happens. Generators simply don't store items.
 - [o] Generators produce items one at a time, never holding the entire sequence in memory.
-  > Correct. Only the current item and the generator's local state exist in memory.
+  > Only the current item and the generator's local state exist in memory.
 - Generators use a special Python data structure that is smaller.
   > Generators don't store data at all, so no special structure is needed.
 - Python automatically writes generator output to disk.
@@ -505,7 +505,7 @@ from itertools import islice
   markdown={`What does \`yield from iterable\` do?
 
 - [o] It yields every item from \`iterable\`, delegating iteration to that iterable.
-  > Correct. It's shorthand for \`for x in iterable: yield x\` and correctly delegates sub-generator methods.
+  > It's shorthand for \`for x in iterable: yield x\` and correctly delegates sub-generator methods.
 - It returns \`iterable\` as a single yielded value.
   > That would be \`yield iterable\`. \`yield from\` unpacks the iterable.
 - It imports all items from \`iterable\` into the current scope.
@@ -520,7 +520,7 @@ from itertools import islice
 - You can restart a generator after it is exhausted by calling \`reset()\`.
   > Generators cannot be reset. Once exhausted, they stay exhausted.
 - [o] Once a generator is exhausted, iterating over it again yields nothing.
-  > Correct. Generators are single-pass. To iterate again, call the generator function again.
+  > Generators are single-pass. To iterate again, call the generator function again.
 - Generators store all yielded values in a hidden list.
   > Generators do not store previous values. They are purely lazy.
 - \`list(infinite_generator())\` is safe because Python auto-detects infinite loops.
@@ -533,7 +533,7 @@ from itertools import islice
 - A new, independent iterator starting from the beginning.
   > \`iter(iterator)\` does NOT reset or clone the iterator.
 - [o] The same iterator object (iterator.__iter__ returns self).
-  > Correct. Iterators return themselves from \`__iter__\`, so they are their own iterables.
+  > Iterators return themselves from \`__iter__\`, so they are their own iterables.
 - A list of all remaining items.
   > \`iter()\` does not consume or materialize items.
 - It raises \`TypeError\` because you cannot call \`iter()\` on an iterator.
@@ -546,7 +546,7 @@ from itertools import islice
 - Pre-computing every prime number up to infinity and storing them in RAM.
   > Infinity cannot be stored. Infinite generators are for lazy, on-demand production.
 - [o] Modeling a stream of events that never ends, consuming only what is needed.
-  > Correct. Infinite generators are perfect for unbounded streams where you pull items as needed.
+  > Infinite generators are perfect for unbounded streams where you pull items as needed.
 - Building a complete list of all natural numbers.
   > Infinite sequences cannot be fully materialized.
 - Raising \`StopIteration\` after the first item.

--- a/content/learn/python-basics/lists.mdx
+++ b/content/learn/python-basics/lists.mdx
@@ -544,7 +544,7 @@ xs[1:4] = [9]
 - \`[1, 9, 4, 5]\`
   > Slice assignment replaces the entire slice, not item-by-item.
 - [o] \`[1, 9, 5]\`
-  > Correct. The slice \`xs[1:4]\` (items 2, 3, 4) is replaced by the single element \`9\`.
+  > The slice \`xs[1:4]\` (items 2, 3, 4) is replaced by the single element \`9\`.
 - \`[1, 9, 2, 3, 4, 5]\`
   > That would be insertion, not slice assignment.
 - A \`ValueError\` because lengths differ
@@ -557,7 +557,7 @@ xs[1:4] = [9]
 - \`sorted(xs)\`
   > \`sorted\` returns a new list and leaves \`xs\` untouched.
 - [o] \`xs.sort()\`
-  > Correct. \`.sort()\` modifies \`xs\` directly and returns \`None\`.
+  > \`.sort()\` modifies \`xs\` directly and returns \`None\`.
 - \`xs + [9]\`
   > \`+\` returns a new list; it does not modify either operand.
 - \`list(xs)\`
@@ -572,7 +572,7 @@ xs[1:4] = [9]
 - \`1\`
   > \`pop()\` with no argument removes the **last** item, not the first.
 - [o] \`3\`
-  > Correct. \`pop()\` removes and returns the last item.
+  > \`pop()\` removes and returns the last item.
 - \`None\`
   > \`pop\` returns the removed item, not \`None\`.`}
 />
@@ -583,7 +583,7 @@ xs[1:4] = [9]
 - O(1)
   > That would be true for a set or dict, not a list.
 - [o] O(n)
-  > Correct. Python scans the list from start to finish in the worst case.
+  > Python scans the list from start to finish in the worst case.
 - O(log n)
   > Lists are not sorted by default, so binary search does not apply.
 - O(n²)

--- a/content/learn/python-basics/loops.mdx
+++ b/content/learn/python-basics/loops.mdx
@@ -457,7 +457,7 @@ for i in range(3):
 - \`0\\n1\\n2\`
   > \`continue\` skips the rest of the iteration, so 1 is never printed.
 - [o] \`0\\n2\`
-  > Correct. \`continue\` skips the \`print\` when \`i == 1\`, so only 0 and 2 print.
+  > \`continue\` skips the \`print\` when \`i == 1\`, so only 0 and 2 print.
 - \`0\\n1\`
   > The loop does not break; it continues to \`i == 2\`.
 - \`2\`
@@ -472,7 +472,7 @@ for i in range(3):
 - When the loop body raises an exception
   > No — exceptions skip the else clause.
 - [o] Only when the loop finishes without hitting \`break\`
-  > Correct. That is what makes it useful for search loops.
+  > That is what makes it useful for search loops.
 - Only when the iterable is empty
   > No — it runs after a **successful** completion, not an empty iterable.`}
 />
@@ -492,7 +492,7 @@ print(i)
 - \`3\`
   > \`i\` retains its last value after the loop exits.
 - [o] \`3\`
-  > Correct. The loop breaks when \`i == 3\`, and \`i\` retains that value.
+  > The loop breaks when \`i == 3\`, and \`i\` retains that value.
 - A \`NameError\`
   > \`i\` is still in scope after the loop.`}
 />
@@ -503,7 +503,7 @@ print(i)
 - \`(0, "a"), (1, "b"), (2, "c")\`
   > That would be the default \`start=0\`.
 - [o] \`(1, "a"), (2, "b"), (3, "c")\`
-  > Correct. \`start=1\` shifts the index to 1-based.
+  > \`start=1\` shifts the index to 1-based.
 - \`("a", 1), ("b", 2), ("c", 3)\`
   > The order is (index, value), not (value, index).
 - \`["a", "b", "c"]\`

--- a/content/learn/python-basics/next-steps.mdx
+++ b/content/learn/python-basics/next-steps.mdx
@@ -279,7 +279,7 @@ Depending on where you want to go:
 - You now know everything there is to know about Python.
   > Nobody does. Python is huge, the ecosystem keeps moving, and there are always new frameworks and techniques to explore.
 - [o] You have a solid foundation — core syntax, collections, functions, classes, generators, decorators — and you're ready to start building real projects.
-  > Correct. That's exactly what a "basics" course is for. The fundamentals you've learned here apply to every Python project you'll touch.
+  > That's exactly what a "basics" course is for. The fundamentals you've learned here apply to every Python project you'll touch.
 - You should keep reading tutorials before writing any real code.
   > The opposite is true. The best way to consolidate what you've learned is to build something, even something small.
 - The standard library and PyPI are too unstable to rely on for production work.

--- a/content/learn/python-basics/numbers.mdx
+++ b/content/learn/python-basics/numbers.mdx
@@ -393,7 +393,7 @@ print(compound_interest(1000, 0.05, 10))
 - \`-3\`
   > C-style integer division would truncate toward zero, giving \`-3\`. Python does not do that.
 - [o] \`-4\`
-  > Correct. Floor division rounds toward negative infinity, so \`7 // -2\` is \`-4\`.
+  > Floor division rounds toward negative infinity, so \`7 // -2\` is \`-4\`.
 - \`3\`
   > That's the absolute value of \`7 // 2\`, but we're dividing by a negative number.
 - An error
@@ -406,7 +406,7 @@ print(compound_interest(1000, 0.05, 10))
 - It is a bug in Python that has not been fixed yet.
   > It is not a bug; it is how all IEEE 754 floating-point arithmetic works across all languages.
 - [o] Floats are stored in binary and cannot represent these decimals exactly.
-  > Correct. \`0.1\` and \`0.2\` are infinitely repeating in binary, so their sum is very slightly off from \`0.3\`.
+  > \`0.1\` and \`0.2\` are infinitely repeating in binary, so their sum is very slightly off from \`0.3\`.
 - The \`==\` operator does not work for floats.
   > \`==\` works fine; the issue is that the values are not exactly equal due to precision limits.
 - Python rounds floats to two decimal places.
@@ -421,7 +421,7 @@ print(compound_interest(1000, 0.05, 10))
 - \`fractions\`
   > \`fractions\` is for exact rational numbers, but \`decimal\` is more commonly used for currency.
 - [o] \`decimal\`
-  > Correct. \`decimal.Decimal\` provides exact decimal arithmetic suitable for financial calculations.
+  > \`decimal.Decimal\` provides exact decimal arithmetic suitable for financial calculations.
 - \`random\`
   > \`random\` is for generating random numbers, not exact arithmetic.`}
 />
@@ -432,7 +432,7 @@ print(compound_interest(1000, 0.05, 10))
 - A very large integer
   > Yes, but more specifically, Python computes it without overflow.
 - [o] A very large integer with no overflow
-  > Correct. Python's \`int\` has arbitrary precision—no overflow, no wraparound.
+  > Python's \`int\` has arbitrary precision—no overflow, no wraparound.
 - \`OverflowError\`
   > Python's integers never overflow (limited only by memory).
 - \`inf\` (infinity)

--- a/content/learn/python-basics/python-history.mdx
+++ b/content/learn/python-basics/python-history.mdx
@@ -138,7 +138,7 @@ over several releases.
 - Linus Torvalds
   > Linus created Linux and git, not Python.
 - [o] Guido van Rossum
-  > Correct. Guido started Python as a hobby project in December 1989.
+  > Guido started Python as a hobby project in December 1989.
 - Dennis Ritchie
   > Dennis created the C programming language in the 1970s.
 - James Gosling
@@ -153,7 +153,7 @@ over several releases.
 - Named after the Greek oracle at Delphi
   > That would be a different story entirely.
 - [o] Named after *Monty Python's Flying Circus*
-  > Correct. Guido was a fan of the British comedy troupe and wanted a "short, unique, and slightly mysterious" name.
+  > Guido was a fan of the British comedy troupe and wanted a "short, unique, and slightly mysterious" name.
 - It stands for "Portable Interpreted Typed High-level Object Notation"
   > Python is not an acronym.`}
 />
@@ -164,7 +164,7 @@ over several releases.
 - List comprehensions were added
   > List comprehensions appeared in Python 2.0 (year 2000).
 - [o] \`print\` became a function instead of a statement
-  > Correct. Python 2 used \`print "hi"\` while Python 3 requires \`print("hi")\`.
+  > Python 2 used \`print "hi"\` while Python 3 requires \`print("hi")\`.
 - The \`def\` keyword was introduced
   > \`def\` has been part of Python since version 0.9.0 in 1991.
 - Indentation became significant

--- a/content/learn/python-basics/sets.mdx
+++ b/content/learn/python-basics/sets.mdx
@@ -324,7 +324,7 @@ print(set_of_sets)
 - \`{1, 2, 3, 4}\`
   > That would be the union (\`|\`), not intersection.
 - [o] \`{2, 3}\`
-  > Correct. \`&\` is set intersection, returning items in both.
+  > \`&\` is set intersection, returning items in both.
 - \`{1, 4}\`
   > That would be symmetric difference (\`^\`).
 - \`{1}\`
@@ -337,7 +337,7 @@ print(set_of_sets)
 - \`{}\`
   > That is an empty **dict**.
 - [o] \`set()\`
-  > Correct. \`set()\` is the only way to create an empty set.
+  > \`set()\` is the only way to create an empty set.
 - \`[]\`
   > That is an empty list.
 - \`()\`
@@ -348,7 +348,7 @@ print(set_of_sets)
   markdown={`What is the time complexity of \`item in s\` where \`s\` is a set?
 
 - [o] O(1) average case
-  > Correct. Sets use hash tables, giving O(1) average-case lookup.
+  > Sets use hash tables, giving O(1) average-case lookup.
 - O(n)
   > That would be true for a list, not a set.
 - O(log n)

--- a/content/learn/python-basics/strings.mdx
+++ b/content/learn/python-basics/strings.mdx
@@ -462,7 +462,7 @@ print(slugify("Python 3.12 Released"))
 - \`"bcd"\`
   > The third number is the step, not the stop. Step of 2 means every other character.
 - [o] \`"bd"\`
-  > Correct. Start at index 1 (\`"b"\`), stop before index 5 (\`"e"\`), step by 2: indices 1 and 3.
+  > Start at index 1 (\`"b"\`), stop before index 5 (\`"e"\`), step by 2: indices 1 and 3.
 - \`"ace"\`
   > That would be \`"abcdef"[0:5:2]\`.
 - An \`IndexError\`
@@ -477,7 +477,7 @@ print(slugify("Python 3.12 Released"))
 - You can mutate a string by assigning to an index: \`s[0] = "H"\`.
   > This raises a \`TypeError\`. Strings are immutable.
 - [o] To "change" a string, you must rebind the variable to a new string.
-  > Correct. \`s = s.upper()\` creates a new string and rebinds \`s\` to it.
+  > \`s = s.upper()\` creates a new string and rebinds \`s\` to it.
 - Immutability means you can't create new strings.
   > You can create as many new strings as you want; you just can't change existing ones.`}
 />
@@ -488,7 +488,7 @@ print(slugify("Python 3.12 Released"))
 - \`"123"\`
   > The format spec \`05d\` means zero-pad to width 5.
 - [o] \`"00123"\`
-  > Correct. \`05d\` means "decimal integer, width 5, zero-padded".
+  > \`05d\` means "decimal integer, width 5, zero-padded".
 - \`"123.00"\`
   > That would require \`f\` (float) or \`.2f\` (two decimal places).
 - An error
@@ -503,7 +503,7 @@ print(slugify("Python 3.12 Released"))
 - \`result = "".join(map(str, items))\`
   > This works and is idiomatic. \`join\` is the best tool for this job.
 - [o] \`result = "".join(str(x) for x in items)\`
-  > Correct. This is idiomatic and efficient—\`join\` does a single allocation.
+  > This is idiomatic and efficient—\`join\` does a single allocation.
 - \`result = ""  # and pray\`
   > Prayer is not a valid optimization strategy.`}
 />

--- a/content/learn/python-basics/syntax-and-indentation.mdx
+++ b/content/learn/python-basics/syntax-and-indentation.mdx
@@ -321,7 +321,7 @@ print(long_sum(1, 2, 3, 4, 5))
 - Keywords \`begin ... end\`
   > That is the Pascal/Ruby style. Python does not use those keywords.
 - [o] Indentation
-  > Correct. A colon starts a block, and indentation defines its scope.
+  > A colon starts a block, and indentation defines its scope.
 - Parentheses \`( ... )\`
   > Parentheses group expressions, not blocks.`}
 />
@@ -334,7 +334,7 @@ print(long_sum(1, 2, 3, 4, 5))
 - Two spaces
   > Two-space indentation is common in JavaScript and Ruby, but PEP 8 prefers four for Python.
 - [o] Four spaces
-  > Correct. PEP 8 mandates four spaces per indentation level.
+  > PEP 8 mandates four spaces per indentation level.
 - Eight spaces
   > Eight is what a tab expanded to in Python 2 and is considered too wide for nested code.`}
 />
@@ -347,7 +347,7 @@ print(long_sum(1, 2, 3, 4, 5))
 - IndentationError
   > This is raised when indentation is missing or inconsistent, but mixing tabs and spaces has its own error.
 - [o] TabError
-  > Correct. Python 3 raises a \`TabError\` if a single block mixes tabs and spaces.
+  > Python 3 raises a \`TabError\` if a single block mixes tabs and spaces.
 - RuntimeError
   > Runtime errors occur during execution, not parsing.`}
 />
@@ -360,7 +360,7 @@ print(long_sum(1, 2, 3, 4, 5))
 - flake8
   > flake8 is also a linter, not a formatter.
 - [o] black
-  > Correct. black is the most popular Python formatter and enforces a consistent style with almost no configuration.
+  > black is the most popular Python formatter and enforces a consistent style with almost no configuration.
 - mypy
   > mypy is a type checker, not a formatter.`}
 />

--- a/content/learn/python-basics/tuples.mdx
+++ b/content/learn/python-basics/tuples.mdx
@@ -326,7 +326,7 @@ Named tuples are immutable. For mutable record types with methods, reach for `@d
 - \`(1)\`
   > This is just the integer \`1\` in parentheses, not a tuple.
 - [o] \`(1,)\`
-  > Correct. The trailing comma is what makes it a tuple.
+  > The trailing comma is what makes it a tuple.
 - \`[1]\`
   > This is a list, not a tuple.
 - \`{1}\`
@@ -339,7 +339,7 @@ Named tuples are immutable. For mutable record types with methods, reach for `@d
 - Tuples are faster to iterate than lists.
   > The performance difference is negligible and not the right reason.
 - [o] Tuples are immutable and hashable, so they can be used as dict keys.
-  > Correct. Immutability also signals that the pair is a fixed-size record.
+  > Immutability also signals that the pair is a fixed-size record.
 - Lists cannot contain floats.
   > Lists can absolutely contain floats.
 - Tuples support more methods than lists.
@@ -357,7 +357,7 @@ print(rest)
 - \`(2, 3, 4)\`
   > The \`*rest\` catches items as a **list**, not a tuple.
 - [o] \`[2, 3, 4]\`
-  > Correct. The star unpacking always produces a list.
+  > The star unpacking always produces a list.
 - \`2\`
   > \`*rest\` catches **all** remaining items, not just one.
 - A \`ValueError\``}

--- a/content/learn/python-basics/variables.mdx
+++ b/content/learn/python-basics/variables.mdx
@@ -286,7 +286,7 @@ print(nums)
 - \`[1, 2, 3]\`
   > Assignment binds \`also_nums\` to the same list object that \`nums\` references. Both names point to the same list in memory.
 - [o] \`[1, 2, 3, 4]\`
-  > Correct. \`nums\` and \`also_nums\` are two names for the same list. Mutating through one name is visible through the other.
+  > \`nums\` and \`also_nums\` are two names for the same list. Mutating through one name is visible through the other.
 - A \`NameError\`
   > No error—\`nums\` is defined before \`also_nums\` references it.
 - \`[4]\`
@@ -301,7 +301,7 @@ print(nums)
 - \`_private\`
   > Valid. Leading underscores are allowed.
 - [o] \`2nd_place\`
-  > Correct. Identifiers cannot start with a digit.
+  > Identifiers cannot start with a digit.
 - \`café\`
   > Valid. Python 3 allows Unicode letters in identifiers.`}
 />
@@ -318,7 +318,7 @@ y = y + [30]
 - \`[10, 20, 30, 30]\`
   > \`y + [30]\` creates a new list; it doesn't mutate the original.
 - [o] \`[10, 20]\`
-  > Correct. The line \`y = y + [30]\` creates a new list and rebinds \`y\` to it. The original list \`x\` references is unchanged.
+  > The line \`y = y + [30]\` creates a new list and rebinds \`y\` to it. The original list \`x\` references is unchanged.
 - \`[10, 20, 30]\`
   > That's the value of \`y\` after the reassignment, not \`x\`.
 - An error

--- a/content/learn/python-basics/virtual-environments.mdx
+++ b/content/learn/python-basics/virtual-environments.mdx
@@ -286,7 +286,7 @@ The `.venv/` directory is never committed. Your teammates and CI systems recreat
 - It makes \`import\` statements run faster.
   > Virtual environments do not affect import speed.
 - [o] It isolates each project's dependencies so they do not conflict with each other or with the system Python.
-  > Correct. Different projects can pin different versions of the same library safely.
+  > Different projects can pin different versions of the same library safely.
 - It is the only way to use \`pip\`.
   > You can use \`pip\` without a venv (not recommended), but venvs are the only safe way to manage dependencies.
 - It compiles your code to a single executable.
@@ -297,7 +297,7 @@ The `.venv/` directory is never committed. Your teammates and CI systems recreat
   markdown={`What does activating a virtual environment do?
 
 - [o] It modifies your shell's \`PATH\` so \`python\` and \`pip\` point to the venv's binaries.
-  > Correct. Activation is purely a shell trick — no system-wide changes are made.
+  > Activation is purely a shell trick — no system-wide changes are made.
 - It permanently changes the system Python installation.
   > Activation is temporary and local to the current shell session. Closing the terminal reverts it.
 - It installs all packages listed in \`requirements.txt\`.
@@ -312,7 +312,7 @@ The `.venv/` directory is never committed. Your teammates and CI systems recreat
 - The \`.venv/\` directory, so everyone has the same packages.
   > Virtual environments are NOT portable. Commit a lockfile instead.
 - [o] \`requirements.txt\` or \`pyproject.toml\`, so teammates can recreate the environment.
-  > Correct. Lockfiles and metadata files are portable; the venv itself is not.
+  > Lockfiles and metadata files are portable; the venv itself is not.
 - Nothing — each developer should figure out dependencies on their own.
   > Without a lockfile, your project is not reproducible.
 - Only the Python interpreter binary.
@@ -325,7 +325,7 @@ The `.venv/` directory is never committed. Your teammates and CI systems recreat
 - \`npm\`
   > \`npm\` is for JavaScript, not Python.
 - [o] \`uv\`
-  > Correct. \`uv\` is a Rust-based tool that replaces \`pip\`, \`pip-tools\`, and \`venv\` with a much faster implementation.
+  > \`uv\` is a Rust-based tool that replaces \`pip\`, \`pip-tools\`, and \`venv\` with a much faster implementation.
 - \`conda\`
   > \`conda\` is a separate package manager primarily for scientific computing. It's powerful but not the same as \`pip\` + \`venv\`.
 - \`virtualenv\`

--- a/content/learn/scientific-computing-python/arrays-and-tensors.mdx
+++ b/content/learn/scientific-computing-python/arrays-and-tensors.mdx
@@ -356,7 +356,7 @@ assert np.allclose(weighted_centroid(pts, ws), expected)`,
 
 - \`(2, 3, 4)\`
 - [o] \`(2, 3, 5)\`
-  > Correct. The shared index \`k\` is summed away, and the remaining free indices are \`i\` (size 2), \`j\` (size 3), and \`l\` (size 5).
+  > The shared index \`k\` is summed away, and the remaining free indices are \`i\` (size 2), \`j\` (size 3), and \`l\` (size 5).
 - \`(4, 5)\`
 - \`(2, 5)\`
 

--- a/content/learn/scientific-computing-python/floating-point.mdx
+++ b/content/learn/scientific-computing-python/floating-point.mdx
@@ -319,7 +319,7 @@ assert stable_err < naive_err, "stable should be at least as accurate as naive"`
 
 - $0.0$
 - [o] $1.0$
-  > Correct. With sign 0, biased exponent 1023 (unbiased 0), and mantissa 0, the value is $(-1)^0 \\cdot (1 + 0) \\cdot 2^0 = 1$.
+  > With sign 0, biased exponent 1023 (unbiased 0), and mantissa 0, the value is $(-1)^0 \\cdot (1 + 0) \\cdot 2^0 = 1$.
 - $1023.0$
 - $-0.0$
 

--- a/content/learn/scientific-computing-python/fortran-and-matlab.mdx
+++ b/content/learn/scientific-computing-python/fortran-and-matlab.mdx
@@ -223,7 +223,7 @@ This layering — interpreted glue on top of compiled numerical kernels — is t
 - The functions \`linspace\`, \`zeros\`, \`ones\`, \`eye\` in NumPy
 - The use of the \`@\` operator for matrix multiplication
 - [o] The Global Interpreter Lock
-  > Correct — the GIL is a CPython implementation detail that has nothing to do with MATLAB. The other three items were all deliberate design choices to make MATLAB-trained engineers feel at home in Python.
+  > The GIL is a CPython implementation detail that has nothing to do with MATLAB. The other three items were all deliberate design choices to make MATLAB-trained engineers feel at home in Python.
 
 Compatibility with prior scientific tools is one of the reasons SciPy spread so quickly through engineering and physics departments.`}
 />

--- a/content/learn/scientific-computing-python/linear-algebra-essentials.mdx
+++ b/content/learn/scientific-computing-python/linear-algebra-essentials.mdx
@@ -366,7 +366,7 @@ Knowing what your library is actually doing lets you predict its runtime and sta
 
 - It is the only factorization that exists for SPD matrices
 - [o] It requires roughly half the operations of LU, needs no pivoting (because it is unconditionally stable for SPD inputs), and uses half the storage
-  > Correct. SPD structure unlocks a factorization that is both faster and more stable. Any time you can prove your matrix is SPD — covariance matrices, mass matrices, Laplacians — switch to Cholesky.
+  > SPD structure unlocks a factorization that is both faster and more stable. Any time you can prove your matrix is SPD — covariance matrices, mass matrices, Laplacians — switch to Cholesky.
 - It allows complex eigenvalues
 - It is required to compute inverses
 

--- a/content/learn/scientific-computing-python/ordinary-differential-equations.mdx
+++ b/content/learn/scientific-computing-python/ordinary-differential-equations.mdx
@@ -356,7 +356,7 @@ def time_to_apex(v0):
 - 4
 - 8
 - [o] 16
-  > Correct. RK4 is fourth-order accurate, so the error scales as $h^4$. Halving $h$ shrinks the error by $2^4 = 16$. This favorable scaling is exactly why RK4 dominated explicit ODE solving for decades.
+  > RK4 is fourth-order accurate, so the error scales as $h^4$. Halving $h$ shrinks the error by $2^4 = 16$. This favorable scaling is exactly why RK4 dominated explicit ODE solving for decades.
 
 This is also why high-order methods can deliver far more accuracy *per function evaluation* than low-order ones for smooth problems.`}
 />

--- a/content/learn/scientific-computing-python/python-in-science.mdx
+++ b/content/learn/scientific-computing-python/python-in-science.mdx
@@ -280,7 +280,7 @@ The slowness of the interpreter is irrelevant when 99% of compute time is spent 
 - pandas → NumPy → Matplotlib → SciPy
 - SciPy → NumPy → BLAS/LAPACK
 - [o] Almost every other scientific package is built on top of NumPy; SciPy adds higher-level algorithms (optimize, integrate, signal, stats) and itself depends on NumPy and on FORTRAN libraries like BLAS/LAPACK/MINPACK
-  > Correct. NumPy is the foundation: it defines the array type and the broadcasting rules. SciPy sits on top of NumPy and provides algorithms; under the hood many of those algorithms are FORTRAN. pandas, scikit-learn, scikit-image, PyTorch, xarray, AstroPy all assume NumPy arrays.
+  > NumPy is the foundation: it defines the array type and the broadcasting rules. SciPy sits on top of NumPy and provides algorithms; under the hood many of those algorithms are FORTRAN. pandas, scikit-learn, scikit-image, PyTorch, xarray, AstroPy all assume NumPy arrays.
 - All four packages are siblings with no dependency relationships
 
 Understanding this layering helps you debug performance problems and pick the right library for a given task.`}

--- a/content/learn/scientific-computing-python/rise-of-computational-science.mdx
+++ b/content/learn/scientific-computing-python/rise-of-computational-science.mdx
@@ -225,7 +225,7 @@ The pattern outlasted ENIAC and outlasted FORTRAN — it is still how a 2026 sup
 
 - The grid spacing becomes too coarse
 - [o] The numerical scheme violates the CFL stability condition: each step amplifies, rather than damps, the high-frequency error modes
-  > Correct. The forward-time, centered-space (FTCS) scheme is *conditionally stable*. When $\\alpha \\, dt / dx^2 > 1/2$, the discrete update is no longer a contraction and any small round-off error grows exponentially.
+  > The forward-time, centered-space (FTCS) scheme is *conditionally stable*. When $\\alpha \\, dt / dx^2 > 1/2$, the discrete update is no longer a contraction and any small round-off error grows exponentially.
 - Python runs out of memory
 - Matplotlib cannot plot the values
 

--- a/content/learn/systems-programming-c/arrays-and-pointers.mdx
+++ b/content/learn/systems-programming-c/arrays-and-pointers.mdx
@@ -360,7 +360,7 @@ int main(void) {
 - The total number of bytes in the original array.
   > That information is lost on the way in — the array has decayed.
 - [o] The size of a pointer (because \`a\` has decayed to \`int *\`).
-  > Correct. This is why you must pass the length as a separate parameter.
+  > This is why you must pass the length as a separate parameter.
 - The number of elements in the array.
   > That would be \`n\` (which you must pass in), not \`sizeof(a)\`.
 - Always zero.
@@ -375,7 +375,7 @@ int main(void) {
 - \`3 * sizeof(int)\`
   > Same — that would be the byte distance, not the element count.
 - [o] 3 elements
-  > Correct. \`p\` points three ints past the start of \`a\`.
+  > \`p\` points three ints past the start of \`a\`.
 - Undefined behavior
   > Subtracting two pointers into the same array (within bounds) is well-defined.`}
 />
@@ -390,7 +390,7 @@ int main(void) {
 - The write silently fails and leaves memory unchanged.
   > The write goes through; what it stomps on depends on the layout.
 - [o] It is undefined behavior — it may crash, may overwrite unrelated data, or may appear to work.
-  > Correct. Out-of-bounds memory access is one of the most dangerous C bugs.`}
+  > Out-of-bounds memory access is one of the most dangerous C bugs.`}
 />
 
 <Callout type="success" title="Next: strings">

--- a/content/learn/systems-programming-c/c-toolchain.mdx
+++ b/content/learn/systems-programming-c/c-toolchain.mdx
@@ -285,7 +285,7 @@ int square(int x) {
   markdown={`Which build stage replaces \`#include <stdio.h>\` with the actual contents of \`stdio.h\`?
 
 - [o] The preprocessor
-  > Correct. \`#include\` is a textual directive handled before the compiler ever parses C.
+  > \`#include\` is a textual directive handled before the compiler ever parses C.
 - The compiler
   > By the time the compiler runs, the include has already been expanded into the translation unit.
 - The assembler
@@ -302,7 +302,7 @@ int square(int x) {
 - A missing semicolon in your code.
   > That would also be a compile-time error, not a link-time error.
 - [o] The function was declared (via a header) but the library that defines it was not passed to the linker, or the object file containing it was not compiled in.
-  > Correct. "Undefined reference" is the linker's way of saying it cannot find a body for a name.
+  > "Undefined reference" is the linker's way of saying it cannot find a body for a name.
 - The CPU does not support the \`strdup\` instruction.
   > CPUs do not have function-specific instructions for libc functions.`}
 />
@@ -315,7 +315,7 @@ int square(int x) {
 - To hide the contents of the header from other developers.
   > Include guards do not hide anything; the file is still plain text.
 - [o] To prevent the same header from being textually included more than once in a single translation unit, which would re-declare types and functions.
-  > Correct. Without guards, transitive includes can re-declare the same names and break compilation.
+  > Without guards, transitive includes can re-declare the same names and break compilation.
 - Because the C standard library requires it.
   > It is a convention, not a standard library requirement.`}
 />

--- a/content/learn/systems-programming-c/data-types-and-memory.mdx
+++ b/content/learn/systems-programming-c/data-types-and-memory.mdx
@@ -322,7 +322,7 @@ int main(void) {
 - It is always exactly 16 bits.
   > 16 bits is the standard's *minimum*, not a requirement.
 - [o] It is at least 16 bits; the actual size depends on the target platform.
-  > Correct. Use the fixed-width types in \`<stdint.h>\` when you need exact widths.
+  > Use the fixed-width types in \`<stdint.h>\` when you need exact widths.
 - It is whatever the operating system kernel decides at runtime.
   > Sizes are baked in at compile time, not selected at runtime.`}
 />
@@ -337,7 +337,7 @@ int main(void) {
 - \`size_t\`
   > \`size_t\` is pointer-sized (32 or 64 bits depending on the platform).
 - [o] \`uint32_t\` (from \`<stdint.h>\`)
-  > Correct. The \`<stdint.h>\` fixed-width types are how you commit to an exact size.`}
+  > The \`<stdint.h>\` fixed-width types are how you commit to an exact size.`}
 />
 
 <MultipleChoice
@@ -346,7 +346,7 @@ int main(void) {
 - \`0xAA\`
   > That would be the big-endian order.
 - [o] \`0xDD\`
-  > Correct. Little-endian places the *least* significant byte first.
+  > Little-endian places the *least* significant byte first.
 - \`0xCC\`
   > \`0xCC\` is one of the middle bytes.
 - It is unpredictable.

--- a/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -428,7 +428,7 @@ int main(void) {
 - Assume it succeeded and keep using the same pointer.
   > A failed \`realloc\` returns \`NULL\`; using \`NULL\` as if it were the old block is UB.
 - [o] Assign the result to a temporary first; if \`NULL\`, free the old block (which is still valid) and bail out.
-  > Correct. \`p = realloc(p, n);\` leaks the original on failure; the temporary pattern avoids it.
+  > \`p = realloc(p, n);\` leaks the original on failure; the temporary pattern avoids it.
 - Call \`realloc\` again immediately; the second call usually succeeds.
   > Failure usually means low memory; retrying without changes does not help.
 - Use \`free\` on the original block and then \`malloc\` a new one.
@@ -443,7 +443,7 @@ int main(void) {
 - Zeroing is impossible without kernel support.
   > The OS does sometimes pre-zero pages, but the standard library is allowed to skip it.
 - [o] Zeroing has a cost; programs that are about to overwrite every byte anyway should not pay it. \`calloc\` exists for when you actually want zeros.
-  > Correct. \`malloc\` is the bare-minimum allocator; \`calloc\` is the zeroing variant.
+  > \`malloc\` is the bare-minimum allocator; \`calloc\` is the zeroing variant.
 - Because \`malloc\` always returns memory that was previously \`free\`d, which is already zeroed.
   > Freed memory is **not** guaranteed to be zeroed; it contains the previous user's bytes.`}
 />
@@ -458,7 +458,7 @@ int main(void) {
 - Print it to stdout for debugging.
   > Even printing the value (as a pointer) is fine, but *dereferencing* it is UB. Most code should simply stop using it.
 - [o] Stop using it (and ideally set it to \`NULL\` so accidental later uses become immediate NULL-pointer crashes instead of silent corruption).
-  > Correct. \`free(p); p = NULL;\` is a well-known defensive pattern.`}
+  > \`free(p); p = NULL;\` is a well-known defensive pattern.`}
 />
 
 <Callout type="success" title="On to composite types">

--- a/content/learn/systems-programming-c/memory-bugs.mdx
+++ b/content/learn/systems-programming-c/memory-bugs.mdx
@@ -443,7 +443,7 @@ int main(void) {
 - Wrap every \`free\` in a \`try / catch\`.
   > C has no \`try / catch\`.
 - [o] After \`free(p);\`, immediately set \`p = NULL;\`. Future \`free(NULL)\` is a no-op and \`*p\` immediately crashes instead of silently corrupting memory.
-  > Correct. This is one of the most common C defensive idioms.
+  > This is one of the most common C defensive idioms.
 - Call \`free\` twice in a row to be certain.
   > That is the bug, not the defense.`}
 />
@@ -456,7 +456,7 @@ int main(void) {
 - It always allocates extra memory you forget to free.
   > It does not allocate at all.
 - [o] It has no way to know how big \`buf\` is and will keep copying until it finds a \`'\\0'\` in \`user_input\`, overflowing the buffer if the input is too long.
-  > Correct. Use \`snprintf\` or another length-aware API.
+  > Use \`snprintf\` or another length-aware API.
 - It corrupts the file descriptor table.
   > It does not touch file descriptors.`}
 />
@@ -467,7 +467,7 @@ int main(void) {
 - The CPU refuses to execute the read.
   > The CPU executes it without complaint; the *language* says the result is undefined.
 - [o] The C standard explicitly declares the read undefined behavior; the compiler is allowed to assume it never happens and may optimize accordingly, producing surprising results.
-  > Correct. UB is about what the language guarantees, not just about runtime values.
+  > UB is about what the language guarantees, not just about runtime values.
 - It always reads the value zero.
   > It does not — stack memory contains whatever the previous use left there.
 - The OS will trap and terminate the program.

--- a/content/learn/systems-programming-c/memory-layout.mdx
+++ b/content/learn/systems-programming-c/memory-layout.mdx
@@ -256,7 +256,7 @@ int main(void) {
 - \`.data\` — the binary grows by ~400 KB to store the zeros.
   > That would be true if the array were *non-zero* initialized.
 - [o] \`.bss\` — only metadata is stored; the OS zeroes the region at load time, so the binary stays small.
-  > Correct. BSS exists precisely so zero-initialized globals do not bloat your binary.
+  > BSS exists precisely so zero-initialized globals do not bloat your binary.
 - The heap — \`malloc\` is called implicitly at program start.
   > Globals are not heap-allocated; they have static storage duration.
 - The stack — the runtime pushes the array on entry to \`main\`.
@@ -269,7 +269,7 @@ int main(void) {
 - Because the address may be the same as another local on the heap.
   > Locals do not live on the heap.
 - [o] The local lives in the function's stack frame, which is destroyed when the function returns; the returned address is now dangling.
-  > Correct. Reading or writing through that pointer is undefined behavior.
+  > Reading or writing through that pointer is undefined behavior.
 - Because the compiler aliases it to \`NULL\` automatically.
   > It does not.
 - Because the OS swaps the variable out of memory to disk.
@@ -284,7 +284,7 @@ int main(void) {
 - It becomes \`const\` and cannot be modified.
   > \`static\` does not imply \`const\`.
 - [o] Its storage class changes from automatic (stack) to static (BSS/.data); it is initialized once and keeps its value across calls.
-  > Correct. The variable's *visibility* stays local to the function, but its *lifetime* becomes the whole program.
+  > The variable's *visibility* stays local to the function, but its *lifetime* becomes the whole program.
 - The variable is moved to the heap.
   > Static variables live in BSS or .data, not on the heap.`}
 />

--- a/content/learn/systems-programming-c/pointers.mdx
+++ b/content/learn/systems-programming-c/pointers.mdx
@@ -364,7 +364,7 @@ int main(void) {
 - It takes the address of \`p\`.
   > That is the unary \`&\` operator.
 - [o] It reads (or assigns to) the \`int\` value stored at the address \`p\` holds.
-  > Correct. \`*\` is the *dereference* operator.
+  > \`*\` is the *dereference* operator.
 - It marks \`p\` as a pointer in the declaration.
   > That meaning of \`*\` only applies in declarations, not in expressions.`}
 />
@@ -377,7 +377,7 @@ int main(void) {
 - Because the compiler optimizes the swap away.
   > Even with optimization disabled, the function still cannot affect the caller's variables.
 - [o] Because C passes arguments **by value** — the function gets copies of the caller's ints, and modifying the copies leaves the originals untouched.
-  > Correct. To modify the caller's variables you must pass *pointers* to them.
+  > To modify the caller's variables you must pass *pointers* to them.
 - Because \`int\` is not large enough to be swapped on this machine.
   > Size has nothing to do with it.`}
 />
@@ -388,7 +388,7 @@ int main(void) {
 - You cannot change \`p\` to point at a different \`int\`.
   > That would require \`int *const p\` (a const *pointer*, not a pointer to const).
 - [o] You cannot modify the \`int\` that \`p\` currently points at through \`p\`.
-  > Correct. \`const int *p\` is a pointer to a *const* int; the pointer itself can be reassigned, but writes through it are forbidden.
+  > \`const int *p\` is a pointer to a *const* int; the pointer itself can be reassigned, but writes through it are forbidden.
 - The pointer is automatically initialized to \`NULL\`.
   > Initialization is unrelated to \`const\`.
 - The compiler stores the int in read-only memory.

--- a/content/learn/systems-programming-c/real-world-disasters.mdx
+++ b/content/learn/systems-programming-c/real-world-disasters.mdx
@@ -367,7 +367,7 @@ already absorbed the most important lesson of this chapter.
 - A double-free during certificate rotation.
   > Not Heartbleed.
 - [o] A buffer **over-read**: the server trusted an attacker-supplied length field and \`memcpy\`'d that many bytes out of its own memory back to the attacker.
-  > Correct. The defensive lesson is "never trust a length field from the network without checking it against what you actually received."
+  > The defensive lesson is "never trust a length field from the network without checking it against what you actually received."
 - A stack overflow during certificate parsing.
   > Heartbleed was a *read* past a heap buffer; no stack frame was overwritten.`}
 />
@@ -380,7 +380,7 @@ already absorbed the most important lesson of this chapter.
 - \`malloc\`
   > \`malloc\` itself was not the issue.
 - [o] \`gets\`, which reads input into a buffer with no length check at all.
-  > Correct. \`gets\` is so dangerous it was deprecated in C99 and removed in C11.
+  > \`gets\` is so dangerous it was deprecated in C99 and removed in C11.
 - \`strncpy\`
   > \`strncpy\` has its own footguns but did not cause this incident.`}
 />
@@ -393,7 +393,7 @@ already absorbed the most important lesson of this chapter.
 - Double-free.
   > Same — no double free was involved.
 - [o] An *off-by-one* error (the end-of-buffer test used \`==\` instead of \`>=\`), causing a buffer over-read.
-  > Correct. A one-character fix; weeks of cache purging to clean up.
+  > A one-character fix; weeks of cache purging to clean up.
 - An integer overflow during certificate signing.
   > Cloudbleed was an HTML-rewriting parser bug, unrelated to certificates.`}
 />
@@ -406,7 +406,7 @@ already absorbed the most important lesson of this chapter.
 - Always cast \`size_t\` to \`int\` to keep types simple.
   > The opposite — that is a common source of integer-truncation bugs.
 - [o] Cross-check every length that comes from outside the program (network, file, user) against the size of the buffer it will be written to or read from.
-  > Correct. Almost every catastrophe on the page reduces to "trusted a length field that should have been validated."
+  > Almost every catastrophe on the page reduces to "trusted a length field that should have been validated."
 - Always use \`gets()\` because it is the simplest input function.
   > Never use \`gets()\` — it is the canonical example of *what not to do*.`}
 />

--- a/content/learn/systems-programming-c/stack-and-functions.mdx
+++ b/content/learn/systems-programming-c/stack-and-functions.mdx
@@ -362,7 +362,7 @@ int main(void) {
 - The variable is allocated successfully but slowly.
   > The allocation is just a stack-pointer adjustment; size, not speed, is the issue.
 - [o] The program runs out of stack and crashes (stack overflow).
-  > Correct. Large buffers belong on the heap (\`malloc\`), not on the stack.`}
+  > Large buffers belong on the heap (\`malloc\`), not on the stack.`}
 />
 
 <MultipleChoice
@@ -382,7 +382,7 @@ char *greeting(void) {
 - It forgets to null-terminate.
   > The literal "Hello" is already null-terminated.
 - [o] It returns a pointer to a local array whose stack frame is destroyed the moment the function returns; the caller dereferences a dangling pointer.
-  > Correct. Either let the caller pass in a buffer or allocate on the heap and document the ownership.`}
+  > Either let the caller pass in a buffer or allocate on the heap and document the ownership.`}
 />
 
 <MultipleChoice
@@ -393,7 +393,7 @@ char *greeting(void) {
 - The compiler can vectorize iteration but never recursion.
   > Vectorization is unrelated.
 - [o] It uses a constant number of stack frames regardless of \`n\`, eliminating the risk of stack overflow for large inputs.
-  > Correct. Without guaranteed tail-call optimization, deep recursion is a real risk in C.
+  > Without guaranteed tail-call optimization, deep recursion is a real risk in C.
 - The recursive version is undefined behavior in standard C.
   > It is perfectly well-defined.`}
 />

--- a/content/learn/systems-programming-c/strings.mdx
+++ b/content/learn/systems-programming-c/strings.mdx
@@ -356,7 +356,7 @@ int main(void) {
 - 5 bytes
   > Close, but it forgets the terminator.
 - [o] 6 bytes (5 characters + the trailing \`'\\0'\`)
-  > Correct. Every string literal has an implicit null terminator.
+  > Every string literal has an implicit null terminator.
 - It depends on the encoding; cannot be determined.
   > Plain string literals are bytes; the null terminator is always counted.`}
 />
@@ -369,7 +369,7 @@ int main(void) {
 - It always crashes the program in a controlled way.
   > It is undefined behavior; the crash is *possible* but not guaranteed.
 - [o] String literals may live in read-only memory; writing through a non-\`const\` pointer to a literal is undefined behavior.
-  > Correct. Use \`char s[] = "hello";\` to get a writable copy.
+  > Use \`char s[] = "hello";\` to get a writable copy.
 - It corrupts the system clock.
   > That is not how memory works.`}
 />
@@ -382,7 +382,7 @@ int main(void) {
 - \`strncpy(dst, src, sizeof dst);\`
   > Subtle bug: if \`src\` is too long, \`dst\` will not be null-terminated.
 - [o] \`snprintf(dst, sizeof dst, "%s", src);\`
-  > Correct. \`snprintf\` always writes a terminator and tells you how many bytes it would have written.
+  > \`snprintf\` always writes a terminator and tells you how many bytes it would have written.
 - \`memcpy(dst, src, strlen(src));\`
   > Also unsafe (no terminator) and does not check destination size.`}
 />

--- a/content/learn/systems-programming-c/structs-and-unions.mdx
+++ b/content/learn/systems-programming-c/structs-and-unions.mdx
@@ -542,7 +542,7 @@ int main(void) {
 - The compiler inserts random bytes for security.
   > Padding is for alignment, not for security.
 - [o] The compiler inserts padding so each member sits at a properly aligned offset and so arrays of the struct keep their members aligned.
-  > Correct. Reordering fields by descending alignment usually shrinks the struct.
+  > Reordering fields by descending alignment usually shrinks the struct.
 - The struct must always be a multiple of 12 bytes by language rule.
   > There is no such rule.
 - \`char\` is actually 4 bytes on most platforms.
@@ -557,7 +557,7 @@ int main(void) {
 - The union always uses the sum of its members' sizes.
   > A union uses the size of its *largest* member.
 - [o] All members share the same storage; the union holds at most one of them at a time, and its size is the size of the largest member (plus padding).
-  > Correct. Writing one member overwrites the others.
+  > Writing one member overwrites the others.
 - Unions are always initialized to zero on declaration.
   > Initialization rules are the same as for any other variable.`}
 />
@@ -570,7 +570,7 @@ int main(void) {
 - A nested struct.
   > Nested structs do not change allocation count.
 - [o] A flexible array member declared as the last field, e.g. \`char data[];\`, allocated via \`malloc(sizeof *s + n)\`.
-  > Correct. One allocation holds the header and the payload contiguously.
+  > One allocation holds the header and the payload contiguously.
 - A bitfield.
   > Bitfields pack small integers, not variable-length data.`}
 />

--- a/content/learn/systems-programming-c/why-c-for-systems.mdx
+++ b/content/learn/systems-programming-c/why-c-for-systems.mdx
@@ -177,7 +177,7 @@ constantly.
 - Direct access to hardware addresses and registers
   > That is a real C advantage; volatile pointers map to MMIO.
 - [o] Built-in safety against out-of-bounds memory access
-  > Correct. C deliberately does **not** check array bounds; that's why memory bugs are such a recurring theme in this course.`}
+  > C deliberately does **not** check array bounds; that's why memory bugs are such a recurring theme in this course.`}
 />
 
 <MultipleChoice
@@ -188,7 +188,7 @@ constantly.
 - The program will reliably crash with a clear error message.
   > UB has no required behavior; "appears to work" is a frequent and dangerous outcome.
 - [o] The standard imposes no requirements: the compiler may produce any code at all, including code that appears to work in testing.
-  > Correct. UB is the root cause of many silent C bugs.
+  > UB is the root cause of many silent C bugs.
 - It is only a problem in debug builds; optimizers ignore it.
   > Optimizers actively assume UB never happens, which can make the symptoms worse, not better.`}
 />
@@ -199,7 +199,7 @@ constantly.
 - Because every C compiler emits the same assembly language.
   > Different targets emit completely different assembly.
 - [o] Because C exposes the underlying machine model — flat addressable memory, fixed-size values, and direct pointer arithmetic — while still letting you retarget the compiler to many CPUs.
-  > Correct. C is high enough to be portable but low enough to map closely to hardware.
+  > C is high enough to be portable but low enough to map closely to hardware.
 - Because C programs are written in mnemonics like \`MOV\` and \`ADD\`.
   > Those are assembly mnemonics; C is a higher-level language than assembly.
 - Because every C statement maps to exactly one CPU instruction.

--- a/content/learn/typescript-from-scratch/any-unknown-never.mdx
+++ b/content/learn/typescript-from-scratch/any-unknown-never.mdx
@@ -474,7 +474,7 @@ try {
 - \`unknown\` is deprecated, use \`any\`
 - \`any\` is type-safe, \`unknown\` is not
 - [o] \`any\` bypasses type checking, \`unknown\` forces narrowing
-  > Correct! \`unknown\` is the type-safe alternative to \`any\`.
+  > \`unknown\` is the type-safe alternative to \`any\`.
 - They are identical
 
 \`unknown\` accepts any value but blocks operations until you narrow the type.`}
@@ -486,7 +486,7 @@ try {
 - A function that returns nothing (\`void\`)
 - A value that is \`null\` or \`undefined\`
 - [o] A type with no values (the empty set)
-  > Correct! \`never\` is the bottom type — no value can inhabit it.
+  > \`never\` is the bottom type — no value can inhabit it.
 - A value that is both \`string\` and \`number\`
 
 \`never\` appears in unreachable code paths, functions that never return, and impossible type intersections.`}

--- a/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
+++ b/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
@@ -461,7 +461,7 @@ The compiler ensures you check `resp.type` before accessing `results`. If you ad
 - Reduces code duplication
   > That's a benefit, but not the main one. The key is *synchronization*.
 - [o] Ensures both sides agree on the contract at compile time
-  > Correct. If the server changes a type, the client gets a compile error immediately. The contract is enforced by the compiler.
+  > If the server changes a type, the client gets a compile error immediately. The contract is enforced by the compiler.
 - Improves runtime performance
   > Types are erased at runtime; there's no performance impact.
 
@@ -486,7 +486,7 @@ What must the caller do to access \`data\`?
 - Check \`data !== undefined\`
   > The type system guarantees \`data\` is present when \`status === "ok"\`, but you still need to narrow.
 - [o] Check \`status === "ok"\` to narrow the discriminated union
-  > Correct. Once you check \`status\`, TypeScript narrows to the \`ok\` branch, where \`data\` is guaranteed.
+  > Once you check \`status\`, TypeScript narrows to the \`ok\` branch, where \`data\` is guaranteed.
 - Cast \`response.data as User\`
   > Casting is unsafe and defeats the purpose of the discriminated union.
 

--- a/content/learn/typescript-from-scratch/arrays-and-tuples.mdx
+++ b/content/learn/typescript-from-scratch/arrays-and-tuples.mdx
@@ -399,7 +399,7 @@ type, arrays do not.**
 - \`any[]\`
 - \`Array<number | string | boolean>\`
 - [o] \`(number | string | boolean)[]\`
-  > Correct! TypeScript infers a union array type because the elements have different types.
+  > TypeScript infers a union array type because the elements have different types.
 - \`[number, string, boolean]\` (tuple)
 
 TypeScript infers an array type, not a tuple, because the length is not encoded. If you want a tuple, you must annotate explicitly: \`const x: [number, string, boolean] = [1, "two", true];\``}
@@ -410,7 +410,7 @@ TypeScript infers an array type, not a tuple, because the length is not encoded.
 
 - \`[number, string]\`
 - [o] \`[string, number]\`
-  > Correct! The order in a tuple type corresponds to the order of the elements.
+  > The order in a tuple type corresponds to the order of the elements.
 - \`{ 0: string, 1: number }\`
 - \`string | number\`
 

--- a/content/learn/typescript-from-scratch/birth-of-typescript.mdx
+++ b/content/learn/typescript-from-scratch/birth-of-typescript.mdx
@@ -181,7 +181,7 @@ One of TypeScript's most distinctive features is its **structural type system** 
 
 - TypeScript used a faster compiler than Flow or Closure Compiler
 - [o] TypeScript had to be a strict superset of JavaScript, so any valid JS is valid TS
-  > Correct! This "JavaScript-plus-types" philosophy meant developers could rename \`.js\` to \`.ts\` and gradually add annotations. Older tools like Closure Compiler required extensive rewrites or non-standard syntax.
+  > This "JavaScript-plus-types" philosophy meant developers could rename \`.js\` to \`.ts\` and gradually add annotations. Older tools like Closure Compiler required extensive rewrites or non-standard syntax.
 - TypeScript was the first language to add type annotations to JavaScript
 - TypeScript only worked with Microsoft's Visual Studio editor
 

--- a/content/learn/typescript-from-scratch/branded-types.mdx
+++ b/content/learn/typescript-from-scratch/branded-types.mdx
@@ -436,7 +436,7 @@ export function sendEmail(to: Email, message: string): string {
 - The smart constructor function
   > The smart constructor creates the brand, but it's the intersection type that enforces incompatibility.
 - [o] The intersection with a phantom property
-  > Correct. The intersection \`T & { readonly __brand: ... }\` adds a type-level property that makes the branded type structurally distinct from the base type.
+  > The intersection \`T & { readonly __brand: ... }\` adds a type-level property that makes the branded type structurally distinct from the base type.
 - The \`as\` cast inside the constructor
   > The cast is necessary to create the value, but it doesn't enforce safety. The type itself does.
 
@@ -453,7 +453,7 @@ The phantom property exists only in the type system, adding a "tag" that prevent
 - String brands are less type-safe
   > Both are equally type-safe. The difference is in collision risk.
 - [o] \`unique symbol\` prevents accidental collisions across modules
-  > Correct. Each \`unique symbol\` declaration creates a distinct type, even if named the same. String literals can collide.
+  > Each \`unique symbol\` declaration creates a distinct type, even if named the same. String literals can collide.
 - \`unique symbol\` has better runtime performance
   > Brands are purely compile-time constructs; there's no runtime difference.
 

--- a/content/learn/typescript-from-scratch/discriminated-unions.mdx
+++ b/content/learn/typescript-from-scratch/discriminated-unions.mdx
@@ -403,7 +403,7 @@ export type Notification = { type: "info"; message: string };
 - The code compiles and runs, but crashes at runtime when the new variant is encountered.
   > No. With exhaustiveness checking (\`const _exhaustive: never = value\`), the code won't even *compile* if you miss a case. The compiler catches it at build time.
 - [o] The code fails to compile because the unhandled variant isn't assignable to \`never\`.
-  > Correct! The exhaustiveness check tries to assign the leftover variant to \`never\`. If any variant is unhandled, it still has a type, and assigning it to \`never\` is a type error. This is exactly what we want: the compiler forces you to handle every case.
+  > The exhaustiveness check tries to assign the leftover variant to \`never\`. If any variant is unhandled, it still has a type, and assigning it to \`never\` is a type error. This is exactly what we want: the compiler forces you to handle every case.
 - The new variant is ignored, and the \`default\` case handles it silently.
   > No. If you have exhaustiveness checking, the \`default\` case tries to assign the value to \`never\`. If a variant is unhandled, this fails at compile time, not runtime.
 

--- a/content/learn/typescript-from-scratch/error-handling-with-types.mdx
+++ b/content/learn/typescript-from-scratch/error-handling-with-types.mdx
@@ -482,7 +482,7 @@ TypeScript doesn't have special syntax, but discriminated unions and type narrow
 - Faster runtime performance
   > \`Result\` has similar performance to exceptions; the benefit is static safety, not speed.
 - [o] Errors are visible in the type signature and must be handled
-  > Correct. The return type \`Result<T, E>\` documents that the function can fail, and the compiler forces you to check \`.ok\` before accessing the value.
+  > The return type \`Result<T, E>\` documents that the function can fail, and the compiler forces you to check \`.ok\` before accessing the value.
 - Easier to write
   > \`Result\` requires more boilerplate (but combinators help). The payoff is correctness.
 
@@ -504,7 +504,7 @@ What happens if \`parseNumber\` returns an error?
 - \`sqrt\` is called with the error
   > \`andThen\` only calls \`fn\` if the result is \`ok\`. Errors short-circuit.
 - [o] \`sqrt\` is not called; the error propagates
-  > Correct. \`andThen\` checks \`result.ok\`. If false, it returns the error immediately without calling \`sqrt\`.
+  > \`andThen\` checks \`result.ok\`. If false, it returns the error immediately without calling \`sqrt\`.
 - The program throws an exception
   > \`Result\` doesn't throw. Errors are returned as values.
 

--- a/content/learn/typescript-from-scratch/evolution-of-javascript.mdx
+++ b/content/learn/typescript-from-scratch/evolution-of-javascript.mdx
@@ -136,7 +136,7 @@ That solution was **TypeScript**. And its story begins at Microsoft, with a lang
 
 - JavaScript became slower over time
 - [o] The lack of static type checking made it hard to catch errors across many modules
-  > Correct! In large codebases, typos, refactoring mistakes, and type mismatches that JavaScript can't catch at compile time lead to runtime bugs. The bigger the project, the harder it is to track these issues manually.
+  > In large codebases, typos, refactoring mistakes, and type mismatches that JavaScript can't catch at compile time lead to runtime bugs. The bigger the project, the harder it is to track these issues manually.
 - Browsers stopped supporting older JavaScript features
 - JavaScript doesn't support asynchronous programming
 

--- a/content/learn/typescript-from-scratch/functions-and-signatures.mdx
+++ b/content/learn/typescript-from-scratch/functions-and-signatures.mdx
@@ -445,7 +445,7 @@ signatures are machine-checked documentation.**
 - They are identical
 - \`void\` is for async functions, \`undefined\` is for sync functions
 - [o] \`void\` means "don't care about the return value," \`undefined\` means "explicitly returns undefined"
-  > Correct! \`void\` is for side-effect functions; \`undefined\` is for functions that explicitly return \`undefined\`.
+  > \`void\` is for side-effect functions; \`undefined\` is for functions that explicitly return \`undefined\`.
 - \`void\` is deprecated
 
 \`void\` is the conventional return type for side-effect functions like event handlers.`}
@@ -456,7 +456,7 @@ signatures are machine-checked documentation.**
 
 - It's a spread operator for objects
 - [o] It's a rest parameter that collects arguments into an array
-  > Correct! The rest parameter collects all remaining arguments into a single array.
+  > The rest parameter collects all remaining arguments into a single array.
 - It's optional parameter syntax
 - It's an error
 

--- a/content/learn/typescript-from-scratch/generic-constraints.mdx
+++ b/content/learn/typescript-from-scratch/generic-constraints.mdx
@@ -415,7 +415,7 @@ If you call \`getValue({ x: 10, y: "hello" }, "y")\`, what is the return type?
 - \`string | number\`
   > No. The compiler knows you passed \`"y"\`, so it narrows \`K\` to \`"y"\` specifically. The return type is \`T["y"]\`, which is \`string\`.
 - [o] \`string\`
-  > Correct! \`K\` is inferred as \`"y"\`, and \`T["y"]\` is \`string\`, so the return type is \`string\`.
+  > \`K\` is inferred as \`"y"\`, and \`T["y"]\` is \`string\`, so the return type is \`string\`.
 - \`T[K]\`
   > Partially correct — the return type *is* \`T[K]\`, but the compiler simplifies it to \`string\` based on the specific call. The concrete return type is \`string\`.
 

--- a/content/learn/typescript-from-scratch/generics-basics.mdx
+++ b/content/learn/typescript-from-scratch/generics-basics.mdx
@@ -437,7 +437,7 @@ What is the return type of \`getFirst([1, 2, 3])\`?
 - \`T\`
   > No. \`T\` is inferred as \`number\`, but the return type is \`T | undefined\` to account for empty arrays. The answer is \`number | undefined\`.
 - [o] \`number | undefined\`
-  > Correct! The compiler infers \`T = number\` from the array \`[1, 2, 3]\`, so the return type is \`number | undefined\`.
+  > The compiler infers \`T = number\` from the array \`[1, 2, 3]\`, so the return type is \`number | undefined\`.
 - \`number\`
   > No. The function returns \`T | undefined\` because \`arr[0]\` could be \`undefined\` if the array is empty. The return type is \`number | undefined\`, not just \`number\`.
 

--- a/content/learn/typescript-from-scratch/how-typescript-works.mdx
+++ b/content/learn/typescript-from-scratch/how-typescript-works.mdx
@@ -346,7 +346,7 @@ The types never reach production. They're a *compile-time tool* for correctness 
 - They are checked by the JavaScript engine for validation
 - They are converted into runtime type guards
 - [o] They are erased during compilation and do not exist in the emitted JavaScript
-  > Correct! TypeScript performs type checking at *compile time*, then removes all type annotations before emitting JavaScript. The runtime behavior is identical to plain JS — there's no runtime type enforcement unless you add it yourself.
+  > TypeScript performs type checking at *compile time*, then removes all type annotations before emitting JavaScript. The runtime behavior is identical to plain JS — there's no runtime type enforcement unless you add it yourself.
 - They are kept as comments in the JavaScript output
 
 This is why TypeScript is so fast and lightweight: it adds zero runtime overhead. The tradeoff is that you can't rely on TypeScript to validate data from external sources (like APIs) — you need runtime validation for that.`}

--- a/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
+++ b/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
@@ -356,7 +356,7 @@ What is \`ColorName\`?
 - \`string\`
   > \`keyof\` produces a union of literal types, not the broad \`string\` type.
 - [o] \`"red" | "green" | "blue"\`
-  > Correct. \`typeof colors\` lifts the object to a type, and \`keyof\` extracts its keys as a union.
+  > \`typeof colors\` lifts the object to a type, and \`keyof\` extracts its keys as a union.
 - \`"#f00" | "#0f0" | "#00f"\`
   > Those are the *values*, not the keys.
 
@@ -379,7 +379,7 @@ How many string literal types does \`Combined\` contain?
 - 2
   > Template literals distribute over unions, producing the Cartesian product.
 - [o] 4
-  > Correct: \`"getName" | "getAge" | "setName" | "setAge"\`. Each \`Prefix\` is combined with each \`Prop\`.
+  > The result is \`"getName" | "getAge" | "setName" | "setAge"\`. Each \`Prefix\` is combined with each \`Prop\`.
 - 8
   > There are only 2 prefixes and 2 props, so 2 × 2 = 4 combinations.
 

--- a/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
+++ b/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
@@ -388,7 +388,7 @@ What is \`Result\`?
 - \`{ value: "a" | "b" }\`
   > This would be true if the conditional didn't distribute. But it does.
 - [o] \`{ value: "a" } | { value: "b" }\`
-  > Correct. The conditional distributes over the union, producing two separate object types, then unioning them.
+  > The conditional distributes over the union, producing two separate object types, then unioning them.
 - \`never\`
   > The condition \`T extends any\` is always true, so we always get the true branch.
 
@@ -410,7 +410,7 @@ What properties does \`Result\` have?
 - Both \`a\` and \`0\`
   > Remapping with \`never\` filters out that key. Since \`0\` is a number key, it's excluded.
 - [o] Only \`a\`
-  > Correct. The remapping \`K extends string ? K : never\` keeps only string keys. The numeric key \`0\` is mapped to \`never\` and omitted.
+  > The remapping \`K extends string ? K : never\` keeps only string keys. The numeric key \`0\` is mapped to \`never\` and omitted.
 - Neither (empty object)
   > \`a\` is a string key, so it passes the filter.
 

--- a/content/learn/typescript-from-scratch/modeling-domains-with-types.mdx
+++ b/content/learn/typescript-from-scratch/modeling-domains-with-types.mdx
@@ -562,7 +562,7 @@ Which type definition makes illegal states **unrepresentable**?
 - \`type Flag = { enabled: boolean; percentage?: number }\`
   > No. This allows \`enabled: false, percentage: 50\` (disabled but with a percentage?) and \`enabled: true, percentage: undefined\` (enabled for everyone or for a percentage?). The type is ambiguous.
 - [o] \`type Flag = { kind: "disabled" } | { kind: "enabled-all" } | { kind: "enabled-percentage"; percentage: number }\`
-  > Correct! Each state is a distinct variant. Disabled has no percentage, enabled-all has no percentage, and enabled-percentage requires a percentage. Illegal states cannot be represented.
+  > Each state is a distinct variant. Disabled has no percentage, enabled-all has no percentage, and enabled-percentage requires a percentage. Illegal states cannot be represented.
 - \`type Flag = { kind: "disabled" | "enabled-all" | "enabled-percentage"; percentage?: number }\`
   > No. This allows \`kind: "disabled", percentage: 50\` (disabled but with a percentage?). The discriminant and the optional field are independent, so invalid combinations are possible.
 

--- a/content/learn/typescript-from-scratch/next-steps.mdx
+++ b/content/learn/typescript-from-scratch/next-steps.mdx
@@ -237,7 +237,7 @@ You've built a strong foundation. You understand types as a design tool, not jus
 - Memorize every utility type
   > Utility types are useful, but the best next step is *building* something to apply what you've learned.
 - [o] Build a project using TypeScript
-  > Correct. The best way to solidify your knowledge is to apply it to a real project. Pick a framework or runtime, and start building.
+  > The best way to solidify your knowledge is to apply it to a real project. Pick a framework or runtime, and start building.
 - Read the TypeScript compiler source code
   > That's advanced and not necessary for most developers. Focus on practical projects first.
 

--- a/content/learn/typescript-from-scratch/objects-and-interfaces.mdx
+++ b/content/learn/typescript-from-scratch/objects-and-interfaces.mdx
@@ -553,7 +553,7 @@ if (!output.includes("alice") || !output.includes("dark")) {
 
 - The property is required but can be \`null\`
 - [o] The property is optional and may be absent
-  > Correct! The \`?\` marks a property as optional, so it may be present or missing entirely.
+  > The \`?\` marks a property as optional, so it may be present or missing entirely.
 - The property is readonly
 - The property is deprecated
 
@@ -565,7 +565,7 @@ An optional property has type \`T | undefined\`, and you must handle both cases 
 
 - No, TypeScript uses nominal typing
 - [o] Yes, TypeScript uses structural typing
-  > Correct! Types are compatible if they have the same shape, regardless of their name.
+  > Types are compatible if they have the same shape, regardless of their name.
 - Only if one explicitly extends the other
 - Only if both are declared as \`type\` aliases
 

--- a/content/learn/typescript-from-scratch/primitive-types.mdx
+++ b/content/learn/typescript-from-scratch/primitive-types.mdx
@@ -353,7 +353,7 @@ console.log("100°C =", celsiusToFahrenheit(100), "°F");
 
 - \`let x: Number = 10;\`
 - [o] \`let x: number = 10;\`
-  > Correct! Always use the lowercase primitive type \`number\`.
+  > Always use the lowercase primitive type \`number\`.
 - \`let x: num = 10;\`
 - \`let x = Number(10);\`
 
@@ -365,7 +365,7 @@ The capitalized \`Number\` refers to the object wrapper, which is almost never w
 
 - \`number\` (the general number type)
 - [o] \`42\` (the literal type)
-  > Correct! When you use \`const\`, TypeScript infers the literal type because the value cannot change.
+  > When you use \`const\`, TypeScript infers the literal type because the value cannot change.
 - \`any\`
 - \`unknown\`
 

--- a/content/learn/typescript-from-scratch/scalable-architecture.mdx
+++ b/content/learn/typescript-from-scratch/scalable-architecture.mdx
@@ -553,7 +553,7 @@ We won't dive into monorepo tooling here, but know that TypeScript's type system
 - The application layer
   > The domain is the *innermost* layer; it depends on nothing outside itself.
 - [o] Nothing (it's pure)
-  > Correct. The domain layer contains pure business logic and types. It has no dependencies on infrastructure or application layers.
+  > The domain layer contains pure business logic and types. It has no dependencies on infrastructure or application layers.
 - The infrastructure layer
   > Infrastructure depends on domain, not the other way around.
 
@@ -570,7 +570,7 @@ Keeping the domain pure makes it testable, reusable, and easy to reason about.`}
 - The application layer is at the bottom
   > The physical layer order doesn't matter. Dependency *direction* matters.
 - [o] The application depends on an interface, not a concrete implementation
-  > Correct. Dependency inversion means high-level modules (application) depend on abstractions (interfaces), not low-level modules (infrastructure). This allows swapping implementations.
+  > Dependency inversion means high-level modules (application) depend on abstractions (interfaces), not low-level modules (infrastructure). This allows swapping implementations.
 - The domain depends on the infrastructure
   > That would violate layering. The domain should never depend on infrastructure.
 

--- a/content/learn/typescript-from-scratch/setup-and-tsconfig.mdx
+++ b/content/learn/typescript-from-scratch/setup-and-tsconfig.mdx
@@ -467,7 +467,7 @@ In the next section, we'll dive into the **core type system**: primitives, objec
 - \`noImplicitAny\`
 - \`esModuleInterop\`
 - [o] \`strictNullChecks\` (enabled by \`strict: true\`)
-  > Correct! \`strictNullChecks\` makes \`null\` and \`undefined\` separate types, so you must explicitly handle them. This eliminates the most common source of runtime errors in JavaScript: \`Cannot read property 'x' of null/undefined\`. It's enabled by \`"strict": true\`.
+  > \`strictNullChecks\` makes \`null\` and \`undefined\` separate types, so you must explicitly handle them. This eliminates the most common source of runtime errors in JavaScript: \`Cannot read property 'x' of null/undefined\`. It's enabled by \`"strict": true\`.
 - \`skipLibCheck\`
 
 While \`noImplicitAny\` prevents untyped variables and \`esModuleInterop\` improves module syntax, \`strictNullChecks\` directly prevents the "billion-dollar mistake" of null-pointer dereferences.`}

--- a/content/learn/typescript-from-scratch/static-analysis-in-action.mdx
+++ b/content/learn/typescript-from-scratch/static-analysis-in-action.mdx
@@ -362,7 +362,7 @@ Why does \`s.length\` compile without error in the second \`return\`?
 - Because \`.length\` is always safe
   > \`.length\` is not safe on \`null\`. The compiler needs to narrow the type.
 - [o] Because the compiler narrows \`s\` to \`string\` after the \`null\` check
-  > Correct. Control flow analysis tracks the \`if (s === null)\` check and infers that \`s\` is \`string\` (not \`null\`) in the else branch.
+  > Control flow analysis tracks the \`if (s === null)\` check and infers that \`s\` is \`string\` (not \`null\`) in the else branch.
 - Because of a type cast
   > There's no cast here. The compiler infers the narrowing automatically.
 

--- a/content/learn/typescript-from-scratch/structural-typing.mdx
+++ b/content/learn/typescript-from-scratch/structural-typing.mdx
@@ -346,9 +346,9 @@ interface Pet {
 Which statement is **true** in TypeScript's structural type system?
 
 - \`Dog\` is assignable to \`Pet\` because it has all required properties (and more).
-  > Correct! A \`Dog\` has everything a \`Pet\` needs (\`name\`), plus extra (\`breed\`). Structural typing allows extra properties.
+  > A \`Dog\` has everything a \`Pet\` needs (\`name\`), plus extra (\`breed\`). Structural typing allows extra properties.
 - [o] \`Dog\` is assignable to \`Pet\` because it has all required properties (and more).
-  > Correct! A \`Dog\` has everything a \`Pet\` needs (\`name\`), plus extra (\`breed\`). Structural typing allows extra properties.
+  > A \`Dog\` has everything a \`Pet\` needs (\`name\`), plus extra (\`breed\`). Structural typing allows extra properties.
 - \`Pet\` is assignable to \`Dog\` because \`Dog\` is more specific.
   > No. A \`Pet\` doesn't have a \`breed\` property, so it can't satisfy \`Dog\`. Structural typing requires *at least* the declared properties.
 - Neither is assignable to the other because they have different names.

--- a/content/learn/typescript-from-scratch/type-aliases-and-literals.mdx
+++ b/content/learn/typescript-from-scratch/type-aliases-and-literals.mdx
@@ -413,7 +413,7 @@ types from existing ones, all at compile time.
 
 - \`string\` (the general string type)
 - [o] \`"north"\` (the literal type)
-  > Correct! \`const\` bindings infer the literal type because the value cannot change.
+  > \`const\` bindings infer the literal type because the value cannot change.
 - \`"north" | "south" | "east" | "west"\`
 - \`any\`
 

--- a/content/learn/typescript-from-scratch/type-inference.mdx
+++ b/content/learn/typescript-from-scratch/type-inference.mdx
@@ -311,7 +311,7 @@ console.log(total);
 - \`let x = 42;\`
   > No. Because \`let\` allows reassignment, the compiler widens the type to \`number\`.
 - [o] \`const x = 42;\`
-  > Correct! \`const\` prevents reassignment, so TypeScript locks the type to the literal \`42\`.
+  > \`const\` prevents reassignment, so TypeScript locks the type to the literal \`42\`.
 - \`const x: number = 42;\`
   > No. You've explicitly annotated it as \`number\`, overriding the literal inference.
 

--- a/content/learn/typescript-from-scratch/type-narrowing.mdx
+++ b/content/learn/typescript-from-scratch/type-narrowing.mdx
@@ -528,7 +528,7 @@ if (result !== 25) throw new Error("Expected 25, got " + result);
 
 - \`if (value) { ... }\`
 - [o] \`if (typeof value === "string") { ... }\`
-  > Correct! The \`typeof\` guard narrows to \`string\` in the \`if\` branch.
+  > The \`typeof\` guard narrows to \`string\` in the \`if\` branch.
 - \`if (value instanceof String) { ... }\`
 - \`if ("length" in value) { ... }\`
 
@@ -540,7 +540,7 @@ if (result !== 25) throw new Error("Expected 25, got " + result);
 
 - It converts \`x\` to a string at runtime
 - [o] It tells the compiler that \`x\` is a \`string\` if the function returns \`true\`
-  > Correct! Type predicates enable custom narrowing logic.
+  > Type predicates enable custom narrowing logic.
 - It asserts that \`x\` is always a string
 - It's a syntax error
 

--- a/content/learn/typescript-from-scratch/unions-and-intersections.mdx
+++ b/content/learn/typescript-from-scratch/unions-and-intersections.mdx
@@ -495,7 +495,7 @@ try {
 - A value that is both a string and a number
 - A value that is neither a string nor a number
 - [o] A value that is either a string or a number
-  > Correct! Union types represent "this or that" — the value can be either member of the union.
+  > Union types represent "this or that" — the value can be either member of the union.
 - A value that is only a string
 
 Union types widen the set of acceptable values.`}
@@ -506,7 +506,7 @@ Union types widen the set of acceptable values.`}
 
 - A value that is either A or B
 - [o] A value that has all properties from both A and B
-  > Correct! Intersection types merge properties — the result must satisfy both constraints.
+  > Intersection types merge properties — the result must satisfy both constraints.
 - A value that has no properties
 - A value that is compatible with neither A nor B
 

--- a/content/learn/typescript-from-scratch/utility-types.mdx
+++ b/content/learn/typescript-from-scratch/utility-types.mdx
@@ -556,7 +556,7 @@ type Mystery<T> = { [K in keyof T]-?: T[K] };
 - \`Partial<T>\`
   > \`Partial\` adds \`?\`, not removes it.
 - [o] \`Required<T>\`
-  > Correct. The \`-?\` modifier removes optionality, making all properties required.
+  > The \`-?\` modifier removes optionality, making all properties required.
 - \`Readonly<T>\`
   > \`Readonly\` uses \`readonly\`, not \`-?\`.
 
@@ -580,7 +580,7 @@ What is \`Result\`?
 - \`{ id: number; name: string }\`
   > \`ReturnType\` extracts the return type *as-is*, which is the Promise, not the resolved value.
 - [o] \`Promise<{ id: number; name: string }>\`
-  > Correct. \`ReturnType\` captures the function's return type exactly.
+  > \`ReturnType\` captures the function's return type exactly.
 - \`string\`
   > The function doesn't return a string.
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Correct-answer choice explanations were prefixed with "Correct!", "Correct.", or "Correct —", which were displayed to learners even when they selected a *wrong* answer — giving misleading positive feedback
- Stripped these affirmative prefixes from 844 explanations across 392 MDX content files
- For "Correct — remainder text" cases, the first letter of the remainder is capitalized to maintain sentence casing
- One additional case "Correct: ..." in `keyof-typeof-template-literals.mdx` was rephrased to "The result is ..."
- Two edge cases left untouched: "Correct for the default deque-backed stack." and "Correct implementations preserve both keys." — here "Correct" is used as a substantive adjective, not an affirmative prefix

## Test plan

- [ ] Visit `/learn/multiple-choice` and select an incorrect answer — the correct choice explanation should no longer start with "Correct!"
- [ ] Confirm correct-answer explanations still appear and read naturally without the removed prefix
- [ ] Spot-check a few lessons across different courses (e.g. practical-r-for-beginners, typescript-from-scratch, java-programming-for-beginners)

https://claude.ai/code/session_0158iQ6MqC8ouCMygbDa2MRD
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0158iQ6MqC8ouCMygbDa2MRD)_