### PR TITLE
fix(learn): render mermaid diagrams at natural size

### DIFF
--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -6,11 +6,11 @@
   font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
 }
 
-/* Let the diagram fill the available column width and center within it.
+/* Render the diagram at its natural (intrinsic) size, centered in the column.
    Mermaid emits the SVG with width="100%" plus an inline `max-width:<W>px`
-   cap equal to the diagram's intrinsic width, which otherwise locks it to
-   that natural (often small) size. Overriding the cap lets the SVG — which
-   carries a viewBox — scale up uniformly to the column width. */
+   cap equal to the diagram's intrinsic width. Leaving that cap intact keeps
+   the diagram at its default size on wide columns while still letting it
+   scale down to fit narrower ones (the SVG carries a viewBox). */
 .wrap > div:first-child {
   width: 100%;
 }
@@ -18,9 +18,7 @@
 .wrap > div:first-child svg {
   display: block;
   margin-inline: auto;
-  width: 100%;
   height: auto;
-  max-width: 100% !important;
 }
 
 .expandBtn {


### PR DESCRIPTION
## Problem

In the `/learn` section (fumadocs), mermaid diagrams were expanding to take the **full column width**, producing unnaturally large diagrams.

## Cause

Mermaid renders its SVG with `width="100%"` plus an inline `max-width:<W>px` cap equal to the diagram's *intrinsic* width — that cap is what normally keeps a diagram at its natural size while still letting it shrink on narrow screens.

`app/_components/mdx/mermaid.module.css` was deliberately overriding that cap:

```css
.wrap > div:first-child svg {
  display: block;
  margin-inline: auto;
  width: 100%;
  height: auto;
  max-width: 100% !important;   /* ← removes Mermaid's natural-size cap */
}
```

With the cap gone, the `viewBox`-backed SVG scaled up uniformly to fill the entire column.

## Fix

Drop the `width: 100%` and `max-width: 100% !important` overrides so Mermaid's default cap applies again:

- **Wide columns:** diagram renders at its natural (intrinsic) size — no more giant diagrams.
- **Narrow columns:** still scales down to fit (the SVG carries a `viewBox`).
- **Centering preserved** via `margin-inline: auto`.

The fullscreen/zoom modal is unaffected — it has its own `.stage svg { max-width: none !important }` rule.

## Verification note

This is a CSS-module-only change. `node_modules` isn't installed in this fresh container, so I didn't spin up the dev server for a screenshot — the fix is the exact inverse of the override the original inline comment documents. Worth a quick visual check on `/learn/mermaid-test` (and a real diagram page) in a running instance to confirm the look.

https://claude.ai/code/session_01CUdtC23RbRZvjvinuh8Ur7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUdtC23RbRZvjvinuh8Ur7)_