### PR TITLE
Remove next-page navigation callouts from /learn pages

### DIFF
--- a/content/learn/beginners-javascript/index.mdx
+++ b/content/learn/beginners-javascript/index.mdx
@@ -131,8 +131,3 @@ finding out why.
 You don't have to memorise this course. You only need to read
 carefully, *type the examples yourself*, and try the challenges.
 Understanding will sneak up on you.
-
-<Callout type="success">
-Ready? Open **The story of programming languages** in the sidebar to
-begin.
-</Callout>

--- a/content/learn/c-programming-for-beginners/index.mdx
+++ b/content/learn/c-programming-for-beginners/index.mdx
@@ -97,8 +97,3 @@ By the time you reach the last page, you will:
   moment to learn.
 - **Draw pictures.** Memory diagrams, arrows, boxes. Programming is a
   visual subject hiding inside a text editor.
-
-<Callout type="success">
-When you're ready, click **The story of computers** in the sidebar to
-begin. We promise — no syntax yet.
-</Callout>

--- a/content/learn/data-analysis-python-pandas/index.mdx
+++ b/content/learn/data-analysis-python-pandas/index.mdx
@@ -142,8 +142,3 @@ syntax is googlable, but *judgment* — knowing when to filter
 before grouping, when to keep raw versus cleaned data, when a
 median tells you more than a mean — is not. We will spend a lot of
 time on judgment.
-
-<Callout type="success">
-Ready to begin? Click **History of Data** in the sidebar to start
-the story.
-</Callout>

--- a/content/learn/database-design-postgresql/index.mdx
+++ b/content/learn/database-design-postgresql/index.mdx
@@ -143,9 +143,3 @@ INSERT INTO orders_flat VALUES
 -- with itself. That fragility is a design problem, not a query problem.
 SELECT * FROM orders_flat;`}
 />
-
-<Callout type="success">
-Ready? Open **Why Software Needs Structured Data** in the sidebar to
-begin — we start with the most important question of all: *why does
-any of this matter?*
-</Callout>

--- a/content/learn/database-design-postgresql/thinking-in-entities.mdx
+++ b/content/learn/database-design-postgresql/thinking-in-entities.mdx
@@ -52,8 +52,7 @@ connected. But the first pass is about finding the things.
 
 <Callout type="info" title="Nouns are clues, not commands">
 Some nouns are only attributes. In "customer email," `customer` is an
-entity, but `email` is probably a column on `customers`. We will make
-that distinction more carefully on the next page.
+entity, but `email` is probably a column on `customers`.
 </Callout>
 
 ## Candidate entities are boxes

--- a/content/learn/intro-data-viz-plotly/index.mdx
+++ b/content/learn/intro-data-viz-plotly/index.mdx
@@ -137,8 +137,3 @@ fig.show()
 
 If that looks intimidating right now — good. Every line of that
 chart will feel obvious by the time you reach the end of the course.
-
-<Callout type="success">
-Ready to begin? Click **The History of Visual Communication** in
-the sidebar to start the story.
-</Callout>

--- a/content/learn/intro-modern-csharp/anders-and-birth-of-csharp.mdx
+++ b/content/learn/intro-modern-csharp/anders-and-birth-of-csharp.mdx
@@ -212,9 +212,3 @@ software.
 - It's the same as \`dynamic\`
   > \`dynamic\` defers type checks to runtime; \`var\` does not.`}
 />
-
-<Callout type="success">
-You now know who designed C#, and roughly *why*. Next we'll zoom
-out and see how .NET evolved — from Windows-only framework to the
-cross-platform, open-source platform it is today.
-</Callout>

--- a/content/learn/intro-modern-csharp/capstone-task-tracker.mdx
+++ b/content/learn/intro-modern-csharp/capstone-task-tracker.mdx
@@ -245,9 +245,3 @@ just for fun):
    `All()` by priority then by ID.
 4. Add an `IDictionary<int, TaskItem>` index so lookups by ID don't
    require scanning the list.
-
-<Callout type="success">
-You've now written, end-to-end, a small but properly-structured
-C# program. The final chapter points to where you can go from
-here.
-</Callout>

--- a/content/learn/intro-modern-csharp/classes-and-objects.mdx
+++ b/content/learn/intro-modern-csharp/classes-and-objects.mdx
@@ -343,9 +343,3 @@ Console.WriteLine($"perimeter={r.Perimeter()}");
 - It is required to return a value
   > A constructor has no return type.`}
 />
-
-<Callout type="success">
-You can now design and create your own kinds of things. Next we
-make those things *robust* by hiding their internals — the
-discipline of **encapsulation and abstraction**.
-</Callout>

--- a/content/learn/intro-modern-csharp/collections.mdx
+++ b/content/learn/intro-modern-csharp/collections.mdx
@@ -302,9 +302,3 @@ public static class WordCounter
 - It adds the key with a default value
   > That would be surprising; the indexer doesn't do that on read.`}
 />
-
-<Callout type="success">
-You can now choose the right container for the job. Next, we look
-at what happens when things *go wrong* — and how C#'s exception
-system helps you respond.
-</Callout>

--- a/content/learn/intro-modern-csharp/computational-thinking.mdx
+++ b/content/learn/intro-modern-csharp/computational-thinking.mdx
@@ -335,9 +335,3 @@ Console.WriteLine($"sum of evens = {sum}");
 - Refactoring
   > Refactoring changes existing code without changing behavior; that's a different activity.`}
 />
-
-<Callout type="success">
-You now have the mental toolkit. Next we look *inside* the machine
-and see what actually happens when your program runs — **how
-programs execute**.
-</Callout>

--- a/content/learn/intro-modern-csharp/control-flow.mdx
+++ b/content/learn/intro-modern-csharp/control-flow.mdx
@@ -387,9 +387,3 @@ real test was watching the whole time.
 - Ends the program
   > It does not.`}
 />
-
-<Callout type="success">
-You can now write programs that branch and repeat. Next: how to
-package logic into reusable units called **methods**, and why
-modular code is worth so much more than clever code.
-</Callout>

--- a/content/learn/intro-modern-csharp/debugging-and-reasoning.mdx
+++ b/content/learn/intro-modern-csharp/debugging-and-reasoning.mdx
@@ -230,9 +230,3 @@ initial value of `max`. Initialize it to `xs[0]` and try again.
 - Git makes it impossible
   > Git is perfectly happy with multi-change commits.`}
 />
