### PR TITLE
Use Source Serif 4 for sidebar, headings, TOC, page nav, and card body text on /learn pages

### DIFF
--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -1,7 +1,11 @@
 .wrap {
   position: relative;
-  font-size: 1rem;
+  /* 15px matches themeVariables.fontSize so Mermaid measures and renders at
+     the same size — container controls what the SVG inherits */
+  font-size: 15px;
   font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
+  display: flex;
+  justify-content: center;
 }
 
 .expandBtn {

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -51,7 +51,12 @@ function MermaidContent({ chart }: { chart: string }) {
   });
 
   const { svg, bindFunctions } = use(
-    cachePromise(`${chart}-${resolvedTheme}`, () => {
+    cachePromise(`${chart}-${resolvedTheme}`, async () => {
+      // Wait for all fonts (including Source Serif 4) to finish loading
+      // before asking Mermaid to measure text and size nodes. Without this,
+      // Mermaid measures with the browser fallback font (Georgia / serif),
+      // which is narrower than Source Serif 4, so labels overflow their boxes.
+      await document.fonts.ready;
       return mermaid.render(id, chart.replaceAll("\\n", "\n"));
     }),
   );

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -45,7 +45,7 @@ function MermaidContent({ chart }: { chart: string }) {
     startOnLoad: false,
     securityLevel: "strict",
     fontFamily: '"Source Serif 4", Georgia, "Times New Roman", serif',
-    fontSize: 13,
+    fontSize: 14,
     themeCSS: "margin: 1.5rem auto 0;",
     theme: resolvedTheme === "dark" ? "dark" : "neutral",
   });

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -45,9 +45,16 @@ function MermaidContent({ chart }: { chart: string }) {
     startOnLoad: false,
     securityLevel: "strict",
     fontFamily: '"Source Serif 4", Georgia, "Times New Roman", serif',
-    fontSize: 14,
+    fontSize: 15,
     themeCSS: "margin: 1.5rem auto 0;",
     theme: resolvedTheme === "dark" ? "dark" : "neutral",
+    themeVariables: {
+      // Controls the font-size written into the SVG's inline <style> block.
+      // Without this, Mermaid inherits the container's computed size (16px
+      // from the 1rem wrapper) and writes that into the SVG, overriding the
+      // fontSize config above which only governs text measurement.
+      fontSize: "15px",
+    },
   });
 
   const { svg, bindFunctions } = use(
@@ -58,8 +65,8 @@ function MermaidContent({ chart }: { chart: string }) {
       // explicitly triggered. `fonts.load()` guarantees the face is available
       // (or settles with a no-op if it can't load) before we render.
       await Promise.allSettled([
-        document.fonts.load('400 13px "Source Serif 4"'),
-        document.fonts.load('700 13px "Source Serif 4"'),
+        document.fonts.load('400 15px "Source Serif 4"'),
+        document.fonts.load('700 15px "Source Serif 4"'),
       ]);
       return mermaid.render(id, chart.replaceAll("\\n", "\n"));
     }),

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -45,18 +45,22 @@ function MermaidContent({ chart }: { chart: string }) {
     startOnLoad: false,
     securityLevel: "strict",
     fontFamily: '"Source Serif 4", Georgia, "Times New Roman", serif',
-    fontSize: 14,
+    fontSize: 13,
     themeCSS: "margin: 1.5rem auto 0;",
     theme: resolvedTheme === "dark" ? "dark" : "neutral",
   });
 
   const { svg, bindFunctions } = use(
     cachePromise(`${chart}-${resolvedTheme}`, async () => {
-      // Wait for all fonts (including Source Serif 4) to finish loading
-      // before asking Mermaid to measure text and size nodes. Without this,
-      // Mermaid measures with the browser fallback font (Georgia / serif),
-      // which is narrower than Source Serif 4, so labels overflow their boxes.
-      await document.fonts.ready;
+      // Explicitly request Source Serif 4 at the weight/size Mermaid will use
+      // before asking it to measure text. `document.fonts.ready` is insufficient
+      // because font-display:swap fonts may not be in the "ready" set until
+      // explicitly triggered. `fonts.load()` guarantees the face is available
+      // (or settles with a no-op if it can't load) before we render.
+      await Promise.allSettled([
+        document.fonts.load('400 13px "Source Serif 4"'),
+        document.fonts.load('700 13px "Source Serif 4"'),
+      ]);
       return mermaid.render(id, chart.replaceAll("\\n", "\n"));
     }),
   );

