### PR TITLE
Disable font ligatures globally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -15,4 +15,11 @@ html {
 
 *, *::before, *::after {
   box-sizing: border-box;
+  /* Disable font ligatures everywhere so sequences like => and == render as
+     separate glyphs instead of being combined into a single character. This
+     matters most for monospace fonts (JetBrains Mono, Fira Code, Cascadia
+     Code) used in code blocks, but we apply it to every element so no text
+     anywhere gets ligature substitution. */
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0, "clig" 0, "calt" 0, "dlig" 0;
 }


### PR DESCRIPTION
## Problem

In code blocks, the monospace fonts (JetBrains Mono / Fira Code / Cascadia Code) were applying programming ligatures, combining symbol sequences like `=>` and `==` into single glyphs:

> `.Where(n => n % 2 == 0).`

The code editors (CodeMirror / challenge cards) already disabled ligatures, but ordinary `<code>` blocks and other text did not.

## Fix

Disable ligature font features on the universal selector (`*, *::before, *::after`) in `app/globals.css`:

```css
font-variant-ligatures: none;
font-feature-settings: "liga" 0, "clig" 0, "calt" 0, "dlig" 0;
```

Applying this to every element (rather than relying on inheritance) ensures no element anywhere — code blocks, prose, headings — gets ligature substitution. `globals.css` is imported by the root layout, so this covers all routes including `/learn`. Only the four ligature features are disabled; kerning and other typographic features are untouched.

https://claude.ai/code/session_01BmJK2KcPC18m7PXNXgAeFB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmJK2KcPC18m7PXNXgAeFB)_