### PR TITLE
Add "Natural Language Processing with Python" course

### DIFF
--- a/content/learn/natural-language-processing-python/bag-of-words.mdx
+++ b/content/learn/natural-language-processing-python/bag-of-words.mdx
@@ -1,0 +1,318 @@
+---
+title: "From Text to Features: Bag-of-Words"
+description: Algorithms need numbers, not words. The bag-of-words model turns each document into a vector of word counts over a shared vocabulary. Building a document-term matrix by hand, binary vs. count features, and the limitations (lost order, sparsity, no semantics) that motivate n-grams and beyond.
+---
+
+Everything so far has produced *words* — clean tokens, roots, tags, n-grams.
+But most algorithms that *use* text, from a spam filter to a clustering
+routine, do not consume words. They consume **numbers**. The bridge from a
+list of tokens to a row of numbers is called **feature extraction**, and the
+oldest, simplest, and still-everywhere technique for it is the **bag-of-words**
+model.
+
+The name is the whole idea: take a document, throw all its words into a bag,
+and shake it. You keep *which* words appear and *how many times*, but you throw
+away the *order*. A document becomes a tally of word counts — and a tally is
+just a vector of numbers, which is exactly what an algorithm can work with.
+
+## The feature extraction process
+
+Bag-of-words turns a whole collection of documents into a table of numbers in
+a fixed sequence of steps.
+
+```mermaid
+flowchart TB
+    D["Documents<br/>doc1, doc2, doc3"] --> P["Tokenize + clean<br/>each document"]
+    P --> V["Build the vocabulary<br/>(all distinct words across the corpus)"]
+    V --> M["Count each vocabulary word<br/>in each document"]
+    M --> X["Document-term matrix<br/>rows = documents, columns = words, cells = counts"]
+    X --> C["Feed the matrix to a classifier"]
+```
+
+The output is a **document-term matrix**: one row per document, one column per
+vocabulary word, and each cell holding how many times that word appeared in
+that document. Every row is a numeric vector that represents its document, and
+that is precisely the form a classifier wants.
+
+## Building it by hand
+
+The model is simple enough to build from scratch with a `Counter`, and doing
+so demystifies it completely. Watch a tiny three-document corpus become a
+matrix of numbers.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the tokenizer this page needs. nltk.download()
+# isn't available here, so we fetch the archives directly.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize`}
+  initialCode={`from collections import Counter
+import pandas as pd
+
+corpus = [
+    "the cat sat on the mat",
+    "the dog sat on the log",
+    "the cat and the dog played",
+]
+
+# 1. Tokenize + clean each document into a list of words.
+docs = [[t.lower() for t in word_tokenize(d) if t.isalpha()] for d in corpus]
+
+# 2. Build the vocabulary: every distinct word, in sorted order.
+vocab = sorted({word for doc in docs for word in doc})
+print("Vocabulary:", vocab)
+
+# 3. Count each vocabulary word in each document -> one vector per document.
+rows = []
+for doc in docs:
+    counts = Counter(doc)
+    rows.append([counts[word] for word in vocab])
+
+# 4. Assemble the document-term matrix.
+dtm = pd.DataFrame(rows, columns=vocab, index=["doc1", "doc2", "doc3"])
+display(dtm)
+`}
+/>
+
+That table *is* the bag-of-words representation. Read doc1's row: "the" appears
+twice (a 2 in the "the" column), "cat", "sat", "on", and "mat" once each, and
+every other vocabulary word zero times. The sentence has become a row of
+integers — and crucially, all three rows have the **same length** (the size of
+the vocabulary), so they can be compared, added, and fed to an algorithm
+uniformly.
+
+<Callout type="info" title="Why a shared vocabulary matters">
+Every document is counted against the *same* vocabulary, so every document
+vector has the same dimensions in the same order. That alignment is what lets
+an algorithm treat "count of the word 'cat'" as a consistent feature across all
+documents. Build the vocabulary once from your whole corpus, then vectorize
+each document against it.
+</Callout>
+
+## Counts vs. presence (binary bag-of-words)
+
+Sometimes you care only *whether* a word appears, not how often — for short
+texts or spam-style signals, presence is enough and is less swayed by length.
+That variant is **binary** bag-of-words: each cell is 1 or 0 instead of a
+count.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`from collections import Counter
+
+vocab = ["cheap", "free", "meeting", "report", "winner"]
+
+def count_vector(tokens, vocab):
+    counts = Counter(tokens)
+    return [counts[w] for w in vocab]
+
+def binary_vector(tokens, vocab):
+    present = set(tokens)
+    return [1 if w in present else 0 for w in vocab]
+
+spam = "free free free winner cheap".split()
+
+print("vocab:        ", vocab)
+print("count vector: ", count_vector(spam, vocab))
+print("binary vector:", binary_vector(spam, vocab))
+`}
+/>
+
+The count vector records that "free" appeared three times (a strong spam
+signal); the binary vector just records that it appeared at all. Which is
+better depends on the task — another small pipeline choice, in the spirit of
+the previous page.
+
+<Callout type="tip" title="In practice you'd reach for a vectorizer">
+Building bag-of-words by hand, as we just did, is the right way to *understand*
+it. In real projects you would typically use a ready-made vectorizer (such as
+scikit-learn's `CountVectorizer`) that does tokenizing, vocabulary-building, and
+counting in one step and returns an efficient sparse matrix. The mechanics are
+identical to what you just coded — vocabulary, then per-document counts — so you
+now know exactly what such a tool produces under the hood.
+</Callout>
+
+## The limitations (and what they motivate)
+
+Bag-of-words is powerful for its simplicity, but its simplifications are real
+and worth naming, because each one points to a technique you have met or will
+meet.
+
+- **It ignores word order.** "dog bites man" and "man bites dog" produce the
+  *identical* bag. This is the blind spot **n-grams** patch: adding bigram
+  columns ("not good", "machine learning") puts a little order back in.
+- **It is sparse and high-dimensional.** A real vocabulary has tens of
+  thousands of words, so each document vector is mostly zeros. This costs
+  memory and is why real tools use *sparse* matrices, and why stopword removal
+  and stemming/lemmatization (which shrink the vocabulary) help here.
+- **It has no notion of meaning.** "great" and "excellent" are different
+  columns with nothing connecting them; the model has no idea they are
+  near-synonyms. Capturing meaning is what **word embeddings** (like Word2Vec)
+  were invented for — conceptually, they place similar words near each other in
+  a numeric space so "great" and "excellent" are close rather than unrelated.
+  That is a topic for later study; bag-of-words remains the right first model
+  to understand.
+
+<Callout type="warn" title="Bag-of-words throws away order — on purpose">
+The "bag" metaphor is a literal description: order is gone. For many tasks
+(topic detection, spam filtering) that loss is acceptable and the simplicity is
+worth it. For tasks where order is meaning (sentiment, where "not good" must
+not look like "good not"), compensate by adding n-gram features. Knowing *what*
+bag-of-words discards tells you exactly when you need to shore it up.
+</Callout>
+
+<MultipleChoice
+  markdown={`In a bag-of-words representation, what does each **column** of the
+document-term matrix correspond to?
+
+- One document in the corpus
+- [o] One word in the shared vocabulary, with each cell counting that word's occurrences in a document
+  > Rows are documents and columns are vocabulary words; a cell is the count (or presence) of that word in that document. The shared columns make all document vectors comparable.
+- One sentence in a document
+- One character in the text
+
+Columns are vocabulary words; rows are documents; cells are counts.`}
+/>
+
+## Your turn: vectorize a document
+
+<ChallengeCard
+  adapter="python"
+  title="Turn a document into a bag-of-words vector"
+  category="feature extraction · bag-of-words · vectors"
+  estimatedTime="~6 min"
+  instructions={`Write a function \`bow_vector(tokens, vocab)\` that returns the bag-of-words
+**count vector** for one document: a list with the same length as \`vocab\`,
+where position \`i\` holds the number of times \`vocab[i]\` appears in \`tokens\`.
+Words in \`tokens\` that are not in \`vocab\` are simply ignored.
+
+For example, with \`vocab = ["cat", "dog", "fish"]\` and
+\`tokens = ["dog", "cat", "dog", "bird"]\`, the result is \`[1, 2, 0]\` — one
+"cat", two "dog", zero "fish", and "bird" ignored.
+
+Tip: \`collections.Counter\` makes this clean (it returns 0 for missing keys).`}
+  initCode={`from collections import Counter`}
+  initialCode={`def bow_vector(tokens, vocab):
+    # return a list of counts aligned to vocab
+    return []
+
+print(bow_vector(["dog", "cat", "dog", "bird"], ["cat", "dog", "fish"]))
+`}
+  solutionCode={`def bow_vector(tokens, vocab):
+    counts = Counter(tokens)
+    return [counts[w] for w in vocab]
+
+print(bow_vector(["dog", "cat", "dog", "bird"], ["cat", "dog", "fish"]))
+`}
+  tests={[
+    {
+      id: "basic_counts",
+      name: "Counts vocabulary words correctly",
+      description: "['dog','cat','dog','bird'] over ['cat','dog','fish'] -> [1,2,0]",
+      code: `out = bow_vector(["dog", "cat", "dog", "bird"], ["cat", "dog", "fish"])
+assert out == [1, 2, 0], "Got: " + repr(out)`,
+    },
+    {
+      id: "length_matches_vocab",
+      name: "Vector length equals vocabulary size",
+      description: "One entry per vocabulary word",
+      code: `vocab = ["a", "b", "c", "d", "e"]
+out = bow_vector(["a", "a", "c"], vocab)
+assert len(out) == len(vocab), "Expected length " + str(len(vocab)) + "; got " + str(len(out))`,
+    },
+    {
+      id: "ignores_oov",
+      name: "Ignores words not in the vocabulary",
+      description: "Out-of-vocabulary words contribute nothing",
+      code: `out = bow_vector(["x", "y", "z"], ["cat", "dog"])
+assert out == [0, 0], "Out-of-vocab words should be ignored; got " + repr(out)`,
+    },
+    {
+      id: "empty_doc",
+      name: "Empty document is all zeros",
+      description: "No tokens -> a zero vector of the right length",
+      code: `out = bow_vector([], ["cat", "dog", "fish"])
+assert out == [0, 0, 0], "Got: " + repr(out)`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`Why do we convert text to a bag-of-words vector at all?
+
+- Because vectors take less disk space than text
+- [o] Because most algorithms operate on numbers, not words, so each document must be turned into a fixed-length numeric vector before it can be fed to them
+  > Feature extraction bridges words and math. A bag-of-words vector gives every document the same numeric shape (one entry per vocabulary word), which is exactly what classifiers and clustering algorithms require.
+- Because it makes the text easier for humans to read
+- Because it translates the document into another language
+
+The point is to produce numeric features an algorithm can consume.`}
+/>
+
+<MultipleChoice
+  markdown={`"dog bites man" and "man bites dog" produce the *same* bag-of-words vector.
+What does this reveal, and how is it commonly addressed?
+
+- It is a bug in the counting code
+- [o] Bag-of-words discards word order, so different orderings of the same words collapse together; adding n-gram (e.g., bigram) features puts some local order back
+  > The bag keeps counts but not order, so both sentences have identical word tallies. When order matters, bigram/trigram features ("bites man" vs "bites dog") restore enough of it to distinguish them.
+- It means the two sentences have different vocabularies
+- It proves bag-of-words cannot be used for any real task
+
+Order-loss is inherent to the bag; n-grams are the standard remedy.`}
+/>
+
+<MultipleChoice
+  markdown={`How does **binary** bag-of-words differ from **count** bag-of-words?
+
+- Binary uses words; count uses numbers
+- [o] Binary records only whether each word is present (1 or 0); count records how many times it appears
+  > Both share the same vocabulary-aligned vector shape. Binary collapses any nonzero count to 1, which can be more robust to document length, while counts preserve frequency information that may itself be a useful signal.
+- Binary is always more accurate than count
+- They produce vectors of different lengths
+
+Presence (1/0) versus frequency (counts) is the only difference, and which is better depends on the task.`}
+/>
+
+<MultipleChoice
+  markdown={`Bag-of-words gives "great" and "excellent" entirely separate columns with no
+connection between them. What limitation is this, and what technique is aimed
+at it?
+
+- A sparsity problem, fixed by stopword removal
+- [o] It captures no *meaning*/similarity between words; word embeddings (e.g., Word2Vec) address it by placing similar words close together in a numeric space
+  > Bag-of-words treats every word as an independent dimension, so synonyms are unrelated. Embeddings encode semantic similarity numerically, so related words end up near each other — a more advanced topic, but the conceptual fix for this exact limitation.
+- A word-order problem, fixed by n-grams
+- There is no limitation here
+
+Bag-of-words has no semantics; embeddings are the conceptual answer to that gap.`}
+/>
+
+You can now turn documents into numeric features. In the final page we put the
+*entire* course together — preprocessing choices, features, and a touch of
+n-gram thinking — to build a small but complete **rule-based sentiment
+classifier** from scratch, and watch every earlier lesson pay off.

--- a/content/learn/natural-language-processing-python/choosing-your-pipeline.mdx
+++ b/content/learn/natural-language-processing-python/choosing-your-pipeline.mdx
@@ -1,0 +1,396 @@
+---
+title: Designing the Right Preprocessing Pipeline
+description: The most important skill in classic NLP — choosing which preprocessing steps to apply. There is no universal pipeline; each step adds or destroys information, and the right choice depends entirely on the downstream task. A decision framework, a task-by-task table, and how to evaluate choices empirically.
+---
+
+If you remember one page from this course, make it this one. Every previous
+page taught a *technique*. This page teaches the *judgment* to combine those
+techniques well — and that judgment, far more than knowing the function names,
+is what separates someone who can run NLTK from someone who can build a text
+system that works.
+
+The central truth is uncomfortable for beginners who want a recipe: **there is
+no universal "correct" pipeline.** Lowercasing, stopword removal, stemming,
+lemmatization, n-grams — each is a *choice*, and a step that sharpens one task
+will quietly sabotage another. Choosing well means understanding what each
+step does to your data and matching it to what your task needs.
+
+## The pipeline is a menu, not a fixed recipe
+
+Picture the steps as a menu of optional transformations. Only tokenization is
+nearly mandatory; everything after it is a decision.
+
+```mermaid
+flowchart TD
+    T["Tokenize<br/>(almost always)"] --> C1{"Lowercase?"}
+    C1 --> C2{"Remove stopwords?"}
+    C2 --> C3{"Stem or lemmatize?"}
+    C3 --> C4{"Add n-grams?"}
+    C4 --> A["Analysis"]
+```
+
+Each diamond is a question with no default answer. To answer it, apply a
+single guiding principle.
+
+<Callout type="info" title="The one question to ask at every step">
+For each optional step, ask: **"Does the information this step changes or
+destroys matter to my task?"** Lowercasing destroys capitalization — does your
+task need it (names, acronyms)? Stopword removal destroys function words —
+does your task need them (negation, phrases, author style)? If the destroyed
+information is noise for your task, apply the step. If it is signal, skip it.
+That single question resolves most pipeline decisions.
+</Callout>
+
+## A decision framework
+
+Two of the highest-stakes choices can be captured in a small decision tree.
+
+```mermaid
+flowchart TD
+    Q1{"Does word order or negation<br/>carry the meaning? (sentiment, phrases)"}
+    Q1 -->|"yes"| K1["KEEP stopwords and negation<br/>ADD bigrams/trigrams"]
+    Q1 -->|"no"| Q2{"Do you need readable, real-word<br/>roots, or just grouping keys?"}
+    Q2 -->|"readable / semantic"| L["LEMMATIZE (POS-aware)<br/>keep meaning, real words"]
+    Q2 -->|"grouping at scale"| S["STEM<br/>fast, recall-oriented"]
+```
+
+This does not cover every case, but it captures the two decisions people get
+wrong most often: stripping negation before sentiment, and reaching for
+stemming when meaning matters.
+
+## Task by task
+
+The clearest way to internalize "it depends" is to walk through real tasks and
+see the *opposite* choices they demand.
+
+**Search indexing.** You want a query for "running" to match "ran" and "runs".
+Lowercase (case is noise for matching), remove stopwords (they bloat the index
+and rarely help relevance), and **stem** (fast, and a stem is only ever
+compared to other stems). Readability does not matter — no human sees the
+index.
+
+**Topic analysis / keyword extraction.** You want the content words that say
+what a document is about. Lowercase, remove stopwords (they drown out content),
+and **lemmatize** so the keywords you surface are real words a person can read.
+
+**Sentiment analysis.** Now the calculus flips. **Do not** strip stopwords
+naively — negations ("not", "no", "nor") and contrasts ("but") live there and
+reverse meaning. Lowercasing is usually fine but ALL-CAPS can be a signal worth
+keeping. Punctuation like "!" can carry intensity. And **bigrams help a lot**,
+because "not good" must survive as a unit. The aggressive cleaning that helps
+topic analysis is exactly wrong here.
+
+**Authorship attribution.** The most counterintuitive case. Here the
+**stopwords are the signal** — an author's unconscious rate of "the", "of",
+"that" is a fingerprint — and the content words are noise. So you *keep*
+stopwords and often discard content words: the inverse of every other task.
+
+**Named-entity recognition.** Capitalization is the main clue that "Apple" is a
+company. **Do not lowercase**, do not strip stopwords (they delimit entities),
+and tag parts of speech *before* any normalization.
+
+Here is the same advice as a table. Read across each row and notice that no two
+columns agree.
+
+| Task | Lowercase? | Remove stopwords? | Stem / Lemmatize? | N-grams? |
+| --- | --- | --- | --- | --- |
+| Search indexing | yes | yes | stem | sometimes |
+| Topic / keywords | yes | yes | lemmatize | sometimes |
+| Sentiment analysis | careful | **no** (keep negation) | light, if any | **bigrams help** |
+| Authorship attribution | no | **no** (it's the signal) | no | sometimes |
+| Named-entity recognition | **no** | no | no | n/a |
+
+The cells disagree everywhere. That disagreement *is* the lesson: preprocessing
+must be designed for the task, not applied by reflex.
+
+## Seeing it: one text, two pipelines
+
+Let us run a single sentence through a "topic" pipeline and a "sentiment"
+pipeline and watch them produce deliberately different results.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the tokenizer and stopwords this page needs.
+# nltk.download() isn't available here, so we fetch the archives directly.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("corpora", "stopwords")
+from nltk.tokenize import word_tokenize
+from nltk.corpus import stopwords
+from nltk.util import ngrams`}
+  initialCode={`review = "The plot was not good, but the acting was brilliant!"
+stop = set(stopwords.words("english"))
+
+# TOPIC pipeline: lowercase, drop punctuation, drop ALL stopwords.
+topic = [t.lower() for t in word_tokenize(review) if t.isalpha()]
+topic = [t for t in topic if t not in stop]
+print("TOPIC features (what is it about?):")
+print("  ", topic)
+
+# SENTIMENT pipeline: lowercase, drop punctuation, KEEP negation/contrast,
+# and add bigrams so 'not good' survives as a unit.
+keep = {"not", "no", "nor", "never", "but"}
+sent_stop = stop - keep
+sent = [t.lower() for t in word_tokenize(review) if t.isalpha()]
+sent = [t for t in sent if t not in sent_stop]
+sent_bigrams = list(ngrams(sent, 2))
+print("SENTIMENT features (how does it feel?):")
+print("  unigrams:", sent)
+print("  bigrams: ", sent_bigrams)
+`}
+/>
+
+Look at the difference. The topic pipeline threw away "not" and "but" — fine,
+because for "what is this review about?" the answer is "plot, acting". But the
+sentiment pipeline *kept* them and added the bigram `("not", "good")`, because
+for "how does the reviewer feel?" those words are everything. Same input,
+deliberately different preprocessing, because the tasks need different
+information preserved.
+
+<Callout type="danger" title="The cardinal sin: copy-pasting someone else's pipeline">
+The most common real-world NLP mistake is lifting a preprocessing snippet from
+a blog post — usually "lowercase, remove stopwords, stem" — and applying it to
+a task it was never meant for. That exact recipe is great for search and
+disastrous for sentiment. Always re-derive the pipeline from *your* task, even
+if the code looks boilerplate.
+</Callout>
+
+## How to actually decide: evaluate, do not guess
+
+The framework above gets you a strong starting point, but the honest answer to
+"should I remove stopwords here?" is often **try it both ways and measure on
+your task.** This is called an **ablation**: hold everything else fixed, toggle
+one step, and compare results on a metric you care about.
+
+```mermaid
+flowchart LR
+    A["Pick a metric<br/>tied to your task"] --> B["Run WITH the step"]
+    A --> C["Run WITHOUT the step"]
+    B --> D{"Which scores better<br/>on your data?"}
+    C --> D
+    D --> E["Keep the winning choice<br/>repeat for the next step"]
+```
+
+The key discipline is to change **one step at a time** so you can attribute any
+change in the result to that step. If you flip three options at once and the
+score moves, you have learned nothing about which one mattered. Disciplined,
+one-at-a-time evaluation turns pipeline design from superstition into
+engineering.
+
+<Callout type="tip" title="Defaults are a starting point, not an answer">
+Reasonable defaults for an unknown task: tokenize, lowercase, and *keep*
+stopwords until you have a reason to drop them (dropping is the riskier,
+information-destroying move). Then evaluate each additional step against your
+metric. Starting conservative and adding aggression only when it earns its keep
+is safer than starting aggressive and hoping.
+</Callout>
+
+<MultipleChoice
+  markdown={`What is the single most useful question to ask when deciding whether to apply
+a preprocessing step?
+
+- "Is this step in the most popular tutorial?"
+- [o] "Does the information this step adds or destroys matter to my specific task?"
+  > Every step changes the data — lowercasing destroys case, stopword removal destroys function words. The decision reduces to whether that changed information is noise or signal *for your task*. That question resolves most pipeline choices.
+- "Is this step the fastest to run?"
+- "Does this step reduce the number of tokens?"
+
+Match the step to whether the affected information is signal or noise for your task.`}
+/>
+
+## Your turn: a configurable, task-aware step
+
+The cleanest way to respect "it depends" in code is to make a step
+*configurable* and choose the setting per task. Implement a preprocessing
+function whose stopword removal can be turned off — so the *same* function
+serves both a topic pipeline (remove stopwords) and a sentiment pipeline (keep
+them).
+
+<ChallengeCard
+  adapter="python"
+  title="A pipeline with a task-aware switch"
+  category="pipeline design · trade-offs · configuration"
+  estimatedTime="~7 min"
+  instructions={`Write \`preprocess(text, remove_stopwords)\` that:
+
+1. Word-tokenizes \`text\`.
+2. Lowercases each token and keeps only alphabetic tokens.
+3. **If** \`remove_stopwords\` is \`True\`, also removes English stopwords;
+   if it is \`False\`, leaves all words in.
+
+This single switch lets the same function serve a topic pipeline
+(\`remove_stopwords=True\`) and a sentiment pipeline
+(\`remove_stopwords=False\`, so negations survive).
+
+Examples:
+
+- \`preprocess("This is NOT good", True)\` -> \`["good"]\`
+- \`preprocess("This is NOT good", False)\` -> \`["this", "is", "not", "good"]\``}
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("corpora", "stopwords")
+from nltk.tokenize import word_tokenize
+from nltk.corpus import stopwords
+stop = set(stopwords.words("english"))`}
+  initialCode={`def preprocess(text, remove_stopwords):
+    tokens = word_tokenize(text)
+    # lowercase + keep alphabetic
+    # then conditionally remove stopwords
+    return tokens
+
+print("topic    :", preprocess("This is NOT good", True))
+print("sentiment:", preprocess("This is NOT good", False))
+`}
+  solutionCode={`def preprocess(text, remove_stopwords):
+    tokens = [t.lower() for t in word_tokenize(text) if t.isalpha()]
+    if remove_stopwords:
+        tokens = [t for t in tokens if t not in stop]
+    return tokens
+
+print("topic    :", preprocess("This is NOT good", True))
+print("sentiment:", preprocess("This is NOT good", False))
+`}
+  tests={[
+    {
+      id: "remove_true",
+      name: "remove_stopwords=True drops stopwords",
+      description: "'This is NOT good' -> ['good']",
+      code: `out = preprocess("This is NOT good", True)
+assert out == ["good"], "Got: " + repr(out)`,
+    },
+    {
+      id: "remove_false_keeps_negation",
+      name: "remove_stopwords=False keeps negation",
+      description: "'This is NOT good' -> ['this','is','not','good']",
+      code: `out = preprocess("This is NOT good", False)
+assert out == ["this", "is", "not", "good"], "Got: " + repr(out)`,
+    },
+    {
+      id: "lowercased",
+      name: "Always lowercases and drops punctuation",
+      description: "Both modes lowercase and remove punctuation",
+      code: `out = preprocess("WOW, Amazing!", False)
+assert out == ["wow", "amazing"], "Got: " + repr(out)`,
+    },
+    {
+      id: "returns_list",
+      name: "Returns a list in both modes",
+      description: "preprocess returns a list",
+      code: `assert isinstance(preprocess("hello world", True), list)
+assert isinstance(preprocess("hello world", False), list)`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`Why is the "standard" recipe *lowercase → remove stopwords → stem* a poor
+default for **sentiment analysis**?
+
+- It is too slow for product reviews
+- [o] Stopword removal deletes negations like "not", and stemming/over-cleaning erodes the phrase-level cues sentiment depends on, so a negative review can look positive
+  > Sentiment lives in negation, contrast, and short phrases — exactly what that recipe destroys. The recipe suits search/topic tasks; for sentiment, keep negation and prefer bigrams over aggressive cleaning.
+- Stemming is not available in NLTK
+- Lowercasing is never allowed
+
+The classic recipe optimizes for the wrong information when the task is sentiment.`}
+/>
+
+<MultipleChoice
+  markdown={`For **authorship attribution** (deciding who wrote an anonymous text), how
+should you treat stopwords, and why?
+
+- Remove them, because they never carry useful information
+- [o] Keep them — an author's habitual use of function words ("the", "of", "that") is a distinctive fingerprint, so here the stopwords are the signal and content words are closer to noise
+  > Authorship attribution famously relies on stopword usage patterns, which are stable and hard to fake. This is the inverse of topic analysis, and a vivid example of why pipeline choices are task-specific.
+- Replace each stopword with a random word
+- Lowercase them but keep everything else uppercase
+
+What is noise for one task can be the entire signal for another.`}
+/>
+
+<MultipleChoice
+  markdown={`You want to know empirically whether removing stopwords helps your classifier.
+What is the disciplined way to find out?
+
+- Flip stopword removal, lemmatization, and n-grams all at once and see if the score changes
+- [o] Run an ablation: hold everything else fixed, toggle *only* stopword removal, and compare your task metric with vs. without — so any change is attributable to that one step
+  > Changing one step at a time (an ablation) isolates its effect. If you change several options simultaneously and the score moves, you cannot tell which step caused it. One-at-a-time evaluation turns guessing into measurement.
+- Ask which option is most popular online and use that
+- Always remove stopwords; measuring is unnecessary
+
+Isolating one variable at a time is how you actually learn what helps.`}
+/>
+
+<MultipleChoice
+  markdown={`A reasonable *conservative default* for a brand-new task you do not yet
+understand is to:
+
+- Apply every preprocessing step as aggressively as possible
+- [o] Tokenize, lowercase, and keep stopwords (avoid the information-destroying steps) until evaluation shows a step earns its place
+  > Removing information is the risky, irreversible move. Starting conservative — minimal destruction — and adding steps only when they measurably help is safer than starting aggressive and hoping nothing important was thrown away.
+- Skip tokenization to save time
+- Remove all words and keep only punctuation
+
+Start by destroying as little as possible, then add aggression only when it proves its worth.`}
+/>
+
+<MultipleChoice
+  markdown={`Which statement is the truest summary of preprocessing design?
+
+- There is one correct pipeline that works for every NLP task
+- [o] The right pipeline depends on the downstream task; each step trades information away or adds it, and good design matches those trades to what the task needs
+  > "It depends on the task" is not a cop-out — it is the core skill. Each step is a deliberate trade, and matching trades to task requirements is what designing a pipeline *means*.
+- Preprocessing never affects results, so any pipeline is fine
+- More preprocessing always produces better results
+
+No universal recipe exists; deliberate, task-driven choices do.`}
+/>
+
+You now know how to *choose* your steps. The last two pages turn clean tokens
+into something a model can consume — first by converting text into numeric
+**features** (bag-of-words), then by assembling everything into a working
+**rule-based sentiment classifier.**

--- a/content/learn/natural-language-processing-python/frequency-distributions.mdx
+++ b/content/learn/natural-language-processing-python/frequency-distributions.mdx
@@ -1,0 +1,432 @@
+---
+title: Word Frequencies and Lexical Diversity
+description: Once text is clean tokens, the first thing you measure is how often each word appears. NLTK's FreqDist, .most_common(), lexical diversity, hapaxes, and the long-tailed shape of language — plus why raw frequency alone is dominated by stopwords.
+---
+
+You now know how to turn a paragraph into a clean list of tokens. The
+simplest — and most useful — thing you can do with that list is *count*. How
+many words are there? How many *distinct* words? Which words appear most? How
+varied is the vocabulary? These basic statistics are the foundation of search
+ranking, keyword extraction, spam scoring, and a surprising amount of "text
+analytics".
+
+## Counting words with `FreqDist`
+
+You could count words with a plain `collections.Counter`, and that is exactly
+what is happening under the hood. NLTK wraps it in a `FreqDist` ("frequency
+distribution") that adds text-specific conveniences.
+
+```mermaid
+flowchart LR
+    A["Clean tokens:<br/>fox, dog, fox, run, fox, dog"] --> B["FreqDist<br/>(tally each word)"]
+    B --> C["Counts:<br/>fox=3, dog=2, run=1"]
+    C --> D["most_common(2):<br/>[('fox', 3), ('dog', 2)]"]
+```
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the tokenizer data this page needs. nltk.download()
+# isn't available in this environment, so we fetch the archives directly.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize
+from nltk.probability import FreqDist`}
+  initialCode={`text = """The fox runs. The dog runs too. The fox and the dog run together,
+and the fox is faster than the dog, but the dog is happier than the fox."""
+
+tokens = [t.lower() for t in word_tokenize(text) if t.isalpha()]
+fd = FreqDist(tokens)
+
+print("Total words (N):     ", fd.N())
+print("Distinct words:      ", len(fd))
+print("5 most common:       ", fd.most_common(5))
+print("Count of 'fox':      ", fd["fox"])
+print("Count of 'zebra':    ", fd["zebra"], "(absent words are 0, no error)")
+print("Relative freq 'the': ", round(fd.freq("the"), 3))
+`}
+/>
+
+A few `FreqDist` methods you will use constantly:
+
+- `fd.most_common(n)` — the `n` highest-frequency words as `(word, count)`
+  pairs, already sorted. The everyday workhorse.
+- `fd.N()` — the total number of word tokens (counting repeats).
+- `len(fd)` — the number of *distinct* words (the vocabulary size).
+- `fd["word"]` — the count of a word; missing words return `0` rather than
+  raising, because `FreqDist` is a `dict` subclass.
+- `fd.freq("word")` — the *relative* frequency, i.e. count divided by `N()`.
+
+<Callout type="info" title="FreqDist is just a smarter Counter">
+`FreqDist` subclasses `collections.Counter`, so everything you know about
+`Counter` works, and you can build one from any iterable of tokens. NLTK adds
+text-flavored helpers like `most_common`, `hapaxes`, `freq`, and plotting. If
+you ever do not have NLTK handy, `Counter(tokens).most_common(n)` gets you the
+same top-words list.
+</Callout>
+
+## Lexical diversity: how varied is the vocabulary?
+
+Two texts can have the same length but very different richness. A text that
+says "very very very good" uses four words but only two *distinct* ones. The
+ratio of distinct words to total words is called **lexical diversity**, and
+it is a quick, classic measure of how repetitive or varied a text is.
+
+$$\text{lexical diversity} = \frac{\text{number of distinct words}}{\text{total number of words}}$$
+
+A value near 1 means almost every word is unique (highly varied); a value
+near 0 means heavy repetition.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize`}
+  initialCode={`def lexical_diversity(tokens):
+    if not tokens:
+        return 0.0
+    return len(set(tokens)) / len(tokens)
+
+repetitive = word_tokenize("very very very good good good good")
+varied = word_tokenize("an unusually eclectic vocabulary brimming with novelty")
+
+print("Repetitive text diversity:", round(lexical_diversity(repetitive), 3))
+print("Varied text diversity:    ", round(lexical_diversity(varied), 3))
+`}
+/>
+
+The repetitive text scores low; the varied text scores near 1. Lexical
+diversity is used to compare writing styles, gauge reading level, flag
+machine-generated or spammy text (which often repeats), and track how an
+author's vocabulary changes across works.
+
+<Callout type="warn" title="Lexical diversity depends on length">
+Longer texts almost always have *lower* lexical diversity, because common
+words inevitably repeat as the text grows. This means you cannot fairly
+compare the raw diversity of a tweet to that of a novel. For honest
+comparisons, measure equal-length samples (or use length-corrected variants).
+The simple ratio is a great intuition-builder, not a length-proof metric.
+</Callout>
+
+## The long tail: language is lopsided
+
+If you sort words by frequency, you find a striking, universal pattern: a tiny
+number of words are extraordinarily common, and a huge number appear just
+once or twice. The single most frequent word ("the") often accounts for ~7%
+of all tokens by itself, and the "long tail" of rare words stretches on
+forever. (This regularity is known as **Zipf's law**.)
+
+Words that appear exactly once have their own name — **hapaxes** — and
+`FreqDist` will list them for you. Let us visualize the lopsidedness with a
+bar chart of the top words.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize
+from nltk.probability import FreqDist`}
+  initialCode={`import matplotlib.pyplot as plt
+
+text = """A search engine reads text and indexes the words in the text so that
+a user can search for words. When a user searches, the engine finds the text
+that best matches the words the user typed, ranking the best text first."""
+
+tokens = [t.lower() for t in word_tokenize(text) if t.isalpha()]
+fd = FreqDist(tokens)
+
+print("Words appearing exactly once (hapaxes):", fd.hapaxes())
+
+top = fd.most_common(8)
+labels = [w for w, c in top]
+counts = [c for w, c in top]
+
+plt.figure(figsize=(7, 3.5))
+plt.bar(labels, counts)
+plt.title("Top 8 words (notice how 'the' towers over the rest)")
+plt.ylabel("count")
+plt.xticks(rotation=45, ha="right")
+plt.tight_layout()
+plt.show()
+`}
+/>
+
+The bar for "the" dwarfs the others, and a pile of words appear only once.
+This shape repeats in essentially every natural-language text.
+
+## A catch: raw frequency is dominated by stopwords
+
+The long-tail shape leads directly to a practical problem. If you just ask
+"what are the most frequent words?", the answer is almost always the
+stopwords — "the", "a", "of" — which tell you *nothing* about the topic. The
+content words you actually care about are buried below them.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("corpora", "stopwords")
+from nltk.tokenize import word_tokenize
+from nltk.corpus import stopwords
+from nltk.probability import FreqDist`}
+  initialCode={`text = """A search engine reads text and indexes the words in the text so that
+a user can search for words. When a user searches, the engine finds the text
+that best matches the words the user typed, ranking the best text first."""
+
+tokens = [t.lower() for t in word_tokenize(text) if t.isalpha()]
+stop = set(stopwords.words("english"))
+
+print("Top 5 WITH stopwords:   ", FreqDist(tokens).most_common(5))
+
+content = [t for t in tokens if t not in stop]
+print("Top 5 WITHOUT stopwords:", FreqDist(content).most_common(5))
+`}
+/>
+
+With stopwords, the top words are "the", "a", "that" — useless for guessing
+the topic. Without them, "text", "words", "search", "user", and "engine" rise
+to the top — and you can immediately tell this passage is about search. This
+is *why* keyword extraction almost always removes stopwords first, and it is a
+concrete payoff of the choice you studied two pages ago.
+
+<Callout type="tip" title="Frequency is a starting point, not the finish line">
+"Most frequent equals most important" is a tempting but flawed heuristic. The
+most frequent words are usually the least informative (stopwords), and even
+among content words, a word common in *this* document but also common in
+*every* document is not very distinctive. The classic fix is to weight a word
+by how rare it is across documents — the idea behind **TF-IDF**. You do not
+need it yet, but file away that frequency alone over-rewards the commonplace.
+</Callout>
+
+<MultipleChoice
+  markdown={`You build a \`FreqDist\` over the raw tokens of a news article and ask for
+\`most_common(5)\`. The result is "the", "to", "of", "a", "and". Why is this
+unhelpful for figuring out the article's topic, and what is the usual fix?
+
+- The article has no topic; nothing can be done
+- [o] The most frequent words are stopwords that appear in nearly all text; removing stopwords first surfaces the content words that actually indicate the topic
+  > Language is long-tailed, so function words dominate raw counts. Filtering stopwords before counting lets topical content words rise to the top — which is exactly why keyword extraction removes them first.
+- \`FreqDist\` counted wrong; use \`Counter\` instead
+- You must lemmatize before any counting will work at all
+
+Raw frequency over-represents the commonplace; stopword removal is the standard first remedy.`}
+/>
+
+## Your turn: basic text statistics
+
+<ChallengeCard
+  adapter="python"
+  title="Compute diversity and the top words"
+  category="frequencies · FreqDist · lexical diversity"
+  estimatedTime="~6 min"
+  instructions={`Implement two functions over a list of tokens:
+
+1. \`lexical_diversity(tokens)\` — return the number of distinct tokens divided
+   by the total number of tokens, as a float. For an empty list, return
+   \`0.0\` (avoid dividing by zero).
+2. \`top_words(tokens, n)\` — return the \`n\` most common tokens as a list of
+   \`(word, count)\` pairs. Use \`FreqDist\` (already imported).
+
+For example, with \`tokens = ["a", "b", "a", "c", "a", "b"]\`,
+\`lexical_diversity(tokens)\` is \`0.5\` and \`top_words(tokens, 2)\` is
+\`[("a", 3), ("b", 2)]\`.`}
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import micropip
+await micropip.install("nltk")
+import nltk
+from nltk.probability import FreqDist`}
+  initialCode={`def lexical_diversity(tokens):
+    # distinct / total, or 0.0 if empty
+    return 0.0
+
+def top_words(tokens, n):
+    # use FreqDist(...).most_common(n)
+    return []
+
+sample = ["a", "b", "a", "c", "a", "b"]
+print("diversity:", lexical_diversity(sample))
+print("top 2:    ", top_words(sample, 2))
+`}
+  solutionCode={`def lexical_diversity(tokens):
+    if not tokens:
+        return 0.0
+    return len(set(tokens)) / len(tokens)
+
+def top_words(tokens, n):
+    return FreqDist(tokens).most_common(n)
+
+sample = ["a", "b", "a", "c", "a", "b"]
+print("diversity:", lexical_diversity(sample))
+print("top 2:    ", top_words(sample, 2))
+`}
+  tests={[
+    {
+      id: "diversity_basic",
+      name: "Lexical diversity is correct",
+      description: "3 distinct of 6 total -> 0.5",
+      code: `import math
+assert math.isclose(lexical_diversity(["a","b","a","c","a","b"]), 0.5), \
+    "Got: " + repr(lexical_diversity(["a","b","a","c","a","b"]))`,
+    },
+    {
+      id: "diversity_empty",
+      name: "Empty input returns 0.0 (no ZeroDivisionError)",
+      description: "Guard against dividing by zero",
+      code: `assert lexical_diversity([]) == 0.0, "Empty list should give 0.0"`,
+    },
+    {
+      id: "top_words_order",
+      name: "top_words returns sorted (word, count) pairs",
+      description: "Most common first",
+      code: `assert top_words(["a","b","a","c","a","b"], 2) == [("a", 3), ("b", 2)], \
+    "Got: " + repr(top_words(["a","b","a","c","a","b"], 2))`,
+    },
+    {
+      id: "top_words_n",
+      name: "Respects the count n",
+      description: "Asking for 1 returns exactly one pair",
+      code: `out = top_words(["x","y","x","z","x"], 1)
+assert out == [("x", 3)], "Got: " + repr(out)`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`What does \`fd.most_common(3)\` return for a \`FreqDist\` \`fd\`?
+
+- The three rarest words in the text
+- [o] The three highest-frequency items as \`(word, count)\` pairs, sorted from most to least frequent
+  > \`most_common(n)\` gives the top \`n\` entries by count, already ordered, as tuples. It is the standard way to pull "top words" out of a frequency distribution.
+- A random sample of three words
+- The first three words in the original text
+
+It returns the most frequent items, as ordered (word, count) tuples.`}
+/>
+
+<MultipleChoice
+  markdown={`A text of 100 tokens contains 40 distinct words. What is its lexical
+diversity, and what does that number mean?
+
+- 100 / 40 = 2.5; the text is highly varied
+- [o] 40 / 100 = 0.4; on average each distinct word is used about 2.5 times, indicating moderate repetition
+  > Lexical diversity is distinct ÷ total = 0.4. Lower values mean more repetition. (Equivalently, total ÷ distinct = 2.5 average uses per word.) The metric ranges from near 0, very repetitive, to near 1, every word unique.
+- 0.4; the text is completely unique with no repeats
+- It cannot be computed without removing stopwords
+
+Distinct over total is 0.4 here, signaling fairly repetitive text.`}
+/>
+
+<MultipleChoice
+  markdown={`Language follows a long-tailed (Zipfian) frequency pattern. Which statement
+captures a practical consequence?
+
+- Every word in a text appears roughly the same number of times
+- [o] A handful of words (mostly stopwords) account for a large share of all tokens, while a great many words appear only once or twice — so raw frequency is dominated by uninformative words
+  > The lopsided distribution means top-by-count is mostly function words, and the informative content sits in the long tail. This is why we remove stopwords and why frequency alone is a weak importance signal.
+- Rare words are always more frequent than common words
+- Frequency counts are impossible to compute for real text
+
+The lopsidedness explains both stopword dominance and the need for smarter weighting than raw counts.`}
+/>
+
+<MultipleChoice
+  markdown={`What is a **hapax** (as in \`fd.hapaxes()\`)?
+
+- A word that appears in every document
+- [o] A word that appears exactly once in the text
+  > "Hapax" (from "hapax legomenon") means a word occurring a single time. \`FreqDist.hapaxes()\` returns them. They make up a large fraction of the vocabulary in most texts — the far end of the long tail.
+- The most frequent word in the text
+- A punctuation token
+
+Hapaxes are the once-only words — abundant, and a hallmark of the long tail.`}
+/>
+
+You can now measure *which* words appear and how often. But counts treat every
+word as an isolated atom — they have no idea that "book" can be a noun or a
+verb. To capture that, we need to know each word's role in the sentence:
+**part-of-speech tagging**, next.