--- a/app/learn/[[...slug]]/page.tsx
+++ b/app/learn/[[...slug]]/page.tsx
@@ -41,7 +41,7 @@ export default async function LearnPage(props: LearnPageProps) {
 
   const MDX = page.data.body;
   const slug = params.slug ?? [];
-  const courseSlug = slug.length > 1 ? slug[0] : null;
+  const courseSlug = slug.length >= 1 ? slug[0] : null;
   const courseTitle = courseSlug ? await getCourseTitle(courseSlug) : null;
 
   return (

--- a/app/learn/[[...slug]]/page.tsx
+++ b/app/learn/[[...slug]]/page.tsx
@@ -7,6 +7,9 @@
  * `notFound()` for unknown slugs lets Next.js render its standard 404.
  */
 import { notFound } from "next/navigation";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import Link from "next/link";
 import {
   DocsBody,
   DocsDescription,
@@ -20,15 +23,34 @@ interface LearnPageProps {
   params: Promise<{ slug?: string[] }>;
 }
 
+async function getCourseTitle(courseSlug: string): Promise<string | null> {
+  try {
+    const metaPath = path.join(process.cwd(), "content", "learn", courseSlug, "meta.json");
+    const raw = await readFile(metaPath, "utf-8");
+    const meta = JSON.parse(raw) as { title?: string };
+    return meta.title ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export default async function LearnPage(props: LearnPageProps) {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
   const MDX = page.data.body;
+  const slug = params.slug ?? [];
+  const courseSlug = slug.length > 1 ? slug[0] : null;
+  const courseTitle = courseSlug ? await getCourseTitle(courseSlug) : null;
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
+      {courseTitle && courseSlug && (
+        <Link href={`/learn/${courseSlug}`} data-course-label="">
+          {courseTitle}
+        </Link>
+      )}
       <DocsTitle>{page.data.title}</DocsTitle>
       {page.data.description ? (
         <DocsDescription>{page.data.description}</DocsDescription>

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -119,6 +119,18 @@ samp {
   color: hsl(0, 0%, 80%);
 }
 
+/* Sidebar navigation links, folder-trigger buttons, and separator labels
+   ("Dataslope" logo link included) → Source Serif. The opsz axis is set
+   to 14 for text at ~13–15 px to get the optical balance right at small
+   sizes. Letter-spacing resets to 0 to undo the tight `body` tracking. */
+#nd-sidebar a,
+#nd-sidebar button,
+#nd-sidebar p {
+  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+  font-variation-settings: "opsz" 14;
+  letter-spacing: 0;
+}
+
 /* Item 3: Dark mode — make the sidebar use the same background as the content
    area (#121212) instead of the default card color (#191919). Also bring
    prose body text in line with the Fumadocs foreground token so it matches
@@ -135,15 +147,19 @@ body {
   letter-spacing: -0.011em;
 }
 
-/* Tighten headings a touch more — Inter looks crispest with negative
-   tracking at display sizes. */
+/* Source Serif 4 for headings — the opsz axis is bumped to 20 so the
+   typeface self-optimises at display sizes (wider apertures, adjusted
+   contrast). Letter-spacing resets to 0 to undo the tight Inter value
+   set on `body` above. */
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  letter-spacing: -0.02em;
+  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+  font-variation-settings: "opsz" 20;
+  letter-spacing: 0;
 }
 
 /* ── Syntax highlighting (highlight.js, GitHub theme) ────────────────
@@ -364,18 +380,67 @@ code.hljs {
   letter-spacing: 0;
 }
 
-/* Restore sans-serif inside challenge / quiz / code components in case any
-   of those elements happen to fall under a .prose ancestor. */
+/* ── TOC navigation ──────────────────────────────────────────────────────
+   Each TOC item is an <a> inside #nd-toc (desktop) or inside the mobile
+   popover ([data-toc-popover-content]). The panel title is an <h3>.
+   opsz 14 is appropriate for the small (~13–14 px) text used here.
+   ─────────────────────────────────────────────────────────────────────── */
+#nd-toc a,
+#nd-toc h3,
+[data-toc-popover-content] a {
+  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+  font-variation-settings: "opsz" 14;
+  letter-spacing: 0;
+}
+
+/* ── Page-footer navigation (prev / next) ────────────────────────────────
+   The footer <a> links each contain <p> elements for the page name and
+   the "Previous / Next page" label. They live inside a <div> that is a
+   direct child of #nd-page (outside .prose). Targeting #nd-page > div a p
+   avoids touching breadcrumb links (which use <span>, not <p>).
+   ─────────────────────────────────────────────────────────────────────── */
+#nd-page > div a p {
+  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+  font-variation-settings: "opsz" 14;
+  letter-spacing: 0;
+}
+
+/* ── Source Serif for MCQ and challenge card body text ──────────────────
+   The .prose rule above excludes these components so its prose font-size
+   (1.125 rem) doesn't bleed in. We apply Source Serif here directly at a
+   smaller opsz that suits the ~14–15 px text used inside the cards.
+
+   Neither component's header uses <p> or <li> — the badge, mode label,
+   title, and status labels are all rendered as <span> or <div> — so no
+   extra header exclusion is needed: they naturally stay in Inter (their
+   CSS module sets font-family on the .card container, which those spans
+   inherit).
+
+   <code>, <pre>, and elements with explicit font-family in their CSS
+   module (e.g. .submitBtn, .sqlResultTable) are unaffected because those
+   rules directly target those selectors with higher specificity or
+   explicit values that beat inheritance.
+   ─────────────────────────────────────────────────────────────────────── */
 [data-flavor] p,
 [data-flavor] li,
-[data-flavor] td,
-[data-flavor] th,
 [data-testid="challenge-card"] p,
 [data-testid="challenge-card"] li,
+[aria-label="Multiple choice question"] p,
+[aria-label="Multiple choice question"] li {
+  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+  font-variation-settings: "opsz" 14;
+  letter-spacing: 0;
+}
+
+/* Restore sans-serif on <td> and <th> inside challenge/quiz cards.
+   These cover SQL result tables (.sqlResultTable) and markdown tables in
+   instructions. The CSS module sets font-family: mono on .sqlResultTable
+   itself (inherited by td/th), so forcing sans-serif here avoids the
+   Source Serif rule overriding that inherited mono value. */
+[data-flavor] td,
+[data-flavor] th,
 [data-testid="challenge-card"] td,
 [data-testid="challenge-card"] th,
-[aria-label="Multiple choice question"] p,
-[aria-label="Multiple choice question"] li,
 [aria-label="Multiple choice question"] td,
 [aria-label="Multiple choice question"] th {
   font-family: var(--font-sans);

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -360,6 +360,10 @@ code.hljs {
    - .nd-codeblock, pre, code         code blocks
    - [data-rehype-pretty-code-figure] Fumadocs syntax-highlighted code
    - [data-callout], .callout         legacy callout selectors (kept for safety)
+   - svg *                            Mermaid renders labels as <p> inside
+                                      <foreignObject>; forcing 1.125rem here
+                                      overrides Mermaid's own font-size and the
+                                      text overflows its measured node boxes
    - h1–h6                            headings (handled separately)
    Optical size axis (opsz) is enabled via font-variation-settings so the
    typeface self-optimises at body text sizes. Letter-spacing resets to 0
@@ -371,7 +375,8 @@ code.hljs {
   :where([data-testid="challenge-card"] *),
   :where([aria-label="Multiple choice question"] *),
   :where(.nd-codeblock *, pre *, [data-rehype-pretty-code-figure] *),
-  :where([data-callout] *, .callout *)
+  :where([data-callout] *, .callout *),
+  :where(svg *)
 ) {
   font-family: var(--font-serif), Georgia, "Times New Roman", serif;
   font-size: 1.125rem;

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -359,7 +359,7 @@ code.hljs {
    - [aria-label="Multiple choice question"]  quiz components
    - .nd-codeblock, pre, code         code blocks
    - [data-rehype-pretty-code-figure] Fumadocs syntax-highlighted code
-   - .callout, [data-callout]         callout blocks
+   - [data-callout], .callout         legacy callout selectors (kept for safety)
    - h1–h6                            headings (handled separately)
    Optical size axis (opsz) is enabled via font-variation-settings so the
    typeface self-optimises at body text sizes. Letter-spacing resets to 0
@@ -378,6 +378,29 @@ code.hljs {
   line-height: 1.75;
   font-variation-settings: "opsz" 16;
   letter-spacing: 0;
+}
+
+/* ── Table and callout font-size override ────────────────────────────────
+   Tables and callouts are compact, information-dense contexts — scale
+   their Source Serif text back to 1rem (16px) with tighter leading.
+
+   Fumadocs v16 callouts don't use [data-callout] or .callout — the
+   CalloutContainer renders a plain <div> with an inline CSS custom
+   property (--callout-color). That property is the most reliable hook.
+   ─────────────────────────────────────────────────────────────────────── */
+.prose :where(td, th):not(
+  :where([class~="not-prose"], [class~="not-prose"] *),
+  :where([data-flavor] *),
+  :where([data-testid="challenge-card"] *),
+  :where([aria-label="Multiple choice question"] *)
+) {
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.prose [style*="--callout-color"] :where(p, li) {
+  font-size: 1rem;
+  line-height: 1.6;
 }
 
 /* ── TOC navigation ──────────────────────────────────────────────────────
@@ -430,6 +453,25 @@ code.hljs {
   font-family: var(--font-serif), Georgia, "Times New Roman", serif;
   font-variation-settings: "opsz" 14;
   letter-spacing: 0;
+}
+
+/* ── Course breadcrumb label ─────────────────────────────────────────────
+   Rendered above DocsTitle on pages nested inside a course (slug length > 1).
+   Styled as a small, muted serif link so it reads as context, not a heading.
+   ─────────────────────────────────────────────────────────────────────── */
+[data-course-label] {
+  display: block;
+  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+  font-size: 0.875rem;
+  font-variation-settings: "opsz" 12;
+  letter-spacing: 0;
+  color: var(--color-fd-muted-foreground);
+  text-decoration: none;
+  margin-bottom: 0.25rem;
+}
+
+[data-course-label]:hover {
+  text-decoration: underline;
 }
 
 /* Restore sans-serif on <td> and <th> inside challenge/quiz cards.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -177,6 +177,12 @@ export default function Home() {
               </span>
               <span className={styles.courseArrow} aria-hidden="true">→</span>
             </Link>
+            <Link href="/learn/sql-analytics-duckdb" className={styles.courseCard}>
+              <span className={styles.courseTitle}>
+                SQL Analytics with DuckDB
+              </span>
+              <span className={styles.courseArrow} aria-hidden="true">→</span>
+            </Link>
           </div>
         </section>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
 import Link from "next/link";
 import styles from "./root.module.css";
 
@@ -5,6 +7,35 @@ export const metadata = {
   title: "Dataslope",
   description: "Dataslope — browser-based playgrounds and tooling.",
 };
+
+interface CourseMeta {
+  title: string;
+  root?: boolean;
+}
+
+async function getCourses(): Promise<{ slug: string; title: string }[]> {
+  const learnDir = path.join(process.cwd(), "content", "learn");
+  const entries = await readdir(learnDir, { withFileTypes: true });
+
+  const courses: { slug: string; title: string }[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const raw = await readFile(
+        path.join(learnDir, entry.name, "meta.json"),
+        "utf-8",
+      );
+      const meta = JSON.parse(raw) as CourseMeta;
+      if (meta.root && meta.title) {
+        courses.push({ slug: entry.name, title: meta.title });
+      }
+    } catch {
+      // No meta.json or unreadable — skip
+    }
+  }
+
+  return courses.sort((a, b) => a.title.localeCompare(b.title));
+}
 
 function GitHubIcon() {
   return (
@@ -20,7 +51,9 @@ function GitHubIcon() {
   );
 }
 
-export default function Home() {
+export default async function Home() {
+  const courses = await getCourses();
+
   return (
     <main className={styles.main}>
       <div className={styles.container}>
@@ -56,133 +89,18 @@ export default function Home() {
         <section className={styles.courses}>
           <h2 className={styles.coursesHeading}>Courses</h2>
           <div className={styles.courseList}>
-            <Link href="/learn/typescript-from-scratch" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                TypeScript from Scratch
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/beginners-javascript" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                Beginner&apos;s Guide to JavaScript
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/python-basics" className={styles.courseCard}>
-              <span className={styles.courseTitle}>Python Basics</span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/mastering-dsa-cpp" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                Mastering Data Structures and Algorithms with C++
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/oop-blueprint-java" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                Object-Oriented Programming Blueprint with Java
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link
-              href="/learn/java-programming-for-beginners"
-              className={styles.courseCard}
-            >
-              <span className={styles.courseTitle}>
-                Java Programming for Beginners
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/systems-programming-c" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                Systems Programming with C
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link
-              href="/learn/java-collections-and-generics-deep-dive"
-              className={styles.courseCard}
-            >
-              <span className={styles.courseTitle}>
-                Java Collections and Generics Deep Dive
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/csharp-linq-functional" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                C# LINQ and Functional Patterns
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link
-              href="/learn/functional-programming-typescript"
-              className={styles.courseCard}
-            >
-              <span className={styles.courseTitle}>
-                Functional Programming with TypeScript
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/intro-modern-csharp" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                Introduction to Modern C#
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/practical-r-for-beginners" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                Practical R for Beginners
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link
-              href="/learn/data-analysis-python-pandas"
-              className={styles.courseCard}
-            >
-              <span className={styles.courseTitle}>
-                Data Analysis with Python Pandas
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link
-              href="/learn/intro-sql-postgres"
-              className={styles.courseCard}
-            >
-              <span className={styles.courseTitle}>
-                Introduction to SQL and Relational Databases with PostgreSQL
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/scientific-computing-python" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                Scientific Computing with Python
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/intro-data-viz-plotly" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                Introduction to Data Visualization with Plotly
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/c-programming-for-beginners" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                C Programming for Beginners
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/from-zero-to-cpp" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                From Zero to C++ Programming
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
-            <Link href="/learn/sql-analytics-duckdb" className={styles.courseCard}>
-              <span className={styles.courseTitle}>
-                SQL Analytics with DuckDB
-              </span>
-              <span className={styles.courseArrow} aria-hidden="true">→</span>
-            </Link>
+            {courses.map(({ slug, title }) => (
+              <Link
+                key={slug}
+                href={`/learn/${slug}`}
+                className={styles.courseCard}
+              >
+                <span className={styles.courseTitle}>{title}</span>
+                <span className={styles.courseArrow} aria-hidden="true">
+                  →
+                </span>
+              </Link>
+            ))}
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary

- **Source Serif 4 typography on `/learn` pages**: Applied to sidebar (including logo), h1–h6 headings, TOC navigation, page footer nav (prev/next), and prose body text (`p`, `li`, `td`, `th`). Code blocks, non-Inter sections, MCQ headers, and challenge card headers are unaffected.
- **MCQ and challenge card body text**: Source Serif applied to `p` and `li` inside `[data-flavor]`, `[data-testid="challenge-card"]`, and `[aria-label="Multiple choice question"]`. Table cells (`td`/`th`) inside these components stay as sans-serif to protect SQL result tables.
- **Tables and callouts scaled to 1rem**: The 1.125rem Source Serif rule was too large for information-dense table and callout contexts. Override rules bring `td`/`th` and Fumadocs v16 callout text (detected via `[style*="--callout-color"]`) back to `1rem` / `1.6` line-height.
- **SVG excluded from prose font-size**: Mermaid renders node labels as `<p>` inside `<foreignObject>` inside the SVG. Adding `:where(svg *)` to the prose rule's exclusion list prevents the 1.125rem body rule from inflating those labels and causing text to overflow their measured boxes.
- **Mermaid font fixed at 15px**: The `.wrap` container sets `font-size: 15px` (was `1rem` = 16px), which the SVG inherits. `themeVariables.fontSize: "15px"` explicitly controls what Mermaid writes into the SVG's inline `<style>` block. `fontSize: 15` and `document.fonts.load()` calls are aligned to the same size. `document.fonts.load()` (replacing `document.fonts.ready`) explicitly triggers Source Serif 4 before Mermaid measures text widths, so box sizes match the rendered font.
- **Mermaid charts horizontally centered**: `.wrap` uses `display: flex; justify-content: center`. The expand button is `position: absolute` so it's unaffected.
- **Course breadcrumb label**: All pages within a course (including the course welcome/index page) now show a small muted serif link above the page title with the course name, read from the course's `meta.json`. Styled as `0.875rem` Source Serif with hover underline.
- **Auto-generated course list on homepage**: `app/page.tsx` scans `content/learn/*/meta.json` at build time and lists every course where `"root": true`, sorted alphabetically. Adding a new course folder with a root `meta.json` automatically appears on the homepage — no manual list maintenance needed.
- **SQL Analytics with DuckDB course link**: Present in the auto-generated list once the course folder is created.

## Test plan

- [ ] Visit a `/learn` page — sidebar, headings, TOC, and prev/next nav should render in Source Serif 4
- [ ] Check a page with a `<table>` — cells should be 16px (1rem) Source Serif, not 18px
- [ ] Check a page with a callout — callout body text should be 16px (1rem)
- [ ] Check a page with a Mermaid diagram — all node labels should be fully visible at 15px, no text overflow; chart should be horizontally centered
- [ ] Confirm Mermaid label font-size is 15px in DevTools (not 16px)
- [ ] Visit a nested course page (e.g. `/learn/typescript-from-scratch/evolution-of-javascript`) — a small course-name link should appear above the page title; clicking it navigates to the course index
- [ ] Visit a course welcome/index page (e.g. `/learn/typescript-from-scratch`) — course label should also appear there
- [ ] Confirm the course label does NOT appear on top-level standalone pages (e.g. `/learn`)
- [ ] Confirm the homepage course list is generated automatically from `content/learn/` and matches all folders with `"root": true` in their `meta.json`

https://claude.ai/code/session_01KkLhQgnBKDHUUz2mSfwLNS