-
-<Callout type="success">
-You now have a method, not just luck, for chasing bugs. Next, we
-look at the resources programs use — memory, file handles, network
-connections — and how C# helps you clean them up.
-</Callout>

--- a/content/learn/intro-modern-csharp/early-programming-complexity.mdx
+++ b/content/learn/intro-modern-csharp/early-programming-complexity.mdx
@@ -208,8 +208,3 @@ that is the next chapter of our story.
 - Universities weren't training enough programmers
   > Workforce size was a separate concern; the crisis was about the *practice* of building software.`}
 />
-
-<Callout type="success">
-Next: how a radically different idea — **objects** — promised to
-tame this complexity. On to *The rise of object-oriented programming*.
-</Callout>

--- a/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
+++ b/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
@@ -330,9 +330,3 @@ catch (ArgumentException)
 - Replacing classes with structs
   > Unrelated to abstraction.`}
 />
-
-<Callout type="success">
-Your classes can now defend themselves. Next, we let one class
-*build on* another — the family-tree mechanics of **inheritance and
-polymorphism**.
-</Callout>

--- a/content/learn/intro-modern-csharp/error-handling.mdx
+++ b/content/learn/intro-modern-csharp/error-handling.mdx
@@ -354,9 +354,3 @@ Console.WriteLine(SafeMath.SumNumbers(data));
 - It uses too much memory
   > Memory isn't the issue.`}
 />
-
-<Callout type="success">
-You can now respond to failure deliberately. Next, we look at the
-mental and practical tools for finding bugs in the first place —
-**debugging and reasoning about programs**.
-</Callout>

--- a/content/learn/intro-modern-csharp/evolution-of-dotnet.mdx
+++ b/content/learn/intro-modern-csharp/evolution-of-dotnet.mdx
@@ -235,8 +235,3 @@ runtime, so every example you see should run in your browser.
 - Making C# look more like assembly
   > The trend has been in the opposite direction.`}
 />
-
-<Callout type="success">
-Last stop on our story: a single page summarizing **why C# matters
-today**, and then we dive into the actual programming.
-</Callout>

--- a/content/learn/intro-modern-csharp/how-programs-execute.mdx
+++ b/content/learn/intro-modern-csharp/how-programs-execute.mdx
@@ -299,8 +299,3 @@ picture.
 - Slows your program down on purpose
   > It does occasionally pause work to scan the heap, but its purpose is to *reclaim* memory, not to slow things down.`}
 />
-
-<Callout type="success">
-We've seen *how* C# runs. Next, a closer look at the layer that makes
-all of that possible: **managed runtimes**.
-</Callout>

--- a/content/learn/intro-modern-csharp/index.mdx
+++ b/content/learn/intro-modern-csharp/index.mdx
@@ -146,8 +146,3 @@ you what a real C# program looks like. By the end of the course,
 every line of that example will feel obvious.
 
 ## Where to next
-
-<Callout type="success">
-Click **Early programming and software complexity** in the sidebar to
-begin the story.
-</Callout>

--- a/content/learn/intro-modern-csharp/inheritance-and-polymorphism.mdx
+++ b/content/learn/intro-modern-csharp/inheritance-and-polymorphism.mdx
@@ -321,9 +321,3 @@ foreach (var s in shapes)
 - [o] Use inheritance for genuine "is-a" relationships; use composition for "has-a" relationships
   > Many design problems get simpler when you reach for composition first.`}
 />
-
-<Callout type="success">
-You've now met the heart of OOP. Next we look at the most-used
-*collections* in C# — the everyday containers like \`List\`,
-\`Dictionary\`, and \`HashSet\`.
-</Callout>

--- a/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
+++ b/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
@@ -222,8 +222,3 @@ ergonomics) has borrowed ideas from them.
 - Microsoft was legally barred from using Java
   > Microsoft *did* implement Java; the legal trouble came after, over extensions.`}
 />
-
-<Callout type="success">
-With the threat clear, Microsoft started building its own answer.
-Next: **Microsoft's vision for .NET**.
-</Callout>

--- a/content/learn/intro-modern-csharp/managed-runtimes.mdx
+++ b/content/learn/intro-modern-csharp/managed-runtimes.mdx
@@ -240,9 +240,3 @@ that's invisible. You just write C#.
 - C# files are larger
   > File size isn't the cost being paid.`}
 />
-
-<Callout type="success">
-You now have the conceptual layer cake clearly in mind. Time to
-zoom *into* it. Next: **variables and memory** — the smallest piece
-of any program.
-</Callout>

--- a/content/learn/intro-modern-csharp/methods-and-modularity.mdx
+++ b/content/learn/intro-modern-csharp/methods-and-modularity.mdx
@@ -408,9 +408,3 @@ Console.WriteLine($"max={Stats.Max(data)}");
 - Smaller methods use less memory
   > Method size has almost no impact on memory usage.`}
 />
-
-<Callout type="success">
-You can now break a program into named pieces. Next we take the
-*biggest* step of the course: bundling data **and** methods together
-into a single thing called an **object**. On to **Classes and Objects**.
-</Callout>

--- a/content/learn/intro-modern-csharp/microsoft-dotnet-vision.mdx
+++ b/content/learn/intro-modern-csharp/microsoft-dotnet-vision.mdx
@@ -213,8 +213,3 @@ it does? On to **Anders Hejlsberg and the birth of C#**.
 - To make .NET incompatible with Java
   > Compatibility decisions are separate from the type system.`}
 />
-
-<Callout type="success">
-Next: the man who designed C#, and why his background made C# look
-the way it does. On to **Anders Hejlsberg and the birth of C#**.
-</Callout>

