### PR TITLE
Format duckdb initSql seeds to canonical sql-formatter style (round-trip)

### DIFF
--- a/content/learn/sql-analytics-duckdb/aggregate-functions.mdx
+++ b/content/learn/sql-analytics-duckdb/aggregate-functions.mdx
@@ -42,12 +42,18 @@ produces its own number.
 <SqlCodeBlock
   dialect="duckdb"
   title="A one-line revenue report"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, customer TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'Ada',120),(2,'Bo',80),(3,'Ada',45),
-  (4,'Cy',200),(5,'Bo',60),(6,'Cy',95),(7,'Ada',30);`}
+  initSql={`CREATE TABLE orders (id INTEGER, customer TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'Ada', 120),
+  (2, 'Bo', 80),
+  (3, 'Ada', 45),
+  (4, 'Cy', 200),
+  (5, 'Bo', 60),
+  (6, 'Cy', 95),
+  (7, 'Ada', 30);`}
   starterCode={`SELECT
   COUNT(*) AS num_orders,
   SUM(amount) AS revenue,
@@ -74,12 +80,17 @@ analysis:
 <SqlCodeBlock
   dialect="duckdb"
   title="Three kinds of counting"
-  initSql={`CREATE TABLE visits (
-  id INTEGER, user_id INTEGER, referrer TEXT
-);
-INSERT INTO visits VALUES
-  (1, 10, 'google'), (2, 10, NULL), (3, 11, 'google'),
-  (4, 12, 'twitter'), (5, 11, NULL), (6, 10, 'twitter');`}
+  initSql={`CREATE TABLE visits (id INTEGER, user_id INTEGER, referrer TEXT);
+
+INSERT INTO
+  visits
+VALUES
+  (1, 10, 'google'),
+  (2, 10, NULL),
+  (3, 11, 'google'),
+  (4, 12, 'twitter'),
+  (5, 11, NULL),
+  (6, 10, 'twitter');`}
   starterCode={`SELECT
   COUNT(*) AS total_visits,
   COUNT(referrer) AS visits_with_referrer,
@@ -101,11 +112,16 @@ zero and drag an average down.
 <SqlCodeBlock
   dialect="duckdb"
   title="AVG skips the unknowns"
-  initSql={`CREATE TABLE ratings (
-  product TEXT, score INTEGER
-);
-INSERT INTO ratings VALUES
-  ('A', 5), ('A', 3), ('A', NULL), ('B', 4), ('B', NULL);`}
+  initSql={`CREATE TABLE ratings (product TEXT, score INTEGER);
+
+INSERT INTO
+  ratings
+VALUES
+  ('A', 5),
+  ('A', 3),
+  ('A', NULL),
+  ('B', 4),
+  ('B', NULL);`}
   starterCode={`SELECT
   product,
   COUNT(*) AS rows,
@@ -133,11 +149,17 @@ average with a filter.
 <SqlCodeBlock
   dialect="duckdb"
   title="Summarize only the big orders"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,120),(2,30),(3,200),(4,45),(5,95),(6,15);`}
+  initSql={`CREATE TABLE orders (id INTEGER, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 120),
+  (2, 30),
+  (3, 200),
+  (4, 45),
+  (5, 95),
+  (6, 15);`}
   starterCode={`SELECT
   COUNT(*) AS big_orders,
   ROUND(AVG(amount), 2) AS avg_big_order

--- a/content/learn/sql-analytics-duckdb/analytical-vs-transactional-workloads.mdx
+++ b/content/learn/sql-analytics-duckdb/analytical-vs-transactional-workloads.mdx
@@ -96,11 +96,12 @@ any special syntax.
   title="A column-shaped question"
   initSql={`CREATE TABLE orders AS
 SELECT
-  i                                   AS id,
-  DATE '2024-01-01' + (i % 90)        AS order_date,
-  (i * 37) % 500 + 10                 AS amount,
-  ['West','East','North','South'][(i % 4) + 1] AS region
-FROM range(1, 5001) t(i);`}
+  i AS id,
+  DATE '2024-01-01' + (i % 90) AS order_date,
+  (i * 37) % 500 + 10 AS amount,
+  ['West', 'East', 'North', 'South'] [(i % 4) + 1] AS region
+FROM
+  range(1, 5001) t (i);`}
   starterCode={`-- Reads only the columns it needs (region, amount)
 -- across 5,000 rows, and returns just 4 summary rows.
 SELECT

--- a/content/learn/sql-analytics-duckdb/analytics-vs-application-development.mdx
+++ b/content/learn/sql-analytics-duckdb/analytics-vs-application-development.mdx
@@ -83,19 +83,18 @@ single order is the answer; the *pattern across orders* is.
 <SqlCodeBlock
   dialect="duckdb"
   title="A net, not a needle"