--- a/content/learn/natural-language-processing-python/index.mdx
+++ b/content/learn/natural-language-processing-python/index.mdx
@@ -1,0 +1,211 @@
+---
+title: Welcome
+description: A foundations-first tour of classic Natural Language Processing with Python and NLTK — built around intuition, trade-offs, and the reasoning behind every step in a text pipeline.
+---
+
+Welcome to **Natural Language Processing with Python**. This course is for
+the person who can already write Python — strings, lists, loops,
+dictionaries, a comprehension or two, maybe a regular expression — and who
+keeps hearing the phrase "natural language processing" and wants to
+understand what it *actually is*, not just which function to call.
+
+Human language is gloriously messy. The word "lead" can be a metal or a
+verb. "New York" is two words but one thing. "don't" hides the word "not"
+inside a contraction. A period sometimes ends a sentence and sometimes ends
+"Dr." Computers are superb at exact, regular data and hopeless at the
+ambiguous, irregular, context-soaked data that is ordinary text. NLP is the
+collection of techniques we use to bridge that gap — to turn a paragraph a
+human wrote into something a program can count, compare, and reason about.
+
+This is not an API reference. You can always look up the arguments to
+`word_tokenize`. What you cannot google in the moment is **judgment**:
+whether you should lowercase your text, whether removing stopwords will help
+or quietly destroy your meaning, whether stemming is good enough or you need
+lemmatization. That judgment is the real subject of this course.
+
+<Callout type="info" title="No setup required">
+Every code block on every page runs a full Python environment right here, in
+this page. There is nothing to install — no Python, no NLTK, no data
+packages. Edit the code, press **Run**, and the output appears beneath the
+editor. The challenge cards work the same way: write a solution, press
+**Check Answer**, and see which tests pass. Each interactive block quietly
+loads the NLTK data it needs in a collapsed, read-only setup section so you
+can focus entirely on the NLP code.
+</Callout>
+
+## Who this course is for
+
+You will feel at home here if most of these describe you:
+
+- You are comfortable writing Python: functions, loops, lists, dictionaries,
+  list comprehensions.
+- You know basic string methods: `strip`, `split`, `lower`, `replace`.
+- You have seen the `re` module and understand what a regular expression is,
+  even if you reach for a cheat sheet.
+
+You do **not** need:
+
+- Any prior NLP or linguistics background.
+- Any machine learning experience.
+- Statistics or heavy mathematics.
+
+<Callout type="warn" title="This is a foundations course, on purpose">
+We focus on the classic, transparent toolkit of NLP — tokenization,
+normalization, stopwords, stemming, lemmatization, frequency analysis,
+part-of-speech tagging, and n-grams — all through **NLTK**, the Natural
+Language Toolkit. We deliberately **do not** cover deep learning,
+transformers, BERT, GPT, attention, or word embeddings beyond the occasional
+concept. Those are wonderful topics, but they make far more sense once the
+fundamentals below are second nature. Master how text actually flows through
+a pipeline first, and the modern tools become much easier to learn.
+</Callout>
+
+## What you will be able to do
+
+By the end you will be able to:
+
+- Explain *why* raw text is hard for computers, in terms of ambiguity and
+  structure.
+- Break text into sentences and words correctly — and explain why
+  `text.split()` is not tokenization.
+- Normalize text (case folding, punctuation stripping) and reason about what
+  that normalization throws away.
+- Decide *whether* to remove stopwords — and recognize the tasks where
+  removing them is a serious mistake.
+- Choose between **stemming** and **lemmatization** and justify the choice.
+- Measure a text with frequency distributions and lexical diversity.
+- Tag words with their part of speech and use those tags downstream.
+- Capture local word order with **bigrams** and **trigrams**.
+- Turn documents into features (bag-of-words) and build a small, transparent
+  **rule-based sentiment classifier** from scratch.
+
+## How the course is organized
+
+```mermaid
+flowchart TD
+    A["Foundations<br/>what NLP is, the pipeline"] --> B["Tokenization and Normalization<br/>split text, fold case, strip noise"]
+    B --> C["Counting and Structure<br/>frequencies, POS tags, n-grams"]
+    C --> D["Putting It Together<br/>choosing a pipeline, features, a classifier"]
+```
+
+Notice that **tokenization and normalization** come first and everything
+else builds on them. That ordering is intentional. Almost every mistake in a
+text pipeline is really a tokenization or normalization mistake that
+propagated downstream. We establish those habits early and return to them on
+nearly every page.
+
+## A taste of what is coming
+
+Here is a complete, classic NLP pipeline. It takes a short paragraph and runs
+it through the whole journey of this course: split into words, normalize,
+drop stopwords, reduce to dictionary roots, and count what is left. Press
+**Run** — and then open the collapsed setup section above the editor if you
+are curious what is being loaded for you.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads just the data this page needs. nltk.download()
+# isn't available in this environment, so we fetch the data archives
+# directly and unpack them into NLTK's data directory.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("corpora", "stopwords")
+await _load_nltk("corpora", "wordnet")
+from nltk.tokenize import word_tokenize
+from nltk.corpus import stopwords
+from nltk.stem import WordNetLemmatizer`}
+  initialCode={`text = (
+    "Natural language processing lets computers work with human language. "
+    "It powers the search bars, spam filters, and assistants you use daily."
+)
+
+# 1. TOKENIZE: split the text into individual words and punctuation.
+tokens = word_tokenize(text)
+
+# 2. NORMALIZE: lowercase, and keep only alphabetic tokens (drop punctuation).
+words = [t.lower() for t in tokens if t.isalpha()]
+
+# 3. REMOVE STOPWORDS: drop ultra-common words that carry little meaning.
+stop = set(stopwords.words("english"))
+content = [w for w in words if w not in stop]
+
+# 4. LEMMATIZE: reduce words to their dictionary form.
+lemmatizer = WordNetLemmatizer()
+lemmas = [lemmatizer.lemmatize(w) for w in content]
+
+print("Tokens:  ", tokens)
+print("Content: ", content)
+print("Lemmas:  ", lemmas)
+`}
+/>
+
+Five short steps, and a result a program can actually work with. You do not
+yet need to understand every line — that is what the next pages are for. But
+notice the *shape* already: **tokenize, normalize, filter, reduce, count.**
+That shape barely changes from project to project. Every technique in this
+course is a way to do one of those steps better, or a reason to skip one of
+them on purpose.
+
+## How the interactive widgets work
+
+You will meet three kinds of widget:
+
+1. **Executable code blocks** — like the one above. Edit and re-run them as
+   much as you like; experimentation is the entire point.
+2. **Challenge cards** — small problems with hidden tests. You write the
+   solution and press **Check Answer** to see which tests pass.
+3. **Multiple-choice questions** — quick conceptual checks with an
+   explanation for *every* option, right or wrong.
+
+<Callout type="info" title="Each code block starts fresh">
+Variables you define in one code block are **not** carried into the next one,
+even on the same page. When a block needs setup from an earlier one, we
+either repeat it or provide it for you in the read-only setup section. This
+keeps every example self-contained and re-runnable in any order. The first
+run on a page does a little loading; after that, runs are quick.
+</Callout>
+
+## A note on philosophy
+
+Most NLP tutorials are a parade of function calls: tokenize, stem, remove
+stopwords, admire the output, move on. You finish with a vocabulary but no
+understanding, and the first time your results look strange you have no idea
+why.
+
+We take the slower, more durable path. For every step in the pipeline we ask
+the same questions: **What ambiguity or structural problem does this solve?
+Why does it exist? When should you reach for it — and when should you
+absolutely not? What do people get wrong about it? Where does it show up in
+the real world?** Tools only make sense once you understand the job they
+were built for.
+
+<Callout type="tip" title="How to use this course">
+Run every code block. Then change something — the input text, a rule, the
+order of two steps — and predict what will happen before you press **Run**
+again. The gap between what you expected and what you got is exactly where
+the learning happens.
+</Callout>
+
+Let us start at the very beginning: what makes human text so hard for a
+computer in the first place?

--- a/content/learn/natural-language-processing-python/meta.json
+++ b/content/learn/natural-language-processing-python/meta.json
@@ -1,0 +1,25 @@
+{
+    "title": "Natural Language Processing with Python",
+    "description": "A foundations-first course on classic NLP with NLTK — tokenization, normalization, stopwords, stemming, lemmatization, frequency analysis, POS tagging, and n-grams. Built around intuition: what each preprocessing step solves, when to use it, and when it quietly hurts you. For learners comfortable with Python strings, lists, loops, and basic regular expressions.",
+    "root": true,
+    "pages": [
+        "index",
+        "---Foundations---",
+        "what-is-nlp",
+        "the-nlp-pipeline",
+        "---Tokenization & Normalization---",
+        "tokenization",
+        "text-normalization",
+        "stopwords",
+        "stemming-and-lemmatization",
+        "---Counting & Structure---",
+        "frequency-distributions",
+        "pos-tagging",
+        "ngrams",
+        "---Putting It Together---",
+        "choosing-your-pipeline",
+        "bag-of-words",
+        "rule-based-sentiment",
+        "next-steps"
+    ]
+}

--- a/content/learn/natural-language-processing-python/next-steps.mdx
+++ b/content/learn/natural-language-processing-python/next-steps.mdx
@@ -1,0 +1,135 @@
+---
+title: Where to Go Next
+description: A recap of the classic NLP pipeline you now command, and a map of where to go from here — machine-learning text classification, modern toolkits, embeddings, and transformers — all built on the foundations you just learned.
+---
+
+You started this course with a flat string of characters and the vague sense
+that human language is "hard for computers." You are finishing it able to walk
+any paragraph through a complete, deliberate pipeline — and, more importantly,
+able to *explain every choice along the way.* That is real, durable
+understanding, and it is the part of NLP that does not go out of date.
+
+## What you can now do
+
+Look back at the journey. Each stage is something you can now reason about, not
+just run.
+
+```mermaid
+flowchart LR
+    A["Raw text"] --> B["Tokenize<br/>(words, sentences)"]
+    B --> C["Normalize<br/>(case, punctuation)"]
+    C --> D["Filter / reduce<br/>(stopwords, stem, lemmatize)"]
+    D --> E["Analyze<br/>(frequencies, POS, n-grams)"]
+    E --> F["Features<br/>(bag-of-words)"]
+    F --> G["Decision<br/>(classify)"]
+```
+
+Concretely, you can now:
+
+- Explain **why** raw text is hard — ambiguity and missing structure — and what
+  a pipeline is for.
+- **Tokenize** into words and sentences, and articulate why `.split()` is not
+  tokenization.
+- **Normalize** with case folding and punctuation stripping, while naming what
+  each step throws away.
+- Decide **whether** to remove stopwords — and recognize the negation trap that
+  makes it dangerous for sentiment.
+- Choose between **stemming** and **lemmatization**, and lemmatize accurately
+  using POS tags.
+- Measure text with **frequency distributions** and **lexical diversity**.
+- Capture local order with **bigrams and trigrams**, and explain the sparsity
+  trade-off.
+- Turn documents into **bag-of-words features**.
+- Assemble all of it into a working, explainable **sentiment classifier**.
+
+<Callout type="success" title="The most important takeaway">
+It is not any single function — it is the judgment to *design a pipeline for a
+task*. You learned that there is no universal recipe, that every step trades
+information away or adds it, and that matching those trades to the job is the
+real skill. That judgment transfers to every NLP tool you will ever use.
+</Callout>
+
+## From rules to learning: machine-learning text classification
+
+Your rule-based sentiment classifier used a hand-written lexicon. The natural
+next step is to let a model **learn** word sentiment (and much more) from
+labeled examples. The classic recipe is wonderfully close to what you already
+know: take your **bag-of-words** (or TF-IDF-weighted) features and feed them to
+a simple classifier like Naive Bayes or logistic regression.
+
+- **TF-IDF** is the upgrade to raw counts we flagged on the frequencies page:
+  it down-weights words that are common across *all* documents and up-weights
+  the distinctive ones, so "the" stops dominating and topical words shine.
+- **Naive Bayes** and **logistic regression** are the workhorse text
+  classifiers — fast, strong baselines that consume exactly the kind of feature
+  vectors you built by hand.
+
+If you want to take this step, the [Machine Learning with
+scikit-learn](/learn/machine-learning-scikit-learn) course picks up right here,
+with train/test discipline, model evaluation, and the reasoning behind each
+algorithm. Everything you learned about preprocessing feeds directly into it.
+
+<Callout type="info" title="Your foundations do not disappear">
+Every modern approach — TF-IDF models, spaCy pipelines, even giant
+transformers — still **tokenizes and normalizes text** as a first step. The
+specifics differ (transformers use subword tokenization, for instance), but the
+*concepts* are the ones you just learned. You are not starting over; you are
+adding floors to a foundation you already poured.
+</Callout>
+
+## Modern toolkits and topics to explore
+
+When you are ready to broaden out, here is the lay of the land — and how it
+connects back to what you know.
+
+- **spaCy** — a fast, production-oriented library that does tokenization, POS
+  tagging, lemmatization, and named-entity recognition out of the box. It makes
+  different speed/accuracy trade-offs than NLTK, but every concept maps onto a
+  page from this course.
+- **Named-entity recognition (NER)** — pulling people, places, and
+  organizations out of text. It builds directly on POS tagging and the
+  capitalization signal you learned not to throw away.
+- **Topic modeling (e.g., LDA)** — discovering the themes that run through a
+  collection of documents, built on the bag-of-words representation you now
+  understand.
+- **Word embeddings (Word2Vec, GloVe)** — the conceptual fix for bag-of-words'
+  blindness to meaning: they place similar words near each other in a numeric
+  space, so "great" and "excellent" are close rather than unrelated.
+- **Transformers (BERT, GPT)** — the deep-learning models behind modern
+  assistants and translators. They are powerful and complex, and they make far
+  more sense *after* you understand tokens, normalization, and why text needs
+  structure — which is exactly what you now have.
+
+<Callout type="tip" title="A piece of advice as you go further">
+Resist the urge to jump straight to the most powerful model. The discipline you
+practiced here — *ask what the task needs, choose steps deliberately, evaluate
+one change at a time, prefer the simplest thing that works* — matters even more
+as the tools get more powerful and more opaque. A transparent baseline you
+understand beats a black box you do not.
+</Callout>
+
+## Keep practicing
+
+The fastest way to cement these skills is to use them on text you care about.
+Grab a few product reviews, a chunk of an article, your own writing — and run it
+through the pipeline. Tokenize it. Look at its frequency distribution. Tag its
+parts of speech. Pull out its bigrams. Score its sentiment with the classifier
+you built. Then change a preprocessing choice and watch what happens.
+
+If you want adjacent foundations, these Dataslope courses pair naturally with
+this one:
+
+- [Machine Learning with scikit-learn](/learn/machine-learning-scikit-learn) —
+  the natural next step: learn classifiers from labeled text features.
+- [Data Analysis with Python Pandas](/learn/data-analysis-python-pandas) — for
+  wrangling and summarizing the tabular results your pipelines produce.
+- [Statistics for Data Science with Python](/learn/statistics-for-data-science-python)
+  — for reasoning carefully about the counts and distributions you measure.
+
+<Callout type="success" title="Well done">
+You have built a genuine, working understanding of how text becomes something a
+computer can reason about — from a raw string all the way to a classified
+verdict, with sound judgment at every step. That foundation will serve you
+across the entire field of natural language processing. Go build something with
+it.
+</Callout>

--- a/content/learn/natural-language-processing-python/ngrams.mdx
+++ b/content/learn/natural-language-processing-python/ngrams.mdx
@@ -1,0 +1,403 @@
+---
+title: "N-grams: Bigrams and Trigrams"
+description: Single tokens throw away word order, but meaning often lives in word combinations. N-grams capture local context by sliding a window over the tokens. Generating bigrams and trigrams with nltk.util.ngrams, counting phrases, and the sparsity trade-off as n grows.
+---
+
+Every analysis step so far has a quiet blind spot: it treats words
+*individually*. A bag of words knows the document contains "not" and "good"
+but has no idea they sat next to each other as "not good". It sees "New" and
+"York" but not "New York". **Word order carries meaning**, and to capture even
+a little of it we use **n-grams**.
+
+An **n-gram** is a contiguous sequence of `n` tokens. A 1-gram (**unigram**)
+is a single word. A 2-gram (**bigram**) is a pair of adjacent words. A 3-gram
+(**trigram**) is a run of three. By looking at adjacent groups instead of lone
+words, n-grams capture local context that single tokens lose.
+
+## The sliding window
+
+The mental image is a window of width `n` that slides along the token list one
+step at a time. Each position is one n-gram, and consecutive windows
+**overlap**.
+
+```mermaid
+flowchart TB
+    S["Tokens: the / quick / brown / fox"]
+    S --> B1["window 1: (the, quick)"]
+    S --> B2["window 2: (quick, brown)"]
+    S --> B3["window 3: (brown, fox)"]
+```
+
+Notice the overlap: "quick" appears in both window 1 and window 2. That is
+deliberate — overlapping windows ensure every adjacent pair is captured. For a
+list of `k` tokens there are `k - n + 1` n-grams (here, `4 - 2 + 1 = 3`
+bigrams).
+
+## Generating n-grams with `nltk.util.ngrams`
+
+NLTK gives you `ngrams(tokens, n)`, which yields the windows as tuples. It
+returns a generator, so wrap it in `list(...)` to see or reuse the results.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the tokenizer data this page needs. nltk.download()
+# isn't available here, so we fetch the archives directly.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize
+from nltk.util import ngrams`}
+  initialCode={`tokens = [t.lower() for t in word_tokenize("The quick brown fox jumps")
+          if t.isalpha()]
+print("tokens:", tokens)
+print()
+
+bigrams = list(ngrams(tokens, 2))
+trigrams = list(ngrams(tokens, 3))
+
+print("bigrams (n=2): ", bigrams)
+print("trigrams (n=3):", trigrams)
+print()
+print(f"{len(tokens)} tokens -> {len(bigrams)} bigrams, {len(trigrams)} trigrams")
+`}
+/>
+
+Each bigram is a 2-tuple of adjacent words; each trigram is a 3-tuple. The
+counts match the formula: 5 tokens give `5 - 2 + 1 = 4` bigrams and
+`5 - 3 + 1 = 3` trigrams.
+
+<Callout type="info" title="Several ways to the same n-grams">
+`nltk.util.ngrams(tokens, n)` is the general tool — pass any `n`. NLTK also
+offers the convenience shortcuts `nltk.bigrams(tokens)` and
+`nltk.trigrams(tokens)` for the two most common cases. All three return
+generators of tuples, so wrap them in `list()` to materialize them. We use
+`ngrams(tokens, n)` here because it makes the role of `n` explicit.
+</Callout>
+
+## Why n-grams matter: order is meaning
+
+Two quick demonstrations of what unigrams miss and bigrams catch.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize
+from nltk.util import ngrams`}
+  initialCode={`a = [t.lower() for t in word_tokenize("the food was not good")]
+b = [t.lower() for t in word_tokenize("the food was good")]
+
+# As a SET of single words, the only difference is the lone word 'not'.
+print("Unigram sets differ only by:", set(a) ^ set(b))
+
+# As BIGRAMS, the telling pair 'not good' appears in one and not the other.
+print("Bigrams of a:", list(ngrams(a, 2)))
+print("'not good' in a?", ("not", "good") in list(ngrams(a, 2)))
+print("'not good' in b?", ("not", "good") in list(ngrams(b, 2)))
+`}
+/>
+
+The bigram `("not", "good")` is a concrete, countable feature that a sentiment
+model can learn is negative — something no single-word feature can express.
+This is one of the simplest, most effective upgrades to a bag-of-words model:
+add bigrams so that negations and key phrases survive.
+
+## Counting n-grams reveals phrases
+
+Counting n-grams (with `FreqDist` or `Counter`, just like words) surfaces the
+common *phrases* in a text — the building blocks of autocomplete, phrase
+search, and collocation discovery.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize
+from nltk.util import ngrams
+from nltk.probability import FreqDist`}
+  initialCode={`text = """machine learning is fun. machine learning is powerful.
+i love machine learning and natural language processing."""
+
+tokens = [t.lower() for t in word_tokenize(text) if t.isalpha()]
+bigram_counts = FreqDist(ngrams(tokens, 2))
+
+print("Most common bigrams:")
+for pair, count in bigram_counts.most_common(3):
+    print(f"  {pair}  x{count}")
+`}
+/>
+
+"machine learning" rises to the top as the most frequent bigram — the counter
+discovered a meaningful two-word phrase purely from co-occurrence. This is the
+seed of **collocation** detection (finding word pairs that go together more
+than chance would predict) and of **next-word prediction**: given "machine",
+the data suggests "learning" is a likely follow-up.
+
+<Callout type="tip" title="N-grams are the intuition behind autocomplete">
+When your phone suggests the next word, a classic approach is an n-gram
+*language model*: count which word most often follows the previous one or two
+words, and suggest that. "United" is often followed by "States"; "machine" by
+"learning". You are not building a full language model here, but you now see
+its core mechanism — counting n-grams — with your own eyes.
+</Callout>
+
+## The trade-off: bigger n is not better
+
+It is tempting to think "if bigrams help, 5-grams must help more." They
+usually do not. As `n` grows, each specific n-gram becomes rarer, until almost
+every one appears just once and counting them tells you nothing. This is the
+**sparsity** problem.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize
+from nltk.util import ngrams
+from nltk.probability import FreqDist`}
+  initialCode={`text = """the cat sat on the mat. the dog sat on the log.
+the cat sat on the log. the dog sat on the mat."""
+tokens = [t.lower() for t in word_tokenize(text) if t.isalpha()]
+
+for n in [1, 2, 3, 4]:
+    grams = list(ngrams(tokens, n))
+    fd = FreqDist(grams)
+    distinct = len(fd)
+    repeated = sum(1 for g, c in fd.items() if c > 1)
+    print(f"n={n}: {len(grams):2} {n}-grams, {distinct:2} distinct, "
+          f"{repeated:2} that repeat")
+`}
+/>
+
+Watch the "that repeat" column collapse as `n` grows. At `n=1` and `n=2` many
+n-grams recur, so counts are meaningful. By `n=4` almost every window is
+unique — there is no pattern left to count. In practice, **bigrams and
+trigrams are the sweet spot**: enough context to be useful, common enough to
+still carry statistical signal. Going higher usually buys sparsity, a
+ballooning feature space, and little else.
+
+<Callout type="warn" title="Two costs of large n">
+**Sparsity:** rare n-grams give unreliable counts. **Explosion:** the number
+of possible n-grams grows astronomically with `n`, so your feature space and
+memory blow up while most entries are zero. Both push you toward small `n`.
+Reach past trigrams only with a specific reason and a lot of data.
+</Callout>
+
+<MultipleChoice
+  markdown={`Why does adding the bigram \`("not", "good")\` help a sentiment model that
+single words could not?
+
+- Bigrams are faster to compute than single words
+- [o] A lone "not" and a lone "good" do not capture that they were adjacent; the bigram preserves the local order so the model can learn that "not good" is negative
+  > Single-word features discard order, so "not" and "good" look independent. The bigram is a concrete feature encoding their adjacency, letting the model associate the *phrase* with negative sentiment. Capturing local order is exactly what n-grams add.
+- Bigrams remove stopwords automatically
+- Bigrams translate the text into another language
+
+N-grams reintroduce the local word order that a bag of single words throws away.`}
+/>
+
+## Your turn: generate n-grams
+
+<ChallengeCard
+  adapter="python"
+  title="Build bigrams and trigrams"
+  category="n-grams · nltk.util.ngrams · word order"
+  estimatedTime="~6 min"
+  instructions={`Write a function \`get_ngrams(tokens, n)\` that returns a **list** of all
+n-grams of \`tokens\`, where each n-gram is a tuple of \`n\` adjacent tokens. Use
+\`ngrams\` from \`nltk.util\` (already imported) and remember it returns a
+generator, so wrap it in \`list(...)\`.
+
+For example:
+
+- \`get_ngrams(["a", "b", "c", "d"], 2)\` -> \`[("a","b"), ("b","c"), ("c","d")]\`
+- \`get_ngrams(["a", "b", "c", "d"], 3)\` -> \`[("a","b","c"), ("b","c","d")]\``}
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import micropip
+await micropip.install("nltk")
+import nltk
+from nltk.util import ngrams`}
+  initialCode={`def get_ngrams(tokens, n):
+    # return a list of n-gram tuples
+    return []
+
+print(get_ngrams(["a", "b", "c", "d"], 2))
+print(get_ngrams(["a", "b", "c", "d"], 3))
+`}
+  solutionCode={`def get_ngrams(tokens, n):
+    return list(ngrams(tokens, n))
+
+print(get_ngrams(["a", "b", "c", "d"], 2))
+print(get_ngrams(["a", "b", "c", "d"], 3))
+`}
+  tests={[
+    {
+      id: "bigrams",
+      name: "Produces correct bigrams",
+      description: "n=2 over 4 tokens -> 3 adjacent pairs",
+      code: `out = get_ngrams(["a", "b", "c", "d"], 2)
+assert out == [("a","b"), ("b","c"), ("c","d")], "Got: " + repr(out)`,
+    },
+    {
+      id: "trigrams",
+      name: "Produces correct trigrams",
+      description: "n=3 over 4 tokens -> 2 adjacent triples",
+      code: `out = get_ngrams(["a", "b", "c", "d"], 3)
+assert out == [("a","b","c"), ("b","c","d")], "Got: " + repr(out)`,
+    },
+    {
+      id: "is_list",
+      name: "Returns a list, not a generator",
+      description: "The generator must be materialized with list()",
+      code: `out = get_ngrams(["x", "y", "z"], 2)
+assert isinstance(out, list), "Expected a list; did you wrap ngrams(...) in list()?"`,
+    },
+    {
+      id: "count_formula",
+      name: "Count matches k - n + 1",
+      description: "10 tokens, n=2 -> 9 bigrams",
+      code: `out = get_ngrams(list("abcdefghij"), 2)
+assert len(out) == 9, "Expected 9 bigrams from 10 tokens; got " + str(len(out))`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`A **trigram** is:
+
+- A word that appears exactly three times
+- [o] A contiguous sequence of three adjacent tokens
+  > An n-gram is \`n\` adjacent tokens; a trigram is the \`n = 3\` case — three words in a row, captured as a 3-tuple. It is about adjacency, not frequency.
+- The three most common words in a text
+- A sentence with three words
+
+N-grams are defined by their length \`n\`, and a trigram has length three.`}
+/>
+
+<MultipleChoice
+  markdown={`A token list has 12 tokens. How many bigrams does it produce?
+
+- 12
+- [o] 11
+  > The number of n-grams is \`k - n + 1\`. For \`k = 12\` tokens and \`n = 2\`, that is \`12 - 2 + 1 = 11\`. Each window of width 2 slides one step, and the last window starts at the 11th token.
+- 6
+- 24
+
+Sliding a width-2 window over 12 tokens lands in 11 positions.`}
+/>
+
+<MultipleChoice
+  markdown={`Why are bigrams and trigrams usually preferred over much larger n-grams
+(say, 6-grams)?
+
+- Larger n-grams are illegal in NLTK
+- [o] As n grows, specific n-grams become increasingly rare (sparse) and the feature space explodes, so large n-grams carry little statistical signal while costing a lot of memory
+  > Long n-grams almost always appear once, so counts stop being informative, and the number of possible n-grams grows enormously. Bigrams and trigrams balance useful context against sparsity — the practical sweet spot.
+- Larger n-grams are always slower to type
+- Bigrams capture the entire meaning of any document
+
+Sparsity and explosion are the twin reasons to keep n small.`}
+/>
+
+<MultipleChoice
+  markdown={`\`nltk.util.ngrams(tokens, n)\` returns a generator. What must you do to get a
+reusable list of tuples you can index and count?
+
+- Nothing; a generator already behaves like a list
+- [o] Wrap it in \`list(...)\`, e.g. \`list(ngrams(tokens, n))\`, to materialize the n-grams into a list
+  > Generators are consumed once and cannot be indexed. Wrapping in \`list()\` materializes the n-grams so you can index them, count them, or iterate more than once.
+- Convert it to a string with \`str(...)\`
+- Call \`.sort()\` on the generator
+
+Materializing with \`list()\` is the standard step before reusing or counting n-grams.`}
+/>
+
+You have now met every classic building block: tokens, normalized tokens,
+filtered tokens, roots, counts, tags, and n-grams. The final section puts them
+to work — starting with the most important skill of all: **choosing which of
+these steps your task actually needs.**