--- a/content/learn/intro-modern-csharp/resource-management.mdx
+++ b/content/learn/intro-modern-csharp/resource-management.mdx
@@ -262,10 +262,3 @@ production bugs.
 - It hides what's happening
   > It makes the intent *clearer*, not more hidden.`}
 />
-
-<Callout type="success">
-You now understand the split between memory (the GC's job) and
-everything else (your job, made easy with \`using\`). Next we step
-back from the language and talk about the *human* discipline of
-**writing maintainable software**.
-</Callout>

--- a/content/learn/intro-modern-csharp/rise-of-oop.mdx
+++ b/content/learn/intro-modern-csharp/rise-of-oop.mdx
@@ -253,9 +253,3 @@ spend a large part of this course learning to think in objects.
 - C# requires every field to be private
   > It doesn't — \`public\` and other modifiers are also allowed; you choose deliberately.`}
 />
-
-<Callout type="success">
-Next: while OOP was spreading, a parallel story was unfolding —
-the rise of **Windows** and the enormous enterprise software
-ecosystem Microsoft built around it.
-</Callout>

--- a/content/learn/intro-modern-csharp/software-organization.mdx
+++ b/content/learn/intro-modern-csharp/software-organization.mdx
@@ -256,9 +256,3 @@ clearer place emerges.
 - It makes the program start faster
   > Startup isn't really affected.`}
 />
-
-<Callout type="success">
-You've now zoomed all the way out from "what's a variable" to
-"how do we structure a whole codebase." Time to put it all
-together — the **capstone**: a small task tracker app.
-</Callout>

--- a/content/learn/intro-modern-csharp/type-system.mdx
+++ b/content/learn/intro-modern-csharp/type-system.mdx
@@ -381,8 +381,3 @@ What is in \`a\`?
 - Convert it to \`double\` first and then to \`int\`
   > Doesn't solve the "what if it's not a number?" problem.`}
 />
-
-<Callout type="success">
-You now know the rules of the type system. Next: how to make
-decisions and repeat work with **control flow**.
-</Callout>

--- a/content/learn/intro-modern-csharp/variables-and-memory.mdx
+++ b/content/learn/intro-modern-csharp/variables-and-memory.mdx
@@ -317,9 +317,3 @@ Console.WriteLine($"b = {b}");
 - They're the same — pick either one
   > They're meaningfully different.`}
 />
-
-<Callout type="success">
-You now understand what a variable *is*. Next we look at the rule
-the compiler enforces about *what kind of value* a variable can
-hold: the **type system**.
-</Callout>

--- a/content/learn/intro-modern-csharp/why-csharp-matters.mdx
+++ b/content/learn/intro-modern-csharp/why-csharp-matters.mdx
@@ -269,9 +269,3 @@ By the end of this course, every line above will feel obvious.
 - It runs faster than every other language
   > Performance varies; that's not the educational argument.`}
 />
-
-<Callout type="success">
-That's the end of the story. The rest of this course is hands-on.
-Next: **computational thinking** — the very first habit any
-programmer develops, and the one that pays off forever.
-</Callout>

--- a/content/learn/intro-modern-csharp/windows-and-enterprise-software.mdx
+++ b/content/learn/intro-modern-csharp/windows-and-enterprise-software.mdx
@@ -179,8 +179,3 @@ the first place — **Java**.
 - C++ wasn't installed on enough machines
   > Compiler installation wasn't the bottleneck.`}
 />
-
-<Callout type="success">
-Next: the language that pushed Microsoft to build .NET in the first
-place. On to **Java and the rise of managed runtimes**.
-</Callout>

--- a/content/learn/intro-modern-csharp/writing-maintainable-software.mdx
+++ b/content/learn/intro-modern-csharp/writing-maintainable-software.mdx
@@ -240,9 +240,3 @@ A short, rotating set of habits that compound massively:
 - Nothing — comments should always be removed
   > Sometimes a comment is exactly what saves the reader.`}
 />
-
-<Callout type="success">
-You've now met the habits that turn working code into *good* code.
-Next, we zoom out to look at how programs are organized into
-files, namespaces, and projects — **software organization**.
-</Callout>

--- a/content/learn/intro-sql-postgres/how-data-is-stored.mdx
+++ b/content/learn/intro-sql-postgres/how-data-is-stored.mdx
@@ -65,8 +65,7 @@ computer answer questions about the data mechanically and quickly.
 This rows-and-columns shape is the same one you see in a
 spreadsheet — and that is no accident. The grid is just an
 extremely natural way to lay out facts about many similar things.
-The difference is what the *system around the grid* can do, which
-is the subject of the next two pages.
+The difference is what the *system around the grid* can do.
 </Callout>
 
 ## A table is described by its columns

--- a/content/learn/intro-sql-postgres/index.mdx
+++ b/content/learn/intro-sql-postgres/index.mdx
@@ -141,7 +141,3 @@ species, and age from the pets table, but only the cats, sorted
 from oldest to youngest."* By the time you finish the **Querying
 Data** section, reading and writing queries like this will feel
 natural.
-
-<Callout type="success">
-Ready? Open **What Is a Database?** in the sidebar to begin.
-</Callout>

--- a/content/learn/intro-sql-postgres/thinking-in-entities.mdx
+++ b/content/learn/intro-sql-postgres/thinking-in-entities.mdx
@@ -140,8 +140,7 @@ the entire modeling reflex in miniature.
 Spending a few minutes naming entities, attributes, and
 relationships *before* creating tables prevents the most common
 beginner mistake: cramming many different things into one giant
-table. The next pages turn these sketches into ER diagrams and clean
-schemas.
+table.
 </Callout>
 
 ## Check your understanding

--- a/content/learn/java-collections-and-generics-deep-dive/birth-of-containers.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/birth-of-containers.mdx
@@ -305,9 +305,3 @@ Collections Framework.
 - It was removed in Java 9
   > It still exists; it's just considered legacy.`}
 />
-
-<Callout type="success" title="Next up">
-The Java team eventually accepted that the first-generation
-containers needed a redesign. In 1998 they shipped the answer: the
-**Java Collections Framework**.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
@@ -434,9 +434,3 @@ public class Bag<T> {
 - It is slower than \`List<Integer>\` at runtime
   > Performance is identical.`}
 />
