### PR TITLE
Theme Mermaid diagrams with the brand color system (light + dark)

### DIFF
--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -181,15 +181,17 @@ Use `color-mix()` for tints (the playground already does this): `color-mix(in sr
 
 ### 4.3 Fourth consumer — Mermaid diagrams (JS, not CSS)
 
-`/learn` renders Mermaid diagrams (flowcharts dominate, plus ER, sequence, class, state, gantt, mindmaps). Mermaid **can't read `var(--ds-*)`** — it runs color math (khroma) over its theme variables and needs concrete colors. So instead of the stock **`neutral`** (light) / **`dark`** themes, `app/_components/mdx/mermaid.tsx` now builds Mermaid's customizable **`base`** theme from the brand palette for **both** modes: it resolves the `--ds-*` tokens to hex at render time (via `getComputedStyle`, keeping `brand.css` the source of truth, with literal fallbacks) and maps them onto Mermaid's `themeVariables`.
+`/learn` renders Mermaid diagrams (flowcharts dominate, plus ER, sequence, class, state, gantt, mindmaps). Mermaid **can't read `var(--ds-*)`** — it runs color math (khroma) over its theme variables and needs concrete colors. So instead of the stock **`neutral`** (light) / **`dark`** themes, `app/_components/mdx/mermaid.tsx` builds Mermaid's customizable **`base`** theme from the brand palette: it resolves the `--ds-*` tokens to hex at render time (via `getComputedStyle`, keeping `brand.css` the source of truth, with literal fallbacks) and maps them onto Mermaid's `themeVariables`.
 
-The mapping mirrors the rest of the system:
-- **Nodes** — light: soft `blue-50` fill, `blue-600` border, `gray-900` text; dark: `gray-800` card, bright `blue-400` border, `gray-50` text (the blue border is the consistent brand signal across modes).
-- **Structure** — neutral `--ds-gray-*` for edges, arrowheads, lifelines, and subgraph/cluster backgrounds, so the chrome stays quiet and brand blue reads as the accent.
+**One light palette, in both modes — the legibility constraint that shapes everything.** ~200 MDX diagrams hand-color nodes with `classDef` using **light pastel fills and no text color** (e.g. `classDef bad fill:#fee2e2,stroke:#b91c1c`). Mermaid exposes a *single* global node-text color, so it must be **dark** to stay readable on those author fills — which means our own node fills must be light too. The diagram is therefore **light-based in both modes**, and dark mode is handled by rendering the whole figure on a soft **light "figure card"** (a `border-radius`'d white panel in `mermaid.module.css`, applied to both the inline diagram and the fullscreen modal). This keeps every label dark-on-light and author pastels legible, with no per-element light/dark juggling.
+
+The mapping, tuned to be soft and low-border (per the report updates):
+- **Nodes** — soft `blue-50` fill, **minimal `blue-200` hairline** border (not the old bold accent border), `gray-900` text. Author `classDef` fills keep their colors; only the bold default borders were toned down.
+- **Structure** — neutral `--ds-gray-*` for edges, arrowheads, lifelines, and subgraph/cluster backgrounds; edge-label backdrops blend into the canvas/card.
 - **Semantic hues keep their meaning** — yellow "sticky-note" notes; red critical-path and "today" markers in gantt.
-- **Categorical wheel** — mindmaps cycle the **seven-hue** wheel (§1.1): light = soft `-200` fills under dark labels, dark = deep `-800` fills under light labels. (Mermaid re-applies overrides *after* its internal derivation, so these exact values reach the SVG — its built-in `cScale` darkening is bypassed.)
+- **Categorical wheel** — mindmaps cycle the **seven-hue** wheel (§1.1) as soft `-200` fills under dark labels, identical in both modes. (Mermaid re-applies overrides *after* its internal derivation, so these exact values reach the SVG — its built-in `cScale` darkening is bypassed.)
 
-Every node/line/text pairing is WCAG-AA verified, and the output was spot-checked with **Playwright** across all diagram types in light and dark.
+Every node/label pairing is dark-on-light (WCAG-AA), and the output was spot-checked with **Playwright** across all diagram types in light and dark — including the author-`classDef` pages that exposed the original dark-mode legibility bug.
 
 ### 4.4 Result
 