--- a/content/learn/natural-language-processing-python/pos-tagging.mdx
+++ b/content/learn/natural-language-processing-python/pos-tagging.mdx
@@ -1,0 +1,456 @@
+---
+title: "Part-of-Speech (POS) Tagging"
+description: Labeling each word with its grammatical role — noun, verb, adjective — using NLTK's pos_tag. Why context decides the tag, the Penn Treebank tagset, building syntactic patterns, and using POS tags to lemmatize accurately.
+---
+
+So far every step has treated words as interchangeable atoms: a token is a
+token, counted and filtered without regard to its *role* in the sentence. But
+the same word can play different roles. In "I caught a **fish**", "fish" is a
+noun. In "We **fish** every weekend", "fish" is a verb. To a frequency counter
+these are identical; grammatically they could not be more different.
+
+**Part-of-speech (POS) tagging** assigns each word its grammatical category —
+noun, verb, adjective, adverb, and so on. It is the first step that pays
+attention to *syntax* rather than just the word's spelling, and it unlocks a
+lot: better lemmatization, extracting "all the nouns", recognizing names, and
+finding grammatical patterns.
+
+## The problem POS tagging solves: words wear many hats
+
+A word's category depends on **context**, not just the word itself. This is
+why POS tagging cannot be a simple dictionary lookup — the same spelling needs
+different tags in different sentences.
+
+```mermaid
+flowchart LR
+    A["'I caught a fish'"] --> A1["fish -> NN<br/>(noun)"]
+    B["'We fish on weekends'"] --> B1["fish -> VBP<br/>(verb)"]
+```
+
+A tagger must read the surrounding words to decide. NLTK's default tagger,
+the **averaged perceptron tagger**, does exactly that: it was trained on a
+large hand-tagged corpus and predicts each word's tag from features of the
+word and its neighbors. Let us watch it disambiguate "fish".
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the tokenizer and the part-of-speech tagger model.
+# nltk.download() isn't available here, so we fetch the archives directly.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("taggers", "averaged_perceptron_tagger_eng")
+from nltk import pos_tag
+from nltk.tokenize import word_tokenize`}
+  initialCode={`for sentence in ["I caught a big fish.",
+                 "We fish on weekends."]:
+    tokens = word_tokenize(sentence)
+    tagged = pos_tag(tokens)
+    # Show just the word 'fish' and the tag it received.
+    for word, tag in tagged:
+        if word.lower() == "fish":
+            print(f"{sentence!r}\n   -> 'fish' tagged as {tag}")
+`}
+/>
+
+Same word, two sentences, two different tags — `NN` (noun) in the first,
+`VBP` (a verb tag) in the second. The tagger got there from context. This is
+*the* reason POS tagging is more than a lookup table.
+
+## Reading the tags: the Penn Treebank tagset
+
+`pos_tag` returns a list of `(word, tag)` tuples. The tags come from the
+**Penn Treebank** tagset, which is more fine-grained than "noun/verb" — it
+distinguishes singular from plural nouns, verb tenses, and so on. You do not
+need to memorize all ~36 tags, but you should recognize the common families.
+
+| Tag | Meaning | Example |
+| --- | --- | --- |
+| `NN` / `NNS` | noun, singular / plural | dog / dogs |
+| `NNP` / `NNPS` | proper noun, singular / plural | Alice / Americas |
+| `VB` / `VBD` / `VBG` / `VBZ` | verb: base / past / gerund / 3rd-person | run / ran / running / runs |
+| `JJ` / `JJR` / `JJS` | adjective / comparative / superlative | big / bigger / biggest |
+| `RB` | adverb | quickly |
+| `DT` | determiner | the, a |
+| `IN` | preposition / subordinating conjunction | in, of |
+| `PRP` | personal pronoun | I, you, it |
+| `CC` | coordinating conjunction | and, but |
+
+<Callout type="tip" title="The first letter is the shortcut">
+You can decode most tags from their first letter: `N…` is a noun, `V…` is a
+verb, `J…` is an adjective, `R…` is an adverb. This is so useful that we will
+use it in code in a moment to convert Penn tags into the simpler categories a
+lemmatizer wants. When you only care about coarse categories, `tag[0]` or
+`tag.startswith("NN")` is often all you need.
+</Callout>
+
+Here is a full sentence tagged, laid out as a tree of word-to-tag mappings.
+
+```mermaid
+flowchart TD
+    S["Sentence:<br/>'The tall man reads books'"]
+    S --> W1["The"]
+    S --> W2["tall"]
+    S --> W3["man"]
+    S --> W4["reads"]
+    S --> W5["books"]
+    W1 --> T1["DT<br/>determiner"]
+    W2 --> T2["JJ<br/>adjective"]
+    W3 --> T3["NN<br/>noun, singular"]
+    W4 --> T4["VBZ<br/>verb, 3rd-person singular"]
+    W5 --> T5["NNS<br/>noun, plural"]
+```
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("taggers", "averaged_perceptron_tagger_eng")
+from nltk import pos_tag
+from nltk.tokenize import word_tokenize`}
+  initialCode={`sentence = "The tall man reads books."
+tagged = pos_tag(word_tokenize(sentence))
+
+for word, tag in tagged:
+    print(f"  {word:10} {tag}")
+`}
+/>
+
+## A real payoff: extracting syntactic patterns
+
+Once words carry tags, you can pull out grammatical patterns cheaply. Want
+every noun in a document (to guess what it is about)? Keep tokens whose tag
+starts with `NN`. Want adjectives (useful for opinion mining)? Keep `JJ`. This
+"filter by tag" move is the backbone of simple information extraction.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("taggers", "averaged_perceptron_tagger_eng")
+from nltk import pos_tag
+from nltk.tokenize import word_tokenize`}
+  initialCode={`text = "The talented young engineer quietly designed a brilliant new system."
+tagged = pos_tag(word_tokenize(text))
+
+nouns = [w for w, t in tagged if t.startswith("NN")]
+adjectives = [w for w, t in tagged if t.startswith("JJ")]
+verbs = [w for w, t in tagged if t.startswith("VB")]
+adverbs = [w for w, t in tagged if t.startswith("RB")]
+
+print("Nouns:     ", nouns)
+print("Adjectives:", adjectives)
+print("Verbs:     ", verbs)
+print("Adverbs:   ", adverbs)
+`}
+/>
+
+## POS tagging makes lemmatization accurate
+
+Remember the big lemmatization gotcha: `WordNetLemmatizer` assumes every word
+is a noun unless told otherwise, so verbs come back unchanged. POS tagging is
+the missing piece. Tag first, convert each Penn tag to the coarse category
+WordNet understands, then lemmatize with that category. This is the standard,
+accurate lemmatization recipe.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("taggers", "averaged_perceptron_tagger_eng")
+await _load_nltk("corpora", "wordnet")
+from nltk import pos_tag
+from nltk.tokenize import word_tokenize
+from nltk.stem import WordNetLemmatizer
+from nltk.corpus import wordnet`}
+  initialCode={`lemmatizer = WordNetLemmatizer()
+
+def to_wordnet_pos(treebank_tag):
+    # Map a Penn Treebank tag to the coarse POS WordNet expects.
+    if treebank_tag.startswith("J"):
+        return wordnet.ADJ
+    if treebank_tag.startswith("V"):
+        return wordnet.VERB
+    if treebank_tag.startswith("R"):
+        return wordnet.ADV
+    return wordnet.NOUN   # default, including N* tags
+
+sentence = "The runners were running and they had eaten well."
+tagged = pos_tag(word_tokenize(sentence))
+
+print("Naive (default noun) lemmas:")
+print("  ", [lemmatizer.lemmatize(w) for w, t in tagged])
+
+print("POS-aware lemmas:")
+print("  ", [lemmatizer.lemmatize(w, to_wordnet_pos(t)) for w, t in tagged])
+`}
+/>
+
+Compare the two lines. Without POS, "running" and "eaten" survive unchanged.
+With POS, "running" → "run" and "eaten" → "eat". The tagger supplied the
+context the lemmatizer needed. This tag-then-lemmatize pattern is worth
+committing to memory — it is how accurate normalization is done in practice.
+
+<Callout type="warn" title="Tagging is contextual, and not perfect">
+Because the tagger predicts from context, it can be *wrong* — especially on
+short, ungrammatical, or unusual text (headlines, tweets, product titles). It
+is right the large majority of the time on well-formed English, but treat its
+output as a strong guess, not gospel. Lowercasing or stripping punctuation
+*before* tagging tends to hurt accuracy, since the tagger uses capitalization
+and punctuation as clues — another reason to tag relatively early.
+</Callout>
+
+<MultipleChoice
+  markdown={`Why can't part-of-speech tagging be done with a simple dictionary that maps
+each word to one fixed tag?
+
+- Dictionaries are too slow to look words up in
+- [o] A word's part of speech depends on context — "fish" is a noun in "I caught a fish" but a verb in "we fish on weekends" — so the same word needs different tags in different sentences
+  > Many words are category-ambiguous. The correct tag depends on the surrounding words, which is why taggers read context (and why NLTK's tagger is a trained model, not a lookup table).
+- Every word in English has exactly one possible part of speech
+- Tagging only works on numbers
+
+Context-dependence is the whole reason POS tagging is a prediction problem, not a lookup.`}
+/>
+
+## Real-world uses of POS tags
+
+- **Accurate lemmatization** (as above) — the most common pairing.
+- **Named-entity recognition** builds on proper-noun tags (`NNP`) to find
+  people, places, and organizations.
+- **Information extraction**: pull all noun phrases to summarize "what" a
+  document discusses, or adjective–noun pairs for opinion mining ("great
+  battery", "slow service").
+- **Grammar and writing tools** flag, e.g., a sentence with no verb.
+- **Search**: knowing a query word is a verb vs. a noun can sharpen results.
+
+## Your turn: extract the nouns
+
+<ChallengeCard
+  adapter="python"
+  title="Pull every noun out of a sentence"
+  category="POS tagging · pos_tag · syntactic filtering"
+  estimatedTime="~6 min"
+  instructions={`Write a function \`get_nouns(text)\` that returns a list of the words in
+\`text\` that are tagged as nouns — that is, words whose Penn Treebank tag
+**starts with** \`"NN"\` (this covers \`NN\`, \`NNS\`, \`NNP\`, and \`NNPS\`, so both
+common and proper nouns count).
+
+Steps: word-tokenize the text, run \`pos_tag\` on the tokens, then keep the
+words whose tag starts with \`"NN"\`.
+
+For example, \`get_nouns("The hungry cat chased a small mouse.")\` should return
+\`["cat", "mouse"]\`.`}
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("taggers", "averaged_perceptron_tagger_eng")
+from nltk import pos_tag
+from nltk.tokenize import word_tokenize`}
+  initialCode={`def get_nouns(text):
+    # tokenize -> pos_tag -> keep words whose tag starts with "NN"
+    return []
+
+print(get_nouns("The hungry cat chased a small mouse."))
+print(get_nouns("Alice traveled to Paris."))
+`}
+  solutionCode={`def get_nouns(text):
+    tagged = pos_tag(word_tokenize(text))
+    return [w for w, t in tagged if t.startswith("NN")]
+
+print(get_nouns("The hungry cat chased a small mouse."))
+print(get_nouns("Alice traveled to Paris."))
+`}
+  tests={[
+    {
+      id: "common_nouns",
+      name: "Finds the common nouns",
+      description: "'The hungry cat chased a small mouse.' -> ['cat', 'mouse']",
+      code: `out = get_nouns("The hungry cat chased a small mouse.")
+assert out == ["cat", "mouse"], "Got: " + repr(out)`,
+    },
+    {
+      id: "proper_nouns",
+      name: "Includes proper nouns (NNP)",
+      description: "'Alice' and 'Paris' should both be returned",
+      code: `out = get_nouns("Alice traveled to Paris.")
+assert "Alice" in out and "Paris" in out, "Got: " + repr(out)`,
+    },
+    {
+      id: "excludes_nonnouns",
+      name: "Excludes determiners, verbs, adjectives",
+      description: "'the', 'chased', 'hungry' must not appear",
+      code: `out = get_nouns("The hungry cat chased a small mouse.")
+for w in ["the", "chased", "hungry", "small", "a"]:
+    assert w not in out, "Should not include " + repr(w) + "; got " + repr(out)`,
+    },
+    {
+      id: "returns_list",
+      name: "Returns a list",
+      description: "get_nouns should return a list",
+      code: `assert isinstance(get_nouns("Dogs bark."), list), "Should return a list"`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`What does \`pos_tag\` return when given a list of tokens?
+
+- A single string naming the sentence's overall grammar
+- [o] A list of \`(word, tag)\` tuples, one per token, where the tag is the word's part of speech in context
+  > \`pos_tag\` pairs each token with a Penn Treebank tag, producing tuples like \`("book", "NN")\`. You typically iterate over these pairs to filter by category or feed POS into lemmatization.
+- A list of only the nouns
+- The lemmatized form of each word
+
+It tags every token with its grammatical category, as (word, tag) pairs.`}
+/>
+
+<MultipleChoice
+  markdown={`In the Penn Treebank tagset, which tags would the filter \`tag.startswith("NN")\`
+match?
+
+- Only \`NN\` (singular common nouns)
+- [o] \`NN\`, \`NNS\`, \`NNP\`, and \`NNPS\` — singular and plural common nouns *and* proper nouns
+  > All noun tags begin with "NN": \`NN\`/\`NNS\` for common nouns and \`NNP\`/\`NNPS\` for proper nouns. The prefix test is a handy way to grab "all nouns" at once.
+- All verbs
+- Determiners and prepositions
+
+The "NN" prefix covers the whole noun family, common and proper, singular and plural.`}
+/>
+
+<MultipleChoice
+  markdown={`Why does tagging *before* lemmatizing produce better results than lemmatizing
+alone?
+
+- Tagging makes the text shorter
+- [o] The tag tells the lemmatizer each word's part of speech, so verbs lemmatize as verbs ("running" → "run") instead of being left unchanged under the default noun assumption
+  > \`WordNetLemmatizer\` needs the POS to do its job; without it, verbs and adjectives often pass through unchanged. POS tagging supplies that information, enabling the accurate tag-then-lemmatize pipeline.
+- Lemmatizing first would delete all the verbs
+- Tagging removes stopwords automatically
+
+POS tags give the lemmatizer the context it needs to reduce non-nouns correctly.`}
+/>
+
+<MultipleChoice
+  markdown={`A teammate runs the tagger on a batch of all-lowercase, punctuation-stripped
+product titles and gets noticeably worse tags than on clean sentences. What is
+the most likely reason?
+
+- The tagger only works in the morning
+- [o] The tagger uses capitalization and punctuation as contextual clues; stripping them away beforehand removes signal the model relies on, lowering accuracy
+  > Aggressive normalization before tagging deletes cues (capital letters for proper nouns, sentence punctuation) that the tagger uses. Tag earlier — on text that still has its case and punctuation — then normalize.
+- POS tagging cannot be applied to product titles at all
+- The titles need to be translated first
+
+This is the recurring order lesson: normalize after tagging, not before, when tags matter.`}
+/>
+
+You can now label words by grammatical role. Notice a limitation though: every
+step so far treats words *individually*. But "New York", "machine learning",
+and "not good" are multi-word units whose meaning lives in the *combination*.
+To capture local word order, we turn to **n-grams**.

