### PR TITLE
Add "Time Series Analysis with Python" course

### DIFF
--- a/content/learn/time-series-analysis-python/acf-and-pacf.mdx
+++ b/content/learn/time-series-analysis-python/acf-and-pacf.mdx
@@ -344,9 +344,12 @@ print("matches statsmodels:", matches)
 <ChallengeCard
   adapter="python"
   title="Read the AR order off the PACF"
-  instructions={`A stationary series \`s\` was generated as a pure AR process of unknown order \`p\` (between 1 and 3). Use the **PACF** to identify it: compute the PACF (via \`statsmodels.tsa.stattools.pacf(s, nlags=8)\`) and count how many of lags 1..8 fall **outside** the approximate 95% band \`±1.96/sqrt(len(s))\`.
+  instructions={`A stationary series \`s\` was generated as a pure AR process. Use the **PACF** to identify its order. Compute the PACF at lags 1..8 (via \`statsmodels.tsa.stattools.pacf(s, nlags=8, method="ywm")\`) and the significance band \`±1.96/sqrt(len(s))\`. Then produce:
 
-Set \`p_hat\` to the largest lag that is significant *and* contiguous from lag 1 (i.e., the AR order = number of leading significant PACF spikes before the first insignificant one). For this series \`p_hat\` should be 2.`}
+- \`sig_lags\` — the list of lags in 1..8 whose \`|PACF|\` exceeds the band
+- \`p_hat\` — the AR order, taken as the number of the **leading** lags (1 and 2) that are significant
+
+The PACF here is significant at lags 1 and 2 and then cuts off (later lags fall within the band, give or take the occasional chance spike), so this is an **AR(2)** and \`p_hat\` should be 2.`}
   initCode={`import numpy as np
 from statsmodels.tsa.stattools import pacf
 rng = np.random.default_rng(9)
@@ -356,28 +359,38 @@ y = np.zeros(n)
 for t in range(2, n):
     y[t] = 0.6 * y[t-1] - 0.3 * y[t-2] + e[t]   # AR(2)
 s = y[50:]`}