@@ -255,7 +257,15 @@ Deliberately **left alone:** non-brand decoratives (violet/purple `--ch-violet-*
 
 Across Phases 5–6: **ChallengeCard 81 → 34** unique vars (−58%), **MCQ 57 → 15** (−74%). **0 dangling references**, build green, lint clean, 445 tests pass throughout.
 
-**Phase 7 — Mermaid chart theme — ✅ done.** `app/_components/mdx/mermaid.tsx` previously selected Mermaid's stock `neutral` (light) / `dark` themes. It now builds the customizable **`base`** theme from the brand palette for both modes (see §4.3), so diagrams match the rest of `/learn`. This is also what motivated the **three decorative hues** (§1.1): mindmaps and other categorical diagrams now cycle the seven-hue brand wheel instead of Mermaid's off-brand defaults. Typecheck + lint clean; verified visually with Playwright across flowchart / ER / sequence / class / state / gantt / mindmap in light and dark.
+**Phase 7 — Mermaid chart theme — ✅ done.** `app/_components/mdx/mermaid.tsx` previously selected Mermaid's stock `neutral` (light) / `dark` themes. It now builds the customizable **`base`** theme from the brand palette (see §4.3), so diagrams match the rest of `/learn`. This is also what motivated the **three decorative hues** (§1.1): mindmaps and other categorical diagrams cycle the seven-hue brand wheel instead of Mermaid's off-brand defaults.
+
+A follow-up pass refined the look after dark-mode review:
+- **Fixed a dark-mode legibility bug.** The first cut used dark nodes + light text in dark mode, which made the ~200 author `classDef` light-pastel nodes (light fill + inherited light text) unreadable. Switched to a single **light palette in both modes** with dark text, rendered on a soft **light figure card** in dark mode (§4.3) — author pastels and edge labels are now legible everywhere.
+- **Minimized borders.** Default node borders dropped from the bold `blue-600` to a soft `blue-200` hairline.
+- **Softer, less "poppy" palette.** Low-contrast `-50/-200` fills, neutral-gray connectors, and the figure card give a calmer, more figure-like look.
+- **`/color-test`** now also renders the teal / purple / orange ramps + ink anchors, so the QA gate covers the decorative hues.
+
+Typecheck + lint clean, 450 unit tests pass; verified visually with Playwright across flowchart / ER / sequence / class / state / gantt / mindmap in light and dark (incl. author-`classDef` pages).
 
 ---
 
@@ -280,7 +290,7 @@ The same dark-native asymmetry from §2 applies to illustrations, but illustrati
 2. **One `app/brand.css` token layer** (✅ shipped) — brand hue ramps, ink anchors, semantic roles, **a shared neutral ramp (`--ds-gray-*`, `--ds-white/black`)**, and **three non-semantic decorative hues (teal/purple/orange)** for categorical use in charts and illustrations (§1.1) — adapted into each world (CSS modules → tokens, Fumadocs `--color-fd-*` remap, playground `--primary/...` remap). Dark overrides target both `.dark` (/learn) and `[data-theme="dark"]` (/playground); dark-only home uses the raw ramp. Components (challenge cards, quizzes, code blocks) keep only semantic aliases — all literal palette values now live in `brand.css`.
 3. **Lock semantic meaning** (blue=primary, green=success, red=error, yellow=attention; decoratives carry none) and the accessibility do/don'ts.
 4. **Migrate playground → learn → home**, using `/color-test` as the QA gate; then de-dupe ad-hoc hex.
-5. **Charts (Mermaid):** the `/learn` diagram theme is built from the brand palette (Mermaid `base` theme, both modes) instead of the stock neutral/dark themes; mindmaps cycle the seven-hue categorical wheel (§4.3). Playwright-verified.
+5. **Charts (Mermaid):** the `/learn` diagram theme is built from the brand palette (Mermaid `base` theme) instead of the stock neutral/dark themes. It uses one **soft light palette with dark text in both modes** — required so author `classDef` pastel fills stay legible — rendered on a light **figure card** in dark mode, with minimal hairline borders; mindmaps cycle the seven-hue categorical wheel (§4.3). Playwright-verified in light and dark.
 6. **Illustrations:** feasible and well-suited in both modes — transparent backgrounds + mid-tone palette use (or SVG), bright hues for dark, slightly tempered for light.
 
 ---

--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -183,15 +183,17 @@ Use `color-mix()` for tints (the playground already does this): `color-mix(in sr
 
 `/learn` renders Mermaid diagrams (flowcharts dominate, plus ER, sequence, class, state, gantt, mindmaps). Mermaid **can't read `var(--ds-*)`** — it runs color math (khroma) over its theme variables and needs concrete colors. So instead of the stock **`neutral`** (light) / **`dark`** themes, `app/_components/mdx/mermaid.tsx` builds Mermaid's customizable **`base`** theme from the brand palette: it resolves the `--ds-*` tokens to hex at render time (via `getComputedStyle`, keeping `brand.css` the source of truth, with literal fallbacks) and maps them onto Mermaid's `themeVariables`.
 
-**One light palette, in both modes — the legibility constraint that shapes everything.** ~200 MDX diagrams hand-color nodes with `classDef` using **light pastel fills and no text color** (e.g. `classDef bad fill:#fee2e2,stroke:#b91c1c`). Mermaid exposes a *single* global node-text color, so it must be **dark** to stay readable on those author fills — which means our own node fills must be light too. The diagram is therefore **light-based in both modes**, and dark mode is handled by rendering the whole figure on a soft **light "figure card"** (a `border-radius`'d white panel in `mermaid.module.css`, applied to both the inline diagram and the fullscreen modal). This keeps every label dark-on-light and author pastels legible, with no per-element light/dark juggling.
+**A light theme in light mode and a real dark theme in dark mode**, so each matches the surrounding page. Light: soft tints on white. Dark: layered slate (page < cluster < node) with light text — genuinely dark, *not* a white card on a dark page.
 
-The mapping, tuned to be soft and low-border (per the report updates):
-- **Nodes** — soft `blue-100` fill (light enough to stay calm, dark enough to read as "blue" on the white card; `blue-50` looked colorless), a **soft `blue-300` hairline** border (not the old bold accent border), `gray-900` text. Author `classDef` fills keep their colors; only the bold default borders were toned down.
-- **Structure** — neutral `--ds-gray-*` for edges, arrowheads, lifelines, and subgraph/cluster backgrounds; edge-label backdrops blend into the canvas/card.
-- **Semantic hues keep their meaning** — yellow "sticky-note" notes; red critical-path and "today" markers in gantt.
-- **Categorical wheel** — mindmaps cycle the **seven-hue** wheel (§1.1) as soft `-200` fills under dark labels, identical in both modes. (Mermaid re-applies overrides *after* its internal derivation, so these exact values reach the SVG — its built-in `cScale` darkening is bypassed.)
+**The legibility wrinkle (and how it's solved).** ~200 MDX diagrams hand-color nodes with `classDef` using **light pastel fills and no text color** (e.g. `classDef bad fill:#fee2e2,stroke:#b91c1c`). Mermaid exposes a *single* global node-text color, so a dark theme's light text would be light-on-light on those author fills. The fix is `adaptNodeLabels`: after render (the SVG must be in the DOM, since `classDef` fills come from injected CSS classes), it reads each flowchart node's **own fill luminance** and sets that node's label color — **dark text on light fills, light text on dark fills**. So default nodes go properly dark (light text) while author pastels keep dark text; the colored nodes read as intentional emphasis. It's idempotent and harmless in light mode.
 
-Every node/label pairing is dark-on-light (WCAG-AA), and the output was spot-checked with **Playwright** across all diagram types in light and dark — including the author-`classDef` pages that exposed the original dark-mode legibility bug.
+The mapping, tuned soft and low-border (per the report updates):
+- **Nodes** — light: soft `blue-100` fill, soft `blue-300` hairline border. Dark: `gray-700` node on a `gray-800` cluster on the `gray-900`/page, subtle `gray-600` border. Label color is then set per-node by `adaptNodeLabels`.
+- **Structure** — neutral `--ds-gray-*` connectors/arrowheads/lifelines; free-floating text (titles, sequence signals) follows the page foreground; edge-label backdrops blend into the page.
+- **Semantic hues keep their meaning** — yellow notes; red critical-path / "today" markers in gantt.
+- **Categorical wheel** — mindmaps cycle the **seven-hue** wheel (§1.1): soft `-200` fills + dark labels in light, deep `-800` fills + light labels in dark. (Mermaid re-applies overrides *after* its internal derivation, so these reach the SVG verbatim — its `cScale` darkening is bypassed; mindmap sections aren't `.node`, so `adaptNodeLabels` leaves them alone.)
+
+Spot-checked with **Playwright** across all diagram types in light and dark — including the author-`classDef` pages that exposed the original dark-mode legibility bug.
 
 ### 4.4 Result
 
@@ -259,15 +261,12 @@ Across Phases 5–6: **ChallengeCard 81 → 34** unique vars (−58%), **MCQ 57 
 
 **Phase 7 — Mermaid chart theme — ✅ done.** `app/_components/mdx/mermaid.tsx` previously selected Mermaid's stock `neutral` (light) / `dark` themes. It now builds the customizable **`base`** theme from the brand palette (see §4.3), so diagrams match the rest of `/learn`. This is also what motivated the **three decorative hues** (§1.1): mindmaps and other categorical diagrams cycle the seven-hue brand wheel instead of Mermaid's off-brand defaults.
 
-A follow-up pass refined the look after dark-mode review:
-- **Fixed a dark-mode legibility bug.** The first cut used dark nodes + light text in dark mode, which made the ~200 author `classDef` light-pastel nodes (light fill + inherited light text) unreadable. Switched to a single **light palette in both modes** with dark text, rendered on a soft **light figure card** in dark mode (§4.3) — author pastels and edge labels are now legible everywhere.
-- **Minimized borders.** Default node borders dropped from the bold `blue-600` to a soft `blue-300` hairline.
-- **Softer, less "poppy" palette.** Low-contrast fills, neutral-gray connectors, and the figure card give a calmer, more figure-like look.
-- **`/color-test`** now also renders the teal / purple / orange ramps + ink anchors, so the QA gate covers the decorative hues.
+Dark mode took a few review iterations to get right (recorded here because each step informed the final design):
+1. **First cut** — dark nodes + light text. Broke the ~200 author `classDef` light-pastel nodes (light fill + inherited light text → invisible).
+2. **Light figure card** — flipped to one light palette in both modes, rendered on a white "figure card" in dark mode. Legible, but (a) the card used `width: fit-content`, which collapsed the SVG (it's sized `width:100%; max-width:<W>px`, so a shrink-to-fit parent gives ~0 width), and (b) `blue-50` fills looked washed-out on white. Also reviewers (rightly) read a white card on a dark page as "still light mode."
+3. **Final — a real dark theme + `adaptNodeLabels`.** Dark mode now uses a genuine dark theme (layered slate, light text, no card); the card CSS is removed. The author-pastel constraint is solved by `adaptNodeLabels`, which sets each node's label color from its own fill luminance (§4.3) — so default nodes go dark while author pastels keep dark text. Node fills are `blue-100`/`blue-300` in light, `gray-700`/`gray-600` in dark.
 
-A second dark-mode review caught two more issues, now fixed:
-- **Shrinking.** The figure card used `width: fit-content`, but the SVG is sized `width: 100%; max-width: <W>px` — a shrink-to-fit parent gave it ~0 intrinsic width, collapsing the diagram. The card now keeps `width: 100%` (the SVG renders at its natural size, centered).
-- **Washed-out colors.** `blue-50` node fills were nearly indistinguishable from the white card. Bumped to `blue-100` (clearly blue, still soft) with a `blue-300` edge.
+Alongside: **minimized borders** (default node border `blue-600` → soft hairline), a **softer, less "poppy" palette**, and **`/color-test`** now renders the teal / purple / orange ramps + ink anchors so the QA gate covers the decorative hues. Verified with Playwright across flowchart / ER / sequence / class / state / gantt / mindmap in both modes (incl. author-`classDef` pages); dark-mode SVG widths match light mode (no shrinking).
 
 Typecheck + lint clean, 450 unit tests pass; verified visually with Playwright across flowchart / ER / sequence / class / state / gantt / mindmap in light and dark (incl. author-`classDef` pages).
 
@@ -294,7 +293,7 @@ The same dark-native asymmetry from §2 applies to illustrations, but illustrati
 2. **One `app/brand.css` token layer** (✅ shipped) — brand hue ramps, ink anchors, semantic roles, **a shared neutral ramp (`--ds-gray-*`, `--ds-white/black`)**, and **three non-semantic decorative hues (teal/purple/orange)** for categorical use in charts and illustrations (§1.1) — adapted into each world (CSS modules → tokens, Fumadocs `--color-fd-*` remap, playground `--primary/...` remap). Dark overrides target both `.dark` (/learn) and `[data-theme="dark"]` (/playground); dark-only home uses the raw ramp. Components (challenge cards, quizzes, code blocks) keep only semantic aliases — all literal palette values now live in `brand.css`.
 3. **Lock semantic meaning** (blue=primary, green=success, red=error, yellow=attention; decoratives carry none) and the accessibility do/don'ts.
 4. **Migrate playground → learn → home**, using `/color-test` as the QA gate; then de-dupe ad-hoc hex.
-5. **Charts (Mermaid):** the `/learn` diagram theme is built from the brand palette (Mermaid `base` theme) instead of the stock neutral/dark themes. It uses one **soft light palette with dark text in both modes** — required so author `classDef` pastel fills stay legible — rendered on a light **figure card** in dark mode, with minimal hairline borders; mindmaps cycle the seven-hue categorical wheel (§4.3). Playwright-verified in light and dark.
+5. **Charts (Mermaid):** the `/learn` diagram theme is built from the brand palette (Mermaid `base` theme) instead of the stock neutral/dark themes — a light theme in light mode and a real dark theme in dark mode. Author `classDef` pastel fills (which carry no text color) stay legible via `adaptNodeLabels`, which sets each node's label color from its own fill luminance; mindmaps cycle the seven-hue categorical wheel (§4.3). Minimal hairline borders, soft palette. Playwright-verified in light and dark.
 6. **Illustrations:** feasible and well-suited in both modes — transparent backgrounds + mid-tone palette use (or SVG), bright hues for dark, slightly tempered for light.
 
 ---

--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -186,7 +186,7 @@ Use `color-mix()` for tints (the playground already does this): `color-mix(in sr
 **One light palette, in both modes — the legibility constraint that shapes everything.** ~200 MDX diagrams hand-color nodes with `classDef` using **light pastel fills and no text color** (e.g. `classDef bad fill:#fee2e2,stroke:#b91c1c`). Mermaid exposes a *single* global node-text color, so it must be **dark** to stay readable on those author fills — which means our own node fills must be light too. The diagram is therefore **light-based in both modes**, and dark mode is handled by rendering the whole figure on a soft **light "figure card"** (a `border-radius`'d white panel in `mermaid.module.css`, applied to both the inline diagram and the fullscreen modal). This keeps every label dark-on-light and author pastels legible, with no per-element light/dark juggling.
 
 The mapping, tuned to be soft and low-border (per the report updates):
-- **Nodes** — soft `blue-50` fill, **minimal `blue-200` hairline** border (not the old bold accent border), `gray-900` text. Author `classDef` fills keep their colors; only the bold default borders were toned down.
+- **Nodes** — soft `blue-100` fill (light enough to stay calm, dark enough to read as "blue" on the white card; `blue-50` looked colorless), a **soft `blue-300` hairline** border (not the old bold accent border), `gray-900` text. Author `classDef` fills keep their colors; only the bold default borders were toned down.
 - **Structure** — neutral `--ds-gray-*` for edges, arrowheads, lifelines, and subgraph/cluster backgrounds; edge-label backdrops blend into the canvas/card.
 - **Semantic hues keep their meaning** — yellow "sticky-note" notes; red critical-path and "today" markers in gantt.
 - **Categorical wheel** — mindmaps cycle the **seven-hue** wheel (§1.1) as soft `-200` fills under dark labels, identical in both modes. (Mermaid re-applies overrides *after* its internal derivation, so these exact values reach the SVG — its built-in `cScale` darkening is bypassed.)
@@ -261,9 +261,13 @@ Across Phases 5–6: **ChallengeCard 81 → 34** unique vars (−58%), **MCQ 57 
 
 A follow-up pass refined the look after dark-mode review:
 - **Fixed a dark-mode legibility bug.** The first cut used dark nodes + light text in dark mode, which made the ~200 author `classDef` light-pastel nodes (light fill + inherited light text) unreadable. Switched to a single **light palette in both modes** with dark text, rendered on a soft **light figure card** in dark mode (§4.3) — author pastels and edge labels are now legible everywhere.
-- **Minimized borders.** Default node borders dropped from the bold `blue-600` to a soft `blue-200` hairline.
-- **Softer, less "poppy" palette.** Low-contrast `-50/-200` fills, neutral-gray connectors, and the figure card give a calmer, more figure-like look.
+- **Minimized borders.** Default node borders dropped from the bold `blue-600` to a soft `blue-300` hairline.
+- **Softer, less "poppy" palette.** Low-contrast fills, neutral-gray connectors, and the figure card give a calmer, more figure-like look.
 - **`/color-test`** now also renders the teal / purple / orange ramps + ink anchors, so the QA gate covers the decorative hues.
+
+A second dark-mode review caught two more issues, now fixed:
+- **Shrinking.** The figure card used `width: fit-content`, but the SVG is sized `width: 100%; max-width: <W>px` — a shrink-to-fit parent gave it ~0 intrinsic width, collapsing the diagram. The card now keeps `width: 100%` (the SVG renders at its natural size, centered).
+- **Washed-out colors.** `blue-50` node fills were nearly indistinguishable from the white card. Bumped to `blue-100` (clearly blue, still soft) with a `blue-300` edge.
 
 Typecheck + lint clean, 450 unit tests pass; verified visually with Playwright across flowchart / ER / sequence / class / state / gantt / mindmap in light and dark (incl. author-`classDef` pages).
 

--- a/agent-outputs/20260606-0540-brand-color-system.md
+++ b/agent-outputs/20260606-0540-brand-color-system.md
@@ -17,6 +17,20 @@
 
 These already appear in your mockup (alien, astronaut, topic chips) and the playground tokens are *almost* this blue already (`--primary: oklch(68% 0.18 250)` ≈ `#148CFF`), so alignment is low-friction.
 
+### 1.1 Decorative / categorical hues (added for charts & illustrations)
+
+The four-color palette is intentionally small and **semantically loaded** — green/red/yellow are locked to success/error/warning (§5), which leaves **blue as the only meaning-free hue**. That's fine for UI, but **diagrams and illustrations need categorical variety**: a flowchart with several node groups, a Mermaid **mindmap** (which assigns a different color per branch), or an illustration with several distinct shapes. A content audit confirms the gap — across the `/learn` MDX, authors hand-color Mermaid nodes in **~480 places**, reaching for **seven-plus hue families** (purple `#e9d5ff`, pink `#fbcfe8`, orange `#fed7aa`, teal `#dee`, …), i.e. well beyond the four brand colors and off-brand.
+
+So we add **three decorative hues** — **teal, purple, orange** — generated with the *same* OKLCH method as the brand ramps (constant hue, interpolated L/C, gamut-mapped; 500 = base). They carry **no semantic meaning**; use them purely to tell series/branches apart. With blue they form a seven-step categorical wheel: **blue · teal · green · yellow · orange · red · purple**.
+
+| Decorative hue | 500 (base) | Ink (700 — AA body text on white) |
+|---|---|---|
+| **Teal** (hue ≈192) | `#00AEAA` | `#007B79` (5.1:1) |
+| **Purple** (hue ≈300) | `#AB77FA` | `#7A51B6` (5.7:1) |
+| **Orange** (hue ≈55) | `#E47600` | `#A35200` (5.6:1) |
+
+Full 50–900 ramps ship in `app/brand.css` as `--ds-{teal,purple,orange}-{step}` (plus `--ds-{hue}` and `--ds-{hue}-ink` aliases), mirroring the four brand ramps. Like the brand hues they are **dark-native**: the 500s clear AA body text on dark, the 700s clear AA on white.
+
 ---
 
 ## 2. The one thing that shapes everything: this palette is **dark-mode-native**
@@ -47,7 +61,7 @@ Define, for each brand hue, a **bright "signal" value** (the hex above — used 
 
 ### 2.2 The full 50–900 tonal ramps
 
-Generated in **OKLCH** (constant hue; lightness/chroma interpolated toward white for the light steps and toward near-black for the dark steps; every value gamut-mapped to valid sRGB). **500 = your exact brand color.** These are now shipped in `app/brand.css` as `--ds-{hue}-{step}` tokens; the "ink" roles in §2.1 are remapped onto ramp steps (`blue-700`, `green-800`, `red-700`, `yellow-800`) so everything references one ramp.
+Generated in **OKLCH** (constant hue; lightness/chroma interpolated toward white for the light steps and toward near-black for the dark steps; every value gamut-mapped to valid sRGB). **500 = your exact brand color.** These are now shipped in `app/brand.css` as `--ds-{hue}-{step}` tokens; the "ink" roles in §2.1 are remapped onto ramp steps (`blue-700`, `green-800`, `red-700`, `yellow-800`) so everything references one ramp. The three **decorative** hues from §1.1 ship as parallel `--ds-{teal,purple,orange}-*` ramps in the same file, built the same way.
 
 | Step | Blue | Green | Red | Yellow |
 |---|---|---|---|---|
@@ -165,9 +179,21 @@ Use `color-mix()` for tints (the playground already does this): `color-mix(in sr
 
 > **Leave the per-editor-theme palettes alone.** `THEME_PALETTES` / `applyThemePalette` deliberately recolor the chrome to match the *chosen code theme* (Dracula, Nord…). Those are user-selected editor aesthetics, not brand surfaces — keep them independent. Only the brand-signal tokens above should be unified.
 
-### 4.3 Result
+### 4.3 Fourth consumer — Mermaid diagrams (JS, not CSS)
 
-One file defines the palette; each route reads it through its native token system; the `.dark` class flips light↔dark everywhere at once. Adding a color or fixing a shade is a one-line change in `brand.css`.
+`/learn` renders Mermaid diagrams (flowcharts dominate, plus ER, sequence, class, state, gantt, mindmaps). Mermaid **can't read `var(--ds-*)`** — it runs color math (khroma) over its theme variables and needs concrete colors. So instead of the stock **`neutral`** (light) / **`dark`** themes, `app/_components/mdx/mermaid.tsx` now builds Mermaid's customizable **`base`** theme from the brand palette for **both** modes: it resolves the `--ds-*` tokens to hex at render time (via `getComputedStyle`, keeping `brand.css` the source of truth, with literal fallbacks) and maps them onto Mermaid's `themeVariables`.
+
+The mapping mirrors the rest of the system:
+- **Nodes** — light: soft `blue-50` fill, `blue-600` border, `gray-900` text; dark: `gray-800` card, bright `blue-400` border, `gray-50` text (the blue border is the consistent brand signal across modes).
+- **Structure** — neutral `--ds-gray-*` for edges, arrowheads, lifelines, and subgraph/cluster backgrounds, so the chrome stays quiet and brand blue reads as the accent.
+- **Semantic hues keep their meaning** — yellow "sticky-note" notes; red critical-path and "today" markers in gantt.
+- **Categorical wheel** — mindmaps cycle the **seven-hue** wheel (§1.1): light = soft `-200` fills under dark labels, dark = deep `-800` fills under light labels. (Mermaid re-applies overrides *after* its internal derivation, so these exact values reach the SVG — its built-in `cScale` darkening is bypassed.)
+
+Every node/line/text pairing is WCAG-AA verified, and the output was spot-checked with **Playwright** across all diagram types in light and dark.
+
+### 4.4 Result
+
+One file defines the palette; each route reads it through its native token system (CSS tokens, Fumadocs `--color-fd-*`, the playground `--primary/...`, and now Mermaid's JS `themeVariables`); the `.dark` class flips light↔dark everywhere at once. Adding a color or fixing a shade is a one-line change in `brand.css`.
 
 ---
 
@@ -181,6 +207,8 @@ Consistency comes from **meaning**, not just shared hex. Lock these mappings:
 | **Green** | success / go | "Run", passing tests, correct answers, positive deltas | links or generic accents (reads as "success") |
 | **Red** | error / stop | failures, destructive actions, wrong answers, validation errors | decoration (alarms users) |
 | **Yellow** | attention | highlights, warnings, "new" badges, callout accents | body text on light; large fills behind dark text only with care |
+
+**Decorative hues (teal/purple/orange) are the exception to "meaning":** they are deliberately *non-semantic* — use them only for categorical distinction in charts, diagrams, and illustrations, never to imply success/error/warning and not as a second "primary." See §1.1.
 
 **Accessibility do/don'ts:**
 - ✅ Use the **ink variants** for any text/link/icon on **light** backgrounds; use the **bright** hues for text on **dark**.
@@ -227,6 +255,8 @@ Deliberately **left alone:** non-brand decoratives (violet/purple `--ch-violet-*
 
 Across Phases 5–6: **ChallengeCard 81 → 34** unique vars (−58%), **MCQ 57 → 15** (−74%). **0 dangling references**, build green, lint clean, 445 tests pass throughout.
 
+**Phase 7 — Mermaid chart theme — ✅ done.** `app/_components/mdx/mermaid.tsx` previously selected Mermaid's stock `neutral` (light) / `dark` themes. It now builds the customizable **`base`** theme from the brand palette for both modes (see §4.3), so diagrams match the rest of `/learn`. This is also what motivated the **three decorative hues** (§1.1): mindmaps and other categorical diagrams now cycle the seven-hue brand wheel instead of Mermaid's off-brand defaults. Typecheck + lint clean; verified visually with Playwright across flowchart / ER / sequence / class / state / gantt / mindmap in light and dark.
+
 ---
 
 ## 7. Feasibility for AI illustration generation (light **and** dark mode)
@@ -238,7 +268,7 @@ The same dark-native asymmetry from §2 applies to illustrations, but illustrati
 - **On dark mode:** the bright palette is ideal — saturated blue/green/red/yellow shapes pop against `#121212`. No adjustment needed.
 - **On light mode:** large saturated **shapes** read fine on white, but **yellow and light-green areas can look weak/washed** on a pure-white page. Mitigate by: (a) giving shapes a subtle darker outline or shadow, (b) composing on the brand's **off-white surface** rather than pure `#fff`, or (c) leaning on blue/red as the dominant hues with yellow/green as accents.
 - **The rule (ties to the illustration report §7):** generate art with a **transparent background** and a **theme-agnostic, mid-tone application** of the palette so a single asset reads on both themes — OR use **SVG** (Recraft) where fills can be brand tokens and even adapt via CSS. Avoid baking pure-white or pure-black backgrounds into raster art.
-- **Consistency:** feed these exact hex values into the house-style prompt preamble (already updated in the illustration report) and cap each illustration to **2–3 of the four** brand colors to avoid a circus look. Use the per-course accent trick (swap one hue per course) for variety within the system.
+- **Consistency:** feed these exact hex values into the house-style prompt preamble (already updated in the illustration report) and cap each illustration to **2–3 hues** to avoid a circus look — drawn from the four brand colors, or from the decorative hues (§1.1) when an image needs non-semantic categorical accents. Use the per-course accent trick (swap one hue per course) for variety within the system.
 
 **Verdict:** the palette is a strong fit for AI illustration in both modes. Dark mode is "free"; light mode needs the transparent-background + mid-tone discipline already recommended for illustrations generally. See `20260605-0532-ai-image-generation-for-course-illustrations.md` §7 and Appendix A for the prompt mechanics.
 
@@ -247,10 +277,11 @@ The same dark-native asymmetry from §2 applies to illustrations, but illustrati
 ## 8. Summary
 
 1. **Adopt two values per hue** — a bright "signal" (your four hex) and a darker "ink" for light-mode text. The palette is dark-native; light mode needs the ink variants.
-2. **One `app/brand.css` token layer** (✅ shipped) — brand hue ramps, ink anchors, semantic roles, **and a shared neutral ramp (`--ds-gray-*`, `--ds-white/black`)** — adapted into each of the three worlds (CSS modules → tokens, Fumadocs `--color-fd-*` remap, playground `--primary/...` remap). Dark overrides target both `.dark` (/learn) and `[data-theme="dark"]` (/playground); dark-only home uses the raw ramp. Components (challenge cards, quizzes, code blocks) keep only semantic aliases — all literal palette values now live in `brand.css`.
-3. **Lock semantic meaning** (blue=primary, green=success, red=error, yellow=attention) and the accessibility do/don'ts.
+2. **One `app/brand.css` token layer** (✅ shipped) — brand hue ramps, ink anchors, semantic roles, **a shared neutral ramp (`--ds-gray-*`, `--ds-white/black`)**, and **three non-semantic decorative hues (teal/purple/orange)** for categorical use in charts and illustrations (§1.1) — adapted into each world (CSS modules → tokens, Fumadocs `--color-fd-*` remap, playground `--primary/...` remap). Dark overrides target both `.dark` (/learn) and `[data-theme="dark"]` (/playground); dark-only home uses the raw ramp. Components (challenge cards, quizzes, code blocks) keep only semantic aliases — all literal palette values now live in `brand.css`.
+3. **Lock semantic meaning** (blue=primary, green=success, red=error, yellow=attention; decoratives carry none) and the accessibility do/don'ts.
 4. **Migrate playground → learn → home**, using `/color-test` as the QA gate; then de-dupe ad-hoc hex.
-5. **Illustrations:** feasible and well-suited in both modes — transparent backgrounds + mid-tone palette use (or SVG), bright hues for dark, slightly tempered for light.
+5. **Charts (Mermaid):** the `/learn` diagram theme is built from the brand palette (Mermaid `base` theme, both modes) instead of the stock neutral/dark themes; mindmaps cycle the seven-hue categorical wheel (§4.3). Playwright-verified.
+6. **Illustrations:** feasible and well-suited in both modes — transparent backgrounds + mid-tone palette use (or SVG), bright hues for dark, slightly tempered for light.
 
 ---
 
@@ -268,5 +299,11 @@ WCAG AA: **4.5:1** body text · **3:1** large/bold text, icons, UI boundaries.
 | Red-ink `#D5323C` | 4.83 | — |
 | Green-ink `#178017` | 5.08 | — |
 | Amber-ink `#8A6D00` | 4.92 | — |
+| Teal `#00AEAA` | 2.75 | 6.81 |
+| Purple `#AB77FA` | 3.11 | 6.02 |
+| Orange `#E47600` | 3.05 | 6.15 |
+| Teal-ink `#007B79` | 5.11 | — |
+| Purple-ink `#7A51B6` | 5.71 | — |
+| Orange-ink `#A35200` | 5.58 | — |
 
 *Computed via the standard WCAG relative-luminance formula; re-verify any shipped value in a contrast checker.*

--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -11,14 +11,29 @@
    cap equal to the diagram's intrinsic width. Leaving that cap intact keeps
    the diagram at its default size on wide columns while still letting it
    scale down to fit narrower ones (the SVG carries a viewBox). */
-.wrap > div:first-child {
+.wrap > .diagram {
   width: 100%;
 }
 
-.wrap > div:first-child svg {
+.diagram svg {
   display: block;
   margin-inline: auto;
   height: auto;
+}
+
+/* Dark mode: the Mermaid theme is light in both modes (so author classDef
+   pastel fills keep dark, legible text). Render it on a soft "figure card" so
+   the light diagram reads cleanly on the dark page. The card hugs the diagram
+   (fit-content) rather than spanning the whole column. Applies to both the
+   inline diagram and the fullscreen modal stage (both carry .diagram). */
+:global(.dark) .diagram {
+  width: fit-content;
+  max-width: 100%;
+  margin-inline: auto;
+  background: var(--ds-white, #ffffff);
+  padding: 0.85rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
 }
 
 .expandBtn {

--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -23,17 +23,18 @@
 
 /* Dark mode: the Mermaid theme is light in both modes (so author classDef
    pastel fills keep dark, legible text). Render it on a soft "figure card" so
-   the light diagram reads cleanly on the dark page. The card hugs the diagram
-   (fit-content) rather than spanning the whole column. Applies to both the
-   inline diagram and the fullscreen modal stage (both carry .diagram). */
+   the light diagram reads cleanly on the dark page. Only add the card surface
+   here — do NOT set `width`: the inline diagram keeps `width: 100%` from the
+   rule above, and the SVG (sized `width:100%; max-width:<W>px`) would COLLAPSE
+   to near-zero inside a shrink-to-fit parent. `box-sizing: border-box` keeps
+   the padding within the column. Applies to both the inline diagram and the
+   fullscreen modal stage (both carry .diagram). */
 :global(.dark) .diagram {
-  width: fit-content;
-  max-width: 100%;
-  margin-inline: auto;
+  box-sizing: border-box;
   background: var(--ds-white, #ffffff);
-  padding: 0.85rem 1.1rem;
+  padding: 1rem 1.25rem;
   border-radius: 12px;
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  border: 1px solid var(--ds-gray-200, #e5e7eb);
 }
 
 .expandBtn {

--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -21,22 +21,6 @@
   height: auto;
 }
 
-/* Dark mode: the Mermaid theme is light in both modes (so author classDef
-   pastel fills keep dark, legible text). Render it on a soft "figure card" so
-   the light diagram reads cleanly on the dark page. Only add the card surface
-   here — do NOT set `width`: the inline diagram keeps `width: 100%` from the
-   rule above, and the SVG (sized `width:100%; max-width:<W>px`) would COLLAPSE
-   to near-zero inside a shrink-to-fit parent. `box-sizing: border-box` keeps
-   the padding within the column. Applies to both the inline diagram and the
-   fullscreen modal stage (both carry .diagram). */
-:global(.dark) .diagram {
-  box-sizing: border-box;
-  background: var(--ds-white, #ffffff);
-  padding: 1rem 1.25rem;
-  border-radius: 12px;
-  border: 1px solid var(--ds-gray-200, #e5e7eb);
-}
-
 .expandBtn {
   position: absolute;
   top: 8px;

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -50,45 +50,39 @@ function cachePromise<T>(key: string, setPromise: () => Promise<T>): Promise<T> 
 
 // ─── Brand-themed Mermaid palette ──────────────────────────────────────────
 //
-// Mermaid runs color math (khroma) over its theme variables, so it needs
-// concrete colors rather than `var(--ds-*)` strings. We resolve the brand
-// tokens (app/brand.css) to hex at render time, keeping that file the single
-// source of truth, and fall back to the literal brand values — mirrored below,
-// kept in sync with app/brand.css — if a token is ever missing (e.g. before
-// the stylesheet applies). Only the steps the theme actually uses are listed.
+// Diagrams use one SOFT, LIGHT palette from the brand system (app/brand.css)
+// in *both* modes, via Mermaid's customizable "base" theme. It's light in both
+// modes for two reasons:
+//   1. Many MDX diagrams hand-color nodes with `classDef` light pastel fills
+//      and no text color (e.g. `fill:#fee2e2`). One global node-text color must
+//      be dark to stay legible on them — so every box is light with dark text.
+//   2. With all text dark, we render the whole figure on a soft light "card" in
+//      dark mode (see mermaid.module.css) so it reads cleanly on a dark page —
+//      no per-element light/dark juggling, and author pastels always work.
+// Borders are deliberately minimal (soft hairlines) and the palette is
+// low-contrast (updates from the brand report). Mermaid runs color math
+// (khroma) over these values and needs concrete colors, so we resolve the
+// brand tokens to hex at render time (brand.css stays the source of truth)
+// with literal fallbacks.
 const BRAND_FALLBACKS: Record<string, string> = {
   "--ds-blue-50": "#E8F2FF",
   "--ds-blue-100": "#D1E6FF",
   "--ds-blue-200": "#AED3FF",
-  "--ds-blue-400": "#5BA7FF",
-  "--ds-blue-600": "#0878DD",
-  "--ds-blue-800": "#00519C",
   "--ds-teal-200": "#AAE0DD",
-  "--ds-teal-600": "#009491",
-  "--ds-teal-800": "#006361",
   "--ds-green-200": "#B4EAAF",
-  "--ds-green-800": "#006F01",
   "--ds-red-200": "#FFC2BF",
   "--ds-red-500": "#FF4F59",
   "--ds-red-600": "#DC3F49",
-  "--ds-red-800": "#99212C",
   "--ds-yellow-100": "#FDF5D9",
   "--ds-yellow-200": "#FEF0C3",
-  "--ds-yellow-600": "#D4B651",
-  "--ds-yellow-800": "#836D1C",
   "--ds-orange-200": "#F6CAAD",
-  "--ds-orange-800": "#844200",
   "--ds-purple-200": "#DBCAFC",
-  "--ds-purple-800": "#634094",
-  "--ds-gray-50": "#f9fafb",
-  "--ds-gray-300": "#d1d5db",
-  "--ds-gray-400": "#9ca3af",
-  "--ds-gray-500": "#6b7280",
-  "--ds-gray-600": "#4b5563",
-  "--ds-gray-700": "#374151",
-  "--ds-gray-800": "#1f2937",
+  "--ds-gray-50": "#F9FAFB",
+  "--ds-gray-200": "#E5E7EB",
+  "--ds-gray-300": "#D1D5DB",
+  "--ds-gray-400": "#9CA3AF",
   "--ds-gray-900": "#111827",
-  "--ds-white": "#ffffff",
+  "--ds-white": "#FFFFFF",
 };
 
 function readBrand(): (token: keyof typeof BRAND_FALLBACKS) => string {
@@ -104,38 +98,32 @@ function readBrand(): (token: keyof typeof BRAND_FALLBACKS) => string {
   return (token) => resolved[token] ?? BRAND_FALLBACKS[token];
 }
 
-// Build Mermaid `themeVariables` for the brand "base" theme. Light mode places
-// dark text/soft-blue nodes on a white page; dark mode places light text on
-// dark cards with a bright-blue accent border. All node/line/text pairings are
-// WCAG-AA verified. Semantic brand hues (green/red/yellow) keep their meaning
-// (success/error/warning notes & critical tasks); the seven-hue categorical
-// wheel colors multi-branch diagrams (mindmaps) without semantic collisions.
-function brandThemeVariables(isDark: boolean): Record<string, string | boolean> {
+function brandThemeVariables(): Record<string, string | boolean> {
   const c = readBrand();
 
-  const text = isDark ? c("--ds-gray-50") : c("--ds-gray-900");
-  const surface = isDark ? c("--ds-gray-900") : c("--ds-white");
-  const nodeFill = isDark ? c("--ds-gray-800") : c("--ds-blue-50");
-  const nodeBorder = isDark ? c("--ds-blue-400") : c("--ds-blue-600");
-  const line = isDark ? c("--ds-gray-400") : c("--ds-gray-500");
-  const lifeline = isDark ? c("--ds-gray-500") : c("--ds-gray-400");
-  const signal = isDark ? c("--ds-gray-300") : c("--ds-gray-600");
-  const clusterFill = isDark ? c("--ds-gray-900") : c("--ds-gray-50");
-  const clusterBorder = isDark ? c("--ds-gray-700") : c("--ds-gray-300");
+  const ink = c("--ds-gray-900"); // all text — dark, sits on light fills/card
+  const canvas = c("--ds-white"); // diagram canvas + edge-label backdrop blend
+  const nodeFill = c("--ds-blue-50"); // soft node fill
+  const nodeEdge = c("--ds-blue-200"); // minimal hairline border
+  const softFill = c("--ds-gray-50"); // clusters / subgraphs / alt rows
+  const softEdge = c("--ds-gray-200");
+  const line = c("--ds-gray-400"); // connectors
 
-  // Categorical wheel (mindmaps): light = soft -200 fills under dark labels;
-  // dark = deep -800 fills under light labels. Mermaid re-applies overrides
-  // after its internal derivation, so these exact values reach the SVG.
-  const step = isDark ? "800" : "200";
+  // Categorical wheel (mindmaps): soft -200 fills under dark labels. Mermaid
+  // re-applies overrides after its internal derivation, so these reach the SVG
+  // verbatim (its cScale darkening is bypassed).
   const wheel = ["blue", "teal", "green", "yellow", "orange", "red", "purple"];
   const cScale: Record<string, string> = {};
   for (let i = 0; i < 12; i++) {
-    cScale[`cScale${i}`] = c(`--ds-${wheel[i % wheel.length]}-${step}` as keyof typeof BRAND_FALLBACKS);
+    cScale[`cScale${i}`] = c(
+      `--ds-${wheel[i % wheel.length]}-200` as keyof typeof BRAND_FALLBACKS,
+    );
   }
 
   return {
-    darkMode: isDark,
-    background: surface,
+    // Light-based in both modes; dark mode is handled by a CSS figure card.
+    darkMode: false,
+    background: canvas,
     fontFamily: '"Source Serif 4", Georgia, "Times New Roman", serif',
     // Controls the font-size written into the SVG's inline <style> block.
     // Without this, Mermaid inherits the container's computed size (16px from
@@ -143,77 +131,84 @@ function brandThemeVariables(isDark: boolean): Record<string, string | boolean> 
     // config which only governs text measurement.
     fontSize: "15px",
 
-    // Primary nodes (flowchart / class / state / ER) + sequence actors
+    // Nodes (flowchart / class / state / ER) + sequence actors
     primaryColor: nodeFill,
-    primaryBorderColor: nodeBorder,
-    primaryTextColor: text,
-    nodeTextColor: text,
+    primaryBorderColor: nodeEdge,
+    primaryTextColor: ink,
+    nodeTextColor: ink,
 
-    // Secondary / tertiary — clusters/subgraphs and accents
-    secondaryColor: isDark ? c("--ds-gray-700") : c("--ds-teal-200"),
-    secondaryBorderColor: isDark ? c("--ds-gray-600") : c("--ds-teal-600"),
-    secondaryTextColor: text,
-    tertiaryColor: clusterFill,
-    tertiaryBorderColor: clusterBorder,
-    tertiaryTextColor: text,
+    // Secondary / tertiary — clusters/subgraphs + gentle accents
+    secondaryColor: c("--ds-blue-100"),
+    secondaryBorderColor: nodeEdge,
+    secondaryTextColor: ink,
+    tertiaryColor: softFill,
+    tertiaryBorderColor: softEdge,
+    tertiaryTextColor: ink,
 
-    // Edges / arrows / labels
+    // Connectors + labels (edge-label backdrops blend into the canvas/card)
     lineColor: line,
     arrowheadColor: line,
-    textColor: text,
-    titleColor: text,
-    edgeLabelBackground: surface,
+    textColor: ink,
+    titleColor: ink,
+    edgeLabelBackground: canvas,
 
-    // Notes (sequence + flowchart) — bright "sticky note" in both modes
+    // Notes — soft yellow, dark text
     noteBkgColor: c("--ds-yellow-100"),
-    noteBorderColor: c("--ds-yellow-600"),
-    noteTextColor: c("--ds-gray-900"),
+    noteBorderColor: c("--ds-yellow-200"),
+    noteTextColor: ink,
 
     // Sequence diagrams
     actorBkg: nodeFill,
-    actorBorder: nodeBorder,
-    actorTextColor: text,
-    actorLineColor: lifeline,
-    signalColor: signal,
-    signalTextColor: text,
+    actorBorder: nodeEdge,
+    actorTextColor: ink,
+    actorLineColor: c("--ds-gray-300"),
+    signalColor: line,
+    signalTextColor: ink,
     labelBoxBkgColor: nodeFill,
-    labelBoxBorderColor: nodeBorder,
-    labelTextColor: text,
-    loopTextColor: text,
-    activationBkgColor: isDark ? c("--ds-gray-700") : c("--ds-blue-100"),
-    activationBorderColor: nodeBorder,
-    sequenceNumberColor: isDark ? c("--ds-gray-900") : c("--ds-white"),
+    labelBoxBorderColor: nodeEdge,
+    labelTextColor: ink,
+    loopTextColor: ink,
+    activationBkgColor: c("--ds-blue-100"),
+    activationBorderColor: nodeEdge,
+    sequenceNumberColor: ink,
 
     // Class diagrams
-    classText: text,
+    classText: ink,
+
+    // State diagrams — keep composite/alt backgrounds light (they default to
+    // `background`) so nested state text stays legible.
+    compositeBackground: softFill,
+    altBackground: softFill,
+    compositeTitleBackground: nodeFill,
+    compositeBorder: nodeEdge,
 
     // ER diagrams — alternating attribute rows
-    attributeBackgroundColorOdd: clusterFill,
-    attributeBackgroundColorEven: surface,
+    attributeBackgroundColorOdd: softFill,
+    attributeBackgroundColorEven: canvas,
 
     // Gantt charts
-    sectionBkgColor: isDark ? c("--ds-gray-800") : c("--ds-gray-50"),
-    altSectionBkgColor: surface,
-    sectionBkgColor2: isDark ? c("--ds-gray-700") : c("--ds-blue-50"),
-    taskBkgColor: nodeFill,
-    taskBorderColor: nodeBorder,
-    activeTaskBkgColor: isDark ? c("--ds-blue-800") : c("--ds-blue-200"),
-    activeTaskBorderColor: nodeBorder,
-    gridColor: clusterBorder,
-    doneTaskBkgColor: isDark ? c("--ds-gray-700") : c("--ds-gray-300"),
-    doneTaskBorderColor: c("--ds-gray-500"),
-    critBkgColor: isDark ? c("--ds-red-800") : c("--ds-red-200"),
+    sectionBkgColor: softFill,
+    altSectionBkgColor: canvas,
+    sectionBkgColor2: c("--ds-blue-50"),
+    taskBkgColor: c("--ds-blue-100"),
+    taskBorderColor: nodeEdge,
+    activeTaskBkgColor: c("--ds-blue-200"),
+    activeTaskBorderColor: nodeEdge,
+    gridColor: softEdge,
+    doneTaskBkgColor: c("--ds-gray-200"),
+    doneTaskBorderColor: c("--ds-gray-400"),
+    critBkgColor: c("--ds-red-200"),
     critBorderColor: c("--ds-red-600"),
     todayLineColor: c("--ds-red-500"),
-    taskTextColor: text,
-    taskTextDarkColor: c("--ds-gray-900"),
-    taskTextLightColor: c("--ds-white"),
-    taskTextOutsideColor: text,
+    taskTextColor: ink,
+    taskTextDarkColor: ink,
+    taskTextLightColor: ink,
+    taskTextOutsideColor: ink,
 
     // Categorical scale (mindmaps / pie) + mindmap root node
-    scaleLabelColor: text,
-    git0: isDark ? c("--ds-gray-800") : c("--ds-blue-100"),
-    gitBranchLabel0: text,
+    scaleLabelColor: ink,
+    git0: c("--ds-blue-100"),
+    gitBranchLabel0: ink,
     ...cScale,
   };
 }
@@ -230,10 +225,11 @@ function MermaidContent({ chart }: { chart: string }) {
     fontSize: 15,
     themeCSS: "margin: 1.5rem auto 0;",
     // Drive diagram colors from the DataSlope brand palette (app/brand.css) via
-    // the customizable "base" theme, instead of Mermaid's stock neutral (light)
-    // / dark themes, so charts match the rest of /learn in both modes.
+    // the customizable "base" theme, instead of Mermaid's stock neutral/dark
+    // themes. The theme is light-based in both modes; free-floating text blends
+    // with the page so it reads on light and dark (see brandThemeVariables).
     theme: "base",
-    themeVariables: brandThemeVariables(resolvedTheme === "dark"),
+    themeVariables: brandThemeVariables(),
   });
 
   const { svg, bindFunctions } = use(
@@ -256,6 +252,7 @@ function MermaidContent({ chart }: { chart: string }) {
   return (
     <div className={styles.wrap}>
       <div
+        className={styles.diagram}
         ref={(container) => {
           if (container) bindFunctions?.(container);
         }}
@@ -532,7 +529,11 @@ function MermaidFullscreen({
               transform: `translate(${tx}px, ${ty}px)`,
             }}
           >
-            <div ref={stageRef} dangerouslySetInnerHTML={{ __html: svg }} />
+            <div
+              className={styles.diagram}
+              ref={stageRef}
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
           </div>
         </div>
       </div>

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -103,8 +103,10 @@ function brandThemeVariables(): Record<string, string | boolean> {
 
   const ink = c("--ds-gray-900"); // all text — dark, sits on light fills/card
   const canvas = c("--ds-white"); // diagram canvas + edge-label backdrop blend
-  const nodeFill = c("--ds-blue-50"); // soft node fill
-  const nodeEdge = c("--ds-blue-200"); // minimal hairline border
+  // blue-100 reads clearly on white (blue-50 was nearly invisible); blue-300
+  // gives a soft-but-visible edge without the old bold border.
+  const nodeFill = c("--ds-blue-100");
+  const nodeEdge = c("--ds-blue-300");
   const softFill = c("--ds-gray-50"); // clusters / subgraphs / alt rows
   const softEdge = c("--ds-gray-200");
   const line = c("--ds-gray-400"); // connectors

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -50,37 +50,52 @@ function cachePromise<T>(key: string, setPromise: () => Promise<T>): Promise<T> 
 
 // ─── Brand-themed Mermaid palette ──────────────────────────────────────────
 //
-// Diagrams use one SOFT, LIGHT palette from the brand system (app/brand.css)
-// in *both* modes, via Mermaid's customizable "base" theme. It's light in both
-// modes for two reasons:
-//   1. Many MDX diagrams hand-color nodes with `classDef` light pastel fills
-//      and no text color (e.g. `fill:#fee2e2`). One global node-text color must
-//      be dark to stay legible on them — so every box is light with dark text.
-//   2. With all text dark, we render the whole figure on a soft light "card" in
-//      dark mode (see mermaid.module.css) so it reads cleanly on a dark page —
-//      no per-element light/dark juggling, and author pastels always work.
-// Borders are deliberately minimal (soft hairlines) and the palette is
-// low-contrast (updates from the brand report). Mermaid runs color math
-// (khroma) over these values and needs concrete colors, so we resolve the
-// brand tokens to hex at render time (brand.css stays the source of truth)
-// with literal fallbacks.
+// Diagrams are themed from the brand color system (app/brand.css) via Mermaid's
+// customizable "base" theme — a LIGHT theme in light mode and a DARK theme in
+// dark mode, so each matches the surrounding page (no white card on a dark
+// page).
+//
+// The wrinkle: ~200 MDX diagrams hand-color nodes with `classDef` using light
+// pastel fills and *no* text color (e.g. `classDef bad fill:#fee2e2`). Mermaid
+// has one global node-text color, so in a dark theme (light text) those author
+// nodes would be light-on-light. We fix that after render with
+// `adaptNodeLabels`, which sets each node's label color from its *own* fill
+// luminance — dark text on light fills, light text on dark fills — so author
+// pastels stay legible while our default nodes go properly dark.
+//
+// Mermaid runs color math (khroma) over theme values and needs concrete colors,
+// so we resolve the brand tokens to hex at render time (brand.css stays the
+// source of truth) with literal fallbacks.
 const BRAND_FALLBACKS: Record<string, string> = {
   "--ds-blue-50": "#E8F2FF",
   "--ds-blue-100": "#D1E6FF",
   "--ds-blue-200": "#AED3FF",
+  "--ds-blue-300": "#8ABFFF",
+  "--ds-blue-800": "#00519C",
   "--ds-teal-200": "#AAE0DD",
+  "--ds-teal-800": "#006361",
   "--ds-green-200": "#B4EAAF",
+  "--ds-green-800": "#006F01",
   "--ds-red-200": "#FFC2BF",
   "--ds-red-500": "#FF4F59",
   "--ds-red-600": "#DC3F49",
+  "--ds-red-800": "#99212C",
   "--ds-yellow-100": "#FDF5D9",
   "--ds-yellow-200": "#FEF0C3",
+  "--ds-yellow-600": "#D4B651",
+  "--ds-yellow-800": "#836D1C",
   "--ds-orange-200": "#F6CAAD",
+  "--ds-orange-800": "#844200",
   "--ds-purple-200": "#DBCAFC",
+  "--ds-purple-800": "#634094",
   "--ds-gray-50": "#F9FAFB",
   "--ds-gray-200": "#E5E7EB",
   "--ds-gray-300": "#D1D5DB",
   "--ds-gray-400": "#9CA3AF",
+  "--ds-gray-500": "#6B7280",
+  "--ds-gray-600": "#4B5563",
+  "--ds-gray-700": "#374151",
+  "--ds-gray-800": "#1F2937",
   "--ds-gray-900": "#111827",
   "--ds-white": "#FFFFFF",
 };
@@ -98,34 +113,44 @@ function readBrand(): (token: keyof typeof BRAND_FALLBACKS) => string {
   return (token) => resolved[token] ?? BRAND_FALLBACKS[token];
 }
 
-function brandThemeVariables(): Record<string, string | boolean> {
+function brandThemeVariables(isDark: boolean): Record<string, string | boolean> {
   const c = readBrand();
 
-  const ink = c("--ds-gray-900"); // all text — dark, sits on light fills/card
-  const canvas = c("--ds-white"); // diagram canvas + edge-label backdrop blend
-  // blue-100 reads clearly on white (blue-50 was nearly invisible); blue-300
-  // gives a soft-but-visible edge without the old bold border.
-  const nodeFill = c("--ds-blue-100");
-  const nodeEdge = c("--ds-blue-300");
-  const softFill = c("--ds-gray-50"); // clusters / subgraphs / alt rows
-  const softEdge = c("--ds-gray-200");
-  const line = c("--ds-gray-400"); // connectors
+  // Surfaces & text, keyed by mode. Light: soft tints on white. Dark: layered
+  // slate (page < cluster < node) with light text. `nodeText` is the theme
+  // default; adaptNodeLabels overrides it per node from the node's own fill.
+  const nodeFill = isDark ? c("--ds-gray-700") : c("--ds-blue-100");
+  const nodeEdge = isDark ? c("--ds-gray-600") : c("--ds-blue-300");
+  const nodeText = isDark ? c("--ds-gray-50") : c("--ds-gray-900");
+  const clusterFill = isDark ? c("--ds-gray-800") : c("--ds-gray-50");
+  const clusterEdge = isDark ? c("--ds-gray-700") : c("--ds-gray-200");
+  const pageText = isDark ? c("--ds-gray-50") : c("--ds-gray-900"); // free-floating
+  const surface = isDark ? c("--ds-gray-900") : c("--ds-white");
+  const line = c("--ds-gray-400"); // connectors — visible on light and dark
+  const lifeline = isDark ? c("--ds-gray-500") : c("--ds-gray-300");
+  const edgeLabelBg = isDark ? c("--ds-gray-900") : c("--ds-white");
+  const accentFill = isDark ? c("--ds-gray-600") : c("--ds-blue-100");
 
-  // Categorical wheel (mindmaps): soft -200 fills under dark labels. Mermaid
-  // re-applies overrides after its internal derivation, so these reach the SVG
-  // verbatim (its cScale darkening is bypassed).
+  // Notes — bright sticky in light; muted slate with a yellow edge in dark.
+  const noteFill = isDark ? c("--ds-gray-700") : c("--ds-yellow-100");
+  const noteEdge = isDark ? c("--ds-yellow-600") : c("--ds-yellow-200");
+
+  // Categorical wheel (mindmaps): light = soft -200 + dark labels; dark = deep
+  // -800 + light labels. (Mermaid re-applies overrides after derivation, so
+  // these reach the SVG verbatim; mindmap sections aren't `.node`, so
+  // adaptNodeLabels leaves them alone.)
+  const step = isDark ? "800" : "200";
   const wheel = ["blue", "teal", "green", "yellow", "orange", "red", "purple"];
   const cScale: Record<string, string> = {};
   for (let i = 0; i < 12; i++) {
     cScale[`cScale${i}`] = c(
-      `--ds-${wheel[i % wheel.length]}-200` as keyof typeof BRAND_FALLBACKS,
+      `--ds-${wheel[i % wheel.length]}-${step}` as keyof typeof BRAND_FALLBACKS,
     );
   }
 
   return {
-    // Light-based in both modes; dark mode is handled by a CSS figure card.
-    darkMode: false,
-    background: canvas,
+    darkMode: isDark,
+    background: surface,
     fontFamily: '"Source Serif 4", Georgia, "Times New Roman", serif',
     // Controls the font-size written into the SVG's inline <style> block.
     // Without this, Mermaid inherits the container's computed size (16px from
@@ -136,83 +161,121 @@ function brandThemeVariables(): Record<string, string | boolean> {
     // Nodes (flowchart / class / state / ER) + sequence actors
     primaryColor: nodeFill,
     primaryBorderColor: nodeEdge,
-    primaryTextColor: ink,
-    nodeTextColor: ink,
+    primaryTextColor: nodeText,
+    nodeTextColor: nodeText,
 
     // Secondary / tertiary — clusters/subgraphs + gentle accents
-    secondaryColor: c("--ds-blue-100"),
+    secondaryColor: accentFill,
     secondaryBorderColor: nodeEdge,
-    secondaryTextColor: ink,
-    tertiaryColor: softFill,
-    tertiaryBorderColor: softEdge,
-    tertiaryTextColor: ink,
+    secondaryTextColor: nodeText,
+    tertiaryColor: clusterFill,
+    tertiaryBorderColor: clusterEdge,
+    tertiaryTextColor: nodeText,
 
-    // Connectors + labels (edge-label backdrops blend into the canvas/card)
+    // Connectors + free-floating text (titles / signals sit on the page)
     lineColor: line,
     arrowheadColor: line,
-    textColor: ink,
-    titleColor: ink,
-    edgeLabelBackground: canvas,
+    textColor: pageText,
+    titleColor: pageText,
+    edgeLabelBackground: edgeLabelBg,
 
-    // Notes — soft yellow, dark text
-    noteBkgColor: c("--ds-yellow-100"),
-    noteBorderColor: c("--ds-yellow-200"),
-    noteTextColor: ink,
+    // Notes
+    noteBkgColor: noteFill,
+    noteBorderColor: noteEdge,
+    noteTextColor: nodeText,
 
     // Sequence diagrams
     actorBkg: nodeFill,
     actorBorder: nodeEdge,
-    actorTextColor: ink,
-    actorLineColor: c("--ds-gray-300"),
+    actorTextColor: nodeText,
+    actorLineColor: lifeline,
     signalColor: line,
-    signalTextColor: ink,
+    signalTextColor: pageText,
     labelBoxBkgColor: nodeFill,
     labelBoxBorderColor: nodeEdge,
-    labelTextColor: ink,
-    loopTextColor: ink,
-    activationBkgColor: c("--ds-blue-100"),
+    labelTextColor: nodeText,
+    loopTextColor: pageText,
+    activationBkgColor: accentFill,
     activationBorderColor: nodeEdge,
-    sequenceNumberColor: ink,
+    sequenceNumberColor: isDark ? c("--ds-gray-900") : c("--ds-white"),
 
     // Class diagrams
-    classText: ink,
+    classText: nodeText,
 
-    // State diagrams — keep composite/alt backgrounds light (they default to
-    // `background`) so nested state text stays legible.
-    compositeBackground: softFill,
-    altBackground: softFill,
+    // State diagrams (composite/alt backgrounds follow the cluster surface)
+    compositeBackground: clusterFill,
+    altBackground: clusterFill,
     compositeTitleBackground: nodeFill,
     compositeBorder: nodeEdge,
 
     // ER diagrams — alternating attribute rows
-    attributeBackgroundColorOdd: softFill,
-    attributeBackgroundColorEven: canvas,
+    attributeBackgroundColorOdd: clusterFill,
+    attributeBackgroundColorEven: surface,
 
     // Gantt charts
-    sectionBkgColor: softFill,
-    altSectionBkgColor: canvas,
-    sectionBkgColor2: c("--ds-blue-50"),
-    taskBkgColor: c("--ds-blue-100"),
+    sectionBkgColor: clusterFill,
+    altSectionBkgColor: surface,
+    sectionBkgColor2: isDark ? c("--ds-gray-700") : c("--ds-blue-50"),
+    taskBkgColor: nodeFill,
     taskBorderColor: nodeEdge,
-    activeTaskBkgColor: c("--ds-blue-200"),
+    activeTaskBkgColor: isDark ? c("--ds-gray-600") : c("--ds-blue-200"),
     activeTaskBorderColor: nodeEdge,
-    gridColor: softEdge,
-    doneTaskBkgColor: c("--ds-gray-200"),
-    doneTaskBorderColor: c("--ds-gray-400"),
-    critBkgColor: c("--ds-red-200"),
+    gridColor: clusterEdge,
+    doneTaskBkgColor: isDark ? c("--ds-gray-700") : c("--ds-gray-300"),
+    doneTaskBorderColor: c("--ds-gray-500"),
+    critBkgColor: isDark ? c("--ds-red-800") : c("--ds-red-200"),
     critBorderColor: c("--ds-red-600"),
     todayLineColor: c("--ds-red-500"),
-    taskTextColor: ink,
-    taskTextDarkColor: ink,
-    taskTextLightColor: ink,
-    taskTextOutsideColor: ink,
+    taskTextColor: nodeText,
+    taskTextDarkColor: c("--ds-gray-900"),
+    taskTextLightColor: c("--ds-gray-50"),
+    taskTextOutsideColor: pageText,
 
     // Categorical scale (mindmaps / pie) + mindmap root node
-    scaleLabelColor: ink,
-    git0: c("--ds-blue-100"),
-    gitBranchLabel0: ink,
+    scaleLabelColor: nodeText,
+    git0: nodeFill,
+    gitBranchLabel0: nodeText,
     ...cScale,
   };
+}
+
+// Relative luminance (WCAG) of an "rgb(r, g, b)" string, or null if unparseable.
+function rgbLuminance(rgb: string): number | null {
+  const m = rgb.match(/[\d.]+/g);
+  if (!m || m.length < 3) return null;
+  const [r, g, b] = m.slice(0, 3).map((n) => {
+    const v = Number(n) / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+// Set each flowchart node's label color from its own fill luminance, so author
+// `classDef` pastel fills (which carry no text color) stay legible: dark text on
+// light fills, light text on dark fills. Runs after the SVG is in the DOM —
+// fills can come from injected CSS classes, so getComputedStyle is required.
+// Idempotent, and harmless in light mode (re-asserts dark-on-light).
+function adaptNodeLabels(root: Element | null): void {
+  if (!root) return;
+  const DARK = "#111827"; // --ds-gray-900
+  const LIGHT = "#F3F4F6"; // --ds-gray-100
+  root.querySelectorAll(".node").forEach((node) => {
+    const shape = node.querySelector("rect, polygon, circle, ellipse, path");
+    if (!shape) return;
+    const lum = rgbLuminance(getComputedStyle(shape).fill);
+    if (lum == null) return;
+    const color = lum > 0.4 ? DARK : LIGHT;
+    node
+      .querySelectorAll<HTMLElement>(
+        "foreignObject div, foreignObject span, foreignObject p",
+      )
+      .forEach((el) => {
+        el.style.color = color;
+      });
+    node.querySelectorAll<SVGElement>("text, tspan").forEach((el) => {
+      el.style.fill = color;
+    });
+  });
 }
 
 function MermaidContent({ chart }: { chart: string }) {
@@ -227,11 +290,11 @@ function MermaidContent({ chart }: { chart: string }) {
     fontSize: 15,
     themeCSS: "margin: 1.5rem auto 0;",
     // Drive diagram colors from the DataSlope brand palette (app/brand.css) via
-    // the customizable "base" theme, instead of Mermaid's stock neutral/dark
-    // themes. The theme is light-based in both modes; free-floating text blends
-    // with the page so it reads on light and dark (see brandThemeVariables).
+    // the customizable "base" theme: a light theme in light mode and a dark
+    // theme in dark mode (adaptNodeLabels keeps author classDef pastels legible
+    // in the dark theme). Replaces Mermaid's stock neutral/dark themes.
     theme: "base",
-    themeVariables: brandThemeVariables(),
+    themeVariables: brandThemeVariables(resolvedTheme === "dark"),
   });
 
   const { svg, bindFunctions } = use(
@@ -256,7 +319,10 @@ function MermaidContent({ chart }: { chart: string }) {
       <div
         className={styles.diagram}
         ref={(container) => {
-          if (container) bindFunctions?.(container);
+          if (container) {
+            bindFunctions?.(container);
+            adaptNodeLabels(container);
+          }
         }}
         dangerouslySetInnerHTML={{ __html: svg }}
       />
@@ -340,6 +406,9 @@ function MermaidFullscreen({
       if (!viewport || !stage) return;
       const svgEl = stage.querySelector("svg");
       if (!svgEl) return;
+      // Keep author classDef pastel nodes legible in the dark theme (matches
+      // the inline diagram).
+      adaptNodeLabels(stage);
       const bbox = svgEl.getBoundingClientRect();
       const naturalW = bbox.width;
       const naturalH = bbox.height;

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -48,6 +48,176 @@ function cachePromise<T>(key: string, setPromise: () => Promise<T>): Promise<T> 
   return promise;
 }
 
+// ─── Brand-themed Mermaid palette ──────────────────────────────────────────
+//
+// Mermaid runs color math (khroma) over its theme variables, so it needs
+// concrete colors rather than `var(--ds-*)` strings. We resolve the brand
+// tokens (app/brand.css) to hex at render time, keeping that file the single
+// source of truth, and fall back to the literal brand values — mirrored below,
+// kept in sync with app/brand.css — if a token is ever missing (e.g. before
+// the stylesheet applies). Only the steps the theme actually uses are listed.
+const BRAND_FALLBACKS: Record<string, string> = {
+  "--ds-blue-50": "#E8F2FF",
+  "--ds-blue-100": "#D1E6FF",
+  "--ds-blue-200": "#AED3FF",
+  "--ds-blue-400": "#5BA7FF",
+  "--ds-blue-600": "#0878DD",
+  "--ds-blue-800": "#00519C",
+  "--ds-teal-200": "#AAE0DD",
+  "--ds-teal-600": "#009491",
+  "--ds-teal-800": "#006361",
+  "--ds-green-200": "#B4EAAF",
+  "--ds-green-800": "#006F01",
+  "--ds-red-200": "#FFC2BF",
+  "--ds-red-500": "#FF4F59",
+  "--ds-red-600": "#DC3F49",
+  "--ds-red-800": "#99212C",
+  "--ds-yellow-100": "#FDF5D9",
+  "--ds-yellow-200": "#FEF0C3",
+  "--ds-yellow-600": "#D4B651",
+  "--ds-yellow-800": "#836D1C",
+  "--ds-orange-200": "#F6CAAD",
+  "--ds-orange-800": "#844200",
+  "--ds-purple-200": "#DBCAFC",
+  "--ds-purple-800": "#634094",
+  "--ds-gray-50": "#f9fafb",
+  "--ds-gray-300": "#d1d5db",
+  "--ds-gray-400": "#9ca3af",
+  "--ds-gray-500": "#6b7280",
+  "--ds-gray-600": "#4b5563",
+  "--ds-gray-700": "#374151",
+  "--ds-gray-800": "#1f2937",
+  "--ds-gray-900": "#111827",
+  "--ds-white": "#ffffff",
+};
+
+function readBrand(): (token: keyof typeof BRAND_FALLBACKS) => string {
+  let resolved: Record<string, string> = BRAND_FALLBACKS;
+  if (typeof window !== "undefined") {
+    const root = getComputedStyle(document.documentElement);
+    resolved = { ...BRAND_FALLBACKS };
+    for (const name of Object.keys(BRAND_FALLBACKS)) {
+      const value = root.getPropertyValue(name).trim();
+      if (value) resolved[name] = value;
+    }
+  }
+  return (token) => resolved[token] ?? BRAND_FALLBACKS[token];
+}
+
+// Build Mermaid `themeVariables` for the brand "base" theme. Light mode places
+// dark text/soft-blue nodes on a white page; dark mode places light text on
+// dark cards with a bright-blue accent border. All node/line/text pairings are
+// WCAG-AA verified. Semantic brand hues (green/red/yellow) keep their meaning
+// (success/error/warning notes & critical tasks); the seven-hue categorical
+// wheel colors multi-branch diagrams (mindmaps) without semantic collisions.
+function brandThemeVariables(isDark: boolean): Record<string, string | boolean> {
+  const c = readBrand();
+
+  const text = isDark ? c("--ds-gray-50") : c("--ds-gray-900");
+  const surface = isDark ? c("--ds-gray-900") : c("--ds-white");
+  const nodeFill = isDark ? c("--ds-gray-800") : c("--ds-blue-50");
+  const nodeBorder = isDark ? c("--ds-blue-400") : c("--ds-blue-600");
+  const line = isDark ? c("--ds-gray-400") : c("--ds-gray-500");
+  const lifeline = isDark ? c("--ds-gray-500") : c("--ds-gray-400");
+  const signal = isDark ? c("--ds-gray-300") : c("--ds-gray-600");
+  const clusterFill = isDark ? c("--ds-gray-900") : c("--ds-gray-50");
+  const clusterBorder = isDark ? c("--ds-gray-700") : c("--ds-gray-300");
+
+  // Categorical wheel (mindmaps): light = soft -200 fills under dark labels;
+  // dark = deep -800 fills under light labels. Mermaid re-applies overrides
+  // after its internal derivation, so these exact values reach the SVG.
+  const step = isDark ? "800" : "200";
+  const wheel = ["blue", "teal", "green", "yellow", "orange", "red", "purple"];
+  const cScale: Record<string, string> = {};
+  for (let i = 0; i < 12; i++) {
+    cScale[`cScale${i}`] = c(`--ds-${wheel[i % wheel.length]}-${step}` as keyof typeof BRAND_FALLBACKS);
+  }
+
+  return {
+    darkMode: isDark,
+    background: surface,
+    fontFamily: '"Source Serif 4", Georgia, "Times New Roman", serif',
+    // Controls the font-size written into the SVG's inline <style> block.
+    // Without this, Mermaid inherits the container's computed size (16px from
+    // the 1rem wrapper) and writes that into the SVG, overriding the fontSize
+    // config which only governs text measurement.
+    fontSize: "15px",
+
+    // Primary nodes (flowchart / class / state / ER) + sequence actors
+    primaryColor: nodeFill,
+    primaryBorderColor: nodeBorder,
+    primaryTextColor: text,
+    nodeTextColor: text,
+
+    // Secondary / tertiary — clusters/subgraphs and accents
+    secondaryColor: isDark ? c("--ds-gray-700") : c("--ds-teal-200"),
+    secondaryBorderColor: isDark ? c("--ds-gray-600") : c("--ds-teal-600"),
+    secondaryTextColor: text,
+    tertiaryColor: clusterFill,
+    tertiaryBorderColor: clusterBorder,
+    tertiaryTextColor: text,
+
+    // Edges / arrows / labels
+    lineColor: line,
+    arrowheadColor: line,
+    textColor: text,
+    titleColor: text,
+    edgeLabelBackground: surface,
+
+    // Notes (sequence + flowchart) — bright "sticky note" in both modes
+    noteBkgColor: c("--ds-yellow-100"),
+    noteBorderColor: c("--ds-yellow-600"),
+    noteTextColor: c("--ds-gray-900"),
+
+    // Sequence diagrams
+    actorBkg: nodeFill,
+    actorBorder: nodeBorder,
+    actorTextColor: text,
+    actorLineColor: lifeline,
+    signalColor: signal,
+    signalTextColor: text,
+    labelBoxBkgColor: nodeFill,
+    labelBoxBorderColor: nodeBorder,
+    labelTextColor: text,
+    loopTextColor: text,
+    activationBkgColor: isDark ? c("--ds-gray-700") : c("--ds-blue-100"),
+    activationBorderColor: nodeBorder,
+    sequenceNumberColor: isDark ? c("--ds-gray-900") : c("--ds-white"),
+
+    // Class diagrams
+    classText: text,
+
+    // ER diagrams — alternating attribute rows
+    attributeBackgroundColorOdd: clusterFill,
+    attributeBackgroundColorEven: surface,
+
+    // Gantt charts
+    sectionBkgColor: isDark ? c("--ds-gray-800") : c("--ds-gray-50"),
+    altSectionBkgColor: surface,
+    sectionBkgColor2: isDark ? c("--ds-gray-700") : c("--ds-blue-50"),
+    taskBkgColor: nodeFill,
+    taskBorderColor: nodeBorder,
+    activeTaskBkgColor: isDark ? c("--ds-blue-800") : c("--ds-blue-200"),
+    activeTaskBorderColor: nodeBorder,
+    gridColor: clusterBorder,
+    doneTaskBkgColor: isDark ? c("--ds-gray-700") : c("--ds-gray-300"),
+    doneTaskBorderColor: c("--ds-gray-500"),
+    critBkgColor: isDark ? c("--ds-red-800") : c("--ds-red-200"),
+    critBorderColor: c("--ds-red-600"),
+    todayLineColor: c("--ds-red-500"),
+    taskTextColor: text,
+    taskTextDarkColor: c("--ds-gray-900"),
+    taskTextLightColor: c("--ds-white"),
+    taskTextOutsideColor: text,
+
+    // Categorical scale (mindmaps / pie) + mindmap root node
+    scaleLabelColor: text,
+    git0: isDark ? c("--ds-gray-800") : c("--ds-blue-100"),
+    gitBranchLabel0: text,
+    ...cScale,
+  };
+}
+
 function MermaidContent({ chart }: { chart: string }) {
   const id = useId();
   const { resolvedTheme } = useTheme();
@@ -59,14 +229,11 @@ function MermaidContent({ chart }: { chart: string }) {
     fontFamily: '"Source Serif 4", Georgia, "Times New Roman", serif',
     fontSize: 15,
     themeCSS: "margin: 1.5rem auto 0;",
-    theme: resolvedTheme === "dark" ? "dark" : "neutral",
-    themeVariables: {
-      // Controls the font-size written into the SVG's inline <style> block.
-      // Without this, Mermaid inherits the container's computed size (16px
-      // from the 1rem wrapper) and writes that into the SVG, overriding the
-      // fontSize config above which only governs text measurement.
-      fontSize: "15px",
-    },
+    // Drive diagram colors from the DataSlope brand palette (app/brand.css) via
+    // the customizable "base" theme, instead of Mermaid's stock neutral (light)
+    // / dark themes, so charts match the rest of /learn in both modes.
+    theme: "base",
+    themeVariables: brandThemeVariables(resolvedTheme === "dark"),
   });
 
   const { svg, bindFunctions } = use(

--- a/app/brand.css
+++ b/app/brand.css
@@ -3,7 +3,9 @@
  * ----------------------------------------------------------------------------
  * Imported once in app/layout.tsx so every route (/, /learn, /playground) can
  * read these tokens. Defines:
- *   1. Full 50–900 tonal ramps for the four brand hues (500 = the brand color).
+ *   1. Full 50–900 tonal ramps for the four brand hues (500 = the brand color),
+ *      plus three decorative "categorical" hues (teal/purple/orange) for charts
+ *      and illustrations that need more than four distinct, non-semantic colors.
  *   2. Raw hue aliases (--ds-blue → --ds-blue-500, etc.).
  *   3. Mode-agnostic "ink" anchors that clear WCAG AA body text on white.
  *   4. Semantic role tokens, with light-mode defaults and dark-mode overrides.
@@ -68,17 +70,69 @@
   --ds-yellow-800: #836D1C; /* AA body text on white (5.0:1) */
   --ds-yellow-900: #624F00;
 
+  /* ── Decorative / categorical hues (NON-SEMANTIC) ──────────────────────
+   * Extend the four brand hues to give charts, diagrams (Mermaid mindmaps,
+   * pie/quadrant) and illustrations categorical variety. Unlike green/red/
+   * yellow — which are LOCKED to success/error/warning (see brand report §5) —
+   * these carry no meaning; use them purely to tell series/branches apart.
+   * Same OKLCH method as the brand ramps (constant hue, interpolated L/C,
+   * gamut-mapped to sRGB; 500 = the base hue). Together with blue they form a
+   * seven-step categorical wheel: blue · teal · green · yellow · orange · red ·
+   * purple. The 700 steps clear WCAG AA body text on white (the "ink" role). */
+
+  /* ── Teal (hue ≈192) ──────────────────────────────────────────────── */
+  --ds-teal-50:  #E6F6F5;
+  --ds-teal-100: #CFEDEB;
+  --ds-teal-200: #AAE0DD;
+  --ds-teal-300: #80D3CF;
+  --ds-teal-400: #3BC4BF;
+  --ds-teal-500: #00AEAA; /* base */
+  --ds-teal-600: #009491;
+  --ds-teal-700: #007B79; /* AA body text on white (5.1:1) */
+  --ds-teal-800: #006361;
+  --ds-teal-900: #004E4C;
+
+  /* ── Purple (hue ≈300) ────────────────────────────────────────────── */
+  --ds-purple-50:  #F4EFFE;
+  --ds-purple-100: #EAE0FD;
+  --ds-purple-200: #DBCAFC;
+  --ds-purple-300: #CCB3FB;
+  --ds-purple-400: #BB96FA;
+  --ds-purple-500: #AB77FA; /* base */
+  --ds-purple-600: #9263D7;
+  --ds-purple-700: #7A51B6; /* AA body text on white (5.7:1) */
+  --ds-purple-800: #634094;
+  --ds-purple-900: #4E3177;
+
+  /* ── Orange (hue ≈55) ─────────────────────────────────────────────── */
+  --ds-orange-50:  #FDEFE6;
+  --ds-orange-100: #FAE0D0;
+  --ds-orange-200: #F6CAAD;
+  --ds-orange-300: #F1B288;
+  --ds-orange-400: #EB9558;
+  --ds-orange-500: #E47600; /* base */
+  --ds-orange-600: #C36400;
+  --ds-orange-700: #A35200; /* AA body text on white (5.6:1) */
+  --ds-orange-800: #844200;
+  --ds-orange-900: #693300;
+
   /* ── Raw hue aliases (= the 500 brand value) ──────────────────────── */
   --ds-blue:   var(--ds-blue-500);
   --ds-green:  var(--ds-green-500);
   --ds-red:    var(--ds-red-500);
   --ds-yellow: var(--ds-yellow-500);
+  --ds-teal:   var(--ds-teal-500);
+  --ds-purple: var(--ds-purple-500);
+  --ds-orange: var(--ds-orange-500);
 
   /* ── "Ink" anchors: AA-on-white text/link/icon colors ─────────────── */
   --ds-blue-ink:  var(--ds-blue-700);
   --ds-green-ink: var(--ds-green-800);
   --ds-red-ink:   var(--ds-red-700);
   --ds-amber-ink: var(--ds-yellow-800);
+  --ds-teal-ink:   var(--ds-teal-700);
+  --ds-purple-ink: var(--ds-purple-700);
+  --ds-orange-ink: var(--ds-orange-700);
 
   /* ── Neutral foundation (Tailwind gray ramp) ──────────────────────────
    * Shared by the card / quiz / codeblock components, which each used to

--- a/app/color-test/page.tsx
+++ b/app/color-test/page.tsx
@@ -68,8 +68,20 @@ const SWATCH_DEFS: SwatchDef[] = [
   { name: "--ds-green-ink", label: "Green ink", isTextColor: true },
   { name: "--ds-red-ink", label: "Red ink", isTextColor: true },
   { name: "--ds-amber-ink", label: "Amber ink", isTextColor: true },
+  // Decorative-hue "ink" anchors (non-semantic; AA-on-white from brand.css).
+  { name: "--ds-teal-ink", label: "Teal ink", isTextColor: true },
+  { name: "--ds-purple-ink", label: "Purple ink", isTextColor: true },
+  { name: "--ds-orange-ink", label: "Orange ink", isTextColor: true },
   // Full 50–900 brand ramps (brand.css). 500 = the brand color.
   ...(["blue", "green", "red", "yellow"] as const).flatMap((hue) =>
+    [50, 100, 200, 300, 400, 500, 600, 700, 800, 900].map((step) => ({
+      name: `--ds-${hue}-${step}`,
+      label: `${hue} ${step}`,
+    })),
+  ),
+  // Decorative / categorical ramps (teal, purple, orange) — non-semantic,
+  // for charts (Mermaid mindmaps) and illustrations. 500 = the base hue.
+  ...(["teal", "purple", "orange"] as const).flatMap((hue) =>
     [50, 100, 200, 300, 400, 500, 600, 700, 800, 900].map((step) => ({
       name: `--ds-${hue}-${step}`,
       label: `${hue} ${step}`,


### PR DESCRIPTION
## What & why

Re-theme Mermaid diagrams onto the brand color system (replacing the stock `neutral`/`dark` themes), add the decorative colors the palette was missing, and make both light and dark mode legible + aesthetic.

## Changes

**`app/brand.css` — three decorative, non-semantic hues**
- Added **teal**, **purple**, **orange** as full 50–900 OKLCH ramps (same method as the brand ramps; 500 = base), plus `--ds-{hue}` and `--ds-{hue}-ink` aliases.
- The four brand hues are semantically loaded (green/red/yellow = success/error/warning), leaving only blue free for decoration. A content audit found authors hand-coloring diagram nodes with ~8 hue families, so the palette needed non-semantic categorical colors. With blue these form a seven-step wheel: **blue · teal · green · yellow · orange · red · purple**.

**`app/_components/mdx/mermaid.tsx` + `mermaid.module.css` — brand theme**
- Replaced the `neutral`/`dark` theme selection with Mermaid's customizable **`base`** theme: a **light theme in light mode and a genuine dark theme in dark mode** (layered slate surfaces, light text — not a white card on a dark page). Colors resolved to hex at render time (khroma needs concrete values).
- **Legibility (the hard part):** ~200 MDX diagrams hand-color nodes with `classDef` light pastel fills and *no* text color (e.g. `fill:#fee2e2`). Mermaid has one global node-text color, so a dark theme's light text would be light-on-light there. Solved with **`adaptNodeLabels`**: after render, each flowchart node's label color is set from its own fill luminance — dark text on light fills, light text on dark fills. Default nodes go properly dark; author pastels keep dark text and read as intentional emphasis.
- **Minimal borders** (soft hairlines, not the old bold `blue-600`), **soft low-contrast palette**, mindmaps cycle the seven-hue wheel (soft `-200` in light, deep `-800` in dark), yellow notes & red gantt criticals keep their meaning.

**`app/color-test/page.tsx`** — added the teal/purple/orange ramps + ink anchors to the QA page.

**`agent-outputs/20260606-0540-brand-color-system.md`** — documented decorative hues (§1.1), Mermaid as a fourth consumer (§4.3), Phase 7 (full dark-mode iteration history), and the summary/appendix.

## Review history (dark mode took a few rounds)
1. First themed pass (dark nodes + light text) — broke author `classDef` pastel nodes.
2. Switched to a light "figure card" in dark mode — legible, but reviewers read the white card as still-light-mode, and it had a sizing/contrast bug.
3. **Final:** a real dark theme + `adaptNodeLabels` (above) — genuinely dark, all nodes legible, no card.

## Verification
- `tsc` clean, `eslint` clean, **450/450** unit tests pass.
- **Playwright** across flowchart, ER, sequence, class, state, gantt, mindmap in **light and dark** (incl. the author-`classDef` pages that exposed the legibility bug): default nodes dark with light text, author pastels legible with dark text, no white card, dark-mode widths match light mode.

https://claude.ai/code/session_011mgVhMK6iw5SBaRJ4YLYXs