--- a/content/learn/natural-language-processing-python/rule-based-sentiment.mdx
+++ b/content/learn/natural-language-processing-python/rule-based-sentiment.mdx
@@ -1,0 +1,435 @@
+---
+title: "A Rule-Based Sentiment Classifier"
+description: The capstone — assemble tokenization, normalization, deliberate stopword choices, and negation handling into a working lexicon-based sentiment classifier. Watch why keeping negation matters, see how text flows through the whole pipeline, and learn the limits of rule-based methods.
+---
+
+Time to put it all together. In this final build we will write a **rule-based
+sentiment classifier** — a program that reads a sentence and decides whether it
+is positive, negative, or neutral — using nothing but the classic techniques
+from this course and a hand-made word list. No machine learning, no training
+data, no black box. Every decision it makes, you will be able to explain.
+
+This capstone matters for two reasons. First, lexicon-based sentiment is
+genuinely used in the real world (it is transparent, needs no training data,
+and is easy to audit). Second, building it forces every earlier lesson to pay
+off at once — especially the warning about negation and stopwords.
+
+## The idea: score words against a lexicon
+
+A **sentiment lexicon** is just two sets of words: ones that signal positive
+feeling ("good", "love", "excellent") and ones that signal negative feeling
+("bad", "hate", "terrible"). To score a sentence, tokenize it, look up each
+word, add up the polarities, and read off the sign of the total. Here is the
+full flow — trace it top to bottom, because it is the entire course in one
+diagram.
+
+```mermaid
+flowchart TD
+    A["Raw review text"] --> B["Tokenize + lowercase<br/>(keep stopwords AND negation!)"]
+    B --> C["For each token:<br/>look it up in the sentiment lexicon"]
+    C --> D{"Was a negation<br/>seen just before?"}
+    D -->|"yes"| E["Flip the word's polarity<br/>(good becomes negative)"]
+    D -->|"no"| F["Use the polarity as-is"]
+    E --> G["Add to a running score"]
+    F --> G
+    G --> H{"Final score?"}
+    H -->|"above zero"| P["positive"]
+    H -->|"below zero"| N["negative"]
+    H -->|"exactly zero"| Z["neutral"]
+```
+
+Notice step B already encodes a decision you learned to make: we **keep**
+stopwords and negation, because — as the stopwords page warned — stripping
+"not" would flip a review's meaning. The pipeline you are building is a direct
+application of the judgment from the "choosing your pipeline" page.
+
+## A naive first attempt (and why it fails)
+
+Let us start with the obvious version: count positive words, count negative
+words, compare. It will work on simple sentences and then fail in a way you can
+now predict.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the tokenizer this page needs. nltk.download()
+# isn't available here, so we fetch the archives directly.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize`}
+  initialCode={`POSITIVE = {"good", "great", "love", "excellent", "amazing", "wonderful", "best"}
+NEGATIVE = {"bad", "terrible", "hate", "awful", "worst", "poor", "boring"}
+
+def naive_sentiment(text):
+    tokens = [t.lower() for t in word_tokenize(text)]
+    score = sum(1 for t in tokens if t in POSITIVE) \
+          - sum(1 for t in tokens if t in NEGATIVE)
+    return "positive" if score > 0 else "negative" if score < 0 else "neutral"
+
+for review in ["I love this movie", "This film is terrible", "It is not good"]:
+    print(f"{naive_sentiment(review):9} <- {review!r}")
+`}
+/>
+
+The first two are right. The third — "It is not good" — is scored
+**positive**, because the naive counter sees the word "good" and is blind to
+the "not" sitting right in front of it. This is the exact negation failure we
+have been warning about since the stopwords page, now caught red-handed.
+
+<Callout type="warn" title="The naive bag-of-words sentiment trap">
+Counting positive and negative words independently *is* a bag-of-words model,
+and it inherits bag-of-words' blindness to order. "not good" contains the
+positive word "good", so the naive model calls it positive. Fixing this is
+exactly why we kept "not" in our tokens and why local order (the previous
+token) has to be part of the logic.
+</Callout>
+
+## Adding negation handling
+
+The fix is to track whether the previous token was a negation and, if so, flip
+the polarity of the next sentiment word. We also reset the negation at
+punctuation, so it does not bleed across clauses. This is a tiny amount of
+"local order" awareness — the same insight behind n-grams.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize`}
+  initialCode={`POSITIVE = {"good", "great", "love", "excellent", "amazing", "wonderful", "best"}
+NEGATIVE = {"bad", "terrible", "hate", "awful", "worst", "poor", "boring"}
+NEGATIONS = {"not", "no", "never", "n't"}
+RESET = {".", "!", "?", ",", ";", "but"}   # clause boundaries reset negation
+
+def sentiment(text):
+    tokens = [t.lower() for t in word_tokenize(text)]
+    score = 0
+    negate = False
+    for t in tokens:
+        if t in NEGATIONS:
+            negate = True
+            continue
+        if t in RESET:
+            negate = False
+            continue
+        polarity = 1 if t in POSITIVE else -1 if t in NEGATIVE else 0
+        if polarity != 0:
+            if negate:
+                polarity = -polarity   # flip: 'not good' -> negative
+                negate = False
+            score += polarity
+    return "positive" if score > 0 else "negative" if score < 0 else "neutral"
+
+tests = ["I love this movie", "This film is terrible", "It is not good",
+         "This is not bad at all", "The plot was good but the acting was awful"]
+for review in tests:
+    print(f"{sentiment(review):9} <- {review!r}")
+`}
+/>
+
+Now "It is not good" is correctly **negative**, and — satisfyingly — "This is
+not bad at all" comes out **positive**, because the negation flipped the
+negative word "bad" into a positive contribution. You just taught a program the
+difference between "good" and "not good" using only tokenization and a single
+boolean flag for local order. That is classic NLP working exactly as designed.
+
+<Callout type="success" title="Every lesson showed up here">
+Look back at what this classifier used: **tokenization** (to get words and split
+punctuation), **case folding** (so "Good" matches "good"), a deliberate choice
+to **keep stopwords** (so "not" survives), **lexicon lookup** (a form of
+feature extraction), and **local-order awareness** (the n-gram insight, as a
+negation flag). The whole course converged on one small, explainable program.
+</Callout>
+
+## The limits of rules — and when to graduate to learning
+
+Rule-based sentiment is transparent and needs no training data, but it has real
+ceilings you should respect:
+
+- **Sarcasm and irony.** "Oh *great*, another delay." The words say positive;
+  the meaning is negative. Rules cannot see the wink.
+- **Context and domain.** "unpredictable" is bad for a car's brakes but good
+  for a thriller's plot. A fixed lexicon cannot know which.
+- **Coverage.** Any word missing from your lexicon contributes nothing. Slang,
+  typos, and new expressions slip through.
+- **Intensity and mixed opinion.** "good" and "phenomenal" both score +1; a
+  review that is half-praise, half-complaint nets out to a muddle.
+
+These limits are *why* machine-learning approaches exist: instead of a
+hand-written lexicon, they **learn** word sentiment (and more) from thousands of
+labeled examples, picking up sarcasm cues, domain meanings, and intensity that
+no hand-built list captures. But notice — those models still tokenize,
+normalize, and make the very preprocessing choices you practiced here. You have
+built the foundation they stand on.
+
+<Callout type="tip" title="Why start with rules?">
+Even when you eventually reach for machine learning, a rule-based baseline is
+worth building first: it is fast, transparent, needs no labeled data, and gives
+you a score to beat. If a simple lexicon already solves your problem, you may not
+need anything more complicated — recall the very first page's advice that a
+clear rule often beats a model.
+</Callout>
+
+<MultipleChoice
+  markdown={`The naive word-counting classifier labels "It is not good" as positive. Which
+earlier lesson explains this failure most directly?
+
+- Stemming should have been applied first
+- [o] Counting positive/negative words independently ignores word order, so "not good" looks positive because of "good" — the same order-blindness as bag-of-words, fixable with negation/local-order handling
+  > Independent word counting is a bag-of-words model and shares its blindness to order. "not good" must be read as a unit (or via a negation flag) for the negative meaning to register.
+- The text was not lowercased
+- "good" is a stopword and should have been removed
+
+Order-blindness is the culprit; negation handling (a touch of local order) is the fix.`}
+/>
+
+## Your turn: build the negation-aware classifier
+
+This is the capstone challenge. Implement the negation-aware scoring loop using
+the lexicon and helper sets provided for you.
+
+<ChallengeCard
+  adapter="python"
+  title="Implement a negation-aware sentiment classifier"
+  category="capstone · lexicon · negation · the whole pipeline"
+  estimatedTime="~12 min"
+  instructions={`Write \`classify(text)\` that returns \`"positive"\`, \`"negative"\`, or
+\`"neutral"\`. Use the provided \`POSITIVE\`, \`NEGATIVE\`, \`NEGATIONS\`, and
+\`RESET\` sets.
+
+Algorithm:
+
+1. Tokenize \`text\` and lowercase every token.
+2. Keep a running \`score\` (start at 0) and a \`negate\` flag (start \`False\`).
+3. For each token, in order:
+   - If it is in \`NEGATIONS\`, set \`negate = True\` and move on.
+   - If it is in \`RESET\` (punctuation or "but"), set \`negate = False\` and move on.
+   - Otherwise compute its polarity: \`+1\` if in \`POSITIVE\`, \`-1\` if in
+     \`NEGATIVE\`, else \`0\`. If the polarity is nonzero and \`negate\` is
+     \`True\`, **flip** the polarity and reset \`negate\` to \`False\`. Add the
+     polarity to \`score\`.
+4. Return \`"positive"\` if \`score > 0\`, \`"negative"\` if \`score < 0\`,
+   otherwise \`"neutral"\`.
+
+This should make "this is not good" negative and "this is not bad" positive.`}
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize
+
+POSITIVE = {"good", "great", "love", "excellent", "amazing", "wonderful", "best", "nice"}
+NEGATIVE = {"bad", "terrible", "hate", "awful", "worst", "poor", "boring", "broken"}
+NEGATIONS = {"not", "no", "never", "n't"}
+RESET = {".", "!", "?", ",", ";", "but"}`}
+  initialCode={`def classify(text):
+    tokens = [t.lower() for t in word_tokenize(text)]
+    score = 0
+    negate = False
+    for t in tokens:
+        # 1. handle negation words
+        # 2. handle reset tokens
+        # 3. score sentiment words, flipping when negated
+        pass
+    # return "positive" / "negative" / "neutral" based on score
+    return "neutral"
+
+for review in ["I love it", "This is not good", "Not bad at all"]:
+    print(f"{classify(review):9} <- {review!r}")
+`}
+  solutionCode={`def classify(text):
+    tokens = [t.lower() for t in word_tokenize(text)]
+    score = 0
+    negate = False
+    for t in tokens:
+        if t in NEGATIONS:
+            negate = True
+            continue
+        if t in RESET:
+            negate = False
+            continue
+        polarity = 1 if t in POSITIVE else -1 if t in NEGATIVE else 0
+        if polarity != 0:
+            if negate:
+                polarity = -polarity
+                negate = False
+            score += polarity
+    if score > 0:
+        return "positive"
+    if score < 0:
+        return "negative"
+    return "neutral"
+
+for review in ["I love it", "This is not good", "Not bad at all"]:
+    print(f"{classify(review):9} <- {review!r}")
+`}
+  tests={[
+    {
+      id: "plain_positive",
+      name: "Plain positive review",
+      description: "'I love this movie' -> positive",
+      code: `assert classify("I love this movie") == "positive", "Got: " + classify("I love this movie")`,
+    },
+    {
+      id: "plain_negative",
+      name: "Plain negative review",
+      description: "'This film is terrible' -> negative",
+      code: `assert classify("This film is terrible") == "negative", "Got: " + classify("This film is terrible")`,
+    },
+    {
+      id: "negated_positive",
+      name: "Negation flips positive to negative",
+      description: "'It is not good' -> negative",
+      code: `assert classify("It is not good") == "negative", "Got: " + classify("It is not good")`,
+    },
+    {
+      id: "negated_negative",
+      name: "Negation flips negative to positive",
+      description: "'This is not bad' -> positive (not bad = good)",
+      code: `assert classify("This is not bad") == "positive", "Got: " + classify("This is not bad")`,
+    },
+    {
+      id: "neutral",
+      name: "No sentiment words -> neutral",
+      description: "'It is a wooden chair' -> neutral",
+      code: `assert classify("It is a wooden chair") == "neutral", "Got: " + classify("It is a wooden chair")`,
+    },
+    {
+      id: "reset_after_but",
+      name: "Negation resets at a clause boundary",
+      description: "'Not great, but terrible' stays negative (the 'but' resets negation before 'terrible')",
+      code: `assert classify("Not great, but terrible") == "negative", "Got: " + classify("Not great, but terrible")`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`What is the core idea of a **lexicon-based** (rule-based) sentiment
+classifier?
+
+- It learns word sentiment from thousands of labeled training examples
+- [o] It scores text by looking each word up in hand-made lists of positive and negative words and summing the polarities
+  > Lexicon-based sentiment uses curated word lists rather than learned parameters. It is transparent and needs no training data — you can read exactly why it produced a given score.
+- It translates the text and counts the characters
+- It uses a neural network to predict sentiment
+
+A hand-built lexicon plus a scoring rule, with no training data, defines the lexicon-based approach.`}
+/>
+
+<MultipleChoice
+  markdown={`Why does the classifier deliberately **keep** stopwords like "not" instead of
+removing them?
+
+- Because removing stopwords is computationally expensive
+- [o] Because "not" is a negation that reverses sentiment; removing it (it is on the standard stopword list) would turn "not good" into "good" and flip the result
+  > This is the payoff of the stopwords lesson. Negations carry the meaning in opinionated text, so a sentiment pipeline keeps them. Stripping them would silently invert the classifier's verdict.
+- Because stopwords are the most positive words
+- Because NLTK forbids removing stopwords
+
+Keeping negation is a deliberate, task-driven choice — exactly the judgment this course builds.`}
+/>
+
+<MultipleChoice
+  markdown={`Which of these is a genuine limitation of rule-based sentiment that motivates
+machine-learning approaches?
+
+- It is unable to lowercase text
+- [o] It cannot detect sarcasm ("Oh great, another delay"), handle domain-specific meanings, or score words missing from its lexicon
+  > Fixed word lists miss sarcasm, context-dependent meaning, and any vocabulary they do not contain. Learning-based models infer these from labeled data — though they still rely on the same preprocessing you practiced.
+- It runs only on Tuesdays
+- It cannot process more than one sentence
+
+Sarcasm, context, and coverage gaps are the real ceilings of a hand-built lexicon.`}
+/>
+
+<MultipleChoice
+  markdown={`In the negation-aware algorithm, what is the purpose of the \`RESET\` set
+(punctuation and "but")?
+
+- To delete those tokens from the text
+- [o] To clear the negation flag at clause boundaries so a negation does not incorrectly carry over and flip a word in a later clause
+  > Negation should affect only the nearby word, not everything after it. Resetting at punctuation and "but" stops "not great, but terrible" from having the "not" wrongly flip "terrible". It scopes the negation to its clause.
+- To add extra weight to positive words
+- To convert the text to uppercase
+
+Resetting negation at boundaries keeps its effect local, which is what makes the heuristic work.`}
+/>
+
+<MultipleChoice
+  markdown={`Even when you plan to use machine learning later, why is building a
+rule-based baseline first a good idea?
+
+- It is required before any model can be trained
+- [o] It is fast, transparent, needs no labeled data, and gives a concrete score to beat — and sometimes it already solves the problem well enough
+  > A simple, explainable baseline sets a bar and may suffice on its own. It also sanity-checks your data and preprocessing. Reaching for a heavier model makes sense only once the baseline proves inadequate.
+- It guarantees higher accuracy than any model
+- It removes the need to tokenize text
+
+Start simple and transparent; add complexity only when it earns its place.`}
+/>
+
+You have built a complete, explainable NLP program from raw text to a labeled
+verdict — using only the classic toolkit. That is a real accomplishment. The
+final page points you toward where to go from here.

