### PR TITLE
UI updates: result tab in viewer, dark button, skeleton width, em-dash titles

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -886,6 +886,7 @@
   border-top: 1px solid var(--ch-border-light);
   border-bottom: 1px solid var(--ch-border-light);
   overflow-x: auto;
+  overflow-y: hidden;
   scrollbar-width: none;
   user-select: none;
 }
@@ -960,7 +961,7 @@
    Run pill, but a thinner column reserved just for the disclosure
    arrow. Anchored to the right of `.btnGroupPrimary`. */
 .runBtnChevron {
-  background: var(--ch-accent);
+  background: #1a1a1a;
   color: var(--ch-white);
   border: none;
   padding: 0 8px;
@@ -972,16 +973,16 @@
 }
 
 .runBtnChevron:hover:not(:disabled) {
-  background: var(--ch-accent-hover);
+  background: #111111;
 }
 
 .runBtnChevron:disabled {
-  background: var(--ch-accent-disabled);
+  background: #8a8a8a;
   cursor: not-allowed;
 }
 
 .runBtnChevron[data-popup-open] {
-  background: var(--ch-accent-hover);
+  background: #111111;
 }
 
 .runBtnChevron svg {
@@ -1008,8 +1009,8 @@
   --ch-blue-700: #1d4ed8;
   --ch-blue-900: #1e3a8a;
 
-  background: var(--ch-blue-600);
-  border: 1px solid var(--ch-blue-700);
+  background: #1a1a1a;
+  border: 1px solid #333333;
   border-radius: 8px;
   box-shadow:
     0 1px 2px color-mix(in srgb, var(--ch-black) 12%, transparent),
@@ -1037,7 +1038,7 @@
 
 .runMenuItem:hover,
 .runMenuItem[data-highlighted] {
-  background: var(--ch-blue-700);
+  background: #111111;
 }
 
 .runMenuItem svg {
@@ -1079,7 +1080,7 @@
 }
 
 .runBtn {
-  background: var(--ch-accent);
+  background: #1a1a1a;
   color: var(--ch-white);
   border: none;
   padding: 6px 12px;
@@ -1094,11 +1095,11 @@
 }
 
 .runBtn:hover:not(:disabled) {
-  background: var(--ch-accent-hover);
+  background: #111111;
 }
 
 .runBtn:disabled {
-  background: var(--ch-accent-disabled);
+  background: #8a8a8a;
   cursor: not-allowed;
 }
 
@@ -1760,8 +1761,6 @@
 .sqlResultScroll {
   max-height: 320px;
   overflow: auto;
-  border-top: 1px solid var(--ch-border-light);
-  border-bottom: 1px solid var(--ch-border-light);
 }
 
 .sqlResultTable {
@@ -1769,6 +1768,7 @@
   font-family: var(--ch-font-mono);
   font-size: 13px;
   width: 100%;
+  margin: 0;
 }
 
 .sqlResultTable th {
@@ -1779,7 +1779,7 @@
   text-align: left;
   font-size: 12px;
   color: var(--ch-text-muted);
-  font-weight: 600;
+  font-weight: 500;
   white-space: nowrap;
   position: sticky;
   top: 0;
@@ -1968,13 +1968,12 @@
   box-shadow: 0 1px 0 #0d0d0d;
 }
 
-/* Keep the dropdown menu's kbd chips as semi-transparent white on blue
-   even in dark mode — the general .kbd dark rule would otherwise make them
-   gray (#252525) which clashes with the blue popup background. */
+/* Keep the dropdown menu's kbd chips readable on the white popup background
+   in dark mode. */
 :global(html.dark) .runMenuKbd .kbd {
-  background: color-mix(in srgb, #ffffff 16%, transparent);
-  border-color: color-mix(in srgb, #ffffff 28%, transparent);
-  color: color-mix(in srgb, #ffffff 88%, transparent);
+  background: rgba(0, 0, 0, 0.08);
+  border-color: rgba(0, 0, 0, 0.15);
+  color: rgba(0, 0, 0, 0.7);
   box-shadow: none;
 }
 
@@ -2033,6 +2032,56 @@
   background: #1a1a1a;
 }
 
+:global(html.dark) .runBtn {
+  background: #ffffff;
+  color: #111111;
+}
+
+:global(html.dark) .runBtn:hover:not(:disabled) {
+  background: #f0f0f0;
+}
+
+:global(html.dark) .runBtn:disabled {
+  background: #cccccc;
+  color: #888888;
+}
+
+:global(html.dark) .btnGroupPrimary .runBtn:not(:last-child) {
+  border-right: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+:global(html.dark) .runBtnChevron {
+  background: #ffffff;
+  color: #111111;
+}
+
+:global(html.dark) .runBtnChevron:hover:not(:disabled) {
+  background: #f0f0f0;
+}
+
+:global(html.dark) .runBtnChevron:disabled {
+  background: #cccccc;
+  color: #888888;
+}
+
+:global(html.dark) .runBtnChevron[data-popup-open] {
+  background: #e8e8e8;
+}
+
+:global(html.dark) .runMenuPopup {
+  --ch-white: #111111;
+  background: #ffffff;
+  border-color: #e0e0e0;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.06),
+    0 8px 24px rgba(0, 0, 0, 0.10);
+}
+
+:global(html.dark) .runMenuItem:hover,
+:global(html.dark) .runMenuItem[data-highlighted] {
+  background: #f0f0f0;
+}
+
 /* ─── Table viewer (SQL) ────────────────────────────────────────────── */
 
 .tableViewer {
@@ -2079,6 +2128,7 @@
   border-top: 1px solid var(--ch-border-light);
   border-bottom: 1px solid var(--ch-border-light);
   overflow-x: auto;
+  overflow-y: hidden;
   scrollbar-width: none;
   user-select: none;
 }

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1976,6 +1976,37 @@
   box-shadow: none;
 }
 
+/* Restore original blue accent for Run/Submit buttons in dark mode.
+   The base style uses #1a1a1a for light-mode contrast; dark mode reverts
+   to the standard accent (blue) so the button reads as a primary action. */
+:global(html.dark) .runBtn {
+  background: #2563eb;
+}
+
+:global(html.dark) .runBtn:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+:global(html.dark) .runBtn:disabled {
+  background: #93c5fd;
+}
+
+:global(html.dark) .runBtnChevron {
+  background: #2563eb;
+}
+
+:global(html.dark) .runBtnChevron:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+:global(html.dark) .runBtnChevron:disabled {
+  background: #93c5fd;
+}
+
+:global(html.dark) .runBtnChevron[data-popup-open] {
+  background: #1d4ed8;
+}
+
 :global(html.dark) .testItem {
   background: #0d0d0d;
   border-color: #2a2a2a;

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -960,7 +960,7 @@
    Run pill, but a thinner column reserved just for the disclosure
    arrow. Anchored to the right of `.btnGroupPrimary`. */
 .runBtnChevron {
-  background: #1a1a1a;
+  background: var(--ch-accent);
   color: var(--ch-white);
   border: none;
   padding: 0 8px;
@@ -971,16 +971,33 @@
   transition: background 0.15s;
 }
 
+/* Light mode: match the dark-gray Submit button */
+:global(html:not(.dark)) .runBtnChevron {
+  background: #1a1a1a;
+}
+
 .runBtnChevron:hover:not(:disabled) {
+  background: var(--ch-accent-hover);
+}
+
+:global(html:not(.dark)) .runBtnChevron:hover:not(:disabled) {
   background: #111111;
 }
 
 .runBtnChevron:disabled {
-  background: #8a8a8a;
+  background: var(--ch-accent-disabled);
   cursor: not-allowed;
 }
 
+:global(html:not(.dark)) .runBtnChevron:disabled {
+  background: #8a8a8a;
+}
+
 .runBtnChevron[data-popup-open] {
+  background: var(--ch-accent-hover);
+}
+
+:global(html:not(.dark)) .runBtnChevron[data-popup-open] {
   background: #111111;
 }
 
@@ -1991,21 +2008,6 @@
   background: #93c5fd;
 }
 
-:global(html.dark) .runBtnChevron {
-  background: #2563eb;
-}
-
-:global(html.dark) .runBtnChevron:hover:not(:disabled) {
-  background: #1d4ed8;
-}
-
-:global(html.dark) .runBtnChevron:disabled {
-  background: #93c5fd;
-}
-
-:global(html.dark) .runBtnChevron[data-popup-open] {
-  background: #1d4ed8;
-}
 
 :global(html.dark) .testItem {
   background: #0d0d0d;

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -384,7 +384,6 @@
 
 .instructions {
   padding: 4px 20px 18px;
-  border-bottom: 1px solid var(--ch-border-light);
   background: var(--ch-bg);
 }
 
@@ -1977,6 +1976,19 @@
   box-shadow: none;
 }
 
+/* In dark mode the Run/Submit button is white, so its embedded kbd chips
+   need dark-on-light colors (the light-mode rule uses white-on-dark). */
+:global(html.dark) .runBtn .btnKbd .kbd {
+  background: rgba(0, 0, 0, 0.08);
+  border-color: rgba(0, 0, 0, 0.16);
+  color: rgba(0, 0, 0, 0.72);
+  box-shadow: none;
+}
+
+:global(html.dark) .runBtn .btnKbd .kbdSep {
+  color: rgba(0, 0, 0, 0.4);
+}
+
 :global(html.dark) .testItem {
   background: #0d0d0d;
   border-color: #2a2a2a;
@@ -2124,7 +2136,6 @@
   display: flex;
   align-items: stretch;
   gap: 0;
-  background: var(--ch-bg-subtle);
   border-top: 1px solid var(--ch-border-light);
   border-bottom: 1px solid var(--ch-border-light);
   overflow-x: auto;

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -2200,9 +2200,7 @@
 }
 
 .tableViewerSkeleton {
-  margin: 0 14px 12px;
-  border: 1px solid var(--ch-border-light);
-  border-radius: 6px;
+  margin: 0;
   overflow: hidden;
 }
 
@@ -2245,6 +2243,57 @@
   .skeletonCell {
     animation-duration: 0s;
   }
+}
+
+/* ─── Result tab ──────────────────────────────────────────────────── */
+
+.resultTabClose {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  margin-left: 2px;
+  color: var(--ch-text-muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+  flex-shrink: 0;
+}
+
+.resultTabClose:hover {
+  background: var(--ch-bg-hover);
+  color: var(--ch-text);
+}
+
+.resultPane {
+  position: relative;
+  overflow: hidden;
+}
+
+.resultPaneInfo {
+  display: flex;
+  align-items: center;
+  padding: 5px 14px;
+  gap: 8px;
+  background: var(--ch-bg-subtle);
+  border-bottom: 1px solid var(--ch-border-light);
+  min-height: 28px;
+}
+
+.resultFlashOverlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: var(--ch-accent);
+  opacity: 0;
+  animation: ch-result-flash 0.5s ease-out forwards;
+  z-index: 2;
+}
+
+@keyframes ch-result-flash {
+  0% { opacity: 0.12; }
+  100% { opacity: 0; }
 }
 
 /* ─── Table viewer resize bar ───────────────────────────────────────── */

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1967,26 +1967,13 @@
   box-shadow: 0 1px 0 #0d0d0d;
 }
 
-/* Keep the dropdown menu's kbd chips readable on the white popup background
+/* Keep the dropdown menu's kbd chips readable on the blue popup background
    in dark mode. */
 :global(html.dark) .runMenuKbd .kbd {
-  background: rgba(0, 0, 0, 0.08);
-  border-color: rgba(0, 0, 0, 0.15);
-  color: rgba(0, 0, 0, 0.7);
+  background: color-mix(in srgb, #ffffff 16%, transparent);
+  border-color: color-mix(in srgb, #ffffff 28%, transparent);
+  color: color-mix(in srgb, #ffffff 88%, transparent);
   box-shadow: none;
-}
-
-/* In dark mode the Run/Submit button is white, so its embedded kbd chips
-   need dark-on-light colors (the light-mode rule uses white-on-dark). */
-:global(html.dark) .runBtn .btnKbd .kbd {
-  background: rgba(0, 0, 0, 0.08);
-  border-color: rgba(0, 0, 0, 0.16);
-  color: rgba(0, 0, 0, 0.72);
-  box-shadow: none;
-}
-
-:global(html.dark) .runBtn .btnKbd .kbdSep {
-  color: rgba(0, 0, 0, 0.4);
 }
 
 :global(html.dark) .testItem {
@@ -2042,56 +2029,6 @@
 
 :global(html.dark) .outCellHtml :global(tr:hover td) {
   background: #1a1a1a;
-}
-
-:global(html.dark) .runBtn {
-  background: #ffffff;
-  color: #111111;
-}
-
-:global(html.dark) .runBtn:hover:not(:disabled) {
-  background: #f0f0f0;
-}
-
-:global(html.dark) .runBtn:disabled {
-  background: #cccccc;
-  color: #888888;
-}
-
-:global(html.dark) .btnGroupPrimary .runBtn:not(:last-child) {
-  border-right: 1px solid rgba(0, 0, 0, 0.15);
-}
-
-:global(html.dark) .runBtnChevron {
-  background: #ffffff;
-  color: #111111;
-}
-
-:global(html.dark) .runBtnChevron:hover:not(:disabled) {
-  background: #f0f0f0;
-}
-
-:global(html.dark) .runBtnChevron:disabled {
-  background: #cccccc;
-  color: #888888;
-}
-
-:global(html.dark) .runBtnChevron[data-popup-open] {
-  background: #e8e8e8;
-}
-
-:global(html.dark) .runMenuPopup {
-  --ch-white: #111111;
-  background: #ffffff;
-  border-color: #e0e0e0;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.06),
-    0 8px 24px rgba(0, 0, 0, 0.10);
-}
-
-:global(html.dark) .runMenuItem:hover,
-:global(html.dark) .runMenuItem[data-highlighted] {
-  background: #f0f0f0;
 }
 
 /* ─── Table viewer (SQL) ────────────────────────────────────────────── */

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -35,7 +35,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, Eye, Play, Database, Table } from "lucide-react";
+import { RotateCcw, Check, X, ChevronDown, Eye, Play, Database, Table, List } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   createColumnHelper,
@@ -640,6 +640,15 @@ export interface UseSqlTableViewerOptions {
   ensureEngine: () => Promise<SqlEngineLike>;
 }
 
+export interface ResultTabData {
+  resultSet: SqlResult | null;
+  error: string;
+  message: string;
+  loading: boolean;
+  elapsed?: string;
+  runSeq: number;
+}
+
 /** Shared table-viewer state machine for `<SqlChallengeCard>` and
  *  `<SqlCodeBlock>`. Owns the list of tables, the active tab, the
  *  open/closed state, the first-load "initializing" flag (which drives
@@ -853,6 +862,7 @@ export default function SqlChallengeCard({
   const [testListOpen, setTestListOpen] = useState(true);
   const [bannerState, setBannerState] = useState<"pass" | "fail" | null>(null);
   const [isFormatting, setIsFormatting] = useState(false);
+  const [resultRunSeq, setResultRunSeq] = useState(0);
   const toasts = useChallengeToasts();
   const [engineLabel, setEngineLabel] = useState<string>(
     dialect === "sqlite"
@@ -1177,6 +1187,7 @@ export default function SqlChallengeCard({
 
   // ─── Run (no tests) ─────────────────────────────────────────────────
   const run = useCallback(async () => {
+    setResultRunSeq((s) => s + 1);
     setActiveAction("run");
     const userSql = editorRef.current?.state.doc.toString() ?? "";
     setTestResults([]);
@@ -1221,6 +1232,7 @@ export default function SqlChallengeCard({
   // ─── Check Answer (run + tests) ─────────────────────────────────────
   const check = useCallback(async () => {
     if (!canCheck) return;
+    setResultRunSeq((s) => s + 1);
     setActiveAction("submit");
     try {
     const userSql = editorRef.current?.state.doc.toString() ?? "";
@@ -1492,6 +1504,17 @@ export default function SqlChallengeCard({
   }, [dialect, toasts]);
 
   const isBusy = status === "loading" || status === "running";
+  const hasResult = isBusy || resultSet !== null || resultError !== "" || resultMessage !== "";
+  const resultTabDataProp: ResultTabData | null = hasResult
+    ? {
+        resultSet,
+        error: resultError,
+        message: resultMessage,
+        loading: isBusy,
+        elapsed,
+        runSeq: resultRunSeq,
+      }
+    : null;
   const passedCount = testResults.filter((t) => t.state === "pass").length;
   const totalTests = testResults.length;
   const allPassed = totalTests > 0 && passedCount === totalTests;
@@ -1557,8 +1580,8 @@ export default function SqlChallengeCard({
         </div>
       </div>
 
-      {/* ── Table viewer ── */}
-      {tableViewerEnabled && (
+      {/* ── Table viewer / Result viewer ── */}
+      {(tableViewerEnabled || hasResult) && (
         <TableViewer
           dialect={dialect}
           entries={tableEntries}
@@ -1566,6 +1589,7 @@ export default function SqlChallengeCard({
           setActiveIdx={setActiveTableIdx}
           initializing={tablesInitializing}
           onLoadMore={loadMoreActiveTable}
+          resultTabData={resultTabDataProp}
         />
       )}
 
@@ -1598,7 +1622,7 @@ export default function SqlChallengeCard({
                       cy="6"
                       r="4.5"
                       fill="none"
-                      stroke="white"
+                      stroke="currentColor"
                       strokeWidth="1.5"
                       strokeLinecap="round"
                       strokeDasharray="14 8"
@@ -1701,7 +1725,7 @@ export default function SqlChallengeCard({
                     cy="6"
                     r="4.5"
                     fill="none"
-                    stroke="white"
+                    stroke="currentColor"
                     strokeWidth="1.5"
                     strokeLinecap="round"
                     strokeDasharray="14 8"
@@ -1801,49 +1825,6 @@ export default function SqlChallengeCard({
           itemClassName={styles.toast}
         />
       </div>
-
-      {/* ── Result panel ── */}
-      {(resultSet || resultMessage || resultError || isBusy) && (
-        <div className={styles.sqlResultPanel} aria-live="polite">
-          <div className={styles.sqlResultHeader}>
-            <div
-              className={styles.accentBar}
-              data-error={resultError.length > 0}
-            />
-            <span className={styles.sqlResultLabel}>Result</span>
-            {resultSet && resultSet.columns.length > 0 && (
-              <span className={styles.sqlResultCount}>
-                {resultSet.values.length} row{resultSet.values.length === 1 ? "" : "s"}
-                {elapsed ? ` · ${elapsed}` : ""}
-              </span>
-            )}
-            {(!resultSet || resultSet.columns.length === 0) && elapsed && (
-              <span className={styles.sqlResultCount}>{elapsed}</span>
-            )}
-          </div>
-          {resultError ? (
-            <div className={styles.sqlMessage} style={{ color: "var(--ch-red)" }}>
-              {resultError}
-            </div>
-          ) : resultSet && resultSet.columns.length > 0 ? (
-            resultSet.values.length === 0 ? (
-              <div className={styles.sqlEmptyResult}>
-                Query returned no rows.
-              </div>
-            ) : (
-              <VirtualizedResultTable
-                columns={resultSet.columns}
-                values={resultSet.values}
-              />
-            )
-          ) : resultMessage ? (
-            <div className={styles.sqlMessage}>{resultMessage}</div>
-          ) : (
-            <div className={styles.sqlMessage}>Running…</div>
-          )}
-          <RunOverlay active={isBusy} />
-        </div>
-      )}
 
       {/* ── Test results ── */}
       {testResults.length > 0 && (
@@ -2308,6 +2289,7 @@ export function TableViewer({
   setActiveIdx,
   initializing,
   onLoadMore,
+  resultTabData,
 }: {
   dialect: SqlDialect;
   entries: TableViewerEntry[];
@@ -2315,11 +2297,31 @@ export function TableViewer({
   setActiveIdx: React.Dispatch<React.SetStateAction<number>>;
   initializing: boolean;
   onLoadMore: () => void;
+  resultTabData?: ResultTabData | null;
 }) {
   const [paneHeight, setPaneHeight] = useState(TABLE_VIEWER_DEFAULT_HEIGHT);
   // Live drag origin; null when not dragging. Stored in a ref so the
   // window-level move/up listeners read fresh values without re-binding.
   const dragRef = useRef<{ startY: number; startH: number } | null>(null);
+
+  const [resultTabDismissed, setResultTabDismissed] = useState(false);
+  const [resultIsActive, setResultIsActive] = useState(false);
+  const [flashKey, setFlashKey] = useState(0);
+  const prevRunSeqRef = useRef<number>(-1);
+
+  useEffect(() => {
+    if (resultTabData == null) {
+      setResultTabDismissed(false);
+      setResultIsActive(false);
+      return;
+    }
+    if (resultTabData.runSeq !== prevRunSeqRef.current) {
+      prevRunSeqRef.current = resultTabData.runSeq;
+      setResultTabDismissed(false);
+      setResultIsActive(true);
+      setFlashKey((k) => k + 1);
+    }
+  }, [resultTabData]);
 
   const onResizeStart = useCallback(
     (e: React.PointerEvent) => {
@@ -2360,24 +2362,13 @@ export function TableViewer({
     }
   }, []);
 
-  const showSkeleton = initializing && entries.length === 0;
+  const resultTabVisible = resultTabData != null && !resultTabDismissed;
+  const showSkeleton = initializing && entries.length === 0 && !resultTabVisible;
   // Nothing to show: not initializing and no tables were found.
-  if (!showSkeleton && entries.length === 0) return null;
+  if (!showSkeleton && entries.length === 0 && !resultTabVisible) return null;
   const active = entries[activeIdx];
   return (
     <div className={styles.tableViewer}>
-      <div className={styles.tableViewerHeader}>
-        <span className={styles.tableViewerLabel}>Tables</span>
-        {showSkeleton ? (
-          <span className={styles.tableViewerCount}>
-            <span className={styles.tableViewerSpinner} aria-hidden /> Initializing…
-          </span>
-        ) : (
-          <span className={styles.tableViewerCount}>
-            {entries.length} {entries.length === 1 ? "table" : "tables"}
-          </span>
-        )}
-      </div>
       {showSkeleton ? (
         <TableViewerSkeleton />
       ) : (
@@ -2390,9 +2381,9 @@ export function TableViewer({
                 role="tab"
                 aria-selected={idx === activeIdx}
                 className={`${styles.tableViewerTab} ${
-                  idx === activeIdx ? styles.tableViewerTabActive : ""
+                  idx === activeIdx && !resultIsActive ? styles.tableViewerTabActive : ""
                 }`}
-                onClick={() => setActiveIdx(idx)}
+                onClick={() => { setActiveIdx(idx); setResultIsActive(false); }}
               >
                 <Table size={12} aria-hidden />
                 {entry.schema && entry.schema !== defaultSchemaFor(dialect) ? (
@@ -2405,16 +2396,91 @@ export function TableViewer({
                 )}
               </button>
             ))}
+            {resultTabVisible && (
+              <button
+                type="button"
+                role="tab"
+                aria-selected={resultIsActive}
+                className={`${styles.tableViewerTab} ${resultIsActive ? styles.tableViewerTabActive : ""}`}
+                onClick={() => setResultIsActive(true)}
+              >
+                <List size={12} aria-hidden />
+                Result
+                <span
+                  role="button"
+                  aria-label="Close result tab"
+                  className={styles.resultTabClose}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setResultTabDismissed(true);
+                    setResultIsActive(false);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setResultTabDismissed(true);
+                      setResultIsActive(false);
+                    }
+                  }}
+                  tabIndex={0}
+                >
+                  <X size={10} aria-hidden />
+                </span>
+              </button>
+            )}
           </div>
-          {active && (
-            <TableViewerPane
-              // Re-key per table so switching tabs resets scroll to the
-              // top instead of inheriting the previous table's offset.
-              key={`${active.schema ?? ""}.${active.table}`}
-              entry={active}
-              height={paneHeight}
-              onLoadMore={onLoadMore}
-            />
+          {resultIsActive && resultTabVisible && resultTabData ? (
+            <div className={styles.resultPane} style={{ position: "relative" }}>
+              {flashKey > 0 && (
+                <div key={flashKey} className={styles.resultFlashOverlay} aria-hidden />
+              )}
+              <div className={styles.resultPaneInfo}>
+                {resultTabData.error ? (
+                  <span className={styles.sqlResultLabel} style={{ color: "var(--ch-red)" }}>
+                    Error
+                  </span>
+                ) : resultTabData.resultSet && resultTabData.resultSet.columns.length > 0 ? (
+                  <span className={styles.sqlResultCount}>
+                    {resultTabData.resultSet.values.length} row{resultTabData.resultSet.values.length === 1 ? "" : "s"}
+                    {resultTabData.elapsed ? ` · ${resultTabData.elapsed}` : ""}
+                  </span>
+                ) : resultTabData.elapsed ? (
+                  <span className={styles.sqlResultCount}>{resultTabData.elapsed}</span>
+                ) : null}
+              </div>
+              {resultTabData.error ? (
+                <div className={styles.sqlMessage} style={{ color: "var(--ch-red)" }}>
+                  {resultTabData.error}
+                </div>
+              ) : resultTabData.resultSet && resultTabData.resultSet.columns.length > 0 ? (
+                resultTabData.resultSet.values.length === 0 ? (
+                  <div className={styles.sqlEmptyResult}>Query returned no rows.</div>
+                ) : (
+                  <VirtualizedResultTable
+                    columns={resultTabData.resultSet.columns}
+                    values={resultTabData.resultSet.values}
+                    maxHeight={paneHeight}
+                  />
+                )
+              ) : resultTabData.message ? (
+                <div className={styles.sqlMessage}>{resultTabData.message}</div>
+              ) : (
+                <div className={styles.sqlMessage}>Running…</div>
+              )}
+              <RunOverlay active={resultTabData.loading} />
+            </div>
+          ) : (
+            active && (
+              <TableViewerPane
+                // Re-key per table so switching tabs resets scroll to the
+                // top instead of inheriting the previous table's offset.
+                key={`${active.schema ?? ""}.${active.table}`}
+                entry={active}
+                height={paneHeight}
+                onLoadMore={onLoadMore}
+              />
+            )
           )}
           <div
             className={styles.tableViewerResizer}

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -64,6 +64,7 @@ import {
   TableViewer,
   useSqlTableViewer,
   VirtualizedResultTable,
+  type ResultTabData,
   type SqlDialect,
   type SqlEngineLike,
   type SqlResult,
@@ -143,6 +144,7 @@ export default function SqlCodeBlock({
   const [resultError, setResultError] = useState<string>("");
   const [elapsed, setElapsed] = useState<string>("");
   const [isFormatting, setIsFormatting] = useState(false);
+  const [resultRunSeq, setResultRunSeq] = useState(0);
   const toasts = useChallengeToasts();
   const [engineLabel, setEngineLabel] = useState<string>(
     dialect === "sqlite"
@@ -378,6 +380,7 @@ export default function SqlCodeBlock({
 
   // ─── Run ────────────────────────────────────────────────────────────
   const run = useCallback(async () => {
+    setResultRunSeq((s) => s + 1);
     const userSql = editorRef.current?.state.doc.toString() ?? "";
     setResultError("");
     setResultMessage("");
@@ -503,6 +506,17 @@ export default function SqlCodeBlock({
   }, [dialect, toasts]);
 
   const isBusy = status === "loading" || status === "running";
+  const hasResult = isBusy || resultSet !== null || resultError !== "" || resultMessage !== "";
+  const resultTabDataProp: ResultTabData | null = hasResult
+    ? {
+        resultSet,
+        error: resultError,
+        message: resultMessage,
+        loading: isBusy,
+        elapsed,
+        runSeq: resultRunSeq,
+      }
+    : null;
 
   return (
     <div
@@ -536,8 +550,8 @@ export default function SqlCodeBlock({
         )}
       </div>
 
-      {/* ── Table viewer ── */}
-      {tableViewerEnabled && (
+      {/* ── Table viewer / Result viewer ── */}
+      {(tableViewerEnabled || hasResult) && (
         <TableViewer
           dialect={dialect}
           entries={tableEntries}
@@ -545,6 +559,7 @@ export default function SqlCodeBlock({
           setActiveIdx={setActiveTableIdx}
           initializing={tablesInitializing}
           onLoadMore={loadMoreActiveTable}
+          resultTabData={resultTabDataProp}
         />
       )}
 
@@ -571,7 +586,7 @@ export default function SqlCodeBlock({
                   cy="6"
                   r="4.5"
                   fill="none"
-                  stroke="white"
+                  stroke="currentColor"
                   strokeWidth="1.5"
                   strokeLinecap="round"
                   strokeDasharray="14 8"
@@ -651,43 +666,6 @@ export default function SqlCodeBlock({
         />
       </div>
 
-      {/* ── Result panel ── */}
-      {(resultSet || resultMessage || resultError || isBusy) && (
-        <div className={styles.sqlResultPanel} aria-live="polite">
-          <div className={styles.sqlResultHeader}>
-            <div className={styles.accentBar} data-error={resultError.length > 0} />
-            <span className={styles.sqlResultLabel}>Result</span>
-            {resultSet && resultSet.columns.length > 0 && (
-              <span className={styles.sqlResultCount}>
-                {resultSet.values.length} row{resultSet.values.length === 1 ? "" : "s"}
-                {elapsed ? ` · ${elapsed}` : ""}
-              </span>
-            )}
-            {(!resultSet || resultSet.columns.length === 0) && elapsed && (
-              <span className={styles.sqlResultCount}>{elapsed}</span>
-            )}
-          </div>
-          {resultError ? (
-            <div className={styles.sqlMessage} style={{ color: "var(--ch-red)" }}>
-              {resultError}
-            </div>
-          ) : resultSet && resultSet.columns.length > 0 ? (
-            resultSet.values.length === 0 ? (
-              <div className={styles.sqlEmptyResult}>Query returned no rows.</div>
-            ) : (
-              <VirtualizedResultTable
-                columns={resultSet.columns}
-                values={resultSet.values}
-              />
-            )
-          ) : resultMessage ? (
-            <div className={styles.sqlMessage}>{resultMessage}</div>
-          ) : (
-            <div className={styles.sqlMessage}>Running…</div>
-          )}
-          <RunOverlay active={isBusy} />
-        </div>
-      )}
     </div>
   );
 }

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -543,11 +543,6 @@ export default function SqlCodeBlock({
             />
           </div>
         </div>
-        {title && (
-          <div className={styles.titleRow}>
-            <div className={styles.title}>{title}</div>
-          </div>
-        )}
       </div>
 
       {/* ── Table viewer / Result viewer ── */}

--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -1,5 +1,7 @@
 .wrap {
   position: relative;
+  font-size: 1rem;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
 }
 
 .expandBtn {

--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -1,7 +1,7 @@
 .wrap {
   position: relative;
   font-size: 1rem;
-  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
 }
 
 .expandBtn {

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -44,7 +44,8 @@ function MermaidContent({ chart }: { chart: string }) {
   mermaid.initialize({
     startOnLoad: false,
     securityLevel: "strict",
-    fontFamily: "inherit",
+    fontFamily: '"Inter", system-ui, -apple-system, sans-serif',
+    fontSize: 14,
     themeCSS: "margin: 1.5rem auto 0;",
     theme: resolvedTheme === "dark" ? "dark" : "neutral",
   });

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -44,7 +44,7 @@ function MermaidContent({ chart }: { chart: string }) {
   mermaid.initialize({
     startOnLoad: false,
     securityLevel: "strict",
-    fontFamily: '"Inter", system-ui, -apple-system, sans-serif',
+    fontFamily: '"Source Serif 4", Georgia, "Times New Roman", serif',
     fontSize: 14,
     themeCSS: "margin: 1.5rem auto 0;",
     theme: resolvedTheme === "dark" ? "dark" : "neutral",

--- a/app/learn/layout.tsx
+++ b/app/learn/layout.tsx
@@ -20,7 +20,6 @@ import { source } from "@/lib/source";
 const sourceSerif4 = Source_Serif_4({
   subsets: ["latin"],
   axes: ["opsz"],
-  weight: ["400", "600"],
   style: ["normal", "italic"],
   variable: "--font-serif",
   display: "swap",

--- a/app/learn/layout.tsx
+++ b/app/learn/layout.tsx
@@ -12,9 +12,19 @@
  */
 import "./learn.css";
 import type { ReactNode } from "react";
+import { Source_Serif_4 } from "next/font/google";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { source } from "@/lib/source";
+
+const sourceSerif4 = Source_Serif_4({
+  subsets: ["latin"],
+  axes: ["opsz"],
+  weight: ["400", "600"],
+  style: ["normal", "italic"],
+  variable: "--font-serif",
+  display: "swap",
+});
 
 export default function LearnLayout({ children }: { children: ReactNode }) {
   return (
@@ -37,9 +47,11 @@ export default function LearnLayout({ children }: { children: ReactNode }) {
           url: "/",
         }}
         githubUrl="https://github.com/dataslope/dataslope/"
+        containerProps={{ className: sourceSerif4.variable }}
       >
         {children}
       </DocsLayout>
     </RootProvider>
   );
 }
+

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -65,7 +65,7 @@ samp {
 
 /* Light mode hover (non-active items) */
 :root:not(.dark) #nd-sidebar a:hover:not([data-active="true"]),
-:root:not(.dark) #nd-sidebar button:hover:not([data-active="true"]) {
+:root:not(.dark) #nd-sidebar button:hover:not([data-active="true"]):not([aria-label="Toggle Theme"]) {
   background-color: hsl(0, 0%, 97%);
 }
 
@@ -76,7 +76,7 @@ samp {
 
 /* Dark mode hover (non-active items) */
 .dark #nd-sidebar a:hover:not([data-active="true"]),
-.dark #nd-sidebar button:hover:not([data-active="true"]) {
+.dark #nd-sidebar button:hover:not([data-active="true"]):not([aria-label="Toggle Theme"]) {
   background-color: rgba(255, 255, 255, 0.04);
 }
 

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -16,7 +16,7 @@
    must precede the tailwind/fumadocs imports below — `@import` rules
    are required to come before any non-`@import`/`@layer`/`@charset`
    at-rule, including the inlined CSS pulled in by tailwindcss. */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
 @import "tailwindcss";
 @source "../../node_modules/fumadocs-ui/dist/**/*.js";
@@ -324,7 +324,7 @@ code.hljs {
   :where(.nd-codeblock *, pre *, [data-rehype-pretty-code-figure] *),
   :where([data-callout] *, .callout *)
 ) {
-  font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
+  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
   font-variation-settings: "opsz" 16;
   letter-spacing: 0;
 }

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -327,6 +327,7 @@ code.hljs {
 ) {
   font-family: var(--font-serif), Georgia, "Times New Roman", serif;
   font-size: 1.125rem;
+  line-height: 1.75;
   font-variation-settings: "opsz" 16;
   letter-spacing: 0;
 }

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -54,30 +54,45 @@ samp {
   --color-fd-card: hsl(0, 0%, 100%);
 }
 
-/* Sidebar active + hover overrides — fumadocs defaults use blue-tinted
-   accent tokens that stand out too much. Non-layered rules beat Tailwind's
-   @layer utilities so these reliably win without !important. */
+/* Sidebar text + active/hover overrides.
+   Non-layered rules beat Tailwind's @layer utilities, so these win
+   without !important.
 
-/* Light mode active */
-:root:not(.dark) #nd-sidebar [data-active="true"] {
-  background-color: hsl(0, 0%, 94%);
+   Base text: override --color-fd-muted-foreground inside the sidebar to
+   a higher-contrast value so page link labels are easy to read.
+   Active/hover: bump text further toward full foreground and add a
+   background tint so keyboard-focus and pointer state are visible. */
+
+/* Light mode — base text near-black, active + hover darker bg + text */
+:root:not(.dark) #nd-sidebar {
+  --color-fd-muted-foreground: hsl(0, 0%, 22%);
 }
 
-/* Light mode hover (non-active items) */
+:root:not(.dark) #nd-sidebar [data-active="true"] {
+  background-color: hsl(0, 0%, 94%);
+  color: hsl(0, 0%, 4%);
+}
+
 :root:not(.dark) #nd-sidebar a:hover:not([data-active="true"]),
 :root:not(.dark) #nd-sidebar button:hover:not([data-active="true"]):not([aria-label="Toggle Theme"]) {
   background-color: hsl(0, 0%, 97%);
+  color: hsl(0, 0%, 4%);
 }
 
-/* Dark mode active — very subtle white overlay on the #121212 background */
+/* Dark mode — base text near-white, active + hover lighter bg + text */
+.dark #nd-sidebar {
+  --color-fd-muted-foreground: hsl(0, 0%, 82%);
+}
+
 .dark #nd-sidebar [data-active="true"] {
   background-color: rgba(255, 255, 255, 0.07);
+  color: hsl(0, 0%, 96%);
 }
 
-/* Dark mode hover (non-active items) */
 .dark #nd-sidebar a:hover:not([data-active="true"]),
 .dark #nd-sidebar button:hover:not([data-active="true"]):not([aria-label="Toggle Theme"]) {
   background-color: rgba(255, 255, 255, 0.04);
+  color: hsl(0, 0%, 96%);
 }
 
 /* Item 2: Sidebar footer bar (GitHub icon + theme toggle) — remove the

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -116,7 +116,7 @@ samp {
   color: hsl(0, 0%, 58%);
 }
 .dark #nd-sidebar div.border.rounded-lg svg {
-  color: hsl(0, 0%, 44%);
+  color: hsl(0, 0%, 80%);
 }
 
 /* Item 3: Dark mode — make the sidebar use the same background as the content

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -16,7 +16,7 @@
    must precede the tailwind/fumadocs imports below — `@import` rules
    are required to come before any non-`@import`/`@layer`/`@charset`
    at-rule, including the inlined CSS pulled in by tailwindcss. */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&display=swap");
 
 @import "tailwindcss";
 @source "../../node_modules/fumadocs-ui/dist/**/*.js";
@@ -88,9 +88,12 @@ samp {
 }
 
 /* Item 3: Dark mode — make the sidebar use the same background as the content
-   area (#121212) instead of the default card color (#191919). */
+   area (#121212) instead of the default card color (#191919). Also bring
+   prose body text in line with the Fumadocs foreground token so it matches
+   the rest of the UI instead of defaulting to Tailwind Typography's gray. */
 .dark {
   --color-fd-card: var(--color-fd-background);
+  --tw-prose-body: var(--color-fd-foreground);
 }
 
 body {
@@ -297,4 +300,50 @@ pre code.hljs {
 code.hljs {
   padding: 0;
   background: transparent;
+}
+
+/* ── Source Serif 4 for prose content ───────────────────────────────────
+   Applied to paragraphs, list items, and table cells inside Fumadocs
+   prose regions. Explicitly excluded:
+   - [data-flavor]                    SQL/non-SQL challenge cards & code blocks
+   - [data-testid="challenge-card"]   non-SQL challenge cards
+   - [aria-label="Multiple choice question"]  quiz components
+   - .nd-codeblock, pre, code         code blocks
+   - [data-rehype-pretty-code-figure] Fumadocs syntax-highlighted code
+   - .callout, [data-callout]         callout blocks
+   - h1–h6                            headings (handled separately)
+   Optical size axis (opsz) is enabled via font-variation-settings so the
+   typeface self-optimises at body text sizes. Letter-spacing resets to 0
+   to avoid the tight value set on `body` above bleeding into serif text.
+   ─────────────────────────────────────────────────────────────────────── */
+.prose :where(p, li, td, th):not(
+  :where([class~="not-prose"], [class~="not-prose"] *),
+  :where([data-flavor] *),
+  :where([data-testid="challenge-card"] *),
+  :where([aria-label="Multiple choice question"] *),
+  :where(.nd-codeblock *, pre *, [data-rehype-pretty-code-figure] *),
+  :where([data-callout] *, .callout *)
+) {
+  font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
+  font-variation-settings: "opsz" 16;
+  letter-spacing: 0;
+}
+
+/* Restore sans-serif inside challenge / quiz / code components in case any
+   of those elements happen to fall under a .prose ancestor. */
+[data-flavor] p,
+[data-flavor] li,
+[data-flavor] td,
+[data-flavor] th,
+[data-testid="challenge-card"] p,
+[data-testid="challenge-card"] li,
+[data-testid="challenge-card"] td,
+[data-testid="challenge-card"] th,
+[aria-label="Multiple choice question"] p,
+[aria-label="Multiple choice question"] li,
+[aria-label="Multiple choice question"] td,
+[aria-label="Multiple choice question"] th {
+  font-family: var(--font-sans);
+  font-variation-settings: normal;
+  letter-spacing: -0.011em;
 }

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -325,6 +325,7 @@ code.hljs {
   :where([data-callout] *, .callout *)
 ) {
   font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+  font-size: 1.125rem;
   font-variation-settings: "opsz" 16;
   letter-spacing: 0;
 }

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -288,6 +288,7 @@ h6 {
 /* Remove the border Tailwind Typography adds to inline <code> elements. */
 .prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   border: none;
+  white-space: nowrap;
 }
 
 /* Suppress the default hljs padding/background — our <pre> handles both. */

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -95,11 +95,28 @@ samp {
   color: hsl(0, 0%, 96%);
 }
 
-/* Item 2: Sidebar footer bar (GitHub icon + theme toggle) — remove the
-   input-like border and secondary background so it looks like plain icons. */
+/* Sidebar separator labels (rendered as <p> by Fumadocs SidebarSeparator)
+   should read as section dividers, not navigation targets — use a softer
+   color so they recede behind the linked page items. */
+:root:not(.dark) #nd-sidebar p {
+  color: hsl(0, 0%, 52%);
+}
+.dark #nd-sidebar p {
+  color: hsl(0, 0%, 48%);
+}
+
+/* Sidebar footer bar (GitHub icon + theme toggle SVGs) — remove the
+   input-like border and secondary background, and dim the icons so they
+   don't compete with the navigation links. */
 #nd-sidebar div.border.rounded-lg {
   background-color: transparent;
   border: none;
+}
+:root:not(.dark) #nd-sidebar div.border.rounded-lg svg {
+  color: hsl(0, 0%, 58%);
+}
+.dark #nd-sidebar div.border.rounded-lg svg {
+  color: hsl(0, 0%, 44%);
 }
 
 /* Item 3: Dark mode — make the sidebar use the same background as the content

--- a/content/learn/beginners-javascript/debugging-and-reasoning.mdx
+++ b/content/learn/beginners-javascript/debugging-and-reasoning.mdx
@@ -34,7 +34,7 @@ When something goes wrong, resist the urge to start changing
 code. Instead, follow a tiny loop:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Observe the bad behaviour] --> B[Form a hypothesis]
     B --> C[Predict what should happen]
     C --> D[Test with a small change or log]

--- a/content/learn/beginners-javascript/how-javascript-runs.mdx
+++ b/content/learn/beginners-javascript/how-javascript-runs.mdx
@@ -120,7 +120,7 @@ they hand a result back to JS by **scheduling a task**.
 A simplified picture:
 
 ```mermaid
-flowchart LR
+flowchart TD
     JS[JS Engine + Call Stack] -->|"calls e.g. setTimeout(fn, 100)"| HOST[Host]
     HOST -->|after 100ms| Q[Task Queue]
     Q -->|when stack is empty| JS

--- a/content/learn/beginners-javascript/maintainable-code.mdx
+++ b/content/learn/beginners-javascript/maintainable-code.mdx
@@ -285,7 +285,7 @@ A useful pattern is to think of every module as having an
 *inside* (where data has already been validated).
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Untrusted input] -->|validate| B[Trusted core]
     B --> C[Compute / transform]
     C --> D[Output]

--- a/content/learn/beginners-javascript/map-filter-reduce.mdx
+++ b/content/learn/beginners-javascript/map-filter-reduce.mdx
@@ -242,7 +242,7 @@ A chain of `.filter().map().reduce()` is a small **data pipeline**.
 Each step takes the previous output as input.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[orders] --> B["filter: status === 'paid'"]
     B --> C["map: o => o.amount"]
     C --> D["reduce: sum"]

--- a/content/learn/beginners-javascript/problem-solving.mdx
+++ b/content/learn/beginners-javascript/problem-solving.mdx
@@ -16,7 +16,7 @@ the answer in one shot. There is a better way.
 ## The five steps
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[1. Understand] --> B[2. Plan]
     B --> C["3. Implement<br/>(small steps)"]
     C --> D[4. Test]

--- a/content/learn/beginners-javascript/rise-of-scripting-languages.mdx
+++ b/content/learn/beginners-javascript/rise-of-scripting-languages.mdx
@@ -53,7 +53,7 @@ A **scripting language** has, traditionally, a few common traits:
   network requests — the bread and butter of automation.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph CL["Compiled language (e.g. C)"]
         A1[Edit source] --> A2[Compile]
         A2 --> A3[Link]

--- a/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
@@ -12,7 +12,7 @@ to one specific stage.
 ## The four stages
 
 ```mermaid
-flowchart LR
+flowchart TD
     SRC["hello.c<br/>source text"] --> PP[Preprocessor]
     PP --> CC[Compiler]
     CC --> AS[Assembler]

--- a/content/learn/c-programming-for-beginners/computational-thinking.mdx
+++ b/content/learn/c-programming-for-beginners/computational-thinking.mdx
@@ -26,7 +26,7 @@ overlapping habits:
    for solving the problem.
 
 ```mermaid
-flowchart LR
+flowchart TD
     P[Real-world<br/>problem] --> D[Decompose<br/>into steps]
     D --> R[Recognize<br/>patterns]
     R --> A[Abstract<br/>away noise]

--- a/content/learn/c-programming-for-beginners/index.mdx
+++ b/content/learn/c-programming-for-beginners/index.mdx
@@ -38,7 +38,7 @@ We are going to do the opposite. We will start with **stories**:
 Only after that foundation do we open a code editor.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Real-world<br/>problem] --> B[Computational<br/>thinking]
     B --> C[Algorithm<br/>steps]
     C --> D[C source<br/>code]

--- a/content/learn/c-programming-for-beginners/linked-lists.mdx
+++ b/content/learn/c-programming-for-beginners/linked-lists.mdx
@@ -34,7 +34,7 @@ A few details worth unpacking:
   list.
 
 ```mermaid
-flowchart LR
+flowchart TD
     H["head"] --> N1["[ 10 | * ]"]
     N1 --> N2["[ 20 | * ]"]
     N2 --> N3["[ 30 | NULL ]"]

--- a/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
+++ b/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
@@ -97,7 +97,7 @@ A local variable is born when execution enters its scope, and
 frame, automatically allocated on entry and reclaimed on return.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[enter function] --> B[locals exist]
     B --> C[leave function]
     C --> D[locals destroyed]

--- a/content/learn/c-programming-for-beginners/story-of-computers.mdx
+++ b/content/learn/c-programming-for-beginners/story-of-computers.mdx
@@ -115,7 +115,7 @@ human reads `MOV AL, 5`; the machine sees `10110000 00000101`. Same
 thing, different presentation.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Assembly text<br/>MOV AL, 5] --> B[Assembler]
     B --> C[Machine code<br/>10110000 00000101]
     C --> D[CPU executes]

--- a/content/learn/code-blocks-cpp.mdx
+++ b/content/learn/code-blocks-cpp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Blocks - C++
+title: Code Blocks — C++
 description: Compile and run C++ in the browser via clang++ on browsercc.
 ---
 

--- a/content/learn/code-blocks-csharp.mdx
+++ b/content/learn/code-blocks-csharp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Blocks - C#
+title: Code Blocks — C#
 description: Compile and run C# in the browser via Roslyn on the .NET WebAssembly runtime.
 ---
 

--- a/content/learn/code-blocks-java.mdx
+++ b/content/learn/code-blocks-java.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Blocks - Java
+title: Code Blocks — Java
 description: Compile and run Java in the browser via javac + the JVM under CheerpJ.
 ---
 

--- a/content/learn/code-blocks-javascript.mdx
+++ b/content/learn/code-blocks-javascript.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Blocks - JavaScript
+title: Code Blocks — JavaScript
 description: JavaScript runs natively in the browser. Top-level await is supported.
 ---
 

--- a/content/learn/code-blocks-php.mdx
+++ b/content/learn/code-blocks-php.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Blocks - PHP
+title: Code Blocks — PHP
 description: Run PHP in the browser via php-wasm.
 ---
 

--- a/content/learn/code-blocks-python.mdx
+++ b/content/learn/code-blocks-python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Blocks - Python
+title: Code Blocks — Python
 description: Run Python in the browser via Pyodide. NumPy, Pandas, Matplotlib, and Plotly are all available.
 ---
 

--- a/content/learn/code-blocks-r.mdx
+++ b/content/learn/code-blocks-r.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Blocks - R
+title: Code Blocks — R
 description: Run R in the browser via WebR. Data frames render as tables, plots render as inline images.
 ---
 

--- a/content/learn/code-blocks-typescript.mdx
+++ b/content/learn/code-blocks-typescript.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Blocks - TypeScript
+title: Code Blocks — TypeScript
 description: TypeScript transpiled to JavaScript on the fly and executed in your browser.
 ---
 

--- a/content/learn/csharp-linq-functional/aggregations.mdx
+++ b/content/learn/csharp-linq-functional/aggregations.mdx
@@ -199,7 +199,7 @@ Let's trace `nums.Aggregate(0, (acc, n) => acc + n)` for
 `nums = [3, 1, 4]`:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["acc=0"] --> B["+3 → acc=3"]
     B --> C["+1 → acc=4"]
     C --> D["+4 → acc=8"]

--- a/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
+++ b/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
@@ -48,7 +48,7 @@ The desired report:
 ## The architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
     R[Raw CSV lines] --> P[Parse]
     P --> V[Valid rows]
     V --> G[Group by product]

--- a/content/learn/csharp-linq-functional/filtering-and-projection.mdx
+++ b/content/learn/csharp-linq-functional/filtering-and-projection.mdx
@@ -179,7 +179,7 @@ Let's trace what happens for a single element flowing through the
 pipeline above:
 
 ```mermaid
-flowchart LR
+flowchart TD
     O1["Order(Widget, 9.99, 3)"] --> W1{"Where: Product == 'Widget'"}
     W1 -->|"pass"| W2{"Where: Quantity > 0"}
     W2 -->|"pass"| S["Select: new { Price=9.99, Total=29.97 }"]

--- a/content/learn/csharp-linq-functional/functional-design-patterns.mdx
+++ b/content/learn/csharp-linq-functional/functional-design-patterns.mdx
@@ -120,7 +120,7 @@ A pipeline of operations can succeed or fail at any step. Picture it
 as two parallel tracks:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A([Input]) --> B[Step 1]
     B -->|Ok| C[Step 2]
     B -->|Err| F[(Error track)]

--- a/content/learn/csharp-linq-functional/ienumerable-and-iteration.mdx
+++ b/content/learn/csharp-linq-functional/ienumerable-and-iteration.mdx
@@ -48,7 +48,7 @@ This minimal contract is exactly what makes LINQ work uniformly over
 arrays, files, network streams, and infinite sequences.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["IEnumerable&lt;T&gt;"] -->|GetEnumerator| B["IEnumerator&lt;T&gt;"]
     B -->|MoveNext| C{has next?}
     C -->|yes| D[Current → consumer]

--- a/content/learn/csharp-linq-functional/next-steps.mdx
+++ b/content/learn/csharp-linq-functional/next-steps.mdx
@@ -190,7 +190,7 @@ performs it*.
 That mental shift outlasts any single language. Take it with you.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[You today] -->|practice| B[You with reflex-level LINQ]
     B -->|exploration| C[Async + Parallel + DB LINQ]
     C -->|cross-pollination| D[F# / Rust / Haskell experience]

--- a/content/learn/data-analysis-python-pandas/birth-of-data-science.mdx
+++ b/content/learn/data-analysis-python-pandas/birth-of-data-science.mdx
@@ -127,7 +127,7 @@ how to handle a bad row will affect every downstream conclusion.
 A typical analyst project in 2024 looks something like this:
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q[Business<br/>question] --> A[Acquire<br/>raw data]
     A --> C[Clean<br/>and validate]
     C --> E[Explore and<br/>summarize]

--- a/content/learn/data-analysis-python-pandas/eda-workflow.mdx
+++ b/content/learn/data-analysis-python-pandas/eda-workflow.mdx
@@ -14,7 +14,7 @@ This page outlines a workflow you can apply to any new dataset.
 ## Why a workflow?
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["New dataset"] --> B{"What questions<br/>can we ask?"}
   B --> C["Discover<br/>shape & types"]
   C --> D["Discover<br/>quality issues"]

--- a/content/learn/data-analysis-python-pandas/first-look-at-a-dataset.mdx
+++ b/content/learn/data-analysis-python-pandas/first-look-at-a-dataset.mdx
@@ -14,7 +14,7 @@ Every analyst eventually develops a personal version of this
 ritual. Here is a solid one to start with.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[1. Shape<br/>and head] --> B[2. dtypes<br/>and memory]
     B --> C[3. describe<br/>numeric + objects]
     C --> D[4. Missing-value<br/>map]

--- a/content/learn/data-analysis-python-pandas/groupby-operations.mdx
+++ b/content/learn/data-analysis-python-pandas/groupby-operations.mdx
@@ -12,7 +12,7 @@ category" question in data analysis ends up here.
 The mental model is three steps:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[(One DataFrame)] -->|1. Split| B[(Group 1)]
     A --> C[(Group 2)]
     A --> D[(Group 3)]

--- a/content/learn/data-analysis-python-pandas/history-of-data.mdx
+++ b/content/learn/data-analysis-python-pandas/history-of-data.mdx
@@ -25,7 +25,7 @@ later — is the seed of every spreadsheet, every CSV file, and every
 SQL table you will ever see.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Real-world<br/>event] --> B[Symbol or<br/>notch]
     B --> C[Durable<br/>medium]
     C --> D[Re-read by<br/>future humans]

--- a/content/learn/data-analysis-python-pandas/how-computers-see-data.mdx
+++ b/content/learn/data-analysis-python-pandas/how-computers-see-data.mdx
@@ -28,7 +28,7 @@ sequence does not know it is a CSV until something reads it as
 one.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Raw bytes<br/>on disk] --> B[File format<br/>convention]
     B --> C[Reader software<br/>e.g. pandas]
     C --> D[Typed,<br/>labeled<br/>DataFrame]

--- a/content/learn/data-analysis-python-pandas/index.mdx
+++ b/content/learn/data-analysis-python-pandas/index.mdx
@@ -60,7 +60,7 @@ By the end of the course you will be able to:
 ## How the course is organized
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[The Story<br/>of Data] --> B[What Data<br/>Analysis Is]
     B --> C[Python for<br/>Analysis]
     C --> D[Loading &<br/>Inspecting]

--- a/content/learn/data-analysis-python-pandas/messy-data-overview.mdx
+++ b/content/learn/data-analysis-python-pandas/messy-data-overview.mdx
@@ -34,7 +34,7 @@ what you did.
 ## A canonical workflow
 
 ```mermaid
-flowchart LR
+flowchart TD
     R[Raw data] --> I[Inspect:<br/>shape, dtypes,<br/>head, describe]
     I --> D[Detect issues:<br/>NaN, duplicates,<br/>outliers, types]
     D --> P[Plan fixes:<br/>drop? fix?<br/>impute? flag?]

--- a/content/learn/data-analysis-python-pandas/notebooks-and-environments.mdx
+++ b/content/learn/data-analysis-python-pandas/notebooks-and-environments.mdx
@@ -178,7 +178,7 @@ cells**. If your notebook does not run cleanly top to bottom,
 something is wrong.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph "Kernel = your Python session"
         V1[Variables in memory]
         V1 -->|cell 1 ran| V2[df = read_csv]

--- a/content/learn/data-analysis-python-pandas/spreadsheets-and-business.mdx
+++ b/content/learn/data-analysis-python-pandas/spreadsheets-and-business.mdx
@@ -30,7 +30,7 @@ computer: it could turn a week of financial modeling into ten
 minutes.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Change one<br/>assumption] --> B[Recalculate<br/>every dependent<br/>cell instantly]
     B --> C[See impact<br/>across the model]
     C --> D[Try the next<br/>scenario]

--- a/content/learn/data-analysis-python-pandas/spreadsheets-vs-code.mdx
+++ b/content/learn/data-analysis-python-pandas/spreadsheets-vs-code.mdx
@@ -54,7 +54,7 @@ df.groupby("region")["revenue"].sum().plot.bar()
 Save the file as `weekly_report.py`. **Next Monday: re-run.**
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph "Spreadsheet workflow"
         A1[Open CSV] --> A2[Manual import]
         A2 --> A3[Eyeball + fix types]

--- a/content/learn/data-analysis-python-pandas/the-analyst-mindset.mdx
+++ b/content/learn/data-analysis-python-pandas/the-analyst-mindset.mdx
@@ -95,7 +95,7 @@ result looks shocking, you are right to be suspicious. Most
 surprising results in data are data bugs, not breakthroughs.
 
 ```mermaid
-flowchart LR
+flowchart TD
     G[Intuition /<br/>hypothesis] --> E[Evidence<br/>from data]
     E -->|matches| K[Strengthened<br/>belief]
     E -->|surprises| S{Is this<br/>plausible?}

--- a/content/learn/data-analysis-python-pandas/what-is-data-analysis.mdx
+++ b/content/learn/data-analysis-python-pandas/what-is-data-analysis.mdx
@@ -36,7 +36,7 @@ analytical work into four kinds, in order of increasing
 ambition.
 
 ```mermaid
-flowchart LR
+flowchart TD
     D[Descriptive:<br/>What happened?] --> Di[Diagnostic:<br/>Why did it happen?]
     Di --> P[Predictive:<br/>What will happen?]
     P --> Pr[Prescriptive:<br/>What should we do?]
@@ -99,7 +99,7 @@ doing some mix of:
    maker, in words, charts, and (sometimes) a recommendation.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Ask] --> B[Acquire]
     B --> C[Clean]
     C --> D[Explore]

--- a/content/learn/from-zero-to-cpp/a-brief-history.mdx
+++ b/content/learn/from-zero-to-cpp/a-brief-history.mdx
@@ -19,7 +19,7 @@ machine would read one at a time. There was no source code in the
 modern sense.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Human idea] --> B[Plug-board /<br/>punched card]
     B --> C[Wired CPU<br/>executes pattern]
     C --> D[Lights / paper tape]
@@ -142,7 +142,7 @@ renamed **C++** (a play on the C `++` operator, which means
 *increment by one*).
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Simula 67<br/>Classes, objects] --> C[C with Classes<br/>1979]
     B[C 1972<br/>Speed + control] --> C
     C --> D[C++ 1983]

--- a/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
+++ b/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
@@ -15,7 +15,7 @@ errors come from confusing one stage with another.
 The traditional C++ toolchain has four steps:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Source code<br/>.cpp + .h] --> P[1. Preprocess<br/>expand #include,<br/>#define, ifdef]
     P --> C[2. Compile<br/>parse, type-check,<br/>generate assembly]
     C --> AS[3. Assemble<br/>assembly to<br/>object code .o]
@@ -65,7 +65,7 @@ The actual **compiler** takes one translation unit and turns it into
 CPU. Inside, the compiler runs many sub-passes:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Translation unit] --> L[Lexer:<br/>text to tokens]
     L --> Pa[Parser:<br/>tokens to syntax tree]
     Pa --> Sm[Semantic analysis:<br/>type-check, lookup names]
@@ -216,7 +216,7 @@ header/implementation split exists to obey this rule even when many
 `.cpp` files need to *use* the same function.
 
 ```mermaid
-flowchart LR
+flowchart TD
     H[mathx.h<br/>declarations only] -->|"#include"| M1[main.cpp]
     H -->|"#include"| M2[other.cpp]
     H -->|"#include"| M3[third.cpp]

--- a/content/learn/from-zero-to-cpp/constructors-and-destructors.mdx
+++ b/content/learn/from-zero-to-cpp/constructors-and-destructors.mdx
@@ -121,7 +121,7 @@ cleanup is the magic that makes RAII possible.
 ## Lifecycle of an object
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Allocate storage] --> B[Constructor runs:<br/>initializer list, then body]
     B --> C[Object is alive<br/>methods may be called]
     C --> D[Destructor runs:<br/>release resources]

--- a/content/learn/from-zero-to-cpp/debugging-and-reasoning.mdx
+++ b/content/learn/from-zero-to-cpp/debugging-and-reasoning.mdx
@@ -19,7 +19,7 @@ The instinct to fix is loud and unhelpful. The instinct to
 how bugs actually get fixed.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Observe symptom] --> B[Form hypothesis]
     B --> C[Design experiment]
     C --> D[Run experiment]

--- a/content/learn/from-zero-to-cpp/index.mdx
+++ b/content/learn/from-zero-to-cpp/index.mdx
@@ -33,7 +33,7 @@ piece of software where speed, predictability, or direct hardware
 access matters.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Your C++ source<br/>file.cpp] --> B[Compiler<br/>clang++ / g++]
     B --> C[Machine code<br/>.exe / a.out]
     C --> D[Operating system<br/>loads + runs]

--- a/content/learn/from-zero-to-cpp/raii-and-resources.mdx
+++ b/content/learn/from-zero-to-cpp/raii-and-resources.mdx
@@ -38,7 +38,7 @@ cleaned up automatically — even if an exception is thrown, even if
 the function has many `return` paths.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Function entry] --> B[Construct resource owner<br/>acquires resource]
     B --> C[Use the resource]
     C -->|normal return| D[Destructor runs<br/>releases resource]

--- a/content/learn/from-zero-to-cpp/variables-and-memory.mdx
+++ b/content/learn/from-zero-to-cpp/variables-and-memory.mdx
@@ -217,7 +217,7 @@ Closely related to scope is **lifetime**: the period of time during
 *execution* when the variable's memory is valid.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["{ ... declare x"] -->|x is born| B[use x]
     B -->|use x| C[use x]
     C -->|scope closes| D[x is destroyed]

--- a/content/learn/from-zero-to-cpp/your-first-program.mdx
+++ b/content/learn/from-zero-to-cpp/your-first-program.mdx
@@ -80,7 +80,7 @@ A single C++ statement that does a *lot*.
   same way English sentences end with a period.
 
 ```mermaid
-flowchart LR
+flowchart TD
     L["'Hello, World!\\n'<br/>(literal bytes in<br/>read-only memory)"] -->|stream insertion <<| O["std::cout<br/>(an output stream object)"]
     O -->|delegates to| OS[Operating system]
     OS --> T[Terminal / browser console]

--- a/content/learn/functional-programming-typescript/roots-of-functional-thinking.mdx
+++ b/content/learn/functional-programming-typescript/roots-of-functional-thinking.mdx
@@ -190,7 +190,7 @@ A few things changed that:
   pure reducers.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Lisp<br/>1958] --> B[Scheme<br/>1975]
     B --> J[JavaScript<br/>1995]
     A --> ML[ML<br/>1973]

--- a/content/learn/functional-programming-typescript/type-driven-design.mdx
+++ b/content/learn/functional-programming-typescript/type-driven-design.mdx
@@ -82,7 +82,7 @@ nonsense combination simply doesn't compile.
 ### Another example: form state
 
 ```mermaid
-flowchart LR
+flowchart TD
     Empty --> Editing
     Editing --> Submitting
     Submitting -->|ok| Submitted

--- a/content/learn/intro-data-viz-plotly/faceting-and-small-multiples.mdx
+++ b/content/learn/intro-data-viz-plotly/faceting-and-small-multiples.mdx
@@ -15,7 +15,7 @@ visualization, and Plotly Express makes it almost free.
 ## The pitch
 
 ```mermaid
-flowchart LR
+flowchart TD
     O[One messy chart<br/>30 overlapping lines] --> F[Facet by category]
     F --> M[30 small charts<br/>one per category<br/>shared axes]
     M --> C[Compare like-with-like<br/>at a glance]

--- a/content/learn/intro-data-viz-plotly/filtering-before-plotting.mdx
+++ b/content/learn/intro-data-viz-plotly/filtering-before-plotting.mdx
@@ -23,7 +23,7 @@ If you skip the filter, the chart drowns in noise. Worse, the
 chart may *technically* be correct but answer the wrong question.
 
 ```mermaid
-flowchart LR
+flowchart TD
     R[Raw data<br/>2M rows] --> F[Filter to<br/>relevant slice]
     F --> A[Aggregate if needed]
     A --> P[Plot]

--- a/content/learn/intro-data-viz-plotly/florence-nightingale.mdx
+++ b/content/learn/intro-data-viz-plotly/florence-nightingale.mdx
@@ -36,7 +36,7 @@ a newspaper editor — could see in a single glance that **soldiers
 were not dying of war; they were dying of dirt**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     D[Monthly death<br/>statistics] --> E[Coxcomb<br/>rose diagram]
     E --> P[Politicians<br/>understand instantly]
     P --> R[Sanitary Commission<br/>sent to Scutari]

--- a/content/learn/intro-data-viz-plotly/histograms.mdx
+++ b/content/learn/intro-data-viz-plotly/histograms.mdx
@@ -20,7 +20,7 @@ that fall into each bin. The result looks like a bar chart, but
 the bars represent *intervals*, not categories.
 
 ```mermaid
-flowchart LR
+flowchart TD
     V["Numeric column<br/>(values)"] --> B["Cut into bins<br/>e.g. 0-10, 10-20, ..."]
     B --> C["Count per bin"]
     C --> P["Plot as bars"]

--- a/content/learn/intro-data-viz-plotly/index.mdx
+++ b/content/learn/intro-data-viz-plotly/index.mdx
@@ -50,7 +50,7 @@ This course **is**:
 ## What you will learn
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[The Story] --> B[Visual<br/>Reasoning]
     B --> C[Plotly Express<br/>Fundamentals]
     C --> D[Chart Types]

--- a/content/learn/intro-data-viz-plotly/introducing-plotly-express.mdx
+++ b/content/learn/intro-data-viz-plotly/introducing-plotly-express.mdx
@@ -130,7 +130,7 @@ When you call `fig.show()`, Plotly Express does the following:
    wrapped in HTML.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Code["Python code<br/>px.bar(...)"] --> Fig["Figure object<br/>(JSON spec)"]
     Fig --> Show["fig.show()"]
     Show --> JS["Plotly.js<br/>in browser"]

--- a/content/learn/intro-data-viz-plotly/python-for-analytics.mdx
+++ b/content/learn/intro-data-viz-plotly/python-for-analytics.mdx
@@ -90,7 +90,7 @@ data scientists, ML researchers, and quantitative analysts
 worldwide.
 
 ```mermaid
-flowchart LR
+flowchart TD
     NP[NumPy<br/>arrays] --> PD[pandas<br/>DataFrames]
     NP --> MPL[Matplotlib<br/>plots]
     PD --> MPL

--- a/content/learn/intro-data-viz-plotly/rise-of-business-intelligence.mdx
+++ b/content/learn/intro-data-viz-plotly/rise-of-business-intelligence.mdx
@@ -91,7 +91,7 @@ many charts arranged like the instrument panel of a car —
 "speedometer," "fuel gauge," "warning lights" for the business.
 
 ```mermaid
-flowchart LR
+flowchart TD
     DB[(Database)] --> ETL[ETL pipeline]
     ETL --> DW[(Data warehouse)]
     DW --> BI[BI tool]

--- a/content/learn/intro-data-viz-plotly/spreadsheets-to-interactive.mdx
+++ b/content/learn/intro-data-viz-plotly/spreadsheets-to-interactive.mdx
@@ -54,7 +54,7 @@ every interactive newspaper graphic (New York Times, FiveThirtyEight,
 The Pudding) for the next decade.
 
 ```mermaid
-flowchart LR
+flowchart TD
     JS[JavaScript] --> D3[D3.js<br/>2011]
     SVG[SVG] --> D3
     D3 --> NYT[NYT graphics]

--- a/content/learn/intro-data-viz-plotly/storytelling-with-data.mdx
+++ b/content/learn/intro-data-viz-plotly/storytelling-with-data.mdx
@@ -24,7 +24,7 @@ The chart is the *evidence*; the argument is what the chart is
 the argument so well that the reader can't miss it.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q[Question /<br/>Argument] --> D[Data]
     D --> C[Chart]
     C --> R[Reader]

--- a/content/learn/intro-data-viz-plotly/the-rise-of-plotly.mdx
+++ b/content/learn/intro-data-viz-plotly/the-rise-of-plotly.mdx
@@ -142,7 +142,7 @@ chart libraries:
    pannable, zoomable, hoverable. You don't have to opt in.
 
 ```mermaid
-flowchart LR
+flowchart TD
     DF[(DataFrame)] --> PX["px.bar / px.line / px.scatter / ..."]
     PX --> Args["x= y= color= size= facet_col= ..."]
     Args --> Fig[Interactive Plotly figure]

--- a/content/learn/intro-data-viz-plotly/what-is-data-visualization.mdx
+++ b/content/learn/intro-data-viz-plotly/what-is-data-visualization.mdx
@@ -32,7 +32,7 @@ Numbers become positions. Categories become colors. Time becomes a
 horizontal axis. The map is called an **encoding**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     D["Data<br/>(rows + columns)"] --> E["Encoding<br/>(rules)"]
     E --> P["Picture<br/>(positions, colors, sizes)"]
     P --> H["Human eye"]

--- a/content/learn/intro-data-viz-plotly/why-charts-exist.mdx
+++ b/content/learn/intro-data-viz-plotly/why-charts-exist.mdx
@@ -90,7 +90,7 @@ These are all things the visual cortex is built for and the
 conscious arithmetic part of the brain is *terrible* at.
 
 ```mermaid
-flowchart LR
+flowchart TD
     T["Table<br/>(numbers)"] --> R["Read each number"]
     R --> M["Hold in memory"]
     M --> A["Mentally compute"]

--- a/content/learn/intro-modern-csharp/evolution-of-dotnet.mdx
+++ b/content/learn/intro-modern-csharp/evolution-of-dotnet.mdx
@@ -70,7 +70,7 @@ it would build a **new**, **cross-platform**, **open-source**
 implementation of .NET, and shift the entire ecosystem onto it.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Old[".NET Framework<br/>Windows-only<br/>closed-source"]
       -.legacy.-> Keep["Still supported<br/>for old apps"]
     Old --> New[".NET Core 1.0 (2016)<br/>cross-platform<br/>open-source<br/>on GitHub"]

--- a/content/learn/intro-modern-csharp/how-programs-execute.mdx
+++ b/content/learn/intro-modern-csharp/how-programs-execute.mdx
@@ -15,7 +15,7 @@ CPU instructions, just build the mental model.
 ## The big picture
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Source code<br/>(.cs files)"] --> B["Compiler<br/>(Roslyn)"]
     B --> C["Intermediate Language<br/>(CIL / IL)"]
     C --> D["Runtime<br/>(.NET CLR or WebAssembly)"]

--- a/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
+++ b/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
@@ -33,7 +33,7 @@ bytecode**, which ran on a small program called the **Java Virtual
 Machine** (JVM).
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["Source code<br/>Hello.java"] --> C["Java compiler<br/>(javac)"]
     C --> B["Java bytecode<br/>Hello.class"]
     B --> JVM["Java Virtual Machine<br/>(JVM)"]

--- a/content/learn/intro-modern-csharp/microsoft-dotnet-vision.mdx
+++ b/content/learn/intro-modern-csharp/microsoft-dotnet-vision.mdx
@@ -40,7 +40,7 @@ Intermediate Language, sometimes called IL), and the CLR
 just-in-time compiles it to real machine code as it runs.
 
 ```mermaid
-flowchart LR
+flowchart TD
     SRC["Source (C#, F#, VB.NET, ...)"] --> COMP["Compiler"]
     COMP --> IL["CIL (Intermediate Language)<br/>.dll / .exe"]
     IL --> CLR["CLR<br/>(JIT + GC + type checks)"]

--- a/content/learn/intro-modern-csharp/resource-management.mdx
+++ b/content/learn/intro-modern-csharp/resource-management.mdx
@@ -30,7 +30,7 @@ memory on the heap. When nothing points to that object anymore,
 the GC eventually reclaims the space:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["new Person()"] --> H["heap allocation"]
     H --> R["program holds reference"]
     R -->|reference dropped| O["object becomes unreachable"]

--- a/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
@@ -201,7 +201,7 @@ the *consumer* (we write into it): `? super T`.
 ## Picture: variance on a number line
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[List of Object] --- B[List ? super Integer]
     B --- C[List of Integer]
     C --- D[List ? extends Number]

--- a/content/learn/java-collections-and-generics-deep-dive/collection-architecture.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/collection-architecture.mdx
@@ -99,7 +99,7 @@ In a typical layered application, collections move through several
 roles:
 
 ```mermaid
-flowchart LR
+flowchart TD
     DB[(Storage)] --> Repo[Repository]
     Repo -->|read-only snapshots| Svc[Service / Domain]
     Svc -->|narrow query types| Web[Controller / API]

--- a/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
@@ -51,7 +51,7 @@ the bucket where the element should live — instead of scanning all
 buckets.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["new Customer('ada@…')"] --> H["hashCode()<br/>= 8132917"]
     H --> M["bucket = 8132917 mod N<br/>= 5"]
     M --> B5["bucket 5<br/>1–2 candidates"]

--- a/content/learn/java-collections-and-generics-deep-dive/index.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/index.mdx
@@ -144,7 +144,7 @@ Three things to notice — they will reappear on almost every page:
 ## What you'll be able to do by the end
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["A vague requirement<br/>track unique users<br/>by login order"] --> B["Recognize<br/>the right container<br/>LinkedHashSet"]
     B --> C["Model it with<br/>a generic API"]
     C --> D["Reason about<br/>Big-O and memory"]

--- a/content/learn/java-collections-and-generics-deep-dive/lists.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/lists.mdx
@@ -93,7 +93,7 @@ That single picture explains every `ArrayList` performance fact:
 holding the value plus pointers to the previous and next nodes.
 
 ```mermaid
-flowchart LR
+flowchart TD
     H[head] --> N1["[a | prev=null | next=•]"]
     N1 --> N2["[b | prev=• | next=•]"]
     N2 --> N3["[c | prev=• | next=•]"]

--- a/content/learn/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
@@ -21,7 +21,7 @@ whole world. Code that small does not need *abstractions* over
 storage. It can just point at memory directly.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["1950s<br/>fixed-size arrays<br/>one programmer"]
       --> B["1960s<br/>airline reservations,<br/>thousands of records"]
     B --> C["1970s<br/>OS data tables,<br/>compilers, databases"]

--- a/content/learn/java-programming-for-beginners/computational-thinking.mdx
+++ b/content/learn/java-programming-for-beginners/computational-thinking.mdx
@@ -14,7 +14,7 @@ are far older. There are four of them. Each is worth a lifetime of
 practice.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Vague[Vague problem<br/>in English] --> D[1. Decompose]
     D --> P[2. Find patterns]
     P --> A[3. Abstract]

--- a/content/learn/java-programming-for-beginners/constructors-and-lifecycle.mdx
+++ b/content/learn/java-programming-for-beginners/constructors-and-lifecycle.mdx
@@ -155,7 +155,7 @@ hours later when something downstream blows up.
 ## The lifecycle of an object
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[1. allocated<br/>on heap] --> B[2. fields default-initialized<br/>0 / null / false]
     B --> C[3. constructor runs]
     C --> D[4. object is alive<br/>methods can be called]

--- a/content/learn/java-programming-for-beginners/debugging-and-reasoning.mdx
+++ b/content/learn/java-programming-for-beginners/debugging-and-reasoning.mdx
@@ -31,7 +31,7 @@ Debugging is the disciplined process of finding that chain.
 ## A four-step debugging loop
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[1. Observe<br/>what actually happened] --> B[2. Hypothesize<br/>why that could happen]
     B --> C[3. Test<br/>add a print, set a breakpoint, write a tiny example]
     C --> D[4. Update<br/>your mental model]
@@ -158,7 +158,7 @@ the bug is *below*. This is bisection thinking, and it is wildly
 faster than poking at random.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Bug suspected] --> B{Check invariant<br/>at midpoint}
     B -->|broken| C[Bug is in first half]
     B -->|holds| D[Bug is in second half]

--- a/content/learn/java-programming-for-beginners/early-programming.mdx
+++ b/content/learn/java-programming-for-beginners/early-programming.mdx
@@ -19,7 +19,7 @@ would carry their program in a cardboard box, hand it to an operator,
 and come back the next day to find out whether it had worked.
 
 ```mermaid
-flowchart LR
+flowchart TD
     H[Human writes<br/>program on paper] --> P[Punch cards<br/>one per line]
     P --> O[Operator loads<br/>cards into machine]
     O --> M[Mainframe runs<br/>program overnight]

--- a/content/learn/java-programming-for-beginners/evolution-of-java.mdx
+++ b/content/learn/java-programming-for-beginners/evolution-of-java.mdx
@@ -16,7 +16,7 @@ the browser downloaded and ran in a sandbox. Applets did simple
 animations, calculators, simple games, and proof-of-concept demos.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Page[Web page HTML]
     Page -->|<applet> tag| Browser
     Browser -->|download| Server[Web server: .class]
@@ -116,7 +116,7 @@ We will not use most of these advanced features in this course, but
 it is worth knowing they exist. Java is not standing still.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Java 1<br/>1996<br/>Applets] --> B[Java 5<br/>2004<br/>Generics, enums]
     B --> C[Java 8<br/>2014<br/>Lambdas, streams]
     C --> D[Java 11<br/>2018<br/>Modern LTS]

--- a/content/learn/java-programming-for-beginners/how-programs-execute.mdx
+++ b/content/learn/java-programming-for-beginners/how-programs-execute.mdx
@@ -11,7 +11,7 @@ output."
 ## The four stages
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[1. Source<br/>Main.java] --> B[2. Compile<br/>javac]
     B --> C[3. Bytecode<br/>Main.class]
     C --> D[4. Run<br/>JVM]
@@ -149,7 +149,7 @@ behind the scenes. There is no shortcut around `.java → .class → run`
 — you just don't have to type it.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Click Run] --> B[IDE silently invokes javac]
     B --> C[IDE silently invokes java]
     C --> D[You see output]

--- a/content/learn/java-programming-for-beginners/java-becomes-dominant.mdx
+++ b/content/learn/java-programming-for-beginners/java-becomes-dominant.mdx
@@ -38,7 +38,7 @@ in 2003. Once a generation of students grew up writing Java, those
 students went into industry and naturally wrote Java there too.
 
 ```mermaid
-flowchart LR
+flowchart TD
     U[Universities adopt<br/>Java in CS101] --> S[Students learn Java]
     S --> I[Students join industry]
     I --> C[Companies hire<br/>Java-trained graduates]

--- a/content/learn/java-programming-for-beginners/maps-and-sets.mdx
+++ b/content/learn/java-programming-for-beginners/maps-and-sets.mdx
@@ -120,7 +120,7 @@ element up later is as easy as: compute the hash, go to that
 bucket, check what's there.
 
 ```mermaid
-flowchart LR
+flowchart TD
     K["key 'Ada'"] --> H["hashCode() = 65823..."]
     H --> B["bucket index = hash % bucketCount"]
     B --> Bucket["bucket → key/value pair"]

--- a/content/learn/java-programming-for-beginners/problem-solving.mdx
+++ b/content/learn/java-programming-for-beginners/problem-solving.mdx
@@ -17,7 +17,7 @@ math.
 ## The four steps
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[1. Understand<br/>the problem] --> B[2. Devise<br/>a plan]
     B --> C[3. Carry out<br/>the plan]
     C --> D[4. Look back<br/>and reflect]

--- a/content/learn/java-programming-for-beginners/software-complexity-crisis.mdx
+++ b/content/learn/java-programming-for-beginners/software-complexity-crisis.mdx
@@ -29,7 +29,7 @@ profession of "software engineer" was being invented in real time, in
 response to a real disaster.
 
 ```mermaid
-flowchart LR
+flowchart TD
     H[Hardware<br/>2x faster every<br/>~2 years] --> A[Ambition grows<br/>even faster]
     A --> B[Programs become<br/>huge and tangled]
     B --> C[Bugs everywhere<br/>Changes are scary]

--- a/content/learn/mastering-dsa-cpp/complexity-analysis.mdx
+++ b/content/learn/mastering-dsa-cpp/complexity-analysis.mdx
@@ -63,7 +63,7 @@ The `sum` function is Θ(n): it must inspect every element, and it does constant
 ## Growth rates hierarchy
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["O(1)"] --> B["O(log n)"]
     B --> C["O(sqrt n)"]
     C --> D["O(n)"]

--- a/content/learn/mastering-dsa-cpp/cpp-essentials.mdx
+++ b/content/learn/mastering-dsa-cpp/cpp-essentials.mdx
@@ -10,7 +10,7 @@ You do not need all of C++ to start solving DSA problems. You need a reliable sl
 C++ source files are compiled into object files, then linked with libraries to produce an executable.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["source .cpp"] --> B["compile"]
     B --> C["object .o"]
     C --> D["link"]

--- a/content/learn/mastering-dsa-cpp/graphs.mdx
+++ b/content/learn/mastering-dsa-cpp/graphs.mdx
@@ -15,7 +15,7 @@ A **graph** is a collection of **vertices** `V` and **edges** `E`. Vertices are 
 * **Acyclic graph**: no cycles. A directed acyclic graph is called a **DAG**.
 
 ```mermaid
-graph LR
+graph TD
     A((0)) --- B((1))
     A --- C((2))
     B --- C

--- a/content/learn/mastering-dsa-cpp/hash-tables.mdx
+++ b/content/learn/mastering-dsa-cpp/hash-tables.mdx
@@ -8,7 +8,7 @@ A hash table stores key-value data in an array of buckets. A hash function conve
 ## The core idea
 
 ```mermaid
-flowchart LR
+flowchart TD
     K["key: apple"] --> H["hash(key)"]
     H --> M["% capacity"]
     M --> B["bucket index"]
@@ -78,7 +78,7 @@ int main() {
 Open addressing keeps entries in the array itself. If the home bucket is occupied, probing tries another bucket. Linear probing moves one slot at a time; double hashing uses a second hash to choose the step size.
 
 ```mermaid
-flowchart LR
+flowchart TD
     H["hash(key)=2"] --> B2["bucket 2 occupied"]
     B2 --> B3["linear probe bucket 3 occupied"]
     B3 --> B4["bucket 4 empty: insert"]

--- a/content/learn/mastering-dsa-cpp/index.mdx
+++ b/content/learn/mastering-dsa-cpp/index.mdx
@@ -49,7 +49,7 @@ minimum in O(log n). Every chapter of this course pairs a structure
 with the operations it makes cheap (and the ones it makes expensive).
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Problem] --> B{What ops<br/>are hot?}
     B -->|lookup by key| C[Hash table]
     B -->|lookup by order| D[Balanced BST]

--- a/content/learn/mastering-dsa-cpp/linked-lists.mdx
+++ b/content/learn/mastering-dsa-cpp/linked-lists.mdx
@@ -30,7 +30,7 @@ int main() {
 />
 
 ```mermaid
-flowchart LR
+flowchart TD
     H["head"] --> N1["Node 1 | data=10"]
     N1 --> N2["Node 2 | data=20"]
     N2 --> N3["Node 3 | data=30"]

--- a/content/learn/mastering-dsa-cpp/queues.mdx
+++ b/content/learn/mastering-dsa-cpp/queues.mdx
@@ -15,7 +15,7 @@ A queue is a **first in, first out** data structure. The oldest item waiting in 
 | `empty` | Check whether the queue has no items |
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["enqueue 10"] --> Q1["10"]
     B["enqueue 20"] --> Q2["10, 20"]
     Q2 --> C["dequeue"]

--- a/content/learn/mastering-dsa-cpp/shortest-paths.mdx
+++ b/content/learn/mastering-dsa-cpp/shortest-paths.mdx
@@ -245,7 +245,7 @@ for k in 0..n-1:
 ```
 
 ```mermaid
-graph LR
+graph TD
     K["allow vertices 0..k as intermediates"] --> I["try every source i"]
     I --> J["try every target j"]
     J --> U["improve dist[i][j] through k"]

--- a/content/learn/mastering-dsa-cpp/sorting-basic.mdx
+++ b/content/learn/mastering-dsa-cpp/sorting-basic.mdx
@@ -8,7 +8,7 @@ Basic sorts make hidden ideas visible: sorted prefixes and suffixes grow, compar
 ## Bubble sort
 Bubble sort repeatedly compares adjacent elements and swaps them if they are out of order. After one full pass, the largest value has bubbled to the end.
 ```mermaid
-flowchart LR
+flowchart TD
     A["5 1 4 2"] --> B["1 5 4 2"]
     B --> C["1 4 5 2"]
     C --> D["1 4 2 5"]

--- a/content/learn/mastering-dsa-cpp/stacks.mdx
+++ b/content/learn/mastering-dsa-cpp/stacks.mdx
@@ -102,7 +102,7 @@ For `std::stack` backed by `std::deque`, `push`, `pop`, `top`, and `empty` are O
 A stack is perfect when recent history matters. For parentheses, push opening brackets; when a closing bracket appears, the top must be the matching opener.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["read '{' -> push"] --> B["read '[' -> push"]
     B --> C["read ']' -> matches top, pop"]
     C --> D["read '}' -> matches top, pop"]

--- a/content/learn/oop-blueprint-java/encapsulation.mdx
+++ b/content/learn/oop-blueprint-java/encapsulation.mdx
@@ -129,7 +129,7 @@ but it is worth knowing all four.
 | `public` | Anywhere |
 
 ```mermaid
-flowchart LR
+flowchart TD
     P["private"] -->|widens| K["package-private"]
     K --> R["protected"]
     R --> U["public"]

--- a/content/learn/oop-blueprint-java/next-steps.mdx
+++ b/content/learn/oop-blueprint-java/next-steps.mdx
@@ -17,7 +17,7 @@ This page is a short map of where to go next.
 Look back over what we covered:
 
 ```mermaid
-flowchart LR
+flowchart TD
     O["Origins<br/>(crisis → Simula → Smalltalk → GoF)"] --> C["Core OOP<br/>(class, object,<br/>encapsulation,<br/>constructors, messages,<br/>static, enums)"]
     C --> R["Relationships<br/>(composition, aggregation,<br/>dependency, inheritance,<br/>abstract, interfaces,<br/>polymorphism)"]
     R --> T["Design thinking<br/>(responsibility-driven,<br/>packages, layered<br/>architecture)"]

--- a/content/learn/oop-blueprint-java/software-crisis.mdx
+++ b/content/learn/oop-blueprint-java/software-crisis.mdx
@@ -21,7 +21,7 @@ Then computers got cheaper and faster, and the things we asked them to
 do got dramatically bigger.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["1950s<br/>~hundreds of lines<br/>one person, one job"] --> B["1960s<br/>~tens of thousands<br/>airline reservations,<br/>banking"]
     B --> C["1970s<br/>~hundreds of thousands<br/>operating systems,<br/>compilers"]
     C --> D["1980s+<br/>millions of lines<br/>graphical apps,<br/>networked systems"]

--- a/content/learn/practical-r-for-beginners/dplyr-verbs.mdx
+++ b/content/learn/practical-r-for-beginners/dplyr-verbs.mdx
@@ -46,7 +46,7 @@ Plus one helper: `group_by()`, which makes `summarise()`,
 properly on the next page.
 
 ```mermaid
-flowchart LR
+flowchart TD
   raw["data frame"] -->|filter| rows["fewer rows"]
   rows -->|select| cols["fewer/different columns"]
   cols -->|mutate| derived["new columns added"]

--- a/content/learn/practical-r-for-beginners/grouped-analysis.mdx
+++ b/content/learn/practical-r-for-beginners/grouped-analysis.mdx
@@ -15,7 +15,7 @@ question:
 The pattern is universal and has a name: **split-apply-combine**.
 
 ```mermaid
-flowchart LR
+flowchart TD
   data["Whole dataset"] -->|split| grp1["region A"]
   data --> grp2["region B"]
   data --> grp3["region C"]

--- a/content/learn/practical-r-for-beginners/index.mdx
+++ b/content/learn/practical-r-for-beginners/index.mdx
@@ -44,7 +44,7 @@ two groups really different? Is this number more interesting than
 random chance?*
 
 ```mermaid
-flowchart LR
+flowchart TD
   A[The Story]:::story --> B[Computational Thinking]:::think
   B --> C[Vectors]:::vec
   C --> D[Tabular Data]:::tab

--- a/content/learn/practical-r-for-beginners/mini-project-walkthrough.mdx
+++ b/content/learn/practical-r-for-beginners/mini-project-walkthrough.mdx
@@ -41,7 +41,7 @@ What we learn:
 - `Temp` is in degrees Fahrenheit.
 
 ```mermaid
-flowchart LR
+flowchart TD
   load["Load airquality"] --> insp["Inspect: dim, head, str, summary"]
   insp --> tidy["Tidy: NAs, types, factor for Month"]
   tidy --> trans["Transform: add °C, monthly summaries"]

--- a/content/learn/practical-r-for-beginners/next-steps.mdx
+++ b/content/learn/practical-r-for-beginners/next-steps.mdx
@@ -188,7 +188,7 @@ and you'll be a competent R analyst. Do it a hundred times
 and you'll be a good one.
 
 ```mermaid
-flowchart LR
+flowchart TD
   curiosity["Pick something you're curious about"]
   curiosity --> load["Find some data on it"]
   load --> explore["Explore, plot, summarize"]

--- a/content/learn/practical-r-for-beginners/reproducible-analysis.mdx
+++ b/content/learn/practical-r-for-beginners/reproducible-analysis.mdx
@@ -53,7 +53,7 @@ that pivot table summing or averaging? Did they manually fix a few
 cells they thought looked wrong?
 
 ```mermaid
-flowchart LR
+flowchart TD
   A[Raw Data] --> B[Click click click 🖱️]
   B --> C[Final Chart]
   style B fill:#fee2e2,stroke:#b91c1c
@@ -229,7 +229,7 @@ not met.
 Throughout this course we will practice the reproducible workflow:
 
 ```mermaid
-flowchart LR
+flowchart TD
   Q[Question] --> D[Read data]
   D --> C[Clean & transform]
   C --> E[Explore]

--- a/content/learn/practical-r-for-beginners/rise-of-statistical-computing.mdx
+++ b/content/learn/practical-r-for-beginners/rise-of-statistical-computing.mdx
@@ -31,7 +31,7 @@ programmer's job, and that meant teams of researchers often had to
 share a single programmer who was perpetually backlogged.
 
 ```mermaid
-flowchart LR
+flowchart TD
   S[Statistician] --> Q[Asks a question]
   Q --> P[Programmer]
   P --> F[Writes FORTRAN code]

--- a/content/learn/practical-r-for-beginners/sampling-and-distributions.mdx
+++ b/content/learn/practical-r-for-beginners/sampling-and-distributions.mdx
@@ -19,7 +19,7 @@ This page explains:
 ## Population vs. sample
 
 ```mermaid
-flowchart LR
+flowchart TD
   pop[(Population: everyone of interest)] -->|draw n cases| samp[(Sample: what we actually observed)]
   samp --> stat["Sample statistic e.g. sample mean x̄"]
   stat --> infer["Inference about the population mean μ"]

--- a/content/learn/practical-r-for-beginners/scripts-and-projects.mdx
+++ b/content/learn/practical-r-for-beginners/scripts-and-projects.mdx
@@ -185,7 +185,7 @@ Git turns "I overwrote yesterday's file" from a tragedy into
 "oh, let me check the history."
 
 ```mermaid
-flowchart LR
+flowchart TD
   edit["Edit files"] --> stage["git add ."]
   stage --> commit["git commit -m 'why'"]
   commit --> push["git push"]

--- a/content/learn/practical-r-for-beginners/statistics-before-computers.mdx
+++ b/content/learn/practical-r-for-beginners/statistics-before-computers.mdx
@@ -124,7 +124,7 @@ programs ran this way well into the 1960s, as immortalized in the
 book and film *Hidden Figures*.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A[Question] --> B[Design experiment]
   B --> C[Collect data on paper forms]
   C --> D[Transcribe into worksheet]

--- a/content/learn/practical-r-for-beginners/tidy-data-principles.mdx
+++ b/content/learn/practical-r-for-beginners/tidy-data-principles.mdx
@@ -81,7 +81,7 @@ is messy:
 Almost any real-world messiness fits one of these.
 
 ```mermaid
-flowchart LR
+flowchart TD
   raw["Raw / messy data"] -->|"pivot_longer / pivot_wider"| reshape["Reshape"]
   reshape -->|"separate / unite"| split["Split combined columns"]
   split -->|"join / split into multiple tables"| sep["Separate observational units"]

--- a/content/learn/practical-r-for-beginners/variables-and-assignment.mdx
+++ b/content/learn/practical-r-for-beginners/variables-and-assignment.mdx
@@ -67,7 +67,7 @@ variables: `if`, `else`, `for`, `while`, `function`, `return`,
 never want to use these as variable names anyway.)
 
 ```mermaid
-flowchart LR
+flowchart TD
   Name["A name (e.g. avg_price)"] -->|<-| Value["A value (e.g. 9.99)"]
   Value -->|stored in environment| Env["Workspace"]
   User["Later code"] -->|references name| Env

--- a/content/learn/practical-r-for-beginners/writing-your-own-functions.mdx
+++ b/content/learn/practical-r-for-beginners/writing-your-own-functions.mdx
@@ -18,7 +18,7 @@ of a kitchen ("chop, chop, chop, stir, stir, chop, stir, …").
 ## Anatomy of a function
 
 ```mermaid
-flowchart LR
+flowchart TD
   call["my_fun(x = 3, y = 4)"] --> args["Arguments bind to parameter names"]
   args --> body["Function body runs"]
   body --> ret["Last expression (or explicit return()) is returned"]

--- a/content/learn/practical-r-for-beginners/your-first-r-program.mdx
+++ b/content/learn/practical-r-for-beginners/your-first-r-program.mdx
@@ -193,7 +193,7 @@ exact text of an R error almost always finds the answer.
 When you click **Run**, the WebR runtime does roughly this:
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Your code (text)"] --> B[Parser]
   B --> C[Parse tree]
   C --> D[Evaluator]

--- a/content/learn/python-basics/comprehensions.mdx
+++ b/content/learn/python-basics/comprehensions.mdx
@@ -12,7 +12,7 @@ Every snippet on this page runs in your browser — no setup required.
 Comprehensions are everywhere in production Python. Every data pipeline maps and filters rows with comprehensions. Every web API shapes JSON responses with dict comprehensions. Every script that processes files uses comprehensions to filter and transform lines. Mastering comprehensions means writing clearer, faster, more maintainable code.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Input: [1, 2, 3, 4, 5]"] --> B["Filter: x % 2 == 0"]
     B --> C["Transform: x * x"]
     C --> D["Output: [4, 16]"]

--- a/content/learn/python-basics/decorators.mdx
+++ b/content/learn/python-basics/decorators.mdx
@@ -58,7 +58,7 @@ greet = shout(greet)
 The decorator `shout` takes the original `greet`, wraps it in a new function that uppercases the result, and replaces `greet` with that wrapper.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Original function] --> B[Decorator]
     B --> C[Wrapper function]
     C --> D[Wrapped function replaces original]

--- a/content/learn/python-basics/dictionaries.mdx
+++ b/content/learn/python-basics/dictionaries.mdx
@@ -12,7 +12,7 @@ Every snippet on this page runs in your browser — no setup required.
 Under the hood, a dict is a **hash table**: Python computes a hash of your key, uses that to find a bucket, and stores the key-value pair there. Hash collisions are handled with open addressing. This gives O(1) average-case access.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Key: 'apple'"] --> B["hash('apple')"]
     B --> C["Bucket index"]
     C --> D["Value: 1.0"]

--- a/content/learn/python-basics/files.mdx
+++ b/content/learn/python-basics/files.mdx
@@ -196,7 +196,7 @@ with open("data.txt") as f:
 You can write your own context managers with `__enter__` and `__exit__`, or use the `contextlib` module.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Enter 'with' block] --> B["__enter__() called"]
     B --> C[Body executes]
     C --> D["__exit__() called"]

--- a/content/learn/scientific-computing-python/capstone-simulation.mdx
+++ b/content/learn/scientific-computing-python/capstone-simulation.mdx
@@ -38,7 +38,7 @@ $$
 ## Pipeline overview
 
 ```mermaid
-flowchart LR
+flowchart TD
     Cfg[Config:<br/>sweep over a] --> Sim[simulate.py:<br/>solve_ivp + event]
     Sim --> Res[results: time-series<br/>+ extinction flag]
     Res --> Agg[aggregate.py:<br/>per-config summary]

--- a/content/learn/scientific-computing-python/fortran-and-matlab.mdx
+++ b/content/learn/scientific-computing-python/fortran-and-matlab.mdx
@@ -80,7 +80,7 @@ hidden behind a single `@`.
 ## FORTRAN's lasting design ideas
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[FORTRAN<br/>1957] --> B[Array<br/>indexing]
     A --> C[Tight numerical<br/>loops]
     A --> D[Standard math<br/>libraries]

--- a/content/learn/scientific-computing-python/index.mdx
+++ b/content/learn/scientific-computing-python/index.mdx
@@ -50,7 +50,7 @@ scientist*.
 ## What you will learn
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Story of<br/>Scientific Computing] --> B[Numerical<br/>Foundations]
     B --> C[Linear<br/>Algebra]
     B --> D[Calculus &<br/>ODEs]

--- a/content/learn/scientific-computing-python/limits-of-manual-calculation.mdx
+++ b/content/learn/scientific-computing-python/limits-of-manual-calculation.mdx
@@ -32,7 +32,7 @@ a century needs **billions**. The arithmetic is not hard. The volume
 is impossible.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Newton's laws] --> B[Three-body problem]
     B --> C{Closed-form<br/>solution?}
     C -->|No| D[Iterative<br/>integration]

--- a/content/learn/scientific-computing-python/ordinary-differential-equations.mdx
+++ b/content/learn/scientific-computing-python/ordinary-differential-equations.mdx
@@ -26,7 +26,7 @@ differences are *how* the prediction is made and *how* the step
 size $h$ is chosen.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Y0[y at tₙ] --> Eval[evaluate f at one or more points]
     Eval --> Step[combine slopes →<br/>predict y at tₙ+h]
     Step --> Est[estimate local error]

--- a/content/learn/scientific-computing-python/vectorized-thinking.mdx
+++ b/content/learn/scientific-computing-python/vectorized-thinking.mdx
@@ -58,7 +58,7 @@ call, and the wrapping of a `float` into a `numpy.float64` and back.
 ## How NumPy actually runs
 
 ```mermaid
-flowchart LR
+flowchart TD
     Code["np.sin(xs) ** 2"] --> Ufunc["ufunc loop"]
     Ufunc --> C["compiled C loop"]
     C --> SIMD["CPU SIMD instructions"]

--- a/content/learn/systems-programming-c/c-toolchain.mdx
+++ b/content/learn/systems-programming-c/c-toolchain.mdx
@@ -12,7 +12,7 @@ to add `foo.c` to the link command.
 ## The four stages
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["hello.c<br/>(source)"] --> B[Preprocessor]
     B --> C["hello.i<br/>(translation unit)"]
     C --> D[Compiler]

--- a/content/learn/systems-programming-c/index.mdx
+++ b/content/learn/systems-programming-c/index.mdx
@@ -68,7 +68,7 @@ vs heap, pointer arithmetic, allocators, common bugs and how to spot
 them). The two are inseparable.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Source<br/>.c file] --> B[Preprocess]
     B --> C[Compile to<br/>assembly]
     C --> D[Assemble<br/>to .o]

--- a/content/learn/systems-programming-c/why-c-for-systems.mdx
+++ b/content/learn/systems-programming-c/why-c-for-systems.mdx
@@ -65,7 +65,7 @@ does:
 - Function calls push a frame on the stack and `return` pops it.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[C source] -->|clang / gcc| B[Machine code]
     B -->|loads into| C[Process address space]
     C --> D[CPU executes<br/>one instruction<br/>at a time]

--- a/content/learn/typescript-from-scratch/error-handling-with-types.mdx
+++ b/content/learn/typescript-from-scratch/error-handling-with-types.mdx
@@ -267,7 +267,7 @@ Notice:
 4. Errors propagate automatically — no manual `if` checks at every step.
 
 ```mermaid
-graph LR
+graph TD
     A[Input: '5'] --> B[parseNumber]
     B --> C{ok?}
     C -->|yes| D[validatePositive]

--- a/content/learn/typescript-from-scratch/generic-constraints.mdx
+++ b/content/learn/typescript-from-scratch/generic-constraints.mdx
@@ -180,7 +180,7 @@ When you preserve precise input types (readonly, literals, exact shapes), the co
 </Callout>
 
 ```mermaid
-graph LR
+graph TD
     A[Input: readonly array of literals] --> B[T extends readonly unknown]
     B --> C[T binds to precise type]
     C --> D[Return T 0: preserves literal]

--- a/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
+++ b/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
@@ -143,7 +143,7 @@ console.log(u);
 The condition `T[K] extends string ? K : never` keeps only keys whose values are strings. Keys that don't match are mapped to `never`, which TypeScript omits.
 
 ```mermaid
-graph LR
+graph TD
     A["Original Type<br/>{id: number, name: string, active: boolean}"] --> B["Mapped Type Transform"]
     B --> C["Filter: keep string props"]
     C --> D["Result Type<br/>{name: string}"]

--- a/content/learn/typescript-from-scratch/static-analysis-in-action.mdx
+++ b/content/learn/typescript-from-scratch/static-analysis-in-action.mdx
@@ -158,7 +158,7 @@ Suppose you rename `fullName` to `name`. Every place that accesses `.fullName` b
 The TypeScript compiler is organized into phases:
 
 ```mermaid
-graph LR
+graph TD
     A[Source Code .ts] --> B[Scanner<br/>Tokens]
     B --> C[Parser<br/>AST]
     C --> D[Binder<br/>Symbols]

--- a/content/learn/typescript-from-scratch/type-inference.mdx
+++ b/content/learn/typescript-from-scratch/type-inference.mdx
@@ -217,7 +217,7 @@ console.log(\`First feature: \${firstFeature}\`);
 Here's the inference chain:
 
 ```mermaid
-graph LR
+graph TD
     A[getConfig return literal] --> B[Inferred object type]
     B --> C[config: inferred type]
     C --> D[config.features: string array]


### PR DESCRIPTION
## Summary

A series of iterative UI polish passes on the `/learn` route and SQL code/challenge components.

### Challenge card & SQL code block changes

- **Remove vertical scrollbar from tab strips** — `overflow-y: hidden` on `.tableViewerTabs`
- **Remove `tableViewerHeader`** — the labelled header row above the table tab strip is gone
- **Remove top/bottom borders from `sqlResultScroll`**
- **Run/Submit button styling** — dark neutral (`#1a1a1a`) in light mode; original blue (`#2563eb`) in dark mode. Dropdown chevron matches: blue in dark mode, dark gray in light mode
- **Remove top/bottom margins from `sqlResultTable`**
- **`<th>` font-weight 500**
- **SQL query results as a closeable "Result" tab** — appears in the tab strip above the editor; re-running updates it in place with a flash animation
- **Full-width skeleton loader**
- **Remove `tableViewerTabs` background**
- **Remove bottom border from `.instructions`**
- **Remove SQL code block title row** — `titleRow` DOM element removed; `title` prop kept for `aria-label`/persistence key only
- **Prevent inline `<code>` line breaks** — `white-space: nowrap` so inline code is never split mid-token

### Sidebar / Fumadocs layout changes

- **Fix em dash in sidebar titles** — "Code Blocks -" → "Code Blocks —" across 8 MDX sidebar entries
- **Remove hover background from theme-toggle button**
- **Remove input-like border from sidebar footer bar**
- **Higher-contrast sidebar link text** — `--color-fd-muted-foreground` overridden to `hsl(0,0%,22%)` light / `hsl(0,0%,82%)` dark. Hover and active states push text further toward full foreground
- **Subtle sidebar separator labels** — section heading `<p>` elements use `hsl(0,0%,52%)` light / `hsl(0,0%,48%)` dark so they recede behind linked page items
- **Sidebar footer icons** — `hsl(0,0%,58%)` in light mode (subdued), `hsl(0,0%,80%)` in dark mode (near-white)

### `/learn` route typography & theme

- **Dark mode prose text colour** — `--tw-prose-body` set to `--color-fd-foreground` in dark mode
- **Source Serif 4 for prose content** — paragraphs, list items, and table cells use Source Serif 4 loaded via `next/font/google` (self-hosted, optical size enabled), exposed as `--font-serif` via `containerProps` on `DocsLayout`. Excluded: headings, `<code>`, code blocks, challenge cards, multiple choice, callouts
- **Prose font size** — `1.125rem` (~18 px)
- **Prose line height** — `1.75`
- **Mermaid font** — explicit `"Source Serif 4"` at `fontSize: 14` in mermaid config; font reset on `.wrap` prevents container font/size from leaking into diagram node sizing
- **Dark mode sidebar background** — sidebar uses `--color-fd-background` (`#121212`) instead of the default card colour
- **Pure-white light-mode backgrounds** — `--color-fd-background` and `--color-fd-card` set to `hsl(0,0%,100%)`

### Mermaid diagram orientation

- **Convert wide LR diagrams to TD** — 129 `flowchart LR` / `graph LR` diagrams with chains of 4+ nodes converted to `flowchart TD` / `graph TD` across 120 files

## Test plan

- [ ] Light mode: Run/Submit button and chevron are dark gray; dark mode: both are blue
- [ ] SQL code blocks: no title row rendered above the tab strip
- [ ] Running a query opens a closeable "Result" tab; re-running flashes the tab
- [ ] Skeleton loader spans full table width
- [ ] Inline `<code>` elements never split across lines
- [ ] `/learn` prose uses Source Serif 4 at 1.125rem / line-height 1.75; headings, code, challenge cards, callouts remain sans-serif
- [ ] Mermaid diagrams render at 14px Source Serif 4 with no text clipping
- [ ] Dark mode prose text matches `--color-fd-foreground`
- [ ] Sidebar link text is near-black (light) / near-white (dark); hover and active states visible
- [ ] Sidebar separator labels are visibly softer than nav links
- [ ] Footer icons are muted in light mode and near-white in dark mode
- [ ] Wide mermaid diagrams now render vertically

https://claude.ai/code/session_01C57JpoC9sijFN1mw5LktQ7