### PR TITLE
Add project MCP servers (Mermaid, Next.js DevTools, Playwright, DuckDB) via .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,6 +8,16 @@
       "type": "stdio",
       "command": "npx",
       "args": ["-y", "next-devtools-mcp@latest"]
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    },
+    "duckdb": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["mcp-server-motherduck", "--db-path", ":memory:"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "mermaid": {
+      "type": "http",
+      "url": "https://mcp.mermaid.ai/mcp"
+    },
+    "next-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "next-devtools-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a project-scoped `.mcp.json` registering four Model Context Protocol servers, so any coding agent working in this repo gets the tools automatically (committed = shared with the team and available in Claude Code web sessions).

```json
{
  "mcpServers": {
    "mermaid":       { "type": "http",  "url": "https://mcp.mermaid.ai/mcp" },
    "next-devtools": { "type": "stdio", "command": "npx",  "args": ["-y", "next-devtools-mcp@latest"] },
    "playwright":    { "type": "stdio", "command": "npx",  "args": ["-y", "@playwright/mcp@latest"] },
    "duckdb":        { "type": "stdio", "command": "uvx",  "args": ["mcp-server-motherduck", "--db-path", ":memory:"] }
  }
}
```

## Why

All four are "close-the-loop" tools that let an agent verify its work against ground truth instead of guessing:

- **`mermaid`** ([mcp.mermaid.ai](https://mermaid.ai/docs/ai/mcp-server), HTTP, token-free core tools) — validate/render Mermaid diagrams against the real renderer. The repo has **500+ ```mermaid blocks across 250+ lesson files**; a malformed diagram currently renders as a silent error box on the live site.
- **`next-devtools`** ([official, Next 16+](https://nextjs.org/docs/app/guides/mcp)) — live build/type/runtime errors, routes, and project metadata from the dev server. Project is on `next ^16.2.4` ✓.
- **`playwright`** ([@playwright/mcp, Microsoft](https://playwright.dev/docs/getting-started-mcp)) — drive a real browser via accessibility snapshots; pairs with the existing `playwright.config.ts` e2e suite.
- **`duckdb`** ([MotherDuck's mcp-server-motherduck](https://github.com/motherduckdb/mcp-server-motherduck)) — run/validate SQL against a real DuckDB engine. Pinned to `:memory:` so an agent can validate the SQL in the DuckDB lessons (create tables, run queries) with **no file and no MotherDuck account**.

## Verification

Confirmed both newly-added stdio launchers resolve in the cloud environment:
- `uvx mcp-server-motherduck --help` → resolves, pulls DuckDB, reports `:memory:` as the default db and `--motherduck-token` as optional (runs token-free locally).
- `npx -y @playwright/mcp@latest --help` → resolves ("Playwright MCP").

## Setup notes

- **No secrets committed.** Mermaid and DuckDB run token-free as configured; `next-devtools`/`playwright` are fetched on demand via `npx`.
- **Playwright browsers:** the server loads, but browser tools need a one-time `npx playwright install` (not present in fresh containers).
- **Web-session caveats:** `mermaid` needs outbound egress to `mcp.mermaid.ai` (subject to the environment's network policy); `next-devtools` is most useful when a `next dev` server is running.
- **Verify locally:** `claude mcp list` (or `/mcp` in-session). Tools appear as `mcp__mermaid__*`, `mcp__next-devtools__*`, `mcp__playwright__*`, `mcp__duckdb__*`.
- **Still available** if wanted later: `@eslint/mcp` (lint/fix; compatible with ESLint 9.39). To switch DuckDB onto a real database, change `--db-path` to a `.duckdb` file or `md:` (with a token).

https://claude.ai/code/session_01GsKWxRyaGWPmdtVpSYWZY5