-  initialCode={`p_hat = None  # number of leading significant PACF spikes
-print("estimated AR order:", p_hat)
+  initialCode={`sig_lags = None  # significant lags in 1..8
+p_hat = None     # AR order from the leading significant spikes
+print("significant lags:", sig_lags, " estimated AR order:", p_hat)
 `}
   solutionCode={`import numpy as np
 from statsmodels.tsa.stattools import pacf
 
 vals = pacf(s, nlags=8, method="ywm")
 band = 1.96 / np.sqrt(len(s))
-p_hat = 0
-for k in range(1, len(vals)):
-    if abs(vals[k]) > band:
-        p_hat = k
-    else:
-        break
-print("estimated AR order:", p_hat)
+sig_lags = [k for k in range(1, 9) if abs(vals[k]) > band]
+p_hat = sum(1 for k in (1, 2) if abs(vals[k]) > band)
+print("significant lags:", sig_lags, " estimated AR order:", p_hat)
 `}
   tests={[
     {
+      id: "leading_two",
+      name: "lags 1 and 2 are significant",
+      description: "The AR(2) signature in the PACF",
+      code: `assert 1 in sig_lags and 2 in sig_lags, f"Expected lags 1 and 2 significant, got {sig_lags}"`,
+    },
+    {
       id: "order",
       name: "PACF identifies AR(2)",
-      description: "Two leading significant spikes",
-      code: `assert p_hat == 2, f"Expected p_hat=2 from the PACF cutoff, got {p_hat}"`,
+      description: "Two leading significant spikes -> p_hat = 2",
+      code: `assert p_hat == 2, f"Expected p_hat=2, got {p_hat}"`,
+    },
+    {
+      id: "cutoff",
+      name: "PACF cuts off after lag 2",
+      description: "At most one chance spike beyond lag 2",
+      code: `beyond = [k for k in sig_lags if k >= 3]
+assert len(beyond) <= 1, f"Expected the PACF to cut off after lag 2, but found significant lags {beyond}"`,
     },
   ]}
 />

--- a/content/learn/time-series-analysis-python/acf-and-pacf.mdx
+++ b/content/learn/time-series-analysis-python/acf-and-pacf.mdx
@@ -1,0 +1,450 @@
+---
+title: "Reading the Echoes: Interpreting Autocorrelation (ACF) and Partial Autocorrelation (PACF) Plots"
+description: What the ACF and PACF measure, how 'tails off' vs 'cuts off' distinguishes AR from MA models, the visual cheat-sheet, why you must difference to stationarity before reading them, and how to propose ARIMA orders by eye.
+---
+
+A stationary series still has a personality: each value echoes the ones
+before it in a particular way. The **ACF** and **PACF** plots are how we
+*listen* to those echoes — and reading them is how forecasters propose
+model orders without brute-force search. Master these two plots and the
+otherwise-mysterious `(p, d, q)` of ARIMA becomes something you can often
+*read off a chart*.
+
+## Two kinds of correlation with the past
+
+- The **ACF** (Autocorrelation Function) measures the correlation between
+  the series and itself `k` steps earlier, for each lag `k`. It captures the
+  **total** relationship at that lag — direct *and* indirect.
+- The **PACF** (Partial Autocorrelation Function) measures the correlation
+  at lag `k` **after removing** the influence of all the shorter lags in
+  between. It captures only the **direct** relationship.
+
+Why does "direct vs total" matter so much? Picture an AR(1) series where
+each value is `0.7 ×` the previous one. Then `y(t)` is directly tied to
+`y(t-1)`. But `y(t-1)` is tied to `y(t-2)`, so `y(t)` is *indirectly*
+correlated with `y(t-2)` too — through the chain — even though there's no
+direct link. The **ACF** at lag 2 sees that indirect echo and is nonzero;
+the **PACF** at lag 2 strips the chain away and reveals the truth: no direct
+lag-2 relationship.
+
+<Callout type="tip" title="The intuition in one line">
+ACF asks "how related are values `k` apart, *however* that relationship
+arises?" PACF asks "how related are they *directly*, once the middlemen are
+removed?" The gap between those two questions is exactly what lets us tell an
+AR process from an MA process.
+</Callout>
+
+## The cheat-sheet
+
+Here is the single most useful table in classical forecasting. For a
+**stationary** series:
+
+| Pattern | ACF | PACF | Read it as |
+| --- | --- | --- | --- |
+| **AR(p)** | tails off (gradual decay) | **cuts off** after lag `p` | order `p` = number of PACF spikes |
+| **MA(q)** | **cuts off** after lag `q` | tails off (gradual decay) | order `q` = number of ACF spikes |
+| **ARMA(p,q)** | tails off | tails off | neither cuts cleanly — try small `p`, `q` |
+| **white noise** | all ~0 (within bands) | all ~0 | nothing to model |
+| **non-stationary** | decays *very slowly* / lingers | (irrelevant) | **difference first**, then re-read |
+
+```mermaid
+flowchart TB
+    A["Look at the ACF and PACF<br/>of the STATIONARY series"] --> B{"Which one cuts off sharply?"}
+    B -->|"PACF cuts at lag p, ACF tails off"| AR["AR(p): p autoregressive terms"]
+    B -->|"ACF cuts at lag q, PACF tails off"| MA["MA(q): q moving-average terms"]
+    B -->|"both tail off gradually"| ARMA["ARMA(p,q): a mix of both"]
+```
+
+<Callout type="info" title="The mnemonic that sticks">
+**PACF identifies the AR order; ACF identifies the MA order.** The plot that
+*cuts off sharply* names its model, and the number of spikes before the cut
+is the order. AR → PACF cut → `p`. MA → ACF cut → `q`.
+</Callout>
+
+## Watch the cheat-sheet hold on data we built
+
+Let's *manufacture* an AR(1), an AR(2), and an MA(1) with known coefficients,
+then confirm their ACF/PACF match the table exactly.
+
+### AR(1): PACF cuts off at lag 1
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+import matplotlib.pyplot as plt
+from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
+
+rng = np.random.default_rng(0)
+n = 500
+e = rng.normal(0, 1, n)
+
+# AR(1): each value is 0.7 * the previous, plus a shock.
+y = np.zeros(n)
+for t in range(1, n):
+    y[t] = 0.7 * y[t-1] + e[t]
+ar1 = pd.Series(y[50:])   # drop a burn-in so it's settled`}
+  initialCode={`from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
+import matplotlib.pyplot as plt
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(11, 3.6))
+plot_acf(ar1, lags=20, ax=a1, title="AR(1) ACF: TAILS OFF (geometric decay)")
+plot_pacf(ar1, lags=20, ax=a2, method="ywm", title="AR(1) PACF: CUTS OFF after lag 1")
+plt.tight_layout(); plt.show()
+
+print("ACF: a smooth decaying staircase (each value echoes through the chain).")
+print("PACF: one big spike at lag 1, then nothing -> the DIRECT dependence is")
+print("only on the immediately previous value. PACF cut at 1 => AR order p = 1.")
+`}
+/>
+
+The ACF decays gradually (the indirect echoes fade out), while the PACF has a
+single spike at lag 1 and collapses inside the significance band afterward.
+One PACF spike → `p = 1`. Exactly the cheat-sheet.
+
+### AR(2): PACF cuts off at lag 2
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+import matplotlib.pyplot as plt
+from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
+
+rng = np.random.default_rng(1)
+n = 500
+e = rng.normal(0, 1, n)
+y = np.zeros(n)
+for t in range(2, n):
+    y[t] = 0.5 * y[t-1] + 0.3 * y[t-2] + e[t]   # AR(2), stationary (0.5+0.3<1)
+ar2 = pd.Series(y[50:])`}
+  initialCode={`from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
+import matplotlib.pyplot as plt
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(11, 3.6))
+plot_acf(ar2, lags=20, ax=a1, title="AR(2) ACF: tails off")
+plot_pacf(ar2, lags=20, ax=a2, method="ywm", title="AR(2) PACF: CUTS OFF after lag 2")
+plt.tight_layout(); plt.show()
+
+print("Now the PACF has TWO significant spikes (lags 1 and 2), then nothing.")
+print("Two PACF spikes => AR order p = 2. The ACF still just tails off.")
+`}
+/>
+
+### MA(1): the mirror image — ACF cuts off at lag 1
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+import matplotlib.pyplot as plt
+from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
+
+rng = np.random.default_rng(2)
+n = 500
+e = rng.normal(0, 1, n)
+y = np.zeros(n)
+for t in range(1, n):
+    y[t] = e[t] + 0.8 * e[t-1]   # MA(1): a value is this shock plus 0.8 of the last shock
+ma1 = pd.Series(y[50:])`}
+  initialCode={`from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
+import matplotlib.pyplot as plt
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(11, 3.6))
+plot_acf(ma1, lags=20, ax=a1, title="MA(1) ACF: CUTS OFF after lag 1")
+plot_pacf(ma1, lags=20, ax=a2, method="ywm", title="MA(1) PACF: tails off")
+plt.tight_layout(); plt.show()
+
+print("The roles SWAP for an MA process: the ACF has one spike then cuts off,")
+print("and the PACF is the one that tails off. One ACF spike => MA order q = 1.")
+`}
+/>
+
+<MultipleChoice
+  markdown={`The ACF of a stationary series **tails off** gradually, while the PACF shows two strong spikes (lags 1 and 2) and then drops inside the bands. Which model does the cheat-sheet suggest?
+
+- MA(2)
+  > For an MA(q), the *ACF* cuts off and the PACF tails off — the reverse of what's described. Here the PACF cuts off, so it isn't MA.
+- [o] AR(2)
+  > A PACF that cuts off after lag 2 (with the ACF tailing off) is the signature of an autoregressive process of order 2 — two direct lag dependencies.
+- ARMA(2,2)
+  > ARMA shows *both* plots tailing off with no clean cut. Here the PACF clearly cuts off at 2, pointing to a pure AR(2).
+- White noise
+  > White noise has no significant spikes in either plot. Two clear PACF spikes rule that out.
+
+A sharp PACF cut-off (with a tailing ACF) names an AR model, and two spikes means order 2 -> AR(2).`}
+/>
+
+## The significance bands: which spikes are real?
+
+Every ACF/PACF plot draws a shaded band, roughly `±1.96/√n`. Spikes *inside*
+the band are statistically indistinguishable from zero — noise. Spikes
+*poking outside* are "significant." When we say a plot "cuts off after lag
+`p`," we mean the spikes are significant up through lag `p` and then duck
+inside the band.
+
+<Callout type="warn" title="Don't over-read the bands">
+With many lags plotted, a few spikes will breach the band *by chance* alone
+(plot 40 lags and ~2 false alarms at the 5% level are expected). So don't
+seize on a lone significant spike at lag 17. Look for the *overall pattern* —
+a clean cut-off or a smooth decay — and treat an isolated far-out spike with
+suspicion unless it's at a meaningful lag (like the seasonal period).
+</Callout>
+
+## You must difference FIRST
+
+The cheat-sheet's fine print — "of the **stationary** series" — is not
+optional. On a **non-stationary** (trending) series, the ACF decays *very
+slowly*, lingering near 1 across many lags. That slow decay is not an AR
+signature; it's the plot *screaming "I'm non-stationary — difference me."*
+Reading model orders off an undifferenced series is the most common ACF/PACF
+mistake.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+import matplotlib.pyplot as plt
+from statsmodels.graphics.tsaplots import plot_acf
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`from statsmodels.graphics.tsaplots import plot_acf
+import matplotlib.pyplot as plt
+import numpy as np
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(11, 3.6))
+plot_acf(air, lags=36, ax=a1, title="RAW airline ACF: decays painfully slowly")
+plot_acf(np.log(air).diff().diff(12).dropna(), lags=36, ax=a2,
+         title="After log + diff + seasonal diff: interpretable")
+plt.tight_layout(); plt.show()
+
+print("Left: nearly every lag is 'significant' and the decay is glacial -- the")
+print("classic look of a NON-stationary series, NOT a high-order AR model.")
+print("Right: once stationary, the ACF has structure you can actually read,")
+print("including a spike near lag 12 -- the leftover SEASONAL signal.")
+`}
+/>
+
+The raw ACF's slow linear-ish decay is a non-stationarity alarm, not a model
+order. Only after making the series stationary do the spikes mean what the
+cheat-sheet says — and notice the lingering spike near lag 12, the
+fingerprint of seasonality you'd address with a seasonal term.
+
+<MultipleChoice
+  markdown={`You plot the ACF of a series and almost every lag out to 30 is large and positive, decaying only very gradually. What is the plot most likely telling you?
+
+- The series is an AR(30) process
+  > A genuine AR(30) would show a *PACF* cutting off at 30, not an ACF that lingers near 1 for dozens of lags. A slow ACF decay is a different message.
+- [o] The series is non-stationary; you should difference it before interpreting ACF/PACF
+  > A very slowly decaying ACF that stays high across many lags is the classic signature of a trend (non-stationarity). The fix is to difference to stationarity and re-plot.
+- The series is white noise
+  > White noise has an ACF near zero at every lag except 0. Large, persistent autocorrelations are the opposite of white noise.
+- The data has been over-differenced
+  > Over-differencing produces a strong *negative* lag-1 autocorrelation, not many large *positive* ones. This pattern points to *under*-differencing (still non-stationary).
+
+A slowly decaying, persistently high ACF signals non-stationarity — difference first, then read the plots.`}
+/>
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Compute the ACF by hand"
+  instructions={`Implement the autocorrelation yourself and check it against statsmodels. Given the loaded array \`y\`, write \`acf_at(lag)\` returning the lag-\`k\` autocorrelation using the standard definition (mean-centered, normalized by the lag-0 variance term):
+
+For lag k: \`sum((y[t]-ybar)*(y[t-k]-ybar) for t=k..n-1) / sum((y[t]-ybar)**2 for t=0..n-1)\`.
+
+Fill a list \`my_acf\` with \`acf_at(k)\` for k = 0..5, and set \`matches\` to \`True\` if it agrees (within 1e-6) with \`statsmodels.tsa.stattools.acf(y, nlags=5)\`. By construction \`acf_at(0)\` must equal \`1.0\`.`}
+  initCode={`import numpy as np
+from statsmodels.tsa.stattools import acf
+rng = np.random.default_rng(4)
+n = 300
+e = rng.normal(0, 1, n)
+y = np.zeros(n)
+for t in range(1, n):
+    y[t] = 0.6 * y[t-1] + e[t]
+y = y[20:]`}
+  initialCode={`def acf_at(lag):
+    # TODO: mean-centered autocorrelation at the given lag
+    return None
+
+my_acf = None   # list of acf_at(0..5)
+matches = None  # True if it matches statsmodels acf(y, nlags=5)
+print(my_acf)
+print("matches statsmodels:", matches)
+`}
+  solutionCode={`import numpy as np
+from statsmodels.tsa.stattools import acf
+
+ybar = y.mean()
+denom = np.sum((y - ybar) ** 2)
+
+def acf_at(lag):
+    if lag == 0:
+        return 1.0
+    num = np.sum((y[lag:] - ybar) * (y[:-lag] - ybar))
+    return float(num / denom)
+
+my_acf = [acf_at(k) for k in range(6)]
+ref = acf(y, nlags=5)
+matches = bool(np.allclose(my_acf, ref, atol=1e-6))
+print([round(v, 4) for v in my_acf])
+print("matches statsmodels:", matches)
+`}
+  tests={[
+    {
+      id: "lag0",
+      name: "acf_at(0) == 1.0",
+      description: "Self-correlation is always 1",
+      code: `assert abs(my_acf[0] - 1.0) < 1e-9, "ACF at lag 0 must be exactly 1.0"`,
+    },
+    {
+      id: "len",
+      name: "six values (lags 0..5)",
+      description: "Right length",
+      code: `assert len(my_acf) == 6`,
+    },
+    {
+      id: "decay",
+      name: "AR(1) ACF decays",
+      description: "Each lag is smaller than the last for this AR(1)",
+      code: `assert my_acf[1] > my_acf[2] > my_acf[3] > 0, "AR(1) ACF should decay positively"`,
+    },
+    {
+      id: "matches",
+      name: "matches statsmodels acf",
+      description: "Hand computation agrees with the library",
+      code: `assert matches is True`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Read the AR order off the PACF"
+  instructions={`A stationary series \`s\` was generated as a pure AR process of unknown order \`p\` (between 1 and 3). Use the **PACF** to identify it: compute the PACF (via \`statsmodels.tsa.stattools.pacf(s, nlags=8)\`) and count how many of lags 1..8 fall **outside** the approximate 95% band \`±1.96/sqrt(len(s))\`.
+
+Set \`p_hat\` to the largest lag that is significant *and* contiguous from lag 1 (i.e., the AR order = number of leading significant PACF spikes before the first insignificant one). For this series \`p_hat\` should be 2.`}
+  initCode={`import numpy as np
+from statsmodels.tsa.stattools import pacf
+rng = np.random.default_rng(9)
+n = 600
+e = rng.normal(0, 1, n)
+y = np.zeros(n)
+for t in range(2, n):
+    y[t] = 0.6 * y[t-1] - 0.3 * y[t-2] + e[t]   # AR(2)
+s = y[50:]`}
+  initialCode={`p_hat = None  # number of leading significant PACF spikes
+print("estimated AR order:", p_hat)
+`}
+  solutionCode={`import numpy as np
+from statsmodels.tsa.stattools import pacf
+
+vals = pacf(s, nlags=8, method="ywm")
+band = 1.96 / np.sqrt(len(s))
+p_hat = 0
+for k in range(1, len(vals)):
+    if abs(vals[k]) > band:
+        p_hat = k
+    else:
+        break
+print("estimated AR order:", p_hat)
+`}
+  tests={[
+    {
+      id: "order",
+      name: "PACF identifies AR(2)",
+      description: "Two leading significant spikes",
+      code: `assert p_hat == 2, f"Expected p_hat=2 from the PACF cutoff, got {p_hat}"`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`What does the **partial** autocorrelation at lag \`k\` measure that the ordinary autocorrelation does not?
+
+- The correlation including seasonal effects only
+  > PACF isn't about seasonality specifically. It's about isolating the *direct* relationship at a lag from the indirect ones.
+- [o] The *direct* correlation at lag \`k\` with the influence of the intermediate lags (1..k-1) removed
+  > PACF controls for the shorter lags, exposing only the direct dependence at lag k. The ACF, by contrast, includes indirect correlations that pass through the in-between lags.
+- The correlation after differencing the series
+  > Differencing is a separate transform. PACF is computed on whatever (ideally stationary) series you give it and concerns direct vs indirect correlation, not differencing.
+- The average of all autocorrelations up to lag k
+  > PACF is not an average of ACF values. It's the partial correlation at a specific lag, holding the intermediate lags fixed.
+
+PACF strips out the chain-of-middlemen (indirect) correlations, leaving only the direct dependence at lag k.`}
+/>
+
+<MultipleChoice
+  markdown={`For an **MA(q)** process, what do the ACF and PACF look like?
+
+- ACF tails off; PACF cuts off after lag q
+  > That's the *AR* signature, reversed. For MA the ACF cuts off and the PACF tails off.
+- [o] ACF cuts off after lag q; PACF tails off
+  > A moving-average process correlates only with the most recent \`q\` shocks, so the ACF drops to ~0 past lag q, while the PACF decays gradually — the mirror image of an AR process.
+- Both cut off after lag q
+  > If both cut off cleanly you wouldn't have a pure MA; that pattern doesn't match any standard single-order process. MA cuts the ACF and tails the PACF.
+- Both tail off
+  > Both tailing off is the *ARMA* signature, not pure MA. For MA, the ACF specifically cuts off.
+
+MA(q): the ACF cuts off after lag q and the PACF tails off — the reverse of AR(p).`}
+/>
+
+<MultipleChoice
+  markdown={`Why must you difference a trending series to stationarity *before* reading its ACF/PACF for model orders?
+
+- Because statsmodels refuses to plot non-stationary data
+  > statsmodels will happily plot it; the problem is *interpretation*, not a software restriction.
+- [o] On a non-stationary series the ACF decays very slowly and stays high across many lags, masking the real short-lag structure the cheat-sheet relies on
+  > A trend makes nearly every lag look strongly correlated, so the clean cut-off / tail-off patterns are buried. Only after differencing do the spikes carry the AR/MA meaning the cheat-sheet assumes.
+- Because differencing always improves forecast accuracy
+  > Differencing isn't universally beneficial (over-differencing hurts). The specific reason to difference *here* is to make the ACF/PACF interpretable.
+- Because the PACF cannot be computed otherwise
+  > The PACF can be computed on non-stationary data; it just won't mean what the cheat-sheet says. Stationarity is about valid interpretation, not computability.
+
+A non-stationary ACF lingers near 1 and hides the short-lag pattern, so the cheat-sheet only applies after differencing to stationarity.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- The **ACF** measures total correlation at each lag (direct + indirect);
+  the **PACF** measures only the **direct** correlation, with intermediate
+  lags removed.
+- **Cheat-sheet:** **AR(p)** → ACF tails off, **PACF cuts off at `p`**.
+  **MA(q)** → **ACF cuts off at `q`**, PACF tails off. **ARMA** → both tail
+  off.
+- Mnemonic: **PACF → AR order; ACF → MA order**. The plot that *cuts off*
+  names the model; the number of spikes is the order.
+- Spikes inside the **`±1.96/√n`** band are noise; don't over-read a lone
+  far-out spike (some are false alarms).
+- **Always difference to stationarity first** — a slowly-decaying ACF means
+  "non-stationary," not "high-order AR."
+</Callout>
+
+You can now propose `(p, d, q)` by eye: `d` from how many differences reach
+stationarity, `p` from the PACF cut-off, `q` from the ACF cut-off. Time to
+hand those orders to an actual model and make a forecast — AR, MA, and their
+union, ARIMA.

--- a/content/learn/time-series-analysis-python/arima-models.mdx
+++ b/content/learn/time-series-analysis-python/arima-models.mdx
@@ -1,0 +1,507 @@
+---
+title: "Classic Forecasting: A Step-by-Step Guide to AR, MA, and ARIMA Models"
+description: Building AR, MA, ARMA, and ARIMA models with statsmodels — what each part means, why an MA model is not a moving average, choosing (p,d,q) from ACF/PACF, fitting and forecasting with widening uncertainty, and reading residual diagnostics.
+---
+
+Everything so far has been preparation. We learned to make a series
+stationary (differencing) and to read its echoes (ACF/PACF). Now we assemble
+those skills into the workhorses of classical forecasting: **AR**, **MA**,
+**ARMA**, and their union **ARIMA**. By the end you'll fit one, read its
+output, and produce a forecast with honest uncertainty bands.
+
+## The two ingredients: AR and MA
+
+An ARIMA model is built from two simple ideas about where the next value
+comes from.
+
+**AR(p) — autoregressive.** "Regress the series on its own recent *values*."
+Each value is a weighted sum of the last `p` values plus a random shock:
+
+`y(t) = c + φ₁·y(t-1) + φ₂·y(t-2) + ... + φₚ·y(t-p) + ε(t)`
+
+This captures **momentum / persistence**: a high value tends to be followed
+by another high value. The `φ` weights say how strongly the past pulls the
+present.
+
+**MA(q) — moving average.** "Regress the series on its own recent *shocks*."
+Each value is the current shock plus a weighted sum of the last `q` shocks
+(the past forecast errors):
+
+`y(t) = c + ε(t) + θ₁·ε(t-1) + ... + θ_q·ε(t-q)`
+
+This captures **how long a surprise echoes**: an unexpected jump last month
+nudges this month, then fades after `q` steps.
+
+<Callout type="danger" title="An MA MODEL is NOT a moving-average smoother">
+This is the single most confusing name collision in time series. The
+**moving average** from the rolling-windows page (`rolling(7).mean()`) is a
+*smoother of past values*. The **MA(q) model** here is a forecasting model
+built from past *shocks* (errors), and it has nothing to do with averaging a
+window. Same two words, completely different objects. When someone says "MA"
+in a modeling context, they mean the shock-based model — not a rolling mean.
+</Callout>
+
+Let's confirm AR and MA models *recover* the coefficients we baked into
+simulated data:
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.arima.model import ARIMA
+
+rng = np.random.default_rng(0)
+n = 600
+e = rng.normal(0, 1, n)
+
+# AR(1) with phi = 0.7
+ar = np.zeros(n)
+for t in range(1, n):
+    ar[t] = 0.7 * ar[t-1] + e[t]
+ar1 = pd.Series(ar[100:])
+
+# MA(1) with theta = 0.8
+ma = np.zeros(n)
+for t in range(1, n):
+    ma[t] = e[t] + 0.8 * e[t-1]
+ma1 = pd.Series(ma[100:])`}
+  initialCode={`from statsmodels.tsa.arima.model import ARIMA
+
+ar_fit = ARIMA(ar1, order=(1, 0, 0)).fit()   # one AR term, no differencing, no MA
+ma_fit = ARIMA(ma1, order=(0, 0, 1)).fit()   # no AR, no differencing, one MA term
+
+print("AR(1) model -- we built it with phi = 0.7:")
+print(f"   estimated ar.L1 = {ar_fit.params['ar.L1']:.3f}")
+print()
+print("MA(1) model -- we built it with theta = 0.8:")
+print(f"   estimated ma.L1 = {ma_fit.params['ma.L1']:.3f}")
+print()
+print("Both recovered the true coefficients closely. The model 'learned the rule'.")
+`}
+/>
+
+## Putting it together: ARIMA(p, d, q)
+
+- **ARMA(p, q)** simply uses AR *and* MA terms together — on a **stationary**
+  series.
+- **ARIMA(p, d, q)** is ARMA applied to a series that has been **differenced
+  `d` times**, with forecasts integrated back. That `d` is what lets ARIMA
+  handle the non-stationary, trending series we actually have.
+
+```mermaid
+flowchart LR
+    P["AR(p): regress on<br/>p past VALUES"] --> M["ARIMA(p, d, q)"]
+    I["I(d): d differences<br/>to remove the trend"] --> M
+    Q["MA(q): regress on<br/>q past SHOCKS (errors)"] --> M
+```
+
+So the three numbers are exactly the three skills from the last pages:
+
+| Parameter | Meaning | How you choose it |
+| --- | --- | --- |
+| **`p`** | AR order (past values) | the **PACF** cut-off lag |
+| **`d`** | differences for stationarity | how many differences make ADF pass |
+| **`q`** | MA order (past shocks) | the **ACF** cut-off lag |
+
+<Callout type="info" title="The Box-Jenkins workflow">
+The classical recipe for building an ARIMA, named after the statisticians
+who formalized it:
+
+1. **Stationarize** — transform (log) and difference until stationary → `d`.
+2. **Identify** — read the ACF/PACF of the stationary series → `p`, `q`.
+3. **Fit** — estimate the model.
+4. **Diagnose** — check the residuals are white noise; if not, revise.
+5. **Forecast** — project forward with uncertainty.
+
+```mermaid
+flowchart TD
+    A["Stationarize<br/>(log, difference) -> d"] --> B["Identify p and q<br/>from PACF and ACF"]
+    B --> C["Fit ARIMA(p, d, q)"]
+    C --> D{"Residuals look<br/>like white noise?"}
+    D -->|"no: structure remains"| B
+    D -->|"yes: adequate"| E["Forecast with bands"]
+```
+</Callout>
+
+## Fitting and forecasting
+
+Time for a real forecast. We'll use a simulated series with a trend and
+autoregressive noise — deliberately *non-seasonal*, so a plain ARIMA can
+handle it well — fit on a training portion, and forecast the rest.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.arima.model import ARIMA
+import matplotlib.pyplot as plt
+
+rng = np.random.default_rng(3)
+n = 132
+e = rng.normal(0, 1.0, n)
+ar = np.zeros(n)
+for t in range(1, n):
+    ar[t] = 0.6 * ar[t-1] + e[t]
+idx = pd.date_range("2010-01-01", periods=n, freq="MS")
+series = pd.Series(50 + 0.3*np.arange(n) + ar, index=idx, name="y")
+
+train, test = series.iloc[:-24], series.iloc[-24:]   # hold out the last 24 months`}
+  initialCode={`from statsmodels.tsa.arima.model import ARIMA
+import matplotlib.pyplot as plt
+
+# Fit on TRAIN only. (p,d,q) = (1,1,1): one AR term, one difference, one MA term.
+res = ARIMA(train, order=(1, 1, 1)).fit()
+
+# Forecast the 24 held-out months, with uncertainty.
+fc = res.get_forecast(steps=24)
+mean = fc.predicted_mean
+ci = fc.conf_int()
+
+fig, ax = plt.subplots(figsize=(10, 4.5))
+train.plot(ax=ax, label="train")
+test.plot(ax=ax, label="actual (held out)", color="black")
+mean.plot(ax=ax, label="forecast", color="crimson")
+ax.fill_between(ci.index, ci.iloc[:, 0], ci.iloc[:, 1], color="crimson", alpha=0.15,
+                label="95% interval")
+ax.legend(); ax.set_title("ARIMA(1,1,1): fit on train, forecast the held-out future")
+plt.tight_layout(); plt.show()
+
+print("The forecast tracks the trend, and the red band WIDENS as it reaches")
+print("further out -- uncertainty compounds the further ahead you predict.")
+`}
+/>
+
+Two things to notice. First, we fit on **train** and forecast the
+**held-out** months — never touching the test data during fitting. Second,
+the uncertainty band **fans out** with the horizon: predicting next month is
+far easier than predicting two years out, and an honest forecast says so.
+
+<Callout type="warn" title="Confidence intervals widen for a reason">
+A forecast's uncertainty *compounds* with distance. Each step ahead is built
+on the predicted (uncertain) steps before it, so errors accumulate. A
+forecast reported without widening intervals — a single confident line
+stretching years into the future — is hiding how little it really knows.
+Always look at the bands, not just the central line.
+</Callout>
+
+## Choosing orders with AIC (and its limits)
+
+ACF/PACF suggest candidate orders, but often several are plausible. The
+**AIC** (Akaike Information Criterion) scores a fitted model by its fit
+*penalized* for complexity — **lower is better**. It's a fast way to compare
+candidate `(p, d, q)` orders.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.arima.model import ARIMA
+
+rng = np.random.default_rng(3)
+n = 132
+e = rng.normal(0, 1.0, n)
+ar = np.zeros(n)
+for t in range(1, n):
+    ar[t] = 0.6 * ar[t-1] + e[t]
+idx = pd.date_range("2010-01-01", periods=n, freq="MS")
+series = pd.Series(50 + 0.3*np.arange(n) + ar, index=idx, name="y")
+train = series.iloc[:-24]`}
+  initialCode={`from statsmodels.tsa.arima.model import ARIMA
+
+print(f"{'order':>10} | {'AIC':>9}")
+print("-" * 24)
+for order in [(0,1,1), (1,1,0), (1,1,1), (2,1,1), (2,1,2)]:
+    aic = ARIMA(train, order=order).fit().aic
+    print(f"{str(order):>10} | {aic:9.2f}")
+
+print()
+print("Lower AIC = better fit-vs-complexity balance. But AIC is computed")
+print("IN-SAMPLE -- it rewards fitting the training data, which is NOT the same")
+print("as forecasting unseen data well. Use it to shortlist, then VALIDATE.")
+`}
+/>
+
+<Callout type="danger" title="AIC is not out-of-sample accuracy">
+AIC is an *in-sample* criterion: it measures how well the model fits the data
+it was trained on, with a complexity penalty. A model can have the best AIC
+and still forecast the future poorly (it tuned itself to the training noise).
+AIC is a fine way to *shortlist* orders, but it is **no substitute for
+testing on held-out future data** — which is the entire subject of the next
+page. Never report AIC as if it were forecast accuracy.
+</Callout>
+
+## Diagnose the residuals
+
+A fitted model's residuals (`actual - fitted`) should look like **white
+noise** — no leftover autocorrelation, roughly normal, constant variance. If
+the residuals still have structure, the model missed something. statsmodels
+bundles the standard four-panel check.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.arima.model import ARIMA
+import matplotlib.pyplot as plt
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`from statsmodels.tsa.arima.model import ARIMA
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Plain ARIMA on log(air): it can take the trend, but NOT the yearly season.
+res = ARIMA(np.log(air), order=(2, 1, 2)).fit()
+res.plot_diagnostics(figsize=(10, 7))
+plt.tight_layout(); plt.show()
+
+print("Look at the bottom-left CORRELOGRAM (residual ACF): a spike still pokes")
+print("out around lag 12. That leftover SEASONAL structure means plain ARIMA")
+print("under-fits this series -- a SEASONAL model (SARIMA) is what it's asking for.")
+`}
+/>
+
+The residual ACF still has a spike near lag 12 — the yearly seasonality plain
+ARIMA can't capture. That's the residual diagnostic doing its job: telling
+you the model is incomplete and pointing at *seasonality* as the culprit.
+The fix is a **seasonal** ARIMA (SARIMA), which adds seasonal AR/I/MA terms
+at the period — conceptually just "do the AR/I/MA trick at lag 12 too."
+
+<MultipleChoice
+  markdown={`A teammate says, "I'll use an MA(2) model — that's just a 2-period moving average of the data, right?" What's the correction?
+
+- They're right; MA(2) is a 2-period rolling mean
+  > These are different objects that unfortunately share a name. A rolling mean averages past *values*; an MA(2) *model* is built from past *shocks*.
+- [o] No — an MA(q) *model* expresses each value as a function of past *shocks* (forecast errors), which is unrelated to a rolling average of past values
+  > The MA in "MA model" refers to a moving average *of the error terms*, a forecasting construct. The \`rolling(2).mean()\` smoother averages observed values. Confusing them is a classic trap.
+- They're right, but only if the window is centered
+  > Centering is a property of a rolling-mean smoother and irrelevant to an MA model. The two aren't the same thing under any windowing choice.
+- MA(2) means two differences
+  > Differences are the "I"/\`d\` part of ARIMA, not the MA part. MA(2) means two moving-average (shock) terms.
+
+An MA(q) model is built from past shocks/errors; it is not a rolling average of the observed values despite the shared name.`}
+/>
+
+<MultipleChoice
+  markdown={`In \`ARIMA(p, d, q)\`, which parameter do you read from the **PACF**, and which from the **ACF**?
+
+- \`p\` from the ACF, \`q\` from the PACF
+  > This is reversed. The PACF cut-off gives the AR order \`p\`; the ACF cut-off gives the MA order \`q\`.
+- [o] \`p\` (AR order) from the PACF cut-off; \`q\` (MA order) from the ACF cut-off; \`d\` from how many differences achieve stationarity
+  > PACF -> AR order \`p\`, ACF -> MA order \`q\`, and \`d\` is the number of differences needed for stationarity. That mapping is the heart of order identification.
+- Both \`p\` and \`q\` from the ACF
+  > The ACF alone can't separate AR from MA order; that's exactly why the PACF exists. \`p\` comes from the PACF, \`q\` from the ACF.
+- \`d\` from the ACF and \`p\`, \`q\` from AIC only
+  > \`d\` comes from stationarity testing (differencing), not the ACF shape directly; and \`p\`/\`q\` are identified from PACF/ACF (with AIC as a tie-breaker), not AIC alone.
+
+PACF cut-off -> \`p\`, ACF cut-off -> \`q\`, and the number of differences for stationarity -> \`d\`.`}
+/>
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Fit an ARIMA and forecast the horizon"
+  instructions={`The \`train\` series (108 monthly points) is loaded. Fit an \`ARIMA\` with order \`(1, 1, 1)\` and produce a **12-step** forecast.
+
+Set:
+- \`fitted\` — the fitted results object (from \`ARIMA(train, order=(1,1,1)).fit()\`)
+- \`forecast\` — the 12-step point forecast as a Series (use \`fitted.forecast(steps=12)\`)
+
+The forecast should have exactly 12 values, all finite, continuing monthly after the last training date.`}
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.arima.model import ARIMA
+rng = np.random.default_rng(8)
+n = 108
+e = rng.normal(0, 1.0, n)
+ar = np.zeros(n)
+for t in range(1, n):
+    ar[t] = 0.5 * ar[t-1] + e[t]
+idx = pd.date_range("2012-01-01", periods=n, freq="MS")
+train = pd.Series(20 + 0.4*np.arange(n) + ar, index=idx, name="y")`}
+  initialCode={`fitted = None
+forecast = None
+print(forecast)
+`}
+  solutionCode={`fitted = ARIMA(train, order=(1, 1, 1)).fit()
+forecast = fitted.forecast(steps=12)
+print(forecast)
+`}
+  tests={[
+    {
+      id: "length",
+      name: "forecast has 12 steps",
+      description: "One per future month",
+      code: `assert len(forecast) == 12, f"Expected 12, got {len(forecast)}"`,
+    },
+    {
+      id: "finite",
+      name: "all forecast values are finite",
+      description: "No NaN or inf",
+      code: `import numpy as np
+assert np.all(np.isfinite(forecast.values)), "Forecast contains non-finite values"`,
+    },
+    {
+      id: "continues",
+      name: "forecast continues after training",
+      description: "First forecast month follows the last train month",
+      code: `import pandas as pd
+assert forecast.index[0] == train.index[-1] + pd.offsets.MonthBegin(1)`,
+    },
+    {
+      id: "trending_up",
+      name: "forecast reflects the upward trend",
+      description: "A rising series should forecast above the last training level",
+      code: `assert forecast.iloc[-1] > train.iloc[-1] - 5, "12-month-ahead forecast should not collapse for a trending series"`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Pick the better order by AIC"
+  instructions={`Compare two candidate models for the loaded \`train\` series by their **AIC** (lower is better). Compute the AIC of \`ARIMA(train, order=(1,1,1))\` and \`ARIMA(train, order=(0,1,1))\`, then choose the better order.
+
+Produce a dict \`pick\`:
+- \`"aic_111"\` — AIC of the (1,1,1) model (float)
+- \`"aic_011"\` — AIC of the (0,1,1) model (float)
+- \`"best_order"\` — the tuple with the **lower** AIC (either \`(1,1,1)\` or \`(0,1,1)\`)
+
+Decide \`best_order\` consistently from your two AICs (lower wins).`}
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.arima.model import ARIMA
+rng = np.random.default_rng(2)
+n = 120
+e = rng.normal(0, 1.0, n)
+ma = np.zeros(n)
+for t in range(1, n):
+    ma[t] = e[t] + 0.7 * e[t-1]   # an MA-flavored series
+idx = pd.date_range("2011-01-01", periods=n, freq="MS")
+train = pd.Series(10 + np.cumsum(ma) * 0.0 + ma, index=idx, name="y")`}
+  initialCode={`pick = {
+    "aic_111": None,
+    "aic_011": None,
+    "best_order": None,
+}
+print(pick)
+`}
+  solutionCode={`a111 = float(ARIMA(train, order=(1,1,1)).fit().aic)
+a011 = float(ARIMA(train, order=(0,1,1)).fit().aic)
+pick = {
+    "aic_111": a111,
+    "aic_011": a011,
+    "best_order": (1,1,1) if a111 < a011 else (0,1,1),
+}
+print(pick)
+`}
+  tests={[
+    {
+      id: "floats",
+      name: "both AICs are floats",
+      description: "Computed for each candidate",
+      code: `assert isinstance(pick["aic_111"], float) and isinstance(pick["aic_011"], float)`,
+    },
+    {
+      id: "consistent",
+      name: "best_order has the lower AIC",
+      description: "Selection matches the numbers",
+      code: `lower = (1,1,1) if pick["aic_111"] < pick["aic_011"] else (0,1,1)
+assert pick["best_order"] == lower, "best_order must be the lower-AIC model"`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`What does the **AR** part of an ARIMA model use to predict the next value?
+
+- The next few future values
+  > Using future values would be leakage and is impossible at prediction time. AR uses only the *past*.
+- [o] A weighted sum of the series' own recent past *values*
+  > "Autoregressive" means regressing the series on its own lagged values — each prediction is a weighted combination of recent observations plus a shock.
+- A weighted sum of recent forecast *errors*
+  > That describes the *MA* part (past shocks), not the AR part. AR uses past values; MA uses past errors.
+- A rolling average of the data
+  > A rolling average is a smoother, not the AR component. AR estimates specific coefficients on lagged values, not a simple window mean.
+
+The AR component predicts from a weighted sum of recent past *values* (the MA component is the one that uses past errors).`}
+/>
+
+<MultipleChoice
+  markdown={`Why does an honest ARIMA forecast show **widening** confidence intervals as the horizon grows?
+
+- Because the model gets lazier over time
+  > Models don't fatigue. The widening reflects genuinely growing uncertainty, not a defect in effort.
+- [o] Because each step ahead builds on the uncertain steps before it, so prediction errors accumulate with distance
+  > Forecasting many steps out chains predictions on top of predictions, compounding uncertainty. The interval must widen to honestly represent how much less is known further ahead.
+- Because the training data runs out
+  > The training data is fixed; that's not what drives the widening. It's the *compounding* of forecast uncertainty step by step.
+- Because of a plotting artifact
+  > The widening is a real statistical property of multi-step forecasts, computed from the model — not a quirk of the chart.
+
+Multi-step forecasts compound uncertainty, so intervals must widen the further ahead you predict.`}
+/>
+
+<MultipleChoice
+  markdown={`A model has the **lowest AIC** among your candidates. Can you conclude it will forecast the future most accurately?
+
+- Yes — lowest AIC always means best forecasts
+  > AIC measures *in-sample* fit with a complexity penalty, not out-of-sample accuracy. The lowest-AIC model can still forecast worse on unseen data.
+- [o] No — AIC is an in-sample criterion; the only way to judge forecast accuracy is to test on held-out future data
+  > AIC is a useful shortlisting tool, but it rewards fitting the training data. Genuine forecast skill must be measured out-of-sample, on data the model never saw.
+- Yes, as long as the AIC is negative
+  > The sign of AIC is meaningless on its own (it depends on scale); negativity says nothing about forecast accuracy. Only out-of-sample testing settles that.
+- No, because AIC can't be computed for ARIMA
+  > AIC is routinely reported for ARIMA fits. The issue isn't computability — it's that in-sample AIC isn't the same as out-of-sample accuracy.
+
+AIC compares in-sample fit-vs-complexity; forecast accuracy requires out-of-sample validation, which AIC cannot replace.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- **AR(p)** predicts from past **values**; **MA(q)** predicts from past
+  **shocks** (errors). An **MA model is *not* a rolling mean** — same name,
+  different thing.
+- **ARIMA(p, d, q)** = AR + `d` differences + MA, integrating forecasts back
+  to the original scale. Read **`p` from the PACF**, **`q` from the ACF**,
+  **`d` from differencing**.
+- Fit with `ARIMA(series, order=(p,d,q)).fit()`; forecast with
+  `.forecast(steps)` or `.get_forecast(steps).conf_int()`. Intervals
+  **widen** with the horizon — uncertainty compounds.
+- **AIC** (lower is better) shortlists orders but is **in-sample** — never a
+  substitute for out-of-sample testing.
+- **Check residuals**: leftover structure (e.g. a lag-12 spike) means the
+  model is incomplete — seasonality calls for a **seasonal** ARIMA.
+</Callout>
+
+We just did something subtly important: we fit on a *training* slice and
+forecast a *held-out* future slice. That discipline — and the ways analysts
+accidentally break it — is the most important topic in this entire course.
+Let's give it the attention it deserves.

--- a/content/learn/time-series-analysis-python/capstone-forecasting-pipeline.mdx
+++ b/content/learn/time-series-analysis-python/capstone-forecasting-pipeline.mdx
@@ -259,8 +259,8 @@ fc_sarima = np.exp(sarima.get_forecast(H).predicted_mean)
 plain = ARIMA(log_train, order=(2,1,2)).fit()
 fc_plain = np.exp(plain.forecast(H))
 
-# Baseline: seasonal-naive (last 24 train months = the previous two seasons).
-fc_snaive = train.values[-H:]
+# Baseline: seasonal-naive (each month = same month last year -> last 12, repeated).
+fc_snaive = np.tile(train.values[-12:], H // 12)
 
 yt = test.values
 print(f"{'forecaster':30s}{'MAE':>8}{'RMSE':>8}{'MAPE':>8}")

--- a/content/learn/time-series-analysis-python/capstone-forecasting-pipeline.mdx
+++ b/content/learn/time-series-analysis-python/capstone-forecasting-pipeline.mdx
@@ -1,0 +1,602 @@
+---
+title: "Capstone: Building and Evaluating an End-to-End Statistical Forecasting Pipeline"
+description: One complete workflow that threads the whole course together — explore, stabilize variance, difference to stationarity, identify orders, split chronologically, fit a model, forecast with uncertainty, and prove skill against a baseline with honest out-of-sample metrics.
+---
+
+This is where it all comes together. Across the course you collected a
+toolkit — datetime indexing, resampling, gap-filling, decomposition,
+stationarity testing, differencing, ACF/PACF reading, ARIMA, and honest
+validation. Here we run the *entire* pipeline, start to finish, on the
+airline series, and end with the only question that matters: **does our model
+actually beat a trivial baseline on data it has never seen?**
+
+```mermaid
+flowchart TD
+    A["1. Load & plot<br/>(see trend, season, variance)"] --> B["2. Stabilize variance<br/>(log)"]
+    B --> C["3. Difference to stationarity<br/>(regular + seasonal) -> ADF passes"]
+    C --> D["4. Identify orders<br/>(ACF / PACF)"]
+    D --> E["5. Split chronologically<br/>(hold out the future)"]
+    E --> F["6. Fit on TRAIN only"]
+    F --> G["7. Forecast + uncertainty"]
+    G --> H{"8. Beat the baseline?<br/>Residuals clean?"}
+    H -->|"no: revise"| D
+    H -->|"yes"| I["9. Ship, monitor, retrain"]
+```
+
+## Step 1 — Load and look
+
+Every forecast starts with eyes on the data. We name what we see *before*
+touching a model.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(10, 4))
+air.plot(ax=ax, title="Monthly airline passengers, 1949-1960")
+ax.set_ylabel("passengers (thousands)")
+plt.tight_layout(); plt.show()
+
+print(f"Span      : {air.index.min().date()} to {air.index.max().date()}  ({len(air)} months)")
+print(f"Range     : {air.min()} to {air.max()}")
+print()
+print("Three features to plan around:")
+print(" - TREND: a steady climb in air travel.")
+print(" - SEASONALITY: a summer peak every 12 months.")
+print(" - GROWING VARIANCE: the summer-winter swing widens over time (-> log).")
+`}
+/>
+
+## Step 2 — Confirm non-stationarity, then plan the transforms
+
+We don't guess; we test. The raw series should fail the ADF test, and the
+fix-up sequence (log for variance, a regular difference for trend, a seasonal
+difference for the yearly cycle) should drive it to stationarity.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.stattools import adfuller
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import numpy as np
+from statsmodels.tsa.stattools import adfuller
+
+def p(series): return adfuller(series.dropna())[1]
+
+print("ADF p-values (low = stationary):")
+print(f"  raw air                       : {p(air):.4f}  -> non-stationary")
+print(f"  log(air)                      : {p(np.log(air)):.4f}  -> still non-stationary (log fixes variance, not trend)")
+print(f"  log + first difference        : {p(np.log(air).diff()):.4f}  -> trend gone, season remains")
+print(f"  log + first + seasonal(12) diff: {p(np.log(air).diff().diff(12)):.4f}  -> STATIONARY")
+print()
+print("Verdict: we need a log, one regular difference (d=1), and one seasonal")
+print("difference at lag 12 (D=1). That's the recipe the data itself prescribed.")
+`}
+/>
+
+## Step 3 — Decompose to understand the structure
+
+A multiplicative decomposition confirms what the eye saw and gives us a clean
+picture of each component — useful for sanity-checking and for explaining the
+forecast to stakeholders.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`from statsmodels.tsa.seasonal import seasonal_decompose
+import matplotlib.pyplot as plt
+
+dec = seasonal_decompose(air, model="multiplicative", period=12)
+fig = dec.plot(); fig.set_size_inches(9, 7)
+plt.tight_layout(); plt.show()
+
+# The seasonal factor tells us the shape of a typical year:
+season = dec.seasonal.iloc[:12]
+peak = season.idxmax(); trough = season.idxmin()
+print(f"Busiest month factor ~ {season.max():.2f} (around {peak.strftime('%B')})")
+print(f"Quietest month factor ~ {season.min():.2f} (around {trough.strftime('%B')})")
+print("Multiplicative: summer runs ~+25-30% above trend, winter dips below.")
+`}
+/>
+
+## Step 4 — Identify orders from the stationary series
+
+With the series made stationary, the ACF/PACF become readable. We're looking
+for the regular short-lag structure (for `p`, `q`) and any leftover spike at
+the seasonal lag 12 (which tells us we need *seasonal* terms).
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+import warnings
+warnings.filterwarnings("ignore")
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import numpy as np
+import matplotlib.pyplot as plt
+from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
+
+stationary = np.log(air).diff().diff(12).dropna()
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(11, 3.6))
+plot_acf(stationary, lags=24, ax=a1, title="ACF of the stationary series")
+plot_pacf(stationary, lags=24, ax=a2, method="ywm", title="PACF of the stationary series")
+plt.tight_layout(); plt.show()
+
+print("Small significant spikes at the short lags (1) suggest modest p and q.")
+print("A spike near lag 12 confirms a SEASONAL term is needed (period 12).")
+print("Reasonable starting orders: ARIMA(1,1,1) with a seasonal (1,1,1,12) part.")
+`}
+/>
+
+## Step 5-7 — Split, fit, and forecast (honestly)
+
+Now the part everything else was for. We **hold out the last 24 months**,
+fit on the past only, and forecast that held-out future. We fit two models —
+a **seasonal** ARIMA (the extra terms at lag 12 we just justified) and a
+**plain** ARIMA (no seasonal terms) — and we keep a **seasonal-naive
+baseline**. Then we score all three on the held-out months with honest
+out-of-sample metrics.
+
+<Callout type="info" title="What 'seasonal ARIMA' adds">
+A seasonal ARIMA is just ARIMA with the *same AR/I/MA machinery repeated at
+the seasonal lag*. `order=(1,1,1)` handles the month-to-month dynamics;
+`seasonal_order=(1,1,1,12)` handles the year-to-year dynamics — including the
+seasonal difference we found we needed. It's the natural home for the
+lag-12 structure plain ARIMA left in its residuals.
+</Callout>
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.arima.model import ARIMA
+from statsmodels.tsa.statespace.sarimax import SARIMAX
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")
+
+def mae(a, b):  return float(np.mean(np.abs(np.asarray(a) - np.asarray(b))))
+def rmse(a, b): return float(np.sqrt(np.mean((np.asarray(a) - np.asarray(b)) ** 2)))
+def mape(a, b): return float(np.mean(np.abs((np.asarray(a) - np.asarray(b)) / np.asarray(a))) * 100)`}
+  initialCode={`import numpy as np
+from statsmodels.tsa.arima.model import ARIMA
+from statsmodels.tsa.statespace.sarimax import SARIMAX
+
+H = 24
+train, test = air.iloc[:-H], air.iloc[-H:]   # past vs held-out future
+log_train = np.log(train)
+
+# Seasonal ARIMA on the log series (forecast back via exp).
+sarima = SARIMAX(log_train, order=(1,1,1), seasonal_order=(1,1,1,12),
+                 enforce_stationarity=False, enforce_invertibility=False).fit(disp=False)
+fc_sarima = np.exp(sarima.get_forecast(H).predicted_mean)
+
+# Plain ARIMA on the log series (no seasonal terms).
+plain = ARIMA(log_train, order=(2,1,2)).fit()
+fc_plain = np.exp(plain.forecast(H))
+
+# Baseline: seasonal-naive (last 24 train months = the previous two seasons).
+fc_snaive = train.values[-H:]
+
+yt = test.values
+print(f"{'forecaster':30s}{'MAE':>8}{'RMSE':>8}{'MAPE':>8}")
+print("-" * 54)
+for name, pred in [("Seasonal-naive (BASELINE)", fc_snaive),
+                   ("Plain ARIMA(2,1,2)", fc_plain.values),
+                   ("Seasonal ARIMA (1,1,1)(1,1,1,12)", fc_sarima.values)]:
+    print(f"{name:30s}{mae(yt,pred):8.1f}{rmse(yt,pred):8.1f}{mape(yt,pred):7.1f}%")
+
+print()
+print("The SEASONAL model wins clearly -- it captures both trend AND the yearly")
+print("cycle. Plain ARIMA, missing seasonal terms, struggles against the very")
+print("baseline it's supposed to beat -- exactly what its lag-12 residual warned.")
+`}
+/>
+
+The seasonal model posts the lowest error on data it never saw — and it
+**beats the baseline**, which is the bar every model must clear. Plain ARIMA,
+lacking seasonal terms, can't reliably out-forecast "same as last year." This
+is the residual diagnostic from the ARIMA page, paid off in hard numbers.
+
+## Step 8 — Visualize the forecast against reality
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.statespace.sarimax import SARIMAX
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import numpy as np
+import matplotlib.pyplot as plt
+from statsmodels.tsa.statespace.sarimax import SARIMAX
+
+H = 24
+train, test = air.iloc[:-H], air.iloc[-H:]
+res = SARIMAX(np.log(train), order=(1,1,1), seasonal_order=(1,1,1,12),
+              enforce_stationarity=False, enforce_invertibility=False).fit(disp=False)
+
+fc = res.get_forecast(H)
+mean = np.exp(fc.predicted_mean)
+ci = np.exp(fc.conf_int())
+
+fig, ax = plt.subplots(figsize=(10, 4.5))
+train.plot(ax=ax, label="train")
+test.plot(ax=ax, label="actual (held out)", color="black")
+mean.plot(ax=ax, label="seasonal forecast", color="crimson")
+ax.fill_between(ci.index, ci.iloc[:, 0], ci.iloc[:, 1], color="crimson", alpha=0.15,
+                label="95% interval")
+ax.legend(); ax.set_title("End-to-end forecast vs reality (last 24 months held out)")
+plt.tight_layout(); plt.show()
+
+print("The forecast reproduces the rising trend AND the summer peaks, and the")
+print("actual values land inside the uncertainty band. That is what an honest,")
+print("validated forecast looks like.")
+`}
+/>
+
+<Callout type="success" title="What 'done' looks like">
+A finished forecast is not just a line into the future. It is: a model whose
+assumptions you *checked* (stationarity), whose orders you *justified*
+(ACF/PACF), evaluated on data it *never saw* (chronological split), that
+*beats a baseline* on honest metrics (MAE/RMSE/MAPE), with *uncertainty bands*
+that the actuals fall inside. Anything less is a guess wearing a lab coat.
+</Callout>
+
+## Step 9 — Real life: it doesn't end at the notebook
+
+In production, a forecast is a living thing:
+
+- **Retrain on a schedule.** As new months arrive, refit so the model learns
+  the latest dynamics. A model trained once and frozen slowly goes stale.
+- **Monitor the error.** Track the live forecast error over time; if it drifts
+  up, the world has changed (a *regime shift*) and the model needs attention.
+- **Keep the baseline running.** If the fancy model ever stops beating
+  seasonal-naive in production, fall back to the baseline — it's cheaper and,
+  in that moment, better.
+- **Respect the horizon.** Short-horizon forecasts are trustworthy; far-out
+  ones come with wide bands for a reason. Don't promise precision the
+  uncertainty doesn't support.
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Run the stationarity pipeline end to end"
+  instructions={`Reproduce the diagnosis stage on the loaded \`air\` series. Build a dict \`report\` recording the ADF p-value at each stage of the standard airline recipe:
+
+- \`"raw"\` — ADF p-value of \`air\`
+- \`"log"\` — ADF p-value of \`np.log(air)\`
+- \`"log_diff"\` — ADF p-value of \`np.log(air).diff()\`
+- \`"log_diff_sdiff"\` — ADF p-value of \`np.log(air).diff().diff(12)\`
+
+Drop NaNs before each test. Also set \`is_stationary_final\` to \`True\` if the final stage's p-value is below 0.05. The full recipe should reach stationarity.`}
+  initCode={`import pandas as pd
+import numpy as np
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.stattools import adfuller
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import numpy as np
+from statsmodels.tsa.stattools import adfuller
+
+report = {
+    "raw": None,
+    "log": None,
+    "log_diff": None,
+    "log_diff_sdiff": None,
+}
+is_stationary_final = None
+print(report)
+print("final stationary:", is_stationary_final)
+`}
+  solutionCode={`import numpy as np
+from statsmodels.tsa.stattools import adfuller
+
+def p(s): return float(adfuller(s.dropna())[1])
+
+loga = np.log(air)
+report = {
+    "raw": p(air),
+    "log": p(loga),
+    "log_diff": p(loga.diff()),
+    "log_diff_sdiff": p(loga.diff().diff(12)),
+}
+is_stationary_final = report["log_diff_sdiff"] < 0.05
+print(report)
+print("final stationary:", is_stationary_final)
+`}
+  tests={[
+    {
+      id: "keys",
+      name: "report has all four stages",
+      description: "Correct keys, all floats",
+      code: `assert set(report.keys()) == {"raw", "log", "log_diff", "log_diff_sdiff"}
+assert all(isinstance(v, float) for v in report.values())`,
+    },
+    {
+      id: "raw_nonstationary",
+      name: "raw series is non-stationary",
+      description: "High p-value before transforms",
+      code: `assert report["raw"] > 0.05, "Raw airline series should be non-stationary"`,
+    },
+    {
+      id: "final_stationary",
+      name: "full recipe reaches stationarity",
+      description: "log + diff + seasonal diff passes ADF",
+      code: `assert report["log_diff_sdiff"] < 0.05 and is_stationary_final is True`,
+    },
+    {
+      id: "improves",
+      name: "differencing helps",
+      description: "Differenced p-value is far below the raw one",
+      code: `assert report["log_diff"] < report["raw"]`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Honest evaluation: does the seasonal baseline beat a flat forecast?"
+  instructions={`Do a clean chronological evaluation. Hold out the **last 12 months** of \`air\` as the test set (train = the rest). Forecast those 12 months two ways and score each by **MAE** and **RMSE** on the held-out actuals:
+
+- seasonal-naive: each test month = the value 12 months earlier (the last 12 of \`train\`)
+- flat mean: every test month = the mean of \`train\`
+
+Produce a dict \`evaluation\` with these exact key names:
+- \`"snaive_mae"\`, \`"snaive_rmse"\`, \`"mean_mae"\`, \`"mean_rmse"\` (all floats)
+- \`"snaive_better"\` — \`True\` if seasonal-naive has the lower MAE
+
+Use only \`train\` to build both forecasts — never peek at the test set.`}
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import numpy as np
+
+evaluation = {
+    "snaive_mae": None, "snaive_rmse": None,
+    "mean_mae": None, "mean_rmse": None,
+    "snaive_better": None,
+}
+print(evaluation)
+`}
+  solutionCode={`import numpy as np
+
+H = 12
+train, test = air.iloc[:-H], air.iloc[-H:]
+yt = test.values
+
+snaive = train.values[-H:]
+flat = np.full(H, train.mean())
+
+def mae(a, b):  return float(np.mean(np.abs(a - b)))
+def rmse(a, b): return float(np.sqrt(np.mean((a - b) ** 2)))
+
+evaluation = {
+    "snaive_mae": mae(yt, snaive),
+    "snaive_rmse": rmse(yt, snaive),
+    "mean_mae": mae(yt, flat),
+    "mean_rmse": rmse(yt, flat),
+}
+evaluation["snaive_better"] = evaluation["snaive_mae"] < evaluation["mean_mae"]
+print(evaluation)
+`}
+  tests={[
+    {
+      id: "keys",
+      name: "all five outputs present",
+      description: "Four floats and a bool",
+      code: `need = {"snaive_mae","snaive_rmse","mean_mae","mean_rmse","snaive_better"}
+assert need.issubset(evaluation.keys())
+assert all(isinstance(evaluation[k], float) for k in ["snaive_mae","snaive_rmse","mean_mae","mean_rmse"])`,
+    },
+    {
+      id: "snaive_wins",
+      name: "seasonal-naive beats the flat mean",
+      description: "Seasonality carries real signal here",
+      code: `assert evaluation["snaive_mae"] < evaluation["mean_mae"]
+assert evaluation["snaive_better"] is True`,
+    },
+    {
+      id: "rmse_ge_mae",
+      name: "RMSE >= MAE for both",
+      description: "A basic metric sanity check",
+      code: `assert evaluation["snaive_rmse"] >= evaluation["snaive_mae"] - 1e-9
+assert evaluation["mean_rmse"] >= evaluation["mean_mae"] - 1e-9`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`In the pipeline, **why fit the model on \`log(train)\` and exponentiate the forecasts** rather than modeling the raw passengers directly?
+
+- Because logs make the numbers smaller and faster to compute
+  > Speed isn't the reason, and the magnitude of the numbers is irrelevant to the model. The log addresses a statistical property.
+- [o] The log stabilizes the series' variance, which grows with the level (multiplicative seasonality), making it suitable for the additive, constant-variance assumptions of ARIMA
+  > The airline series' swings widen as the level rises. A log compresses that growing variance into a roughly constant one, matching what ARIMA expects; exponentiating returns forecasts to the original scale.
+- Because ARIMA cannot accept positive numbers
+  > ARIMA handles positive data fine. The log is about taming *growing variance*, not a restriction on sign or magnitude.
+- Because the log removes the trend
+  > A log does not remove a trend (differencing does). It specifically stabilizes the *variance*; the trend is handled separately by the differencing term.
+
+Logging stabilizes the variance that grows with the level, aligning the series with ARIMA's constant-variance assumptions; exponentiating undoes it.`}
+/>
+
+<MultipleChoice
+  markdown={`The seasonal model scored the lowest error on the held-out months. What single comparison makes that result *meaningful* rather than just a number?
+
+- That its AIC was the lowest
+  > AIC is an in-sample criterion and wasn't even computed here. What makes the out-of-sample number meaningful is beating a baseline on that same held-out data.
+- [o] That it beat the seasonal-naive **baseline** on the same honest, held-out test
+  > An error figure only has meaning relative to a reference. Beating "same as last year" on data the model never saw is what proves the model added real skill.
+- That it used more parameters than the alternatives
+  > More parameters is a cost, not evidence of value — it raises overfitting risk. Skill is shown by out-of-sample performance versus a baseline, not by complexity.
+- That its forecast line looked smooth
+  > Visual smoothness says nothing about accuracy. A smooth, confident, wrong forecast is still wrong; the baseline comparison on held-out data is the real test.
+
+An out-of-sample error is meaningful only against a baseline on the same honest test — beating seasonal-naive is the proof of added skill.`}
+/>
+
+<MultipleChoice
+  markdown={`Which sequence correctly orders the core pipeline steps?
+
+- Fit model -> check stationarity -> split chronologically -> evaluate
+  > Fitting before checking stationarity or splitting risks modeling a non-stationary series and leaking the future. Diagnosis and the split must come first.
+- [o] Explore -> stabilize/difference to stationarity -> identify orders -> split chronologically -> fit on train -> forecast -> compare to baseline
+  > You diagnose and prepare the series, identify orders, hold out the future, fit only on the past, forecast, and finally judge against a baseline. Each step depends on the ones before it.
+- Split randomly -> fit -> exponentiate -> done
+  > A random split leaks the future, and "done" skips stationarity, order identification, uncertainty, and the baseline comparison that make a forecast trustworthy.
+- Decompose -> forecast the trend component -> stop
+  > The decomposition trend is a backward-looking smoother, not a forecast, and this skips stationarity, fitting, the chronological split, and validation entirely.
+
+Diagnose and prepare first, hold out the future before fitting, and finish by proving skill against a baseline — order matters.`}
+/>
+
+<Callout type="success" title="Course wrap-up">
+You can now take a raw, messy, seasonal, non-stationary series and:
+
+- get it onto a clean **timeline**, **resample** it, and fill its **gaps**;
+- **decompose** it and recognize trend, seasonality, and noise;
+- test and engineer **stationarity** with the ADF test and **differencing**;
+- read **ACF/PACF** to propose **ARIMA** orders;
+- **fit** a model and forecast with honest **uncertainty**;
+- and — most importantly — **validate chronologically**, measure with
+  **MAE/RMSE/MAPE**, and prove your model **beats a baseline** without leaking
+  the future.
+
+That last skill is the one that separates forecasts you can stake decisions
+on from numbers that merely look impressive. Keep the discipline, keep a
+baseline running, and keep your training set firmly in the past.
+</Callout>

--- a/content/learn/time-series-analysis-python/capstone-forecasting-pipeline.mdx
+++ b/content/learn/time-series-analysis-python/capstone-forecasting-pipeline.mdx
@@ -271,16 +271,19 @@ for name, pred in [("Seasonal-naive (BASELINE)", fc_snaive),
     print(f"{name:30s}{mae(yt,pred):8.1f}{rmse(yt,pred):8.1f}{mape(yt,pred):7.1f}%")
 
 print()
-print("The SEASONAL model wins clearly -- it captures both trend AND the yearly")
-print("cycle. Plain ARIMA, missing seasonal terms, struggles against the very")
-print("baseline it's supposed to beat -- exactly what its lag-12 residual warned.")
+print("The SEASONAL model wins clearly -- it captures both the trend AND the")
+print("yearly cycle. Plain ARIMA handles the trend but leaves the seasonality in")
+print("its errors, so it trails the seasonal model -- exactly what its lag-12")
+print("residual spike warned about on the ARIMA page.")
 `}
 />
 
 The seasonal model posts the lowest error on data it never saw — and it
-**beats the baseline**, which is the bar every model must clear. Plain ARIMA,
-lacking seasonal terms, can't reliably out-forecast "same as last year." This
-is the residual diagnostic from the ARIMA page, paid off in hard numbers.
+**beats the baseline**, which is the bar every model must clear. Plain ARIMA
+captures the trend but, lacking seasonal terms, leaves the yearly cycle in its
+errors, so it trails the seasonal model. The gap between them is precisely the
+seasonality that plain ARIMA's lag-12 residual spike warned about on the ARIMA
+page — the residual diagnostic, paid off in hard numbers.
 
 ## Step 8 — Visualize the forecast against reality
 

--- a/content/learn/time-series-analysis-python/chronological-validation.mdx
+++ b/content/learn/time-series-analysis-python/chronological-validation.mdx
@@ -468,7 +468,7 @@ assert tr[0] == 0 and tr[-1] == 59 and te[0] == 60 and te[-1] == 71`,
 
 Compute the test-set **MAE** for two forecasts of those 24 months:
 
-- \`mae_snaive\` — the seasonal-naive forecast (each test month = the value 12 months before it; here, use the last 24 months of the *training* set, since the test horizon equals 24 = 2x12).
+- \`mae_snaive\` — the seasonal-naive forecast: each test month equals the value from the same month one year earlier. For this 24-month horizon that is the **last 12 training months repeated twice** (\`np.tile(train.values[-12:], 2)\`).
 - \`mae_mean\` — a trivial flat forecast equal to the training mean, repeated 24 times.
 
 Set \`baseline_wins\` to \`True\` if the seasonal-naive MAE is lower than the flat-mean MAE (it should be — seasonality matters here).`}
@@ -499,7 +499,7 @@ print("seasonal-naive MAE:", mae_snaive, " flat-mean MAE:", mae_mean, " snaive w
   solutionCode={`import numpy as np
 h = 24
 train, test = air.iloc[:-h], air.iloc[-h:]
-snaive_pred = train.values[-h:]                 # last 24 train months (= 2 seasons)
+snaive_pred = np.tile(train.values[-12:], 2)    # seasonal naive: last 12 months, repeated
 mean_pred = np.full(h, train.mean())
 mae_snaive = float(np.mean(np.abs(test.values - snaive_pred)))
 mae_mean = float(np.mean(np.abs(test.values - mean_pred)))

--- a/content/learn/time-series-analysis-python/chronological-validation.mdx
+++ b/content/learn/time-series-analysis-python/chronological-validation.mdx
@@ -1,0 +1,627 @@
+---
+title: "The Cardinal Sin: Preventing Data Leakage with Chronological Validation Splits"
+description: Why a random train/test split is catastrophic for time series, how to evaluate forecasts honestly with chronological splits and walk-forward backtesting, the MAE/RMSE/MAPE metrics coded by hand, and the many sneaky ways the future leaks into the past.
+---
+
+This is the most important page in the course. You can fit a flawless ARIMA
+and still ship a disaster — if you *evaluate* it wrong. The discipline that
+separates a real forecaster from someone with a good-looking notebook is
+**honest validation**: measuring a model's true ability to project into a
+future it has never seen. Get this wrong and every accuracy number you report
+is a comfortable fiction.
+
+<Callout type="danger" title="The cardinal rule, one more time">
+**You may only use the past to predict the future, never the reverse.** Every
+validation technique on this page is a mechanism for enforcing that rule.
+Every leakage bug is a way it gets broken. If you remember one thing from
+this entire course, make it this.
+</Callout>
+
+## The cardinal sin: a random split
+
+The default split in nearly every ML tutorial — shuffle the rows, take 80%
+for training and 20% for testing — is **catastrophic** for time series. When
+you randomly assign rows, a test point from March ends up *surrounded in the
+training set* by February and April. The model gets to peek at both sides of
+every test point. It will score brilliantly in evaluation and collapse in
+production, where the future genuinely doesn't exist yet.
+
+```mermaid
+flowchart TB
+    subgraph BAD["WRONG: random / k-fold split (test points time-surrounded by train)"]
+        direction LR
+        b1["Jan<br/>train"] --> b2["Feb<br/>TEST"] --> b3["Mar<br/>train"] --> b4["Apr<br/>TEST"] --> b5["May<br/>train"]
+    end
+    subgraph GOOD["RIGHT: chronological split (train is the past, test is the future)"]
+        direction LR
+        g1["Jan<br/>train"] --> g2["Feb<br/>train"] --> g3["Mar<br/>train"] --> g4["Apr<br/>TEST"] --> g5["May<br/>TEST"]
+    end
+```
+
+Let's *measure* the leakage. We'll take a smooth-ish series and "predict"
+held-out points two ways: a random hold-out (where each test point still has
+neighbours on **both** sides inside the training set) versus a chronological
+hold-out (where the test points are at the **end**, with no future neighbour
+to lean on).
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+
+rng = np.random.default_rng(0)
+n = 120
+idx = pd.date_range("2010-01-01", periods=n, freq="D")
+# A smooth-ish series (random walk with drift): neighbours are very informative.
+y = pd.Series(np.cumsum(rng.normal(0, 1, n)) + 0.3*np.arange(n), index=idx)`}
+  initialCode={`import numpy as np
+
+vals = y.values
+positions = np.arange(n)
+
+# --- RANDOM hold-out: test points scattered through time ---
+test_pos = rng.choice(np.arange(3, n-3), size=24, replace=False)
+train_mask = np.ones(n, bool); train_mask[test_pos] = False
+# "Predict" each test point by interpolating between its TRAIN neighbours.
+# Because the split is random, those neighbours sit on BOTH sides in time.
+pred_random = np.interp(test_pos, positions[train_mask], vals[train_mask])
+mae_random = np.mean(np.abs(vals[test_pos] - pred_random))
+
+# --- CHRONOLOGICAL hold-out: test points are the LAST 24 ---
+split = n - 24
+# The same interpolation idea now has NO future neighbour, so it degenerates
+# into extrapolation (carry the last known value) -- the honest situation.
+pred_chrono = np.full(24, vals[:split][-1])
+mae_chrono = np.mean(np.abs(vals[split:] - pred_chrono))
+
+print(f"MAE with RANDOM hold-out (interpolating between past+future): {mae_random:6.2f}")
+print(f"MAE with CHRONOLOGICAL hold-out (honest extrapolation):       {mae_chrono:6.2f}")
+print()
+print("The random split looks far more accurate -- but only because it let the")
+print("'forecast' peek at future neighbours that will NOT exist in production.")
+print("That gap is pure data leakage. The chronological number is the real one.")
+`}
+/>
+
+The random hold-out reports a tiny error — and it's a lie. It only achieved
+that by interpolating between training points that lie in the test point's
+*future*. In production those future points don't exist, so the method can't
+work, and the honest chronological number is many times larger. **The random
+split didn't measure forecasting; it measured interpolation.**
+
+<MultipleChoice
+  markdown={`Why is k-fold cross-validation with random folds — the standard for ordinary tabular data — the *wrong* choice for time series?
+
+- It's too slow for large time series
+  > Speed isn't the problem. The flaw is that random folds destroy the temporal ordering that the evaluation must respect.
+- [o] Random folds put future observations in the training set for some folds, leaking future information into predictions about the past and inflating the score
+  > In a random fold, training rows can come from *after* a test row in time. The model effectively sees the future, so its measured accuracy is optimistic and unattainable in production.
+- It can only be used for classification
+  > k-fold works for regression too; the issue is specifically temporal leakage, not the task type.
+- It requires shuffling, which pandas can't do
+  > pandas shuffles fine. The point is that shuffling a time series is exactly what *causes* the leakage — it's a correctness problem, not a tooling one.
+
+Random folds mix future into training, leaking information; time series needs splits that keep train strictly before test.`}
+/>
+
+## Measuring error honestly: MAE, RMSE, MAPE
+
+Once you have an honest chronological forecast, you need a number for "how
+close." Three metrics dominate, and each makes a different trade-off. Code
+them by hand once and you'll never misread them again.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import numpy as np
+
+def mae(y_true, y_pred):
+    # Mean Absolute Error: average size of the miss, in the data's own units.
+    return np.mean(np.abs(y_true - y_pred))
+
+def rmse(y_true, y_pred):
+    # Root Mean Squared Error: like MAE but SQUARES errors first, so big
+    # misses are punished much harder. Same units as the data.
+    return np.sqrt(np.mean((y_true - y_pred) ** 2))
+
+def mape(y_true, y_pred):
+    # Mean Absolute Percentage Error: scale-free, reported as a percent.
+    return np.mean(np.abs((y_true - y_pred) / y_true)) * 100
+
+# Two forecasts of the same truth: one with small even misses, one that is
+# usually perfect but has a single huge blunder.
+y_true   = np.array([100, 100, 100, 100, 100], dtype=float)
+even     = np.array([105,  95, 104,  96, 100], dtype=float)  # small, spread out
+oneblump = np.array([100, 100, 100, 100, 140], dtype=float)  # one big miss
+
+for name, pred in [("even misses", even), ("one big blunder", oneblump)]:
+    print(f"{name:16s}  MAE={mae(y_true,pred):5.1f}  RMSE={rmse(y_true,pred):5.1f}  MAPE={mape(y_true,pred):4.1f}%")
+
+print()
+print("Same MAE-ish scale, but RMSE PUNISHES the single big blunder far more.")
+print("Choose RMSE when large errors are especially costly; MAE when every")
+print("unit of error counts equally; MAPE to compare across different scales.")
+`}
+/>
+
+| Metric | What it measures | Reach for it when | Watch out for |
+| --- | --- | --- | --- |
+| **MAE** | average absolute miss, in data units | you want a robust, interpretable number; every unit counts equally | doesn't single out big misses |
+| **RMSE** | like MAE but squares errors first | large errors are *disproportionately* costly (capacity, safety) | sensitive to outliers |
+| **MAPE** | average miss as a **percent** | comparing across series of different scales | **explodes near zero**, undefined at zero, asymmetric (over- vs under-forecast) |
+
+<Callout type="warn" title="MAPE has sharp edges">
+MAPE divides by the actual value, so it **blows up when the truth is near
+zero** and is **undefined at exactly zero**. It's also asymmetric — it
+punishes over-forecasting and under-forecasting unequally. It's wonderful for
+comparing a model across products of wildly different sales volumes, but a
+poor choice for series that pass through zero (temperatures in Celsius,
+net flows). When in doubt, report MAE *and* RMSE, and add MAPE only when a
+percentage genuinely makes sense.
+</Callout>
+
+## Beyond one split: walk-forward backtesting
+
+A single train/test split gives *one* estimate of forecast skill — and one
+estimate is noisy. Maybe that particular tail happened to be easy or hard.
+**Backtesting** (time-series cross-validation) re-runs the forecast across
+*many* successive cut-off points and averages the skill. The iron rule holds
+in every fold: **train is always strictly before test.**
+
+```mermaid
+flowchart TB
+    subgraph F1["Fold 1"]
+        direction LR
+        a1["train: months 1-60"] --> p1["test: 61-72"]
+    end
+    subgraph F2["Fold 2 (train grows)"]
+        direction LR
+        a2["train: months 1-72"] --> p2["test: 73-84"]
+    end
+    subgraph F3["Fold 3 (train grows)"]
+        direction LR
+        a3["train: months 1-84"] --> p3["test: 85-96"]
+    end
+```
+
+The picture above is the **expanding-window** (anchored) scheme: the training
+set grows each fold while the test window marches forward. A **rolling-window**
+scheme instead keeps the training window a fixed *size* and slides it — useful
+when old history stops being relevant. Either way, you get several honest
+out-of-sample scores instead of one.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")
+
+def mae(yt, yp):
+    return float(np.mean(np.abs(np.asarray(yt) - np.asarray(yp))))`}
+  initialCode={`import numpy as np
+
+# Expanding-window backtest of a SEASONAL-NAIVE forecaster (predict each month
+# with the value 12 months earlier). Fast, leakage-free, and a strong baseline.
+def seasonal_naive_forecast(train, horizon, m=12):
+    last_season = train.values[-m:]
+    reps = int(np.ceil(horizon / m))
+    return np.tile(last_season, reps)[:horizon]
+
+initial, horizon, step = 60, 12, 12
+fold_maes = []
+for cut in range(initial, len(air) - horizon + 1, step):
+    train = air.iloc[:cut]            # the PAST only
+    test  = air.iloc[cut:cut+horizon] # the next 12 months (the FUTURE)
+    pred  = seasonal_naive_forecast(train, horizon)
+    e = mae(test.values, pred)
+    fold_maes.append(e)
+    print(f"train up to {train.index[-1].date()}  ->  test MAE = {e:6.1f}")
+
+print()
+print(f"Backtest MAE across {len(fold_maes)} folds: mean = {np.mean(fold_maes):.1f}, "
+      f"std = {np.std(fold_maes):.1f}")
+print("One holdout would have given just ONE of these numbers -- and you'd never")
+print("know how lucky or unlucky that single tail was. Many folds = a stable estimate.")
+`}
+/>
+
+Each fold trains only on its past and is scored on its future; averaging the
+folds gives a far steadier estimate of real skill than any single split. And
+notice we backtested a **baseline** (seasonal-naive) — because the real
+question is never "what's my error?" but "**do I beat the baseline on the same
+honest test?**"
+
+<MultipleChoice
+  markdown={`What is the defining property that every fold of a *time-series* backtest must satisfy?
+
+- Each fold must contain the same number of points
+  > Equal sizes are convenient but not the defining requirement. In expanding-window backtesting the training set deliberately grows each fold.
+- [o] In every fold, all training timestamps come strictly *before* all test timestamps — the model only ever learns from the past
+  > Keeping train entirely before test in every fold is exactly what prevents future leakage and mirrors real forecasting. It's the non-negotiable property.
+- The folds must be chosen randomly for fairness
+  > Random folds are precisely what breaks time-series validation by leaking the future. Fairness here means temporal order, not randomness.
+- Each test point must appear in the training set of another fold
+  > A test point appearing in any fold's *training* set means the model trained on data it's later tested on — leakage. Test points must stay out of all training sets that precede them in time.
+
+The essential property is temporal: train strictly precedes test in every fold, so the model never sees the future.`}
+/>
+
+## The other ways the future leaks in
+
+A chronological split is necessary but not *sufficient*. Leakage sneaks in
+through preprocessing too. Each of these silently hands the model information
+it won't have at prediction time:
+
+- **Scaling/normalizing with global statistics.** Computing a mean/std (or
+  min/max) over the *entire* series, including the test portion, leaks the
+  future's distribution into training. Fit the scaler on **train only**.
+- **Future-aware feature engineering.** Centered rolling windows, `shift(-k)`
+  leads, `bfill`, and linear interpolation all read *future* values. Safe for
+  retrospective charts, leakage as model inputs.
+- **Imputation or decomposition on the full series.** Filling gaps or
+  decomposing using all the data lets test-period values influence training.
+- **Tuning on the test set.** If you pick `(p, d, q)` by trying many options
+  and keeping the one with the best *test* score, the test set has trained
+  your choices. You need a separate **validation** set (or nested CV); the
+  final test set is looked at **once**.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import numpy as np
+
+rng = np.random.default_rng(1)
+series = np.concatenate([rng.normal(10, 1, 80), rng.normal(40, 5, 20)])  # level jumps late
+split = 80
+train, test = series[:split], series[split:]
+
+# WRONG: standardize using stats from the WHOLE series (peeks at the test jump).
+g_mean, g_std = series.mean(), series.std()
+wrong_train = (train - g_mean) / g_std
+
+# RIGHT: standardize using TRAIN stats only.
+t_mean, t_std = train.mean(), train.std()
+right_train = (train - t_mean) / t_std
+
+print(f"Global mean used on train (LEAKY): {g_mean:5.2f}  <- pulled up by the test-era jump")
+print(f"Train-only mean (correct)        : {t_mean:5.2f}")
+print()
+print("The leaky version centers training data using a mean inflated by data")
+print("the model shouldn't have seen yet. Always fit transforms on TRAIN only.")
+`}
+/>
+
+<Callout type="danger" title="Look at preprocessing, not just the split">
+The split is the famous leak, but the subtle ones live in preprocessing.
+Before trusting any backtest, ask of every transformation: *"could this step
+have seen data from the test period?"* Scalers, imputers, decompositions,
+feature lags, and hyperparameter choices must all be derived from the
+training data of each fold — never from the whole series.
+</Callout>
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Implement the three error metrics in NumPy"
+  instructions={`Code the forecasting metrics from scratch. Given true and predicted arrays, implement:
+
+- \`mae(y_true, y_pred)\` — mean absolute error
+- \`rmse(y_true, y_pred)\` — root mean squared error
+- \`mape(y_true, y_pred)\` — mean absolute percentage error (as a percent, i.e. multiplied by 100)
+
+Then evaluate them on the provided \`y_true\` and \`y_pred\` and store the results (as plain floats) in a dict \`scores\` with keys \`"mae"\`, \`"rmse"\`, \`"mape"\`.`}
+  initCode={`import numpy as np
+y_true = np.array([200.0, 210.0, 190.0, 220.0, 205.0])
+y_pred = np.array([198.0, 215.0, 185.0, 219.0, 210.0])`}
+  initialCode={`import numpy as np
+
+def mae(y_true, y_pred):
+    return None
+
+def rmse(y_true, y_pred):
+    return None
+
+def mape(y_true, y_pred):
+    return None
+
+scores = {"mae": None, "rmse": None, "mape": None}
+print(scores)
+`}
+  solutionCode={`import numpy as np
+
+def mae(y_true, y_pred):
+    return float(np.mean(np.abs(y_true - y_pred)))
+
+def rmse(y_true, y_pred):
+    return float(np.sqrt(np.mean((y_true - y_pred) ** 2)))
+
+def mape(y_true, y_pred):
+    return float(np.mean(np.abs((y_true - y_pred) / y_true)) * 100)
+
+scores = {
+    "mae": mae(y_true, y_pred),
+    "rmse": rmse(y_true, y_pred),
+    "mape": mape(y_true, y_pred),
+}
+print(scores)
+`}
+  tests={[
+    {
+      id: "mae",
+      name: "MAE is correct",
+      description: "Mean absolute error of the sample",
+      code: `import numpy as np
+assert abs(scores["mae"] - np.mean(np.abs(y_true - y_pred))) < 1e-9`,
+    },
+    {
+      id: "rmse",
+      name: "RMSE is correct",
+      description: "Root mean squared error of the sample",
+      code: `import numpy as np
+assert abs(scores["rmse"] - np.sqrt(np.mean((y_true - y_pred) ** 2))) < 1e-9`,
+    },
+    {
+      id: "mape",
+      name: "MAPE is a percent",
+      description: "Mean absolute percentage error times 100",
+      code: `import numpy as np
+assert abs(scores["mape"] - np.mean(np.abs((y_true - y_pred)/y_true))*100) < 1e-9`,
+    },
+    {
+      id: "rmse_ge_mae",
+      name: "RMSE >= MAE (a sanity identity)",
+      description: "RMSE never falls below MAE",
+      code: `assert scores["rmse"] >= scores["mae"] - 1e-9`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Generate leakage-free expanding-window folds"
+  instructions={`Write \`expanding_folds(n, initial, horizon, step)\` that yields \`(train_idx, test_idx)\` pairs for an **expanding-window** backtest over \`n\` points:
+
+- The first fold trains on indices \`0..initial-1\` and tests on \`initial..initial+horizon-1\`.
+- Each later fold's training set **grows** to include everything before its test window; the test window advances by \`step\`.
+- Stop when a full \`horizon\`-length test window no longer fits.
+
+Return the list of folds as \`folds\` (a list of \`(train_idx, test_idx)\` tuples, where each is a list/range of integer positions). Every fold's training indices must all be **less than** all of its test indices (leakage-free).`}
+  initCode={`n, initial, horizon, step = 100, 60, 12, 12`}
+  initialCode={`def expanding_folds(n, initial, horizon, step):
+    folds = []
+    # TODO: build (train_idx, test_idx) tuples
+    return folds
+
+folds = expanding_folds(n, initial, horizon, step)
+for tr, te in folds:
+    print(f"train 0..{tr[-1]}  test {te[0]}..{te[-1]}")
+`}
+  solutionCode={`def expanding_folds(n, initial, horizon, step):
+    folds = []
+    cut = initial
+    while cut + horizon <= n:
+        train_idx = list(range(0, cut))
+        test_idx = list(range(cut, cut + horizon))
+        folds.append((train_idx, test_idx))
+        cut += step
+    return folds
+
+folds = expanding_folds(n, initial, horizon, step)
+for tr, te in folds:
+    print(f"train 0..{tr[-1]}  test {te[0]}..{te[-1]}")
+`}
+  tests={[
+    {
+      id: "nonempty",
+      name: "produces folds",
+      description: "At least three fit for these settings",
+      code: `assert len(folds) >= 3, f"Expected several folds, got {len(folds)}"`,
+    },
+    {
+      id: "leakfree",
+      name: "every fold is leakage-free",
+      description: "All train indices precede all test indices",
+      code: `for tr, te in folds:
+    assert max(tr) < min(te), "Train must come strictly before test in every fold"`,
+    },
+    {
+      id: "expanding",
+      name: "training set expands",
+      description: "Each fold trains on more than the last",
+      code: `lens = [len(tr) for tr, te in folds]
+assert all(lens[i] < lens[i+1] for i in range(len(lens)-1)), "Training window should grow"`,
+    },
+    {
+      id: "horizon",
+      name: "test windows have the right length",
+      description: "Each test window is `horizon` long",
+      code: `assert all(len(te) == 12 for tr, te in folds)`,
+    },
+    {
+      id: "first_fold",
+      name: "first fold matches the spec",
+      description: "Train 0..59, test 60..71",
+      code: `tr, te = folds[0]
+assert tr[0] == 0 and tr[-1] == 59 and te[0] == 60 and te[-1] == 71`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Beat the baseline on an honest split"
+  instructions={`Evaluate a forecaster against the seasonal-naive baseline on a **single chronological** split. The airline \`air\` series is loaded; hold out the **last 24 months** as the test set (train = the rest).
+
+Compute the test-set **MAE** for two forecasts of those 24 months:
+
+- \`mae_snaive\` — the seasonal-naive forecast (each test month = the value 12 months before it; here, use the last 24 months of the *training* set, since the test horizon equals 24 = 2x12).
+- \`mae_mean\` — a trivial flat forecast equal to the training mean, repeated 24 times.
+
+Set \`baseline_wins\` to \`True\` if the seasonal-naive MAE is lower than the flat-mean MAE (it should be — seasonality matters here).`}
+  initCode={`import numpy as np
+import pandas as pd
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import numpy as np
+mae_snaive = None
+mae_mean = None
+baseline_wins = None
+print("seasonal-naive MAE:", mae_snaive, " flat-mean MAE:", mae_mean, " snaive wins:", baseline_wins)
+`}
+  solutionCode={`import numpy as np
+h = 24
+train, test = air.iloc[:-h], air.iloc[-h:]
+snaive_pred = train.values[-h:]                 # last 24 train months (= 2 seasons)
+mean_pred = np.full(h, train.mean())
+mae_snaive = float(np.mean(np.abs(test.values - snaive_pred)))
+mae_mean = float(np.mean(np.abs(test.values - mean_pred)))
+baseline_wins = mae_snaive < mae_mean
+print("seasonal-naive MAE:", round(mae_snaive,1), " flat-mean MAE:", round(mae_mean,1),
+      " snaive wins:", baseline_wins)
+`}
+  tests={[
+    {
+      id: "computed",
+      name: "both MAEs are floats",
+      description: "Evaluated on the held-out 24 months",
+      code: `assert isinstance(mae_snaive, float) and isinstance(mae_mean, float)`,
+    },
+    {
+      id: "snaive_better",
+      name: "seasonal-naive beats the flat mean",
+      description: "Using last year's pattern beats ignoring seasonality",
+      code: `assert mae_snaive < mae_mean, "Seasonal-naive should beat a flat mean on this seasonal series"`,
+    },
+    {
+      id: "flag",
+      name: "baseline_wins is set correctly",
+      description: "Consistent with the two MAEs",
+      code: `assert baseline_wins == (mae_snaive < mae_mean) and baseline_wins is True`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`A model scores 2% error on a *random* 80/20 split but 18% error in production. What's the most likely explanation?
+
+- The production data is fundamentally different
+  > A 9x degradation that appears only after deployment is the classic fingerprint of evaluation leakage, not of the world suddenly changing.
+- [o] The random split leaked future information into training, so the 2% was optimistic; the honest, leakage-free error is closer to the 18% seen in production
+  > Random splitting let test points be time-surrounded by training points, measuring interpolation rather than forecasting. Production has no such future context, so the true error surfaces.
+- The model needs more training epochs
+  > Classical models like ARIMA aren't trained in "epochs," and more training wouldn't close a gap caused by a leaky *evaluation*. The fix is an honest chronological split.
+- 2% and 18% are both correct and unrelated
+  > They measure the same model's accuracy and should roughly agree under honest evaluation. The large discrepancy is the symptom that the 2% came from a leaky split.
+
+A great-in-testing, bad-in-production gap on temporal data points to leakage from a random split; the production figure is the honest one.`}
+/>
+
+<MultipleChoice
+  markdown={`You standardize your features using the mean and standard deviation computed over the **entire** dataset, then do a chronological train/test split. Is this safe?
+
+- Yes — a chronological split is all you need
+  > A chronological split fixes the *split*, but the scaler already peeked. Computing global statistics over all data lets the test period's distribution leak into training.
+- [o] No — the scaler's statistics include the test period, leaking future information; fit the scaler on the training data only
+  > Any transform whose parameters are learned from the whole series (mean, std, min/max, imputation values) leaks the future. Scalers must be fit on train and merely *applied* to test.
+- Yes, as long as you don't shuffle
+  > Not shuffling preserves order, but the global scaler still saw the test distribution. Order and preprocessing are two separate leakage channels.
+- It only matters for classification problems
+  > Scaling leakage affects forecasting and regression just as much. The principle — derive all transforms from training data only — is universal.
+
+Even with a chronological split, fitting a scaler (or imputer) on the full series leaks the future; learn such parameters from training data alone.`}
+/>
+
+<MultipleChoice
+  markdown={`Why report a forecast's error from a multi-fold **backtest** rather than a single train/test split?
+
+- A single split is mathematically invalid
+  > A single chronological split is perfectly valid; it's just *noisy*. Backtesting improves the estimate rather than fixing an invalidity.
+- [o] One split gives a single, noisy estimate that may have landed on an unusually easy or hard period; averaging several folds yields a more stable, trustworthy measure of skill
+  > Different tails of history vary in difficulty. Multiple folds average over that luck, so the reported skill is less dependent on which single window you happened to hold out.
+- Backtesting lets you train on the test set
+  > Backtesting does the opposite — it rigorously keeps train before test in every fold. It never trains on test data.
+- It makes the model itself more accurate
+  > Backtesting is an *evaluation* procedure; it measures skill, it doesn't change the model's accuracy. Its value is a more reliable estimate.
+
+Multiple folds average away the luck of a single holdout, giving a steadier estimate of true out-of-sample skill.`}
+/>
+
+<MultipleChoice
+  markdown={`Which metric would be the **most problematic** choice for evaluating forecasts of a series whose values regularly pass through and near **zero** (e.g., net hourly energy flow that can be positive, negative, or zero)?
+
+- MAE
+  > MAE just averages absolute misses in the data's units; zeros cause it no trouble at all.
+- RMSE
+  > RMSE squares errors but never divides by the actual value, so values near zero don't destabilize it.
+- [o] MAPE
+  > MAPE divides each error by the actual value, so it explodes as the truth approaches zero and is undefined at exactly zero — exactly the situation described.
+- They are all equally appropriate here
+  > They are not: only MAPE involves dividing by the (near-zero) actual, which makes it blow up. MAE and RMSE are fine here.
+
+MAPE divides by the actual value, so series that pass through zero make it unstable or undefined; prefer MAE/RMSE there.`}
+/>
+
+<MultipleChoice
+  markdown={`You try 30 different \`(p, d, q)\` combinations and keep the one with the lowest error **on your test set**. What's the hidden problem?
+
+- Nothing — picking the best test score is the goal
+  > If the *test* set chose your model, it's no longer an untouched measure of generalization. You've let it train your decision, so its score is optimistic.
+- [o] The test set has now influenced model selection, so its score is optimistic; you need a separate validation set (or nested CV), and the final test set should be evaluated only once
+  > Selecting among many models by test performance is a form of leakage — the test set tuned your choice. Hold out a separate validation set for tuning and reserve the test set for a single, final, honest estimate.
+- 30 combinations is too few to be reliable
+  > The count isn't the issue; even choosing among two by test score leaks. The problem is *using the test set to choose at all*.
+- ARIMA orders should never be compared
+  > Comparing orders is normal and useful — just not on the final test set. Use a validation split or information criteria for selection.
+
+Choosing a model by its test-set score lets the test set tune you; use a separate validation set and touch the test set only once.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- A **random / k-fold split leaks the future** into training and reports
+  fantasy accuracy. Time series demands **chronological** splits: train is the
+  past, test is the future.
+- **Backtest** with **walk-forward** folds (expanding or rolling window) for a
+  stable skill estimate — and in every fold, **train strictly precedes test**.
+- Code metrics by hand: **MAE** (robust, in-units), **RMSE** (punishes big
+  misses), **MAPE** (scale-free percent, but **breaks near zero**).
+- Leakage hides in **preprocessing** too: fit scalers/imputers/decompositions
+  on **train only**, avoid future-aware features (centered windows, leads,
+  bfill/interpolate as inputs), and never tune on the **test** set.
+- Always compare to a **baseline** on the *same* honest backtest — skill is
+  relative.
+</Callout>
+
+You now have every piece: shaping a timeline, reshaping its resolution,
+handling gaps, decomposing structure, achieving stationarity, reading
+ACF/PACF, fitting ARIMA, and — above all — validating honestly. The capstone
+threads them into one end-to-end pipeline.

--- a/content/learn/time-series-analysis-python/decomposition-trend-seasonality.mdx
+++ b/content/learn/time-series-analysis-python/decomposition-trend-seasonality.mdx
@@ -1,0 +1,458 @@
+---
+title: "Decomposing the Signals: Dissecting Trend, Seasonality, and Residuals"
+description: Splitting a series into trend, seasonal, and residual components with seasonal_decompose — additive vs multiplicative models, why AirPassengers needs multiplicative (or a log), reading the residual as a diagnostic, and deseasonalizing to reveal true growth.
+---
+
+A real time series is several stories told at once: a slow climb, a yearly
+rhythm, and a haze of randomness on top. **Decomposition** pulls those
+apart so you can study each on its own. It's both a *diagnostic* (what is
+this series actually made of?) and a *preparation step* (strip the
+seasonality so you can see the real growth). The mental model is one line:
+
+```mermaid
+flowchart TB
+    O["Observed series<br/>(what you measured)"] --> T["Trend<br/>(slow long-run level)"]
+    O --> S["Seasonal<br/>(repeating fixed-period cycle)"]
+    O --> R["Residual / Noise<br/>(unexplained remainder)"]
+    T --> SUM["Additive:  Observed = Trend + Seasonal + Residual<br/>Multiplicative:  Observed = Trend x Seasonal x Residual"]
+    S --> SUM
+    R --> SUM
+```
+
+## See it recover components we built ourselves
+
+The honest way to trust a tool is to feed it data whose answer you already
+know. We'll *construct* a series from a known trend, a known seasonal sine,
+and known noise, then ask `seasonal_decompose` to hand the pieces back.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from statsmodels.tsa.seasonal import seasonal_decompose
+
+rng = np.random.default_rng(0)
+n = 96                                   # 8 years of monthly data
+idx = pd.date_range("2014-01-01", periods=n, freq="MS")
+t = np.arange(n)
+true_trend    = 50 + 0.8 * t             # a straight climb we put in by hand
+true_seasonal = 12 * np.sin(2*np.pi*t/12)  # a yearly wave, constant size
+true_noise    = rng.normal(0, 3, n)      # random haze
+y = pd.Series(true_trend + true_seasonal + true_noise, index=idx, name="y")`}
+  initialCode={`from statsmodels.tsa.seasonal import seasonal_decompose
+import matplotlib.pyplot as plt
+
+# period=12 tells it the seasonal cycle is 12 months long.
+result = seasonal_decompose(y, model="additive", period=12)
+
+fig = result.plot()
+fig.set_size_inches(9, 7)
+plt.tight_layout()
+plt.show()
+
+print("Top to bottom: Observed, Trend, Seasonal, Residual.")
+print("The recovered Trend is our straight climb; the Seasonal panel is our")
+print("yearly wave repeated 8 times; the Residual is just the leftover noise.")
+`}
+/>
+
+Four panels: the original on top, then the smooth **trend** it extracted,
+the repeating **seasonal** wave, and the **residual** — what's left when you
+subtract the other two. For data we built additively, the residual is
+shapeless noise, exactly as it should be.
+
+<Callout type="info" title="How seasonal_decompose actually works (the short version)">
+1. **Trend** — estimate it with a centered moving average whose window is
+   the seasonal period (so the season averages out). This is why the trend
+   has `NaN`s at both ends: the moving average needs a full window.
+2. **Seasonal** — subtract the trend, then *average* the leftovers at each
+   position in the cycle (all Januaries together, all Februaries, ...). That
+   average shape is repeated across the whole span.
+3. **Residual** — whatever remains after removing trend and seasonal.
+
+It's a deliberately simple recipe, which makes it fast, transparent, and a
+great first look — not a forecasting model.
+</Callout>
+
+## Additive or multiplicative? Read the seasonal swings
+
+The choice between the two models isn't a coin flip — the data tells you:
+
+- **Additive** (`Observed = Trend + Seasonal + Residual`): use it when the
+  seasonal swings are **roughly the same size** regardless of the level. The
+  summer bump is "+30" whether the series sits at 100 or at 500.
+- **Multiplicative** (`Observed = Trend x Seasonal x Residual`): use it when
+  the seasonal swings **grow with the level**. The summer bump is "+30%" — so
+  it's small when the series is low and large when it's high.
+
+The airline series is the textbook multiplicative case: its summer-to-winter
+swing is tiny in 1949 and huge by 1960. Watch what additive does with that.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`from statsmodels.tsa.seasonal import seasonal_decompose
+import matplotlib.pyplot as plt
+
+# Decompose the airline series BOTH ways and compare the RESIDUALS.
+res_add = seasonal_decompose(air, model="additive",       period=12).resid.dropna()
+res_mul = seasonal_decompose(air, model="multiplicative",  period=12).resid.dropna()
+
+fig, (a1, a2) = plt.subplots(2, 1, figsize=(10, 6), sharex=True)
+res_add.plot(ax=a1, title="Additive residual (note the widening FUNNEL = misfit)")
+a1.axhline(0, color="grey", lw=0.8)
+res_mul.plot(ax=a2, title="Multiplicative residual (flat band around 1.0 = good fit)")
+a2.axhline(1, color="grey", lw=0.8)
+plt.tight_layout(); plt.show()
+
+# Quantify: does the residual spread grow over time?
+half = len(res_add) // 2
+print("Additive residual std  -- early:", round(res_add[:half].std(),2),
+      " late:", round(res_add[half:].std(),2), " (grows -> bad)")
+print("Multiplicative resid std-- early:", round(res_mul[:half].std(),3),
+      " late:", round(res_mul[half:].std(),3), " (stable -> good)")
+`}
+/>
+
+The additive residual **fans out** — small early, large late — because an
+additive model insists the seasonal swing is a fixed size, and it simply
+*can't* represent a swing that grows. That leftover structure is the model
+telling you "wrong assumption." The multiplicative residual stays a flat
+band around 1.0: the right model leaves behind nothing but noise.
+
+<Callout type="tip" title="The residual is your report card">
+A good decomposition leaves a residual that looks like **structureless
+noise** — no trend, no repeating wave, no funnel. *Any* leftover pattern
+means a component was mis-estimated or the wrong model was chosen. You'll
+use this exact instinct later to judge forecasting models: fit is good when
+the residuals are boring.
+</Callout>
+
+<MultipleChoice
+  markdown={`A monthly series sits near 200 in its early years with a summer peak about +20 above trend, and near 1000 in its later years with a summer peak about +100 above trend. Additive or multiplicative?
+
+- Additive, because the peaks are always above the trend
+  > "Above the trend" doesn't decide it; the *size* of the swing does. Here the swing grows from ~20 to ~100, which an additive model (fixed-size season) can't represent.
+- [o] Multiplicative, because the seasonal swing grows in proportion to the level (~10% of the level in both eras)
+  > +20 on 200 and +100 on 1000 are both about 10% — a constant *percentage*, which is exactly multiplicative seasonality. The swing scales with the level.
+- Neither; the series has no seasonality
+  > It clearly has a repeating summer peak — that's seasonality. The only question is whether its size is constant (additive) or proportional (multiplicative).
+- It doesn't matter which you pick
+  > It matters a lot: an additive fit here leaves a funnel-shaped residual (visible misfit), while multiplicative leaves clean noise. The wrong choice corrupts every downstream component.
+
+When the seasonal swing scales with the level (constant percentage), the model is multiplicative; constant absolute swing means additive.`}
+/>
+
+## The log trick: turn multiplicative into additive
+
+There's an elegant shortcut. Taking the **logarithm** of a multiplicative
+series makes it *additive*, because `log(T x S x R) = log T + log S + log R`.
+A log compresses the big late-period swings and stretches the small early
+ones until they're the same size — exactly what an additive model wants.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import numpy as np
+import matplotlib.pyplot as plt
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(11, 4))
+air.plot(ax=a1, title="Original: seasonal swings GROW with the level")
+np.log(air).plot(ax=a2, title="log(passengers): swings now ROUGHLY CONSTANT")
+plt.tight_layout(); plt.show()
+
+print("On the log scale the early and late seasonal swings are about equal,")
+print("so an ADDITIVE decomposition of log(air) == a MULTIPLICATIVE one of air.")
+print("The log also tames the growing variance -- a preview of stationarity.")
+`}
+/>
+
+<Callout type="info" title="Why we'll keep reaching for the log">
+Stabilizing a growing variance with a log shows up again and again: it's
+step one for the airline series before differencing, and it's why
+forecasters so often model `log(sales)` instead of `sales`. A log turns
+"multiplies by" into "adds to," which is the linear world our classical
+models live in.
+</Callout>
+
+## Deseasonalizing: revealing the real growth
+
+One of decomposition's most practical payoffs is **seasonal adjustment** —
+removing the seasonal component so the underlying trend isn't drowned out by
+the yearly wave. "Are sales *really* up, or is it just December?" is a
+deseasonalizing question.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`from statsmodels.tsa.seasonal import seasonal_decompose
+import matplotlib.pyplot as plt
+
+dec = seasonal_decompose(air, model="multiplicative", period=12)
+
+# For a MULTIPLICATIVE model, deseasonalize by DIVIDING out the seasonal factor.
+deseasonalized = air / dec.seasonal
+
+fig, ax = plt.subplots(figsize=(10, 4))
+air.plot(ax=ax, alpha=0.4, label="original (seasonal wobble)")
+deseasonalized.plot(ax=ax, linewidth=2, label="seasonally adjusted")
+ax.legend(); ax.set_title("Removing the seasonal factor exposes the underlying growth")
+plt.tight_layout(); plt.show()
+
+print("The adjusted line is smooth: with December's spike and November's dip")
+print("divided out, the steady climb in demand is unmistakable.")
+`}
+/>
+
+<Callout type="danger" title="The decomposition 'trend' is not a forecast">
+Just like a rolling mean, the **trend** component is a *backward-looking
+smoother* of data you already have — it even has `NaN`s at both ends where
+the moving average runs out. It describes the past; it does not project the
+future. To forecast, you still need a model (ARIMA is coming). Seeing the
+trend curve and imagining it "continuing" is the same misconception we
+flagged for moving averages, in a new costume.
+</Callout>
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Decompose and rebuild (additive reconstruction)"
+  instructions={`An additively-built monthly series \`y\` is loaded. Run an **additive** \`seasonal_decompose\` with \`period=12\` and store it in \`dec\`. Then verify the additive identity by reconstructing the series:
+
+- \`recon\` = \`dec.trend + dec.seasonal + dec.resid\`
+- \`max_err\` = the maximum absolute difference between \`recon\` and \`y\`, computed only where \`recon\` is not \`NaN\` (the trend/residual are \`NaN\` at the ends).
+
+For a true additive decomposition, the pieces must add back to the original, so \`max_err\` should be tiny (below \`1e-6\`).`}
+  initCode={`import numpy as np
+import pandas as pd
+rng = np.random.default_rng(1)
+n = 72
+idx = pd.date_range("2015-01-01", periods=n, freq="MS")
+t = np.arange(n)
+y = pd.Series(40 + 0.5*t + 8*np.sin(2*np.pi*t/12) + rng.normal(0, 2, n),
+              index=idx, name="y")`}
+  initialCode={`from statsmodels.tsa.seasonal import seasonal_decompose
+dec = None
+recon = None
+max_err = None
+print("max reconstruction error:", max_err)
+`}
+  solutionCode={`from statsmodels.tsa.seasonal import seasonal_decompose
+dec = seasonal_decompose(y, model="additive", period=12)
+recon = dec.trend + dec.seasonal + dec.resid
+mask = recon.notna()
+max_err = float((recon[mask] - y[mask]).abs().max())
+print("max reconstruction error:", max_err)
+`}
+  tests={[
+    {
+      id: "has_components",
+      name: "dec exposes trend, seasonal, resid",
+      description: "It's a real decomposition result",
+      code: `assert all(hasattr(dec, a) for a in ["trend", "seasonal", "resid"])`,
+    },
+    {
+      id: "reconstructs",
+      name: "components add back to the original",
+      description: "Additive identity holds where defined",
+      code: `assert max_err is not None and max_err < 1e-6, f"Reconstruction error too large: {max_err}"`,
+    },
+    {
+      id: "trend_has_nans",
+      name: "trend has NaNs at the ends",
+      description: "Moving-average edges are undefined",
+      code: `assert dec.trend.isna().sum() >= 12, "Classical trend should be NaN for ~one period at each end"`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Let the residual pick the model"
+  instructions={`A multiplicative series \`m\` is loaded (its seasonal swings grow with the level). Fit **both** an additive and a multiplicative \`seasonal_decompose\` (\`period=12\`). Measure how much each residual's spread *grows* over time by comparing the std of the first half to the second half of each residual (drop NaNs first).
+
+Produce a dict \`growth\` with:
+
+- \`"additive_ratio"\` — (late-half std) / (early-half std) of the **additive** residual
+- \`"multiplicative_ratio"\` — the same ratio for the **multiplicative** residual
+
+The additive model can't handle growing swings, so its residual spread balloons: \`additive_ratio\` should be clearly larger than \`multiplicative_ratio\`.`}
+  initCode={`import numpy as np
+import pandas as pd
+rng = np.random.default_rng(5)
+n = 120
+idx = pd.date_range("2010-01-01", periods=n, freq="MS")
+t = np.arange(n)
+level = 100 + 4*t
+m = pd.Series(level * (1 + 0.25*np.sin(2*np.pi*t/12)) * rng.normal(1, 0.03, n),
+              index=idx, name="m")`}
+  initialCode={`from statsmodels.tsa.seasonal import seasonal_decompose
+
+def half_ratio(resid):
+    r = resid.dropna()
+    h = len(r) // 2
+    return float(r.iloc[h:].std() / r.iloc[:h].std())
+
+growth = {
+    "additive_ratio": None,
+    "multiplicative_ratio": None,
+}
+print(growth)
+`}
+  solutionCode={`from statsmodels.tsa.seasonal import seasonal_decompose
+
+def half_ratio(resid):
+    r = resid.dropna()
+    h = len(r) // 2
+    return float(r.iloc[h:].std() / r.iloc[:h].std())
+
+growth = {
+    "additive_ratio": half_ratio(seasonal_decompose(m, model="additive", period=12).resid),
+    "multiplicative_ratio": half_ratio(seasonal_decompose(m, model="multiplicative", period=12).resid),
+}
+print(growth)
+`}
+  tests={[
+    {
+      id: "keys",
+      name: "growth has both float ratios",
+      description: "Correct keys and types",
+      code: `assert set(growth.keys()) == {"additive_ratio", "multiplicative_ratio"}
+assert all(isinstance(v, float) for v in growth.values())`,
+    },
+    {
+      id: "additive_worse",
+      name: "additive residual spread grows more",
+      description: "Wrong model -> funnel-shaped residual",
+      code: `assert growth["additive_ratio"] > growth["multiplicative_ratio"], "Additive residual should fan out more than multiplicative"`,
+    },
+    {
+      id: "additive_grows",
+      name: "additive ratio clearly exceeds 1",
+      description: "The funnel is real",
+      code: `assert growth["additive_ratio"] > 1.3, f"Expected clear growth, got {growth['additive_ratio']}"`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`In the equation \`Observed = Trend + Seasonal + Residual\`, what should the **residual** ideally look like?
+
+- A clean repeating wave
+  > A repeating wave in the residual means *leftover seasonality* — the seasonal component was under-estimated. A good residual has no such pattern.
+- A steady upward slope
+  > A slope in the residual means *leftover trend*. The trend component should have absorbed it; its presence signals a misfit.
+- [o] Structureless noise with no visible trend, cycle, or funnel
+  > The residual is what's left after the structured parts are removed, so ideally it's pure randomness. Any remaining pattern indicates a component was mis-estimated or the wrong model was used.
+- Exactly zero everywhere
+  > Real data has genuine randomness, so a perfectly flat-zero residual would be suspicious (or overfit). "Boring noise," not "nothing," is the goal.
+
+A well-specified decomposition leaves only patternless noise in the residual; any structure is a red flag.`}
+/>
+
+<MultipleChoice
+  markdown={`Why does the classical \`seasonal_decompose\` **trend** component have \`NaN\` values at the very start and end of the series?
+
+- Because the data is missing there
+  > The observed data exists at the ends; it's the *trend estimate* that's undefined there, not the raw data.
+- [o] Because the trend is a centered moving average over the seasonal period, and a full window isn't available at the edges
+  > Estimating the trend needs a full-period window centered on each point. Near the boundaries there aren't enough neighbours on one side, so the moving average — and thus the trend — is undefined.
+- Because seasonality cannot be computed at the edges
+  > The *seasonal* component is defined everywhere (it's a repeated average shape). It's specifically the moving-average *trend* that runs out of window at the ends.
+- Because of a bug in statsmodels
+  > It's expected behavior, not a bug: a centered moving average mathematically cannot reach the edges. (STL and model-based methods handle ends differently.)
+
+The trend is a centered moving average, which has no full window at the boundaries, leaving \`NaN\`s there.`}
+/>
+
+<MultipleChoice
+  markdown={`Taking \`log\` of a series before an **additive** decomposition is equivalent to what?
+
+- Removing the trend entirely
+  > A log doesn't remove the trend; it rescales the values. The trend remains (now on a log scale).
+- [o] A **multiplicative** decomposition of the original series, because \`log(T x S x R) = log T + log S + log R\`
+  > The logarithm turns products into sums, so additive structure on the log scale corresponds to multiplicative structure on the original scale. That's why a log + additive fit handles growing seasonal swings.
+- Converting the data to percentages
+  > A log is not a percentage transform. It does compress proportional changes, but the result is log-units, not percents.
+- Making the series perfectly stationary
+  > A log stabilizes growing *variance* but does nothing about trend or seasonality, so the result is generally still non-stationary. Differencing handles those, as we'll see next.
+
+Because logs turn multiplication into addition, an additive decomposition of \`log(y)\` is a multiplicative decomposition of \`y\`.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- Decomposition splits a series into **Trend + Seasonal + Residual**
+  (additive) or **Trend x Seasonal x Residual** (multiplicative).
+- Use **additive** when seasonal swings are a constant *size*,
+  **multiplicative** when they grow with the *level* (e.g. AirPassengers).
+- `seasonal_decompose(series, model=..., period=...)` estimates the trend by
+  a centered moving average (hence the end `NaN`s), the seasonal by averaging
+  per cycle-position, and the residual as the remainder.
+- A **`log`** turns a multiplicative series additive and tames growing
+  variance — a step we'll reuse for stationarity.
+- The **residual is a diagnostic**: a funnel or leftover wave means the wrong
+  model or a mis-estimated component.
+- **Deseasonalizing** (subtract or divide out the seasonal) reveals the true
+  underlying growth — but the trend component is still a *smoother*, not a
+  forecast.
+</Callout>
+
+We keep bumping into the same words — the airline series' growing variance
+and persistent trend make it "non-stationary," and we keep promising to fix
+that. It's time to make that idea precise: what stationarity *is*, why
+classical models demand it, and how to test for it.

--- a/content/learn/time-series-analysis-python/decomposition-trend-seasonality.mdx
+++ b/content/learn/time-series-analysis-python/decomposition-trend-seasonality.mdx
@@ -117,25 +117,25 @@ res_add = seasonal_decompose(air, model="additive",       period=12).resid.dropn
 res_mul = seasonal_decompose(air, model="multiplicative",  period=12).resid.dropna()
 
 fig, (a1, a2) = plt.subplots(2, 1, figsize=(10, 6), sharex=True)
-res_add.plot(ax=a1, title="Additive residual (note the widening FUNNEL = misfit)")
+res_add.plot(ax=a1, title="Additive residual: leftover STRUCTURE remains (misfit)")
 a1.axhline(0, color="grey", lw=0.8)
-res_mul.plot(ax=a2, title="Multiplicative residual (flat band around 1.0 = good fit)")
+res_mul.plot(ax=a2, title="Multiplicative residual: flat band around 1.0 (good fit)")
 a2.axhline(1, color="grey", lw=0.8)
 plt.tight_layout(); plt.show()
 
-# Quantify: does the residual spread grow over time?
-half = len(res_add) // 2
-print("Additive residual std  -- early:", round(res_add[:half].std(),2),
-      " late:", round(res_add[half:].std(),2), " (grows -> bad)")
-print("Multiplicative resid std-- early:", round(res_mul[:half].std(),3),
-      " late:", round(res_mul[half:].std(),3), " (stable -> good)")
+# The multiplicative residual is tight, featureless noise around 1.0.
+print(f"Multiplicative residual: std = {res_mul.std():.3f} around 1.0 -> clean noise.")
+print("The ADDITIVE residual (top panel) is NOT clean noise: it has visible")
+print("structure, swelling where the level sits farthest from its average,")
+print("because a fixed-size additive season can't track a swing that grows.")
 `}
 />
 
-The additive residual **fans out** — small early, large late — because an
-additive model insists the seasonal swing is a fixed size, and it simply
-*can't* represent a swing that grows. That leftover structure is the model
-telling you "wrong assumption." The multiplicative residual stays a flat
+The additive residual carries **visible leftover structure** — its swings are
+largest where the level sits farthest from its average — because an additive
+model insists the seasonal swing is a fixed size and *can't* represent a swing
+that grows with the level. That structure is the model telling you "wrong
+assumption." The multiplicative residual, by contrast, is a flat, featureless
 band around 1.0: the right model leaves behind nothing but noise.
 
 <Callout type="tip" title="The residual is your report card">
@@ -321,69 +321,75 @@ print("max reconstruction error:", max_err)
 
 <ChallengeCard
   adapter="python"
-  title="Let the residual pick the model"
-  instructions={`A multiplicative series \`m\` is loaded (its seasonal swings grow with the level). Fit **both** an additive and a multiplicative \`seasonal_decompose\` (\`period=12\`). Measure how much each residual's spread *grows* over time by comparing the std of the first half to the second half of each residual (drop NaNs first).
+  title="Detect multiplicative seasonality from the data"
+  instructions={`The decision between additive and multiplicative comes down to one question: **do the seasonal swings grow with the level?** Measure that directly on the airline \`air\` series.
 
-Produce a dict \`growth\` with:
+For each calendar year, compute two numbers: the year's **mean** level and the year's **range** (its max minus its min — a proxy for the size of the seasonal swing). Then compute the correlation between the yearly means and the yearly ranges.
 
-- \`"additive_ratio"\` — (late-half std) / (early-half std) of the **additive** residual
-- \`"multiplicative_ratio"\` — the same ratio for the **multiplicative** residual
+Produce:
 
-The additive model can't handle growing swings, so its residual spread balloons: \`additive_ratio\` should be clearly larger than \`multiplicative_ratio\`.`}
-  initCode={`import numpy as np
-import pandas as pd
-rng = np.random.default_rng(5)
-n = 120
-idx = pd.date_range("2010-01-01", periods=n, freq="MS")
-t = np.arange(n)
-level = 100 + 4*t
-m = pd.Series(level * (1 + 0.25*np.sin(2*np.pi*t/12)) * rng.normal(1, 0.03, n),
-              index=idx, name="m")`}
-  initialCode={`from statsmodels.tsa.seasonal import seasonal_decompose
+- \`yearly_mean\` — a Series of each year's mean (use \`air.resample("YE").mean()\`)
+- \`yearly_range\` — a Series of each year's (max - min)
+- \`swing_level_corr\` — the correlation between \`yearly_mean\` and \`yearly_range\` (a float)
+- \`is_multiplicative\` — \`True\` if \`swing_level_corr > 0.7\`
 
-def half_ratio(resid):
-    r = resid.dropna()
-    h = len(r) // 2
-    return float(r.iloc[h:].std() / r.iloc[:h].std())
-
-growth = {
-    "additive_ratio": None,
-    "multiplicative_ratio": None,
-}
-print(growth)
+A strong positive correlation means the swing scales with the level, so the series is **multiplicative** (which the airline data clearly is).`}
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`yearly_mean = None
+yearly_range = None
+swing_level_corr = None
+is_multiplicative = None
+print("corr:", swing_level_corr, " multiplicative:", is_multiplicative)
 `}
-  solutionCode={`from statsmodels.tsa.seasonal import seasonal_decompose
-
-def half_ratio(resid):
-    r = resid.dropna()
-    h = len(r) // 2
-    return float(r.iloc[h:].std() / r.iloc[:h].std())
-
-growth = {
-    "additive_ratio": half_ratio(seasonal_decompose(m, model="additive", period=12).resid),
-    "multiplicative_ratio": half_ratio(seasonal_decompose(m, model="multiplicative", period=12).resid),
-}
-print(growth)
+  solutionCode={`yearly_mean = air.resample("YE").mean()
+yearly_range = air.resample("YE").agg(lambda x: x.max() - x.min())
+swing_level_corr = float(yearly_mean.corr(yearly_range))
+is_multiplicative = swing_level_corr > 0.7
+print("corr:", round(swing_level_corr, 3), " multiplicative:", is_multiplicative)
 `}
   tests={[
     {
-      id: "keys",
-      name: "growth has both float ratios",
-      description: "Correct keys and types",
-      code: `assert set(growth.keys()) == {"additive_ratio", "multiplicative_ratio"}
-assert all(isinstance(v, float) for v in growth.values())`,
+      id: "series",
+      name: "yearly aggregates are Series of length 12",
+      description: "One value per year, 1949-1960",
+      code: `import pandas as pd
+assert isinstance(yearly_mean, pd.Series) and isinstance(yearly_range, pd.Series)
+assert len(yearly_mean) == 12 and len(yearly_range) == 12`,
     },
     {
-      id: "additive_worse",
-      name: "additive residual spread grows more",
-      description: "Wrong model -> funnel-shaped residual",
-      code: `assert growth["additive_ratio"] > growth["multiplicative_ratio"], "Additive residual should fan out more than multiplicative"`,
+      id: "corr_float",
+      name: "swing_level_corr is a float",
+      description: "Correlation computed",
+      code: `assert isinstance(swing_level_corr, float)`,
     },
     {
-      id: "additive_grows",
-      name: "additive ratio clearly exceeds 1",
-      description: "The funnel is real",
-      code: `assert growth["additive_ratio"] > 1.3, f"Expected clear growth, got {growth['additive_ratio']}"`,
+      id: "strong_positive",
+      name: "swing scales with level (strong positive correlation)",
+      description: "The defining property of multiplicative seasonality",
+      code: `assert swing_level_corr > 0.7, f"Expected strong positive correlation, got {swing_level_corr}"`,
+    },
+    {
+      id: "flag",
+      name: "classified as multiplicative",
+      description: "The airline series is multiplicative",
+      code: `assert is_multiplicative is True`,
     },
   ]}
 />

--- a/content/learn/time-series-analysis-python/differencing.mdx
+++ b/content/learn/time-series-analysis-python/differencing.mdx
@@ -1,0 +1,496 @@
+---
+title: "Detrending Data: Mastering Differencing to Make a Series Stationary"
+description: How subtracting consecutive values removes a trend, why the difference of a line is a constant, seasonal differencing to kill a yearly cycle, the over-differencing trap, and integration as the inverse — the 'I' in ARIMA.
+---
+
+The Augmented Dickey-Fuller test kept handing us the same prescription:
+*difference the series*. **Differencing** is the workhorse transformation
+that turns a trending, non-stationary series into a stationary one — and it's
+the operation hiding behind the `d` in **ARIMA**. This page is about *why*
+it works, how far to take it, and the classic mistake of taking it one step
+too far.
+
+## What differencing is
+
+First differencing replaces each value with the **change since the previous
+value**:
+
+`y'(t) = y(t) - y(t-1)`
+
+You stop modeling the *level* of the series and start modeling its
+*step-to-step change*. That single shift in perspective is what removes a
+trend — because a series can wander far from its starting level while its
+*changes* stay small and well-behaved.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`# Differencing by hand is just "value minus its lag":
+manual  = air - air.shift(1)
+builtin = air.diff()           # the convenient version
+
+frame = pd.DataFrame({"passengers": air, "shift(1)": air.shift(1),
+                      "manual diff": manual, ".diff()": builtin}).head(6)
+print(frame)
+print()
+print("They match exactly:", manual.dropna().equals(builtin.dropna()))
+print("The first value is NaN -- there's no earlier month to subtract.")
+`}
+/>
+
+`y.diff()` is exactly `y - y.shift(1)`. The first entry is `NaN` because the
+very first observation has no predecessor — differencing always costs you
+one row per difference.
+
+## Why differencing kills a trend
+
+Here's the intuition made exact: **the difference of a straight line is a
+constant.** If a series climbs by the same amount every step, then its
+*changes* are all identical — a flat, stationary series. Differencing
+converts "a steadily rising level" into "a steady rate," and a steady rate
+has no trend.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+import numpy as np
+
+# A PERFECT linear trend: y = 3t + 10.
+t = np.arange(12)
+line = pd.Series(3 * t + 10, name="line")
+
+print("The line itself climbs forever (non-stationary mean):")
+print(line.tolist())
+print()
+print("Its first difference is a CONSTANT 3 -- the trend is gone:")
+print(line.diff().dropna().tolist())
+print()
+print("Differencing turned 'rising level' into 'constant change'.")
+print("A curved (quadratic) trend needs a SECOND difference to flatten;")
+print("each difference peels off one degree of polynomial trend.")
+`}
+/>
+
+A linear trend vanishes after **one** difference; a curved (quadratic) trend
+needs **two**. In practice almost every real series is stationary after
+`d = 1` or `d = 2` differences — you rarely need more.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.stattools import adfuller
+import matplotlib.pyplot as plt
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import matplotlib.pyplot as plt
+from statsmodels.tsa.stattools import adfuller
+
+diff1 = air.diff().dropna()
+
+fig, (a1, a2) = plt.subplots(2, 1, figsize=(10, 6))
+air.plot(ax=a1, title="Raw passengers: strong upward TREND (non-stationary)")
+diff1.plot(ax=a2, title="First difference: trend gone, now hovers around a level")
+a2.axhline(0, color="grey", lw=0.8)
+plt.tight_layout(); plt.show()
+
+print(f"Raw ADF p-value          : {adfuller(air)[1]:.4f}  (non-stationary)")
+print(f"First-difference ADF p   : {adfuller(diff1)[1]:.4f}  (much lower!)")
+print()
+print("Notice the differenced series still has a SEASONAL wobble -- the yearly")
+print("hump survived. First differencing removed the trend, not the season.")
+`}
+/>
+
+The trend is gone after one difference, and the ADF p-value collapses. But
+look closely: a *seasonal* wobble remains. First differencing removes the
+**trend**, not the **seasonality** — those need a different cut.
+
+## Seasonal differencing: subtract one season ago
+
+To remove a seasonal cycle of period `m`, subtract the value from one full
+season earlier: `y(t) - y(t-m)`. For monthly data with a yearly cycle that's
+`y.diff(12)` — each month minus the same month last year. The repeating
+pattern cancels against its own copy.
+
+```mermaid
+flowchart LR
+    L["Level series y(t)<br/>trend + yearly season"] -->|"first difference: y(t) - y(t-1)"| D1["Changes series<br/>(trend removed, season remains)"]
+    D1 -->|"seasonal difference: y(t) - y(t-12)"| D2["Stationary-looking<br/>(trend AND season removed)"]
+```
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.stattools import adfuller
+import matplotlib.pyplot as plt
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import numpy as np
+import matplotlib.pyplot as plt
+from statsmodels.tsa.stattools import adfuller
+
+# The full recipe for the airline series:
+#   1) log    -> stabilize the growing variance
+#   2) diff(1) -> remove the trend
+#   3) diff(12)-> remove the yearly seasonality
+log_air = np.log(air)
+stage = {
+    "1) log(air)":               log_air,
+    "2) + first difference":     log_air.diff(),
+    "3) + seasonal difference":  log_air.diff().diff(12),
+}
+for name, s in stage.items():
+    print(f"{name:28s} ADF p = {adfuller(s.dropna())[1]:.4f}")
+
+final = log_air.diff().diff(12).dropna()
+fig, ax = plt.subplots(figsize=(10, 3.5))
+final.plot(ax=ax, title="log -> diff(1) -> diff(12): looks stationary at last")
+ax.axhline(0, color="grey", lw=0.8)
+plt.tight_layout(); plt.show()
+
+print()
+print("Each transform drives the p-value down. The final series has no trend,")
+print("no yearly cycle, and a stable spread -- ready for an ARIMA-style model.")
+`}
+/>
+
+<Callout type="info" title="This is exactly what SARIMA automates">
+The recipe "log, then a regular difference, then a seasonal difference" is
+what a *seasonal* ARIMA (SARIMA) encodes in its orders. We'll keep our hands
+on the wheel with plain ARIMA and pre-difference manually, but know that the
+`d` (regular differences) and `D` (seasonal differences) parameters are just
+this page, parameterized. Differencing isn't a side-trick — it's half of
+what ARIMA *is*.
+</Callout>
+
+## The over-differencing trap
+
+If one difference is good, are two always better? **No.** Differencing a
+series that's *already* stationary doesn't help — it *injects* artificial
+structure and inflates the variance. The fingerprint of over-differencing is
+a strong **negative lag-1 autocorrelation** (around `-0.5`) and a variance
+that went *up* instead of down.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+import numpy as np
+
+rng = np.random.default_rng(0)
+noise = pd.Series(rng.normal(0, 1, 500))     # ALREADY stationary white noise
+over  = noise.diff().dropna()                # difference it anyway (a mistake)
+
+print(f"Variance before differencing : {noise.var():.3f}")
+print(f"Variance after  differencing : {over.var():.3f}   (went UP ~2x -- bad)")
+print()
+print(f"Lag-1 autocorrelation before : {noise.autocorr(1):+.3f}  (~0, as expected)")
+print(f"Lag-1 autocorrelation after  : {over.autocorr(1):+.3f}  (~ -0.5 -- the over-diff signature)")
+print()
+print("Differencing stationary data manufactured a strong negative correlation")
+print("and doubled the variance. Use the SMALLEST d that achieves stationarity.")
+`}
+/>
+
+<Callout type="danger" title="Use the minimum number of differences">
+More differencing is not safer. Each unnecessary difference adds noise,
+raises the variance, and stamps a spurious `-0.5` lag-1 autocorrelation onto
+the series that your model will then waste effort "explaining." The goal is
+the **smallest `d`** that makes the series stationary (usually 0, 1, or 2) —
+not the `d` that gives the tiniest ADF p-value. If a series is already
+stationary, the correct `d` is **0**.
+</Callout>
+
+<MultipleChoice
+  markdown={`After differencing, a series shows a variance *higher* than before and a lag-1 autocorrelation of about **-0.5**. What likely happened?
+
+- The series became more stationary; this is ideal
+  > A jump in variance and a strong negative lag-1 autocorrelation are *warning signs*, not signs of success. A well-differenced series has lower or similar variance and near-zero short-lag autocorrelation.
+- [o] It was over-differenced — differencing an already-stationary series injected a spurious negative autocorrelation and inflated the variance
+  > Those two symptoms together are the classic over-differencing fingerprint. The fix is to step back to fewer differences (use the minimum \`d\` that reaches stationarity).
+- The seasonal period is wrong
+  > A wrong seasonal period shows up as leftover seasonal spikes, not as a uniform +variance and -0.5 lag-1 autocorrelation. This pattern points specifically to over-differencing.
+- The data must be re-logged
+  > A log addresses growing *variance from a multiplicative effect*, not the artifacts of over-differencing. The remedy here is fewer differences, not another transform.
+
+Inflated variance plus a ~-0.5 lag-1 autocorrelation is the textbook signature of over-differencing; reduce \`d\`.`}
+/>
+
+## Undoing it: integration (the 'I' in ARIMA)
+
+If you difference a series to model it, you must eventually **undo** the
+difference to get a forecast back on the original scale. The inverse of
+differencing is a **cumulative sum** plus the starting value — a process
+called **integration**. That's literally what the "I" in AR**I**MA stands
+for: *Integrated*, meaning the model works on a differenced series and
+integrates its forecasts back up.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [112,118,132,129,121,135,148,148,136,119,104,118,
+               115,126,141,135,125,149,170,170,158,133,114,140]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import numpy as np
+
+changes = air.diff().dropna()           # the differenced series
+start   = air.iloc[0]                    # the one anchor we must remember
+
+# Integrate: cumulative-sum the changes and add back the starting level.
+reconstructed = pd.concat([
+    pd.Series([start], index=[air.index[0]]),
+    start + changes.cumsum(),
+])
+
+print("Original vs reconstructed (first 6):")
+print(pd.DataFrame({"original": air, "reconstructed": reconstructed}).head(6))
+print()
+print("Perfect recovery:", np.allclose(air.values, reconstructed.values))
+print()
+print("Differencing is reversible IF you keep the starting value. ARIMA does")
+print("this bookkeeping for you -- you give it 'd' and it integrates forecasts back.")
+`}
+/>
+
+<MultipleChoice
+  markdown={`What does the **"I" (Integrated)** in ARIMA refer to?
+
+- That the model integrates data from multiple sources
+  > "Integrated" here is a time-series term, not a data-engineering one. It has nothing to do with combining datasets.
+- [o] That the model is fit on a *differenced* series and its forecasts are integrated (cumulatively summed) back to the original scale
+  > Differencing makes the series stationary; "integration" is the inverse operation that reverses the differencing so forecasts land on the original units. The \`d\` parameter says how many times.
+- That it numerically integrates a differential equation
+  > Despite the shared word, ARIMA's "integration" is just the discrete inverse of differencing (a cumulative sum), not calculus on a differential equation.
+- That all components are combined into one number
+  > The "I" specifically denotes differencing-and-undoing, separate from the AR and MA parts. It isn't a generic "combine everything" step.
+
+The "I" means the model operates on differenced data and integrates (cumulatively sums) its forecasts back to the original scale.`}
+/>
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Difference by hand, the seasonal way"
+  instructions={`The airline \`air\` series is loaded. Without using \`.diff()\`, build the **seasonal difference** at period 12 using \`shift\`: \`seasonal(t) = air(t) - air(t-12)\`. Call it \`manual_sdiff\`.
+
+Then confirm it equals the built-in \`air.diff(12)\` by setting \`matches\` to \`True\` if they're equal everywhere both are defined (drop NaNs before comparing).`}
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`manual_sdiff = None   # air(t) - air(t-12), using shift
+matches = None        # True if it equals air.diff(12)
+print(manual_sdiff.dropna().head() if manual_sdiff is not None else None)
+print("matches:", matches)
+`}
+  solutionCode={`manual_sdiff = air - air.shift(12)
+matches = bool(manual_sdiff.dropna().round(9).equals(air.diff(12).dropna().round(9)))
+print(manual_sdiff.dropna().head())
+print("matches:", matches)
+`}
+  tests={[
+    {
+      id: "shape",
+      name: "first 12 are NaN",
+      description: "No 'same month last year' for the first year",
+      code: `assert manual_sdiff.iloc[:12].isna().all(), "First 12 should be NaN"`,
+    },
+    {
+      id: "value",
+      name: "correct seasonal difference",
+      description: "Jan 1950 minus Jan 1949 = 115 - 112 = 3",
+      code: `import pandas as pd
+assert manual_sdiff.loc[pd.Timestamp("1950-01-01")] == 3`,
+    },
+    {
+      id: "matches_builtin",
+      name: "equals air.diff(12)",
+      description: "Manual and built-in agree",
+      code: `assert matches is True`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Pick the minimum d (don't over-difference)"
+  instructions={`A series \`s\` is loaded that is stationary after exactly **one** difference. For \`d\` in 0, 1, 2, 3, compute the ADF p-value of the \`d\`-times-differenced series and the lag-1 autocorrelation. Choose \`best_d\`: the **smallest** \`d\` whose ADF p-value is below 0.05 (the minimum differences that achieve stationarity — do NOT just pick the smallest p-value).
+
+Also set \`over_diff_ac\` to the lag-1 autocorrelation at \`d = 2\` (one difference too many), which should be clearly negative — the over-differencing signature.`}
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.stattools import adfuller
+rng = np.random.default_rng(7)
+# Random walk with drift -> stationary after ONE difference.
+s = pd.Series(np.cumsum(rng.normal(0.3, 1.0, 300)), name="s")`}
+  initialCode={`best_d = None        # smallest d with ADF p < 0.05
+over_diff_ac = None  # lag-1 autocorrelation at d = 2
+print("best_d:", best_d, " over-diff lag-1 ac:", over_diff_ac)
+`}
+  solutionCode={`best_d = None
+acs = {}
+for d in range(0, 4):
+    x = s.copy()
+    for _ in range(d):
+        x = x.diff()
+    x = x.dropna()
+    p = adfuller(x)[1]
+    acs[d] = float(x.autocorr(1))
+    if best_d is None and p < 0.05:
+        best_d = d
+over_diff_ac = acs[2]
+print("best_d:", best_d, " over-diff lag-1 ac:", round(over_diff_ac, 3))
+`}
+  tests={[
+    {
+      id: "min_d",
+      name: "minimum d is 1",
+      description: "One difference reaches stationarity",
+      code: `assert best_d == 1, f"Expected best_d=1, got {best_d}"`,
+    },
+    {
+      id: "over_negative",
+      name: "d=2 shows negative lag-1 autocorrelation",
+      description: "Over-differencing signature",
+      code: `assert over_diff_ac is not None and over_diff_ac < -0.2, f"Expected clearly negative, got {over_diff_ac}"`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`Why does taking the **first difference** of a series remove a *linear* trend?
+
+- Because it deletes the largest values
+  > Differencing doesn't delete values by size; it subtracts each value from the next. Magnitude isn't the mechanism.
+- [o] Because the difference of a straight line is a constant, so a steadily-rising level becomes a flat (trend-free) series of changes
+  > A linear trend climbs by the same amount each step; those equal steps are a constant when you difference, leaving a series with no trend in its mean.
+- Because it converts the data to percentages
+  > Differencing yields absolute changes, not percentages. (Percentage change is a *different* transform.) Either way, it's the constant-difference-of-a-line property that removes the trend.
+- Because it makes all values positive
+  > Differenced values are frequently negative (whenever the series falls). Sign has nothing to do with why the trend disappears.
+
+The difference of a line is a constant, so first differencing turns a rising level into trend-free changes.`}
+/>
+
+<MultipleChoice
+  markdown={`Your monthly series has both a trend and a strong yearly cycle. First differencing removed the trend but a 12-month wobble remains. What should you do?
+
+- Difference again with \`diff()\` (a second regular difference)
+  > A second *regular* difference targets curvature in the trend, not seasonality. The yearly wobble would survive, and you'd risk over-differencing.
+- [o] Apply a *seasonal* difference, \`diff(12)\`, to subtract each month from the same month a year earlier
+  > Seasonal differencing at the cycle length cancels the repeating yearly pattern against its own prior-year copy — exactly the leftover structure here.
+- Increase the rolling-window size
+  > A larger rolling window smooths for *visualization* but doesn't remove seasonality from the series you'll model. Seasonal differencing is the targeted fix.
+- Re-run the ADF test until it passes
+  > Re-running a test changes nothing about the data. You must transform the series (seasonal difference) to remove the cycle, then test.
+
+Leftover seasonality after a regular difference calls for a *seasonal* difference at the cycle length (\`diff(12)\` for monthly-yearly).`}
+/>
+
+<MultipleChoice
+  markdown={`A series tests stationary (ADF p = 0.01) with **no** differencing. What is the appropriate \`d\`?
+
+- [o] d = 0 — it's already stationary, so differencing would only add noise
+  > A low ADF p-value with the raw series means stationarity is already satisfied. The correct number of differences is zero; differencing further would over-difference.
+- d = 1, because every series needs at least one difference
+  > Not every series needs differencing — only non-stationary ones. An already-stationary series should be left at d = 0.
+- d = 2, to be safe
+  > "To be safe" is exactly the over-differencing mindset. Extra differences inject a spurious negative autocorrelation and inflate variance.
+- Whatever gives the smallest p-value
+  > Chasing the smallest p-value leads straight to over-differencing. The aim is the *minimum* d that achieves stationarity, which here is 0.
+
+If the raw series is already stationary, the right choice is d = 0; more differencing only harms.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- **Differencing** (`y.diff()` = `y - y.shift(1)`) models the *change* rather
+  than the *level*, which removes a trend because the difference of a line is
+  a constant.
+- A **linear** trend needs one difference; a **curved** trend needs two —
+  rarely more.
+- **Seasonal differencing** (`y.diff(m)`) removes a cycle of period `m`
+  (`diff(12)` for monthly-yearly). The airline recipe is **log → diff(1) →
+  diff(12)**.
+- This is the **`d`** (and seasonal `D`) of ARIMA, made explicit.
+- **Over-differencing** is real: it inflates variance and stamps a `-0.5`
+  lag-1 autocorrelation. Use the **minimum `d`** that reaches stationarity;
+  if already stationary, `d = 0`.
+- **Integration** (cumulative sum + starting value) inverts differencing —
+  the **"I"** in ARIMA, used to put forecasts back on the original scale.
+</Callout>
+
+We now have a stationary series. But "stationary" only means the *rules* are
+fixed — it doesn't tell us *what* those rules are. To choose a model we need
+to read the series' internal echoes: how strongly each value relates to the
+ones before it. That's the job of the ACF and PACF plots.

--- a/content/learn/time-series-analysis-python/handling-missing-temporal-data.mdx
+++ b/content/learn/time-series-analysis-python/handling-missing-temporal-data.mdx
@@ -1,0 +1,412 @@
+---
+title: "Mind the Gap: Intelligently Handling Missing Temporal Values"
+description: Why you usually fill rather than drop temporal gaps, how to expose missing timestamps with reindex, and the three core fill assumptions — forward-fill, backward-fill, and linear interpolation — including which ones secretly peek at the future.
+---
+
+In an ordinary table, a missing value is often handled by deleting the row.
+In a time series you usually **can't** — drop a row and you punch a hole in
+the regular spacing that `resample`, `rolling`, and every model rely on.
+Worse, a single `NaN` poisons any window that touches it. So the temporal
+question is rarely "drop or keep?" but "**what do I believe happened
+during the gap?**" — and every fill method is a different answer to that
+question.
+
+<Callout type="info" title="Two kinds of 'missing' in time series">
+1. **A missing value at a present timestamp** — the row exists, but the
+   value is `NaN` (the sensor returned nothing at 14:00).
+2. **A missing timestamp entirely** — the row isn't even there (no record
+   for 14:00 at all), so the gap is *invisible* until you put the series on
+   a complete calendar.
+
+The second is sneakier, because the series *looks* complete. Always check.
+</Callout>
+
+## Step 1: expose the gaps with `reindex`
+
+A series can hide gaps simply by skipping timestamps. The fix is to
+`reindex` onto a *complete* `date_range`, which turns every absent
+timestamp into an explicit `NaN` you can see and deal with.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+
+# Daily readings, but Jan 3 and Jan 4 were never recorded -- the rows are
+# simply absent, so the series LOOKS like 4 tidy points.
+s = pd.Series(
+    [10, 12, 18, 20],
+    index=pd.to_datetime(["2014-01-01", "2014-01-02", "2014-01-05", "2014-01-06"]),
+    name="reading",
+)
+print("As delivered (gaps are invisible):")
+print(s)
+print()
+
+# Put it on a COMPLETE daily calendar to surface the holes.
+full = pd.date_range(s.index.min(), s.index.max(), freq="D")
+exposed = s.reindex(full)
+print("After reindexing to a full daily range (gaps now show as NaN):")
+print(exposed)
+print()
+print("Missing days revealed:", int(exposed.isna().sum()))
+`}
+/>
+
+Until you reindex, those two missing days are silent — averages and plots
+quietly pretend Jan 2 connects straight to Jan 5. Surfacing the gaps is the
+prerequisite for filling them honestly.
+
+## The three core fill strategies
+
+Once gaps are explicit `NaN`s, you choose how to fill. The three workhorses
+encode three different beliefs about the unseen interval:
+
+```mermaid
+flowchart TB
+    subgraph FFILL["Forward-fill: carry the LAST known value forward"]
+        direction LR
+        F1["10"] --> F2["10 (copied)"] --> F3["10 (copied)"] --> F4["40"]
+    end
+    subgraph BFILL["Back-fill: pull the NEXT known value backward (uses the future!)"]
+        direction LR
+        B1["10"] --> B2["40 (copied)"] --> B3["40 (copied)"] --> B4["40"]
+    end
+    subgraph INTERP["Linear interpolation: glide in a straight line between knowns"]
+        direction LR
+        I1["10"] --> I2["20 (computed)"] --> I3["30 (computed)"] --> I4["40"]
+    end
+```
+
+The same gap — two missing points between a 10 and a 40 — gets three
+different answers. Let's compute exactly that:
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+import numpy as np
+
+s = pd.Series([10, np.nan, np.nan, 40],
+              index=pd.date_range("2014-01-01", periods=4, freq="D"), name="y")
+
+table = pd.DataFrame({
+    "raw":     s,
+    "ffill":   s.ffill(),                       # last known value carried forward
+    "bfill":   s.bfill(),                       # next known value pulled back
+    "linear":  s.interpolate(method="linear"),  # straight line between knowns
+})
+print(table)
+print()
+print("ffill  -> 10, 10  (assumes the value HELD until it next changed)")
+print("bfill  -> 40, 40  (assumes the next value applied retroactively)")
+print("linear -> 20, 30  (assumes a smooth, steady glide)")
+print()
+print("Three different stories about the same two unknown days.")
+`}
+/>
+
+### When each one is right
+
+- **Forward-fill (`ffill`)** — "the last value **held** until it next
+  changed." Perfect for *state* / *step* signals: a thermostat setting, a
+  posted price, an account balance, a configuration flag. These genuinely
+  stay constant until an event changes them.
+- **Backward-fill (`bfill`)** — "the **next** known value applied during the
+  gap." Useful for the *leading edge* (filling `NaN`s before the first real
+  reading) or when a value is logged at the *end* of the period it describes.
+- **Linear interpolation** — "the value **glided smoothly** between the two
+  knowns." Ideal for *continuous physical* quantities sampled with dropouts:
+  temperature, sensor voltage, a slowly drifting measurement.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+# A smooth-ish daily temperature with three dropout days.
+idx = pd.date_range("2014-05-01", periods=15, freq="D")
+temp = pd.Series([18,19,21,np.nan,np.nan,np.nan,24,23,22,24,25,np.nan,26,27,28.0],
+                 index=idx, name="temp_c")
+
+fig, ax = plt.subplots(figsize=(10, 4))
+temp.interpolate(method="linear").plot(ax=ax, marker="o", label="linear interpolation")
+temp.ffill().plot(ax=ax, marker="s", alpha=0.6, label="forward-fill (flat steps)")
+ax.scatter(temp.dropna().index, temp.dropna().values, color="black", zorder=5, label="actually measured")
+ax.legend(); ax.set_title("For a smooth physical quantity, interpolation looks natural")
+plt.tight_layout(); plt.show()
+
+print("Interpolation traces a believable glide for temperature.")
+print("Forward-fill makes ugly flat steps here -- wrong assumption for a")
+print("continuously varying quantity (but right for a thermostat SETTING).")
+`}
+/>
+
+## The leakage twist: which fills peek at the future?
+
+Here is the subtlety that separates a careful analyst from a sloppy one.
+Look again at *what each method reads*:
+
+- **`ffill`** uses only the **past** (the last value before the gap). It is
+  the **only** method here you can compute *online*, at the moment of the
+  gap, without seeing the future.
+- **`bfill`** reads the **next** value — which is in the **future** relative
+  to the gap.
+- **Linear interpolation** reads **both** the value before *and* the value
+  after — so it also uses the **future**.
+
+```mermaid
+flowchart LR
+    G["Gap at time t"] --> Q{"Which neighbors<br/>does the fill read?"}
+    Q -->|"only the PAST value"| FF["ffill -- safe as a live feature"]
+    Q -->|"the FUTURE value"| BF["bfill -- leaks the future"]
+    Q -->|"PAST and FUTURE values"| IN["interpolate -- leaks the future"]
+```
+
+<Callout type="danger" title="bfill and interpolation are future-aware">
+For *historical analysis and charting*, interpolation and back-fill are
+perfectly fine — the whole series already exists, so using both neighbors
+is legitimate. But if you are filling gaps in a **feature that feeds a
+forecast**, `bfill` and `interpolate` smuggle the future into the present —
+the same leakage sin as a centered rolling window or a random split. In an
+online/forecasting setting, **forward-fill is the safe default**, because it
+only ever looks backward.
+</Callout>
+
+<MultipleChoice
+  markdown={`You're building features to forecast tomorrow's value and need to fill an occasional missing sensor reading *as the data streams in*. Which fill method is safe to use, and why?
+
+- Linear interpolation, because it's the most accurate
+  > Interpolation reads the value *after* the gap to draw its straight line. At the moment of the gap that future value doesn't exist yet, so using it leaks future information into a live feature.
+- Backward-fill, because it carries the correct next value
+  > The "next value" is in the future relative to the gap. Pulling it backward into a forecasting feature is leakage — you couldn't actually know it at prediction time.
+- [o] Forward-fill, because it uses only the last known (past) value and never reads anything after the gap
+  > \`ffill\` is past-only: it carries the most recent observation forward. That's computable in real time without peeking ahead, which is exactly what an online forecasting feature requires.
+- It doesn't matter; all fills use the same information
+  > They use very different information: \`ffill\` looks back, \`bfill\` looks forward, and interpolation looks both ways. Only the backward-looking one is leakage-free for live features.
+
+Online/forecasting features must be computable from the past alone, so \`ffill\` is the safe choice; \`bfill\` and interpolation read the future.`}
+/>
+
+## The domain question: is "missing" really zero?
+
+Before any fill method, ask the most important question: **does this gap
+mean "unknown," or does it mean "nothing happened"?** They are completely
+different, and choosing wrong fabricates data.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+import numpy as np
+
+# A shop's daily sales. It is CLOSED on Sundays, so those days have no sales
+# rows -- but that's not "unknown sales," it's "zero sales."
+idx = pd.date_range("2014-03-03", periods=7, freq="D")   # Mon .. Sun
+sales = pd.Series([200, 180, 210, 190, 260, 300, np.nan], index=idx, name="sales")
+print("Sunday is missing because the shop was CLOSED:")
+print(sales)
+print()
+
+wrong = sales.interpolate(method="linear")   # invents ~330 phantom Sunday sales
+right = sales.fillna(0)                       # closed means zero
+
+print(f"Interpolation invents Sunday sales of ~{wrong.iloc[-1]:.0f} (PHANTOM revenue).")
+print(f"The correct fill is 0 -- the shop genuinely sold nothing.")
+`}
+/>
+
+<Callout type="warn" title="No method substitutes for domain knowledge">
+Forward-fill, interpolation, and the rest are *mechanical*. They don't know
+whether your gap is an unrecorded measurement or a real zero. A closed shop,
+a sensor that's off, a holiday with no trading — these are *zeros or
+genuine absences*, not values to interpolate. Decide what the gap *means*
+first; only then pick a fill.
+</Callout>
+
+## When dropping is actually fine
+
+Filling isn't always required. `dropna()` is acceptable when gaps are
+**rare and scattered**, you're computing an order-independent summary (like
+an overall mean), and you won't subsequently rely on regular spacing. But
+for anything that needs an unbroken timeline — resampling, rolling windows,
+most models — fill rather than drop, so the calendar stays intact.
+
+<MultipleChoice
+  markdown={`Why is deleting rows with \`dropna()\` often a poor choice for time series, even though it's common for cross-sectional data?
+
+- It always changes the column dtypes
+  > Dropping rows doesn't alter dtypes. The real issue is structural, not about types.
+- [o] It breaks the regular time spacing the series depends on, so resampling, rolling windows, and models that assume evenly spaced observations misbehave
+  > Removing a timestamp leaves an uneven gap. A 7-day rolling window or a model expecting monthly steps will now silently span the wrong real-world interval, corrupting results.
+- It's computationally too expensive
+  > \`dropna\` is cheap. Cost isn't the concern — preserving the timeline is.
+- pandas forbids dropping rows from a time series
+  > pandas allows it; it's just usually unwise. Sometimes (rare, scattered gaps) dropping is fine — but it's a judgment call, not a prohibition.
+
+Dropping rows punctures the even spacing that time-series tooling assumes, which is why filling (preserving the calendar) is usually preferred.`}
+/>
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Expose gaps, then forward-fill a state signal"
+  instructions={`A series \`status\` records a machine's power setting, logged only when it *changes*. Two calendar days have no row at all. Produce \`filled\`:
+
+1. Reindex \`status\` onto a **complete daily** range from its first to its last timestamp (exposing the missing days as \`NaN\`).
+2. **Forward-fill** the gaps, because a power setting *holds* until it's next changed.
+
+The result should be a daily Series with no \`NaN\`s, where each missing day carries the most recent prior setting.`}
+  initCode={`import pandas as pd
+status = pd.Series(
+    [3, 5, 2],
+    index=pd.to_datetime(["2014-07-01", "2014-07-02", "2014-07-05"]),
+    name="power",
+)`}
+  initialCode={`filled = None  # reindex to daily, then forward-fill
+print(filled)
+`}
+  solutionCode={`full = pd.date_range(status.index.min(), status.index.max(), freq="D")
+filled = status.reindex(full).ffill()
+print(filled)
+`}
+  tests={[
+    {
+      id: "daily_complete",
+      name: "complete daily calendar (5 days)",
+      description: "Jul 1 through Jul 5, no gaps",
+      code: `import pandas as pd
+assert len(filled) == 5
+assert (filled.index == pd.date_range("2014-07-01", "2014-07-05", freq="D")).all()`,
+    },
+    {
+      id: "no_nans",
+      name: "no missing values remain",
+      description: "Every day has a setting",
+      code: `assert filled.notna().all()`,
+    },
+    {
+      id: "ffill_semantics",
+      name: "gaps carry the LAST prior value",
+      description: "Jul 3 and Jul 4 should hold Jul 2's value (5)",
+      code: `import pandas as pd
+assert filled.loc[pd.Timestamp("2014-07-03")] == 5
+assert filled.loc[pd.Timestamp("2014-07-04")] == 5`,
+    },
+    {
+      id: "not_interpolated",
+      name: "not interpolated",
+      description: "Forward-fill makes flat steps, not a glide",
+      code: `import pandas as pd
+assert filled.loc[pd.Timestamp("2014-07-04")] == 5, "Interpolation would give ~4.x here; ffill must give 5"`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Interpolate a continuous sensor (and only the interior)"
+  instructions={`A daily \`temp\` Series of temperatures has interior dropout days as \`NaN\`. Temperature varies continuously, so fill the *interior* gaps with **linear interpolation**. Produce \`smooth\` where every originally-interior \`NaN\` is replaced by the straight-line value between its known neighbours.
+
+Then compute \`may4\` — the interpolated value on \`2014-05-04\`, which sits exactly halfway between the known May 3 (=20.0) and May 5 (=24.0), so it should be \`22.0\`.`}
+  initCode={`import pandas as pd
+import numpy as np
+idx = pd.date_range("2014-05-01", periods=7, freq="D")
+temp = pd.Series([18.0, 19.0, 20.0, np.nan, 24.0, 25.0, 26.0], index=idx, name="temp")`}
+  initialCode={`smooth = None  # linear interpolation of the interior gap
+may4 = None     # the value on 2014-05-04
+print(smooth)
+print("May 4:", may4)
+`}
+  solutionCode={`smooth = temp.interpolate(method="linear")
+may4 = float(smooth.loc[pd.Timestamp("2014-05-04")])
+print(smooth)
+print("May 4:", may4)
+`}
+  tests={[
+    {
+      id: "no_interior_nans",
+      name: "interior gap is filled",
+      description: "No NaNs remain",
+      code: `assert smooth.notna().all()`,
+    },
+    {
+      id: "halfway",
+      name: "May 4 is the midpoint 22.0",
+      description: "Linear interpolation between 20 and 24",
+      code: `assert abs(may4 - 22.0) < 1e-9, f"Expected 22.0, got {may4}"`,
+    },
+    {
+      id: "knowns_untouched",
+      name: "known values are unchanged",
+      description: "Interpolation only fills NaNs",
+      code: `import pandas as pd
+assert smooth.loc[pd.Timestamp("2014-05-01")] == 18.0
+assert smooth.loc[pd.Timestamp("2014-05-05")] == 24.0`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`A gap sits between a known value of 100 (Monday) and a known value of 160 (Thursday), with Tuesday and Wednesday missing. Match each method to the Tuesday/Wednesday pair it produces.
+
+- ffill -> 120/140, bfill -> 100/100, interpolate -> 160/160
+  > These are scrambled. Forward-fill copies the *past* (100), not a glide; interpolation produces the in-between glide (120/140); back-fill copies the *future* (160).
+- [o] ffill -> 100/100, bfill -> 160/160, interpolate -> 120/140
+  > Forward-fill carries Monday's 100 forward; back-fill pulls Thursday's 160 backward; linear interpolation steps evenly from 100 to 160 (120 then 140).
+- ffill -> 160/160, bfill -> 100/100, interpolate -> 130/130
+  > Forward-fill uses the *last* value (100), not the next; back-fill uses the *next* (160), not the previous; and interpolation gives a rising 120/140, not a flat 130/130.
+- All three give 130/130
+  > Only a midpoint-constant scheme would give 130/130. The three real methods give distinctly different shapes: flat-back, flat-forward, and a rising line.
+
+Forward-fill copies the prior value, back-fill copies the next, and linear interpolation walks a straight line between them.`}
+/>
+
+<MultipleChoice
+  markdown={`A store is **closed on public holidays**, so those days have no sales rows. What's the right way to handle them before computing monthly totals?
+
+- Linearly interpolate the holiday sales from the surrounding open days
+  > Interpolation would invent sales on days the store was shut, inflating the monthly total with revenue that never happened.
+- Forward-fill the previous day's sales onto the holiday
+  > Forward-fill would also fabricate sales for a closed day. The shop sold nothing; carrying yesterday's figure forward overstates the total.
+- [o] Fill those days with 0, because "closed" means genuinely zero sales, not unknown sales
+  > The gap here encodes a real zero, not a missing measurement. Filling with 0 records the truth; any interpolation or carry-forward would invent phantom revenue.
+- Drop the holidays and ignore them
+  > Dropping is defensible for a *mean*, but for a monthly *total* you want the holiday counted as the zero it truly was, so the month's sum is correct and the calendar stays intact.
+
+When a gap means "nothing happened" (a closed store), the correct fill is 0 — fill methods that infer a value fabricate data.`}
+/>
+
+<MultipleChoice
+  markdown={`For *historical analysis of an already-complete dataset* (not a live forecast), is it acceptable to use linear interpolation to fill interior gaps in a continuously varying sensor signal?
+
+- No, interpolation is never allowed
+  > Interpolation is a standard, sensible choice for continuous quantities. The only context where it's off-limits is a *live forecasting feature*, where reading the future value is leakage.
+- [o] Yes — on a complete historical series, using both neighbours is legitimate, and interpolation suits a continuously varying quantity
+  > When the whole series already exists and you're analysing the past, reading the point after the gap isn't leakage; it's just using available data. For smooth physical signals, interpolation is often the most faithful fill.
+- Only if you also shuffle the series first
+  > Shuffling would destroy the temporal order entirely and is never appropriate for a time series. It has nothing to do with whether interpolation is acceptable.
+- Only for categorical data
+  > Interpolation is for *numeric*, continuous data; it's meaningless for categories. Categorical gaps are better handled with forward-fill or an explicit "unknown" label.
+
+Interpolation is appropriate for continuous signals in retrospective analysis; it's only problematic as a *forward-looking feature*, where it leaks the future.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- In time series you usually **fill** gaps rather than drop rows, to
+  preserve the regular spacing tooling depends on.
+- **Expose hidden gaps** by `reindex`-ing onto a complete `date_range` —
+  missing *timestamps* are invisible until you do.
+- The three fills are three *assumptions*: **`ffill`** (value held),
+  **`bfill`** (next value applied), **linear interpolation** (smooth glide).
+- **Leakage check:** `ffill` looks only backward (safe for live features);
+  `bfill` and `interpolate` read the **future** (fine for retrospective
+  analysis, leakage for forecasting features).
+- Ask whether a gap means **"unknown" or "zero"** — a closed shop is a real
+  0, not a value to interpolate. Domain knowledge beats any method.
+</Callout>
+
+Your series is now clean, evenly spaced, and gap-free. That means we can
+finally take it apart — separating the trend, the seasonal cycle, and the
+leftover noise into pieces we can study one at a time.

--- a/content/learn/time-series-analysis-python/index.mdx
+++ b/content/learn/time-series-analysis-python/index.mdx
@@ -1,0 +1,210 @@
+---
+title: Welcome
+description: An intuition-first tour of classical time series analysis and statistical forecasting with pandas and statsmodels — built around the one idea that changes everything: in time series, the order of the data IS the information.
+---
+
+Welcome to **Time Series Analysis with Python**. You already know how to
+load a DataFrame, filter it, group it, and plot a line chart. You can
+answer "*what happened?*" This course teaches the harder, more valuable
+question: "*what happens next — and how much should I trust my answer?*"
+
+That second question is where time series analysis lives. A table of
+sales numbers and a table of *monthly* sales numbers look almost
+identical, but they are not the same kind of object. The second one has
+a **spine**: each row is glued to the rows before and after it by the
+passage of time. Reorder the rows of an ordinary table and you lose
+nothing. Reorder the rows of a time series and you have **destroyed the
+data** — because in a time series, the *order is the information*.
+
+<Callout type="info" title="What we assume you already know">
+You can write basic Python (slicing, list comprehensions), use pandas
+(`DataFrame`, `Series`, filtering), make a simple line chart, and you
+remember what a mean, a variance, and a correlation are. You do **not**
+need any prior time series, signal processing, or forecasting
+background. We build all of that from intuition.
+</Callout>
+
+## See the thesis in ten seconds
+
+Here is the whole course in one experiment. We take a real monthly series
+— airline passenger counts — and measure how strongly each month relates
+to the month before it (its **lag-1 autocorrelation**). Then we *shuffle*
+the rows and measure again. Run it.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+
+# Monthly international airline passengers (thousands), Jan 1949 - Dec 1960.
+# The single most famous teaching series in all of forecasting.
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`# Correlation of each month with the PREVIOUS month (lag-1 autocorrelation).
+ordered_corr = air.corr(air.shift(1))
+
+# Now shuffle the values, destroying their time order, and measure again.
+shuffled = air.sample(frac=1.0, random_state=0).reset_index(drop=True)
+shuffled_corr = shuffled.corr(shuffled.shift(1))
+
+print(f"Lag-1 correlation, time order intact : {ordered_corr:.3f}")
+print(f"Lag-1 correlation, after shuffling   : {shuffled_corr:.3f}")
+print()
+print("The ordered series is almost perfectly predictable from its own past.")
+print("Shuffling threw that predictability in the trash. The order WAS the signal.")
+`}
+/>
+
+The ordered series has a lag-1 correlation near **0.95** — knowing this
+month tells you almost exactly what last month was. After shuffling, that
+structure collapses toward zero. Every tool in this course exists to
+*find, measure, and exploit* that kind of temporal structure — and the
+final third of the course is about **not fooling yourself** when you use
+it to predict the future.
+
+<Callout type="tip" title="The mantra for this whole course">
+Cross-sectional data answers "*who?*" Time series data answers
+"*when?*" — and "when" comes with a rule cross-sectional data never has:
+**you may only ever learn from the past to predict the future, never the
+reverse.** Break that rule and every accuracy number you compute becomes
+a comfortable lie.
+</Callout>
+
+## This is a reasoning course, not an API reference
+
+Most time series material is either a wall of equations or a tour of
+function signatures (`resample`, `rolling`, `adfuller`, `ARIMA`...) with
+no story connecting them. This course is the opposite. For every concept
+and every transformation we ask:
+
+- **What temporal problem does it solve?** Why was it invented?
+- **When should you use it — and when should you *not*?**
+- **What do people get wrong about it?** (The misconceptions sink more
+  projects than the math ever does.)
+- **Where does it show up in real work?** — energy demand, inventory
+  planning, web traffic, retail sales.
+
+You will still see formulas and tests, but only when they make the
+intuition *clearer*. The computer does the arithmetic; your job is to
+know which question you're asking and whether the answer makes sense.
+
+## What you'll be able to do by the end
+
+- Recognize **why temporal data needs its own toolkit** and why ordinary
+  machine-learning habits (shuffling, random splits) quietly corrupt it.
+- Wield pandas's **time machinery** — `DatetimeIndex`, frequencies,
+  partial-string slicing, `shift`, `resample`, `rolling`.
+- **Resample** between time resolutions (daily ⇄ weekly ⇄ monthly) and
+  know when you are *summarizing* versus *inventing* data.
+- Fill **missing timestamps** the right way — and explain why forward-fill,
+  back-fill, and interpolation are three different *assumptions*, not three
+  buttons.
+- **Decompose** a series into trend, seasonality, and residual, and read
+  each piece.
+- Define **stationarity**, test for it with the **Augmented Dickey-Fuller**
+  test, and create it with **differencing**.
+- Read **ACF and PACF** plots well enough to propose ARIMA orders by eye.
+- Fit and interpret **AR, MA, ARMA, and ARIMA** models with statsmodels.
+- Evaluate forecasts with **MAE, RMSE, and MAPE** coded by hand in NumPy.
+- Design a **chronological backtest** that estimates real-world forecast
+  skill without leaking the future into the past.
+
+## How the course is organized
+
+We move from *understanding* time, to *reshaping* it, to *modeling* its
+structure, and finally to *forecasting and honestly evaluating* the
+result.
+
+```mermaid
+flowchart TD
+    A["The Time Dimension<br/>(why order is information)"] --> B["Reshaping Time<br/>(resample, rolling, gaps)"]
+    B --> C["Structure & Stationarity<br/>(decompose, test, difference)"]
+    C --> D["Reading the Echoes<br/>(ACF and PACF)"]
+    D --> E["Classic Forecasting<br/>(AR, MA, ARIMA)"]
+    E --> F["Chronological Validation<br/>(backtesting without leakage)"]
+    F --> G["Capstone<br/>(an end-to-end pipeline)"]
+```
+
+Each section builds on the one before it. The conceptual heart of the
+course is the run of pages on **stationarity**, **differencing**,
+**ACF/PACF**, and especially **chronological validation** — if those
+click, forecasting becomes a craft you can reason about instead of a
+black box you poke.
+
+<Callout type="warn" title="The most important page is near the end">
+We treat **validation** as the single most important topic in the whole
+course — more important than any individual model. A mediocre model
+honestly evaluated is worth ten brilliant models evaluated with a leaky
+random split. We will hammer this point until it is reflex.
+</Callout>
+
+## The tools we use
+
+Every code block on every page is runnable. Edit it, click **Run**, and
+the output appears underneath. We lean on four libraries and nothing
+heavier — no scikit-learn, no deep learning, no automated forecasting
+frameworks. Classical time series analysis needs surprisingly little
+machinery.
+
+| Library | What we use it for |
+| --- | --- |
+| **pandas** | The `DatetimeIndex`, resampling, rolling windows, gap-filling |
+| **NumPy** | Simulating series, vectorized math, hand-coded error metrics |
+| **matplotlib** | Line charts, component subplots, ACF/PACF plots |
+| **statsmodels** | Decomposition, the ADF test, ACF/PACF, ARIMA models |
+
+<Callout type="info" title="Each code block runs on its own">
+Variables you define in one code block are **not** shared with the next,
+even on the same page. Every block starts fresh, so each example is
+self-contained. When a block needs setup data (like the airline series
+above), it is created in collapsed **initialization code** you can expand
+to inspect.
+</Callout>
+
+## Meet the datasets
+
+Real time series teaching needs data with *visible* structure. We use a
+small, hand-picked cast that runs instantly in your browser:
+
+- **Airline passengers** (144 monthly points, 1949-1960) — our hero
+  series. It has a rising **trend**, a strong yearly **seasonal** swing
+  that *grows* over time, and is gloriously non-stationary. Perfect for
+  decomposition, differencing, and ARIMA.
+- **Simulated series** with *known* trend, seasonality, and noise — so we
+  can check whether a tool recovers the truth we baked in.
+- **Small, gappy sensor and traffic series** — for practicing missing-data
+  strategies where the right answer depends on the assumption you make.
+
+Nothing here is bigger than a few hundred numbers. Time series intuition
+does not come from big data; it comes from *seeing* the structure, and a
+few hundred well-chosen points show it more clearly than a million noisy
+ones.
+
+## How the interactive widgets work
+
+You'll meet three kinds of interactive elements:
+
+1. **Code blocks** — editable, runnable Python. Change a window size, a
+   differencing order, an ARIMA parameter, and re-run to see the effect.
+2. **Challenge cards** — small problems with hidden tests. Write a
+   solution, click **Submit**, and see which tests pass. These are where
+   the learning sticks, so do them.
+3. **Multiple-choice questions** — quick conceptual checks with an
+   explanation for *every* option, right or wrong.
+
+Let's begin where every honest time series project must: with *why* this
+data refuses to be treated like an ordinary table.

--- a/content/learn/time-series-analysis-python/index.mdx
+++ b/content/learn/time-series-analysis-python/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Welcome
-description: An intuition-first tour of classical time series analysis and statistical forecasting with pandas and statsmodels — built around the one idea that changes everything: in time series, the order of the data IS the information.
+description: "An intuition-first tour of classical time series analysis and statistical forecasting with pandas and statsmodels — built around the one idea that changes everything: in time series, the order of the data IS the information."
 ---
 
 Welcome to **Time Series Analysis with Python**. You already know how to

--- a/content/learn/time-series-analysis-python/meta.json
+++ b/content/learn/time-series-analysis-python/meta.json
@@ -1,0 +1,24 @@
+{
+    "title": "Time Series Analysis with Python",
+    "description": "An intuition-first course on classical time series analysis and statistical forecasting with pandas and statsmodels — datetime indexing, resampling, rolling windows, missing-data handling, decomposition, stationarity, differencing, ACF/PACF, ARIMA, and rigorous chronological backtesting that prevents data leakage.",
+    "root": true,
+    "pages": [
+        "index",
+        "---The Time Dimension---",
+        "what-makes-time-series-unique",
+        "the-pandas-timeline",
+        "---Reshaping Time---",
+        "resampling-and-aggregation",
+        "rolling-and-expanding-windows",
+        "handling-missing-temporal-data",
+        "---Structure & Stationarity---",
+        "decomposition-trend-seasonality",
+        "stationarity",
+        "differencing",
+        "acf-and-pacf",
+        "---Forecasting & Validation---",
+        "arima-models",
+        "chronological-validation",
+        "capstone-forecasting-pipeline"
+    ]
+}

--- a/content/learn/time-series-analysis-python/resampling-and-aggregation.mdx
+++ b/content/learn/time-series-analysis-python/resampling-and-aggregation.mdx
@@ -1,0 +1,467 @@
+---
+title: "Resampling and Aggregation: Changing the Temporal Resolution"
+description: Downsampling versus upsampling — using resample() to summarize a series to a coarser grid (and why sum vs mean matters) or to stretch it onto a finer grid (and why that invents data rather than discovering it).
+---
+
+Real time series rarely arrive at the resolution you want to analyze them
+at. Sensors log every second but you reason in hours; sales come in daily
+but the business plans monthly. **Resampling** is how you change the
+*temporal resolution* of a series — and it splits cleanly into two
+operations with very different risks.
+
+```mermaid
+flowchart TB
+    subgraph DOWN["Downsampling: daily to monthly (SUMMARIZE)"]
+        direction LR
+        D1["~30 daily points"] -->|"aggregate (sum / mean)"| D2["1 monthly point"]
+    end
+    subgraph UP["Upsampling: monthly to daily (INVENT a finer grid)"]
+        direction LR
+        U1["1 monthly point"] -->|"add empty slots, then fill"| U2["~30 daily slots<br/>(most are assumptions)"]
+    end
+```
+
+- **Downsampling** goes from fine to coarse (daily → monthly). You have
+  *more* data than you need and must **summarize** it. The only question is
+  *which* summary: sum? mean? last value?
+- **Upsampling** goes from coarse to fine (monthly → daily). You have
+  *fewer* points than the target grid and must **invent** the in-between
+  values. This does not create information — it encodes an assumption.
+
+<Callout type="info" title="resample is groupby for time">
+`df.resample("ME")` is the time-aware twin of `df.groupby(...)`. It slices
+the timeline into regular buckets ("every month," "every week") and then
+waits for you to tell it how to aggregate each bucket. The frequency string
+("D", "W", "ME") names the bucket size; the method (`.sum()`, `.mean()`)
+names the summary.
+</Callout>
+
+## Downsampling: summarizing to a coarser grid
+
+Let's build a daily series — website visits with a slow upward trend and a
+weekend dip — and roll it up.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+
+rng = np.random.default_rng(0)
+days = pd.date_range("2014-01-01", periods=120, freq="D")
+trend = np.linspace(100, 160, 120)
+weekend_dip = np.where(days.weekday >= 5, -25, 5)   # Sat/Sun are quieter
+visits = pd.Series(
+    (trend + weekend_dip + rng.normal(0, 6, 120)).round().astype(int),
+    index=days, name="visits",
+)`}
+  initialCode={`print("Daily visits (first 10 days):")
+print(visits.head(10))
+print()
+
+# Weekly TOTAL visits (sum), weeks ending Sunday:
+print("Weekly totals (sum):")
+print(visits.resample("W").sum().head())
+print()
+
+# Monthly AVERAGE daily visits (mean):
+print("Monthly average daily visits (mean):")
+print(visits.resample("ME").mean().round(1))
+`}
+/>
+
+One series, two resamples, two very different numbers — and they answer
+different questions:
+
+- `resample("W").sum()` → "**how many** visits did we get each week?"
+- `resample("ME").mean()` → "what did a **typical day** look like each
+  month?"
+
+### Sum or mean? Match the aggregation to the quantity
+
+This is the choice beginners get wrong most often. The rule:
+
+- **Sum** when the values are *flows / counts* that accumulate: sales,
+  visits, units sold, rainfall, energy *consumed*. Ten daily visit counts
+  genuinely add up to a weekly total.
+- **Mean** when the values are *levels / rates* that don't accumulate:
+  temperature, price, CPU utilization, a stock's closing level. The monthly
+  "temperature" is the *average* of its days, never their sum (summing 30
+  daily temperatures of 20°C into "600°C for the month" is nonsense).
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+rng = np.random.default_rng(1)
+days = pd.date_range("2014-06-01", periods=30, freq="D")
+# A FLOW: units sold per day. A LEVEL: that day's average temperature.
+units_sold = pd.Series(rng.integers(20, 60, 30), index=days, name="units")
+temp_c     = pd.Series((22 + 4*np.sin(np.arange(30)/3) + rng.normal(0,1,30)).round(1),
+                       index=days, name="temp_c")`}
+  initialCode={`# Roll both up to a single monthly number, the RIGHT way for each.
+print("Units sold is a FLOW -> SUM:")
+print("  June total units:", units_sold.resample("ME").sum().iloc[0])
+print()
+print("Temperature is a LEVEL -> MEAN:")
+print("  June average temp:", temp_c.resample("ME").mean().round(2).iloc[0], "C")
+print()
+print("Summing temperatures would be meaningless:")
+print("  WRONG 'June temp' as a sum:", temp_c.resample("ME").sum().round(1).iloc[0], "C  <- nonsense")
+`}
+/>
+
+<MultipleChoice
+  markdown={`You have **hourly air-temperature** readings and want one value per day. Which resampling aggregation is correct?
+
+- \`resample("D").sum()\`
+  > Summing 24 hourly temperatures produces a meaningless number in the hundreds. Temperature is a *level*, not a flow — adding it up has no physical meaning.
+- [o] \`resample("D").mean()\`
+  > Temperature is a level/rate, so the natural daily summary is the average of the day's hourly readings. (A max/min is also reasonable if you specifically want the day's high or low.)
+- \`resample("D").count()\`
+  > \`count\` returns *how many* readings there were that day (usually 24), not the temperature itself. It answers a question about data completeness, not climate.
+- It doesn't matter; all aggregations give the same answer
+  > They give very different answers — sum is ~24x the mean here. Choosing the aggregation that matches the quantity is the whole point.
+
+Levels (temperature, price) call for \`mean\` (or min/max); flows (sales, visits) call for \`sum\`.`}
+/>
+
+### More than one summary at once
+
+You don't have to pick a single aggregation. `.agg([...])` returns several
+columns side by side — handy for a quick profile of each bucket.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+rng = np.random.default_rng(0)
+days = pd.date_range("2014-01-01", periods=120, freq="D")
+trend = np.linspace(100, 160, 120)
+weekend_dip = np.where(days.weekday >= 5, -25, 5)
+visits = pd.Series(
+    (trend + weekend_dip + rng.normal(0, 6, 120)).round().astype(int),
+    index=days, name="visits",
+)`}
+  initialCode={`weekly = visits.resample("W").agg(["sum", "mean", "min", "max"]).round(1)
+print("Per-week profile:")
+print(weekly.head())
+print()
+print("The 'max' and 'min' columns show the best and worst day each week.")
+`}
+/>
+
+And monthly data downsamples further still — our airline series rolls up to
+quarterly or yearly views that make the long-run **trend** obvious:
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`# Monthly -> yearly average: the trend, stripped of seasonality.
+print("Average monthly passengers, by YEAR:")
+print(air.resample("YE").mean().round(0))
+print()
+# Monthly -> yearly TOTAL: total passengers flown each year (a flow -> sum).
+print("Total passengers flown each YEAR:")
+print(air.resample("YE").sum())
+print()
+print("Downsampling to yearly removes the within-year seasonal wiggle,")
+print("leaving the steady climb in air travel - the long-run trend.")
+`}
+/>
+
+<Callout type="tip" title="Downsampling is a seasonality filter">
+Notice the yearly resample above has *no* summer hump — averaging a full
+year folds the 12-month seasonal cycle into a single number. Downsampling
+to the seasonal period (or a multiple of it) is a quick, crude way to
+*see the trend* without the seasonality shouting over it. We'll do this far
+more carefully with decomposition soon.
+</Callout>
+
+## Upsampling: stretching onto a finer grid
+
+Upsampling is the riskier direction. Going monthly → daily, you're asking
+for ~30x more rows than you have data for. pandas inserts the new
+timestamps but leaves them empty — because it has no honest value to put
+there.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air3 = pd.Series(_passengers, index=idx, name="passengers")  # first 3 years`}
+  initialCode={`# Upsample monthly -> daily. asfreq() lays down the finer grid and leaves
+# the brand-new in-between days as NaN, because there is no data for them.
+daily = air3.resample("D").asfreq()
+
+print("First 8 daily slots after upsampling a MONTHLY series:")
+print(daily.head(8))
+print()
+print(f"Real data points : {air3.notna().sum()}")
+print(f"Rows after upsample: {len(daily)}")
+print(f"NaNs introduced  : {daily.isna().sum()}  <- pandas refuses to fabricate these")
+`}
+/>
+
+Those `NaN`s are pandas being *honest*: it knows the value on January 15th
+1949, but it has no idea what happened on January 16th — that day was never
+measured. To get numbers there you must **assume** something, and the
+assumption you choose is a modeling decision (the entire subject of the
+next page):
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air3 = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`daily = air3.resample("D").asfreq()
+
+# Assumption A: "the value holds until the next reading" (forward fill).
+held = daily.ffill()
+# Assumption B: "the value glides smoothly between readings" (interpolate).
+glided = daily.interpolate(method="linear")
+
+print("Jan 1 .. Jan 5 under two different ASSUMPTIONS:")
+compare = pd.DataFrame({"forward_fill": held, "interpolate": glided})
+print(compare.head(5))
+print()
+print("Same data, different invented values. Upsampling didn't add knowledge;")
+print("it forced us to declare what we believe happened between observations.")
+`}
+/>
+
+<Callout type="danger" title="Upsampling does not create information">
+The most dangerous misconception about resampling: that upsampling
+*reveals* finer detail. It does not. A monthly series upsampled to daily
+has exactly as much information as it did before — one real number per
+month — now smeared across 30 invented slots. Every value between the real
+observations is a guess whose quality depends entirely on whether your
+fill assumption matches reality. Never report upsampled points as if they
+were measured.
+</Callout>
+
+<MultipleChoice
+  markdown={`A colleague upsamples a **monthly** revenue series to **daily** with linear interpolation and announces, "Now we have daily revenue figures." What's the problem?
+
+- Nothing — interpolation correctly recovers the daily values
+  > Interpolation can't recover values that were never recorded. The smooth daily line is a straight-line *guess* between the two monthly anchors, not measured daily revenue.
+- Linear interpolation is too slow on large data
+  > Performance isn't the issue here; correctness of interpretation is. Even if it ran instantly, the "daily revenue" would still be fabricated.
+- [o] Upsampling invents the in-between values; the "daily" figures are interpolated assumptions, not measurements, and carry no new information
+  > One real number per month, stretched across ~30 slots, is still one number per month of actual information. Presenting the interpolated days as data overstates what is known.
+- They should have used \`sum\` instead of interpolation
+  > \`sum\` is an aggregation for *downsampling*; it doesn't apply when going to a finer grid. The real fix is to stop treating invented values as measurements, not to switch aggregation.
+
+Upsampling reshapes the grid and forces an assumption; it never adds information that wasn't measured.`}
+/>
+
+## `resample().asfreq()` vs `resample().mean()`: a quick contrast
+
+- **Downsampling** *must* aggregate (`.sum()`, `.mean()`, `.last()`, ...)
+  because many points fall in each new bucket.
+- **Upsampling** has *at most one* original point per new bucket, so there's
+  nothing to aggregate — you use `.asfreq()` to lay down the grid, then a
+  fill method to populate it.
+
+<MultipleChoice
+  markdown={`Which statement correctly pairs the direction with what you must supply?
+
+- Downsampling needs a fill method; upsampling needs an aggregation
+  > This is backwards. Going to a *coarser* grid has many points per bucket (needs an aggregation); going to a *finer* grid has empty slots (needs a fill).
+- [o] Downsampling needs an aggregation (sum/mean/...); upsampling needs a fill method (ffill/interpolate/...)
+  > Coarser buckets contain multiple original points, so you must summarize them; finer buckets contain gaps, so you must decide how to fill them. The direction dictates the tool.
+- Both directions need an aggregation
+  > Upsampling has at most one real point per new slot, so there's nothing to aggregate. It needs a fill rule, not a summary.
+- Neither needs anything; pandas picks automatically
+  > pandas deliberately refuses to pick for you — it leaves \`NaN\`s on upsample and requires an explicit method on downsample, precisely so you make the modeling choice consciously.
+
+Coarser grid -> aggregate the many; finer grid -> fill the gaps.`}
+/>
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Daily visits to weekly totals"
+  instructions={`A daily \`visits\` Series (90 days) is loaded. Build \`weekly_total\`: the **total** visits per week, with weeks ending on **Sunday** (the \`"W"\` default). The result should be a Series indexed by week-ending dates.
+
+Then also compute \`busiest_week\` — the week-ending \`Timestamp\` with the highest total.`}
+  initCode={`import pandas as pd
+import numpy as np
+rng = np.random.default_rng(7)
+days = pd.date_range("2014-01-01", periods=90, freq="D")
+visits = pd.Series(rng.integers(80, 200, 90), index=days, name="visits")`}
+  initialCode={`weekly_total = None   # total visits per week (sum)
+busiest_week = None   # week-ending Timestamp with the max total
+print(weekly_total.head() if weekly_total is not None else None)
+print("busiest:", busiest_week)
+`}
+  solutionCode={`weekly_total = visits.resample("W").sum()
+busiest_week = weekly_total.idxmax()
+print(weekly_total.head())
+print("busiest:", busiest_week.date(), "with", int(weekly_total.max()), "visits")
+`}
+  tests={[
+    {
+      id: "is_series",
+      name: "weekly_total is a Series",
+      description: "Type check",
+      code: `import pandas as pd
+assert isinstance(weekly_total, pd.Series)`,
+    },
+    {
+      id: "is_sum",
+      name: "values are weekly sums",
+      description: "Total visits across the whole series is preserved",
+      code: `assert int(weekly_total.sum()) == int(visits.sum()), "Sum of weekly totals must equal the grand total"`,
+    },
+    {
+      id: "weekly_freq",
+      name: "buckets are weekly",
+      description: "Roughly 90/7 ~ 13-14 weeks",
+      code: `assert 12 <= len(weekly_total) <= 14, f"Expected ~13 weekly buckets, got {len(weekly_total)}"`,
+    },
+    {
+      id: "busiest",
+      name: "busiest_week is the argmax",
+      description: "It matches the week with the largest total",
+      code: `assert weekly_total.loc[busiest_week] == weekly_total.max()`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Choose the right aggregation for each series"
+  instructions={`You have two daily series for June: \`rainfall_mm\` (millimetres of rain that fell each day — a FLOW) and \`humidity_pct\` (the day's average relative humidity — a LEVEL). Produce a one-row-per-month summary as a dict \`june\` with:
+
+- \`"total_rain"\` — June's total rainfall (the correct aggregation for a flow), as a float
+- \`"avg_humidity"\` — June's typical humidity (the correct aggregation for a level), as a float rounded to 1 decimal
+
+Pick \`sum\` vs \`mean\` to match what each quantity *means*.`}
+  initCode={`import pandas as pd
+import numpy as np
+rng = np.random.default_rng(3)
+days = pd.date_range("2014-06-01", periods=30, freq="D")
+rainfall_mm  = pd.Series(rng.gamma(1.2, 3.0, 30).round(1), index=days, name="rain")
+humidity_pct = pd.Series((60 + rng.normal(0, 8, 30)).clip(20, 100).round(1),
+                         index=days, name="humidity")`}
+  initialCode={`june = {
+    "total_rain": None,     # rainfall is a FLOW
+    "avg_humidity": None,   # humidity is a LEVEL
+}
+print(june)
+`}
+  solutionCode={`june = {
+    "total_rain": float(rainfall_mm.resample("ME").sum().iloc[0]),
+    "avg_humidity": float(humidity_pct.resample("ME").mean().round(1).iloc[0]),
+}
+print(june)
+`}
+  tests={[
+    {
+      id: "keys",
+      name: "june has both float values",
+      description: "Correct keys and types",
+      code: `assert set(june.keys()) == {"total_rain", "avg_humidity"}
+assert all(isinstance(v, float) for v in june.values())`,
+    },
+    {
+      id: "rain_is_sum",
+      name: "total_rain is the SUM of daily rainfall",
+      description: "Flows accumulate",
+      code: `assert abs(june["total_rain"] - float(rainfall_mm.sum())) < 1e-6, "Rainfall should be summed"`,
+    },
+    {
+      id: "humidity_is_mean",
+      name: "avg_humidity is the MEAN of daily humidity",
+      description: "Levels average",
+      code: `assert abs(june["avg_humidity"] - round(float(humidity_pct.mean()), 1)) < 0.05, "Humidity should be averaged"`,
+    },
+    {
+      id: "not_swapped",
+      name: "aggregations are not swapped",
+      description: "Sum and mean are clearly different here",
+      code: `assert june["total_rain"] > june["avg_humidity"], "Looks like sum/mean were swapped"`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`How is \`df.resample("ME")\` most accurately described?
+
+- A way to delete rows to make the series shorter
+  > Resampling reorganizes the timeline into buckets and aggregates; it isn't row deletion. Downsampling *summarizes* groups of rows rather than dropping them arbitrarily.
+- [o] A time-aware \`groupby\` that buckets the index into regular periods, awaiting an aggregation to summarize each bucket
+  > \`resample\` groups by fixed time windows the way \`groupby\` groups by a key, then applies a summary (\`.sum()\`, \`.mean()\`, ...) to each window.
+- A method that always returns one row per original row
+  > Downsampling returns *fewer* rows (one per bucket) and upsampling returns *more*; it rarely preserves the original row count.
+- A plotting function
+  > Resampling transforms data; it draws nothing. You might plot the result afterward, but that's a separate step.
+
+\`resample\` is \`groupby\` for the time axis: bucket by period, then aggregate.`}
+/>
+
+<MultipleChoice
+  markdown={`A daily count of **support tickets** is resampled to monthly. Which aggregation gives "how many tickets did we handle that month," and why?
+
+- \`mean\`, because monthly figures should be averages
+  > \`mean\` gives the typical tickets-per-day, not the monthly workload. "How many that month" is a total, not an average.
+- [o] \`sum\`, because ticket counts are a flow that accumulates over the month
+  > Counts of events are flows; the month's volume is the sum of its days. \`sum\` answers "how many in total," which is the question asked.
+- \`last\`, because only the final day matters
+  > \`last\` keeps a single day's count and discards the rest of the month — it answers nothing about the month's volume.
+- \`max\`, because the busiest day represents the month
+  > \`max\` reports the single worst day, not the monthly total. It's a useful extra statistic but not "how many that month."
+
+Event counts are flows, so the monthly volume is a \`sum\`; \`mean\` would answer a different ("typical day") question.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- **Resampling changes temporal resolution**; it's `groupby` for the time
+  axis.
+- **Downsampling** (fine → coarse) **summarizes**: choose **`sum`** for
+  *flows* (sales, visits, rainfall) and **`mean`** (or min/max) for *levels*
+  (temperature, price). Picking the wrong one produces nonsense.
+- **Upsampling** (coarse → fine) **invents** the in-between values. `asfreq`
+  lays down the grid as `NaN`s; you then fill with an *assumption*.
+- **Upsampling adds no information** — never present interpolated points as
+  measurements.
+- Downsampling to (a multiple of) the seasonal period is a quick way to see
+  the underlying **trend**.
+</Callout>
+
+Upsampling left us staring at a grid full of `NaN`s, and even real-world
+data arrives with holes. How you fill those gaps is not a button-press but
+a genuine assumption about what happened when you weren't looking — which
+is exactly the next page.

--- a/content/learn/time-series-analysis-python/rolling-and-expanding-windows.mdx
+++ b/content/learn/time-series-analysis-python/rolling-and-expanding-windows.mdx
@@ -1,0 +1,515 @@
+---
+title: "Moving Windows: Smoothing Data with Rolling and Expanding Statistics"
+description: Shifting and lagging with shift(), moving averages with rolling(), cumulative statistics with expanding() — the window-size trade-off, the trailing-vs-centered leakage trap, and why a moving average is a smoother of the past, never a forecast of the future.
+---
+
+Raw time series are noisy. Underneath the jitter there's usually a calmer
+story — a trend, a seasonal shape — and **moving-window** statistics are
+how you turn the volume down on the noise to hear it. This page covers
+three closely related tools: **`shift`** (look at the past), **`rolling`**
+(summarize a sliding window of the past), and **`expanding`** (summarize
+everything so far). It also covers the two ways people quietly cheat with
+them.
+
+## First, looking backward: `shift`
+
+Almost every time series operation needs to compare *now* to *then*.
+`shift(k)` moves the data forward by `k` steps, so each row lines up with a
+value from its own past (a **lag**). `shift(-k)` does the reverse (a
+**lead**, peeking ahead).
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+
+s = pd.Series([10, 12, 11, 15, 14],
+              index=pd.date_range("2014-01-01", periods=5, freq="D"),
+              name="y")
+
+frame = pd.DataFrame({
+    "y": s,
+    "lag1 (yesterday)": s.shift(1),    # pull the PAST up to today
+    "lead1 (tomorrow)": s.shift(-1),   # pull the FUTURE back to today
+})
+print(frame)
+print()
+
+# 'shift' is how you compute change over time:
+print("Day-over-day change (y - y.shift(1)):")
+print((s - s.shift(1)).tolist())
+`}
+/>
+
+`shift(1)` is the building block for almost everything later: a lag feature,
+a day-over-day change, a percentage return, and — crucially — the
+**differencing** we'll use to fight non-stationarity. Notice the first
+`lag1` is `NaN`: there's no day *before* the first day to borrow from.
+
+<Callout type="warn" title="shift(-1) peeks at the future — handle with care">
+`shift(1)` (a lag) is always safe: it brings *past* information to the
+present. `shift(-1)` (a lead) brings *future* information to the present,
+which is exactly the kind of move that causes leakage if it sneaks into a
+forecasting feature. Leads are fine for analysis ("what happened next?")
+but must never become an input your model uses to predict the present.
+</Callout>
+
+## The moving average: `rolling`
+
+A **rolling** (or *moving*) statistic slides a fixed-size window along the
+series and computes a summary at each stop. The **moving average** —
+`rolling(window=N).mean()` — is the classic noise filter: each point
+becomes the average of itself and its `N-1` predecessors, so random
+up-and-down jitter cancels out while the slow signal survives.
+
+```mermaid
+flowchart TB
+    subgraph ROLL["Rolling window = 3 (fixed size, slides forward)"]
+        direction LR
+        R1["mean of y1, y2, y3"] --> R2["mean of y2, y3, y4"] --> R3["mean of y3, y4, y5"]
+    end
+    subgraph EXP["Expanding window (grows from the start)"]
+        direction LR
+        E1["mean of y1"] --> E2["mean of y1, y2"] --> E3["mean of y1, y2, y3"]
+    end
+```
+
+Watch a 12-month moving average dissolve the airline series' seasonal hump
+and lay its trend bare. **Change the `window` and re-run** to feel the
+trade-off.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import matplotlib.pyplot as plt
+
+window = 12   # <-- change me! try 3 (noisy), 12 (kills seasonality), 36 (very smooth)
+
+ma = air.rolling(window=window).mean()
+
+fig, ax = plt.subplots(figsize=(10, 4))
+air.plot(ax=ax, alpha=0.4, label="raw (monthly)")
+ma.plot(ax=ax, linewidth=2.5, label=f"{window}-month moving average")
+ax.legend()
+ax.set_title(f"Rolling mean smooths the noise (window = {window})")
+plt.tight_layout()
+plt.show()
+
+print(f"The first {window-1} values are NaN: a full {window}-wide window")
+print("isn't available until that many points have gone by.")
+`}
+/>
+
+A 12-month window is special here: because it spans exactly one seasonal
+cycle, averaging over it *cancels the seasonality* and leaves a clean
+trend. Try `window=3` and the line stays jagged (barely any smoothing);
+try `window=36` and it becomes a sweeping curve that lags far behind the
+data. That tension is the whole art of choosing a window.
+
+<Callout type="info" title="The window-size trade-off">
+- **Small window** → *responsive* but *noisy*. It hugs the data and reacts
+  fast, but barely smooths.
+- **Large window** → *smooth* but *laggy*. It produces a clean line, but it
+  reacts slowly and trails behind turning points.
+
+There's no universally right size — it depends on what you're trying to
+see. To remove a known cycle, set the window to that cycle's length (12 for
+monthly-yearly, 7 for daily-weekly).
+</Callout>
+
+### The leading NaNs and `min_periods`
+
+By default a rolling statistic refuses to compute until it has a *full*
+window, so the first `N-1` results are `NaN`. If you'd rather get partial
+answers at the start, allow them with `min_periods`.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [112,118,132,129,121,135,148,148,136,119,104,118]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`print("Default: needs a full window, so the first 2 are NaN:")
+print(air.rolling(3).mean().round(1).head())
+print()
+print("min_periods=1: compute as soon as there's at least 1 point:")
+print(air.rolling(3, min_periods=1).mean().round(1).head())
+`}
+/>
+
+## The trailing-vs-centered trap (a leakage classic)
+
+By default, `rolling` is **trailing**: the window at time *t* ends at *t*
+and reaches *backward*. That's exactly right for forecasting — at time *t*
+you only know the past and present. But pandas also offers `center=True`,
+which centers the window on *t*, reaching *into the future*. That's fine
+for *visualizing* a trend, but poison if the result becomes a model input.
+
+```mermaid
+flowchart LR
+    subgraph TRAIL["Trailing window at time t (SAFE for forecasting)"]
+        direction LR
+        T1["averages y(t-2), y(t-1), y(t)"] --> T2["uses only PAST and present"]
+    end
+    subgraph CENT["Centered window at time t (LEAKS the future)"]
+        direction LR
+        C1["averages y(t-1), y(t), y(t+1)"] --> C2["includes y(t+1): the FUTURE"]
+    end
+```
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+
+s = pd.Series([10, 20, 30, 40, 50],
+              index=pd.date_range("2014-01-01", periods=5, freq="D"), name="y")
+
+frame = pd.DataFrame({
+    "y": s,
+    "trailing": s.rolling(3).mean(),                 # ends AT t (past-facing)
+    "centered": s.rolling(3, center=True).mean(),    # straddles t (future-facing)
+})
+print(frame)
+print()
+print("On 2014-01-02 the centered mean is (10+20+30)/3 = 20.0 -- it used")
+print("2014-01-03, a day that hadn't happened yet at the time of 01-02.")
+print("Great for a smooth trend line; FORBIDDEN as a forecasting feature.")
+`}
+/>
+
+<MultipleChoice
+  markdown={`You're engineering features to **forecast** tomorrow's demand and add a 7-day moving average computed with \`rolling(7, center=True)\`. Why is this a problem?
+
+- Centered windows are slower to compute
+  > Performance is irrelevant. The issue is *what information* the feature contains, not how fast it's produced.
+- [o] A centered window at day t averages in days *after* t, so the feature secretly contains future values — data leakage that inflates accuracy and can't be reproduced at prediction time
+  > To center a 7-day window on day t you need days t+1, t+2, t+3, which don't exist yet when you're forecasting. The feature smuggles the future into the present; in production those days are unknown, so the model collapses.
+- Nothing is wrong; centering is more accurate
+  > It *looks* more accurate precisely because it cheated. The apparent accuracy evaporates in production, where future days aren't available to center on.
+- It only matters if the window is larger than 7
+  > Any centered window of size > 1 reaches into the future. The leakage exists at window 3 just as at window 70.
+
+Centered rolling features include future observations, which is leakage; forecasting features must use trailing windows only.`}
+/>
+
+## The biggest misconception: a moving average is **not** a forecast
+
+This one sinks real projects. A rolling mean is a **smoother of data you
+already have**. It describes the *past*. It has no machinery to project
+*beyond* the last observation — the line simply *stops* where your data
+stops. People see a smooth upward moving-average curve and imagine it
+"continuing," but the moving average itself predicts nothing.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import matplotlib.pyplot as plt
+
+ma = air.rolling(12).mean()
+
+fig, ax = plt.subplots(figsize=(10, 4))
+air.plot(ax=ax, alpha=0.35, label="raw")
+ma.plot(ax=ax, linewidth=2.5, label="12-month moving average")
+
+# Mark where the DATA ends. The moving average ends there too -- it cannot
+# step a single month into 1961 on its own.
+last = air.index[-1]
+ax.axvline(last, color="crimson", linestyle="--")
+ax.text(last, air.min(), " data ends here\\n the MA cannot go further",
+        color="crimson", va="bottom")
+ax.legend(); ax.set_title("A moving average smooths the past; it does not forecast")
+plt.tight_layout(); plt.show()
+
+print("The orange curve stops at the red line. To say anything about 1961")
+print("you need a MODEL (ARIMA, later) - not a backward-looking average.")
+`}
+/>
+
+<Callout type="danger" title="Smoother vs forecast">
+A moving average answers "*what has the recent level been?*" A forecast
+answers "*what will the value be next?*" They are different questions. The
+moving average has no concept of "next" — at the final point it's just the
+average of the last `N` observations, and it physically cannot extend past
+your data. When you need the future, you need a *model*. Confusing a
+trailing average with a projection is one of the most common rookie errors
+in forecasting.
+</Callout>
+
+## Rolling spread: measuring changing volatility
+
+`rolling` isn't only for means. A rolling **standard deviation** tracks how
+*volatile* the series is over time — and on the airline data it climbs,
+quantifying the "swings get bigger" effect we eyeballed earlier. (That
+growing spread is a non-stationarity we'll learn to fix.)
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import matplotlib.pyplot as plt
+
+roll_std = air.rolling(12).std()
+
+fig, ax = plt.subplots(figsize=(10, 3.5))
+roll_std.plot(ax=ax, color="purple")
+ax.set_title("12-month rolling standard deviation (volatility) is RISING")
+ax.set_ylabel("std of passengers")
+plt.tight_layout(); plt.show()
+
+print("Early years:", round(roll_std.dropna().iloc[0], 1),
+      " Late years:", round(roll_std.dropna().iloc[-1], 1))
+print("The spread roughly TRIPLES - the variance is not constant over time.")
+`}
+/>
+
+## Expanding windows: everything so far
+
+Where `rolling(N)` looks back a fixed `N` steps, **`expanding`** looks back
+*all the way to the start*, growing as it goes. `expanding().mean()` is the
+running (cumulative) average — "the average of everything up to and
+including now." It's the honest, leakage-free way to say "the typical value
+*so far*," because at each point it only knows the past.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+import numpy as np
+
+rng = np.random.default_rng(0)
+s = pd.Series(rng.normal(50, 10, 30),
+              index=pd.date_range("2014-01-01", periods=30, freq="D"))
+
+cmp = pd.DataFrame({
+    "value": s.round(1),
+    "rolling7_mean": s.rolling(7).mean().round(1),    # last 7 days
+    "expanding_mean": s.expanding().mean().round(1),  # all days so far
+})
+print(cmp.head(10))
+print()
+print("rolling7 forgets data older than 7 days; expanding never forgets.")
+print("Both use only PAST+present, so both are safe to use as-of each date.")
+`}
+/>
+
+<Callout type="tip" title="Rolling vs expanding, in one line">
+Use **rolling** when only the *recent* past is relevant (last week's
+traffic, last 30 days' volatility). Use **expanding** when *all* history
+should count equally (a running lifetime average, a cumulative total). For
+something in between — recent points matter more but old ones still count —
+there's exponential weighting, `ewm(span=...).mean()`.
+</Callout>
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="A trailing 7-day average (no peeking)"
+  instructions={`A daily \`visits\` Series is loaded. Compute \`smooth\`: a **7-day trailing** moving average (each day = the mean of that day and the 6 days before it). It must use only past-and-present data — do **not** center the window.
+
+The first 6 entries should be \`NaN\` (a full 7-day window isn't available yet), and from day 7 onward each value is a true 7-day mean.`}
+  initCode={`import pandas as pd
+import numpy as np
+rng = np.random.default_rng(11)
+days = pd.date_range("2014-01-01", periods=40, freq="D")
+visits = pd.Series((150 + rng.normal(0, 20, 40)).round().astype(int),
+                   index=days, name="visits")`}
+  initialCode={`smooth = None  # 7-day TRAILING moving average
+print(smooth.head(10) if smooth is not None else None)
+`}
+  solutionCode={`smooth = visits.rolling(window=7).mean()
+print(smooth.head(10))
+`}
+  tests={[
+    {
+      id: "type_len",
+      name: "smooth is a Series of the right length",
+      description: "Same length as input",
+      code: `import pandas as pd
+assert isinstance(smooth, pd.Series) and len(smooth) == len(visits)`,
+    },
+    {
+      id: "leading_nans",
+      name: "first 6 are NaN, 7th is not",
+      description: "Full-window default behavior (trailing)",
+      code: `assert smooth.iloc[:6].isna().all(), "First 6 should be NaN"
+assert not pd.isna(smooth.iloc[6]), "7th value should be defined"`,
+    },
+    {
+      id: "is_trailing",
+      name: "window is trailing, not centered",
+      description: "7th value equals the mean of the first 7 days",
+      code: `import numpy as np
+assert abs(smooth.iloc[6] - visits.iloc[:7].mean()) < 1e-9, "Value at index 6 must be mean of days 0..6 (trailing)"`,
+    },
+    {
+      id: "not_centered",
+      name: "not accidentally centered",
+      description: "A centered window would define index 3, not leave it NaN",
+      code: `import pandas as pd
+assert pd.isna(smooth.iloc[3]), "Index 3 should be NaN for a trailing window (it wouldn't be if centered)"`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Prove that a centered window leaks the future"
+  instructions={`Using the loaded series \`s\`, compute two 3-wide moving averages at index position 1 (the second point):
+
+- \`trailing_at_1\` — \`s.rolling(3, min_periods=1).mean()\` value at position 1
+- \`centered_at_1\` — \`s.rolling(3, center=True).mean()\` value at position 1
+
+Then set \`uses_future\` to \`True\` if the centered value at position 1 depends on \`s.iloc[2]\` (a point *after* position 1), and \`False\` otherwise. Decide it by checking whether the centered average at position 1 equals \`(s.iloc[0] + s.iloc[1] + s.iloc[2]) / 3\`.`}
+  initCode={`import pandas as pd
+s = pd.Series([10.0, 20.0, 30.0, 40.0, 50.0],
+              index=pd.date_range("2014-01-01", periods=5, freq="D"), name="s")`}
+  initialCode={`trailing_at_1 = None
+centered_at_1 = None
+uses_future = None
+print(trailing_at_1, centered_at_1, uses_future)
+`}
+  solutionCode={`trailing_at_1 = float(s.rolling(3, min_periods=1).mean().iloc[1])
+centered_at_1 = float(s.rolling(3, center=True).mean().iloc[1])
+uses_future = abs(centered_at_1 - (s.iloc[0] + s.iloc[1] + s.iloc[2]) / 3) < 1e-9
+print("trailing@1:", trailing_at_1, " centered@1:", centered_at_1, " uses_future:", uses_future)
+`}
+  tests={[
+    {
+      id: "trailing_value",
+      name: "trailing@1 uses only points 0 and 1",
+      description: "(10+20)/2 = 15",
+      code: `assert abs(trailing_at_1 - 15.0) < 1e-9, f"Expected 15.0, got {trailing_at_1}"`,
+    },
+    {
+      id: "centered_value",
+      name: "centered@1 = (10+20+30)/3 = 20",
+      description: "It pulled in point 2 (the future)",
+      code: `assert abs(centered_at_1 - 20.0) < 1e-9, f"Expected 20.0, got {centered_at_1}"`,
+    },
+    {
+      id: "leak_flag",
+      name: "uses_future is True",
+      description: "The centered window depended on a later point",
+      code: `assert uses_future is True, "Centered window at index 1 does depend on s.iloc[2]"`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`What is the primary purpose of a moving (rolling) average?
+
+- To forecast future values of the series
+  > A moving average can't step beyond the last data point — it only summarizes data you already have. Forecasting needs a model, not a backward-looking average.
+- [o] To smooth out short-term noise so longer-term structure (trend, seasonal shape) becomes visible
+  > Averaging a sliding window cancels random jitter while preserving slow movements, which is exactly what makes the trend easier to see.
+- To remove all the data points and replace them with one number
+  > It produces one smoothed value *per position*, not a single number. The series keeps its length (minus the leading window).
+- To convert the series to a different frequency
+  > Changing frequency is resampling. A rolling mean keeps the original frequency and just smooths it.
+
+A rolling average is a noise filter that reveals slow structure — it is not a forecaster and doesn't change frequency.`}
+/>
+
+<MultipleChoice
+  markdown={`You apply \`rolling(30).mean()\` and the line becomes very smooth but reacts slowly, trailing well behind sharp turns in the data. To make it track turning points more responsively, you should:
+
+- Increase the window to 60
+  > A larger window smooths *more* and lags *more*, making the trailing problem worse, not better.
+- [o] Decrease the window (e.g., to 7), accepting more noise in exchange for faster responsiveness
+  > Smaller windows hug the data and react quickly. The cost is less smoothing — the responsiveness-vs-smoothness trade-off in action.
+- Switch to \`center=True\`
+  > Centering shifts *when* the average is plotted (and leaks the future), but it doesn't fundamentally make a 30-wide window more responsive. It would also be unsafe for forecasting.
+- Use \`expanding().mean()\` instead
+  > An expanding window includes *all* history, so it reacts even more sluggishly than a 30-day window, not less.
+
+Responsiveness comes from a smaller window; smoothness comes from a larger one — you trade one for the other.`}
+/>
+
+<MultipleChoice
+  markdown={`Which window type uses **all** observations from the start of the series up to the current point?
+
+- \`rolling(10)\`
+  > A rolling window of size 10 forgets anything older than 10 steps; it does not span the whole history.
+- [o] \`expanding()\`
+  > An expanding window grows from the first observation, so at each point it summarizes every value seen so far — the running/cumulative view.
+- \`shift(1)\`
+  > \`shift\` just lags the series by one step; it computes no window statistic at all.
+- \`rolling(1)\`
+  > A window of 1 contains only the current point — the opposite of "all history."
+
+\`expanding()\` accumulates the entire past; \`rolling(N)\` keeps only the most recent \`N\`.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- **`shift(k)`** lags the series (`k>0`, safe, past-facing) or leads it
+  (`k<0`, future-facing — leakage risk). It's the basis of change, returns,
+  and differencing.
+- **`rolling(N).mean()`** is a moving-average **smoother**: small `N` =
+  responsive but noisy, large `N` = smooth but laggy. Match `N` to a cycle
+  to cancel it (12 for monthly-yearly).
+- Rolling defaults to **trailing** (past-facing, safe). **`center=True`**
+  reaches into the future — fine for visualizing, **leakage** if used as a
+  forecasting feature.
+- A moving average **describes the past and cannot forecast** — it stops
+  where your data stops. Confusing a smoother with a projection is a classic
+  error.
+- **`rolling(N).std()`** tracks changing volatility; **`expanding()`**
+  accumulates all history (running mean/total).
+</Callout>
+
+Windows assume the data is *there* to average. But real series have holes —
+a sensor drops out, a day goes unrecorded — and a single `NaN` can poison a
+rolling window. How you fill those gaps is a genuine assumption about the
+unseen, and that's next.

--- a/content/learn/time-series-analysis-python/stationarity.mdx
+++ b/content/learn/time-series-analysis-python/stationarity.mdx
@@ -1,0 +1,493 @@
+---
+title: "The Concept of Stationarity: Why it Matters and How to Test for It"
+description: What stationarity means in plain language, why classical models like ARIMA require it, how to see non-stationarity in changing mean and variance, and how to test for it with the Augmented Dickey-Fuller test — including the null hypothesis everyone gets backwards.
+---
+
+Stationarity is the gatekeeper concept of classical forecasting. Almost
+every model on the pages ahead — AR, MA, ARMA, ARIMA — *assumes* it, and if
+you skip the check, you'll fit a model to conditions that won't hold and get
+a confident, wrong forecast. The good news: the idea is far more intuitive
+than its intimidating name.
+
+## What "stationary" actually means
+
+A series is **stationary** when its *statistical properties don't change
+over time*. The mean stays put, the variance stays roughly constant, and
+the way each value relates to its recent past (the autocorrelation
+structure) is the same in 1949 as in 1960. The series might wiggle wildly,
+but the **rules generating the wiggles never change**.
+
+<Callout type="tip" title="The 'rules of the game' analogy">
+You can only learn the rules of a game by watching it played — *if the rules
+stay the same*. A stationary series is a fair game with fixed rules: what you
+learn from the first half still applies to the second. A non-stationary
+series keeps changing the rules mid-play (the average drifts, the swings
+grow), so what you learned from the past no longer describes the future.
+Forecasting needs the rules to hold still.
+</Callout>
+
+The formal ("weak" / covariance) definition is just that intuition in three
+bullets:
+
+1. **Constant mean** — no trend; the series hovers around a fixed level.
+2. **Constant variance** — the size of the fluctuations doesn't grow or
+   shrink over time.
+3. **Autocovariance depends only on the lag** — how related two points are
+   depends only on *how far apart* they are, not on *when* they occur.
+
+## Seeing non-stationarity
+
+The two most common violations are easy to *see*: a drifting mean (a trend)
+and a changing variance (a widening or narrowing band). Let's put a
+stationary series next to both.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+rng = np.random.default_rng(0)
+n = 200
+idx = pd.date_range("2014-01-01", periods=n, freq="D")
+
+stationary    = pd.Series(rng.normal(0, 1, n), index=idx)                       # fixed rules
+moving_mean   = pd.Series(rng.normal(0, 1, n) + np.linspace(0, 8, n), index=idx) # mean drifts up
+moving_var    = pd.Series(rng.normal(0, 1, n) * np.linspace(0.3, 5, n), index=idx) # spread grows`}
+  initialCode={`fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True)
+
+for ax, s, title in zip(
+    axes,
+    [stationary, moving_mean, moving_var],
+    ["STATIONARY: constant mean and variance",
+     "NON-stationary: the MEAN drifts upward (a trend)",
+     "NON-stationary: the VARIANCE grows (a widening funnel)"],
+):
+    s.plot(ax=ax, color="steelblue", lw=0.9)
+    s.rolling(20).mean().plot(ax=ax, color="crimson", lw=2)   # rolling mean
+    ax.set_title(title)
+
+plt.tight_layout(); plt.show()
+
+print("Top: the red rolling mean stays flat and the band keeps a fixed width.")
+print("Middle: the rolling mean climbs -> the mean is time-dependent.")
+print("Bottom: the mean is flat but the band fans out -> variance is time-dependent.")
+print("Only the top series is stationary.")
+`}
+/>
+
+Watch the red rolling mean. In the stationary panel it stays flat and the
+spread is constant. In the second it *climbs* — the mean depends on time. In
+the third the mean is flat but the band *fans out* — the variance depends on
+time. Either kind of drift breaks stationarity.
+
+<MultipleChoice
+  markdown={`Which series is **stationary**?
+
+- A stock's daily *price*, which wanders up over years
+  > A price that drifts has a time-dependent mean (and often growing variance) — the hallmark of non-stationarity. Prices are the classic non-stationary ("random walk") example.
+- Monthly *retail sales* with a rising trend and a December spike every year
+  > A rising trend means a drifting mean and the yearly spike means the distribution depends on the season — two violations at once. Clearly non-stationary.
+- [o] Daily *changes* in a stock's price, hovering around zero with a roughly constant spread
+  > Differencing a price into day-to-day changes typically yields a series with a fixed (near-zero) mean and stable variance — approximately stationary. This is exactly why we model *returns* rather than *prices*.
+- A sensor reading whose fluctuations grow larger every year
+  > Growing fluctuations are a time-dependent variance, which violates stationarity even if the mean stays flat.
+
+A flat mean *and* a stable variance (like price *changes*) is stationary; trends, seasonal spikes, and growing variance are not.`}
+/>
+
+## Why models demand it
+
+Here's the crux. A model like AR learns a *fixed* rule — "this value is
+about 0.7 times the previous value, plus a shock." Those coefficients are
+**constants**. They can only be true if the relationship they describe stays
+the same through time, which is exactly what stationarity guarantees. Point
+a fixed-coefficient model at a trending series and it's like fitting one
+straight line through data whose true level keeps moving — the coefficients
+describe an average of conditions that never actually occur.
+
+<Callout type="info" title="Stationarity is what makes the past usable">
+Forecasting is, at bottom, the bet that *the future will behave like the
+past*. Stationarity is the precise statement of when that bet is fair: when
+the generating rules are constant, the patterns you estimate from history
+keep holding. That's why we transform a non-stationary series into a
+stationary one *before* modeling — we're manufacturing the very condition
+that makes learning from the past valid.
+</Callout>
+
+## Testing for it: the Augmented Dickey-Fuller (ADF) test
+
+Eyeballing is essential but subjective. The **Augmented Dickey-Fuller**
+test makes it quantitative. It checks for a **unit root** — the signature of
+a "random walk" style non-stationarity where the series has no fixed level
+to return to. Its hypotheses are where everyone trips:
+
+<Callout type="danger" title="The ADF null hypothesis is BACKWARDS from intuition">
+- **H0 (null):** the series **has a unit root** → it is **NON-stationary**.
+- **H1 (alternative):** the series is **stationary**.
+
+So a **small p-value (< 0.05) means STATIONARY** (you reject the
+non-stationary null), and a **large p-value means you could NOT show
+stationarity** (treat it as non-stationary). This is the reverse of the
+"small p = something interesting" reflex from most other tests. Read it
+slowly: **low p → stationary, high p → non-stationary.**
+</Callout>
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.stattools import adfuller
+
+def adf_report(series, name):
+    s = pd.Series(series).dropna()
+    stat, p, used_lag, nobs, crit, _ = adfuller(s)
+    verdict = "STATIONARY (reject the unit-root null)" if p < 0.05 \
+              else "NON-stationary (cannot reject the null)"
+    print(f"{name}")
+    print(f"   ADF statistic : {stat:8.3f}")
+    print(f"   p-value       : {p:8.4f}")
+    print(f"   5% crit value : {crit['5%']:8.3f}  (reject H0 when ADF stat < this)")
+    print(f"   verdict       : {verdict}\\n")
+
+rng = np.random.default_rng(0)`}
+  initialCode={`# A genuinely stationary series: white noise around 0.
+white = rng.normal(0, 1, 300)
+adf_report(white, "White noise (should be STATIONARY)")
+
+# A random walk: each step adds a shock, so it wanders with no fixed level.
+walk = np.cumsum(rng.normal(0, 1, 300))
+adf_report(walk, "Random walk (should be NON-stationary)")
+`}
+/>
+
+White noise gives a tiny p-value (reject the null → stationary). The random
+walk gives a large p-value (can't reject → non-stationary). The ADF
+*statistic* tells the same story: it's very negative for the stationary
+series and near zero for the walk. The rule of thumb — **more negative than
+the 5% critical value → stationary** — agrees with the p-value.
+
+Now the airline series, which we've been calling non-stationary all along:
+
+<CodeBlock
+  adapter="python"
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.stattools import adfuller
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")
+
+def adf_report(series, name):
+    s = pd.Series(series).dropna()
+    stat, p, *_ = adfuller(s)
+    verdict = "STATIONARY" if p < 0.05 else "NON-stationary"
+    print(f"{name:38s} p-value = {p:7.4f}  ->  {verdict}")`}
+  initialCode={`adf_report(air, "Raw airline passengers")
+adf_report(np.log(air), "log(passengers)")
+adf_report(air.diff(), "First difference of passengers")
+adf_report(np.log(air).diff(), "First difference of log(passengers)")
+
+print()
+print("Raw series: high p -> non-stationary (the trend dominates).")
+print("A log alone doesn't fix it (log tames variance, not the trend).")
+print("DIFFERENCING collapses the p-value -> that's the cure (next page).")
+`}
+/>
+
+The raw series has a large p-value — non-stationary, as promised. A log
+alone barely helps (it fixes *variance*, not the *trend*). But a single
+**difference** drops the p-value dramatically. That preview is the entire
+motivation for the next page.
+
+<MultipleChoice
+  markdown={`You run \`adfuller\` on a series and get a p-value of **0.78**. What do you conclude?
+
+- The series is stationary, because the p-value is high
+  > This reverses the ADF logic. A *high* p-value means you could *not* reject the non-stationary null — it points to non-stationarity, not stationarity.
+- [o] You cannot reject the unit-root null, so you treat the series as non-stationary
+  > With p = 0.78 there's no evidence against the null (which *is* non-stationarity), so the series is treated as non-stationary and likely needs differencing.
+- The test failed and the result is unusable
+  > A p-value of 0.78 is a perfectly valid result; it simply indicates non-stationarity. Nothing failed.
+- The series is definitely a random walk
+  > High p is *consistent* with a random walk but doesn't prove that specific model — only that stationarity couldn't be established. "Non-stationary" is the right, careful conclusion.
+
+In the ADF test the null is non-stationarity, so a high p-value (here 0.78) means you can't reject it — treat the series as non-stationary.`}
+/>
+
+<MultipleChoice
+  markdown={`A colleague says: "My ADF p-value is 0.001, so I should difference the series to make it stationary." What's wrong?
+
+- Nothing — differencing is always a good idea
+  > Differencing a series that's *already* stationary ("over-differencing") adds noise and can hurt your model. It isn't free or always beneficial.
+- [o] A p-value of 0.001 already indicates the series IS stationary, so no differencing is needed — differencing it would over-difference
+  > Low p means reject the non-stationary null: the series is stationary as-is. Differencing it anyway introduces artifacts (often a strong negative lag-1 autocorrelation) and is a mistake.
+- The p-value should be compared to 0.5, not 0.05
+  > The conventional threshold is 0.05 (sometimes 0.01), not 0.5. But the deeper error is the direction: p = 0.001 means *stop*, you're already stationary.
+- ADF p-values can't be that small
+  > They absolutely can — a strongly stationary series produces very small p-values. The issue is interpreting it, not its magnitude.
+
+A tiny ADF p-value means the series is already stationary; differencing it would over-difference and add noise.`}
+/>
+
+## The honest caveats
+
+ADF is a tool, not an oracle. Use it *with* your eyes and rolling
+statistics, never instead of them:
+
+- It tests for a **unit root** specifically. It is **not** a direct test of
+  *seasonality* or *changing variance*. A strongly seasonal series can give
+  confusing ADF results, and a series with a stable mean but exploding
+  variance can still look "stationary" to ADF.
+- **Failing to reject is not proof of non-stationarity.** Like all such
+  tests, ADF has limited *power* on short series — it may simply lack the
+  evidence to reject, which is weaker than proving the null.
+- There are companion tests (KPSS flips the hypotheses; running both and
+  cross-checking is common practice). For this course, ADF plus a careful
+  look at the plot and rolling mean/variance is enough.
+
+```mermaid
+flowchart TD
+    A["Raw series"] --> B{"Constant mean,<br/>variance, and<br/>autocorrelation?"}
+    B -->|"yes (ADF p < 0.05)"| C["Stationary: ready to model"]
+    B -->|"no (ADF p >= 0.05)"| D["Non-stationary"]
+    D --> E["Stabilize variance with a log"]
+    D --> F["Remove trend/season by differencing"]
+    E --> G["Re-test with ADF"]
+    F --> G
+    G --> B
+```
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Run the ADF test and read it correctly"
+  instructions={`Two series are loaded: \`noise\` (white noise) and \`walk\` (a random walk). Use \`adfuller\` to fill a dict \`adf\` with:
+
+- \`"noise_p"\` — the ADF p-value for \`noise\` (a float)
+- \`"walk_p"\` — the ADF p-value for \`walk\` (a float)
+- \`"noise_is_stationary"\` — \`True\` if \`noise_p < 0.05\`, else \`False\`
+- \`"walk_is_stationary"\` — \`True\` if \`walk_p < 0.05\`, else \`False\`
+
+Remember the ADF direction: **low p-value means stationary**. The white noise should test stationary; the random walk should not.`}
+  initCode={`import numpy as np
+from statsmodels.tsa.stattools import adfuller
+rng = np.random.default_rng(123)
+noise = rng.normal(0, 1, 400)
+walk = np.cumsum(rng.normal(0, 1, 400))`}
+  initialCode={`adf = {
+    "noise_p": None,
+    "walk_p": None,
+    "noise_is_stationary": None,
+    "walk_is_stationary": None,
+}
+print(adf)
+`}
+  solutionCode={`noise_p = float(adfuller(noise)[1])
+walk_p = float(adfuller(walk)[1])
+adf = {
+    "noise_p": noise_p,
+    "walk_p": walk_p,
+    "noise_is_stationary": noise_p < 0.05,
+    "walk_is_stationary": walk_p < 0.05,
+}
+print(adf)
+`}
+  tests={[
+    {
+      id: "keys",
+      name: "all four keys present and typed",
+      description: "Two floats, two bools",
+      code: `assert set(adf.keys()) == {"noise_p", "walk_p", "noise_is_stationary", "walk_is_stationary"}
+assert isinstance(adf["noise_p"], float) and isinstance(adf["walk_p"], float)
+assert isinstance(adf["noise_is_stationary"], bool) and isinstance(adf["walk_is_stationary"], bool)`,
+    },
+    {
+      id: "noise_stationary",
+      name: "white noise tests stationary",
+      description: "Low p-value for noise",
+      code: `assert adf["noise_p"] < 0.05 and adf["noise_is_stationary"] is True`,
+    },
+    {
+      id: "walk_nonstationary",
+      name: "random walk tests non-stationary",
+      description: "High p-value for the walk",
+      code: `assert adf["walk_p"] > 0.05 and adf["walk_is_stationary"] is False`,
+    },
+    {
+      id: "direction",
+      name: "flags follow the low-p-means-stationary rule",
+      description: "Booleans match their p-values",
+      code: `assert adf["noise_is_stationary"] == (adf["noise_p"] < 0.05)
+assert adf["walk_is_stationary"] == (adf["walk_p"] < 0.05)`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Find how many differences reach stationarity"
+  instructions={`The airline \`air\` series is non-stationary. Working on \`np.log(air)\` to tame the variance, find the **smallest number of first-differences** \`d\` (try 0, 1, 2) at which the Augmented Dickey-Fuller p-value first drops below 0.05.
+
+Apply \`.diff()\` \`d\` times (dropping NaNs before testing). Store that smallest \`d\` in \`d_needed\` (an int), and the corresponding p-value in \`p_at_d\` (a float). For this series, one difference of the log is enough.`}
+  initCode={`import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+from statsmodels.tsa.stattools import adfuller
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`series = np.log(air)
+d_needed = None
+p_at_d = None
+print("d:", d_needed, " p:", p_at_d)
+`}
+  solutionCode={`series = np.log(air)
+d_needed = None
+p_at_d = None
+for d in range(0, 3):
+    transformed = series.copy()
+    for _ in range(d):
+        transformed = transformed.diff()
+    p = float(adfuller(transformed.dropna())[1])
+    if p < 0.05:
+        d_needed = d
+        p_at_d = p
+        break
+print("d:", d_needed, " p:", p_at_d)
+`}
+  tests={[
+    {
+      id: "found",
+      name: "a stationary d was found",
+      description: "d_needed and p_at_d are set",
+      code: `assert d_needed is not None and p_at_d is not None`,
+    },
+    {
+      id: "one_diff",
+      name: "one difference suffices",
+      description: "log + a single difference reaches stationarity",
+      code: `assert d_needed == 1, f"Expected d=1 for log(air), got {d_needed}"`,
+    },
+    {
+      id: "p_below",
+      name: "p-value is below 0.05 at that d",
+      description: "It really is stationary there",
+      code: `assert p_at_d < 0.05, f"p at d={d_needed} should be < 0.05, got {p_at_d}"`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`In plain terms, a series is **stationary** when:
+
+- Its values never change
+  > Stationary series fluctuate freely — often a lot. What stays fixed is the *statistical behavior* (mean, variance, autocorrelation), not the individual values.
+- It is always increasing at a steady rate
+  > A steady increase is a *trend* — a drifting mean — which is the opposite of stationary.
+- [o] Its statistical properties (mean, variance, autocorrelation) stay constant over time — the rules generating it don't change
+  > Constant mean and variance plus a lag-only autocorrelation structure is exactly stationarity: the data-generating "rules" hold still, so the past is representative of the future.
+- It has no random component at all
+  > Stationary series are typically *full* of randomness (white noise is the purest example). Stationarity constrains how that randomness behaves over time, not whether it exists.
+
+Stationarity is about constant statistical behavior over time, not constant values or the absence of randomness.`}
+/>
+
+<MultipleChoice
+  markdown={`Why do classical models like AR and ARIMA *require* (approximate) stationarity?
+
+- Because they run faster on stationary data
+  > Speed isn't the reason. The requirement is about validity: the model's assumptions, not its runtime.
+- [o] They estimate fixed coefficients describing how a value relates to its past; those constants are only meaningful if that relationship doesn't drift over time
+  > A fixed rule ("each value is ~0.7 of the previous plus a shock") can only be correct if the rule holds throughout. A trending mean or growing variance makes the "constant" relationship a moving target the coefficients can't capture.
+- Because stationary data has no noise to model
+  > Stationary data is typically *mostly* noise; the models exist precisely to describe that noise's structure. Stationarity is about constancy, not the absence of noise.
+- Because non-stationary data cannot be stored in pandas
+  > pandas stores any series fine. The constraint is statistical — fixed-coefficient models need stable generating rules — not a storage limitation.
+
+Fixed-coefficient models assume a stable relationship through time, which is exactly what stationarity provides.`}
+/>
+
+<MultipleChoice
+  markdown={`Which is the correct ADF decision rule at the 5% level?
+
+- p-value > 0.05 -> stationary; p-value < 0.05 -> non-stationary
+  > This is backwards. The ADF *null* is non-stationarity, so a *small* p rejects it (stationary) and a *large* p fails to reject it (non-stationary).
+- [o] p-value < 0.05 -> reject the unit-root null -> stationary; p-value >= 0.05 -> fail to reject -> non-stationary
+  > Because the null is "has a unit root (non-stationary)," a small p-value is evidence *for* stationarity, and a large one leaves you treating the series as non-stationary.
+- Any p-value means the series is stationary
+  > The p-value's *magnitude* is the whole point; it discriminates between the two conclusions rather than always pointing one way.
+- The ADF test ignores p-values and uses only the mean
+  > ADF produces a test statistic and p-value (and critical values). It does not decide based on the raw mean.
+
+Low p rejects the non-stationary null (stationary); high p fails to reject it (non-stationary).`}
+/>
+
+<MultipleChoice
+  markdown={`You fail to reject the ADF null (p = 0.30) on a short series of 24 points. Which statement is most accurate?
+
+- This proves the series is non-stationary
+  > "Fail to reject" is not "prove." On a short series the test may simply lack the *power* to detect stationarity; absence of evidence isn't proof of the null.
+- [o] You couldn't establish stationarity; treat it as non-stationary, but note that on only 24 points the test has low power, so confirm with plots and rolling statistics
+  > A high p-value means no evidence against non-stationarity, so you act as if non-stationary — while remembering that short series make the test weak, so corroborating with eyes and rolling stats is essential.
+- The series must be differenced exactly twice
+  > Nothing in a single p-value prescribes a specific number of differences. You'd test after each difference, and often one (or zero) is right.
+- The test is invalid below 30 points
+  > There's no hard cutoff that invalidates ADF; rather, *power* degrades on short series, making conclusions less reliable — a reason for caution, not invalidity.
+
+Failing to reject means stationarity wasn't established (act as non-stationary), but low power on short series demands corroboration.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- A series is **stationary** when its mean, variance, and autocorrelation
+  structure are **constant over time** — the generating rules hold still.
+- Models like **ARIMA require it** because they fit *fixed coefficients* that
+  only make sense when the relationship they describe doesn't drift.
+- Common violations: a **trend** (drifting mean) and **changing variance**
+  (widening band). See them with a plot plus a rolling mean/std.
+- The **ADF test**'s null is **non-stationarity** (a unit root). **Low p
+  (< 0.05) → stationary; high p → non-stationary.** This is the reverse of
+  the usual p-value reflex.
+- ADF tests a *unit root* specifically — pair it with your eyes; "fail to
+  reject" is not proof, especially on short series.
+- The cures are a **log** (for variance) and **differencing** (for trend and
+  seasonality) — next.
+</Callout>
+
+The ADF test kept pointing at the same fix: differencing. Let's make that
+precise — what differencing does, why subtracting consecutive values
+annihilates a trend, and how to avoid the trap of doing it one time too many.

--- a/content/learn/time-series-analysis-python/stationarity.mdx
+++ b/content/learn/time-series-analysis-python/stationarity.mdx
@@ -206,16 +206,21 @@ adf_report(air.diff(), "First difference of passengers")
 adf_report(np.log(air).diff(), "First difference of log(passengers)")
 
 print()
-print("Raw series: high p -> non-stationary (the trend dominates).")
+print("Raw series: high p (~0.99) -> non-stationary (the trend dominates).")
 print("A log alone doesn't fix it (log tames variance, not the trend).")
-print("DIFFERENCING collapses the p-value -> that's the cure (next page).")
+print("One difference collapses p from ~0.99 to ~0.05-0.07 -- ALMOST there.")
+print("This series is famously BORDERLINE: the seasonal difference (next page)")
+print("is what finally tips it firmly below 0.05.")
 `}
 />
 
 The raw series has a large p-value — non-stationary, as promised. A log
-alone barely helps (it fixes *variance*, not the *trend*). But a single
-**difference** drops the p-value dramatically. That preview is the entire
-motivation for the next page.
+alone barely helps (it fixes *variance*, not the *trend*). A single
+**difference** drops the p-value dramatically — from about 0.99 to roughly
+0.05–0.07 — but this series is a famous *borderline* case that hovers right
+at the threshold because strong seasonality remains. It takes a **seasonal**
+difference, on the next page, to push it firmly into stationary territory.
+That preview is the entire motivation for what comes next.
 
 <MultipleChoice
   markdown={`You run \`adfuller\` on a series and get a p-value of **0.78**. What do you conclude?
@@ -344,10 +349,14 @@ assert adf["walk_is_stationary"] == (adf["walk_p"] < 0.05)`,
 
 <ChallengeCard
   adapter="python"
-  title="Find how many differences reach stationarity"
-  instructions={`The airline \`air\` series is non-stationary. Working on \`np.log(air)\` to tame the variance, find the **smallest number of first-differences** \`d\` (try 0, 1, 2) at which the Augmented Dickey-Fuller p-value first drops below 0.05.
+  title="Confirm the transform pipeline reaches stationarity"
+  instructions={`The airline \`air\` series is non-stationary. Build the fully transformed series and show it becomes stationary. Compute:
 
-Apply \`.diff()\` \`d\` times (dropping NaNs before testing). Store that smallest \`d\` in \`d_needed\` (an int), and the corresponding p-value in \`p_at_d\` (a float). For this series, one difference of the log is enough.`}
+- \`stationary\` = \`np.log(air).diff().diff(12)\` — a log to tame the growing variance, a first difference for the trend, and a seasonal difference at lag 12 for the yearly cycle.
+- \`p_raw\` = the ADF p-value of the raw \`air\` (a float).
+- \`p_stationary\` = the ADF p-value of \`stationary\` after dropping NaNs (a float).
+
+The raw series should be non-stationary (\`p_raw\` > 0.05) while the transformed series should be stationary (\`p_stationary\` < 0.05). (Note: a *single* difference of this series is famously borderline on the ADF test — the seasonal difference is what tips it firmly into stationarity.)`}
   initCode={`import numpy as np
 import pandas as pd
 import warnings
@@ -369,43 +378,40 @@ _passengers = [
 ]
 idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
 air = pd.Series(_passengers, index=idx, name="passengers")`}
-  initialCode={`series = np.log(air)
-d_needed = None
-p_at_d = None
-print("d:", d_needed, " p:", p_at_d)
+  initialCode={`stationary = None
+p_raw = None
+p_stationary = None
+print("p_raw:", p_raw, " p_stationary:", p_stationary)
 `}
-  solutionCode={`series = np.log(air)
-d_needed = None
-p_at_d = None
-for d in range(0, 3):
-    transformed = series.copy()
-    for _ in range(d):
-        transformed = transformed.diff()
-    p = float(adfuller(transformed.dropna())[1])
-    if p < 0.05:
-        d_needed = d
-        p_at_d = p
-        break
-print("d:", d_needed, " p:", p_at_d)
+  solutionCode={`stationary = np.log(air).diff().diff(12)
+p_raw = float(adfuller(air.dropna())[1])
+p_stationary = float(adfuller(stationary.dropna())[1])
+print("p_raw:", round(p_raw, 4), " p_stationary:", round(p_stationary, 4))
 `}
   tests={[
     {
-      id: "found",
-      name: "a stationary d was found",
-      description: "d_needed and p_at_d are set",
-      code: `assert d_needed is not None and p_at_d is not None`,
+      id: "set",
+      name: "p_raw and p_stationary are floats",
+      description: "Both ADF p-values computed",
+      code: `assert isinstance(p_raw, float) and isinstance(p_stationary, float)`,
     },
     {
-      id: "one_diff",
-      name: "one difference suffices",
-      description: "log + a single difference reaches stationarity",
-      code: `assert d_needed == 1, f"Expected d=1 for log(air), got {d_needed}"`,
+      id: "raw_nonstationary",
+      name: "raw air is non-stationary",
+      description: "High ADF p-value before transforming",
+      code: `assert p_raw > 0.05, f"Raw series should be non-stationary, got p={p_raw}"`,
     },
     {
-      id: "p_below",
-      name: "p-value is below 0.05 at that d",
-      description: "It really is stationary there",
-      code: `assert p_at_d < 0.05, f"p at d={d_needed} should be < 0.05, got {p_at_d}"`,
+      id: "transformed_stationary",
+      name: "transformed series is stationary",
+      description: "log + diff + seasonal diff passes ADF",
+      code: `assert p_stationary < 0.05, f"Transformed series should be stationary, got p={p_stationary}"`,
+    },
+    {
+      id: "improved",
+      name: "transforming lowered the p-value",
+      description: "The pipeline moved toward stationarity",
+      code: `assert p_stationary < p_raw`,
     },
   ]}
 />

--- a/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
+++ b/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
@@ -1,0 +1,579 @@
+---
+title: "Mastering the Pandas Timeline: DatetimeIndex, Frequency, and Alignment"
+description: How pandas turns dates into a first-class index — parsing with to_datetime, the DatetimeIndex, Timestamp vs Period, frequency strings, partial-string slicing, the .dt accessor, and the automatic alignment that makes time series arithmetic safe.
+---
+
+A time series only becomes *easy* in pandas once the timestamps live in the
+**index**, not in an ordinary column. Promote your dates to a
+`DatetimeIndex` and a whole toolbox unlocks: slice by `"1955"`, resample to
+weekly, roll a 7-day average, and — the quiet hero of this page —
+**automatically align** two series by date so you never make an
+off-by-one error again. This page is about getting your data onto that
+timeline correctly.
+
+## From strings to timestamps: `pd.to_datetime`
+
+Dates almost always arrive as **text**. The first job of any time series
+workflow is to parse that text into real timestamps. `pd.to_datetime` is
+the workhorse.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+
+raw = ["2014-01-05", "2014-02-10", "2014-03-30"]
+ts = pd.to_datetime(raw)
+
+print(ts)
+print()
+print("type of the whole thing:", type(ts).__name__)   # DatetimeIndex
+print("type of one element:    ", type(ts[0]).__name__) # Timestamp
+print()
+print("It understands the calendar:")
+print("  day names:", list(ts.day_name()))
+print("  is 2014 a leap year? Feb has", ts[1].days_in_month, "days")
+`}
+/>
+
+Two new types just appeared, and they matter:
+
+- **`Timestamp`** — pandas's version of a single moment in time (one
+  observation's "when"). It's calendar-aware: it knows weekdays, month
+  lengths, leap years.
+- **`DatetimeIndex`** — an *array* of `Timestamp`s, purpose-built to be a
+  DataFrame or Series index.
+
+<Callout type="tip" title="Parse early, parse once">
+Convert date columns to real timestamps the moment the data lands, then
+forget they were ever strings. String dates are a trap: `"2014-1-5"`,
+`"01/05/2014"`, and `"Jan 5, 2014"` all *look* like dates but sort and
+compare like gibberish until parsed. `pd.to_datetime` handles all three.
+</Callout>
+
+When some values are unparseable, choose your failure mode explicitly:
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+
+messy = pd.Series(["2014-01-05", "not-a-date", "2014-03-30"])
+
+# errors="coerce" turns the bad value into NaT (Not-a-Time), the datetime
+# equivalent of NaN, while keeping the column a proper datetime.
+parsed = pd.to_datetime(messy, errors="coerce")
+print(parsed)
+print()
+print("dtype stays datetime:", parsed.dtype)
+print("count of valid dates:", parsed.notna().sum())
+`}
+/>
+
+`NaT` ("Not a Time") is to timestamps what `NaN` is to numbers. Using
+`errors="coerce"` keeps the column correctly typed while flagging the bad
+rows — far better than letting one typo turn the whole column back into
+text.
+
+## Setting a `DatetimeIndex`
+
+The pivotal move: take a parsed date column and make it the index.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+
+df = pd.DataFrame({
+    "date":  ["2014-01-05", "2014-01-06", "2014-01-07", "2014-01-08"],
+    "sales": [120, 135, 98, 110],
+})
+
+# Step 1: parse the text into timestamps.
+df["date"] = pd.to_datetime(df["date"])
+# Step 2: promote that column to the index.
+df = df.set_index("date")
+
+print(df)
+print()
+print("index type:", type(df.index).__name__)   # DatetimeIndex
+print("Now the timeline tools are available.")
+`}
+/>
+
+<Callout type="info" title="Why the index, not a column?">
+pandas reserves its time-series superpowers — partial-string slicing,
+`resample`, `rolling`, automatic alignment — for data indexed by a
+`DatetimeIndex`. A date sitting in a normal column is just data; a date in
+the *index* is a coordinate the library can navigate. When in doubt with
+time series, **put time in the index**.
+</Callout>
+
+## Building a timeline from scratch: `date_range`
+
+When you need a regular grid of timestamps — for simulated data, for a
+forecast horizon, or to reindex onto a clean calendar — `pd.date_range`
+generates one. The `freq` argument sets the spacing.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+
+print("Six month-STARTS (freq='MS'):")
+print(pd.date_range("2014-01-01", periods=6, freq="MS").tolist())
+print()
+print("Six calendar days (freq='D'):")
+print(pd.date_range("2014-01-01", periods=6, freq="D").tolist())
+print()
+print("Four weekly points, weeks ending Sunday (freq='W'):")
+print(pd.date_range("2014-01-01", periods=4, freq="W").tolist())
+print()
+print("End-date form instead of periods:")
+print(pd.date_range(start="2014-01-01", end="2014-06-01", freq="MS").tolist())
+`}
+/>
+
+### The frequency cheat sheet (and a version gotcha)
+
+Frequency strings are short codes for "how far apart." The ones you'll use
+constantly:
+
+| Code | Meaning | Example use |
+| --- | --- | --- |
+| `D` | calendar day | daily sales, daily visits |
+| `W` | weekly (Sunday-ending by default; `W-MON` to change) | weekly reports |
+| `MS` | month **start** | monthly series labeled on the 1st |
+| `ME` | month **end** | monthly series labeled on the last day |
+| `QE` | quarter end | quarterly revenue |
+| `YE` | year end | annual totals |
+| `h` | hourly | energy demand per hour |
+| `min` | minute | sensor readings |
+
+<Callout type="danger" title="The 'M' -> 'ME' rename you WILL trip over">
+In **older pandas** (and almost every tutorial and Stack Overflow answer
+online), monthly frequency was just `"M"` (month end) and `"A"`/`"Y"` was
+year end. Modern pandas (2.2+) **renamed** these to `"ME"`, `"YE"`,
+`"QE"`, and lowercased hourly to `"h"`. The old codes still *work* for now
+but emit a noisy `FutureWarning`. This course uses the modern codes
+(`"ME"`, `"YE"`, `"h"`) so output stays clean — but when you paste code
+from the internet and see "M is deprecated," now you know the one-line
+fix: append an `E`.
+</Callout>
+
+## Partial-string slicing: the feature you'll use hourly
+
+With a `DatetimeIndex`, you can select by *partial* date strings. pandas
+figures out the range you mean. We'll use the airline series to show it
+off.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`# A whole year, just by naming it:
+print("All of 1955:")
+print(air.loc["1955"].tolist())
+print()
+
+# A date-string RANGE (inclusive on both ends):
+print("Summer 1955 (June to September):")
+print(air.loc["1955-06":"1955-09"])
+print()
+
+# Aggregate a slice directly:
+print("Average monthly passengers in 1960:", round(air.loc["1960"].mean(), 1))
+print("Peak month across the whole series:", air.idxmax().date(), "=", air.max())
+`}
+/>
+
+Notice that `air.loc["1955-06":"1955-09"]` is **inclusive of the end** —
+unlike normal Python slicing, which excludes the stop. That's deliberate:
+you asked for "through September," so you get September. This partial-string
+slicing is the single most convenient thing about a `DatetimeIndex`.
+
+<MultipleChoice
+  markdown={`With a \`DatetimeIndex\`, what does \`air.loc["1955-06":"1955-09"]\` return?
+
+- The single value at 1955-06 only
+  > A colon makes it a *range*, not a single lookup. This selects every month in the span, not one point.
+- [o] Every monthly value from June 1955 through September 1955, inclusive of September
+  > Partial-string slicing on a DatetimeIndex expands each endpoint to the period it names and includes the end — so June, July, August, and September 1955 all come back.
+- June through August 1955, excluding September (like normal Python slicing)
+  > Label-based datetime slicing is *inclusive* of the stop, unlike positional Python slicing. September is included.
+- An error, because those strings are not exact timestamps in the index
+  > Partial strings are exactly what datetime slicing is built for; pandas resolves "1955-09" to that whole month. No exact-match is required.
+
+DatetimeIndex slicing resolves partial strings to spans and is inclusive of the end label.`}
+/>
+
+## Reading calendar parts: the `.dt` accessor and index attributes
+
+To pull out the year, month, weekday, or quarter, use `.dt` on a datetime
+*column*, or the matching attribute directly on a `DatetimeIndex`.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import pandas as pd
+
+# Directly off the index:
+print("First five years :", air.index.year[:5].tolist())
+print("First five months:", air.index.month[:5].tolist())
+
+# As a DataFrame with derived calendar columns via .dt:
+df = air.reset_index()
+df.columns = ["date", "passengers"]
+df["year"]    = df["date"].dt.year
+df["month"]   = df["date"].dt.month_name().str[:3]
+df["quarter"] = df["date"].dt.quarter
+
+# Which month, on average, is busiest? (Seasonality, previewed.)
+by_month = df.groupby(df["date"].dt.month)["passengers"].mean().round(0)
+print()
+print("Average passengers by calendar month (1=Jan ... 12=Dec):")
+print(by_month)
+print()
+print("Peak travel months are the summer (Jul/Aug) - that's the seasonality.")
+`}
+/>
+
+Grouping by `date.dt.month` already reveals the yearly seasonal shape —
+summer months tower over winter ones. We'll formalize that into a proper
+*seasonal component* later; for now, notice how `.dt` turns timestamps into
+ordinary grouping keys.
+
+## Timestamp vs Period: a point versus a span
+
+There are two honest ways to say "March 2014," and pandas gives you both:
+
+```mermaid
+flowchart TB
+    TS["Timestamp<br/>2014-03-15 00:00:00<br/>(a single instant)"]
+    PD["Period<br/>2014-03<br/>(the whole month, Mar 1 to Mar 31)"]
+    TS -. "a point on the line" .-> LINE["the timeline"]
+    PD -. "a span of the line" .-> LINE["the timeline"]
+```
+
+- A **`Timestamp`** is an *instant* — "the reading taken at 14:32:05."
+- A **`Period`** is a *span* — "the month of March," "the year 1955," "Q3."
+
+Monthly sales aren't really a value *at* March 1st; they're the total *over
+all of March*. That's conceptually a `Period`. Most of the time we still
+use a `Timestamp` index (it plays nicer with plotting and resampling) and
+just remember the value summarizes a span — but knowing the distinction
+keeps you from nonsense like "the sales at exactly midnight on the 1st."
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+
+instant = pd.Timestamp("2014-03-15 14:32:05")
+month   = pd.Period("2014-03", freq="M")
+
+print("Timestamp:", instant, "-> just the minute:", instant.minute)
+print("Period:   ", month, "-> spans", month.start_time, "to", month.end_time)
+print()
+
+# A Period knows what comes next, calendar-correctly:
+print("This period:", month, " next period:", month + 1)
+
+# Is our instant inside that month?
+print("Is the instant within the period?",
+      month.start_time <= instant <= month.end_time)
+`}
+/>
+
+<MultipleChoice
+  markdown={`A dataset holds **total monthly electricity consumption**. Conceptually, is each value better described as a \`Timestamp\` or a \`Period\`?
+
+- A \`Timestamp\`, because every value needs an exact moment
+  > A monthly total isn't measured *at* one instant; it accumulates across the whole month. Forcing it to a single instant ("midnight on the 1st") misrepresents what the number means.
+- [o] A \`Period\`, because the value summarizes consumption over an entire month-long span, not at one instant
+  > Totals and averages over a calendar month are spans by nature — exactly what a \`Period\` represents. (In practice we often still index by a \`Timestamp\` for convenience, while remembering it stands for the whole month.)
+- Neither — monthly data can't be represented in pandas
+  > pandas represents monthly data comfortably with either type; the question is which one matches the *meaning*. A span-valued total maps most naturally to a \`Period\`.
+- It must be a \`Timestamp\` or resampling won't work
+  > Resampling works on a \`DatetimeIndex\` regardless of this conceptual point. The distinction here is about correctly interpreting what the value represents.
+
+A total accumulated over a month is a span — conceptually a \`Period\` — even if we often store it under a \`Timestamp\` for tooling convenience.`}
+/>
+
+## The quiet hero: automatic alignment
+
+Here is the feature that prevents a whole category of silent bugs. When you
+combine two pandas objects, the operation aligns them **by index label**,
+not by position. Add two series and pandas matches March-to-March,
+April-to-April — even if they're in different orders or have different
+lengths. Where a label is missing on one side, the result is `NaN`.
+
+```mermaid
+flowchart LR
+    A["Series A<br/>Jan-01, Jan-02, Jan-03"] --> U["Align on the union<br/>of the two indices"]
+    B["Series B<br/>Jan-02, Jan-03, Jan-04"] --> U
+    U --> R["Jan-01 = NaN<br/>Jan-02 = A+B<br/>Jan-03 = A+B<br/>Jan-04 = NaN"]
+```
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import pandas as pd
+
+a = pd.Series([1, 2, 3],
+              index=pd.to_datetime(["2014-01-01", "2014-01-02", "2014-01-03"]))
+b = pd.Series([10, 20, 30],
+              index=pd.to_datetime(["2014-01-02", "2014-01-03", "2014-01-04"]))
+
+print("a + b aligns by DATE, not by position:")
+print(a + b)
+print()
+print("Jan-01 and Jan-04 are NaN: each exists in only ONE series, so")
+print("there's nothing to add. pandas refuses to guess.")
+`}
+/>
+
+Compare that to plain Python lists or NumPy arrays, which add by
+*position*: `[1,2,3] + [10,20,30]` would pair the first with the first
+regardless of what dates they represent. If your two series happened to
+start on different dates, NumPy would happily add January to February and
+hand you a confidently wrong answer. pandas's label alignment is the
+guardrail.
+
+<Callout type="warn" title="Alignment is a feature, but watch for the NaNs">
+Label alignment saves you from off-by-one disasters — but it *introduces*
+`NaN`s wherever the two indices don't overlap. After combining series with
+different date ranges, always check for new missing values. The fix is
+usually `.dropna()`, an explicit `.reindex(...)`, or `fill_value=0` on the
+arithmetic (e.g. `a.add(b, fill_value=0)`).
+</Callout>
+
+## How it all fits together
+
+Everything on this page is one pipeline: get messy date text onto a clean
+timeline, and the rest of pandas' time tooling switches on.
+
+```mermaid
+flowchart LR
+    S["Raw date strings"] -->|"pd.to_datetime()"| T["DatetimeIndex"]
+    T --> SL["Partial-string slicing<br/>df.loc['1955']"]
+    T --> RS["resample()<br/>(next page)"]
+    T --> RW["rolling()"]
+    T --> AL["Automatic alignment"]
+```
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Put a sales log on the timeline"
+  instructions={`A small DataFrame \`log\` has two columns: \`day\` (date strings) and \`units\` (integers). Build a Series called \`daily\` that:
+
+1. Parses \`day\` into real timestamps.
+2. Uses those timestamps as a \`DatetimeIndex\`.
+3. Contains the \`units\` values, ordered by date ascending.
+
+The result must be a \`pd.Series\` whose \`.index\` is a \`DatetimeIndex\` of length 5, sorted in time order.`}
+  initCode={`import pandas as pd
+
+log = pd.DataFrame({
+    "day":   ["2014-02-03", "2014-02-01", "2014-02-04", "2014-02-02", "2014-02-05"],
+    "units": [9, 5, 12, 7, 3],
+})`}
+  initialCode={`# Build the time-indexed Series 'daily' here.
+daily = None
+print(daily)
+`}
+  solutionCode={`parsed = pd.to_datetime(log["day"])
+daily = pd.Series(log["units"].values, index=parsed, name="units").sort_index()
+print(daily)
+print()
+print("index type:", type(daily.index).__name__)
+`}
+  tests={[
+    {
+      id: "is_series",
+      name: "daily is a Series",
+      description: "Type check",
+      code: `import pandas as pd
+assert isinstance(daily, pd.Series), "daily should be a pandas Series"`,
+    },
+    {
+      id: "datetime_index",
+      name: "index is a DatetimeIndex",
+      description: "Timestamps are in the index",
+      code: `import pandas as pd
+assert isinstance(daily.index, pd.DatetimeIndex), "index must be a DatetimeIndex"`,
+    },
+    {
+      id: "length",
+      name: "five rows",
+      description: "All observations kept",
+      code: `assert len(daily) == 5`,
+    },
+    {
+      id: "sorted",
+      name: "sorted in time order",
+      description: "Index is monotonically increasing",
+      code: `assert daily.index.is_monotonic_increasing, "index must be sorted ascending"`,
+    },
+    {
+      id: "value_at_date",
+      name: "values match their dates",
+      description: "Feb 4 should hold 12 units",
+      code: `import pandas as pd
+assert daily.loc[pd.Timestamp("2014-02-04")] == 12`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Combine two partial series with alignment"
+  instructions={`Two daily Series, \`store_a\` and \`store_b\`, cover *overlapping but not identical* date ranges. Produce a Series \`total\` giving the **combined** daily units across both stores, where:
+
+- On days present in both, add them.
+- On days present in only one store, use that store's value alone (treat the missing store as 0).
+
+The result should have **one row per date in the union** of the two indices, sorted ascending, with no \`NaN\`s. (Hint: \`Series.add(other, fill_value=0)\`.)`}
+  initCode={`import pandas as pd
+
+store_a = pd.Series(
+    [10, 12, 9],
+    index=pd.to_datetime(["2014-03-01", "2014-03-02", "2014-03-03"]),
+)
+store_b = pd.Series(
+    [4, 6, 8],
+    index=pd.to_datetime(["2014-03-02", "2014-03-03", "2014-03-04"]),
+)`}
+  initialCode={`total = None  # combine with alignment; missing -> 0
+print(total)
+`}
+  solutionCode={`total = store_a.add(store_b, fill_value=0).sort_index()
+print(total)
+`}
+  tests={[
+    {
+      id: "union_length",
+      name: "covers the union of dates (4 days)",
+      description: "Mar 1 through Mar 4",
+      code: `assert len(total) == 4, f"Expected 4 dates, got {len(total)}"`,
+    },
+    {
+      id: "no_nans",
+      name: "no missing values",
+      description: "fill_value=0 removed the gaps",
+      code: `assert total.notna().all(), "There should be no NaNs after fill_value=0"`,
+    },
+    {
+      id: "overlap_added",
+      name: "overlap days are summed",
+      description: "Mar 2 = 12 + 4 = 16",
+      code: `import pandas as pd
+assert total.loc[pd.Timestamp("2014-03-02")] == 16`,
+    },
+    {
+      id: "solo_days_kept",
+      name: "solo days keep their single value",
+      description: "Mar 1 = 10 (store_a only), Mar 4 = 8 (store_b only)",
+      code: `import pandas as pd
+assert total.loc[pd.Timestamp("2014-03-01")] == 10
+assert total.loc[pd.Timestamp("2014-03-04")] == 8`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`Why promote a date column to the **index** instead of leaving it as a regular column?
+
+- It saves memory
+  > Memory is not the motivation, and the savings are negligible. The point is unlocking behavior, not shrinking storage.
+- [o] A \`DatetimeIndex\` unlocks partial-string slicing, \`resample\`, \`rolling\`, and automatic alignment — features that don't work on a plain column
+  > pandas attaches its time-series machinery to the index. With dates in the index you can write \`df.loc["1955"]\`, \`df.resample("ME")\`, and rely on label alignment; with dates in a column you can't.
+- It automatically removes duplicate dates
+  > Setting an index does not deduplicate; you can have repeated index labels. Deduplication is a separate, explicit step.
+- It converts the data to a NumPy array
+  > Indexing has nothing to do with converting to NumPy, and you wouldn't want that — you'd lose the very label-awareness that makes the index useful.
+
+The index is where pandas keeps its time-series powers; a date in a column is inert by comparison.`}
+/>
+
+<MultipleChoice
+  markdown={`You write \`pd.date_range("2024-01-01", periods=6, freq="M")\` and pandas prints a \`FutureWarning\` about \`'M'\` being deprecated. What's the corrected frequency code in modern pandas?
+
+- \`"Month"\`
+  > Frequency codes are short aliases, not English words. \`"Month"\` is not a valid alias.
+- [o] \`"ME"\` (month end) — modern pandas renamed \`"M"\` to \`"ME"\` and \`"Y"\`/\`"A"\` to \`"YE"\`
+  > The deprecation is purely a rename: append \`E\` for the "end" anchored aliases. \`"M"\` becomes \`"ME"\`, \`"Q"\` becomes \`"QE"\`, \`"Y"\` becomes \`"YE"\`.
+- \`"MS"\`, which is identical to the old \`"M"\`
+  > \`"MS"\` is month *start* (labels on the 1st); the old \`"M"\` was month *end* (labels on the last day). They are not identical — the direct replacement for \`"M"\` is \`"ME"\`.
+- There is no replacement; monthly frequency was removed
+  > Monthly frequency is alive and well — only its spelling changed. \`"ME"\` is the current month-end alias.
+
+The \`'M'\` -> \`'ME'\` rename (and \`'Y'\` -> \`'YE'\`, \`'Q'\` -> \`'QE'\`) is a spelling change; the behavior is unchanged.`}
+/>
+
+<MultipleChoice
+  markdown={`Two Series indexed by date are added with \`a + b\`. \`a\` covers Jan 1-3 and \`b\` covers Jan 2-4. What happens on Jan 1 and Jan 4 in the result?
+
+- They're dropped from the output entirely
+  > Alignment uses the *union* of indices, so both dates appear in the result — they aren't silently dropped.
+- They're added to the nearest available date
+  > pandas never guesses by proximity. It matches labels exactly and refuses to invent a partner for an unmatched date.
+- [o] Both become \`NaN\`, because each date exists in only one of the two Series and there's nothing to add it to
+  > Label alignment pairs identical dates; Jan 1 (only in \`a\`) and Jan 4 (only in \`b\`) have no counterpart, so the sum is undefined and pandas marks it \`NaN\`.
+- They use 0 for the missing side automatically
+  > Plain \`+\` does not assume 0 for missing labels — that would be a silent guess. You'd get \`NaN\`. To treat missing as 0 you must opt in with \`a.add(b, fill_value=0)\`.
+
+Arithmetic aligns on the union of labels and yields \`NaN\` where a label is missing on one side, unless you explicitly supply a \`fill_value\`.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- **`pd.to_datetime`** parses date text into **`Timestamp`** values; bad
+  rows become **`NaT`** with `errors="coerce"`.
+- Put time in the **index** (a **`DatetimeIndex`**) to unlock slicing,
+  resampling, rolling, and alignment.
+- **`pd.date_range(..., freq=...)`** builds a regular timeline. Modern freq
+  codes: `D`, `W`, **`ME`**/`MS`, `QE`, **`YE`**, `h`, `min` — and remember
+  the old **`M`** is now **`ME`**.
+- **Partial-string slicing** (`air.loc["1955"]`, `air.loc["1955-06":"1955-09"]`)
+  is inclusive of the end and is the most convenient `DatetimeIndex` trick.
+- **`Timestamp`** is an instant; **`Period`** is a span. Monthly totals are
+  conceptually spans.
+- **Automatic alignment** matches operations by index label, not position —
+  a guardrail against off-by-one bugs — but it creates `NaN`s where indices
+  don't overlap.
+</Callout>
+
+You can now get any dataset onto a clean timeline. Next we change the
+*resolution* of that timeline — squeezing daily data up to monthly, or
+stretching monthly data down to daily — with `resample`.

--- a/content/learn/time-series-analysis-python/what-makes-time-series-unique.mdx
+++ b/content/learn/time-series-analysis-python/what-makes-time-series-unique.mdx
@@ -1,0 +1,681 @@
+---
+title: "The Time Dimension: What Makes Time Series Data Unique?"
+description: Why temporal data needs its own toolkit — temporal dependence, autocorrelation, the failure of the i.i.d. assumption, and why shuffling or random-splitting a time series silently destroys it.
+---
+
+Before a single forecast, before `resample` or `ARIMA`, you need one idea
+in your bones: **a time series is not an ordinary table that happens to
+have a date column.** It is a fundamentally different object, and almost
+every mistake beginners make comes from forgetting that. This page is the
+"why" the rest of the course rests on.
+
+## What actually is a time series?
+
+A **time series** is a sequence of observations recorded in time order —
+written `y₁, y₂, y₃, …, yₜ, …` — where the *order carries meaning*.
+
+The subscript is not a row number you could reshuffle — it is a
+**timestamp**. `yₜ` is "the value *at time* t," and it sits between
+`yₜ₋₁` (its past) and `yₜ₊₁` (its future). Examples are everywhere:
+
+- Monthly airline passengers, electricity demand every hour, daily website
+  visits, a store's weekly sales, a patient's heart rate per second.
+
+Contrast that with **cross-sectional data**: the heights of 500 people, or
+one row per customer with their lifetime spend. There, each row is a
+separate, self-contained unit. Row 7 and row 200 have no relationship just
+because one is printed above the other. You can sort the table any way you
+like and *nothing is lost*.
+
+<Callout type="info" title="The one-line definition">
+Cross-sectional data is a **set** of independent observations. A time
+series is a **sequence** of dependent ones. The difference between a set
+and a sequence is the whole game.
+</Callout>
+
+## The defining property: temporal dependence
+
+Here is what makes a time series special, stated plainly: **the value now
+is related to the values just before it.** Hot days cluster near hot days.
+A busy traffic week tends to follow a busy traffic week. Today's stock
+price is yesterday's price plus a nudge. This "a value remembers its
+recent past" property is called **temporal dependence**, and when we
+measure it as a correlation, we call it **autocorrelation** — a series
+correlated *with itself* at an earlier time.
+
+Let's see it directly. We plot each month's airline-passenger count
+against the *previous* month's count. If there were no temporal
+dependence, this would be a shapeless cloud. Watch what actually happens.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+
+# Monthly international airline passengers (thousands), 1949-1960.
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import matplotlib.pyplot as plt
+
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+
+# Left: this month vs last month. Tight diagonal = strong dependence.
+ax1.scatter(air.shift(1), air, s=18)
+ax1.set_xlabel("passengers last month  (y at t-1)")
+ax1.set_ylabel("passengers this month  (y at t)")
+ax1.set_title("Time order INTACT")
+
+# Right: shuffle first, breaking the time order, then do the same plot.
+shuffled = air.sample(frac=1.0, random_state=1).reset_index(drop=True)
+ax2.scatter(shuffled.shift(1), shuffled, s=18, color="crimson")
+ax2.set_xlabel("'previous' value (meaningless now)")
+ax2.set_ylabel("value")
+ax2.set_title("After SHUFFLING")
+
+plt.tight_layout()
+plt.show()
+
+print("Left: a tight upward band — each month is close to the one before it.")
+print("Right: a formless cloud — shuffling deleted the relationship entirely.")
+`}
+/>
+
+The left panel is a tight diagonal band: this month is almost always close
+to last month. The right panel — *the exact same numbers*, just shuffled —
+is a structureless blob. **The information did not live in the values. It
+lived in their order.** That single picture is the reason this course
+exists.
+
+<Callout type="tip" title="Autocorrelation in one sentence">
+Autocorrelation is just *correlation a series has with a time-shifted copy
+of itself*. High lag-1 autocorrelation means "this value is a good guess
+for the next value" — which is exactly what makes forecasting possible at
+all. A series with **zero** autocorrelation at every lag is pure noise:
+unpredictable by definition.
+</Callout>
+
+## Why this breaks your usual statistical instincts
+
+Most introductory statistics and machine learning quietly assume your
+observations are **i.i.d.** — *independent and identically distributed*.
+"Independent" means knowing one observation tells you nothing about
+another. "Identically distributed" means every observation is drawn from
+the same fixed distribution (same mean, same variance, forever).
+
+A time series violates **both** halves, on purpose:
+
+```mermaid
+flowchart TB
+    subgraph CS["Cross-sectional data (i.i.d.)"]
+        direction LR
+        C1["obs 1"]
+        C2["obs 2"]
+        C3["obs 3"]
+        C4["obs 4"]
+    end
+    subgraph TS["Time series (dependent, evolving)"]
+        direction LR
+        T1["y at t-1"] --> T2["y at t"] --> T3["y at t+1"] --> T4["y at t+2"]
+    end
+    CS -. "rows are islands<br/>shuffle freely" .-> NOTE1["order does not matter"]
+    TS -. "each value leans on the last<br/>mean and variance drift" .-> NOTE2["order is everything"]
+```
+
+- **Not independent:** `y_t` depends on `y_{t-1}`. That's temporal
+  dependence — the thing we just plotted.
+- **Not identically distributed:** the airline series' average in 1949 is
+  nowhere near its average in 1960 (the **trend**), and its month-to-month
+  swings get *bigger* over time (changing **variance**). The distribution
+  is a moving target.
+
+So the comfortable tools that assume i.i.d. data — a plain mean as "the"
+value, a standard error of `s/√n`, a random train/test split — are not
+just less accurate on a time series. They are **answering the wrong
+question**, and they often fail silently, handing you a confident number
+that is wrong.
+
+<MultipleChoice
+  markdown={`A dataset has one row per hospital patient: age, blood pressure, and whether they were readmitted. A colleague calls it "time series data" because it was collected over several months. Are they right?
+
+- Yes — any data collected over time is time series data
+  > The *collection* spanning time doesn't make it a time series. What matters is whether the **order of the rows carries meaning** and whether each value depends on the previous one. Here the rows are independent patients.
+- [o] No — this is cross-sectional data; each patient is an independent unit and reordering the rows loses nothing
+  > Each row is a self-contained observation with no dependence on the row above it. You could sort by age or shuffle randomly and lose no information — the hallmark of cross-sectional, not time series, data.
+- Yes — because there is a time element in "several months"
+  > A vague time span in the background isn't the same as an ordered index where $y_t$ depends on $y_{t-1}$. These patients are not a sequence; they're a set.
+- It depends on how many patients there are
+  > Sample size has nothing to do with it. A million independent patients is still cross-sectional; twelve ordered monthly totals is a time series.
+
+A time series requires a meaningful order and dependence between consecutive values — not merely that data was gathered across some time span.`}
+/>
+
+## The four moving parts of a time series
+
+When you stare at a real series, you are usually looking at several effects
+layered on top of each other. We'll spend whole pages on these later; for
+now, just learn to *see* them:
+
+```mermaid
+flowchart LR
+    O["Observed series"] --> TR["Trend<br/>(long-run drift up or down)"]
+    O --> SE["Seasonality<br/>(fixed-period cycles: yearly, weekly)"]
+    O --> CY["Cyclic<br/>(swings with no fixed period)"]
+    O --> NO["Noise / residual<br/>(the unpredictable remainder)"]
+```
+
+- **Trend** — the slow march up or down. Airline travel grew year over
+  year.
+- **Seasonality** — a cycle with a *fixed, known period*. Passengers spike
+  every summer; retail spikes every December; electricity demand spikes
+  every evening. The period is calendar-locked.
+- **Cyclic** — longer swings with *no fixed period*, like economic booms
+  and recessions. Easy to confuse with seasonality, but a recession doesn't
+  arrive on a schedule the way summer does.
+- **Noise** — whatever is left after the structured parts: genuinely
+  unpredictable wiggle.
+
+<Callout type="warn" title="Seasonal is not the same as cyclic">
+Beginners use "cyclical" for both. Keep them apart: **seasonal** has a
+*fixed calendar period* (every 12 months, every 7 days) and is highly
+predictable; **cyclic** has a *variable period* (booms and busts) and is
+much harder to forecast. When someone says "sales are cyclical," ask "on
+what fixed period?" If they can't name one, it's cyclic, not seasonal.
+</Callout>
+
+Let's look at the hero series and name its parts by eye before we ever
+compute anything.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(10, 4))
+air.plot(ax=ax)
+ax.set_title("Monthly airline passengers, 1949-1960")
+ax.set_ylabel("passengers (thousands)")
+ax.set_xlabel("")
+plt.tight_layout()
+plt.show()
+
+print("Look for three things with your eyes:")
+print(" 1) TREND     - the whole series drifts upward year over year.")
+print(" 2) SEASONALITY - a repeating within-year hump (summer peak, winter dip).")
+print(" 3) GROWING VARIANCE - the summer-to-winter swing gets WIDER over time.")
+`}
+/>
+
+You can read all three structures straight off the chart: a rising trend,
+a yearly hump that repeats 12 times, and seasonal swings that get *wider*
+as the level rises. That last detail — variance growing with the level —
+is a clue we'll cash in later when we choose between additive and
+multiplicative models and when we reach for a log transform.
+
+## Why shuffling is sabotage (and where it sneaks in)
+
+You would never *manually* shuffle a time series — but a random train/test
+split does exactly that, and it's the default in almost every ML tutorial.
+Here's the trap, made concrete.
+
+When you randomly assign rows to "train" and "test", a test point from
+**March** ends up surrounded in the training set by **February and April**.
+Your model effectively gets to peek at the future on both sides of every
+test point. It will look brilliant in evaluation and then fall on its face
+in production, where the future is genuinely unavailable.
+
+```mermaid
+flowchart LR
+    R1["Jan<br/>train"] --> R2["Feb<br/>test"] --> R3["Mar<br/>train"] --> R4["Apr<br/>test"] --> R5["May<br/>train"] --> R6["Jun<br/>test"]
+```
+
+*Random split (WRONG):* train and test are interleaved in time. To
+"predict" February the model is allowed to learn from January **and**
+March — it has seen the future. This is **data leakage**.
+
+```mermaid
+flowchart LR
+    B1["Jan<br/>train"] --> B2["Feb<br/>train"] --> B3["Mar<br/>train"] --> B4["Apr<br/>test"] --> B5["May<br/>test"] --> B6["Jun<br/>test"]
+```
+
+*Chronological split (RIGHT):* train is the earlier block, test is the
+later block. The model only ever learns from the past to predict the
+future — exactly the situation it will face in real life.
+
+<Callout type="danger" title="The cardinal rule of time series">
+**You may only use the past to predict the future, never the reverse.**
+Any procedure that lets information from later time steps influence a
+prediction about an earlier one is **data leakage**, and it inflates your
+accuracy with a number you can never reproduce in production. A random
+train/test split is the most common way this rule gets broken. We devote a
+whole page to doing splits correctly — it's that important.
+</Callout>
+
+Let's *measure* the leakage, not just assert it. We'll quantify how much
+the order matters by destroying it and watching predictability evaporate.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`# A laughably simple forecaster: "next month = this month" (a naive forecast).
+# How good is it when order is intact vs destroyed?
+
+def naive_mae(series):
+    s = series.reset_index(drop=True)
+    pred = s.shift(1)            # predict each value with the previous one
+    err = (s - pred).dropna()
+    return float(np.mean(np.abs(err)))
+
+ordered_mae = naive_mae(air)
+shuffled_mae = naive_mae(air.sample(frac=1.0, random_state=3))
+
+print(f"Naive forecast error (time order intact): {ordered_mae:6.1f}")
+print(f"Naive forecast error (shuffled):          {shuffled_mae:6.1f}")
+print()
+print("With order intact, 'tomorrow = today' is a decent forecast.")
+print("Shuffled, the same rule is useless — because there's no 'last month' anymore.")
+`}
+/>
+
+With the time order intact, the dead-simple rule "next month equals this
+month" has a modest error — there's real structure to exploit. Shuffle the
+series and that same rule's error roughly *triples*, because a shuffled
+"previous value" is just a random other month. The predictability was a
+property of the *sequence*, and the moment you treat the data as an
+unordered set, it's gone.
+
+<MultipleChoice
+  markdown={`Why is a standard random train/test split (the kind \`train_test_split(shuffle=True)\` performs) considered **catastrophic** for time series forecasting?
+
+- It makes training slower because the data is out of order
+  > Speed is irrelevant. The problem is statistical, not computational: a random split corrupts what the evaluation *means*.
+- It throws away too much data for testing
+  > The proportion of held-out data isn't the issue. Even a 99/1 random split leaks, because the single test point is still surrounded in time by training points.
+- [o] It leaks future information into training: test points end up time-surrounded by training points, so the model "sees" the future and reports accuracy it can never achieve in production
+  > A randomly chosen test point from March is flanked in the training set by February and April. The model effectively interpolates between known future and past values — information it will never have when forecasting for real.
+- It only works if the series is stationary
+  > Stationarity is a separate concern. A random split leaks regardless of stationarity; the leakage comes from interleaving time, not from the series' statistical properties.
+
+The defining sin is leakage of future information into the past, which makes evaluation optimistic and irreproducible.`}
+/>
+
+## Real-world stakes
+
+This isn't academic. Treating temporal data as an unordered table, or
+evaluating it with a leaky split, produces forecasts that *look* great in
+a notebook and lose money in production:
+
+- **Energy demand** — a utility under-forecasts the evening peak and has to
+  buy emergency power at 10x the price, or over-forecasts and pays to spin
+  up plants that idle.
+- **Inventory planning** — a retailer that ignores seasonality orders summer
+  stock for a winter product, eating storage costs and stock-outs at once.
+- **Web traffic / capacity** — a team validates an auto-scaling model with a
+  random split, ships it, and gets paged at 3 a.m. when the real Monday
+  spike it "predicted perfectly" in testing arrives unannounced.
+- **Public health** — case-count forecasts that leak future data overstate
+  confidence, and confident-but-wrong forecasts erode trust fast.
+
+In every case the failure is the same: the order of the data was the most
+important variable, and it got thrown away — either by shuffling, or by an
+evaluation that pretended the future was available.
+
+<Callout type="info" title="Where time series shows up in jobs">
+"Demand forecasting," "capacity planning," "anomaly detection on metrics,"
+"churn *timing*," "sensor / IoT analytics," and most of "operations
+analytics" are time series work wearing different hats. The intuition you
+build here transfers directly.
+</Callout>
+
+## A first, honest forecast baseline
+
+Here's a habit worth forming on day one: **always start with a trivial
+baseline.** Two are classic:
+
+- The **naive forecast** — predict the next value equals the last value
+  (`ŷₜ = yₜ₋₁`). Surprisingly hard to beat on many series.
+- The **seasonal naive forecast** — predict the next value equals the value
+  one full season ago (`ŷₜ = yₜ₋ₘ`, with `m = 12` for monthly data with
+  yearly seasonality). For strongly seasonal series, this is the baseline
+  to beat.
+
+If your fancy ARIMA can't beat "same as last year," the ARIMA is not
+adding value. Let's compute both baselines so the idea is concrete.
+
+<CodeBlock
+  adapter="python"
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`y = air.values.astype(float)
+
+# Naive: predict y[t] using y[t-1].
+naive_pred = y[:-1]
+naive_true = y[1:]
+naive_mae = np.mean(np.abs(naive_true - naive_pred))
+
+# Seasonal naive: predict y[t] using y[t-12] (same month, last year).
+m = 12
+snaive_pred = y[:-m]
+snaive_true = y[m:]
+snaive_mae = np.mean(np.abs(snaive_true - snaive_pred))
+
+print(f"Naive (last month)      MAE: {naive_mae:6.2f}")
+print(f"Seasonal naive (last yr) MAE: {snaive_mae:6.2f}")
+print()
+print("Seasonal naive wins big here: this series repeats yearly, so")
+print("'same month last year' is a far better guess than 'last month'.")
+print("Any real model must beat the BETTER of these baselines to earn its keep.")
+`}
+/>
+
+The seasonal-naive baseline crushes the plain naive one, because the
+airline series' strongest structure is its *yearly* cycle. This is your
+first lesson in matching the method to the structure — and a benchmark
+we'll hold every fancy model to.
+
+## Practice
+
+<ChallengeCard
+  adapter="python"
+  title="Measure how shuffling destroys autocorrelation"
+  instructions={`The airline \`air\` series is loaded. Write a function \`lag1_autocorr(series)\` that returns the **lag-1 autocorrelation**: the Pearson correlation between the series and itself shifted forward by one step (drop the resulting missing value). Use it to fill a dict \`result\` with two keys:
+
+- \`"ordered"\` — lag-1 autocorrelation of \`air\` as-is (a float)
+- \`"shuffled"\` — lag-1 autocorrelation of \`air\` after \`air.sample(frac=1.0, random_state=0)\` (a float)
+
+The ordered value should be high (above 0.8); the shuffled value should be small in magnitude (below 0.4). This is the whole thesis of the page, measured.`}
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`def lag1_autocorr(series):
+    # TODO: correlate the series with itself shifted by 1 step.
+    return None
+
+result = {
+    "ordered": None,
+    "shuffled": None,
+}
+print(result)
+`}
+  solutionCode={`def lag1_autocorr(series):
+    s = series.reset_index(drop=True)
+    return float(s.corr(s.shift(1)))
+
+result = {
+    "ordered": lag1_autocorr(air),
+    "shuffled": lag1_autocorr(air.sample(frac=1.0, random_state=0)),
+}
+print(result)
+`}
+  tests={[
+    {
+      id: "keys",
+      name: "result has both keys as floats",
+      description: "ordered and shuffled present and numeric",
+      code: `assert set(result.keys()) == {"ordered", "shuffled"}
+assert all(isinstance(result[k], float) for k in result)`,
+    },
+    {
+      id: "ordered_high",
+      name: "ordered autocorrelation is high",
+      description: "Time order intact means strong lag-1 dependence",
+      code: `assert result["ordered"] > 0.8, f"Expected > 0.8, got {result['ordered']}"`,
+    },
+    {
+      id: "shuffled_low",
+      name: "shuffled autocorrelation is small",
+      description: "Shuffling destroys the dependence",
+      code: `assert abs(result["shuffled"]) < 0.4, f"Expected |corr| < 0.4, got {result['shuffled']}"`,
+    },
+    {
+      id: "ordered_beats_shuffled",
+      name: "order matters",
+      description: "Ordered dependence far exceeds shuffled",
+      code: `assert result["ordered"] - abs(result["shuffled"]) > 0.4`,
+    },
+  ]}
+/>
+
+<ChallengeCard
+  adapter="python"
+  title="Make a leakage-free chronological split"
+  instructions={`Given the \`air\` series (144 monthly points), build a chronological train/test split that holds out the **last 24 months** for testing. Produce:
+
+- \`train\` — a Series of the first 120 observations
+- \`test\` — a Series of the final 24 observations
+
+The split must be **leakage-free**: every timestamp in \`train\` must come strictly *before* every timestamp in \`test\`. Do **not** shuffle.`}
+  initCode={`import pandas as pd
+import numpy as np
+_passengers = [
+    112,118,132,129,121,135,148,148,136,119,104,118,
+    115,126,141,135,125,149,170,170,158,133,114,140,
+    145,150,178,163,172,178,199,199,184,162,146,166,
+    171,180,193,181,183,218,230,242,209,191,172,194,
+    196,196,236,235,229,243,264,272,237,211,180,201,
+    204,188,235,227,234,264,302,293,259,229,203,229,
+    242,233,267,269,270,315,364,347,312,274,237,278,
+    284,277,317,313,318,374,413,405,355,306,271,306,
+    315,301,356,348,355,422,465,467,404,347,305,336,
+    340,318,362,348,363,435,491,505,404,359,310,337,
+    360,342,406,396,420,472,548,559,463,407,362,405,
+    417,391,419,461,472,535,622,606,508,461,390,432,
+]
+idx = pd.date_range("1949-01-01", periods=len(_passengers), freq="MS")
+air = pd.Series(_passengers, index=idx, name="passengers")`}
+  initialCode={`h = 24  # forecast horizon / test length
+train = None
+test = None
+print("train:", None if train is None else train.shape)
+print("test :", None if test is None else test.shape)
+`}
+  solutionCode={`h = 24
+train = air.iloc[:-h]
+test = air.iloc[-h:]
+print("train:", train.shape, "->", train.index.min().date(), "to", train.index.max().date())
+print("test :", test.shape, "->", test.index.min().date(), "to", test.index.max().date())
+`}
+  tests={[
+    {
+      id: "sizes",
+      name: "train has 120, test has 24",
+      description: "Correct split sizes",
+      code: `assert len(train) == 120 and len(test) == 24`,
+    },
+    {
+      id: "no_overlap",
+      name: "no shared timestamps",
+      description: "Train and test indices are disjoint",
+      code: `assert len(train.index.intersection(test.index)) == 0`,
+    },
+    {
+      id: "chronological",
+      name: "train is entirely before test (leakage-free)",
+      description: "Every train date precedes every test date",
+      code: `assert train.index.max() < test.index.min(), "Leakage: train overlaps the future"`,
+    },
+    {
+      id: "covers_all",
+      name: "together they cover the series",
+      description: "No rows dropped",
+      code: `assert len(train) + len(test) == len(air)`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`Which property is the *defining* feature that separates a time series from a cross-sectional dataset?
+
+- It has more rows
+  > Size is irrelevant. A three-row monthly series is a time series; a million-row customer table is not.
+- It contains a date column somewhere
+  > Merely having a date *column* doesn't make data a time series — the patient table earlier had a collection date but was cross-sectional. What matters is dependence and meaningful order.
+- [o] Its observations are ordered in time and each value is statistically dependent on nearby values
+  > Temporal ordering *plus* dependence between neighboring values is exactly what makes the sequence a time series and what lets us forecast at all.
+- Its values are always increasing
+  > Time series can trend up, down, oscillate, or wander. Monotonic growth is neither required nor common.
+
+The essence is an ordered sequence with dependence between neighbors — not size, not the mere presence of a date, not monotonicity.`}
+/>
+
+<MultipleChoice
+  markdown={`A series of daily temperatures has high lag-1 autocorrelation. What does that practically mean?
+
+- Tomorrow's temperature is completely random
+  > High autocorrelation means the opposite of random: today is a strong clue about tomorrow.
+- [o] Today's temperature is a strong predictor of tomorrow's — consecutive values tend to be close
+  > Lag-1 autocorrelation measures how tightly each value tracks the one before it. High values mean "tomorrow looks a lot like today," which is what makes a naive forecast competitive.
+- The temperatures have no trend
+  > Autocorrelation and trend are different things; a series can have strong lag-1 autocorrelation with or without a trend.
+- The data must be stationary
+  > High autocorrelation says nothing on its own about stationarity. Strongly trending (non-stationary) series often have *very* high lag-1 autocorrelation.
+
+Lag-1 autocorrelation quantifies how much each value resembles its immediate predecessor.`}
+/>
+
+<MultipleChoice
+  markdown={`You build a model, evaluate it with a random 80/20 split, and get a stunning 2% error. In production it gets 15% error. What is the most likely cause?
+
+- The production data is simply harder
+  > A 7x degradation that appears only in production is the classic signature of leakage in evaluation, not of the world suddenly getting harder.
+- The model is too simple
+  > A too-simple model would look bad in *both* testing and production. The tell here is that testing looked great and only production was bad.
+- [o] Data leakage from the random split: in testing the model saw future-adjacent points, an advantage it loses in production
+  > The random split let test points be time-surrounded by training points, so evaluation measured interpolation, not true forecasting. Production has no such future context, so the honest error is far higher.
+- You used too few features
+  > More features wouldn't close a gap that exists *because* the evaluation was leaky. The fix is an honest chronological split, not a richer model.
+
+A great-in-testing, terrible-in-production gap on temporal data almost always traces back to a leaky (random) split.`}
+/>
+
+<MultipleChoice
+  markdown={`A retailer's sales rise every November-December without fail, peaking the same weeks each year. The economy also pushes sales up and down over multi-year booms and busts that don't follow a calendar. Which labels fit?
+
+- Both effects are "seasonal"
+  > The calendar-locked holiday spike is seasonal, but multi-year booms with no fixed period are *cyclic*, not seasonal. Lumping them together hides that one is far more predictable than the other.
+- Both effects are "trend"
+  > Trend is the slow one-directional drift. Neither a repeating December spike nor up-and-down booms is a single-direction trend.
+- [o] The November-December spike is seasonal (fixed calendar period); the multi-year booms and busts are cyclic (no fixed period)
+  > Seasonality has a fixed, known period locked to the calendar; cyclic swings have a variable period and are much harder to forecast. Naming them correctly tells you which is predictable.
+- The holiday spike is cyclic; the booms are seasonal
+  > This reverses the definitions. Fixed calendar period = seasonal; variable period = cyclic.
+
+Fixed, calendar-locked period means seasonal; variable-length swings mean cyclic — and the distinction predicts how forecastable each is.`}
+/>
+
+<MultipleChoice
+  markdown={`Why do we insist on computing a **seasonal naive** baseline (this month = same month last year) before fitting any sophisticated model?
+
+- Because sophisticated models are always worse
+  > Sophisticated models are often better — but not always, and not for free. The baseline is how you *find out* whether the complexity earned anything.
+- [o] Because a model that can't beat a trivial baseline isn't adding value, and the baseline tells us how much real skill any model contributes
+  > Baselines convert "the error is 30" into "the error is 30, versus 35 for doing nothing" — that comparison is what makes an accuracy number meaningful. If ARIMA can't beat "same as last year," it's not worth its complexity.
+- Because seasonal naive is always the most accurate forecast
+  > It frequently isn't — good models beat it. Its job is to be a cheap, honest yardstick, not to win.
+- Because it makes the data stationary
+  > Computing a baseline forecast does nothing to the series' stationarity. The baseline is an evaluation reference, not a transformation.
+
+Baselines turn raw error numbers into meaningful comparisons and guard against shipping complexity that adds nothing.`}
+/>
+
+<Callout type="success" title="Key takeaways">
+- A **time series** is an *ordered sequence of dependent observations* —
+  not a table with a date column. The **order is information**.
+- The defining property is **temporal dependence** (measured as
+  **autocorrelation**): each value leans on its recent past.
+- Time series violate the **i.i.d.** assumption on both counts — values are
+  *dependent*, and the distribution *drifts* (trend, changing variance).
+- **Shuffling** destroys the signal; a **random train/test split** is
+  shuffling in disguise and causes **data leakage** — great test scores,
+  terrible production.
+- The **cardinal rule**: only ever use the **past** to predict the
+  **future**.
+- A series layers **trend**, **seasonality** (fixed period), **cyclic**
+  swings (variable period), and **noise** — learn to see them.
+- Always start with a **naive** and **seasonal-naive baseline**; real
+  models must beat them to justify their complexity.
+</Callout>
+
+Now that you respect the time dimension, let's pick up the tool that makes
+all of this practical in Python: pandas's `DatetimeIndex`, the spine that
+turns an ordinary `Series` into a time-aware one.


### PR DESCRIPTION
## Time Series Analysis with Python

A new intuition-first course on classical time series analysis and statistical forecasting with **pandas** and **statsmodels** — no scikit-learn, no deep learning, no heavy forecasting frameworks. It targets learners who already know Python, pandas basics, simple plotting, and descriptive statistics.

**Status: complete and builds green** — 13 pages (welcome + 12 content pages), ~6,500 lines of MDX.

> **Build fix (latest commit):** an earlier Vercel build failed with `YAMLException: bad indentation of a mapping entry (2:179)` on `index.mdx`. Cause: the frontmatter `description:` was an unquoted YAML scalar containing a colon-space (`…changes everything: in time series…`), which the YAML parser reads as a mapping separator. Fixed by quoting the description. I validated the frontmatter of **all 13 pages** with `js-yaml` (the parser fumadocs uses) and ran a full local `next build` — it now completes successfully (`✓ 727/727 static pages`, all 13 course pages prerendered, exit 0).

### Central thesis
In a time series, **the order of the data IS the information** — which is why shuffling destroys it and why a random train/test split causes catastrophic data leakage. The course treats **chronological validation** as its single most important topic.

### Pages (`content/learn/time-series-analysis-python/`)
1. **The Time Dimension** — what makes time series unique (temporal dependence, the i.i.d. failure, why shuffling/random splits leak)
2. **Mastering the Pandas Timeline** — `DatetimeIndex`, `Timestamp` vs `Period`, frequency, partial-string slicing, alignment
3. **Resampling & Aggregation** — down/upsampling, sum-vs-mean, why upsampling invents data
4. **Moving Windows** — `shift`, rolling/expanding statistics, the centered-window leak, "a smoother is not a forecast"
5. **Mind the Gap** — `ffill`/`bfill`/interpolation as three assumptions, which ones peek at the future
6. **Decomposing the Signals** — trend/seasonal/residual, additive vs multiplicative, the log trick
7. **The Concept of Stationarity** — intuition + the ADF test (with its commonly-flipped null hypothesis)
8. **Detrending** — differencing, seasonal differencing, over-differencing, integration as the "I" in ARIMA
9. **Reading the Echoes** — ACF vs PACF, the AR/MA cheat-sheet
10. **Classic Forecasting** — AR, MA, ARMA, ARIMA; fit, forecast, AIC, residual diagnostics
11. **The Cardinal Sin** — chronological validation, walk-forward backtesting, MAE/RMSE/MAPE by hand, preprocessing leakage
12. **Capstone** — an end-to-end pipeline that beats a baseline out-of-sample

### Interactivity
- **61** runnable code blocks · **25** challenge cards (with hidden tests + reference solutions) · **62** single-answer MCQs (denser on foundational pages) · **22** Mermaid diagrams

### Design notes
- **Browser-safe data**: the canonical 144-point AirPassengers series is embedded as literal data (the R `get_rdataset` path needs network); plus small simulated series with known structure. Nothing exceeds a few hundred points.
- **Version-correct for the runtime** (pandas 2.3.3, numpy 2.2.5, statsmodels 0.14.4): modern frequency aliases (`ME`/`YE`/`h`) in runnable code, with the classic `M`→`ME` rename taught as a real-world gotcha; `.ffill()`/`.bfill()` over deprecated `fillna(method=)`.
- **Numerically honest**: e.g., the course is candid that AirPassengers' single-difference ADF p-value is famously borderline (~0.05–0.07), and graded challenges were designed to be robust to such borderline/noisy statsmodels outputs.

### Validation performed
- **Full `next build` passes locally** (Turbopack, Next 16.2.6): `✓ 727/727` static pages, all 13 time-series pages prerendered, exit 0.
- YAML frontmatter of all 13 pages parses with `js-yaml`.
- All 13 MDX files compile with `@mdx-js/mdx`.
- All 22 Mermaid diagrams parse against the **installed mermaid 11.15.0** (in a real browser via Playwright).
- All 271 Python snippets pass `ast` syntax checks.
- MCQ explanations contain no affirmative openers (per `AGENTS.md`); every MCQ is single-answer; no `pyodide` references; no manual `# H1` headings.

https://claude.ai/code/session_01GYJ8wKtgzxy1xgUaA9UZzf