### PR TITLE
Speed up /learn dev compile: scope Tailwind scan + load MDX on demand

### DIFF
--- a/app/learn/[[...slug]]/page.tsx
+++ b/app/learn/[[...slug]]/page.tsx
@@ -25,10 +25,14 @@ export default async function LearnPage(props: LearnPageProps) {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
-  const MDX = page.data.body;
+  // The docs collection uses `dynamic` mode (see `source.config.ts`), so the
+  // compiled MDX body and TOC are fetched on demand here rather than being
+  // bundled with the route. Frontmatter fields (title, description, full)
+  // remain available directly on `page.data`.
+  const { body: MDX, toc } = await page.data.load();
 
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
+    <DocsPage toc={toc} full={page.data.full}>
       <DocsTitle>{page.data.title}</DocsTitle>
       {page.data.description ? (
         <DocsDescription>{page.data.description}</DocsDescription>

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -18,7 +18,16 @@
    at-rule, including the inlined CSS pulled in by tailwindcss. */
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
-@import "tailwindcss";
+/* `source(none)` disables Tailwind v4's automatic content detection,
+   which otherwise crawls the entire project on every CSS compile. In this
+   repo that sweep walks large non-source trees (public/, cdn-assets/,
+   agent-outputs/, the 800-file content/ tree) and added ~2 minutes to the
+   /learn dev compile on a cold cache. The app authors no Tailwind utility
+   classes of its own — only Fumadocs UI uses them — so the single explicit
+   `@source` below (Fumadocs's prebuilt JS) is the complete set of class
+   names Tailwind needs to scan. If app code ever starts using Tailwind
+   utilities directly, add an `@source` for those files here. */
+@import "tailwindcss" source(none);
 @source "../../node_modules/fumadocs-ui/dist/**/*.js";
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";

--- a/lib/source.ts
+++ b/lib/source.ts
@@ -8,7 +8,10 @@
  */
 import { loader } from "fumadocs-core/source";
 import { lucideIconsPlugin } from "fumadocs-core/source/plugins/lucide-icons";
-import { docs } from "@/.source/server";
+// `dynamic` mode (see `source.config.ts`) emits the `docs` collection from
+// `.source/dynamic`, where each lesson body is compiled on demand from disk
+// at request time instead of being bundled into the route graph.
+import { docs } from "@/.source/dynamic";
 
 export const source = loader({
   baseUrl: "/learn",

--- a/source.config.ts
+++ b/source.config.ts
@@ -33,6 +33,19 @@ import rehypeKatex from "rehype-katex";
 
 export const docs = defineDocs({
   dir: "content/learn",
+  docs: {
+    // Compile each lesson's MDX body on demand at request time instead of
+    // bundling all ~800 files into the route graph. By default the generated
+    // `.source/server.ts` statically imports every lesson, so the first
+    // request to any `/learn` page makes Turbopack compile all ~800 bodies
+    // (each through the remark/rehype/Shiki pipeline) before the page can
+    // render. `dynamic` keeps the bodies out of the bundler entirely:
+    // Fumadocs reads + compiles the requested file with its own MDX compiler
+    // at request time, so only the visited page is built. The body and TOC
+    // are then loaded via `await page.data.load()` (see `page.tsx`), and the
+    // collection is consumed from `.source/dynamic` (see `lib/source.ts`).
+    dynamic: true,
+  },
 });
 
 export default defineConfig({


### PR DESCRIPTION
## What

The first request to any `/learn` page took **~3 minutes** to compile in dev. Two stacked changes bring the cold compile down to **~25–30s (~6×)**, with no change to rendered output.

| Configuration | Cold `/learn` compile |
|---|---|
| Baseline | ~172s |
| + Tailwind `source(none)` (commit 1) | ~55s |
| + Fumadocs `dynamic` MDX (commit 2) | ~25–30s |

## Root cause

I started from the hypothesis that the postinstall/almostnode worker build or the MDX content was to blame, but measuring each piece ruled both out:

- **Postinstall steps are fast** (`fumadocs-mdx` ~1s, `patch-almostnode` <1s, `build-almostnode-workers` ~1s).
- Bisecting the `/learn` route graph pinned the dominant cost on `app/learn/learn.css`:

| `learn.css` contents | Cold `/learn` compile |
|---|---|
| Gutted (no Tailwind) | 24.4s |
| Just `@import "tailwindcss"` | 152.7s |
| Full (original) | 172s |

`@import "tailwindcss"` alone added **~128s**: Tailwind v4's **automatic content detection** crawls the whole project on every CSS compile, and this repo has large non-source trees (`public/` ~44M, `cdn-assets/` ~35M, `agent-outputs/` ~11M, plus the ~800-file `content/`). `learn.css` is the app's only Tailwind entry point, so it hit every `/learn` page.

The remaining ~30s after that fix is Turbopack compiling all ~800 MDX bodies, which the generated `.source/server.ts` imports statically.

## Changes

**1. Scope Tailwind content detection** — the app authors no Tailwind utility classes of its own (only Fumadocs UI does, already covered by the explicit `@source`):
```css
@import "tailwindcss" source(none);
@source "../../node_modules/fumadocs-ui/dist/**/*.js";
```

**2. Load MDX bodies on demand** (`docs: { dynamic: true }`) — Fumadocs compiles the requested lesson with its own MDX compiler at request time instead of bundling all ~800 into the route graph. The page reads the body/TOC via `await page.data.load()`.

## Verification

- Cold `/learn` dev compile: **~172s → ~25–30s**; content pages compile in ~1–2s.
- Rendered output unchanged — sidebar, prose/serif typography, TOC, inline code, and code blocks all style correctly (verified visually with Playwright).
- HMR on MDX content edits still works (tested: edited a lesson body, change appeared on re-request without restart).
- `tsc --noEmit` passes against the generated dynamic types.

## Tradeoffs of the `dynamic` change (dev/runtime only)

`next build` still statically generates every page, so production and CI build are unaffected. In dev: the search index (`/api/search`) now builds from on-demand body compiles (first search in a session compiles the bodies it indexes), and content-error overlays are less rich since bodies are compiled by Fumadocs' runtime compiler rather than Turbopack.