### PR TITLE
Brand color system (palette tokens, cleanup) + AI illustration research

### DIFF
--- a/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
+++ b/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
@@ -159,6 +159,8 @@ Mood: {curiosity / clarity / momentum}.
 16:9 hero banner, centered composition, safe margins.
 ```
 
+> **Ready-to-run versions** of this template — concrete, copy-paste prompts tied to real DataSlope chapters, with per-service tweaks for transparency/SVG — are in **Appendix A**.
+
 ---
 
 ## 6. Integration into the existing stack
@@ -364,7 +366,7 @@ This alone removes the most fragile Hobby limit. What remains is raw bandwidth �
 
 ## 10. Recommended rollout
 
-**Phase 0 — Style discovery (free, ~1 day).** Use Google AI Studio's free tier (and an aggregator for A/B) to nail a house style on **3–5 chapters across different courses**. Produce "golden" reference images. Decide medium, palette, aspect ratios — **and the default light/dark strategy (§7): transparent raster + theme-agnostic palette, or SVG.** Test every candidate on both the light and dark theme before locking the style.
+**Phase 0 — Style discovery (free, ~1 day).** Use Google AI Studio's free tier (and an aggregator for A/B) to nail a house style on **3–5 chapters across different courses** — start with the **ready-to-run prompts in Appendix A**. Produce "golden" reference images. Decide medium, palette, aspect ratios — **and the default light/dark strategy (§7): transparent raster + theme-agnostic palette, or SVG.** Test every candidate on both the light and dark theme before locking the style.
 
 **Phase 1 — Pipeline + pilot (small).** Build `scripts/generate-illustrations.mjs`, the manifest, and the `<Illustration>` component. Generate **hero images for one full course** (e.g. `practical-r-for-beginners`, ~30 chapters) on **Imagen 4 Fast**. Review, commit, ship behind the existing render path. Cost: a few dollars.
 
@@ -384,6 +386,106 @@ This alone removes the most fragile Hobby limit. What remains is raw bandwidth �
 4. **Provider preference / constraints** — any existing GCP or OpenAI account, data-residency, or licensing constraints that should pick the API for us?
 5. **Asset hosting (§8)** — on Vercel Hobby today: start with **pre-optimize + jsDelivr (free)**, then graduate to **Cloudflare R2 (free egress)** as traffic grows? Or do you want a managed transformer (Bunny / Cloudflare Images) from day one? Also: is DataSlope commercial (which would require Vercel Pro regardless)?
 6. **Dark-mode default (§7)** — standardize on transparent raster + theme-agnostic palette (one asset, lowest maintenance), lean into SVG for spot art, or accept `srcDark` two-variant cost for hero images? This decision shapes both the model choice and the component/manifest design.
+
+---
+
+## Appendix A — Ready-to-test sample prompts
+
+Copy-paste prompts for the **Phase 0 bake-off** (§10). They're built on real DataSlope chapters so you can judge results in context. **Method:** run the *same* prompt across services (Imagen 4, GPT Image 1.5, Ideogram 4.0, Recraft V4.1, Flux 2, Nano Banana) and compare style, coherence, text accuracy, and how each reads on **both light and dark backgrounds**.
+
+### A.0 Shared house-style preamble (prepend to every prompt)
+
+Replace the bracketed tokens with your real brand values once chosen (§11 Q1/Q3). Keeping this string **identical** across images is what creates a coherent set.
+
+```
+Flat vector editorial illustration. Clean geometric shapes, generous negative
+space, limited palette of [#3B82F6 primary], [#F59E0B accent], and warm neutral
+tones, soft long shadows, subtle paper grain. Friendly, modern, calm. Centered
+composition with safe margins. Transparent background.
+NEGATIVE: no text, no letters, no numbers, no labels, no watermark, no UI chrome,
+no photorealism, no harsh pure-white or pure-black fills, no busy backgrounds.
+```
+
+> **Per-service tweaks for the preamble**
+> - **Imagen 4 / Flux 2 / Nano Banana:** these don't emit alpha — drop "Transparent background," generate on a **mid-tone neutral** so the art reads on both themes, or run a background-removal pass after (§3.4).
+> - **GPT Image 1.5:** keep "Transparent background" *and* pass the API param `background:"transparent"`, `format:"png"`.
+> - **Ideogram 4.0:** enable its **background-removal / transparency** option; it also honors the negative-text rule well.
+> - **Recraft V4.1 Vector:** select the **Vector / SVG** output and a flat "digital illustration" style; vectors are inherently background-free and theme via CSS.
+> - Most APIs take a separate `negative_prompt` field — move the `NEGATIVE:` line there if so.
+
+### A.1 Decorative hero banner — *“The Age of Data”* (16:9)
+
+```
+[HOUSE STYLE]
+Subject: a sweeping conceptual hero image for a chapter about how the modern
+world became saturated with data. Scene: countless small luminous data points
+flowing like rivers across a stylized landscape and converging into a single
+calm glowing hub. A lone human silhouette stands looking toward the hub,
+conveying curiosity and scale. 16:9 banner, cinematic but minimal.
+```
+*Good first test of overall style and palette. Evaluate: does it feel editorial vs. generic-AI?*
+
+### A.2 Conceptual metaphor — *“Vectorized Computation”* (4:3)
+
+```
+[HOUSE STYLE]
+Subject: a visual metaphor for performing the same operation on many values at
+once. Scene: a row of identical gears mounted along a single conveyor belt, all
+turning in perfect unison, with small uniform parcels riding the belt and being
+stamped simultaneously. Sense of effortless parallelism and rhythm.
+```
+*Tests whether the model can render a clean, legible metaphor without clutter.*
+
+### A.3 Conceptual metaphor — *“Missing Values”* (4:3)
+
+```
+[HOUSE STYLE]
+Subject: a gentle metaphor for gaps in a dataset. Scene: a woven fabric or grid
+of soft tiles where a few tiles are missing, leaving clean empty silhouettes;
+one tile is being lifted away. Calm, non-alarming mood — gaps as a normal part
+of real data, not an error.
+```
+*Tests subtlety and negative space. Check it doesn't add scary "error" connotations.*
+
+### A.4 Transparent spot illustration — *“Tidy Data Principles”* (1:1)
+
+```
+[HOUSE STYLE]
+Subject: a small spot illustration contrasting messy vs. tidy data. Scene: on
+one side a tangled, jumbled pile of mismatched cards; an arrow; on the other
+side the same cards snapped into a neat aligned grid. No text on the cards.
+Square, transparent background, suitable as an inline figure.
+```
+*Best on GPT Image 1.5 (transparent), Ideogram 4 (transparent), or Recraft Vector. The cutout test — inspect edges on a dark background for halos.*
+
+### A.5 SVG icon set — section/topic icons (1:1, vector)
+
+```
+[HOUSE STYLE — but as: minimal line + flat-fill ICON, 2px uniform strokes,
+single foreground color so it can inherit currentColor]
+Subject: a cohesive set of simple topic icons for an R course: (1) a data frame
+as a small table grid, (2) a vector as three stacked arrows, (3) a distribution
+as a smooth bell curve, (4) a pipe operator as two linked chevrons. Each icon
+centered on its own square, consistent stroke weight and corner radius.
+```
+*Generate on **Recraft V4.1 Vector**. The payoff: true SVG that recolors via CSS for dark mode (§7 Strategy A) and stays crisp at any size. Evaluate stroke consistency across the set.*
+
+### A.6 Text-rendering stress test — labeled mini-diagram (4:3)
+
+```
+[HOUSE STYLE — allow text for THIS test only; remove the no-text negatives]
+Subject: a friendly labeled illustration of the data-analysis loop. Scene: four
+rounded nodes in a circle connected by arrows, each clearly labeled with exactly
+one word: "Import", "Tidy", "Model", "Communicate". Crisp, legible sans-serif
+lettering, correct spelling.
+```
+*Only for comparing **typography** models — **Ideogram 4.0**, **Nano Banana Pro**, **GPT Image 1.5**. Verdict usually: even the best models misspell at label density, which is exactly why §2 says keep precise labeled diagrams on **Mermaid**. This test is to confirm that for yourself.*
+
+### A.7 Per-course accent variant (consistency probe)
+
+Re-run **A.1** with only the accent color swapped (e.g. `[#10B981 accent]` for a Python course vs. `[#3B82F6]` for R). Everything else identical. *Confirms the house-style system yields "same family, different course" rather than random drift (§5.2).*
+
+> **What to record per run:** model, exact prompt, seed, aspect ratio, whether transparency was native or post-processed, and a screenshot on **both** light and dark backgrounds. Drop the winners into the manifest schema from §6.3 as your "golden" references.
 
 ---
 

--- a/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
+++ b/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
@@ -15,6 +15,7 @@
 - **Recommended primary API: Google Imagen 4 (Fast/Standard)** for decorative art at **$0.02–$0.04/image**, with **Google Gemini "Nano Banana Pro" (Gemini 3 Pro Image, ~$0.134/image)** or **OpenAI GPT Image 1.5 (~$0.04/image)** reserved for the rare illustration that must contain **legible text/labels**. All three render text far better than the 2024-era models.
 - **Cost is not the constraint.** One illustration per chapter (781 images) costs **~$16–$31** at Imagen 4 Fast/Standard rates. Even a lavish budget of one hero + 3 section images per chapter (~3,100 images) lands around **$62–$420** depending on tier. The real costs are **art-direction, consistency, review, and accessibility**, not API spend.
 - **Build a one-off generation script + a JSON manifest + committed PNG/WebP assets.** Do **not** generate at request time or live build time (slow, nondeterministic, costs recur, breaks offline/preview builds). Generate offline, review, commit the images, and reference them through a new `<Illustration>` MDX component backed by `next/image`.
+- **Dark mode is a first-class constraint, not an afterthought.** The `/learn` site runs **next-themes** via Fumadocs `RootProvider`, toggling a `.dark` **class** on `<html>` (confirmed in `app/learn/layout.tsx` and `app/_components/mdx/mermaid.tsx`, which already re-renders per theme). A raster illustration baked onto a **white background will look broken in dark mode**. Solve it with: **(a) transparent-background art** that lets the page background show through, **(b) SVG art recolored via `currentColor`/CSS variables** so it themes automatically, or **(c) two committed variants** (light/dark) swapped by the `<Illustration>` component — the same `useTheme()` pattern Mermaid already uses. See §7.
 
 ---
 
@@ -66,6 +67,21 @@ Prices are **per generated 1024×1024 (1K) output image** unless noted. The mark
 - **The rare label-heavy "infographic" illustration:** **Nano Banana Pro** — but first ask whether Mermaid/SVG is the better tool (usually yes).
 - **Crisp scalable icons/spot-illustrations for the web:** evaluate **Recraft V3 vector** (SVG scales perfectly at any DPI and is tiny).
 - **Prototyping:** Google AI Studio free tier, then a multi-model aggregator for the A/B bake-off.
+
+### 3.4 Transparency & SVG support by model (matters for dark mode — see §7)
+
+| Model | Native transparent PNG (alpha) | Native SVG / vector | Practical note |
+|---|---|---|---|
+| **Recraft V4 / V3 Vector** | n/a (vector) | **Yes — true editable SVG** | Only major API that emits production SVG; best path for icons/spot art that must theme cleanly |
+| **OpenAI GPT Image 1.5** | **Yes** (`background: "transparent"`, request PNG/WebP) | No | Best raster route to a clean alpha cutout from a prompt |
+| **OpenAI GPT Image 2** | **No** (per OpenAI docs — common failure point) | No | Use 1.5 if you need transparency |
+| **Google Imagen 4** | No | No | Opaque output; needs background removal for transparency |
+| **Google Nano Banana / Pro** | Limited / inconsistent | No | Treat as opaque; post-process if you need alpha |
+| **Flux 2** | **No** | No | Cannot output transparency natively |
+| **Runware LayerDiffuse** | **Yes (built-in alpha at generation)** | No | Purpose-built for one-step transparent raster |
+| **Background-removal APIs** (e.g. remove.bg, Recraft vectorizer, Transparify) | Yes (post-process any image) | Some vectorize | The universal fallback: generate opaque, then strip the background |
+
+**Two reliable routes to transparency:** (1) pick a model that emits alpha directly (**GPT Image 1.5** or **LayerDiffuse**), or (2) generate opaque on any model and run a **background-removal pass**. For anything icon-like, **SVG from Recraft** sidesteps the whole problem because vectors carry no background and recolor via CSS.
 
 ---
 
@@ -193,6 +209,9 @@ export function Illustration({ id }: { id: string }) {
 {
   "practical-r/the-age-of-data/hero": {
     "src": "/illustrations/practical-r-for-beginners/the-age-of-data/hero.webp",
+    "srcDark": null,
+    "format": "raster",
+    "transparent": true,
     "width": 1600, "height": 900,
     "alt": "Abstract flat-vector scene of data streams converging into a glowing hub",
     "caption": null,
@@ -203,6 +222,8 @@ export function Illustration({ id }: { id: string }) {
   }
 }
 ```
+
+The `format`, `transparent`, and `srcDark` fields drive the light/dark-mode behavior described in **§7**: `format:"svg"` entries inline and recolor via CSS; transparent raster entries render on any theme; and a non-null `srcDark` tells `<Illustration>` to swap variants per theme via `useTheme()`.
 
 ### 6.4 Generation script
 
@@ -217,7 +238,62 @@ Add `scripts/generate-illustrations.mjs` (ESM, matching `scripts/check-mcq.mjs` 
 
 ---
 
-## 7. Quality, legal, and accessibility
+## 7. SVG, transparency, and light/dark mode
+
+This is the section that most affects whether illustrations *look intentional* on DataSlope, because the `/learn` site ships a real dark theme.
+
+### 7.1 The problem, concretely
+
+`app/learn/layout.tsx` wraps every lesson in Fumadocs's `RootProvider`, which uses **next-themes**. Theme switching adds/removes a **`.dark` class on `<html>`** (it is *not* purely a `prefers-color-scheme` media query — a user can manually toggle). `app/_components/mdx/mermaid.tsx` already imports `useTheme` from `next-themes` and re-renders diagrams when the theme flips.
+
+Consequences for raster art:
+
+- A PNG with a **solid white background** sits in a glaring white box on a dark page. A solid dark background does the inverse in light mode.
+- Because next-themes toggles a **class**, a pure CSS `<picture media="(prefers-color-scheme: dark)">` approach **will not track the manual toggle** — it only follows the OS setting. Theme-aware swapping must key off the `.dark` class (CSS) or `useTheme()` (JS), not the media query alone.
+
+### 7.2 Four strategies (use the right one per art type)
+
+**Strategy A — SVG that recolors itself (best for icons / line art / simple spot illustrations).**
+Generate vector art with **Recraft V4/V3 Vector**, then make it theme-aware by letting strokes/fills inherit `currentColor` or reference CSS custom properties. Inline the SVG (or load it so its `fill`/`stroke` can be CSS-driven) and it adapts to *any* theme automatically — one asset, infinitely scalable, ~a few KB, no white box ever. This is the cleanest dark-mode answer and also the most accessible (crisp at any zoom/DPI).
+- Caveat: complex/painterly SVGs with baked-in hex colors won't auto-recolor — you'd post-process to swap a known palette to CSS variables, or treat them like raster (Strategy C).
+
+**Strategy B — Transparent-background raster that works on both themes (best for hero/decorative art).**
+Generate a **transparent PNG/WebP** (GPT Image 1.5 `background:"transparent"`, LayerDiffuse, or generate-then-background-remove) using a **theme-agnostic palette**: avoid near-white and near-black; favor your brand accent + mid-tones; use soft shadows/glows that read on both light and dark. One asset, no theme logic. ~80% of decorative needs can be met this way and it's the lowest-maintenance option.
+- Watch-outs: subtle anti-aliasing halos around edges show on dark backgrounds (check at generation); fine dark linework can vanish on dark bg, so prefer shapes with their own fill over thin outlines.
+
+**Strategy C — Two committed variants, swapped by the component (best when an image genuinely needs different treatment per theme).**
+Generate/store a **light** and **dark** version, list both in the manifest (`src` + `srcDark`), and have `<Illustration>` pick using `useTheme()` — mirroring exactly what `mermaid.tsx` does today. Costs 2× the assets/generation and doubles review, so reserve it for high-value images (e.g. course hero banners) where a single asset can't satisfy both.
+- No-JS / SSR nicety: you can also render both and toggle with CSS `.dark` class utilities (`hidden dark:block` / `block dark:hidden`) so there's no theme flash before hydration.
+
+**Strategy D — CSS containment (fallback for legacy/opaque images).**
+If you're stuck with an opaque raster, wrap it in a `<figure>` with consistent padding and a **theme-neutral container** (e.g. a soft card surface using the theme's surface variable, rounded corners, subtle border) so the image reads as an intentional framed element rather than a clashing rectangle. Avoid `filter: invert()` hacks — they wreck colored art and only sometimes work for pure black/white line drawings.
+
+### 7.3 Decision guide
+
+```mermaid
+flowchart TD
+    A["New illustration"] --> B{"Icon / line art /<br/>simple shapes?"}
+    B -- Yes --> C["SVG via Recraft<br/>+ currentColor / CSS vars<br/>(Strategy A)"]
+    B -- No --> D{"Can one image read well<br/>on light AND dark?"}
+    D -- Yes --> E["Transparent raster,<br/>theme-agnostic palette<br/>(Strategy B)"]
+    D -- No --> F["Two variants + srcDark,<br/>swap via useTheme()<br/>(Strategy C)"]
+```
+
+### 7.4 What this means for the component and manifest (extends §6)
+
+- **Manifest** gains optional fields: `format` (`"svg" | "raster"`), `srcDark`, and `transparent: true`. SVG entries can be inlined; raster entries go through `next/image`.
+- **`<Illustration>`** reads the theme with `useTheme()` (already a project dependency) and chooses `srcDark` when present and `.dark` is active; otherwise renders the single theme-agnostic asset. For SVG, render inline so CSS can drive `fill`/`stroke`.
+- **Generation script** records which strategy each slot used and, for transparency, whether alpha was native or added via a background-removal pass (provenance for later re-runs).
+
+### 7.5 Recommended default
+
+- **Spot/icon art → Strategy A (Recraft SVG).** Themes for free, tiny, scalable, accessible.
+- **Hero/decorative art → Strategy B (transparent raster, theme-agnostic palette).** One asset, low maintenance; this should cover most chapters.
+- **Strategy C only for marquee images** where the extra asset is worth it. **Strategy D** is a stopgap, not a plan.
+
+---
+
+## 8. Quality, legal, and accessibility
 
 - **Accessibility (required).** Every illustration needs meaningful **`alt` text** (stored in the manifest, human-reviewed). Decorative-only images should be marked decorative (empty alt / `aria-hidden`) so screen readers skip them. This is the single most important non-cost consideration.
 - **Don't put load-bearing information only in an image.** If an illustration conveys a concept, the prose must convey it too (it already does). Images supplement, never replace, text — also protects you if an image is wrong or fails to load.
@@ -228,9 +304,9 @@ Add `scripts/generate-illustrations.mjs` (ESM, matching `scripts/check-mcq.mjs` 
 
 ---
 
-## 8. Recommended rollout
+## 9. Recommended rollout
 
-**Phase 0 — Style discovery (free, ~1 day).** Use Google AI Studio's free tier (and an aggregator for A/B) to nail a house style on **3–5 chapters across different courses**. Produce "golden" reference images. Decide medium, palette, aspect ratios.
+**Phase 0 — Style discovery (free, ~1 day).** Use Google AI Studio's free tier (and an aggregator for A/B) to nail a house style on **3–5 chapters across different courses**. Produce "golden" reference images. Decide medium, palette, aspect ratios — **and the default light/dark strategy (§7): transparent raster + theme-agnostic palette, or SVG.** Test every candidate on both the light and dark theme before locking the style.
 
 **Phase 1 — Pipeline + pilot (small).** Build `scripts/generate-illustrations.mjs`, the manifest, and the `<Illustration>` component. Generate **hero images for one full course** (e.g. `practical-r-for-beginners`, ~30 chapters) on **Imagen 4 Fast**. Review, commit, ship behind the existing render path. Cost: a few dollars.
 
@@ -238,17 +314,18 @@ Add `scripts/generate-illustrations.mjs` (ESM, matching `scripts/check-mcq.mjs` 
 
 **Phase 3 — Selective section art & conceptual explainers.** Add section/metaphor images only where they earn their place. Use GPT Image 1.5 / Nano Banana where a few legible words are genuinely needed. Keep precise diagrams on **Mermaid**.
 
-**Phase 4 — Optional hardening.** Consider Recraft SVG for icon-like spot art, a custom fine-tune/LoRA for tighter brand consistency, and/or CDN offload if repo size grows.
+**Phase 4 — Optional hardening.** Consider Recraft SVG for icon-like spot art (themes for free in dark mode), `srcDark` variants for marquee heroes that need them, a custom fine-tune/LoRA for tighter brand consistency, and/or CDN offload if repo size grows.
 
 ---
 
-## 9. Open questions for you
+## 10. Open questions for you
 
 1. **Style direction** — flat vector / isometric / line-art / painterly? (Drives model choice and the locked preamble.)
 2. **Density** — hero-only, or hero + section art? (Drives count and review burden.)
 3. **Brand palette** — should illustrations pull DataSlope's Tailwind theme colors for cohesion?
 4. **Provider preference / constraints** — any existing GCP or OpenAI account, data-residency, or licensing constraints that should pick the API for us?
 5. **Asset hosting** — commit to repo (simple) vs reuse the jsDelivr CDN pattern (keeps repo lean)?
+6. **Dark-mode default (§7)** — standardize on transparent raster + theme-agnostic palette (one asset, lowest maintenance), lean into SVG for spot art, or accept `srcDark` two-variant cost for hero images? This decision shapes both the model choice and the component/manifest design.
 
 ---
 
@@ -274,5 +351,12 @@ Add `scripts/generate-illustrations.mjs` (ESM, matching `scripts/check-mcq.mjs` 
 - [AI art style libraries & keywords 2026 (GensGPT)](https://www.gensgpt.com/blog/ai-art-style-libraries-popular-styles-keywords-2026-guide)
 - [Replicate pricing](https://replicate.com/pricing)
 - [fal.ai image generators](https://fal.ai/learn/tools/ai-image-generators)
+- [OpenAI image generation guide — background/transparency parameter](https://developers.openai.com/api/docs/guides/image-generation)
+- [GPT-Image-2 transparent background limitations (Apiyi)](https://help.apiyi.com/en/gpt-image-2-transparent-background-not-supported-en.html)
+- [Can AI generate transparent images? (ZSky AI)](https://zsky.ai/blog/can-ai-generate-transparent-images)
+- [LayerDiffuse — built-in transparency at generation (Runware)](https://runware.ai/blog/introducing-layerdiffuse-generate-images-with-built-in-transparency-in-one-step)
+- [Recraft V3 SVG — text-to-SVG API (Replicate)](https://replicate.com/recraft-ai/recraft-v3-svg)
+- [Recraft V4 models & SVG output (Recraft docs)](https://www.recraft.ai/docs/recraft-models/recraft-V4)
+- [Transparent PNGs from any AI generator (Transparify)](https://transparify.app/blog/ai-image-transparent-background)
 
 > **Pricing caveat:** Image-API prices change frequently and vary by region, resolution, and aggregator markup. Figures above reflect June 2026 estimates aggregated from the sources listed — re-confirm against live vendor pricing pages before committing budget.

--- a/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
+++ b/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
@@ -16,6 +16,8 @@
 - **Cost is not the constraint.** One illustration per chapter (781 images) costs **~$16–$31** at Imagen 4 Fast/Standard rates. Even a lavish budget of one hero + 3 section images per chapter (~3,100 images) lands around **$62–$420** depending on tier. The real costs are **art-direction, consistency, review, and accessibility**, not API spend.
 - **Build a one-off generation script + a JSON manifest + committed PNG/WebP assets.** Do **not** generate at request time or live build time (slow, nondeterministic, costs recur, breaks offline/preview builds). Generate offline, review, commit the images, and reference them through a new `<Illustration>` MDX component backed by `next/image`.
 - **Dark mode is a first-class constraint, not an afterthought.** The `/learn` site runs **next-themes** via Fumadocs `RootProvider`, toggling a `.dark` **class** on `<html>` (confirmed in `app/learn/layout.tsx` and `app/_components/mdx/mermaid.tsx`, which already re-renders per theme). A raster illustration baked onto a **white background will look broken in dark mode**. Solve it with: **(a) transparent-background art** that lets the page background show through, **(b) SVG art recolored via `currentColor`/CSS variables** so it themes automatically, or **(c) two committed variants** (light/dark) swapped by the `<Illustration>` component — the same `useTheme()` pattern Mermaid already uses. See §7.
+- **Hosting: don't let Vercel's image optimizer meter you.** On the **Hobby plan**, `next/image` optimization is capped at **5,000 transformations/month** — hundreds of illustrations × responsive sizes × formats blow past it on the first crawl (then new images 402). Since art is pre-generated, **optimize once at build, set `next/image` to `unoptimized`/custom-loader, and serve from a CDN**. Recommended path: **jsDelivr (free, already in your stack) now → Cloudflare R2 (free egress) as traffic grows.** Keep the app on Vercel; just decouple image delivery. See §8.
+- **Latest models (June 2026):** prefer **Recraft V4.1** (incl. V4.1 Vector for SVG) and **Ideogram 4.0** (best-in-class text *plus* native transparency/background removal) over their prior versions. See §3.
 
 ---
 
@@ -50,8 +52,10 @@ Prices are **per generated 1024×1024 (1K) output image** unless noted. The mark
 | **Google Nano Banana Pro** (Gemini 3 Pro Image) | **$0.134** (1K/2K) | 4K $0.24 | **Best-in-class** | No | Best for legible text/labels; **50% off** via Batch/Flex ($0.067) |
 | **Google Nano Banana 2** (Gemini 3.1 Flash Image) | **$0.067** (1K) | 2K $0.101, 4K $0.151 | Excellent | No | **50% off** via Batch; 0.5K ~$0.045 |
 | **Flux 2 [schnell]** | **$0.015** | dev $0.025, **pro $0.05** | Good | No | Megapixel-based pricing; photorealism; self-host option exists |
-| **Ideogram 3.0** | **$0.03** (Standard) | Quality $0.09 | **Excellent (typography)** | No | Specialist for readable text in images |
-| **Recraft V3** | **$0.04** (raster) | **$0.08 (vector/SVG)** | Excellent | **Yes (true SVG)** | Only major model emitting scalable SVG — interesting for crisp web icons |
+| **Ideogram 4.0** *(latest)* | **$0.03** (Turbo) | Default $0.06, Quality $0.10 | **Best-in-class typography** | No (raster) | **Native background removal / transparency + editable text layers**; multilingual text; bounding-box layout control; **open weights** (commercial license) |
+| **Ideogram 3.0** | **$0.03** (Standard) | Quality $0.09 | **Excellent (typography)** | No | Prior gen; still fine for readable text in images |
+| **Recraft V4.1** *(latest, May 2026)* | ~$0.04 (raster) | **~$0.08 (vector/SVG)** | Excellent | **Yes (true SVG)** | Three variants: **V4.1** (expressive), **V4.1 Vector** (logos/precision SVG), **V4.1 Utility** (clean mockups/product shots); improved photorealism + coherence over V4 |
+| **Recraft V3** | **$0.04** (raster) | **$0.08 (vector/SVG)** | Excellent | **Yes (true SVG)** | Prior gen; still a solid SVG workhorse |
 
 ### 3.2 Free tiers & discounts worth knowing
 
@@ -63,16 +67,18 @@ Prices are **per generated 1024×1024 (1K) output image** unless noted. The mark
 ### 3.3 Recommendation by use case
 
 - **Decorative hero/section art (the bulk):** **Imagen 4 Fast → Standard.** Cheapest, fast, consistent enough with a strong style prompt.
-- **Conceptual art that needs a few legible words:** **GPT Image 1.5** or **Nano Banana 2** (Batch tier).
-- **The rare label-heavy "infographic" illustration:** **Nano Banana Pro** — but first ask whether Mermaid/SVG is the better tool (usually yes).
-- **Crisp scalable icons/spot-illustrations for the web:** evaluate **Recraft V3 vector** (SVG scales perfectly at any DPI and is tiny).
+- **Conceptual art that needs a few legible words:** **GPT Image 1.5**, **Ideogram 4.0**, or **Nano Banana 2** (Batch tier). Ideogram 4 is the typography specialist *and* gives native transparency/background removal in one shot — a strong pick when you need clean labeled cutouts.
+- **The rare label-heavy "infographic" illustration:** **Nano Banana Pro** or **Ideogram 4.0 Quality** — but first ask whether Mermaid/SVG is the better tool (usually yes).
+- **Crisp scalable icons/spot-illustrations for the web:** **Recraft V4.1 Vector** (true SVG, scales perfectly at any DPI, ~KB-sized, themes via CSS). V4.1 Utility is handy for clean front-facing product/mockup shots.
+- **Latest-model note (June 2026):** Prefer **Recraft V4.1** over V3 and **Ideogram 4.0** over 3.0 — both are current-gen with better coherence; V3/3.0 remain fine fallbacks. The flagship raster trio (Imagen 4, GPT Image 1.5/2, Nano Banana) is unchanged as the decorative workhorse.
 - **Prototyping:** Google AI Studio free tier, then a multi-model aggregator for the A/B bake-off.
 
 ### 3.4 Transparency & SVG support by model (matters for dark mode — see §7)
 
 | Model | Native transparent PNG (alpha) | Native SVG / vector | Practical note |
 |---|---|---|---|
-| **Recraft V4 / V3 Vector** | n/a (vector) | **Yes — true editable SVG** | Only major API that emits production SVG; best path for icons/spot art that must theme cleanly |
+| **Recraft V4.1 / V3 Vector** | n/a (vector) | **Yes — true editable SVG** | Only major API that emits production SVG; best path for icons/spot art that must theme cleanly |
+| **Ideogram 4.0** | **Yes** (native background removal / transparency) | No | One-shot transparent raster *with* best-in-class text — strong for labeled cutouts |
 | **OpenAI GPT Image 1.5** | **Yes** (`background: "transparent"`, request PNG/WebP) | No | Best raster route to a clean alpha cutout from a prompt |
 | **OpenAI GPT Image 2** | **No** (per OpenAI docs — common failure point) | No | Use 1.5 if you need transparency |
 | **Google Imagen 4** | No | No | Opaque output; needs background removal for transparency |
@@ -170,7 +176,7 @@ public/illustrations/{course-slug}/{chapter-slug}/section-2.webp
 
 - Serve via **`next/image`** for automatic responsive sizing, lazy-loading, and modern formats.
 - Keep them in `public/` (mirrors how `tools.jar` and brand assets are already handled) rather than colocating in `content/` — Fumadocs treats `content/learn` as MDX page sources, and binary blobs there add noise.
-- If repo size becomes a concern (hundreds of WebP at ~50–150KB each ≈ tens of MB — manageable), consider pushing to the **same jsDelivr CDN pattern already used** for the .NET runtime and PGlite (`app/_components/runtime/cdn.ts`). Not needed for v1.
+- If repo size becomes a concern (hundreds of WebP at ~50–150KB each ≈ tens of MB — manageable), consider pushing to the **same jsDelivr CDN pattern already used** for the .NET runtime and PGlite (`app/_components/runtime/cdn.ts`). **See §8 for the full hosting/delivery strategy** — important because you're on Vercel's Hobby plan, where `next/image` optimization and bandwidth have caps that hundreds of illustrations can hit.
 
 ### 6.2 New `<Illustration>` MDX component
 
@@ -293,7 +299,59 @@ flowchart TD
 
 ---
 
-## 8. Quality, legal, and accessibility
+## 8. Image hosting & delivery at scale
+
+You're on **Vercel's Hobby plan** today. Adding hundreds of illustrations changes the bandwidth and image-optimization math, so this section covers what breaks first and the affordable, scalable paths.
+
+### 8.1 What the Hobby plan actually limits (June 2026)
+
+| Resource | Hobby monthly allowance | What consumes it |
+|---|---|---|
+| **Bandwidth (Fast Data Transfer)** | **100 GB** | Every image byte served from `public/` or `next/image` |
+| **Edge requests** | **1 M** | Every asset request (each image = ≥1 request) |
+| **Image Optimization transformations** | **5,000** | Each unique `next/image` (src × size × format) the first time it's optimized |
+| **Image cache reads / writes** | **300K / 100K** | Serving/creating optimized variants |
+
+Two things bite first:
+
+- **The 5,000 transformations cap.** `next/image` creates a *separate* optimized variant per source × resolution × format. 781 heroes × ~4 responsive widths × 2 formats (WebP/AVIF) ≈ **6,000+ transformations** — you blow the monthly cap on the **first** crawl, after which **new images return HTTP 402** until the 30-day window resets (already-cached variants keep working).
+- **100 GB bandwidth.** At ~100 KB/image, 100 GB ≈ **1 M image views/month** before you're capped — fine now, but it's shared with all other page/app traffic and scales linearly with growth.
+
+> **Also worth flagging:** Vercel's **Hobby plan is for non-commercial use**. If DataSlope monetizes (or you want to lift these caps), you're on **Pro (~$20/seat/mo)** regardless — where the same image work becomes *metered* ($0.05/1K transformations, $0.40/1M cache reads, $4/1M cache writes, plus bandwidth). The strategies below keep that meter near zero.
+
+### 8.2 The key move: stop paying Vercel to optimize already-optimized images
+
+Because DataSlope **pre-generates illustrations offline**, they can be **optimized once at build time** (sharp/Squoosh → fixed-width WebP/AVIF + SVG). That makes Vercel's on-the-fly optimizer redundant. Bypass it so you never touch the 5K transformation cap:
+
+- Set `<Image unoptimized />` (or `images.unoptimized = true`) — serve the pre-optimized file as-is, **0 transformations**. You still get layout/lazy-load benefits of `next/image`.
+- **Or** a **custom loader** (`images.loader = "custom"`) that points at an external CDN/transformer (Cloudflare, Bunny) instead of Vercel's.
+- SVGs (Strategy A in §7) are already tiny and need no optimization at all.
+
+This alone removes the most fragile Hobby limit. What remains is raw bandwidth — addressed by offloading delivery to a CDN.
+
+### 8.3 Hosting options, cheapest-to-richest
+
+| Option | Cost model | Egress | Transforms | Best when |
+|---|---|---|---|---|
+| **jsDelivr** *(already in your stack)* | **Free** (OSS/GitHub/npm-backed) | Free | None | Public, pre-optimized static assets; you already serve the .NET runtime + PGlite this way (`app/_components/runtime/cdn.ts`) |
+| **Cloudflare R2 + CDN** | $0.015/GB stored (10 GB free), $4.50/M writes (10M free) | **Free** | Via Workers/Image Resizing (opt-in) | Highest-traffic, pre-optimized assets — free egress decouples image bandwidth from app growth |
+| **Bunny.net** | $0.01/GB storage + **$0.005/GB** bandwidth (EU/NA) | Cheap | Bunny Optimizer (WebP/AVIF, resize) | Dead-simple pay-as-you-go CDN with optional auto-optimization; pennies at this scale |
+| **Cloudflare Images** | $5/100K stored + $1/100K delivered | Free | **Built-in** | You want on-the-fly resizing without managing a pipeline; ~60–80% cheaper than Cloudinary |
+| **Cloudinary / imgix** | From ~$99/mo | Included | Rich API | Heavy dynamic transformation needs — **overkill here**, skip |
+| **Vercel `next/image` (status quo)** | Free within Hobby caps, then metered on Pro | Counts to plan | Built-in (5K cap) | Small asset counts only; the thing we're offloading |
+
+### 8.4 Recommendation for DataSlope
+
+1. **Now / v1 — pre-optimize + serve via jsDelivr (free).** Since assets are static, public, and committed to GitHub, jsDelivr is a zero-cost CDN you're *already using*. Pre-optimize at build (WebP/AVIF + SVG), reference via the existing CDN base-URL pattern, set `next/image` to `unoptimized`/custom-loader. Result: **~0 Vercel image transformations, near-zero Vercel image bandwidth, $0 hosting.** Caveat: jsDelivr is a best-effort fair-use OSS service (per-file size limits, public-only) — perfect for course art, not for private/huge assets.
+2. **As traffic grows — move the images to Cloudflare R2.** **Free egress** is the decisive feature: image bandwidth no longer scales your Vercel bill or competes with the 100 GB app allowance. Storage for hundreds of MB of art is cents/month. Keep serving via a custom `next/image` loader. This is the **scalable, affordable** answer for sustained growth.
+3. **If you want zero pipeline work — Bunny.net or Cloudflare Images.** Both add automatic resize/format at trivial cost and offload all egress. Reach for these only if managing a build-time optimize step becomes annoying.
+4. **Keep the Next.js app on Vercel.** The point isn't to leave Vercel — it's to **decouple image delivery from the app** so static art (which is what illustrations are) rides a cheap/free CDN while Vercel handles the dynamic app. The manifest's `src`/`srcDark` (from §6.3) just point at CDN URLs, so switching hosts later is a one-line base-URL change.
+
+> **Rule of thumb:** illustrations are immutable, cacheable, public static files — exactly what CDNs serve for free or near-free. Don't pay a serverless platform's metered image pricing to deliver them.
+
+---
+
+## 9. Quality, legal, and accessibility
 
 - **Accessibility (required).** Every illustration needs meaningful **`alt` text** (stored in the manifest, human-reviewed). Decorative-only images should be marked decorative (empty alt / `aria-hidden`) so screen readers skip them. This is the single most important non-cost consideration.
 - **Don't put load-bearing information only in an image.** If an illustration conveys a concept, the prose must convey it too (it already does). Images supplement, never replace, text — also protects you if an image is wrong or fails to load.
@@ -304,7 +362,7 @@ flowchart TD
 
 ---
 
-## 9. Recommended rollout
+## 10. Recommended rollout
 
 **Phase 0 — Style discovery (free, ~1 day).** Use Google AI Studio's free tier (and an aggregator for A/B) to nail a house style on **3–5 chapters across different courses**. Produce "golden" reference images. Decide medium, palette, aspect ratios — **and the default light/dark strategy (§7): transparent raster + theme-agnostic palette, or SVG.** Test every candidate on both the light and dark theme before locking the style.
 
@@ -318,13 +376,13 @@ flowchart TD
 
 ---
 
-## 10. Open questions for you
+## 11. Open questions for you
 
 1. **Style direction** — flat vector / isometric / line-art / painterly? (Drives model choice and the locked preamble.)
 2. **Density** — hero-only, or hero + section art? (Drives count and review burden.)
 3. **Brand palette** — should illustrations pull DataSlope's Tailwind theme colors for cohesion?
 4. **Provider preference / constraints** — any existing GCP or OpenAI account, data-residency, or licensing constraints that should pick the API for us?
-5. **Asset hosting** — commit to repo (simple) vs reuse the jsDelivr CDN pattern (keeps repo lean)?
+5. **Asset hosting (§8)** — on Vercel Hobby today: start with **pre-optimize + jsDelivr (free)**, then graduate to **Cloudflare R2 (free egress)** as traffic grows? Or do you want a managed transformer (Bunny / Cloudflare Images) from day one? Also: is DataSlope commercial (which would require Vercel Pro regardless)?
 6. **Dark-mode default (§7)** — standardize on transparent raster + theme-agnostic palette (one asset, lowest maintenance), lean into SVG for spot art, or accept `srcDark` two-variant cost for hero images? This decision shapes both the model choice and the component/manifest design.
 
 ---
@@ -358,5 +416,14 @@ flowchart TD
 - [Recraft V3 SVG — text-to-SVG API (Replicate)](https://replicate.com/recraft-ai/recraft-v3-svg)
 - [Recraft V4 models & SVG output (Recraft docs)](https://www.recraft.ai/docs/recraft-models/recraft-V4)
 - [Transparent PNGs from any AI generator (Transparify)](https://transparify.app/blog/ai-image-transparent-background)
+- [Recraft V4.1 announcement](https://www.recraft.ai/blog/recraft-v4-1-more-beautiful-by-nature)
+- [Ideogram 4.0 model page](https://ideogram.ai/models/4.0/)
+- [Vercel Image Optimization — limits & pricing](https://vercel.com/docs/image-optimization/limits-and-pricing)
+- [Vercel Hobby plan limits](https://vercel.com/docs/plans/hobby)
+- [Increased Hobby usage limits for Image Optimization (Vercel changelog)](https://vercel.com/changelog/increased-hobby-usage-limits-for-image-optimization)
+- [Media storage cost comparison: S3 vs R2 vs Cloudinary (LeanOps)](https://leanopstech.com/blog/media-storage-serverless-cost-comparison-2026/)
+- [Cloudflare Images pricing 2026 (LeanOps)](https://leanopstech.com/blog/cloudflare-images-pricing-2026/)
+- [Cloudflare Images pricing — real cost math (TheImageCDN)](https://theimagecdn.com/docs/cloudflare-images-pricing)
+- [Bunny.net vs Cloudflare 2026 (Kunal Ganglani)](https://www.kunalganglani.com/blog/bunnynet-vs-cloudflare-2026)
 
 > **Pricing caveat:** Image-API prices change frequently and vary by region, resolution, and aggregator markup. Figures above reflect June 2026 estimates aggregated from the sources listed — re-confirm against live vendor pricing pages before committing budget.

--- a/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
+++ b/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
@@ -1,0 +1,278 @@
+# AI Image Generation for Course Illustrations — Research Report
+
+**Date:** 2026-06-05
+**Author:** Claude (research agent)
+**Scope:** Evaluate AI image-generation APIs for adding decorative and explanatory illustrations to DataSlope courses; estimate cost; design a context-aware programmatic generation pipeline that fits the existing Next.js / Fumadocs / MDX stack.
+
+---
+
+## 1. Executive summary
+
+- **DataSlope has 28 courses / 781 MDX chapters / ~6,100 `## ` sections** and currently uses **zero raster illustrations** in content. The only visuals today are **Mermaid diagrams** (client-rendered SVG) and **runtime-generated plots** (base64 PNG from R/Python code cells). There is no image-asset folder, image component, or CDN image pipeline for content yet.
+- **Two very different needs are bundled in "illustrations":**
+  - **Decorative / conceptual art** (chapter hero images, section banners, mood/metaphor art) → *a great fit for AI image generation.*
+  - **Explanatory technical diagrams** (data flow, architecture, algorithm steps, ER diagrams) → *mostly a poor fit for raster AI image gen.* These should keep using **Mermaid** (already in the stack, version-controlled, accessible, editable). Use AI only for *conceptual* explanatory art (e.g. "a vector as an arrow in 2-D space") where literal accuracy of labels isn't load-bearing.
+- **Recommended primary API: Google Imagen 4 (Fast/Standard)** for decorative art at **$0.02–$0.04/image**, with **Google Gemini "Nano Banana Pro" (Gemini 3 Pro Image, ~$0.134/image)** or **OpenAI GPT Image 1.5 (~$0.04/image)** reserved for the rare illustration that must contain **legible text/labels**. All three render text far better than the 2024-era models.
+- **Cost is not the constraint.** One illustration per chapter (781 images) costs **~$16–$31** at Imagen 4 Fast/Standard rates. Even a lavish budget of one hero + 3 section images per chapter (~3,100 images) lands around **$62–$420** depending on tier. The real costs are **art-direction, consistency, review, and accessibility**, not API spend.
+- **Build a one-off generation script + a JSON manifest + committed PNG/WebP assets.** Do **not** generate at request time or live build time (slow, nondeterministic, costs recur, breaks offline/preview builds). Generate offline, review, commit the images, and reference them through a new `<Illustration>` MDX component backed by `next/image`.
+
+---
+
+## 2. What "illustrations" should and shouldn't be AI-generated
+
+| Need | Example in DataSlope | Best tool | Why |
+|---|---|---|---|
+| Chapter hero / header art | Banner atop `the-age-of-data.mdx` | **AI image gen** | Decorative, no factual labels, sets tone |
+| Section break / metaphor art | "missing values as gaps in a fabric" | **AI image gen** | Conceptual, evocative |
+| Conceptual explanatory art | "a vector as an arrow", "tidy vs messy data" | **AI image gen (with caution)** | OK if labels are minimal/none; verify accuracy |
+| Precise technical diagram | dplyr pipeline, ER diagram, control flow | **Mermaid (keep)** | Exact labels, editable, diffable, accessible, free |
+| Data plots / charts | distributions, ggplot output | **Runtime code cells (keep)** | Already live + reproducible |
+| Diagrams needing exact in-image text | labeled architecture with 10 boxes | **Mermaid or SVG** | AI text rendering improved but still error-prone at density |
+
+**Key judgement:** AI image generation is strongest for the *decorative and conceptual* layer that DataSlope completely lacks today. It is weakest exactly where DataSlope is already strong (precise diagrams via Mermaid, live plots). Lean into the gap; don't replace what works.
+
+---
+
+## 3. API landscape & pricing (June 2026)
+
+Prices are **per generated 1024×1024 (1K) output image** unless noted. The market has commoditized: most "standard" tiers cluster at **$0.02–$0.06/image**. Numbers below are corroborated across vendor docs and multiple pricing trackers (see Sources); treat them as *current estimates* — verify against live vendor pricing before committing budget, as these shift frequently.
+
+### 3.1 Comparison table
+
+| Provider / model | Price/image (1K) | Higher tiers | Text-in-image | SVG/vector | Notes |
+|---|---|---|---|---|---|
+| **Google Imagen 4 Fast** | **$0.02** | Standard $0.04, Ultra $0.06 | Good | No | Cheapest official option; text-to-image only; great default for decorative art |
+| **Google Imagen 4 Standard** | **$0.04** | Ultra $0.06 | Good | No | Best quality/price balance |
+| **OpenAI GPT Image 1.5** | **~$0.04** (medium) | low ~$0.009, high ~$0.167 | **Excellent** | No | Strong instruction-following; flagship (gpt-image-1 deprecates 2026-10-23) |
+| **OpenAI GPT Image 1 Mini** | **$0.005–$0.036** | — | Good | No | Budget floor; good for drafts/iteration |
+| **OpenAI GPT Image 2** | $0.005–$0.211 | medium ~$0.041–0.053, high ~$0.165–0.211 | **Excellent** | No | Latest flagship; portrait/landscape slightly cheaper than square |
+| **Google Nano Banana Pro** (Gemini 3 Pro Image) | **$0.134** (1K/2K) | 4K $0.24 | **Best-in-class** | No | Best for legible text/labels; **50% off** via Batch/Flex ($0.067) |
+| **Google Nano Banana 2** (Gemini 3.1 Flash Image) | **$0.067** (1K) | 2K $0.101, 4K $0.151 | Excellent | No | **50% off** via Batch; 0.5K ~$0.045 |
+| **Flux 2 [schnell]** | **$0.015** | dev $0.025, **pro $0.05** | Good | No | Megapixel-based pricing; photorealism; self-host option exists |
+| **Ideogram 3.0** | **$0.03** (Standard) | Quality $0.09 | **Excellent (typography)** | No | Specialist for readable text in images |
+| **Recraft V3** | **$0.04** (raster) | **$0.08 (vector/SVG)** | Excellent | **Yes (true SVG)** | Only major model emitting scalable SVG — interesting for crisp web icons |
+
+### 3.2 Free tiers & discounts worth knowing
+
+- **Google AI Studio** offers a generous free image tier (reported up to ~500 images/day) — ideal for **prototyping and style exploration at zero cost** before committing.
+- **Google Vertex AI**: $300 free trial credit for new GCP accounts.
+- **Batch APIs** (OpenAI, Google) cut rates ~**50%** for non-interactive bulk jobs — perfect for a one-shot generation run over hundreds of chapters.
+- **Aggregators** (fal.ai, Replicate, OpenRouter) give a single API key across many models for easy A/B testing, at a small markup, with volume discounts (~15–25%) at 100K+ images.
+
+### 3.3 Recommendation by use case
+
+- **Decorative hero/section art (the bulk):** **Imagen 4 Fast → Standard.** Cheapest, fast, consistent enough with a strong style prompt.
+- **Conceptual art that needs a few legible words:** **GPT Image 1.5** or **Nano Banana 2** (Batch tier).
+- **The rare label-heavy "infographic" illustration:** **Nano Banana Pro** — but first ask whether Mermaid/SVG is the better tool (usually yes).
+- **Crisp scalable icons/spot-illustrations for the web:** evaluate **Recraft V3 vector** (SVG scales perfectly at any DPI and is tiny).
+- **Prototyping:** Google AI Studio free tier, then a multi-model aggregator for the A/B bake-off.
+
+---
+
+## 4. Cost estimates for DataSlope
+
+Content scale: **781 chapters**, **~6,100 sections**.
+
+| Illustration policy | # images | @ Imagen 4 Fast ($0.02) | @ Imagen 4 Std ($0.04) | @ Nano Banana Pro Batch ($0.067) |
+|---|---|---|---|---|
+| 1 hero per chapter | 781 | **$16** | **$31** | $52 |
+| 1 hero + 2 section images/chapter | ~2,343 | $47 | $94 | $157 |
+| 1 hero + every section (~6,100) | ~6,881 | $138 | $275 | $461 |
+
+**Add realistic overhead for iteration.** Plan for **~3–5× the raw count** in actual API calls because you'll regenerate for style misses, bad anatomy, off-brief results, and prompt tuning. Even at 5× the most generous policy, you're looking at **low hundreds to ~$1–2K** of API spend total — a rounding error next to the human review time.
+
+**Bottom line:** budget **$50–$200 for a first pass** (1 hero/chapter with iteration headroom on Imagen 4), and treat the API bill as negligible. Allocate effort instead to art direction, a consistency system, and review.
+
+---
+
+## 5. Context-aware programmatic generation strategy
+
+The interesting engineering problem is **turning each chapter's content into a good prompt automatically**, while keeping a **consistent house style** across 781 chapters.
+
+### 5.1 Two-stage pipeline: text → prompt → image
+
+```mermaid
+flowchart LR
+    A["chapter.mdx<br/>(frontmatter + body)"] --> B["extract context<br/>title, description,<br/>headings, key terms"]
+    B --> C["LLM: write image prompt<br/>(house-style template +<br/>chapter context)"]
+    C --> D["image API<br/>(Imagen 4)"]
+    D --> E["post-process<br/>resize, WebP, optimize"]
+    E --> F["commit asset +<br/>manifest entry"]
+    F --> G["&lt;Illustration&gt; MDX<br/>component renders it"]
+```
+
+**Stage 1 — Context extraction (deterministic).** Parse each `.mdx`: pull `title` + `description` from frontmatter, the `## ` headings, and optionally the first paragraph of each section. This is cheap and reuses patterns already in `scripts/check-mcq.mjs` (which already reads and parses MDX files).
+
+**Stage 2 — Prompt synthesis (LLM, e.g. Claude).** Feed the extracted context + a **fixed house-style preamble** into an LLM that returns a tight image prompt. This is where "include the relevant chapter content" actually happens — the LLM distills the lesson into a concrete, drawable scene and *strips anything that would force literal text into the image*. Cost is trivial (a few cents per chapter).
+
+**Stage 3 — Image generation.** Send the synthesized prompt to the image API. Generate **n=2–4 candidates** per slot so a human can pick the best.
+
+> Why an LLM in the middle rather than prompting the image model with raw markdown? Image models follow *scene descriptions*, not lesson text. The LLM converts "this chapter explains vectorized computation in R" into "a row of identical gears turning in unison along a conveyor belt, flat vector illustration, …" — which is what actually produces good art.
+
+### 5.2 House-style system (the hard part)
+
+Consistency across hundreds of images is the difference between "looks designed" and "looks like a random AI dump." Techniques, in order of reliability:
+
+1. **A locked style preamble** appended to every prompt — fixed palette (ideally pull DataSlope brand colors from Tailwind theme), medium ("flat vector editorial illustration / isometric / line art"), lighting, composition, negative prompts ("no text, no watermark, no photorealism"). Reuse the **identical** string for every image.
+2. **Style reference images** — most APIs (GPT Image edits, Gemini, Flux) accept a reference image to condition style. Generate 2–3 "golden" reference illustrations you love, then condition every subsequent generation on them.
+3. **Seed pinning** — fix the random seed per style family for reproducibility where the API supports it.
+4. **Per-course accent** — vary only one controlled dimension (e.g. accent color) per course so courses feel distinct but the system feels unified.
+5. **(Advanced) Custom LoRA / fine-tune** on a curated set if you later want pixel-tight brand consistency at scale — overkill for v1.
+
+### 5.3 Suggested prompt template (illustrative)
+
+```
+[HOUSE STYLE — constant]
+Flat vector editorial illustration, clean geometric shapes, generous negative
+space, limited palette of {brand_primary}, {brand_accent}, warm neutral background,
+soft long shadows, subtle grain. Friendly and modern. No text, no labels, no
+letters, no numbers, no watermark, no UI chrome, not photorealistic.
+
+[CHAPTER CONTEXT — from LLM, per chapter]
+Subject: a single clear visual metaphor for "{chapter_title}".
+Scene: {one concrete drawable scene the LLM derived from the chapter}.
+Mood: {curiosity / clarity / momentum}.
+
+[FRAMING]
+16:9 hero banner, centered composition, safe margins.
+```
+
+---
+
+## 6. Integration into the existing stack
+
+The codebase is **Next.js 16 + Fumadocs 16 + dynamic MDX** (`source.config.ts` uses Fumadocs `dynamic` mode; MDX compiled on demand). Custom MDX components are registered in `mdx-components.tsx` (`CodeBlock`, `ChallengeCard`, `Mermaid`, etc.). There is **no `images.remotePatterns` config** in `next.config.ts` and **no content image folder** today.
+
+### 6.1 Where assets live
+
+Recommended: **commit optimized images into the repo** and serve them as static assets.
+
+```
+public/illustrations/{course-slug}/{chapter-slug}/hero.webp
+public/illustrations/{course-slug}/{chapter-slug}/section-2.webp
+```
+
+- Serve via **`next/image`** for automatic responsive sizing, lazy-loading, and modern formats.
+- Keep them in `public/` (mirrors how `tools.jar` and brand assets are already handled) rather than colocating in `content/` — Fumadocs treats `content/learn` as MDX page sources, and binary blobs there add noise.
+- If repo size becomes a concern (hundreds of WebP at ~50–150KB each ≈ tens of MB — manageable), consider pushing to the **same jsDelivr CDN pattern already used** for the .NET runtime and PGlite (`app/_components/runtime/cdn.ts`). Not needed for v1.
+
+### 6.2 New `<Illustration>` MDX component
+
+Add a component and register it in `mdx-components.tsx` alongside `Mermaid`:
+
+```mdx
+<Illustration id="practical-r/the-age-of-data/hero" />
+```
+
+```tsx
+// app/_components/mdx/Illustration.tsx (sketch)
+import Image from "next/image";
+import manifest from "@/content/illustrations.manifest.json";
+
+export function Illustration({ id }: { id: string }) {
+  const meta = manifest[id];               // { src, width, height, alt, credit }
+  if (!meta) return null;                  // fail soft if not yet generated
+  return (
+    <figure className="my-6">
+      <Image src={meta.src} width={meta.width} height={meta.height}
+             alt={meta.alt} className="rounded-lg" />
+      {meta.caption && <figcaption>{meta.caption}</figcaption>}
+    </figure>
+  );
+}
+```
+
+- Referencing by **`id` + manifest** (rather than raw `<img src>`) means MDX authors don't hardcode paths, the alt text/caption live in one reviewed place, and missing images fail soft instead of 404-ing.
+- For a zero-MDX-edit option, a remark plugin could auto-inject a hero from the manifest based on the page slug — but the explicit component is clearer and easier to review.
+
+### 6.3 The manifest
+
+`content/illustrations.manifest.json` (committed) is the source of truth linking IDs → file, dimensions, **alt text**, caption, the prompt used, model, and generation date:
+
+```json
+{
+  "practical-r/the-age-of-data/hero": {
+    "src": "/illustrations/practical-r-for-beginners/the-age-of-data/hero.webp",
+    "width": 1600, "height": 900,
+    "alt": "Abstract flat-vector scene of data streams converging into a glowing hub",
+    "caption": null,
+    "model": "imagen-4.0-fast",
+    "prompt": "Flat vector editorial illustration ...",
+    "seed": 12345,
+    "generatedAt": "2026-06-05"
+  }
+}
+```
+
+### 6.4 Generation script
+
+Add `scripts/generate-illustrations.mjs` (ESM, matching `scripts/check-mcq.mjs` conventions) and an npm script. It should:
+
+1. Walk `content/learn/**/*.mdx`, read frontmatter + headings.
+2. For each slot **not already in the manifest** (idempotent — never regenerate/charge for existing art unless `--force`), call the LLM for a prompt, then the image API for n candidates.
+3. Write candidates to a `/_review` staging dir; a human approves one.
+4. On approval: optimize (resize, WebP), write to `public/illustrations/...`, update the manifest, commit.
+
+> **Run offline, not in `build`/`dev`/`postinstall`.** Generation is slow, nondeterministic, costs money, and needs human review — it must never be on the request path or the CI build path. Contrast with the existing `build-almostnode-workers.mjs` (deterministic, free, safe to run on every build). Image generation is a deliberate, reviewed, occasional batch job.
+
+---
+
+## 7. Quality, legal, and accessibility
+
+- **Accessibility (required).** Every illustration needs meaningful **`alt` text** (stored in the manifest, human-reviewed). Decorative-only images should be marked decorative (empty alt / `aria-hidden`) so screen readers skip them. This is the single most important non-cost consideration.
+- **Don't put load-bearing information only in an image.** If an illustration conveys a concept, the prose must convey it too (it already does). Images supplement, never replace, text — also protects you if an image is wrong or fails to load.
+- **Factual accuracy review.** AI art invents details. For anything semi-explanatory, a human must confirm it isn't subtly *teaching the wrong thing* (e.g. a mislabeled axis, a wrong arrow direction). This is why conceptual-only + Mermaid-for-precision is the safe split.
+- **Licensing / commercial use.** Major API providers (OpenAI, Google, Black Forest Labs, Ideogram, Recraft) grant commercial-use rights to API-generated images, but **terms vary and change** — confirm the current ToS for your chosen provider, and keep the **manifest's prompt/model/date** as a provenance record. Consider whether you want C2PA/provenance metadata.
+- **Consistency review gate.** A human picks among n candidates and rejects off-style results before commit. Budget this time; it's the real cost.
+- **Performance.** Use `next/image`, ship WebP/AVIF, lazy-load below-the-fold, and cap hero file sizes (~100–150KB). Hundreds of small WebP in `public/` is fine; revisit CDN offload only if repo/deploy size becomes painful.
+
+---
+
+## 8. Recommended rollout
+
+**Phase 0 — Style discovery (free, ~1 day).** Use Google AI Studio's free tier (and an aggregator for A/B) to nail a house style on **3–5 chapters across different courses**. Produce "golden" reference images. Decide medium, palette, aspect ratios.
+
+**Phase 1 — Pipeline + pilot (small).** Build `scripts/generate-illustrations.mjs`, the manifest, and the `<Illustration>` component. Generate **hero images for one full course** (e.g. `practical-r-for-beginners`, ~30 chapters) on **Imagen 4 Fast**. Review, commit, ship behind the existing render path. Cost: a few dollars.
+
+**Phase 2 — Scale heroes.** Roll hero-per-chapter across all 28 courses (781 images) once the style holds. Cost: ~$16–$31 + iteration.
+
+**Phase 3 — Selective section art & conceptual explainers.** Add section/metaphor images only where they earn their place. Use GPT Image 1.5 / Nano Banana where a few legible words are genuinely needed. Keep precise diagrams on **Mermaid**.
+
+**Phase 4 — Optional hardening.** Consider Recraft SVG for icon-like spot art, a custom fine-tune/LoRA for tighter brand consistency, and/or CDN offload if repo size grows.
+
+---
+
+## 9. Open questions for you
+
+1. **Style direction** — flat vector / isometric / line-art / painterly? (Drives model choice and the locked preamble.)
+2. **Density** — hero-only, or hero + section art? (Drives count and review burden.)
+3. **Brand palette** — should illustrations pull DataSlope's Tailwind theme colors for cohesion?
+4. **Provider preference / constraints** — any existing GCP or OpenAI account, data-residency, or licensing constraints that should pick the API for us?
+5. **Asset hosting** — commit to repo (simple) vs reuse the jsDelivr CDN pattern (keeps repo lean)?
+
+---
+
+## Sources
+
+- [OpenAI API Pricing (official)](https://openai.com/api/pricing/)
+- [GPT Image 1 model docs (OpenAI)](https://developers.openai.com/api/docs/models/gpt-image-1)
+- [OpenAI image API pricing 2026 (AI Free API)](https://www.aifreeapi.com/en/posts/openai-image-generation-api-pricing)
+- [OpenAI GPT Image pricing calculator (CostGoat)](https://costgoat.com/pricing/openai-images)
+- [Gemini Developer API pricing (official)](https://ai.google.dev/gemini-api/docs/pricing)
+- [Nano Banana image generation docs (Google)](https://ai.google.dev/gemini-api/docs/image-generation)
+- [Gemini 3 Pro Image / Nano Banana Pro (Google AI Studio)](https://aistudio.google.com/models/gemini-3-pro-image)
+- [Gemini image free tier & limits (AI Free API)](https://www.aifreeapi.com/en/posts/gemini-image-generation-free-api)
+- [Nano Banana Pro pricing (LaoZhang AI)](https://blog.laozhang.ai/en/posts/nano-banana-pro-pricing)
+- [FLUX API pricing (Black Forest Labs)](https://bfl.ai/pricing)
+- [Flux vs Ideogram vs Recraft API comparison (APIScout)](https://apiscout.dev/guides/flux-vs-ideogram-vs-recraft-image-gen-api-2026)
+- [AI image generation API pricing — 12 providers (Digital Applied)](https://www.digitalapplied.com/blog/ai-image-generation-api-pricing-comparison-2026)
+- [AI image generation API pricing June 2026 (BuildMVPFast)](https://www.buildmvpfast.com/api-costs/ai-image)
+- [AI image pricing: Google vs OpenAI (IntuitionLabs)](https://intuitionlabs.ai/articles/ai-image-generation-pricing-google-openai)
+- [AI image generation API comparison 2026 (TokenMix)](https://tokenmix.ai/blog/ai-image-generation-api-comparison)
+- [Best AI image models 2026 (Melies)](https://melies.co/compare/ai-image-models)
+- [Keep AI images consistent — 7 techniques (ZSky AI)](https://zsky.ai/blog/ai-image-consistency-tips)
+- [AI art style libraries & keywords 2026 (GensGPT)](https://www.gensgpt.com/blog/ai-art-style-libraries-popular-styles-keywords-2026-guide)
+- [Replicate pricing](https://replicate.com/pricing)
+- [fal.ai image generators](https://fal.ai/learn/tools/ai-image-generators)
+
+> **Pricing caveat:** Image-API prices change frequently and vary by region, resolution, and aggregator markup. Figures above reflect June 2026 estimates aggregated from the sources listed — re-confirm against live vendor pricing pages before committing budget.

--- a/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
+++ b/agent-outputs/20260605-0532-ai-image-generation-for-course-illustrations.md
@@ -299,6 +299,8 @@ flowchart TD
 - **Hero/decorative art → Strategy B (transparent raster, theme-agnostic palette).** One asset, low maintenance; this should cover most chapters.
 - **Strategy C only for marquee images** where the extra asset is worth it. **Strategy D** is a stopgap, not a plan.
 
+> **Brand palette × dark mode:** DataSlope's palette (blue `#148CFF`, green `#20C621`, red `#FF4F59`, yellow `#FFDD6C`) is **dark-mode-native** — all four read well on dark; on white, yellow/green areas can look washed out. That's exactly why Strategy B's *transparent background + mid-tone palette* (or SVG) is the right default here. Full analysis — including how the same palette themes the rest of the site — is in `20260606-0540-brand-color-system.md` §7.
+
 ---
 
 ## 8. Image hosting & delivery at scale
@@ -395,13 +397,16 @@ Copy-paste prompts for the **Phase 0 bake-off** (§10). They're built on real Da
 
 ### A.0 Shared house-style preamble (prepend to every prompt)
 
-Replace the bracketed tokens with your real brand values once chosen (§11 Q1/Q3). Keeping this string **identical** across images is what creates a coherent set.
+These use DataSlope's **brand palette** (blue `#148CFF`, green `#20C621`, red `#FF4F59`, yellow `#FFDD6C`). Keep this string **identical** across images for a coherent set, and **cap each illustration to 2–3 of the four hues** to avoid a circus look. See the brand color report (`20260606-0540-brand-color-system.md`) for how the same palette themes the rest of the site and why it's dark-mode-native.
 
 ```
 Flat vector editorial illustration. Clean geometric shapes, generous negative
-space, limited palette of [#3B82F6 primary], [#F59E0B accent], and warm neutral
-tones, soft long shadows, subtle paper grain. Friendly, modern, calm. Centered
-composition with safe margins. Transparent background.
+space. Brand palette: azure blue #148CFF (primary), bright green #20C621, coral
+red #FF4F59, warm yellow #FFDD6C — use only 2–3 of these per image plus warm
+neutral tones. Mid-tone application (avoid washed-out pastels and pure-white or
+pure-black areas) so the art reads on BOTH light and dark backgrounds. Soft long
+shadows, subtle paper grain. Friendly, modern, calm. Centered composition with
+safe margins. Transparent background.
 NEGATIVE: no text, no letters, no numbers, no labels, no watermark, no UI chrome,
 no photorealism, no harsh pure-white or pure-black fills, no busy backgrounds.
 ```
@@ -483,7 +488,7 @@ lettering, correct spelling.
 
 ### A.7 Per-course accent variant (consistency probe)
 
-Re-run **A.1** with only the accent color swapped (e.g. `[#10B981 accent]` for a Python course vs. `[#3B82F6]` for R). Everything else identical. *Confirms the house-style system yields "same family, different course" rather than random drift (§5.2).*
+Re-run **A.1** holding the brand blue `#148CFF` as the constant primary and swapping only the secondary accent per course (e.g. green `#20C621` for an R course vs. yellow `#FFDD6C` for a Python course). Everything else identical. *Confirms the house-style system yields "same family, different course" rather than random drift (§5.2).*
 
 > **What to record per run:** model, exact prompt, seed, aspect ratio, whether transparency was native or post-processed, and a screenshot on **both** light and dark backgrounds. Drop the winners into the manifest schema from §6.3 as your "golden" references.
 

--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -193,17 +193,25 @@ Consistency comes from **meaning**, not just shared hex. Lock these mappings:
 
 ## 6. Migration plan
 
-> **Status: Phases 0–3 are implemented in this branch** (build green, lint clean, 445 unit tests pass). Phase 4 (de-dupe) and a light-mode home redesign remain.
+> **Status: Phases 0–4 are implemented in this branch** (build green, lint clean, 445 unit tests pass). Only a light-mode home **redesign** remains (a deliberate design decision, not a mechanical task).
 
 **Phase 0 — Define & QA — ✅ done.** `app/brand.css` ships the full ramps + ink + semantic-role tokens, imported once in `app/layout.tsx`. The **`/color-test`** route now renders the four ink anchors and all 40 ramp swatches (each with copy-to-clipboard), so it doubles as the acceptance gate.
 
 **Phase 1 — Playground — ✅ done.** `playground.css` repoints `--primary/--blue/--green/--red/--yellow` (and `--primary-glow` via `color-mix`) at the brand tokens. The editor-theme palettes (`THEME_PALETTES`) are deliberately untouched.
 
-**Phase 2 — Learn — ✅ done (primary/ring).** `learn.css` maps `--color-fd-primary` → `--ds-blue-ink` (light) / `--ds-blue-400` (dark) and `--color-fd-ring` → brand blue. Remapping individual callout/admonition accents is a follow-up if you want them brand-tinted too.
+**Phase 2 — Learn — ✅ done (primary/ring + callouts).** `learn.css` maps `--color-fd-primary` → `--ds-blue-ink` (light) / `--ds-blue-400` (dark) and `--color-fd-ring` → brand blue. **Callouts/admonitions are now brand-tinted too:** Fumadocs derives each callout's bar + icon from `--callout-color: var(--color-fd-<type>, --color-fd-muted)`, so `learn.css` defines `--color-fd-info/warning/error/success` (AA "ink" steps in light mode, brighter brand steps in dark) — info=blue, warning=yellow, error=red, success=green. This also adds color where callouts previously fell back to muted gray.
 
 **Phase 3 — Home — ✅ tokenized (still dark-only).** `root.module.css` now pulls its blue/green accents and the title gradient from the ramp (`var(--ds-blue)`, `var(--ds-green)`, `var(--ds-blue-400)`). It remains dark-only by design — **adding a light mode to the home route is a separate design decision** (no theme switch exists there yet) and was intentionally *not* done unilaterally.
 
-**Phase 4 — De-dupe — ⬜ todo.** Sweep the ~10 ad-hoc blues / multiple greens/ambers still hardcoded in component CSS modules and replace with tokens. Add a lint rule or CI grep to flag new raw-hex brand colors so drift doesn't return.
+**Phase 4 — De-dupe — ✅ done (interactive components).** The big repeated offenders now source from the brand ramp:
+- **`ChallengeCard.module.css`** — its documented `--ch-{blue,green,red}-*` palette scale + the `--ch-amber-500` accent + the dark-mode `.runBtn` literals all repoint to `--ds-*` (one audit surface, as the file's own comments intended).
+- **`MultipleChoiceQuestion.module.css`** — same treatment for the mirrored `--mc-*` scale, plus the badge/code-text literals.
+- **`sqlPlayground.css`** — its semantic accents (`--danger/--ok-accent/--err-accent/--accent`) were *never defined*, so every call site fell back to a hardcoded Tailwind hex. They're now defined once in `playground.css` `:root` → brand. The ~23 inline `var(--token, #hex)` fallbacks remain only as an inert safety net (the codebase's defensive pattern).
+- **`mermaid.module.css`** + **`playground/home.module.css`** — stray blue literals → `--ds-blue-400`.
+
+Deliberately **left alone:** non-brand decoratives (violet/purple `--ch-violet-*`, the SQL editor-theme palettes), neutral grays/surfaces/backgrounds, and a few dark-mode `rgba()` wash tints (perceptually identical at 12–30% alpha; not worth the churn/risk).
+
+*Not yet done:* a lint rule / CI grep to flag **new** raw-hex brand colors so drift doesn't creep back — recommended as a small follow-up.
 
 > Sequence rationale (as executed): playground → learn → home went from "tokens already exist" to "tokens partially exist (Fumadocs)" to "no tokens," i.e. easiest-to-hardest and lowest-to-highest visual risk.
 

--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -1,0 +1,225 @@
+# DataSlope Brand Color System — Usage Across `/`, `/learn`, `/playground`
+
+**Date:** 2026-06-06
+**Author:** Claude (research agent)
+**Scope:** How to apply the four-color brand palette consistently across the three styling "worlds" of the app (the home route, the Fumadocs `/learn` route, and the `/playground` route), with light/dark-mode accessibility, a concrete token architecture, and a migration plan. Companion to `20260605-0532-ai-image-generation-for-course-illustrations.md` (illustration feasibility is summarized in §7 here and detailed there).
+
+---
+
+## 1. The palette
+
+| Role (proposed) | Hex | Notes |
+|---|---|---|
+| **Primary — Blue** | `#148CFF` | Brand color; links, primary actions, active state, focus |
+| **Green** | `#20C621` | Success, "Run", correct answers, positive |
+| **Red** | `#FF4F59` | Errors, destructive, incorrect answers |
+| **Yellow** | `#FFDD6C` | Highlights, warnings, accents, "new" |
+
+These already appear in your mockup (alien, astronaut, topic chips) and the playground tokens are *almost* this blue already (`--primary: oklch(68% 0.18 250)` ≈ `#148CFF`), so alignment is low-friction.
+
+---
+
+## 2. The one thing that shapes everything: this palette is **dark-mode-native**
+
+WCAG contrast of each brand color against a white vs. a dark (`#121212`) background:
+
+| Color | On **white** | On **dark `#121212`** | Usable as… |
+|---|---|---|---|
+| Blue `#148CFF` | **3.37:1** | **5.55:1** | white → UI/large text/icons only; dark → body text ✓ |
+| Green `#20C621` | **2.29:1** | **8.17:1** | white → **decorative fill only**; dark → body text ✓ |
+| Red `#FF4F59` | **3.22:1** | **5.81:1** | white → UI/large text/icons only; dark → body text ✓ |
+| Yellow `#FFDD6C` | **1.33:1** | **14.10:1** | white → **highlight/fill only, never text**; dark → body text ✓ |
+
+WCAG AA needs **4.5:1** for body text, **3:1** for large/bold text, icons, and UI component boundaries.
+
+**Reading:** On **dark backgrounds the saturated palette is perfect** — every hue clears AA for body text. On **white**, the bright versions are too light for body text; blue and red just clear the 3:1 UI/large-text bar, while green and yellow are decorative-only.
+
+### 2.1 Consequence — you need two variants per hue
+
+Define, for each brand hue, a **bright "signal" value** (the hex above — used for fills, accents, dark-mode text, illustration) and a **darker "ink" value** for light-mode text/links/borders. Verified candidates that clear ~5:1 on white:
+
+| Hue | Bright "signal" | Light-mode **ink** (text/links on white) |
+|---|---|---|
+| Blue | `#148CFF` | **`#0A6ED6`** (4.98:1) |
+| Red | `#FF4F59` | **`#D5323C`** (4.83:1) |
+| Green | `#20C621` | **`#178017`** (5.08:1) |
+| Yellow | `#FFDD6C` | *(yellow can't be text on white — pair with* **`#8A6D00`** *amber-ink, 4.92:1, for warning text)* |
+
+> Generate a full 50–900 tint/shade ramp per hue with a tool (e.g. Leonardo, Radix Colors custom, or `oklch()` lightness steps) rather than hand-picking — but the four "ink" anchors above are the ones accessibility hinges on. **Re-verify any value you ship in a contrast checker.**
+
+---
+
+## 3. Why consistency is hard today: three independent styling worlds
+
+| Route | How it's styled now | Theme tokens | Light/dark |
+|---|---|---|---|
+| **`/` (home)** | `app/root.module.css` (CSS module), **hardcoded hex** | none | **dark-only** (`#0f1117` bg; gradient `#4f8ef7→#34d399`) |
+| **`/learn`** | `app/learn/learn.css` — **Tailwind v4 + Fumadocs UI** | `--color-fd-*` (Fumadocs) | light + dark via `.dark` class |
+| **`/playground`** | `app/_components/playground.css` + CSS modules | **`--primary/--blue/--green/--red/--yellow`** (OKLCH) + per-editor-theme palettes | light + dark via `applyMode` |
+
+Plus: colors are duplicated as raw hex across components (~10 distinct blues, multiple greens/ambers/reds). There is **no shared brand-token layer** any of the three can reference. `#148CFF` appears nowhere yet.
+
+**Theme mechanism is consistent, though:** all routes ride **next-themes**, which toggles a **`.dark` class on `<html>`** (confirmed in `app/learn/layout.tsx`, `mermaid.tsx`). That class is the universal hook for light/dark token swaps.
+
+---
+
+## 4. Proposed architecture: one brand-token layer, three adapters
+
+Introduce a single source of truth, then *adapt* it into each world rather than rewriting each world.
+
+### 4.1 Layer 1 — global brand tokens (`app/brand.css`, imported once)
+
+A plain CSS file with **raw hues** and **semantic roles** that remap for dark mode. No Tailwind needed, so it works for the CSS-module routes and Fumadocs alike. Import it in the root `app/layout.tsx` (it's tiny and framework-agnostic).
+
+```css
+/* app/brand.css — single source of truth for brand color */
+:root {
+  /* raw brand hues (bright "signal" values) */
+  --ds-blue:   #148CFF;
+  --ds-green:  #20C621;
+  --ds-red:    #FF4F59;
+  --ds-yellow: #FFDD6C;
+
+  /* light-mode "ink" variants (AA body text on white) */
+  --ds-blue-ink:   #0A6ED6;
+  --ds-green-ink:  #178017;
+  --ds-red-ink:    #D5323C;
+  --ds-amber-ink:  #8A6D00;
+
+  /* ── semantic roles — LIGHT MODE defaults ── */
+  --ds-primary:        var(--ds-blue);      /* fills, buttons, active bg */
+  --ds-link:           var(--ds-blue-ink);  /* text/links on light bg   */
+  --ds-focus:          var(--ds-blue);      /* focus ring               */
+  --ds-success:        var(--ds-green-ink);
+  --ds-success-fill:   var(--ds-green);
+  --ds-danger:         var(--ds-red-ink);
+  --ds-danger-fill:    var(--ds-red);
+  --ds-warning:        var(--ds-amber-ink);
+  --ds-warning-fill:   var(--ds-yellow);
+}
+
+.dark {
+  /* On dark bg the bright hues ARE the readable values, so roles
+     point straight at them — no ink variants needed. */
+  --ds-link:     var(--ds-blue);
+  --ds-success:  var(--ds-green);
+  --ds-danger:   var(--ds-red);
+  --ds-warning:  var(--ds-yellow);
+}
+```
+
+Use `color-mix()` for tints (the playground already does this): `color-mix(in srgb, var(--ds-primary) 12%, transparent)` for hover/selected backgrounds, so you never hand-pick a tint again.
+
+### 4.2 Layer 2 — three adapters
+
+**Home `/` (`root.module.css`):** replace hardcoded hex with the tokens, and add a light mode. The title gradient becomes `linear-gradient(135deg, var(--ds-blue), var(--ds-green))`; surfaces switch on `.dark`. This is the biggest visual change because the home route is currently dark-only.
+
+**Learn `/learn` (`learn.css`):** map the brand tokens onto the **Fumadocs** tokens — the file already has `:root:not(.dark)` and `.dark` hooks, so add:
+
+```css
+:root {
+  --color-fd-primary: var(--ds-link);          /* doc links, active nav */
+  --color-fd-ring:    var(--ds-focus);
+}
+.dark { --color-fd-primary: var(--ds-blue); }
+```
+
+…and similarly point callouts/admonitions at `--ds-warning-fill`, `--ds-danger`, etc. Fumadocs derives most accents from `--color-fd-primary`, so this one remap re-tints most of the docs UI.
+
+**Playground `/playground` (`playground.css`):** the static `:root` block (lines ~28–33) already defines `--primary/--blue/--green/--red/--yellow`. Point them at the brand tokens:
+
+```css
+:root {
+  --primary: var(--ds-primary);
+  --blue:    var(--ds-blue);
+  --green:   var(--ds-success);
+  --red:     var(--ds-danger);
+  --yellow:  var(--ds-warning);
+}
+```
+
+> **Leave the per-editor-theme palettes alone.** `THEME_PALETTES` / `applyThemePalette` deliberately recolor the chrome to match the *chosen code theme* (Dracula, Nord…). Those are user-selected editor aesthetics, not brand surfaces — keep them independent. Only the brand-signal tokens above should be unified.
+
+### 4.3 Result
+
+One file defines the palette; each route reads it through its native token system; the `.dark` class flips light↔dark everywhere at once. Adding a color or fixing a shade is a one-line change in `brand.css`.
+
+---
+
+## 5. Semantic usage rules (keep it disciplined)
+
+Consistency comes from **meaning**, not just shared hex. Lock these mappings:
+
+| Color | Means | Use for | Don't use for |
+|---|---|---|---|
+| **Blue** | primary / interactive | links, primary buttons, active nav, focus ring, brand moments | success or error states |
+| **Green** | success / go | "Run", passing tests, correct answers, positive deltas | links or generic accents (reads as "success") |
+| **Red** | error / stop | failures, destructive actions, wrong answers, validation errors | decoration (alarms users) |
+| **Yellow** | attention | highlights, warnings, "new" badges, callout accents | body text on light; large fills behind dark text only with care |
+
+**Accessibility do/don'ts:**
+- ✅ Use the **ink variants** for any text/link/icon on **light** backgrounds; use the **bright** hues for text on **dark**.
+- ✅ Bright hues are always fine for **fills, buttons, borders ≥3:1**, and **graphics/illustration**.
+- ❌ Never put **yellow text on white**, or **green body text on white**.
+- ✅ Pair colored fills with a foreground token that has ≥4.5:1 against the fill (e.g. white text on the blue button: white on `#148CFF` ≈ 3.4:1 → use for large/bold button labels, or darken the button slightly for small text).
+- ✅ Don't rely on color alone for meaning (correct/incorrect) — pair with an icon or label.
+
+---
+
+## 6. Migration plan
+
+**Phase 0 — Define & QA (½ day).** Add `app/brand.css` with the tokens from §4.1. Extend the existing **`/color-test`** route (it's already a palette harness) to render brand swatches + the ink variants with live contrast readouts in both modes. This is your acceptance gate.
+
+**Phase 1 — Playground.** Lowest-risk: it already has the token slots. Repoint `--primary/--blue/--green/--red/--yellow` to brand tokens; visually verify the Run button, error states, and selection tints across a couple of editor themes.
+
+**Phase 2 — Learn.** Remap `--color-fd-primary`/`--color-fd-ring` (and callout accents) to brand tokens in `learn.css`. Check links, active sidebar item, focus rings, and admonition colors in both modes.
+
+**Phase 3 — Home.** Replace hardcoded hex in `root.module.css` with tokens **and add a light mode** (currently dark-only). Biggest visual delta — do it last, with design review.
+
+**Phase 4 — De-dupe.** Sweep the ~10 ad-hoc blues / multiple greens/ambers in component CSS modules and replace with tokens. Add a lint rule or CI grep to flag new raw-hex brand colors so drift doesn't return.
+
+> Sequence rationale: playground → learn → home goes from "tokens already exist" to "tokens partially exist (Fumadocs)" to "no tokens + needs a new light mode," i.e. easiest-to-hardest and lowest-to-highest visual risk.
+
+---
+
+## 7. Feasibility for AI illustration generation (light **and** dark mode)
+
+**Short answer: yes — and this palette is especially well-suited to it, with one rule.**
+
+The same dark-native asymmetry from §2 applies to illustrations, but illustrations are **graphics, not text**, so they live under the 3:1 UI bar, not the 4.5:1 text bar — which gives more freedom. Practical guidance:
+
+- **On dark mode:** the bright palette is ideal — saturated blue/green/red/yellow shapes pop against `#121212`. No adjustment needed.
+- **On light mode:** large saturated **shapes** read fine on white, but **yellow and light-green areas can look weak/washed** on a pure-white page. Mitigate by: (a) giving shapes a subtle darker outline or shadow, (b) composing on the brand's **off-white surface** rather than pure `#fff`, or (c) leaning on blue/red as the dominant hues with yellow/green as accents.
+- **The rule (ties to the illustration report §7):** generate art with a **transparent background** and a **theme-agnostic, mid-tone application** of the palette so a single asset reads on both themes — OR use **SVG** (Recraft) where fills can be brand tokens and even adapt via CSS. Avoid baking pure-white or pure-black backgrounds into raster art.
+- **Consistency:** feed these exact hex values into the house-style prompt preamble (already updated in the illustration report) and cap each illustration to **2–3 of the four** brand colors to avoid a circus look. Use the per-course accent trick (swap one hue per course) for variety within the system.
+
+**Verdict:** the palette is a strong fit for AI illustration in both modes. Dark mode is "free"; light mode needs the transparent-background + mid-tone discipline already recommended for illustrations generally. See `20260605-0532-ai-image-generation-for-course-illustrations.md` §7 and Appendix A for the prompt mechanics.
+
+---
+
+## 8. Summary
+
+1. **Adopt two values per hue** — a bright "signal" (your four hex) and a darker "ink" for light-mode text. The palette is dark-native; light mode needs the ink variants.
+2. **One `app/brand.css` token layer**, adapted into each of the three worlds (CSS modules → tokens, Fumadocs `--color-fd-*` remap, playground `--primary/...` remap). The `.dark` class flips everything.
+3. **Lock semantic meaning** (blue=primary, green=success, red=error, yellow=attention) and the accessibility do/don'ts.
+4. **Migrate playground → learn → home**, using `/color-test` as the QA gate; then de-dupe ad-hoc hex.
+5. **Illustrations:** feasible and well-suited in both modes — transparent backgrounds + mid-tone palette use (or SVG), bright hues for dark, slightly tempered for light.
+
+---
+
+## Appendix — contrast reference (for the QA harness)
+
+WCAG AA: **4.5:1** body text · **3:1** large/bold text, icons, UI boundaries.
+
+| Foreground | on white `#fff` | on dark `#121212` |
+|---|---|---|
+| Blue `#148CFF` | 3.37 | 5.55 |
+| Green `#20C621` | 2.29 | 8.17 |
+| Red `#FF4F59` | 3.22 | 5.81 |
+| Yellow `#FFDD6C` | 1.33 | 14.10 |
+| Blue-ink `#0A6ED6` | 4.98 | — |
+| Red-ink `#D5323C` | 4.83 | — |
+| Green-ink `#178017` | 5.08 | — |
+| Amber-ink `#8A6D00` | 4.92 | — |
+
+*Computed via the standard WCAG relative-luminance formula; re-verify any shipped value in a contrast checker.*

--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -217,7 +217,7 @@ Deliberately **left alone:** non-brand decoratives (violet/purple `--ch-violet-*
 
 **Phase 5 — Variable cleanup — ✅ done.** Once the components pulled brand colors from `--ds-*`, their local Tailwind-style palette scales (`--ch-*`, `--mc-*`) became a redundant pass-through layer. Cleaned up:
 - **ChallengeCard:** 81 → **46** vars (−43%). The `--ch-{blue,green,red,amber}-NNN` numeric steps were collapsed — every usage now points at `--ds-*` directly (a provably appearance-preserving change, since each step already resolved to the identical `--ds-*` value), and the dead `--ch-purple*`, unused slates, and `--ch-badge-bg/border` were removed. Only the **neutral** Tailwind palette + the **semantic aliases** (`--ch-accent`, `--ch-bg`, `--ch-green`…) remain.
-- **MultipleChoiceQuestion:** 57 → **26** vars (−54%), same treatment.
+- **MultipleChoiceQuestion:** 57 → **24** vars (−58%), same treatment. A follow-up pass also migrated its **dark-mode block** — which still hardcoded Tailwind hues (`rgba(22,163,74,…)` green, `rgba(220,38,38,…)` red, `rgba(217,119,6,…)` amber, `rgba(59,130,246,…)` blue, and `#86efac`/`#fca5a5`/`#fcd34d` verdict text) — to brand tokens (washes via `color-mix(... var(--ds-*) …)`, text via the `--ds-*-300` ramp). MCQ now sources **every** brand color from the palette in both light and dark; only neutrals/surfaces remain as literals.
 - **CodeBlock:** repointed `--cb-yellow` off the removed `--ch-amber-500` to `--ds-yellow-500`; dropped the dead `--cb-white`/`--cb-font-ui`. (Note: CodeBlock consumes ChallengeCard's `--ch-*` cross-file — verified before any removal.)
 - **learn.css:** merged the duplicate `:root:not(.dark)` / `.dark` brand→Fumadocs blocks into one pair.
 

--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -45,7 +45,24 @@ Define, for each brand hue, a **bright "signal" value** (the hex above — used 
 | Green | `#20C621` | **`#178017`** (5.08:1) |
 | Yellow | `#FFDD6C` | *(yellow can't be text on white — pair with* **`#8A6D00`** *amber-ink, 4.92:1, for warning text)* |
 
-> Generate a full 50–900 tint/shade ramp per hue with a tool (e.g. Leonardo, Radix Colors custom, or `oklch()` lightness steps) rather than hand-picking — but the four "ink" anchors above are the ones accessibility hinges on. **Re-verify any value you ship in a contrast checker.**
+### 2.2 The full 50–900 tonal ramps
+
+Generated in **OKLCH** (constant hue; lightness/chroma interpolated toward white for the light steps and toward near-black for the dark steps; every value gamut-mapped to valid sRGB). **500 = your exact brand color.** These are now shipped in `app/brand.css` as `--ds-{hue}-{step}` tokens; the "ink" roles in §2.1 are remapped onto ramp steps (`blue-700`, `green-800`, `red-700`, `yellow-800`) so everything references one ramp.
+
+| Step | Blue | Green | Red | Yellow |
+|---|---|---|---|---|
+| 50  | `#E8F2FF` | `#E8F9E6` | `#FFEDEC` | `#FDF8E8` |
+| 100 | `#D1E6FF` | `#D4F3D1` | `#FFDCDA` | `#FDF5D9` |
+| 200 | `#AED3FF` | `#B4EAAF` | `#FFC2BF` | `#FEF0C3` |
+| 300 | `#8ABFFF` | `#93E08E` | `#FFA6A3` | `#FEEBAC` |
+| 400 | `#5BA7FF` | `#66D361` | `#FF807F` | `#FFE48E` |
+| **500** | **`#148CFF`** | **`#20C621`** | **`#FF4F59`** | **`#FFDD6C`** |
+| 600 | `#0878DD` | `#0AA80F` | `#DC3F49` | `#D4B651` |
+| 700 | `#0064BD` | `#008B03` | `#BA303A` | `#AB9137` |
+| 800 | `#00519C` | `#006F01` | `#99212C` | `#836D1C` |
+| 900 | `#00407F` | `#005600` | `#7C141F` | `#624F00` |
+
+**Text-on-white safety (WCAG AA, ≥4.5:1 body):** Blue ≥ **700** (5.9:1), Green ≥ **800** (6.4:1; 700 is 4.5 borderline), Red ≥ **700** (5.9:1), Yellow ≥ **800** (5.0:1). On dark (`#121212`) the 500s and below all clear AA. Pick a 600/700 for hover/pressed states of a 500 fill. *Re-verify any shipped text value in a contrast checker.*
 
 ---
 
@@ -59,7 +76,13 @@ Define, for each brand hue, a **bright "signal" value** (the hex above — used 
 
 Plus: colors are duplicated as raw hex across components (~10 distinct blues, multiple greens/ambers/reds). There is **no shared brand-token layer** any of the three can reference. `#148CFF` appears nowhere yet.
 
-**Theme mechanism is consistent, though:** all routes ride **next-themes**, which toggles a **`.dark` class on `<html>`** (confirmed in `app/learn/layout.tsx`, `mermaid.tsx`). That class is the universal hook for light/dark token swaps.
+**Theme mechanisms differ per route** (verified in code — an earlier draft of this report over-simplified this):
+
+- **`/learn`** uses **next-themes** (via Fumadocs `RootProvider`), toggling a **`.dark` class** on `<html>`.
+- **`/playground`** uses a **`data-theme="light|dark"` attribute** on `<html>`, driven by the selected editor theme (`applyMode` in `playgroundTheme.ts`) — *not* next-themes.
+- **`/`** has **no theme switch at all** — it's hardcoded dark.
+
+So there is no single universal hook. The fix (below) keeps token **values** global and has each route's dark override target **both** `.dark` *and* `[data-theme="dark"]`, while the dark-only home consumes the raw bright ramp directly.
 
 ---
 
@@ -70,6 +93,8 @@ Introduce a single source of truth, then *adapt* it into each world rather than 
 ### 4.1 Layer 1 — global brand tokens (`app/brand.css`, imported once)
 
 A plain CSS file with **raw hues** and **semantic roles** that remap for dark mode. No Tailwind needed, so it works for the CSS-module routes and Fumadocs alike. Import it in the root `app/layout.tsx` (it's tiny and framework-agnostic).
+
+> The snippet below is an **abridged illustration**. The **authoritative version shipped in `app/brand.css`** also includes the full 50–900 ramps from §2.2 and targets both dark hooks (`.dark, [data-theme="dark"]`). Read that file for the exact tokens.
 
 ```css
 /* app/brand.css — single source of truth for brand color */
@@ -168,17 +193,19 @@ Consistency comes from **meaning**, not just shared hex. Lock these mappings:
 
 ## 6. Migration plan
 
-**Phase 0 — Define & QA (½ day).** Add `app/brand.css` with the tokens from §4.1. Extend the existing **`/color-test`** route (it's already a palette harness) to render brand swatches + the ink variants with live contrast readouts in both modes. This is your acceptance gate.
+> **Status: Phases 0–3 are implemented in this branch** (build green, lint clean, 445 unit tests pass). Phase 4 (de-dupe) and a light-mode home redesign remain.
 
-**Phase 1 — Playground.** Lowest-risk: it already has the token slots. Repoint `--primary/--blue/--green/--red/--yellow` to brand tokens; visually verify the Run button, error states, and selection tints across a couple of editor themes.
+**Phase 0 — Define & QA — ✅ done.** `app/brand.css` ships the full ramps + ink + semantic-role tokens, imported once in `app/layout.tsx`. The **`/color-test`** route now renders the four ink anchors and all 40 ramp swatches (each with copy-to-clipboard), so it doubles as the acceptance gate.
 
-**Phase 2 — Learn.** Remap `--color-fd-primary`/`--color-fd-ring` (and callout accents) to brand tokens in `learn.css`. Check links, active sidebar item, focus rings, and admonition colors in both modes.
+**Phase 1 — Playground — ✅ done.** `playground.css` repoints `--primary/--blue/--green/--red/--yellow` (and `--primary-glow` via `color-mix`) at the brand tokens. The editor-theme palettes (`THEME_PALETTES`) are deliberately untouched.
 
-**Phase 3 — Home.** Replace hardcoded hex in `root.module.css` with tokens **and add a light mode** (currently dark-only). Biggest visual delta — do it last, with design review.
+**Phase 2 — Learn — ✅ done (primary/ring).** `learn.css` maps `--color-fd-primary` → `--ds-blue-ink` (light) / `--ds-blue-400` (dark) and `--color-fd-ring` → brand blue. Remapping individual callout/admonition accents is a follow-up if you want them brand-tinted too.
 
-**Phase 4 — De-dupe.** Sweep the ~10 ad-hoc blues / multiple greens/ambers in component CSS modules and replace with tokens. Add a lint rule or CI grep to flag new raw-hex brand colors so drift doesn't return.
+**Phase 3 — Home — ✅ tokenized (still dark-only).** `root.module.css` now pulls its blue/green accents and the title gradient from the ramp (`var(--ds-blue)`, `var(--ds-green)`, `var(--ds-blue-400)`). It remains dark-only by design — **adding a light mode to the home route is a separate design decision** (no theme switch exists there yet) and was intentionally *not* done unilaterally.
 
-> Sequence rationale: playground → learn → home goes from "tokens already exist" to "tokens partially exist (Fumadocs)" to "no tokens + needs a new light mode," i.e. easiest-to-hardest and lowest-to-highest visual risk.
+**Phase 4 — De-dupe — ⬜ todo.** Sweep the ~10 ad-hoc blues / multiple greens/ambers still hardcoded in component CSS modules and replace with tokens. Add a lint rule or CI grep to flag new raw-hex brand colors so drift doesn't return.
+
+> Sequence rationale (as executed): playground → learn → home went from "tokens already exist" to "tokens partially exist (Fumadocs)" to "no tokens," i.e. easiest-to-hardest and lowest-to-highest visual risk.
 
 ---
 
@@ -200,7 +227,7 @@ The same dark-native asymmetry from §2 applies to illustrations, but illustrati
 ## 8. Summary
 
 1. **Adopt two values per hue** — a bright "signal" (your four hex) and a darker "ink" for light-mode text. The palette is dark-native; light mode needs the ink variants.
-2. **One `app/brand.css` token layer**, adapted into each of the three worlds (CSS modules → tokens, Fumadocs `--color-fd-*` remap, playground `--primary/...` remap). The `.dark` class flips everything.
+2. **One `app/brand.css` token layer** (✅ shipped), adapted into each of the three worlds (CSS modules → tokens, Fumadocs `--color-fd-*` remap, playground `--primary/...` remap). Dark overrides target both `.dark` (/learn) and `[data-theme="dark"]` (/playground); dark-only home uses the raw ramp.
 3. **Lock semantic meaning** (blue=primary, green=success, red=error, yellow=attention) and the accessibility do/don'ts.
 4. **Migrate playground → learn → home**, using `/color-test` as the QA gate; then de-dupe ad-hoc hex.
 5. **Illustrations:** feasible and well-suited in both modes — transparent backgrounds + mid-tone palette use (or SVG), bright hues for dark, slightly tempered for light.

--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -215,6 +215,14 @@ Deliberately **left alone:** non-brand decoratives (violet/purple `--ch-violet-*
 
 > Sequence rationale (as executed): playground → learn → home went from "tokens already exist" to "tokens partially exist (Fumadocs)" to "no tokens," i.e. easiest-to-hardest and lowest-to-highest visual risk.
 
+**Phase 5 — Variable cleanup — ✅ done.** Once the components pulled brand colors from `--ds-*`, their local Tailwind-style palette scales (`--ch-*`, `--mc-*`) became a redundant pass-through layer. Cleaned up:
+- **ChallengeCard:** 81 → **46** vars (−43%). The `--ch-{blue,green,red,amber}-NNN` numeric steps were collapsed — every usage now points at `--ds-*` directly (a provably appearance-preserving change, since each step already resolved to the identical `--ds-*` value), and the dead `--ch-purple*`, unused slates, and `--ch-badge-bg/border` were removed. Only the **neutral** Tailwind palette + the **semantic aliases** (`--ch-accent`, `--ch-bg`, `--ch-green`…) remain.
+- **MultipleChoiceQuestion:** 57 → **26** vars (−54%), same treatment.
+- **CodeBlock:** repointed `--cb-yellow` off the removed `--ch-amber-500` to `--ds-yellow-500`; dropped the dead `--cb-white`/`--cb-font-ui`. (Note: CodeBlock consumes ChallengeCard's `--ch-*` cross-file — verified before any removal.)
+- **learn.css:** merged the duplicate `:root:not(.dark)` / `.dark` brand→Fumadocs blocks into one pair.
+
+Net **−90 lines**, **0 dangling references**, build green, 445 tests pass.
+
 ---
 
 ## 7. Feasibility for AI illustration generation (light **and** dark mode)

--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -221,7 +221,11 @@ Deliberately **left alone:** non-brand decoratives (violet/purple `--ch-violet-*
 - **CodeBlock:** repointed `--cb-yellow` off the removed `--ch-amber-500` to `--ds-yellow-500`; dropped the dead `--cb-white`/`--cb-font-ui`. (Note: CodeBlock consumes ChallengeCard's `--ch-*` cross-file — verified before any removal.)
 - **learn.css:** merged the duplicate `:root:not(.dark)` / `.dark` brand→Fumadocs blocks into one pair.
 
-Net **−90 lines**, **0 dangling references**, build green, 445 tests pass.
+**Phase 6 — Shared neutral foundation — ✅ done.** The last duplication was the **neutral gray scale**, defined identically in *both* ChallengeCard (`--ch-gray-*`) and MCQ (`--mc-gray-*`) and consumed cross-file by CodeBlock. Hoisted a single Tailwind gray ramp (`--ds-gray-50…900`) plus `--ds-white`/`--ds-black` into `app/brand.css`, and pointed all three components at it (gray/white/black usages → `--ds-*`, local scales deleted). Appearance-preserving (the `--ds-gray-NNN` values equal the Tailwind values the components already used) and slightly **more robust** — code blocks now resolve neutrals from `:root` instead of relying on a `.card` ancestor.
+- ChallengeCard local vars **46 → 34**; MCQ **24 → 15**; ~88 references now share the ramp.
+- ChallengeCard keeps a small local `--ch-slate-*` set (cool-gray surfaces — *not* duplicated elsewhere, so left in place).
+
+Across Phases 5–6: **ChallengeCard 81 → 34** unique vars (−58%), **MCQ 57 → 15** (−74%). **0 dangling references**, build green, lint clean, 445 tests pass throughout.
 
 ---
 
@@ -243,7 +247,7 @@ The same dark-native asymmetry from §2 applies to illustrations, but illustrati
 ## 8. Summary
 
 1. **Adopt two values per hue** — a bright "signal" (your four hex) and a darker "ink" for light-mode text. The palette is dark-native; light mode needs the ink variants.
-2. **One `app/brand.css` token layer** (✅ shipped), adapted into each of the three worlds (CSS modules → tokens, Fumadocs `--color-fd-*` remap, playground `--primary/...` remap). Dark overrides target both `.dark` (/learn) and `[data-theme="dark"]` (/playground); dark-only home uses the raw ramp.
+2. **One `app/brand.css` token layer** (✅ shipped) — brand hue ramps, ink anchors, semantic roles, **and a shared neutral ramp (`--ds-gray-*`, `--ds-white/black`)** — adapted into each of the three worlds (CSS modules → tokens, Fumadocs `--color-fd-*` remap, playground `--primary/...` remap). Dark overrides target both `.dark` (/learn) and `[data-theme="dark"]` (/playground); dark-only home uses the raw ramp. Components (challenge cards, quizzes, code blocks) keep only semantic aliases — all literal palette values now live in `brand.css`.
 3. **Lock semantic meaning** (blue=primary, green=success, red=error, yellow=attention) and the accessibility do/don'ts.
 4. **Migrate playground → learn → home**, using `/color-test` as the QA gate; then de-dupe ad-hoc hex.
 5. **Illustrations:** feasible and well-suited in both modes — transparent backgrounds + mid-tone palette use (or SVG), bright hues for dark, slightly tempered for light.

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -25,37 +25,25 @@
      module uses. */
 
   /* Local neutral palette (Tailwind) */
-  --ch-white: #ffffff;
-  --ch-black: #000000;
   --ch-slate-50: #f8fafc;
   --ch-slate-100: #f1f5f9;
   --ch-slate-200: #e2e8f0;
   --ch-slate-900: #0f172a;
-  --ch-gray-50: #f9fafb;
-  --ch-gray-100: #f3f4f6;
-  --ch-gray-200: #e5e7eb;
-  --ch-gray-300: #d1d5db;
-  --ch-gray-400: #9ca3af;
-  --ch-gray-500: #6b7280;
-  --ch-gray-700: #374151;
-  --ch-gray-800: #1f2937;
-  --ch-gray-900: #111827;
-  --ch-neutral-50: #fafafa;
   --ch-violet-50: #f5f3ff;
   --ch-violet-100: #ede9fe;
   --ch-violet-500: #8b5cf6;
   --ch-violet-600: #7c3aed;
 
   /* Semantic aliases */
-  --ch-bg: var(--ch-white);
-  --ch-bg-muted: var(--ch-neutral-50);
-  --ch-bg-subtle: var(--ch-gray-50);
-  --ch-bg-hover: var(--ch-gray-100);
-  --ch-border: var(--ch-gray-200);
-  --ch-border-light: var(--ch-gray-100);
-  --ch-text: var(--ch-gray-900);
-  --ch-text-secondary: var(--ch-gray-500);
-  --ch-text-muted: var(--ch-gray-400);
+  --ch-bg: var(--ds-white);
+  --ch-bg-muted: var(--ds-gray-50);
+  --ch-bg-subtle: var(--ds-gray-50);
+  --ch-bg-hover: var(--ds-gray-100);
+  --ch-border: var(--ds-gray-200);
+  --ch-border-light: var(--ds-gray-100);
+  --ch-text: var(--ds-gray-900);
+  --ch-text-secondary: var(--ds-gray-500);
+  --ch-text-muted: var(--ds-gray-400);
   --ch-accent: var(--ds-blue-600);
   --ch-accent-hover: var(--ds-blue-700);
   --ch-accent-disabled: var(--ds-blue-300);
@@ -65,8 +53,8 @@
   --ch-red: var(--ds-red-600);
   --ch-red-bg: var(--ds-red-50);
   --ch-badge-color: var(--ch-accent);
-  --ch-scrollbar-thumb: var(--ch-gray-300);
-  --ch-scrollbar-thumb-hover: var(--ch-gray-400);
+  --ch-scrollbar-thumb: var(--ds-gray-300);
+  --ch-scrollbar-thumb-hover: var(--ds-gray-400);
   /* Modal backdrop: slate-900 at 55% opacity. */
   --ch-overlay: color-mix(in srgb, var(--ch-slate-900) 55%, transparent);
 
@@ -75,8 +63,8 @@
     "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   --ch-radius: 8px;
   --ch-shadow:
-    0 1px 3px color-mix(in srgb, var(--ch-black) 8%, transparent),
-    0 1px 2px color-mix(in srgb, var(--ch-black) 5%, transparent);
+    0 1px 3px color-mix(in srgb, var(--ds-black) 8%, transparent),
+    0 1px 2px color-mix(in srgb, var(--ds-black) 5%, transparent);
 
   background: var(--ch-bg);
   border: 1px solid var(--ch-border);
@@ -140,7 +128,7 @@
   width: 13px;
   height: 13px;
   flex-shrink: 0;
-  color: var(--ch-gray-900);
+  color: var(--ds-gray-900);
 }
 
 .badge {
@@ -379,10 +367,10 @@
 .instructionsBody code {
   font-family: var(--ch-font-mono);
   font-size: 12px;
-  background: var(--ch-gray-100);
+  background: var(--ds-gray-100);
   border-radius: 4px;
   padding: 1px 5px;
-  color: var(--ch-gray-900);
+  color: var(--ds-gray-900);
 }
 
 .instructionsBody ul,
@@ -621,7 +609,7 @@
   padding: 6px 14px;
   background: var(--ch-bg);
   border: none;
-  color: var(--ch-gray-700);
+  color: var(--ds-gray-700);
   font-family: var(--ch-font-ui);
   font-size: 12px;
   font-weight: 400;
@@ -630,7 +618,7 @@
 }
 
 .initToggle:hover {
-  color: var(--ch-gray-900);
+  color: var(--ds-gray-900);
   background: var(--ch-bg-hover);
 }
 
@@ -644,7 +632,7 @@
   width: 100%;
   padding: 6px 14px;
   background: var(--ch-bg);
-  color: var(--ch-gray-700);
+  color: var(--ds-gray-700);
   font-family: var(--ch-font-ui);
   font-size: 12px;
   font-weight: 400;
@@ -670,7 +658,7 @@
 .initLabel {
   flex: 1;
   letter-spacing: 0;
-  color: var(--ch-gray-700);
+  color: var(--ds-gray-700);
 }
 
 .initMeta {
@@ -831,13 +819,13 @@
   font-family: var(--ch-font-ui);
   font-size: 12px;
   font-weight: 500;
-  color: var(--ch-gray-700);
+  color: var(--ds-gray-700);
   cursor: pointer;
   transition: color 0.12s, background 0.12s;
 }
 
 .initCollapseBtn:hover {
-  color: var(--ch-gray-900);
+  color: var(--ds-gray-900);
   background: var(--ch-bg-hover);
 }
 
@@ -919,7 +907,7 @@
 /* Hairline divider between the main Submit/Run pill and the chevron
    that opens the dropdown — only when both halves are present. */
 .btnGroupPrimary .runBtn:not(:last-child) {
-  border-right: 1px solid color-mix(in srgb, var(--ch-white) 22%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--ds-white) 22%, transparent);
 }
 
 /* Chevron half of the split button — same accent fill as the main
@@ -927,7 +915,7 @@
    arrow. Anchored to the right of `.btnGroupPrimary`. */
 .runBtnChevron {
   background: var(--ch-accent);
-  color: var(--ch-white);
+  color: var(--ds-white);
   border: none;
   padding: 0 8px;
   cursor: pointer;
@@ -984,15 +972,13 @@
    Tailwind palette + semantic tokens the menu actually needs here so
    the popup renders with the same blue chrome as the Submit button. */
 .runMenuPopup {
-  --ch-white: #ffffff;
-  --ch-black: #000000;
 
   background: #1a1a1a;
   border: 1px solid #333333;
   border-radius: 8px;
   box-shadow:
-    0 1px 2px color-mix(in srgb, var(--ch-black) 12%, transparent),
-    0 8px 24px color-mix(in srgb, var(--ch-black) 22%, transparent);
+    0 1px 2px color-mix(in srgb, var(--ds-black) 12%, transparent),
+    0 8px 24px color-mix(in srgb, var(--ds-black) 22%, transparent);
   min-width: 240px;
   font-family: "Inter", system-ui, -apple-system, sans-serif;
   outline: none;
@@ -1007,7 +993,7 @@
   background: transparent;
   border: none;
   border-radius: 5px;
-  color: var(--ch-white);
+  color: var(--ds-white);
   font-size: 14px;
   cursor: pointer;
   text-align: left;
@@ -1040,9 +1026,9 @@
 /* Kbd chips inside the menu mirror the embedded kbd inside the Run
    button — semi-transparent white pill on the accent background. */
 .runMenuKbd .kbd {
-  background: color-mix(in srgb, var(--ch-white) 16%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ch-white) 28%, transparent);
-  color: color-mix(in srgb, var(--ch-white) 88%, transparent);
+  background: color-mix(in srgb, var(--ds-white) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ds-white) 28%, transparent);
+  color: color-mix(in srgb, var(--ds-white) 88%, transparent);
   box-shadow: none;
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   font-size: 11.5px;
@@ -1053,13 +1039,13 @@
 }
 
 .runMenuKbd .kbdSep {
-  color: color-mix(in srgb, var(--ch-white) 50%, transparent);
+  color: color-mix(in srgb, var(--ds-white) 50%, transparent);
   font-size: 12px;
 }
 
 .runBtn {
   background: #1a1a1a;
-  color: var(--ch-white);
+  color: var(--ds-white);
   border: none;
   padding: 6px 12px;
   font-size: 14px;
@@ -1124,18 +1110,18 @@
 }
 
 .runBtn .btnKbd .kbd {
-  background: color-mix(in srgb, var(--ch-white) 16%, transparent);
-  border-color: color-mix(in srgb, var(--ch-white) 28%, transparent);
-  color: color-mix(in srgb, var(--ch-white) 88%, transparent);
+  background: color-mix(in srgb, var(--ds-white) 16%, transparent);
+  border-color: color-mix(in srgb, var(--ds-white) 28%, transparent);
+  color: color-mix(in srgb, var(--ds-white) 88%, transparent);
   box-shadow: none;
 }
 
 .runBtn .btnKbd .kbdSep {
-  color: color-mix(in srgb, var(--ch-white) 50%, transparent);
+  color: color-mix(in srgb, var(--ds-white) 50%, transparent);
 }
 
 .kbd {
-  background: var(--ch-white);
+  background: var(--ds-white);
   border: 1px solid var(--ch-border);
   border-radius: 4px;
   padding: 2px 5px;
@@ -1397,8 +1383,8 @@
   opacity: 0;
   transition: opacity 0.18s ease;
   z-index: 0;
-  -webkit-mask-image: linear-gradient(to top, var(--ch-black) 35%, transparent 100%);
-  mask-image: linear-gradient(to top, var(--ch-black) 35%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to top, var(--ds-black) 35%, transparent 100%);
+  mask-image: linear-gradient(to top, var(--ds-black) 35%, transparent 100%);
 }
 
 .runOverlay.runOverlayActive {
@@ -1561,9 +1547,9 @@
 }
 
 .testPill[data-state="pending"] {
-  background: var(--ch-gray-100);
+  background: var(--ds-gray-100);
   color: var(--ch-text-muted);
-  border: 1px solid var(--ch-gray-200);
+  border: 1px solid var(--ds-gray-200);
 }
 
 .testChevron {
@@ -1588,7 +1574,7 @@
   gap: 8px;
   padding: 8px 10px;
   border-radius: 6px;
-  background: var(--ch-white);
+  background: var(--ds-white);
   border: 1px solid var(--ch-border-light);
 }
 
@@ -1614,7 +1600,7 @@
 }
 
 .testIcon[data-state="pending"] {
-  background: var(--ch-gray-100);
+  background: var(--ds-gray-100);
   color: var(--ch-text-muted);
 }
 
@@ -1875,10 +1861,10 @@
   --ch-red-bg: color-mix(in srgb, var(--ds-red-500) 12%, transparent);
   /* Badge inherits the dark-mode accent (the var() declared above
      auto-tracks --ch-accent), but bg/border need explicit dark tints. */
-  --ch-overlay: color-mix(in srgb, var(--ch-black) 65%, transparent);
+  --ch-overlay: color-mix(in srgb, var(--ds-black) 65%, transparent);
   --ch-shadow:
-    0 1px 2px color-mix(in srgb, var(--ch-black) 50%, transparent),
-    0 1px 3px color-mix(in srgb, var(--ch-black) 40%, transparent);
+    0 1px 2px color-mix(in srgb, var(--ds-black) 50%, transparent),
+    0 1px 3px color-mix(in srgb, var(--ds-black) 40%, transparent);
 }
 
 /* Match CodeMirror editor background to page background in dark mode —
@@ -1903,7 +1889,7 @@
 
 :global(html.dark) .initToggle,
 :global(html.dark) .initHeaderStatic {
-  color: var(--ch-gray-300);
+  color: var(--ds-gray-300);
 }
 
 :global(html.dark) .initToggle:hover {
@@ -1912,11 +1898,11 @@
 }
 
 :global(html.dark) .initLabel {
-  color: var(--ch-gray-300);
+  color: var(--ds-gray-300);
 }
 
 :global(html.dark) .initCollapseBtn {
-  color: var(--ch-gray-300);
+  color: var(--ds-gray-300);
 }
 
 :global(html.dark) .initCollapseBtn:hover {
@@ -2275,10 +2261,10 @@
 }
 
 .tableViewerEmpty code {
-  background: var(--ch-gray-100);
+  background: var(--ds-gray-100);
   border-radius: 3px;
   padding: 1px 5px;
-  color: var(--ch-gray-900);
+  color: var(--ds-gray-900);
 }
 
 :global(html.dark) .tableViewerEmpty code {
@@ -2325,8 +2311,8 @@
   letter-spacing: -0.01em;
   border-radius: 6px;
   box-shadow:
-    0 10px 25px color-mix(in srgb, var(--ch-black) 15%, transparent),
-    0 4px 10px color-mix(in srgb, var(--ch-black) 10%, transparent);
+    0 10px 25px color-mix(in srgb, var(--ds-black) 15%, transparent),
+    0 4px 10px color-mix(in srgb, var(--ds-black) 10%, transparent);
   animation: ch-toast-in 0.16s ease-out;
   max-width: 320px;
 }
@@ -2341,7 +2327,7 @@
   justify-content: center;
   background: transparent;
   border: none;
-  color: color-mix(in srgb, var(--ch-gray-50) 70%, transparent);
+  color: color-mix(in srgb, var(--ds-gray-50) 70%, transparent);
   padding: 2px;
   border-radius: 3px;
   cursor: pointer;
@@ -2349,8 +2335,8 @@
 }
 
 .toast>button:hover {
-  color: var(--ch-white);
-  background: color-mix(in srgb, var(--ch-white) 12%, transparent);
+  color: var(--ds-white);
+  background: color-mix(in srgb, var(--ds-white) 12%, transparent);
 }
 
 @keyframes ch-toast-in {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -15,26 +15,22 @@
      CodeBlock — challenges are meant to feel like a worksheet, not a
      console.
 
-     Color tokens come straight from the Tailwind v4 palette
-     (https://tailwindcss.com/docs/colors). Palette tokens live in
-     the first block; the semantic aliases (--ch-bg, --ch-text…)
-     that the rest of the module references are derived from them.
-     We duplicate the palette locally rather than reading Tailwind's
-     own `--color-…` vars because Tailwind's preflight is only
-     imported on /learn; this module is also used by /playground. */
+     Neutral tokens (grays/slates) come from the Tailwind v4 palette
+     (https://tailwindcss.com/docs/colors) and live locally in the first
+     block, because Tailwind's preflight is only imported on /learn while
+     this module is also used by /playground. Brand colors — accent/success/
+     error — are NOT duplicated here: the semantic aliases below reference the
+     global brand ramp (`--ds-*` from app/brand.css) directly. The semantic
+     aliases (--ch-bg, --ch-text, --ch-accent…) are what the rest of the
+     module uses. */
 
-  /* Tailwind palette tokens */
+  /* Local neutral palette (Tailwind) */
   --ch-white: #ffffff;
   --ch-black: #000000;
   --ch-slate-50: #f8fafc;
   --ch-slate-100: #f1f5f9;
   --ch-slate-200: #e2e8f0;
-  --ch-slate-300: #cbd5e1;
-  --ch-slate-400: #94a3b8;
-  --ch-slate-700: #334155;
-  --ch-slate-800: #1e293b;
   --ch-slate-900: #0f172a;
-  --ch-slate-950: #020617;
   --ch-gray-50: #f9fafb;
   --ch-gray-100: #f3f4f6;
   --ch-gray-200: #e5e7eb;
@@ -44,33 +40,11 @@
   --ch-gray-700: #374151;
   --ch-gray-800: #1f2937;
   --ch-gray-900: #111827;
-  --ch-zinc-100: #f4f4f5;
   --ch-neutral-50: #fafafa;
-  --ch-blue-50: var(--ds-blue-50);
-  --ch-blue-100: var(--ds-blue-100);
-  --ch-blue-200: var(--ds-blue-200);
-  --ch-blue-300: var(--ds-blue-300);
-  --ch-blue-500: var(--ds-blue-500);
-  --ch-blue-600: var(--ds-blue-600);
-  --ch-blue-700: var(--ds-blue-700);
-  --ch-blue-800: var(--ds-blue-800);
-  --ch-blue-900: var(--ds-blue-900);
-  --ch-green-50: var(--ds-green-50);
-  --ch-green-100: var(--ds-green-100);
-  --ch-green-200: var(--ds-green-200);
-  --ch-green-500: var(--ds-green-500);
-  --ch-green-600: var(--ds-green-600);
-  --ch-red-50: var(--ds-red-50);
-  --ch-red-100: var(--ds-red-100);
-  --ch-red-200: var(--ds-red-200);
-  --ch-red-500: var(--ds-red-500);
-  --ch-red-600: var(--ds-red-600);
-  --ch-red-900: var(--ds-red-900);
   --ch-violet-50: #f5f3ff;
   --ch-violet-100: #ede9fe;
   --ch-violet-500: #8b5cf6;
   --ch-violet-600: #7c3aed;
-  --ch-amber-500: var(--ds-yellow-500);
 
   /* Semantic aliases */
   --ch-bg: var(--ch-white);
@@ -82,20 +56,15 @@
   --ch-text: var(--ch-gray-900);
   --ch-text-secondary: var(--ch-gray-500);
   --ch-text-muted: var(--ch-gray-400);
-  --ch-accent: var(--ch-blue-600);
-  --ch-accent-hover: var(--ch-blue-700);
-  --ch-accent-disabled: var(--ch-blue-300);
-  --ch-green: var(--ch-green-600);
-  --ch-green-dot: var(--ch-green-500);
-  --ch-green-bg: var(--ch-green-50);
-  --ch-red: var(--ch-red-600);
-  --ch-red-bg: var(--ch-red-50);
-  --ch-purple: var(--ch-violet-600);
-  --ch-purple-bg: var(--ch-violet-50);
-  --ch-purple-border: var(--ch-violet-100);
+  --ch-accent: var(--ds-blue-600);
+  --ch-accent-hover: var(--ds-blue-700);
+  --ch-accent-disabled: var(--ds-blue-300);
+  --ch-green: var(--ds-green-600);
+  --ch-green-dot: var(--ds-green-500);
+  --ch-green-bg: var(--ds-green-50);
+  --ch-red: var(--ds-red-600);
+  --ch-red-bg: var(--ds-red-50);
   --ch-badge-color: var(--ch-accent);
-  --ch-badge-bg: var(--ch-blue-50);
-  --ch-badge-border: var(--ch-blue-100);
   --ch-scrollbar-thumb: var(--ch-gray-300);
   --ch-scrollbar-thumb-hover: var(--ch-gray-400);
   /* Modal backdrop: slate-900 at 55% opacity. */
@@ -544,7 +513,7 @@
 
 .statusDot[data-status="loading"],
 .statusDot[data-status="running"] {
-  background: var(--ch-amber-500);
+  background: var(--ds-yellow-500);
   animation: ch-pulse 1s ease-in-out infinite;
 }
 
@@ -1017,10 +986,6 @@
 .runMenuPopup {
   --ch-white: #ffffff;
   --ch-black: #000000;
-  --ch-blue-500: var(--ds-blue-500);
-  --ch-blue-600: var(--ds-blue-600);
-  --ch-blue-700: var(--ds-blue-700);
-  --ch-blue-900: var(--ds-blue-900);
 
   background: #1a1a1a;
   border: 1px solid #333333;
@@ -1586,13 +1551,13 @@
 .testPill[data-state="pass"] {
   background: var(--ch-green-bg);
   color: var(--ch-green);
-  border: 1px solid var(--ch-green-200);
+  border: 1px solid var(--ds-green-200);
 }
 
 .testPill[data-state="fail"] {
   background: var(--ch-red-bg);
   color: var(--ch-red);
-  border: 1px solid var(--ch-red-200);
+  border: 1px solid var(--ds-red-200);
 }
 
 .testPill[data-state="pending"] {
@@ -1699,13 +1664,13 @@
 .banner[data-state="pass"] {
   background: var(--ch-green-bg);
   color: var(--ch-green);
-  border-top-color: var(--ch-green-200);
+  border-top-color: var(--ds-green-200);
 }
 
 .banner[data-state="fail"] {
   background: var(--ch-red-bg);
   color: var(--ch-red);
-  border-top-color: var(--ch-red-200);
+  border-top-color: var(--ds-red-200);
 }
 
 .bannerIcon {
@@ -1719,11 +1684,11 @@
 }
 
 .banner[data-state="pass"] .bannerIcon {
-  background: var(--ch-green-100);
+  background: var(--ds-green-100);
 }
 
 .banner[data-state="fail"] .bannerIcon {
-  background: var(--ch-red-100);
+  background: var(--ds-red-100);
 }
 
 .bannerSub {
@@ -1880,11 +1845,6 @@
      above are still available). All values come from the Tailwind
      palette so a future colour audit only has to look at these
      palette aliases. */
-  --ch-slate-950: #020617;
-  --ch-blue-400: var(--ds-blue-400);
-  --ch-green-400: var(--ds-green-400);
-  --ch-red-400: var(--ds-red-400);
-  --ch-red-500: var(--ds-red-500);
   --ch-violet-300: #c4b5fd;
   --ch-violet-500: #8b5cf6;
 
@@ -1905,21 +1865,16 @@
   --ch-text-muted: #808080;
   --ch-scrollbar-thumb: rgba(255, 255, 255, 0.15);
   --ch-scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
-  --ch-accent: var(--ch-blue-500);
-  --ch-accent-hover: var(--ch-blue-400);
-  --ch-accent-disabled: var(--ch-blue-700);
-  --ch-green: var(--ch-green-400);
-  --ch-green-dot: var(--ch-green-500);
-  --ch-green-bg: color-mix(in srgb, var(--ch-green-500) 12%, transparent);
-  --ch-red: var(--ch-red-400);
-  --ch-red-bg: color-mix(in srgb, var(--ch-red-500) 12%, transparent);
-  --ch-purple: var(--ch-violet-300);
-  --ch-purple-bg: color-mix(in srgb, var(--ch-violet-500) 14%, transparent);
-  --ch-purple-border: color-mix(in srgb, var(--ch-violet-500) 32%, transparent);
+  --ch-accent: var(--ds-blue-500);
+  --ch-accent-hover: var(--ds-blue-400);
+  --ch-accent-disabled: var(--ds-blue-700);
+  --ch-green: var(--ds-green-400);
+  --ch-green-dot: var(--ds-green-500);
+  --ch-green-bg: color-mix(in srgb, var(--ds-green-500) 12%, transparent);
+  --ch-red: var(--ds-red-400);
+  --ch-red-bg: color-mix(in srgb, var(--ds-red-500) 12%, transparent);
   /* Badge inherits the dark-mode accent (the var() declared above
      auto-tracks --ch-accent), but bg/border need explicit dark tints. */
-  --ch-badge-bg: color-mix(in srgb, var(--ch-blue-500) 14%, transparent);
-  --ch-badge-border: color-mix(in srgb, var(--ch-blue-500) 32%, transparent);
   --ch-overlay: color-mix(in srgb, var(--ch-black) 65%, transparent);
   --ch-shadow:
     0 1px 2px color-mix(in srgb, var(--ch-black) 50%, transparent),
@@ -2016,13 +1971,13 @@
 }
 
 :global(html.dark) .testPill[data-state="pass"] {
-  background: color-mix(in srgb, var(--ch-green-500) 12%, transparent);
-  border-color: color-mix(in srgb, var(--ch-green-500) 28%, transparent);
+  background: color-mix(in srgb, var(--ds-green-500) 12%, transparent);
+  border-color: color-mix(in srgb, var(--ds-green-500) 28%, transparent);
 }
 
 :global(html.dark) .testPill[data-state="fail"] {
-  background: color-mix(in srgb, var(--ch-red-500) 12%, transparent);
-  border-color: color-mix(in srgb, var(--ch-red-500) 28%, transparent);
+  background: color-mix(in srgb, var(--ds-red-500) 12%, transparent);
+  border-color: color-mix(in srgb, var(--ds-red-500) 28%, transparent);
 }
 
 :global(html.dark) .testPill[data-state="pending"] {
@@ -2031,19 +1986,19 @@
 }
 
 :global(html.dark) .banner[data-state="pass"] {
-  border-top-color: color-mix(in srgb, var(--ch-green-500) 28%, transparent);
+  border-top-color: color-mix(in srgb, var(--ds-green-500) 28%, transparent);
 }
 
 :global(html.dark) .banner[data-state="fail"] {
-  border-top-color: color-mix(in srgb, var(--ch-red-500) 28%, transparent);
+  border-top-color: color-mix(in srgb, var(--ds-red-500) 28%, transparent);
 }
 
 :global(html.dark) .banner[data-state="pass"] .bannerIcon {
-  background: color-mix(in srgb, var(--ch-green-500) 22%, transparent);
+  background: color-mix(in srgb, var(--ds-green-500) 22%, transparent);
 }
 
 :global(html.dark) .banner[data-state="fail"] .bannerIcon {
-  background: color-mix(in srgb, var(--ch-red-500) 22%, transparent);
+  background: color-mix(in srgb, var(--ds-red-500) 22%, transparent);
 }
 
 :global(html.dark) .outCellHtml :global(th) {
@@ -2377,7 +2332,7 @@
 }
 
 .toast[data-kind="warn"] {
-  background: var(--ch-red-900);
+  background: var(--ds-red-900);
 }
 
 .toast>button {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -46,31 +46,31 @@
   --ch-gray-900: #111827;
   --ch-zinc-100: #f4f4f5;
   --ch-neutral-50: #fafafa;
-  --ch-blue-50: #eff6ff;
-  --ch-blue-100: #dbeafe;
-  --ch-blue-200: #bfdbfe;
-  --ch-blue-300: #93c5fd;
-  --ch-blue-500: #3b82f6;
-  --ch-blue-600: #2563eb;
-  --ch-blue-700: #1d4ed8;
-  --ch-blue-800: #1e40af;
-  --ch-blue-900: #1e3a8a;
-  --ch-green-50: #f0fdf4;
-  --ch-green-100: #dcfce7;
-  --ch-green-200: #bbf7d0;
-  --ch-green-500: #22c55e;
-  --ch-green-600: #16a34a;
-  --ch-red-50: #fef2f2;
-  --ch-red-100: #fee2e2;
-  --ch-red-200: #fecaca;
-  --ch-red-500: #ef4444;
-  --ch-red-600: #dc2626;
-  --ch-red-900: #7f1d1d;
+  --ch-blue-50: var(--ds-blue-50);
+  --ch-blue-100: var(--ds-blue-100);
+  --ch-blue-200: var(--ds-blue-200);
+  --ch-blue-300: var(--ds-blue-300);
+  --ch-blue-500: var(--ds-blue-500);
+  --ch-blue-600: var(--ds-blue-600);
+  --ch-blue-700: var(--ds-blue-700);
+  --ch-blue-800: var(--ds-blue-800);
+  --ch-blue-900: var(--ds-blue-900);
+  --ch-green-50: var(--ds-green-50);
+  --ch-green-100: var(--ds-green-100);
+  --ch-green-200: var(--ds-green-200);
+  --ch-green-500: var(--ds-green-500);
+  --ch-green-600: var(--ds-green-600);
+  --ch-red-50: var(--ds-red-50);
+  --ch-red-100: var(--ds-red-100);
+  --ch-red-200: var(--ds-red-200);
+  --ch-red-500: var(--ds-red-500);
+  --ch-red-600: var(--ds-red-600);
+  --ch-red-900: var(--ds-red-900);
   --ch-violet-50: #f5f3ff;
   --ch-violet-100: #ede9fe;
   --ch-violet-500: #8b5cf6;
   --ch-violet-600: #7c3aed;
-  --ch-amber-500: #f59e0b;
+  --ch-amber-500: var(--ds-yellow-500);
 
   /* Semantic aliases */
   --ch-bg: var(--ch-white);
@@ -1017,10 +1017,10 @@
 .runMenuPopup {
   --ch-white: #ffffff;
   --ch-black: #000000;
-  --ch-blue-500: #3b82f6;
-  --ch-blue-600: #2563eb;
-  --ch-blue-700: #1d4ed8;
-  --ch-blue-900: #1e3a8a;
+  --ch-blue-500: var(--ds-blue-500);
+  --ch-blue-600: var(--ds-blue-600);
+  --ch-blue-700: var(--ds-blue-700);
+  --ch-blue-900: var(--ds-blue-900);
 
   background: #1a1a1a;
   border: 1px solid #333333;
@@ -1881,10 +1881,10 @@
      palette so a future colour audit only has to look at these
      palette aliases. */
   --ch-slate-950: #020617;
-  --ch-blue-400: #60a5fa;
-  --ch-green-400: #4ade80;
-  --ch-red-400: #f87171;
-  --ch-red-500: #ef4444;
+  --ch-blue-400: var(--ds-blue-400);
+  --ch-green-400: var(--ds-green-400);
+  --ch-red-400: var(--ds-red-400);
+  --ch-red-500: var(--ds-red-500);
   --ch-violet-300: #c4b5fd;
   --ch-violet-500: #8b5cf6;
 
@@ -1994,15 +1994,15 @@
    The base style uses #1a1a1a for light-mode contrast; dark mode reverts
    to the standard accent (blue) so the button reads as a primary action. */
 :global(html.dark) .runBtn {
-  background: #2563eb;
+  background: var(--ds-blue-600);
 }
 
 :global(html.dark) .runBtn:hover:not(:disabled) {
-  background: #1d4ed8;
+  background: var(--ds-blue-700);
 }
 
 :global(html.dark) .runBtn:disabled {
-  background: #93c5fd;
+  background: var(--ds-blue-300);
 }
 
 

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -18,14 +18,14 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap");
 
 .outputScope {
-  --cb-black: var(--ch-black);
+  --cb-black: var(--ds-black);
   --cb-slate-200: var(--ch-slate-200);
-  --cb-slate-500: var(--ch-gray-500);
+  --cb-slate-500: var(--ds-gray-500);
   --cb-slate-700: var(--ch-border);
   --cb-slate-800: var(--ch-bg-subtle);
   --cb-slate-900: var(--ch-bg-muted);
-  --cb-gray-200: var(--ch-gray-200);
-  --cb-gray-800: var(--ch-gray-800);
+  --cb-gray-200: var(--ds-gray-200);
+  --cb-gray-800: var(--ds-gray-800);
   --cb-neutral-100: var(--ch-bg-subtle);
   --cb-neutral-300: var(--ch-border);
   --cb-bg: var(--ch-bg);

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -18,7 +18,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap");
 
 .outputScope {
-  --cb-white: var(--ch-white);
   --cb-black: var(--ch-black);
   --cb-slate-200: var(--ch-slate-200);
   --cb-slate-500: var(--ch-gray-500);
@@ -39,8 +38,7 @@
   --cb-accent: var(--ch-accent);
   --cb-green: var(--ch-green);
   --cb-red: var(--ch-red);
-  --cb-yellow: var(--ch-amber-500);
-  --cb-font-ui: var(--ch-font-ui);
+  --cb-yellow: var(--ds-yellow-500);
   --cb-font-mono: var(--ch-font-mono);
   --cb-radius: var(--ch-radius);
   position: relative;

--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -47,8 +47,8 @@
 }
 
 .expandBtn:hover {
-  background: var(--color-fd-accent, rgba(79, 142, 247, 0.15));
-  border-color: var(--color-fd-primary, #4f8ef7);
+  background: var(--color-fd-accent, color-mix(in srgb, var(--ds-blue) 15%, transparent));
+  border-color: var(--color-fd-primary, var(--ds-blue-400));
 }
 
 .modalBackdrop {

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -4,20 +4,18 @@
    The visual language intentionally mirrors `ChallengeCard.module.css`
    (paper card chrome, blue badge header, slate text, accent submit
    button, green/red status banner) so the two embeddable components
-   feel like one product. Tokens are duplicated locally rather than
-   imported because CSS modules can't share custom properties across
-   files reliably, and the playground bundle doesn't load Tailwind's
-   preflight that defines the `--color-…` vars. */
+   feel like one product. Neutral tokens are duplicated locally (the
+   playground bundle doesn't load Tailwind's preflight that defines the
+   `--color-…` vars); brand colors come from the global `--ds-*` ramp
+   (app/brand.css). */
 
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap");
 
 .card {
-  /* Tailwind palette tokens — kept in sync with ChallengeCard.module.css */
+  /* Local neutral palette (Tailwind) — kept in sync with ChallengeCard;
+     brand accent colors are referenced from --ds-* below. */
   --mc-white: #ffffff;
   --mc-black: #000000;
-  --mc-slate-100: #f1f5f9;
-  --mc-slate-200: #e2e8f0;
-  --mc-slate-900: #0f172a;
   --mc-gray-50: #f9fafb;
   --mc-gray-100: #f3f4f6;
   --mc-gray-200: #e5e7eb;
@@ -26,49 +24,21 @@
   --mc-gray-500: #6b7280;
   --mc-gray-700: #374151;
   --mc-gray-900: #111827;
-  --mc-zinc-100: #f4f4f5;
   --mc-neutral-50: #fafafa;
-  --mc-blue-50: var(--ds-blue-50);
-  --mc-blue-100: var(--ds-blue-100);
-  --mc-blue-200: var(--ds-blue-200);
-  --mc-blue-300: var(--ds-blue-300);
-  --mc-blue-500: var(--ds-blue-500);
-  --mc-blue-600: var(--ds-blue-600);
-  --mc-blue-700: var(--ds-blue-700);
-  --mc-blue-800: var(--ds-blue-800);
-  --mc-blue-900: var(--ds-blue-900);
-  --mc-green-50: var(--ds-green-50);
-  --mc-green-100: var(--ds-green-100);
-  --mc-green-200: var(--ds-green-200);
-  --mc-green-500: var(--ds-green-500);
-  --mc-green-600: var(--ds-green-600);
-  --mc-green-700: var(--ds-green-700);
-  --mc-red-50: var(--ds-red-50);
-  --mc-red-100: var(--ds-red-100);
-  --mc-red-200: var(--ds-red-200);
-  --mc-red-600: var(--ds-red-600);
-  --mc-red-700: var(--ds-red-700);
-  --mc-amber-50: var(--ds-yellow-50);
-  --mc-amber-200: var(--ds-yellow-200);
-  --mc-amber-700: var(--ds-yellow-700);
 
   /* Semantic aliases — these mirror ChallengeCard's --ch-* naming so a
      reader who knows one stylesheet can read the other. */
   --mc-bg: var(--mc-white);
-  --mc-bg-muted: var(--mc-neutral-50);
   --mc-bg-subtle: var(--mc-gray-50);
   --mc-bg-hover: var(--mc-gray-100);
   --mc-border: var(--mc-gray-200);
   --mc-border-light: var(--mc-gray-100);
   --mc-text: var(--mc-gray-900);
-  --mc-text-secondary: var(--mc-gray-500);
   --mc-text-muted: var(--mc-gray-400);
-  --mc-accent: var(--mc-blue-600);
-  --mc-accent-hover: var(--mc-blue-700);
-  --mc-accent-disabled: var(--mc-blue-300);
+  --mc-accent: var(--ds-blue-600);
+  --mc-accent-hover: var(--ds-blue-700);
+  --mc-accent-disabled: var(--ds-blue-300);
   --mc-badge-color: var(--mc-accent);
-  --mc-badge-bg: var(--mc-blue-50);
-  --mc-badge-border: var(--mc-blue-100);
 
   --mc-font-ui: "Inter", system-ui, -apple-system, sans-serif;
   --mc-font-mono:
@@ -108,7 +78,7 @@
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--mc-blue-500);
+  color: var(--ds-blue-500);
   flex-shrink: 0;
   white-space: nowrap;
 }
@@ -247,12 +217,12 @@
 /* Post-submit verdicts. */
 .choice[data-verdict="correct-selected"],
 .choice[data-verdict="correct-missed"] {
-  background: var(--mc-green-50);
+  background: var(--ds-green-50);
   box-shadow: none;
 }
 
 .choice[data-verdict="wrong-selected"] {
-  background: var(--mc-red-50);
+  background: var(--ds-red-50);
   box-shadow: none;
 }
 
@@ -358,13 +328,13 @@
 
 .choice[data-verdict="correct-selected"] .choiceMark,
 .choice[data-verdict="correct-missed"] .choiceMark {
-  background: var(--mc-green-100);
-  color: var(--mc-green-700);
+  background: var(--ds-green-100);
+  color: var(--ds-green-700);
 }
 
 .choice[data-verdict="wrong-selected"] .choiceMark {
-  background: var(--mc-red-100);
-  color: var(--mc-red-700);
+  background: var(--ds-red-100);
+  color: var(--ds-red-700);
 }
 
 .choiceExplanation {
@@ -388,12 +358,12 @@
 
 .choice[data-verdict="correct-selected"] .choiceExplanation,
 .choice[data-verdict="correct-missed"] .choiceExplanation {
-  border-left-color: var(--mc-green-500);
+  border-left-color: var(--ds-green-500);
   background: var(--mc-white);
 }
 
 .choice[data-verdict="wrong-selected"] .choiceExplanation {
-  border-left-color: var(--mc-red-600);
+  border-left-color: var(--ds-red-600);
   background: var(--mc-white);
 }
 
@@ -402,24 +372,24 @@
    surface. */
 .choice[data-verdict="correct-selected"] .choiceLabel code,
 .choice[data-verdict="correct-missed"] .choiceLabel code {
-  background: var(--mc-green-200);
-  color: var(--mc-green-700);
+  background: var(--ds-green-200);
+  color: var(--ds-green-700);
 }
 
 .choice[data-verdict="wrong-selected"] .choiceLabel code {
-  background: var(--mc-red-200);
-  color: var(--mc-red-700);
+  background: var(--ds-red-200);
+  color: var(--ds-red-700);
 }
 
 .choice[data-verdict="correct-selected"] .choiceExplanation code,
 .choice[data-verdict="correct-missed"] .choiceExplanation code {
-  background: var(--mc-green-100);
-  color: var(--mc-green-700);
+  background: var(--ds-green-100);
+  color: var(--ds-green-700);
 }
 
 .choice[data-verdict="wrong-selected"] .choiceExplanation code {
-  background: var(--mc-red-100);
-  color: var(--mc-red-700);
+  background: var(--ds-red-100);
+  color: var(--ds-red-700);
 }
 
 /* The explanation block hangs off to the right of the input + glyph.
@@ -509,18 +479,18 @@
 }
 
 .banner[data-state="pass"] {
-  background: var(--mc-green-50);
-  color: var(--mc-green-700);
+  background: var(--ds-green-50);
+  color: var(--ds-green-700);
 }
 
 .banner[data-state="fail"] {
-  background: var(--mc-red-50);
-  color: var(--mc-red-700);
+  background: var(--ds-red-50);
+  color: var(--ds-red-700);
 }
 
 .banner[data-state="partial"] {
-  background: var(--mc-amber-50);
-  color: var(--mc-amber-700);
+  background: var(--ds-yellow-50);
+  color: var(--ds-yellow-700);
 }
 
 .bannerIcon {
@@ -534,15 +504,15 @@
 }
 
 .banner[data-state="pass"] .bannerIcon {
-  background: var(--mc-green-100);
+  background: var(--ds-green-100);
 }
 
 .banner[data-state="fail"] .bannerIcon {
-  background: var(--mc-red-100);
+  background: var(--ds-red-100);
 }
 
 .banner[data-state="partial"] .bannerIcon {
-  background: var(--mc-amber-200);
+  background: var(--ds-yellow-200);
 }
 
 .bannerSub {
@@ -603,16 +573,12 @@
      All surface tokens use black-based colour-mix so they stay neutral
      — no blue-tinted slate values. */
   --mc-bg: var(--color-fd-background, #121212);
-  --mc-bg-muted: color-mix(in srgb, var(--color-fd-background, #121212) 70%, #000000);
   --mc-bg-subtle: color-mix(in srgb, var(--color-fd-background, #121212) 85%, #000000);
   --mc-bg-hover: #222222;
   --mc-border: #2e2e2e;
   --mc-border-light: #232323;
   --mc-text: #e0e0e0;
-  --mc-text-secondary: #b0b0b0;
   --mc-text-muted: #808080;
-  --mc-badge-bg: color-mix(in srgb, var(--mc-blue-500) 14%, transparent);
-  --mc-badge-border: color-mix(in srgb, var(--mc-blue-500) 32%, transparent);
   --mc-badge-color: var(--ds-blue-300);
 }
 

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -21,10 +21,8 @@
   --mc-gray-200: #e5e7eb;
   --mc-gray-300: #d1d5db;
   --mc-gray-400: #9ca3af;
-  --mc-gray-500: #6b7280;
   --mc-gray-700: #374151;
   --mc-gray-900: #111827;
-  --mc-neutral-50: #fafafa;
 
   /* Semantic aliases — these mirror ChallengeCard's --ch-* naming so a
      reader who knows one stylesheet can read the other. */
@@ -588,26 +586,26 @@
 
 :global(html.dark) .choice[data-verdict="correct-selected"],
 :global(html.dark) .choice[data-verdict="correct-missed"] {
-  background: rgba(22, 163, 74, 0.15);
+  background: color-mix(in srgb, var(--ds-green) 15%, transparent);
 }
 
 :global(html.dark) .choice[data-verdict="wrong-selected"] {
-  background: rgba(220, 38, 38, 0.15);
+  background: color-mix(in srgb, var(--ds-red) 15%, transparent);
 }
 
 :global(html.dark) .banner[data-state="pass"] {
-  background: rgba(22, 163, 74, 0.12);
-  color: #86efac;
+  background: color-mix(in srgb, var(--ds-green) 12%, transparent);
+  color: var(--ds-green-300);
 }
 
 :global(html.dark) .banner[data-state="fail"] {
-  background: rgba(220, 38, 38, 0.12);
-  color: #fca5a5;
+  background: color-mix(in srgb, var(--ds-red) 12%, transparent);
+  color: var(--ds-red-300);
 }
 
 :global(html.dark) .banner[data-state="partial"] {
-  background: rgba(217, 119, 6, 0.12);
-  color: #fcd34d;
+  background: color-mix(in srgb, var(--ds-yellow) 12%, transparent);
+  color: var(--ds-yellow-300);
 }
 
 :global(html.dark) .choiceLabel code,
@@ -639,36 +637,36 @@
    light mode — override to a translucent tinted dark surface. */
 :global(html.dark) .choice[data-verdict="correct-selected"] .choiceExplanation,
 :global(html.dark) .choice[data-verdict="correct-missed"] .choiceExplanation {
-  background: rgba(22, 163, 74, 0.08);
+  background: color-mix(in srgb, var(--ds-green) 8%, transparent);
 }
 
 :global(html.dark) .choice[data-verdict="wrong-selected"] .choiceExplanation {
-  background: rgba(220, 38, 38, 0.08);
+  background: color-mix(in srgb, var(--ds-red) 8%, transparent);
 }
 
 /* Choice mark icons — replace light green/red fill with translucent dark tints. */
 :global(html.dark) .choice[data-verdict="correct-selected"] .choiceMark,
 :global(html.dark) .choice[data-verdict="correct-missed"] .choiceMark {
-  background: rgba(22, 163, 74, 0.2);
-  color: #86efac;
+  background: color-mix(in srgb, var(--ds-green) 20%, transparent);
+  color: var(--ds-green-300);
 }
 
 :global(html.dark) .choice[data-verdict="wrong-selected"] .choiceMark {
-  background: rgba(220, 38, 38, 0.2);
-  color: #fca5a5;
+  background: color-mix(in srgb, var(--ds-red) 20%, transparent);
+  color: var(--ds-red-300);
 }
 
 /* Banner icon circles — light green/red fills need dark-mode tints. */
 :global(html.dark) .banner[data-state="pass"] .bannerIcon {
-  background: rgba(22, 163, 74, 0.2);
+  background: color-mix(in srgb, var(--ds-green) 20%, transparent);
 }
 
 :global(html.dark) .banner[data-state="fail"] .bannerIcon {
-  background: rgba(220, 38, 38, 0.2);
+  background: color-mix(in srgb, var(--ds-red) 20%, transparent);
 }
 
 :global(html.dark) .banner[data-state="partial"] .bannerIcon {
-  background: rgba(217, 119, 6, 0.2);
+  background: color-mix(in srgb, var(--ds-yellow) 20%, transparent);
 }
 
 /* Retry button uses an explicit white background in light mode. */
@@ -692,7 +690,7 @@
 /* Disabled submit button is too vivid (blue-300) in dark mode — tone it
    down to a dim translucent blue so it reads as inactive. */
 :global(html.dark) .submitBtn:disabled {
-  background: rgba(59, 130, 246, 0.5);
+  background: color-mix(in srgb, var(--ds-blue) 50%, transparent);
   color: rgba(255, 255, 255, 0.5);
   cursor: not-allowed;
 }
@@ -729,12 +727,12 @@
    that blends with the dark green / dark red surface instead of gray. */
 :global(html.dark) .choice[data-verdict="correct-selected"] .choiceExplanation code,
 :global(html.dark) .choice[data-verdict="correct-missed"] .choiceExplanation code {
-  background: rgba(22, 163, 74, 0.3);
+  background: color-mix(in srgb, var(--ds-green) 30%, transparent);
   color: var(--ds-green-200);
 }
 
 :global(html.dark) .choice[data-verdict="wrong-selected"] .choiceExplanation code {
-  background: rgba(220, 38, 38, 0.3);
+  background: color-mix(in srgb, var(--ds-red) 30%, transparent);
   color: var(--ds-red-200);
 }
 

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -28,29 +28,29 @@
   --mc-gray-900: #111827;
   --mc-zinc-100: #f4f4f5;
   --mc-neutral-50: #fafafa;
-  --mc-blue-50: #eff6ff;
-  --mc-blue-100: #dbeafe;
-  --mc-blue-200: #bfdbfe;
-  --mc-blue-300: #93c5fd;
-  --mc-blue-500: #3b82f6;
-  --mc-blue-600: #2563eb;
-  --mc-blue-700: #1d4ed8;
-  --mc-blue-800: #1e40af;
-  --mc-blue-900: #1e3a8a;
-  --mc-green-50: #f0fdf4;
-  --mc-green-100: #dcfce7;
-  --mc-green-200: #bbf7d0;
-  --mc-green-500: #22c55e;
-  --mc-green-600: #16a34a;
-  --mc-green-700: #15803d;
-  --mc-red-50: #fef2f2;
-  --mc-red-100: #fee2e2;
-  --mc-red-200: #fecaca;
-  --mc-red-600: #dc2626;
-  --mc-red-700: #b91c1c;
-  --mc-amber-50: #fffbeb;
-  --mc-amber-200: #fde68a;
-  --mc-amber-700: #b45309;
+  --mc-blue-50: var(--ds-blue-50);
+  --mc-blue-100: var(--ds-blue-100);
+  --mc-blue-200: var(--ds-blue-200);
+  --mc-blue-300: var(--ds-blue-300);
+  --mc-blue-500: var(--ds-blue-500);
+  --mc-blue-600: var(--ds-blue-600);
+  --mc-blue-700: var(--ds-blue-700);
+  --mc-blue-800: var(--ds-blue-800);
+  --mc-blue-900: var(--ds-blue-900);
+  --mc-green-50: var(--ds-green-50);
+  --mc-green-100: var(--ds-green-100);
+  --mc-green-200: var(--ds-green-200);
+  --mc-green-500: var(--ds-green-500);
+  --mc-green-600: var(--ds-green-600);
+  --mc-green-700: var(--ds-green-700);
+  --mc-red-50: var(--ds-red-50);
+  --mc-red-100: var(--ds-red-100);
+  --mc-red-200: var(--ds-red-200);
+  --mc-red-600: var(--ds-red-600);
+  --mc-red-700: var(--ds-red-700);
+  --mc-amber-50: var(--ds-yellow-50);
+  --mc-amber-200: var(--ds-yellow-200);
+  --mc-amber-700: var(--ds-yellow-700);
 
   /* Semantic aliases — these mirror ChallengeCard's --ch-* naming so a
      reader who knows one stylesheet can read the other. */
@@ -613,7 +613,7 @@
   --mc-text-muted: #808080;
   --mc-badge-bg: color-mix(in srgb, var(--mc-blue-500) 14%, transparent);
   --mc-badge-border: color-mix(in srgb, var(--mc-blue-500) 32%, transparent);
-  --mc-badge-color: #93c5fd;
+  --mc-badge-color: var(--ds-blue-300);
 }
 
 :global(html.dark) .choice[data-selected="true"] {
@@ -764,12 +764,12 @@
 :global(html.dark) .choice[data-verdict="correct-selected"] .choiceExplanation code,
 :global(html.dark) .choice[data-verdict="correct-missed"] .choiceExplanation code {
   background: rgba(22, 163, 74, 0.3);
-  color: #bbf7d0;
+  color: var(--ds-green-200);
 }
 
 :global(html.dark) .choice[data-verdict="wrong-selected"] .choiceExplanation code {
   background: rgba(220, 38, 38, 0.3);
-  color: #fecaca;
+  color: var(--ds-red-200);
 }
 
 /* Overall explanation paragraph text is white in dark mode. */

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -14,25 +14,16 @@
 .card {
   /* Local neutral palette (Tailwind) — kept in sync with ChallengeCard;
      brand accent colors are referenced from --ds-* below. */
-  --mc-white: #ffffff;
-  --mc-black: #000000;
-  --mc-gray-50: #f9fafb;
-  --mc-gray-100: #f3f4f6;
-  --mc-gray-200: #e5e7eb;
-  --mc-gray-300: #d1d5db;
-  --mc-gray-400: #9ca3af;
-  --mc-gray-700: #374151;
-  --mc-gray-900: #111827;
 
   /* Semantic aliases — these mirror ChallengeCard's --ch-* naming so a
      reader who knows one stylesheet can read the other. */
-  --mc-bg: var(--mc-white);
-  --mc-bg-subtle: var(--mc-gray-50);
-  --mc-bg-hover: var(--mc-gray-100);
-  --mc-border: var(--mc-gray-200);
-  --mc-border-light: var(--mc-gray-100);
-  --mc-text: var(--mc-gray-900);
-  --mc-text-muted: var(--mc-gray-400);
+  --mc-bg: var(--ds-white);
+  --mc-bg-subtle: var(--ds-gray-50);
+  --mc-bg-hover: var(--ds-gray-100);
+  --mc-border: var(--ds-gray-200);
+  --mc-border-light: var(--ds-gray-100);
+  --mc-text: var(--ds-gray-900);
+  --mc-text-muted: var(--ds-gray-400);
   --mc-accent: var(--ds-blue-600);
   --mc-accent-hover: var(--ds-blue-700);
   --mc-accent-disabled: var(--ds-blue-300);
@@ -43,8 +34,8 @@
     "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   --mc-radius: 8px;
   --mc-shadow:
-    0 1px 3px color-mix(in srgb, var(--mc-black) 8%, transparent),
-    0 1px 2px color-mix(in srgb, var(--mc-black) 5%, transparent);
+    0 1px 3px color-mix(in srgb, var(--ds-black) 8%, transparent),
+    0 1px 2px color-mix(in srgb, var(--ds-black) 5%, transparent);
 
   background: var(--mc-bg);
   border: 1px solid var(--mc-border);
@@ -135,10 +126,10 @@
 .bodyMd code {
   font-family: var(--mc-font-mono);
   font-size: 13.5px;
-  background: var(--mc-gray-100);
+  background: var(--ds-gray-100);
   border-radius: 4px;
   padding: 1px 5px;
-  color: var(--mc-gray-900);
+  color: var(--ds-gray-900);
 }
 
 .bodyMd ul,
@@ -201,7 +192,7 @@
 }
 
 .choice:not([data-locked="true"]):hover {
-  background: var(--mc-gray-50);
+  background: var(--ds-gray-50);
 }
 
 .choice[data-selected="true"] {
@@ -236,7 +227,7 @@
   flex-shrink: 0;
   margin-top: 3px;
   cursor: inherit;
-  background: var(--mc-gray-100);
+  background: var(--ds-gray-100);
   box-shadow: none;
   transition: box-shadow 0.12s, background 0.12s;
 }
@@ -250,12 +241,12 @@
 }
 
 .choiceInput:checked {
-  background: var(--mc-gray-900);
-  box-shadow: 0 0 0 1.5px var(--mc-gray-400);
+  background: var(--ds-gray-900);
+  box-shadow: 0 0 0 1.5px var(--ds-gray-400);
 }
 
 .choiceInput[type="radio"]:checked {
-  background: radial-gradient(circle, #fff 30%, var(--mc-gray-900) 31%);
+  background: radial-gradient(circle, #fff 30%, var(--ds-gray-900) 31%);
   box-shadow: none;
 }
 
@@ -282,10 +273,10 @@
 .choiceLabel code {
   font-family: var(--mc-font-mono);
   font-size: 13.5px;
-  background: var(--mc-gray-100);
+  background: var(--ds-gray-100);
   border-radius: 4px;
   padding: 1px 5px;
-  color: var(--mc-gray-900);
+  color: var(--ds-gray-900);
 }
 
 /* Code blocks inside choice labels (multi-line code answers). */
@@ -343,7 +334,7 @@
   border-radius: 4px;
   font-size: 13.5px;
   line-height: 1.6;
-  color: var(--mc-gray-700);
+  color: var(--ds-gray-700);
 }
 
 .choiceExplanation p {
@@ -357,12 +348,12 @@
 .choice[data-verdict="correct-selected"] .choiceExplanation,
 .choice[data-verdict="correct-missed"] .choiceExplanation {
   border-left-color: var(--ds-green-500);
-  background: var(--mc-white);
+  background: var(--ds-white);
 }
 
 .choice[data-verdict="wrong-selected"] .choiceExplanation {
   border-left-color: var(--ds-red-600);
-  background: var(--mc-white);
+  background: var(--ds-white);
 }
 
 /* In light mode, `code` elements inside green/red choice rows need
@@ -417,7 +408,7 @@
   align-items: center;
   gap: 6px;
   background: var(--mc-accent);
-  color: var(--mc-white);
+  color: var(--ds-white);
   border: none;
   border-radius: 6px;
   padding: 7px 14px;
@@ -441,7 +432,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: var(--mc-white);
+  background: var(--ds-white);
   color: var(--mc-text);
   border: 1px solid var(--mc-border);
   border-radius: 6px;
@@ -455,7 +446,7 @@
 
 .retryBtn:hover {
   background: var(--mc-bg-hover);
-  border-color: var(--mc-gray-300);
+  border-color: var(--ds-gray-300);
   color: var(--mc-text);
 }
 
@@ -539,7 +530,7 @@
 .overallBody {
   font-size: 14px;
   line-height: 1.7;
-  color: var(--mc-gray-700);
+  color: var(--ds-gray-700);
 }
 
 .overallBody p {
@@ -553,10 +544,10 @@
 .overallBody code {
   font-family: var(--mc-font-mono);
   font-size: 13.5px;
-  background: var(--mc-gray-100);
+  background: var(--ds-gray-100);
   border-radius: 4px;
   padding: 1px 5px;
-  color: var(--mc-gray-900);
+  color: var(--ds-gray-900);
 }
 
 /* ─── Dark mode ───────────────────────────────────────────────────── */
@@ -706,7 +697,7 @@
    Use background-color (not the background shorthand) so it doesn't
    reset background-image, which would hide the checkbox checkmark. */
 :global(html.dark) .choiceInput:checked {
-  background-color: var(--mc-gray-900);
+  background-color: var(--ds-gray-900);
   box-shadow: 0 0 0 1.5px rgba(255, 255, 255, 0.25);
 }
 

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -35,6 +35,15 @@
   --green: var(--ds-green);
   --red: var(--ds-red);
   --yellow: var(--ds-yellow);
+  /* Semantic accents consumed by the SQL playground (sqlPlayground.css) via
+     `var(--danger, …)`, `var(--ok-accent, …)`, etc. Previously these were
+     undefined, so each call site fell back to a hardcoded Tailwind hex.
+     Defining them here once routes the SQL UI's success/error/focus colors
+     through the brand palette; the inline fallbacks remain as a safety net. */
+  --accent: var(--ds-blue);
+  --danger: var(--ds-red);
+  --ok-accent: var(--ds-green);
+  --err-accent: var(--ds-red);
   --font-mono:
     "JetBrains Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace;
   --font-ui: "Inter", system-ui, -apple-system, sans-serif;

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -25,12 +25,16 @@
      `--text-complementary`. */
   --accent1: oklch(68% 0.18 250);
   --accent2: oklch(75% 0.2 85);
-  --primary: oklch(68% 0.18 250);
-  --primary-glow: oklch(68% 0.18 250 / 0.15);
-  --blue: oklch(68% 0.18 250);
-  --green: oklch(68% 0.18 145);
-  --red: oklch(62% 0.18 15);
-  --yellow: oklch(78% 0.16 85);
+  /* Brand-signal tokens — sourced from brand.css so the Run button, error
+     states, and selection tints match the rest of the site. The editor-theme
+     palettes (applyThemePalette / THEME_PALETTES) intentionally stay separate;
+     they recolor the chrome to the user's chosen code theme, not the brand. */
+  --primary: var(--ds-blue);
+  --primary-glow: color-mix(in srgb, var(--ds-blue) 15%, transparent);
+  --blue: var(--ds-blue);
+  --green: var(--ds-green);
+  --red: var(--ds-red);
+  --yellow: var(--ds-yellow);
   --font-mono:
     "JetBrains Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace;
   --font-ui: "Inter", system-ui, -apple-system, sans-serif;

--- a/app/brand.css
+++ b/app/brand.css
@@ -1,0 +1,104 @@
+/* ============================================================================
+ * brand.css — DataSlope brand color system (single source of truth)
+ * ----------------------------------------------------------------------------
+ * Imported once in app/layout.tsx so every route (/, /learn, /playground) can
+ * read these tokens. Defines:
+ *   1. Full 50–900 tonal ramps for the four brand hues (500 = the brand color).
+ *   2. Raw hue aliases (--ds-blue → --ds-blue-500, etc.).
+ *   3. Mode-agnostic "ink" anchors that clear WCAG AA body text on white.
+ *   4. Semantic role tokens, with light-mode defaults and dark-mode overrides.
+ *
+ * Theme mechanisms differ per route — the dark overrides below target BOTH:
+ *   - `.dark`              → /learn (next-themes / Fumadocs)
+ *   - `[data-theme=dark]`  → /playground (editor-theme driven)
+ * The home route (/) is currently dark-only and consumes the raw hue ramps
+ * directly (its accents are decorative, which read fine on dark).
+ *
+ * Ramps were generated in OKLCH (constant hue, lightness/chroma interpolated
+ * toward white/near-black, gamut-mapped). Re-verify any value used for text in
+ * a contrast checker before relying on it. WCAG AA: 4.5:1 body, 3:1 large/UI.
+ * ========================================================================== */
+
+:root {
+  /* ── Blue (primary) ───────────────────────────────────────────────── */
+  --ds-blue-50:  #E8F2FF;
+  --ds-blue-100: #D1E6FF;
+  --ds-blue-200: #AED3FF;
+  --ds-blue-300: #8ABFFF;
+  --ds-blue-400: #5BA7FF;
+  --ds-blue-500: #148CFF; /* brand */
+  --ds-blue-600: #0878DD;
+  --ds-blue-700: #0064BD; /* AA body text on white (5.9:1) */
+  --ds-blue-800: #00519C;
+  --ds-blue-900: #00407F;
+
+  /* ── Green (success) ──────────────────────────────────────────────── */
+  --ds-green-50:  #E8F9E6;
+  --ds-green-100: #D4F3D1;
+  --ds-green-200: #B4EAAF;
+  --ds-green-300: #93E08E;
+  --ds-green-400: #66D361;
+  --ds-green-500: #20C621; /* brand */
+  --ds-green-600: #0AA80F;
+  --ds-green-700: #008B03;
+  --ds-green-800: #006F01; /* AA body text on white (6.4:1) */
+  --ds-green-900: #005600;
+
+  /* ── Red (danger) ─────────────────────────────────────────────────── */
+  --ds-red-50:  #FFEDEC;
+  --ds-red-100: #FFDCDA;
+  --ds-red-200: #FFC2BF;
+  --ds-red-300: #FFA6A3;
+  --ds-red-400: #FF807F;
+  --ds-red-500: #FF4F59; /* brand */
+  --ds-red-600: #DC3F49;
+  --ds-red-700: #BA303A; /* AA body text on white (5.9:1) */
+  --ds-red-800: #99212C;
+  --ds-red-900: #7C141F;
+
+  /* ── Yellow (attention) ───────────────────────────────────────────── */
+  --ds-yellow-50:  #FDF8E8;
+  --ds-yellow-100: #FDF5D9;
+  --ds-yellow-200: #FEF0C3;
+  --ds-yellow-300: #FEEBAC;
+  --ds-yellow-400: #FFE48E;
+  --ds-yellow-500: #FFDD6C; /* brand */
+  --ds-yellow-600: #D4B651;
+  --ds-yellow-700: #AB9137;
+  --ds-yellow-800: #836D1C; /* AA body text on white (5.0:1) */
+  --ds-yellow-900: #624F00;
+
+  /* ── Raw hue aliases (= the 500 brand value) ──────────────────────── */
+  --ds-blue:   var(--ds-blue-500);
+  --ds-green:  var(--ds-green-500);
+  --ds-red:    var(--ds-red-500);
+  --ds-yellow: var(--ds-yellow-500);
+
+  /* ── "Ink" anchors: AA-on-white text/link/icon colors ─────────────── */
+  --ds-blue-ink:  var(--ds-blue-700);
+  --ds-green-ink: var(--ds-green-800);
+  --ds-red-ink:   var(--ds-red-700);
+  --ds-amber-ink: var(--ds-yellow-800);
+
+  /* ── Semantic roles — LIGHT MODE defaults ─────────────────────────── */
+  --ds-primary:      var(--ds-blue);      /* fills, primary buttons, active   */
+  --ds-link:         var(--ds-blue-ink);  /* text/links on a light surface    */
+  --ds-focus:        var(--ds-blue);      /* focus ring (UI, 3:1 is enough)   */
+  --ds-success:      var(--ds-green-ink);
+  --ds-success-fill: var(--ds-green);
+  --ds-danger:       var(--ds-red-ink);
+  --ds-danger-fill:  var(--ds-red);
+  --ds-warning:      var(--ds-amber-ink);
+  --ds-warning-fill: var(--ds-yellow);
+}
+
+/* ── Semantic roles — DARK MODE ───────────────────────────────────────
+ * On dark surfaces the bright 500s already clear AA body text, so text
+ * roles point straight at them (no ink needed). Targets both dark hooks. */
+.dark,
+[data-theme="dark"] {
+  --ds-link:    var(--ds-blue-400);
+  --ds-success: var(--ds-green-400);
+  --ds-danger:  var(--ds-red-400);
+  --ds-warning: var(--ds-yellow-400);
+}

--- a/app/brand.css
+++ b/app/brand.css
@@ -80,6 +80,23 @@
   --ds-red-ink:   var(--ds-red-700);
   --ds-amber-ink: var(--ds-yellow-800);
 
+  /* ── Neutral foundation (Tailwind gray ramp) ──────────────────────────
+   * Shared by the card / quiz / codeblock components, which each used to
+   * duplicate this scale locally (--ch-gray-*, --mc-gray-*). (ChallengeCard
+   * also keeps a small local --ch-slate-* set for its cool-gray surfaces.) */
+  --ds-white: #ffffff;
+  --ds-black: #000000;
+  --ds-gray-50:  #f9fafb;
+  --ds-gray-100: #f3f4f6;
+  --ds-gray-200: #e5e7eb;
+  --ds-gray-300: #d1d5db;
+  --ds-gray-400: #9ca3af;
+  --ds-gray-500: #6b7280;
+  --ds-gray-600: #4b5563;
+  --ds-gray-700: #374151;
+  --ds-gray-800: #1f2937;
+  --ds-gray-900: #111827;
+
   /* ── Semantic roles — LIGHT MODE defaults ─────────────────────────── */
   --ds-primary:      var(--ds-blue);      /* fills, primary buttons, active   */
   --ds-link:         var(--ds-blue-ink);  /* text/links on a light surface    */

--- a/app/color-test/page.tsx
+++ b/app/color-test/page.tsx
@@ -63,6 +63,18 @@ const SWATCH_DEFS: SwatchDef[] = [
   { name: "--green", label: "Green" },
   { name: "--red", label: "Red" },
   { name: "--yellow", label: "Yellow" },
+  // Brand "ink" anchors (AA-on-white text colors from brand.css).
+  { name: "--ds-blue-ink", label: "Blue ink", isTextColor: true },
+  { name: "--ds-green-ink", label: "Green ink", isTextColor: true },
+  { name: "--ds-red-ink", label: "Red ink", isTextColor: true },
+  { name: "--ds-amber-ink", label: "Amber ink", isTextColor: true },
+  // Full 50–900 brand ramps (brand.css). 500 = the brand color.
+  ...(["blue", "green", "red", "yellow"] as const).flatMap((hue) =>
+    [50, 100, 200, 300, 400, 500, 600, 700, 800, 900].map((step) => ({
+      name: `--ds-${hue}-${step}`,
+      label: `${hue} ${step}`,
+    })),
+  ),
 ];
 
 function resolveCssVarToHex(varName: string): string {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import "./brand.css";
 import "./globals.css";
 
 const inter = Inter({

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -76,6 +76,25 @@ samp {
   --color-fd-ring: var(--ds-blue);
 }
 
+/* Callout / admonition accents. Fumadocs's Callout sets
+   `--callout-color: var(--color-fd-<type>, var(--color-fd-muted))` and uses it
+   for the left bar (at 50% alpha) and the type icon. Define the four semantic
+   tokens so callouts read in the brand palette instead of falling back to
+   muted gray. The icon/bar sit on the light/dark card surface, so light mode
+   uses the AA "ink" steps and dark mode uses the brighter brand steps. */
+:root:not(.dark) {
+  --color-fd-info: var(--ds-blue-ink);
+  --color-fd-warning: var(--ds-amber-ink);
+  --color-fd-error: var(--ds-red-ink);
+  --color-fd-success: var(--ds-green-ink);
+}
+.dark {
+  --color-fd-info: var(--ds-blue-400);
+  --color-fd-warning: var(--ds-yellow-400);
+  --color-fd-error: var(--ds-red-400);
+  --color-fd-success: var(--ds-green-400);
+}
+
 /* Sidebar text + active/hover overrides.
    Non-layered rules beat Tailwind's @layer utilities, so these win
    without !important.

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -63,6 +63,19 @@ samp {
   --color-fd-card: hsl(0, 0%, 100%);
 }
 
+/* Brand accent → Fumadocs. --color-fd-primary drives doc links, the active
+   sidebar item, and most UI accents; --color-fd-ring drives focus outlines.
+   Light mode uses the AA-on-white blue "ink" (brand.css); dark mode uses the
+   brighter brand blue, which reads well on the dark surface. */
+:root:not(.dark) {
+  --color-fd-primary: var(--ds-blue-ink);
+  --color-fd-ring: var(--ds-blue);
+}
+.dark {
+  --color-fd-primary: var(--ds-blue-400);
+  --color-fd-ring: var(--ds-blue);
+}
+
 /* Sidebar text + active/hover overrides.
    Non-layered rules beat Tailwind's @layer utilities, so these win
    without !important.

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -63,32 +63,23 @@ samp {
   --color-fd-card: hsl(0, 0%, 100%);
 }
 
-/* Brand accent → Fumadocs. --color-fd-primary drives doc links, the active
-   sidebar item, and most UI accents; --color-fd-ring drives focus outlines.
-   Light mode uses the AA-on-white blue "ink" (brand.css); dark mode uses the
-   brighter brand blue, which reads well on the dark surface. */
+/* Brand accents → Fumadocs tokens. --color-fd-primary drives doc links, the
+   active sidebar item, and most UI accents; --color-fd-ring is the focus
+   outline. Callouts derive `--callout-color: var(--color-fd-<type>, …)` for
+   their bar + icon, so --color-fd-{info,warning,error,success} brand-tint
+   admonitions (otherwise they fall back to muted gray). Light mode uses the
+   AA-on-white "ink" steps; dark mode uses the brighter brand steps. */
 :root:not(.dark) {
   --color-fd-primary: var(--ds-blue-ink);
   --color-fd-ring: var(--ds-blue);
-}
-.dark {
-  --color-fd-primary: var(--ds-blue-400);
-  --color-fd-ring: var(--ds-blue);
-}
-
-/* Callout / admonition accents. Fumadocs's Callout sets
-   `--callout-color: var(--color-fd-<type>, var(--color-fd-muted))` and uses it
-   for the left bar (at 50% alpha) and the type icon. Define the four semantic
-   tokens so callouts read in the brand palette instead of falling back to
-   muted gray. The icon/bar sit on the light/dark card surface, so light mode
-   uses the AA "ink" steps and dark mode uses the brighter brand steps. */
-:root:not(.dark) {
   --color-fd-info: var(--ds-blue-ink);
   --color-fd-warning: var(--ds-amber-ink);
   --color-fd-error: var(--ds-red-ink);
   --color-fd-success: var(--ds-green-ink);
 }
 .dark {
+  --color-fd-primary: var(--ds-blue-400);
+  --color-fd-ring: var(--ds-blue);
   --color-fd-info: var(--ds-blue-400);
   --color-fd-warning: var(--ds-yellow-400);
   --color-fd-error: var(--ds-red-400);

--- a/app/playground/home.module.css
+++ b/app/playground/home.module.css
@@ -47,7 +47,7 @@
 }
 
 .card:hover {
-  border-color: #4f8ef7;
+  border-color: var(--ds-blue-400);
 }
 
 .logo {

--- a/app/root.module.css
+++ b/app/root.module.css
@@ -19,7 +19,7 @@
 .title {
   font-size: 3rem;
   margin: 0 0 0.5rem;
-  background: linear-gradient(135deg, #4f8ef7, #34d399);
+  background: linear-gradient(135deg, var(--ds-blue), var(--ds-green));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -46,7 +46,7 @@
 }
 
 .cta:hover {
-  border-color: #4f8ef7;
+  border-color: var(--ds-blue-400);
   background: #1b2230;
 }
 
@@ -80,7 +80,7 @@
 }
 
 .ctaSecondary:hover {
-  border-color: #4f8ef7;
+  border-color: var(--ds-blue-400);
   color: #e2e8f0;
   background: #1b2230;
 }
@@ -97,7 +97,7 @@
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #4f8ef7;
+  color: var(--ds-blue-400);
   margin: 0 0 0.75rem;
 }
 
@@ -121,7 +121,7 @@
 }
 
 .courseCard:hover {
-  border-color: #4f8ef7;
+  border-color: var(--ds-blue-400);
   background: #1b2230;
 }
 
@@ -131,7 +131,7 @@
 }
 
 .courseArrow {
-  color: #4f8ef7;
+  color: var(--ds-blue-400);
   transition: transform 0.15s;
 }
 


### PR DESCRIPTION
## Summary

This branch delivers a **unified brand color system** across the app, a thorough **CSS variable cleanup** of the learning components, and two **research reports**.

## 1. Brand color token system (`app/brand.css`)

Single source of truth, imported once in `app/layout.tsx`:
- **Brand hue ramps** — full 50–900 OKLCH ramps for blue `#148CFF`, green `#20C621`, red `#FF4F59`, yellow `#FFDD6C` (500 = the brand color, all gamut-mapped).
- **AA-on-white "ink" anchors** + **semantic role tokens** (light defaults, dark overrides targeting both `.dark` and `[data-theme="dark"]`).
- **Shared neutral foundation** — Tailwind gray ramp (`--ds-gray-50…900`) + `--ds-white`/`--ds-black`.

Wired into all three styling "worlds":
- **`/playground`** — `--primary/--blue/--green/--red/--yellow` (+ the SQL `--danger/--ok-accent/--err-accent/--accent`) repointed to brand tokens; editor-theme palettes left independent.
- **`/learn`** (Fumadocs) — `--color-fd-primary`/`-ring` and the callout tokens `--color-fd-{info,warning,error,success}` mapped to brand (ink in light, brighter steps in dark); callouts were previously muted gray.
- **`/` home** — accents + title gradient tokenized (stays dark-only by design).
- **`/color-test`** — renders the ink anchors + all 40 brand ramp swatches as a QA harness.

## 2. CSS cleanup of learning components

Once components pulled brand colors from `--ds-*`, their local palettes became redundant. Cleaned up with provably appearance-preserving, mechanical refactors:
- **ChallengeCard:** **81 → 34** vars (−58%). Collapsed the `--ch-{blue,green,red,amber}-NNN` pass-through steps to `--ds-*`, removed dead vars, migrated neutrals to the shared ramp. Keeps only semantic aliases + a small local `--ch-slate-*` set.
- **MultipleChoiceQuestion:** **57 → 15** vars (−74%). Same collapse, **plus** migrating the dark-mode block (verdict/banner washes + text) off hardcoded Tailwind hues to brand `color-mix()` / `--ds-*` ramp — so MCQ uses the palette in both light *and* dark.
- **CodeBlock:** repointed to `--ds-yellow-500` / shared neutrals; removed dead vars.
- **learn.css:** merged duplicate `:root`/`.dark` blocks.

All brand colors across these components now flow through `--ds-*`; only neutrals/surfaces remain as literals.

## 3. Research reports (`agent-outputs/`)

- `20260605-0532-ai-image-generation-for-course-illustrations.md` — AI image-gen APIs & June-2026 pricing, cost estimates for the 781-chapter corpus, a context-aware generation pipeline, SVG/transparency, light/dark strategy, Vercel-Hobby hosting options, and ready-to-test prompts (using the real palette).
- `20260606-0540-brand-color-system.md` — the design + accessibility analysis behind the implementation: palette is dark-mode-native, contrast tables, the 50–900 ramps, per-route token architecture, and the phased migration log (Phases 0–6).

## Verification

Every step verified: `npm run build` green (799 pages), `npm run lint` clean (0 errors), `npm test` **445/445 pass**, and grep-confirmed **0 dangling variable references**. Visual/pixel review still recommended (the environment can't screenshot).

## Follow-ups (not in this PR)
- A CI grep/lint rule to flag new raw-hex brand colors.
- Optional: a light-mode home redesign; bumping green-on-white text in cards to a darker step (pre-existing sub-AA).

https://claude.ai/code/session_01P5ZSCa2xos2L8WxSRd4rHn