--- a/content/learn/natural-language-processing-python/stemming-and-lemmatization.mdx
+++ b/content/learn/natural-language-processing-python/stemming-and-lemmatization.mdx
@@ -1,0 +1,402 @@
+---
+title: "Stemming vs. Lemmatization"
+description: Two ways to collapse 'run', 'runs', 'running', and 'ran' into one root. Stemming chops suffixes with fast rules and may produce non-words; lemmatization looks up real dictionary forms but needs part-of-speech. Which to choose, and why lemmatization wins for meaning.
+---
+
+Tokenization and normalization handle *spelling* variation. But there is a
+deeper kind of redundancy in language: the same word appears in many
+**grammatical forms**. "run", "runs", "running", and "ran" are four surface
+forms of one underlying word. "study", "studies", "studied", and "studying"
+are four forms of another. If you are counting words or matching a search
+query, you usually want all forms of a word to collapse into one.
+
+There are two classic techniques for that collapse, and the difference
+between them — in mechanism, in output, and in when to use them — is one of
+the most clarifying things you can learn in NLP.
+
+## The shared goal: reduce words to a root
+
+Both techniques map many forms to one. The disagreement is entirely about
+*how*, and that "how" has big consequences.
+
+```mermaid
+flowchart TB
+    W["Word: 'studies'"] --> S["STEMMING (Porter)<br/>apply suffix-chopping rules"]
+    W --> L["LEMMATIZATION (WordNet)<br/>look up the dictionary form"]
+    S --> S1["chop the ending -> 'studi'<br/>fast, no dictionary,<br/>result may not be a real word"]
+    L --> L1["map to lemma -> 'study'<br/>needs a dictionary and POS,<br/>result is always a real word"]
+```
+
+**Stemming** is crude and mechanical: it strips suffixes according to fixed
+rules. It is fast, needs no dictionary, and frequently produces fragments
+that are not real words ("studi", "happi"). **Lemmatization** is principled:
+it looks the word up in a vocabulary and returns its **lemma** — the proper
+dictionary headword ("study", "happy"). It is slower, needs a dictionary, and
+works best when you tell it the word's part of speech.
+
+## Stemming: chopping with the Porter algorithm
+
+The most famous stemmer is the **Porter stemmer**, a set of suffix-stripping
+rules from 1980 that is still everywhere. Watch it work — and watch it
+misbehave.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# PorterStemmer is pure Python and needs no downloaded data, but we still
+# install NLTK itself.
+import micropip
+await micropip.install("nltk")
+import nltk`}
+  initialCode={`from nltk.stem import PorterStemmer
+
+stemmer = PorterStemmer()
+
+words = ["run", "runs", "running", "ran",
+         "study", "studies", "studying",
+         "happy", "happily", "happiness",
+         "organization", "organize", "organ"]
+
+for w in words:
+    print(f"  {w:14} -> {stemmer.stem(w)}")
+`}
+/>
+
+Read that output carefully — it teaches stemming's whole personality:
+
+- **It works on regular forms.** "running" and "runs" both stem to "run".
+  "studies" and "studying" both stem to "studi".
+- **It misses irregulars.** "ran" stays "ran" — the rules only chop suffixes,
+  they do not know that "ran" is the past tense of "run".
+- **Its output is often not a real word.** "studies" → "studi", "happily" →
+  "happili", "happiness" → "happi". These stems are fine as *internal keys*
+  but useless if you need to show them to a human or look them up.
+- **It can over-stem.** Notice "organization", "organize", and "organ" can
+  collapse toward the same short stem, conflating words with quite different
+  meanings. Crushing distinct words together is called **over-stemming**.
+
+<Callout type="info" title="A stem is a key, not a word">
+The right mental model: a stem is an *opaque identifier* that groups related
+forms, not a meaningful word. "studi" is a perfectly good grouping key —
+every form of "study" maps to it consistently — but it is not English. As
+long as you only ever compare stems to other stems (does the query stem match
+the document stem?), the fact that they are not real words does not matter.
+</Callout>
+
+## Lemmatization: looking up the dictionary form
+
+Lemmatization returns the **lemma** — the canonical dictionary form. NLTK's
+`WordNetLemmatizer` uses the WordNet lexical database to do it. The result is
+always a real word, but there is a catch you must understand.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads WordNet, the lexical database the lemmatizer uses.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("corpora", "wordnet")
+from nltk.stem import WordNetLemmatizer`}
+  initialCode={`lemmatizer = WordNetLemmatizer()
+
+# WordNetLemmatizer defaults to treating each word as a NOUN.
+print("Default (noun) lemmas:")
+for w in ["running", "ran", "studies", "better", "was"]:
+    print(f"  {w:10} -> {lemmatizer.lemmatize(w)}")
+
+print()
+# Tell it the part of speech and the results change dramatically.
+print("With the correct part of speech:")
+print("  running (verb)     ->", lemmatizer.lemmatize("running", pos="v"))
+print("  ran (verb)         ->", lemmatizer.lemmatize("ran", pos="v"))
+print("  studies (verb)     ->", lemmatizer.lemmatize("studies", pos="v"))
+print("  was (verb)         ->", lemmatizer.lemmatize("was", pos="v"))
+print("  better (adjective) ->", lemmatizer.lemmatize("better", pos="a"))
+`}
+/>
+
+This is the most important — and most surprising — fact about
+`WordNetLemmatizer`: **by default it assumes every word is a noun.** Because
+"running" can be a noun ("the running of the race"), `lemmatize("running")`
+returns "running" *unchanged*. Only when you pass `pos="v"` does it know to
+treat it as a verb and return "run".
+
+With the right part of speech, look how good it is: "ran" → "run", "was" →
+"be", "better" → "good". A stemmer could never produce "be" from "was" or
+"good" from "better", because those are not suffix operations — they require
+*knowing* the word.
+
+<Callout type="warn" title="The number-one lemmatization bug">
+`WordNetLemmatizer.lemmatize(word)` with no `pos` argument treats `word` as a
+noun, so most verbs and adjectives come back unchanged and beginners conclude
+"lemmatization doesn't do anything." It does — you just have to tell it the
+part of speech. This is exactly why lemmatization and **part-of-speech
+tagging** (the next page but one) are natural partners: tag first to learn
+each word's POS, then lemmatize with that POS for accurate results.
+</Callout>
+
+## Stemming vs. lemmatization, side by side
+
+Let us run both on the same words so the trade-off is unmistakable.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("corpora", "wordnet")
+from nltk.stem import PorterStemmer, WordNetLemmatizer`}
+  initialCode={`stemmer = PorterStemmer()
+lemmatizer = WordNetLemmatizer()
+
+words = ["studies", "studying", "happily", "better", "was", "mice", "feet"]
+
+print(f"{'word':12}{'stem':12}{'lemma (verb)':14}")
+print("-" * 38)
+for w in words:
+    stem = stemmer.stem(w)
+    lemma = lemmatizer.lemmatize(w, pos="v")
+    print(f"{w:12}{stem:12}{lemma:14}")
+`}
+/>
+
+Notice "happily" stems to the non-word "happili" but you would need an
+adjective/adverb lemma to handle it well; "was" stems to "wa" (nonsense) but
+lemmatizes to "be"; "mice" and "feet" defeat the stemmer entirely (suffix
+rules cannot turn "mice" into "mouse") while a lemmatizer with a dictionary
+can. Stemming is fast and approximate; lemmatization is slower and correct.
+
+<MultipleChoice
+  markdown={`Why does \`WordNetLemmatizer().lemmatize("running")\` return "running"
+unchanged, while \`lemmatize("running", pos="v")\` returns "run"?
+
+- Because "running" has no lemma
+- [o] The lemmatizer defaults to treating the word as a *noun*, and "running" is a valid noun, so it is left as-is; supplying \`pos="v"\` tells it to treat the word as a verb, whose lemma is "run"
+  > Lemmatization is part-of-speech sensitive. With the default noun assumption, "running" (a gerund/noun) is already a lemma. Only by specifying the verb reading does it reduce to "run". This is why POS tagging pairs naturally with lemmatization.
+- It is a bug in NLTK
+- "running" and "run" are unrelated words
+
+The default-noun behavior trips up nearly everyone the first time; the fix is to pass the correct POS.`}
+/>
+
+## When to use which
+
+```mermaid
+flowchart TB
+    Q{"What do you need from the root?"}
+    Q -->|"speed, scale, and rough grouping<br/>(result need not be a real word)"| ST["Use STEMMING<br/>e.g. search indexing, large-scale IR"]
+    Q -->|"real words and accurate meaning<br/>(human-readable, semantic tasks)"| LE["Use LEMMATIZATION<br/>e.g. chatbots, dictionaries, careful analysis"]
+```
+
+**Reach for stemming when** you are processing huge volumes and you only ever
+compare stems to stems — classically, a **search engine**. If a user searches
+"running shoes", stemming both the query and the documents to "run" lets the
+search match "runs", "ran", and "running" alike. Nobody ever sees the stem
+"run" rendered on screen, so it does not matter that some stems are not words.
+
+**Reach for lemmatization when** the root must be a real word or meaning
+matters: building features for careful analysis, normalizing text a human
+will read, or any **semantic** application where "good" and "better" should
+unify and "be" should capture "was/is/were/been". The cost is speed and the
+need for a dictionary (and, ideally, POS tags), but the output is principled.
+
+<Callout type="tip" title="The one-line summary">
+**Stemming** is fast, dictionary-free suffix-chopping that may produce
+non-words — great for search and recall at scale. **Lemmatization** is
+slower, dictionary-backed, POS-aware reduction to real words — better whenever
+meaning or readability matters. When in doubt for a semantic task, prefer
+lemmatization.
+</Callout>
+
+## Common misconceptions
+
+- **"They are the same thing."** No. Different mechanism (rules vs. lookup),
+  different output (fragments vs. real words), different cost.
+- **"Stems are real words."** Often not — "studi", "happi", "wa". A stem is a
+  grouping key, not a vocabulary word.
+- **"Lemmatization always changes the word."** No — with the default noun POS,
+  many words come back unchanged. You frequently need POS for it to do its
+  job.
+- **"More aggressive reduction is always better."** No — over-stemming merges
+  unrelated words ("organ" and "organization"), which can hurt as much as it
+  helps.
+
+## Your turn: lemmatize verbs correctly
+
+<ChallengeCard
+  adapter="python"
+  title="Lemmatize a list of verbs"
+  category="lemmatization · POS-aware roots"
+  estimatedTime="~6 min"
+  instructions={`Write a function \`verb_lemmas(words)\` that lemmatizes each word **as a
+verb** and returns the list of lemmas. Use the provided \`lemmatizer\` and pass
+\`pos="v"\` so verbs are reduced correctly.
+
+For example, \`verb_lemmas(["running", "ran", "studies"])\` should return
+\`["run", "run", "study"]\`. Notice the irregular "ran" correctly becomes
+"run" — something a stemmer cannot do.`}
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("corpora", "wordnet")
+from nltk.stem import WordNetLemmatizer
+lemmatizer = WordNetLemmatizer()`}
+  initialCode={`def verb_lemmas(words):
+    # Lemmatize each word as a verb (pos="v") and return the list.
+    return words
+
+print(verb_lemmas(["running", "ran", "studies"]))
+print(verb_lemmas(["was", "are", "been"]))
+`}
+  solutionCode={`def verb_lemmas(words):
+    return [lemmatizer.lemmatize(w, pos="v") for w in words]
+
+print(verb_lemmas(["running", "ran", "studies"]))
+print(verb_lemmas(["was", "are", "been"]))
+`}
+  tests={[
+    {
+      id: "regular_verbs",
+      name: "Reduces regular verb forms",
+      description: "['running','studies','jumps'] -> ['run','study','jump']",
+      code: `out = verb_lemmas(["running", "studies", "jumps"])
+assert out == ["run", "study", "jump"], "Got: " + repr(out)`,
+    },
+    {
+      id: "irregular_ran",
+      name: "Handles the irregular 'ran'",
+      description: "'ran' -> 'run' (a stemmer cannot do this)",
+      code: `out = verb_lemmas(["ran"])
+assert out == ["run"], "Got: " + repr(out)`,
+    },
+    {
+      id: "to_be",
+      name: "Reduces forms of 'to be'",
+      description: "['was','are','been'] -> ['be','be','be']",
+      code: `out = verb_lemmas(["was", "are", "been"])
+assert out == ["be", "be", "be"], "Got: " + repr(out)`,
+    },
+    {
+      id: "returns_list",
+      name: "Returns a list of the same length",
+      description: "One lemma per input word",
+      code: `out = verb_lemmas(["walking", "talking", "singing"])
+assert isinstance(out, list) and len(out) == 3, "Got: " + repr(out)`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`Which statement correctly contrasts stemming and lemmatization?
+
+- Stemming uses a dictionary; lemmatization uses suffix rules
+- [o] Stemming chops suffixes with fixed rules and may output non-words; lemmatization looks words up in a vocabulary and returns real dictionary forms (and benefits from knowing the part of speech)
+  > That is the core distinction: rule-based chopping (fast, approximate, possibly non-words) versus dictionary lookup (slower, principled, real words, POS-aware). Reversing them is a common mix-up.
+- They are identical and interchangeable
+- Lemmatization is always faster than stemming
+
+Mechanism, output, and cost all differ — and that difference drives the choice.`}
+/>
+
+<MultipleChoice
+  markdown={`A search engine team wants queries like "running shoes" to also match pages
+containing "ran" and "runs". Speed at massive scale matters; the reduced form
+is never shown to users. Which technique fits best?
+
+- [o] Stemming — fast, dictionary-free, and fine that the stem may not be a real word, since it is only ever compared to other stems
+  > Search/IR is the textbook case for stemming: huge volume, only stem-to-stem comparison, and no need for human-readable output. Lemmatization's accuracy is not worth its extra cost here.
+- Lemmatization, because real words are required for matching
+- Neither; search cannot use root reduction
+- Both must always be applied together
+
+When the root is an internal key and scale matters, stemming is the pragmatic choice.`}
+/>
+
+<MultipleChoice
+  markdown={`Why can a lemmatizer turn "was" into "be" while a stemmer cannot?
+
+- The stemmer is broken
+- [o] "was" → "be" is an irregular mapping that requires *knowing* the word (a dictionary lookup), not stripping a suffix; stemmers only remove endings
+  > Lemmatization consults a lexical database that records irregular forms, so it can map "was/is/were/been" to "be" and "better" to "good". Stemming has no such knowledge — it only chops suffixes, which cannot transform "was" into "be".
+- Stemmers only work on nouns
+- "was" and "be" are unrelated
+
+Dictionary knowledge is exactly what lets lemmatization handle irregulars that defeat suffix rules.`}
+/>
+
+<MultipleChoice
+  markdown={`What is **over-stemming**?
+
+- Running the stemmer more than once
+- [o] When the stemmer reduces *distinct* words (like "organ" and "organization") to the same stem, wrongly merging different meanings
+  > Over-stemming is excessive collapsing: unrelated words share a stem and become indistinguishable. It is one of the quality costs of crude rule-based stemming, and a reason lemmatization is preferred when meaning matters.
+- When a stem is longer than the original word
+- When lemmatization fails to change a word
+
+Aggressive suffix stripping sometimes glues together words that should stay separate.`}
+/>
+
+You now know how to collapse word forms to a root. Before we can lemmatize
+*accurately*, though, we need to know each word's part of speech — and that is
+coming up. But first, let us put your clean tokens to work and actually
+**measure** a text: how many distinct words, which are most frequent, and how
+varied the vocabulary is.

--- a/content/learn/natural-language-processing-python/stopwords.mdx
+++ b/content/learn/natural-language-processing-python/stopwords.mdx
@@ -1,0 +1,486 @@
+---
+title: Identifying and Removing Stopwords
+description: What stopwords are, why removing them can sharpen a topic analysis — and why removing them can quietly destroy a sentiment analysis. The negation trap, domain-specific stoplists, and how to decide whether to filter at all.
+---
+
+Some words are everywhere. In almost any English text, "the", "is", "of",
+"and", and "to" are among the most frequent words — and they are also among
+the *least* informative about what the text is *about*. These ultra-common,
+low-content words are called **stopwords**, and deciding whether to remove
+them is one of the most consequential — and most frequently botched — choices
+in a text pipeline.
+
+This page has a split personality on purpose. The first half shows you why
+removing stopwords is useful. The second half shows you a task where removing
+them is a disaster. Holding both in your head is the whole point.
+
+## What are stopwords, and why remove them?
+
+A stopword is a word so common and grammatically functional that it carries
+little meaning *on its own*. NLTK ships a ready-made English list. Let us look
+at it.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the data this page needs. nltk.download() isn't
+# available in this environment, so we fetch the data archives directly
+# and unpack them into NLTK's data directory.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("corpora", "stopwords")
+from nltk.corpus import stopwords`}
+  initialCode={`stop = stopwords.words("english")
+
+print("Number of English stopwords:", len(stop))
+print("First 25:", stop[:25])
+print()
+print("Is 'the' a stopword? ", "the" in stop)
+print("Is 'python' a stopword?", "python" in stop)
+`}
+/>
+
+The list is short — under 200 words — but those words make up a huge fraction
+of any text. Removing them has two appealing effects: it shrinks your data,
+and it concentrates attention on **content words** (nouns, verbs, adjectives)
+that actually signal the topic.
+
+```mermaid
+flowchart LR
+    A["Tokens:<br/>the, movie, was, great"] --> F{"In stopword list?"}
+    F -->|"yes"| D["Dropped:<br/>the, was"]
+    F -->|"no"| K["Kept (content words):<br/>movie, great"]
+```
+
+Here is the filter in action. The pattern is always the same: build a `set`
+of stopwords for fast lookup, then keep only the tokens that are not in it.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("corpora", "stopwords")
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.corpus import stopwords
+from nltk.tokenize import word_tokenize`}
+  initialCode={`text = "The quick brown fox jumps over the lazy dog in the park"
+stop = set(stopwords.words("english"))   # a set -> fast membership tests
+
+tokens = [t.lower() for t in word_tokenize(text)]
+content = [t for t in tokens if t not in stop]
+
+print("All tokens:   ", tokens)
+print("Content words:", content)
+print(f"Removed {len(tokens) - len(content)} of {len(tokens)} tokens.")
+`}
+/>
+
+The content words — "quick", "brown", "fox", "jumps", "lazy", "dog", "park" —
+tell you what the sentence is *about*. The stopwords — "the", "over", "in" —
+mostly just hold the grammar together. For a task like topic detection or
+building a search index, dropping them is a clear win.
+
+<Callout type="info" title="Why a set, not a list?">
+Checking `token in stop` is done once per token, potentially millions of
+times. Membership testing in a Python `set` is roughly constant time, while a
+`list` scans every element. Converting the stopword list to a `set` once,
+up front, can make the filtering step dramatically faster on large texts. It
+is a small habit that scales well.
+</Callout>
+
+## The negation trap: when removing stopwords is a disaster
+
+Now the other personality. Look closely at what is *in* the stopword list.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("corpora", "stopwords")
+from nltk.corpus import stopwords`}
+  initialCode={`stop = set(stopwords.words("english"))
+
+for word in ["not", "no", "nor", "never", "but", "against", "don't", "won't"]:
+    print(f"  is '{word}' a stopword? {word in stop}")
+`}
+/>
+
+The negation words — "not", "no", "nor" — are stopwords. So are many negated
+contractions. These are the words that *reverse meaning*, and the standard
+stoplist deletes them. Watch what that does to a negative product review.
+
+```mermaid
+flowchart TB
+    A["'The movie was not good'<br/>(clearly negative)"] --> B["remove stopwords<br/>the, was, not are ALL stopwords"]
+    B --> C["'movie good'"]
+    C --> D["Now looks POSITIVE<br/>the meaning flipped!"]
+```
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("corpora", "stopwords")
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.corpus import stopwords
+from nltk.tokenize import word_tokenize`}
+  initialCode={`review = "The movie was not good at all"
+stop = set(stopwords.words("english"))
+
+tokens = [t.lower() for t in word_tokenize(review)]
+content = [t for t in tokens if t not in stop]
+
+print("Original review:", review)
+print("After stopwords:", content)
+print()
+print("A naive sentiment reader now sees the word 'good' and no 'not'.")
+print("The negative review has been turned positive.")
+`}
+/>
+
+The review "not good" became simply "good". A sentiment system reading the
+filtered tokens would conclude the reviewer *liked* the movie — the exact
+opposite of the truth. This is not a contrived edge case; negation is
+everywhere in opinionated text, and blindly removing stopwords before
+sentiment analysis is a classic, costly mistake.
+
+<Callout type="danger" title="Do not remove stopwords before sentiment analysis (at least not naively)">
+The standard stopword list contains the very words that carry sentiment
+structure: negations ("not", "no", "nor"), contrasts ("but"), and
+intensity ("very" — also a stopword). Strip them and you can flip a review's
+meaning. For sentiment, either **keep stopwords**, or use a **custom list
+that preserves negation and contrast words**. The same caution applies to any
+task where small function words change meaning.
+</Callout>
+
+## More tasks where stopwords are precious
+
+Sentiment is not the only place the default list hurts. Stopwords are
+essential — sometimes they are the *entire signal* — in several tasks:
+
+- **Phrases and idioms.** "To be or not to be" is *all* stopwords. Remove
+  them and the most famous line in English vanishes into nothing.
+- **Machine translation.** Function words encode tense, number, and
+  relationships. You cannot translate by throwing them away.
+- **Question answering.** "Who" vs "whom", "can" vs "cannot" — the small
+  words often *are* the question.
+- **Authorship attribution.** Remarkably, *how* an author uses stopwords
+  (their unconscious rate of "the", "of", "that") is a fingerprint used to
+  identify who wrote a text. Here the stopwords are the data and the content
+  words are the noise — the exact inverse of topic analysis.
+
+<Callout type="warn" title="Two more misconceptions to retire">
+**"Always remove stopwords."** No — it is a task-dependent choice, and for a
+large class of tasks it is harmful. **"The stopword list is universal."**
+Also no. There is no single official list; NLTK's differs from spaCy's and
+from scikit-learn's, and the right list for *your* domain often needs
+customizing. In a corpus of movie reviews, the word "movie" is so ubiquitous
+it acts like a stopword; in legal text, "herein" and "pursuant" might. Good
+practitioners curate the list for the job.
+</Callout>
+
+## Customizing the stoplist
+
+Because the list is just a Python collection, you can add domain-specific
+noise words and — crucially — remove words you must keep.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("corpora", "stopwords")
+from nltk.corpus import stopwords`}
+  initialCode={`base = set(stopwords.words("english"))
+
+# Keep negation/contrast words so sentiment survives:
+keep = {"not", "no", "nor", "never", "but"}
+# Add domain noise words (imagine a corpus of movie reviews):
+add = {"movie", "film", "watch"}
+
+custom = (base - keep) | add
+
+print("'not' still a stopword?  ", "not" in custom, "  <- kept for sentiment")
+print("'movie' now a stopword?  ", "movie" in custom, " <- added domain noise word")
+print("'the' still a stopword?  ", "the" in custom)
+`}
+/>
+
+This three-line recipe — start from the base list, *subtract* the words you
+must protect, *add* the words specific to your domain — is how stopword
+removal is done responsibly in practice.
+
+<MultipleChoice
+  markdown={`A sentiment analysis pipeline removes NLTK's default English stopwords before
+scoring reviews. Reviews like "this is not good" keep getting classified as
+positive. What is the root cause?
+
+- The reviews are too short to classify
+- [o] "not" is on the stopword list, so removing stopwords deletes the negation and "not good" collapses to "good", flipping the sentiment
+  > NLTK's stopword list includes negation words. Stripping them throws away the words that reverse meaning, so negative statements look positive. For sentiment, preserve negation (or keep stopwords entirely).
+- Sentiment analysis is impossible in Python
+- The pipeline forgot to lowercase the text
+
+Negation lives in the stoplist, and sentiment lives in negation — a dangerous combination.`}
+/>
+
+## Your turn: filter stopwords without losing negation
+
+<ChallengeCard
+  adapter="python"
+  title="Remove stopwords but keep the negations"
+  category="stopwords · sentiment-safe filtering"
+  estimatedTime="~7 min"
+  instructions={`Write a function \`clean_keep_negation(tokens)\` that removes English
+stopwords from a list of **already-lowercased** tokens, but **preserves**
+these negation/contrast words so sentiment survives: \`not\`, \`no\`, \`nor\`,
+\`never\`, \`but\`.
+
+Build a custom stop set by starting from \`stopwords.words("english")\` and
+subtracting those five words, then keep only tokens not in that custom set.
+
+For example, given \`["this", "is", "not", "good"]\`, the function should
+return \`["not", "good"]\` — ordinary stopwords gone, the negation kept.`}
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("corpora", "stopwords")
+from nltk.corpus import stopwords`}
+  initialCode={`KEEP = {"not", "no", "nor", "never", "but"}
+
+def clean_keep_negation(tokens):
+    # Build a custom stop set, then filter.
+    return tokens
+
+print(clean_keep_negation(["this", "is", "not", "good"]))
+print(clean_keep_negation(["the", "food", "was", "never", "fresh"]))
+`}
+  solutionCode={`KEEP = {"not", "no", "nor", "never", "but"}
+
+def clean_keep_negation(tokens):
+    custom = set(stopwords.words("english")) - KEEP
+    return [t for t in tokens if t not in custom]
+
+print(clean_keep_negation(["this", "is", "not", "good"]))
+print(clean_keep_negation(["the", "food", "was", "never", "fresh"]))
+`}
+  tests={[
+    {
+      id: "keeps_not",
+      name: "Keeps the negation 'not'",
+      description: "['this','is','not','good'] -> ['not','good']",
+      code: `out = clean_keep_negation(["this", "is", "not", "good"])
+assert out == ["not", "good"], "Got: " + repr(out)`,
+    },
+    {
+      id: "keeps_never",
+      name: "Keeps 'never' and drops ordinary stopwords",
+      description: "['the','food','was','never','fresh'] -> ['food','never','fresh']",
+      code: `out = clean_keep_negation(["the", "food", "was", "never", "fresh"])
+assert out == ["food", "never", "fresh"], "Got: " + repr(out)`,
+    },
+    {
+      id: "removes_ordinary",
+      name: "Still removes ordinary stopwords",
+      description: "Common stopwords like 'the','is','of' must be gone",
+      code: `out = clean_keep_negation(["the", "is", "of", "apple"])
+assert out == ["apple"], "Got: " + repr(out)`,
+    },
+    {
+      id: "all_kept_words_survive",
+      name: "All five protected words survive",
+      description: "not, no, nor, never, but are each preserved",
+      code: `out = clean_keep_negation(["not", "no", "nor", "never", "but"])
+assert set(out) == {"not", "no", "nor", "never", "but"}, "Got: " + repr(out)`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`What best describes a **stopword**?
+
+- A word that signals the end of a sentence
+- [o] A very common, low-content word (like "the", "is", "of") that appears across nearly all texts and carries little topical meaning on its own
+  > Stopwords are high-frequency function words. They are everywhere, so they say little about what a *particular* document is about — which is why topic-focused tasks often remove them.
+- A misspelled word that should be corrected
+- A word that must always be removed from any text
+
+Stopwords are defined by being common and low-content, not by being errors or by any "must remove" rule.`}
+/>
+
+<MultipleChoice
+  markdown={`For which task is removing stopwords most clearly **beneficial**?
+
+- [o] Building a search index where you want to match on meaningful content words
+  > Search and topic analysis benefit from dropping ubiquitous function words so that matching and counting focus on content. This is the classic motivating use case for stopword removal.
+- Analyzing the sentiment of opinionated product reviews
+  > Sentiment is exactly where stopword removal backfires, because negation words live in the stoplist.
+- Translating a sentence from English to French
+  > Translation needs function words to encode grammar; removing them breaks it.
+- Identifying which author wrote an anonymous text
+  > Authorship attribution often relies on stopword usage patterns as a fingerprint.
+
+Topic-oriented matching is the sweet spot; the other three are cases where stopwords matter.`}
+/>
+
+<MultipleChoice
+  markdown={`Why is "the stopword list is universal and official" a misconception?
+
+- Because stopword lists change every day
+- [o] Because there is no single canonical list — different libraries ship different lists, and the right list depends on your domain (a movie corpus might treat "movie" as a stopword)
+  > Stoplists are conventions, not standards. NLTK, spaCy, and scikit-learn all differ, and effective practitioners customize the list for their domain rather than treating any one list as authoritative.
+- Because stopwords do not exist in English
+- Because only nouns can be stopwords
+
+Treat any stoplist as a starting point to curate, not a fixed law.`}
+/>
+
+<MultipleChoice
+  markdown={`You must remove ordinary stopwords from movie reviews but protect negation so
+sentiment survives. Which approach is correct?
+
+- Remove every stopword, then add "not" back to random positions
+- [o] Start from the base stoplist, subtract the negation/contrast words you must keep, and filter tokens against that customized set
+  > Subtracting protected words from the base set (then filtering) cleanly removes ordinary stopwords while leaving negation intact. It is the standard responsible recipe for sentiment-safe filtering.
+- Skip tokenization so stopwords never appear
+- Convert the reviews to uppercase first
+
+Customizing the set — subtract what you must keep, add domain noise — is how this is done in practice.`}
+/>
+
+<MultipleChoice
+  markdown={`Converting the stopword list to a Python \`set\` before filtering mainly
+improves:
+
+- The accuracy of the filtering
+- [o] The speed, because membership tests (\`token in stop\`) are roughly constant-time in a set versus a linear scan in a list
+  > A set gives near-constant-time lookups, so checking each token against it is far faster than scanning a list — important when filtering large corpora. It does not change *which* tokens are removed, only how fast.
+- The number of stopwords in the list
+- The language of the text
+
+Same result, faster execution — a cheap and worthwhile habit.`}
+/>
+
+Stopword removal trims the *common* words. The next page tackles a different
+kind of redundancy: the fact that "run", "runs", "running", and "ran" are all
+the same underlying word wearing different endings. That is the job of
+**stemming and lemmatization**.