-  initSql={`CREATE TABLE orders (
-  id        INTEGER,
-  category  TEXT,
-  amount    DECIMAL(10, 2)
-);
-INSERT INTO orders VALUES
-  (1, 'Books',       12.00),
+  initSql={`CREATE TABLE orders (id INTEGER, category TEXT, amount DECIMAL(10, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'Books', 12.00),
   (2, 'Electronics', 240.00),
-  (3, 'Books',        9.50),
+  (3, 'Books', 9.50),
   (4, 'Electronics', 180.00),
-  (5, 'Home',         45.00),
-  (6, 'Books',       22.00),
-  (7, 'Home',        30.00);`}
+  (5, 'Home', 45.00),
+  (6, 'Books', 22.00),
+  (7, 'Home', 30.00);`}
   starterCode={`SELECT
   category,
   COUNT(*) AS num_orders,

--- a/content/learn/sql-analytics-duckdb/building-business-metrics.mdx
+++ b/content/learn/sql-analytics-duckdb/building-business-metrics.mdx
@@ -36,15 +36,21 @@ against zero. `COUNT(DISTINCT ...)` ensures you count *people*, not events.
 <SqlCodeBlock
   dialect="duckdb"
   title="Visit-to-purchase conversion per channel"
-  initSql={`CREATE TABLE events (
-  user_id INTEGER, channel TEXT, action TEXT
-);
-INSERT INTO events VALUES
-  (1,'ads','visit'),(1,'ads','purchase'),
-  (2,'ads','visit'),
-  (3,'organic','visit'),(3,'organic','purchase'),
-  (4,'organic','visit'),(5,'organic','visit'),(5,'organic','purchase'),
-  (6,'ads','visit'),(6,'ads','purchase');`}
+  initSql={`CREATE TABLE events (user_id INTEGER, channel TEXT, action TEXT);
+
+INSERT INTO
+  events
+VALUES
+  (1, 'ads', 'visit'),
+  (1, 'ads', 'purchase'),
+  (2, 'ads', 'visit'),
+  (3, 'organic', 'visit'),
+  (3, 'organic', 'purchase'),
+  (4, 'organic', 'visit'),
+  (5, 'organic', 'visit'),
+  (5, 'organic', 'purchase'),
+  (6, 'ads', 'visit'),
+  (6, 'ads', 'purchase');`}
   starterCode={`SELECT
   channel,
   COUNT(DISTINCT user_id) FILTER(
@@ -92,10 +98,26 @@ whole job.
   dialect="duckdb"
   title="ARPU vs. ARPPU — two honest, different numbers"
   initSql={`CREATE TABLE users (id INTEGER);
-INSERT INTO users SELECT i FROM range(1, 11) t(i);   -- 10 users
-CREATE TABLE payments (user_id INTEGER, amount DECIMAL(8,2));
-INSERT INTO payments VALUES
-  (1, 50), (1, 20), (3, 100), (7, 30);               -- only 3 users paid`}
+
+INSERT INTO
+  users
+SELECT
+  i
+FROM
+  range(1, 11) t (i);
+
+-- 10 users
+CREATE TABLE payments (user_id INTEGER, amount DECIMAL(8, 2));
+
+INSERT INTO
+  payments
+VALUES
+  (1, 50),
+  (1, 20),
+  (3, 100),
+  (7, 30);
+
+-- only 3 users paid`}
   starterCode={`SELECT
   (
     SELECT
@@ -136,8 +158,9 @@ series — a direct application of the window-function lessons.
   initSql={`CREATE TABLE orders AS
 SELECT
   DATE '2024-01-01' + (i * 9) AS order_date,
-  (i * 23) % 150 + 50         AS amount
-FROM range(0, 30) t(i);`}
+  (i * 23) % 150 + 50 AS amount
+FROM
+  range(0, 30) t (i);`}
   starterCode={`WITH
   monthly AS (
     SELECT

--- a/content/learn/sql-analytics-duckdb/common-table-expressions.mdx
+++ b/content/learn/sql-analytics-duckdb/common-table-expressions.mdx
@@ -42,12 +42,23 @@ readable pipeline:
   dialect="duckdb"
   title="The same analysis as a readable pipeline"
   initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, status TEXT, amount DECIMAL(8,2)
+  id INTEGER,
+  region TEXT,
+  status TEXT,
+  amount DECIMAL(8, 2)
 );
-INSERT INTO orders VALUES
-  (1,'West','paid',120),(2,'West','refunded',45),(3,'East','paid',200),
-  (4,'East','paid',50),(5,'North','paid',60),(6,'West','paid',95),
-  (7,'East','paid',150),(8,'North','refunded',30);`}
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 'paid', 120),
+  (2, 'West', 'refunded', 45),
+  (3, 'East', 'paid', 200),
+  (4, 'East', 'paid', 50),
+  (5, 'North', 'paid', 60),
+  (6, 'West', 'paid', 95),
+  (7, 'East', 'paid', 150),
+  (8, 'North', 'refunded', 30);`}
   starterCode={`WITH
   paid AS (
     SELECT
@@ -111,12 +122,19 @@ it. Here, each region's revenue is compared to the company-wide average.
 <SqlCodeBlock
   dialect="duckdb"
   title="Compare each region to the overall average"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),(4,'East',200),
-  (5,'North',60),(6,'West',95),(7,'East',150),(8,'North',100);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60),
+  (6, 'West', 95),
+  (7, 'East', 150),
+  (8, 'North', 100);`}
   starterCode={`WITH
   region_rev AS (
     SELECT

--- a/content/learn/sql-analytics-duckdb/conditional-logic.mdx
+++ b/content/learn/sql-analytics-duckdb/conditional-logic.mdx
@@ -20,11 +20,18 @@ continuous or messy column into clean, analysis-ready categories.
 <SqlCodeBlock
   dialect="duckdb"
   title="Bucket amounts into size labels"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,15),(2,120),(3,45),(4,250),(5,8),(6,95),(7,500);`}
+  initSql={`CREATE TABLE orders (id INTEGER, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 15),
+  (2, 120),
+  (3, 45),
+  (4, 250),
+  (5, 8),
+  (6, 95),
+  (7, 500);`}
   starterCode={`SELECT
   id,
   amount,
@@ -53,11 +60,19 @@ your toolkit for good.
 <SqlCodeBlock
   dialect="duckdb"
   title="How many orders in each size bucket?"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,15),(2,120),(3,45),(4,250),(5,8),(6,95),(7,500),(8,60);`}
+  initSql={`CREATE TABLE orders (id INTEGER, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 15),
+  (2, 120),
+  (3, 45),
+  (4, 250),
+  (5, 8),
+  (6, 95),
+  (7, 500),
+  (8, 60);`}
   starterCode={`SELECT
   CASE
     WHEN amount < 50 THEN 'small'
@@ -85,12 +100,23 @@ mobile vs. desktop — all side by side.
   dialect="duckdb"
   title="Paid and refunded totals, side by side"
   initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, status TEXT, amount DECIMAL(8,2)
+  id INTEGER,
+  region TEXT,
+  status TEXT,
+  amount DECIMAL(8, 2)
 );
-INSERT INTO orders VALUES
-  (1,'West','paid',120),(2,'West','refunded',45),(3,'East','paid',200),
-  (4,'East','paid',50),(5,'North','refunded',60),(6,'West','paid',95),
-  (7,'East','refunded',30),(8,'North','paid',100);`}
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 'paid', 120),
+  (2, 'West', 'refunded', 45),
+  (3, 'East', 'paid', 200),
+  (4, 'East', 'paid', 50),
+  (5, 'North', 'refunded', 60),
+  (6, 'West', 'paid', 95),
+  (7, 'East', 'refunded', 30),
+  (8, 'North', 'paid', 100);`}
   starterCode={`SELECT
   region,
   SUM(
@@ -141,11 +167,21 @@ which expresses conditional aggregation more clearly than `CASE` inside
   dialect="duckdb"
   title="The same idea, written with FILTER"
   initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, status TEXT, amount DECIMAL(8,2)
+  id INTEGER,
+  region TEXT,
+  status TEXT,
+  amount DECIMAL(8, 2)
 );
-INSERT INTO orders VALUES
-  (1,'West','paid',120),(2,'West','refunded',45),(3,'East','paid',200),
-  (4,'East','paid',50),(5,'North','refunded',60),(6,'West','paid',95);`}
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 'paid', 120),
+  (2, 'West', 'refunded', 45),
+  (3, 'East', 'paid', 200),
+  (4, 'East', 'paid', 50),
+  (5, 'North', 'refunded', 60),
+  (6, 'West', 'paid', 95);`}
   starterCode={`SELECT
   region,
   SUM(amount) FILTER(
@@ -185,10 +221,18 @@ Two small but constant companions of conditional logic:
   dialect="duckdb"
   title="Safe defaults and safe division"
   initSql={`CREATE TABLE line_items (
-  id INTEGER, amount DECIMAL(8,2), quantity INTEGER, discount DECIMAL(8,2)
+  id INTEGER,
+  amount DECIMAL(8, 2),
+  quantity INTEGER,
+  discount DECIMAL(8, 2)
 );
-INSERT INTO line_items VALUES
-  (1, 100, 4, NULL), (2, 60, 0, 5), (3, 80, 2, NULL);`}
+
+INSERT INTO
+  line_items
+VALUES
+  (1, 100, 4, NULL),
+  (2, 60, 0, 5),
+  (3, 80, 2, NULL);`}
   starterCode={`SELECT
   id,
   COALESCE(discount, 0) AS discount_filled,

--- a/content/learn/sql-analytics-duckdb/filtering-and-slicing.mdx
+++ b/content/learn/sql-analytics-duckdb/filtering-and-slicing.mdx
@@ -34,10 +34,11 @@ ends.
   title="Orders in a price band and a date window"
   initSql={`CREATE TABLE orders AS
 SELECT
-  i                              AS id,
-  DATE '2024-01-01' + (i % 120)  AS order_date,
-  (i * 13) % 300 + 10            AS amount
-FROM range(1, 401) t(i);`}
+  i AS id,
+  DATE '2024-01-01' + (i % 120) AS order_date,
+  (i * 13) % 300 + 10 AS amount
+FROM
+  range(1, 401) t (i);`}
   starterCode={`SELECT
   id,
   order_date,
@@ -66,12 +67,21 @@ chain of `OR`s.
   dialect="duckdb"
   title="Just the categories we care about"
   initSql={`CREATE TABLE products (
-  id INTEGER, name TEXT, category TEXT, price DECIMAL(7,2)
+  id INTEGER,
+  name TEXT,
+  category TEXT,
+  price DECIMAL(7, 2)
 );
-INSERT INTO products VALUES
-  (1,'Pen','Office',1.50),(2,'Laptop','Electronics',999.00),
-  (3,'Notebook','Office',3.25),(4,'Phone','Electronics',699.00),
-  (5,'Mug','Kitchen',8.00),(6,'Desk','Furniture',150.00);`}
+
+INSERT INTO
+  products
+VALUES
+  (1, 'Pen', 'Office', 1.50),
+  (2, 'Laptop', 'Electronics', 999.00),
+  (3, 'Notebook', 'Office', 3.25),
+  (4, 'Phone', 'Electronics', 699.00),
+  (5, 'Mug', 'Kitchen', 8.00),
+  (6, 'Desk', 'Furniture', 150.00);`}
   starterCode={`SELECT
   name,
   category,
@@ -97,14 +107,15 @@ starting with "A", emails at a domain, codes containing a substring.
 <SqlCodeBlock
   dialect="duckdb"
   title="Pattern matching on text"
-  initSql={`CREATE TABLE people (
-  id INTEGER, name TEXT, email TEXT
-);
-INSERT INTO people VALUES
-  (1,'Ada Lovelace','ada@math.org'),
-  (2,'Alan Turing','alan@compute.io'),
-  (3,'Grace Hopper','grace@navy.mil'),
-  (4,'Annie Easley','annie@nasa.gov');`}
+  initSql={`CREATE TABLE people (id INTEGER, name TEXT, email TEXT);
+
+INSERT INTO
+  people
+VALUES
+  (1, 'Ada Lovelace', 'ada@math.org'),
+  (2, 'Alan Turing', 'alan@compute.io'),
+  (3, 'Grace Hopper', 'grace@navy.mil'),
+  (4, 'Annie Easley', 'annie@nasa.gov');`}
   starterCode={`SELECT
   name,
   email
@@ -126,12 +137,17 @@ what you intended. Make your grouping explicit.
 <SqlCodeBlock
   dialect="duckdb"
   title="Parentheses make the intent unambiguous"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(7,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',250),(2,'East',50),(3,'West',30),
-  (4,'East',300),(5,'North',120),(6,'West',400);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(7, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 250),
+  (2, 'East', 50),
+  (3, 'West', 30),
+  (4, 'East', 300),
+  (5, 'North', 120),
+  (6, 'West', 400);`}
   starterCode={`-- "Big orders, but only from West or East."
 SELECT
   id,

--- a/content/learn/sql-analytics-duckdb/filtering-groups.mdx
+++ b/content/learn/sql-analytics-duckdb/filtering-groups.mdx
@@ -41,12 +41,18 @@ about `SUM(amount)` — a group total — so it belongs in `HAVING`.
 <SqlCodeBlock
   dialect="duckdb"
   title="Only the high-revenue regions"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),
-  (4,'East',200),(5,'North',60),(6,'West',95),(7,'East',30);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60),
+  (6, 'West', 95),
+  (7, 'East', 30);`}
   starterCode={`SELECT
   region,
   SUM(amount) AS revenue
@@ -74,12 +80,23 @@ selects which resulting groups *survive*.
   dialect="duckdb"
   title="Filter rows first, then filter groups"
   initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, status TEXT, amount DECIMAL(8,2)
+  id INTEGER,
+  region TEXT,
+  status TEXT,
+  amount DECIMAL(8, 2)
 );
