### PR TITLE
CORS proxy Vercel previews; R download/print fixes; CSV-from-URL examples

### DIFF
--- a/__tests__/corsProxy.test.ts
+++ b/__tests__/corsProxy.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseAllowedOrigins,
+  isOriginInAllowList,
+  wildcardOriginToRegExp,
+  isLocalhostOrigin,
+} from "../cloudflare-cors-proxy/src/origins";
+
+const ALLOW = parseAllowedOrigins(
+  "http://localhost:3000,https://dataslope.com,https://www.dataslope.com,https://dataslope.vercel.app,https://dataslope-*-ye-joo-parks-projects.vercel.app",
+);
+
+describe("parseAllowedOrigins", () => {
+  it("separates exact entries from wildcard patterns", () => {
+    expect(ALLOW.exact.has("https://dataslope.com")).toBe(true);
+    expect(ALLOW.exact.has("https://dataslope.vercel.app")).toBe(true);
+    expect(ALLOW.patterns).toHaveLength(1);
+  });
+
+  it("trims whitespace and strips trailing slashes", () => {
+    const a = parseAllowedOrigins(" https://dataslope.com/ , https://x.com ");
+    expect(a.exact.has("https://dataslope.com")).toBe(true);
+    expect(a.exact.has("https://x.com")).toBe(true);
+  });
+
+  it("ignores empty entries", () => {
+    const a = parseAllowedOrigins("https://a.com,,  ,https://b.com");
+    expect(a.exact.size).toBe(2);
+  });
+});
+
+describe("isOriginInAllowList — exact origins", () => {
+  it("accepts configured production and localhost origins", () => {
+    expect(isOriginInAllowList("https://dataslope.com", ALLOW)).toBe(true);
+    expect(isOriginInAllowList("https://www.dataslope.com", ALLOW)).toBe(true);
+    expect(isOriginInAllowList("http://localhost:3000", ALLOW)).toBe(true);
+    expect(isOriginInAllowList("https://dataslope.vercel.app", ALLOW)).toBe(true);
+  });
+
+  it("rejects unrelated origins", () => {
+    expect(isOriginInAllowList("https://evil.com", ALLOW)).toBe(false);
+    expect(isOriginInAllowList("https://dataslope.com.evil.com", ALLOW)).toBe(
+      false,
+    );
+  });
+});
+
+describe("isOriginInAllowList — Vercel preview wildcards", () => {
+  it("accepts branch/commit preview deployments under the team scope", () => {
+    expect(
+      isOriginInAllowList(
+        "https://dataslope-git-claude-focused-barde-c4a546-ye-joo-parks-projects.vercel.app",
+        ALLOW,
+      ),
+    ).toBe(true);
+    expect(
+      isOriginInAllowList(
+        "https://dataslope-git-claude-vigilant-feyn-a92c1c-ye-joo-parks-projects.vercel.app",
+        ALLOW,
+      ),
+    ).toBe(true);
+    // Bare per-deployment hash form.
+    expect(
+      isOriginInAllowList(
+        "https://dataslope-a92c1c-ye-joo-parks-projects.vercel.app",
+        ALLOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a same-named project under a different (attacker) team scope", () => {
+    // The `*` cannot cross the team-scope suffix, so a different scope fails.
+    expect(
+      isOriginInAllowList(
+        "https://dataslope-abc-evil-team-projects.vercel.app",
+        ALLOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not let the wildcard cross a dot into another domain", () => {
+    expect(
+      isOriginInAllowList(
+        "https://dataslope-x.ye-joo-parks-projects.vercel.app",
+        ALLOW,
+      ),
+    ).toBe(false);
+    expect(
+      isOriginInAllowList(
+        "https://dataslope-x-ye-joo-parks-projects.vercel.app.evil.com",
+        ALLOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("requires the https scheme exactly", () => {
+    expect(
+      isOriginInAllowList(
+        "http://dataslope-x-ye-joo-parks-projects.vercel.app",
+        ALLOW,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isLocalhostOrigin", () => {
+  it("accepts localhost on any port and scheme", () => {
+    expect(isLocalhostOrigin("http://localhost:3000")).toBe(true);
+    expect(isLocalhostOrigin("http://localhost:8787")).toBe(true);
+    expect(isLocalhostOrigin("https://localhost")).toBe(true);
+  });
+
+  it("rejects non-localhost and malformed origins", () => {
+    expect(isLocalhostOrigin("https://dataslope.com")).toBe(false);
+    expect(isLocalhostOrigin("http://localhost.evil.com")).toBe(false);
+    expect(isLocalhostOrigin("not a url")).toBe(false);
+  });
+});
+
+describe("wildcardOriginToRegExp", () => {
+  it("escapes regex metacharacters in the literal segments", () => {
+    const re = wildcardOriginToRegExp("https://a.b-*.example.app");
+    // The dots are literal, not 'any char'.
+    expect(re.test("https://aXb-123.example.app")).toBe(false);
+    expect(re.test("https://a.b-123.example.app")).toBe(true);
+  });
+
+  it("requires at least one character for the wildcard", () => {
+    const re = wildcardOriginToRegExp("https://app-*.vercel.app");
+    expect(re.test("https://app-.vercel.app")).toBe(false);
+    expect(re.test("https://app-x.vercel.app")).toBe(true);
+  });
+});

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -1673,6 +1673,62 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     const collected: Omit<OutputCell, "id" | "elapsed">[] = [];
     const firstId = outputCounter.current + 1;
     newRunFirstIdRef.current = firstId;
+
+    // Mirror files the runtime created during the run (e.g. an R
+    // download.file() destination) into the Files pane and persist them to
+    // OPFS so they survive reloads and are re-staged on the next run.
+    // Called in both the success and error paths — a file may have been
+    // written before later user code threw — and is safe to call twice
+    // because the runtime clears its tracking list after the first read.
+    const syncCreatedFiles = async () => {
+      if (!rt.collectCreatedFiles) return;
+      let created: Map<string, Uint8Array>;
+      try {
+        created = await rt.collectCreatedFiles();
+      } catch {
+        return;
+      }
+      if (created.size === 0) return;
+
+      const wsId = workspaceIdRef.current;
+      const codePaths = new Set(filesRef.current.map((f) => f.filename));
+      const added: string[] = [];
+      for (const [path, bytes] of created) {
+        // Don't shadow an open code tab with a same-named data file.
+        if (codePaths.has(path)) continue;
+        if (wsId) {
+          try {
+            await writeDataFile(wsId, path, bytes);
+          } catch {
+            // OPFS write failed — still surface it in the in-memory list.
+          }
+        }
+        setVirtualFiles((prev) => {
+          const filtered = prev.filter((f) => f.path !== path);
+          return [...filtered, { path, size: bytes.length, isFolder: false }];
+        });
+        // Auto-expand ancestor folders so a nested download is visible.
+        const segments = path.split("/").filter(Boolean);
+        if (segments.length > 1) {
+          setExpandedFolders((prev) => {
+            const next = new Set(prev);
+            let cur = "";
+            for (let i = 0; i < segments.length - 1; i++) {
+              cur = cur ? `${cur}/${segments[i]}` : segments[i];
+              next.add(cur);
+            }
+            return next;
+          });
+        }
+        added.push(path);
+      }
+      if (added.length === 1) {
+        showToast(`Saved "${added[0]}" to Files.`);
+      } else if (added.length > 1) {
+        showToast(`Saved ${added.length} files to Files.`);
+      }
+    };
+
     try {
       // Stage all currently-open workspace files into the runtime's
       // virtual file system so multi-file `import`s, `include`s, etc.
@@ -1702,6 +1758,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
         (cell) => collected.push(cell),
         entryFilename ? { entryFilename } : undefined,
       );
+      await syncCreatedFiles();
       const elapsed = `${((performance.now() - t0) / 1000).toFixed(2)}s`;
       const merged = mergeConsecutiveStdout(collected);
       setOutputsForFile(targetFileId, (prev) => [
@@ -1721,6 +1778,9 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, waitMs));
       setStatusState("ready");
     } catch (err) {
+      // User code may have downloaded a file before later throwing — surface
+      // it in the Files pane even though the run ultimately errored.
+      await syncCreatedFiles();
       const elapsed = `${((performance.now() - t0) / 1000).toFixed(2)}s`;
       const msg = err instanceof Error ? err.message : String(err);
       const mergedOnErr = mergeConsecutiveStdout(collected);

--- a/app/_components/runtime/javascript.tsx
+++ b/app/_components/runtime/javascript.tsx
@@ -95,6 +95,30 @@ console.log(\`\\nTotal wall time: \${elapsed}ms (parallel)\`);
 `,
   },
   {
+    key: "fetch_csv",
+    title: "Fetch CSV from URL",
+    desc: "Read a remote CSV with fetch()",
+    code: `// raw.githubusercontent.com sends permissive CORS headers, so fetch()
+// works directly. User code is wrapped in an async function, so
+// top-level await is fine.
+const url =
+  "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv";
+const text = await (await fetch(url)).text();
+
+// Minimal CSV parse — this dataset has no quoted/embedded commas.
+const [header, ...rows] = text.trim().split(/\\r?\\n/);
+const cols = header.split(",");
+const data = rows.map((line) => {
+  const cells = line.split(",");
+  return Object.fromEntries(cols.map((c, i) => [c, cells[i]]));
+});
+
+console.log(\`\${data.length} rows × \${cols.length} columns\`);
+console.log("columns:", cols.join(", "));
+console.log("first 5 rows:", data.slice(0, 5));
+`,
+  },
+  {
     key: "node_modules",
     title: "Node.js Modules",
     desc: "require('path'), require('crypto'), require('os')",

--- a/app/_components/runtime/python.tsx
+++ b/app/_components/runtime/python.tsx
@@ -71,6 +71,26 @@ display(df.head(10))
 `,
   },
   {
+    key: "read_csv_url",
+    title: "Read CSV from URL",
+    desc: "Load a remote CSV with pandas",
+    code: `import pandas as pd
+
+# raw.githubusercontent.com sends permissive CORS headers, so pandas can
+# read the CSV straight from the URL — no download or proxy needed.
+url = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv"
+penguins = pd.read_csv(url)
+
+print(f"{penguins.shape[0]} rows × {penguins.shape[1]} columns")
+print()
+print("Penguins per species:")
+print(penguins["species"].value_counts())
+
+# A returned DataFrame renders as a table.
+penguins.head()
+`,
+  },
+  {
     key: "plotly_line",
     title: "Plotly Line Chart",
     desc: "Interactive time-series plot",

--- a/app/_components/runtime/r.tsx
+++ b/app/_components/runtime/r.tsx
@@ -699,10 +699,12 @@ const CREATED_FILES_PATH = "/tmp/.pg_created_files";
 //
 // 1. download.file(): WebR's built-in download.file() already works in the
 //    playground (it performs the request synchronously inside the worker). We
-//    only wrap it so the destination file is mirrored into the Files pane — the
-//    actual fetch is delegated unchanged to utils::download.file(), so
-//    cross-origin hosts still need permissive CORS headers (or the CORS proxy),
-//    exactly like pandas.read_csv in the Python runtime.
+//    wrap it to (a) mirror the destination file into the Files pane and
+//    (b) print its "trying URL" / "downloaded …" progress to stdout instead of
+//    stderr, which the playground styles as an error. The actual fetch is
+//    delegated unchanged to utils::download.file(), so cross-origin hosts still
+//    need permissive CORS headers (or the CORS proxy), exactly like
+//    pandas.read_csv in the Python runtime.
 //
 // 2. print(): base R prints every row of a plain data.frame, which can freeze
 //    the page for large frames. We override the print generic (an ordinary
@@ -715,13 +717,25 @@ const R_SESSION_SETUP = String.raw`
 suppressWarnings(dir.create("/tmp", showWarnings = FALSE))
 
 local({
-  download_file <- function(url, destfile, ...) {
-    status <- utils::download.file(url, destfile, ...)
-    if (!missing(destfile) && is.character(destfile) && length(destfile) == 1L &&
-        nzchar(destfile) && file.exists(destfile)) {
+  download_file <- function(url, destfile,
+                            method = getOption("download.file.method", "auto"),
+                            quiet = FALSE, ...) {
+    # Mirror R's familiar progress lines to stdout instead of stderr. The
+    # playground styles any stderr output as an error, which made a successful
+    # download look like it had failed. download.file's own messages are
+    # silenced with quiet = TRUE and re-emitted here via cat().
+    if (!isTRUE(quiet)) cat(sprintf("trying URL '%s'\n", url))
+    status <- utils::download.file(url, destfile, method = method, quiet = TRUE, ...)
+    if (is.character(destfile) && length(destfile) == 1L && nzchar(destfile) &&
+        file.exists(destfile)) {
       abs <- if (startsWith(destfile, "/")) destfile else file.path(getwd(), destfile)
       try(cat(abs, "\n", sep = "", file = "/tmp/.pg_created_files", append = TRUE),
           silent = TRUE)
+      if (!isTRUE(quiet)) {
+        size <- file.info(destfile)$size
+        cat(sprintf("downloaded %s bytes\n",
+                    format(size, big.mark = ",", scientific = FALSE)))
+      }
     }
     invisible(status)
   }

--- a/app/_components/runtime/r.tsx
+++ b/app/_components/runtime/r.tsx
@@ -55,6 +55,26 @@ head(df, 10)
 `,
   },
   {
+    key: "read_csv_url",
+    title: "Read CSV from URL",
+    desc: "Download a remote CSV & read it",
+    code: `# raw.githubusercontent.com sends permissive CORS headers, so the file can be
+# downloaded directly (no proxy needed). The download also shows up in the
+# Files pane on the left.
+url <- "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv"
+download.file(url, "penguins.csv")
+
+penguins <- read.csv("penguins.csv")
+
+cat(nrow(penguins), "rows x", ncol(penguins), "columns\\n\\n")
+cat("Penguins per species:\\n")
+print(table(penguins$species))
+
+# A returned data.frame renders as a table.
+head(penguins)
+`,
+  },
+  {
     key: "lm",
     title: "Linear Model",
     desc: "Fit a linear regression",

--- a/app/_components/runtime/r.tsx
+++ b/app/_components/runtime/r.tsx
@@ -688,114 +688,88 @@ function rowsFromDataFrame(value: unknown): Record<string, unknown>[] | null {
 // Working directory inside the WebR Emscripten FS (matches `getwd()` output).
 const WEB_USER_HOME = "/home/web_user";
 
-// Newline-separated list of absolute paths written by our download.file()
-// override during a run. Read back by collectCreatedFiles() so downloads show
-// up in the Files pane, then cleared.
+// Newline-separated list of absolute paths created during a run (currently
+// download.file() destinations). Read back by collectCreatedFiles() so
+// downloads appear in the Files pane, then cleared.
 const CREATED_FILES_PATH = "/tmp/.pg_created_files";
 
-// One-time R setup that installs a working download.file().
+// One-time R setup, run once after the runtime initialises and kept on the
+// search path so it survives the per-run wipe of the global environment (and
+// never shows up in the user's ls()).
 //
-// WebR's built-in download.file() performs a synchronous network request
-// through its main↔worker channel, which only succeeds when the page is
-// cross-origin isolated (SharedArrayBuffer available). The playground is not
-// cross-origin isolated, so the built-in stalls after printing "trying URL"
-// and never writes the file. We replace it with a synchronous XMLHttpRequest
-// run directly inside the WebR worker via webr::eval_js — fully self-contained,
-// so it works regardless of the communication channel. Cross-origin hosts
-// still need permissive CORS headers (or the CORS proxy), exactly like
-// pandas.read_csv in the Python runtime.
+// 1. download.file(): WebR's built-in download.file() already works in the
+//    playground (it performs the request synchronously inside the worker). We
+//    only wrap it so the destination file is mirrored into the Files pane — the
+//    actual fetch is delegated unchanged to utils::download.file(), so
+//    cross-origin hosts still need permissive CORS headers (or the CORS proxy),
+//    exactly like pandas.read_csv in the Python runtime.
 //
-// The override is attached to the search path (not .GlobalEnv) so it survives
-// the per-run wipe of the global environment in run() and never appears in the
-// user's ls(). Each successful download appends its destination path to
-// CREATED_FILES_PATH so the playground can mirror it into the Files pane.
-const R_NET_SETUP = String.raw`
+// 2. print(): base R prints every row of a plain data.frame, which can freeze
+//    the page for large frames. We override the print generic (an ordinary
+//    search-path lookup, unlike an S3 method which UseMethod won't pick up from
+//    an attached env) to show the first 10 and last 5 rows with an ellipsis —
+//    the same Jupyter-style truncation already used for auto-printed frames
+//    (see dataFrameToHtml). Only plain data.frames are affected; tibbles,
+//    data.tables, etc. keep their own already-truncating print methods.
+const R_SESSION_SETUP = String.raw`
 suppressWarnings(dir.create("/tmp", showWarnings = FALSE))
 
-.pg_download_file <- function(url, destfile, quiet = FALSE, mode = "wb", ...) {
-  if (missing(destfile) || is.null(destfile) || !nzchar(destfile)) {
-    stop("'destfile' must be a non-empty file path")
+local({
+  download_file <- function(url, destfile, ...) {
+    status <- utils::download.file(url, destfile, ...)
+    if (!missing(destfile) && is.character(destfile) && length(destfile) == 1L &&
+        nzchar(destfile) && file.exists(destfile)) {
+      abs <- if (startsWith(destfile, "/")) destfile else file.path(getwd(), destfile)
+      try(cat(abs, "\n", sep = "", file = "/tmp/.pg_created_files", append = TRUE),
+          silent = TRUE)
+    }
+    invisible(status)
   }
-  if (length(url) != 1L) stop("'url' must be a single string")
-  if (!quiet) message(sprintf("trying URL '%s'", url))
 
-  url_path    <- "/tmp/.pg_dl_url"
-  data_path   <- "/tmp/.pg_dl_data"
-  status_path <- "/tmp/.pg_dl_status"
-  unlink(c(data_path, status_path))
-  writeBin(charToRaw(enc2utf8(url)), url_path)
-
-  js <- r"---(
-(function () {
-  try {
-    var fs = Module.FS;
-    var raw = fs.readFile('/tmp/.pg_dl_url');
-    var url = '';
-    for (var i = 0; i < raw.length; i++) url += String.fromCharCode(raw[i]);
-    url = url.trim();
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, false);
-    xhr.overrideMimeType('text/plain; charset=x-user-defined');
-    try { xhr.responseType = 'arraybuffer'; } catch (e) {}
-    xhr.send(null);
-    var status = xhr.status || 0;
-    fs.writeFile('/tmp/.pg_dl_status', new TextEncoder().encode(String(status)));
-    if (status >= 200 && status < 300) {
-      var bytes;
-      if (xhr.response && typeof xhr.response.byteLength === 'number') {
-        bytes = new Uint8Array(xhr.response);
-      } else {
-        var text = xhr.responseText || '';
-        bytes = new Uint8Array(text.length);
-        for (var j = 0; j < text.length; j++) bytes[j] = text.charCodeAt(j) & 255;
+  print_override <- function(x, ...) {
+    # Only plain data.frames (e.g. from read.csv / data.frame). tibbles,
+    # data.tables, etc. keep their own already-truncating print methods.
+    if (identical(class(x), "data.frame")) {
+      n <- nrow(x)
+      if (is.finite(n) && n > 20L && ncol(x) >= 1L) {
+        done <- tryCatch({
+          head_n <- 10L; tail_n <- 5L
+          top <- format(utils::head(x, head_n))
+          bot <- format(utils::tail(x, tail_n))
+          sep <- top[1, , drop = FALSE]; sep[] <- "..."; rownames(sep) <- "..."
+          block <- as.matrix(rbind(top, sep, bot))
+          base::print(block, quote = FALSE, right = TRUE)
+          cat(sprintf("# %s rows total; showing first %d and last %d\n",
+                      format(n, big.mark = ","), head_n, tail_n))
+          TRUE
+        }, error = function(e) FALSE)
+        if (isTRUE(done)) return(invisible(x))
       }
-      fs.writeFile('/tmp/.pg_dl_data', bytes);
     }
-    return status;
-  } catch (err) {
-    try {
-      Module.FS.writeFile('/tmp/.pg_dl_status', new TextEncoder().encode('-1'));
-    } catch (e2) {}
-    return -1;
-  }
-})()
-)---"
-
-  invisible(webr::eval_js(js))
-
-  status <- tryCatch(
-    as.integer(readLines(status_path, warn = FALSE))[1],
-    error = function(e) NA_integer_
-  )
-  if (length(status) == 0L || is.na(status)) status <- -1L
-
-  if (status >= 200 && status < 300 && file.exists(data_path)) {
-    dest_dir <- dirname(destfile)
-    if (nzchar(dest_dir) && dest_dir != "." && !dir.exists(dest_dir)) {
-      dir.create(dest_dir, recursive = TRUE, showWarnings = FALSE)
-    }
-    ok <- file.copy(data_path, destfile, overwrite = TRUE)
-    unlink(data_path)
-    if (!isTRUE(ok)) stop(sprintf("cannot write downloaded data to '%s'", destfile))
-    size <- file.info(destfile)$size
-    if (!quiet) message(sprintf("downloaded %d bytes", as.integer(size)))
-    abs_path <- if (startsWith(destfile, "/")) destfile else file.path(getwd(), destfile)
-    cat(abs_path, "\n", sep = "", file = "/tmp/.pg_created_files", append = TRUE)
-    return(invisible(0L))
+    base::print(x, ...)
   }
 
-  stop(sprintf(
-    "cannot open URL '%s'%s",
-    url,
-    if (status > 0) sprintf(": HTTP status was %d", status) else ": download failed"
-  ))
-}
-
-while ("webr:playground-net" %in% search()) detach("webr:playground-net")
-attach(list(download.file = .pg_download_file),
-       name = "webr:playground-net", warn.conflicts = FALSE)
-rm(.pg_download_file)
+  while ("webr:playground" %in% search()) detach("webr:playground")
+  attach(list(download.file = download_file, print = print_override),
+         name = "webr:playground", warn.conflicts = FALSE)
+})
 `;
+
+// Backstop against a single run flooding the UI with megabytes of text (e.g.
+// printing a huge vector or matrix), which can freeze the browser. Keep the
+// head and tail so the output stays useful. Large data frames are truncated
+// more nicely by the print.data.frame override above; this catches everything
+// else.
+const MAX_CELL_TEXT_CHARS = 250_000;
+function capCellText(text: string): string {
+  if (text.length <= MAX_CELL_TEXT_CHARS) return text;
+  const headLen = Math.floor(MAX_CELL_TEXT_CHARS * 0.75);
+  const tailLen = MAX_CELL_TEXT_CHARS - headLen;
+  const head = text.slice(0, headLen);
+  const tail = text.slice(text.length - tailLen);
+  const hidden = text.length - head.length - tail.length;
+  return `${head}\n\n… ${hidden.toLocaleString()} characters of output hidden …\n\n${tail}`;
+}
 
 class WebRRuntime implements LanguageRuntime {
   private installedPackages = new Set<string>();
@@ -878,7 +852,7 @@ class WebRRuntime implements LanguageRuntime {
 
     await this.webR.evalRVoid(
       `rm(list = ls(envir = .GlobalEnv, all.names = TRUE), envir = .GlobalEnv)
-unlink(c("${CREATED_FILES_PATH}", "/tmp/.pg_dl_url", "/tmp/.pg_dl_data", "/tmp/.pg_dl_status"))`,
+unlink("${CREATED_FILES_PATH}")`,
     );
 
     const shelter: ShelterInstance = await new this.webR.Shelter();
@@ -908,9 +882,9 @@ unlink(c("${CREATED_FILES_PATH}", "/tmp/.pg_dl_url", "/tmp/.pg_dl_data", "/tmp/.
         else if (o.type === "stderr") stderrBuf += String(o.data) + "\n";
       }
       if (stdoutBuf.trim())
-        emit({ type: "stdout", content: stdoutBuf.trim() });
+        emit({ type: "stdout", content: capCellText(stdoutBuf.trim()) });
       if (stderrBuf.trim())
-        emit({ type: "stderr", content: stderrBuf.trim() });
+        emit({ type: "stderr", content: capCellText(stderrBuf.trim()) });
 
       for (const bmp of result.images) {
         const b64 = await imageBitmapToPngBase64(bmp);
@@ -970,9 +944,9 @@ unlink(c("${CREATED_FILES_PATH}", "/tmp/.pg_dl_url", "/tmp/.pg_dl_data", "/tmp/.
               else if (o.type === "stderr") printStderr += String(o.data) + "\n";
             }
             if (printStdout.trim())
-              emit({ type: "stdout", content: printStdout.trim() });
+              emit({ type: "stdout", content: capCellText(printStdout.trim()) });
             if (printStderr.trim())
-              emit({ type: "stderr", content: printStderr.trim() });
+              emit({ type: "stderr", content: capCellText(printStderr.trim()) });
             for (const bmp of printCapture.images) {
               const b64 = await imageBitmapToPngBase64(bmp);
               emit({ type: "image", content: b64 });
@@ -1097,13 +1071,13 @@ export const rAdapter: LanguageAdapter = {
       `options(device = function() webr::canvas(width = 720, height = 432, capture = TRUE))`,
     );
 
-    // Install a browser-native download.file() that works without
-    // cross-origin isolation (see R_NET_SETUP). Best-effort: a failure here
-    // shouldn't block the runtime from starting.
+    // Install the Files-pane download hook and large-data.frame print
+    // truncation (see R_SESSION_SETUP). Best-effort: a failure here shouldn't
+    // block the runtime from starting.
     try {
-      await webR.evalRVoid(R_NET_SETUP);
+      await webR.evalRVoid(R_SESSION_SETUP);
     } catch (err) {
-      console.error("[webr] failed to install download.file override", err);
+      console.error("[webr] failed to install playground session setup", err);
     }
 
     return new WebRRuntime(webR);

--- a/app/_components/runtime/r.tsx
+++ b/app/_components/runtime/r.tsx
@@ -536,6 +536,7 @@ interface WebRShelterConstructor {
 }
 interface WebRFS {
   writeFile(path: string, data: Uint8Array): Promise<void>;
+  readFile(path: string): Promise<Uint8Array>;
   mkdir(path: string): Promise<void>;
   unlink(path: string): Promise<void>;
 }
@@ -687,6 +688,115 @@ function rowsFromDataFrame(value: unknown): Record<string, unknown>[] | null {
 // Working directory inside the WebR Emscripten FS (matches `getwd()` output).
 const WEB_USER_HOME = "/home/web_user";
 
+// Newline-separated list of absolute paths written by our download.file()
+// override during a run. Read back by collectCreatedFiles() so downloads show
+// up in the Files pane, then cleared.
+const CREATED_FILES_PATH = "/tmp/.pg_created_files";
+
+// One-time R setup that installs a working download.file().
+//
+// WebR's built-in download.file() performs a synchronous network request
+// through its main↔worker channel, which only succeeds when the page is
+// cross-origin isolated (SharedArrayBuffer available). The playground is not
+// cross-origin isolated, so the built-in stalls after printing "trying URL"
+// and never writes the file. We replace it with a synchronous XMLHttpRequest
+// run directly inside the WebR worker via webr::eval_js — fully self-contained,
+// so it works regardless of the communication channel. Cross-origin hosts
+// still need permissive CORS headers (or the CORS proxy), exactly like
+// pandas.read_csv in the Python runtime.
+//
+// The override is attached to the search path (not .GlobalEnv) so it survives
+// the per-run wipe of the global environment in run() and never appears in the
+// user's ls(). Each successful download appends its destination path to
+// CREATED_FILES_PATH so the playground can mirror it into the Files pane.
+const R_NET_SETUP = String.raw`
+suppressWarnings(dir.create("/tmp", showWarnings = FALSE))
+
+.pg_download_file <- function(url, destfile, quiet = FALSE, mode = "wb", ...) {
+  if (missing(destfile) || is.null(destfile) || !nzchar(destfile)) {
+    stop("'destfile' must be a non-empty file path")
+  }
+  if (length(url) != 1L) stop("'url' must be a single string")
+  if (!quiet) message(sprintf("trying URL '%s'", url))
+
+  url_path    <- "/tmp/.pg_dl_url"
+  data_path   <- "/tmp/.pg_dl_data"
+  status_path <- "/tmp/.pg_dl_status"
+  unlink(c(data_path, status_path))
+  writeBin(charToRaw(enc2utf8(url)), url_path)
+
+  js <- r"---(
+(function () {
+  try {
+    var fs = Module.FS;
+    var raw = fs.readFile('/tmp/.pg_dl_url');
+    var url = '';
+    for (var i = 0; i < raw.length; i++) url += String.fromCharCode(raw[i]);
+    url = url.trim();
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, false);
+    xhr.overrideMimeType('text/plain; charset=x-user-defined');
+    try { xhr.responseType = 'arraybuffer'; } catch (e) {}
+    xhr.send(null);
+    var status = xhr.status || 0;
+    fs.writeFile('/tmp/.pg_dl_status', new TextEncoder().encode(String(status)));
+    if (status >= 200 && status < 300) {
+      var bytes;
+      if (xhr.response && typeof xhr.response.byteLength === 'number') {
+        bytes = new Uint8Array(xhr.response);
+      } else {
+        var text = xhr.responseText || '';
+        bytes = new Uint8Array(text.length);
+        for (var j = 0; j < text.length; j++) bytes[j] = text.charCodeAt(j) & 255;
+      }
+      fs.writeFile('/tmp/.pg_dl_data', bytes);
+    }
+    return status;
+  } catch (err) {
+    try {
+      Module.FS.writeFile('/tmp/.pg_dl_status', new TextEncoder().encode('-1'));
+    } catch (e2) {}
+    return -1;
+  }
+})()
+)---"
+
+  invisible(webr::eval_js(js))
+
+  status <- tryCatch(
+    as.integer(readLines(status_path, warn = FALSE))[1],
+    error = function(e) NA_integer_
+  )
+  if (length(status) == 0L || is.na(status)) status <- -1L
+
+  if (status >= 200 && status < 300 && file.exists(data_path)) {
+    dest_dir <- dirname(destfile)
+    if (nzchar(dest_dir) && dest_dir != "." && !dir.exists(dest_dir)) {
+      dir.create(dest_dir, recursive = TRUE, showWarnings = FALSE)
+    }
+    ok <- file.copy(data_path, destfile, overwrite = TRUE)
+    unlink(data_path)
+    if (!isTRUE(ok)) stop(sprintf("cannot write downloaded data to '%s'", destfile))
+    size <- file.info(destfile)$size
+    if (!quiet) message(sprintf("downloaded %d bytes", as.integer(size)))
+    abs_path <- if (startsWith(destfile, "/")) destfile else file.path(getwd(), destfile)
+    cat(abs_path, "\n", sep = "", file = "/tmp/.pg_created_files", append = TRUE)
+    return(invisible(0L))
+  }
+
+  stop(sprintf(
+    "cannot open URL '%s'%s",
+    url,
+    if (status > 0) sprintf(": HTTP status was %d", status) else ": download failed"
+  ))
+}
+
+while ("webr:playground-net" %in% search()) detach("webr:playground-net")
+attach(list(download.file = .pg_download_file),
+       name = "webr:playground-net", warn.conflicts = FALSE)
+rm(.pg_download_file)
+`;
+
 class WebRRuntime implements LanguageRuntime {
   private installedPackages = new Set<string>();
   // Absolute FS paths written during the previous prepareFileSystem call.
@@ -767,7 +877,8 @@ class WebRRuntime implements LanguageRuntime {
     const installWarnings = await this.ensurePackages(code);
 
     await this.webR.evalRVoid(
-      `rm(list = ls(envir = .GlobalEnv, all.names = TRUE), envir = .GlobalEnv)`,
+      `rm(list = ls(envir = .GlobalEnv, all.names = TRUE), envir = .GlobalEnv)
+unlink(c("${CREATED_FILES_PATH}", "/tmp/.pg_dl_url", "/tmp/.pg_dl_data", "/tmp/.pg_dl_status"))`,
     );
 
     const shelter: ShelterInstance = await new this.webR.Shelter();
@@ -876,6 +987,56 @@ class WebRRuntime implements LanguageRuntime {
       await shelter.purge();
     }
   }
+
+  /**
+   * Returns files created during the run that should appear in the Files
+   * pane — currently the destinations written by our download.file()
+   * override, recorded in CREATED_FILES_PATH. Paths are returned relative
+   * to the WebR home directory (the playground's working directory) so they
+   * line up with the names shown in the Files pane. The tracking list is
+   * cleared after reading so each file is reported at most once.
+   */
+  async collectCreatedFiles(): Promise<Map<string, Uint8Array>> {
+    const out = new Map<string, Uint8Array>();
+
+    let listBytes: Uint8Array;
+    try {
+      listBytes = await this.webR.FS.readFile(CREATED_FILES_PATH);
+    } catch {
+      // No download happened this run — the tracking file doesn't exist.
+      return out;
+    }
+
+    const paths = [
+      ...new Set(
+        new TextDecoder()
+          .decode(listBytes)
+          .split("\n")
+          .map((p) => p.trim())
+          .filter(Boolean),
+      ),
+    ];
+
+    for (const abs of paths) {
+      try {
+        const bytes = await this.webR.FS.readFile(abs);
+        const rel = abs.startsWith(`${WEB_USER_HOME}/`)
+          ? abs.slice(WEB_USER_HOME.length + 1)
+          : (abs.split("/").pop() ?? abs);
+        if (rel) out.set(rel, bytes);
+      } catch {
+        // File was removed before we read it back — skip it.
+      }
+    }
+
+    try {
+      await this.webR.FS.unlink(CREATED_FILES_PATH);
+    } catch {
+      // Best-effort cleanup; the next run also clears it.
+    }
+
+    return out;
+  }
 }
 
 export const rAdapter: LanguageAdapter = {
@@ -935,6 +1096,15 @@ export const rAdapter: LanguageAdapter = {
     await webR.evalRVoid(
       `options(device = function() webr::canvas(width = 720, height = 432, capture = TRUE))`,
     );
+
+    // Install a browser-native download.file() that works without
+    // cross-origin isolation (see R_NET_SETUP). Best-effort: a failure here
+    // shouldn't block the runtime from starting.
+    try {
+      await webR.evalRVoid(R_NET_SETUP);
+    } catch (err) {
+      console.error("[webr] failed to install download.file override", err);
+    }
 
     return new WebRRuntime(webR);
   },

--- a/app/_components/runtime/typescript.tsx
+++ b/app/_components/runtime/typescript.tsx
@@ -147,6 +147,32 @@ console.log(\`\\nTotal wall time: \${elapsed}ms (parallel)\`);
 `,
   },
   {
+    key: "fetch_csv",
+    title: "Fetch CSV from URL",
+    desc: "Read a remote CSV with fetch()",
+    code: `// raw.githubusercontent.com sends permissive CORS headers, so fetch()
+// works directly. User code is wrapped in an async function, so
+// top-level await is fine.
+const url =
+  "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv";
+const text: string = await (await fetch(url)).text();
+
+// Minimal CSV parse — this dataset has no quoted/embedded commas.
+const [header, ...rows] = text.trim().split(/\\r?\\n/);
+const cols: string[] = header.split(",");
+
+type Penguin = Record<string, string>;
+const data: Penguin[] = rows.map((line) => {
+  const cells = line.split(",");
+  return Object.fromEntries(cols.map((c, i) => [c, cells[i]])) as Penguin;
+});
+
+console.log(\`\${data.length} rows × \${cols.length} columns\`);
+console.log("columns:", cols.join(", "));
+console.log("first 5 rows:", data.slice(0, 5));
+`,
+  },
+  {
     key: "node_modules",
     title: "Node.js Modules",
     desc: "Typed access to crypto, path, os",

--- a/app/_components/types.ts
+++ b/app/_components/types.ts
@@ -120,6 +120,18 @@ export interface LanguageRuntime {
    *  the runtime created on previous runs that are no longer in `files`
    *  should be removed so renames and deletions in the UI propagate. */
   prepareFileSystem?(files: Map<string, Uint8Array>): Promise<void>;
+  /** Optional: after `run()` resolves, return any files the runtime
+   *  created during the run that should be surfaced in the Files pane,
+   *  keyed by their workspace-relative path (e.g. a CSV fetched by R's
+   *  `download.file()`). The playground persists these to OPFS and adds
+   *  them to the Files pane so they survive reloads and are re-staged on
+   *  subsequent runs. Returns an empty map when nothing was created.
+   *
+   *  Called once per run (in both the success and error paths, since a
+   *  file may have been written before user code later threw), so
+   *  implementations must clear their internal tracking after returning
+   *  to avoid reporting the same file twice. */
+  collectCreatedFiles?(): Promise<Map<string, Uint8Array>>;
 }
 
 export interface LanguageAdapter {

--- a/cloudflare-cors-proxy/README.md
+++ b/cloudflare-cors-proxy/README.md
@@ -61,8 +61,31 @@ The following origins are whitelisted by default:
 | `https://dataslope.com` | Production site |
 | `https://www.dataslope.com` | Production site (www) |
 | `https://dataslope.vercel.app` | Vercel preview/staging |
+| `https://dataslope-*-ye-joo-parks-projects.vercel.app` | Vercel branch/commit preview deployments |
 
 Any `localhost` port is also allowed automatically during local development (`wrangler dev`).
+
+#### Wildcard entries (Vercel previews)
+
+Vercel generates a unique hostname for every branch and commit deployment, e.g.
+
+```
+https://dataslope-git-claude-focused-barde-c4a546-ye-joo-parks-projects.vercel.app
+https://dataslope-git-claude-vigilant-feyn-a92c1c-ye-joo-parks-projects.vercel.app
+```
+
+Listing each one is impractical, so an `ALLOWED_ORIGINS` entry may contain a `*`
+wildcard. The `*` matches **one hostname label** — one or more characters that
+are not a `.` or `/` — so it stays scoped to a single host and can never match a
+different registrable domain.
+
+The default entry `https://dataslope-*-ye-joo-parks-projects.vercel.app` matches
+both examples above. Note the team-scope suffix (`-ye-joo-parks-projects`) is
+deliberately part of the pattern: only the project owner can deploy under that
+scope, so an attacker cannot register a `dataslope`-named project elsewhere and
+get a matching preview host. Avoid an over-broad pattern such as
+`https://dataslope-*.vercel.app`, which *would* match an attacker-controlled
+`dataslope-xyz-evil-team.vercel.app`.
 
 To change the allowlist, edit `ALLOWED_ORIGINS` in `wrangler.toml` (for non-sensitive values) or set it as a Cloudflare secret for production (see [Configuration](#configuration)).
 

--- a/cloudflare-cors-proxy/src/index.ts
+++ b/cloudflare-cors-proxy/src/index.ts
@@ -19,10 +19,20 @@
  *    headers are kept so authenticated API calls work.
  */
 
+import {
+  parseAllowedOrigins,
+  isOriginInAllowList,
+  isLocalhostOrigin,
+} from "./origins";
+
 export interface Env {
   /**
    * Comma-separated list of allowed Origin values, e.g.:
    *   "http://localhost:3000,https://dataslope.com,https://dataslope.vercel.app"
+   *
+   * Entries may contain a `*` wildcard that matches a single hostname label
+   * (no dots, no slashes) so Vercel preview deployments can be allowed, e.g.:
+   *   "https://dataslope-*-ye-joo-parks-projects.vercel.app"
    *
    * Configure in wrangler.toml [vars] for development, or via
    * `wrangler secret put ALLOWED_ORIGINS` / Cloudflare dashboard for production.
@@ -102,15 +112,6 @@ function errorResponse(
   });
 }
 
-function parseAllowedOrigins(raw: string): Set<string> {
-  return new Set(
-    raw
-      .split(",")
-      .map((o) => o.trim().replace(/\/+$/, ""))
-      .filter(Boolean),
-  );
-}
-
 /**
  * Returns true when the hostname looks like a private / loopback address that
  * should never be reachable via the proxy.
@@ -165,23 +166,6 @@ function stripHopByHopHeaders(headers: Headers): Record<string, string> {
   return out;
 }
 
-/**
- * Returns true when the origin is localhost (any port, http or https).
- * Uses URL parsing rather than a regex to avoid potential ReDoS on
- * pathological inputs.
- */
-function isLocalhostOrigin(origin: string): boolean {
-  try {
-    const url = new URL(origin);
-    return (
-      (url.protocol === "http:" || url.protocol === "https:") &&
-      url.hostname === "localhost"
-    );
-  } catch {
-    return false;
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Main handler
 // ---------------------------------------------------------------------------
@@ -203,7 +187,7 @@ export default {
     // normalizedOrigin is a non-null string (TypeScript narrows accordingly).
     const isAllowedOrigin =
       normalizedOrigin === null ||
-      allowedOrigins.has(normalizedOrigin) ||
+      isOriginInAllowList(normalizedOrigin, allowedOrigins) ||
       // Also allow any localhost port during local development.
       isLocalhostOrigin(normalizedOrigin);
 

--- a/cloudflare-cors-proxy/src/origins.ts
+++ b/cloudflare-cors-proxy/src/origins.ts
@@ -1,0 +1,78 @@
+/**
+ * Origin allow-list matching for the Dataslope CORS proxy.
+ *
+ * Kept free of any Cloudflare Workers types so the logic can be unit-tested
+ * from the main project's Node/Vitest suite without pulling Workers globals
+ * (`ExportedHandler`, etc.) into the app's TypeScript program.
+ */
+
+/**
+ * An allow-list of Origins, split into exact matches and wildcard patterns.
+ * Most entries are exact strings (fast Set lookup); entries containing a `*`
+ * (e.g. Vercel preview deployments) are compiled to anchored RegExps.
+ */
+export interface AllowList {
+  /** Exact origin strings (no trailing slash). */
+  exact: Set<string>;
+  /** Compiled wildcard patterns (see {@link wildcardOriginToRegExp}). */
+  patterns: RegExp[];
+}
+
+/**
+ * Compiles a wildcard origin entry into an anchored RegExp.
+ *
+ * A `*` matches one or more characters *within a single hostname label* —
+ * i.e. it never matches a `.` (a label separator) or `/` (a path separator).
+ * That keeps a pattern like `https://dataslope-*.vercel.app` scoped to the
+ * intended host: it can match `dataslope-abc123.vercel.app` but never
+ * `dataslope-abc.evil.com` or `evil.com/dataslope-.vercel.app`.
+ *
+ * Splitting on `*` first, then escaping each literal segment, ensures the
+ * regex-escaping and the wildcard substitution can't interfere with one
+ * another (e.g. an escaped `.` is never mistaken for the wildcard).
+ */
+export function wildcardOriginToRegExp(pattern: string): RegExp {
+  const body = pattern
+    .split("*")
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("[^./]+");
+  return new RegExp(`^${body}$`);
+}
+
+export function parseAllowedOrigins(raw: string): AllowList {
+  const exact = new Set<string>();
+  const patterns: RegExp[] = [];
+  for (const entry of raw
+    .split(",")
+    .map((o) => o.trim().replace(/\/+$/, ""))
+    .filter(Boolean)) {
+    if (entry.includes("*")) {
+      patterns.push(wildcardOriginToRegExp(entry));
+    } else {
+      exact.add(entry);
+    }
+  }
+  return { exact, patterns };
+}
+
+/** Returns true when `origin` matches an exact entry or a wildcard pattern. */
+export function isOriginInAllowList(origin: string, allow: AllowList): boolean {
+  return allow.exact.has(origin) || allow.patterns.some((re) => re.test(origin));
+}
+
+/**
+ * Returns true when the origin is localhost (any port, http or https).
+ * Uses URL parsing rather than a regex to avoid potential ReDoS on
+ * pathological inputs.
+ */
+export function isLocalhostOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      url.hostname === "localhost"
+    );
+  } catch {
+    return false;
+  }
+}

--- a/cloudflare-cors-proxy/wrangler.toml
+++ b/cloudflare-cors-proxy/wrangler.toml
@@ -7,5 +7,11 @@ compatibility_flags = ["nodejs_compat"]
 # Comma-separated list of allowed Origin hosts (no trailing slash).
 # Override via `wrangler secret put ALLOWED_ORIGINS` or in your Cloudflare dashboard
 # for production secrets, or set them here for non-sensitive defaults.
-ALLOWED_ORIGINS = "http://localhost:3000,https://dataslope.com,https://www.dataslope.com,https://dataslope.vercel.app"
+#
+# A "*" in an entry is a wildcard that matches one hostname label (no dots,
+# no slashes), so Vercel preview deployments are matched by including the
+# team scope suffix. The scope suffix is what keeps this safe: only the
+# project owner can deploy under "*-ye-joo-parks-projects.vercel.app", so an
+# attacker cannot register a project that produces a matching preview host.
+ALLOWED_ORIGINS = "http://localhost:3000,https://dataslope.com,https://www.dataslope.com,https://dataslope.vercel.app,https://dataslope-*-ye-joo-parks-projects.vercel.app"
 

--- a/e2e/csv-examples.spec.ts
+++ b/e2e/csv-examples.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Verifies the "Read/Fetch CSV from URL" examples added to the Python, R,
+// JavaScript and TypeScript playgrounds. Each loads the example from the
+// Examples menu, runs it, and asserts the remote penguins.csv was read.
+//
+// Needs the heavy runtimes (fetched from CDNs) and reaches a real
+// raw.githubusercontent.com CSV, so it's kept out of the default e2e run.
+// Enable with:
+//
+//   CSV_E2E=1 npx playwright test e2e/csv-examples.spec.ts
+
+const ENABLED = !!process.env.CSV_E2E;
+
+async function waitForRuntimeReady(page: Page) {
+  await page.waitForFunction(
+    () => {
+      const banner = document.querySelector(".loading-banner, .pg-status");
+      const text = banner?.textContent ?? "";
+      if (text.startsWith("Failed to load")) throw new Error(text);
+      const btn = document.querySelector(".run-btn");
+      return !!btn && !btn.hasAttribute("disabled");
+    },
+    null,
+    { timeout: 150_000 },
+  );
+}
+
+async function loadExampleByTitle(page: Page, title: string) {
+  await page.locator('button[aria-label="Examples"]').click();
+  const item = page
+    .locator(".example-item")
+    .filter({ has: page.locator(".ex-title", { hasText: title }) });
+  await item.first().waitFor({ state: "visible", timeout: 10_000 });
+  await item.first().click();
+  // Loading an example over the (different) default code pops a confirm.
+  const danger = page.locator(".confirm-popup .confirm-btn-danger");
+  try {
+    await danger.waitFor({ state: "visible", timeout: 2500 });
+    await danger.click();
+  } catch {
+    /* no dialog — editor already matched / was empty */
+  }
+}
+
+async function runAndCollect(page: Page) {
+  const runBtn = page.locator(".run-btn").first();
+  await runBtn.click();
+  await expect(runBtn).toBeDisabled({ timeout: 5_000 }).catch(() => {});
+  await expect(runBtn).toBeEnabled({ timeout: 150_000 });
+  await page
+    .waitForFunction(
+      () =>
+        [...document.querySelectorAll(".out-cell")].length > 0 &&
+        [...document.querySelectorAll(".out-cell")].every((c) =>
+          (c.querySelector(".cell-time")?.textContent ?? "").includes("Done in"),
+        ),
+      null,
+      { timeout: 150_000 },
+    )
+    .catch(() => {});
+
+  const cells = await page.locator(".out-cell").all();
+  const out: { type: string; body: string }[] = [];
+  for (const cell of cells) {
+    const cls = (await cell.getAttribute("class")) ?? "";
+    const type =
+      cls
+        .split(/\s+/)
+        .find((c) =>
+          ["stdout", "stderr", "html", "image", "plot"].includes(c),
+        ) ?? "unknown";
+    const body = (await cell.locator(".out-cell-body").textContent()) ?? "";
+    out.push({ type, body });
+  }
+  return out;
+}
+
+const ERROR_MARKERS =
+  /Traceback|is not defined|could not find function|cannot open URL|ReferenceError|SyntaxError|Error:/;
+
+test.describe("CSV-from-URL examples", () => {
+  test.skip(!ENABLED, "set CSV_E2E=1 to run (needs runtimes / network)");
+
+  test("Python: Read CSV from URL", async ({ page }) => {
+    await page.goto("/playground/python");
+    await waitForRuntimeReady(page);
+    await loadExampleByTitle(page, "Read CSV from URL");
+    const cells = await runAndCollect(page);
+    const all = cells.map((c) => `[${c.type}] ${c.body}`).join("\n");
+    expect(all, all).toContain("344 rows");
+    expect(all, all).toContain("Adelie");
+    expect(all, all).not.toMatch(ERROR_MARKERS);
+    expect(cells.some((c) => c.type === "html")).toBe(true); // head() table
+  });
+
+  test("R: Read CSV from URL", async ({ page }) => {
+    await page.goto("/playground/r");
+    await waitForRuntimeReady(page);
+    await loadExampleByTitle(page, "Read CSV from URL");
+    const cells = await runAndCollect(page);
+    const all = cells.map((c) => `[${c.type}] ${c.body}`).join("\n");
+    const stderr = cells
+      .filter((c) => c.type === "stderr")
+      .map((c) => c.body)
+      .join("\n");
+    expect(all, all).toContain("344 rows");
+    expect(all, all).toContain("Adelie");
+    expect(all, all).not.toMatch(ERROR_MARKERS);
+    // Download progress is normal output, not an error cell.
+    expect(stderr, stderr).not.toContain("trying URL");
+    expect(cells.some((c) => c.type === "html")).toBe(true); // head() table
+  });
+
+  test("JavaScript: Fetch CSV from URL", async ({ page }) => {
+    await page.goto("/playground/javascript");
+    await waitForRuntimeReady(page);
+    await loadExampleByTitle(page, "Fetch CSV from URL");
+    const cells = await runAndCollect(page);
+    const all = cells.map((c) => `[${c.type}] ${c.body}`).join("\n");
+    expect(all, all).toContain("344 rows");
+    expect(all, all).toContain("species");
+    expect(all, all).toContain("Adelie");
+    expect(all, all).not.toMatch(ERROR_MARKERS);
+  });
+
+  test("TypeScript: Fetch CSV from URL", async ({ page }) => {
+    await page.goto("/playground/typescript");
+    await waitForRuntimeReady(page);
+    await loadExampleByTitle(page, "Fetch CSV from URL");
+    const cells = await runAndCollect(page);
+    const all = cells.map((c) => `[${c.type}] ${c.body}`).join("\n");
+    expect(all, all).toContain("344 rows");
+    expect(all, all).toContain("species");
+    expect(all, all).toContain("Adelie");
+    expect(all, all).not.toMatch(ERROR_MARKERS);
+  });
+});

--- a/e2e/r-download.spec.ts
+++ b/e2e/r-download.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Verifies the R playground's download.file() fix: a file fetched with
+// download.file() must (1) actually download (WebR's built-in stalls without
+// cross-origin isolation) and (2) show up in the Files pane.
+//
+// This test reaches the real WebR CDN and a real raw.githubusercontent.com
+// CSV (~4 MB), so it is intentionally kept out of the default e2e run to avoid
+// external-network flakiness. Enable it with:
+//
+//   R_NET_E2E=1 npx playwright test e2e/r-download.spec.ts
+//
+// (The webServer + Chromium are booted by playwright.config.ts as usual.)
+
+const ENABLED = !!process.env.R_NET_E2E;
+
+const CSV_URL =
+  "https://raw.githubusercontent.com/bdi593/datasets/refs/heads/main/zillow-properties/zillow_properties_champaign_urbana_savoy.csv";
+const CSV_NAME = "zillow_properties_champaign_urbana_savoy.csv";
+
+async function waitForRuntimeReady(page: Page) {
+  await page.waitForFunction(
+    () => {
+      const banner = document.querySelector(".loading-banner, .pg-status");
+      const text = banner?.textContent ?? "";
+      if (text.startsWith("Failed to load")) {
+        throw new Error(text);
+      }
+      const btn = document.querySelector(".run-btn");
+      return !!btn && !btn.hasAttribute("disabled");
+    },
+    null,
+    { timeout: 150_000 },
+  );
+}
+
+/** Replace the CodeMirror editor's contents with `code`. */
+async function setEditorCode(page: Page, code: string) {
+  const content = page.locator(".cm-content").first();
+  await content.click();
+  await page.keyboard.press("Control+A");
+  // insertText replaces the selection in a single bulk input event, so
+  // CodeMirror's per-keystroke bracket auto-closing doesn't mangle the text.
+  await page.keyboard.insertText(code);
+}
+
+async function runAndCollect(page: Page) {
+  const runBtn = page.locator(".run-btn").first();
+  await runBtn.click();
+  await expect(runBtn).toBeDisabled({ timeout: 5_000 }).catch(() => {});
+  await expect(runBtn).toBeEnabled({ timeout: 150_000 });
+  await page
+    .waitForFunction(
+      () =>
+        [...document.querySelectorAll(".out-cell")].length > 0 &&
+        [...document.querySelectorAll(".out-cell")].every((c) =>
+          (c.querySelector(".cell-time")?.textContent ?? "").includes("Done in"),
+        ),
+      null,
+      { timeout: 150_000 },
+    )
+    .catch(() => {});
+
+  const cells = await page.locator(".out-cell").all();
+  const out: { type: string; body: string }[] = [];
+  for (const cell of cells) {
+    const cls = (await cell.getAttribute("class")) ?? "";
+    const type =
+      cls
+        .split(/\s+/)
+        .find((c) =>
+          ["stdout", "stderr", "html", "image", "plot"].includes(c),
+        ) ?? "unknown";
+    const body = (await cell.locator(".out-cell-body").textContent()) ?? "";
+    out.push({ type, body });
+  }
+  return out;
+}
+
+test.describe("R download.file()", () => {
+  test.skip(!ENABLED, "set R_NET_E2E=1 to run (reaches external network)");
+
+  test("downloads a CSV and shows it in the Files pane", async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on("pageerror", (e) => pageErrors.push(e.message));
+
+    await page.goto("/playground/r");
+    await waitForRuntimeReady(page);
+
+    await setEditorCode(
+      page,
+      `download.file("${CSV_URL}", "${CSV_NAME}")\n` +
+        `cat("exists:", file.exists("${CSV_NAME}"), "\\n")\n` +
+        `cat("nbytes:", file.info("${CSV_NAME}")$size, "\\n")`,
+    );
+
+    const cells = await runAndCollect(page);
+    const allText = cells.map((c) => `[${c.type}] ${c.body}`).join("\n");
+
+    // The download must not error. download.file() prints "trying URL" /
+    // "downloaded N bytes" via message() (an stderr cell) — those are
+    // expected, so we look for genuine failure markers instead of any stderr.
+    expect(allText, allText).not.toMatch(/cannot open URL/i);
+    expect(allText, allText).not.toMatch(/could not find function/i);
+    expect(allText, allText).not.toMatch(/download failed/i);
+    expect(allText, allText).not.toMatch(/Error[:\s]/);
+
+    // The file exists in the R working directory with real content.
+    expect(allText).toContain("exists: TRUE");
+    expect(allText).toMatch(/nbytes:\s*\d{4,}/); // at least a few KB
+
+    // …and it now appears in the Files pane.
+    await page.locator('[aria-label="Files"]').first().click();
+    await expect(
+      page.locator(".playground-files-name", { hasText: CSV_NAME }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Guard against page errors from the download path, but tolerate the
+    // app's pre-existing benign OPFS "NotFoundError" that fires on first
+    // load of a brand-new workspace (create:false reads in fileStorage /
+    // databaseStorage), which is unrelated to this feature.
+    const relevantErrors = pageErrors.filter(
+      (m) => !/requested file or directory could not be found/i.test(m),
+    );
+    expect(relevantErrors, relevantErrors.join("\n")).toEqual([]);
+  });
+});

--- a/e2e/r-download.spec.ts
+++ b/e2e/r-download.spec.ts
@@ -1,18 +1,17 @@
 import { test, expect, type Page } from "@playwright/test";
 
-// Verifies the R playground's download.file() fix: a file fetched with
-// download.file() must (1) actually download (WebR's built-in stalls without
-// cross-origin isolation) and (2) show up in the Files pane.
+// E2E coverage for the R playground's data-handling fixes:
+//   1. download.file() saves a file that shows up in the Files pane.
+//   2. Printing a large data.frame is truncated (head + ellipsis + tail)
+//      instead of dumping every row and freezing the page.
 //
-// This test reaches the real WebR CDN and a real raw.githubusercontent.com
-// CSV (~4 MB), so it is intentionally kept out of the default e2e run to avoid
-// external-network flakiness. Enable it with:
+// Both need the heavy WebR runtime (fetched from a CDN), and the download
+// test also reaches a real raw.githubusercontent.com CSV (~4 MB), so this
+// spec is kept out of the default e2e run. Enable it with:
 //
-//   R_NET_E2E=1 npx playwright test e2e/r-download.spec.ts
-//
-// (The webServer + Chromium are booted by playwright.config.ts as usual.)
+//   R_E2E=1 npx playwright test e2e/r-download.spec.ts
 
-const ENABLED = !!process.env.R_NET_E2E;
+const ENABLED = !!process.env.R_E2E;
 
 const CSV_URL =
   "https://raw.githubusercontent.com/bdi593/datasets/refs/heads/main/zillow-properties/zillow_properties_champaign_urbana_savoy.csv";
@@ -77,13 +76,10 @@ async function runAndCollect(page: Page) {
   return out;
 }
 
-test.describe("R download.file()", () => {
-  test.skip(!ENABLED, "set R_NET_E2E=1 to run (reaches external network)");
+test.describe("R playground data handling", () => {
+  test.skip(!ENABLED, "set R_E2E=1 to run (needs the WebR runtime / network)");
 
-  test("downloads a CSV and shows it in the Files pane", async ({ page }) => {
-    const pageErrors: string[] = [];
-    page.on("pageerror", (e) => pageErrors.push(e.message));
-
+  test("download.file() saves a CSV into the Files pane", async ({ page }) => {
     await page.goto("/playground/r");
     await waitForRuntimeReady(page);
 
@@ -97,31 +93,49 @@ test.describe("R download.file()", () => {
     const cells = await runAndCollect(page);
     const allText = cells.map((c) => `[${c.type}] ${c.body}`).join("\n");
 
-    // The download must not error. download.file() prints "trying URL" /
-    // "downloaded N bytes" via message() (an stderr cell) — those are
-    // expected, so we look for genuine failure markers instead of any stderr.
+    // download.file() prints "trying URL" / "downloaded N bytes" via message()
+    // (an stderr cell) — those are expected, so look for genuine failure
+    // markers rather than treating any stderr as a failure.
     expect(allText, allText).not.toMatch(/cannot open URL/i);
     expect(allText, allText).not.toMatch(/could not find function/i);
     expect(allText, allText).not.toMatch(/download failed/i);
-    expect(allText, allText).not.toMatch(/Error[:\s]/);
 
-    // The file exists in the R working directory with real content.
+    // The file exists in the R working directory with real content…
     expect(allText).toContain("exists: TRUE");
-    expect(allText).toMatch(/nbytes:\s*\d{4,}/); // at least a few KB
+    expect(allText).toMatch(/nbytes:\s*\d{4,}/);
 
     // …and it now appears in the Files pane.
     await page.locator('[aria-label="Files"]').first().click();
     await expect(
       page.locator(".playground-files-name", { hasText: CSV_NAME }),
     ).toBeVisible({ timeout: 10_000 });
+  });
 
-    // Guard against page errors from the download path, but tolerate the
-    // app's pre-existing benign OPFS "NotFoundError" that fires on first
-    // load of a brand-new workspace (create:false reads in fileStorage /
-    // databaseStorage), which is unrelated to this feature.
-    const relevantErrors = pageErrors.filter(
-      (m) => !/requested file or directory could not be found/i.test(m),
+  test("printing a large data.frame is truncated to head + tail", async ({
+    page,
+  }) => {
+    await page.goto("/playground/r");
+    await waitForRuntimeReady(page);
+
+    // 500 rows; each label is unique so we can prove the middle is hidden.
+    await setEditorCode(
+      page,
+      `df <- data.frame(idx = 1:500, label = sprintf("row-%03d", 1:500),\n` +
+        `                 stringsAsFactors = FALSE)\n` +
+        `print(df)`,
     );
-    expect(relevantErrors, relevantErrors.join("\n")).toEqual([]);
+
+    const cells = await runAndCollect(page);
+    const stdout = cells
+      .filter((c) => c.type === "stdout")
+      .map((c) => c.body)
+      .join("\n");
+
+    expect(stdout, stdout).toContain("row-001"); // head present
+    expect(stdout, stdout).toContain("row-500"); // tail present
+    expect(stdout, stdout).toContain("..."); // ellipsis row
+    expect(stdout, stdout).toMatch(/500 rows total/);
+    // The hidden middle must NOT be dumped (this is the page-freeze guard).
+    expect(stdout, stdout).not.toContain("row-250");
   });
 });

--- a/e2e/r-download.spec.ts
+++ b/e2e/r-download.spec.ts
@@ -92,13 +92,22 @@ test.describe("R playground data handling", () => {
 
     const cells = await runAndCollect(page);
     const allText = cells.map((c) => `[${c.type}] ${c.body}`).join("\n");
+    const stdoutText = cells
+      .filter((c) => c.type === "stdout")
+      .map((c) => c.body)
+      .join("\n");
+    const stderrText = cells
+      .filter((c) => c.type === "stderr")
+      .map((c) => c.body)
+      .join("\n");
 
-    // download.file() prints "trying URL" / "downloaded N bytes" via message()
-    // (an stderr cell) — those are expected, so look for genuine failure
-    // markers rather than treating any stderr as a failure.
     expect(allText, allText).not.toMatch(/cannot open URL/i);
     expect(allText, allText).not.toMatch(/could not find function/i);
     expect(allText, allText).not.toMatch(/download failed/i);
+
+    // The progress lines are shown as normal output, not as an error cell.
+    expect(stdoutText, stdoutText).toContain("trying URL");
+    expect(stderrText, stderrText).not.toContain("trying URL");
 
     // The file exists in the R working directory with real content…
     expect(allText).toContain("exists: TRUE");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     // E2E tests live in `e2e/` and are run by Playwright
     // (`npm run test:e2e`). Keep Vitest from picking them up so that
     // `npm test` stays a fast Node-only check.
-    exclude: ["node_modules/**", "dist/**", ".next/**", "e2e/**"],
+    // Match nested node_modules too (e.g. cloudflare-cors-proxy/node_modules)
+    // so we never pick up third-party package tests when the worker's deps
+    // are installed locally.
+    exclude: ["**/node_modules/**", "dist/**", ".next/**", "e2e/**"],
   },
 });


### PR DESCRIPTION
Four things, across the CORS proxy and the playgrounds.

## 1 — CORS proxy: allow Vercel preview URLs

Vercel mints a unique host per branch/commit, e.g.
`https://dataslope-git-claude-focused-barde-c4a546-ye-joo-parks-projects.vercel.app`,
so they can't be listed individually.

- `ALLOWED_ORIGINS` entries may now contain a `*` wildcard that matches **one
  hostname label** (one or more chars that are not `.` or `/`) — it stays scoped
  to a single host and can never cross a dot into another domain.
- Added the default pattern
  `https://dataslope-*-ye-joo-parks-projects.vercel.app` to `wrangler.toml`.
  The team-scope suffix is deliberately part of the pattern: only the project
  owner can deploy under that scope, so an attacker can't register a
  `dataslope`-named project elsewhere and get a matching host. (An over-broad
  `https://dataslope-*.vercel.app` **would** be exploitable and is called out in
  the README.)
- Matching logic extracted to a Cloudflare-type-free `origins.ts` and
  unit-tested (`__tests__/corsProxy.test.ts`, 13 cases incl. the attacker-scope
  rejection).

## 2 — R `download.file()`: Files pane + no fake "error"

Testing `main` showed WebR's **built-in `download.file()` already works** — the
red “ERROR” cell was just R's `message("trying URL…")` rendered with stderr
styling, not a failure (the file downloads and `read.csv()` reads it). So the
earlier synchronous-XHR reimplementation was reverted.

- `download.file()` is now a thin wrapper that delegates the fetch to
  `utils::download.file()` **unchanged** and (a) records the destination so the
  new `LanguageRuntime.collectCreatedFiles()` hook can mirror it into the **Files
  pane** (persisted to OPFS, re-staged on later runs), and (b) silences
  download.file's own progress (`quiet = TRUE`) and re-emits the familiar
  `trying URL` / `downloaded … bytes` lines to **stdout** so they no longer look
  like an error. Real errors still propagate.
- Cross-origin hosts still need CORS / the proxy, exactly like
  `pandas.read_csv` — the proxied URL from the report works (the deployed worker
  already allows localhost; Vercel previews are covered by #1 after deploy).

## 3 — Large `data.frame` printing no longer freezes the page

`print(df)` on a plain data.frame dumped **every** row, which could hang the tab.

- Override the `print` generic (an ordinary search-path lookup — an attached S3
  `print.data.frame` is *not* picked up by `UseMethod`, which the e2e caught) to
  show the first 10 + `…` + last 5 rows with a `# N rows total` footer, matching
  the existing auto-print HTML truncation. Only plain `data.frame`s are affected;
  tibbles / data.tables keep their own methods.
- Added a 250k-char per-cell output backstop so any other runaway text can't
  freeze the browser either.

## 4 — “Read/Fetch CSV from URL” examples (Python, R, JS, TS)

New Examples-menu entry in each of the four playgrounds, reading seaborn's
`penguins.csv` from raw.githubusercontent.com (permissive CORS, no proxy):

- **Python** `pd.read_csv(url)` → shape, species counts, `head()` table.
- **R** `download.file(url, …)` + `read.csv()` → counts + `head()` table; the
  download also lands in the Files pane.
- **JavaScript / TypeScript** `fetch()` + a minimal CSV parse (dataset has no
  quoted commas) → shape, columns, first rows.

## Verification

- `vitest run __tests__/corsProxy.test.ts` → 13 passed. Full `vitest run`: only a
  pre-existing, unrelated `opfs.workspace` failure; `tsc` 0 errors.
- Deployed proxy already serves the proxied report URL for a localhost origin
  (HTTP 200, full 3.94 MB, correct `Access-Control-Allow-Origin`).
- **Playwright**, all passing:
  - `R_E2E=1 … e2e/r-download.spec.ts` (2): download → Files pane, `trying URL`
    on **stdout** not stderr; 500-row `print(df)` → head + `…` + tail + footer,
    middle row absent.
  - `CSV_E2E=1 … e2e/csv-examples.spec.ts` (4): each playground's CSV example
    reads the 344-row penguins dataset with no error.

> Pre-existing, unrelated to this PR: `__tests__/opfs.workspace.test.ts` has one
> failing case and `Playground.tsx:759` trips a lint rule — both reproduce on a
> clean tree.

## Deploy notes (#1)

The wildcard logic lives in the worker code, so redeploy the proxy for it to take
effect: `cd cloudflare-cors-proxy && npm run deploy`. If `ALLOWED_ORIGINS` is a
Cloudflare **secret** (it overrides `wrangler.toml`), add the
`https://dataslope-*-ye-joo-parks-projects.vercel.app` entry to the secret too.

https://claude.ai/code/session_01Sy5iJvAsBvMTBSEU2veHeg