--- a/content/learn/natural-language-processing-python/text-normalization.mdx
+++ b/content/learn/natural-language-processing-python/text-normalization.mdx
@@ -1,0 +1,312 @@
+---
+title: "Text Normalization: Case Folding and Punctuation"
+description: Why we lowercase text and strip punctuation — to make tokens that should be equal actually compare equal — and what that normalization quietly throws away. When case folding helps, when it destroys meaning (acronyms, names, shouting), and how to strip punctuation safely.
+---
+
+After tokenization you have a list of word-shaped strings. But to a computer,
+`"The"`, `"the"`, and `"THE"` are three completely different strings, and
+`"dog"` and `"dog."` are two. If you counted words right now, you would
+triple-count "the" and miss matches constantly. **Normalization** is the step
+that reduces this surface-level variation so that tokens which *should* be
+treated as the same actually are.
+
+The two workhorse normalization steps — and the focus of this page — are
+**case folding** (lowercasing) and **punctuation stripping**. Both are
+simple to do and surprisingly consequential to get wrong.
+
+## Case folding: collapsing "The", "the", and "THE"
+
+Computers compare strings by their exact characters, so `"The" == "the"` is
+`False`. For most counting and matching tasks, that distinction is noise: you
+do not care that one "the" started a sentence and another did not. Case
+folding — usually just `str.lower()` — collapses all of them into one form.
+
+```mermaid
+flowchart LR
+    A["'The'"] --> X["lowercase"]
+    B["'the'"] --> X
+    C["'THE'"] --> X
+    X --> Y["'the'<br/>one token, counted once"]
+```
+
+<CodeBlock
+  adapter="python"
+  initialCode={`words = ["The", "the", "THE", "Dog", "dog", "DOG"]
+
+# Without normalization, casing creates spurious distinct words.
+print("Distinct as-is:    ", len(set(words)), "->", set(words))
+
+# Case folding collapses them.
+folded = [w.lower() for w in words]
+print("Distinct lowercased:", len(set(folded)), "->", set(folded))
+`}
+/>
+
+Six "different" words became two. If your goal is to count how often each
+word appears, that collapse is exactly right — "The" at the start of a
+sentence and "the" in the middle are the same word, and you want them tallied
+together.
+
+<Callout type="info" title="lower() vs casefold()">
+Python has two lowercasing methods. `str.lower()` is the everyday choice.
+`str.casefold()` is more aggressive and handles some non-English cases — most
+famously the German "ß", which `casefold()` turns into "ss". For English text
+they behave identically; reach for `casefold()` when you are doing
+case-insensitive matching across many languages. Throughout this course we
+use `lower()`.
+</Callout>
+
+## When you should NOT lowercase
+
+Here is where beginners get burned: lowercasing is **lossy**, and sometimes
+the case carries real information you need. Folding it away is a one-way
+door.
+
+- **Named entities.** "Apple" the company and "apple" the fruit are different
+  things, and capitalization is the main clue. Lowercase first and you have
+  thrown away the signal a name-recognition system relies on.
+- **Acronyms.** "US" (United States) becomes "us" (the pronoun). "WHO" (the
+  health organization) becomes "who". These collisions can be serious.
+- **Sentiment and emphasis.** "this is FINE" shouted in all caps carries
+  different emotional weight than "this is fine". For some sentiment tasks,
+  ALL-CAPS is a feature worth keeping, not erasing.
+- **Part-of-speech tagging.** Taggers use capitalization as a hint that a
+  word is a proper noun. Lowercasing *before* tagging removes that hint and
+  can make the tagger worse — a reason to tag first, normalize later.
+
+<Callout type="warn" title="Normalization is information destruction (on purpose)">
+Every normalization step *deletes* information so that the remaining tokens
+compare more easily. That is its entire job — but it means the step can never
+be undone, and if the information you deleted mattered to your task, you have
+quietly made things worse. Always ask: *what am I throwing away, and does my
+task need it?* For plain word-counting, casing is noise. For entity
+recognition, casing is signal.
+</Callout>
+
+<CodeBlock
+  adapter="python"
+  initialCode={`# Same letters, very different meanings — case is the only clue.
+print("US".lower(), "  <- 'US' the country becomes the pronoun 'us'")
+print("WHO".lower(), " <- 'WHO' the organization becomes the question word 'who'")
+print("Apple".lower(), "<- the company becomes the fruit")
+
+# For shouting, case can be a sentiment signal:
+review = "this product is GARBAGE"
+print("Has ALL-CAPS word:", any(w.isupper() and len(w) > 1 for w in review.split()))
+`}
+/>
+
+## Punctuation stripping
+
+The second normalization workhorse is removing punctuation. After
+tokenization you often have standalone punctuation tokens (`","`, `"!"`,
+`"."`) and sometimes punctuation still clinging to words. For most
+bag-of-words style tasks, punctuation is noise you want gone. There are a few
+common ways to strip it; know more than one.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`import re
+import string
+
+text = "Hello, World! It's a GREAT day... isn't it?"
+
+# Approach 1 — keep only alphabetic tokens after a naive split.
+approach1 = [w for w in text.split() if w.isalpha()]
+print("1. isalpha filter: ", approach1)
+
+# Approach 2 — strip punctuation characters from each token with str.translate.
+table = str.maketrans("", "", string.punctuation)
+approach2 = [w.translate(table) for w in text.lower().split()]
+approach2 = [w for w in approach2 if w]   # drop any now-empty strings
+print("2. translate:      ", approach2)
+
+# Approach 3 — pull out runs of letters with a regular expression.
+approach3 = re.findall(r"[a-z]+", text.lower())
+print("3. regex findall:  ", approach3)
+
+print()
+print("string.punctuation =", repr(string.punctuation))
+`}
+/>
+
+Compare the three results carefully — they disagree, and the disagreements
+are instructive:
+
+- **Approach 1** (`isalpha` filter) drops "World!" *entirely* because the
+  whole token "World!" is not alphabetic. That is probably not what you
+  wanted — you lost the word, not just the punctuation.
+- **Approach 2** (`translate`) removes punctuation *characters*, turning
+  "World!" into "world" and "It's" into "its". It keeps the words but glues
+  contractions together ("its").
+- **Approach 3** (regex `[a-z]+`) extracts runs of letters, so "isn't"
+  becomes two tokens, "isn" and "t".
+
+There is no single right answer; each approach makes a different trade-off
+about contractions and partial-punctuation tokens. The lesson is to *look at
+what your stripping actually does* rather than trusting it blindly.
+
+<Callout type="tip" title="The order trap, again">
+Strip punctuation *after* tokenizing, not before. If you delete all the
+periods first, you destroy the very clues a sentence tokenizer needs to find
+sentence boundaries — and you may even merge two sentences into one run-on.
+Tokenize, then clean.
+</Callout>
+
+<MultipleChoice
+  markdown={`Why is lowercasing described as a *lossy* operation?
+
+- Because it makes the text take up less memory
+- [o] Because it permanently discards capitalization, which sometimes carries real meaning (e.g., "Apple" vs "apple", "US" vs "us"), and that information cannot be recovered afterward
+  > Case folding throws away the distinction between upper and lower case. For word-counting that distinction is noise, but for names and acronyms it is signal — and once folded, it is gone for good.
+- Because it always introduces spelling errors
+- Because it converts the text into a different language
+
+"Lossy" means information is destroyed; whether that matters depends entirely on your task.`}
+/>
+
+## What normalization gives and takes
+
+It is worth holding both effects in your head at once.
+
+```mermaid
+flowchart TB
+    R["Raw tokens:<br/>'The', 'Apple', 'is', 'GREAT', '!'"]
+    R --> G["Normalization gains:<br/>'the'='The', fewer distinct forms,<br/>cleaner counts and matches"]
+    R --> L["Normalization losses:<br/>'Apple' the company looks like 'apple' the fruit,<br/>shouting 'GREAT' looks calm, '!' is gone"]
+```
+
+For a search index or a word-frequency study, the gains dominate and the
+losses are irrelevant — lowercase away. For named-entity recognition or
+emphasis-sensitive sentiment, the losses can be fatal — be careful, or skip
+the step. Same operation, opposite verdict, depending on the task.
+
+## Your turn: write a normalizer
+
+<ChallengeCard
+  adapter="python"
+  title="Normalize text to lowercase words"
+  category="normalization · case folding · punctuation"
+  estimatedTime="~6 min"
+  instructions={`Write a function \`normalize(text)\` that returns a list of normalized words:
+
+1. Lowercase the whole string.
+2. Remove punctuation characters (the ones in \`string.punctuation\`).
+3. Split on whitespace and drop any empty strings.
+
+For example, \`normalize("Hello, World!")\` should return \`['hello',
+'world']\`. The \`string\` module is already imported for you.
+
+(Heads up: because step 2 removes the apostrophe, a contraction like "it's"
+will become "its". That is a real side effect of character-level punctuation
+stripping — you do not need to fix it here, just be aware of it.)`}
+  initCode={`import string`}
+  initialCode={`def normalize(text):
+    # 1. lowercase
+    # 2. remove punctuation characters
+    # 3. split and drop empties
+    return []
+
+print(normalize("Hello, World!"))
+print(normalize("Wow!!!  Amazing??"))
+`}
+  solutionCode={`def normalize(text):
+    text = text.lower()
+    table = str.maketrans("", "", string.punctuation)
+    text = text.translate(table)
+    return [w for w in text.split() if w]
+
+print(normalize("Hello, World!"))
+print(normalize("Wow!!!  Amazing??"))
+`}
+  tests={[
+    {
+      id: "basic",
+      name: "Lowercases and strips punctuation",
+      description: "'Hello, World!' -> ['hello', 'world']",
+      code: `assert normalize("Hello, World!") == ["hello", "world"], "Got: " + repr(normalize("Hello, World!"))`,
+    },
+    {
+      id: "multi_punct",
+      name: "Handles repeated punctuation and extra spaces",
+      description: "'Wow!!!  Amazing??' -> ['wow', 'amazing']",
+      code: `assert normalize("Wow!!!  Amazing??") == ["wow", "amazing"], "Got: " + repr(normalize("Wow!!!  Amazing??"))`,
+    },
+    {
+      id: "all_lower",
+      name: "Everything is lowercase",
+      description: "No uppercase letters survive",
+      code: `out = normalize("APPLE Banana cHeRrY")
+assert out == ["apple", "banana", "cherry"], "Got: " + repr(out)`,
+    },
+    {
+      id: "no_empties",
+      name: "No empty strings in the output",
+      description: "Stripped-away tokens must not leave empty items",
+      code: `out = normalize("!!! ... ???  hi")
+assert "" not in out, "Found an empty string in: " + repr(out)
+assert out == ["hi"], "Got: " + repr(out)`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`For a system that counts how often each word appears in a news article, why
+is lowercasing usually the right call?
+
+- It makes the article shorter
+- [o] Different capitalizations of the same word ("The", "the", "THE") are the same word for counting purposes, so folding them together gives accurate totals
+  > When the unit of interest is "how often does this word occur", casing is noise. Collapsing it prevents the same word from being split across several count buckets.
+- It translates the article into another language
+- It is required before any text can be stored
+
+Word-frequency counting is the textbook case where case folding clearly helps.`}
+/>
+
+<MultipleChoice
+  markdown={`A team building a system to detect company names in news ("Apple announced…")
+lowercases all text as the very first step and then complains the system
+confuses companies with common nouns. What went wrong?
+
+- Lowercasing is too slow for news text
+- [o] Capitalization is a key signal for recognizing names, and lowercasing first destroyed it — for this task, case folding is harmful
+  > Named-entity recognition leans heavily on capitalization to spot proper nouns. Folding case away up front removes the exact clue the task depends on. Some tasks should skip or delay normalization.
+- The system needed more punctuation, not less
+- News articles cannot be processed by computers
+
+Whether to normalize is task-dependent; here the "harmless" step was actively destructive.`}
+/>
+
+<MultipleChoice
+  markdown={`You strip punctuation by keeping only tokens where \`token.isalpha()\` is
+\`True\`. On the token \`"World!"\` what happens, and why might that surprise
+you?
+
+- "World!" becomes "World" with the "!" removed
+- [o] The entire token "World!" is dropped, because the whole string is not alphabetic — so you lose the word, not just the punctuation
+  > \`"World!".isalpha()\` is \`False\` because of the "!", so the filter discards the whole token. To keep the word and only remove the mark, strip the punctuation characters (e.g., with \`str.translate\` or a regex) instead of filtering whole tokens.
+- It raises an error
+- It splits into "World" and "!"
+
+Knowing exactly what each stripping technique does — including what it deletes — is the difference between clean data and silent data loss.`}
+/>
+
+<MultipleChoice
+  markdown={`Why should punctuation stripping generally come *after* sentence
+tokenization, not before?
+
+- Punctuation cannot be removed from a tokenized list
+- [o] Sentence tokenizers use periods, question marks, and exclamation points to find sentence boundaries; removing them first destroys those clues and can merge separate sentences
+  > The marks you want to strip are the same marks a sentence tokenizer relies on. Strip them up front and you blind the tokenizer. Tokenize into sentences first, then clean within them.
+- Stripping punctuation changes the language of the text
+- It does not matter; order is irrelevant here
+
+This is another instance of the recurring theme that *order matters* in a pipeline.`}
+/>
+
+Case folding and punctuation stripping shrink the *number of distinct
+spellings*. But two related words like "running" and "runs" still look
+unrelated, and ultra-common words like "the" still dominate the counts. We
+tackle the common words next: **stopwords**.

--- a/content/learn/natural-language-processing-python/the-nlp-pipeline.mdx
+++ b/content/learn/natural-language-processing-python/the-nlp-pipeline.mdx
@@ -1,0 +1,406 @@
+---
+title: The Anatomy of an NLP Pipeline
+description: The standard sequence of preprocessing steps text flows through — tokenize, normalize, filter, reduce, analyze — seen as one picture. Why it is a pipeline of transformations, why most steps are optional, and why order matters.
+---
+
+On the last page we said NLP adds structure to text in *layers*. Those layers
+are usually arranged as a **pipeline**: a fixed sequence of steps where the
+output of each step becomes the input to the next. Before we spend a page
+each on the individual steps, it is worth seeing the whole assembly line at
+once, because the shape will repeat on nearly every page that follows.
+
+## The standard text preprocessing pipeline
+
+Here is the canonical flow. Almost every classic NLP project is some subset
+of these steps, in roughly this order.
+
+```mermaid
+flowchart TD
+    A["Raw text<br/>(a string)"] --> B["Sentence tokenization<br/>split into sentences (optional)"]
+    B --> C["Word tokenization<br/>split into words and punctuation"]
+    C --> D["Case folding<br/>lowercase the tokens"]
+    D --> E["Cleaning<br/>drop punctuation and non-words"]
+    E --> F["Stopword removal<br/>drop ultra-common words (optional)"]
+    F --> G["Stemming or lemmatization<br/>reduce words to a root (optional)"]
+    G --> H["Analysis<br/>counts, n-grams, POS tags, features"]
+```
+
+Read it top to bottom. Raw text comes in; a clean, normalized list of units
+comes out, ready to be counted or fed into a model. Three things about this
+picture matter more than the picture itself.
+
+**First, it is a pipeline of transformations.** At each step you are holding
+a value — first a string, then a list of tokens — and you apply one
+transformation to get the next value. This is exactly the list-comprehension
+style of Python you already know: `tokens = [t.lower() for t in tokens]` *is*
+the case-folding step.
+
+**Second, most steps are optional.** Only tokenization is nearly always
+present. Whether you lowercase, whether you remove stopwords, whether you
+stem or lemmatize — those are *choices*, and making them well is the single
+most important skill in classic NLP. We give that skill its own page later
+([Designing the Right Pipeline](./choosing-your-pipeline)).
+
+**Third, order matters.** Removing punctuation before tokenizing can destroy
+information a tokenizer needs (those periods help it find sentence ends).
+Lowercasing before part-of-speech tagging can confuse a tagger that uses
+capitalization as a clue. The same steps in a different order can give
+different — sometimes worse — results.
+
+<Callout type="info" title="The pipeline is a sequence of transformations on a list">
+After tokenization, your text is just a Python list of strings, and every
+later step is a transformation of that list into another list: filter out
+some items, lowercase the rest, replace each with its root. If you are
+comfortable with list comprehensions, you already understand the *mechanics*
+of an NLP pipeline. The hard part is never the code — it is deciding which
+transformations to apply.
+</Callout>
+
+## Watching a list flow through the pipeline
+
+Let us make "a pipeline is a sequence of list transformations" concrete. The
+block below runs the standard steps and prints the list after each one, so
+you can watch it shrink and change. Read each printed line against the
+diagram above.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the data this page needs. nltk.download() isn't
+# available in this environment, so we fetch the data archives directly
+# and unpack them into NLTK's data directory.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("corpora", "stopwords")
+await _load_nltk("corpora", "wordnet")
+from nltk.tokenize import word_tokenize
+from nltk.corpus import stopwords
+from nltk.stem import WordNetLemmatizer`}
+  initialCode={`text = "The Cats are RUNNING quickly, and the dogs are barking loudly!"
+
+# Step 1 — word tokenization
+tokens = word_tokenize(text)
+print("1. tokenized: ", tokens)
+
+# Step 2 — case folding (lowercase)
+tokens = [t.lower() for t in tokens]
+print("2. lowercased:", tokens)
+
+# Step 3 — cleaning (keep only alphabetic tokens)
+tokens = [t for t in tokens if t.isalpha()]
+print("3. cleaned:   ", tokens)
+
+# Step 4 — stopword removal
+stop = set(stopwords.words("english"))
+tokens = [t for t in tokens if t not in stop]
+print("4. no stops:  ", tokens)
+
+# Step 5 — lemmatization (reduce to dictionary form)
+lemmatizer = WordNetLemmatizer()
+tokens = [lemmatizer.lemmatize(t) for t in tokens]
+print("5. lemmatized:", tokens)
+`}
+/>
+
+Each `print` is one row of the pipeline diagram. The list started as nine
+tokens including punctuation and shrank to a handful of meaningful roots. Try
+commenting out step 4 (stopword removal) and re-running — notice how much
+longer the final list becomes, and ask yourself whether those extra words
+would help or hurt whatever you planned to do next. That question has no
+universal answer, which is exactly why these steps are choices.
+
+<Callout type="tip" title="Experiment: reorder the steps">
+Move the lowercasing step (step 2) to *after* stopword removal and re-run.
+The stopword list is all lowercase, so comparing un-lowercased tokens like
+`"The"` against it silently fails to remove them. This is a tiny taste of why
+*order matters* — a theme we will keep returning to.
+</Callout>
+
+## The two families of steps: cleaning vs. analysis
+
+It helps to mentally split the pipeline into two halves.
+
+```mermaid
+flowchart LR
+    subgraph PRE["Preprocessing (cleaning)"]
+        direction TB
+        p1["Tokenize"] --> p2["Normalize"] --> p3["Filter / reduce"]
+    end
+    subgraph ANA["Analysis (extracting value)"]
+        direction TB
+        a1["Count frequencies"]
+        a2["Tag parts of speech"]
+        a3["Build n-grams"]
+        a4["Make features"]
+    end
+    PRE --> ANA
+```
+
+The **preprocessing** half turns raw text into clean, comparable units. It is
+mostly mechanical and mostly the same from project to project. The
+**analysis** half is where you actually extract value, and it depends on your
+goal: a search engine counts and indexes, an autocomplete builds n-grams, a
+classifier builds features. Crucially, *the analysis you intend to do should
+drive the preprocessing choices you make* — not the other way around. We will
+see this dependency again and again.
+
+<MultipleChoice
+  markdown={`In the pipeline, why is it accurate to say "most steps are optional, but
+tokenization usually is not"?
+
+- Tokenization is the only step that is fast enough to run
+- [o] Almost every later step operates on *tokens*, so you need tokens before you can lowercase, filter, count, or tag them — whereas lowercasing, stopword removal, and stemming are choices that depend on the task
+  > Tokenization produces the list of units everything else transforms. Without it there is nothing to lowercase or count. The later steps add or remove information and are applied (or skipped) based on what you are trying to achieve.
+- Tokenization is the last thing you do, after counting
+- Stopword removal must always happen before tokenization
+
+You cannot transform a list of tokens you have not produced yet.`}
+/>
+
+## Order matters: a concrete example
+
+We just hinted at it; let us prove it. The block below runs the *same three
+operations* — lowercase, remove stopwords, keep alphabetic — but in two
+different orders, and compares the results.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("corpora", "stopwords")
+from nltk.tokenize import word_tokenize
+from nltk.corpus import stopwords`}
+  initialCode={`text = "The The THE end is near"
+stop = set(stopwords.words("english"))   # all lowercase, includes 'the'
+tokens = word_tokenize(text)
+
+# Order A: lowercase FIRST, then remove stopwords  (correct)
+a = [t.lower() for t in tokens]
+a = [t for t in a if t not in stop]
+
+# Order B: remove stopwords FIRST, then lowercase  (buggy)
+b = [t for t in tokens if t not in stop]
+b = [t.lower() for t in b]
+
+print("Order A (lowercase then filter):", a)
+print("Order B (filter then lowercase):", b)
+`}
+/>
+
+Order A correctly removes all three "the"s, because by the time we compare
+against the lowercase stopword list, every token is lowercase. Order B leaves
+`"The"` and `"THE"` behind, because they did not match the lowercase `"the"`
+in the stoplist at the moment we filtered. Same operations, different order,
+different — and in this case wrong — result.
+
+<Callout type="warn" title="Order bugs are silent">
+Notice that Order B did not crash. It produced a perfectly reasonable-looking
+list that happened to be wrong. Pipeline ordering bugs almost never raise an
+error; they quietly corrupt your data and you only notice when your downstream
+results look off. Reasoning carefully about order is a real part of the craft.
+</Callout>
+
+## Your turn: assemble a mini pipeline
+
+Time to build the cleaning half yourself. The challenge below asks you to
+write a `preprocess` function that runs the standard cleaning steps in the
+right order. The hidden tests check the output on a couple of sentences,
+including one where a stopword changes everything.
+
+<ChallengeCard
+  adapter="python"
+  title="Build a text-cleaning pipeline"
+  category="pipeline · tokenize · normalize · filter"
+  estimatedTime="~7 min"
+  instructions={`Write a function \`preprocess(text)\` that returns a list of clean tokens by
+running these steps **in this order**:
+
+1. Word-tokenize the text with \`word_tokenize\`.
+2. Lowercase every token.
+3. Keep only tokens that are fully alphabetic (use \`.isalpha()\` to drop
+   punctuation and numbers).
+4. Remove English stopwords (use the provided \`stop\` set).
+
+Return the resulting list. For example, \`preprocess("The quick brown
+foxes!")\` should return \`['quick', 'brown', 'foxes']\`.
+
+The \`word_tokenize\` function and the \`stop\` set are already available from
+the setup section.`}
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+await _load_nltk("corpora", "stopwords")
+from nltk.tokenize import word_tokenize
+from nltk.corpus import stopwords
+stop = set(stopwords.words("english"))`}
+  initialCode={`def preprocess(text):
+    # your code here — return a list of clean tokens
+    tokens = word_tokenize(text)
+    # ... lowercase, keep alphabetic, drop stopwords ...
+    return tokens
+
+print(preprocess("The quick brown foxes are jumping!"))
+print(preprocess("It is NOT a good day."))
+`}
+  solutionCode={`def preprocess(text):
+    tokens = word_tokenize(text)
+    tokens = [t.lower() for t in tokens]
+    tokens = [t for t in tokens if t.isalpha()]
+    tokens = [t for t in tokens if t not in stop]
+    return tokens
+
+print(preprocess("The quick brown foxes are jumping!"))
+print(preprocess("It is NOT a good day."))
+`}
+  tests={[
+    {
+      id: "returns_list",
+      name: "Returns a list",
+      description: "preprocess should return a Python list",
+      code: `assert isinstance(preprocess("Hello world"), list), "preprocess must return a list"`,
+    },
+    {
+      id: "basic_clean",
+      name: "Cleans a simple sentence",
+      description: "Stopwords removed, punctuation dropped, lowercased",
+      code: `assert preprocess("The quick brown foxes are jumping!") == ["quick", "brown", "foxes", "jumping"], \
+    "Got: " + repr(preprocess("The quick brown foxes are jumping!"))`,
+    },
+    {
+      id: "stopwords_and_punct",
+      name: "Drops stopwords and punctuation",
+      description: "'It is NOT a good day.' should reduce to ['good', 'day']",
+      code: `assert preprocess("It is NOT a good day.") == ["good", "day"], \
+    "Got: " + repr(preprocess("It is NOT a good day."))`,
+    },
+    {
+      id: "all_lowercase",
+      name: "Output is all lowercase",
+      description: "No uppercase letters should survive",
+      code: `out = preprocess("APPLE Banana CHERRY")
+assert all(w == w.lower() for w in out), "Found a non-lowercase token: " + repr(out)`,
+    },
+    {
+      id: "no_punctuation",
+      name: "No punctuation tokens remain",
+      description: "Pure-punctuation tokens must be filtered out",
+      code: `out = preprocess("Wow!!! Really??? Yes...")
+assert all(w.isalpha() for w in out), "Found a non-alphabetic token: " + repr(out)`,
+    },
+  ]}
+/>
+
+<Callout type="success" title="Notice what the second test taught you">
+`preprocess("It is NOT a good day.")` returned `['good', 'day']`. The word
+**"not"** vanished — it is on NLTK's stopword list — and with it, the entire
+meaning of the sentence flipped from negative to positive. That is a preview
+of one of the most important cautionary tales in this course, which we will
+tell in full on the [stopwords page](./stopwords). Removing stopwords is not
+free; sometimes it throws away the very words that matter.
+</Callout>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`Why can applying the *same* preprocessing steps in a *different* order
+produce different results?
+
+- It cannot — order never affects the outcome of preprocessing
+- [o] Each step transforms the data the next step sees, so (for example) filtering before lowercasing compares differently-cased tokens against a lowercase stopword list and misses some
+  > Steps are not independent; each one changes the input to the next. Lowercasing after filtering means the filter saw the original casing, so case-mismatched stopwords slip through. Order changes what each step actually operates on.
+- Reordering steps changes which version of Python runs
+- Only the first step has any effect; the rest are ignored
+
+Pipelines are sequential transformations, so the order of those transformations is part of the logic.`}
+/>
+
+<MultipleChoice
+  markdown={`A colleague says, "I always remove stopwords and stem every text, no matter
+the project — it's just good hygiene." What is the best response?
+
+- They are right; more preprocessing is always better
+- [o] Preprocessing steps are choices that should be driven by the downstream task; some steps that help one task (like topic counting) actively hurt another (like sentiment analysis)
+  > There is no universally correct pipeline. Stopword removal helps when you want content words for topic analysis but can destroy sentiment or phrase meaning. The right steps depend on what you are trying to do — which is why "choosing the pipeline" gets its own page.
+- They are right, because stemming and stopword removal are required by NLTK
+- They are wrong because preprocessing should never be done at all
+
+"It depends on the task" is the honest, correct answer — and the core skill this course builds.`}
+/>
+
+<MultipleChoice
+  markdown={`Thinking of the pipeline as "a sequence of transformations on a list of
+tokens" is useful mainly because:
+
+- It proves that NLP requires no programming
+- [o] Once text is tokenized, each later step is just a filter or map over a list — a pattern you already know — so the difficulty shifts from *coding* the steps to *choosing* them
+  > After tokenization you are holding a Python list of strings, and lowercasing, filtering stopwords, and stemming are ordinary list comprehensions. The mechanics are familiar; the judgment about which transformations to apply is the real work.
+- It means the order of operations is irrelevant
+- It guarantees every pipeline gives the same output
+
+The mental model reframes NLP preprocessing as list-wrangling plus good judgment.`}
+/>
+
+With the whole assembly line in view, we can now study each station properly.
+We start where the pipeline starts: **tokenization** — and why breaking text
+into words and sentences is far subtler than it looks.

--- a/content/learn/natural-language-processing-python/tokenization.mdx
+++ b/content/learn/natural-language-processing-python/tokenization.mdx
@@ -1,0 +1,420 @@
+---
+title: Sentence and Word Tokenization
+description: Why breaking text into words and sentences is a real linguistic problem, not a call to .split(). How word_tokenize handles contractions and punctuation, how sentence tokenization survives 'Dr.' and decimals, and when tokenization choices matter downstream.
+---
+
+Tokenization is the very first transformation in almost every pipeline, and
+it is the one beginners most often underestimate. A **token** is a single
+meaningful unit of text — usually a word, but also a number, a punctuation
+mark, or a symbol. **Tokenization** is the process of cutting a raw string
+into that list of tokens. It sounds trivial. It is not.
+
+The reason it is not trivial is everything we saw on the first page:
+contractions hide words, punctuation glues itself to words, and a period
+means three different things. A good tokenizer encodes a surprising amount of
+linguistic knowledge to get the cuts right.
+
+<Callout type="warn" title="The misconception to unlearn first">
+"Tokenization is just `string.split()`." This is the single most common
+misunderstanding in beginner NLP. Splitting on whitespace is a crude
+approximation that fails the moment punctuation or contractions appear — and
+they always appear. Real tokenization makes *linguistically informed* cuts:
+it knows that the comma in "butter," is not part of the word, and that "n't"
+in "don't" is a separate, meaningful unit.
+</Callout>
+
+## Word tokenization: where `.split()` breaks
+
+Let us put the naive approach and a real tokenizer side by side on one tiny,
+nasty input.
+
+```mermaid
+flowchart TB
+    S["Input text: don't stop!"]
+    S --> SP["text.split()"]
+    S --> TK["word_tokenize(text)"]
+    SP --> SP1["['don't', 'stop!']<br/>contraction hidden,<br/>'!' glued to 'stop'"]
+    TK --> TK1["['do', 'n't', 'stop', '!']<br/>negation 'n't' exposed,<br/>'!' separated cleanly"]
+```
+
+`split()` produced two items, both subtly broken: the negation inside "don't"
+is invisible, and "stop!" would never match the word "stop". The tokenizer
+produced four clean units, and crucially it pulled "n't" out as its own token
+— which matters enormously for tasks like sentiment analysis, where negation
+flips meaning.
+
+See it run for real. The setup section above the editor loads the tokenizer
+for you.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the data this page needs. nltk.download() isn't
+# available in this environment, so we fetch the data archives directly
+# and unpack them into NLTK's data directory.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize, sent_tokenize`}
+  initialCode={`text = "I don't think Mr. Lee's plan will work, but we'll see!"
+
+print("split():        ", text.split())
+print("word_tokenize():", word_tokenize(text))
+`}
+/>
+
+Study the differences token by token:
+
+- `"don't"` becomes `['do', "n't"]` — the negation is now a separate token.
+- `"Lee's"` becomes `['Lee', "'s"]` — the possessive is split off.
+- `"we'll"` becomes `['we', "'ll"]` — the future-tense marker is exposed.
+- `","` and `"!"` become their own tokens instead of clinging to words.
+
+None of that happens with `split()`. The tokenizer is applying rules learned
+from how English is actually written.
+
+<Callout type="info" title="How does it know? (a peek, not a deep dive)">
+NLTK's default word tokenizer is based on the **Penn Treebank** conventions —
+a fixed set of regular-expression rules built from a large hand-annotated
+corpus of English. The rules say things like "split a leading or trailing
+quote", "separate `n't`, `'re`, `'ll`, `'s`", and "keep decimal numbers
+together". You do not need to memorize the rules. The lesson is that
+tokenization is *encoded linguistic knowledge*, which is exactly why a
+one-line `split()` cannot replace it.
+</Callout>
+
+<MultipleChoice
+  markdown={`After \`word_tokenize("don't")\`, the result is \`['do', "n't"]\`. Why is
+splitting the contraction this way valuable for something like sentiment
+analysis?
+
+- It makes the text shorter and therefore faster to process
+- [o] It exposes the negation \`"n't"\` as its own token, so a later step can detect that the sentence is being negated
+  > Negation flips sentiment ("good" vs. "not good"). If "don't" stays glued, a program never sees the negation. Splitting it out gives downstream steps a fighting chance to handle it correctly.
+- It converts the word into a number
+- It removes the word entirely, which is what we want
+
+Surfacing hidden function words like negation is one of the quiet superpowers of real tokenization.`}
+/>
+
+## Sentence tokenization: where splitting on "." breaks
+
+The mirror-image problem appears one level up. To split a paragraph into
+sentences, your instinct might be `text.split(".")`. That fails immediately,
+because a period is wildly overloaded: it ends sentences, but it also
+abbreviates "Dr." and "U.S.A.", and it marks the decimal in "2.5".
+
+```mermaid
+flowchart TB
+    T["Text: Dr. Lee earned 2.5 million. He smiled."]
+    T --> N["Naive: text.split('.')"]
+    T --> P["sent_tokenize() (Punkt)"]
+    N --> N1["broken fragments:<br/>'Dr', ' Lee earned 2', '5 million', ' He smiled'<br/>split inside 'Dr.' and '2.5'"]
+    P --> P1["2 clean sentences:<br/>'Dr. Lee earned 2.5 million.'<br/>'He smiled.'"]
+```
+
+NLTK's sentence tokenizer, **Punkt**, is smarter. It carries a list of known
+abbreviations and a model of how sentences typically end, so it does not
+mistake the period in "Dr." or "2.5" for a sentence boundary. Watch it work.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import sent_tokenize`}
+  initialCode={`text = "Dr. Lee earned 2.5 million. He smiled. Wasn't that great?"
+
+# Naive: split on every period.
+naive = text.split(".")
+print("Naive split('.') ->", len(naive), "pieces")
+for piece in naive:
+    print("   ", repr(piece))
+
+print()
+
+# Punkt: real sentence tokenization.
+sentences = sent_tokenize(text)
+print("sent_tokenize() ->", len(sentences), "sentences")
+for s in sentences:
+    print("   ", repr(s))
+`}
+/>
+
+The naive split shattered "Dr." and "2.5" into nonsense and missed that "?"
+also ends a sentence. Punkt returned exactly three clean sentences. This is
+why sentence tokenization is its own step with its own tool, not a string
+method.
+
+<Callout type="tip" title="The usual order: sentences first, then words">
+When a task cares about sentence boundaries (summarization, sentence-level
+sentiment, or anything that processes one sentence at a time), the common
+pattern is to call `sent_tokenize` first, then `word_tokenize` on each
+sentence. When you only need a flat bag of words (counting, search indexing),
+you can skip straight to `word_tokenize` on the whole text. Choose based on
+whether sentence structure matters to what you are doing.
+</Callout>
+
+## When the "right" tokens depend on your domain
+
+There is rarely one universally correct tokenization — it depends on what the
+text *is*. Consider social media: in the tweet "Loving #NLP @ the
+conference 😀", do you want "#NLP" kept whole as a hashtag, or split into "#"
+and "NLP"? Do you want the emoji preserved as a token? The default
+`word_tokenize` will not treat hashtags or emoji specially; NLTK ships a
+`TweetTokenizer` that does.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize, TweetTokenizer`}
+  initialCode={`tweet = "Loving #NLP @dataslope, this is sooo cool!!! :)"
+
+print("Default word_tokenize:")
+print("  ", word_tokenize(tweet))
+
+print("TweetTokenizer:")
+tt = TweetTokenizer()
+print("  ", tt.tokenize(tweet))
+`}
+/>
+
+Notice how the default tokenizer breaks "#NLP" into "#" and "NLP" and may
+split the emoticon, while `TweetTokenizer` keeps the hashtag, handle, and
+`:)` intact. Neither is "wrong" — they serve different goals. The takeaway:
+*the correct tokenization is the one that preserves the units your task cares
+about.* This is your first encounter with the recurring theme that pipeline
+choices are task-dependent.
+
+<MultipleChoice
+  markdown={`Why does \`text.split(".")\` fail as a sentence splitter on the text
+"Dr. Lee earned 2.5 million."?
+
+- Periods are invisible characters that \`split\` cannot see
+- [o] The period is overloaded — it appears in abbreviations ("Dr.") and decimals ("2.5") as well as at sentence ends — so splitting on every period cuts in the wrong places
+  > A sentence tokenizer must distinguish a period that ends a sentence from one that abbreviates a title or marks a decimal. \`split(".")\` treats them all the same and shatters "Dr." and "2.5".
+- \`split\` can only divide a string into two pieces
+- The sentence has no periods in it
+
+Punkt exists precisely to tell sentence-ending periods apart from the other kinds.`}
+/>
+
+## Where tokenization shows up in the real world
+
+- **Search engines** tokenize your query and every indexed document so that
+  the words can be matched. If "running" and "running," tokenized
+  differently, your search would silently miss results. Consistent
+  tokenization on both sides is what makes search work at all.
+- **Spam filters and classifiers** count tokens; bad tokenization means
+  counting "free!" and "free" as different words, weakening the signal.
+- **Machine translation and assistants** tokenize input before doing
+  anything else; the quality ceiling of the whole system is partly set here.
+- **Code and log analysis** needs custom tokenizers, because the "words" of a
+  log line or a programming language are not English words.
+
+In all of these, tokenization is invisible when it works and catastrophic
+when it does not — a classic piece of infrastructure.
+
+## Your turn: tokenize a tricky paragraph
+
+<ChallengeCard
+  adapter="python"
+  title="Count sentences and expose a contraction"
+  category="tokenization · sent_tokenize · word_tokenize"
+  estimatedTime="~6 min"
+  instructions={`A short paragraph is provided in the variable \`text\`. Using the tokenizers
+loaded for you:
+
+1. Create \`sentences\` by sentence-tokenizing \`text\` with \`sent_tokenize\`.
+2. Create \`tokens\` by word-tokenizing \`text\` with \`word_tokenize\`.
+
+The paragraph contains the abbreviation "Dr.", the decimal "98.6", and the
+contraction "didn't". A correct sentence tokenizer must **not** break on the
+period inside "Dr." or "98.6", and a correct word tokenizer must split
+"didn't" so that the negation token \`"n't"\` appears in \`tokens\`.`}
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import sent_tokenize, word_tokenize`}
+  initialCode={`text = "Dr. Adams measured 98.6 degrees. The patient didn't complain."
+
+sentences = None  # sent_tokenize the text
+tokens = None     # word_tokenize the text
+
+print("sentences:", sentences)
+print("tokens:   ", tokens)
+`}
+  solutionCode={`text = "Dr. Adams measured 98.6 degrees. The patient didn't complain."
+
+sentences = sent_tokenize(text)
+tokens = word_tokenize(text)
+
+print("sentences:", sentences)
+print("tokens:   ", tokens)
+`}
+  tests={[
+    {
+      id: "two_sentences",
+      name: "Finds exactly 2 sentences",
+      description: "'Dr.' and '98.6' must not be treated as sentence ends",
+      code: `assert isinstance(sentences, list), "sentences should be a list"
+assert len(sentences) == 2, "Expected 2 sentences, got " + str(len(sentences)) + ": " + repr(sentences)`,
+    },
+    {
+      id: "tokens_list",
+      name: "tokens is a list",
+      description: "word_tokenize returns a list of tokens",
+      code: `assert isinstance(tokens, list), "tokens should be a list"`,
+    },
+    {
+      id: "negation_exposed",
+      name: "Contraction split exposes the negation",
+      description: "'didn't' should produce the token \"n't\"",
+      code: `assert "n't" in tokens, "Expected the negation token \\"n't\\" in tokens; got " + repr(tokens)`,
+    },
+    {
+      id: "punct_separated",
+      name: "Sentence-ending period is its own token",
+      description: "word_tokenize separates punctuation from words",
+      code: `assert "." in tokens, "Expected '.' as a separate token; got " + repr(tokens)`,
+    },
+  ]}
+/>
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`What is a **token**, in the NLP sense?
+
+- Always exactly one English word
+- A single character of text
+- [o] A single meaningful unit of text — typically a word, but also a number, punctuation mark, or symbol — produced by tokenization
+  > Tokens are the atomic units a pipeline works with. Most are words, but punctuation marks, numbers, and symbols are tokens too. Tokenization is the step that decides where one token ends and the next begins.
+- The numeric ID a database assigns to a row
+
+Tokens are units of text, and they are not limited to dictionary words.`}
+/>
+
+<MultipleChoice
+  markdown={`Which task most clearly calls for **sentence** tokenization (not just word
+tokenization)?
+
+- Counting how many times the word "data" appears in a document
+- Building a search index of all the words in a corpus
+- [o] Summarizing a document by selecting its most important *sentences*
+  > Summarization that picks whole sentences obviously needs sentence boundaries first. Pure word-counting and search indexing operate on a flat bag of words and do not require knowing where sentences begin and end.
+- Lowercasing every word in a document
+
+If your unit of analysis is the sentence, you need a sentence tokenizer; if it is the word, you may not.`}
+/>
+
+<MultipleChoice
+  markdown={`A teammate tokenizes a set of tweets with the default \`word_tokenize\` and is
+surprised that "#MachineLearning" is split into "#" and "MachineLearning",
+losing the hashtag. What is the best fix?
+
+- Give up on tokenizing tweets; it is impossible
+- [o] Use a tokenizer suited to the domain, such as NLTK's \`TweetTokenizer\`, which keeps hashtags, mentions, and emoticons intact
+  > There is no single correct tokenization — it depends on which units matter. For social media, a tweet-aware tokenizer preserves hashtags and handles emoji, which the general-purpose tokenizer is not designed to do.
+- Manually delete every "#" before tokenizing
+- Switch from Python to a different programming language
+
+Matching the tokenizer to the text is part of designing the pipeline well.`}
+/>
+
+<MultipleChoice
+  markdown={`Why is "tokenization is just \`string.split()\`" a harmful misconception?
+
+- \`split()\` is actually slower than tokenization
+- [o] \`split()\` only cuts on whitespace, so it leaves punctuation attached to words and never separates contractions — corrupting every count, match, and comparison built on the tokens
+  > Whitespace splitting ignores all linguistic structure. "good." and "good" become different tokens, "don't" hides its negation, and downstream steps inherit all of these errors. Real tokenization makes informed cuts that \`split()\` cannot.
+- \`split()\` changes the language of the text
+- There is no difference; they are the same thing
+
+Everything downstream depends on good tokens, which is why this misconception is so costly.`}
+/>
+
+You now have clean tokens. But "The", "the", and "THE" are still three
+different strings to a computer, and "running" still looks unrelated to
+"runs". The next two pages fix that, starting with **normalization**.