-
-<Callout type="success" title="Next up">
-We have the *what* of generics. The next page is the *how at
-runtime*: type erasure, why arrays and generics don't mix, and the
-small bag of consequences every Java programmer eventually trips on.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/capstone-music-library.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/capstone-music-library.mdx
@@ -247,10 +247,3 @@ That single class touches every major idea in the course:
 - The original list is unmodifiable
   > It is mutable inside the class.`}
 />
-
-<Callout type="success" title="One chapter to go">
-Congratulations. You've built a non-trivial domain model on top of
-the Collections Framework. The final chapter is a brief look at
-**what comes next** — streams in depth, concurrent collections, and
-the wider world of data-structure libraries.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/collection-architecture.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/collection-architecture.mdx
@@ -352,9 +352,3 @@ public class Inbox {
 - \`Set<Item>\` for "uniqueness"
   > Same memory problem and the wrong shape.`}
 />
-
-<Callout type="success" title="Next up">
-Theory in hand, it's time for the **capstone**: a multi-file
-challenge that combines lists, sets, maps, and comparators into a
-working music library.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/comparable-and-comparator.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/comparable-and-comparator.mdx
@@ -364,9 +364,3 @@ public final class Leaderboard {
 - Sorts only by \`a\`
   > It also breaks ties by \`b\`.`}
 />
-
-<Callout type="success" title="Next up">
-With ordering settled, we'll look at *iteration* — the many ways
-collections can be traversed, including streams and the much-loved
-`Iterator.remove()`.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/data-modeling-with-collections.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/data-modeling-with-collections.mdx
@@ -354,9 +354,3 @@ public final class OrderIndex {
 - It's required by the Collections API
   > It is not.`}
 />
-
-<Callout type="success" title="Next up">
-Modeling decisions made, we'll zoom out one more level and look at
-**collection architecture** — how to keep your APIs clean as
-collections cross layers of an application.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
@@ -420,9 +420,3 @@ public class UniquenessTracker {
 - Implement \`Comparable\`
   > \`Comparable\` is about ordering, not value equality.`}
 />
-
-<Callout type="success" title="Foundations, complete">
-We have iteration, equality, and hashing — the three contracts every
-container depends on. Now we turn to generics in depth: how to
-*declare* parameterized types and methods of our own.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
@@ -398,9 +398,3 @@ ada / 36
 - The legacy \`Stack\` does not compile in modern Java
   > It still compiles; it is just considered legacy.`}
 />
-
-<Callout type="success" title="Next up">
-Generics get genuinely subtle when one type "contains" another:
-`List<Dog>` vs `List<Animal>`, `List<? extends Number>` vs
-`List<? super Integer>`. That is the next page.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/immutable-collections.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/immutable-collections.mdx
@@ -371,9 +371,3 @@ public final class Roster {
 - It throws \`NullPointerException\`
   > That's for null elements/keys/values.`}
 />
-
-<Callout type="success" title="Next up">
-With safe data structures in hand, we move from "which container?"
-to "what *shape* of data should I model with collections?" — the
-heart of **data modeling**.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/iterables-and-iterators.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/iterables-and-iterators.mdx
@@ -452,9 +452,3 @@ public class Countdown implements Iterable<Integer> {
 - Convert the map to a \`List\` and iterate that
   > Unnecessary copying; \`entrySet()\` already does what you need.`}
 />
-
-<Callout type="success" title="Next up">
-We now have a uniform walking protocol. The next foundation is what
-makes two elements *the same* (`equals`) and how a hash table finds
-them quickly (`hashCode`).
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/iteration-patterns.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/iteration-patterns.mdx
@@ -398,9 +398,3 @@ for (Integer n : list) if (n % 2 == 0) list.remove(n);
 - When you need to mutate the source collection
   > Streams must not mutate their source.`}
 />
-
-<Callout type="success" title="Next up">
-We've seen *how* to iterate. Next, we'll look at *how much it
-costs* — the performance characteristics that make you reach for one
-container over another.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/lists.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/lists.mdx
@@ -381,9 +381,3 @@ public class RecentHistory<E> {
 - An immutable list snapshot
   > Sublists are mutable views, not immutable snapshots.`}
 />
-
-<Callout type="success" title="Next up">
-Lists keep duplicates. Next: **sets**, where every element is unique
-— and where the work of `equals` and `hashCode` from the foundations
-chapter starts paying off.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/maps.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/maps.mdx
@@ -398,9 +398,3 @@ public class Grouper {
 - It is automatically thread-safe
   > It is not.`}
 />
-
-<Callout type="success" title="Next up">
-The two collection families left to meet are the queues and deques —
-the FIFO and double-ended structures that everything from a print
-job to a BFS algorithm depends on.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
@@ -277,9 +277,3 @@ flowchart TD
 - \`new LinkedList<>()\`
   > More memory and slower iteration in almost every scenario.`}
 />
-
-<Callout type="success" title="Next up">
-Now that we know what each container costs, let's look at when you
-should *forbid* changes to one — the topic of **immutable
-collections**.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
@@ -397,9 +397,3 @@ public class SlidingWindow<E> {
 - It mutates the queue
   > Iteration alone doesn't mutate; only \`poll()\` removes.`}
 />
-
-<Callout type="success" title="Next up">
-We have the whole zoo of containers. Now we get back to the
-*operations* that work across them — starting with **ordering**:
-`Comparable` and `Comparator`.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/sets.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/sets.mdx
@@ -350,8 +350,3 @@ public class Distinct {
 - It throws \`UnsupportedOperationException\`
   > That is for immutable collections, not for mutating elements.`}
 />
-
-<Callout type="success" title="Next up">
-Sets answer "is this in here?". The next page answers "what's
-associated with this?" — **maps**.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/the-collections-framework.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-collections-framework.mdx
@@ -453,10 +453,3 @@ public class Roster {
 - The garbage collector treats interfaces and classes differently
   > It does not.`}
 />
-
-<Callout type="success" title="Next up">
-We have a beautiful framework. There is still one hole: every method
-on `Collection` and `Map` still talks about `Object`. The next page
-tells the story of how Java 5 generics closed that hole — and changed
-the language forever.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
@@ -346,11 +346,3 @@ simple: **always provide the type argument.**
 - The JVM forbids it at runtime
   > It runs fine; the cost is in correctness, not compilation.`}
 />
-
-<Callout type="success" title="Origins, complete">
-We have walked from raw arrays, through first-generation containers,
-through the Collections Framework, to Java 5 generics. From here on
-out the *types* are honest, and we can start using the framework in
-anger. Next: the contract that every collection lives or dies by —
-**iteration**.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
@@ -251,9 +251,3 @@ string.
 - That Java forbids modules from owning their own data
   > It does not.`}
 />
-
-<Callout type="success" title="Next up">
-We have the problem. Next: how the first Java containers — `Vector`,
-`Stack`, `Hashtable`, `Enumeration` — tried to solve it, and why
-they ultimately had to be redesigned.
-</Callout>

--- a/content/learn/java-collections-and-generics-deep-dive/type-erasure.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/type-erasure.mdx
@@ -287,9 +287,3 @@ and many reflective APIs.
 - Switch to a different language
   > Unnecessary; the \`Class<T>\` idiom handles essentially every case.`}
 />