-INSERT INTO orders VALUES
-  (1,'West','paid',120),(2,'East','paid',80),(3,'West','refunded',45),
-  (4,'East','paid',200),(5,'North','paid',60),(6,'West','paid',95),
-  (7,'East','refunded',300),(8,'North','paid',100);`}
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 'paid', 120),
+  (2, 'East', 'paid', 80),
+  (3, 'West', 'refunded', 45),
+  (4, 'East', 'paid', 200),
+  (5, 'North', 'paid', 60),
+  (6, 'West', 'paid', 95),
+  (7, 'East', 'refunded', 300),
+  (8, 'North', 'paid', 100);`}
   starterCode={`SELECT
   region,
   COUNT(*) AS paid_orders,

--- a/content/learn/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
+++ b/content/learn/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
@@ -25,12 +25,21 @@ inside an aggregate.* You write the dimensions once.
   dialect="duckdb"
   title="GROUP BY ALL infers the grouping columns"
   initSql={`CREATE TABLE sales (
-  region TEXT, product TEXT, channel TEXT, amount DECIMAL(8,2)
+  region TEXT,
+  product TEXT,
+  channel TEXT,
+  amount DECIMAL(8, 2)
 );
-INSERT INTO sales VALUES
-  ('West','Widget','online',120),('West','Gadget','store',80),
-  ('East','Widget','online',200),('East','Gadget','online',50),
-  ('North','Widget','store',75),('West','Widget','online',60);`}
+
+INSERT INTO
+  sales
+VALUES
+  ('West', 'Widget', 'online', 120),
+  ('West', 'Gadget', 'store', 80),
+  ('East', 'Widget', 'online', 200),
+  ('East', 'Gadget', 'online', 50),
+  ('North', 'Widget', 'store', 75),
+  ('West', 'Widget', 'online', 60);`}
   starterCode={`SELECT
   region,
   product,
@@ -84,13 +93,16 @@ each level rolls up into the one above (product → region → everything).
 <SqlCodeBlock
   dialect="duckdb"
   title="Subtotals per region and a grand total with ROLLUP"
-  initSql={`CREATE TABLE sales (
-  region TEXT, product TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO sales VALUES
-  ('West','Widget',120),('West','Gadget',80),
-  ('East','Widget',200),('East','Gadget',50),
-  ('North','Widget',75);`}
+  initSql={`CREATE TABLE sales (region TEXT, product TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  sales
+VALUES
+  ('West', 'Widget', 120),
+  ('West', 'Gadget', 80),
+  ('East', 'Widget', 200),
+  ('East', 'Gadget', 50),
+  ('North', 'Widget', 75);`}
   starterCode={`SELECT
   region,
   product,
@@ -119,12 +131,15 @@ the marginal totals.
 <SqlCodeBlock
   dialect="duckdb"
   title="All marginal subtotals with CUBE"
-  initSql={`CREATE TABLE sales (
-  region TEXT, product TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO sales VALUES
-  ('West','Widget',120),('West','Gadget',80),
-  ('East','Widget',200),('East','Gadget',50);`}
+  initSql={`CREATE TABLE sales (region TEXT, product TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  sales
+VALUES
+  ('West', 'Widget', 120),
+  ('West', 'Gadget', 80),
+  ('East', 'Widget', 200),
+  ('East', 'Gadget', 50);`}
   starterCode={`SELECT
   region,
   product,
@@ -151,11 +166,15 @@ rows unambiguously.
 <SqlCodeBlock
   dialect="duckdb"
   title="Label subtotal rows with GROUPING()"
-  initSql={`CREATE TABLE sales (
-  region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO sales VALUES
-  ('West',120),('West',80),('East',200),('East',50);`}
+  initSql={`CREATE TABLE sales (region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  sales
+VALUES
+  ('West', 120),
+  ('West', 80),
+  ('East', 200),
+  ('East', 50);`}
   starterCode={`SELECT
   CASE
     WHEN GROUPING (region) = 1 THEN 'ALL REGIONS'

--- a/content/learn/sql-analytics-duckdb/grouping-data.mdx
+++ b/content/learn/sql-analytics-duckdb/grouping-data.mdx
@@ -32,12 +32,18 @@ whatever you aggregated.
 <SqlCodeBlock
   dialect="duckdb"
   title="Revenue per region"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),
-  (4,'East',200),(5,'North',60),(6,'West',95),(7,'East',30);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60),
+  (6, 'West', 95),
+  (7, 'East', 30);`}
   starterCode={`SELECT
   region,
   COUNT(*) AS orders,
@@ -74,12 +80,17 @@ flowchart LR
 <SqlCodeBlock
   dialect="duckdb"
   title="The rule in action — every column is grouped or aggregated"
-  initSql={`CREATE TABLE sales (
-  region TEXT, product TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO sales VALUES
-  ('West','Widget',120),('West','Gadget',80),('East','Widget',200),
-  ('East','Gadget',50),('North','Widget',75),('West','Widget',60);`}
+  initSql={`CREATE TABLE sales (region TEXT, product TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  sales
+VALUES
+  ('West', 'Widget', 120),
+  ('West', 'Gadget', 80),
+  ('East', 'Widget', 200),
+  ('East', 'Gadget', 50),
+  ('North', 'Widget', 75),
+  ('West', 'Widget', 60);`}
   starterCode={`SELECT
   region, -- grouped
   product, -- grouped
@@ -111,11 +122,19 @@ This is where grouping becomes genuinely creative.
 <SqlCodeBlock
   dialect="duckdb"
   title="Group by a derived bucket"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,15),(2,120),(3,45),(4,250),(5,8),(6,95),(7,500),(8,60);`}
+  initSql={`CREATE TABLE orders (id INTEGER, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 15),
+  (2, 120),
+  (3, 45),
+  (4, 250),
+  (5, 8),
+  (6, 95),
+  (7, 500),
+  (8, 60);`}
   starterCode={`SELECT
   CASE
     WHEN amount < 50 THEN 'small'

--- a/content/learn/sql-analytics-duckdb/index.mdx
+++ b/content/learn/sql-analytics-duckdb/index.mdx
@@ -140,19 +140,18 @@ per-region summary — the essence of analytical SQL.
 <SqlCodeBlock
   dialect="duckdb"
   title="From raw sales to a ranked summary"
-  initSql={`CREATE TABLE sales (
-  region   TEXT,
-  product  TEXT,
-  amount   DECIMAL(10, 2)
-);
-INSERT INTO sales VALUES
-  ('West',  'Widget', 120.00),
-  ('West',  'Gadget',  80.50),
-  ('East',  'Widget', 200.00),
-  ('East',  'Gadget',  50.00),
-  ('North', 'Widget',  75.25),
-  ('West',  'Widget',  60.00),
-  ('East',  'Widget',  90.00);`}
+  initSql={`CREATE TABLE sales (region TEXT, product TEXT, amount DECIMAL(10, 2));
+
+INSERT INTO
+  sales
+VALUES
+  ('West', 'Widget', 120.00),
+  ('West', 'Gadget', 80.50),
+  ('East', 'Widget', 200.00),
+  ('East', 'Gadget', 50.00),
+  ('North', 'Widget', 75.25),
+  ('West', 'Widget', 60.00),
+  ('East', 'Widget', 90.00);`}
   starterCode={`SELECT
   region,
   COUNT(*) AS orders,

--- a/content/learn/sql-analytics-duckdb/loading-and-generating-data.mdx
+++ b/content/learn/sql-analytics-duckdb/loading-and-generating-data.mdx
@@ -109,10 +109,11 @@ so later queries can build on it.
   title="Generate once, then query the saved table"
   initSql={`CREATE TABLE daily_sales AS
 SELECT
-  DATE '2024-01-01' + (i % 90)                 AS day,
-  ['West','East','North','South'][(i % 4) + 1] AS region,
-  (i * 17) % 400 + 10                          AS amount
-FROM range(1, 901) t(i);`}
+  DATE '2024-01-01' + (i % 90) AS day,
+  ['West', 'East', 'North', 'South'] [(i % 4) + 1] AS region,
+  (i * 17) % 400 + 10 AS amount
+FROM
+  range(1, 901) t (i);`}
   starterCode={`-- daily_sales was built by the init step above.
 SELECT
   region,

--- a/content/learn/sql-analytics-duckdb/next-steps.mdx
+++ b/content/learn/sql-analytics-duckdb/next-steps.mdx
@@ -62,10 +62,14 @@ before running it.
   title="Monthly paid revenue, share of total, and growth"
   initSql={`CREATE TABLE orders AS
 SELECT
-  DATE '2024-01-01' + (i * 6)              AS order_date,
-  CASE WHEN i % 5 = 0 THEN 'refunded' ELSE 'paid' END AS status,
-  (i * 19) % 200 + 40                      AS amount
-FROM range(0, 60) t(i);`}
+  DATE '2024-01-01' + (i * 6) AS order_date,
+  CASE
+    WHEN i % 5 = 0 THEN 'refunded'
+    ELSE 'paid'
+  END AS status,
+  (i * 19) % 200 + 40 AS amount
+FROM
+  range(0, 60) t (i);`}
   starterCode={`WITH
   monthly AS (
     SELECT
@@ -119,10 +123,11 @@ groups, and keep the top of each.
   instructions={`A table \`sales\` is pre-loaded with columns \`category\`, \`product\`, and \`amount\`. Return one row per category containing the \`category\`, the \`product\` with the highest total revenue in that category, and that \`revenue\`. Columns: \`category\`, \`product\`, \`revenue\`. Sort by \`revenue\` descending.`}
   initSql={`CREATE TABLE sales AS
 SELECT
-  ['Books','Electronics','Home'][(i % 3) + 1]                 AS category,
-  ['A','B','C','D'][(i % 4) + 1]                              AS product,
-  (i * 17) % 100 + 10                                         AS amount
-FROM range(1, 61) t(i);`}
+  ['Books', 'Electronics', 'Home'] [(i % 3) + 1] AS category,
+  ['A', 'B', 'C', 'D'] [(i % 4) + 1] AS product,
+  (i * 17) % 100 + 10 AS amount
+FROM
+  range(1, 61) t (i);`}
   starterCode={`-- Hint: total revenue per (category, product), then keep the
 -- top product within each category.
 SELECT

--- a/content/learn/sql-analytics-duckdb/pivoting-and-reshaping.mdx
+++ b/content/learn/sql-analytics-duckdb/pivoting-and-reshaping.mdx
@@ -54,12 +54,17 @@ makes the mechanics visible.
 <SqlCodeBlock
   dialect="duckdb"
   title="Manual pivot: quarters into columns"
-  initSql={`CREATE TABLE sales (
-  region TEXT, quarter TEXT, amount INTEGER
-);
-INSERT INTO sales VALUES
-  ('West','Q1',100),('West','Q2',140),('West','Q1',20),
-  ('East','Q1',200),('East','Q2',90),('North','Q2',75);`}
+  initSql={`CREATE TABLE sales (region TEXT, quarter TEXT, amount INTEGER);
+
+INSERT INTO
+  sales
+VALUES
+  ('West', 'Q1', 100),
+  ('West', 'Q2', 140),
+  ('West', 'Q1', 20),
+  ('East', 'Q1', 200),
+  ('East', 'Q2', 90),
+  ('North', 'Q2', 75);`}
   starterCode={`SELECT
   region,
   SUM(amount) FILTER(
@@ -91,12 +96,17 @@ the aggregate, and DuckDB discovers the distinct values for you.
 <SqlCodeBlock
   dialect="duckdb"
   title="The same pivot with PIVOT syntax"
-  initSql={`CREATE TABLE sales (
-  region TEXT, quarter TEXT, amount INTEGER
-);
-INSERT INTO sales VALUES
-  ('West','Q1',100),('West','Q2',140),('West','Q1',20),
-  ('East','Q1',200),('East','Q2',90),('North','Q2',75);`}
+  initSql={`CREATE TABLE sales (region TEXT, quarter TEXT, amount INTEGER);
+
+INSERT INTO
+  sales
+VALUES
+  ('West', 'Q1', 100),
+  ('West', 'Q2', 140),
+  ('West', 'Q1', 20),
+  ('East', 'Q1', 200),
+  ('East', 'Q2', 90),
+  ('North', 'Q2', 75);`}
   starterCode={`PIVOT sales ON quarter -- values of this column become columns
 USING SUM(amount) -- aggregate that fills each cell
 GROUP BY
@@ -120,11 +130,17 @@ into rows.
   dialect="duckdb"
   title="UNPIVOT: month columns back into rows"
   initSql={`CREATE TABLE wide_sales (
-  region TEXT, jan INTEGER, feb INTEGER, mar INTEGER
+  region TEXT,
+  jan INTEGER,
+  feb INTEGER,
+  mar INTEGER
 );
-INSERT INTO wide_sales VALUES
+
+INSERT INTO
+  wide_sales
+VALUES
   ('West', 100, 140, 90),
-  ('East', 200,  60, 120);`}
+  ('East', 200, 60, 120);`}
   starterCode={`UNPIVOT wide_sales ON jan,
 feb,
 mar -- these columns become rows

--- a/content/learn/sql-analytics-duckdb/profiling-a-dataset.mdx
+++ b/content/learn/sql-analytics-duckdb/profiling-a-dataset.mdx
@@ -47,10 +47,11 @@ column span*. `COUNT(*)`, `MIN`, and `MAX` answer both at once.
   title="Size and span in one query"
   initSql={`CREATE TABLE signups AS
 SELECT
-  i                              AS id,
-  DATE '2024-01-01' + (i % 200)  AS signup_date,
-  (i * 11) % 5                    AS plan_id
-FROM range(1, 1201) t(i);`}
+  i AS id,
+  DATE '2024-01-01' + (i % 200) AS signup_date,
+  (i * 11) % 5 AS plan_id
+FROM
+  range(1, 1201) t (i);`}
   starterCode={`SELECT
   COUNT(*) AS rows,
   MIN(signup_date) AS earliest,
@@ -74,10 +75,11 @@ also reveals **duplicates**.
   title="Distinct counts expose categories and duplicates"
   initSql={`CREATE TABLE signups AS
 SELECT
-  i                              AS id,
-  DATE '2024-01-01' + (i % 200)  AS signup_date,
-  (i * 11) % 5                    AS plan_id
-FROM range(1, 1201) t(i);`}
+  i AS id,
+  DATE '2024-01-01' + (i % 200) AS signup_date,
+  (i * 11) % 5 AS plan_id
+FROM
+  range(1, 1201) t (i);`}
   starterCode={`SELECT
   COUNT(*) AS rows,
   COUNT(DISTINCT id) AS distinct_ids,
@@ -99,12 +101,17 @@ check.
 <SqlCodeBlock
   dialect="duckdb"
   title="Find the missing emails"
-  initSql={`CREATE TABLE users (
-  id INTEGER, email TEXT, country TEXT
-);
-INSERT INTO users VALUES
-  (1, 'a@x.com', 'US'), (2, NULL, 'US'), (3, 'c@x.com', NULL),
-  (4, NULL, 'CA'), (5, 'e@x.com', 'US'), (6, 'f@x.com', NULL);`}
+  initSql={`CREATE TABLE users (id INTEGER, email TEXT, country TEXT);
+
+INSERT INTO
+  users
+VALUES
+  (1, 'a@x.com', 'US'),
+  (2, NULL, 'US'),
+  (3, 'c@x.com', NULL),
+  (4, NULL, 'CA'),
+  (5, 'e@x.com', 'US'),
+  (6, 'f@x.com', NULL);`}
   starterCode={`SELECT
   COUNT(*) AS rows,
   COUNT(email) AS has_email,
@@ -129,11 +136,12 @@ average, and approximate quantiles.
   title="Profile every column at once with SUMMARIZE"
   initSql={`CREATE TABLE orders AS
 SELECT
-  i                                            AS id,
-  DATE '2024-01-01' + (i % 90)                 AS order_date,
-  ['Books','Electronics','Home'][(i % 3) + 1]  AS category,
-  (i * 13) % 300 + 20                          AS amount
-FROM range(1, 501) t(i);`}
+  i AS id,
+  DATE '2024-01-01' + (i % 90) AS order_date,
+  ['Books', 'Electronics', 'Home'] [(i % 3) + 1] AS category,
+  (i * 13) % 300 + 20 AS amount
+FROM
+  range(1, 501) t (i);`}
   starterCode={`SUMMARIZE orders;`}
 />
 

--- a/content/learn/sql-analytics-duckdb/ranking-and-row-number.mdx
+++ b/content/learn/sql-analytics-duckdb/ranking-and-row-number.mdx
@@ -20,12 +20,17 @@ once you have decided the order.
 <SqlCodeBlock
   dialect="duckdb"
   title="Number orders from biggest to smallest"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),
-  (4,'East',200),(5,'North',60),(6,'West',95);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60),
+  (6, 'West', 95);`}
   starterCode={`SELECT
   id,
   amount,
@@ -51,12 +56,17 @@ how you ask "rank within each region" — every region gets its own 1, 2,
 <SqlCodeBlock
   dialect="duckdb"
   title="Rank orders within each region"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),
-  (4,'East',200),(5,'North',60),(6,'West',95);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60),
+  (6, 'West', 95);`}
   starterCode={`SELECT
   region,
   id,
@@ -92,12 +102,18 @@ run.
 <SqlCodeBlock
   dialect="duckdb"
   title="Top 2 orders per region with QUALIFY"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),
-  (4,'East',200),(5,'North',60),(6,'West',95),(7,'East',150);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60),
+  (6, 'West', 95),
+  (7, 'East', 150);`}
   starterCode={`SELECT
   region,
   id,
@@ -136,11 +152,16 @@ source of confusion.
 <SqlCodeBlock
   dialect="duckdb"
   title="See how the three handle ties"
-  initSql={`CREATE TABLE scores (
-  player TEXT, points INTEGER
-);
-INSERT INTO scores VALUES
-  ('Ada',100),('Bo',100),('Cy',90),('Di',80),('Eli',80);`}
+  initSql={`CREATE TABLE scores (player TEXT, points INTEGER);
+
+INSERT INTO
+  scores
+VALUES
+  ('Ada', 100),
+  ('Bo', 100),
+  ('Cy', 90),
+  ('Di', 80),
+  ('Eli', 80);`}
   starterCode={`SELECT
   player,
   points,

--- a/content/learn/sql-analytics-duckdb/reproducible-analytical-workflows.mdx
+++ b/content/learn/sql-analytics-duckdb/reproducible-analytical-workflows.mdx
@@ -43,11 +43,16 @@ rows tie on the sort key, SQL may return them in either order — so a
 <SqlCodeBlock
   dialect="duckdb"
   title="A stable top-N with a tiebreaker"
-  initSql={`CREATE TABLE products (
-  id INTEGER, name TEXT, sales INTEGER
-);
-INSERT INTO products VALUES
-  (1,'A',100),(2,'B',100),(3,'C',100),(4,'D',90),(5,'E',80);`}
+  initSql={`CREATE TABLE products (id INTEGER, name TEXT, sales INTEGER);
+
+INSERT INTO
+  products
+VALUES
+  (1, 'A', 100),
+  (2, 'B', 100),
+  (3, 'C', 100),
+  (4, 'D', 90),
+  (5, 'E', 80);`}
   starterCode={`SELECT
   id,
   name,
@@ -112,11 +117,21 @@ metric's meaning consistent.
   dialect="duckdb"
   title="A view encodes one canonical definition"
   initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, status TEXT, amount DECIMAL(8,2)
+  id INTEGER,
+  region TEXT,
+  status TEXT,
+  amount DECIMAL(8, 2)
 );
-INSERT INTO orders VALUES
-  (1,'West','paid',120),(2,'West','refunded',45),(3,'East','paid',200),
-  (4,'East','paid',50),(5,'North','paid',60),(6,'West','paid',95);`}
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 'paid', 120),
+  (2, 'West', 'refunded', 45),
+  (3, 'East', 'paid', 200),
+  (4, 'East', 'paid', 50),
+  (5, 'North', 'paid', 60),
+  (6, 'West', 'paid', 95);`}
   starterCode={`CREATE OR REPLACE VIEW paid_revenue_by_region AS
 SELECT
   region,

--- a/content/learn/sql-analytics-duckdb/running-totals-and-moving-averages.mdx
+++ b/content/learn/sql-analytics-duckdb/running-totals-and-moving-averages.mdx
@@ -20,13 +20,14 @@ constant total.
 <SqlCodeBlock
   dialect="duckdb"
   title="Cumulative revenue by day"
-  initSql={`CREATE TABLE daily (
-  day DATE, revenue INTEGER
-);
-INSERT INTO daily VALUES
+  initSql={`CREATE TABLE daily (day DATE, revenue INTEGER);
+
+INSERT INTO
+  daily
+VALUES
   (DATE '2024-01-01', 100),
   (DATE '2024-01-02', 140),
-  (DATE '2024-01-03',  90),
+  (DATE '2024-01-03', 90),
   (DATE '2024-01-04', 200),
   (DATE '2024-01-05', 120);`}
   starterCode={`SELECT
@@ -65,15 +66,16 @@ Combine `PARTITION BY` with the ordered window to get a running total that
 <SqlCodeBlock
   dialect="duckdb"
   title="Cumulative revenue within each region"
-  initSql={`CREATE TABLE sales (
-  region TEXT, day DATE, revenue INTEGER
-);
-INSERT INTO sales VALUES
+  initSql={`CREATE TABLE sales (region TEXT, day DATE, revenue INTEGER);
+
+INSERT INTO
+  sales
+VALUES
   ('West', DATE '2024-01-01', 100),
   ('West', DATE '2024-01-02', 140),
-  ('West', DATE '2024-01-03',  90),
+  ('West', DATE '2024-01-03', 90),
   ('East', DATE '2024-01-01', 200),
-  ('East', DATE '2024-01-02',  60),
+  ('East', DATE '2024-01-02', 60),
   ('East', DATE '2024-01-03', 120);`}
   starterCode={`SELECT
   region,
@@ -105,13 +107,14 @@ trivial.
 <SqlCodeBlock
   dialect="duckdb"
   title="Day-over-day change with LAG"
-  initSql={`CREATE TABLE daily (
-  day DATE, revenue INTEGER
-);
-INSERT INTO daily VALUES
+  initSql={`CREATE TABLE daily (day DATE, revenue INTEGER);
+
+INSERT INTO
+  daily
+VALUES
   (DATE '2024-01-01', 100),
   (DATE '2024-01-02', 140),
-  (DATE '2024-01-03',  90),
+  (DATE '2024-01-03', 90),
   (DATE '2024-01-04', 200);`}
   starterCode={`SELECT
   day,
@@ -145,13 +148,14 @@ out noise.
 <SqlCodeBlock
   dialect="duckdb"
   title="3-day moving average"
-  initSql={`CREATE TABLE daily (
-  day DATE, revenue INTEGER
-);
-INSERT INTO daily VALUES
+  initSql={`CREATE TABLE daily (day DATE, revenue INTEGER);
+
+INSERT INTO
+  daily
+VALUES
   (DATE '2024-01-01', 100),
   (DATE '2024-01-02', 140),
-  (DATE '2024-01-03',  90),
+  (DATE '2024-01-03', 90),
   (DATE '2024-01-04', 200),
   (DATE '2024-01-05', 120),
   (DATE '2024-01-06', 160);`}

--- a/content/learn/sql-analytics-duckdb/sorting-and-top-n.mdx
+++ b/content/learn/sql-analytics-duckdb/sorting-and-top-n.mdx
@@ -20,10 +20,11 @@ top; `LIMIT` lets you read just those.
   title="The five biggest orders"
   initSql={`CREATE TABLE orders AS
 SELECT
-  i                              AS id,
-  ['West','East','North'][(i % 3) + 1] AS region,
-  (i * 37) % 500 + 10            AS amount
-FROM range(1, 201) t(i);`}
+  i AS id,
+  ['West', 'East', 'North'] [(i % 3) + 1] AS region,
+  (i * 37) % 500 + 10 AS amount
+FROM
+  range(1, 201) t (i);`}
   starterCode={`SELECT
   id,
   region,
@@ -51,10 +52,11 @@ region.
   title="Within each region, biggest orders first"
   initSql={`CREATE TABLE orders AS
 SELECT
-  i                              AS id,
-  ['West','East','North'][(i % 3) + 1] AS region,
-  (i * 37) % 500 + 10            AS amount
-FROM range(1, 31) t(i);`}
+  i AS id,
+  ['West', 'East', 'North'] [(i % 3) + 1] AS region,
+  (i * 37) % 500 + 10 AS amount
+FROM
+  range(1, 31) t (i);`}
   starterCode={`SELECT
   region,
   id,
@@ -78,12 +80,15 @@ measure. "Most efficient", "best value", "highest rate" are all
 <SqlCodeBlock
   dialect="duckdb"
   title="Best value: lowest price per gram"
-  initSql={`CREATE TABLE snacks (
-  name TEXT, price DECIMAL(6,2), grams INTEGER
-);
-INSERT INTO snacks VALUES
-  ('Almonds', 6.00, 200), ('Chips', 3.50, 150),
-  ('Trail Mix', 8.00, 400), ('Pretzels', 2.00, 100),
+  initSql={`CREATE TABLE snacks (name TEXT, price DECIMAL(6, 2), grams INTEGER);
+
+INSERT INTO
+  snacks
+VALUES
+  ('Almonds', 6.00, 200),
+  ('Chips', 3.50, 150),
+  ('Trail Mix', 8.00, 400),
+  ('Pretzels', 2.00, 100),
   ('Jerky', 9.00, 90);`}
   starterCode={`SELECT
   name,
@@ -129,10 +134,11 @@ pairs a window function (which you will meet properly soon) with
   title="Top 2 orders within each region"
   initSql={`CREATE TABLE orders AS
 SELECT
-  i                              AS id,
-  ['West','East','North'][(i % 3) + 1] AS region,
-  (i * 37) % 500 + 10            AS amount
-FROM range(1, 31) t(i);`}
+  i AS id,
+  ['West', 'East', 'North'] [(i % 3) + 1] AS region,
+  (i * 37) % 500 + 10 AS amount
+FROM
+  range(1, 31) t (i);`}
   starterCode={`SELECT
   region,
   id,

--- a/content/learn/sql-analytics-duckdb/subqueries-in-analytics.mdx
+++ b/content/learn/sql-analytics-duckdb/subqueries-in-analytics.mdx
@@ -31,11 +31,17 @@ average?"
 <SqlCodeBlock
   dialect="duckdb"
   title="Each order vs. the overall average"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,120),(2,80),(3,45),(4,200),(5,60),(6,95);`}
+  initSql={`CREATE TABLE orders (id INTEGER, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 120),
+  (2, 80),
+  (3, 45),
+  (4, 200),
+  (5, 60),
+  (6, 95);`}
   starterCode={`SELECT
   id,
   amount,
@@ -71,15 +77,30 @@ from customers in the loyalty program."
   dialect="duckdb"
   title="Orders from high-value customers only"
   initSql={`CREATE TABLE orders (
-  id INTEGER, customer_id INTEGER, amount DECIMAL(8,2)
+  id INTEGER,
+  customer_id INTEGER,
+  amount DECIMAL(8, 2)
 );
-INSERT INTO orders VALUES
-  (1,10,120),(2,11,80),(3,10,45),(4,12,200),(5,11,60),(6,13,95);
-CREATE TABLE customers (
-  id INTEGER, tier TEXT
-);
-INSERT INTO customers VALUES
-  (10,'gold'),(11,'silver'),(12,'gold'),(13,'bronze');`}
+
+INSERT INTO
+  orders
+VALUES
+  (1, 10, 120),
+  (2, 11, 80),
+  (3, 10, 45),
+  (4, 12, 200),
+  (5, 11, 60),
+  (6, 13, 95);
+
+CREATE TABLE customers (id INTEGER, tier TEXT);
+
+INSERT INTO
+  customers
+VALUES
+  (10, 'gold'),
+  (11, 'silver'),
+  (12, 'gold'),
+  (13, 'bronze');`}
   starterCode={`SELECT
   id,
   customer_id,
@@ -112,12 +133,17 @@ function or join is often clearer.
 <SqlCodeBlock
   dialect="duckdb"
   title="Each order vs. its own region's average"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),
-  (4,'East',200),(5,'North',60),(6,'West',95);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60),
+  (6, 'West', 95);`}
   starterCode={`SELECT
   o.id,
   o.region,
@@ -152,9 +178,22 @@ placed *any* order" without caring how many.
   dialect="duckdb"
   title="Customers who have ordered at least once"
   initSql={`CREATE TABLE customers (id INTEGER, name TEXT);
-INSERT INTO customers VALUES (1,'Ada'),(2,'Bo'),(3,'Cy');
+
+INSERT INTO
+  customers
+VALUES
+  (1, 'Ada'),
+  (2, 'Bo'),
+  (3, 'Cy');
+
 CREATE TABLE orders (id INTEGER, customer_id INTEGER);
-INSERT INTO orders VALUES (101,1),(102,1),(103,3);`}
+
+INSERT INTO
+  orders
+VALUES
+  (101, 1),
+  (102, 1),
+  (103, 3);`}
   starterCode={`SELECT
   name
 FROM

--- a/content/learn/sql-analytics-duckdb/thinking-in-datasets.mdx
+++ b/content/learn/sql-analytics-duckdb/thinking-in-datasets.mdx
@@ -79,11 +79,12 @@ dataset you never scrolled through:
   title="Building a mental picture in three questions"
   initSql={`CREATE TABLE events AS
 SELECT
-  i                                AS id,
-  DATE '2024-01-01' + (i % 120)    AS day,
-  ['signup','login','purchase','refund'][(i % 4) + 1] AS kind,
-  (i * 17) % 200                   AS value
-FROM range(1, 4001) t(i);`}
+  i AS id,
+  DATE '2024-01-01' + (i % 120) AS day,
+  ['signup', 'login', 'purchase', 'refund'] [(i % 4) + 1] AS kind,
+  (i * 17) % 200 AS value
+FROM
+  range(1, 4001) t (i);`}
   starterCode={`-- Question 1: how big, and what does it span?
 SELECT
   COUNT(*) AS rows,
@@ -101,11 +102,12 @@ Now sharpen the question — *what kinds of events, and how common is each?*
   title="Drill down: the mix of event kinds"
   initSql={`CREATE TABLE events AS
 SELECT
-  i                                AS id,
-  DATE '2024-01-01' + (i % 120)    AS day,
-  ['signup','login','purchase','refund'][(i % 4) + 1] AS kind,
-  (i * 17) % 200                   AS value
-FROM range(1, 4001) t(i);`}
+  i AS id,
+  DATE '2024-01-01' + (i % 120) AS day,
+  ['signup', 'login', 'purchase', 'refund'] [(i % 4) + 1] AS kind,
+  (i * 17) % 200 AS value
+FROM
+  range(1, 4001) t (i);`}
   starterCode={`SELECT
   kind,
   COUNT(*) AS n,

--- a/content/learn/sql-analytics-duckdb/why-duckdb.mdx
+++ b/content/learn/sql-analytics-duckdb/why-duckdb.mdx
@@ -101,11 +101,12 @@ in your browser, so every example is live.
   title="A taste of analyst-friendly DuckDB SQL"
   initSql={`CREATE TABLE sales AS
 SELECT
-  i                                AS id,
-  ['West','East','North','South'][(i % 4) + 1] AS region,
-  ['Widget','Gadget','Gizmo'][(i % 3) + 1]     AS product,
-  (i * 29) % 400 + 20              AS amount
-FROM range(1, 1001) t(i);`}
+  i AS id,
+  ['West', 'East', 'North', 'South'] [(i % 4) + 1] AS region,
+  ['Widget', 'Gadget', 'Gizmo'] [(i % 3) + 1] AS product,
+  (i * 29) % 400 + 20 AS amount
+FROM
+  range(1, 1001) t (i);`}
   starterCode={`-- GROUP BY ALL: group by every non-aggregated column automatically.
 -- SUMMARIZE-style ergonomics with no extra ceremony.
 SELECT

--- a/content/learn/sql-analytics-duckdb/why-window-functions.mdx
+++ b/content/learn/sql-analytics-duckdb/why-window-functions.mdx
@@ -53,12 +53,16 @@ total beside it.
 <SqlCodeBlock
   dialect="duckdb"
   title="The grand total, on every row"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),
-  (4,'East',200),(5,'North',60);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60);`}
   starterCode={`SELECT
   id,
   region,