--- a/content/learn/natural-language-processing-python/what-is-nlp.mdx
+++ b/content/learn/natural-language-processing-python/what-is-nlp.mdx
@@ -1,0 +1,350 @@
+---
+title: What Is Natural Language Processing?
+description: Why human text is genuinely hard for computers — lexical, structural, and referential ambiguity — and what NLP is really trying to do. We build the core intuition that text must be turned into structure before a program can use it.
+---
+
+Imagine you hand a computer this sentence and ask, innocently, "how many
+words is that?"
+
+> "I can't believe Dr. Smith's startup raised \$2.5M — it's unreal!"
+
+You already sense the trouble. Is "can't" one word or two ("can" + "not")?
+Does the period after "Dr" end a sentence? Is "\$2.5M" a word? Is the em dash
+a word? A human reads this in a second and understands it perfectly. A
+computer sees a flat string of characters with no idea where words begin,
+which marks matter, or what any of it *means*. Natural Language Processing
+(NLP) is the field that closes that gap.
+
+## The core problem: text is unstructured
+
+Most data a program handles is **structured**: a number is a number, a date
+has a year-month-day, a database column has a known type. Text is
+**unstructured**. It is just a sequence of characters, and all of its
+meaning — the words, the sentences, the grammar, the intent — is implied
+rather than labeled. Before a program can do anything useful with text, that
+implicit structure has to be made explicit.
+
+```mermaid
+flowchart LR
+    A["Raw text<br/>(a flat string of characters)"] --> B["NLP pipeline<br/>(tokenize, normalize, tag, count)"]
+    B --> C["Structure a program can use<br/>(words, sentences, tags, counts)"]
+```
+
+That is the one-sentence mission of this entire course: **turn unstructured
+text into structure a program can compute with.** Everything else —
+tokenization, normalization, tagging — is a specific technique for adding a
+specific kind of structure.
+
+<Callout type="info" title="A working definition">
+**Natural Language Processing is the set of techniques for getting computers
+to work with human language** — to break it into pieces, measure it, compare
+it, and extract meaning from it. "Natural" language (English, Spanish,
+Japanese) is contrasted with the "formal" languages computers were designed
+for, like Python or SQL, which are unambiguous by construction.
+</Callout>
+
+## Why this is hard: ambiguity everywhere
+
+Formal languages are designed so that every statement has exactly one
+meaning. Human language is the opposite: it is riddled with **ambiguity**,
+and humans resolve it so effortlessly with context that we rarely notice it
+is there. A computer has no such instincts. It is worth seeing the main
+kinds of ambiguity explicitly, because nearly every NLP technique exists to
+fight one of them.
+
+```mermaid
+flowchart TD
+    A["Ambiguity in text"] --> B["Lexical<br/>one word, many meanings"]
+    A --> C["Structural<br/>one sentence, many parse trees"]
+    A --> D["Referential<br/>what does 'it' refer to?"]
+    B --> B1["'lead' = metal? or to guide?"]
+    C --> C1["'I saw the man with the telescope'"]
+    D --> D1["'The trophy didn't fit in the case<br/>because it was too big.'"]
+```
+
+**Lexical ambiguity** is when a single word has multiple meanings. "Lead"
+can be a heavy metal or the act of guiding. "Bank" can be a riverside or a
+place for money. The word is identical; only context decides.
+
+**Structural (syntactic) ambiguity** is when the same words can be grouped
+into different grammatical structures. "I saw the man with the telescope" —
+did you use a telescope to see him, or did you see a man who was holding one?
+Both readings use the exact same words in the exact same order.
+
+**Referential ambiguity** is when it is unclear what a word points to. "The
+trophy didn't fit in the case because it was too big." What was too big — the
+trophy or the case? A human knows instantly (the trophy). A computer has no
+built-in notion of which object would plausibly be "too big."
+
+<Callout type="tip" title="The mental shift">
+Stop thinking of text as words and start thinking of it as *characters with
+hidden structure you must reconstruct.* The hidden structure is where the
+words are, where the sentences end, which word is the verb, and what refers
+to what. NLP is the work of reconstructing that structure, one layer at a
+time.
+</Callout>
+
+## Text is also irregular and noisy
+
+Beyond ambiguity, real text is just *messy* in ways that break naive
+programs:
+
+- **Contractions** hide words: "don't" contains "do" + "not"; "we'll"
+  contains "we" + "will".
+- **Punctuation** is overloaded: a period ends a sentence *and* abbreviates
+  "Dr." *and* marks a decimal in "2.5".
+- **Casing** is inconsistent: "Apple" the company vs. "apple" the fruit, or
+  a word capitalized only because it starts a sentence.
+- **Morphology**: "run", "runs", "running", and "ran" are four spellings of
+  one underlying idea.
+- **Multi-word units**: "New York", "machine learning", and "hot dog" are
+  each one concept written as several words.
+
+Every one of these is a reason a later page exists. Contractions and
+punctuation motivate *tokenization*. Casing motivates *case folding*.
+Morphology motivates *stemming and lemmatization*. Keep this list in mind —
+we are going to dismantle it problem by problem.
+
+## A first look: why `.split()` is not enough
+
+Your instinct, as a Python programmer, is probably to reach for
+`text.split()` to break a sentence into words. It is a reasonable first
+guess, and seeing exactly where it fails is the perfect motivation for what
+comes next. Run this and read the output carefully.
+
+<CodeBlock
+  adapter="python"
+  initialCode={`sentence = "I can't believe it's not butter, Mr. Jones!"
+
+# The naive approach: split on whitespace.
+naive = sentence.split()
+print("split() gives:", naive)
+print("word count:", len(naive))
+`}
+/>
+
+Look at what `.split()` produced. "can't" stayed glued together, so the
+hidden "not" is invisible. "butter," carries a comma stuck to it, so the word
+"butter" and the word "butter," would be counted as two different words.
+"Jones!" has an exclamation mark fused on. The naive split has no idea that
+punctuation is separate from words.
+
+Now watch a real tokenizer handle the same sentence. Do not worry about the
+setup — it is loaded for you in the read-only section above the editor.
+
+<CodeBlock
+  adapter="python"
+  initCode={`# ── NLTK setup (read-only) ─────────────────────────────────────────────
+# Installs NLTK and loads the data this page needs. nltk.download() isn't
+# available in this environment, so we fetch the data archives directly
+# and unpack them into NLTK's data directory.
+import io, os, zipfile
+import micropip
+await micropip.install("nltk")
+import nltk
+from pyodide.http import pyfetch
+
+_GH = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages"
+if "/nltk_data" not in nltk.data.path:
+    nltk.data.path.insert(0, "/nltk_data")
+
+async def _load_nltk(category, package):
+    dest = os.path.join("/nltk_data", category)
+    os.makedirs(dest, exist_ok=True)
+    if os.path.exists(os.path.join(dest, package)):
+        return
+    resp = await pyfetch(_GH + "/" + category + "/" + package + ".zip")
+    if resp.status != 200:
+        raise RuntimeError("Could not download " + category + "/" + package)
+    with zipfile.ZipFile(io.BytesIO(await resp.bytes())) as zf:
+        zf.extractall(dest)
+
+await _load_nltk("tokenizers", "punkt_tab")
+from nltk.tokenize import word_tokenize`}
+  initialCode={`sentence = "I can't believe it's not butter, Mr. Jones!"
+
+tokens = word_tokenize(sentence)
+print("word_tokenize gives:", tokens)
+print("token count:", len(tokens))
+`}
+/>
+
+The tokenizer split "can't" into `ca` + `n't`, exposing the negation. It
+peeled the comma off "butter" and the exclamation mark off "Jones". It even
+left "Mr." intact rather than treating that period as a word. We will study
+exactly how it does this on the [tokenization page](./tokenization) — for now,
+the point is simply that **breaking text into words is a real problem, not a
+one-liner.**
+
+<MultipleChoice
+  markdown={`Why does \`sentence.split()\` give a misleading word list for the sentence above?
+
+- It removes all the vowels from each word
+- [o] It only splits on whitespace, so punctuation stays attached to words and contractions are never separated
+  > \`split()\` knows nothing about language. It cuts on spaces, leaving "butter," and "Jones!" with punctuation fused on and "can't" unsplit, which distorts both the word list and any counts based on it.
+- It splits every character into its own item
+- It automatically lowercases the text, changing the words
+
+The whole job of a tokenizer is to make linguistically sensible cuts that \`split()\` cannot.`}
+/>
+
+## So what does an NLP system actually do?
+
+It almost never tackles "understand this text" in one giant leap. Instead it
+adds structure in **layers**, each layer building on the last. A typical
+analysis pipeline looks like this:
+
+```mermaid
+flowchart LR
+    A["Characters"] --> B["Tokens<br/>(words)"]
+    B --> C["Normalized tokens<br/>(lowercased, cleaned)"]
+    C --> D["Tagged tokens<br/>(part of speech)"]
+    D --> E["Patterns and counts<br/>(frequencies, n-grams, features)"]
+```
+
+Each arrow is a technique you will learn. By the end you will be able to walk
+a paragraph all the way from the left of that diagram to the right, and —
+just as importantly — explain *why* each arrow is there and when you would
+skip it.
+
+<Callout type="warn" title="A common misconception: NLP means AI that 'understands'">
+It is tempting to imagine NLP as a system that reads text and *understands*
+it the way you do. The classic techniques in this course do nothing of the
+kind. They count, match, and transform — mechanically and without
+comprehension. A frequency counter does not know what a word *means*; it
+knows how often it appears. This is not a limitation to apologize for: an
+enormous amount of useful work (search, spam filtering, topic detection) is
+done by systems that never "understand" a thing. Knowing the difference
+between *processing* text and *understanding* it will keep your expectations
+honest.
+</Callout>
+
+## Rules versus learning (a brief orientation)
+
+There are two broad strategies for handling language, and this course leans
+firmly toward the first.
+
+**Rule-based / algorithmic** approaches encode human knowledge directly: a
+list of stopwords, a set of suffix-stripping rules for stemming, a dictionary
+of positive and negative words for sentiment. They are transparent — you can
+read exactly why they did what they did — and they need no training data.
+
+**Learning-based** approaches (machine learning, and the deep-learning models
+behind modern assistants) infer their behavior from large quantities of
+example text instead of hand-written rules. They are powerful but opaque, and
+they assume you already understand the structure of text.
+
+```mermaid
+flowchart TD
+    subgraph RB["Rule-based / classic NLP (this course)"]
+        direction LR
+        r1["Human-written rules<br/>and word lists"] --> r2["Transparent result"]
+    end
+    subgraph LB["Learning-based NLP (later study)"]
+        direction LR
+        l1["Lots of example text"] --> l2["Trained model"]
+    end
+    RB -.-> LB
+```
+
+We focus on classic, rule-based and count-based NLP because it is where the
+durable intuition lives. Once you understand *why* text needs tokenizing,
+normalizing, and tagging, the modern learning-based tools become far easier
+to pick up — they still rely on most of these same ideas under the hood.
+
+## Where NLP shows up in the real world
+
+The techniques in this course are not academic curiosities. They quietly
+power tools you use every day:
+
+- **Search engines** tokenize and normalize both your query and billions of
+  documents so that searching "running" can also find "runs" and "ran".
+- **Spam filters** count suspicious words and phrases to score an email.
+- **Autocomplete and predictive text** lean on n-grams — the probability of
+  the next word given the last one or two.
+- **Voice assistants** convert messy spoken input into tokens before doing
+  anything else.
+- **Sentiment dashboards** scan product reviews or social posts for positive
+  and negative language.
+- **Plagiarism and duplicate detection** compare normalized word sets and
+  n-grams between documents.
+
+In every case, the first thing that happens — before any cleverness — is the
+unglamorous work of turning raw text into clean, comparable units. That is
+what you are about to learn to do well.
+
+## Check your understanding
+
+<MultipleChoice
+  markdown={`A program reads the word "bank" and cannot decide whether it means a
+financial institution or the side of a river. This is an example of which
+kind of ambiguity?
+
+- [o] Lexical ambiguity
+  > Lexical ambiguity is when a single word form has more than one possible meaning. "Bank", "lead", and "bat" are classic examples; only surrounding context resolves them.
+- Structural ambiguity
+  > Structural (syntactic) ambiguity is about how words group into a sentence's grammar, not about a single word having multiple meanings.
+- Referential ambiguity
+  > Referential ambiguity is about what a word like "it" or "they" points to, not about a single word's dictionary meaning.
+- There is no ambiguity here
+
+One word, multiple dictionary meanings — that is lexical ambiguity by definition.`}
+/>
+
+<MultipleChoice
+  markdown={`Which statement best captures what classic NLP techniques (like the ones in
+this course) actually do?
+
+- They make the computer genuinely understand the meaning of text the way a human does
+- [o] They mechanically transform, match, and count text to expose structure — without any real comprehension
+  > Classic NLP is transformation and counting: splitting, normalizing, tagging, tallying. It is enormously useful precisely because so many tasks don't require true understanding.
+- They translate all text into mathematical equations that are always exactly correct
+- They only work on programming languages, not human languages
+
+Useful does not require understanding — a spam filter scores words without knowing what any of them mean.`}
+/>
+
+<MultipleChoice
+  markdown={`"I saw the man with the telescope" can mean either *I used a telescope to see
+him* or *I saw a man who had a telescope*. What kind of ambiguity is this?
+
+- Lexical ambiguity
+  > No single word is ambiguous here; the trouble is how the phrase "with the telescope" attaches to the rest of the sentence.
+- [o] Structural (syntactic) ambiguity
+  > The same words in the same order support two different grammatical structures — two ways of grouping the phrases — which is exactly structural ambiguity.
+- Referential ambiguity
+  > Referential ambiguity would be about an unclear pronoun like "it" or "they"; this sentence has none.
+- Morphological ambiguity
+
+Same words, same order, two valid parse trees — that is structural ambiguity.`}
+/>
+
+<MultipleChoice
+  markdown={`Why is "turn unstructured text into structure" a fair one-line summary of
+NLP's core problem?
+
+- Because text files are larger than other kinds of data
+- [o] Because raw text is just a sequence of characters with all its meaning implied, and programs need that implied structure (words, sentences, tags) made explicit before they can compute with it
+  > Structured data carries its meaning in labeled fields; text hides everything inside a flat string. NLP's foundational job is to recover and make explicit the words, boundaries, and grammar that a program can then use.
+- Because text always needs to be translated into another language first
+- Because computers cannot store text at all
+
+The recurring theme of the whole course: add explicit structure to implicitly-structured text.`}
+/>
+
+<MultipleChoice
+  markdown={`A teammate proposes counting the words in customer reviews using
+\`review.split()\` and tallying the results. What is the most important risk?
+
+- Splitting is far too slow to run on text
+- [o] Punctuation stays attached to words and contractions stay glued, so "great!", "great", and "great." are counted as three different words and counts are distorted
+  > \`split()\` only cuts on whitespace. Without real tokenization, the same word with different trailing punctuation becomes multiple distinct entries, corrupting every count built on top.
+- \`split()\` deletes the reviews from memory
+- \`split()\` only works on numbers
+
+This is precisely why tokenization, not whitespace splitting, is step one of a real pipeline.`}
+/>
+
+In the next section we will zoom out and look at the **whole pipeline** as a
+single picture — the standard sequence of steps that text flows through —
+before we dive into each step in detail.