-
-<Callout type="success" title="Generics, complete">
-We have the full generic picture: declaration, variance, and the
-runtime model. From here on we apply it — starting with the most-used
-container in any language, the `List`.
-</Callout>

--- a/content/learn/mastering-dsa-cpp/index.mdx
+++ b/content/learn/mastering-dsa-cpp/index.mdx
@@ -105,7 +105,3 @@ A roadmap for what to study after this course: advanced graph
 algorithms, string algorithms, computational geometry, randomized and
 parallel algorithms, and where to practice (competitive programming
 judges, system design, low-latency engineering).
-
-<Callout type="success">
-Ready? Click **Why C++ for DSA?** in the sidebar to begin.
-</Callout>

--- a/content/learn/mastering-dsa-cpp/why-cpp-for-dsa.mdx
+++ b/content/learn/mastering-dsa-cpp/why-cpp-for-dsa.mdx
@@ -295,5 +295,3 @@ int main() {
 - List nodes are sorted automatically
   > A list does not sort itself automatically.`}
 />
-
-<Callout type="success" title="Next up">Now that you know why C++ is worth using for DSA, the next page gives you the compact C++ refresher you need for the rest of the course.</Callout>

--- a/content/learn/mastering-ggplot2/cartesian-and-beyond.mdx
+++ b/content/learn/mastering-ggplot2/cartesian-and-beyond.mdx
@@ -94,7 +94,7 @@ that comparison.
 It is tempting to ignore coordinates because the default is almost
 always right. But treating them as a real, swappable component is what
 lets the *same* bar chart become a pie chart, or a Cartesian plot
-become a map projection. The next page makes this dramatic.
+become a map projection.
 </Callout>
 
 <MultipleChoice

--- a/content/learn/mastering-ggplot2/index.mdx
+++ b/content/learn/mastering-ggplot2/index.mdx
@@ -132,8 +132,3 @@ ggplot(mpg, aes(x = displ, y = hwy, color = drv)) +
 Do not worry about understanding it yet. Notice only this: the plot is
 *added together*, one component at a time, with `+`. That is the
 grammar at work.
-
-<Callout type="success">
-Ready? Open **Plotting Systems That Don't Scale** in the sidebar to
-see the problem ggplot2 was invented to solve.
-</Callout>

--- a/content/learn/oop-blueprint-java/abstract-classes.mdx
+++ b/content/learn/oop-blueprint-java/abstract-classes.mdx
@@ -389,9 +389,3 @@ To +1-555-0100: Your code is 1234
 - When you don't want to use \`@Override\`
   > Both abstract classes and interfaces interact with \`@Override\`.`}
 />
-
-<Callout type="success">
-Abstract classes give you partial blueprints. Next: pure contracts
-with **interfaces** — the most flexible way to say "anyone who can
-do *this* is welcome."
-</Callout>

--- a/content/learn/oop-blueprint-java/aggregation-and-dependency.mdx
+++ b/content/learn/oop-blueprint-java/aggregation-and-dependency.mdx
@@ -421,9 +421,3 @@ public class Classroom {
 - It is required for the class to compile
   > It is not required by the compiler.`}
 />
-
-<Callout type="success">
-You now have three of the four basic relationships. Next is the
-fourth — the one that ties classes together as families:
-**inheritance**.
-</Callout>

--- a/content/learn/oop-blueprint-java/birth-of-oop.mdx
+++ b/content/learn/oop-blueprint-java/birth-of-oop.mdx
@@ -337,8 +337,3 @@ That is OOP. The rest of this course is just elaboration.
 - Messages replace all uses of variables
   > Variables still exist; messages are how behavior is invoked across objects.`}
 />
-
-<Callout type="success" title="Up next">
-We have classes and messages. Now we will look at how the **Gang of
-Four** turned these primitives into a vocabulary of *reusable design*.
-</Callout>

--- a/content/learn/oop-blueprint-java/capstone-library-system.mdx
+++ b/content/learn/oop-blueprint-java/capstone-library-system.mdx
@@ -446,9 +446,3 @@ Each of those is a textbook responsibility-driven extension.
 - Modify \`LimitPolicy\` to know about weekends
   > That muddles two policies and breaks the single-responsibility idea.`}
 />
-
-<Callout type="success">
-You built a small but complete OOP system the way the discipline
-intends — small classes, clear responsibilities, plug-in policies,
-no shortcuts. One last short page to wrap up the course.
-</Callout>

--- a/content/learn/oop-blueprint-java/composition.mdx
+++ b/content/learn/oop-blueprint-java/composition.mdx
@@ -421,9 +421,3 @@ Pride and Prejudice by Jane Austen
 - Composition methods always run faster
   > Speed is not the criterion.`}
 />
-
-<Callout type="success">
-You can build big objects out of small ones. Next: the *weaker*
-relationships — **aggregation and dependency** — for when one object
-*uses* another without owning it.
-</Callout>

--- a/content/learn/oop-blueprint-java/constructors-and-state.mdx
+++ b/content/learn/oop-blueprint-java/constructors-and-state.mdx
@@ -362,9 +362,3 @@ bad: invalid email
 - They automatically run faster than mutable objects
   > Performance is not guaranteed; safety is the real benefit.`}
 />