@@ -84,12 +88,16 @@ rows stay.
 <SqlCodeBlock
   dialect="duckdb"
   title="Each order tagged with its region total"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),
-  (4,'East',200),(5,'North',60);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60);`}
   starterCode={`SELECT
   id,
   region,
@@ -122,12 +130,16 @@ Now the original request is one step away — divide each `amount` by its
 <SqlCodeBlock
   dialect="duckdb"
   title="Each order's share of its region"
-  initSql={`CREATE TABLE orders (
-  id INTEGER, region TEXT, amount DECIMAL(8,2)
-);
-INSERT INTO orders VALUES
-  (1,'West',120),(2,'East',80),(3,'West',45),
-  (4,'East',200),(5,'North',60);`}
+  initSql={`CREATE TABLE orders (id INTEGER, region TEXT, amount DECIMAL(8, 2));
+
+INSERT INTO
+  orders
+VALUES
+  (1, 'West', 120),
+  (2, 'East', 80),
+  (3, 'West', 45),
+  (4, 'East', 200),
+  (5, 'North', 60);`}
   starterCode={`SELECT
   id,
   region,

--- a/content/learn/sql-analytics-duckdb/working-with-dates.mdx
+++ b/content/learn/sql-analytics-duckdb/working-with-dates.mdx
@@ -22,9 +22,10 @@ tool is `date_trunc('month', d)`.
   title="Revenue per month with date_trunc"
   initSql={`CREATE TABLE orders AS
 SELECT
-  DATE '2024-01-01' + (i * 5)  AS order_date,
-  (i * 17) % 200 + 20          AS amount
-FROM range(0, 40) t(i);`}
+  DATE '2024-01-01' + (i * 5) AS order_date,
+  (i * 17) % 200 + 20 AS amount
+FROM
+  range(0, 40) t (i);`}
   starterCode={`SELECT
   date_trunc('month', order_date) AS month,
   COUNT(*) AS orders,
@@ -61,8 +62,10 @@ busiest?" by grouping across all weeks.
   dialect="duckdb"
   title="Which day of week sees the most orders?"
   initSql={`CREATE TABLE orders AS
-SELECT DATE '2024-01-01' + i AS order_date
-FROM range(0, 60) t(i);`}
+SELECT
+  DATE '2024-01-01' + i AS order_date
+FROM
+  range(0, 60) t (i);`}
   starterCode={`SELECT
   EXTRACT (
     dow
@@ -96,10 +99,11 @@ calculations.
 <SqlCodeBlock
   dialect="duckdb"
   title="Days since each signup, and a 30-day cutoff"
-  initSql={`CREATE TABLE users (
-  id INTEGER, signup_date DATE
-);
-INSERT INTO users VALUES
+  initSql={`CREATE TABLE users (id INTEGER, signup_date DATE);
+
+INSERT INTO
+  users
+VALUES
   (1, DATE '2024-05-01'),
   (2, DATE '2024-05-20'),
   (3, DATE '2024-04-10'),
@@ -126,10 +130,11 @@ periods show up as zero.
 <SqlCodeBlock
   dialect="duckdb"
   title="Every day present, even the empty ones"
-  initSql={`CREATE TABLE orders (
-  order_date DATE, amount INTEGER
-);
-INSERT INTO orders VALUES
+  initSql={`CREATE TABLE orders (order_date DATE, amount INTEGER);
+
+INSERT INTO
+  orders
+VALUES
   (DATE '2024-03-01', 100),
   (DATE '2024-03-01', 50),
   (DATE '2024-03-03', 80),

--- a/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
+++ b/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
@@ -18,21 +18,24 @@ cheap even on a huge table — you peek, you do not pull everything.
   dialect="duckdb"
   title="Peek at the shape of the data"
   initSql={`CREATE TABLE trips (
-  id        INTEGER,
-  city      TEXT,
-  rider     TEXT,
-  minutes   INTEGER,
-  fare      DECIMAL(6, 2)
+  id INTEGER,
+  city TEXT,
+  rider TEXT,
+  minutes INTEGER,
+  fare DECIMAL(6, 2)
 );
-INSERT INTO trips VALUES
-  (1, 'Seattle',  'Ada',   12,  9.50),
-  (2, 'Seattle',  'Bo',    25, 18.00),
-  (3, 'Portland', 'Cy',     8,  6.25),
-  (4, 'Seattle',  'Ada',   31, 22.75),
-  (5, 'Portland', 'Di',    14, 11.00),
-  (6, 'Boise',    'Eli',   19, 13.50),
-  (7, 'Seattle',  'Bo',     6,  5.00),
-  (8, 'Portland', 'Cy',    22, 16.25);`}
+
+INSERT INTO
+  trips
+VALUES
+  (1, 'Seattle', 'Ada', 12, 9.50),
+  (2, 'Seattle', 'Bo', 25, 18.00),
+  (3, 'Portland', 'Cy', 8, 6.25),
+  (4, 'Seattle', 'Ada', 31, 22.75),
+  (5, 'Portland', 'Di', 14, 11.00),
+  (6, 'Boise', 'Eli', 19, 13.50),
+  (7, 'Seattle', 'Bo', 6, 5.00),
+  (8, 'Portland', 'Cy', 22, 16.25);`}
   starterCode={`-- Always start by *looking*. LIMIT keeps it cheap.
 SELECT
   *
@@ -56,13 +59,24 @@ you are choosing a subset to summarize.
   dialect="duckdb"
   title="Slice: only the long Seattle trips"
   initSql={`CREATE TABLE trips (
-  id        INTEGER, city TEXT, rider TEXT, minutes INTEGER, fare DECIMAL(6,2)
+  id INTEGER,
+  city TEXT,
+  rider TEXT,
+  minutes INTEGER,
+  fare DECIMAL(6, 2)
 );
-INSERT INTO trips VALUES
-  (1,'Seattle','Ada',12,9.50),(2,'Seattle','Bo',25,18.00),
-  (3,'Portland','Cy',8,6.25),(4,'Seattle','Ada',31,22.75),
-  (5,'Portland','Di',14,11.00),(6,'Boise','Eli',19,13.50),
-  (7,'Seattle','Bo',6,5.00),(8,'Portland','Cy',22,16.25);`}
+
+INSERT INTO
+  trips
+VALUES
+  (1, 'Seattle', 'Ada', 12, 9.50),
+  (2, 'Seattle', 'Bo', 25, 18.00),
+  (3, 'Portland', 'Cy', 8, 6.25),
+  (4, 'Seattle', 'Ada', 31, 22.75),
+  (5, 'Portland', 'Di', 14, 11.00),
+  (6, 'Boise', 'Eli', 19, 13.50),
+  (7, 'Seattle', 'Bo', 6, 5.00),
+  (8, 'Portland', 'Cy', 22, 16.25);`}
   starterCode={`SELECT
   rider,
   minutes,
@@ -100,13 +114,24 @@ commit to heavier summarizing.
   dialect="duckdb"
   title="Slice, sort, peek: the three biggest fares overall"
   initSql={`CREATE TABLE trips (
-  id        INTEGER, city TEXT, rider TEXT, minutes INTEGER, fare DECIMAL(6,2)
+  id INTEGER,
+  city TEXT,
+  rider TEXT,
+  minutes INTEGER,
+  fare DECIMAL(6, 2)
 );
-INSERT INTO trips VALUES
-  (1,'Seattle','Ada',12,9.50),(2,'Seattle','Bo',25,18.00),
-  (3,'Portland','Cy',8,6.25),(4,'Seattle','Ada',31,22.75),
-  (5,'Portland','Di',14,11.00),(6,'Boise','Eli',19,13.50),
-  (7,'Seattle','Bo',6,5.00),(8,'Portland','Cy',22,16.25);`}
+
+INSERT INTO
+  trips
+VALUES
+  (1, 'Seattle', 'Ada', 12, 9.50),
+  (2, 'Seattle', 'Bo', 25, 18.00),
+  (3, 'Portland', 'Cy', 8, 6.25),
+  (4, 'Seattle', 'Ada', 31, 22.75),
+  (5, 'Portland', 'Di', 14, 11.00),
+  (6, 'Boise', 'Eli', 19, 13.50),
+  (7, 'Seattle', 'Bo', 6, 5.00),
+  (8, 'Portland', 'Cy', 22, 16.25);`}
   starterCode={`SELECT
   city,
   rider,
@@ -129,13 +154,24 @@ fly. This is where `SELECT` stops *retrieving* and starts *deriving*.
   dialect="duckdb"
   title="Derive a new measure: fare per minute"
   initSql={`CREATE TABLE trips (
-  id        INTEGER, city TEXT, rider TEXT, minutes INTEGER, fare DECIMAL(6,2)
+  id INTEGER,
+  city TEXT,
+  rider TEXT,
+  minutes INTEGER,
+  fare DECIMAL(6, 2)
 );
-INSERT INTO trips VALUES
-  (1,'Seattle','Ada',12,9.50),(2,'Seattle','Bo',25,18.00),
-  (3,'Portland','Cy',8,6.25),(4,'Seattle','Ada',31,22.75),
-  (5,'Portland','Di',14,11.00),(6,'Boise','Eli',19,13.50),
-  (7,'Seattle','Bo',6,5.00),(8,'Portland','Cy',22,16.25);`}
+
+INSERT INTO
+  trips
+VALUES
+  (1, 'Seattle', 'Ada', 12, 9.50),
+  (2, 'Seattle', 'Bo', 25, 18.00),
+  (3, 'Portland', 'Cy', 8, 6.25),
+  (4, 'Seattle', 'Ada', 31, 22.75),
+  (5, 'Portland', 'Di', 14, 11.00),
+  (6, 'Boise', 'Eli', 19, 13.50),
+  (7, 'Seattle', 'Bo', 6, 5.00),
+  (8, 'Portland', 'Cy', 22, 16.25);`}
   starterCode={`SELECT
   rider,
   minutes,

--- a/content/learn/sql-challenge-cards-duckdb.mdx
+++ b/content/learn/sql-challenge-cards-duckdb.mdx
@@ -90,10 +90,14 @@ ORDER BY
   instructions={`Return one row per \`sale_date\` per \`region\` with columns \`sale_date\`, \`region\`, \`revenue\`, and a fourth column \`running_total\` containing the cumulative sum of \`revenue\` within each region, ordered by \`sale_date\`.`}
   initSql={`CREATE TABLE sales AS
 SELECT
-  d                                  AS sale_date,
-  CASE WHEN d % 2 = 0 THEN 'North' ELSE 'South' END AS region,
-  (d * 13) % 100 + 10                AS revenue
-FROM range(1, 9) t(d);`}
+  d AS sale_date,
+  CASE
+    WHEN d % 2 = 0 THEN 'North'
+    ELSE 'South'
+  END AS region,
+  (d * 13) % 100 + 10 AS revenue
+FROM
+  range(1, 9) t (d);`}
   starterCode={`SELECT
   sale_date,
   region,
@@ -150,10 +154,14 @@ ORDER BY
   instructions={`Return one row per \`sale_date\` per \`region\` with columns \`sale_date\`, \`region\`, \`revenue\`, and a fourth column \`running_total\` containing the cumulative sum of \`revenue\` within each region, ordered by \`sale_date\`.`}
   initSql={`CREATE TABLE sales AS
 SELECT
-  d                                  AS sale_date,
-  CASE WHEN d % 2 = 0 THEN 'North' ELSE 'South' END AS region,
-  (d * 13) % 100 + 10                AS revenue
-FROM range(1, 9) t(d);`}
+  d AS sale_date,
+  CASE
+    WHEN d % 2 = 0 THEN 'North'
+    ELSE 'South'
+  END AS region,
+  (d * 13) % 100 + 10 AS revenue
+FROM
+  range(1, 9) t (d);`}
   starterCode={`SELECT
   sale_date,
   region,
@@ -211,10 +219,24 @@ ORDER BY
   title="Average rating per genre"
   instructions={`Two tables are pre-loaded: \`movies\` (with \`id\`, \`title\`, \`genre_id\`, \`rating\`) and \`genres\` (with \`id\`, \`name\`). Return one row per genre with columns \`genre\` and \`avg_rating\` (rounded to one decimal place), sorted by \`avg_rating\` descending.`}
   initSql={`CREATE TABLE genres (id INTEGER, name VARCHAR);
-INSERT INTO genres VALUES (1, 'Drama'), (2, 'Sci-Fi'), (3, 'Comedy');
 
-CREATE TABLE movies (id INTEGER, title VARCHAR, genre_id INTEGER, rating DECIMAL(3,1));
-INSERT INTO movies VALUES
+INSERT INTO
+  genres
+VALUES
+  (1, 'Drama'),
+  (2, 'Sci-Fi'),
+  (3, 'Comedy');
+
+CREATE TABLE movies (
+  id INTEGER,
+  title VARCHAR,
+  genre_id INTEGER,
+  rating DECIMAL(3, 1)
+);
+
+INSERT INTO
+  movies
+VALUES
   (1, 'A', 1, 8.4),
   (2, 'B', 1, 7.6),
   (3, 'C', 2, 9.1),
@@ -262,10 +284,24 @@ ORDER BY
   title="Average rating per genre"
   instructions={`Two tables are pre-loaded: \`movies\` (with \`id\`, \`title\`, \`genre_id\`, \`rating\`) and \`genres\` (with \`id\`, \`name\`). Return one row per genre with columns \`genre\` and \`avg_rating\` (rounded to one decimal place), sorted by \`avg_rating\` descending.`}
   initSql={`CREATE TABLE genres (id INTEGER, name VARCHAR);
-INSERT INTO genres VALUES (1, 'Drama'), (2, 'Sci-Fi'), (3, 'Comedy');
 
-CREATE TABLE movies (id INTEGER, title VARCHAR, genre_id INTEGER, rating DECIMAL(3,1));
-INSERT INTO movies VALUES
+INSERT INTO
+  genres
+VALUES
+  (1, 'Drama'),
+  (2, 'Sci-Fi'),
+  (3, 'Comedy');
+
+CREATE TABLE movies (
+  id INTEGER,
+  title VARCHAR,
+  genre_id INTEGER,
+  rating DECIMAL(3, 1)
+);
+
+INSERT INTO
+  movies
+VALUES
   (1, 'A', 1, 8.4),
   (2, 'B', 1, 7.6),
   (3, 'C', 2, 9.1),
@@ -325,8 +361,8 @@ SELECT
   i AS id,
   ('user_' || i) AS name,
   (i * 37 % 100) AS score
-FROM range(1, 10001) t(i);
-`}
+FROM
+  range(1, 10001) t (i);`}
   starterCode={`SELECT
   *
 FROM
@@ -366,9 +402,12 @@ ORDER BY
   instructions={`A 10,000-row table big is preloaded ...`}
 
   initSql={`CREATE TABLE big AS
-SELECT i AS id, ('user_' || i) AS name, (i * 37 % 100) AS score
-FROM range(1, 10001) t(i);
-`}
+SELECT
+  i AS id,
+  ('user_' || i) AS name,
+  (i * 37 % 100) AS score
+FROM
+  range(1, 10001) t (i);`}
   starterCode={`SELECT
   *
 FROM

--- a/content/learn/sql-code-blocks-duckdb.mdx
+++ b/content/learn/sql-code-blocks-duckdb.mdx
@@ -15,18 +15,21 @@ in the **Tables** viewer above the editor.
 <SqlCodeBlock
   dialect="duckdb"
   title="Browse the books table"
-  initSql={`CREATE TABLE books (
-  id     INTEGER,
-  title  TEXT,
-  author TEXT,
-  year   INTEGER
-);
-INSERT INTO books VALUES
+  initSql={`CREATE TABLE books (id INTEGER, title TEXT, author TEXT, year INTEGER);
+
+INSERT INTO
+  books
+VALUES
   (1, 'Dune', 'Frank Herbert', 1965),
   (2, 'Neuromancer', 'William Gibson', 1984),
   (3, 'Snow Crash', 'Neal Stephenson', 1992),
   (4, 'Foundation', 'Isaac Asimov', 1951),
-  (5, 'The Left Hand of Darkness', 'Ursula K. Le Guin', 1969);`}
+  (
+    5,
+    'The Left Hand of Darkness',
+    'Ursula K. Le Guin',
+    1969
+  );`}
   starterCode={`SELECT
   title,
   author,
@@ -41,18 +44,21 @@ ORDER BY
 <SqlCodeBlock
   dialect="duckdb"
   title="Browse the books table"
-  initSql={`CREATE TABLE books (
-  id     INTEGER,
-  title  TEXT,
-  author TEXT,
-  year   INTEGER
-);
-INSERT INTO books VALUES
+  initSql={`CREATE TABLE books (id INTEGER, title TEXT, author TEXT, year INTEGER);
+
+INSERT INTO
+  books
+VALUES
   (1, 'Dune', 'Frank Herbert', 1965),
   (2, 'Neuromancer', 'William Gibson', 1984),
   (3, 'Snow Crash', 'Neal Stephenson', 1992),
   (4, 'Foundation', 'Isaac Asimov', 1951),
-  (5, 'The Left Hand of Darkness', 'Ursula K. Le Guin', 1969);`}
+  (
+    5,
+    'The Left Hand of Darkness',
+    'Ursula K. Le Guin',
+    1969
+  );`}
   starterCode={`SELECT
   title,
   author,
@@ -132,26 +138,29 @@ Each seeded table shows up as its own tab in the **Tables** viewer.
 <SqlCodeBlock
   dialect="duckdb"
   title="Spend per customer"
-  initSql={`CREATE TABLE customers (
-  id   INTEGER,
-  name TEXT,
-  city TEXT
-);
+  initSql={`CREATE TABLE customers (id INTEGER, name TEXT, city TEXT);
+
 CREATE TABLE orders (
-  id          INTEGER,
+  id INTEGER,
   customer_id INTEGER,
-  amount      DECIMAL(10, 2)
+  amount DECIMAL(10, 2)
 );
-INSERT INTO customers VALUES
+
+INSERT INTO
+  customers
+VALUES
   (1, 'Alice', 'Seattle'),
-  (2, 'Bob',   'Portland'),
+  (2, 'Bob', 'Portland'),
   (3, 'Carol', 'Seattle');
-INSERT INTO orders VALUES
+
+INSERT INTO
+  orders
+VALUES
   (1, 1, 120.00),
-  (2, 1,  80.50),
+  (2, 1, 80.50),
   (3, 2, 200.00),
-  (4, 3,  50.00),
-  (5, 3,  75.25);`}
+  (4, 3, 50.00),
+  (5, 3, 75.25);`}
   starterCode={`SELECT
   c.name,
   c.city,
@@ -168,26 +177,29 @@ ORDER BY
 <SqlCodeBlock
   dialect="duckdb"
   title="Spend per customer"
-  initSql={`CREATE TABLE customers (
-  id   INTEGER,
-  name TEXT,
-  city TEXT
-);
+  initSql={`CREATE TABLE customers (id INTEGER, name TEXT, city TEXT);
+
 CREATE TABLE orders (
-  id          INTEGER,
+  id INTEGER,
   customer_id INTEGER,
-  amount      DECIMAL(10, 2)
+  amount DECIMAL(10, 2)
 );
-INSERT INTO customers VALUES
+
+INSERT INTO
+  customers
+VALUES
   (1, 'Alice', 'Seattle'),
-  (2, 'Bob',   'Portland'),
+  (2, 'Bob', 'Portland'),
   (3, 'Carol', 'Seattle');
-INSERT INTO orders VALUES
+
+INSERT INTO
+  orders
+VALUES
   (1, 1, 120.00),
-  (2, 1,  80.50),
+  (2, 1, 80.50),
   (3, 2, 200.00),
-  (4, 3,  50.00),
-  (5, 3,  75.25);`}
+  (4, 3, 50.00),
+  (5, 3, 75.25);`}
   starterCode={`SELECT
   c.name,
   c.city,
@@ -212,10 +224,11 @@ scroll. Drag the bar at the bottom of the panel to resize it.
   title="Scroll through 10,000 metrics"
   initSql={`CREATE TABLE metrics AS
 SELECT
-  i              AS id,
-  'row-' || i    AS label,
+  i AS id,
+  'row-' || i AS label,
   ROUND(i * 1.5, 2) AS value
-FROM range(1, 10001) AS t(i);`}
+FROM
+  range(1, 10001) AS t (i);`}
   starterCode={`SELECT
   id,
   label,
@@ -232,10 +245,11 @@ ORDER BY
   title="Scroll through 10,000 metrics"
   initSql={`CREATE TABLE metrics AS
 SELECT
-  i              AS id,
-  'row-' || i    AS label,
+  i AS id,
+  'row-' || i AS label,
   ROUND(i * 1.5, 2) AS value
-FROM range(1, 10001) AS t(i);`}
+FROM
+  range(1, 10001) AS t (i);`}
   starterCode={`SELECT
   id,
   label,


### PR DESCRIPTION
## What

Picks up the **remaining DuckDB item** flagged in #447: re-format the `dialect="duckdb"` SQL snippets so every one round-trips under the site's "Format" button (sql-formatter's `duckdb` dialect). Clicking **Format** now reports *"Already formatted"* instead of rewriting them.

## Background

#447 unified the DuckDB Format dialect to `duckdb` but deliberately left the content re-format as "a maintainer call." Measuring the **187** authored duckdb snippets (`starterCode` 94 + `solutionSql` 9 + `initSql` 84) against `sql-formatter`'s `duckdb` rules:

| prop | total | round-trips before | round-trips after |
| :-- | --: | --: | --: |
| `starterCode` | 94 | 94 | 94 |
| `solutionSql` | 9 | 9 | 9 |
| `initSql` | 84 | **0** | 84 |

So `starterCode`/`solutionSql` were already canonical (formatted in #444/#445); the **84 `initSql` seed blocks** were the only holdouts — they'd never been run through sql-formatter, so their hand-aligned `CREATE TABLE` / compact `INSERT` layout differed from canonical output. This formats those 84 blocks across 27 files and leaves the already-canonical props untouched.

> Note: this is the full canonical pass requested — it trades the hand-aligned seed layout (`id        INTEGER` → `id INTEGER`, multi-row `VALUES` expanded) for consistency and Format-button idempotency, exactly the tradeoff #447 described.

## Notes

- **Mechanical only.** sql-formatter normalizes whitespace, keyword case, and line breaks; the executed SQL is semantically identical, so seeded data and challenge tests are unaffected.
- On the two demo pages (`sql-code-blocks-duckdb`, `sql-challenge-cards-duckdb`) the live `<SqlCodeBlock>`/`<SqlChallengeCard>` and their mirrored ```jsx fences are formatted identically, so they stay in sync.
- `remarkPreserveCodeIndent` (from #447) keeps the editor showing this exact formatting.
- Done as a one-off pass (no permanent script re-added, consistent with #447's `scripts/` cleanup).

## Validation

- ✅ **Round-trip:** all 187 duckdb snippets are now idempotent under `sql-formatter({ language: "duckdb" })` (re-run reports 0 changes). sql-formatter version (15.8.0) matches the lockfile, so this matches the site's runtime.
- ✅ **Unit tests:** 445/445 pass (22 files).
- ✅ **MDX compile:** all 27 changed files compile through the real remark/rehype pipeline (incl. `remarkPreserveCodeIndent`).

https://claude.ai/code/session_01XJeEthVFYNjFNmK7XwZuR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJeEthVFYNjFNmK7XwZuR4)_