### PR DESCRIPTION
## Summary

A complete, foundations-first **Natural Language Processing with Python** course built on **NLTK**, added under `content/learn/natural-language-processing-python/`. It's aimed at learners who already know Python (strings, lists, loops, dictionaries, comprehensions, basic `re`) and teaches the classic text pipeline with a heavy emphasis on *intuition and trade-offs* rather than API memorization.

The course deliberately stays on classic, transparent techniques (NLTK only) and avoids deep learning / transformers / embeddings except where mentioned purely conceptually.

## Contents (14 pages)

| # | Page | Focus |
|---|------|-------|
| — | Welcome | course map, no-setup intro, a full-pipeline taster |
| **Foundations** | What Is NLP? | ambiguity (lexical/structural/referential), why text is hard |
| | The Anatomy of an NLP Pipeline | the standard preprocessing workflow; order matters |
| **Tokenization & Normalization** | Sentence & Word Tokenization | why `.split()` isn't tokenization; `word_tokenize`/`sent_tokenize` |
| | Text Normalization | case folding & punctuation stripping; what they destroy |
| | Identifying & Removing Stopwords | the negation trap; when removal *hurts* |
| | Stemming vs. Lemmatization | chopping vs. vocabulary lookup; POS-aware lemmas |
| **Counting & Structure** | Word Frequencies & Lexical Diversity | `FreqDist`, `.most_common()`, the long tail |
| | Part-of-Speech Tagging | `pos_tag`, the Penn tagset, POS → accurate lemmatization |
| | N-grams (Bigrams & Trigrams) | `nltk.util.ngrams`, local order, sparsity |
| **Putting It Together** | Designing the Right Pipeline | task-driven preprocessing trade-offs (emphasized) |
| | From Text to Features: Bag-of-Words | document-term matrix, feature extraction |
| | A Rule-Based Sentiment Classifier | capstone tying the whole pipeline together |
| | Where to Go Next | bridges to ML / modern toolkits |

Every component is explained as: *what ambiguity it solves, why it exists, when to use it, when it hurts, common misconceptions, and real-world uses.* The "Designing the Right Pipeline" page gives substantial coverage to preprocessing evaluation and trade-offs (the negation/stopword trap, stemming vs. lemmatization, ablation-style evaluation).

## Highlights

- **25 Mermaid diagrams** including the standard preprocessing pipeline, `.split()` vs. tokenizer, stemming-vs-lemmatization mechanics, a POS-tag tree, the n-gram sliding window, and the bag-of-words feature-extraction flow.
- Extensive **executable code blocks** and **challenge cards** demonstrating `word_tokenize`/`sent_tokenize`, stopword filtering, `PorterStemmer` vs `WordNetLemmatizer`, `pos_tag` (`averaged_perceptron_tagger_eng`), `FreqDist`/`.most_common()`, and `nltk.util.ngrams`.
- Every interactive block uses **read-only initialization code** to load NLTK data packages directly (no `nltk.download()`), so learners focus on the NLP code.
- **Single-answer MCQs** throughout, weighted toward the foundational/difficult pages, with neutral per-choice explanations (per `AGENTS.md`).
- `<Callout>` admonitions (info/tip/warn/danger/success) used throughout in JSX syntax.

## Verification

- ✅ All **25 Mermaid diagrams** parse against the installed **mermaid 11.15.0** (validated in a headless browser via `mermaid.parse`).
- ✅ All 14 MDX files compile with the fumadocs remark/rehype pipeline; a full `next build` prerenders all 14 pages with **no errors**.
- ✅ All **11 graded challenge reference solutions** were run against real **NLTK 3.9.4** and pass; key in-page demos and prose claims were verified too (e.g., switched the POS noun/verb demo to "fish", which the tagger actually disambiguates, and corrected a stopword-list example).

## How to review

Read `content/learn/natural-language-processing-python/index.mdx` first, then follow the order in `meta.json`. The course appears at `/learn/natural-language-processing-python` in the Learn section.

https://claude.ai/code/session_01QGCEXrsJKGvxvji3ZzjcT6

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGCEXrsJKGvxvji3ZzjcT6)_