-
-<Callout type="success">
-Objects come into existence valid. Now let's look at what they *do*
-once they exist — the messages they respond to, in **Methods and
-Messages**.
-</Callout>

--- a/content/learn/oop-blueprint-java/encapsulation.mdx
+++ b/content/learn/oop-blueprint-java/encapsulation.mdx
@@ -365,9 +365,3 @@ balance=20
 - Because \`public\` methods cannot call \`private\` ones
   > Public methods *can* call private methods of the same class — that is normal.`}
 />
-
-<Callout type="success">
-With encapsulation in your toolbox, you can build objects whose
-internal rules are guaranteed. Next: how an object *comes into
-existence* in a valid state — **constructors and state**.
-</Callout>

--- a/content/learn/oop-blueprint-java/enums.mdx
+++ b/content/learn/oop-blueprint-java/enums.mdx
@@ -358,10 +358,3 @@ SUNDAY weekend? true
 - The number of constants in the enum
   > That would be \`Operation.values().length\`.`}
 />
-
-<Callout type="success">
-You've finished the *core OOP* section: encapsulation, constructors,
-methods as messages, static members, and enums. Next we look at how
-objects *relate* to each other — starting with **composition**, the
-most important relationship in OOP.
-</Callout>

--- a/content/learn/oop-blueprint-java/gang-of-four.mdx
+++ b/content/learn/oop-blueprint-java/gang-of-four.mdx
@@ -284,10 +284,3 @@ We will return to this exercise more formally later in the course.
 - Because \`switch\` is not allowed in object-oriented languages
   > It is fully allowed; the issue is design quality at scale.`}
 />
-
-<Callout type="success" title="The story ends, the work begins">
-That is the origin story: a crisis, a new way of organizing code, and
-a book that gave the new way a shared vocabulary. From here on, we put
-the story aside and *practice* the ideas — starting with the smallest
-unit of OOP: a Java object.
-</Callout>

--- a/content/learn/oop-blueprint-java/index.mdx
+++ b/content/learn/oop-blueprint-java/index.mdx
@@ -147,7 +147,3 @@ packages and layers without losing your mind.
 ### Capstone
 A guided modeling exercise: design a small **library management
 system** end-to-end, exercising every idea in the course.
-
-<Callout type="success">
-Ready? Click **The software crisis** in the sidebar to begin the story.
-</Callout>

--- a/content/learn/oop-blueprint-java/inheritance.mdx
+++ b/content/learn/oop-blueprint-java/inheritance.mdx
@@ -400,8 +400,3 @@ public class Main {
 - You want to avoid creating new files
   > File hygiene is not a design criterion.`}
 />
-
-<Callout type="success">
-You can build is-a relationships. Next we'll see how to design parent
-classes that are *deliberately incomplete* — **abstract classes**.
-</Callout>

--- a/content/learn/oop-blueprint-java/interfaces.mdx
+++ b/content/learn/oop-blueprint-java/interfaces.mdx
@@ -499,9 +499,3 @@ name: 1
 - They are exactly the same since Java 8 added default methods
   > Default methods narrow the gap a little, but they remain distinct concepts.`}
 />
-
-<Callout type="success">
-You can describe contracts that many unrelated classes can fulfill.
-Next, we'll see what *happens* when you call a method through one of
-those contracts: **polymorphism**.
-</Callout>

--- a/content/learn/oop-blueprint-java/methods-and-messages.mdx
+++ b/content/learn/oop-blueprint-java/methods-and-messages.mdx
@@ -418,9 +418,3 @@ Hello, Eve!
 - It removes the need for return values
   > Methods can still return values.`}
 />
-
-<Callout type="success">
-Objects send each other messages. Next, we'll meet the kind of
-methods (and fields) that don't belong to any one object at all —
-**static and utility classes**.
-</Callout>

--- a/content/learn/oop-blueprint-java/objects-and-classes.mdx
+++ b/content/learn/oop-blueprint-java/objects-and-classes.mdx
@@ -376,9 +376,3 @@ a=3, b=1
 - A field automatically named \`this\`
   > \`this\` is a keyword, not a user-defined field.`}
 />
-
-<Callout type="success">
-You know how to declare a class and create objects. Next we will look
-at what *actually happens in the JVM* when you write \`new\` — that
-clears up a lot of mystery about references and \`null\`.
-</Callout>

--- a/content/learn/oop-blueprint-java/objects-in-memory.mdx
+++ b/content/learn/oop-blueprint-java/objects-in-memory.mdx
@@ -336,9 +336,3 @@ many of them.
 - The program throws a \`NullPointerException\`
   > No exception; reassignment is legal.`}
 />
-
-<Callout type="success">
-You can now picture what \`new\` actually does. Time to start using
-that picture to *protect* an object's state — the topic of
-**Encapsulation**.
-</Callout>

--- a/content/learn/oop-blueprint-java/packages-and-architecture.mdx
+++ b/content/learn/oop-blueprint-java/packages-and-architecture.mdx
@@ -388,9 +388,3 @@ package. The domain doesn't move.
 - Use the keyword \`public\` on as many members as possible
   > Visibility breadth and cohesion are unrelated.`}
 />
-
-<Callout type="success">
-You can scale a design from one class to many. Time to put it all
-together: in the **capstone** we'll model a library system end to
-end, using every idea from the course.
-</Callout>

--- a/content/learn/oop-blueprint-java/polymorphism.mdx
+++ b/content/learn/oop-blueprint-java/polymorphism.mdx
@@ -416,10 +416,3 @@ public class Payroll {
 - Your interfaces have only one method
   > Single-method interfaces are common and often fine.`}
 />
-
-<Callout type="success">
-You can build, relate, and combine objects polymorphically. Now we
-shift from mechanics to *thinking*. The next page is about how to
-decide which object should own what behavior:
-**responsibility-driven design**.
-</Callout>

--- a/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
+++ b/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
@@ -485,9 +485,3 @@ balance: 60
 - Don't write public methods at all
   > You absolutely need public methods to expose behavior.`}
 />
-
-<Callout type="success">
-You can decide *where* behavior should live. Next we widen the lens
-from individual objects to whole systems: how to organize code into
-**packages and architecture**.
-</Callout>

