### PR TITLE
Pin playground & docs toasts and empty-state to Inter (no serif leak)

### DIFF
--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -573,6 +573,17 @@
 }
 
 .toastTitle {
+  /* `Toast.Title` renders an <h2>, and the toast is portaled to <body> —
+     outside the /learn docs container that maps `--font-serif` to Source
+     Serif. There the docs' `h1–h6 { font-family: var(--font-serif) }` rule
+     resolves to Tailwind's `ui-serif` default and wins over the Inter set on
+     `.toastRoot` (a directly-matched element rule beats an inherited value).
+     Pin Inter on the title itself so the toast text stays in the UI font. */
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    sans-serif;
   font-weight: 500;
   font-size: 12.5px;
   line-height: 1.35;

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1267,6 +1267,11 @@ body.playground-active {
   height: 100%;
   gap: 6px;
   color: var(--text);
+  /* Pin the empty-state text to Inter. Without this the heading/body simply
+     inherit the document font, which is fine on the standalone playground but
+     lets a serif stack leak in wherever the playground is mounted inside a
+     serif-scoped context (the heading especially — see `.welcome h3`). */
+  font-family: var(--font-ui);
   text-align: center;
   padding: 32px;
 }
@@ -1275,6 +1280,11 @@ body.playground-active {
   font-size: 32px;
 }
 .welcome h3 {
+  /* "Run a query to see results" is an <h3>. A bare `h3` selector (e.g. the
+     /learn docs' `h1–h6 { font-family: var(--font-serif) }`) would otherwise
+     win over the inherited value above, so pin Inter directly here — the
+     `.welcome h3` selector outranks a lone element selector. */
+  font-family: var(--font-ui);
   font-size: 16px;
   font-weight: 500;
   margin: 0;
@@ -3363,6 +3373,10 @@ html[data-playground-theme="light"] .toast {
 }
 
 .toast-title {
+  /* `Toast.Title` renders an <h2>. Pin Inter directly (rather than relying on
+     the `.toast` parent's font-family) so a bare `h1–h6` rule from a
+     serif-scoped host context can't override the inherited value. */
+  font-family: var(--font-ui);
   font-weight: 600;
   font-size: 12.5px;
   line-height: 1.35;
@@ -3370,6 +3384,7 @@ html[data-playground-theme="light"] .toast {
   margin: 0;
 }
 .toast-desc {
+  font-family: var(--font-ui);
   font-size: 11.5px;
   color: var(--text);
   margin-top: 2px;


### PR DESCRIPTION
## What

Ensures the playground UI and the `/learn` docs toasts only ever render in **Inter** (UI) or **JetBrains Mono** (code) — never a serif face. Addresses two reported cases where text rendered in `ui-serif`:

1. The SQL playground empty state **"Run a query to see results"**
2. Toasts such as **"Already formatted — nothing to change."**

## Why it happened

These elements set no `font-family` of their own and relied on inheritance:

- `.welcome h3` (the empty-state heading) is an `<h3>`.
- Base UI's `Toast.Title` renders an `<h2>`, and the toast is portaled to `<body>`.

Inside the `/learn` route, learn.css applies `h1–h6 { font-family: var(--font-serif), … }`. For a **portaled** toast (rendered on `document.body`, *outside* the `DocsLayout` container that maps `--font-serif` to Source Serif), `--font-serif` resolves to **Tailwind v4's default** `ui-serif, Georgia, …`. A directly-matched element rule (`h2`) beats an inherited value, so the toast title rendered serif. The empty-state heading hit the same `h1–h6` rule.

## Fix

Pin the affected elements directly to the UI font. A class selector (`0,1,0`) outranks a bare element selector (`0,0,1`) — both unlayered — so the pin wins even in the serif-scoped `/learn` route:

| File | Selector(s) | Update |
|---|---|---|
| `app/_components/playground.css` | `.welcome`, `.welcome h3`, `.toast-title`, `.toast-desc` | 1 (playground) |
| `app/_components/CodeBlock.module.css` | `.toastTitle` (the portaled docs toast) | 2 (`/learn`) |

## Notes / scope

- Audited every `font-family` in `playground.css` / `sqlPlayground.css`: all resolve to Inter (`--font-ui` / `--font-sans`) or JetBrains Mono (`--font-mono`); the Google Fonts import loads only those two families. The serif was purely an inheritance gap, now closed.
- Challenge-card toasts (`ChallengeCard` / `SqlChallengeCard` / `SqlCodeBlock`) already render as a non-heading `<span>` with `--ch-font-ui` (Inter) and are mounted in-card (not portaled), so they were unaffected and are left as-is.
- Intentional Source Serif usage in `/learn` prose, headings, Mermaid, and timelines is left untouched — only the toast was in scope for Update 2.

## Verification

CSS-only change. Verified by static analysis of the cascade (class-vs-element specificity, unlayered rules) and a full font-family audit of the playground stylesheets. The serif could only reach a portaled toast via the `h1–h6` rule, which confirms `Toast.Title` is a heading and that pinning the title class resolves it.

https://claude.ai/code/session_01EN1GBpqogJfDz3vJxHbW2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01EN1GBpqogJfDz3vJxHbW2d)_