### PR TITLE
Render Mermaid timelines as a responsive React component

### DIFF
--- a/__tests__/timeline.test.ts
+++ b/__tests__/timeline.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { parseMermaidTimeline } from "../app/_components/mdx/timeline";
+
+describe("parseMermaidTimeline", () => {
+  it("extracts the title and one entry per period", () => {
+    const chart = [
+      "timeline",
+      "    title The C family tree",
+      "    1972 : C by Dennis Ritchie at Bell Labs",
+      "    1973 : UNIX rewritten in C",
+    ].join("\n");
+
+    const { title, entries } = parseMermaidTimeline(chart);
+
+    expect(title).toBe("The C family tree");
+    expect(entries).toEqual([
+      { period: "1972", events: ["C by Dennis Ritchie at Bell Labs"] },
+      { period: "1973", events: ["UNIX rewritten in C"] },
+    ]);
+  });
+
+  it("splits only on the first colon so event text may contain colons", () => {
+    const chart = [
+      "timeline",
+      '    1996 : Ihaka & Gentleman publish "R: A Language for Data Analysis"',
+    ].join("\n");
+
+    const { entries } = parseMermaidTimeline(chart);
+
+    expect(entries).toEqual([
+      {
+        period: "1996",
+        events: ['Ihaka & Gentleman publish "R: A Language for Data Analysis"'],
+      },
+    ]);
+  });
+
+  it("attaches continuation lines as extra events under the prior period", () => {
+    const chart = [
+      "timeline",
+      "    1996 : First event",
+      "           Second event on the same year",
+    ].join("\n");
+
+    const { entries } = parseMermaidTimeline(chart);
+
+    expect(entries).toEqual([
+      {
+        period: "1996",
+        events: ["First event", "Second event on the same year"],
+      },
+    ]);
+  });
+
+  it("handles literal \\n escapes from the Mermaid pipeline", () => {
+    const chart = "timeline\\n    title T\\n    2009 : ECMAScript 5";
+
+    const { title, entries } = parseMermaidTimeline(chart);
+
+    expect(title).toBe("T");
+    expect(entries).toEqual([{ period: "2009", events: ["ECMAScript 5"] }]);
+  });
+
+  it("keeps section labels as standalone entries", () => {
+    const chart = [
+      "timeline",
+      "    section 21st century",
+      "    2009 : Node.js",
+    ].join("\n");
+
+    const { entries } = parseMermaidTimeline(chart);
+
+    expect(entries).toEqual([
+      { period: "21st century", events: [] },
+      { period: "2009", events: ["Node.js"] },
+    ]);
+  });
+});

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -12,8 +12,20 @@ import {
 import { useTheme } from "next-themes";
 import { Maximize2, Minus, Plus, RotateCcw, X } from "lucide-react";
 import styles from "./mermaid.module.css";
+import { Timeline } from "./timeline";
 
 export function Mermaid({ chart }: { chart: string }) {
+  // Mermaid lays `timeline` diagrams out horizontally, so a chart with many
+  // year-columns grows far wider than the article column and gets scaled down
+  // until the text is unreadable. Render those with our vertical, responsive
+  // <Timeline> instead; everything else falls through to the Mermaid SVG.
+  if (/^\s*timeline\b/i.test(chart.replace(/\\n/g, "\n"))) {
+    return <Timeline chart={chart} />;
+  }
+  return <MermaidDiagram chart={chart} />;
+}
+
+function MermaidDiagram({ chart }: { chart: string }) {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {

--- a/app/_components/mdx/timeline.module.css
+++ b/app/_components/mdx/timeline.module.css
@@ -42,56 +42,48 @@
   padding: 0.6rem 0;
 }
 
-/* Circular marker sitting on the rail, aligned to the period line. */
+/* Small filled marker sitting on the rail, aligned to each card's top border. */
 .marker {
   position: absolute;
   left: 50%;
-  top: 1.15rem;
-  width: 14px;
-  height: 14px;
+  top: 0.6rem;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
   transform: translate(-50%, -50%);
-  background: var(--color-fd-primary, #4f8ef7);
-  /* Knock a gap in the rail and ring the dot so it reads as a node on the line. */
-  box-shadow:
-    0 0 0 4px var(--color-fd-background, #0f1117),
-    0 0 0 6px var(--color-fd-primary, #4f8ef7);
+  background: var(--color-fd-foreground, #e2e8f0);
   z-index: 1;
 }
 
+/* Cards are borderless apart from a top rule, hugging the rail. */
 .card {
-  max-width: 26rem;
-  padding: 0.65rem 0.95rem;
-  border: 1px solid var(--color-fd-border, #2a3347);
-  border-radius: 8px;
-  background: var(--color-fd-card, rgba(22, 27, 39, 0.6));
+  padding: 0.6rem 0 0;
+  border-top: 1px solid var(--color-fd-border, #2a3347);
 }
 
-/* Even rows sit on the left of the rail (text hugging the rail, right-aligned);
+/* Even rows sit on the left of the rail (text right-aligned, hugging the rail);
    odd rows on the right (left-aligned). */
 .left .card {
   grid-column: 1;
-  justify-self: end;
   text-align: right;
 }
 
 .right .card {
   grid-column: 2;
-  justify-self: start;
   text-align: left;
 }
 
 .period {
   margin: 0 0 0.3rem;
-  font-size: 0.95rem;
+  font-size: 1rem;
   font-weight: 700;
-  color: var(--color-fd-primary, #4f8ef7);
+  color: var(--color-fd-foreground, #e2e8f0);
   font-variant-numeric: tabular-nums;
 }
 
 .event {
   margin: 0.2rem 0;
-  font-size: 0.95rem;
+  font-size: 1rem;
   line-height: 1.45;
   color: var(--color-fd-foreground, #e2e8f0);
 }

--- a/app/_components/mdx/timeline.module.css
+++ b/app/_components/mdx/timeline.module.css
@@ -1,0 +1,129 @@
+.timeline {
+  /* Establish a container so the wide/narrow layout switch below responds to
+     the article column width, not the viewport. */
+  container-type: inline-size;
+  margin: 1.75rem 0;
+  font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
+}
+
+.title {
+  margin: 0 0 1.5rem;
+  text-align: center;
+  font-size: 1.1rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--color-fd-foreground, #e2e8f0);
+}
+
+.track {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* The central rail. */
+.track::before {
+  content: "";
+  position: absolute;
+  top: 0.4rem;
+  bottom: 0.4rem;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--color-fd-border, #2a3347);
+}
+
+.row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 3rem;
+  padding: 0.6rem 0;
+}
+
+/* Circular marker sitting on the rail, aligned to the period line. */
+.marker {
+  position: absolute;
+  left: 50%;
+  top: 1.15rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--color-fd-primary, #4f8ef7);
+  /* Knock a gap in the rail and ring the dot so it reads as a node on the line. */
+  box-shadow:
+    0 0 0 4px var(--color-fd-background, #0f1117),
+    0 0 0 6px var(--color-fd-primary, #4f8ef7);
+  z-index: 1;
+}
+
+.card {
+  max-width: 26rem;
+  padding: 0.65rem 0.95rem;
+  border: 1px solid var(--color-fd-border, #2a3347);
+  border-radius: 8px;
+  background: var(--color-fd-card, rgba(22, 27, 39, 0.6));
+}
+
+/* Even rows sit on the left of the rail (text hugging the rail, right-aligned);
+   odd rows on the right (left-aligned). */
+.left .card {
+  grid-column: 1;
+  justify-self: end;
+  text-align: right;
+}
+
+.right .card {
+  grid-column: 2;
+  justify-self: start;
+  text-align: left;
+}
+
+.period {
+  margin: 0 0 0.3rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--color-fd-primary, #4f8ef7);
+  font-variant-numeric: tabular-nums;
+}
+
+.event {
+  margin: 0.2rem 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: var(--color-fd-foreground, #e2e8f0);
+}
+
+.event:first-of-type {
+  margin-top: 0;
+}
+
+.event:last-child {
+  margin-bottom: 0;
+}
+
+/* Narrow columns: collapse to a single left-railed column so cards keep their
+   full width and stay legible. */
+@container (max-width: 33rem) {
+  .track::before {
+    left: 7px;
+  }
+
+  .row {
+    grid-template-columns: 1fr;
+  }
+
+  .left .card,
+  .right .card {
+    grid-column: 1;
+    justify-self: stretch;
+    text-align: left;
+    margin-left: 1.75rem;
+  }
+
+  .marker {
+    left: 7px;
+  }
+}

--- a/app/_components/mdx/timeline.tsx
+++ b/app/_components/mdx/timeline.tsx
@@ -1,0 +1,137 @@
+import { Fragment, type ReactNode } from "react";
+import styles from "./timeline.module.css";
+
+/**
+ * A single point on the timeline: one time period (the marker on the rail)
+ * plus the one or more event descriptions recorded against it.
+ */
+export interface TimelineEntry {
+  period: string;
+  events: string[];
+}
+
+export interface ParsedTimeline {
+  title?: string;
+  entries: TimelineEntry[];
+}
+
+/**
+ * Parse a Mermaid `timeline` chart into structured data.
+ *
+ * We render these as a native React timeline instead of a Mermaid SVG because
+ * Mermaid lays timelines out horizontally: with a dozen year-columns the SVG
+ * grows far wider than the article column and gets scaled to fit, leaving the
+ * text illegible. The vertical layout below stays readable at any width.
+ *
+ * Supported subset (everything our lesson content actually uses):
+ *
+ *   timeline
+ *       title The C family tree
+ *       1972 : C by Dennis Ritchie at Bell Labs
+ *       1996 : Ihaka & Gentleman publish "R: A Language…"
+ *              Core development team forms (now "R Core")
+ *
+ * Rules:
+ *   - `title <text>`            → diagram title.
+ *   - `section <text>`          → group label (rare in our content; rendered
+ *                                 as a divider so nothing is silently dropped).
+ *   - `<period> : <event>`      → a new marker. Only the FIRST colon splits the
+ *                                 period from the text, because event text
+ *                                 frequently contains colons (book titles, etc.).
+ *   - an indented continuation line with no colon attaches as an additional
+ *     event under the most recent period (Mermaid stacks these).
+ *
+ * Note we deliberately do not split the event text on subsequent colons into
+ * multiple events: none of our timelines rely on that, and doing so would
+ * mangle the common `"Title: Subtitle"` case.
+ */
+export function parseMermaidTimeline(chart: string): ParsedTimeline {
+  // The Mermaid pipeline can hand us literal "\n" escapes rather than real
+  // newlines (see mermaid.tsx), so normalise both forms.
+  const lines = chart.replace(/\\n/g, "\n").split("\n");
+
+  let title: string | undefined;
+  const entries: TimelineEntry[] = [];
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (/^timeline\b/i.test(line)) continue;
+
+    const titleMatch = line.match(/^title\s+(.+)$/i);
+    if (titleMatch) {
+      title = titleMatch[1].trim();
+      continue;
+    }
+
+    const sectionMatch = line.match(/^section\s+(.+)$/i);
+    if (sectionMatch) {
+      entries.push({ period: sectionMatch[1].trim(), events: [] });
+      continue;
+    }
+
+    const colon = line.indexOf(":");
+    if (colon !== -1) {
+      const period = line.slice(0, colon).trim();
+      const event = line.slice(colon + 1).trim();
+      entries.push({ period, events: event ? [event] : [] });
+    } else if (entries.length > 0) {
+      entries[entries.length - 1].events.push(line);
+    }
+  }
+
+  return { title, entries };
+}
+
+/**
+ * Render Mermaid `<br>` separators inside event text as real line breaks.
+ * Event text is plain author prose (no HTML), so this is the only inline
+ * markup we need to honour.
+ */
+function renderEventText(text: string): ReactNode {
+  const parts = text.split(/<br\s*\/?>/i);
+  return parts.map((part, i) => (
+    <Fragment key={i}>
+      {i > 0 && <br />}
+      {part}
+    </Fragment>
+  ));
+}
+
+/**
+ * Vertical, center-railed timeline for Mermaid `timeline` diagrams.
+ *
+ * A single rail runs down the centre with a circular marker for every period;
+ * the event cards alternate left and right of the rail on wide layouts and
+ * collapse to a single left-railed column on narrow ones. Layout switching is
+ * driven by a container query so it responds to the article column width
+ * rather than the viewport.
+ */
+export function Timeline({ chart }: { chart: string }) {
+  const { title, entries } = parseMermaidTimeline(chart);
+  if (entries.length === 0) return null;
+
+  return (
+    <figure className={styles.timeline}>
+      {title && <figcaption className={styles.title}>{title}</figcaption>}
+      <ol className={styles.track}>
+        {entries.map((entry, i) => (
+          <li
+            key={i}
+            className={`${styles.row} ${i % 2 === 0 ? styles.left : styles.right}`}
+          >
+            <span className={styles.marker} aria-hidden="true" />
+            <div className={styles.card}>
+              <p className={styles.period}>{entry.period}</p>
+              {entry.events.map((event, j) => (
+                <p key={j} className={styles.event}>
+                  {renderEventText(event)}
+                </p>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </figure>
+  );
+}


### PR DESCRIPTION
## Problem

Mermaid lays `timeline` diagrams out **horizontally**. With a dozen year-columns the SVG grows far wider than the article column and gets scaled down to fit, leaving the text illegible — exactly the issue reported across our 26 history lessons.

## Fix

Route `timeline` Mermaid charts to a new, native React `<Timeline>` component (everything else still falls through to the Mermaid SVG renderer):

- **Center-aligned vertical rail** with a **circular marker** for every period.
- **Event cards alternate left and right** of the rail on wide layouts.
- **Responsive:** collapses to a single left-railed column on narrow widths. The switch is driven by a CSS **container query**, so it responds to the actual article-column width rather than the viewport.
- Themed entirely with existing Fumadocs `--color-fd-*` tokens, so light/dark both work.

A small parser (`parseMermaidTimeline`) converts the Mermaid `timeline` subset our content uses — `title`, `<period> : <event>`, and indented continuation lines — into structured data. It splits each entry on the **first** colon only, so event text containing colons (book titles like `"R: A Language for Data Analysis"`) stays intact.

Because the routing happens inside the existing `<Mermaid>` component, **all 26 existing timeline diagrams pick up the new rendering with zero content edits**.

## Verification

- New unit tests for the parser (`__tests__/timeline.test.ts`) — title extraction, first-colon splitting, continuation lines, literal `\n` handling, and section labels.
- Full suite green: **450 tests pass**. `eslint` and `tsc --noEmit` clean.
- Rendered a real lesson (`/learn/c-programming-for-beginners/story-of-c`) and verified the alternating desktop layout and the collapsed mobile layout in a headless browser; text is fully legible at both widths.

### Desktop
Alternating cards either side of a center rail with circular markers.

### Mobile
Single left-railed column, full-width cards.

https://claude.ai/code/session_015TnXukk5pzoa67op4yzrsr

---
_Generated by [Claude Code](https://claude.ai/code/session_015TnXukk5pzoa67op4yzrsr)_