--- a/content/learn/oop-blueprint-java/software-crisis.mdx
+++ b/content/learn/oop-blueprint-java/software-crisis.mdx
@@ -219,8 +219,3 @@ that idea. That happens in the next page.
 - More clever \`GOTO\` statements
   > \`GOTO\`-heavy code was part of what made systems unmaintainable.`}
 />
-
-<Callout type="success" title="Next up">
-We have the problem. Next, we meet the people who proposed an answer:
-the birth of OOP in Simula and Smalltalk.
-</Callout>

--- a/content/learn/oop-blueprint-java/static-and-utility.mdx
+++ b/content/learn/oop-blueprint-java/static-and-utility.mdx
@@ -361,9 +361,3 @@ sum=15
 - For any class that has more than ten methods
   > Method count is not a criterion.`}
 />
-
-<Callout type="success">
-You can now reason about both instance and class-level members.
-Next: another way Java models "a small fixed set of values" — the
-**enum**.
-</Callout>

--- a/content/learn/practical-r-for-beginners/index.mdx
+++ b/content/learn/practical-r-for-beginners/index.mdx
@@ -137,7 +137,3 @@ In four lines, we loaded a famous dataset, counted it, and computed
 a group-level summary. The output is a small table comparing the
 three species. This is what data analysis looks like in R: short,
 expressive, and built around *thinking* rather than typing.
-
-<Callout type="success">
-Ready? Click **The Age of Data** in the sidebar to start the story.
-</Callout>

--- a/content/learn/python-basics/index.mdx
+++ b/content/learn/python-basics/index.mdx
@@ -71,8 +71,3 @@ Virtual environments, pip, and a roadmap of intermediate and advanced
 topics worth exploring next: async/await, type hints, context managers,
 metaclasses, and the rich ecosystem of data science, web, and DevOps
 libraries.
-
-<Callout type="success">
-Ready to begin? Click **Python History** in the sidebar to start your
-journey.
-</Callout>

--- a/content/learn/scientific-computing-python/index.mdx
+++ b/content/learn/scientific-computing-python/index.mdx
@@ -141,8 +141,3 @@ plt.tight_layout(); plt.show()
 Right now this code is probably mostly mysterious. By the end of the
 course, every line — the choice of solver, the tolerance, the
 phase-space plot, even the units — will feel obvious.
-
-<Callout type="success">
-Ready to begin? Click **Limits of Manual Calculation** in the sidebar
-to start the story.
-</Callout>

--- a/content/learn/sql-analytics-duckdb/index.mdx
+++ b/content/learn/sql-analytics-duckdb/index.mdx
@@ -168,8 +168,3 @@ orders were placed, how much money came in, and how big was the typical
 order — and show me the biggest regions first."* Reading the raw rows,
 you could not answer that in your head. The query does it instantly, and
 would do it just as instantly over ten million rows.
-
-<Callout type="success">
-Ready? Open **Analytics vs. Application Development** in the sidebar to
-begin.
-</Callout>

--- a/content/learn/sqlite-for-beginners/index.mdx
+++ b/content/learn/sqlite-for-beginners/index.mdx
@@ -140,7 +140,3 @@ species, and age from the pets table, but only the cats, sorted
 from oldest to youngest."* By the time you finish the **Querying
 Data** section, reading and writing queries like this will feel
 natural.
-
-<Callout type="success">
-Ready? Open **What Is a Database?** in the sidebar to begin.
-</Callout>

--- a/content/learn/systems-programming-c/arrays-and-pointers.mdx
+++ b/content/learn/systems-programming-c/arrays-and-pointers.mdx
@@ -392,7 +392,3 @@ int main(void) {
 - [o] It is undefined behavior — it may crash, may overwrite unrelated data, or may appear to work.
   > Out-of-bounds memory access is one of the most dangerous C bugs.`}
 />
-
-<Callout type="success" title="Next: strings">
-A C string is just an array of \`char\` with a special last byte. Up next, we look at how that simple convention powers (and complicates) every piece of text processing in the language.
-</Callout>

--- a/content/learn/systems-programming-c/c-toolchain.mdx
+++ b/content/learn/systems-programming-c/c-toolchain.mdx
@@ -319,7 +319,3 @@ int square(int x) {
 - Because the C standard library requires it.
   > It is a convention, not a standard library requirement.`}
 />
-
-<Callout type="success" title="On to types">
-Now that you know how source becomes a binary, the next page looks at what your variables actually look like once they get there: bytes, widths, signedness, and endianness.
-</Callout>

--- a/content/learn/systems-programming-c/data-types-and-memory.mdx
+++ b/content/learn/systems-programming-c/data-types-and-memory.mdx
@@ -352,7 +352,3 @@ int main(void) {
 - It is unpredictable.
   > It is fully predictable once you know the endianness.`}
 />
-
-<Callout type="success" title="On to pointers">
-You now know what numbers look like in memory. Next we look at the second pillar of C: pointers — values whose contents *are* memory addresses.
-</Callout>

--- a/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -460,9 +460,3 @@ int main(void) {
 - [o] Stop using it (and ideally set it to \`NULL\` so accidental later uses become immediate NULL-pointer crashes instead of silent corruption).
   > \`free(p); p = NULL;\` is a well-known defensive pattern.`}
 />
-
-<Callout type="success" title="On to composite types">
-You can now allocate, resize, and free memory. Next: how to lay out
-multiple fields together with \`struct\` (and what padding does to
-your nice clean diagrams).
-</Callout>

--- a/content/learn/systems-programming-c/index.mdx
+++ b/content/learn/systems-programming-c/index.mdx
@@ -116,7 +116,3 @@ A roadmap for what to study after this course: signals and processes,
 threads and synchronization, sockets and protocols, `mmap` and shared
 memory, sanitizers (ASan/UBSan/MSan), Valgrind, custom allocators,
 embedded toolchains, and Rust as a "modern C" alternative.
-
-<Callout type="success">
-Ready? Click **Why C for systems programming?** in the sidebar to begin.
-</Callout>

--- a/content/learn/systems-programming-c/memory-bugs.mdx
+++ b/content/learn/systems-programming-c/memory-bugs.mdx
@@ -476,6 +476,5 @@ int main(void) {
 
 <Callout type="success" title="You can now read C with open eyes">
 You know the bug classes. Tools like AddressSanitizer and Valgrind
-will be your best friends in real codebases. The final page maps out
-where to go next.
+will be your best friends in real codebases.
 </Callout>

--- a/content/learn/systems-programming-c/memory-layout.mdx
+++ b/content/learn/systems-programming-c/memory-layout.mdx
@@ -288,7 +288,3 @@ int main(void) {
 - The variable is moved to the heap.
   > Static variables live in BSS or .data, not on the heap.`}
 />
