### PR TITLE
Courseware sweep: format multi-file buffers + CS8803/escape fixes (picks up #444)

### DIFF
--- a/content/learn/beginners-javascript/arrays.mdx
+++ b/content/learn/beginners-javascript/arrays.mdx
@@ -349,7 +349,10 @@ console.log("Passed:   ", passed);
   if (xs.length === 0) {
     return { count: 0, min: null, max: null, average: 0, passed: 0 };
   }
-  let min = xs[0], max = xs[0], total = 0, passed = 0;
+  let min = xs[0],
+    max = xs[0],
+    total = 0,
+    passed = 0;
   for (const n of xs) {
     if (n < min) min = n;
     if (n > max) max = n;

--- a/content/learn/beginners-javascript/asynchronous-thinking.mdx
+++ b/content/learn/beginners-javascript/asynchronous-thinking.mdx
@@ -292,7 +292,7 @@ console.log("main: subscriptions registered, waiting for events...");
     {
       filename: "bus.js",
       initialContent: `function createBus() {
-  const listeners = {};   // eventName -> array of callbacks
+  const listeners = {}; // eventName -> array of callbacks
 
   function on(event, cb) {
     (listeners[event] = listeners[event] || []).push(cb);

--- a/content/learn/beginners-javascript/closures.mdx
+++ b/content/learn/beginners-javascript/closures.mdx
@@ -272,11 +272,11 @@ state directly.
 
 const limiter = makeRateLimiter(3);
 
-console.log(limiter("first"));    // allow
-console.log(limiter("second"));   // allow
-console.log(limiter("third"));    // allow
-console.log(limiter("fourth"));   // deny
-console.log(limiter("fifth"));    // deny
+console.log(limiter("first")); // allow
+console.log(limiter("second")); // allow
+console.log(limiter("third")); // allow
+console.log(limiter("fourth")); // deny
+console.log(limiter("fifth")); // deny
 `,
     },
     {

--- a/content/learn/beginners-javascript/debugging-and-reasoning.mdx
+++ b/content/learn/beginners-javascript/debugging-and-reasoning.mdx
@@ -302,12 +302,12 @@ the bug *before* looking at the fix below.
       initialContent: `const { applyDiscounts } = require("./pricing");
 
 const cart = [
-  { name: "Pen",      price: 2,  qty: 3 },
-  { name: "Notebook", price: 5,  qty: 2 },
-  { name: "Laptop",   price: 999, qty: 1 },
+  { name: "Pen", price: 2, qty: 3 },
+  { name: "Notebook", price: 5, qty: 2 },
+  { name: "Laptop", price: 999, qty: 1 },
 ];
 
-console.log("total:", applyDiscounts(cart, 0.10));
+console.log("total:", applyDiscounts(cart, 0.1));
 console.log("cart afterwards:", cart);
 `,
     },
@@ -317,7 +317,7 @@ console.log("cart afterwards:", cart);
 function applyDiscounts(cart, discount) {
   let total = 0;
   for (const item of cart) {
-    item.price = item.price * (1 - discount);   // bug: mutates caller's data!
+    item.price = item.price * (1 - discount); // bug: mutates caller's data!
     total += item.price * item.qty;
   }
   return total;

--- a/content/learn/beginners-javascript/functional-intuition.mdx
+++ b/content/learn/beginners-javascript/functional-intuition.mdx
@@ -297,9 +297,9 @@ specification: "of the paid orders, sum the amounts."
 const { summarise } = require("./summary");
 
 const orders = [
-  { id: 1, customer: "Ada",   amount: 120, status: "paid" },
-  { id: 2, customer: "Linus", amount: 80,  status: "cancelled" },
-  { id: 3, customer: "Ada",   amount: 60,  status: "paid" },
+  { id: 1, customer: "Ada", amount: 120, status: "paid" },
+  { id: 2, customer: "Linus", amount: 80, status: "cancelled" },
+  { id: 3, customer: "Ada", amount: 60, status: "paid" },
   { id: 4, customer: "Grace", amount: 200, status: "paid" },
 ];
 
@@ -334,14 +334,14 @@ function topCustomer(orders) {
   return Object.entries(totals).reduce(
     (best, [customer, total]) =>
       total > best.total ? { customer, total } : best,
-    { customer: null, total: -Infinity }
+    { customer: null, total: -Infinity },
   );
 }
 
 function summarise(orders) {
   return {
-    totalPaid:   totalPaid(orders),
-    byCustomer:  byCustomer(orders),
+    totalPaid: totalPaid(orders),
+    byCustomer: byCustomer(orders),
     topCustomer: topCustomer(orders),
   };
 }

--- a/content/learn/beginners-javascript/javascript-beyond-the-browser.mdx
+++ b/content/learn/beginners-javascript/javascript-beyond-the-browser.mdx
@@ -236,8 +236,18 @@ function daysInMonth(year, month) {
 }
 
 const NAMES = [
-  "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December",
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
 ];
 
 function monthName(month) {

--- a/content/learn/beginners-javascript/maintainable-code.mdx
+++ b/content/learn/beginners-javascript/maintainable-code.mdx
@@ -350,10 +350,10 @@ function doStuff(arr, x) {
 }
 
 const data = [
-  { t: "a", s: "ok",  p: 10, q: 2 },
+  { t: "a", s: "ok", p: 10, q: 2 },
   { t: "a", s: "bad", p: 99, q: 1 },
-  { t: "b", s: "ok",  p:  5, q: 3 },
-  { t: "a", s: "ok",  p:  3, q: 4 },
+  { t: "b", s: "ok", p: 5, q: 3 },
+  { t: "a", s: "ok", p: 3, q: 4 },
 ];
 
 console.log(doStuff(data, "a"));
@@ -373,10 +373,10 @@ After — same behaviour, far clearer:
       initialContent: `const { totalWithTaxForType } = require("./reporting");
 
 const orders = [
-  { type: "a", status: "ok",        price: 10, qty: 2 },
+  { type: "a", status: "ok", price: 10, qty: 2 },
   { type: "a", status: "cancelled", price: 99, qty: 1 },
-  { type: "b", status: "ok",        price:  5, qty: 3 },
-  { type: "a", status: "ok",        price:  3, qty: 4 },
+  { type: "b", status: "ok", price: 5, qty: 3 },
+  { type: "a", status: "ok", price: 3, qty: 4 },
 ];
 
 console.log(totalWithTaxForType(orders, "a"));
@@ -384,7 +384,7 @@ console.log(totalWithTaxForType(orders, "a"));
     },
     {
       filename: "reporting.js",
-      initialContent: `const TAX_RATE = 0.10;
+      initialContent: `const TAX_RATE = 0.1;
 
 function lineTotal(order) {
   return order.price * order.qty;

--- a/content/learn/beginners-javascript/map-filter-reduce.mdx
+++ b/content/learn/beginners-javascript/map-filter-reduce.mdx
@@ -279,10 +279,10 @@ one module owns the transformations, another assembles them.
 
 const orders = [
   { month: "Jan", amount: 120 },
-  { month: "Jan", amount: 80  },
+  { month: "Jan", amount: 80 },
   { month: "Feb", amount: 200 },
-  { month: "Mar", amount: 50  },
-  { month: "Mar", amount: 75  },
+  { month: "Mar", amount: 50 },
+  { month: "Mar", amount: 75 },
   { month: "Mar", amount: 100 },
 ];
 
@@ -302,8 +302,9 @@ console.log("Top month:", topMonth(orders));
 function topMonth(orders) {
   const totals = revenueByMonth(orders);
   return Object.entries(totals).reduce(
-    (best, [month, amount]) => (amount > best.amount ? { month, amount } : best),
-    { month: null, amount: -Infinity }
+    (best, [month, amount]) =>
+      amount > best.amount ? { month, amount } : best,
+    { month: null, amount: -Infinity },
   );
 }
 

--- a/content/learn/beginners-javascript/modular-organization.mdx
+++ b/content/learn/beginners-javascript/modular-organization.mdx
@@ -118,11 +118,13 @@ surface, the freer you are to change the internals.
       filename: "index.js",
       initialContent: `const { format } = require("./currency");
 
-console.log(format(1234.5,  "USD"));
-console.log(format(99,      "EUR"));
+console.log(format(1234.5, "USD"));
+console.log(format(99, "EUR"));
 
 // We DON'T expose the helpers — and we can't even reach them.
-try { require("./currency").pad; } catch (e) {}
+try {
+  require("./currency").pad;
+} catch (e) {}
 console.log("pad exposed?", typeof require("./currency").pad === "function");
 `,
     },
@@ -255,9 +257,9 @@ re-exports.
 const { listActiveUsers, addUser } = require("./users");
 const { createOrder, totalRevenue } = require("./orders");
 
-addUser({ id: 1, name: "Ada",   active: true  });
+addUser({ id: 1, name: "Ada", active: true });
 addUser({ id: 2, name: "Linus", active: false });
-addUser({ id: 3, name: "Grace", active: true  });
+addUser({ id: 3, name: "Grace", active: true });
 
 createOrder({ userId: 1, amount: 50 });
 createOrder({ userId: 1, amount: 30 });
@@ -314,7 +316,7 @@ function add(name, value) {
 }
 
 function getAll(name) {
-  return [...(collections[name] || [])];   // copy to discourage mutation
+  return [...(collections[name] || [])]; // copy to discourage mutation
 }
 
 module.exports = { add, getAll };
@@ -393,8 +395,8 @@ The tests will require \`./budget\` and call the exported functions.`}
 
 budget.addIncome(1000);
 budget.addExpense(120, "food");
-budget.addExpense(80,  "food");
-budget.addExpense(60,  "books");
+budget.addExpense(80, "food");
+budget.addExpense(60, "books");
 
 console.log("balance:", budget.balance());
 console.log("by category:", budget.expensesByCategory());
@@ -403,8 +405,8 @@ console.log("by category:", budget.expensesByCategory());
 
 budget.addIncome(1000);
 budget.addExpense(120, "food");
-budget.addExpense(80,  "food");
-budget.addExpense(60,  "books");
+budget.addExpense(80, "food");
+budget.addExpense(60, "books");
 
 console.log("balance:", budget.balance());
 console.log("by category:", budget.expensesByCategory());

--- a/content/learn/beginners-javascript/nested-data.mdx
+++ b/content/learn/beginners-javascript/nested-data.mdx
@@ -316,9 +316,16 @@ small.
       initialContent: `const { ordersByCustomer, lineTotal } = require("./orders");
 
 const orders = [
-  { id: 1, customer: "Ada",   items: [{ price: 10, qty: 2 }, { price: 5, qty: 1 }] },
+  {
+    id: 1,
+    customer: "Ada",
+    items: [
+      { price: 10, qty: 2 },
+      { price: 5, qty: 1 },
+    ],
+  },
   { id: 2, customer: "Linus", items: [{ price: 20, qty: 3 }] },
-  { id: 3, customer: "Ada",   items: [{ price: 8,  qty: 4 }] },
+  { id: 3, customer: "Ada", items: [{ price: 8, qty: 4 }] },
 ];
 
 const byCustomer = ordersByCustomer(orders);

--- a/content/learn/beginners-javascript/problem-solving.mdx
+++ b/content/learn/beginners-javascript/problem-solving.mdx
@@ -296,9 +296,9 @@ The rules:
       initialContent: `const { finalTotal } = require("./cart");
 
 const cart = [
-  { price: 10.00, quantity: 2 },
-  { price: 4.50,  quantity: 1 },
-  { price: 1.20,  quantity: 5 },
+  { price: 10.0, quantity: 2 },
+  { price: 4.5, quantity: 1 },
+  { price: 1.2, quantity: 5 },
 ];
 
 console.log("No code:    ", finalTotal(cart, ""));

--- a/content/learn/beginners-javascript/strings-and-text.mdx
+++ b/content/learn/beginners-javascript/strings-and-text.mdx
@@ -269,7 +269,10 @@ console.log(summarize(article));
 
 function sentenceCount(text) {
   // Very rough — split on punctuation that ends sentences.
-  return text.split(/[.!?]+/).map((s) => s.trim()).filter(Boolean).length;
+  return text
+    .split(/[.!?]+/)
+    .map((s) => s.trim())
+    .filter(Boolean).length;
 }
 
 function summarize(text) {

--- a/content/learn/beginners-javascript/values-and-types.mdx
+++ b/content/learn/beginners-javascript/values-and-types.mdx
@@ -323,9 +323,9 @@ values, the other uses them.
       filename: "index.js",
       initialContent: `const { square, isEven, describe } = require("./numbers");
 
-console.log(square(7));            // 49
-console.log(isEven(4));            // true
-console.log(isEven(5));            // false
+console.log(square(7)); // 49
+console.log(isEven(4)); // true
+console.log(isEven(5)); // false
 
 console.log(describe(0));
 console.log(describe(-3));
@@ -347,7 +347,7 @@ function isEven(n) {
 
 function describe(n) {
   if (n === 0) return "zero";
-  if (n < 0)   return "negative";
+  if (n < 0) return "negative";
   return "positive";
 }
 

--- a/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
@@ -164,13 +164,13 @@ and click *Run* — both files are compiled and linked together.
   files={[
     {
       filename: "main.c",
-      initialContent: `#include <stdio.h>
-#include "greetings.h"
+      initialContent: `#include "greetings.h"
+#include <stdio.h>
 
 int main(void) {
-    say_hello("world");
-    say_hello("C");
-    return 0;
+  say_hello("world");
+  say_hello("C");
+  return 0;
 }
 `,
     },
@@ -186,12 +186,10 @@ void say_hello(const char *name);
     },
     {
       filename: "greetings.c",
-      initialContent: `#include <stdio.h>
-#include "greetings.h"
+      initialContent: `#include "greetings.h"
+#include <stdio.h>
 
-void say_hello(const char *name) {
-    printf("Hello, %s!\\n", name);
-}
+void say_hello(const char *name) { printf("Hello, %s!\\n", name); }
 `,
     },
   ]}
@@ -243,8 +241,8 @@ flowchart LR
       initialContent: `#include "farewell.h"
 
 int main(void) {
-    say_goodbye("Bell Labs");
-    return 0;
+  say_goodbye("Bell Labs");
+  return 0;
 }
 `,
     },
@@ -267,17 +265,15 @@ void say_goodbye(const char *name);
     },
     {
       filename: "farewell.c",
-      initialContent: `#include <stdio.h>
-#include "farewell.h"
+      initialContent: `#include "farewell.h"
+#include <stdio.h>
 
 // define say_goodbye here
 `,
-      solutionContent: `#include <stdio.h>
-#include "farewell.h"
+      solutionContent: `#include "farewell.h"
+#include <stdio.h>
 
-void say_goodbye(const char *name) {
-    printf("Goodbye, %s!\\n", name);
-}
+void say_goodbye(const char *name) { printf("Goodbye, %s!\\n", name); }
 `,
     },
   ]}

--- a/content/learn/c-programming-for-beginners/dynamic-memory.mdx
+++ b/content/learn/c-programming-for-beginners/dynamic-memory.mdx
@@ -253,20 +253,20 @@ The program must print exactly:
   files={[
     {
       filename: "main.c",
-      initialContent: `#include <stdio.h>
-#include "dynarr.h"
+      initialContent: `#include "dynarr.h"
+#include <stdio.h>
 
 int main(void) {
-    DynArr a;
-    da_init(&a);
-    for (int i = 1; i <= 5; i++) {
-        da_push(&a, i);
-    }
-    for (size_t i = 0; i < a.length; i++) {
-        printf("%d%s", a.data[i], i + 1 == a.length ? "\\n" : " ");
-    }
-    da_free(&a);
-    return 0;
+  DynArr a;
+  da_init(&a);
+  for (int i = 1; i <= 5; i++) {
+    da_push(&a, i);
+  }
+  for (size_t i = 0; i < a.length; i++) {
+    printf("%d%s", a.data[i], i + 1 == a.length ? "\\n" : " ");
+  }
+  da_free(&a);
+  return 0;
 }
 `,
     },
@@ -278,9 +278,9 @@ int main(void) {
 #include <stddef.h>
 
 typedef struct {
-    int   *data;
-    size_t length;
-    size_t capacity;
+  int *data;
+  size_t length;
+  size_t capacity;
 } DynArr;
 
 void da_init(DynArr *a);
@@ -292,46 +292,47 @@ void da_free(DynArr *a);
     },
     {
       filename: "dynarr.c",
-      initialContent: `#include <stdlib.h>
-#include "dynarr.h"
+      initialContent: `#include "dynarr.h"
+#include <stdlib.h>
 
 void da_init(DynArr *a) {
-    // your code here
+  // your code here
 }
 
 void da_push(DynArr *a, int value) {
-    // your code here
+  // your code here
 }
 
 void da_free(DynArr *a) {
-    // your code here
+  // your code here
 }
 `,
-      solutionContent: `#include <stdlib.h>
-#include "dynarr.h"
+      solutionContent: `#include "dynarr.h"
+#include <stdlib.h>
 
 void da_init(DynArr *a) {
-    a->data = NULL;
-    a->length = 0;
-    a->capacity = 0;
+  a->data = NULL;
+  a->length = 0;
+  a->capacity = 0;
 }
 
 void da_push(DynArr *a, int value) {
-    if (a->length == a->capacity) {
-        size_t new_cap = a->capacity == 0 ? 1 : a->capacity * 2;
-        int *new_data = realloc(a->data, new_cap * sizeof(int));
-        if (new_data == NULL) return;
-        a->data = new_data;
-        a->capacity = new_cap;
-    }
-    a->data[a->length++] = value;
+  if (a->length == a->capacity) {
+    size_t new_cap = a->capacity == 0 ? 1 : a->capacity * 2;
+    int *new_data = realloc(a->data, new_cap * sizeof(int));
+    if (new_data == NULL)
+      return;
+    a->data = new_data;
+    a->capacity = new_cap;
+  }
+  a->data[a->length++] = value;
 }
 
 void da_free(DynArr *a) {
-    free(a->data);
-    a->data = NULL;
-    a->length = 0;
-    a->capacity = 0;
+  free(a->data);
+  a->data = NULL;
+  a->length = 0;
+  a->capacity = 0;
 }
 `,
     },

--- a/content/learn/c-programming-for-beginners/linked-lists.mdx
+++ b/content/learn/c-programming-for-beginners/linked-lists.mdx
@@ -244,13 +244,13 @@ The program must print exactly:
       initialContent: `#include "list.h"
 
 int main(void) {
-    Node *head = NULL;
-    head = list_prepend(head, 3);
-    head = list_prepend(head, 2);
-    head = list_prepend(head, 1);
-    list_print(head);
-    list_free(head);
-    return 0;
+  Node *head = NULL;
+  head = list_prepend(head, 3);
+  head = list_prepend(head, 2);
+  head = list_prepend(head, 1);
+  list_print(head);
+  list_free(head);
+  return 0;
 }
 `,
     },
@@ -260,61 +260,62 @@ int main(void) {
 #define LIST_H
 
 typedef struct Node {
-    int          value;
-    struct Node *next;
+  int value;
+  struct Node *next;
 } Node;
 
 Node *list_prepend(Node *head, int value);
-void  list_print(const Node *head);
-void  list_free(Node *head);
+void list_print(const Node *head);
+void list_free(Node *head);
 
 #endif
 `,
     },
     {
       filename: "list.c",
-      initialContent: `#include <stdio.h>
+      initialContent: `#include "list.h"
+#include <stdio.h>
 #include <stdlib.h>
-#include "list.h"
 
 Node *list_prepend(Node *head, int value) {
-    // your code here
-    return head;
+  // your code here
+  return head;
 }
 
 void list_print(const Node *head) {
-    // your code here
+  // your code here
 }
 
 void list_free(Node *head) {
-    // your code here
+  // your code here
 }
 `,
-      solutionContent: `#include <stdio.h>
+      solutionContent: `#include "list.h"
+#include <stdio.h>
 #include <stdlib.h>
-#include "list.h"
 
 Node *list_prepend(Node *head, int value) {
-    Node *n = malloc(sizeof(Node));
-    if (n == NULL) return head;
-    n->value = value;
-    n->next  = head;
-    return n;
+  Node *n = malloc(sizeof(Node));
+  if (n == NULL)
+    return head;
+  n->value = value;
+  n->next = head;
+  return n;
 }
 
 void list_print(const Node *head) {
-    for (const Node *cur = head; cur != NULL; cur = cur->next) {
-        printf("%d%s", cur->value, cur->next == NULL ? "\\n" : " ");
-    }
+  for (const Node *cur = head; cur != NULL; cur = cur->next) {
+    printf("%d%s", cur->value, cur->next == NULL ? "\\n" : " ");
+  }
 }
 
 void list_free(Node *head) {
-    Node *cur = head;
-    while (cur != NULL) {
-        Node *next = cur->next;
-        free(cur);
-        cur = next;
-    }
+  Node *cur = head;
+  while (cur != NULL) {
+    Node *next = cur->next;
+    free(cur);
+    cur = next;
+  }
 }
 `,
     },

--- a/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
+++ b/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
@@ -183,18 +183,18 @@ to compile and run all of them at once.
   files={[
     {
       filename: "main.c",
-      initialContent: `#include <stdio.h>
-#include "stats.h"
+      initialContent: `#include "stats.h"
+#include <stdio.h>
 
 int main(void) {
-    int data[] = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5};
-    int n = (int)(sizeof(data) / sizeof(data[0]));
+  int data[] = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5};
+  int n = (int)(sizeof(data) / sizeof(data[0]));
 
-    printf("count   = %d\\n", n);
-    printf("sum     = %d\\n", sum(data, n));
-    printf("max     = %d\\n", max_value(data, n));
-    printf("average = %.2f\\n", average(data, n));
-    return 0;
+  printf("count   = %d\\n", n);
+  printf("sum     = %d\\n", sum(data, n));
+  printf("max     = %d\\n", max_value(data, n));
+  printf("average = %.2f\\n", average(data, n));
+  return 0;
 }
 `,
     },
@@ -203,8 +203,8 @@ int main(void) {
       initialContent: `#ifndef STATS_H
 #define STATS_H
 
-int    sum(const int *data, int n);
-int    max_value(const int *data, int n);
+int sum(const int *data, int n);
+int max_value(const int *data, int n);
 double average(const int *data, int n);
 
 #endif
@@ -215,24 +215,26 @@ double average(const int *data, int n);
       initialContent: `#include "stats.h"
 
 int sum(const int *data, int n) {
-    int total = 0;
-    for (int i = 0; i < n; i++) {
-        total += data[i];
-    }
-    return total;
+  int total = 0;
+  for (int i = 0; i < n; i++) {
+    total += data[i];
+  }
+  return total;
 }
 
 int max_value(const int *data, int n) {
-    int best = data[0];
-    for (int i = 1; i < n; i++) {
-        if (data[i] > best) best = data[i];
-    }
-    return best;
+  int best = data[0];
+  for (int i = 1; i < n; i++) {
+    if (data[i] > best)
+      best = data[i];
+  }
+  return best;
 }
 
 double average(const int *data, int n) {
-    if (n == 0) return 0.0;
-    return (double)sum(data, n) / n;
+  if (n == 0)
+    return 0.0;
+  return (double)sum(data, n) / n;
 }
 `,
     },
@@ -267,14 +269,14 @@ contract stayed the same. That is the power of modularity.
   files={[
     {
       filename: "main.c",
-      initialContent: `#include <stdio.h>
-#include "calc.h"
+      initialContent: `#include "calc.h"
+#include <stdio.h>
 
 int main(void) {
-    int a = 3, b = 4;
-    printf("%d + %d = %d\\n", a, b, add(a, b));
-    printf("%d * %d = %d\\n", a, b, multiply(a, b));
-    return 0;
+  int a = 3, b = 4;
+  printf("%d + %d = %d\\n", a, b, add(a, b));
+  printf("%d * %d = %d\\n", a, b, multiply(a, b));
+  return 0;
 }
 `,
     },
@@ -297,13 +299,9 @@ int multiply(int a, int b);
 `,
       solutionContent: `#include "calc.h"
 
-int add(int a, int b) {
-    return a + b;
-}
+int add(int a, int b) { return a + b; }
 
-int multiply(int a, int b) {
-    return a * b;
-}
+int multiply(int a, int b) { return a * b; }
 `,
     },
   ]}

--- a/content/learn/challenge-cards-c.mdx
+++ b/content/learn/challenge-cards-c.mdx
@@ -265,7 +265,13 @@ filesystem before each run, so the entry translation unit can
   files={[
     {
       filename: "main.c",
-      initialContent: `#include "utils.h"\n\nint main(void) {\n    greet();\n    return 0;\n}\n`,
+      initialContent: `#include "utils.h"
+
+int main(void) {
+  greet();
+  return 0;
+}
+`,
     },
     {
       filename: "utils.h",
@@ -273,8 +279,18 @@ filesystem before each run, so the entry translation unit can
     },
     {
       filename: "utils.c",
-      initialContent: `#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n    // your code here\n}\n`,
-      solutionContent: `#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n    printf("Hello, World!\\n");\n}\n`,
+      initialContent: `#include "utils.h"
+#include <stdio.h>
+
+void greet(void) {
+  // your code here
+}
+`,
+      solutionContent: `#include "utils.h"
+#include <stdio.h>
+
+void greet(void) { printf("Hello, World!\\n"); }
+`,
     },
   ]}
   tests={[
@@ -296,7 +312,13 @@ filesystem before each run, so the entry translation unit can
   files={[
     {
       filename: "main.c",
-      initialContent: `#include "utils.h"\n\nint main(void) {\n    greet();\n    return 0;\n}\n`,
+      initialContent: `#include "utils.h"
+
+int main(void) {
+  greet();
+  return 0;
+}
+`,
     },
     {
       filename: "utils.h",
@@ -304,8 +326,16 @@ filesystem before each run, so the entry translation unit can
     },
     {
       filename: "utils.c",
-      initialContent: `#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n}\n`,
-      solutionContent: `#include <stdio.h>\n#include "utils.h"\n\nvoid greet(void) {\n    printf("Hello, World!\\n");\n}\n`,
+      initialContent: `#include "utils.h"
+#include <stdio.h>
+
+void greet(void) {}
+`,
+      solutionContent: `#include "utils.h"
+#include <stdio.h>
+
+void greet(void) { printf("Hello, World!\\n"); }
+`,
     },
   ]}
   tests={[

--- a/content/learn/challenge-cards-cpp.mdx
+++ b/content/learn/challenge-cards-cpp.mdx
@@ -271,16 +271,38 @@ filesystem before each run, so the entry translation unit can
   files={[
     {
       filename: "main.cpp",
-      initialContent: `#include "greeter.h"\n\nint main() {\n    Greeter g;\n    g.greet();\n    return 0;\n}\n`,
+      initialContent: `#include "greeter.h"
+
+int main() {
+  Greeter g;
+  g.greet();
+  return 0;
+}
+`,
     },
     {
       filename: "greeter.h",
-      initialContent: `#pragma once\nclass Greeter {\npublic:\n    void greet();\n};\n`,
+      initialContent: `#pragma once
+class Greeter {
+public:
+  void greet();
+};
+`,
     },
     {
       filename: "greeter.cpp",
-      initialContent: `#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n    // your code here\n}\n`,
-      solutionContent: `#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n    std::cout << "Hello, World!\\n";\n}\n`,
+      initialContent: `#include "greeter.h"
+#include <iostream>
+
+void Greeter::greet() {
+  // your code here
+}
+`,
+      solutionContent: `#include "greeter.h"
+#include <iostream>
+
+void Greeter::greet() { std::cout << "Hello, World!\\n"; }
+`,
     },
   ]}
   tests={[
@@ -302,16 +324,36 @@ filesystem before each run, so the entry translation unit can
   files={[
     {
       filename: "main.cpp",
-      initialContent: `#include "greeter.h"\n\nint main() {\n    Greeter g;\n    g.greet();\n    return 0;\n}\n`,
+      initialContent: `#include "greeter.h"
+
+int main() {
+  Greeter g;
+  g.greet();
+  return 0;
+}
+`,
     },
     {
       filename: "greeter.h",
-      initialContent: `#pragma once\nclass Greeter {\npublic:\n    void greet();\n};\n`,
+      initialContent: `#pragma once
+class Greeter {
+public:
+  void greet();
+};
+`,
     },
     {
       filename: "greeter.cpp",
-      initialContent: `#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n}\n`,
-      solutionContent: `#include <iostream>\n#include "greeter.h"\n\nvoid Greeter::greet() {\n    std::cout << "Hello, World!\\n";\n}\n`,
+      initialContent: `#include "greeter.h"
+#include <iostream>
+
+void Greeter::greet() {}
+`,
+      solutionContent: `#include "greeter.h"
+#include <iostream>
+
+void Greeter::greet() { std::cout << "Hello, World!\\n"; }
+`,
     },
   ]}
   tests={[

--- a/content/learn/challenge-cards-java.mdx
+++ b/content/learn/challenge-cards-java.mdx
@@ -142,26 +142,24 @@ so `Main` can reference `Dog` directly without any imports.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Dog d = new Dog();
-        System.out.println(d.bark());
-    }
+  public static void main(String[] args) {
+    Dog d = new Dog();
+    System.out.println(d.bark());
+  }
 }
 `,
     },
     {
       filename: "Dog.java",
       initialContent: `public class Dog {
-    public String bark() {
-        // your code here
-        return "";
-    }
+  public String bark() {
+    // your code here
+    return "";
+  }
 }
 `,
       solutionContent: `public class Dog {
-    public String bark() {
-        return "Woof!";
-    }
+  public String bark() { return "Woof!"; }
 }
 `,
     },
@@ -186,25 +184,21 @@ so `Main` can reference `Dog` directly without any imports.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Dog d = new Dog();
-        System.out.println(d.bark());
-    }
+  public static void main(String[] args) {
+    Dog d = new Dog();
+    System.out.println(d.bark());
+  }
 }
 `,
     },
     {
       filename: "Dog.java",
       initialContent: `public class Dog {
-    public String bark() {
-        return "";
-    }
+  public String bark() { return ""; }
 }
 `,
       solutionContent: `public class Dog {
-    public String bark() {
-        return "Woof!";
-    }
+  public String bark() { return "Woof!"; }
 }
 `,
     },

--- a/content/learn/challenge-cards-php.mdx
+++ b/content/learn/challenge-cards-php.mdx
@@ -268,12 +268,29 @@ sibling files.
   files={[
     {
       filename: "main.php",
-      initialContent: `<?php\nrequire_once "utils.php";\necho greet("World");\n`,
+      initialContent: `<?php
+
+require_once 'utils.php';
+echo greet('World');
+`,
     },
     {
       filename: "utils.php",
-      initialContent: `<?php\nfunction greet($name) {\n    // your code here\n    return "";\n}\n`,
-      solutionContent: `<?php\nfunction greet($name) {\n    return "Hello, {$name}!";\n}\n`,
+      initialContent: `<?php
+
+function greet($name)
+{
+    // your code here
+    return '';
+}
+`,
+      solutionContent: `<?php
+
+function greet($name)
+{
+    return "Hello, {$name}!";
+}
+`,
     },
   ]}
   tests={[
@@ -295,12 +312,28 @@ sibling files.
   files={[
     {
       filename: "main.php",
-      initialContent: `<?php\nrequire_once "utils.php";\necho greet("World");\n`,
+      initialContent: `<?php
+
+require_once 'utils.php';
+echo greet('World');
+`,
     },
     {
       filename: "utils.php",
-      initialContent: `<?php\nfunction greet($name) {\n    return "";\n}\n`,
-      solutionContent: `<?php\nfunction greet($name) {\n    return "Hello, {$name}!";\n}\n`,
+      initialContent: `<?php
+
+function greet($name)
+{
+    return '';
+}
+`,
+      solutionContent: `<?php
+
+function greet($name)
+{
+    return "Hello, {$name}!";
+}
+`,
     },
   ]}
   tests={[

--- a/content/learn/code-blocks-c.mdx
+++ b/content/learn/code-blocks-c.mdx
@@ -51,14 +51,14 @@ Pass a `files` array alongside an `entryFilename` to compile a multi-translation
   files={[
     {
       filename: "main.c",
-      initialContent: `#include <stdio.h>
-#include "mathx.h"
+      initialContent: `#include "mathx.h"
+#include <stdio.h>
 
 int main(void) {
-    int a = 6, b = 7;
-    printf("add(%d, %d) = %d\\n", a, b, add(a, b));
-    printf("mul(%d, %d) = %d\\n", a, b, mul(a, b));
-    return 0;
+  int a = 6, b = 7;
+  printf("add(%d, %d) = %d\\n", a, b, add(a, b));
+  printf("mul(%d, %d) = %d\\n", a, b, mul(a, b));
+  return 0;
 }
 `,
     },
@@ -93,14 +93,14 @@ The MDX source for the example above:
   files={[
     {
       filename: "main.c",
-      initialContent: `#include <stdio.h>
-#include "mathx.h"
+      initialContent: `#include "mathx.h"
+#include <stdio.h>
 
 int main(void) {
-    int a = 6, b = 7;
-    printf("add(%d, %d) = %d\\n", a, b, add(a, b));
-    printf("mul(%d, %d) = %d\\n", a, b, mul(a, b));
-    return 0;
+  int a = 6, b = 7;
+  printf("add(%d, %d) = %d\\n", a, b, add(a, b));
+  printf("mul(%d, %d) = %d\\n", a, b, mul(a, b));
+  return 0;
 }
 `,
     },

--- a/content/learn/code-blocks-cpp.mdx
+++ b/content/learn/code-blocks-cpp.mdx
@@ -53,14 +53,14 @@ Split a class into a header and an implementation file. Every workspace file is 
   files={[
     {
       filename: "main.cpp",
-      initialContent: `#include <iostream>
-#include "greeter.hpp"
+      initialContent: `#include "greeter.hpp"
+#include <iostream>
 
 int main() {
-    Greeter g("C++ Playground");
-    std::cout << g.hello() << "\\n";
-    std::cout << g.bye() << "\\n";
-    return 0;
+  Greeter g("C++ Playground");
+  std::cout << g.hello() << "\\n";
+  std::cout << g.bye() << "\\n";
+  return 0;
 }
 `,
     },
@@ -73,12 +73,12 @@ int main() {
 
 class Greeter {
 public:
-    explicit Greeter(std::string name);
-    std::string hello() const;
-    std::string bye() const;
+  explicit Greeter(std::string name);
+  std::string hello() const;
+  std::string bye() const;
 
 private:
-    std::string name_;
+  std::string name_;
 };
 
 #endif
@@ -91,7 +91,7 @@ private:
 Greeter::Greeter(std::string name) : name_(std::move(name)) {}
 
 std::string Greeter::hello() const { return "Hello, " + name_ + "!"; }
-std::string Greeter::bye() const   { return "Goodbye, " + name_ + "!"; }
+std::string Greeter::bye() const { return "Goodbye, " + name_ + "!"; }
 `,
     },
   ]}
@@ -106,14 +106,14 @@ The MDX source for the example above:
   files={[
     {
       filename: "main.cpp",
-      initialContent: `#include <iostream>
-#include "greeter.hpp"
+      initialContent: `#include "greeter.hpp"
+#include <iostream>
 
 int main() {
-    Greeter g("C++ Playground");
-    std::cout << g.hello() << "\\n";
-    std::cout << g.bye() << "\\n";
-    return 0;
+  Greeter g("C++ Playground");
+  std::cout << g.hello() << "\\n";
+  std::cout << g.bye() << "\\n";
+  return 0;
 }
 `,
     },
@@ -126,12 +126,12 @@ int main() {
 
 class Greeter {
 public:
-    explicit Greeter(std::string name);
-    std::string hello() const;
-    std::string bye() const;
+  explicit Greeter(std::string name);
+  std::string hello() const;
+  std::string bye() const;
 
 private:
-    std::string name_;
+  std::string name_;
 };
 
 #endif
@@ -144,7 +144,7 @@ private:
 Greeter::Greeter(std::string name) : name_(std::move(name)) {}
 
 std::string Greeter::hello() const { return "Hello, " + name_ + "!"; }
-std::string Greeter::bye() const   { return "Goodbye, " + name_ + "!"; }
+std::string Greeter::bye() const { return "Goodbye, " + name_ + "!"; }
 `,
     },
   ]}

--- a/content/learn/code-blocks-csharp.mdx
+++ b/content/learn/code-blocks-csharp.mdx
@@ -63,7 +63,7 @@ Console.WriteLine(g.Bye());
     }
 
     public string Hello() => $"Hello, {_name}!";
-    public string Bye()   => $"Goodbye, {_name}!";
+    public string Bye() => $"Goodbye, {_name}!";
 }
 `,
     },
@@ -96,7 +96,7 @@ Console.WriteLine(g.Bye());
     }
 
     public string Hello() => $"Hello, {_name}!";
-    public string Bye()   => $"Goodbye, {_name}!";
+    public string Bye() => $"Goodbye, {_name}!";
 }
 `,
     },

--- a/content/learn/code-blocks-java.mdx
+++ b/content/learn/code-blocks-java.mdx
@@ -52,30 +52,24 @@ Reference a class declared in a sibling `.java` file. Each workspace file is com
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Greeter g = new Greeter("Java Playground");
-        System.out.println(g.hello());
-        System.out.println(g.bye());
-    }
+  public static void main(String[] args) {
+    Greeter g = new Greeter("Java Playground");
+    System.out.println(g.hello());
+    System.out.println(g.bye());
+  }
 }
 `,
     },
     {
       filename: "Greeter.java",
       initialContent: `public class Greeter {
-    private final String name;
+  private final String name;
 
-    public Greeter(String name) {
-        this.name = name;
-    }
+  public Greeter(String name) { this.name = name; }
 
-    public String hello() {
-        return "Hello, " + name + "!";
-    }
+  public String hello() { return "Hello, " + name + "!"; }
 
-    public String bye() {
-        return "Goodbye, " + name + "!";
-    }
+  public String bye() { return "Goodbye, " + name + "!"; }
 }
 `,
     },
@@ -92,30 +86,24 @@ The MDX source for the example above:
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Greeter g = new Greeter("Java Playground");
-        System.out.println(g.hello());
-        System.out.println(g.bye());
-    }
+  public static void main(String[] args) {
+    Greeter g = new Greeter("Java Playground");
+    System.out.println(g.hello());
+    System.out.println(g.bye());
+  }
 }
 `,
     },
     {
       filename: "Greeter.java",
       initialContent: `public class Greeter {
-    private final String name;
+  private final String name;
 
-    public Greeter(String name) {
-        this.name = name;
-    }
+  public Greeter(String name) { this.name = name; }
 
-    public String hello() {
-        return "Hello, " + name + "!";
-    }
+  public String hello() { return "Hello, " + name + "!"; }
 
-    public String bye() {
-        return "Goodbye, " + name + "!";
-    }
+  public String bye() { return "Goodbye, " + name + "!"; }
 }
 `,
     },

--- a/content/learn/code-blocks-php.mdx
+++ b/content/learn/code-blocks-php.mdx
@@ -49,20 +49,24 @@ echo json_encode($people, JSON_PRETTY_PRINT);
     {
       filename: "index.php",
       initialContent: `<?php
-require_once __DIR__ . "/greetings.php";
 
-echo hello("PHP Playground") . "\\n";
-echo bye("PHP Playground") . "\\n";
+require_once __DIR__ . '/greetings.php';
+
+echo hello('PHP Playground') . "\\n";
+echo bye('PHP Playground') . "\\n";
 `,
     },
     {
       filename: "greetings.php",
       initialContent: `<?php
-function hello(string $name): string {
+
+function hello(string $name): string
+{
     return "Hello, {$name}!";
 }
 
-function bye(string $name): string {
+function bye(string $name): string
+{
     return "Goodbye, {$name}!";
 }
 `,
@@ -80,20 +84,24 @@ The MDX source for the example above:
     {
       filename: "index.php",
       initialContent: `<?php
-require_once __DIR__ . "/greetings.php";
 
-echo hello("PHP Playground") . "\\n";
-echo bye("PHP Playground") . "\\n";
+require_once __DIR__ . '/greetings.php';
+
+echo hello('PHP Playground') . "\\n";
+echo bye('PHP Playground') . "\\n";
 `,
     },
     {
       filename: "greetings.php",
       initialContent: `<?php
-function hello(string $name): string {
+
+function hello(string $name): string
+{
     return "Hello, {$name}!";
 }
 
-function bye(string $name): string {
+function bye(string $name): string
+{
     return "Goodbye, {$name}!";
 }
 `,

--- a/content/learn/csharp-linq-functional/aggregations.mdx
+++ b/content/learn/csharp-linq-functional/aggregations.mdx
@@ -251,8 +251,7 @@ using System.Linq;
 
 public static class Checksum
 {
-    public static int Compute(IEnumerable<int> xs) =>
-        xs.Aggregate(0, (acc, x) => acc * 31 + x);
+    public static int Compute(IEnumerable<int> xs) => xs.Aggregate(0, (acc, x) => acc * 31 + x);
 }
 `,
     },

--- a/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
+++ b/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
@@ -75,18 +75,12 @@ record. *Data first, behavior second* — the functional move.
       initialContent: `using System;
 using System.Linq;
 
-var lines = new[]
-{
-    "2026-05-01,A,2,19.99,paid",
-    "2026-05-01,B,1,49.00,paid",
-    "2026-05-02,A,1,19.99,refund",
-    "2026-05-02,A,5,19.99,paid",
-    "2026-05-03,B,3,49.00,paid",
-    "garbage line should be skipped",
-    "2026-05-04,A,10,19.99,paid",
-    "2026-05-04,B,8,49.00,paid",
-    "2026-05-05,A,1,19.99,refund",
-    "",
+var lines = new[] {
+    "2026-05-01,A,2,19.99,paid",   "2026-05-01,B,1,49.00,paid",
+    "2026-05-02,A,1,19.99,refund", "2026-05-02,A,5,19.99,paid",
+    "2026-05-03,B,3,49.00,paid",   "garbage line should be skipped",
+    "2026-05-04,A,10,19.99,paid",  "2026-05-04,B,8,49.00,paid",
+    "2026-05-05,A,1,19.99,refund", "",
 };
 
 Console.Write(Pipeline.BuildReport(lines));
@@ -94,18 +88,12 @@ Console.Write(Pipeline.BuildReport(lines));
       solutionContent: `using System;
 using System.Linq;
 
-var lines = new[]
-{
-    "2026-05-01,A,2,19.99,paid",
-    "2026-05-01,B,1,49.00,paid",
-    "2026-05-02,A,1,19.99,refund",
-    "2026-05-02,A,5,19.99,paid",
-    "2026-05-03,B,3,49.00,paid",
-    "garbage line should be skipped",
-    "2026-05-04,A,10,19.99,paid",
-    "2026-05-04,B,8,49.00,paid",
-    "2026-05-05,A,1,19.99,refund",
-    "",
+var lines = new[] {
+    "2026-05-01,A,2,19.99,paid",   "2026-05-01,B,1,49.00,paid",
+    "2026-05-02,A,1,19.99,refund", "2026-05-02,A,5,19.99,paid",
+    "2026-05-03,B,3,49.00,paid",   "garbage line should be skipped",
+    "2026-05-04,A,10,19.99,paid",  "2026-05-04,B,8,49.00,paid",
+    "2026-05-05,A,1,19.99,refund", "",
 };
 
 Console.Write(Pipeline.BuildReport(lines));
@@ -158,14 +146,19 @@ public static class Parsing
 {
     public static Txn? ParseLine(string line)
     {
-        if (string.IsNullOrWhiteSpace(line)) return null;
+        if (string.IsNullOrWhiteSpace(line))
+            return null;
         var parts = line.Split(',');
-        if (parts.Length != 5) return null;
+        if (parts.Length != 5)
+            return null;
 
-        if (!DateTime.TryParse(parts[0], CultureInfo.InvariantCulture, DateTimeStyles.None, out var date)) return null;
+        if (!DateTime.TryParse(parts[0], CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+            return null;
         var product = parts[1];
-        if (!int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var qty)) return null;
-        if (!decimal.TryParse(parts[3], NumberStyles.Any, CultureInfo.InvariantCulture, out var price)) return null;
+        if (!int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var qty))
+            return null;
+        if (!decimal.TryParse(parts[3], NumberStyles.Any, CultureInfo.InvariantCulture, out var price))
+            return null;
         var status = parts[4];
 
         return new Txn(date, product, qty, price, status);
@@ -202,18 +195,17 @@ using System.Linq;
 public static class Summarize
 {
     public static IEnumerable<ProductSummary> ByProduct(IEnumerable<Txn> txns) =>
-        txns
-            .GroupBy(t => t.Product)
+        txns.GroupBy(t => t.Product)
             .OrderBy(g => g.Key)
             .Select(g =>
-            {
-                var paid    = g.Where(t => t.Status == "paid");
-                var refund  = g.Where(t => t.Status == "refund");
-                var units   = paid.Sum(t => t.Quantity);
-                var gross   = paid.Sum(t => t.Quantity * t.UnitPrice);
-                var refunds = refund.Sum(t => t.Quantity * t.UnitPrice);
-                return new ProductSummary(g.Key, units, gross, gross - refunds);
-            });
+                    {
+                        var paid = g.Where(t => t.Status == "paid");
+                        var refund = g.Where(t => t.Status == "refund");
+                        var units = paid.Sum(t => t.Quantity);
+                        var gross = paid.Sum(t => t.Quantity * t.UnitPrice);
+                        var refunds = refund.Sum(t => t.Quantity * t.UnitPrice);
+                        return new ProductSummary(g.Key, units, gross, gross - refunds);
+                    });
 }
 `,
     },
@@ -265,7 +257,7 @@ public static class Pipeline
         }
         var totUnits = summaries.Sum(x => x.UnitsSold);
         var totGross = summaries.Sum(x => x.Gross);
-        var totNet   = summaries.Sum(x => x.Net);
+        var totNet = summaries.Sum(x => x.Net);
         sb.AppendLine("=== TOTAL ===");
         sb.AppendLine($"  units sold:   {totUnits}");
         sb.AppendLine($"  gross:        {totGross.ToString("0.00", CultureInfo.InvariantCulture)}");

--- a/content/learn/csharp-linq-functional/composing-pipelines.mdx
+++ b/content/learn/csharp-linq-functional/composing-pipelines.mdx
@@ -178,21 +178,16 @@ to combine before they ever touch LINQ.
       initialContent: `using System;
 using System.Linq;
 
-var events = new[]
-{
-    new LogEvent("INFO",  "boot",        DateTime.UtcNow.AddMinutes(-50)),
-    new LogEvent("WARN",  "slow query",  DateTime.UtcNow.AddMinutes(-30)),
-    new LogEvent("ERROR", "timeout",     DateTime.UtcNow.AddMinutes(-20)),
-    new LogEvent("ERROR", "disk full",   DateTime.UtcNow.AddMinutes(-5)),
-    new LogEvent("INFO",  "request 200", DateTime.UtcNow.AddMinutes(-3)),
+var events = new[] {
+    new LogEvent("INFO", "boot", DateTime.UtcNow.AddMinutes(-50)),
+    new LogEvent("WARN", "slow query", DateTime.UtcNow.AddMinutes(-30)),
+    new LogEvent("ERROR", "timeout", DateTime.UtcNow.AddMinutes(-20)),
+    new LogEvent("ERROR", "disk full", DateTime.UtcNow.AddMinutes(-5)),
+    new LogEvent("INFO", "request 200", DateTime.UtcNow.AddMinutes(-3)),
 };
 
 // Compose: keep last-15-min ERROR events, take the messages, join them.
-var headline = events
-    .Recent(TimeSpan.FromMinutes(15))
-    .OfLevel("ERROR")
-    .Messages()
-    .Join(", ");
+var headline = events.Recent(TimeSpan.FromMinutes(15)).OfLevel("ERROR").Messages().Join(", ");
 
 Console.WriteLine($"Recent errors: {headline}");
 
@@ -201,20 +196,15 @@ public record LogEvent(string Level, string Message, DateTime At);
       solutionContent: `using System;
 using System.Linq;
 
-var events = new[]
-{
-    new LogEvent("INFO",  "boot",        DateTime.UtcNow.AddMinutes(-50)),
-    new LogEvent("WARN",  "slow query",  DateTime.UtcNow.AddMinutes(-30)),
-    new LogEvent("ERROR", "timeout",     DateTime.UtcNow.AddMinutes(-20)),
-    new LogEvent("ERROR", "disk full",   DateTime.UtcNow.AddMinutes(-5)),
-    new LogEvent("INFO",  "request 200", DateTime.UtcNow.AddMinutes(-3)),
+var events = new[] {
+    new LogEvent("INFO", "boot", DateTime.UtcNow.AddMinutes(-50)),
+    new LogEvent("WARN", "slow query", DateTime.UtcNow.AddMinutes(-30)),
+    new LogEvent("ERROR", "timeout", DateTime.UtcNow.AddMinutes(-20)),
+    new LogEvent("ERROR", "disk full", DateTime.UtcNow.AddMinutes(-5)),
+    new LogEvent("INFO", "request 200", DateTime.UtcNow.AddMinutes(-3)),
 };
 
-var headline = events
-    .Recent(TimeSpan.FromMinutes(15))
-    .OfLevel("ERROR")
-    .Messages()
-    .Join(", ");
+var headline = events.Recent(TimeSpan.FromMinutes(15)).OfLevel("ERROR").Messages().Join(", ");
 
 Console.WriteLine($"Recent errors: {headline}");
 
@@ -230,20 +220,18 @@ using System.Linq;
 public static class LogExtensions
 {
     // TODO: return events whose At is within the past 'window' from now.
-    public static IEnumerable<LogEvent> Recent(this IEnumerable<LogEvent> src, TimeSpan window)
-        => throw new NotImplementedException();
+    public static IEnumerable<LogEvent> Recent(this IEnumerable<LogEvent> src,
+                                               TimeSpan window) => throw new NotImplementedException();
 
     // TODO: return only events whose Level matches.
-    public static IEnumerable<LogEvent> OfLevel(this IEnumerable<LogEvent> src, string level)
-        => throw new NotImplementedException();
+    public static IEnumerable<LogEvent> OfLevel(this IEnumerable<LogEvent> src,
+                                                string level) => throw new NotImplementedException();
 
     // TODO: project to the Message strings.
-    public static IEnumerable<string> Messages(this IEnumerable<LogEvent> src)
-        => throw new NotImplementedException();
+    public static IEnumerable<string> Messages(this IEnumerable<LogEvent> src) => throw new NotImplementedException();
 
     // TODO: join strings with the given separator.
-    public static string Join(this IEnumerable<string> src, string sep)
-        => throw new NotImplementedException();
+    public static string Join(this IEnumerable<string> src, string sep) => throw new NotImplementedException();
 }
 `,
       solutionContent: `using System;
@@ -258,14 +246,12 @@ public static class LogExtensions
         return src.Where(e => e.At >= cutoff);
     }
 
-    public static IEnumerable<LogEvent> OfLevel(this IEnumerable<LogEvent> src, string level) =>
-        src.Where(e => e.Level == level);
+    public static IEnumerable<LogEvent> OfLevel(this IEnumerable<LogEvent> src,
+                                                string level) => src.Where(e => e.Level == level);
 
-    public static IEnumerable<string> Messages(this IEnumerable<LogEvent> src) =>
-        src.Select(e => e.Message);
+    public static IEnumerable<string> Messages(this IEnumerable<LogEvent> src) => src.Select(e => e.Message);
 
-    public static string Join(this IEnumerable<string> src, string sep) =>
-        string.Join(sep, src);
+    public static string Join(this IEnumerable<string> src, string sep) => string.Join(sep, src);
 }
 `,
     },

--- a/content/learn/csharp-linq-functional/filtering-and-projection.mdx
+++ b/content/learn/csharp-linq-functional/filtering-and-projection.mdx
@@ -223,13 +223,9 @@ Use \`Where\` and \`Select\`. Do not use \`foreach\`.
   files={[
     {
       filename: "Program.cs",
-      initialContent: `var people = new[]
-{
-    new Person("Ada", 36),
-    new Person("Bilal", 12),
-    new Person("Chiara", 17),
-    new Person("Dmitri", 22),
-    new Person("Esther", 41),
+      initialContent: `var people = new[] {
+    new Person("Ada", 36),    new Person("Bilal", 12),  new Person("Chiara", 17),
+    new Person("Dmitri", 22), new Person("Esther", 41),
 };
 
 foreach (var name in PeopleFilter.AdultNamesUpper(people))
@@ -257,9 +253,7 @@ using System.Linq;
 public static class PeopleFilter
 {
     public static IEnumerable<string> AdultNamesUpper(IEnumerable<Person> people) =>
-        people
-            .Where(p => p.Age >= 18)
-            .Select(p => p.Name.ToUpperInvariant());
+        people.Where(p => p.Age >= 18).Select(p => p.Name.ToUpperInvariant());
 }
 `,
     },

--- a/content/learn/csharp-linq-functional/functional-design-patterns.mdx
+++ b/content/learn/csharp-linq-functional/functional-design-patterns.mdx
@@ -201,35 +201,25 @@ combinator** library.
       initialContent: `using System;
 using System.Linq;
 
-var rule = Validator<string>.All(
-    Validator<string>.NonEmpty("name"),
-    Validator<string>.MaxLen("name", 10),
-    Validator<string>.NoDigits("name")
-);
+var rule = Validator<string>.All(Validator<string>.NonEmpty("name"), Validator<string>.MaxLen("name", 10),
+                                 Validator<string>.NoDigits("name"));
 
 foreach (var name in new[] { "Ada", "", "alongusername", "Ada1" })
 {
     var errs = rule(name).ToList();
-    Console.WriteLine(errs.Count == 0
-        ? $"OK: {name}"
-        : $"BAD '{name}': {string.Join("; ", errs)}");
+    Console.WriteLine(errs.Count == 0 ? $"OK: {name}" : $"BAD '{name}': {string.Join("; ", errs)}");
 }
 `,
       solutionContent: `using System;
 using System.Linq;
 
-var rule = Validator<string>.All(
-    Validator<string>.NonEmpty("name"),
-    Validator<string>.MaxLen("name", 10),
-    Validator<string>.NoDigits("name")
-);
+var rule = Validator<string>.All(Validator<string>.NonEmpty("name"), Validator<string>.MaxLen("name", 10),
+                                 Validator<string>.NoDigits("name"));
 
 foreach (var name in new[] { "Ada", "", "alongusername", "Ada1" })
 {
     var errs = rule(name).ToList();
-    Console.WriteLine(errs.Count == 0
-        ? $"OK: {name}"
-        : $"BAD '{name}': {string.Join("; ", errs)}");
+    Console.WriteLine(errs.Count == 0 ? $"OK: {name}" : $"BAD '{name}': {string.Join("; ", errs)}");
 }
 `,
     },
@@ -245,20 +235,16 @@ public static class Validator<T>
     public delegate IEnumerable<string> Rule(T value);
 
     // TODO: NonEmpty<string>: error "{field} is empty" iff value is null or empty string.
-    public static Rule NonEmpty(string field) =>
-        throw new NotImplementedException();
+    public static Rule NonEmpty(string field) => throw new NotImplementedException();
 
     // TODO: MaxLen<string>: error "{field} too long" iff value.Length > max.
-    public static Rule MaxLen(string field, int max) =>
-        throw new NotImplementedException();
+    public static Rule MaxLen(string field, int max) => throw new NotImplementedException();
 
     // TODO: NoDigits<string>: error "{field} contains digits" iff value has any digit char.
-    public static Rule NoDigits(string field) =>
-        throw new NotImplementedException();
+    public static Rule NoDigits(string field) => throw new NotImplementedException();
 
     // TODO: All: combine rules; concatenate all their errors in argument order.
-    public static Rule All(params Rule[] rules) =>
-        throw new NotImplementedException();
+    public static Rule All(params Rule[] rules) => throw new NotImplementedException();
 }
 `,
       solutionContent: `using System;
@@ -269,23 +255,17 @@ public static class Validator<T>
 {
     public delegate IEnumerable<string> Rule(T value);
 
-    public static Rule NonEmpty(string field) => v =>
-        string.IsNullOrEmpty(v as string)
-            ? new[] { $"{field} is empty" }
-            : Enumerable.Empty<string>();
+    public static Rule NonEmpty(string field) => v => string.IsNullOrEmpty(v as string) ? new[] { $"{field} is empty" }
+                                                                                        : Enumerable.Empty<string>();
 
-    public static Rule MaxLen(string field, int max) => v =>
-        (v as string)?.Length > max
-            ? new[] { $"{field} too long" }
-            : Enumerable.Empty<string>();
+    public static Rule MaxLen(string field, int max) => v => (v as string)?.Length > max? new[] { $"{field} too long" }
+        : Enumerable.Empty<string>();
 
-    public static Rule NoDigits(string field) => v =>
-        (v as string)?.Any(char.IsDigit) == true
-            ? new[] { $"{field} contains digits" }
-            : Enumerable.Empty<string>();
+    public static Rule NoDigits(string field) => v => (v as string)?.Any(char.IsDigit) == true
+                                                          ? new[] { $"{field} contains digits" }
+                                                          : Enumerable.Empty<string>();
 
-    public static Rule All(params Rule[] rules) => v =>
-        rules.SelectMany(r => r(v));
+    public static Rule All(params Rule[] rules) => v => rules.SelectMany(r => r(v));
 }
 `,
     },

--- a/content/learn/csharp-linq-functional/generic-abstractions.mdx
+++ b/content/learn/csharp-linq-functional/generic-abstractions.mdx
@@ -242,8 +242,8 @@ public static class HistogramOp
     //   1) Use a generic constraint so TKey can be compared / used as a dictionary key.
     //   2) Count how many elements of 'source' produce each key (via keySelector).
     //   3) Return pairs ordered by key ascending.
-    public static IEnumerable<(TKey key, int count)> Histogram<T, TKey>(
-        this IEnumerable<T> source, Func<T, TKey> keySelector)
+    public static IEnumerable<(TKey key, int count)> Histogram<T, TKey>(this IEnumerable<T> source,
+                                                                        Func<T, TKey> keySelector)
         where TKey : notnull
     {
         throw new NotImplementedException();
@@ -256,14 +256,11 @@ using System.Linq;
 
 public static class HistogramOp
 {
-    public static IEnumerable<(TKey key, int count)> Histogram<T, TKey>(
-        this IEnumerable<T> source, Func<T, TKey> keySelector)
+    public static IEnumerable<(TKey key, int count)> Histogram<T, TKey>(this IEnumerable<T> source,
+                                                                        Func<T, TKey> keySelector)
         where TKey : notnull
     {
-        return source
-            .GroupBy(keySelector)
-            .OrderBy(g => g.Key)
-            .Select(g => (g.Key, g.Count()));
+        return source.GroupBy(keySelector).OrderBy(g => g.Key).Select(g => (g.Key, g.Count()));
     }
 }
 `,

--- a/content/learn/csharp-linq-functional/higher-order-functions.mdx
+++ b/content/learn/csharp-linq-functional/higher-order-functions.mdx
@@ -293,8 +293,8 @@ using System.Linq;
 
 public static class Filters
 {
-    public static Func<IEnumerable<int>, IEnumerable<int>> Build(Func<int, bool> predicate) =>
-        xs => xs.Where(predicate);
+    public static Func<IEnumerable<int>, IEnumerable<int>> Build(Func<int, bool> predicate) => xs =>
+        xs.Where(predicate);
 }
 `,
     },

--- a/content/learn/csharp-linq-functional/immutability.mdx
+++ b/content/learn/csharp-linq-functional/immutability.mdx
@@ -226,7 +226,7 @@ The given \`Program.cs\` will call your method and print the result.`}
     {
       filename: "Program.cs",
       initialContent: `var a = new Money(10m, "USD");
-var b = new Money(5m,  "USD");
+var b = new Money(5m, "USD");
 var c = Money.Add(a, b);
 
 System.Console.WriteLine($"{a.Amount} {a.Currency}");

--- a/content/learn/csharp-linq-functional/ordering-and-grouping.mdx
+++ b/content/learn/csharp-linq-functional/ordering-and-grouping.mdx
@@ -226,14 +226,9 @@ Ties may be broken in any deterministic way (e.g. by region name).
   files={[
     {
       filename: "Program.cs",
-      initialContent: `var sales = new[]
-{
-    new Sale("EU",   10m),
-    new Sale("APAC", 15m),
-    new Sale("EU",   30m),
-    new Sale("US",   25m),
-    new Sale("EU",    5m),
-    new Sale("APAC", 20m),
+      initialContent: `var sales = new[] {
+    new Sale("EU", 10m), new Sale("APAC", 15m), new Sale("EU", 30m),
+    new Sale("US", 25m), new Sale("EU", 5m),    new Sale("APAC", 20m),
 };
 
 System.Console.WriteLine(SalesReport.TopRegion(sales));
@@ -259,14 +254,13 @@ using System.Linq;
 
 public static class SalesReport
 {
-    public static string TopRegion(IEnumerable<Sale> sales) =>
-        sales
-            .GroupBy(s => s.Region)
-            .Select(g => new { Region = g.Key, Total = g.Sum(s => s.Amount) })
-            .OrderByDescending(r => r.Total)
-            .ThenBy(r => r.Region)
-            .First()
-            .Region;
+    public static string TopRegion(IEnumerable<Sale> sales) => sales.GroupBy(s => s.Region)
+                                                                   .Select(g => new { Region = g.Key,
+                                                                                      Total = g.Sum(s => s.Amount) })
+                                                                   .OrderByDescending(r => r.Total)
+                                                                   .ThenBy(r => r.Region)
+                                                                   .First()
+                                                                   .Region;
 }
 `,
     },

--- a/content/learn/csharp-linq-functional/pure-functions.mdx
+++ b/content/learn/csharp-linq-functional/pure-functions.mdx
@@ -254,8 +254,7 @@ using System.Linq;
 
 public static class MathCore
 {
-    public static int SumOfSquares(IEnumerable<int> xs) =>
-        xs.Sum(x => x * x);
+    public static int SumOfSquares(IEnumerable<int> xs) => xs.Sum(x => x * x);
 
     public static double MeanOfSquares(IEnumerable<int> xs)
     {

--- a/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
+++ b/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
@@ -212,40 +212,36 @@ using System.Linq;
 // authors whose books total > 1500 pages, ordered by author name,
 // printed as "Name: totalPages".
 
-var books = new[]
-{
-    new Book("Knuth",  "TAOCP V1", 650),
-    new Book("Knuth",  "TAOCP V2", 700),
-    new Book("Knuth",  "TAOCP V3", 800),
-    new Book("Skiena", "Algo Design Manual", 730),
-    new Book("Cormen", "CLRS", 1300),
-    new Book("Sedgewick", "Algorithms", 950),
+var books = new[] {
+    new Book("Knuth", "TAOCP V1", 650), new Book("Knuth", "TAOCP V2", 700),
+    new Book("Knuth", "TAOCP V3", 800), new Book("Skiena", "Algo Design Manual", 730),
+    new Book("Cormen", "CLRS", 1300),   new Book("Sedgewick", "Algorithms", 950),
 };
 
 Console.WriteLine("-- query --");
-foreach (var line in QueryStyle.Run(books))  Console.WriteLine(line);
+foreach (var line in QueryStyle.Run(books))
+    Console.WriteLine(line);
 Console.WriteLine("-- method --");
-foreach (var line in MethodStyle.Run(books)) Console.WriteLine(line);
+foreach (var line in MethodStyle.Run(books))
+    Console.WriteLine(line);
 
 public record Book(string Author, string Title, int Pages);
 `,
       solutionContent: `using System;
 using System.Linq;
 
-var books = new[]
-{
-    new Book("Knuth",  "TAOCP V1", 650),
-    new Book("Knuth",  "TAOCP V2", 700),
-    new Book("Knuth",  "TAOCP V3", 800),
-    new Book("Skiena", "Algo Design Manual", 730),
-    new Book("Cormen", "CLRS", 1300),
-    new Book("Sedgewick", "Algorithms", 950),
+var books = new[] {
+    new Book("Knuth", "TAOCP V1", 650), new Book("Knuth", "TAOCP V2", 700),
+    new Book("Knuth", "TAOCP V3", 800), new Book("Skiena", "Algo Design Manual", 730),
+    new Book("Cormen", "CLRS", 1300),   new Book("Sedgewick", "Algorithms", 950),
 };
 
 Console.WriteLine("-- query --");
-foreach (var line in QueryStyle.Run(books))  Console.WriteLine(line);
+foreach (var line in QueryStyle.Run(books))
+    Console.WriteLine(line);
 Console.WriteLine("-- method --");
-foreach (var line in MethodStyle.Run(books)) Console.WriteLine(line);
+foreach (var line in MethodStyle.Run(books))
+    Console.WriteLine(line);
 
 public record Book(string Author, string Title, int Pages);
 `,
@@ -270,12 +266,8 @@ using System.Linq;
 public static class QueryStyle
 {
     public static IEnumerable<string> Run(IEnumerable<Book> books) =>
-        from b in books
-        group b by b.Author into g
-        let total = g.Sum(x => x.Pages)
-        where total > 1500
-        orderby g.Key
-        select $"{g.Key}: {total}";
+        from b in books group b by b.Author into g let total = g.Sum(x => x.Pages)
+        where total> 1500 orderby g.Key select $"{g.Key}: {total}";
 }
 `,
     },
@@ -299,8 +291,7 @@ using System.Linq;
 public static class MethodStyle
 {
     public static IEnumerable<string> Run(IEnumerable<Book> books) =>
-        books
-            .GroupBy(b => b.Author)
+        books.GroupBy(b => b.Author)
             .Select(g => new { Author = g.Key, Total = g.Sum(x => x.Pages) })
             .Where(x => x.Total > 1500)
             .OrderBy(x => x.Author)

--- a/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
+++ b/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
@@ -226,10 +226,9 @@ Use \`SelectMany\` with the two-argument overload.`}
   files={[
     {
       filename: "Program.cs",
-      initialContent: `var customers = new[]
-{
-    new Customer("Ada",    new[] { new Order(1), new Order(2) }),
-    new Customer("Bilal",  new[] { new Order(3) }),
+      initialContent: `var customers = new[] {
+    new Customer("Ada", new[] { new Order(1), new Order(2) }),
+    new Customer("Bilal", new[] { new Order(3) }),
     new Customer("Chiara", new[] { new Order(4), new Order(5), new Order(6) }),
 };
 
@@ -259,9 +258,7 @@ using System.Linq;
 public static class Reports
 {
     public static IEnumerable<string> FlattenOrders(IEnumerable<Customer> customers) =>
-        customers.SelectMany(
-            c => c.Orders,
-            (c, o) => $"{c.Name}:{o.Id}");
+        customers.SelectMany(c => c.Orders, (c, o) => $"{c.Name}:{o.Id}");
 }
 `,
     },

--- a/content/learn/csharp-linq-functional/set-operations.mdx
+++ b/content/learn/csharp-linq-functional/set-operations.mdx
@@ -268,7 +268,7 @@ Use \`Except\` and \`OrderBy\`. Don't write a \`foreach\`.`}
   files={[
     {
       filename: "Program.cs",
-      initialContent: `var last    = new[] { "Ada", "Bilal", "Chiara", "Bilal" };
+      initialContent: `var last = new[] { "Ada", "Bilal", "Chiara", "Bilal" };
 var current = new[] { "Ada", "Chiara", "Dmitri", "Esther", "Dmitri" };
 
 foreach (var name in Roster.NewThisSemester(last, current))

--- a/content/learn/csharp-linq-functional/side-effect-management.mdx
+++ b/content/learn/csharp-linq-functional/side-effect-management.mdx
@@ -205,14 +205,9 @@ using System.Collections.Generic;
 using System.Linq;
 
 // "Shell" — fixed inputs (pretending these came from a file / clock).
-var rawLines = new[]
-{
-    "2026-05-01,paid,120",
-    "2026-05-12,paid,300",
-    "2026-05-20,pending,75",
-    "garbage line",
-    "2026-05-25,paid,40",
-    "2026-05-26,refund,-50",
+var rawLines = new[] {
+    "2026-05-01,paid,120", "2026-05-12,paid,300", "2026-05-20,pending,75",
+    "garbage line",        "2026-05-25,paid,40",  "2026-05-26,refund,-50",
 };
 var today = new DateTime(2026, 5, 26);
 var windowDays = 10;
@@ -224,14 +219,9 @@ Console.WriteLine(report);
 using System.Collections.Generic;
 using System.Linq;
 
-var rawLines = new[]
-{
-    "2026-05-01,paid,120",
-    "2026-05-12,paid,300",
-    "2026-05-20,pending,75",
-    "garbage line",
-    "2026-05-25,paid,40",
-    "2026-05-26,refund,-50",
+var rawLines = new[] {
+    "2026-05-01,paid,120", "2026-05-12,paid,300", "2026-05-20,pending,75",
+    "garbage line",        "2026-05-25,paid,40",  "2026-05-26,refund,-50",
 };
 var today = new DateTime(2026, 5, 26);
 var windowDays = 10;
@@ -273,21 +263,22 @@ public static class Report
     public static string Build(IEnumerable<string> lines, DateTime today, int windowDays)
     {
         var cutoff = today.AddDays(-windowDays);
-        var total = lines
-            .Select(l => l.Split(','))
-            .Where(parts => parts.Length == 3)
-            .Select(parts =>
-            {
-                if (!DateTime.TryParse(parts[0], CultureInfo.InvariantCulture, DateTimeStyles.None, out var d))
-                    return ((DateTime?)null, parts[1], 0m);
-                if (!decimal.TryParse(parts[2], NumberStyles.Any, CultureInfo.InvariantCulture, out var n))
-                    return ((DateTime?)null, parts[1], 0m);
-                return ((DateTime?)d, parts[1], n);
-            })
-            .Where(r => r.Item1 is not null)
-            .Where(r => r.Item2 == "paid")
-            .Where(r => r.Item1!.Value >= cutoff)
-            .Sum(r => r.Item3);
+        var total =
+            lines.Select(l => l.Split(','))
+                .Where(parts => parts.Length == 3)
+                .Select(
+                    parts =>
+                    {
+                        if (!DateTime.TryParse(parts[0], CultureInfo.InvariantCulture, DateTimeStyles.None, out var d))
+                            return ((DateTime?)null, parts[1], 0m);
+                        if (!decimal.TryParse(parts[2], NumberStyles.Any, CultureInfo.InvariantCulture, out var n))
+                            return ((DateTime?)null, parts[1], 0m);
+                        return ((DateTime?)d, parts[1], n);
+                    })
+                .Where(r => r.Item1 is not null)
+                .Where(r => r.Item2 == "paid")
+                .Where(r => r.Item1!.Value >= cutoff)
+                .Sum(r => r.Item3);
 
         return $"PAID in last {windowDays} days: {total}";
     }

--- a/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
+++ b/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
@@ -163,14 +163,14 @@ three files together, links them, and runs the executable.
   files={[
     {
       filename: "main.cpp",
-      initialContent: `#include <iostream>
-#include "mathx.h"
+      initialContent: `#include "mathx.h"
+#include <iostream>
 
 int main() {
-    int a = 6, b = 7;
-    std::cout << "add(" << a << ", " << b << ") = " << add(a, b) << "\\n";
-    std::cout << "mul(" << a << ", " << b << ") = " << mul(a, b) << "\\n";
-    return 0;
+  int a = 6, b = 7;
+  std::cout << "add(" << a << ", " << b << ") = " << add(a, b) << "\\n";
+  std::cout << "mul(" << a << ", " << b << ") = " << mul(a, b) << "\\n";
+  return 0;
 }
 `,
     },
@@ -265,16 +265,37 @@ implementation to the call from `main`.
   files={[
     {
       filename: "main.cpp",
-      initialContent: `#include "greeter.h"\n\nint main() {\n    greet("Ada");\n    greet("Linus");\n    return 0;\n}\n`,
+      initialContent: `#include "greeter.h"
+
+int main() {
+  greet("Ada");
+  greet("Linus");
+  return 0;
+}
+`,
     },
     {
       filename: "greeter.h",
-      initialContent: `#pragma once\n#include <string>\n\nvoid greet(const std::string& name);\n`,
+      initialContent: `#pragma once
+#include <string>
+
+void greet(const std::string &name);
+`,
     },
     {
       filename: "greeter.cpp",
-      initialContent: `#include <iostream>\n#include "greeter.h"\n\nvoid greet(const std::string& name) {\n    // your code here\n}\n`,
-      solutionContent: `#include <iostream>\n#include "greeter.h"\n\nvoid greet(const std::string& name) {\n    std::cout << "Hello, " << name << "!\\n";\n}\n`,
+      initialContent: `#include "greeter.h"
+#include <iostream>
+
+void greet(const std::string &name) {
+  // your code here
+}
+`,
+      solutionContent: `#include "greeter.h"
+#include <iostream>
+
+void greet(const std::string &name) { std::cout << "Hello, " << name << "!\\n"; }
+`,
     },
   ]}
   tests={[

--- a/content/learn/from-zero-to-cpp/functions-and-modularity.mdx
+++ b/content/learn/from-zero-to-cpp/functions-and-modularity.mdx
@@ -290,13 +290,13 @@ into their own file.
   files={[
     {
       filename: "main.cpp",
-      initialContent: `#include <iostream>
-#include "strutil.h"
+      initialContent: `#include "strutil.h"
+#include <iostream>
 
 int main() {
-    std::cout << to_upper("hello") << "\\n";
-    std::cout << repeat("ab", 3) << "\\n";
-    return 0;
+  std::cout << to_upper("hello") << "\\n";
+  std::cout << repeat("ab", 3) << "\\n";
+  return 0;
 }
 `,
     },
@@ -305,8 +305,8 @@ int main() {
       initialContent: `#pragma once
 #include <string>
 
-std::string to_upper(const std::string& s);
-std::string repeat(const std::string& s, int n);
+std::string to_upper(const std::string &s);
+std::string repeat(const std::string &s, int n);
 `,
     },
     {
@@ -314,18 +314,20 @@ std::string repeat(const std::string& s, int n);
       initialContent: `#include "strutil.h"
 #include <cctype>
 
-std::string to_upper(const std::string& s) {
-    std::string out;
-    out.reserve(s.size());
-    for (char c : s) out += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-    return out;
+std::string to_upper(const std::string &s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s)
+    out += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+  return out;
 }
 
-std::string repeat(const std::string& s, int n) {
-    std::string out;
-    out.reserve(s.size() * n);
-    for (int i = 0; i < n; ++i) out += s;
-    return out;
+std::string repeat(const std::string &s, int n) {
+  std::string out;
+  out.reserve(s.size() * n);
+  for (int i = 0; i < n; ++i)
+    out += s;
+  return out;
 }
 `,
     },
@@ -423,7 +425,14 @@ int main() {
   files={[
     {
       filename: "main.cpp",
-      initialContent: `#include <iostream>\n#include "arith.h"\n\nint main() {\n    std::cout << gcd(48, 18);\n    return 0;\n}\n`,
+      initialContent: `#include "arith.h"
+#include <iostream>
+
+int main() {
+  std::cout << gcd(48, 18);
+  return 0;
+}
+`,
     },
     {
       filename: "arith.h",
@@ -431,8 +440,24 @@ int main() {
     },
     {
       filename: "arith.cpp",
-      initialContent: `#include "arith.h"\n\nint gcd(int a, int b) {\n    // your code here\n    return 0;\n}\n`,
-      solutionContent: `#include "arith.h"\n\nint gcd(int a, int b) {\n    while (b != 0) {\n        int t = a % b;\n        a = b;\n        b = t;\n    }\n    return a;\n}\n`,
+      initialContent: `#include "arith.h"
+
+int gcd(int a, int b) {
+  // your code here
+  return 0;
+}
+`,
+      solutionContent: `#include "arith.h"
+
+int gcd(int a, int b) {
+  while (b != 0) {
+    int t = a % b;
+    a = b;
+    b = t;
+  }
+  return a;
+}
+`,
     },
   ]}
   tests={[

--- a/content/learn/functional-programming-typescript/algebraic-data-types.mdx
+++ b/content/learn/functional-programming-typescript/algebraic-data-types.mdx
@@ -423,17 +423,16 @@ square:   16
       filename: "main.ts",
       initialContent: `import { area } from "./shape";
 
-console.log("circle:  ", area({ kind: "circle",    radius: 2 }));
-console.log("rectangle:", area({ kind: "rectangle", width: 3,  height: 4 }));
-console.log("triangle:", area({ kind: "triangle",  base: 5,   height: 6 }));
-console.log("square:  ", area({ kind: "square",    side: 4 }));
+console.log("circle:  ", area({ kind: "circle", radius: 2 }));
+console.log("rectangle:", area({ kind: "rectangle", width: 3, height: 4 }));
+console.log("triangle:", area({ kind: "triangle", base: 5, height: 6 }));
+console.log("square:  ", area({ kind: "square", side: 4 }));
 `,
     },
     {
       filename: "shape.ts",
-      initialContent: `export type Shape =
-  | { kind: "circle"; radius: number };
-  // TODO: add rectangle, triangle, square variants
+      initialContent: `export type Shape = { kind: "circle"; radius: number };
+// TODO: add rectangle, triangle, square variants
 
 export function area(s: Shape): number {
   // TODO: switch over s.kind, return the appropriate area.
@@ -442,17 +441,21 @@ export function area(s: Shape): number {
 }
 `,
       solutionContent: `export type Shape =
-  | { kind: "circle";    radius: number }
+  | { kind: "circle"; radius: number }
   | { kind: "rectangle"; width: number; height: number }
-  | { kind: "triangle";  base: number;  height: number }
-  | { kind: "square";    side: number };
+  | { kind: "triangle"; base: number; height: number }
+  | { kind: "square"; side: number };
 
 export function area(s: Shape): number {
   switch (s.kind) {
-    case "circle":    return Math.PI * s.radius * s.radius;
-    case "rectangle": return s.width * s.height;
-    case "triangle":  return 0.5 * s.base * s.height;
-    case "square":    return s.side * s.side;
+    case "circle":
+      return Math.PI * s.radius * s.radius;
+    case "rectangle":
+      return s.width * s.height;
+    case "triangle":
+      return 0.5 * s.base * s.height;
+    case "square":
+      return s.side * s.side;
     default: {
       const _e: never = s;
       return _e;

--- a/content/learn/functional-programming-typescript/capstone-pipeline.mdx
+++ b/content/learn/functional-programming-typescript/capstone-pipeline.mdx
@@ -71,26 +71,24 @@ console.log(report.bestDay.date, "=", report.bestDay.revenue.toFixed(2));
     },
     {
       filename: "types.ts",
-      initialContent: `export type Result<E, A> =
-  | { kind: "ok"; value: A }
-  | { kind: "err"; error: E };
+      initialContent: `export type Result<E, A> = { kind: "ok"; value: A } | { kind: "err"; error: E };
 
-export const ok  = <E, A>(value: A): Result<E, A> => ({ kind: "ok",  value });
+export const ok = <E, A>(value: A): Result<E, A> => ({ kind: "ok", value });
 export const err = <E, A>(error: E): Result<E, A> => ({ kind: "err", error });
 
 export type Sale = {
-  readonly date:  string;     // YYYY-MM-DD
-  readonly sku:   string;
-  readonly qty:   number;
-  readonly price: number;     // unit price
+  readonly date: string; // YYYY-MM-DD
+  readonly sku: string;
+  readonly qty: number;
+  readonly price: number; // unit price
 };
 
 export type Rejected = { readonly raw: string; readonly error: string };
 
 export type Report = {
-  readonly rejected:   ReadonlyArray<Rejected>;
-  readonly byProduct:  ReadonlyMap<string, number>;     // sku -> revenue
-  readonly bestDay:    { readonly date: string; readonly revenue: number };
+  readonly rejected: ReadonlyArray<Rejected>;
+  readonly byProduct: ReadonlyMap<string, number>; // sku -> revenue
+  readonly bestDay: { readonly date: string; readonly revenue: number };
 };
 `,
     },
@@ -120,12 +118,14 @@ export function parseRow(raw: string): Result<string, Sale> {
 
 export type Priced = Sale & { readonly revenue: number };
 
-export const withRevenue = (s: Sale): Priced =>
-  ({ ...s, revenue: s.qty * s.price });
+export const withRevenue = (s: Sale): Priced => ({
+  ...s,
+  revenue: s.qty * s.price,
+});
 
 export const sumByKey = <A,>(
   xs: ReadonlyArray<A>,
-  key:   (a: A) => string,
+  key: (a: A) => string,
   value: (a: A) => number,
 ): ReadonlyMap<string, number> => {
   const out = new Map<string, number>();
@@ -142,7 +142,10 @@ export const maxByValue = (
   let bestK = "";
   let bestV = -Infinity;
   for (const [k, v] of m) {
-    if (v > bestV) { bestK = k; bestV = v; }
+    if (v > bestV) {
+      bestK = k;
+      bestV = v;
+    }
   }
   return { date: bestK, revenue: Number.isFinite(bestV) ? bestV : 0 };
 };
@@ -156,15 +159,15 @@ import { withRevenue, sumByKey, maxByValue } from "./transform";
 
 // Partition raw rows into accepted Sales and rejected reasons (pure)
 function partition(raws: ReadonlyArray<string>): {
-  sales:    ReadonlyArray<Sale>;
+  sales: ReadonlyArray<Sale>;
   rejected: ReadonlyArray<Rejected>;
 } {
-  const sales:    Sale[]     = [];
+  const sales: Sale[] = [];
   const rejected: Rejected[] = [];
   for (const raw of raws) {
     const r: Result<string, Sale> = parseRow(raw);
     if (r.kind === "ok") sales.push(r.value);
-    else                 rejected.push({ raw, error: r.error });
+    else rejected.push({ raw, error: r.error });
   }
   return { sales, rejected };
 }
@@ -174,9 +177,17 @@ export function runReport(raws: ReadonlyArray<string>): Report {
 
   const priced = sales.map(withRevenue);
 
-  const byProduct = sumByKey(priced, (p) => p.sku,  (p) => p.revenue);
-  const byDay     = sumByKey(priced, (p) => p.date, (p) => p.revenue);
-  const bestDay   = maxByValue(byDay);
+  const byProduct = sumByKey(
+    priced,
+    (p) => p.sku,
+    (p) => p.revenue,
+  );
+  const byDay = sumByKey(
+    priced,
+    (p) => p.date,
+    (p) => p.revenue,
+  );
+  const bestDay = maxByValue(byDay);
 
   return { rejected, byProduct, bestDay };
 }

--- a/content/learn/functional-programming-typescript/category-theory-intuitions.mdx
+++ b/content/learn/functional-programming-typescript/category-theory-intuitions.mdx
@@ -291,7 +291,11 @@ Then in \`main.ts\`, use it to compute \`pair(some(2), some(3))\`,
       initialContent: `import { map2, some, none } from "./combine";
 
 const pair = <A, B>(oa: { kind: string }, ob: { kind: string }) =>
-  map2<A, B, readonly [A, B]>((a, b) => [a, b] as const, oa as never, ob as never);
+  map2<A, B, readonly [A, B]>(
+    (a, b) => [a, b] as const,
+    oa as never,
+    ob as never,
+  );
 
 console.log(pair(some(2), some(3)));
 console.log(pair(none(), some(3)));
@@ -322,7 +326,8 @@ export function map2<A, B, C>(
   oa: Option<A>,
   ob: Option<B>,
 ): Option<C> {
-  if (oa.kind === "some" && ob.kind === "some") return some(f(oa.value, ob.value));
+  if (oa.kind === "some" && ob.kind === "some")
+    return some(f(oa.value, ob.value));
   return none();
 }
 `,

--- a/content/learn/functional-programming-typescript/composable-architecture.mdx
+++ b/content/learn/functional-programming-typescript/composable-architecture.mdx
@@ -233,8 +233,8 @@ import { topSpender, Order } from "./core";
 const orders: Order[] = [
   { customerId: "u1", amount: 10 },
   { customerId: "u2", amount: 99 },
-  { customerId: "u1", amount: 5  },
-  { customerId: "u2", amount: 1  },
+  { customerId: "u1", amount: 5 },
+  { customerId: "u2", amount: 1 },
 ];
 
 const top = topSpender(orders);
@@ -260,10 +260,13 @@ export function topSpender(orders: ReadonlyArray<Order>): string | null {
     acc[o.customerId] = (acc[o.customerId] ?? 0) + o.amount;
     return acc;
   }, {});
-  return Object.entries(totals).reduce(
-    (best, [id, total]) => (best === null || total > best[1] ? [id, total] : best),
-    null as readonly [string, number] | null,
-  )?.[0] ?? null;
+  return (
+    Object.entries(totals).reduce(
+      (best, [id, total]) =>
+        best === null || total > best[1] ? [id, total] : best,
+      null as readonly [string, number] | null,
+    )?.[0] ?? null
+  );
 }
 `,
     },

--- a/content/learn/functional-programming-typescript/declarative-thinking.mdx
+++ b/content/learn/functional-programming-typescript/declarative-thinking.mdx
@@ -306,9 +306,9 @@ toys: 14
 const sales: readonly Sale[] = [
   { category: "books", amount: 20 },
   { category: "books", amount: 30 },
-  { category: "food",  amount: 5  },
-  { category: "food",  amount: 12 },
-  { category: "toys",  amount: 14 },
+  { category: "food", amount: 5 },
+  { category: "food", amount: 12 },
+  { category: "toys", amount: 14 },
 ];
 
 const avg = avgPerCategory(sales);
@@ -324,7 +324,9 @@ for (const line of lines) console.log(line);
       initialContent: `export type Sale = { readonly category: string; readonly amount: number };
 
 // Reimplement this declaratively — no \`for\`, no \`let\`, no mutation.
-export function avgPerCategory(sales: readonly Sale[]): ReadonlyMap<string, number> {
+export function avgPerCategory(
+  sales: readonly Sale[],
+): ReadonlyMap<string, number> {
   const out = new Map<string, number>();
   const totals: Record<string, { sum: number; count: number }> = {};
   for (let i = 0; i < sales.length; i++) {
@@ -341,17 +343,18 @@ export function avgPerCategory(sales: readonly Sale[]): ReadonlyMap<string, numb
 `,
       solutionContent: `export type Sale = { readonly category: string; readonly amount: number };
 
-export function avgPerCategory(sales: readonly Sale[]): ReadonlyMap<string, number> {
-  const totals = sales.reduce<ReadonlyMap<string, { sum: number; count: number }>>(
-    (acc, s) => {
-      const prev = acc.get(s.category) ?? { sum: 0, count: 0 };
-      return new Map(acc).set(s.category, {
-        sum: prev.sum + s.amount,
-        count: prev.count + 1,
-      });
-    },
-    new Map(),
-  );
+export function avgPerCategory(
+  sales: readonly Sale[],
+): ReadonlyMap<string, number> {
+  const totals = sales.reduce<
+    ReadonlyMap<string, { sum: number; count: number }>
+  >((acc, s) => {
+    const prev = acc.get(s.category) ?? { sum: 0, count: 0 };
+    return new Map(acc).set(s.category, {
+      sum: prev.sum + s.amount,
+      count: prev.count + 1,
+    });
+  }, new Map());
 
   return new Map(
     [...totals.entries()].map(([k, { sum, count }]) => [k, sum / count]),

--- a/content/learn/functional-programming-typescript/function-composition.mdx
+++ b/content/learn/functional-programming-typescript/function-composition.mdx
@@ -371,11 +371,11 @@ console.log(slug("  Nice  to !! meet  you  "));
   return fns.reduce((acc, f) => f(acc), x);
 }
 
-export const trim           = (s: string): string => s; // TODO
-export const lower          = (s: string): string => s; // TODO
-export const stripPunct     = (s: string): string => s; // TODO
+export const trim = (s: string): string => s; // TODO
+export const lower = (s: string): string => s; // TODO
+export const stripPunct = (s: string): string => s; // TODO
 export const collapseSpaces = (s: string): string => s; // TODO
-export const hyphenate      = (s: string): string => s; // TODO
+export const hyphenate = (s: string): string => s; // TODO
 
 export const slug = (s: string): string => s; // TODO: pipe the above
 `,
@@ -383,11 +383,12 @@ export const slug = (s: string): string => s; // TODO: pipe the above
   return fns.reduce((acc, f) => f(acc), x);
 }
 
-export const trim           = (s: string): string => s.trim();
-export const lower          = (s: string): string => s.toLowerCase();
-export const stripPunct     = (s: string): string => s.replace(/[^\\p{L}\\p{N}\\s]/gu, "");
+export const trim = (s: string): string => s.trim();
+export const lower = (s: string): string => s.toLowerCase();
+export const stripPunct = (s: string): string =>
+  s.replace(/[^\\p{L}\\p{N}\\s]/gu, "");
 export const collapseSpaces = (s: string): string => s.replace(/\\s+/g, " ");
-export const hyphenate      = (s: string): string => s.replace(/ /g, "-");
+export const hyphenate = (s: string): string => s.replace(/ /g, "-");
 
 export const slug = (s: string): string =>
   pipe(s, trim, lower, stripPunct, collapseSpaces, hyphenate);

--- a/content/learn/functional-programming-typescript/functional-async-workflows.mdx
+++ b/content/learn/functional-programming-typescript/functional-async-workflows.mdx
@@ -248,18 +248,23 @@ errors**. Errors must propagate via the Result channel.
     {
       filename: "workflow.ts",
       initialContent: `export type Result<E, A> = { kind: "ok"; value: A } | { kind: "err"; error: E };
-export const ok  = <E, A>(value: A): Result<E, A> => ({ kind: "ok",  value });
+export const ok = <E, A>(value: A): Result<E, A> => ({ kind: "ok", value });
 export const err = <E, A>(error: E): Result<E, A> => ({ kind: "err", error });
 
 export type TaskResult<E, A> = () => Promise<Result<E, A>>;
 
-export const mapTR = <E, A, B>(t: TaskResult<E, A>, f: (a: A) => B): TaskResult<E, B> =>
+export const mapTR =
+  <E, A, B>(t: TaskResult<E, A>, f: (a: A) => B): TaskResult<E, B> =>
   async () => {
     const r = await t();
     return r.kind === "ok" ? ok(f(r.value)) : r;
   };
 
-export const chainTR = <E, A, B>(t: TaskResult<E, A>, f: (a: A) => TaskResult<E, B>): TaskResult<E, B> =>
+export const chainTR =
+  <E, A, B>(
+    t: TaskResult<E, A>,
+    f: (a: A) => TaskResult<E, B>,
+  ): TaskResult<E, B> =>
   async () => {
     const r = await t();
     return r.kind === "ok" ? f(r.value)() : r;
@@ -268,17 +273,21 @@ export const chainTR = <E, A, B>(t: TaskResult<E, A>, f: (a: A) => TaskResult<E,
 // --- Fake APIs ---
 type User = { id: string; name: string };
 
-export const fetchUser = (id: string): TaskResult<string, User> =>
-  () => Promise.resolve(
-    id === "u1" ? ok({ id, name: "Ada" }) :
-    id === "u2" ? ok({ id, name: "Linus" }) :
-    err("no such user"),
-  );
+export const fetchUser =
+  (id: string): TaskResult<string, User> =>
+  () =>
+    Promise.resolve(
+      id === "u1"
+        ? ok({ id, name: "Ada" })
+        : id === "u2"
+          ? ok({ id, name: "Linus" })
+          : err("no such user"),
+    );
 
-export const fetchLang = (u: User): TaskResult<string, string> =>
-  () => Promise.resolve(
-    u.id === "u1" ? ok("TypeScript") : err("no language set"),
-  );
+export const fetchLang =
+  (u: User): TaskResult<string, string> =>
+  () =>
+    Promise.resolve(u.id === "u1" ? ok("TypeScript") : err("no language set"));
 
 // TODO: implement
 export function run(userId: string): TaskResult<string, string> {
@@ -286,18 +295,23 @@ export function run(userId: string): TaskResult<string, string> {
 }
 `,
       solutionContent: `export type Result<E, A> = { kind: "ok"; value: A } | { kind: "err"; error: E };
-export const ok  = <E, A>(value: A): Result<E, A> => ({ kind: "ok",  value });
+export const ok = <E, A>(value: A): Result<E, A> => ({ kind: "ok", value });
 export const err = <E, A>(error: E): Result<E, A> => ({ kind: "err", error });
 
 export type TaskResult<E, A> = () => Promise<Result<E, A>>;
 
-export const mapTR = <E, A, B>(t: TaskResult<E, A>, f: (a: A) => B): TaskResult<E, B> =>
+export const mapTR =
+  <E, A, B>(t: TaskResult<E, A>, f: (a: A) => B): TaskResult<E, B> =>
   async () => {
     const r = await t();
     return r.kind === "ok" ? ok(f(r.value)) : r;
   };
 
-export const chainTR = <E, A, B>(t: TaskResult<E, A>, f: (a: A) => TaskResult<E, B>): TaskResult<E, B> =>
+export const chainTR =
+  <E, A, B>(
+    t: TaskResult<E, A>,
+    f: (a: A) => TaskResult<E, B>,
+  ): TaskResult<E, B> =>
   async () => {
     const r = await t();
     return r.kind === "ok" ? f(r.value)() : r;
@@ -305,22 +319,29 @@ export const chainTR = <E, A, B>(t: TaskResult<E, A>, f: (a: A) => TaskResult<E,
 
 type User = { id: string; name: string };
 
-export const fetchUser = (id: string): TaskResult<string, User> =>
-  () => Promise.resolve(
-    id === "u1" ? ok({ id, name: "Ada" }) :
-    id === "u2" ? ok({ id, name: "Linus" }) :
-    err("no such user"),
-  );
+export const fetchUser =
+  (id: string): TaskResult<string, User> =>
+  () =>
+    Promise.resolve(
+      id === "u1"
+        ? ok({ id, name: "Ada" })
+        : id === "u2"
+          ? ok({ id, name: "Linus" })
+          : err("no such user"),
+    );
 
-export const fetchLang = (u: User): TaskResult<string, string> =>
-  () => Promise.resolve(
-    u.id === "u1" ? ok("TypeScript") : err("no language set"),
-  );
+export const fetchLang =
+  (u: User): TaskResult<string, string> =>
+  () =>
+    Promise.resolve(u.id === "u1" ? ok("TypeScript") : err("no language set"));
 
 export function run(userId: string): TaskResult<string, string> {
   return chainTR(fetchUser(userId), (user) =>
-    mapTR(fetchLang(user), (lang) =>
-      \`Hello, \${user.name}! Preferred language: \${lang}.\`));
+    mapTR(
+      fetchLang(user),
+      (lang) => \`Hello, \${user.name}! Preferred language: \${lang}.\`,
+    ),
+  );
 }
 `,
     },

--- a/content/learn/functional-programming-typescript/functional-state-management.mdx
+++ b/content/learn/functional-programming-typescript/functional-state-management.mdx
@@ -302,9 +302,9 @@ The reducer must be **pure** — return a new \`State\`; do not mutate
       initialContent: `import { reduce, initial, Action } from "./cart";
 
 const actions: Action[] = [
-  { kind: "add",    sku: "A", qty: 1 },
-  { kind: "add",    sku: "A", qty: 2 },
-  { kind: "add",    sku: "B", qty: 1 },
+  { kind: "add", sku: "A", qty: 1 },
+  { kind: "add", sku: "A", qty: 2 },
+  { kind: "add", sku: "B", qty: 1 },
   { kind: "remove", sku: "B" },
   { kind: "clear" },
 ];
@@ -321,7 +321,7 @@ for (const a of actions) {
       initialContent: `export type Item = { readonly sku: string; readonly qty: number };
 export type State = { readonly items: ReadonlyArray<Item> };
 export type Action =
-  | { kind: "add";    sku: string; qty: number }
+  | { kind: "add"; sku: string; qty: number }
   | { kind: "remove"; sku: string }
   | { kind: "clear" };
 
@@ -335,7 +335,7 @@ export function reduce(state: State, action: Action): State {
       solutionContent: `export type Item = { readonly sku: string; readonly qty: number };
 export type State = { readonly items: ReadonlyArray<Item> };
 export type Action =
-  | { kind: "add";    sku: string; qty: number }
+  | { kind: "add"; sku: string; qty: number }
   | { kind: "remove"; sku: string }
   | { kind: "clear" };
 
@@ -347,7 +347,8 @@ export function reduce(state: State, action: Action): State {
       const exists = state.items.find((i) => i.sku === action.sku);
       const items = exists
         ? state.items.map((i) =>
-            i.sku === action.sku ? { sku: i.sku, qty: i.qty + action.qty } : i)
+            i.sku === action.sku ? { sku: i.sku, qty: i.qty + action.qty } : i,
+          )
         : [...state.items, { sku: action.sku, qty: action.qty }];
       return { items };
     }
@@ -356,7 +357,8 @@ export function reduce(state: State, action: Action): State {
     case "clear":
       return initial;
     default: {
-      const _e: never = action; return _e;
+      const _e: never = action;
+      return _e;
     }
   }
 }

--- a/content/learn/functional-programming-typescript/generic-abstractions-and-type-classes.mdx
+++ b/content/learn/functional-programming-typescript/generic-abstractions-and-type-classes.mdx
@@ -261,32 +261,38 @@ undefined
       filename: "main.ts",
       initialContent: `import { combineAll, sumSG, prodSG, stringSG } from "./semigroup";
 
-console.log(combineAll(sumSG,    [1, 2, 3, 4]));
-console.log(combineAll(prodSG,   [1, 2, 3, 4]));
+console.log(combineAll(sumSG, [1, 2, 3, 4]));
+console.log(combineAll(prodSG, [1, 2, 3, 4]));
 console.log(combineAll(stringSG, ["a", "b", "c"]));
-console.log(combineAll(sumSG,    []));
+console.log(combineAll(sumSG, []));
 `,
     },
     {
       filename: "semigroup.ts",
       initialContent: `export type Semigroup<A> = { concat: (x: A, y: A) => A };
 
-export const sumSG:    Semigroup<number> = { concat: (x, y) => x + y };
-export const prodSG:   Semigroup<number> = { concat: (x, y) => x * y };
+export const sumSG: Semigroup<number> = { concat: (x, y) => x + y };
+export const prodSG: Semigroup<number> = { concat: (x, y) => x * y };
 export const stringSG: Semigroup<string> = { concat: (x, y) => x + y };
 
-export function combineAll<A>(s: Semigroup<A>, xs: ReadonlyArray<A>): A | undefined {
+export function combineAll<A>(
+  s: Semigroup<A>,
+  xs: ReadonlyArray<A>,
+): A | undefined {
   // TODO: fold the list using s.concat.
   return undefined;
 }
 `,
       solutionContent: `export type Semigroup<A> = { concat: (x: A, y: A) => A };
 
-export const sumSG:    Semigroup<number> = { concat: (x, y) => x + y };
-export const prodSG:   Semigroup<number> = { concat: (x, y) => x * y };
+export const sumSG: Semigroup<number> = { concat: (x, y) => x + y };
+export const prodSG: Semigroup<number> = { concat: (x, y) => x * y };
 export const stringSG: Semigroup<string> = { concat: (x, y) => x + y };
 
-export function combineAll<A>(s: Semigroup<A>, xs: ReadonlyArray<A>): A | undefined {
+export function combineAll<A>(
+  s: Semigroup<A>,
+  xs: ReadonlyArray<A>,
+): A | undefined {
   if (xs.length === 0) return undefined;
   return xs.slice(1).reduce((acc, x) => s.concat(acc, x), xs[0]);
 }

--- a/content/learn/functional-programming-typescript/higher-order-functions.mdx
+++ b/content/learn/functional-programming-typescript/higher-order-functions.mdx
@@ -345,8 +345,10 @@ ok
       filename: "main.ts",
       initialContent: `import { every, when, mapInput, type Validator } from "./validators";
 
-const minLen = (n: number): Validator<number> =>
-  (x) => (x >= n ? null : "too short");
+const minLen =
+  (n: number): Validator<number> =>
+  (x) =>
+    x >= n ? null : "too short";
 const hasAt: Validator<string> = (s) => (s.includes("@") ? null : "missing @");
 
 const isEmail: Validator<string> = every(
@@ -373,7 +375,10 @@ export function every<A>(...vs: Validator<A>[]): Validator<A> {
   return () => null;
 }
 
-export function when<A>(pred: (a: A) => boolean, v: Validator<A>): Validator<A> {
+export function when<A>(
+  pred: (a: A) => boolean,
+  v: Validator<A>,
+): Validator<A> {
   // your code here
   return () => null;
 }
@@ -395,7 +400,10 @@ export function every<A>(...vs: Validator<A>[]): Validator<A> {
   };
 }
 
-export function when<A>(pred: (a: A) => boolean, v: Validator<A>): Validator<A> {
+export function when<A>(
+  pred: (a: A) => boolean,
+  v: Validator<A>,
+): Validator<A> {
   return (a) => (pred(a) ? v(a) : null);
 }
 

--- a/content/learn/functional-programming-typescript/immutability.mdx
+++ b/content/learn/functional-programming-typescript/immutability.mdx
@@ -374,7 +374,10 @@ original unchanged: 3
       initialContent: `import { add, remove, setQty, totalQty } from "./cart";
 
 const empty: readonly { id: string; qty: number }[] = [];
-const cart1 = add(add(add(empty, { id: "a", qty: 1 }), { id: "b", qty: 1 }), { id: "c", qty: 1 });
+const cart1 = add(add(add(empty, { id: "a", qty: 1 }), { id: "b", qty: 1 }), {
+  id: "c",
+  qty: 1,
+});
 console.log(\`total items: \${totalQty(cart1)}\`);
 
 const cart2 = remove(cart1, "b");

--- a/content/learn/functional-programming-typescript/option-and-result.mdx
+++ b/content/learn/functional-programming-typescript/option-and-result.mdx
@@ -332,8 +332,10 @@ export const none = <A,>(): Option<A> => ({ kind: "none" });
 
 export const map = <A, B>(o: Option<A>, f: (a: A) => B): Option<B> =>
   o.kind === "none" ? none() : some(f(o.value));
-export const flatMap = <A, B>(o: Option<A>, f: (a: A) => Option<B>): Option<B> =>
-  o.kind === "none" ? none() : f(o.value);
+export const flatMap = <A, B>(
+  o: Option<A>,
+  f: (a: A) => Option<B>,
+): Option<B> => (o.kind === "none" ? none() : f(o.value));
 export const getOrElse = <A,>(o: Option<A>, fb: A): A =>
   o.kind === "none" ? fb : o.value;
 
@@ -345,13 +347,13 @@ const db: Record<string, User> = {
   u3: { id: "u3", managerId: "u2", email: "linus@example.com" },
 };
 
-export const findUser  = (id: string): Option<User> =>
+export const findUser = (id: string): Option<User> =>
   id in db ? some(db[id]) : none();
 
 export const managerOf = (u: User): Option<string> =>
   u.managerId !== undefined ? some(u.managerId) : none();
 
-export const emailOf   = (u: User): Option<string> =>
+export const emailOf = (u: User): Option<string> =>
   u.email !== undefined ? some(u.email) : none();
 
 export function emailOfManagerOf(id: string): Option<string> {
@@ -365,8 +367,10 @@ export const none = <A,>(): Option<A> => ({ kind: "none" });
 
 export const map = <A, B>(o: Option<A>, f: (a: A) => B): Option<B> =>
   o.kind === "none" ? none() : some(f(o.value));
-export const flatMap = <A, B>(o: Option<A>, f: (a: A) => Option<B>): Option<B> =>
-  o.kind === "none" ? none() : f(o.value);
+export const flatMap = <A, B>(
+  o: Option<A>,
+  f: (a: A) => Option<B>,
+): Option<B> => (o.kind === "none" ? none() : f(o.value));
 export const getOrElse = <A,>(o: Option<A>, fb: A): A =>
   o.kind === "none" ? fb : o.value;
 
@@ -378,23 +382,17 @@ const db: Record<string, User> = {
   u3: { id: "u3", managerId: "u2", email: "linus@example.com" },
 };
 
-export const findUser  = (id: string): Option<User> =>
+export const findUser = (id: string): Option<User> =>
   id in db ? some(db[id]) : none();
 
 export const managerOf = (u: User): Option<string> =>
   u.managerId !== undefined ? some(u.managerId) : none();
 
-export const emailOf   = (u: User): Option<string> =>
+export const emailOf = (u: User): Option<string> =>
   u.email !== undefined ? some(u.email) : none();
 
 export function emailOfManagerOf(id: string): Option<string> {
-  return flatMap(
-    flatMap(
-      flatMap(findUser(id), managerOf),
-      findUser,
-    ),
-    emailOf,
-  );
+  return flatMap(flatMap(flatMap(findUser(id), managerOf), findUser), emailOf);
 }
 `,
     },

--- a/content/learn/functional-programming-typescript/pattern-matching.mdx
+++ b/content/learn/functional-programming-typescript/pattern-matching.mdx
@@ -282,9 +282,9 @@ Rules:
       initialContent: `import { apply, Event } from "./interpret";
 
 const events: Event[] = [
-  { kind: "deposit",  amount: 100 },
-  { kind: "withdraw", amount: 30  },
-  { kind: "interest", rate: 0.05  },
+  { kind: "deposit", amount: 100 },
+  { kind: "withdraw", amount: 30 },
+  { kind: "interest", rate: 0.05 },
   { kind: "reset" },
 ];
 
@@ -298,31 +298,37 @@ for (const e of events) {
     {
       filename: "interpret.ts",
       initialContent: `export type Event =
-  | { kind: "deposit";  amount: number }
+  | { kind: "deposit"; amount: number }
   | { kind: "withdraw"; amount: number }
-  | { kind: "interest"; rate:   number }
+  | { kind: "interest"; rate: number }
   | { kind: "reset" };
 
 export function apply(balance: number, e: Event): number {
   // Implement using a switch + exhaustiveness check
-  switch (e.kind) {
+  switch (
+    e.kind
     // TODO: handle every variant
+  ) {
   }
   return balance;
 }
 `,
       solutionContent: `export type Event =
-  | { kind: "deposit";  amount: number }
+  | { kind: "deposit"; amount: number }
   | { kind: "withdraw"; amount: number }
-  | { kind: "interest"; rate:   number }
+  | { kind: "interest"; rate: number }
   | { kind: "reset" };
 
 export function apply(balance: number, e: Event): number {
   switch (e.kind) {
-    case "deposit":  return balance + e.amount;
-    case "withdraw": return balance - e.amount;
-    case "interest": return Math.round((balance * (1 + e.rate)) * 100) / 100;
-    case "reset":    return 0;
+    case "deposit":
+      return balance + e.amount;
+    case "withdraw":
+      return balance - e.amount;
+    case "interest":
+      return Math.round(balance * (1 + e.rate) * 100) / 100;
+    case "reset":
+      return 0;
     default: {
       const _exhaustive: never = e;
       throw new Error(\`unhandled \${JSON.stringify(_exhaustive)}\`);

--- a/content/learn/functional-programming-typescript/type-driven-design.mdx
+++ b/content/learn/functional-programming-typescript/type-driven-design.mdx
@@ -268,7 +268,11 @@ console.log("state:", s.kind);
 s = next(s, { kind: "add-card", card: "4242" });
 console.log("state:", s.kind);
 s = next(s, { kind: "confirm" });
-console.log("state:", s.kind, "orderId=" + (s.kind === "confirmed" ? s.orderId : "?"));
+console.log(
+  "state:",
+  s.kind,
+  "orderId=" + (s.kind === "confirmed" ? s.orderId : "?"),
+);
 `,
     },
     {
@@ -276,14 +280,19 @@ console.log("state:", s.kind, "orderId=" + (s.kind === "confirmed" ? s.orderId :
       initialContent: `type Item = { sku: string; qty: number };
 
 export type Checkout =
-  | { kind: "cart";      items: ReadonlyArray<Item> }
-  | { kind: "shipping";  items: ReadonlyArray<Item>; address: string }
-  | { kind: "paying";    items: ReadonlyArray<Item>; address: string; card: string }
+  | { kind: "cart"; items: ReadonlyArray<Item> }
+  | { kind: "shipping"; items: ReadonlyArray<Item>; address: string }
+  | {
+      kind: "paying";
+      items: ReadonlyArray<Item>;
+      address: string;
+      card: string;
+    }
   | { kind: "confirmed"; orderId: string };
 
 export type Event =
   | { kind: "add-address"; address: string }
-  | { kind: "add-card";    card:    string }
+  | { kind: "add-card"; card: string }
   | { kind: "confirm" };
 
 export function next(state: Checkout, event: Event): Checkout {
@@ -295,14 +304,19 @@ export function next(state: Checkout, event: Event): Checkout {
       solutionContent: `type Item = { sku: string; qty: number };
 
 export type Checkout =
-  | { kind: "cart";      items: ReadonlyArray<Item> }
-  | { kind: "shipping";  items: ReadonlyArray<Item>; address: string }
-  | { kind: "paying";    items: ReadonlyArray<Item>; address: string; card: string }
+  | { kind: "cart"; items: ReadonlyArray<Item> }
+  | { kind: "shipping"; items: ReadonlyArray<Item>; address: string }
+  | {
+      kind: "paying";
+      items: ReadonlyArray<Item>;
+      address: string;
+      card: string;
+    }
   | { kind: "confirmed"; orderId: string };
 
 export type Event =
   | { kind: "add-address"; address: string }
-  | { kind: "add-card";    card:    string }
+  | { kind: "add-card"; card: string }
   | { kind: "confirm" };
 
 let counter = 0;
@@ -316,7 +330,12 @@ export function next(state: Checkout, event: Event): Checkout {
       break;
     case "shipping":
       if (event.kind === "add-card")
-        return { kind: "paying", items: state.items, address: state.address, card: event.card };
+        return {
+          kind: "paying",
+          items: state.items,
+          address: state.address,
+          card: event.card,
+        };
       break;
     case "paying":
       if (event.kind === "confirm")

--- a/content/learn/functional-programming-typescript/typescript-meets-fp.mdx
+++ b/content/learn/functional-programming-typescript/typescript-meets-fp.mdx
@@ -312,9 +312,12 @@ export const makeMessage = (g: Greeting): string => formatGreeting(g);
 
 export function formatGreeting(g: Greeting): string {
   switch (g.language) {
-    case "en": return \`Hello, \${g.name}!\`;
-    case "es": return \`¡Hola, \${g.name}!\`;
-    case "fr": return \`Bonjour, \${g.name}!\`;
+    case "en":
+      return \`Hello, \${g.name}!\`;
+    case "es":
+      return \`¡Hola, \${g.name}!\`;
+    case "fr":
+      return \`Bonjour, \${g.name}!\`;
   }
 }
 `,

--- a/content/learn/intro-modern-csharp/capstone-task-tracker.mdx
+++ b/content/learn/intro-modern-csharp/capstone-task-tracker.mdx
@@ -157,7 +157,9 @@ public class TaskList
 {
     // TODO: implement
     public TaskItem Add(string title) => null!;
-    public void Complete(int id) { }
+    public void Complete(int id)
+    {
+    }
     public int Remaining() => 0;
     public IEnumerable<TaskItem> All() => System.Array.Empty<TaskItem>();
 }
@@ -192,7 +194,9 @@ public class TaskList
     public int Remaining()
     {
         int n = 0;
-        foreach (var t in _items) if (!t.Done) n++;
+        foreach (var t in _items)
+            if (!t.Done)
+                n++;
         return n;
     }
 

--- a/content/learn/intro-modern-csharp/classes-and-objects.mdx
+++ b/content/learn/intro-modern-csharp/classes-and-objects.mdx
@@ -68,6 +68,18 @@ actual accounts.
   adapter="csharp"
   starterCode={`using System;
 
+var alice = new BankAccount();
+alice.Owner = "Alice";
+alice.Deposit(100);
+alice.Withdraw(40);
+
+var bob = new BankAccount();
+bob.Owner = "Bob";
+bob.Deposit(500);
+
+Console.WriteLine($"{alice.Owner}: {alice.Balance}");
+Console.WriteLine($"{bob.Owner}: {bob.Balance}");
+
 public class BankAccount
 {
     public string Owner;
@@ -82,18 +94,6 @@ public class BankAccount
         Balance -= amount;
     }
 }
-
-var alice = new BankAccount();
-alice.Owner = "Alice";
-alice.Deposit(100);
-alice.Withdraw(40);
-
-var bob = new BankAccount();
-bob.Owner = "Bob";
-bob.Deposit(500);
-
-Console.WriteLine($"{alice.Owner}: {alice.Balance}");
-Console.WriteLine($"{bob.Owner}: {bob.Balance}");
 `}
 />
 
@@ -132,6 +132,11 @@ object is created, and is the natural place to put initialization.
   adapter="csharp"
   starterCode={`using System;
 
+var alice = new BankAccount("Alice", 100);
+alice.Withdraw(40);
+
+Console.WriteLine($"{alice.Owner}: {alice.Balance}");
+
 public class BankAccount
 {
     public string Owner;
@@ -152,11 +157,6 @@ public class BankAccount
         Balance -= amount;
     }
 }
-
-var alice = new BankAccount("Alice", 100);
-alice.Withdraw(40);
-
-Console.WriteLine($"{alice.Owner}: {alice.Balance}");
 `}
 />
 
@@ -173,6 +173,9 @@ parameter has the same name as a field.
 <CodeBlock
   adapter="csharp"
   starterCode={`using System;
+
+var p = new Point(3, 4);
+Console.WriteLine(p.DistanceFromOrigin()); // 5
 
 public class Point
 {
@@ -191,9 +194,6 @@ public class Point
         return Math.Sqrt(X * X + Y * Y);
     }
 }
-
-var p = new Point(3, 4);
-Console.WriteLine(p.DistanceFromOrigin()); // 5
 `}
 />
 
@@ -209,6 +209,9 @@ validation or computed logic without breaking callers.
   adapter="csharp"
   starterCode={`using System;
 
+var p = new Person { Name = "Ada", Age = 30 };
+Console.WriteLine($"{p.Name}, adult? {p.IsAdult}");
+
 public class Person
 {
     // auto-implemented property — the compiler creates a hidden field
@@ -218,9 +221,6 @@ public class Person
     // computed (read-only) property
     public bool IsAdult => Age >= 18;
 }
-
-var p = new Person { Name = "Ada", Age = 30 };
-Console.WriteLine($"{p.Name}, adult? {p.IsAdult}");
 `}
 />
 

--- a/content/learn/intro-modern-csharp/collections.mdx
+++ b/content/learn/intro-modern-csharp/collections.mdx
@@ -263,8 +263,10 @@ public static class WordCounter
         var d = new Dictionary<string, int>();
         foreach (var word in text.Split(' '))
         {
-            if (d.ContainsKey(word)) d[word]++;
-            else d[word] = 1;
+            if (d.ContainsKey(word))
+                d[word]++;
+            else
+                d[word] = 1;
         }
         return d;
     }

--- a/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
+++ b/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
@@ -179,8 +179,14 @@ var w = new Wallet("Ada", 50);
 w.Add(100);
 w.Spend(30);
 Console.WriteLine($"{w.Owner} has {w.Cash}");
-try { w.Spend(9999); }
-catch (Exception ex) { Console.WriteLine($"refused: {ex.Message}"); }
+try
+{
+    w.Spend(9999);
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"refused: {ex.Message}");
+}
 `,
     },
     {
@@ -192,21 +198,25 @@ catch (Exception ex) { Console.WriteLine($"refused: {ex.Message}"); }
 
     public Wallet(string owner, decimal initialCash)
     {
-        if (initialCash < 0) throw new ArgumentException("initial cash can't be negative");
+        if (initialCash < 0)
+            throw new ArgumentException("initial cash can't be negative");
         Owner = owner;
         Cash = initialCash;
     }
 
     public void Add(decimal amount)
     {
-        if (amount <= 0) throw new ArgumentException("must be positive");
+        if (amount <= 0)
+            throw new ArgumentException("must be positive");
         Cash += amount;
     }
 
     public void Spend(decimal amount)
     {
-        if (amount <= 0) throw new ArgumentException("must be positive");
-        if (amount > Cash) throw new InvalidOperationException("not enough cash");
+        if (amount <= 0)
+            throw new ArgumentException("must be positive");
+        if (amount > Cash)
+            throw new InvalidOperationException("not enough cash");
         Cash -= amount;
     }
 }
@@ -287,7 +297,8 @@ catch (ArgumentException)
 
     public Counter(int start)
     {
-        if (start < 0) throw new ArgumentException("start cannot be negative");
+        if (start < 0)
+            throw new ArgumentException("start cannot be negative");
         Value = start;
     }
 

--- a/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
+++ b/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
@@ -22,15 +22,15 @@ They are two angles on the same idea: *separating "what" from "how."*
   adapter="csharp"
   starterCode={`using System;
 
-public class BankAccount
-{
-    public double Balance; // anyone can write this
-}
-
 var a = new BankAccount();
 a.Balance = 100;
 a.Balance = -9999; // oops
 Console.WriteLine(a.Balance);
+
+public class BankAccount
+{
+    public double Balance; // anyone can write this
+}
 `}
 />
 
@@ -59,6 +59,13 @@ For now, focus on **`private` for state, `public` for behavior**.
 <CodeBlock
   adapter="csharp"
   starterCode={`using System;
+
+var a = new BankAccount("Alice", 100);
+a.Deposit(50);
+a.Withdraw(30);
+Console.WriteLine($"{a.Owner}: {a.Balance}");
+
+// a.Balance = -9999;   // won't compile — Balance has a private setter
 
 public class BankAccount
 {
@@ -89,13 +96,6 @@ public class BankAccount
         Balance -= amount;
     }
 }
-
-var a = new BankAccount("Alice", 100);
-a.Deposit(50);
-a.Withdraw(30);
-Console.WriteLine($"{a.Owner}: {a.Balance}");
-
-// a.Balance = -9999;   // won't compile — Balance has a private setter
 `}
 />
 
@@ -127,6 +127,10 @@ Consider a `TemperatureSensor`:
   adapter="csharp"
   starterCode={`using System;
 
+var s = new TemperatureSensor();
+Console.WriteLine($"C: {s.Celsius:F2}");
+Console.WriteLine($"F: {s.Fahrenheit:F2}");
+
 public class TemperatureSensor
 {
     private double _rawVoltage = 1.23;
@@ -135,10 +139,6 @@ public class TemperatureSensor
 
     public double Fahrenheit => Celsius * 9.0 / 5.0 + 32;
 }
-
-var s = new TemperatureSensor();
-Console.WriteLine($"C: {s.Celsius:F2}");
-Console.WriteLine($"F: {s.Fahrenheit:F2}");
 `}
 />
 

--- a/content/learn/intro-modern-csharp/error-handling.mdx
+++ b/content/learn/intro-modern-csharp/error-handling.mdx
@@ -330,7 +330,8 @@ Console.WriteLine(SafeMath.SumNumbers(data));
         int total = 0;
         foreach (var s in inputs)
         {
-            if (int.TryParse(s, out var n)) total += n;
+            if (int.TryParse(s, out var n))
+                total += n;
         }
         return total;
     }

--- a/content/learn/intro-modern-csharp/inheritance-and-polymorphism.mdx
+++ b/content/learn/intro-modern-csharp/inheritance-and-polymorphism.mdx
@@ -282,7 +282,10 @@ foreach (var s in shapes)
       solutionContent: `public class Circle : Shape
 {
     public double Radius { get; }
-    public Circle(double r) { Radius = r; }
+    public Circle(double r)
+    {
+        Radius = r;
+    }
     public override double Area() => System.Math.PI * Radius * Radius;
 }
 `,
@@ -299,7 +302,11 @@ foreach (var s in shapes)
 {
     public double Width { get; }
     public double Height { get; }
-    public Rectangle(double w, double h) { Width = w; Height = h; }
+    public Rectangle(double w, double h)
+    {
+        Width = w;
+        Height = h;
+    }
     public override double Area() => Width * Height;
 }
 `,

--- a/content/learn/intro-modern-csharp/inheritance-and-polymorphism.mdx
+++ b/content/learn/intro-modern-csharp/inheritance-and-polymorphism.mdx
@@ -21,6 +21,10 @@ class** adds to or overrides what the base provides.
   adapter="csharp"
   starterCode={`using System;
 
+var d = new Dog("Rex");
+d.Eat();  // inherited from Animal
+d.Bark(); // defined on Dog
+
 public class Animal
 {
     public string Name { get; }
@@ -40,10 +44,6 @@ public class Dog : Animal // "Dog : Animal" reads "Dog inherits from Animal"
 
     public void Bark() => Console.WriteLine($"{Name} says woof!");
 }
-
-var d = new Dog("Rex");
-d.Eat();  // inherited from Animal
-d.Bark(); // defined on Dog
 `}
 />
 
@@ -73,6 +73,12 @@ works, not just add new methods. The base marks the method
   adapter="csharp"
   starterCode={`using System;
 
+Animal a = new Dog("Rex");
+a.Speak(); // "Rex barks!" — even though a's declared type is Animal
+
+a = new Cat("Whiskers");
+a.Speak(); // "Whiskers meows."
+
 public class Animal
 {
     public string Name { get; }
@@ -99,12 +105,6 @@ public class Cat : Animal
     }
     public override void Speak() => Console.WriteLine($"{Name} meows.");
 }
-
-Animal a = new Dog("Rex");
-a.Speak(); // "Rex barks!" — even though a's declared type is Animal
-
-a = new Cat("Whiskers");
-a.Speak(); // "Whiskers meows."
 `}
 />
 
@@ -141,6 +141,10 @@ method** on an **abstract class**.
   adapter="csharp"
   starterCode={`using System;
 
+Shape[] shapes = { new Circle(3), new Square(4) };
+foreach (var s in shapes)
+    s.Describe();
+
 public abstract class Shape
 {
     public abstract double Area(); // no body — derived classes MUST override
@@ -167,10 +171,6 @@ public class Square : Shape
     }
     public override double Area() => Side * Side;
 }
-
-Shape[] shapes = { new Circle(3), new Square(4) };
-foreach (var s in shapes)
-    s.Describe();
 `}
 />
 
@@ -188,6 +188,15 @@ promises to provide. It's pure shape — no fields, no behavior.
   adapter="csharp"
   starterCode={`using System;
 
+void GreetEveryone(IGreeter g, string[] names)
+{
+    foreach (var n in names)
+        Console.WriteLine(g.Greet(n));
+}
+
+GreetEveryone(new English(), new[] { "Ada", "Bob" });
+GreetEveryone(new Japanese(), new[] { "アダ", "ボブ" });
+
 public interface IGreeter
 {
     string Greet(string name);
@@ -202,15 +211,6 @@ public class Japanese : IGreeter
 {
     public string Greet(string name) => $"こんにちは、{name}さん!";
 }
-
-void GreetEveryone(IGreeter g, string[] names)
-{
-    foreach (var n in names)
-        Console.WriteLine(g.Greet(n));
-}
-
-GreetEveryone(new English(), new[] { "Ada", "Bob" });
-GreetEveryone(new Japanese(), new[] { "アダ", "ボブ" });
 `}
 />
 

--- a/content/learn/intro-modern-csharp/methods-and-modularity.mdx
+++ b/content/learn/intro-modern-csharp/methods-and-modularity.mdx
@@ -383,14 +383,17 @@ Console.WriteLine($"max={Stats.Max(data)}");
     public static int Sum(int[] xs)
     {
         int s = 0;
-        foreach (var x in xs) s += x;
+        foreach (var x in xs)
+            s += x;
         return s;
     }
 
     public static int Max(int[] xs)
     {
         int m = xs[0];
-        foreach (var x in xs) if (x > m) m = x;
+        foreach (var x in xs)
+            if (x > m)
+                m = x;
         return m;
     }
 }

--- a/content/learn/intro-modern-csharp/resource-management.mdx
+++ b/content/learn/intro-modern-csharp/resource-management.mdx
@@ -73,6 +73,14 @@ is thrown.
   adapter="csharp"
   starterCode={`using System;
 
+using (var c = new Connection("A"))
+{
+    c.Send("hello");
+    c.Send("world");
+} // c.Dispose() runs here, even if an exception was thrown inside the block
+
+Console.WriteLine("done");
+
 public class Connection : IDisposable
 {
     public string Name { get; }
@@ -89,14 +97,6 @@ public class Connection : IDisposable
         Console.WriteLine($"closed {Name}");
     }
 }
-
-using (var c = new Connection("A"))
-{
-    c.Send("hello");
-    c.Send("world");
-} // c.Dispose() runs here, even if an exception was thrown inside the block
-
-Console.WriteLine("done");
 `}
 />
 
@@ -113,6 +113,16 @@ of the enclosing scope.
   adapter="csharp"
   starterCode={`using System;
 
+void DoWork()
+{
+    using var c = new Connection("B");
+    c.Send("ping");
+    c.Send("pong");
+} // c.Dispose() runs here
+
+DoWork();
+Console.WriteLine("done");
+
 public class Connection : IDisposable
 {
     public string Name { get; }
@@ -124,16 +134,6 @@ public class Connection : IDisposable
     public void Send(string msg) => Console.WriteLine($"{Name}: {msg}");
     public void Dispose() => Console.WriteLine($"closed {Name}");
 }
-
-void DoWork()
-{
-    using var c = new Connection("B");
-    c.Send("ping");
-    c.Send("pong");
-} // c.Dispose() runs here
-
-DoWork();
-Console.WriteLine("done");
 `}
 />
 
@@ -145,17 +145,6 @@ You *could* call `Dispose()` manually:
   adapter="csharp"
   starterCode={`using System;
 
-public class Connection : IDisposable
-{
-    public string Name { get; }
-    public Connection(string name)
-    {
-        Name = name;
-        Console.WriteLine($"opened {name}");
-    }
-    public void Dispose() => Console.WriteLine($"closed {Name}");
-}
-
 var c = new Connection("C");
 try
 {
@@ -165,6 +154,17 @@ try
 finally
 {
     c.Dispose(); // we have to remember
+}
+
+public class Connection : IDisposable
+{
+    public string Name { get; }
+    public Connection(string name)
+    {
+        Name = name;
+        Console.WriteLine($"opened {name}");
+    }
+    public void Dispose() => Console.WriteLine($"closed {Name}");
 }
 `}
 />
@@ -206,6 +206,17 @@ don't have a real filesystem to open. But you can practice the
   starterCode={`using System;
 using System.Collections.Generic;
 
+void Job()
+{
+    using var log = new Logger("job-1");
+    log.Write("start");
+    log.Write("doing work");
+    log.Write("end");
+} // Logger flushed and closed here
+
+Job();
+Console.WriteLine("program continues");
+
 public class Logger : IDisposable
 {
     public string Name { get; }
@@ -223,17 +234,6 @@ public class Logger : IDisposable
         Console.WriteLine($"close {Name}");
     }
 }
-
-void Job()
-{
-    using var log = new Logger("job-1");
-    log.Write("start");
-    log.Write("doing work");
-    log.Write("end");
-} // Logger flushed and closed here
-
-Job();
-Console.WriteLine("program continues");
 `}
 />
 

--- a/content/learn/intro-modern-csharp/writing-maintainable-software.mdx
+++ b/content/learn/intro-modern-csharp/writing-maintainable-software.mdx
@@ -180,12 +180,12 @@ about. Where you can:
   adapter="csharp"
   starterCode={`using System;
 
-public record Money(decimal Amount, string Currency);
-
 var a = new Money(10m, "USD");
 var b = a with { Amount = 25m }; // a is unchanged
 
 Console.WriteLine($"{a}, {b}");
+
+public record Money(decimal Amount, string Currency);
 `}
 />
 

--- a/content/learn/java-collections-and-generics-deep-dive/birth-of-containers.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/birth-of-containers.mdx
@@ -224,38 +224,39 @@ needing one for "list", "set", "map", "queue", "stack",
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Bag bag = new Bag();
-        bag.add("Ada");
-        bag.add("Linus");
-        bag.add("Grace");
+  public static void main(String[] args) {
+    Bag bag = new Bag();
+    bag.add("Ada");
+    bag.add("Linus");
+    bag.add("Grace");
 
-        for (int i = 0; i < bag.size(); i++) {
-            // Downcast required — the bag is untyped.
-            String s = (String) bag.get(i);
-            System.out.println(s);
-        }
+    for (int i = 0; i < bag.size(); i++) {
+      // Downcast required — the bag is untyped.
+      String s = (String)bag.get(i);
+      System.out.println(s);
     }
+  }
 }
 `,
     },
     {
       filename: "Bag.java",
       initialContent: `public class Bag {
-    private Object[] data = new Object[2];
-    private int      size = 0;
+  private Object[] data = new Object[2];
+  private int size = 0;
 
-    public void add(Object o) {
-        if (size == data.length) {
-            Object[] bigger = new Object[data.length * 2];
-            for (int i = 0; i < size; i++) bigger[i] = data[i];
-            data = bigger;
-        }
-        data[size++] = o;
+  public void add(Object o) {
+    if (size == data.length) {
+      Object[] bigger = new Object[data.length * 2];
+      for (int i = 0; i < size; i++)
+        bigger[i] = data[i];
+      data = bigger;
     }
+    data[size++] = o;
+  }
 
-    public Object get(int i) { return data[i]; }
-    public int    size()      { return size; }
+  public Object get(int i) { return data[i]; }
+  public int size() { return size; }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
@@ -276,15 +276,17 @@ differ in the safe direction.
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Integer> ints = new ArrayList<>();
-        ints.add(1); ints.add(2); ints.add(3);
+  public static void main(String[] args) {
+    List<Integer> ints = new ArrayList<>();
+    ints.add(1);
+    ints.add(2);
+    ints.add(3);
 
-        List<Number> nums = new ArrayList<>();   // Number is a supertype of Integer
+    List<Number> nums = new ArrayList<>(); // Number is a supertype of Integer
 
-        Copier.copyAll(nums, ints);              // dest = Number, src = Integer
-        System.out.println(nums);
-    }
+    Copier.copyAll(nums, ints); // dest = Number, src = Integer
+    System.out.println(nums);
+  }
 }
 `,
     },
@@ -293,10 +295,11 @@ public class Main {
       initialContent: `import java.util.List;
 
 public class Copier {
-    // PECS: src produces (? extends T), dest consumes (? super T)
-    public static <T> void copyAll(List<? super T> dest, List<? extends T> src) {
-        for (T x : src) dest.add(x);
-    }
+  // PECS: src produces (? extends T), dest consumes (? super T)
+  public static <T> void copyAll(List<? super T> dest, List<? extends T> src) {
+    for (T x : src)
+      dest.add(x);
+  }
 }
 `,
     },
@@ -348,18 +351,19 @@ Expected output (when the provided \`Main\` runs):
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        Bag<Number> bag = new Bag<>();
-        bag.add(1);
-        bag.add(2);
-        bag.add(3);
+  public static void main(String[] args) {
+    Bag<Number> bag = new Bag<>();
+    bag.add(1);
+    bag.add(2);
+    bag.add(3);
 
-        List<Integer> moreInts = new ArrayList<>();
-        moreInts.add(10); moreInts.add(20);
+    List<Integer> moreInts = new ArrayList<>();
+    moreInts.add(10);
+    moreInts.add(20);
 
-        bag.addAll(moreInts);   // List<Integer> is "? extends Number"
-        System.out.println(bag.all());
-    }
+    bag.addAll(moreInts); // List<Integer> is "? extends Number"
+    System.out.println(bag.all());
+  }
 }
 `,
     },
@@ -369,28 +373,29 @@ public class Main {
 import java.util.List;
 
 public class Bag<T> {
-    private final List<T> data = new ArrayList<>();
+  private final List<T> data = new ArrayList<>();
 
-    public void add(T item) { data.add(item); }
+  public void add(T item) { data.add(item); }
 
-    // TODO: addAll must accept any Iterable<? extends T>
-    public void addAll(/* TODO */) {
-        // TODO
-    }
+  // TODO: addAll must accept any Iterable<? extends T>
+  public void addAll(/* TODO */) {
+    // TODO
+  }
 
-    public List<T> all() { return data; }
+  public List<T> all() { return data; }
 }
 `,
       solutionContent: `import java.util.ArrayList;
 import java.util.List;
 
 public class Bag<T> {
-    private final List<T> data = new ArrayList<>();
-    public void add(T item) { data.add(item); }
-    public void addAll(Iterable<? extends T> items) {
-        for (T x : items) data.add(x);
-    }
-    public List<T> all() { return data; }
+  private final List<T> data = new ArrayList<>();
+  public void add(T item) { data.add(item); }
+  public void addAll(Iterable<? extends T> items) {
+    for (T x : items)
+      data.add(x);
+  }
+  public List<T> all() { return data; }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/capstone-music-library.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/capstone-music-library.mdx
@@ -79,28 +79,33 @@ Hints:
       initialContent: `import java.util.*;
 
 public class Main {
-    public static void main(String[] args) {
-        MusicLibrary lib = new MusicLibrary();
-        lib.add(new Track("Clair de Lune",   "Debussy",  "Suite Bergamasque", List.of("classical","impressionist"), 5));
-        lib.add(new Track("Gymnopedie No.1", "Satie",    "Gymnopedies",       List.of("classical"),                 3));
-        lib.add(new Track("Reverie",         "Debussy",  "Reveries",          List.of("classical","impressionist"), 4));
-        lib.add(new Track("Liebestraum",     "Liszt",    "Liebestraume",      List.of("classical"),                 4));
-        lib.add(new Track("La Mer",          "Debussy",  "Sea Pieces",        List.of("classical","orchestral"),    5));
+  public static void main(String[] args) {
+    MusicLibrary lib = new MusicLibrary();
+    lib.add(new Track("Clair de Lune", "Debussy", "Suite Bergamasque",
+                      List.of("classical", "impressionist"), 5));
+    lib.add(new Track("Gymnopedie No.1", "Satie", "Gymnopedies",
+                      List.of("classical"), 3));
+    lib.add(new Track("Reverie", "Debussy", "Reveries",
+                      List.of("classical", "impressionist"), 4));
+    lib.add(new Track("Liebestraum", "Liszt", "Liebestraume",
+                      List.of("classical"), 4));
+    lib.add(new Track("La Mer", "Debussy", "Sea Pieces",
+                      List.of("classical", "orchestral"), 5));
 
-        System.out.println("Debussy tracks:");
-        for (Track t : lib.byArtist("Debussy")) {
-            System.out.println("  " + t.title());
-        }
-
-        System.out.println("Genres: " + lib.genres());
-
-        System.out.println("Top 3:");
-        for (Track t : lib.topRated(3)) {
-            System.out.println("  " + t.title() + " (" + t.rating() + ")");
-        }
-
-        System.out.println("Debussy albums: " + lib.albumsByArtist("Debussy"));
+    System.out.println("Debussy tracks:");
+    for (Track t : lib.byArtist("Debussy")) {
+      System.out.println("  " + t.title());
     }
+
+    System.out.println("Genres: " + lib.genres());
+
+    System.out.println("Top 3:");
+    for (Track t : lib.topRated(3)) {
+      System.out.println("  " + t.title() + " (" + t.rating() + ")");
+    }
+
+    System.out.println("Debussy albums: " + lib.albumsByArtist("Debussy"));
+  }
 }
 `,
     },
@@ -108,13 +113,8 @@ public class Main {
       filename: "Track.java",
       initialContent: `import java.util.List;
 
-public record Track(
-    String title,
-    String artist,
-    String album,
-    List<String> genres,
-    int rating
-) {}
+public record Track(String title, String artist, String album,
+                    List<String> genres, int rating) {}
 `,
     },
     {
@@ -122,72 +122,72 @@ public record Track(
       initialContent: `import java.util.*;
 
 public class MusicLibrary {
-    // TODO: choose the right shapes for each query
+  // TODO: choose the right shapes for each query
 
-    public void add(Track t) {
-        // TODO
-    }
+  public void add(Track t) {
+    // TODO
+  }
 
-    /** All tracks for the artist, in insertion order. */
-    public List<Track> byArtist(String artist) {
-        // TODO
-        return List.of();
-    }
+  /** All tracks for the artist, in insertion order. */
+  public List<Track> byArtist(String artist) {
+    // TODO
+    return List.of();
+  }
 
-    /** All genres across the library, in insertion order (deduped). */
-    public Set<String> genres() {
-        // TODO
-        return Set.of();
-    }
+  /** All genres across the library, in insertion order (deduped). */
+  public Set<String> genres() {
+    // TODO
+    return Set.of();
+  }
 
-    /** Top n by rating desc, ties broken by title asc. */
-    public List<Track> topRated(int n) {
-        // TODO
-        return List.of();
-    }
+  /** Top n by rating desc, ties broken by title asc. */
+  public List<Track> topRated(int n) {
+    // TODO
+    return List.of();
+  }
 
-    /** Unique albums for the artist, in insertion order. */
-    public Set<String> albumsByArtist(String artist) {
-        // TODO
-        return Set.of();
-    }
+  /** Unique albums for the artist, in insertion order. */
+  public Set<String> albumsByArtist(String artist) {
+    // TODO
+    return Set.of();
+  }
 }
 `,
       solutionContent: `import java.util.*;
 
 public class MusicLibrary {
-    private final List<Track>                tracks      = new ArrayList<>();
-    private final Map<String, List<Track>>   byArtist    = new HashMap<>();
-    private final Set<String>                allGenres   = new LinkedHashSet<>();
-    private final Map<String, Set<String>>   albumsOfArt = new HashMap<>();
+  private final List<Track> tracks = new ArrayList<>();
+  private final Map<String, List<Track>> byArtist = new HashMap<>();
+  private final Set<String> allGenres = new LinkedHashSet<>();
+  private final Map<String, Set<String>> albumsOfArt = new HashMap<>();
 
-    public void add(Track t) {
-        tracks.add(t);
-        byArtist.computeIfAbsent(t.artist(), k -> new ArrayList<>()).add(t);
-        allGenres.addAll(t.genres());
-        albumsOfArt.computeIfAbsent(t.artist(), k -> new LinkedHashSet<>()).add(t.album());
-    }
+  public void add(Track t) {
+    tracks.add(t);
+    byArtist.computeIfAbsent(t.artist(), k -> new ArrayList<>()).add(t);
+    allGenres.addAll(t.genres());
+    albumsOfArt.computeIfAbsent(t.artist(), k -> new LinkedHashSet<>())
+        .add(t.album());
+  }
 
-    public List<Track> byArtist(String artist) {
-        return Collections.unmodifiableList(byArtist.getOrDefault(artist, List.of()));
-    }
+  public List<Track> byArtist(String artist) {
+    return Collections.unmodifiableList(
+        byArtist.getOrDefault(artist, List.of()));
+  }
 
-    public Set<String> genres() {
-        return Collections.unmodifiableSet(allGenres);
-    }
+  public Set<String> genres() { return Collections.unmodifiableSet(allGenres); }
 
-    public List<Track> topRated(int n) {
-        List<Track> copy = new ArrayList<>(tracks);
-        copy.sort(Comparator
-            .comparingInt(Track::rating).reversed()
-            .thenComparing(Track::title));
-        return copy.subList(0, Math.min(n, copy.size()));
-    }
+  public List<Track> topRated(int n) {
+    List<Track> copy = new ArrayList<>(tracks);
+    copy.sort(Comparator.comparingInt(Track::rating)
+                  .reversed()
+                  .thenComparing(Track::title));
+    return copy.subList(0, Math.min(n, copy.size()));
+  }
 
-    public Set<String> albumsByArtist(String artist) {
-        return Collections.unmodifiableSet(
-            albumsOfArt.getOrDefault(artist, Set.of()));
-    }
+  public Set<String> albumsByArtist(String artist) {
+    return Collections.unmodifiableSet(
+        albumsOfArt.getOrDefault(artist, Set.of()));
+  }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/collection-architecture.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/collection-architecture.mdx
@@ -133,26 +133,25 @@ but its API is safe to use everywhere:
       initialContent: `import java.util.*;
 
 public class Main {
-    public static void main(String[] args) {
-        BookRepo repo = new BookRepo(List.of(
-            new Book("978-1", "Clean Code",   "Martin"),
-            new Book("978-2", "Effective Java","Bloch"),
-            new Book("978-3", "TAOCP I",      "Knuth")
-        ));
+  public static void main(String[] args) {
+    BookRepo repo =
+        new BookRepo(List.of(new Book("978-1", "Clean Code", "Martin"),
+                             new Book("978-2", "Effective Java", "Bloch"),
+                             new Book("978-3", "TAOCP I", "Knuth")));
 
-        // Read flows: callers can't accidentally damage repo state
-        System.out.println("all: " + repo.allTitles());
+    // Read flows: callers can't accidentally damage repo state
+    System.out.println("all: " + repo.allTitles());
 
-        Optional<Book> hit = repo.findByIsbn("978-2");
-        hit.ifPresent(b -> System.out.println("found: " + b.title()));
+    Optional<Book> hit = repo.findByIsbn("978-2");
+    hit.ifPresent(b -> System.out.println("found: " + b.title()));
 
-        // Demonstrate that the returned view is read-only
-        try {
-            repo.allTitles().add("hack");
-        } catch (UnsupportedOperationException e) {
-            System.out.println("allTitles is read-only");
-        }
+    // Demonstrate that the returned view is read-only
+    try {
+      repo.allTitles().add("hack");
+    } catch (UnsupportedOperationException e) {
+      System.out.println("allTitles is read-only");
     }
+  }
 }
 `,
     },
@@ -166,24 +165,26 @@ public class Main {
       initialContent: `import java.util.*;
 
 public final class BookRepo {
-    private final Map<String, Book> byIsbn;     // private mutable state, owned here
+  private final Map<String, Book> byIsbn; // private mutable state, owned here
 
-    public BookRepo(Collection<Book> seed) {    // accept the widest sensible input
-        Map<String, Book> m = new LinkedHashMap<>();
-        for (Book b : seed) m.put(b.isbn(), b);
-        this.byIsbn = m;
-    }
+  public BookRepo(Collection<Book> seed) { // accept the widest sensible input
+    Map<String, Book> m = new LinkedHashMap<>();
+    for (Book b : seed)
+      m.put(b.isbn(), b);
+    this.byIsbn = m;
+  }
 
-    public Optional<Book> findByIsbn(String isbn) {
-        return Optional.ofNullable(byIsbn.get(isbn));
-    }
+  public Optional<Book> findByIsbn(String isbn) {
+    return Optional.ofNullable(byIsbn.get(isbn));
+  }
 
-    public List<String> allTitles() {
-        // narrow, ordered, unmodifiable
-        List<String> out = new ArrayList<>(byIsbn.size());
-        for (Book b : byIsbn.values()) out.add(b.title());
-        return Collections.unmodifiableList(out);
-    }
+  public List<String> allTitles() {
+    // narrow, ordered, unmodifiable
+    List<String> out = new ArrayList<>(byIsbn.size());
+    for (Book b : byIsbn.values())
+      out.add(b.title());
+    return Collections.unmodifiableList(out);
+  }
 }
 `,
     },
@@ -240,20 +241,24 @@ caller mutation was blocked
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<String> seed = new ArrayList<>(List.of("hello", "world"));
-        Inbox in = new Inbox(seed);
-        System.out.println(in.messages());
+  public static void main(String[] args) {
+    List<String> seed = new ArrayList<>(List.of("hello", "world"));
+    Inbox in = new Inbox(seed);
+    System.out.println(in.messages());
 
-        seed.add("steal-me");
-        if (!in.messages().contains("steal-me")) System.out.println("external did not leak");
+    seed.add("steal-me");
+    if (!in.messages().contains("steal-me"))
+      System.out.println("external did not leak");
 
-        try { in.messages().add("hack"); }
-        catch (UnsupportedOperationException e) { System.out.println("caller mutation was blocked"); }
-
-        in.add("!");
-        System.out.println(in.messages());
+    try {
+      in.messages().add("hack");
+    } catch (UnsupportedOperationException e) {
+      System.out.println("caller mutation was blocked");
     }
+
+    in.add("!");
+    System.out.println(in.messages());
+  }
 }
 `,
     },
@@ -263,19 +268,17 @@ public class Main {
 import java.util.List;
 
 public class Inbox {
-    private final List<String> msgs;
+  private final List<String> msgs;
 
-    public Inbox(List<String> msgs) {
-        this.msgs = msgs;             // TODO: defensive copy into a mutable list
-    }
+  public Inbox(List<String> msgs) {
+    this.msgs = msgs; // TODO: defensive copy into a mutable list
+  }
 
-    public void add(String m) {
-        msgs.add(m);
-    }
+  public void add(String m) { msgs.add(m); }
 
-    public List<String> messages() {
-        return msgs;                  // TODO: unmodifiable
-    }
+  public List<String> messages() {
+    return msgs; // TODO: unmodifiable
+  }
 }
 `,
       solutionContent: `import java.util.ArrayList;
@@ -283,19 +286,15 @@ import java.util.Collections;
 import java.util.List;
 
 public class Inbox {
-    private final List<String> msgs;
+  private final List<String> msgs;
 
-    public Inbox(List<String> msgs) {
-        this.msgs = new ArrayList<>(msgs);   // own a fresh mutable list
-    }
+  public Inbox(List<String> msgs) {
+    this.msgs = new ArrayList<>(msgs); // own a fresh mutable list
+  }
 
-    public void add(String m) {
-        msgs.add(m);
-    }
+  public void add(String m) { msgs.add(m); }
 
-    public List<String> messages() {
-        return Collections.unmodifiableList(msgs);
-    }
+  public List<String> messages() { return Collections.unmodifiableList(msgs); }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/comparable-and-comparator.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/comparable-and-comparator.mdx
@@ -198,18 +198,15 @@ public class Main {
       initialContent: `import java.util.*;
 
 public class Main {
-    public static void main(String[] args) {
-        List<User> us = new ArrayList<>(List.of(
-            new User("ada",    36, false),
-            new User("linus",  54, true),
-            new User("grace",  85, true),
-            new User("bjarne", 73, false)
-        ));
+  public static void main(String[] args) {
+    List<User> us = new ArrayList<>(
+        List.of(new User("ada", 36, false), new User("linus", 54, true),
+                new User("grace", 85, true), new User("bjarne", 73, false)));
 
-        // active users first, then by age descending, then by name
-        us.sort(UserOrders.activeFirstThenOldestThenName());
-        us.forEach(System.out::println);
-    }
+    // active users first, then by age descending, then by name
+    us.sort(UserOrders.activeFirstThenOldestThenName());
+    us.forEach(System.out::println);
+  }
 }
 `,
     },
@@ -223,15 +220,14 @@ public class Main {
       initialContent: `import java.util.Comparator;
 
 public final class UserOrders {
-    private UserOrders() {}
+  private UserOrders() {}
 
-    public static Comparator<User> activeFirstThenOldestThenName() {
-        // Boolean.compare(false, true) is negative, so reversed() puts true first
-        return Comparator
-            .comparing(User::active, Comparator.reverseOrder())
-            .thenComparing(Comparator.comparingInt(User::age).reversed())
-            .thenComparing(User::name);
-    }
+  public static Comparator<User> activeFirstThenOldestThenName() {
+    // Boolean.compare(false, true) is negative, so reversed() puts true first
+    return Comparator.comparing(User::active, Comparator.reverseOrder())
+        .thenComparing(Comparator.comparingInt(User::age).reversed())
+        .thenComparing(User::name);
+  }
 }
 `,
     },
@@ -263,18 +259,14 @@ Grace 90
       initialContent: `import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Player> ps = List.of(
-            new Player("Ada",    80),
-            new Player("Linus",  95),
-            new Player("Grace",  90),
-            new Player("Bjarne", 95),
-            new Player("Edsger", 85)
-        );
-        for (Player p : Leaderboard.top3(ps)) {
-            System.out.println(p.name() + " " + p.score());
-        }
+  public static void main(String[] args) {
+    List<Player> ps = List.of(new Player("Ada", 80), new Player("Linus", 95),
+                              new Player("Grace", 90), new Player("Bjarne", 95),
+                              new Player("Edsger", 85));
+    for (Player p : Leaderboard.top3(ps)) {
+      System.out.println(p.name() + " " + p.score());
     }
+  }
 }
 `,
     },
@@ -288,27 +280,26 @@ public class Main {
       initialContent: `import java.util.*;
 
 public final class Leaderboard {
-    private Leaderboard() {}
+  private Leaderboard() {}
 
-    public static List<Player> top3(List<Player> players) {
-        // TODO: sort by score desc, then name asc, return first 3
-        return List.of();
-    }
+  public static List<Player> top3(List<Player> players) {
+    // TODO: sort by score desc, then name asc, return first 3
+    return List.of();
+  }
 }
 `,
       solutionContent: `import java.util.*;
 
 public final class Leaderboard {
-    private Leaderboard() {}
+  private Leaderboard() {}
 
-    public static List<Player> top3(List<Player> players) {
-        List<Player> sorted = new ArrayList<>(players);
-        sorted.sort(
-            Comparator.comparingInt(Player::score).reversed()
-                      .thenComparing(Player::name)
-        );
-        return sorted.subList(0, Math.min(3, sorted.size()));
-    }
+  public static List<Player> top3(List<Player> players) {
+    List<Player> sorted = new ArrayList<>(players);
+    sorted.sort(Comparator.comparingInt(Player::score)
+                    .reversed()
+                    .thenComparing(Player::name));
+    return sorted.subList(0, Math.min(3, sorted.size()));
+  }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/data-modeling-with-collections.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/data-modeling-with-collections.mdx
@@ -89,25 +89,29 @@ If we let the **questions** drive the **shape**, we get:
       initialContent: `import java.util.*;
 
 public class Main {
-    public static void main(String[] args) {
-        Library lib = new Library();
-        lib.add(new Track("Clair de Lune",  "Debussy",   "Suite Bergamasque", List.of("classical", "impressionist"), 1200));
-        lib.add(new Track("Gymnopedie No.1","Satie",     "Gymnopedies",       List.of("classical"),                  900));
-        lib.add(new Track("Reverie",        "Debussy",   "Reveries",          List.of("classical"),                  450));
-        lib.add(new Track("Liebestraum",    "Liszt",     "Liebestraume",      List.of("classical", "romantic"),      700));
+  public static void main(String[] args) {
+    Library lib = new Library();
+    lib.add(new Track("Clair de Lune", "Debussy", "Suite Bergamasque",
+                      List.of("classical", "impressionist"), 1200));
+    lib.add(new Track("Gymnopedie No.1", "Satie", "Gymnopedies",
+                      List.of("classical"), 900));
+    lib.add(
+        new Track("Reverie", "Debussy", "Reveries", List.of("classical"), 450));
+    lib.add(new Track("Liebestraum", "Liszt", "Liebestraume",
+                      List.of("classical", "romantic"), 700));
 
-        System.out.println("Debussy tracks:");
-        for (Track t : lib.tracksByArtist("Debussy")) {
-            System.out.println("  " + t.title());
-        }
-
-        System.out.println("All genres: " + new TreeSet<>(lib.allGenres()));
-
-        System.out.println("Top 2:");
-        for (Track t : lib.topLiked(2)) {
-            System.out.println("  " + t.title() + " (" + t.likes() + ")");
-        }
+    System.out.println("Debussy tracks:");
+    for (Track t : lib.tracksByArtist("Debussy")) {
+      System.out.println("  " + t.title());
     }
+
+    System.out.println("All genres: " + new TreeSet<>(lib.allGenres()));
+
+    System.out.println("Top 2:");
+    for (Track t : lib.topLiked(2)) {
+      System.out.println("  " + t.title() + " (" + t.likes() + ")");
+    }
+  }
 }
 `,
     },
@@ -115,13 +119,8 @@ public class Main {
       filename: "Track.java",
       initialContent: `import java.util.List;
 
-public record Track(
-    String title,
-    String artist,
-    String album,
-    List<String> genres,
-    int likes
-) {}
+public record Track(String title, String artist, String album,
+                    List<String> genres, int likes) {}
 `,
     },
     {
@@ -129,34 +128,33 @@ public record Track(
       initialContent: `import java.util.*;
 
 public class Library {
-    // shape: ordered list of tracks
-    private final List<Track> tracks = new ArrayList<>();
+  // shape: ordered list of tracks
+  private final List<Track> tracks = new ArrayList<>();
 
-    // shape: lookup by artist -> list of tracks
-    private final Map<String, List<Track>> byArtist = new HashMap<>();
+  // shape: lookup by artist -> list of tracks
+  private final Map<String, List<Track>> byArtist = new HashMap<>();
 
-    // shape: set of all unique genres seen
-    private final Set<String> genres = new HashSet<>();
+  // shape: set of all unique genres seen
+  private final Set<String> genres = new HashSet<>();
 
-    public void add(Track t) {
-        tracks.add(t);
-        byArtist.computeIfAbsent(t.artist(), k -> new ArrayList<>()).add(t);
-        genres.addAll(t.genres());
-    }
+  public void add(Track t) {
+    tracks.add(t);
+    byArtist.computeIfAbsent(t.artist(), k -> new ArrayList<>()).add(t);
+    genres.addAll(t.genres());
+  }
 
-    public List<Track> tracksByArtist(String artist) {
-        return Collections.unmodifiableList(byArtist.getOrDefault(artist, List.of()));
-    }
+  public List<Track> tracksByArtist(String artist) {
+    return Collections.unmodifiableList(
+        byArtist.getOrDefault(artist, List.of()));
+  }
 
-    public Set<String> allGenres() {
-        return Collections.unmodifiableSet(genres);
-    }
+  public Set<String> allGenres() { return Collections.unmodifiableSet(genres); }
 
-    public List<Track> topLiked(int n) {
-        List<Track> copy = new ArrayList<>(tracks);
-        copy.sort(Comparator.comparingInt(Track::likes).reversed());
-        return copy.subList(0, Math.min(n, copy.size()));
-    }
+  public List<Track> topLiked(int n) {
+    List<Track> copy = new ArrayList<>(tracks);
+    copy.sort(Comparator.comparingInt(Track::likes).reversed());
+    return copy.subList(0, Math.min(n, copy.size()));
+  }
 }
 `,
     },
@@ -256,16 +254,13 @@ carol: [Order[id=4, total=200]]
       initialContent: `import java.util.*;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Order> orders = List.of(
-            new Order(1, "alice", 100),
-            new Order(2, "bob",    40),
-            new Order(3, "alice",  70),
-            new Order(4, "carol", 200)
-        );
-        Map<String, List<Order>> idx = new TreeMap<>(OrderIndex.byCustomer(orders));
-        idx.forEach((k, v) -> System.out.println(k + ": " + v));
-    }
+  public static void main(String[] args) {
+    List<Order> orders =
+        List.of(new Order(1, "alice", 100), new Order(2, "bob", 40),
+                new Order(3, "alice", 70), new Order(4, "carol", 200));
+    Map<String, List<Order>> idx = new TreeMap<>(OrderIndex.byCustomer(orders));
+    idx.forEach((k, v) -> System.out.println(k + ": " + v));
+  }
 }
 `,
     },
@@ -279,26 +274,26 @@ public class Main {
       initialContent: `import java.util.*;
 
 public final class OrderIndex {
-    private OrderIndex() {}
+  private OrderIndex() {}
 
-    public static Map<String, List<Order>> byCustomer(List<Order> orders) {
-        // TODO: use computeIfAbsent + ArrayList
-        return new HashMap<>();
-    }
+  public static Map<String, List<Order>> byCustomer(List<Order> orders) {
+    // TODO: use computeIfAbsent + ArrayList
+    return new HashMap<>();
+  }
 }
 `,
       solutionContent: `import java.util.*;
 
 public final class OrderIndex {
-    private OrderIndex() {}
+  private OrderIndex() {}
 
-    public static Map<String, List<Order>> byCustomer(List<Order> orders) {
-        Map<String, List<Order>> out = new HashMap<>();
-        for (Order o : orders) {
-            out.computeIfAbsent(o.customerId(), k -> new ArrayList<>()).add(o);
-        }
-        return out;
+  public static Map<String, List<Order>> byCustomer(List<Order> orders) {
+    Map<String, List<Order>> out = new HashMap<>();
+    for (Order o : orders) {
+      out.computeIfAbsent(o.customerId(), k -> new ArrayList<>()).add(o);
     }
+    return out;
+  }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
@@ -98,30 +98,34 @@ inside hash-based collections.
 import java.util.Set;
 
 public class Main {
-    public static void main(String[] args) {
-        Set<Point> seen = new HashSet<>();
-        seen.add(new Point(1, 2));
+  public static void main(String[] args) {
+    Set<Point> seen = new HashSet<>();
+    seen.add(new Point(1, 2));
 
-        // Should be true — but the set will say "no."
-        System.out.println("contains (1,2)? " + seen.contains(new Point(1, 2)));
-    }
+    // Should be true — but the set will say "no."
+    System.out.println("contains (1,2)? " + seen.contains(new Point(1, 2)));
+  }
 }
 `,
     },
     {
       filename: "Point.java",
       initialContent: `public class Point {
-    private final int x;
-    private final int y;
-    public Point(int x, int y) { this.x = x; this.y = y; }
+  private final int x;
+  private final int y;
+  public Point(int x, int y) {
+    this.x = x;
+    this.y = y;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof Point)) return false;
-        Point p = (Point) o;
-        return p.x == this.x && p.y == this.y;
-    }
-    // NOTE: no hashCode() override!
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof Point))
+      return false;
+    Point p = (Point)o;
+    return p.x == this.x && p.y == this.y;
+  }
+  // NOTE: no hashCode() override!
 }
 `,
     },
@@ -148,16 +152,16 @@ set never even reaches the `.equals` step.
 import java.util.Set;
 
 public class Main {
-    public static void main(String[] args) {
-        Set<Point> seen = new HashSet<>();
-        seen.add(new Point(1, 2));
-        seen.add(new Point(1, 2));   // duplicate — should be ignored
-        seen.add(new Point(3, 4));
+  public static void main(String[] args) {
+    Set<Point> seen = new HashSet<>();
+    seen.add(new Point(1, 2));
+    seen.add(new Point(1, 2)); // duplicate — should be ignored
+    seen.add(new Point(3, 4));
 
-        System.out.println("size = " + seen.size());
-        System.out.println("contains (1,2)? " + seen.contains(new Point(1, 2)));
-        System.out.println("contains (5,6)? " + seen.contains(new Point(5, 6)));
-    }
+    System.out.println("size = " + seen.size());
+    System.out.println("contains (1,2)? " + seen.contains(new Point(1, 2)));
+    System.out.println("contains (5,6)? " + seen.contains(new Point(5, 6)));
+  }
 }
 `,
     },
@@ -166,22 +170,27 @@ public class Main {
       initialContent: `import java.util.Objects;
 
 public class Point {
-    private final int x;
-    private final int y;
-    public Point(int x, int y) { this.x = x; this.y = y; }
+  private final int x;
+  private final int y;
+  public Point(int x, int y) {
+    this.x = x;
+    this.y = y;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Point)) return false;
-        Point p = (Point) o;
-        return p.x == this.x && p.y == this.y;
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (!(o instanceof Point))
+      return false;
+    Point p = (Point)o;
+    return p.x == this.x && p.y == this.y;
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(x, y);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(x, y);
+  }
 }
 `,
     },
@@ -304,44 +313,50 @@ total unique = 2
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        UniquenessTracker t = new UniquenessTracker();
-        System.out.println("first  Ada@x.com? " + t.register(new Email("Ada@x.com")));
-        System.out.println("again  Ada@x.com? " + t.register(new Email("Ada@x.com")));
-        System.out.println("again  ada@x.com? " + t.register(new Email("ada@x.com")));
-        System.out.println("new    bob@x.com? " + t.register(new Email("bob@x.com")));
-        System.out.println("total unique = " + t.size());
-    }
+  public static void main(String[] args) {
+    UniquenessTracker t = new UniquenessTracker();
+    System.out.println("first  Ada@x.com? " +
+                       t.register(new Email("Ada@x.com")));
+    System.out.println("again  Ada@x.com? " +
+                       t.register(new Email("Ada@x.com")));
+    System.out.println("again  ada@x.com? " +
+                       t.register(new Email("ada@x.com")));
+    System.out.println("new    bob@x.com? " +
+                       t.register(new Email("bob@x.com")));
+    System.out.println("total unique = " + t.size());
+  }
 }
 `,
     },
     {
       filename: "Email.java",
       initialContent: `public class Email {
-    private final String address;
-    public Email(String address) { this.address = address; }
-    public String address() { return address; }
-    // TODO: equals / hashCode that ignore case
+  private final String address;
+  public Email(String address) { this.address = address; }
+  public String address() { return address; }
+  // TODO: equals / hashCode that ignore case
 }
 `,
-      solutionContent: `import java.util.Objects;
-import java.util.Locale;
+      solutionContent: `import java.util.Locale;
+import java.util.Objects;
 
 public class Email {
-    private final String address;
-    public Email(String address) { this.address = address; }
-    public String address() { return address; }
+  private final String address;
+  public Email(String address) { this.address = address; }
+  public String address() { return address; }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Email e)) return false;
-        return e.address.equalsIgnoreCase(this.address);
-    }
-    @Override
-    public int hashCode() {
-        return Objects.hash(address.toLowerCase(Locale.ROOT));
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (!(o instanceof Email e))
+      return false;
+    return e.address.equalsIgnoreCase(this.address);
+  }
+  @Override
+  public int hashCode() {
+    return Objects.hash(address.toLowerCase(Locale.ROOT));
+  }
 }
 `,
     },
@@ -351,23 +366,23 @@ public class Email {
 import java.util.Set;
 
 public class UniquenessTracker {
-    private final Set<Email> seen = new HashSet<>();
-    public boolean register(Email e) {
-        // TODO: return true if this is the first time we have seen e
-        return false;
-    }
-    public int size() { return seen.size(); }
+  private final Set<Email> seen = new HashSet<>();
+  public boolean register(Email e) {
+    // TODO: return true if this is the first time we have seen e
+    return false;
+  }
+  public int size() { return seen.size(); }
 }
 `,
       solutionContent: `import java.util.HashSet;
 import java.util.Set;
 
 public class UniquenessTracker {
-    private final Set<Email> seen = new HashSet<>();
-    public boolean register(Email e) {
-        return seen.add(e);   // Set.add returns true iff the element was new
-    }
-    public int size() { return seen.size(); }
+  private final Set<Email> seen = new HashSet<>();
+  public boolean register(Email e) {
+    return seen.add(e); // Set.add returns true iff the element was new
+  }
+  public int size() { return seen.size(); }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
@@ -170,23 +170,25 @@ typed LIFO container — `push`, `pop`, `peek`, `size`.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Stack<String> s = new Stack<>();
-        s.push("first");
-        s.push("second");
-        s.push("third");
+  public static void main(String[] args) {
+    Stack<String> s = new Stack<>();
+    s.push("first");
+    s.push("second");
+    s.push("third");
 
-        System.out.println("size = "    + s.size());
-        System.out.println("peek = "    + s.peek());
-        System.out.println("pop  = "    + s.pop());
-        System.out.println("pop  = "    + s.pop());
-        System.out.println("size = "    + s.size());
+    System.out.println("size = " + s.size());
+    System.out.println("peek = " + s.peek());
+    System.out.println("pop  = " + s.pop());
+    System.out.println("pop  = " + s.pop());
+    System.out.println("size = " + s.size());
 
-        // A different element type — entirely independent:
-        Stack<Integer> ns = new Stack<>();
-        ns.push(1); ns.push(2); ns.push(3);
-        System.out.println("ns pop = " + ns.pop());
-    }
+    // A different element type — entirely independent:
+    Stack<Integer> ns = new Stack<>();
+    ns.push(1);
+    ns.push(2);
+    ns.push(3);
+    System.out.println("ns pop = " + ns.pop());
+  }
 }
 `,
     },
@@ -197,22 +199,24 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 public class Stack<E> {
-    private final List<E> data = new ArrayList<>();
+  private final List<E> data = new ArrayList<>();
 
-    public void push(E e) { data.add(e); }
+  public void push(E e) { data.add(e); }
 
-    public E pop() {
-        if (data.isEmpty()) throw new NoSuchElementException();
-        return data.remove(data.size() - 1);
-    }
+  public E pop() {
+    if (data.isEmpty())
+      throw new NoSuchElementException();
+    return data.remove(data.size() - 1);
+  }
 
-    public E peek() {
-        if (data.isEmpty()) throw new NoSuchElementException();
-        return data.get(data.size() - 1);
-    }
+  public E peek() {
+    if (data.isEmpty())
+      throw new NoSuchElementException();
+    return data.get(data.size() - 1);
+  }
 
-    public int     size()    { return data.size();    }
-    public boolean isEmpty() { return data.isEmpty(); }
+  public int size() { return data.size(); }
+  public boolean isEmpty() { return data.isEmpty(); }
 }
 `,
     },
@@ -332,32 +336,31 @@ ada / 36
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Pair<String, Integer> p  = new Pair<>("ada", 36);
-        Pair<Integer, String> sp = p.swap();
-        System.out.println(p.first() + " / " + p.second());
-        System.out.println(sp.first() + " / " + sp.second());
-    }
+  public static void main(String[] args) {
+    Pair<String, Integer> p = new Pair<>("ada", 36);
+    Pair<Integer, String> sp = p.swap();
+    System.out.println(p.first() + " / " + p.second());
+    System.out.println(sp.first() + " / " + sp.second());
+  }
 }
 `,
     },
     {
       filename: "Pair.java",
       initialContent: `public class Pair<A, B> {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class Pair<A, B> {
-    private final A first;
-    private final B second;
-    public Pair(A first, B second) {
-        this.first = first; this.second = second;
-    }
-    public A first()  { return first;  }
-    public B second() { return second; }
-    public Pair<B, A> swap() {
-        return new Pair<>(second, first);
-    }
+  private final A first;
+  private final B second;
+  public Pair(A first, B second) {
+    this.first = first;
+    this.second = second;
+  }
+  public A first() { return first; }
+  public B second() { return second; }
+  public Pair<B, A> swap() { return new Pair<>(second, first); }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/immutable-collections.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/immutable-collections.mdx
@@ -209,21 +209,21 @@ The further right you go, the safer your API.
       initialContent: `import java.util.*;
 
 public class Main {
-    public static void main(String[] args) {
-        List<String> initial = new ArrayList<>(List.of("apple", "bread", "cheese"));
-        Catalog c = new Catalog(initial);
+  public static void main(String[] args) {
+    List<String> initial = new ArrayList<>(List.of("apple", "bread", "cheese"));
+    Catalog c = new Catalog(initial);
 
-        // External mutation does not leak into the catalog
-        initial.add("steal-me");
-        System.out.println(c.items());
+    // External mutation does not leak into the catalog
+    initial.add("steal-me");
+    System.out.println(c.items());
 
-        // Caller cannot mutate what they got back
-        try {
-            c.items().add("hack");
-        } catch (UnsupportedOperationException e) {
-            System.out.println("safe: " + e.getClass().getSimpleName());
-        }
+    // Caller cannot mutate what they got back
+    try {
+      c.items().add("hack");
+    } catch (UnsupportedOperationException e) {
+      System.out.println("safe: " + e.getClass().getSimpleName());
     }
+  }
 }
 `,
     },
@@ -232,13 +232,13 @@ public class Main {
       initialContent: `import java.util.List;
 
 public final class Catalog {
-    private final List<String> items;
+  private final List<String> items;
 
-    public Catalog(List<String> items) {
-        this.items = List.copyOf(items);   // snapshot in
-    }
+  public Catalog(List<String> items) {
+    this.items = List.copyOf(items); // snapshot in
+  }
 
-    public List<String> items() { return items; }  // already immutable
+  public List<String> items() { return items; } // already immutable
 }
 `,
     },
@@ -267,20 +267,21 @@ caller mutation was blocked
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<String> names = new ArrayList<>(List.of("Ada", "Grace"));
-        Roster r = new Roster(names);
-        System.out.println(r.names());
+  public static void main(String[] args) {
+    List<String> names = new ArrayList<>(List.of("Ada", "Grace"));
+    Roster r = new Roster(names);
+    System.out.println(r.names());
 
-        names.add("Linus");
-        if (!r.names().contains("Linus")) System.out.println("external mutation didn't leak");
+    names.add("Linus");
+    if (!r.names().contains("Linus"))
+      System.out.println("external mutation didn't leak");
 
-        try {
-            r.names().add("Edsger");
-        } catch (UnsupportedOperationException e) {
-            System.out.println("caller mutation was blocked");
-        }
+    try {
+      r.names().add("Edsger");
+    } catch (UnsupportedOperationException e) {
+      System.out.println("caller mutation was blocked");
     }
+  }
 }
 `,
     },
@@ -289,29 +290,25 @@ public class Main {
       initialContent: `import java.util.List;
 
 public final class Roster {
-    private final List<String> names;
+  private final List<String> names;
 
-    public Roster(List<String> names) {
-        this.names = names;          // TODO: defensive copy
-    }
+  public Roster(List<String> names) {
+    this.names = names; // TODO: defensive copy
+  }
 
-    public List<String> names() {
-        return names;                // TODO: unmodifiable
-    }
+  public List<String> names() {
+    return names; // TODO: unmodifiable
+  }
 }
 `,
       solutionContent: `import java.util.List;
 
 public final class Roster {
-    private final List<String> names;
+  private final List<String> names;
 
-    public Roster(List<String> names) {
-        this.names = List.copyOf(names);
-    }
+  public Roster(List<String> names) { this.names = List.copyOf(names); }
 
-    public List<String> names() {
-        return names;
-    }
+  public List<String> names() { return names; }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/iterables-and-iterators.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/iterables-and-iterators.mdx
@@ -88,10 +88,11 @@ a tiny `IntRange` that produces the integers `[start, end)`:
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        IntRange r = new IntRange(3, 8);
-        for (int n : r) System.out.println(n);
-    }
+  public static void main(String[] args) {
+    IntRange r = new IntRange(3, 8);
+    for (int n : r)
+      System.out.println(n);
+  }
 }
 `,
     },
@@ -101,26 +102,31 @@ a tiny `IntRange` that produces the integers `[start, end)`:
 import java.util.NoSuchElementException;
 
 public class IntRange implements Iterable<Integer> {
-    private final int start;
-    private final int end;
+  private final int start;
+  private final int end;
 
-    public IntRange(int start, int end) {
-        this.start = start;
-        this.end   = end;
-    }
+  public IntRange(int start, int end) {
+    this.start = start;
+    this.end = end;
+  }
 
-    @Override
-    public Iterator<Integer> iterator() {
-        return new Iterator<>() {
-            private int cursor = start;
+  @Override
+  public Iterator<Integer> iterator() {
+    return new Iterator<>() {
+      private int cursor = start;
 
-            @Override public boolean hasNext() { return cursor < end; }
-            @Override public Integer next() {
-                if (!hasNext()) throw new NoSuchElementException();
-                return cursor++;
-            }
-        };
-    }
+      @Override
+      public boolean hasNext() {
+        return cursor < end;
+      }
+      @Override
+      public Integer next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        return cursor++;
+      }
+    };
+  }
 }
 `,
     },
@@ -300,17 +306,19 @@ This is exactly how `Arrays.asList` and friends work conceptually.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        int[] arr = { 10, 20, 30, 40 };
-        IntArrayIterable it = new IntArrayIterable(arr);
+  public static void main(String[] args) {
+    int[] arr = {10, 20, 30, 40};
+    IntArrayIterable it = new IntArrayIterable(arr);
 
-        for (int n : it) System.out.println(n);
+    for (int n : it)
+      System.out.println(n);
 
-        // Walk it a second time — fresh iterator, starts over.
-        int total = 0;
-        for (int n : it) total += n;
-        System.out.println("sum = " + total);
-    }
+    // Walk it a second time — fresh iterator, starts over.
+    int total = 0;
+    for (int n : it)
+      total += n;
+    System.out.println("sum = " + total);
+  }
 }
 `,
     },
@@ -320,21 +328,26 @@ This is exactly how `Arrays.asList` and friends work conceptually.
 import java.util.NoSuchElementException;
 
 public class IntArrayIterable implements Iterable<Integer> {
-    private final int[] data;
+  private final int[] data;
 
-    public IntArrayIterable(int[] data) { this.data = data; }
+  public IntArrayIterable(int[] data) { this.data = data; }
 
-    @Override
-    public Iterator<Integer> iterator() {
-        return new Iterator<>() {
-            private int i = 0;
-            @Override public boolean hasNext() { return i < data.length; }
-            @Override public Integer next() {
-                if (!hasNext()) throw new NoSuchElementException();
-                return data[i++];
-            }
-        };
-    }
+  @Override
+  public Iterator<Integer> iterator() {
+    return new Iterator<>() {
+      private int i = 0;
+      @Override
+      public boolean hasNext() {
+        return i < data.length;
+      }
+      @Override
+      public Integer next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        return data[i++];
+      }
+    };
+  }
 }
 `,
     },
@@ -369,12 +382,14 @@ Expected output:
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Countdown c = new Countdown(3);
-        for (int n : c) System.out.println(n);
-        System.out.println("---");
-        for (int n : c) System.out.println(n);
-    }
+  public static void main(String[] args) {
+    Countdown c = new Countdown(3);
+    for (int n : c)
+      System.out.println(n);
+    System.out.println("---");
+    for (int n : c)
+      System.out.println(n);
+  }
 }
 `,
     },
@@ -383,36 +398,41 @@ Expected output:
       initialContent: `import java.util.Iterator;
 
 public class Countdown implements Iterable<Integer> {
+  // TODO
+  public Countdown(int start) {
     // TODO
-    public Countdown(int start) {
-        // TODO
-    }
+  }
 
-    @Override
-    public Iterator<Integer> iterator() {
-        // TODO
-        return null;
-    }
+  @Override
+  public Iterator<Integer> iterator() {
+    // TODO
+    return null;
+  }
 }
 `,
       solutionContent: `import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 public class Countdown implements Iterable<Integer> {
-    private final int start;
-    public Countdown(int start) { this.start = start; }
+  private final int start;
+  public Countdown(int start) { this.start = start; }
 
-    @Override
-    public Iterator<Integer> iterator() {
-        return new Iterator<>() {
-            private int cursor = start;
-            @Override public boolean hasNext() { return cursor >= 1; }
-            @Override public Integer next() {
-                if (!hasNext()) throw new NoSuchElementException();
-                return cursor--;
-            }
-        };
-    }
+  @Override
+  public Iterator<Integer> iterator() {
+    return new Iterator<>() {
+      private int cursor = start;
+      @Override
+      public boolean hasNext() {
+        return cursor >= 1;
+      }
+      @Override
+      public Integer next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        return cursor--;
+      }
+    };
+  }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/iteration-patterns.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/iteration-patterns.mdx
@@ -236,18 +236,17 @@ The fix is always one of:
       initialContent: `import java.util.*;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Post> posts = List.of(
-            new Post("Ada",   "hello",          true),
-            new Post("Linus","kernel rant",     false),
-            new Post("Grace", "compiler talk",  true),
-            new Post("Edsger","goto considered",true)
-        );
+  public static void main(String[] args) {
+    List<Post> posts = List.of(new Post("Ada", "hello", true),
+                               new Post("Linus", "kernel rant", false),
+                               new Post("Grace", "compiler talk", true),
+                               new Post("Edsger", "goto considered", true));
 
-        System.out.println("imperative: " + FeedFilters.imperative(posts));
-        System.out.println("iterator:   " + FeedFilters.viaIterator(new ArrayList<>(posts)));
-        System.out.println("stream:     " + FeedFilters.viaStream(posts));
-    }
+    System.out.println("imperative: " + FeedFilters.imperative(posts));
+    System.out.println("iterator:   " +
+                       FeedFilters.viaIterator(new ArrayList<>(posts)));
+    System.out.println("stream:     " + FeedFilters.viaStream(posts));
+  }
 }
 `,
     },
@@ -261,31 +260,33 @@ public class Main {
       initialContent: `import java.util.*;
 
 public final class FeedFilters {
-    private FeedFilters() {}
+  private FeedFilters() {}
 
-    /** Loop + ArrayList accumulator. */
-    public static List<String> imperative(List<Post> posts) {
-        List<String> out = new ArrayList<>();
-        for (Post p : posts) if (p.published()) out.add(p.author());
-        return out;
-    }
+  /** Loop + ArrayList accumulator. */
+  public static List<String> imperative(List<Post> posts) {
+    List<String> out = new ArrayList<>();
+    for (Post p : posts)
+      if (p.published())
+        out.add(p.author());
+    return out;
+  }
 
-    /** Iterator.remove on a mutable copy. */
-    public static List<String> viaIterator(List<Post> mutable) {
-        Iterator<Post> it = mutable.iterator();
-        while (it.hasNext()) if (!it.next().published()) it.remove();
-        List<String> out = new ArrayList<>();
-        for (Post p : mutable) out.add(p.author());
-        return out;
-    }
+  /** Iterator.remove on a mutable copy. */
+  public static List<String> viaIterator(List<Post> mutable) {
+    Iterator<Post> it = mutable.iterator();
+    while (it.hasNext())
+      if (!it.next().published())
+        it.remove();
+    List<String> out = new ArrayList<>();
+    for (Post p : mutable)
+      out.add(p.author());
+    return out;
+  }
 
-    /** Declarative pipeline. */
-    public static List<String> viaStream(List<Post> posts) {
-        return posts.stream()
-                    .filter(Post::published)
-                    .map(Post::author)
-                    .toList();
-    }
+  /** Declarative pipeline. */
+  public static List<String> viaStream(List<Post> posts) {
+    return posts.stream().filter(Post::published).map(Post::author).toList();
+  }
 }
 `,
     },
@@ -315,11 +316,12 @@ Expected output:
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<String> ws = new ArrayList<>(List.of("hi", "alpha", "ok", "gamma", "delta"));
-        Pruner.removeShorterThan(ws, 4);
-        System.out.println(ws);
-    }
+  public static void main(String[] args) {
+    List<String> ws =
+        new ArrayList<>(List.of("hi", "alpha", "ok", "gamma", "delta"));
+    Pruner.removeShorterThan(ws, 4);
+    System.out.println(ws);
+  }
 }
 `,
     },
@@ -328,21 +330,21 @@ public class Main {
       initialContent: `import java.util.List;
 
 public final class Pruner {
-    private Pruner() {}
+  private Pruner() {}
 
-    public static void removeShorterThan(List<String> words, int minLen) {
-        // TODO
-    }
+  public static void removeShorterThan(List<String> words, int minLen) {
+    // TODO
+  }
 }
 `,
       solutionContent: `import java.util.List;
 
 public final class Pruner {
-    private Pruner() {}
+  private Pruner() {}
 
-    public static void removeShorterThan(List<String> words, int minLen) {
-        words.removeIf(w -> w.length() < minLen);
-    }
+  public static void removeShorterThan(List<String> words, int minLen) {
+    words.removeIf(w -> w.length() < minLen);
+  }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/lists.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/lists.mdx
@@ -299,15 +299,17 @@ Expected output:
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        RecentHistory<String> h = new RecentHistory<>(3);
-        h.record("a"); h.record("b"); h.record("c");
-        System.out.println(h.items());
-        h.record("d");
-        System.out.println(h.items());
-        h.record("e");
-        System.out.println(h.items());
-    }
+  public static void main(String[] args) {
+    RecentHistory<String> h = new RecentHistory<>(3);
+    h.record("a");
+    h.record("b");
+    h.record("c");
+    System.out.println(h.items());
+    h.record("d");
+    System.out.println(h.items());
+    h.record("e");
+    System.out.println(h.items());
+  }
 }
 `,
     },
@@ -317,23 +319,24 @@ Expected output:
 import java.util.List;
 
 public class RecentHistory<E> {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `import java.util.ArrayList;
 import java.util.List;
 
 public class RecentHistory<E> {
-    private final int limit;
-    private final List<E> data = new ArrayList<>();
-    public RecentHistory(int limit) { this.limit = limit; }
+  private final int limit;
+  private final List<E> data = new ArrayList<>();
+  public RecentHistory(int limit) { this.limit = limit; }
 
-    public void record(E item) {
-        data.add(item);
-        while (data.size() > limit) data.remove(0);
-    }
+  public void record(E item) {
+    data.add(item);
+    while (data.size() > limit)
+      data.remove(0);
+  }
 
-    public List<E> items() { return data; }
+  public List<E> items() { return data; }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/maps.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/maps.mdx
@@ -252,16 +252,16 @@ use `containsKey` to distinguish.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Cache<String, Integer> sq = new Cache<>(k -> {
-            System.out.println("computing " + k);
-            return Integer.parseInt(k) * Integer.parseInt(k);
-        });
+  public static void main(String[] args) {
+    Cache<String, Integer> sq = new Cache<>(k -> {
+      System.out.println("computing " + k);
+      return Integer.parseInt(k) * Integer.parseInt(k);
+    });
 
-        System.out.println(sq.get("3"));
-        System.out.println(sq.get("3"));   // no recomputation
-        System.out.println(sq.get("4"));
-    }
+    System.out.println(sq.get("3"));
+    System.out.println(sq.get("3")); // no recomputation
+    System.out.println(sq.get("4"));
+  }
 }
 `,
     },
@@ -272,14 +272,12 @@ import java.util.Map;
 import java.util.function.Function;
 
 public class Cache<K, V> {
-    private final Map<K, V>       store = new HashMap<>();
-    private final Function<K, V>  loader;
+  private final Map<K, V> store = new HashMap<>();
+  private final Function<K, V> loader;
 
-    public Cache(Function<K, V> loader) { this.loader = loader; }
+  public Cache(Function<K, V> loader) { this.loader = loader; }
 
-    public V get(K key) {
-        return store.computeIfAbsent(key, loader);
-    }
+  public V get(K key) { return store.computeIfAbsent(key, loader); }
 }
 `,
     },
@@ -313,13 +311,12 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class Main {
-    public static void main(String[] args) {
-        List<String> ws = List.of(
-            "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog"
-        );
-        Map<Integer, List<String>> g = new TreeMap<>(Grouper.byLength(ws));
-        g.forEach((k, v) -> System.out.println(k + " -> " + v));
-    }
+  public static void main(String[] args) {
+    List<String> ws =
+        List.of("the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog");
+    Map<Integer, List<String>> g = new TreeMap<>(Grouper.byLength(ws));
+    g.forEach((k, v) -> System.out.println(k + " -> " + v));
+  }
 }
 `,
     },
@@ -328,22 +325,22 @@ public class Main {
       initialContent: `import java.util.*;
 
 public class Grouper {
-    public static Map<Integer, List<String>> byLength(List<String> words) {
-        // TODO: use computeIfAbsent to build lists on demand
-        return new HashMap<>();
-    }
+  public static Map<Integer, List<String>> byLength(List<String> words) {
+    // TODO: use computeIfAbsent to build lists on demand
+    return new HashMap<>();
+  }
 }
 `,
       solutionContent: `import java.util.*;
 
 public class Grouper {
-    public static Map<Integer, List<String>> byLength(List<String> words) {
-        Map<Integer, List<String>> out = new HashMap<>();
-        for (String w : words) {
-            out.computeIfAbsent(w.length(), k -> new ArrayList<>()).add(w);
-        }
-        return out;
+  public static Map<Integer, List<String>> byLength(List<String> words) {
+    Map<Integer, List<String>> out = new HashMap<>();
+    for (String w : words) {
+      out.computeIfAbsent(w.length(), k -> new ArrayList<>()).add(w);
     }
+    return out;
+  }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
@@ -165,17 +165,17 @@ collections library (Eclipse Collections, fastutil, Koloboke).
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        int n = 200_000;
+  public static void main(String[] args) {
+    int n = 200_000;
 
-        long t1 = Bench.time(() -> Bench.appendArrayListNoHint(n));
-        long t2 = Bench.time(() -> Bench.appendArrayListWithHint(n));
-        long t3 = Bench.time(() -> Bench.appendLinkedList(n));
+    long t1 = Bench.time(() -> Bench.appendArrayListNoHint(n));
+    long t2 = Bench.time(() -> Bench.appendArrayListWithHint(n));
+    long t3 = Bench.time(() -> Bench.appendLinkedList(n));
 
-        System.out.println("ArrayList (no hint):   " + t1 + " ms");
-        System.out.println("ArrayList (with hint): " + t2 + " ms");
-        System.out.println("LinkedList:            " + t3 + " ms");
-    }
+    System.out.println("ArrayList (no hint):   " + t1 + " ms");
+    System.out.println("ArrayList (with hint): " + t2 + " ms");
+    System.out.println("LinkedList:            " + t3 + " ms");
+  }
 }
 `,
     },
@@ -186,28 +186,31 @@ import java.util.LinkedList;
 import java.util.List;
 
 public final class Bench {
-    private Bench() {}
+  private Bench() {}
 
-    public static long time(Runnable r) {
-        long t0 = System.currentTimeMillis();
-        r.run();
-        return System.currentTimeMillis() - t0;
-    }
+  public static long time(Runnable r) {
+    long t0 = System.currentTimeMillis();
+    r.run();
+    return System.currentTimeMillis() - t0;
+  }
 
-    public static void appendArrayListNoHint(int n) {
-        List<Integer> xs = new ArrayList<>();
-        for (int i = 0; i < n; i++) xs.add(i);
-    }
+  public static void appendArrayListNoHint(int n) {
+    List<Integer> xs = new ArrayList<>();
+    for (int i = 0; i < n; i++)
+      xs.add(i);
+  }
 
-    public static void appendArrayListWithHint(int n) {
-        List<Integer> xs = new ArrayList<>(n);
-        for (int i = 0; i < n; i++) xs.add(i);
-    }
+  public static void appendArrayListWithHint(int n) {
+    List<Integer> xs = new ArrayList<>(n);
+    for (int i = 0; i < n; i++)
+      xs.add(i);
+  }
 
-    public static void appendLinkedList(int n) {
-        List<Integer> xs = new LinkedList<>();
-        for (int i = 0; i < n; i++) xs.add(i);
-    }
+  public static void appendLinkedList(int n) {
+    List<Integer> xs = new LinkedList<>();
+    for (int i = 0; i < n; i++)
+      xs.add(i);
+  }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
@@ -247,18 +247,19 @@ deadline. The "smallest deadline" task runs next.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Scheduler s = new Scheduler();
-        s.add(new Task("backup",    30));
-        s.add(new Task("email",     10));
-        s.add(new Task("reindex",   50));
-        s.add(new Task("heartbeat",  5));
+  public static void main(String[] args) {
+    Scheduler s = new Scheduler();
+    s.add(new Task("backup", 30));
+    s.add(new Task("email", 10));
+    s.add(new Task("reindex", 50));
+    s.add(new Task("heartbeat", 5));
 
-        while (s.hasWork()) {
-            Task t = s.next();
-            System.out.println("running " + t.name() + " (deadline=" + t.deadline() + ")");
-        }
+    while (s.hasWork()) {
+      Task t = s.next();
+      System.out.println("running " + t.name() + " (deadline=" + t.deadline() +
+                         ")");
     }
+  }
 }
 `,
     },
@@ -273,12 +274,12 @@ deadline. The "smallest deadline" task runs next.
 import java.util.PriorityQueue;
 
 public class Scheduler {
-    private final PriorityQueue<Task> q =
-        new PriorityQueue<>(Comparator.comparingInt(Task::deadline));
+  private final PriorityQueue<Task> q =
+      new PriorityQueue<>(Comparator.comparingInt(Task::deadline));
 
-    public void    add(Task t)  { q.offer(t); }
-    public boolean hasWork()    { return !q.isEmpty(); }
-    public Task    next()       { return q.poll();    }
+  public void add(Task t) { q.offer(t); }
+  public boolean hasWork() { return !q.isEmpty(); }
+  public Task next() { return q.poll(); }
 }
 `,
     },
@@ -312,15 +313,17 @@ Expected output:
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        SlidingWindow<Integer> w = new SlidingWindow<>(3);
-        w.add(1); w.add(2); w.add(3);
-        System.out.println(w.snapshot());
-        w.add(4);
-        System.out.println(w.snapshot());
-        w.add(5);
-        System.out.println(w.snapshot());
-    }
+  public static void main(String[] args) {
+    SlidingWindow<Integer> w = new SlidingWindow<>(3);
+    w.add(1);
+    w.add(2);
+    w.add(3);
+    System.out.println(w.snapshot());
+    w.add(4);
+    System.out.println(w.snapshot());
+    w.add(5);
+    System.out.println(w.snapshot());
+  }
 }
 `,
     },
@@ -332,7 +335,7 @@ import java.util.Deque;
 import java.util.List;
 
 public class SlidingWindow<E> {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `import java.util.ArrayDeque;
@@ -341,17 +344,18 @@ import java.util.Deque;
 import java.util.List;
 
 public class SlidingWindow<E> {
-    private final int capacity;
-    private final Deque<E> dq = new ArrayDeque<>();
+  private final int capacity;
+  private final Deque<E> dq = new ArrayDeque<>();
 
-    public SlidingWindow(int capacity) { this.capacity = capacity; }
+  public SlidingWindow(int capacity) { this.capacity = capacity; }
 
-    public void add(E item) {
-        dq.offerLast(item);
-        if (dq.size() > capacity) dq.pollFirst();
-    }
+  public void add(E item) {
+    dq.offerLast(item);
+    if (dq.size() > capacity)
+      dq.pollFirst();
+  }
 
-    public List<E> snapshot() { return new ArrayList<>(dq); }
+  public List<E> snapshot() { return new ArrayList<>(dq); }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/sets.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/sets.mdx
@@ -216,17 +216,18 @@ incoming stream while preserving first-seen order.
       initialContent: `import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<String> raw = List.of(
-            "alice", "bob", "alice", "carol", "bob", "dave", "alice"
-        );
-        VisitorLog log = new VisitorLog();
-        for (String name : raw) log.record(name);
+  public static void main(String[] args) {
+    List<String> raw =
+        List.of("alice", "bob", "alice", "carol", "bob", "dave", "alice");
+    VisitorLog log = new VisitorLog();
+    for (String name : raw)
+      log.record(name);
 
-        System.out.println("unique visitors, in arrival order:");
-        for (String name : log.uniqueInOrder()) System.out.println("- " + name);
-        System.out.println("count = " + log.uniqueCount());
-    }
+    System.out.println("unique visitors, in arrival order:");
+    for (String name : log.uniqueInOrder())
+      System.out.println("- " + name);
+    System.out.println("count = " + log.uniqueCount());
+  }
 }
 `,
     },
@@ -236,14 +237,14 @@ public class Main {
 import java.util.Set;
 
 public class VisitorLog {
-    private final Set<String> seen = new LinkedHashSet<>();
+  private final Set<String> seen = new LinkedHashSet<>();
 
-    public boolean record(String name) {
-        return seen.add(name);   // returns true on first visit only
-    }
+  public boolean record(String name) {
+    return seen.add(name); // returns true on first visit only
+  }
 
-    public Set<String> uniqueInOrder() { return seen; }
-    public int        uniqueCount()    { return seen.size(); }
+  public Set<String> uniqueInOrder() { return seen; }
+  public int uniqueCount() { return seen.size(); }
 }
 `,
     },
@@ -274,10 +275,10 @@ Expected output:
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        String s = "the quick brown fox jumps over the lazy dog the fox";
-        System.out.println(Distinct.ofWords(s));
-    }
+  public static void main(String[] args) {
+    String s = "the quick brown fox jumps over the lazy dog the fox";
+    System.out.println(Distinct.ofWords(s));
+  }
 }
 `,
     },
@@ -287,10 +288,10 @@ Expected output:
 import java.util.List;
 
 public class Distinct {
-    public static List<String> ofWords(String text) {
-        // TODO: use a LinkedHashSet for "unique in insertion order"
-        return new ArrayList<>();
-    }
+  public static List<String> ofWords(String text) {
+    // TODO: use a LinkedHashSet for "unique in insertion order"
+    return new ArrayList<>();
+  }
 }
 `,
       solutionContent: `import java.util.ArrayList;
@@ -299,13 +300,14 @@ import java.util.List;
 import java.util.Set;
 
 public class Distinct {
-    public static List<String> ofWords(String text) {
-        Set<String> seen = new LinkedHashSet<>();
-        for (String w : text.split("\\\\s+")) {
-            if (!w.isEmpty()) seen.add(w);
-        }
-        return new ArrayList<>(seen);
+  public static List<String> ofWords(String text) {
+    Set<String> seen = new LinkedHashSet<>();
+    for (String w : text.split("\\\\s+")) {
+      if (!w.isEmpty())
+        seen.add(w);
     }
+    return new ArrayList<>(seen);
+  }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/the-collections-framework.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-collections-framework.mdx
@@ -289,33 +289,34 @@ import java.util.List;
 import java.util.Set;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Book> books = new ArrayList<>();
-        books.add(new Book("The Mythical Man-Month", "Brooks"));
-        books.add(new Book("Design Patterns",        "Gang of Four"));
-        books.add(new Book("Effective Java",         "Bloch"));
+  public static void main(String[] args) {
+    List<Book> books = new ArrayList<>();
+    books.add(new Book("The Mythical Man-Month", "Brooks"));
+    books.add(new Book("Design Patterns", "Gang of Four"));
+    books.add(new Book("Effective Java", "Bloch"));
 
-        Set<String> banned = new HashSet<>();
-        banned.add("Brooks");                       // pretend we don't carry Brooks
+    Set<String> banned = new HashSet<>();
+    banned.add("Brooks"); // pretend we don't carry Brooks
 
-        Library lib = new Library(books, banned);
-        for (Book b : lib.available()) {
-            System.out.println(b.title() + " by " + b.author());
-        }
+    Library lib = new Library(books, banned);
+    for (Book b : lib.available()) {
+      System.out.println(b.title() + " by " + b.author());
     }
+  }
 }
 `,
     },
     {
       filename: "Book.java",
       initialContent: `public class Book {
-    private final String title;
-    private final String author;
-    public Book(String title, String author) {
-        this.title = title; this.author = author;
-    }
-    public String title()  { return title; }
-    public String author() { return author; }
+  private final String title;
+  private final String author;
+  public Book(String title, String author) {
+    this.title = title;
+    this.author = author;
+  }
+  public String title() { return title; }
+  public String author() { return author; }
 }
 `,
     },
@@ -326,21 +327,22 @@ import java.util.List;
 import java.util.Set;
 
 public class Library {
-    private final List<Book>   books;
-    private final Set<String>  bannedAuthors;
+  private final List<Book> books;
+  private final Set<String> bannedAuthors;
 
-    public Library(List<Book> books, Set<String> bannedAuthors) {
-        this.books         = books;
-        this.bannedAuthors = bannedAuthors;
-    }
+  public Library(List<Book> books, Set<String> bannedAuthors) {
+    this.books = books;
+    this.bannedAuthors = bannedAuthors;
+  }
 
-    public List<Book> available() {
-        List<Book> out = new ArrayList<>();
-        for (Book b : books) {
-            if (!bannedAuthors.contains(b.author())) out.add(b);
-        }
-        return out;
+  public List<Book> available() {
+    List<Book> out = new ArrayList<>();
+    for (Book b : books) {
+      if (!bannedAuthors.contains(b.author()))
+        out.add(b);
     }
+    return out;
+  }
 }
 `,
     },
@@ -380,17 +382,18 @@ Linus
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        Roster r = new Roster(new ArrayList<>());
-        r.addStudent("Ada");
-        r.addStudent("Grace");
-        r.addStudent("Linus");
+  public static void main(String[] args) {
+    Roster r = new Roster(new ArrayList<>());
+    r.addStudent("Ada");
+    r.addStudent("Grace");
+    r.addStudent("Linus");
 
-        System.out.println("size = " + r.size());
-        System.out.println("has Ada? " + r.has("Ada"));
-        System.out.println("has Bob? " + r.has("Bob"));
-        for (String n : r.all()) System.out.println(n);
-    }
+    System.out.println("size = " + r.size());
+    System.out.println("has Ada? " + r.has("Ada"));
+    System.out.println("has Bob? " + r.has("Bob"));
+    for (String n : r.all())
+      System.out.println(n);
+  }
 }
 `,
     },
@@ -399,18 +402,18 @@ public class Main {
       initialContent: `import java.util.List;
 
 public class Roster {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `import java.util.List;
 
 public class Roster {
-    private final List<String> names;
-    public Roster(List<String> names) { this.names = names; }
-    public void addStudent(String name) { names.add(name); }
-    public int size() { return names.size(); }
-    public boolean has(String name) { return names.contains(name); }
-    public List<String> all() { return names; }
+  private final List<String> names;
+  public Roster(List<String> names) { this.names = names; }
+  public void addStudent(String name) { names.add(name); }
+  public int size() { return names.size(); }
+  public boolean has(String name) { return names.contains(name); }
+  public List<String> all() { return names; }
 }
 `,
     },

--- a/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
@@ -183,17 +183,17 @@ the right type*, with no cast.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Phonebook book = new Phonebook();
-        book.add("Ada",   "555-0101");
-        book.add("Grace", "555-0102");
-        book.add("Linus", "555-0103");
+  public static void main(String[] args) {
+    Phonebook book = new Phonebook();
+    book.add("Ada", "555-0101");
+    book.add("Grace", "555-0102");
+    book.add("Linus", "555-0103");
 
-        // No cast — generic types flow all the way through.
-        String n = book.lookup("Grace");
-        System.out.println("Grace -> " + n.toUpperCase());
-        System.out.println("Bob   -> " + book.lookup("Bob"));
-    }
+    // No cast — generic types flow all the way through.
+    String n = book.lookup("Grace");
+    System.out.println("Grace -> " + n.toUpperCase());
+    System.out.println("Bob   -> " + book.lookup("Bob"));
+  }
 }
 `,
     },
@@ -203,14 +203,12 @@ the right type*, with no cast.
 import java.util.Map;
 
 public class Phonebook {
-    private final Map<String, String> entries = new HashMap<>();
+  private final Map<String, String> entries = new HashMap<>();
 
-    public void add(String name, String number) {
-        entries.put(name, number);
-    }
-    public String lookup(String name) {
-        return entries.get(name);   // returns String, not Object
-    }
+  public void add(String name, String number) { entries.put(name, number); }
+  public String lookup(String name) {
+    return entries.get(name); // returns String, not Object
+  }
 }
 `,
     },
@@ -227,18 +225,18 @@ to *strings*? A general "key-to-record store" looks like this:
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Registry<String, Integer> ages = new Registry<>();
-        ages.add("Ada",   36);
-        ages.add("Linus", 54);
-        System.out.println("Ada is "   + ages.lookup("Ada")   + " years old");
-        System.out.println("Linus is " + ages.lookup("Linus") + " years old");
+  public static void main(String[] args) {
+    Registry<String, Integer> ages = new Registry<>();
+    ages.add("Ada", 36);
+    ages.add("Linus", 54);
+    System.out.println("Ada is " + ages.lookup("Ada") + " years old");
+    System.out.println("Linus is " + ages.lookup("Linus") + " years old");
 
-        Registry<Integer, String> roomByExt = new Registry<>();
-        roomByExt.add(101, "Lobby");
-        roomByExt.add(202, "Suite A");
-        System.out.println("ext 202 -> " + roomByExt.lookup(202));
-    }
+    Registry<Integer, String> roomByExt = new Registry<>();
+    roomByExt.add(101, "Lobby");
+    roomByExt.add(202, "Suite A");
+    System.out.println("ext 202 -> " + roomByExt.lookup(202));
+  }
 }
 `,
     },
@@ -248,10 +246,10 @@ to *strings*? A general "key-to-record store" looks like this:
 import java.util.Map;
 
 public class Registry<K, V> {
-    private final Map<K, V> entries = new HashMap<>();
+  private final Map<K, V> entries = new HashMap<>();
 
-    public void add(K key, V value) { entries.put(key, value); }
-    public V    lookup(K key)        { return entries.get(key);  }
+  public void add(K key, V value) { entries.put(key, value); }
+  public V lookup(K key) { return entries.get(key); }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/arrays-and-collections.mdx
+++ b/content/learn/java-programming-for-beginners/arrays-and-collections.mdx
@@ -190,12 +190,12 @@ Two safe fixes:
       initialContent: `import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Integer> scores = List.of(80, 90, 100, 70, 85);
-        double avg = Stats.average(scores);
-        System.out.println("count = " + scores.size());
-        System.out.println("avg = " + avg);
-    }
+  public static void main(String[] args) {
+    List<Integer> scores = List.of(80, 90, 100, 70, 85);
+    double avg = Stats.average(scores);
+    System.out.println("count = " + scores.size());
+    System.out.println("avg = " + avg);
+  }
 }
 `,
     },
@@ -204,16 +204,16 @@ public class Main {
       initialContent: `import java.util.List;
 
 public class Stats {
-    public static double average(List<Integer> values) {
-        if (values.isEmpty()) {
-            throw new IllegalArgumentException("need at least one value");
-        }
-        long sum = 0;
-        for (int v : values) {
-            sum += v;
-        }
-        return (double) sum / values.size();
+  public static double average(List<Integer> values) {
+    if (values.isEmpty()) {
+      throw new IllegalArgumentException("need at least one value");
     }
+    long sum = 0;
+    for (int v : values) {
+      sum += v;
+    }
+    return (double)sum / values.size();
+  }
 }
 `,
     },
@@ -292,10 +292,10 @@ sumPositive=15
       initialContent: `import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Integer> data = List.of(3, -1, 0, 7, -8, 5);
-        System.out.println("sumPositive=" + Numbers.sumPositive(data));
-    }
+  public static void main(String[] args) {
+    List<Integer> data = List.of(3, -1, 0, 7, -8, 5);
+    System.out.println("sumPositive=" + Numbers.sumPositive(data));
+  }
 }
 `,
     },
@@ -304,22 +304,23 @@ public class Main {
       initialContent: `import java.util.List;
 
 public class Numbers {
-    public static int sumPositive(List<Integer> values) {
-        // TODO
-        return 0;
-    }
+  public static int sumPositive(List<Integer> values) {
+    // TODO
+    return 0;
+  }
 }
 `,
       solutionContent: `import java.util.List;
 
 public class Numbers {
-    public static int sumPositive(List<Integer> values) {
-        int total = 0;
-        for (int v : values) {
-            if (v > 0) total += v;
-        }
-        return total;
+  public static int sumPositive(List<Integer> values) {
+    int total = 0;
+    for (int v : values) {
+      if (v > 0)
+        total += v;
     }
+    return total;
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
+++ b/content/learn/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
@@ -280,9 +280,9 @@ But this table covers an *astonishing* fraction of day-to-day code.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        System.out.println(Reverser.reverse("hello!"));
-    }
+  public static void main(String[] args) {
+    System.out.println(Reverser.reverse("hello!"));
+  }
 }
 `,
     },
@@ -292,27 +292,27 @@ But this table covers an *astonishing* fraction of day-to-day code.
 import java.util.Deque;
 
 public class Reverser {
-    public static String reverse(String s) {
-        // TODO: use a Deque<Character> as a stack
-        return s;
-    }
+  public static String reverse(String s) {
+    // TODO: use a Deque<Character> as a stack
+    return s;
+  }
 }
 `,
       solutionContent: `import java.util.ArrayDeque;
 import java.util.Deque;
 
 public class Reverser {
-    public static String reverse(String s) {
-        Deque<Character> stack = new ArrayDeque<>();
-        for (int i = 0; i < s.length(); i++) {
-            stack.push(s.charAt(i));
-        }
-        StringBuilder out = new StringBuilder(s.length());
-        while (!stack.isEmpty()) {
-            out.append(stack.pop());
-        }
-        return out.toString();
+  public static String reverse(String s) {
+    Deque<Character> stack = new ArrayDeque<>();
+    for (int i = 0; i < s.length(); i++) {
+      stack.push(s.charAt(i));
     }
+    StringBuilder out = new StringBuilder(s.length());
+    while (!stack.isEmpty()) {
+      out.append(stack.pop());
+    }
+    return out.toString();
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/capstone-project.mdx
+++ b/content/learn/java-programming-for-beginners/capstone-project.mdx
@@ -91,109 +91,112 @@ The given \`Main.java\` drives the behavior. Don't change it.`}
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Library lib = new Library();
-        lib.addBook(new Book("Effective Java", 2));
-        lib.addBook(new Book("Refactoring", 1));
+  public static void main(String[] args) {
+    Library lib = new Library();
+    lib.addBook(new Book("Effective Java", 2));
+    lib.addBook(new Book("Refactoring", 1));
 
-        System.out.println("Catalog:");
-        for (Book b : lib.catalog()) {
-            System.out.println("- " + b.title() + " (" + b.availableCopies() + " copies)");
-        }
-
-        Member ada = new Member("ada");
-        Member grace = new Member("grace");
-
-        System.out.println("borrow ok? " + tryBorrow(lib, ada, "Effective Java"));
-        System.out.println("borrow ok? " + tryBorrow(lib, grace, "Effective Java"));
-        System.out.println("borrow ok? " + tryBorrow(lib, ada, "Effective Java")); // none left
-        System.out.println("borrow ok? " + tryBorrow(lib, ada, "Unknown Title"));
-
-        System.out.println("After borrows:");
-        for (Book b : lib.catalog()) {
-            System.out.println("- " + b.title() + " (" + b.availableCopies() + " copies)");
-        }
-
-        System.out.println(ada.name() + " has " + ada.loanCount() + " loan(s)");
-        System.out.println(grace.name() + " has " + grace.loanCount() + " loan(s)");
-
-        System.out.println("return ok? " + tryReturn(lib, ada, "Effective Java"));
-        System.out.println("After ada returns Effective Java:");
-        for (Book b : lib.catalog()) {
-            System.out.println("- " + b.title() + " (" + b.availableCopies() + " copies)");
-        }
-
-        System.out.println("return ok? " + tryReturn(lib, ada, "Refactoring")); // not on loan
+    System.out.println("Catalog:");
+    for (Book b : lib.catalog()) {
+      System.out.println("- " + b.title() + " (" + b.availableCopies() +
+                         " copies)");
     }
 
-    static boolean tryBorrow(Library lib, Member m, String title) {
-        try {
-            lib.borrow(m, title);
-            return true;
-        } catch (BorrowException e) {
-            System.out.println("borrow failed: " + e.getMessage());
-            return false;
-        }
+    Member ada = new Member("ada");
+    Member grace = new Member("grace");
+
+    System.out.println("borrow ok? " + tryBorrow(lib, ada, "Effective Java"));
+    System.out.println("borrow ok? " + tryBorrow(lib, grace, "Effective Java"));
+    System.out.println("borrow ok? " +
+                       tryBorrow(lib, ada, "Effective Java")); // none left
+    System.out.println("borrow ok? " + tryBorrow(lib, ada, "Unknown Title"));
+
+    System.out.println("After borrows:");
+    for (Book b : lib.catalog()) {
+      System.out.println("- " + b.title() + " (" + b.availableCopies() +
+                         " copies)");
     }
 
-    static boolean tryReturn(Library lib, Member m, String title) {
-        try {
-            lib.returnBook(m, title);
-            return true;
-        } catch (BorrowException e) {
-            System.out.println("return failed: " + e.getMessage());
-            return false;
-        }
+    System.out.println(ada.name() + " has " + ada.loanCount() + " loan(s)");
+    System.out.println(grace.name() + " has " + grace.loanCount() + " loan(s)");
+
+    System.out.println("return ok? " + tryReturn(lib, ada, "Effective Java"));
+    System.out.println("After ada returns Effective Java:");
+    for (Book b : lib.catalog()) {
+      System.out.println("- " + b.title() + " (" + b.availableCopies() +
+                         " copies)");
     }
+
+    System.out.println("return ok? " +
+                       tryReturn(lib, ada, "Refactoring")); // not on loan
+  }
+
+  static boolean tryBorrow(Library lib, Member m, String title) {
+    try {
+      lib.borrow(m, title);
+      return true;
+    } catch (BorrowException e) {
+      System.out.println("borrow failed: " + e.getMessage());
+      return false;
+    }
+  }
+
+  static boolean tryReturn(Library lib, Member m, String title) {
+    try {
+      lib.returnBook(m, title);
+      return true;
+    } catch (BorrowException e) {
+      System.out.println("return failed: " + e.getMessage());
+      return false;
+    }
+  }
 }
 `,
     },
     {
       filename: "BorrowException.java",
       initialContent: `public class BorrowException extends RuntimeException {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class BorrowException extends RuntimeException {
-    public BorrowException(String message) {
-        super(message);
-    }
+  public BorrowException(String message) { super(message); }
 }
 `,
     },
     {
       filename: "Book.java",
       initialContent: `public class Book {
-    // TODO: title, totalCopies, availableCopies + methods
+  // TODO: title, totalCopies, availableCopies + methods
 }
 `,
       solutionContent: `public class Book {
-    private final String title;
-    private final int totalCopies;
-    private int availableCopies;
+  private final String title;
+  private final int totalCopies;
+  private int availableCopies;
 
-    public Book(String title, int totalCopies) {
-        this.title = title;
-        this.totalCopies = totalCopies;
-        this.availableCopies = totalCopies;
+  public Book(String title, int totalCopies) {
+    this.title = title;
+    this.totalCopies = totalCopies;
+    this.availableCopies = totalCopies;
+  }
+
+  public String title() { return title; }
+  public int totalCopies() { return totalCopies; }
+  public int availableCopies() { return availableCopies; }
+
+  void borrowOne() {
+    if (availableCopies == 0) {
+      throw new BorrowException("no copies available: " + title);
     }
+    availableCopies--;
+  }
 
-    public String title()       { return title; }
-    public int totalCopies()    { return totalCopies; }
-    public int availableCopies(){ return availableCopies; }
-
-    void borrowOne() {
-        if (availableCopies == 0) {
-            throw new BorrowException("no copies available: " + title);
-        }
-        availableCopies--;
+  void returnOne() {
+    if (availableCopies < totalCopies) {
+      availableCopies++;
     }
-
-    void returnOne() {
-        if (availableCopies < totalCopies) {
-            availableCopies++;
-        }
-    }
+  }
 }
 `,
     },
@@ -203,30 +206,24 @@ The given \`Main.java\` drives the behavior. Don't change it.`}
 import java.util.List;
 
 public class Member {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `import java.util.ArrayList;
 import java.util.List;
 
 public class Member {
-    private final String name;
-    private final List<Book> loans = new ArrayList<>();
+  private final String name;
+  private final List<Book> loans = new ArrayList<>();
 
-    public Member(String name) {
-        this.name = name;
-    }
+  public Member(String name) { this.name = name; }
 
-    public String name()  { return name; }
-    public int loanCount(){ return loans.size(); }
+  public String name() { return name; }
+  public int loanCount() { return loans.size(); }
 
-    void addLoan(Book b) {
-        loans.add(b);
-    }
+  void addLoan(Book b) { loans.add(b); }
 
-    boolean removeLoan(Book b) {
-        return loans.remove(b);
-    }
+  boolean removeLoan(Book b) { return loans.remove(b); }
 }
 `,
     },
@@ -237,7 +234,7 @@ import java.util.List;
 import java.util.TreeMap;
 
 public class Library {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `import java.util.ArrayList;
@@ -245,35 +242,31 @@ import java.util.List;
 import java.util.TreeMap;
 
 public class Library {
-    private final TreeMap<String, Book> catalog = new TreeMap<>();
+  private final TreeMap<String, Book> catalog = new TreeMap<>();
 
-    public void addBook(Book b) {
-        catalog.put(b.title(), b);
-    }
+  public void addBook(Book b) { catalog.put(b.title(), b); }
 
-    public List<Book> catalog() {
-        return new ArrayList<>(catalog.values());
-    }
+  public List<Book> catalog() { return new ArrayList<>(catalog.values()); }
 
-    public void borrow(Member m, String title) {
-        Book b = catalog.get(title);
-        if (b == null) {
-            throw new BorrowException("unknown book: " + title);
-        }
-        b.borrowOne();
-        m.addLoan(b);
+  public void borrow(Member m, String title) {
+    Book b = catalog.get(title);
+    if (b == null) {
+      throw new BorrowException("unknown book: " + title);
     }
+    b.borrowOne();
+    m.addLoan(b);
+  }
 
-    public void returnBook(Member m, String title) {
-        Book b = catalog.get(title);
-        if (b == null) {
-            throw new BorrowException("unknown book: " + title);
-        }
-        if (!m.removeLoan(b)) {
-            throw new BorrowException("not on loan to this member: " + title);
-        }
-        b.returnOne();
+  public void returnBook(Member m, String title) {
+    Book b = catalog.get(title);
+    if (b == null) {
+      throw new BorrowException("unknown book: " + title);
     }
+    if (!m.removeLoan(b)) {
+      throw new BorrowException("not on loan to this member: " + title);
+    }
+    b.returnOne();
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/classes-and-objects.mdx
+++ b/content/learn/java-programming-for-beginners/classes-and-objects.mdx
@@ -135,41 +135,40 @@ has more than one class, we will show each in its own file.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Book hp = new Book("Harry Potter", "J. K. Rowling", 1997);
-        Book lr = new Book("The Lord of the Rings", "J. R. R. Tolkien", 1954);
+  public static void main(String[] args) {
+    Book hp = new Book("Harry Potter", "J. K. Rowling", 1997);
+    Book lr = new Book("The Lord of the Rings", "J. R. R. Tolkien", 1954);
 
-        System.out.println(hp.citation());
-        System.out.println(lr.citation());
-        System.out.println("Older: " + (hp.olderThan(lr) ? hp.title() : lr.title()));
-    }
+    System.out.println(hp.citation());
+    System.out.println(lr.citation());
+    System.out.println("Older: " +
+                       (hp.olderThan(lr) ? hp.title() : lr.title()));
+  }
 }
 `,
     },
     {
       filename: "Book.java",
       initialContent: `public class Book {
-    private final String title;
-    private final String author;
-    private final int    year;
+  private final String title;
+  private final String author;
+  private final int year;
 
-    public Book(String title, String author, int year) {
-        this.title  = title;
-        this.author = author;
-        this.year   = year;
-    }
+  public Book(String title, String author, int year) {
+    this.title = title;
+    this.author = author;
+    this.year = year;
+  }
 
-    public String title()  { return title; }
-    public String author() { return author; }
-    public int    year()   { return year; }
+  public String title() { return title; }
+  public String author() { return author; }
+  public int year() { return year; }
 
-    public String citation() {
-        return author + ", \\"" + title + "\\" (" + year + ")";
-    }
+  public String citation() {
+    return author + ", \\"" + title + "\\" (" + year + ")";
+  }
 
-    public boolean olderThan(Book other) {
-        return this.year < other.year;
-    }
+  public boolean olderThan(Book other) { return this.year < other.year; }
 }
 `,
     },
@@ -274,33 +273,31 @@ d=1
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Counter c = new Counter();
-        c.bump(); c.bump(); c.bump();
-        Counter d = new Counter();
-        d.bump();
-        System.out.println("c=" + c.value());
-        System.out.println("d=" + d.value());
-    }
+  public static void main(String[] args) {
+    Counter c = new Counter();
+    c.bump();
+    c.bump();
+    c.bump();
+    Counter d = new Counter();
+    d.bump();
+    System.out.println("c=" + c.value());
+    System.out.println("d=" + d.value());
+  }
 }
 `,
     },
     {
       filename: "Counter.java",
       initialContent: `public class Counter {
-    // TODO: implement
+  // TODO: implement
 }
 `,
       solutionContent: `public class Counter {
-    private int value = 0;
+  private int value = 0;
 
-    public void bump() {
-        value++;
-    }
+  public void bump() { value++; }
 
-    public int value() {
-        return value;
-    }
+  public int value() { return value; }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/constructors-and-lifecycle.mdx
+++ b/content/learn/java-programming-for-beginners/constructors-and-lifecycle.mdx
@@ -270,46 +270,44 @@ rejected: low must be less than high
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Range r = new Range(0, 5);
-        System.out.println("length=" + r.length());
-        System.out.println("contains 3 = " + r.contains(3));
-        System.out.println("contains 5 = " + r.contains(5));
+  public static void main(String[] args) {
+    Range r = new Range(0, 5);
+    System.out.println("length=" + r.length());
+    System.out.println("contains 3 = " + r.contains(3));
+    System.out.println("contains 5 = " + r.contains(5));
 
-        try {
-            Range bad = new Range(5, 5);
-        } catch (IllegalArgumentException e) {
-            System.out.println("rejected: " + e.getMessage());
-        }
+    try {
+      Range bad = new Range(5, 5);
+    } catch (IllegalArgumentException e) {
+      System.out.println("rejected: " + e.getMessage());
     }
+  }
 }
 `,
     },
     {
       filename: "Range.java",
       initialContent: `public class Range {
-    // TODO: implement
+  // TODO: implement
 }
 `,
       solutionContent: `public class Range {
-    private final int low;
-    private final int high;
+  private final int low;
+  private final int high;
 
-    public Range(int low, int high) {
-        if (low >= high) {
-            throw new IllegalArgumentException("low must be less than high");
-        }
-        this.low = low;
-        this.high = high;
+  public Range(int low, int high) {
+    if (low >= high) {
+      throw new IllegalArgumentException("low must be less than high");
     }
+    this.low = low;
+    this.high = high;
+  }
 
-    public int low()    { return low; }
-    public int high()   { return high; }
-    public int length() { return high - low; }
+  public int low() { return low; }
+  public int high() { return high; }
+  public int length() { return high - low; }
 
-    public boolean contains(int n) {
-        return n >= low && n < high;
-    }
+  public boolean contains(int n) { return n >= low && n < high; }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/control-flow.mdx
+++ b/content/learn/java-programming-for-beginners/control-flow.mdx
@@ -297,25 +297,25 @@ Buzz
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        // TODO: print FizzBuzz from 1 to 15
-    }
+  public static void main(String[] args) {
+    // TODO: print FizzBuzz from 1 to 15
+  }
 }
 `,
       solutionContent: `public class Main {
-    public static void main(String[] args) {
-        for (int i = 1; i <= 15; i++) {
-            if (i % 15 == 0) {
-                System.out.println("FizzBuzz");
-            } else if (i % 3 == 0) {
-                System.out.println("Fizz");
-            } else if (i % 5 == 0) {
-                System.out.println("Buzz");
-            } else {
-                System.out.println(i);
-            }
-        }
+  public static void main(String[] args) {
+    for (int i = 1; i <= 15; i++) {
+      if (i % 15 == 0) {
+        System.out.println("FizzBuzz");
+      } else if (i % 3 == 0) {
+        System.out.println("Fizz");
+      } else if (i % 5 == 0) {
+        System.out.println("Buzz");
+      } else {
+        System.out.println(i);
+      }
     }
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/encapsulation-and-abstraction.mdx
+++ b/content/learn/java-programming-for-beginners/encapsulation-and-abstraction.mdx
@@ -64,52 +64,47 @@ million-line software systems without going insane.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        BankAccount a = new BankAccount("Ada");
-        a.deposit(500);
-        boolean ok1 = a.withdraw(200);
-        boolean ok2 = a.withdraw(9999);
-        System.out.println("owner=" + a.owner());
-        System.out.println("ok1=" + ok1);
-        System.out.println("ok2=" + ok2);
-        System.out.println("balance=" + a.balance());
-    }
+  public static void main(String[] args) {
+    BankAccount a = new BankAccount("Ada");
+    a.deposit(500);
+    boolean ok1 = a.withdraw(200);
+    boolean ok2 = a.withdraw(9999);
+    System.out.println("owner=" + a.owner());
+    System.out.println("ok1=" + ok1);
+    System.out.println("ok2=" + ok2);
+    System.out.println("balance=" + a.balance());
+  }
 }
 `,
     },
     {
       filename: "BankAccount.java",
       initialContent: `public class BankAccount {
-    private final String owner;
-    private long balanceCents = 0;
+  private final String owner;
+  private long balanceCents = 0;
 
-    public BankAccount(String owner) {
-        this.owner = owner;
-    }
+  public BankAccount(String owner) { this.owner = owner; }
 
-    public String owner() {
-        return owner;
-    }
+  public String owner() { return owner; }
 
-    public long balance() {
-        return balanceCents;
-    }
+  public long balance() { return balanceCents; }
 
-    public void deposit(long cents) {
-        if (cents <= 0) {
-            throw new IllegalArgumentException("must be positive");
-        }
-        balanceCents += cents;
+  public void deposit(long cents) {
+    if (cents <= 0) {
+      throw new IllegalArgumentException("must be positive");
     }
+    balanceCents += cents;
+  }
 
-    public boolean withdraw(long cents) {
-        if (cents <= 0) {
-            throw new IllegalArgumentException("must be positive");
-        }
-        if (cents > balanceCents) return false;
-        balanceCents -= cents;
-        return true;
+  public boolean withdraw(long cents) {
+    if (cents <= 0) {
+      throw new IllegalArgumentException("must be positive");
     }
+    if (cents > balanceCents)
+      return false;
+    balanceCents -= cents;
+    return true;
+  }
 }
 `,
     },
@@ -251,47 +246,45 @@ after illegal change: 24
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Thermostat t = new Thermostat(20);
-        System.out.println("target=" + t.target());
+  public static void main(String[] args) {
+    Thermostat t = new Thermostat(20);
+    System.out.println("target=" + t.target());
 
-        t.setTarget(24);
-        System.out.println("after legal change: " + t.target());
+    t.setTarget(24);
+    System.out.println("after legal change: " + t.target());
 
-        t.setTarget(100);
-        System.out.println("after illegal change: " + t.target());
-    }
+    t.setTarget(100);
+    System.out.println("after illegal change: " + t.target());
+  }
 }
 `,
     },
     {
       filename: "Thermostat.java",
       initialContent: `public class Thermostat {
-    // TODO: implement
+  // TODO: implement
 }
 `,
       solutionContent: `public class Thermostat {
-    private int targetC;
+  private int targetC;
 
-    public Thermostat(int initialTarget) {
-        this.targetC = clamp(initialTarget);
-    }
+  public Thermostat(int initialTarget) { this.targetC = clamp(initialTarget); }
 
-    public int target() {
-        return targetC;
-    }
+  public int target() { return targetC; }
 
-    public void setTarget(int newTarget) {
-        if (newTarget >= 5 && newTarget <= 35) {
-            this.targetC = newTarget;
-        }
+  public void setTarget(int newTarget) {
+    if (newTarget >= 5 && newTarget <= 35) {
+      this.targetC = newTarget;
     }
+  }
 
-    private int clamp(int v) {
-        if (v < 5)  return 5;
-        if (v > 35) return 35;
-        return v;
-    }
+  private int clamp(int v) {
+    if (v < 5)
+      return 5;
+    if (v > 35)
+      return 35;
+    return v;
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/exception-handling.mdx
+++ b/content/learn/java-programming-for-beginners/exception-handling.mdx
@@ -229,37 +229,37 @@ a normal end of input, use a `boolean hasNext()` instead.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        printSafe("42");
-        printSafe("oops");
-        printSafe(null);
-        System.out.println("done");
-    }
+  public static void main(String[] args) {
+    printSafe("42");
+    printSafe("oops");
+    printSafe(null);
+    System.out.println("done");
+  }
 
-    static void printSafe(String s) {
-        try {
-            int n = SafeParser.parse(s);
-            System.out.println("parsed " + n);
-        } catch (IllegalArgumentException e) {
-            System.out.println("bad input: " + e.getMessage());
-        }
+  static void printSafe(String s) {
+    try {
+      int n = SafeParser.parse(s);
+      System.out.println("parsed " + n);
+    } catch (IllegalArgumentException e) {
+      System.out.println("bad input: " + e.getMessage());
     }
+  }
 }
 `,
     },
     {
       filename: "SafeParser.java",
       initialContent: `public class SafeParser {
-    public static int parse(String s) {
-        if (s == null) {
-            throw new IllegalArgumentException("input was null");
-        }
-        try {
-            return Integer.parseInt(s);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("not a number: " + s);
-        }
+  public static int parse(String s) {
+    if (s == null) {
+      throw new IllegalArgumentException("input was null");
     }
+    try {
+      return Integer.parseInt(s);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("not a number: " + s);
+    }
+  }
 }
 `,
     },
@@ -333,35 +333,35 @@ done
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        System.out.println("10/2 = " + SafeMath.divide(10, 2));
-        try {
-            int r = SafeMath.divide(10, 0);
-            System.out.println("10/0 = " + r);
-        } catch (IllegalArgumentException e) {
-            System.out.println("10/0 -> " + e.getMessage());
-        }
-        System.out.println("done");
+  public static void main(String[] args) {
+    System.out.println("10/2 = " + SafeMath.divide(10, 2));
+    try {
+      int r = SafeMath.divide(10, 0);
+      System.out.println("10/0 = " + r);
+    } catch (IllegalArgumentException e) {
+      System.out.println("10/0 -> " + e.getMessage());
     }
+    System.out.println("done");
+  }
 }
 `,
     },
     {
       filename: "SafeMath.java",
       initialContent: `public class SafeMath {
-    public static int divide(int a, int b) {
-        // TODO
-        return 0;
-    }
+  public static int divide(int a, int b) {
+    // TODO
+    return 0;
+  }
 }
 `,
       solutionContent: `public class SafeMath {
-    public static int divide(int a, int b) {
-        if (b == 0) {
-            throw new IllegalArgumentException("cannot divide by zero");
-        }
-        return a / b;
+  public static int divide(int a, int b) {
+    if (b == 0) {
+      throw new IllegalArgumentException("cannot divide by zero");
     }
+    return a / b;
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/inheritance-and-polymorphism.mdx
+++ b/content/learn/java-programming-for-beginners/inheritance-and-polymorphism.mdx
@@ -50,62 +50,60 @@ The arrow with the open triangle means "extends." `Circle` and
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Shape[] shapes = {
-            new Circle(2.0),
-            new Rectangle(3.0, 4.0),
-            new Circle(1.0),
-        };
+  public static void main(String[] args) {
+    Shape[] shapes = {
+        new Circle(2.0),
+        new Rectangle(3.0, 4.0),
+        new Circle(1.0),
+    };
 
-        for (Shape s : shapes) {
-            System.out.println(s.describe());
-        }
+    for (Shape s : shapes) {
+      System.out.println(s.describe());
     }
+  }
 }
 `,
     },
     {
       filename: "Shape.java",
       initialContent: `public abstract class Shape {
-    public abstract double area();
+  public abstract double area();
 
-    public String describe() {
-        return getClass().getSimpleName() + " with area " + area();
-    }
+  public String describe() {
+    return getClass().getSimpleName() + " with area " + area();
+  }
 }
 `,
     },
     {
       filename: "Circle.java",
       initialContent: `public class Circle extends Shape {
-    private final double radius;
+  private final double radius;
 
-    public Circle(double radius) {
-        this.radius = radius;
-    }
+  public Circle(double radius) { this.radius = radius; }
 
-    @Override
-    public double area() {
-        return Math.PI * radius * radius;
-    }
+  @Override
+  public double area() {
+    return Math.PI * radius * radius;
+  }
 }
 `,
     },
     {
       filename: "Rectangle.java",
       initialContent: `public class Rectangle extends Shape {
-    private final double width;
-    private final double height;
+  private final double width;
+  private final double height;
 
-    public Rectangle(double width, double height) {
-        this.width = width;
-        this.height = height;
-    }
+  public Rectangle(double width, double height) {
+    this.width = width;
+    this.height = height;
+  }
 
-    @Override
-    public double area() {
-        return width * height;
-    }
+  @Override
+  public double area() {
+    return width * height;
+  }
 }
 `,
     },
@@ -174,46 +172,44 @@ and can call a superclass constructor via `super(...)` as the
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Employee e = new Employee("Ada", 50000);
-        Manager  m = new Manager("Grace", 80000, 10);
-        System.out.println(e.describe());
-        System.out.println(m.describe());
-    }
+  public static void main(String[] args) {
+    Employee e = new Employee("Ada", 50000);
+    Manager m = new Manager("Grace", 80000, 10);
+    System.out.println(e.describe());
+    System.out.println(m.describe());
+  }
 }
 `,
     },
     {
       filename: "Employee.java",
       initialContent: `public class Employee {
-    protected final String name;
-    protected final int    salary;
+  protected final String name;
+  protected final int salary;
 
-    public Employee(String name, int salary) {
-        this.name = name;
-        this.salary = salary;
-    }
+  public Employee(String name, int salary) {
+    this.name = name;
+    this.salary = salary;
+  }
 
-    public String describe() {
-        return name + " (salary " + salary + ")";
-    }
+  public String describe() { return name + " (salary " + salary + ")"; }
 }
 `,
     },
     {
       filename: "Manager.java",
       initialContent: `public class Manager extends Employee {
-    private final int reports;
+  private final int reports;
 
-    public Manager(String name, int salary, int reports) {
-        super(name, salary);            // must be the first line
-        this.reports = reports;
-    }
+  public Manager(String name, int salary, int reports) {
+    super(name, salary); // must be the first line
+    this.reports = reports;
+  }
 
-    @Override
-    public String describe() {
-        return super.describe() + " managing " + reports + " people";
-    }
+  @Override
+  public String describe() {
+    return super.describe() + " managing " + reports + " people";
+  }
 }
 `,
     },
@@ -310,56 +306,54 @@ Hello, I say Meow.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Animal[] zoo = { new Dog(), new Cat() };
-        for (Animal a : zoo) {
-            System.out.println(a.greet());
-        }
+  public static void main(String[] args) {
+    Animal[] zoo = {new Dog(), new Cat()};
+    for (Animal a : zoo) {
+      System.out.println(a.greet());
     }
+  }
 }
 `,
     },
     {
       filename: "Animal.java",
       initialContent: `public abstract class Animal {
-    // TODO: declare speak() abstract
-    // TODO: implement greet()
+  // TODO: declare speak() abstract
+  // TODO: implement greet()
 }
 `,
       solutionContent: `public abstract class Animal {
-    public abstract String speak();
+  public abstract String speak();
 
-    public String greet() {
-        return "Hello, I say " + speak();
-    }
+  public String greet() { return "Hello, I say " + speak(); }
 }
 `,
     },
     {
       filename: "Dog.java",
       initialContent: `public class Dog extends Animal {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class Dog extends Animal {
-    @Override
-    public String speak() {
-        return "Woof!";
-    }
+  @Override
+  public String speak() {
+    return "Woof!";
+  }
 }
 `,
     },
     {
       filename: "Cat.java",
       initialContent: `public class Cat extends Animal {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class Cat extends Animal {
-    @Override
-    public String speak() {
-        return "Meow.";
-    }
+  @Override
+  public String speak() {
+    return "Meow.";
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/interfaces.mdx
+++ b/content/learn/java-programming-for-beginners/interfaces.mdx
@@ -33,44 +33,42 @@ constructor, and (traditionally) no method bodies.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Greeter formal = new FormalGreeter();
-        Greeter casual = new CasualGreeter();
+  public static void main(String[] args) {
+    Greeter formal = new FormalGreeter();
+    Greeter casual = new CasualGreeter();
 
-        say(formal, "Ada");
-        say(casual, "Ada");
-    }
+    say(formal, "Ada");
+    say(casual, "Ada");
+  }
 
-    static void say(Greeter g, String name) {
-        System.out.println(g.greet(name));
-    }
+  static void say(Greeter g, String name) { System.out.println(g.greet(name)); }
 }
 `,
     },
     {
       filename: "Greeter.java",
       initialContent: `public interface Greeter {
-    String greet(String name);
+  String greet(String name);
 }
 `,
     },
     {
       filename: "FormalGreeter.java",
       initialContent: `public class FormalGreeter implements Greeter {
-    @Override
-    public String greet(String name) {
-        return "Good day, " + name + ".";
-    }
+  @Override
+  public String greet(String name) {
+    return "Good day, " + name + ".";
+  }
 }
 `,
     },
     {
       filename: "CasualGreeter.java",
       initialContent: `public class CasualGreeter implements Greeter {
-    @Override
-    public String greet(String name) {
-        return "hey " + name + "!";
-    }
+  @Override
+  public String greet(String name) {
+    return "hey " + name + "!";
+  }
 }
 `,
     },
@@ -146,42 +144,42 @@ your class is — it just trusts the contract.
       initialContent: `import java.util.Arrays;
 
 public class Main {
-    public static void main(String[] args) {
-        Book[] shelf = {
-            new Book("Java", 320),
-            new Book("Go",   180),
-            new Book("Rust", 450),
-        };
+  public static void main(String[] args) {
+    Book[] shelf = {
+        new Book("Java", 320),
+        new Book("Go", 180),
+        new Book("Rust", 450),
+    };
 
-        Arrays.sort(shelf);
+    Arrays.sort(shelf);
 
-        for (Book b : shelf) {
-            System.out.println(b);
-        }
+    for (Book b : shelf) {
+      System.out.println(b);
     }
+  }
 }
 `,
     },
     {
       filename: "Book.java",
       initialContent: `public class Book implements Comparable<Book> {
-    private final String title;
-    private final int    pages;
+  private final String title;
+  private final int pages;
 
-    public Book(String title, int pages) {
-        this.title = title;
-        this.pages = pages;
-    }
+  public Book(String title, int pages) {
+    this.title = title;
+    this.pages = pages;
+  }
 
-    @Override
-    public int compareTo(Book other) {
-        return Integer.compare(this.pages, other.pages);
-    }
+  @Override
+  public int compareTo(Book other) {
+    return Integer.compare(this.pages, other.pages);
+  }
 
-    @Override
-    public String toString() {
-        return title + " (" + pages + " pages)";
-    }
+  @Override
+  public String toString() {
+    return title + " (" + pages + " pages)";
+  }
 }
 `,
     },
@@ -292,68 +290,66 @@ Hi, Ada!
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Printable[] items = {
-            new Invoice(7, 1299),
-            new Greeting("Ada"),
-        };
-        for (Printable p : items) {
-            System.out.println(p.toReport());
-        }
+  public static void main(String[] args) {
+    Printable[] items = {
+        new Invoice(7, 1299),
+        new Greeting("Ada"),
+    };
+    for (Printable p : items) {
+      System.out.println(p.toReport());
     }
+  }
 }
 `,
     },
     {
       filename: "Printable.java",
       initialContent: `public interface Printable {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public interface Printable {
-    String toReport();
+  String toReport();
 }
 `,
     },
     {
       filename: "Invoice.java",
       initialContent: `public class Invoice implements Printable {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class Invoice implements Printable {
-    private final int id;
-    private final int totalCents;
+  private final int id;
+  private final int totalCents;
 
-    public Invoice(int id, int totalCents) {
-        this.id = id;
-        this.totalCents = totalCents;
-    }
+  public Invoice(int id, int totalCents) {
+    this.id = id;
+    this.totalCents = totalCents;
+  }
 
-    @Override
-    public String toReport() {
-        return "Invoice #" + id + ": " + totalCents + "c";
-    }
+  @Override
+  public String toReport() {
+    return "Invoice #" + id + ": " + totalCents + "c";
+  }
 }
 `,
     },
     {
       filename: "Greeting.java",
       initialContent: `public class Greeting implements Printable {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class Greeting implements Printable {
-    private final String who;
+  private final String who;
 
-    public Greeting(String who) {
-        this.who = who;
-    }
+  public Greeting(String who) { this.who = who; }
 
-    @Override
-    public String toReport() {
-        return "Hi, " + who + "!";
-    }
+  @Override
+  public String toReport() {
+    return "Hi, " + who + "!";
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/maps-and-sets.mdx
+++ b/content/learn/java-programming-for-beginners/maps-and-sets.mdx
@@ -159,19 +159,17 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class Main {
-    public static void main(String[] args) {
-        List<String> words = List.of(
-            "to", "be", "or", "not", "to", "be"
-        );
+  public static void main(String[] args) {
+    List<String> words = List.of("to", "be", "or", "not", "to", "be");
 
-        Map<String, Integer> counts = WordCounter.count(words);
+    Map<String, Integer> counts = WordCounter.count(words);
 
-        // TreeMap gives us sorted keys for deterministic output
-        TreeMap<String, Integer> sorted = new TreeMap<>(counts);
-        for (Map.Entry<String, Integer> e : sorted.entrySet()) {
-            System.out.println(e.getKey() + " " + e.getValue());
-        }
+    // TreeMap gives us sorted keys for deterministic output
+    TreeMap<String, Integer> sorted = new TreeMap<>(counts);
+    for (Map.Entry<String, Integer> e : sorted.entrySet()) {
+      System.out.println(e.getKey() + " " + e.getValue());
     }
+  }
 }
 `,
     },
@@ -182,13 +180,13 @@ import java.util.List;
 import java.util.Map;
 
 public class WordCounter {
-    public static Map<String, Integer> count(List<String> words) {
-        Map<String, Integer> counts = new HashMap<>();
-        for (String w : words) {
-            counts.merge(w, 1, Integer::sum);
-        }
-        return counts;
+  public static Map<String, Integer> count(List<String> words) {
+    Map<String, Integer> counts = new HashMap<>();
+    for (String w : words) {
+      counts.merge(w, 1, Integer::sum);
     }
+    return counts;
+  }
 }
 `,
     },
@@ -265,10 +263,10 @@ unique=7
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        int n = Letters.uniqueLetterCount("Hello, World! 1234");
-        System.out.println("unique=" + n);
-    }
+  public static void main(String[] args) {
+    int n = Letters.uniqueLetterCount("Hello, World! 1234");
+    System.out.println("unique=" + n);
+  }
 }
 `,
     },
@@ -278,26 +276,26 @@ unique=7
 import java.util.Set;
 
 public class Letters {
-    public static int uniqueLetterCount(String s) {
-        // TODO
-        return 0;
-    }
+  public static int uniqueLetterCount(String s) {
+    // TODO
+    return 0;
+  }
 }
 `,
       solutionContent: `import java.util.HashSet;
 import java.util.Set;
 
 public class Letters {
-    public static int uniqueLetterCount(String s) {
-        Set<Character> seen = new HashSet<>();
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            if (Character.isLetter(c)) {
-                seen.add(Character.toLowerCase(c));
-            }
-        }
-        return seen.size();
+  public static int uniqueLetterCount(String s) {
+    Set<Character> seen = new HashSet<>();
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      if (Character.isLetter(c)) {
+        seen.add(Character.toLowerCase(c));
+      }
     }
+    return seen.size();
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/methods-and-modularity.mdx
+++ b/content/learn/java-programming-for-beginners/methods-and-modularity.mdx
@@ -281,37 +281,39 @@ max = 91
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        int[] xs = {72, 85, 91, 2, 64, 78};
-        System.out.println("min = " + MathTools.min(xs));
-        System.out.println("max = " + MathTools.max(xs));
-    }
+  public static void main(String[] args) {
+    int[] xs = {72, 85, 91, 2, 64, 78};
+    System.out.println("min = " + MathTools.min(xs));
+    System.out.println("max = " + MathTools.max(xs));
+  }
 }
 `,
     },
     {
       filename: "MathTools.java",
       initialContent: `public class MathTools {
-    // TODO: implement static int min(int[] xs)
-    // TODO: implement static int max(int[] xs)
+  // TODO: implement static int min(int[] xs)
+  // TODO: implement static int max(int[] xs)
 }
 `,
       solutionContent: `public class MathTools {
-    public static int min(int[] xs) {
-        int m = xs[0];
-        for (int i = 1; i < xs.length; i++) {
-            if (xs[i] < m) m = xs[i];
-        }
-        return m;
+  public static int min(int[] xs) {
+    int m = xs[0];
+    for (int i = 1; i < xs.length; i++) {
+      if (xs[i] < m)
+        m = xs[i];
     }
+    return m;
+  }
 
-    public static int max(int[] xs) {
-        int m = xs[0];
-        for (int i = 1; i < xs.length; i++) {
-            if (xs[i] > m) m = xs[i];
-        }
-        return m;
+  public static int max(int[] xs) {
+    int m = xs[0];
+    for (int i = 1; i < xs.length; i++) {
+      if (xs[i] > m)
+        m = xs[i];
     }
+    return m;
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/problem-solving.mdx
+++ b/content/learn/java-programming-for-beginners/problem-solving.mdx
@@ -190,30 +190,30 @@ where N is the number of vowels.`}
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        String text = "Hello, beautiful World!";
+  public static void main(String[] args) {
+    String text = "Hello, beautiful World!";
 
-        int count = 0;
-        // TODO: count the vowels in 'text' and store in count
+    int count = 0;
+    // TODO: count the vowels in 'text' and store in count
 
-        System.out.println("vowels = " + count);
-    }
+    System.out.println("vowels = " + count);
+  }
 }
 `,
       solutionContent: `public class Main {
-    public static void main(String[] args) {
-        String text = "Hello, beautiful World!";
+  public static void main(String[] args) {
+    String text = "Hello, beautiful World!";
 
-        int count = 0;
-        String vowels = "aeiouAEIOU";
-        for (int i = 0; i < text.length(); i++) {
-            if (vowels.indexOf(text.charAt(i)) >= 0) {
-                count++;
-            }
-        }
-
-        System.out.println("vowels = " + count);
+    int count = 0;
+    String vowels = "aeiouAEIOU";
+    for (int i = 0; i < text.length(); i++) {
+      if (vowels.indexOf(text.charAt(i)) >= 0) {
+        count++;
+      }
     }
+
+    System.out.println("vowels = " + count);
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/stack-and-heap.mdx
+++ b/content/learn/java-programming-for-beginners/stack-and-heap.mdx
@@ -171,32 +171,32 @@ type:
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        int n = 5;
-        bumpPrimitive(n);
-        System.out.println("after bumpPrimitive: n = " + n);
+  public static void main(String[] args) {
+    int n = 5;
+    bumpPrimitive(n);
+    System.out.println("after bumpPrimitive: n = " + n);
 
-        List<String> items = new ArrayList<>();
-        items.add("a");
-        mutate(items);                  // changes the object
-        System.out.println("after mutate: items = " + items);
+    List<String> items = new ArrayList<>();
+    items.add("a");
+    mutate(items); // changes the object
+    System.out.println("after mutate: items = " + items);
 
-        replace(items);                 // does NOT replace caller's variable
-        System.out.println("after replace: items = " + items);
-    }
+    replace(items); // does NOT replace caller's variable
+    System.out.println("after replace: items = " + items);
+  }
 
-    static void bumpPrimitive(int x) {
-        x = x + 100;                    // local x changes; caller unaffected
-    }
+  static void bumpPrimitive(int x) {
+    x = x + 100; // local x changes; caller unaffected
+  }
 
-    static void mutate(List<String> list) {
-        list.add("b");                  // same object → caller sees change
-    }
+  static void mutate(List<String> list) {
+    list.add("b"); // same object → caller sees change
+  }
 
-    static void replace(List<String> list) {
-        list = new ArrayList<>();       // local reassign; caller unaffected
-        list.add("hidden");
-    }
+  static void replace(List<String> list) {
+    list = new ArrayList<>(); // local reassign; caller unaffected
+    list.add("hidden");
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/the-type-system.mdx
+++ b/content/learn/java-programming-for-beginners/the-type-system.mdx
@@ -258,23 +258,23 @@ where F is the \`double\` value and R is the cast-to-int value.`}
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        double celsius = 36.6;
+  public static void main(String[] args) {
+    double celsius = 36.6;
 
-        // TODO: compute fahrenheit and rounded
-    }
+    // TODO: compute fahrenheit and rounded
+  }
 }
 `,
       solutionContent: `public class Main {
-    public static void main(String[] args) {
-        double celsius = 36.6;
+  public static void main(String[] args) {
+    double celsius = 36.6;
 
-        double fahrenheit = celsius * 9 / 5 + 32;
-        int    rounded    = (int) fahrenheit;
+    double fahrenheit = celsius * 9 / 5 + 32;
+    int rounded = (int)fahrenheit;
 
-        System.out.println("fahrenheit = " + fahrenheit);
-        System.out.println("rounded = " + rounded);
-    }
+    System.out.println("fahrenheit = " + fahrenheit);
+    System.out.println("rounded = " + rounded);
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/variables-and-memory.mdx
+++ b/content/learn/java-programming-for-beginners/variables-and-memory.mdx
@@ -235,27 +235,27 @@ where \`P = 2 * (width + height)\` and \`A = width * height\`.`}
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        int width  = 7;
-        int height = 4;
+  public static void main(String[] args) {
+    int width = 7;
+    int height = 4;
 
-        // TODO: compute perimeter and area, and print exactly:
-        // perimeter = 22
-        // area = 28
-    }
+    // TODO: compute perimeter and area, and print exactly:
+    // perimeter = 22
+    // area = 28
+  }
 }
 `,
       solutionContent: `public class Main {
-    public static void main(String[] args) {
-        int width  = 7;
-        int height = 4;
+  public static void main(String[] args) {
+    int width = 7;
+    int height = 4;
 
-        int perimeter = 2 * (width + height);
-        int area      = width * height;
+    int perimeter = 2 * (width + height);
+    int area = width * height;
 
-        System.out.println("perimeter = " + perimeter);
-        System.out.println("area = " + area);
-    }
+    System.out.println("perimeter = " + perimeter);
+    System.out.println("area = " + area);
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/what-is-a-program.mdx
+++ b/content/learn/java-programming-for-beginners/what-is-a-program.mdx
@@ -169,17 +169,17 @@ Hello, Linus!
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        // TODO: print the three lines exactly as described
-    }
+  public static void main(String[] args) {
+    // TODO: print the three lines exactly as described
+  }
 }
 `,
       solutionContent: `public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello, Ada!");
-        System.out.println("Hello, Grace!");
-        System.out.println("Hello, Linus!");
-    }
+  public static void main(String[] args) {
+    System.out.println("Hello, Ada!");
+    System.out.println("Hello, Grace!");
+    System.out.println("Hello, Linus!");
+  }
 }
 `,
     },

--- a/content/learn/java-programming-for-beginners/your-first-java-program.mdx
+++ b/content/learn/java-programming-for-beginners/your-first-java-program.mdx
@@ -154,25 +154,21 @@ same greeting, split across two files:
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Greeter g = new Greeter("Java");
-        g.greet();
-    }
+  public static void main(String[] args) {
+    Greeter g = new Greeter("Java");
+    g.greet();
+  }
 }
 `,
     },
     {
       filename: "Greeter.java",
       initialContent: `public class Greeter {
-    private final String name;
+  private final String name;
 
-    public Greeter(String name) {
-        this.name = name;
-    }
+  public Greeter(String name) { this.name = name; }
 
-    public void greet() {
-        System.out.println("Hello, " + name + "!");
-    }
+  public void greet() { System.out.println("Hello, " + name + "!"); }
 }
 `,
     },
@@ -202,17 +198,17 @@ Role: First programmer
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        // TODO: print the three lines exactly
-    }
+  public static void main(String[] args) {
+    // TODO: print the three lines exactly
+  }
 }
 `,
       solutionContent: `public class Main {
-    public static void main(String[] args) {
-        System.out.println("Name: Ada Lovelace");
-        System.out.println("Year: 1815");
-        System.out.println("Role: First programmer");
-    }
+  public static void main(String[] args) {
+    System.out.println("Name: Ada Lovelace");
+    System.out.println("Year: 1815");
+    System.out.println("Role: First programmer");
+  }
 }
 `,
     },

--- a/content/learn/natural-language-processing-python/pos-tagging.mdx
+++ b/content/learn/natural-language-processing-python/pos-tagging.mdx
@@ -62,14 +62,13 @@ await _load_nltk("tokenizers", "punkt_tab")
 await _load_nltk("taggers", "averaged_perceptron_tagger_eng")
 from nltk import pos_tag
 from nltk.tokenize import word_tokenize`}
-  starterCode={`for sentence in ["I caught a big fish.",
-                 "We fish on weekends."]:
+  starterCode={`for sentence in ["I caught a big fish.", "We fish on weekends."]:
     tokens = word_tokenize(sentence)
     tagged = pos_tag(tokens)
     # Show just the word 'fish' and the tag it received.
     for word, tag in tagged:
         if word.lower() == "fish":
-            print(f"{sentence!r}\n   -> 'fish' tagged as {tag}")
+            print(f"{sentence!r}\\n   -> 'fish' tagged as {tag}")
 `}
 />
 

--- a/content/learn/oop-blueprint-java/abstract-classes.mdx
+++ b/content/learn/oop-blueprint-java/abstract-classes.mdx
@@ -45,52 +45,52 @@ abstract. Concrete subclasses must implement `area()`.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Shape[] shapes = { new Circle(1), new Square(4) };
-        for (Shape s : shapes) {
-            System.out.println(s.describe());
-        }
-        // Shape s = new Shape();  // would fail: Shape is abstract
+  public static void main(String[] args) {
+    Shape[] shapes = {new Circle(1), new Square(4)};
+    for (Shape s : shapes) {
+      System.out.println(s.describe());
     }
+    // Shape s = new Shape();  // would fail: Shape is abstract
+  }
 }
 `,
     },
     {
       filename: "Shape.java",
       initialContent: `public abstract class Shape {
-    // Concrete behavior shared by every shape:
-    public String describe() {
-        return getClass().getSimpleName() + " with area " + area();
-    }
+  // Concrete behavior shared by every shape:
+  public String describe() {
+    return getClass().getSimpleName() + " with area " + area();
+  }
 
-    // Abstract: every concrete shape must implement this.
-    public abstract double area();
+  // Abstract: every concrete shape must implement this.
+  public abstract double area();
 }
 `,
     },
     {
       filename: "Circle.java",
       initialContent: `public class Circle extends Shape {
-    private final double radius;
-    public Circle(double radius) { this.radius = radius; }
+  private final double radius;
+  public Circle(double radius) { this.radius = radius; }
 
-    @Override
-    public double area() {
-        return Math.PI * radius * radius;
-    }
+  @Override
+  public double area() {
+    return Math.PI * radius * radius;
+  }
 }
 `,
     },
     {
       filename: "Square.java",
       initialContent: `public class Square extends Shape {
-    private final double side;
-    public Square(double side) { this.side = side; }
+  private final double side;
+  public Square(double side) { this.side = side; }
 
-    @Override
-    public double area() {
-        return side * side;
-    }
+  @Override
+  public double area() {
+    return side * side;
+  }
 }
 `,
     },
@@ -136,76 +136,74 @@ sequenceDiagram
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        TaxReturn us = new USTaxReturn(120_000);
-        TaxReturn uk = new UKTaxReturn(120_000);
+  public static void main(String[] args) {
+    TaxReturn us = new USTaxReturn(120_000);
+    TaxReturn uk = new UKTaxReturn(120_000);
 
-        System.out.println(us.file());
-        System.out.println(uk.file());
-    }
+    System.out.println(us.file());
+    System.out.println(uk.file());
+  }
 }
 `,
     },
     {
       filename: "TaxReturn.java",
       initialContent: `public abstract class TaxReturn {
-    protected final double income;
+  protected final double income;
 
-    protected TaxReturn(double income) {
-        this.income = income;
-    }
+  protected TaxReturn(double income) { this.income = income; }
 
-    // The template method — defines the overall shape:
-    public final String file() {
-        gatherIncome();
-        double tax = computeTax();
-        return submit(tax);
-    }
+  // The template method — defines the overall shape:
+  public final String file() {
+    gatherIncome();
+    double tax = computeTax();
+    return submit(tax);
+  }
 
-    // Concrete shared step:
-    protected void gatherIncome() {
-        // pretend we look up forms
-    }
+  // Concrete shared step:
+  protected void gatherIncome() {
+    // pretend we look up forms
+  }
 
-    // Step that varies per country:
-    protected abstract double computeTax();
+  // Step that varies per country:
+  protected abstract double computeTax();
 
-    // Step that varies per country:
-    protected abstract String submit(double tax);
+  // Step that varies per country:
+  protected abstract String submit(double tax);
 }
 `,
     },
     {
       filename: "USTaxReturn.java",
       initialContent: `public class USTaxReturn extends TaxReturn {
-    public USTaxReturn(double income) { super(income); }
+  public USTaxReturn(double income) { super(income); }
 
-    @Override
-    protected double computeTax() {
-        return income * 0.24;
-    }
+  @Override
+  protected double computeTax() {
+    return income * 0.24;
+  }
 
-    @Override
-    protected String submit(double tax) {
-        return "IRS receipt: tax owed $" + tax;
-    }
+  @Override
+  protected String submit(double tax) {
+    return "IRS receipt: tax owed $" + tax;
+  }
 }
 `,
     },
     {
       filename: "UKTaxReturn.java",
       initialContent: `public class UKTaxReturn extends TaxReturn {
-    public UKTaxReturn(double income) { super(income); }
+  public UKTaxReturn(double income) { super(income); }
 
-    @Override
-    protected double computeTax() {
-        return income * 0.20;
-    }
+  @Override
+  protected double computeTax() {
+    return income * 0.20;
+  }
 
-    @Override
-    protected String submit(double tax) {
-        return "HMRC receipt: tax owed £" + tax;
-    }
+  @Override
+  protected String submit(double tax) {
+    return "HMRC receipt: tax owed £" + tax;
+  }
 }
 `,
     },
@@ -265,71 +263,67 @@ To +1-555-0100: Your code is 1234
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Notification a = new EmailNotification("ada@oop.dev", "Welcome!");
-        Notification b = new SmsNotification("+1-555-0100", "Your code is 1234");
-        System.out.println(a.send());
-        System.out.println(b.send());
-    }
+  public static void main(String[] args) {
+    Notification a = new EmailNotification("ada@oop.dev", "Welcome!");
+    Notification b = new SmsNotification("+1-555-0100", "Your code is 1234");
+    System.out.println(a.send());
+    System.out.println(b.send());
+  }
 }
 `,
     },
     {
       filename: "Notification.java",
       initialContent: `public abstract class Notification {
-    // TODO: recipient field, constructor, final send(), abstract body()
+  // TODO: recipient field, constructor, final send(), abstract body()
 }
 `,
       solutionContent: `public abstract class Notification {
-    private final String recipient;
+  private final String recipient;
 
-    protected Notification(String recipient) {
-        this.recipient = recipient;
-    }
+  protected Notification(String recipient) { this.recipient = recipient; }
 
-    public final String send() {
-        return "To " + recipient + ": " + body();
-    }
+  public final String send() { return "To " + recipient + ": " + body(); }
 
-    protected abstract String body();
+  protected abstract String body();
 }
 `,
     },
     {
       filename: "EmailNotification.java",
       initialContent: `public class EmailNotification extends Notification {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class EmailNotification extends Notification {
-    private final String subject;
-    public EmailNotification(String recipient, String subject) {
-        super(recipient);
-        this.subject = subject;
-    }
-    @Override
-    protected String body() {
-        return "Subject: " + subject;
-    }
+  private final String subject;
+  public EmailNotification(String recipient, String subject) {
+    super(recipient);
+    this.subject = subject;
+  }
+  @Override
+  protected String body() {
+    return "Subject: " + subject;
+  }
 }
 `,
     },
     {
       filename: "SmsNotification.java",
       initialContent: `public class SmsNotification extends Notification {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class SmsNotification extends Notification {
-    private final String text;
-    public SmsNotification(String recipient, String text) {
-        super(recipient);
-        this.text = text;
-    }
-    @Override
-    protected String body() {
-        return text;
-    }
+  private final String text;
+  public SmsNotification(String recipient, String text) {
+    super(recipient);
+    this.text = text;
+  }
+  @Override
+  protected String body() {
+    return text;
+  }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/aggregation-and-dependency.mdx
+++ b/content/learn/oop-blueprint-java/aggregation-and-dependency.mdx
@@ -58,28 +58,28 @@ classDiagram
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        // Members exist on their own:
-        Member ada = new Member("Ada");
-        Member ken = new Member("Ken");
+  public static void main(String[] args) {
+    // Members exist on their own:
+    Member ada = new Member("Ada");
+    Member ken = new Member("Ken");
 
-        // The library aggregates them — it holds references, but didn't make them:
-        Library lib = new Library();
-        lib.register(ada);
-        lib.register(ken);
+    // The library aggregates them — it holds references, but didn't make them:
+    Library lib = new Library();
+    lib.register(ada);
+    lib.register(ken);
 
-        System.out.println("members: " + lib.memberCount());
-        System.out.println("ada still exists: " + (ada != null));   // yes, of course
-    }
+    System.out.println("members: " + lib.memberCount());
+    System.out.println("ada still exists: " + (ada != null)); // yes, of course
+  }
 }
 `,
     },
     {
       filename: "Member.java",
       initialContent: `public class Member {
-    private final String name;
-    public Member(String name) { this.name = name; }
-    public String name() { return name; }
+  private final String name;
+  public Member(String name) { this.name = name; }
+  public String name() { return name; }
 }
 `,
     },
@@ -89,17 +89,13 @@ classDiagram
 import java.util.List;
 
 public class Library {
-    // The list is owned by the Library (composition), but the Members
-    // inside it are aggregated — they were created elsewhere.
-    private final List<Member> members = new ArrayList<>();
+  // The list is owned by the Library (composition), but the Members
+  // inside it are aggregated — they were created elsewhere.
+  private final List<Member> members = new ArrayList<>();
 
-    public void register(Member m) {
-        members.add(m);
-    }
+  public void register(Member m) { members.add(m); }
 
-    public int memberCount() {
-        return members.size();
-    }
+  public int memberCount() { return members.size(); }
 }
 `,
     },
@@ -162,44 +158,43 @@ classDiagram
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Order o = new Order("ORD-42", 19.95);
-        Printer console = new Printer();
+  public static void main(String[] args) {
+    Order o = new Order("ORD-42", 19.95);
+    Printer console = new Printer();
 
-        OrderPrinter op = new OrderPrinter();
-        op.print(o, console);   // OrderPrinter doesn't *own* either of these
-    }
+    OrderPrinter op = new OrderPrinter();
+    op.print(o, console); // OrderPrinter doesn't *own* either of these
+  }
 }
 `,
     },
     {
       filename: "Order.java",
       initialContent: `public class Order {
-    private final String id;
-    private final double total;
-    public Order(String id, double total) {
-        this.id = id; this.total = total;
-    }
-    public String id()    { return id;    }
-    public double total() { return total; }
+  private final String id;
+  private final double total;
+  public Order(String id, double total) {
+    this.id = id;
+    this.total = total;
+  }
+  public String id() { return id; }
+  public double total() { return total; }
 }
 `,
     },
     {
       filename: "Printer.java",
       initialContent: `public class Printer {
-    public void write(String line) {
-        System.out.println("[printer] " + line);
-    }
+  public void write(String line) { System.out.println("[printer] " + line); }
 }
 `,
     },
     {
       filename: "OrderPrinter.java",
       initialContent: `public class OrderPrinter {
-    public void print(Order o, Printer printer) {
-        printer.write("Order " + o.id() + " total = " + o.total());
-    }
+  public void print(Order o, Printer printer) {
+    printer.write("Order " + o.id() + " total = " + o.total());
+  }
 }
 `,
     },
@@ -242,35 +237,29 @@ but the simple version is just good Java.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Logger console = new Logger();
-        Greeter g = new Greeter(console);   // Greeter aggregates the logger
-        g.greet("world");
-    }
+  public static void main(String[] args) {
+    Logger console = new Logger();
+    Greeter g = new Greeter(console); // Greeter aggregates the logger
+    g.greet("world");
+  }
 }
 `,
     },
     {
       filename: "Logger.java",
       initialContent: `public class Logger {
-    public void log(String message) {
-        System.out.println("[LOG] " + message);
-    }
+  public void log(String message) { System.out.println("[LOG] " + message); }
 }
 `,
     },
     {
       filename: "Greeter.java",
       initialContent: `public class Greeter {
-    private final Logger logger;          // aggregated, not owned
+  private final Logger logger; // aggregated, not owned
 
-    public Greeter(Logger logger) {
-        this.logger = logger;
-    }
+  public Greeter(Logger logger) { this.logger = logger; }
 
-    public void greet(String name) {
-        logger.log("Hello, " + name + "!");
-    }
+  public void greet(String name) { logger.log("Hello, " + name + "!"); }
 }
 `,
     },
@@ -312,30 +301,30 @@ names=Ada, Bob, Cleo
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Classroom room = new Classroom();
-        System.out.println("size=" + room.size());
+  public static void main(String[] args) {
+    Classroom room = new Classroom();
+    System.out.println("size=" + room.size());
 
-        room.enroll(new Student("Ada"));
-        room.enroll(new Student("Bob"));
-        room.enroll(new Student("Cleo"));
+    room.enroll(new Student("Ada"));
+    room.enroll(new Student("Bob"));
+    room.enroll(new Student("Cleo"));
 
-        System.out.println("size=" + room.size());
-        System.out.println("names=" + room.names());
-    }
+    System.out.println("size=" + room.size());
+    System.out.println("names=" + room.names());
+  }
 }
 `,
     },
     {
       filename: "Student.java",
       initialContent: `public class Student {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class Student {
-    private final String name;
-    public Student(String name) { this.name = name; }
-    public String name() { return name; }
+  private final String name;
+  public Student(String name) { this.name = name; }
+  public String name() { return name; }
 }
 `,
     },
@@ -345,26 +334,27 @@ names=Ada, Bob, Cleo
 import java.util.List;
 
 public class Classroom {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `import java.util.ArrayList;
 import java.util.List;
 
 public class Classroom {
-    private final List<Student> students = new ArrayList<>();
+  private final List<Student> students = new ArrayList<>();
 
-    public void enroll(Student s) { students.add(s); }
-    public int  size()            { return students.size(); }
+  public void enroll(Student s) { students.add(s); }
+  public int size() { return students.size(); }
 
-    public String names() {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < students.size(); i++) {
-            if (i > 0) sb.append(", ");
-            sb.append(students.get(i).name());
-        }
-        return sb.toString();
+  public String names() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < students.size(); i++) {
+      if (i > 0)
+        sb.append(", ");
+      sb.append(students.get(i).name());
     }
+    return sb.toString();
+  }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/birth-of-oop.mdx
+++ b/content/learn/oop-blueprint-java/birth-of-oop.mdx
@@ -92,30 +92,30 @@ the sequence diagram in the actual code.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Cart cart = new Cart();
-        cart.add(new Item("Notebook", 9.99));
-        cart.add(new Item("Pen",      4.50));
+  public static void main(String[] args) {
+    Cart cart = new Cart();
+    cart.add(new Item("Notebook", 9.99));
+    cart.add(new Item("Pen", 4.50));
 
-        Order order = new Order(cart);
-        System.out.println("Order total: $" + order.totalString());
-    }
+    Order order = new Order(cart);
+    System.out.println("Order total: $" + order.totalString());
+  }
 }
 `,
     },
     {
       filename: "Item.java",
       initialContent: `public class Item {
-    private final String name;
-    private final double price;
+  private final String name;
+  private final double price;
 
-    public Item(String name, double price) {
-        this.name = name;
-        this.price = price;
-    }
+  public Item(String name, double price) {
+    this.name = name;
+    this.price = price;
+  }
 
-    public double price() { return price; }
-    public String name()  { return name; }
+  public double price() { return price; }
+  public String name() { return name; }
 }
 `,
     },
@@ -125,28 +125,29 @@ the sequence diagram in the actual code.
 import java.util.List;
 
 public class Cart {
-    private final List<Item> items = new ArrayList<>();
+  private final List<Item> items = new ArrayList<>();
 
-    public void add(Item it) { items.add(it); }
+  public void add(Item it) { items.add(it); }
 
-    public double total() {
-        double sum = 0;
-        for (Item it : items) sum += it.price();   // sending price() to each Item
-        return sum;
-    }
+  public double total() {
+    double sum = 0;
+    for (Item it : items)
+      sum += it.price(); // sending price() to each Item
+    return sum;
+  }
 }
 `,
     },
     {
       filename: "Order.java",
       initialContent: `public class Order {
-    private final Cart cart;
+  private final Cart cart;
 
-    public Order(Cart cart) { this.cart = cart; }
+  public Order(Cart cart) { this.cart = cart; }
 
-    public String totalString() {
-        return String.format("%.2f", cart.total()); // sending total() to the Cart
-    }
+  public String totalString() {
+    return String.format("%.2f", cart.total()); // sending total() to the Cart
+  }
 }
 `,
     },
@@ -221,33 +222,33 @@ internals. Every interaction is a *message*.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        VendingMachine vm = new VendingMachine();
-        vm.stock(new Product("Cola",  150));
-        vm.stock(new Product("Chips", 200));
+  public static void main(String[] args) {
+    VendingMachine vm = new VendingMachine();
+    vm.stock(new Product("Cola", 150));
+    vm.stock(new Product("Chips", 200));
 
-        vm.insertCoins(100);
-        vm.insertCoins(100);
-        Product got = vm.select("Chips");
-        System.out.println("You got: " + (got == null ? "nothing" : got.name()));
-        System.out.println("Change : " + vm.takeChange() + " cents");
-    }
+    vm.insertCoins(100);
+    vm.insertCoins(100);
+    Product got = vm.select("Chips");
+    System.out.println("You got: " + (got == null ? "nothing" : got.name()));
+    System.out.println("Change : " + vm.takeChange() + " cents");
+  }
 }
 `,
     },
     {
       filename: "Product.java",
       initialContent: `public class Product {
-    private final String name;
-    private final int    priceCents;
+  private final String name;
+  private final int priceCents;
 
-    public Product(String name, int priceCents) {
-        this.name = name;
-        this.priceCents = priceCents;
-    }
+  public Product(String name, int priceCents) {
+    this.name = name;
+    this.priceCents = priceCents;
+  }
 
-    public String name()       { return name; }
-    public int    priceCents() { return priceCents; }
+  public String name() { return name; }
+  public int priceCents() { return priceCents; }
 }
 `,
     },
@@ -257,29 +258,29 @@ internals. Every interaction is a *message*.
 import java.util.List;
 
 public class VendingMachine {
-    private final List<Product> inventory = new ArrayList<>();
-    private int credit = 0;
+  private final List<Product> inventory = new ArrayList<>();
+  private int credit = 0;
 
-    public void stock(Product p)          { inventory.add(p); }
-    public void insertCoins(int cents)    { credit += cents; }
+  public void stock(Product p) { inventory.add(p); }
+  public void insertCoins(int cents) { credit += cents; }
 
-    public Product select(String name) {
-        for (int i = 0; i < inventory.size(); i++) {
-            Product p = inventory.get(i);
-            if (p.name().equals(name) && credit >= p.priceCents()) {
-                credit -= p.priceCents();
-                inventory.remove(i);
-                return p;
-            }
-        }
-        return null;
+  public Product select(String name) {
+    for (int i = 0; i < inventory.size(); i++) {
+      Product p = inventory.get(i);
+      if (p.name().equals(name) && credit >= p.priceCents()) {
+        credit -= p.priceCents();
+        inventory.remove(i);
+        return p;
+      }
     }
+    return null;
+  }
 
-    public int takeChange() {
-        int c = credit;
-        credit = 0;
-        return c;
-    }
+  public int takeChange() {
+    int c = credit;
+    credit = 0;
+    return c;
+  }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/capstone-library-system.mdx
+++ b/content/learn/oop-blueprint-java/capstone-library-system.mdx
@@ -148,52 +148,56 @@ miniature.
       initialContent: `import java.util.Arrays;
 
 public class Main {
-    public static void main(String[] args) {
-        Library lib = new Library(new LimitPolicy(2));
+  public static void main(String[] args) {
+    Library lib = new Library(new LimitPolicy(2));
 
-        Book b1 = new Book("Design Patterns", "GoF",     "ISBN-1");
-        Book b2 = new Book("Refactoring",     "Fowler",  "ISBN-2");
-        Book b3 = new Book("OOSC",            "Meyer",   "ISBN-3");
-        for (Book b : Arrays.asList(b1, b2, b3)) lib.addBook(b);
+    Book b1 = new Book("Design Patterns", "GoF", "ISBN-1");
+    Book b2 = new Book("Refactoring", "Fowler", "ISBN-2");
+    Book b3 = new Book("OOSC", "Meyer", "ISBN-3");
+    for (Book b : Arrays.asList(b1, b2, b3))
+      lib.addBook(b);
 
-        Member ada = new Member("Ada", 1);
-        Member bob = new Member("Bob", 2);
-        lib.register(ada);
-        lib.register(bob);
+    Member ada = new Member("Ada", 1);
+    Member bob = new Member("Bob", 2);
+    lib.register(ada);
+    lib.register(bob);
 
-        Loan l1 = lib.borrow(ada, b1, /*today*/ 1, /*loanDays*/ 14);
-        Loan l2 = lib.borrow(ada, b2, /*today*/ 1, /*loanDays*/ 14);
-        Loan l3 = lib.borrow(ada, b3, /*today*/ 1, /*loanDays*/ 14);  // should be refused
+    Loan l1 = lib.borrow(ada, b1, /*today*/ 1, /*loanDays*/ 14);
+    Loan l2 = lib.borrow(ada, b2, /*today*/ 1, /*loanDays*/ 14);
+    Loan l3 =
+        lib.borrow(ada, b3, /*today*/ 1, /*loanDays*/ 14); // should be refused
 
-        System.out.println("l1 issued? " + (l1 != null));
-        System.out.println("l2 issued? " + (l2 != null));
-        System.out.println("l3 issued? " + (l3 != null));
+    System.out.println("l1 issued? " + (l1 != null));
+    System.out.println("l2 issued? " + (l2 != null));
+    System.out.println("l3 issued? " + (l3 != null));
 
-        System.out.println("active loans: " + lib.activeLoans().size());
-        System.out.println("l1 overdue on day 10? " + l1.isOverdue(10));
-        System.out.println("l1 overdue on day 20? " + l1.isOverdue(20));
+    System.out.println("active loans: " + lib.activeLoans().size());
+    System.out.println("l1 overdue on day 10? " + l1.isOverdue(10));
+    System.out.println("l1 overdue on day 20? " + l1.isOverdue(20));
 
-        lib.returnBook(l1);
-        System.out.println("after return, active: " + lib.activeLoans().size());
+    lib.returnBook(l1);
+    System.out.println("after return, active: " + lib.activeLoans().size());
 
-        Loan l4 = lib.borrow(ada, b3, /*today*/ 5, /*loanDays*/ 14);
-        System.out.println("l4 issued? " + (l4 != null));
-    }
+    Loan l4 = lib.borrow(ada, b3, /*today*/ 5, /*loanDays*/ 14);
+    System.out.println("l4 issued? " + (l4 != null));
+  }
 }
 `,
     },
     {
       filename: "Book.java",
       initialContent: `public class Book {
-    private final String title;
-    private final String author;
-    private final String isbn;
-    public Book(String title, String author, String isbn) {
-        this.title = title; this.author = author; this.isbn = isbn;
-    }
-    public String title()  { return title; }
-    public String author() { return author; }
-    public String isbn()   { return isbn; }
+  private final String title;
+  private final String author;
+  private final String isbn;
+  public Book(String title, String author, String isbn) {
+    this.title = title;
+    this.author = author;
+    this.isbn = isbn;
+  }
+  public String title() { return title; }
+  public String author() { return author; }
+  public String isbn() { return isbn; }
 }
 `,
     },
@@ -203,103 +207,104 @@ public class Main {
 import java.util.List;
 
 public class Member {
-    private final String name;
-    private final int id;
-    private final List<Loan> loans = new ArrayList<>();
+  private final String name;
+  private final int id;
+  private final List<Loan> loans = new ArrayList<>();
 
-    public Member(String name, int id) {
-        this.name = name; this.id = id;
-    }
+  public Member(String name, int id) {
+    this.name = name;
+    this.id = id;
+  }
 
-    public String name()  { return name; }
-    public int    id()    { return id; }
+  public String name() { return name; }
+  public int id() { return id; }
 
-    public int loanCount() { return loans.size(); }
-    public void addLoan(Loan loan)    { loans.add(loan); }
-    public void removeLoan(Loan loan) { loans.remove(loan); }
+  public int loanCount() { return loans.size(); }
+  public void addLoan(Loan loan) { loans.add(loan); }
+  public void removeLoan(Loan loan) { loans.remove(loan); }
 }
 `,
     },
     {
       filename: "Loan.java",
       initialContent: `public class Loan {
-    private final Book   book;
-    private final Member member;
-    private final int    dueDay;     // simplified day counter
+  private final Book book;
+  private final Member member;
+  private final int dueDay; // simplified day counter
 
-    public Loan(Book book, Member member, int dueDay) {
-        this.book   = book;
-        this.member = member;
-        this.dueDay = dueDay;
-    }
+  public Loan(Book book, Member member, int dueDay) {
+    this.book = book;
+    this.member = member;
+    this.dueDay = dueDay;
+  }
 
-    public Book   book()   { return book; }
-    public Member member() { return member; }
-    public int    dueDay() { return dueDay; }
+  public Book book() { return book; }
+  public Member member() { return member; }
+  public int dueDay() { return dueDay; }
 
-    public boolean isOverdue(int nowDay) {
-        // TODO: return true iff nowDay is strictly after dueDay.
-        return false;
-    }
+  public boolean isOverdue(int nowDay) {
+    // TODO: return true iff nowDay is strictly after dueDay.
+    return false;
+  }
 }
 `,
       solutionContent: `public class Loan {
-    private final Book   book;
-    private final Member member;
-    private final int    dueDay;
+  private final Book book;
+  private final Member member;
+  private final int dueDay;
 
-    public Loan(Book book, Member member, int dueDay) {
-        this.book   = book;
-        this.member = member;
-        this.dueDay = dueDay;
-    }
+  public Loan(Book book, Member member, int dueDay) {
+    this.book = book;
+    this.member = member;
+    this.dueDay = dueDay;
+  }
 
-    public Book   book()   { return book; }
-    public Member member() { return member; }
-    public int    dueDay() { return dueDay; }
+  public Book book() { return book; }
+  public Member member() { return member; }
+  public int dueDay() { return dueDay; }
 
-    public boolean isOverdue(int nowDay) {
-        return nowDay > dueDay;
-    }
+  public boolean isOverdue(int nowDay) { return nowDay > dueDay; }
 }
 `,
     },
     {
       filename: "BorrowingPolicy.java",
       initialContent: `public interface BorrowingPolicy {
-    boolean mayBorrow(Member member);
+  boolean mayBorrow(Member member);
 }
 `,
     },
     {
       filename: "LimitPolicy.java",
       initialContent: `public class LimitPolicy implements BorrowingPolicy {
-    private final int max;
-    public LimitPolicy(int max) { this.max = max; }
+  private final int max;
+  public LimitPolicy(int max) { this.max = max; }
 
-    @Override
-    public boolean mayBorrow(Member member) {
-        // TODO: return true iff member.loanCount() < max.
-        return true;
-    }
+  @Override
+  public boolean mayBorrow(Member member) {
+    // TODO: return true iff member.loanCount() < max.
+    return true;
+  }
 }
 `,
       solutionContent: `public class LimitPolicy implements BorrowingPolicy {
-    private final int max;
-    public LimitPolicy(int max) { this.max = max; }
+  private final int max;
+  public LimitPolicy(int max) { this.max = max; }
 
-    @Override
-    public boolean mayBorrow(Member member) {
-        return member.loanCount() < max;
-    }
+  @Override
+  public boolean mayBorrow(Member member) {
+    return member.loanCount() < max;
+  }
 }
 `,
     },
     {
       filename: "OpenPolicy.java",
       initialContent: `public class OpenPolicy implements BorrowingPolicy {
-    @Override
-    public boolean mayBorrow(Member member) { return true; }
+  @Override
+  public boolean mayBorrow(Member member) {
+    return true;
+  }
 }
 `,
     },
@@ -309,37 +314,36 @@ public class Member {
 import java.util.List;
 
 public class Library {
-    private final BorrowingPolicy policy;
-    private final List<Book>   books   = new ArrayList<>();
-    private final List<Member> members = new ArrayList<>();
-    private final List<Loan>   active  = new ArrayList<>();
+  private final BorrowingPolicy policy;
+  private final List<Book> books = new ArrayList<>();
+  private final List<Member> members = new ArrayList<>();
+  private final List<Loan> active = new ArrayList<>();
 
-    public Library(BorrowingPolicy policy) {
-        this.policy = policy;
-    }
+  public Library(BorrowingPolicy policy) { this.policy = policy; }
 
-    public void addBook(Book b)      { books.add(b); }
-    public void register(Member m)   { members.add(m); }
+  public void addBook(Book b) { books.add(b); }
+  public void register(Member m) { members.add(m); }
 
-    public Loan borrow(Member m, Book b, int today, int loanDays) {
-        if (!books.contains(b))     return null;
-        if (!policy.mayBorrow(m))   return null;
-        Loan loan = new Loan(b, m, today + loanDays);
-        active.add(loan);
-        m.addLoan(loan);
-        books.remove(b);            // book is off the shelf now
-        return loan;
-    }
+  public Loan borrow(Member m, Book b, int today, int loanDays) {
+    if (!books.contains(b))
+      return null;
+    if (!policy.mayBorrow(m))
+      return null;
+    Loan loan = new Loan(b, m, today + loanDays);
+    active.add(loan);
+    m.addLoan(loan);
+    books.remove(b); // book is off the shelf now
+    return loan;
+  }
 
-    public void returnBook(Loan loan) {
-        if (!active.remove(loan)) return;
-        loan.member().removeLoan(loan);
-        books.add(loan.book());
-    }
+  public void returnBook(Loan loan) {
+    if (!active.remove(loan))
+      return;
+    loan.member().removeLoan(loan);
+    books.add(loan.book());
+  }
 
-    public List<Loan> activeLoans() {
-        return active;
-    }
+  public List<Loan> activeLoans() { return active; }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/composition.mdx
+++ b/content/learn/oop-blueprint-java/composition.mdx
@@ -65,37 +65,37 @@ ownership. The `Engine` is part of the `Car`.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Car c = new Car();
-        System.out.println("Before start, running? " + c.running());
-        c.start();
-        System.out.println("After  start, running? " + c.running());
-        c.stop();
-        System.out.println("After  stop,  running? " + c.running());
-    }
+  public static void main(String[] args) {
+    Car c = new Car();
+    System.out.println("Before start, running? " + c.running());
+    c.start();
+    System.out.println("After  start, running? " + c.running());
+    c.stop();
+    System.out.println("After  stop,  running? " + c.running());
+  }
 }
 `,
     },
     {
       filename: "Engine.java",
       initialContent: `public class Engine {
-    private boolean running;
+  private boolean running;
 
-    public void ignite()   { running = true;  }
-    public void shutOff()  { running = false; }
-    public boolean running() { return running; }
+  public void ignite() { running = true; }
+  public void shutOff() { running = false; }
+  public boolean running() { return running; }
 }
 `,
     },
     {
       filename: "Car.java",
       initialContent: `public class Car {
-    // The engine is constructed and OWNED by the Car.
-    private final Engine engine = new Engine();
+  // The engine is constructed and OWNED by the Car.
+  private final Engine engine = new Engine();
 
-    public void start()  { engine.ignite();  }
-    public void stop()   { engine.shutOff(); }
-    public boolean running() { return engine.running(); }
+  public void start() { engine.ignite(); }
+  public void stop() { engine.shutOff(); }
+  public boolean running() { return engine.running(); }
 }
 `}
   ]}
@@ -142,47 +142,47 @@ for me." It is the everyday verb of composition.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Person p = new Person("Ada", new Address("13 Albemarle St", "London"));
-        System.out.println(p.describe());
-        System.out.println("City: " + p.city());      // Person delegates to Address
-    }
+  public static void main(String[] args) {
+    Person p = new Person("Ada", new Address("13 Albemarle St", "London"));
+    System.out.println(p.describe());
+    System.out.println("City: " + p.city()); // Person delegates to Address
+  }
 }
 `,
     },
     {
       filename: "Address.java",
       initialContent: `public class Address {
-    private final String street;
-    private final String city;
-    public Address(String street, String city) {
-        this.street = street;
-        this.city = city;
-    }
-    public String street() { return street; }
-    public String city()   { return city; }
-    public String oneLine() { return street + ", " + city; }
+  private final String street;
+  private final String city;
+  public Address(String street, String city) {
+    this.street = street;
+    this.city = city;
+  }
+  public String street() { return street; }
+  public String city() { return city; }
+  public String oneLine() { return street + ", " + city; }
 }
 `,
     },
     {
       filename: "Person.java",
       initialContent: `public class Person {
-    private final String  name;
-    private final Address address;
+  private final String name;
+  private final Address address;
 
-    public Person(String name, Address address) {
-        this.name    = name;
-        this.address = address;
-    }
+  public Person(String name, Address address) {
+    this.name = name;
+    this.address = address;
+  }
 
-    public String describe() {
-        return name + " — " + address.oneLine();          // delegation
-    }
+  public String describe() {
+    return name + " — " + address.oneLine(); // delegation
+  }
 
-    public String city() {
-        return address.city();                             // delegation
-    }
+  public String city() {
+    return address.city(); // delegation
+  }
 }
 `,
     },
@@ -234,66 +234,61 @@ classDiagram
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Computer c = new Computer(
-            new Cpu("M4", 10),
-            new Ram(16),
-            new Ssd(512)
-        );
-        System.out.println(c.specs());
-    }
+  public static void main(String[] args) {
+    Computer c = new Computer(new Cpu("M4", 10), new Ram(16), new Ssd(512));
+    System.out.println(c.specs());
+  }
 }
 `,
     },
     {
       filename: "Cpu.java",
       initialContent: `public class Cpu {
-    private final String model;
-    private final int cores;
-    public Cpu(String model, int cores) {
-        this.model = model;
-        this.cores = cores;
-    }
-    public String describe() { return model + " (" + cores + " cores)"; }
+  private final String model;
+  private final int cores;
+  public Cpu(String model, int cores) {
+    this.model = model;
+    this.cores = cores;
+  }
+  public String describe() { return model + " (" + cores + " cores)"; }
 }
 `,
     },
     {
       filename: "Ram.java",
       initialContent: `public class Ram {
-    private final int gb;
-    public Ram(int gb) { this.gb = gb; }
-    public String describe() { return gb + " GB RAM"; }
+  private final int gb;
+  public Ram(int gb) { this.gb = gb; }
+  public String describe() { return gb + " GB RAM"; }
 }
 `,
     },
     {
       filename: "Ssd.java",
       initialContent: `public class Ssd {
-    private final int gb;
-    public Ssd(int gb) { this.gb = gb; }
-    public String describe() { return gb + " GB SSD"; }
+  private final int gb;
+  public Ssd(int gb) { this.gb = gb; }
+  public String describe() { return gb + " GB SSD"; }
 }
 `,
     },
     {
       filename: "Computer.java",
       initialContent: `public class Computer {
-    private final Cpu cpu;
-    private final Ram ram;
-    private final Ssd ssd;
+  private final Cpu cpu;
+  private final Ram ram;
+  private final Ssd ssd;
 
-    public Computer(Cpu cpu, Ram ram, Ssd ssd) {
-        this.cpu = cpu;
-        this.ram = ram;
-        this.ssd = ssd;
-    }
+  public Computer(Cpu cpu, Ram ram, Ssd ssd) {
+    this.cpu = cpu;
+    this.ram = ram;
+    this.ssd = ssd;
+  }
 
-    public String specs() {
-        return "Computer: " + cpu.describe()
-             + ", "         + ram.describe()
-             + ", "         + ssd.describe();
-    }
+  public String specs() {
+    return "Computer: " + cpu.describe() + ", " + ram.describe() + ", " +
+        ssd.describe();
+  }
 }
 `,
     },
@@ -325,49 +320,45 @@ Pride and Prejudice by Jane Austen
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Author austen = new Author("Jane", "Austen");
-        Book   book   = new Book("Pride and Prejudice", austen);
-        System.out.println(book.citation());
-    }
+  public static void main(String[] args) {
+    Author austen = new Author("Jane", "Austen");
+    Book book = new Book("Pride and Prejudice", austen);
+    System.out.println(book.citation());
+  }
 }
 `,
     },
     {
       filename: "Author.java",
       initialContent: `public class Author {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class Author {
-    private final String firstName;
-    private final String lastName;
-    public Author(String firstName, String lastName) {
-        this.firstName = firstName;
-        this.lastName  = lastName;
-    }
-    public String fullName() {
-        return firstName + " " + lastName;
-    }
+  private final String firstName;
+  private final String lastName;
+  public Author(String firstName, String lastName) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+  public String fullName() { return firstName + " " + lastName; }
 }
 `,
     },
     {
       filename: "Book.java",
       initialContent: `public class Book {
-    // TODO — must compose an Author
+  // TODO — must compose an Author
 }
 `,
       solutionContent: `public class Book {
-    private final String title;
-    private final Author author;
-    public Book(String title, Author author) {
-        this.title  = title;
-        this.author = author;
-    }
-    public String citation() {
-        return title + " by " + author.fullName();
-    }
+  private final String title;
+  private final Author author;
+  public Book(String title, Author author) {
+    this.title = title;
+    this.author = author;
+  }
+  public String citation() { return title + " by " + author.fullName(); }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/constructors-and-state.mdx
+++ b/content/learn/oop-blueprint-java/constructors-and-state.mdx
@@ -259,48 +259,48 @@ bad: invalid email
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        try {
-            User u = new User("ada", "ada@oop.dev");
-            System.out.println("ok: " + u.username() + " @ " + u.email());
-        } catch (IllegalArgumentException e) {
-            System.out.println("bad: " + e.getMessage());
-        }
-        try {
-            new User("a", "ada@oop.dev");
-        } catch (IllegalArgumentException e) {
-            System.out.println("bad: " + e.getMessage());
-        }
-        try {
-            new User("ada", "no-at-sign");
-        } catch (IllegalArgumentException e) {
-            System.out.println("bad: " + e.getMessage());
-        }
+  public static void main(String[] args) {
+    try {
+      User u = new User("ada", "ada@oop.dev");
+      System.out.println("ok: " + u.username() + " @ " + u.email());
+    } catch (IllegalArgumentException e) {
+      System.out.println("bad: " + e.getMessage());
     }
+    try {
+      new User("a", "ada@oop.dev");
+    } catch (IllegalArgumentException e) {
+      System.out.println("bad: " + e.getMessage());
+    }
+    try {
+      new User("ada", "no-at-sign");
+    } catch (IllegalArgumentException e) {
+      System.out.println("bad: " + e.getMessage());
+    }
+  }
 }
 `,
     },
     {
       filename: "User.java",
       initialContent: `public class User {
-    // TODO: private final fields + a validating constructor + accessors
+  // TODO: private final fields + a validating constructor + accessors
 }
 `,
       solutionContent: `public class User {
-    private final String username;
-    private final String email;
+  private final String username;
+  private final String email;
 
-    public User(String username, String email) {
-        if (username == null || username.length() < 3)
-            throw new IllegalArgumentException("invalid username");
-        if (email == null || email.indexOf('@') < 0)
-            throw new IllegalArgumentException("invalid email");
-        this.username = username;
-        this.email    = email;
-    }
+  public User(String username, String email) {
+    if (username == null || username.length() < 3)
+      throw new IllegalArgumentException("invalid username");
+    if (email == null || email.indexOf('@') < 0)
+      throw new IllegalArgumentException("invalid email");
+    this.username = username;
+    this.email = email;
+  }
 
-    public String username() { return username; }
-    public String email()    { return email; }
+  public String username() { return username; }
+  public String email() { return email; }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/encapsulation.mdx
+++ b/content/learn/oop-blueprint-java/encapsulation.mdx
@@ -187,52 +187,53 @@ allowed temperature range and a current setting. Outsiders can
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Thermostat t = new Thermostat(60, 80, 68);
-        System.out.println(t.describe());
+  public static void main(String[] args) {
+    Thermostat t = new Thermostat(60, 80, 68);
+    System.out.println(t.describe());
 
-        t.setTarget(75);
-        System.out.println(t.describe());
+    t.setTarget(75);
+    System.out.println(t.describe());
 
-        t.setTarget(120);                // out of range — clamped
-        System.out.println(t.describe());
+    t.setTarget(120); // out of range — clamped
+    System.out.println(t.describe());
 
-        t.setTarget(-10);                // out of range — clamped
-        System.out.println(t.describe());
-    }
+    t.setTarget(-10); // out of range — clamped
+    System.out.println(t.describe());
+  }
 }
 `,
     },
     {
       filename: "Thermostat.java",
       initialContent: `public class Thermostat {
-    private final int minF;
-    private final int maxF;
-    private int target;          // not final — changes over time
+  private final int minF;
+  private final int maxF;
+  private int target; // not final — changes over time
 
-    public Thermostat(int minF, int maxF, int initialTarget) {
-        if (minF >= maxF) throw new IllegalArgumentException("minF must be < maxF");
-        this.minF = minF;
-        this.maxF = maxF;
-        this.target = clamp(initialTarget);
-    }
+  public Thermostat(int minF, int maxF, int initialTarget) {
+    if (minF >= maxF)
+      throw new IllegalArgumentException("minF must be < maxF");
+    this.minF = minF;
+    this.maxF = maxF;
+    this.target = clamp(initialTarget);
+  }
 
-    public void setTarget(int desired) {
-        this.target = clamp(desired);
-    }
+  public void setTarget(int desired) { this.target = clamp(desired); }
 
-    public int target() { return target; }
+  public int target() { return target; }
 
-    public String describe() {
-        return "Thermostat[" + minF + ".." + maxF + "F, target=" + target + "F]";
-    }
+  public String describe() {
+    return "Thermostat[" + minF + ".." + maxF + "F, target=" + target + "F]";
+  }
 
-    // private helper: enforces the invariant in ONE place
-    private int clamp(int value) {
-        if (value < minF) return minF;
-        if (value > maxF) return maxF;
-        return value;
-    }
+  // private helper: enforces the invariant in ONE place
+  private int clamp(int value) {
+    if (value < minF)
+      return minF;
+    if (value > maxF)
+      return maxF;
+    return value;
+  }
 }
 `,
     },
@@ -278,40 +279,43 @@ balance=20
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Wallet w = new Wallet();
-        w.add(100);
-        boolean s1 = w.spend(80);
-        boolean s2 = w.spend(999);
-        System.out.println("spend1=" + s1);
-        System.out.println("spend2=" + s2);
-        System.out.println("balance=" + w.balance());
-    }
+  public static void main(String[] args) {
+    Wallet w = new Wallet();
+    w.add(100);
+    boolean s1 = w.spend(80);
+    boolean s2 = w.spend(999);
+    System.out.println("spend1=" + s1);
+    System.out.println("spend2=" + s2);
+    System.out.println("balance=" + w.balance());
+  }
 }
 `,
     },
     {
       filename: "Wallet.java",
       initialContent: `public class Wallet {
-    // TODO: implement the Wallet class
+  // TODO: implement the Wallet class
 }
 `,
       solutionContent: `public class Wallet {
-    private int cents = 0;
+  private int cents = 0;
 
-    public void add(int amount) {
-        if (amount <= 0) throw new IllegalArgumentException("must be positive");
-        cents += amount;
-    }
+  public void add(int amount) {
+    if (amount <= 0)
+      throw new IllegalArgumentException("must be positive");
+    cents += amount;
+  }
 
-    public boolean spend(int amount) {
-        if (amount <= 0) throw new IllegalArgumentException("must be positive");
-        if (amount > cents) return false;
-        cents -= amount;
-        return true;
-    }
+  public boolean spend(int amount) {
+    if (amount <= 0)
+      throw new IllegalArgumentException("must be positive");
+    if (amount > cents)
+      return false;
+    cents -= amount;
+    return true;
+  }
 
-    public int balance() { return cents; }
+  public int balance() { return cents; }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/enums.mdx
+++ b/content/learn/oop-blueprint-java/enums.mdx
@@ -223,37 +223,37 @@ an enum:
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        double subtotal = 200.00;
-        for (PaymentMethod m : PaymentMethod.values()) {
-            double charged = m.surchargedTotal(subtotal);
-            System.out.printf("%-12s -> %.2f%n", m.label(), charged);
-        }
+  public static void main(String[] args) {
+    double subtotal = 200.00;
+    for (PaymentMethod m : PaymentMethod.values()) {
+      double charged = m.surchargedTotal(subtotal);
+      System.out.printf("%-12s -> %.2f%n", m.label(), charged);
     }
+  }
 }
 `,
     },
     {
       filename: "PaymentMethod.java",
       initialContent: `public enum PaymentMethod {
-    CASH        ("Cash",          0.00),
-    DEBIT_CARD  ("Debit card",    0.01),
-    CREDIT_CARD ("Credit card",   0.025),
-    CRYPTO      ("Crypto wallet", 0.005);
+  CASH("Cash", 0.00),
+  DEBIT_CARD("Debit card", 0.01),
+  CREDIT_CARD("Credit card", 0.025),
+  CRYPTO("Crypto wallet", 0.005);
 
-    private final String label;
-    private final double feeRate;
+  private final String label;
+  private final double feeRate;
 
-    PaymentMethod(String label, double feeRate) {
-        this.label = label;
-        this.feeRate = feeRate;
-    }
+  PaymentMethod(String label, double feeRate) {
+    this.label = label;
+    this.feeRate = feeRate;
+  }
 
-    public String label() { return label; }
+  public String label() { return label; }
 
-    public double surchargedTotal(double subtotal) {
-        return subtotal * (1.0 + feeRate);
-    }
+  public double surchargedTotal(double subtotal) {
+    return subtotal * (1.0 + feeRate);
+  }
 }
 `,
     },
@@ -283,26 +283,30 @@ SUNDAY weekend? true
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        for (Day d : Day.values()) {
-            System.out.println(d + " weekend? " + d.isWeekend());
-        }
+  public static void main(String[] args) {
+    for (Day d : Day.values()) {
+      System.out.println(d + " weekend? " + d.isWeekend());
     }
+  }
 }
 `,
     },
     {
       filename: "Day.java",
       initialContent: `public enum Day {
-    // TODO: list the seven days, then define isWeekend()
+  // TODO: list the seven days, then define isWeekend()
 }
 `,
       solutionContent: `public enum Day {
-    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY,
+  SUNDAY;
 
-    public boolean isWeekend() {
-        return this == SATURDAY || this == SUNDAY;
-    }
+  public boolean isWeekend() { return this == SATURDAY || this == SUNDAY; }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/gang-of-four.mdx
+++ b/content/learn/oop-blueprint-java/gang-of-four.mdx
@@ -104,66 +104,60 @@ classDiagram
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        double subtotal = 100.0;
+  public static void main(String[] args) {
+    double subtotal = 100.0;
 
-        Checkout regular = new Checkout(new RegularPricing());
-        Checkout holiday = new Checkout(new HolidayPricing(0.20));
-        Checkout loyalty = new Checkout(new LoyaltyPricing(15));
+    Checkout regular = new Checkout(new RegularPricing());
+    Checkout holiday = new Checkout(new HolidayPricing(0.20));
+    Checkout loyalty = new Checkout(new LoyaltyPricing(15));
 
-        System.out.println("Regular: $" + regular.total(subtotal));
-        System.out.println("Holiday: $" + holiday.total(subtotal));
-        System.out.println("Loyalty: $" + loyalty.total(subtotal));
-    }
+    System.out.println("Regular: $" + regular.total(subtotal));
+    System.out.println("Holiday: $" + holiday.total(subtotal));
+    System.out.println("Loyalty: $" + loyalty.total(subtotal));
+  }
 }
 `,
     },
     {
       filename: "PricingStrategy.java",
       initialContent: `public interface PricingStrategy {
-    double price(double subtotal);
+  double price(double subtotal);
 }
 `,
     },
     {
       filename: "RegularPricing.java",
       initialContent: `public class RegularPricing implements PricingStrategy {
-    public double price(double subtotal) { return subtotal; }
+  public double price(double subtotal) { return subtotal; }
 }
 `,
     },
     {
       filename: "HolidayPricing.java",
       initialContent: `public class HolidayPricing implements PricingStrategy {
-    private final double discount; // e.g. 0.20 = 20% off
-    public HolidayPricing(double discount) { this.discount = discount; }
-    public double price(double subtotal) {
-        return subtotal * (1.0 - discount);
-    }
+  private final double discount; // e.g. 0.20 = 20% off
+  public HolidayPricing(double discount) { this.discount = discount; }
+  public double price(double subtotal) { return subtotal * (1.0 - discount); }
 }
 `,
     },
     {
       filename: "LoyaltyPricing.java",
       initialContent: `public class LoyaltyPricing implements PricingStrategy {
-    private final double flatOff;
-    public LoyaltyPricing(double flatOff) { this.flatOff = flatOff; }
-    public double price(double subtotal) {
-        return Math.max(0.0, subtotal - flatOff);
-    }
+  private final double flatOff;
+  public LoyaltyPricing(double flatOff) { this.flatOff = flatOff; }
+  public double price(double subtotal) {
+    return Math.max(0.0, subtotal - flatOff);
+  }
 }
 `,
     },
     {
       filename: "Checkout.java",
       initialContent: `public class Checkout {
-    private final PricingStrategy strategy;
-    public Checkout(PricingStrategy strategy) {
-        this.strategy = strategy;
-    }
-    public double total(double subtotal) {
-        return strategy.price(subtotal);
-    }
+  private final PricingStrategy strategy;
+  public Checkout(PricingStrategy strategy) { this.strategy = strategy; }
+  public double total(double subtotal) { return strategy.price(subtotal); }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/inheritance.mdx
+++ b/content/learn/oop-blueprint-java/inheritance.mdx
@@ -39,55 +39,50 @@ is-an Animal*. In Java, the keyword is `extends`.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Animal a = new Animal("Generic");
-        Dog    d = new Dog("Rex");
-        Cat    c = new Cat("Mochi");
+  public static void main(String[] args) {
+    Animal a = new Animal("Generic");
+    Dog d = new Dog("Rex");
+    Cat c = new Cat("Mochi");
 
-        System.out.println(a.name() + ": " + a.speak());
-        System.out.println(d.name() + ": " + d.speak());
-        System.out.println(c.name() + ": " + c.speak());
-    }
+    System.out.println(a.name() + ": " + a.speak());
+    System.out.println(d.name() + ": " + d.speak());
+    System.out.println(c.name() + ": " + c.speak());
+  }
 }
 `,
     },
     {
       filename: "Animal.java",
       initialContent: `public class Animal {
-    private final String name;
+  private final String name;
 
-    public Animal(String name) {
-        this.name = name;
-    }
+  public Animal(String name) { this.name = name; }
 
-    public String name()  { return name; }
-    public String speak() { return "(some sound)"; }
+  public String name() { return name; }
+  public String speak() { return "(some sound)"; }
 }
 `,
     },
     {
       filename: "Dog.java",
       initialContent: `public class Dog extends Animal {
-    public Dog(String name) {
-        super(name);                 // call Animal's constructor
-    }
-    @Override
-    public String speak() {           // override the inherited behavior
-        return "Woof!";
-    }
+  public Dog(String name) {
+    super(name); // call Animal's constructor
+  }
+  @Override public String speak() { // override the inherited behavior
+    return "Woof!";
+  }
 }
 `,
     },
     {
       filename: "Cat.java",
       initialContent: `public class Cat extends Animal {
-    public Cat(String name) {
-        super(name);
-    }
-    @Override
-    public String speak() {
-        return "Meow!";
-    }
+  public Cat(String name) { super(name); }
+  @Override
+  public String speak() {
+    return "Meow!";
+  }
 }
 `,
     },
@@ -160,48 +155,46 @@ explicitly with `super.methodName(...)`.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Employee e  = new Employee("Ada", 5_000);
-        Manager  m  = new Manager("Bob", 5_000, 2_000);
-        System.out.println("Ada earns " + e.monthlyPay());
-        System.out.println("Bob earns " + m.monthlyPay());
-    }
+  public static void main(String[] args) {
+    Employee e = new Employee("Ada", 5_000);
+    Manager m = new Manager("Bob", 5_000, 2_000);
+    System.out.println("Ada earns " + e.monthlyPay());
+    System.out.println("Bob earns " + m.monthlyPay());
+  }
 }
 `,
     },
     {
       filename: "Employee.java",
       initialContent: `public class Employee {
-    private final String name;
-    private final double baseSalary;
+  private final String name;
+  private final double baseSalary;
 
-    public Employee(String name, double baseSalary) {
-        this.name = name;
-        this.baseSalary = baseSalary;
-    }
+  public Employee(String name, double baseSalary) {
+    this.name = name;
+    this.baseSalary = baseSalary;
+  }
 
-    public String name() { return name; }
+  public String name() { return name; }
 
-    public double monthlyPay() {
-        return baseSalary;
-    }
+  public double monthlyPay() { return baseSalary; }
 }
 `,
     },
     {
       filename: "Manager.java",
       initialContent: `public class Manager extends Employee {
-    private final double bonus;
+  private final double bonus;
 
-    public Manager(String name, double baseSalary, double bonus) {
-        super(name, baseSalary);
-        this.bonus = bonus;
-    }
+  public Manager(String name, double baseSalary, double bonus) {
+    super(name, baseSalary);
+    this.bonus = bonus;
+  }
 
-    @Override
-    public double monthlyPay() {
-        return super.monthlyPay() + bonus;       // extends, doesn't replace
-    }
+  @Override
+  public double monthlyPay() {
+    return super.monthlyPay() + bonus; // extends, doesn't replace
+  }
 }
 `,
     },
@@ -282,64 +275,53 @@ Shape with area 16.0
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Shape> shapes = Arrays.asList(
-            new Shape(),
-            new Circle(1.0),
-            new Square(4.0)
-        );
-        for (Shape s : shapes) {
-            System.out.println(s.describe());
-        }
+  public static void main(String[] args) {
+    List<Shape> shapes =
+        Arrays.asList(new Shape(), new Circle(1.0), new Square(4.0));
+    for (Shape s : shapes) {
+      System.out.println(s.describe());
     }
+  }
 }
 `,
     },
     {
       filename: "Shape.java",
       initialContent: `public class Shape {
-    public double area() {
-        return 0.0;
-    }
-    public String describe() {
-        return "Shape with area " + area();
-    }
+  public double area() { return 0.0; }
+  public String describe() { return "Shape with area " + area(); }
 }
 `,
     },
     {
       filename: "Circle.java",
       initialContent: `public class Circle extends Shape {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class Circle extends Shape {
-    private final double radius;
-    public Circle(double radius) {
-        this.radius = radius;
-    }
-    @Override
-    public double area() {
-        return Math.PI * radius * radius;
-    }
+  private final double radius;
+  public Circle(double radius) { this.radius = radius; }
+  @Override
+  public double area() {
+    return Math.PI * radius * radius;
+  }
 }
 `,
     },
     {
       filename: "Square.java",
       initialContent: `public class Square extends Shape {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class Square extends Shape {
-    private final double side;
-    public Square(double side) {
-        this.side = side;
-    }
-    @Override
-    public double area() {
-        return side * side;
-    }
+  private final double side;
+  public Square(double side) { this.side = side; }
+  @Override
+  public double area() {
+    return side * side;
+  }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/interfaces.mdx
+++ b/content/learn/oop-blueprint-java/interfaces.mdx
@@ -41,43 +41,49 @@ opposed to `<|--` for "extends a class"). In Java, the keywords are
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Noisy[] things = { new Dog(), new Doorbell(), new MotionSensor() };
-        for (Noisy n : things) {
-            System.out.println(n.sound());
-        }
+  public static void main(String[] args) {
+    Noisy[] things = {new Dog(), new Doorbell(), new MotionSensor()};
+    for (Noisy n : things) {
+      System.out.println(n.sound());
     }
+  }
 }
 `,
     },
     {
       filename: "Noisy.java",
       initialContent: `public interface Noisy {
-    String sound();
+  String sound();
 }
 `,
     },
     {
       filename: "Dog.java",
       initialContent: `public class Dog implements Noisy {
-    @Override
-    public String sound() { return "Woof!"; }
+  @Override
+  public String sound() {
+    return "Woof!";
+  }
 }
 `,
     },
     {
       filename: "Doorbell.java",
       initialContent: `public class Doorbell implements Noisy {
-    @Override
-    public String sound() { return "Ding-dong"; }
+  @Override
+  public String sound() {
+    return "Ding-dong";
+  }
 }
 `,
     },
     {
       filename: "MotionSensor.java",
       initialContent: `public class MotionSensor implements Noisy {
-    @Override
-    public String sound() { return "BEEP! BEEP!"; }
+  @Override
+  public String sound() {
+    return "BEEP! BEEP!";
+  }
 }
 `,
     },
@@ -188,51 +194,49 @@ interface without breaking every existing implementer.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Greeter polite = new Polite();
-        Greeter casual = new Casual();
-        System.out.println(polite.greet("Ada"));
-        System.out.println(casual.greet("Ada"));
-        System.out.println(polite.farewell("Ada"));   // uses the default
-        System.out.println(casual.farewell("Ada"));   // overridden
-    }
+  public static void main(String[] args) {
+    Greeter polite = new Polite();
+    Greeter casual = new Casual();
+    System.out.println(polite.greet("Ada"));
+    System.out.println(casual.greet("Ada"));
+    System.out.println(polite.farewell("Ada")); // uses the default
+    System.out.println(casual.farewell("Ada")); // overridden
+  }
 }
 `,
     },
     {
       filename: "Greeter.java",
       initialContent: `public interface Greeter {
-    String greet(String name);
+  String greet(String name);
 
-    // Implementers get this for free, but may override:
-    default String farewell(String name) {
-        return "Goodbye, " + name + ".";
-    }
+  // Implementers get this for free, but may override:
+  default String farewell(String name) { return "Goodbye, " + name + "."; }
 }
 `,
     },
     {
       filename: "Polite.java",
       initialContent: `public class Polite implements Greeter {
-    @Override
-    public String greet(String name) {
-        return "Good day, " + name + ".";
-    }
-    // farewell() inherited from the interface
+  @Override
+  public String greet(String name) {
+    return "Good day, " + name + ".";
+  }
+  // farewell() inherited from the interface
 }
 `,
     },
     {
       filename: "Casual.java",
       initialContent: `public class Casual implements Greeter {
-    @Override
-    public String greet(String name) {
-        return "Hey " + name + "!";
-    }
-    @Override
-    public String farewell(String name) {
-        return "Cya, " + name + "!";
-    }
+  @Override
+  public String greet(String name) {
+    return "Hey " + name + "!";
+  }
+  @Override
+  public String farewell(String name) {
+    return "Cya, " + name + "!";
+  }
 }
 `,
     },
@@ -277,56 +281,54 @@ classDiagram
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Checkout c1 = new Checkout(new StripeProcessor());
-        Checkout c2 = new Checkout(new FakeProcessor());
+  public static void main(String[] args) {
+    Checkout c1 = new Checkout(new StripeProcessor());
+    Checkout c2 = new Checkout(new FakeProcessor());
 
-        c1.purchase(2599);
-        c2.purchase(199);
-    }
+    c1.purchase(2599);
+    c2.purchase(199);
+  }
 }
 `,
     },
     {
       filename: "PaymentProcessor.java",
       initialContent: `public interface PaymentProcessor {
-    boolean charge(int cents);
+  boolean charge(int cents);
 }
 `,
     },
     {
       filename: "StripeProcessor.java",
       initialContent: `public class StripeProcessor implements PaymentProcessor {
-    @Override
-    public boolean charge(int cents) {
-        System.out.println("[stripe] charged " + cents + " cents");
-        return true;
-    }
+  @Override
+  public boolean charge(int cents) {
+    System.out.println("[stripe] charged " + cents + " cents");
+    return true;
+  }
 }
 `,
     },
     {
       filename: "FakeProcessor.java",
       initialContent: `public class FakeProcessor implements PaymentProcessor {
-    @Override
-    public boolean charge(int cents) {
-        System.out.println("[fake] pretended to charge " + cents + " cents");
-        return true;
-    }
+  @Override
+  public boolean charge(int cents) {
+    System.out.println("[fake] pretended to charge " + cents + " cents");
+    return true;
+  }
 }
 `,
     },
     {
       filename: "Checkout.java",
       initialContent: `public class Checkout {
-    private final PaymentProcessor processor;
-    public Checkout(PaymentProcessor processor) {
-        this.processor = processor;
-    }
-    public void purchase(int cents) {
-        boolean ok = processor.charge(cents);
-        System.out.println("purchase ok? " + ok);
-    }
+  private final PaymentProcessor processor;
+  public Checkout(PaymentProcessor processor) { this.processor = processor; }
+  public void purchase(int cents) {
+    boolean ok = processor.charge(cents);
+    System.out.println("purchase ok? " + ok);
+  }
 }
 `,
     },
@@ -364,78 +366,78 @@ name: 1
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Length a = new Length(1.0);
-        Length b = new Length(2.0);
-        Length c = new Length(1.0);
-        Length d = new Length(0.5);
-        System.out.println("length: " + Integer.signum(a.compareWith(b)));
-        System.out.println("length: " + Integer.signum(a.compareWith(c)));
-        System.out.println("length: " + Integer.signum(a.compareWith(d)));
+  public static void main(String[] args) {
+    Length a = new Length(1.0);
+    Length b = new Length(2.0);
+    Length c = new Length(1.0);
+    Length d = new Length(0.5);
+    System.out.println("length: " + Integer.signum(a.compareWith(b)));
+    System.out.println("length: " + Integer.signum(a.compareWith(c)));
+    System.out.println("length: " + Integer.signum(a.compareWith(d)));
 
-        Name p = new Name("alpha");
-        Name q = new Name("beta");
-        Name r = new Name("alpha");
-        Name s = new Name("a");
-        System.out.println("name: " + Integer.signum(p.compareWith(q)));
-        System.out.println("name: " + Integer.signum(p.compareWith(r)));
-        System.out.println("name: " + Integer.signum(p.compareWith(s)));
-    }
+    Name p = new Name("alpha");
+    Name q = new Name("beta");
+    Name r = new Name("alpha");
+    Name s = new Name("a");
+    System.out.println("name: " + Integer.signum(p.compareWith(q)));
+    System.out.println("name: " + Integer.signum(p.compareWith(r)));
+    System.out.println("name: " + Integer.signum(p.compareWith(s)));
+  }
 }
 `,
     },
     {
       filename: "Comparable2.java",
       initialContent: `public interface Comparable2<T> {
-    int compareWith(T other);
+  int compareWith(T other);
 }
 `,
     },
     {
       filename: "Length.java",
       initialContent: `public class Length implements Comparable2<Length> {
-    private final double value;
-    public Length(double value) { this.value = value; }
+  private final double value;
+  public Length(double value) { this.value = value; }
 
-    // TODO: implement compareWith
-    @Override
-    public int compareWith(Length other) {
-        return 0;
-    }
+  // TODO: implement compareWith
+  @Override
+  public int compareWith(Length other) {
+    return 0;
+  }
 }
 `,
       solutionContent: `public class Length implements Comparable2<Length> {
-    private final double value;
-    public Length(double value) { this.value = value; }
+  private final double value;
+  public Length(double value) { this.value = value; }
 
-    @Override
-    public int compareWith(Length other) {
-        return Double.compare(this.value, other.value);
-    }
+  @Override
+  public int compareWith(Length other) {
+    return Double.compare(this.value, other.value);
+  }
 }
 `,
     },
     {
       filename: "Name.java",
       initialContent: `public class Name implements Comparable2<Name> {
-    private final String value;
-    public Name(String value) { this.value = value; }
+  private final String value;
+  public Name(String value) { this.value = value; }
 
-    // TODO: implement compareWith
-    @Override
-    public int compareWith(Name other) {
-        return 0;
-    }
+  // TODO: implement compareWith
+  @Override
+  public int compareWith(Name other) {
+    return 0;
+  }
 }
 `,
       solutionContent: `public class Name implements Comparable2<Name> {
-    private final String value;
-    public Name(String value) { this.value = value; }
+  private final String value;
+  public Name(String value) { this.value = value; }
 
-    @Override
-    public int compareWith(Name other) {
-        return this.value.compareTo(other.value);
-    }
+  @Override
+  public int compareWith(Name other) {
+    return this.value.compareTo(other.value);
+  }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/methods-and-messages.mdx
+++ b/content/learn/oop-blueprint-java/methods-and-messages.mdx
@@ -225,30 +225,29 @@ classDiagram
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Item> cart = Arrays.asList(
-            new Item("Apple",  120),
-            new Item("Bread",  300),
-            new Item("Cheese", 550)
-        );
+  public static void main(String[] args) {
+    List<Item> cart =
+        Arrays.asList(new Item("Apple", 120), new Item("Bread", 300),
+                      new Item("Cheese", 550));
 
-        Cashier c = new Cashier();
-        Receipt r = c.ringUp(cart);
-        System.out.println(r.format());
-    }
+    Cashier c = new Cashier();
+    Receipt r = c.ringUp(cart);
+    System.out.println(r.format());
+  }
 }
 `,
     },
     {
       filename: "Item.java",
       initialContent: `public class Item {
-    private final String name;
-    private final int priceCents;
-    public Item(String name, int priceCents) {
-        this.name = name; this.priceCents = priceCents;
-    }
-    public String name()  { return name; }
-    public int    price() { return priceCents; }
+  private final String name;
+  private final int priceCents;
+  public Item(String name, int priceCents) {
+    this.name = name;
+    this.priceCents = priceCents;
+  }
+  public String name() { return name; }
+  public int price() { return priceCents; }
 }
 `,
     },
@@ -258,23 +257,24 @@ public class Main {
 import java.util.List;
 
 public class Receipt {
-    private final List<String> lines = new ArrayList<>();
-    private int total = 0;
+  private final List<String> lines = new ArrayList<>();
+  private int total = 0;
 
-    public void addLine(Item item) {
-        lines.add(String.format("  %-8s %4d", item.name(), item.price()));
-        total += item.price();
-    }
+  public void addLine(Item item) {
+    lines.add(String.format("  %-8s %4d", item.name(), item.price()));
+    total += item.price();
+  }
 
-    public int total() { return total; }
+  public int total() { return total; }
 
-    public String format() {
-        StringBuilder sb = new StringBuilder();
-        for (String l : lines) sb.append(l).append('\\n');
-        sb.append("  ----------\\n");
-        sb.append(String.format("  TOTAL    %4d", total));
-        return sb.toString();
-    }
+  public String format() {
+    StringBuilder sb = new StringBuilder();
+    for (String l : lines)
+      sb.append(l).append('\\n');
+    sb.append("  ----------\\n");
+    sb.append(String.format("  TOTAL    %4d", total));
+    return sb.toString();
+  }
 }
 `,
     },
@@ -283,13 +283,13 @@ public class Receipt {
       initialContent: `import java.util.List;
 
 public class Cashier {
-    public Receipt ringUp(List<Item> items) {
-        Receipt r = new Receipt();
-        for (Item it : items) {
-            r.addLine(it);            // sending addLine() to the Receipt
-        }
-        return r;
+  public Receipt ringUp(List<Item> items) {
+    Receipt r = new Receipt();
+    for (Item it : items) {
+      r.addLine(it); // sending addLine() to the Receipt
     }
+    return r;
+  }
 }
 `,
     },
@@ -335,36 +335,35 @@ Hello, Eve!
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Greeter g = new Greeter();
-        System.out.println(g.greet());
-        System.out.println(g.greet("Ada"));
-        System.out.println(g.greet("Bob", "es"));
-        System.out.println(g.greet("Kenji", "ja"));
-        System.out.println(g.greet("Eve", "fr"));      // fallback
-    }
+  public static void main(String[] args) {
+    Greeter g = new Greeter();
+    System.out.println(g.greet());
+    System.out.println(g.greet("Ada"));
+    System.out.println(g.greet("Bob", "es"));
+    System.out.println(g.greet("Kenji", "ja"));
+    System.out.println(g.greet("Eve", "fr")); // fallback
+  }
 }
 `,
     },
     {
       filename: "Greeter.java",
       initialContent: `public class Greeter {
-    // TODO: three overloaded greet methods
+  // TODO: three overloaded greet methods
 }
 `,
       solutionContent: `public class Greeter {
-    public String greet() {
-        return "Hello!";
-    }
-    public String greet(String name) {
-        return "Hello, " + name + "!";
-    }
-    public String greet(String name, String lang) {
-        if ("en".equals(lang)) return "Hello, " + name + "!";
-        if ("es".equals(lang)) return "Hola, "  + name + "!";
-        if ("ja".equals(lang)) return "こんにちは, " + name + "!";
-        return greet(name);                  // sending a message to this
-    }
+  public String greet() { return "Hello!"; }
+  public String greet(String name) { return "Hello, " + name + "!"; }
+  public String greet(String name, String lang) {
+    if ("en".equals(lang))
+      return "Hello, " + name + "!";
+    if ("es".equals(lang))
+      return "Hola, " + name + "!";
+    if ("ja".equals(lang))
+      return "こんにちは, " + name + "!";
+    return greet(name); // sending a message to this
+  }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/objects-and-classes.mdx
+++ b/content/learn/oop-blueprint-java/objects-and-classes.mdx
@@ -111,41 +111,40 @@ convention from now on. CheerpJ in your browser does the same.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Book hp = new Book("Harry Potter", "J. K. Rowling", 1997);
-        Book lr = new Book("The Lord of the Rings", "J. R. R. Tolkien", 1954);
+  public static void main(String[] args) {
+    Book hp = new Book("Harry Potter", "J. K. Rowling", 1997);
+    Book lr = new Book("The Lord of the Rings", "J. R. R. Tolkien", 1954);
 
-        System.out.println(hp.citation());
-        System.out.println(lr.citation());
-        System.out.println("Older book: " + (hp.olderThan(lr) ? hp.title() : lr.title()));
-    }
+    System.out.println(hp.citation());
+    System.out.println(lr.citation());
+    System.out.println("Older book: " +
+                       (hp.olderThan(lr) ? hp.title() : lr.title()));
+  }
 }
 `,
     },
     {
       filename: "Book.java",
       initialContent: `public class Book {
-    private final String title;
-    private final String author;
-    private final int    year;
+  private final String title;
+  private final String author;
+  private final int year;
 
-    public Book(String title, String author, int year) {
-        this.title  = title;
-        this.author = author;
-        this.year   = year;
-    }
+  public Book(String title, String author, int year) {
+    this.title = title;
+    this.author = author;
+    this.year = year;
+  }
 
-    public String title()  { return title; }
-    public String author() { return author; }
-    public int    year()   { return year; }
+  public String title() { return title; }
+  public String author() { return author; }
+  public int year() { return year; }
 
-    public String citation() {
-        return author + ", \\"" + title + "\\" (" + year + ")";
-    }
+  public String citation() {
+    return author + ", \\"" + title + "\\" (" + year + ")";
+  }
 
-    public boolean olderThan(Book other) {
-        return this.year < other.year;
-    }
+  public boolean olderThan(Book other) { return this.year < other.year; }
 }
 `,
     },
@@ -221,50 +220,46 @@ perimeter: 14.0
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Rectangle r = new Rectangle(4.0, 3.0);
-        System.out.println("area: " + r.area());
-        System.out.println("perimeter: " + r.perimeter());
-    }
+  public static void main(String[] args) {
+    Rectangle r = new Rectangle(4.0, 3.0);
+    System.out.println("area: " + r.area());
+    System.out.println("perimeter: " + r.perimeter());
+  }
 }
 `,
     },
     {
       filename: "Rectangle.java",
       initialContent: `public class Rectangle {
-    // TODO: declare private fields width and height (both double)
+  // TODO: declare private fields width and height (both double)
 
-    public Rectangle(double width, double height) {
-        // TODO: assign the parameters into the fields
-    }
+  public Rectangle(double width, double height) {
+    // TODO: assign the parameters into the fields
+  }
 
-    public double area() {
-        // TODO: return width * height
-        return 0;
-    }
+  public double area() {
+    // TODO: return width * height
+    return 0;
+  }
 
-    public double perimeter() {
-        // TODO: return 2 * (width + height)
-        return 0;
-    }
+  public double perimeter() {
+    // TODO: return 2 * (width + height)
+    return 0;
+  }
 }
 `,
       solutionContent: `public class Rectangle {
-    private final double width;
-    private final double height;
+  private final double width;
+  private final double height;
 
-    public Rectangle(double width, double height) {
-        this.width  = width;
-        this.height = height;
-    }
+  public Rectangle(double width, double height) {
+    this.width = width;
+    this.height = height;
+  }
 
-    public double area() {
-        return width * height;
-    }
+  public double area() { return width * height; }
 
-    public double perimeter() {
-        return 2.0 * (width + height);
-    }
+  public double perimeter() { return 2.0 * (width + height); }
 }
 `,
     },
@@ -301,26 +296,28 @@ a=3, b=1
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Counter a = new Counter();
-        Counter b = new Counter();
-        a.bump(); a.bump(); a.bump();
-        b.bump();
-        System.out.println("a=" + a.value() + ", b=" + b.value());
-    }
+  public static void main(String[] args) {
+    Counter a = new Counter();
+    Counter b = new Counter();
+    a.bump();
+    a.bump();
+    a.bump();
+    b.bump();
+    System.out.println("a=" + a.value() + ", b=" + b.value());
+  }
 }
 `,
     },
     {
       filename: "Counter.java",
       initialContent: `public class Counter {
-    // TODO: a private int field, a bump() method, a value() method
+  // TODO: a private int field, a bump() method, a value() method
 }
 `,
       solutionContent: `public class Counter {
-    private int count = 0;
-    public  void bump()  { count++; }
-    public  int  value() { return count; }
+  private int count = 0;
+  public void bump() { count++; }
+  public int value() { return count; }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/packages-and-architecture.mdx
+++ b/content/learn/oop-blueprint-java/packages-and-architecture.mdx
@@ -267,17 +267,17 @@ concern.
       filename: "Main.java",
       initialContent: `// presentation layer (would live in com.lib.cli)
 public class Main {
-    public static void main(String[] args) {
-        Catalog catalog = new Catalog();
-        catalog.add(new Book("Refactoring", "Fowler"));
-        catalog.add(new Book("OOSC",        "Meyer"));
+  public static void main(String[] args) {
+    Catalog catalog = new Catalog();
+    catalog.add(new Book("Refactoring", "Fowler"));
+    catalog.add(new Book("OOSC", "Meyer"));
 
-        LibraryService svc = new LibraryService(catalog);
-        for (String line : svc.allTitles()) {
-            System.out.println("- " + line);
-        }
-        System.out.println("Find 'OOSC': " + svc.findByTitle("OOSC"));
+    LibraryService svc = new LibraryService(catalog);
+    for (String line : svc.allTitles()) {
+      System.out.println("- " + line);
     }
+    System.out.println("Find 'OOSC': " + svc.findByTitle("OOSC"));
+  }
 }
 `,
     },
@@ -285,14 +285,18 @@ public class Main {
       filename: "Book.java",
       initialContent: `// domain layer (would live in com.lib.model)
 public class Book {
-    private final String title;
-    private final String author;
-    public Book(String title, String author) {
-        this.title = title; this.author = author;
-    }
-    public String title()  { return title; }
-    public String author() { return author; }
-    @Override public String toString() { return title + " — " + author; }
+  private final String title;
+  private final String author;
+  public Book(String title, String author) {
+    this.title = title;
+    this.author = author;
+  }
+  public String title() { return title; }
+  public String author() { return author; }
+  @Override
+  public String toString() {
+    return title + " — " + author;
+  }
 }
 `,
     },
@@ -303,13 +307,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Catalog {
-    private final List<Book> books = new ArrayList<>();
-    public void add(Book b)         { books.add(b); }
-    public List<Book> all()         { return books; }
-    public Book findByTitle(String t) {
-        for (Book b : books) if (b.title().equals(t)) return b;
-        return null;
-    }
+  private final List<Book> books = new ArrayList<>();
+  public void add(Book b) { books.add(b); }
+  public List<Book> all() { return books; }
+  public Book findByTitle(String t) {
+    for (Book b : books)
+      if (b.title().equals(t))
+        return b;
+    return null;
+  }
 }
 `,
     },
@@ -320,21 +326,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class LibraryService {
-    private final Catalog catalog;
-    public LibraryService(Catalog catalog) {
-        this.catalog = catalog;
-    }
+  private final Catalog catalog;
+  public LibraryService(Catalog catalog) { this.catalog = catalog; }
 
-    public List<String> allTitles() {
-        List<String> out = new ArrayList<>();
-        for (Book b : catalog.all()) out.add(b.toString());
-        return out;
-    }
+  public List<String> allTitles() {
+    List<String> out = new ArrayList<>();
+    for (Book b : catalog.all())
+      out.add(b.toString());
+    return out;
+  }
 
-    public String findByTitle(String t) {
-        Book b = catalog.findByTitle(t);
-        return b == null ? "not found" : b.toString();
-    }
+  public String findByTitle(String t) {
+    Book b = catalog.findByTitle(t);
+    return b == null ? "not found" : b.toString();
+  }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/polymorphism.mdx
+++ b/content/learn/oop-blueprint-java/polymorphism.mdx
@@ -110,49 +110,58 @@ brand new `Hexagon` tomorrow, and your function doesn't change.
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Shape> shapes = Arrays.asList(new Circle(2), new Square(3), new Triangle(4, 5));
-        Renderer r = new Renderer();
-        r.drawAll(shapes);
-    }
+  public static void main(String[] args) {
+    List<Shape> shapes =
+        Arrays.asList(new Circle(2), new Square(3), new Triangle(4, 5));
+    Renderer r = new Renderer();
+    r.drawAll(shapes);
+  }
 }
 `,
     },
     {
       filename: "Shape.java",
       initialContent: `public interface Shape {
-    String draw();
+  String draw();
 }
 `,
     },
     {
       filename: "Circle.java",
       initialContent: `public class Circle implements Shape {
-    private final double r;
-    public Circle(double r) { this.r = r; }
-    @Override public String draw() { return "(O) circle r=" + r; }
+  private final double r;
+  public Circle(double r) { this.r = r; }
+  @Override
+  public String draw() {
+    return "(O) circle r=" + r;
+  }
 }
 `,
     },
     {
       filename: "Square.java",
       initialContent: `public class Square implements Shape {
-    private final double s;
-    public Square(double s) { this.s = s; }
-    @Override public String draw() { return "[ ] square s=" + s; }
+  private final double s;
+  public Square(double s) { this.s = s; }
+  @Override
+  public String draw() {
+    return "[ ] square s=" + s;
+  }
 }
 `,
     },
     {
       filename: "Triangle.java",
       initialContent: `public class Triangle implements Shape {
-    private final double base, height;
-    public Triangle(double base, double height) {
-        this.base = base; this.height = height;
-    }
-    @Override public String draw() {
-        return "/\\\\ triangle base=" + base + " height=" + height;
-    }
+  private final double base, height;
+  public Triangle(double base, double height) {
+    this.base = base;
+    this.height = height;
+  }
+  @Override
+  public String draw() {
+    return "/\\\\ triangle base=" + base + " height=" + height;
+  }
 }
 `,
     },
@@ -161,11 +170,11 @@ public class Main {
       initialContent: `import java.util.List;
 
 public class Renderer {
-    public void drawAll(List<Shape> shapes) {
-        for (Shape s : shapes) {
-            System.out.println(s.draw());     // polymorphic call
-        }
+  public void drawAll(List<Shape> shapes) {
+    for (Shape s : shapes) {
+      System.out.println(s.draw()); // polymorphic call
     }
+  }
 }
 `,
     },
@@ -301,58 +310,58 @@ total cents: 800000
 import java.util.List;
 
 public class Main {
-    public static void main(String[] args) {
-        List<Payable> people = Arrays.asList(
-            new SalariedEmployee(500_000),
-            new HourlyEmployee(2_000, 100),     // 2_000 * 100 = 200_000
-            new HourlyEmployee(1_000, 100)      // 1_000 * 100 = 100_000
+  public static void main(String[] args) {
+    List<Payable> people =
+        Arrays.asList(new SalariedEmployee(500_000),
+                      new HourlyEmployee(2_000, 100), // 2_000 * 100 = 200_000
+                      new HourlyEmployee(1_000, 100)  // 1_000 * 100 = 100_000
         );
-        Payroll p = new Payroll();
-        System.out.println("total cents: " + p.totalCents(people));
-    }
+    Payroll p = new Payroll();
+    System.out.println("total cents: " + p.totalCents(people));
+  }
 }
 `,
     },
     {
       filename: "Payable.java",
       initialContent: `public interface Payable {
-    int monthlyPayCents();
+  int monthlyPayCents();
 }
 `,
     },
     {
       filename: "SalariedEmployee.java",
       initialContent: `public class SalariedEmployee implements Payable {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class SalariedEmployee implements Payable {
-    private final int salaryCents;
-    public SalariedEmployee(int salaryCents) {
-        this.salaryCents = salaryCents;
-    }
-    @Override
-    public int monthlyPayCents() { return salaryCents; }
+  private final int salaryCents;
+  public SalariedEmployee(int salaryCents) { this.salaryCents = salaryCents; }
+  @Override
+  public int monthlyPayCents() {
+    return salaryCents;
+  }
 }
 `,
     },
     {
       filename: "HourlyEmployee.java",
       initialContent: `public class HourlyEmployee implements Payable {
-    // TODO
+  // TODO
 }
 `,
       solutionContent: `public class HourlyEmployee implements Payable {
-    private final int hourlyRateCents;
-    private final int hoursWorked;
-    public HourlyEmployee(int hourlyRateCents, int hoursWorked) {
-        this.hourlyRateCents = hourlyRateCents;
-        this.hoursWorked     = hoursWorked;
-    }
-    @Override
-    public int monthlyPayCents() {
-        return hourlyRateCents * hoursWorked;
-    }
+  private final int hourlyRateCents;
+  private final int hoursWorked;
+  public HourlyEmployee(int hourlyRateCents, int hoursWorked) {
+    this.hourlyRateCents = hourlyRateCents;
+    this.hoursWorked = hoursWorked;
+  }
+  @Override
+  public int monthlyPayCents() {
+    return hourlyRateCents * hoursWorked;
+  }
 }
 `,
     },
@@ -361,22 +370,22 @@ public class Main {
       initialContent: `import java.util.List;
 
 public class Payroll {
-    public int totalCents(List<Payable> payees) {
-        // TODO: sum all monthly pays using polymorphic dispatch
-        return 0;
-    }
+  public int totalCents(List<Payable> payees) {
+    // TODO: sum all monthly pays using polymorphic dispatch
+    return 0;
+  }
 }
 `,
       solutionContent: `import java.util.List;
 
 public class Payroll {
-    public int totalCents(List<Payable> payees) {
-        int total = 0;
-        for (Payable p : payees) {
-            total += p.monthlyPayCents();         // polymorphic call
-        }
-        return total;
+  public int totalCents(List<Payable> payees) {
+    int total = 0;
+    for (Payable p : payees) {
+      total += p.monthlyPayCents(); // polymorphic call
     }
+    return total;
+  }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
+++ b/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
@@ -105,34 +105,35 @@ everything"*. The flow of messages is the conversation.
       initialContent: `import java.util.Arrays;
 
 public class Main {
-    public static void main(String[] args) {
-        Menu menu = new Menu();
-        menu.add(new Drink("Espresso",   250));
-        menu.add(new Drink("Latte",      400));
-        menu.add(new Drink("Croissant",  300));
+  public static void main(String[] args) {
+    Menu menu = new Menu();
+    menu.add(new Drink("Espresso", 250));
+    menu.add(new Drink("Latte", 400));
+    menu.add(new Drink("Croissant", 300));
 
-        Order o = new Order();
-        o.add(new LineItem(menu.find("Latte"),     2));
-        o.add(new LineItem(menu.find("Croissant"), 1));
+    Order o = new Order();
+    o.add(new LineItem(menu.find("Latte"), 2));
+    o.add(new LineItem(menu.find("Croissant"), 1));
 
-        Payment p = new Payment();
-        p.charge(o);
+    Payment p = new Payment();
+    p.charge(o);
 
-        System.out.println(new Receipt().format(o));
-    }
+    System.out.println(new Receipt().format(o));
+  }
 }
 `,
     },
     {
       filename: "Drink.java",
       initialContent: `public class Drink {
-    private final String name;
-    private final int priceCents;
-    public Drink(String name, int priceCents) {
-        this.name = name; this.priceCents = priceCents;
-    }
-    public String name()  { return name; }
-    public int    price() { return priceCents; }
+  private final String name;
+  private final int priceCents;
+  public Drink(String name, int priceCents) {
+    this.name = name;
+    this.priceCents = priceCents;
+  }
+  public String name() { return name; }
+  public int price() { return priceCents; }
 }
 `,
     },
@@ -142,34 +143,36 @@ public class Main {
 import java.util.List;
 
 public class Menu {
-    private final List<Drink> drinks = new ArrayList<>();
+  private final List<Drink> drinks = new ArrayList<>();
 
-    public void add(Drink d) { drinks.add(d); }
+  public void add(Drink d) { drinks.add(d); }
 
-    public Drink find(String name) {
-        for (Drink d : drinks) {
-            if (d.name().equals(name)) return d;
-        }
-        throw new IllegalArgumentException("no such drink: " + name);
+  public Drink find(String name) {
+    for (Drink d : drinks) {
+      if (d.name().equals(name))
+        return d;
     }
+    throw new IllegalArgumentException("no such drink: " + name);
+  }
 }
 `,
     },
     {
       filename: "LineItem.java",
       initialContent: `public class LineItem {
-    private final Drink drink;
-    private final int   quantity;
+  private final Drink drink;
+  private final int quantity;
 
-    public LineItem(Drink drink, int quantity) {
-        if (quantity <= 0) throw new IllegalArgumentException("quantity > 0");
-        this.drink = drink;
-        this.quantity = quantity;
-    }
+  public LineItem(Drink drink, int quantity) {
+    if (quantity <= 0)
+      throw new IllegalArgumentException("quantity > 0");
+    this.drink = drink;
+    this.quantity = quantity;
+  }
 
-    public Drink drink()    { return drink; }
-    public int   quantity() { return quantity; }
-    public int   subtotal() { return drink.price() * quantity; }
+  public Drink drink() { return drink; }
+  public int quantity() { return quantity; }
+  public int subtotal() { return drink.price() * quantity; }
 }
 `,
     },
@@ -179,51 +182,51 @@ public class Menu {
 import java.util.List;
 
 public class Order {
-    private final List<LineItem> items = new ArrayList<>();
-    private boolean paid = false;
+  private final List<LineItem> items = new ArrayList<>();
+  private boolean paid = false;
 
-    public void add(LineItem item) { items.add(item); }
+  public void add(LineItem item) { items.add(item); }
 
-    public int total() {
-        int sum = 0;
-        for (LineItem it : items) sum += it.subtotal();
-        return sum;
-    }
+  public int total() {
+    int sum = 0;
+    for (LineItem it : items)
+      sum += it.subtotal();
+    return sum;
+  }
 
-    public boolean isPaid() { return paid; }
-    public void markPaid()  { paid = true; }
+  public boolean isPaid() { return paid; }
+  public void markPaid() { paid = true; }
 
-    public List<LineItem> items() { return items; }
+  public List<LineItem> items() { return items; }
 }
 `,
     },
     {
       filename: "Payment.java",
       initialContent: `public class Payment {
-    public void charge(Order order) {
-        if (order.isPaid()) return;
-        // Pretend we hit a payment gateway here.
-        order.markPaid();
-    }
+  public void charge(Order order) {
+    if (order.isPaid())
+      return;
+    // Pretend we hit a payment gateway here.
+    order.markPaid();
+  }
 }
 `,
     },
     {
       filename: "Receipt.java",
       initialContent: `public class Receipt {
-    public String format(Order o) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("--- RECEIPT ---\\n");
-        for (LineItem it : o.items()) {
-            sb.append(String.format(
-                "%-10s x%-2d  %4d%n",
-                it.drink().name(), it.quantity(), it.subtotal()
-            ));
-        }
-        sb.append("TOTAL          ").append(o.total()).append('\\n');
-        sb.append(o.isPaid() ? "(paid)" : "(unpaid)");
-        return sb.toString();
+  public String format(Order o) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("--- RECEIPT ---\\n");
+    for (LineItem it : o.items()) {
+      sb.append(String.format("%-10s x%-2d  %4d%n", it.drink().name(),
+                              it.quantity(), it.subtotal()));
     }
+    sb.append("TOTAL          ").append(o.total()).append('\\n');
+    sb.append(o.isPaid() ? "(paid)" : "(unpaid)");
+    return sb.toString();
+  }
 }
 `,
     },
@@ -376,55 +379,55 @@ balance: 60
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        Wallet w = new Wallet(100);
-        Buyer  b = new Buyer();
-        System.out.println("bought apple? " + b.shop(w, 40));
-        System.out.println("bought yacht? " + b.shop(w, 1_000_000));
-        System.out.println("balance: " + w.balance());
-    }
+  public static void main(String[] args) {
+    Wallet w = new Wallet(100);
+    Buyer b = new Buyer();
+    System.out.println("bought apple? " + b.shop(w, 40));
+    System.out.println("bought yacht? " + b.shop(w, 1_000_000));
+    System.out.println("balance: " + w.balance());
+  }
 }
 `,
     },
     {
       filename: "Wallet.java",
       initialContent: `public class Wallet {
-    public int cents;          // TODO: encapsulate this
-    public Wallet(int cents) { this.cents = cents; }
+  public int cents; // TODO: encapsulate this
+  public Wallet(int cents) { this.cents = cents; }
 }
 `,
       solutionContent: `public class Wallet {
-    private int cents;
-    public Wallet(int cents) { this.cents = cents; }
+  private int cents;
+  public Wallet(int cents) { this.cents = cents; }
 
-    public boolean buy(int priceCents) {
-        if (priceCents <= 0) throw new IllegalArgumentException("price > 0");
-        if (priceCents > cents) return false;
-        cents -= priceCents;
-        return true;
-    }
+  public boolean buy(int priceCents) {
+    if (priceCents <= 0)
+      throw new IllegalArgumentException("price > 0");
+    if (priceCents > cents)
+      return false;
+    cents -= priceCents;
+    return true;
+  }
 
-    public int balance() { return cents; }
+  public int balance() { return cents; }
 }
 `,
     },
     {
       filename: "Buyer.java",
       initialContent: `public class Buyer {
-    public boolean shop(Wallet w, int priceCents) {
-        // TODO: replace this feature-envy with a single \`tell\` call
-        if (w.cents >= priceCents) {
-            w.cents -= priceCents;
-            return true;
-        }
-        return false;
+  public boolean shop(Wallet w, int priceCents) {
+    // TODO: replace this feature-envy with a single \`tell\` call
+    if (w.cents >= priceCents) {
+      w.cents -= priceCents;
+      return true;
     }
+    return false;
+  }
 }
 `,
       solutionContent: `public class Buyer {
-    public boolean shop(Wallet w, int priceCents) {
-        return w.buy(priceCents);
-    }
+  public boolean shop(Wallet w, int priceCents) { return w.buy(priceCents); }
 }
 `,
     },

--- a/content/learn/oop-blueprint-java/static-and-utility.mdx
+++ b/content/learn/oop-blueprint-java/static-and-utility.mdx
@@ -138,36 +138,35 @@ nobody can mistakenly write `new StringTools()`.
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        System.out.println(StringTools.reverse("OOP"));
-        System.out.println(StringTools.isPalindrome("level"));
-        System.out.println(StringTools.isPalindrome("Java"));
-        System.out.println(StringTools.wordCount("encapsulation is a discipline"));
-    }
+  public static void main(String[] args) {
+    System.out.println(StringTools.reverse("OOP"));
+    System.out.println(StringTools.isPalindrome("level"));
+    System.out.println(StringTools.isPalindrome("Java"));
+    System.out.println(StringTools.wordCount("encapsulation is a discipline"));
+  }
 }
 `,
     },
     {
       filename: "StringTools.java",
       initialContent: `public final class StringTools {
-    private StringTools() {
-        // Never instantiated. This constructor exists only to forbid
-        // \`new StringTools()\`.
-        throw new AssertionError("no instances");
-    }
+  private StringTools() {
+    // Never instantiated. This constructor exists only to forbid
+    // \`new StringTools()\`.
+    throw new AssertionError("no instances");
+  }
 
-    public static String reverse(String s) {
-        return new StringBuilder(s).reverse().toString();
-    }
+  public static String reverse(String s) {
+    return new StringBuilder(s).reverse().toString();
+  }
 
-    public static boolean isPalindrome(String s) {
-        return s.equals(reverse(s));
-    }
+  public static boolean isPalindrome(String s) { return s.equals(reverse(s)); }
 
-    public static int wordCount(String s) {
-        if (s == null || s.isBlank()) return 0;
-        return s.trim().split("\\\\s+").length;
-    }
+  public static int wordCount(String s) {
+    if (s == null || s.isBlank())
+      return 0;
+    return s.trim().split("\\\\s+").length;
+  }
 }
 `,
     },
@@ -275,40 +274,43 @@ sum=15
     {
       filename: "Main.java",
       initialContent: `public class Main {
-    public static void main(String[] args) {
-        System.out.println("max="    + MyMath.max(7, 10));
-        System.out.println("clamp1=" + MyMath.clamp(5,  0, 10));
-        System.out.println("clamp2=" + MyMath.clamp(-3, 0, 10));
-        System.out.println("clamp3=" + MyMath.clamp(99, 0, 10));
-        System.out.println("sum="    + MyMath.sum(new int[]{1, 2, 3, 4, 5}));
-    }
+  public static void main(String[] args) {
+    System.out.println("max=" + MyMath.max(7, 10));
+    System.out.println("clamp1=" + MyMath.clamp(5, 0, 10));
+    System.out.println("clamp2=" + MyMath.clamp(-3, 0, 10));
+    System.out.println("clamp3=" + MyMath.clamp(99, 0, 10));
+    System.out.println("sum=" + MyMath.sum(new int[] {1, 2, 3, 4, 5}));
+  }
 }
 `,
     },
     {
       filename: "MyMath.java",
       initialContent: `public final class MyMath {
-    // TODO: private constructor + the three static methods
+  // TODO: private constructor + the three static methods
 }
 `,
       solutionContent: `public final class MyMath {
-    private MyMath() { throw new AssertionError("no instances"); }
+  private MyMath() { throw new AssertionError("no instances"); }
 
-    public static int max(int a, int b) {
-        return a >= b ? a : b;
-    }
-    public static int clamp(int x, int lo, int hi) {
-        if (lo > hi) throw new IllegalArgumentException("lo > hi");
-        if (x < lo) return lo;
-        if (x > hi) return hi;
-        return x;
-    }
-    public static int sum(int[] xs) {
-        if (xs == null) return 0;
-        int s = 0;
-        for (int v : xs) s += v;
-        return s;
-    }
+  public static int max(int a, int b) { return a >= b ? a : b; }
+  public static int clamp(int x, int lo, int hi) {
+    if (lo > hi)
+      throw new IllegalArgumentException("lo > hi");
+    if (x < lo)
+      return lo;
+    if (x > hi)
+      return hi;
+    return x;
+  }
+  public static int sum(int[] xs) {
+    if (xs == null)
+      return 0;
+    int s = 0;
+    for (int v : xs)
+      s += v;
+    return s;
+  }
 }
 `,
     },

--- a/content/learn/python-basics/classes.mdx
+++ b/content/learn/python-basics/classes.mdx
@@ -582,6 +582,7 @@ print("Equal?", p == q)
 `,
       solutionContent: `from dataclasses import dataclass
 
+
 @dataclass
 class Point:
     x: float

--- a/content/learn/python-basics/files.mdx
+++ b/content/learn/python-basics/files.mdx
@@ -354,22 +354,24 @@ for row in data:
     },
     {
       filename: "sales.csv",
-      initialContent: `product,amount
-Laptop,1200
-Mouse,25
-Keyboard,75
-Monitor,300
+      initialContent: `product, amount
+Laptop, 1200
+Mouse, 25
+Keyboard, 75
+Monitor, 300
 `,
     },
     {
       filename: "parser.py",
       initialContent: `import csv
 
+
 def parse_sales(filename):
     # your code here
     return []
 `,
       solutionContent: `import csv
+
 
 def parse_sales(filename):
     with open(filename) as f:
@@ -423,25 +425,20 @@ print(f"Port: {config['server']['port']}")
     },
     {
       filename: "config.json",
-      initialContent: `{
-  "app_name": "DataSlope",
-  "debug": true,
-  "server": {
-    "host": "localhost",
-    "port": 8000
-  }
-}
+      initialContent: `{"app_name": "DataSlope", "debug": true, "server": {"host": "localhost", "port": 8000}}
 `,
     },
     {
       filename: "config_loader.py",
       initialContent: `import json
 
+
 def load_config(filename):
     # your code here
     return {}
 `,
       solutionContent: `import json
+
 
 def load_config(filename):
     with open(filename) as f:

--- a/content/learn/python-basics/inheritance.mdx
+++ b/content/learn/python-basics/inheritance.mdx
@@ -361,20 +361,22 @@ print(f"Circle area: {c.area():.2f}")
       initialContent: `from abc import ABC, abstractmethod
 import math
 
+
 class Shape(ABC):
     @abstractmethod
-    def area(self):
-        ...
+    def area(self): ...
+
 
 # Define Rectangle and Circle here
 `,
       solutionContent: `from abc import ABC, abstractmethod
 import math
 
+
 class Shape(ABC):
     @abstractmethod
-    def area(self):
-        ...
+    def area(self): ...
+
 
 class Rectangle(Shape):
     def __init__(self, width, height):
@@ -384,12 +386,13 @@ class Rectangle(Shape):
     def area(self):
         return self.width * self.height
 
+
 class Circle(Shape):
     def __init__(self, radius):
         self.radius = radius
 
     def area(self):
-        return math.pi * self.radius ** 2
+        return math.pi * self.radius**2
 `,
     },
   ]}
@@ -454,9 +457,11 @@ for animal in animals:
     # your code here
     pass
 
+
 class Dog(Animal):
     # your code here
     pass
+
 
 class Cat(Animal):
     # your code here
@@ -469,9 +474,11 @@ class Cat(Animal):
     def speak(self):
         return f"{self.name} makes a sound"
 
+
 class Dog(Animal):
     def speak(self):
         return f"{self.name} says woof!"
+
 
 class Cat(Animal):
     def speak(self):
@@ -539,6 +546,7 @@ print(f"{m.name}: \${m.salary()}")
     # your code here
     pass
 
+
 class Manager(Employee):
     # your code here
     pass
@@ -550,6 +558,7 @@ class Manager(Employee):
 
     def salary(self):
         return self.base_salary
+
 
 class Manager(Employee):
     def __init__(self, name, base_salary, bonus):

--- a/content/learn/python-basics/modules.mdx
+++ b/content/learn/python-basics/modules.mdx
@@ -236,12 +236,14 @@ print("variance =", variance(values))
     # your code here
     return 0
 
+
 def variance(values):
     # your code here
     return 0
 `,
       solutionContent: `def mean(values):
     return sum(values) / len(values)
+
 
 def variance(values):
     mu = mean(values)

--- a/content/learn/scientific-computing-python/arrays-and-tensors.mdx
+++ b/content/learn/scientific-computing-python/arrays-and-tensors.mdx
@@ -249,19 +249,25 @@ driver.
 from linalg import project_onto_basis
 
 rng = np.random.default_rng(0)
-basis  = np.array([[1, 0, 0],          # an orthonormal basis for the xy-plane
-                   [0, 1, 0]], dtype=float)
+basis = np.array(
+    [
+        [1, 0, 0],  # an orthonormal basis for the xy-plane
+        [0, 1, 0],
+    ],
+    dtype=float,
+)
 points = rng.standard_normal((5, 3))
 
 proj = project_onto_basis(points, basis)
 print("original  z-components:", points[:, 2].round(2))
-print("projected z-components:", proj[:, 2].round(2))    # all zero
+print("projected z-components:", proj[:, 2].round(2))  # all zero
 print("\\nFrobenius difference :", np.linalg.norm(points - proj).round(4))
 `,
     },
     {
       filename: "linalg.py",
       initialContent: `import numpy as np
+
 
 def project_onto_basis(points: np.ndarray, basis: np.ndarray) -> np.ndarray:
     """Project rows of \`points\` onto the row-space of \`basis\`.

--- a/content/learn/scientific-computing-python/capstone-simulation.mdx
+++ b/content/learn/scientific-computing-python/capstone-simulation.mdx
@@ -71,9 +71,11 @@ for a in sweep:
 
 summary = summarize(all_runs)
 for row in summary:
-    print(f"a = {row['a']:.4f}   "
-          f"P(extinction) = {row['p_extinction']:.2f}   "
-          f"⟨peak prey⟩ = {row['mean_peak_prey']:.1f}")
+    print(
+        f"a = {row['a']:.4f}   "
+        f"P(extinction) = {row['p_extinction']:.2f}   "
+        f"⟨peak prey⟩ = {row['mean_peak_prey']:.1f}"
+    )
 
 small_multiples(all_runs, sweep)
 plt.show()
@@ -84,35 +86,50 @@ plt.show()
       initialContent: `import numpy as np
 from scipy.integrate import solve_ivp
 
+
 def make_rhs(r, K, a, e, m, sigma, rng):
     """Returns f(t, y) with stochastic prey growth perturbation."""
+
     def f(t, z):
         x, y = z
         # Tiny random perturbation in prey growth to make seeds matter
         noise = sigma * rng.standard_normal()
-        return [r*x*(1 - x/K) - a*x*y + noise*x,
-                e*a*x*y - m*y]
+        return [r * x * (1 - x / K) - a * x * y + noise * x, e * a * x * y - m * y]
+
     return f
 
-def run_one(a, seed, r=1.0, K=200.0, e=0.1, m=0.4,
-            sigma=0.02, t_end=200.0):
+
+def run_one(a, seed, r=1.0, K=200.0, e=0.1, m=0.4, sigma=0.02, t_end=200.0):
     rng = np.random.default_rng(seed)
     rhs = make_rhs(r, K, a, e, m, sigma, rng)
 
     # Event: predators go extinct (y drops below 0.5)
-    def extinct(t, z): return z[1] - 0.5
+    def extinct(t, z):
+        return z[1] - 0.5
+
     extinct.terminal = True
     extinct.direction = -1
 
-    sol = solve_ivp(rhs, [0, t_end], y0=[40.0, 9.0],
-                    method="RK45", rtol=1e-7, atol=1e-9,
-                    events=extinct, dense_output=True, max_step=0.5)
+    sol = solve_ivp(
+        rhs,
+        [0, t_end],
+        y0=[40.0, 9.0],
+        method="RK45",
+        rtol=1e-7,
+        atol=1e-9,
+        events=extinct,
+        dense_output=True,
+        max_step=0.5,
+    )
 
     t = np.linspace(0, sol.t[-1], 400)
     x, y = sol.sol(t)
     return {
-        "a": a, "seed": seed,
-        "t": t, "x": x, "y": y,
+        "a": a,
+        "seed": seed,
+        "t": t,
+        "x": x,
+        "y": y,
         "extinct": bool(sol.t_events[0].size),
         "t_extinct": float(sol.t_events[0][0]) if sol.t_events[0].size else None,
     }
@@ -122,6 +139,7 @@ def run_one(a, seed, r=1.0, K=200.0, e=0.1, m=0.4,
       filename: "aggregate.py",
       initialContent: `import numpy as np
 from collections import defaultdict
+
 
 def summarize(runs):
     """Group runs by parameter 'a' and compute summary stats."""
@@ -133,12 +151,14 @@ def summarize(runs):
     for a, group in sorted(groups.items()):
         ext = [r["extinct"] for r in group]
         peaks = [float(np.max(r["x"])) for r in group]
-        out.append({
-            "a": a,
-            "n": len(group),
-            "p_extinction": np.mean(ext),
-            "mean_peak_prey": np.mean(peaks),
-        })
+        out.append(
+            {
+                "a": a,
+                "n": len(group),
+                "p_extinction": np.mean(ext),
+                "mean_peak_prey": np.mean(peaks),
+            }
+        )
     return out
 `,
     },
@@ -147,14 +167,21 @@ def summarize(runs):
       initialContent: `import numpy as np
 import matplotlib.pyplot as plt
 
+
 def small_multiples(runs, sweep):
     cols = len(sweep)
-    fig, axes = plt.subplots(1, cols, figsize=(2.5*cols, 3),
-                             sharex=True, sharey=True,
-                             constrained_layout=True)
+    fig, axes = plt.subplots(
+        1,
+        cols,
+        figsize=(2.5 * cols, 3),
+        sharex=True,
+        sharey=True,
+        constrained_layout=True,
+    )
     for ax, a in zip(axes, sweep):
         for r in runs:
-            if r["a"] != a: continue
+            if r["a"] != a:
+                continue
             color = "tab:red" if r["extinct"] else "tab:blue"
             ax.plot(r["t"], r["x"], color=color, lw=0.8, alpha=0.7)
         ax.set_title(f"a = {a:.3f}", fontsize=10)

--- a/content/learn/scientific-computing-python/matrix-decompositions.mdx
+++ b/content/learn/scientific-computing-python/matrix-decompositions.mdx
@@ -287,19 +287,22 @@ rng = np.random.default_rng(0)
 n, d, k_true = 300, 6, 2
 # Data with intrinsic rank 2 embedded in 6-D + Gaussian noise
 latent = rng.standard_normal((n, k_true))
-basis  = rng.standard_normal((k_true, d))
-data   = latent @ basis + 0.1 * rng.standard_normal((n, d))
+basis = rng.standard_normal((k_true, d))
+data = latent @ basis + 0.1 * rng.standard_normal((n, d))
 
 scores, components, explained = pca_via_svd(data, n_components=3)
 print("Variance explained:", explained.round(4))
 print("First 5 scores rows:\\n", scores[:5].round(3))
-print("\\nReconstruction error (rank 2):",
-      np.linalg.norm(data - scores[:, :2] @ components[:2]) / np.linalg.norm(data))
+print(
+    "\\nReconstruction error (rank 2):",
+    np.linalg.norm(data - scores[:, :2] @ components[:2]) / np.linalg.norm(data),
+)
 `,
     },
     {
       filename: "decompose.py",
       initialContent: `import numpy as np
+
 
 def pca_via_svd(X, n_components):
     """Principal Component Analysis using the SVD.
@@ -315,7 +318,7 @@ def pca_via_svd(X, n_components):
     U, s, Vt = np.linalg.svd(Xc, full_matrices=False)
     scores = U[:, :n_components] * s[:n_components]
     components = Vt[:n_components]
-    var = (s ** 2) / (X.shape[0] - 1)
+    var = (s**2) / (X.shape[0] - 1)
     return scores, components, var[:n_components] / var.sum()
 `,
     },

--- a/content/learn/scientific-computing-python/monte-carlo-methods.mdx
+++ b/content/learn/scientific-computing-python/monte-carlo-methods.mdx
@@ -249,16 +249,19 @@ statistics.
 import matplotlib.pyplot as plt
 from mc import estimate_with_se
 
+
 def integrand(x):
-    return np.exp(-x**2) * np.cos(2*x)
+    return np.exp(-(x**2)) * np.cos(2 * x)
+
 
 # Run Monte Carlo with increasing sample sizes
 Ns = [10**k for k in range(2, 7)]
-ests, ses = zip(*[estimate_with_se(integrand, low=-3, high=3, N=N, seed=0)
-                  for N in Ns])
+ests, ses = zip(*[estimate_with_se(integrand, low=-3, high=3, N=N, seed=0) for N in Ns])
 
 plt.errorbar(Ns, ests, yerr=ses, fmt="o-", capsize=4)
-plt.xscale("log"); plt.xlabel("N"); plt.ylabel("estimate ± SE")
+plt.xscale("log")
+plt.xlabel("N")
+plt.ylabel("estimate ± SE")
 plt.title("Monte Carlo converges as 1/√N")
 plt.show()
 
@@ -269,6 +272,7 @@ for N, est, se in zip(Ns, ests, ses):
     {
       filename: "mc.py",
       initialContent: `import numpy as np
+
 
 def estimate_with_se(f, low, high, N, seed=0):
     """Monte Carlo estimator of ∫ f over [low, high] and its standard error."""

--- a/content/learn/scientific-computing-python/numerical-calculus.mdx
+++ b/content/learn/scientific-computing-python/numerical-calculus.mdx
@@ -214,12 +214,15 @@ whole chapter to it later).
       initialContent: `import numpy as np
 from calc import centered_diff, adaptive_simpson
 
-def f(x): return np.sin(x) * np.exp(-0.1 * x)
+
+def f(x):
+    return np.sin(x) * np.exp(-0.1 * x)
+
 
 # Compare derivatives at a single point
 x0 = 1.5
 print(f"f'({x0}) numeric  : {centered_diff(f, x0):.10f}")
-true = np.cos(x0)*np.exp(-0.1*x0) - 0.1*np.sin(x0)*np.exp(-0.1*x0)
+true = np.cos(x0) * np.exp(-0.1 * x0) - 0.1 * np.sin(x0) * np.exp(-0.1 * x0)
 print(f"f'({x0}) analytic : {true:.10f}")
 
 # Integrate from 0 to 10 to a relative tolerance
@@ -231,15 +234,18 @@ print(f"\\n∫₀¹⁰ f dx ≈ {val:.10f}")
       filename: "calc.py",
       initialContent: `import numpy as np
 
+
 def centered_diff(f, x, h=None):
     """Centered finite difference at near-optimal step size."""
     if h is None:
         h = np.cbrt(np.finfo(float).eps) * max(abs(x), 1.0)
     return (f(x + h) - f(x - h)) / (2 * h)
 
+
 def _simpson(f, a, b, fa, fb, fm):
     m = (a + b) / 2
     return (b - a) / 6 * (fa + 4 * fm + fb)
+
 
 def adaptive_simpson(f, a, b, tol=1e-8):
     """Recursive adaptive Simpson's rule."""
@@ -255,8 +261,9 @@ def adaptive_simpson(f, a, b, tol=1e-8):
         SR = _simpson(f, m, b, fm, fb, frm)
         if abs(SL + SR - S) <= 15 * tol:
             return SL + SR + (SL + SR - S) / 15
-        return (helper(a, m, fa, fm, flm, SL, tol / 2)
-              + helper(m, b, fm, fb, frm, SR, tol / 2))
+        return helper(a, m, fa, fm, flm, SL, tol / 2) + helper(
+            m, b, fm, fb, frm, SR, tol / 2
+        )
 
     return helper(a, b, fa, fb, fm, S, tol)
 `,

--- a/content/learn/scientific-computing-python/ordinary-differential-equations.mdx
+++ b/content/learn/scientific-computing-python/ordinary-differential-equations.mdx
@@ -303,9 +303,15 @@ import matplotlib.pyplot as plt
 from scipy.integrate import solve_ivp
 from lorenz import lorenz_rhs
 
-sol = solve_ivp(lorenz_rhs, [0, 40], [1.0, 1.0, 1.0],
-                args=(10.0, 28.0, 8/3),
-                dense_output=True, rtol=1e-9, atol=1e-12)
+sol = solve_ivp(
+    lorenz_rhs,
+    [0, 40],
+    [1.0, 1.0, 1.0],
+    args=(10.0, 28.0, 8 / 3),
+    dense_output=True,
+    rtol=1e-9,
+    atol=1e-12,
+)
 
 t = np.linspace(0, 40, 8000)
 x, y, z = sol.sol(t)
@@ -322,9 +328,7 @@ plt.show()
       initialContent: `def lorenz_rhs(t, state, sigma, rho, beta):
     """Classic Lorenz 1963 system."""
     x, y, z = state
-    return [sigma * (y - x),
-            x * (rho - z) - y,
-            x * y - beta * z]
+    return [sigma * (y - x), x * (rho - z) - y, x * y - beta * z]
 `,
     },
   ]}

--- a/content/learn/scientific-computing-python/reproducible-experiments.mdx
+++ b/content/learn/scientific-computing-python/reproducible-experiments.mdx
@@ -220,7 +220,7 @@ for damping, omega in itertools.product([0.1, 0.3, 0.5], [1.0, 2.0, 3.0]):
 
 results = []
 for i, cfg in enumerate(configs):
-    seed = SEED_BASE + i             # deterministic per-config seed
+    seed = SEED_BASE + i  # deterministic per-config seed
     final = simulate(**cfg, seed=seed)
     results.append({**cfg, "seed": seed, "final_energy": final})
 
@@ -233,6 +233,7 @@ for r in results:
       initialContent: `import numpy as np
 from scipy.integrate import solve_ivp
 
+
 def simulate(damping=0.1, omega=1.0, seed=0, t_end=20.0):
     """Damped oscillator with stochastic kick; returns final energy."""
     rng = np.random.default_rng(seed)
@@ -241,18 +242,18 @@ def simulate(damping=0.1, omega=1.0, seed=0, t_end=20.0):
 
     def rhs(t, y):
         x, v = y
-        return [v, -damping*v - omega*omega*x]
+        return [v, -damping * v - omega * omega * x]
 
     state = np.array([1.0, 0.0])
     t = 0.0
     for tk in kick_times:
         sol = solve_ivp(rhs, [t, tk], state, rtol=1e-9)
         state = sol.y[:, -1].copy()
-        state[1] += 0.5 * rng.standard_normal()    # random velocity kick
+        state[1] += 0.5 * rng.standard_normal()  # random velocity kick
         t = tk
     sol = solve_ivp(rhs, [t, t_end], state, rtol=1e-9)
     state = sol.y[:, -1]
-    return 0.5 * state[1]**2 + 0.5 * omega**2 * state[0]**2
+    return 0.5 * state[1] ** 2 + 0.5 * omega**2 * state[0] ** 2
 `,
     },
   ]}

--- a/content/learn/scientific-computing-python/root-finding-and-optimization.mdx
+++ b/content/learn/scientific-computing-python/root-finding-and-optimization.mdx
@@ -267,8 +267,8 @@ import matplotlib.pyplot as plt
 from fit import fit_gaussian, gaussian
 
 rng = np.random.default_rng(0)
-x  = np.linspace(-3, 6, 200)
-y  = gaussian(x, amp=3.0, mu=1.5, sigma=0.8) + 0.1*rng.standard_normal(x.size)
+x = np.linspace(-3, 6, 200)
+y = gaussian(x, amp=3.0, mu=1.5, sigma=0.8) + 0.1 * rng.standard_normal(x.size)
 
 params, errors = fit_gaussian(x, y)
 print("estimated parameters (amp, mu, sigma):", params.round(3))
@@ -276,7 +276,8 @@ print("1-σ uncertainties                    :", errors.round(3))
 
 plt.plot(x, y, "o", ms=3, label="data")
 plt.plot(x, gaussian(x, *params), "r-", lw=2, label="fit")
-plt.legend(); plt.show()
+plt.legend()
+plt.show()
 `,
     },
     {
@@ -284,15 +285,15 @@ plt.legend(); plt.show()
       initialContent: `import numpy as np
 from scipy.optimize import curve_fit
 
+
 def gaussian(x, amp, mu, sigma):
-    return amp * np.exp(-((x - mu) / sigma) ** 2 / 2)
+    return amp * np.exp(-(((x - mu) / sigma) ** 2) / 2)
+
 
 def fit_gaussian(x, y):
     """Fit a Gaussian peak; return (params, 1-sigma errors)."""
     # Sensible initial guesses from the data
-    p0 = [y.max() - y.min(),
-          x[np.argmax(y)],
-          (x.max() - x.min()) / 6]
+    p0 = [y.max() - y.min(), x[np.argmax(y)], (x.max() - x.min()) / 6]
     popt, pcov = curve_fit(gaussian, x, y, p0=p0)
     perr = np.sqrt(np.diag(pcov))
     return popt, perr

--- a/content/learn/scientific-computing-python/scientific-visualization.mdx
+++ b/content/learn/scientific-computing-python/scientific-visualization.mdx
@@ -245,9 +245,11 @@ import matplotlib.pyplot as plt
 from plotting import phase_portrait
 from scipy.integrate import solve_ivp
 
+
 def vdp(t, z, mu=1.5):
     x, y = z
-    return [y, mu*(1-x*x)*y - x]
+    return [y, mu * (1 - x * x) * y - x]
+
 
 # Integrate several initial conditions
 trajectories = []
@@ -257,10 +259,14 @@ for x0 in np.linspace(-3, 3, 7):
     trajectories.append(sol.sol(tt).T)
 
 fig, ax = plt.subplots(figsize=(6, 5), constrained_layout=True)
-phase_portrait(ax, trajectories,
-               vector_field=lambda x, y: (y, 1.5*(1-x*x)*y - x),
-               xlim=(-3.5, 3.5), ylim=(-5, 5),
-               title="Van der Pol oscillator")
+phase_portrait(
+    ax,
+    trajectories,
+    vector_field=lambda x, y: (y, 1.5 * (1 - x * x) * y - x),
+    xlim=(-3.5, 3.5),
+    ylim=(-5, 5),
+    title="Van der Pol oscillator",
+)
 plt.show()
 `,
     },
@@ -268,8 +274,10 @@ plt.show()
       filename: "plotting.py",
       initialContent: `import numpy as np
 
-def phase_portrait(ax, trajectories, vector_field,
-                   xlim=(-3, 3), ylim=(-3, 3), grid=25, title=""):
+
+def phase_portrait(
+    ax, trajectories, vector_field, xlim=(-3, 3), ylim=(-3, 3), grid=25, title=""
+):
     """Plot trajectories on top of a streamplot of the vector field."""
     x = np.linspace(*xlim, grid)
     y = np.linspace(*ylim, grid)
@@ -278,10 +286,13 @@ def phase_portrait(ax, trajectories, vector_field,
     ax.streamplot(X, Y, U, V, color="lightgray", density=1.1, linewidth=0.6)
     for traj in trajectories:
         ax.plot(traj[:, 0], traj[:, 1], lw=1.2)
-    ax.set_xlim(xlim); ax.set_ylim(ylim)
-    ax.set_xlabel("x"); ax.set_ylabel("ẋ")
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+    ax.set_xlabel("x")
+    ax.set_ylabel("ẋ")
     ax.set_aspect("equal")
-    if title: ax.set_title(title)
+    if title:
+        ax.set_title(title)
 `,
     },
   ]}

--- a/content/learn/scientific-computing-python/signal-processing.mdx
+++ b/content/learn/scientific-computing-python/signal-processing.mdx
@@ -246,10 +246,15 @@ t, clean, noisy = generate_signal(fs=fs, T=2.0, seed=0)
 recovered = denoise(noisy, fs=fs, cutoff=30.0, order=6)
 
 fig, ax = plt.subplots(3, 1, figsize=(9, 5), sharex=True)
-ax[0].plot(t, clean);     ax[0].set_title("clean signal")
-ax[1].plot(t, noisy);     ax[1].set_title("noisy measurement")
-ax[2].plot(t, recovered); ax[2].set_title("low-pass recovered")
-plt.xlabel("time (s)"); plt.tight_layout(); plt.show()
+ax[0].plot(t, clean)
+ax[0].set_title("clean signal")
+ax[1].plot(t, noisy)
+ax[1].set_title("noisy measurement")
+ax[2].plot(t, recovered)
+ax[2].set_title("low-pass recovered")
+plt.xlabel("time (s)")
+plt.tight_layout()
+plt.show()
 
 rmse = np.sqrt(np.mean((recovered - clean) ** 2))
 print(f"RMSE after denoising: {rmse:.4f}")
@@ -260,12 +265,14 @@ print(f"RMSE after denoising: {rmse:.4f}")
       initialContent: `import numpy as np
 from scipy.signal import butter, sosfiltfilt
 
+
 def generate_signal(fs=2000, T=2.0, seed=0):
     rng = np.random.default_rng(seed)
-    t = np.arange(0, T, 1/fs)
-    clean = np.sin(2*np.pi*4*t) + 0.5*np.sin(2*np.pi*9*t)
-    noise = 0.6*np.sin(2*np.pi*180*t) + 0.4*rng.standard_normal(t.size)
+    t = np.arange(0, T, 1 / fs)
+    clean = np.sin(2 * np.pi * 4 * t) + 0.5 * np.sin(2 * np.pi * 9 * t)
+    noise = 0.6 * np.sin(2 * np.pi * 180 * t) + 0.4 * rng.standard_normal(t.size)
     return t, clean, clean + noise
+
 
 def denoise(x, fs, cutoff=30.0, order=6):
     """Zero-phase Butterworth low-pass."""

--- a/content/learn/scientific-computing-python/vectorized-thinking.mdx
+++ b/content/learn/scientific-computing-python/vectorized-thinking.mdx
@@ -229,6 +229,7 @@ print("Long-run mean    :", traj[1000:].mean() if n > 1000 else traj.mean())
       filename: "kernels.py",
       initialContent: `import numpy as np
 
+
 def logistic_map_trajectory(r: float, x0: float, n: int) -> np.ndarray:
     """Iterate x_{t+1} = r * x_t * (1 - x_t).
 
@@ -239,7 +240,7 @@ def logistic_map_trajectory(r: float, x0: float, n: int) -> np.ndarray:
     x = np.empty(n)
     x[0] = x0
     for t in range(n - 1):
-        x[t+1] = r * x[t] * (1.0 - x[t])
+        x[t + 1] = r * x[t] * (1.0 - x[t])
     return x
 `,
     },

--- a/content/learn/systems-programming-c/c-toolchain.mdx
+++ b/content/learn/systems-programming-c/c-toolchain.mdx
@@ -158,14 +158,14 @@ header / implementation split you would use in a real project.
   files={[
     {
       filename: "main.c",
-      initialContent: `#include <stdio.h>
-#include "mathx.h"
+      initialContent: `#include "mathx.h"
+#include <stdio.h>
 
 int main(void) {
-    int a = 6, b = 7;
-    printf("add(%d, %d) = %d\\n", a, b, add(a, b));
-    printf("mul(%d, %d) = %d\\n", a, b, mul(a, b));
-    return 0;
+  int a = 6, b = 7;
+  printf("add(%d, %d) = %d\\n", a, b, add(a, b));
+  printf("mul(%d, %d) = %d\\n", a, b, mul(a, b));
+  return 0;
 }
 `,
     },
@@ -236,12 +236,12 @@ system. That is why a "hello world" binary is so small.
   files={[
     {
       filename: "main.c",
-      initialContent: `#include <stdio.h>
-#include "util.h"
+      initialContent: `#include "util.h"
+#include <stdio.h>
 
 int main(void) {
-    printf("%d\\n", square(7));
-    return 0;
+  printf("%d\\n", square(7));
+  return 0;
 }
 `,
     },
@@ -258,15 +258,13 @@ int square(int x);
       initialContent: `#include "util.h"
 
 int square(int x) {
-    // your code here
-    return 0;
+  // your code here
+  return 0;
 }
 `,
       solutionContent: `#include "util.h"
 
-int square(int x) {
-    return x * x;
-}
+int square(int x) { return x * x; }
 `,
     },
   ]}

--- a/content/learn/typescript-from-scratch/discriminated-unions.mdx
+++ b/content/learn/typescript-from-scratch/discriminated-unions.mdx
@@ -260,11 +260,15 @@ export type RemoteData<T> =
   | { status: "error"; error: string };
 
 // Type guards
-export function isLoading<T>(state: RemoteData<T>): state is { status: "loading" } {
+export function isLoading<T>(
+  state: RemoteData<T>,
+): state is { status: "loading" } {
   return state.status === "loading";
 }
 
-export function isSuccess<T>(state: RemoteData<T>): state is { status: "success"; data: T } {
+export function isSuccess<T>(
+  state: RemoteData<T>,
+): state is { status: "success"; data: T } {
   return state.status === "success";
 }
 
@@ -312,8 +316,16 @@ export function renderNotification(notif: Notification): string {
 
 // Test cases
 const info: Notification = { type: "info", message: "System updated" };
-const warning: Notification = { type: "warning", message: "Low disk space", severity: 3 };
-const error: Notification = { type: "error", message: "Crash", stack: "at line 42" };
+const warning: Notification = {
+  type: "warning",
+  message: "Low disk space",
+  severity: 3,
+};
+const error: Notification = {
+  type: "error",
+  message: "Crash",
+  stack: "at line 42",
+};
 
 console.log(renderNotification(info));
 console.log(renderNotification(warning));
@@ -336,8 +348,16 @@ export function renderNotification(notif: Notification): string {
 }
 
 const info: Notification = { type: "info", message: "System updated" };
-const warning: Notification = { type: "warning", message: "Low disk space", severity: 3 };
-const error: Notification = { type: "error", message: "Crash", stack: "at line 42" };
+const warning: Notification = {
+  type: "warning",
+  message: "Low disk space",
+  severity: 3,
+};
+const error: Notification = {
+  type: "error",
+  message: "Crash",
+  stack: "at line 42",
+};
 
 console.log(renderNotification(info));
 console.log(renderNotification(warning));

--- a/content/learn/typescript-from-scratch/error-handling-with-types.mdx
+++ b/content/learn/typescript-from-scratch/error-handling-with-types.mdx
@@ -328,20 +328,18 @@ export function parseConfig(input: string): Result<Config, string> {
     },
     {
       filename: "result.ts",
-      initialContent: `export type Result<T, E> =
-  | { ok: true; value: T }
-  | { ok: false; error: E };
+      initialContent: `export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
 
 export function map<T, E, U>(
   result: Result<T, E>,
-  fn: (value: T) => U
+  fn: (value: T) => U,
 ): Result<U, E> {
   return result.ok ? { ok: true, value: fn(result.value) } : result;
 }
 
 export function andThen<T, E, U>(
   result: Result<T, E>,
-  fn: (value: T) => Result<U, E>
+  fn: (value: T) => Result<U, E>,
 ): Result<U, E> {
   return result.ok ? fn(result.value) : result;
 }
@@ -398,25 +396,21 @@ export function parseNumber(input: string): Result<number, string> {
     },
     {
       filename: "result.ts",
-      initialContent: `export type Result<T, E> =
-  | { ok: true; value: T }
-  | { ok: false; error: E };
+      initialContent: `export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
 
 export function map<T, E, U>(
   result: Result<T, E>,
-  fn: (value: T) => U
+  fn: (value: T) => U,
 ): Result<U, E> {
   // Implement
   return { ok: false, error: "Not implemented" as any };
 }
 `,
-      solutionContent: `export type Result<T, E> =
-  | { ok: true; value: T }
-  | { ok: false; error: E };
+      solutionContent: `export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
 
 export function map<T, E, U>(
   result: Result<T, E>,
-  fn: (value: T) => U
+  fn: (value: T) => U,
 ): Result<U, E> {
   if (result.ok) {
     return { ok: true, value: fn(result.value) };

--- a/content/learn/typescript-from-scratch/functions-and-signatures.mdx
+++ b/content/learn/typescript-from-scratch/functions-and-signatures.mdx
@@ -359,7 +359,7 @@ export function addTen(x: number): number {
 
 export function compose(
   f: (x: number) => number,
-  g: (x: number) => number
+  g: (x: number) => number,
 ): (x: number) => number {
   // Your code here
   return (x) => 0;
@@ -372,7 +372,7 @@ console.log("compose(double, addTen)(5):", pipeline(5));
 
 export function compose(
   f: (x: number) => number,
-  g: (x: number) => number
+  g: (x: number) => number,
 ): (x: number) => number {
   return (x) => f(g(x));
 }

--- a/content/learn/typescript-from-scratch/generic-constraints.mdx
+++ b/content/learn/typescript-from-scratch/generic-constraints.mdx
@@ -351,12 +351,18 @@ console.log("Users:", byRole["user"]);
       initialContent: `// TODO: Implement groupBy<T, K extends keyof T>
 // It should return a Record<string, T[]>
 
-export function groupBy<T, K extends keyof T>(array: T[], key: K): Record<string, T[]> {
+export function groupBy<T, K extends keyof T>(
+  array: T[],
+  key: K,
+): Record<string, T[]> {
   // TODO: implement
   return {};
 }
 `,
-      solutionContent: `export function groupBy<T, K extends keyof T>(array: T[], key: K): Record<string, T[]> {
+      solutionContent: `export function groupBy<T, K extends keyof T>(
+  array: T[],
+  key: K,
+): Record<string, T[]> {
   const result: Record<string, T[]> = {};
   for (const item of array) {
     const keyValue = String(item[key]);

--- a/content/learn/typescript-from-scratch/generics-basics.mdx
+++ b/content/learn/typescript-from-scratch/generics-basics.mdx
@@ -327,10 +327,10 @@ The tests will verify that \`map\` transforms the value and returns a new contai
 const numContainer = new Container(42);
 console.log(\`Original: \${numContainer.get()}\`);
 
-const doubled = numContainer.map(n => n * 2);
+const doubled = numContainer.map((n) => n * 2);
 console.log(\`Doubled: \${doubled.get()}\`);
 
-const stringContainer = numContainer.map(n => \`Number: \${n}\`);
+const stringContainer = numContainer.map((n) => \`Number: \${n}\`);
 console.log(\`String: \${stringContainer.get()}\`);
 `,
       solutionContent: `import { Container } from "./container";
@@ -338,10 +338,10 @@ console.log(\`String: \${stringContainer.get()}\`);
 const numContainer = new Container(42);
 console.log(\`Original: \${numContainer.get()}\`);
 
-const doubled = numContainer.map(n => n * 2);
+const doubled = numContainer.map((n) => n * 2);
 console.log(\`Doubled: \${doubled.get()}\`);
 
-const stringContainer = numContainer.map(n => \`Number: \${n}\`);
+const stringContainer = numContainer.map((n) => \`Number: \${n}\`);
 console.log(\`String: \${stringContainer.get()}\`);
 `,
     },

--- a/content/learn/typescript-from-scratch/modeling-domains-with-types.mdx
+++ b/content/learn/typescript-from-scratch/modeling-domains-with-types.mdx
@@ -251,7 +251,12 @@ type OrderState =
   | { status: "draft" }
   | { status: "submitted"; shippingAddress: string }
   | { status: "paid"; paymentId: string; shippingAddress: string }
-  | { status: "shipped"; paymentId: string; shippingAddress: string; trackingNumber: string }
+  | {
+      status: "shipped";
+      paymentId: string;
+      shippingAddress: string;
+      trackingNumber: string;
+    }
   | { status: "cancelled"; reason: string };
 
 export type Order = {
@@ -442,7 +447,11 @@ const draft: Post = {
 const published: Post = {
   id: "p2",
   title: "Published Article",
-  state: { status: "published", slug: "published-article", publishedAt: Date.now() },
+  state: {
+    status: "published",
+    slug: "published-article",
+    publishedAt: Date.now(),
+  },
 };
 
 const archived: Post = {
@@ -480,7 +489,11 @@ const draft: Post = {
 const published: Post = {
   id: "p2",
   title: "Published Article",
-  state: { status: "published", slug: "published-article", publishedAt: Date.now() },
+  state: {
+    status: "published",
+    slug: "published-article",
+    publishedAt: Date.now(),
+  },
 };
 
 const archived: Post = {

--- a/content/learn/typescript-from-scratch/scalable-architecture.mdx
+++ b/content/learn/typescript-from-scratch/scalable-architecture.mdx
@@ -263,7 +263,7 @@ export interface OrderRepository {
 export function createOrder(
   repo: OrderRepository,
   orderId: string,
-  total: number
+  total: number,
 ): Order | null {
   const order = buildOrder(orderId, total);
   if (order) {
@@ -345,7 +345,11 @@ export function validateEmail(email: string): boolean {
       filename: "user/application.ts",
       initialContent: `import { User, validateEmail } from "./domain";
 
-export function createUser(id: string, name: string, email: string): User | null {
+export function createUser(
+  id: string,
+  name: string,
+  email: string,
+): User | null {
   if (!validateEmail(email)) {
     return null;
   }

--- a/scripts/fix-csharp-toplevel.mjs
+++ b/scripts/fix-csharp-toplevel.mjs
@@ -62,8 +62,21 @@ function reorder(body) {
   if (moved === 0) return { rebuilt: body, moved: 0 };
   const kept = [];
   const types = [];
+  // Partition lines into statements (kept) and relocated type declarations
+  // (types). When several type declarations move (e.g. an inheritance example
+  // with a base + derived classes), keep one blank line between consecutive
+  // declarations so they don't jam together — a single blank is clang-format
+  // stable, so the later reformat preserves it.
+  let inType = false;
   for (let i = 0; i < lines.length; i++) {
-    (typeLineFlags[i] ? types : kept).push(lines[i]);
+    if (typeLineFlags[i]) {
+      if (!inType && types.length > 0) types.push("");
+      types.push(lines[i]);
+      inType = true;
+    } else {
+      kept.push(lines[i]);
+      inType = false;
+    }
   }
   while (kept.length && kept[kept.length - 1].trim() === "") kept.pop();
   while (types.length && types[0].trim() === "") types.shift();

--- a/scripts/format-content.mjs
+++ b/scripts/format-content.mjs
@@ -13,8 +13,10 @@
 //   sql         sql-formatter   (dialect-aware, 2-space)
 //
 // Props formatted: `starterCode` (all), `solutionCode` (language challenge
-// cards) and `solutionSql` (SQL challenge cards). `initCode`/`initSql`,
-// `tests` and `instructions` are left untouched.
+// cards) and `solutionSql` (SQL challenge cards), plus the per-file
+// `initialContent`/`solutionContent` of multi-file `files={[ … ]}` blocks.
+// `initCode`/`initSql` (read-only init), `tests` and `instructions` are left
+// untouched.
 //
 // Usage:
 //   node scripts/format-content.mjs            # format everything
@@ -205,6 +207,12 @@ function escapeTemplate(s) {
 }
 
 const PROP_RE = /\b(starterCode|solutionCode|solutionSql)\s*=\s*\{\s*`/g;
+// Multi-file blocks carry code as object properties inside files={[ … ]}:
+//   { filename: "Main.java", initialContent: `…`, solutionContent: `…` }
+// These use the `prop: ` + backtick object form (not the `prop={` + backtick
+// attribute form), so they need their own pattern. Same language as the
+// enclosing <CodeBlock>/<ChallengeCard>.
+const PROP_OBJ_RE = /\b(initialContent|solutionContent)\s*:\s*`/g;
 
 const stats = {
   files: 0,
@@ -223,21 +231,24 @@ async function processFile(file) {
   stats.files++;
   const openers = buildOpeners(src);
 
-  // Collect prop matches with their template spans.
+  // Collect prop matches with their template spans — both the attribute form
+  // (starterCode={`…`}) and the object-property form (initialContent: `…`).
   const edits = [];
-  let m;
-  PROP_RE.lastIndex = 0;
-  while ((m = PROP_RE.exec(src))) {
-    const prop = m[1];
-    const openBacktick = m.index + m[0].length - 1; // index of the `
-    const close = findCloseBacktick(src, openBacktick);
-    if (close === -1) {
-      stats.failed.push(`${file}: ${prop}: unterminated template literal`);
-      continue;
+  for (const re of [PROP_RE, PROP_OBJ_RE]) {
+    let m;
+    re.lastIndex = 0;
+    while ((m = re.exec(src))) {
+      const prop = m[1];
+      const openBacktick = m.index + m[0].length - 1; // index of the `
+      const close = findCloseBacktick(src, openBacktick);
+      if (close === -1) {
+        stats.failed.push(`${file}: ${prop}: unterminated template literal`);
+        continue;
+      }
+      const lang = langAt(openers, m.index);
+      edits.push({ prop, bodyStart: openBacktick + 1, bodyEnd: close, lang });
+      re.lastIndex = close + 1;
     }
-    const lang = langAt(openers, m.index);
-    edits.push({ prop, bodyStart: openBacktick + 1, bodyEnd: close, lang });
-    PROP_RE.lastIndex = close + 1;
   }
 
   // Format each (sequential — formatters are stateful singletons).


### PR DESCRIPTION
Picks up the full-courseware sweep #444 deferred, and extends it to a formatting gap found in review.

## 1. Formatting gap — 572 multi-file buffers were never formatted
#444 claimed all snippets were formatted, but `scripts/format-content.mjs`'s prop regex only matched the **JSX-attribute** forms (`starterCode={`…`}`, `solutionCode`, `solutionSql`). The per-file buffers of **multi-file blocks** — `files={[{ filename, initialContent, solutionContent }]}` — use the **object-property** form (`initialContent: `…``) and were never matched, so they shipped unformatted (e.g. Java/C# multi-file blocks at 4-space while the single-file blocks and the editor's Tab width are 2-space).

- `format-content.mjs`: added `PROP_OBJ_RE` for `initialContent`/`solutionContent`, run through the same eval→format→re-escape path, language resolved from the enclosing `<CodeBlock>`/`<ChallengeCard>`.
- **572 buffers across 139 pages** reformatted with the site's own formatters (clang-format LLVM/Microsoft, `web_fmt` 2-space, `ruff`).

A courseware-wide DRY run confirms `starterCode`/`solutionCode`/`solutionSql` were already clean (#444 did stick for those); the gap was entirely the multi-file object props.

## 2. CS8803 — `intro-modern-csharp` (a C# course #444 never swept)
`detect-cs8803.mjs` flagged **23 type declarations before top-level statements across 5 pages** (each a compile error). Relocated with `fix-csharp-toplevel.mjs` + reformatted; detector now reports **zero** across all 51 `adapter="csharp"` pages. Also improved the fixer to keep a blank line between consecutive relocated types.

## 3. Python escape bug — `nlp/pos-tagging`
A `starterCode` literal wrote `f"...\n..."` with a single backslash → a real newline inside an f-string → `SyntaxError`. Re-encoded to `\\n` + reformatted (same family #444 fixed for C/C++/C#).

## Verification
- `format-content.mjs` DRY re-run → **0** remaining changes across all non-R content.
- `check-mdx` (production fumadocs pipeline) → all changed files compile. *(3 `scientific-computing-python` pages fail `check-mdx` only on pre-existing inline-LaTeX `$…{…}…$`; proven to fail identically at HEAD, untouched here, rendered fine by the real `remarkMath`/`rehypeKatex` pipeline.)*
- `detect-cs8803` → zero; escape detector → zero.

## Known remaining items (need a networked / browser CI run)
- **R blocks (61 R-only pages, ~20 multi-file buffers):** `styler` runs inside WebR, which needs a CDN unreachable in this environment (WebR init times out). Left for a networked run.
- **The live `COURSEWARE=1` runtime sweep** (does every block *execute* without error): needs Playwright browsers + CDN-fetched WASM toolchains, unavailable in this environment — the same constraint #444 hit. This PR completes the deterministic/static portion.
- One intentionally mis-indented ChallengeCard starter (`python-basics/syntax-and-indentation`, *"Fix the broken indentation"*) is correctly skipped by the formatter and left as authored.
- `initCode`/`initSql` (read-only init code) remains excluded, as in #444.

https://claude.ai/code/session_019nVHkLZbLpgGCZU2zhKUBx