-
-<Callout type="success" title="Next: the stack up close">
-You have the map of process memory. Next we focus on the stack: what a *call frame* actually contains, how recursion uses it, and how to overflow it.
-</Callout>

--- a/content/learn/systems-programming-c/pointers.mdx
+++ b/content/learn/systems-programming-c/pointers.mdx
@@ -394,7 +394,3 @@ int main(void) {
 - The compiler stores the int in read-only memory.
   > \`const\` is a promise about access through this pointer, not a statement about where the int lives.`}
 />
-
-<Callout type="success" title="Onward to arrays">
-With pointers under your belt, the next page connects them to arrays — where you will see the famous "array decay" and learn the right way to think about \`a[i]\` and \`*(a + i)\`.
-</Callout>

--- a/content/learn/systems-programming-c/stack-and-functions.mdx
+++ b/content/learn/systems-programming-c/stack-and-functions.mdx
@@ -397,7 +397,3 @@ char *greeting(void) {
 - The recursive version is undefined behavior in standard C.
   > It is perfectly well-defined.`}
 />
-
-<Callout type="success" title="On to the heap">
-The stack is fast but short-lived. To make memory survive across function calls you need the heap — and that means \`malloc\`, \`free\`, and the lifetime discipline that goes with them.
-</Callout>

--- a/content/learn/systems-programming-c/strings.mdx
+++ b/content/learn/systems-programming-c/strings.mdx
@@ -386,7 +386,3 @@ int main(void) {
 - \`memcpy(dst, src, strlen(src));\`
   > Also unsafe (no terminator) and does not check destination size.`}
 />
-
-<Callout type="success" title="On to process memory layout">
-Now that you understand the basic types and pointers, the next chapter zooms out: where do globals, locals, and dynamically allocated values *actually live* in a running C program?
-</Callout>

--- a/content/learn/systems-programming-c/structs-and-unions.mdx
+++ b/content/learn/systems-programming-c/structs-and-unions.mdx
@@ -574,10 +574,3 @@ int main(void) {
 - A bitfield.
   > Bitfields pack small integers, not variable-length data.`}
 />
-
-<Callout type="success" title="On to the bugs">
-You can now build composite types and lay them out efficiently. The
-next page is the long, honest tour of what goes wrong when manual
-memory management bites: leaks, use-after-free, double-free, and
-buffer overruns.
-</Callout>

--- a/content/learn/systems-programming-c/why-c-for-systems.mdx
+++ b/content/learn/systems-programming-c/why-c-for-systems.mdx
@@ -205,7 +205,3 @@ constantly.
 - Because every C statement maps to exactly one CPU instruction.
   > Many C statements compile to several instructions, and the optimizer can collapse or reorder them.`}
 />
-
-<Callout type="success" title="Ready to compile">
-Next we will follow a C program through the four-stage build pipeline: preprocessing, compilation, assembly, and linking.
-</Callout>

--- a/content/learn/typescript-from-scratch/index.mdx
+++ b/content/learn/typescript-from-scratch/index.mdx
@@ -101,8 +101,3 @@ and patterns for keeping a growing codebase coherent.
 ### 7. Compiler and tooling
 A look at what `tsc` is actually doing for you, how editors use the
 language service, and where to go next.
-
-<Callout type="success">
-Ready? Open **Evolution of JavaScript** in the sidebar to start the
-story.
-</Callout>


### PR DESCRIPTION
## Summary

Fumadocs already renders clickable page navigation at the bottom of every lesson, so the callouts that told learners to "open the next page" were redundant with it — and confusing, since the callout itself isn't clickable. This removes those callouts throughout all `/learn` courses.

## What changed (97 files)

**Removed entirely (92 callouts):**
- **17 course index callouts** — the exact pattern from the request, e.g. `typescript-from-scratch/index.mdx`: _"Ready? Open **Evolution of JavaScript** in the sidebar to start the story."_
- **75 end-of-lesson transition teasers** — _"You now know X. Next: Y"_ / _"On to …"_ / _"Up next …"_ — concentrated in the courses that ended nearly every page with one:
  - `intro-modern-csharp` (25)
  - `java-collections-and-generics-deep-dive` (20)
  - `oop-blueprint-java` (19)
  - `systems-programming-c` (10)
  - `mastering-dsa-cpp` (1)

**Trimmed (5 callouts):** substantive content callouts that merely ended with a forward pointer keep their takeaway; only the trailing "…on the next page" sentence was removed (`systems-programming-c/memory-bugs`, `intro-sql-postgres/how-data-is-stored`, `intro-sql-postgres/thinking-in-entities`, `database-design-postgresql/thinking-in-entities`, `mastering-ggplot2/cartesian-and-beyond`).

## Deliberately kept
- **Course-completion callouts** on `next-steps` pages (no next page to open — they're a wrap-up, e.g. "Course complete… keep going").
- **Pure content callouts** — key ideas, takeaways, warnings, examples.
- **Code-block-scope notes** ("a variable defined in one block isn't visible in the next…").

## Verification
- `<Callout>` / `</Callout>` tags remain balanced in every modified file.
- No file lost its trailing newline or gained a trailing blank line.
- A full re-scan finds no remaining "open the next page" callouts; the only residual `next`/`on to` matches are inside ordinary words (e.g. "uni**on to** make", "conventi**on to** internalize").

> Note: the scope (92 removed) is larger than the ~20 estimated up front — several courses end essentially every lesson with a transition callout. All are the same "preview the next page" pattern that was approved for removal.

https://claude.ai/code/session_01KDDWotUAsVcLBUJobVqhPw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDDWotUAsVcLBUJobVqhPw)_