### PR TITLE
Simplify MultipleChoice component to single-answer only

### DIFF
--- a/__tests__/multipleChoiceParse.test.ts
+++ b/__tests__/multipleChoiceParse.test.ts
@@ -29,27 +29,20 @@ and visual stories for decision-making.`;
     expect(q.choices[0].explanation).toMatch(/document creation/);
     expect(q.choices[1].explanation).toMatch(/Correct!/);
     expect(q.choices[2].explanation).toBe("");
-    expect(q.multiAnswer).toBe(false);
-    expect(q.correctIds).toEqual(["1"]);
+    expect(q.correctId).toBe("1");
     expect(q.explanation).toMatch(/decision-making\.$/);
   });
 
-  it("detects multi-answer mode when 2+ choices are marked correct", () => {
-    const src = `Which of the following are valid \`justify-content\` values?
+  it("returns a null correctId when no choice is marked correct", () => {
+    const src = `Pick one.
 
-- [o] flex-start
-- [o] center
-- column
-  > \`column\` is a \`flex-direction\` value, not \`justify-content\`.
-- [o] space-between
-- inline-flex
-  > \`inline-flex\` is a \`display\` value.`;
+- A
+- B
+- C`;
 
     const q = parseQuestion(src);
-    expect(q.multiAnswer).toBe(true);
-    expect(q.correctIds).toEqual(["0", "1", "3"]);
-    expect(q.explanation).toBe("");
-    expect(q.choices[2].explanation).toContain("flex-direction");
+    expect(q.correctId).toBeNull();
+    expect(q.choices.map((c) => c.correct)).toEqual([false, false, false]);
   });
 
   it("preserves math notation in question body and choices", () => {
@@ -110,7 +103,7 @@ The power rule states that $\\frac{d}{dx}[x^n] = nx^{n-1}$.`;
 
     const q = parseQuestion(src);
     expect(q.explanation).toBe("");
-    expect(q.correctIds).toEqual(["1"]);
+    expect(q.correctId).toBe("1");
   });
 
   it("handles CRLF line endings", () => {
@@ -153,8 +146,7 @@ The power rule states that $\\frac{d}{dx}[x^n] = nx^{n-1}$.`;
     expect(q.choices[1].text).toMatch(/```\s*$/);
     // Explanation is separate from the code block.
     expect(q.choices[1].explanation).toContain("Correct");
-    expect(q.multiAnswer).toBe(false);
-    expect(q.correctIds).toEqual(["1"]);
+    expect(q.correctId).toBe("1");
   });
 
   it("parses a fenced code block opened as a continuation line", () => {
@@ -174,7 +166,7 @@ The power rule states that $\\frac{d}{dx}[x^n] = nx^{n-1}$.`;
   });
 
   it("handles multiple fenced code-block choices followed by an explanation", () => {
-    const src = `Which of the following are valid ways to create a list in Python?
+    const src = `Which snippet creates a list in Python?
 
 - [o] \`\`\`python
   my_list = [1, 2, 3]
@@ -183,15 +175,15 @@ The power rule states that $\\frac{d}{dx}[x^n] = nx^{n-1}$.`;
   my_list = (1, 2, 3)
   \`\`\`
   > This creates a tuple, not a list.
-- [o] \`\`\`python
-  my_list = list(range(3))
+- \`\`\`python
+  my_list = {1, 2, 3}
   \`\`\`
+  > This creates a set, not a list.
 
 Lists are ordered, mutable sequences in Python.`;
 
     const q = parseQuestion(src);
-    expect(q.multiAnswer).toBe(true);
-    expect(q.correctIds).toEqual(["0", "2"]);
+    expect(q.correctId).toBe("0");
     expect(q.choices[0].text).toContain("[1, 2, 3]");
     expect(q.choices[1].explanation).toContain("tuple");
     expect(q.explanation).toContain("mutable sequences");

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -2,9 +2,9 @@
    alongside `<ChallengeCard>` on Learn pages.
 
    The visual language intentionally mirrors `ChallengeCard.module.css`
-   (paper card chrome, blue badge header, slate text, accent submit
-   button, green/red status banner) so the two embeddable components
-   feel like one product. Neutral tokens are duplicated locally (the
+   (paper card chrome, blue badge header, slate text, green/red status
+   banner) so the two embeddable components feel like one product.
+   Neutral tokens are duplicated locally (the
    playground bundle doesn't load Tailwind's preflight that defines the
    `--color-…` vars); brand colors come from the global `--ds-*` ramp
    (app/brand.css). */
@@ -25,7 +25,6 @@
   --mc-text: var(--ds-gray-900);
   --mc-text-muted: var(--ds-gray-400);
   --mc-accent: var(--ds-blue-600);
-  --mc-badge-color: var(--mc-accent);
 
   --mc-font-ui: "Inter", system-ui, -apple-system, sans-serif;
   --mc-font-mono:
@@ -70,13 +69,6 @@
   white-space: nowrap;
 }
 
-.badgeDot {
-  width: 5px;
-  height: 5px;
-  background: var(--mc-badge-color);
-  border-radius: 50%;
-}
-
 .modeLabel {
   font-size: 12px;
   color: var(--mc-text-muted);
@@ -90,7 +82,6 @@
   width: 13px;
   height: 13px;
 }
-
 
 /* ─── Question body (markdown-rendered) ───────────────────────────── */
 
@@ -191,10 +182,6 @@
 
 .choice:not([data-locked="true"]):hover {
   background: var(--ds-gray-50);
-}
-
-.choice[data-selected="true"] {
-  /* no background highlight — selection is indicated by the input alone */
 }
 
 .choice[data-locked="true"] {
@@ -506,11 +493,6 @@
   --mc-border-light: #232323;
   --mc-text: #e0e0e0;
   --mc-text-muted: #808080;
-  --mc-badge-color: var(--ds-blue-300);
-}
-
-:global(html.dark) .choice[data-selected="true"] {
-  /* no background highlight in dark mode either */
 }
 
 :global(html.dark) .choice[data-verdict="correct-selected"],

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -25,8 +25,6 @@
   --mc-text: var(--ds-gray-900);
   --mc-text-muted: var(--ds-gray-400);
   --mc-accent: var(--ds-blue-600);
-  --mc-accent-hover: var(--ds-blue-700);
-  --mc-accent-disabled: var(--ds-blue-300);
   --mc-badge-color: var(--mc-accent);
 
   --mc-font-ui: "Inter", system-ui, -apple-system, sans-serif;
@@ -228,33 +226,13 @@
   margin-top: 3px;
   cursor: inherit;
   background: var(--ds-gray-100);
+  border-radius: 50%;
   box-shadow: none;
   transition: box-shadow 0.12s, background 0.12s;
 }
 
-.choiceInput[type="radio"] {
-  border-radius: 50%;
-}
-
-.choiceInput[type="checkbox"] {
-  border-radius: 3px;
-}
-
 .choiceInput:checked {
-  background: var(--ds-gray-900);
-  box-shadow: 0 0 0 1.5px var(--ds-gray-400);
-}
-
-.choiceInput[type="radio"]:checked {
   background: radial-gradient(circle, #fff 30%, var(--ds-gray-900) 31%);
-  box-shadow: none;
-}
-
-.choiceInput[type="checkbox"]:checked {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M2 5l2.5 2.5L8 3' stroke='white' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 9px;
   box-shadow: none;
 }
 
@@ -403,31 +381,6 @@
   background: var(--mc-bg-subtle);
 }
 
-.submitBtn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: var(--mc-accent);
-  color: var(--ds-white);
-  border: none;
-  border-radius: 6px;
-  padding: 7px 14px;
-  font-family: var(--mc-font-ui);
-  font-size: 13.5px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.12s;
-}
-
-.submitBtn:hover:not(:disabled) {
-  background: var(--mc-accent-hover);
-}
-
-.submitBtn:disabled {
-  background: var(--mc-accent-disabled);
-  cursor: not-allowed;
-}
-
 .retryBtn {
   display: inline-flex;
   align-items: center;
@@ -448,12 +401,6 @@
   background: var(--mc-bg-hover);
   border-color: var(--ds-gray-300);
   color: var(--mc-text);
-}
-
-.actionHint {
-  margin-left: auto;
-  font-size: 12px;
-  color: var(--mc-text-muted);
 }
 
 /* ─── Status banner ───────────────────────────────────────────────── */
@@ -477,11 +424,6 @@
   color: var(--ds-red-700);
 }
 
-.banner[data-state="partial"] {
-  background: var(--ds-yellow-50);
-  color: var(--ds-yellow-700);
-}
-
 .bannerIcon {
   width: 22px;
   height: 22px;
@@ -498,10 +440,6 @@
 
 .banner[data-state="fail"] .bannerIcon {
   background: var(--ds-red-100);
-}
-
-.banner[data-state="partial"] .bannerIcon {
-  background: var(--ds-yellow-200);
 }
 
 .bannerSub {
@@ -594,11 +532,6 @@
   color: var(--ds-red-300);
 }
 
-:global(html.dark) .banner[data-state="partial"] {
-  background: color-mix(in srgb, var(--ds-yellow) 12%, transparent);
-  color: var(--ds-yellow-300);
-}
-
 :global(html.dark) .choiceLabel code,
 :global(html.dark) .bodyMd code,
 :global(html.dark) .overallBody code {
@@ -619,7 +552,7 @@
   background: transparent;
 }
 
-/* Unselected radio/checkbox: no ring, subtle fill close to the page bg. */
+/* Unselected radio: no ring, subtle fill close to the page bg. */
 :global(html.dark) .choiceInput:not(:checked) {
   background: rgba(255, 255, 255, 0.05);
 }
@@ -656,10 +589,6 @@
   background: color-mix(in srgb, var(--ds-red) 20%, transparent);
 }
 
-:global(html.dark) .banner[data-state="partial"] .bannerIcon {
-  background: color-mix(in srgb, var(--ds-yellow) 20%, transparent);
-}
-
 /* Retry button uses an explicit white background in light mode. */
 :global(html.dark) .retryBtn {
   background: var(--mc-bg-subtle);
@@ -678,14 +607,6 @@
   background: var(--mc-bg-hover);
 }
 
-/* Disabled submit button is too vivid (blue-300) in dark mode — tone it
-   down to a dim translucent blue so it reads as inactive. */
-:global(html.dark) .submitBtn:disabled {
-  background: color-mix(in srgb, var(--ds-blue) 50%, transparent);
-  color: rgba(255, 255, 255, 0.5);
-  cursor: not-allowed;
-}
-
 /* White explanation text on dark red/green verdict backgrounds. */
 :global(html.dark) .choice[data-verdict="correct-selected"] .choiceExplanation,
 :global(html.dark) .choice[data-verdict="correct-missed"] .choiceExplanation,
@@ -693,24 +614,9 @@
   color: #ffffff;
 }
 
-/* Neutral checked state for radio/checkbox inputs in dark mode.
-   Use background-color (not the background shorthand) so it doesn't
-   reset background-image, which would hide the checkbox checkmark. */
+/* Neutral checked state for the radio input in dark mode. */
 :global(html.dark) .choiceInput:checked {
-  background-color: var(--ds-gray-900);
-  box-shadow: 0 0 0 1.5px rgba(255, 255, 255, 0.25);
-}
-
-:global(html.dark) .choiceInput[type="radio"]:checked {
   background: radial-gradient(circle, white 30%, #fff6 31%);
-  box-shadow: none;
-}
-
-/* In dark mode, checked checkboxes flip to a white box with a dark
-   checkmark so they read as clearly "on" against any dark background. */
-:global(html.dark) .choiceInput[type="checkbox"]:checked {
-  background-color: #ffffff;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M2 5l2.5 2.5L8 3' stroke='%231a1a1a' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   box-shadow: none;
 }
 

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -158,7 +158,6 @@ export default function MultipleChoiceQuestion({
                   when the input itself is clicked. */}
               <div
                 className={styles.choice}
-                data-selected={isSelected ? "true" : "false"}
                 data-locked={submitted ? "true" : "false"}
                 data-verdict={verdict}
                 onClick={() => !submitted && select(choice.id)}

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -7,14 +7,12 @@
  * chrome as `<ChallengeCard>`.
  *
  * Behaviour:
- *   - Single-answer questions render as a radio group; questions with
- *     2+ `[o]` choices render as checkboxes (auto-detected by the
- *     parser).
- *   - Submit reveals per-choice verdicts + the overall explanation.
- *     A "Try Again" button then resets the selection while leaving the
- *     attempt count visible, so learners can iterate as many times as
- *     they like (mirrors the "unlimited attempts" UX of the existing
- *     `<ChallengeCard>` Check-Answer flow).
+ *   - Choices render as a radio group: the learner picks exactly one
+ *     option. Selecting a choice immediately reveals per-choice verdicts
+ *     and the overall explanation.
+ *   - A "Try Again" button then resets the selection so learners can
+ *     iterate as many times as they like (mirrors the "unlimited
+ *     attempts" UX of the existing `<ChallengeCard>` Check-Answer flow).
  *   - All learner-visible Markdown — body, choice labels, per-choice
  *     explanations, overall explanation — is rendered through
  *     react-markdown with GFM + KaTeX + rehype-highlight so authors
@@ -28,16 +26,13 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import rehypeHighlight from "rehype-highlight";
-import { Check, X, RotateCcw, ListChecks, MousePointerClick, ScrollText } from "lucide-react";
-import {
-  parseQuestion,
-  type ParsedChoice,
-  type ParsedQuestion,
-} from "./parseQuestion";
+import { Check, X, RotateCcw, MousePointerClick, ScrollText } from "lucide-react";
+import { parseQuestion, type ParsedChoice } from "./parseQuestion";
 import styles from "./MultipleChoiceQuestion.module.css";
 
-/** Choice verdict assigned after Submit. Drives the per-choice colour
- *  ring + glyph and is read off `data-verdict` in the stylesheet. */
+/** Choice verdict assigned after the learner picks an answer. Drives the
+ *  per-choice colour ring + glyph and is read off `data-verdict` in the
+ *  stylesheet. */
 type Verdict =
   | "correct-selected"
   | "correct-missed"
@@ -83,30 +78,6 @@ function computeVerdict(
   return "neutral";
 }
 
-function summariseResult(
-  parsed: ParsedQuestion,
-  selectedIds: Set<string>,
-): "pass" | "fail" | "partial" {
-  // Treat the answer set as a set comparison: every correct choice
-  // must be selected, and no incorrect choice may be selected. In
-  // multi-answer questions, picking *some* of the correct choices
-  // without any wrong ones earns a "partial" banner — useful feedback
-  // even though the question isn't fully right.
-  const correct = new Set(parsed.correctIds);
-  let selectedCorrect = 0;
-  let selectedWrong = 0;
-  for (const id of selectedIds) {
-    if (correct.has(id)) selectedCorrect++;
-    else selectedWrong++;
-  }
-  const allCorrectPicked = selectedCorrect === correct.size;
-  if (allCorrectPicked && selectedWrong === 0) return "pass";
-  if (parsed.multiAnswer && selectedCorrect > 0 && selectedWrong === 0) {
-    return "partial";
-  }
-  return "fail";
-}
-
 export default function MultipleChoiceQuestion({
   markdown,
   badge = "Question",
@@ -116,48 +87,31 @@ export default function MultipleChoiceQuestion({
   // this component with the new source.
   const parsed = useMemo(() => parseQuestion(markdown), [markdown]);
 
-  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
-  const [, setAttempts] = useState(0);
 
-  const toggle = (id: string) => {
+  const select = (id: string) => {
+    // Picking a choice locks the card and reveals feedback immediately —
+    // a single-answer question has no separate Submit step.
     if (submitted) return;
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (parsed.multiAnswer) {
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
-      } else {
-        next.clear();
-        next.add(id);
-      }
-      return next;
-    });
-    if (!parsed.multiAnswer) {
-      setSubmitted(true);
-      setAttempts((n) => n + 1);
-    }
-  };
-
-  const onSubmit = () => {
-    if (selected.size === 0) return;
+    setSelectedId(id);
     setSubmitted(true);
-    setAttempts((n) => n + 1);
   };
 
   const onRetry = () => {
-    // Reset selection but keep the attempt counter — the learner has
-    // earned that. The overall explanation hides again so the second
-    // attempt isn't trivially cued by the previous reveal.
-    setSelected(new Set());
+    // Reset the selection so the learner can try again. The overall
+    // explanation hides again so the next attempt isn't trivially cued
+    // by the previous reveal.
+    setSelectedId(null);
     setSubmitted(false);
   };
 
-  const result = submitted ? summariseResult(parsed, selected) : null;
-  const inputType = parsed.multiAnswer ? "checkbox" : "radio";
+  const result: "pass" | "fail" | null = submitted
+    ? selectedId !== null && selectedId === parsed.correctId
+      ? "pass"
+      : "fail"
+    : null;
   const groupName = useId();
-
-  const correctCount = parsed.correctIds.length;
 
   return (
     <section className={styles.card} aria-label="Multiple choice question">
@@ -167,17 +121,8 @@ export default function MultipleChoiceQuestion({
           {badge}
         </span>
         <span className={styles.modeLabel}>
-          {parsed.multiAnswer ? (
-            <>
-              <ListChecks aria-hidden />
-              Select all that apply ({correctCount})
-            </>
-          ) : (
-            <>
-              <MousePointerClick aria-hidden />
-              Select one
-            </>
-          )}
+          <MousePointerClick aria-hidden />
+          Select one
         </span>
       </header>
 
@@ -194,11 +139,11 @@ export default function MultipleChoiceQuestion({
           inside a choice label is valid HTML. */}
       <div
         className={styles.choiceList}
-        role={parsed.multiAnswer ? "group" : "radiogroup"}
+        role="radiogroup"
         aria-label="Answer choices"
       >
         {parsed.choices.map((choice) => {
-          const isSelected = selected.has(choice.id);
+          const isSelected = selectedId === choice.id;
           const verdict = computeVerdict(choice, isSelected, submitted);
           // Show explanations for all choices after submit so learners
           // can understand why each option is right or wrong.
@@ -216,16 +161,16 @@ export default function MultipleChoiceQuestion({
                 data-selected={isSelected ? "true" : "false"}
                 data-locked={submitted ? "true" : "false"}
                 data-verdict={verdict}
-                onClick={() => !submitted && toggle(choice.id)}
+                onClick={() => !submitted && select(choice.id)}
               >
                 <input
                   className={styles.choiceInput}
-                  type={inputType}
+                  type="radio"
                   name={groupName}
                   value={choice.id}
                   checked={isSelected}
                   disabled={submitted}
-                  onChange={() => toggle(choice.id)}
+                  onChange={() => select(choice.id)}
                   onClick={(e) => e.stopPropagation()}
                 />
                 <div className={styles.choiceContent}>
@@ -260,28 +205,12 @@ export default function MultipleChoiceQuestion({
         })}
       </div>
 
-      {((!submitted && parsed.multiAnswer) || submitted) ? (
+      {submitted ? (
         <div className={styles.actionBar}>
-          {!submitted ? (
-            <button
-              type="button"
-              className={styles.submitBtn}
-              onClick={onSubmit}
-              disabled={selected.size === 0}
-            >
-              Submit
-            </button>
-          ) : (
-            <button type="button" className={styles.retryBtn} onClick={onRetry}>
-              <RotateCcw size={13} aria-hidden />
-              Try again
-            </button>
-          )}
-          {!submitted && parsed.multiAnswer ? (
-            <span className={styles.actionHint}>
-              Pick every option that applies, then submit.
-            </span>
-          ) : null}
+          <button type="button" className={styles.retryBtn} onClick={onRetry}>
+            <RotateCcw size={13} aria-hidden />
+            Try again
+          </button>
         </div>
       ) : null}
 
@@ -290,26 +219,16 @@ export default function MultipleChoiceQuestion({
           <span className={styles.bannerIcon}>
             {result === "pass" ? (
               <Check size={14} strokeWidth={3} aria-hidden />
-            ) : result === "partial" ? (
-              <ListChecks size={14} strokeWidth={2.5} aria-hidden />
             ) : (
               <X size={14} strokeWidth={3} aria-hidden />
             )}
           </span>
           <span>
-            {result === "pass"
-              ? "Correct!"
-              : result === "partial"
-                ? "Partially correct"
-                : "Not quite — try again"}
+            {result === "pass" ? "Correct!" : "Not quite — try again"}
             <span className={styles.bannerSub}>
               {result === "pass"
-                ? parsed.multiAnswer
-                  ? "You selected every correct option."
-                  : "Great choice."
-                : result === "partial"
-                  ? `You picked ${selected.size} of ${correctCount} correct options.`
-                  : "Review the explanations and give it another go."}
+                ? "Great choice."
+                : "Review the explanations and give it another go."}
             </span>
           </span>
         </div>

--- a/app/_components/multipleChoice/parseQuestion.ts
+++ b/app/_components/multipleChoice/parseQuestion.ts
@@ -35,8 +35,8 @@
  *   - The first unindented, non-blank, non-choice line after the choices
  *     block opens the overall explanation; everything after it is
  *     captured verbatim.
- *   - Multi-answer mode is auto-detected — when 2+ choices are flagged
- *     `[o]`, the renderer presents checkboxes; otherwise a radio group.
+ *   - Exactly one choice should be flagged `[o]`; the renderer presents
+ *     the choices as a single-answer radio group.
  */
 
 export interface ParsedChoice {
@@ -58,10 +58,8 @@ export interface ParsedQuestion {
   choices: ParsedChoice[];
   /** Markdown source of everything after the choices block. */
   explanation: string;
-  /** True when 2+ choices are flagged correct — checkbox preview. */
-  multiAnswer: boolean;
-  /** Set of choice ids that are correct (convenience). */
-  correctIds: string[];
+  /** Id of the correct choice (`[o]`), or null when none is marked. */
+  correctId: string | null;
 }
 
 const CHOICE_RE = /^-\s+(?:\[(o|O| |x|X)\]\s+)?(.*)$/;
@@ -245,7 +243,7 @@ export function parseQuestion(source: string): ParsedQuestion {
     explanationLines.push(line);
   }
 
-  const correctIds = choices.filter((c) => c.correct).map((c) => c.id);
+  const correctChoice = choices.find((c) => c.correct);
   const trimBlock = (text: string) =>
     text.replace(/^\n+/, "").replace(/\n+$/, "");
 
@@ -255,7 +253,6 @@ export function parseQuestion(source: string): ParsedQuestion {
     // added during continuation-appending are stripped cleanly.
     choices: choices.map((c) => ({ ...c, text: trimBlock(c.text) })),
     explanation: trimBlock(explanationLines.join("\n")),
-    multiAnswer: correctIds.length > 1,
-    correctIds,
+    correctId: correctChoice ? correctChoice.id : null,
   };
 }

--- a/content/learn/multiple-choice.mdx
+++ b/content/learn/multiple-choice.mdx
@@ -22,14 +22,14 @@ with the prose.
 
 ### Notes
 
-- Mark multiple choices `[o]` to make it a multi-answer question
-  (checkbox preview).
+- Mark the correct choice with `[o]`. Each question has exactly one
+  correct answer.
 - Use `*` or `1.` for lists inside the question body — `-` is reserved
   for choices.
 - Math works anywhere — `$x^2$` for inline and `$$\int_0^\infty$$` for
   display equations.
-- Learners can submit, see per-choice feedback, and click **Try again**
-  to keep iterating — attempts are tracked in the header.
+- Learners pick an answer, see per-choice feedback, and can click **Try
+  again** to keep iterating.
 - Code blocks in choices are fully highlighted (Python, SQL, JS, and
   many other languages are auto-detected by highlight.js).
 
@@ -95,38 +95,7 @@ What is $\frac{d}{dx}[x^2]$?
 The power rule states that $\frac{d}{dx}[x^n] = nx^{n-1}$.
 ````
 
-## 3. Multi-answer (select all that apply)
-
-Flag two or more choices `[o]` and the component automatically switches
-to a checkbox preview. The status banner distinguishes a fully-correct
-answer from a *partial* one (some correct picks but not all) so
-learners get a useful nudge instead of a binary pass/fail.
-
-<MultipleChoice
-  markdown={`Which of the following are valid \`justify-content\` values? Select all that apply.
-
-- [o] flex-start
-- [o] center
-- column
-  > \`column\` is a \`flex-direction\` value, not \`justify-content\`.
-- [o] space-between
-- inline-flex
-  > \`inline-flex\` is a \`display\` value.`}
-/>
-
-````markdown
-Which of the following are valid `justify-content` values? Select all that apply.
-
-- [o] flex-start
-- [o] center
-- column
-  > `column` is a `flex-direction` value, not `justify-content`.
-- [o] space-between
-- inline-flex
-  > `inline-flex` is a `display` value.
-````
-
-## 4. Rich question body
+## 3. Rich question body
 
 The question body is full Markdown — lists, inline code, **bold**, and
 fenced code blocks all work. Remember to use `*` or `1.` for any lists
@@ -177,7 +146,7 @@ The function multiplies the sum of `prices` by `1 + tax_rate`. With the default
 tax rate of 7 %, the result is `60 × 1.07 = 64.2`.
 ````
 
-## 5. Code blocks as choices (single answer)
+## 4. Code blocks as choices
 
 Choices can be fenced code blocks — ideal for questions that ask learners
 to identify the correct snippet. Open the fence right after `- ` (or
@@ -237,60 +206,3 @@ Which snippet correctly creates a pandas DataFrame with columns A and B?
 A `DataFrame` is pandas's primary 2-D data structure. Pass a plain dict
 where each key becomes a column label and each value is the column's data.
 ````
-
-## 6. Code blocks as choices (multi-answer)
-
-Code-block choices work with the multi-answer (checkbox) mode too — just
-mark two or more choices `[o]`. Below, learners must identify every valid
-way to create a Python list.
-
-<MultipleChoice
-  markdown={`Which of the following create a Python **list**? Select all that apply.
-
-- [o] \`\`\`python
-  my_list = [1, 2, 3]
-  \`\`\`
-  > Square-bracket literal syntax produces a \`list\`.
-- \`\`\`python
-  my_list = (1, 2, 3)
-  \`\`\`
-  > This creates a **tuple**, not a list. Use \`list((1, 2, 3))\` to convert.
-- [o] \`\`\`python
-  my_list = list(range(3))
-  \`\`\`
-  > \`list()\` converts any iterable, including \`range\`, into a list.
-- \`\`\`python
-  my_list = {1, 2, 3}
-  \`\`\`
-  > Curly braces without key-value pairs create a **set**, not a list.
-
-Lists are ordered, mutable sequences; tuples are immutable; sets are
-unordered. Knowing which literal syntax produces which type is essential
-for writing correct Python.`}
-/>
-
-````markdown
-Which of the following create a Python **list**? Select all that apply.
-
-- [o] ```python
-  my_list = [1, 2, 3]
-  ```
-  > Square-bracket literal syntax produces a `list`.
-- ```python
-  my_list = (1, 2, 3)
-  ```
-  > This creates a **tuple**, not a list. Use `list((1, 2, 3))` to convert.
-- [o] ```python
-  my_list = list(range(3))
-  ```
-  > `list()` converts any iterable, including `range`, into a list.
-- ```python
-  my_list = {1, 2, 3}
-  ```
-  > Curly braces without key-value pairs create a **set**, not a list.
-
-Lists are ordered, mutable sequences; tuples are immutable; sets are
-unordered. Knowing which literal syntax produces which type is essential
-for writing correct Python.
-````
-

--- a/content/learn/practical-r-for-beginners/your-first-r-program.mdx
+++ b/content/learn/practical-r-for-beginners/your-first-r-program.mdx
@@ -259,12 +259,25 @@ per-element behavior.
 ## Test your understanding
 
 <MultipleChoice
-  markdown={`Which of these lines will produce visible output when run by itself?
+  markdown={`Which of these lines shows output by **auto-printing** — i.e. without an explicit print call?
 
 - \`x <- 5\`
   > Assignment produces no automatic output — the result is stored, not printed.
 - [o] \`5 + 3\`
   > An unassigned expression auto-prints its result.
+- \`# print("hello")\`
+  > That is a comment — everything after \`#\` is ignored.
+- \`print(5)\`
+  > This does show output, but through an explicit \`print()\` call rather than auto-printing.`}
+/>
+
+<MultipleChoice
+  markdown={`Which of these lines shows output through an **explicit** print call?
+
+- \`x <- 5\`
+  > Assignment produces no automatic output — the result is stored, not printed.
+- \`5 + 3\`
+  > This does show output, but by auto-printing an unassigned expression — there is no explicit call.
 - \`# print("hello")\`
   > That is a comment — everything after \`#\` is ignored.
 - [o] \`print(5)\`

--- a/scripts/check-mcq.mjs
+++ b/scripts/check-mcq.mjs
@@ -1,11 +1,13 @@
 // Lints <MultipleChoice> blocks in content/learn for the rules that keep
 // every question answerable, non-contradictory, and neutrally worded:
 //
-//   1. no-correct          — every question must mark at least one `- [o]`
-//                            answer (multi-answer "select all" is allowed).
-//   2. too-few-choices     — a question needs at least 2 choices.
-//   3. duplicate-choice    — no two choices may be verbatim identical.
-//   4. affirmative-opener  — a choice explanation may not start with an
+//   1. no-correct          — every question must mark exactly one `- [o]`
+//                            answer; a question with none is unwinnable.
+//   2. multiple-correct    — the component is single-answer, so a question
+//                            may not mark more than one `- [o]` choice.
+//   3. too-few-choices     — a question needs at least 2 choices.
+//   4. duplicate-choice    — no two choices may be verbatim identical.
+//   5. affirmative-opener  — a choice explanation may not start with an
 //                            affirmation ("Yes.", "Right!", "Exactly,",
 //                            "This works"…). Explanations render for ALL
 //                            choices after submit, so a learner who picked a
@@ -120,7 +122,9 @@ export function lintSource(src, file) {
     const add = (rule, detail) => violations.push({ file, rule, detail });
 
     if (choices.length < 2) add("too-few-choices", `${choices.length} choice(s) — ${stem}`);
-    if (choices.filter((c) => c.correct).length === 0) add("no-correct", stem);
+    const correctCount = choices.filter((c) => c.correct).length;
+    if (correctCount === 0) add("no-correct", stem);
+    else if (correctCount > 1) add("multiple-correct", `${correctCount} correct — ${stem}`);
 
     const seen = new Set();
     for (const c of choices) {
@@ -177,5 +181,5 @@ if (isMain) {
     console.error(`\n${violations.length} MCQ violation(s) across ${files.length} file(s).`);
     process.exit(1);
   }
-  console.log(`✓ all MCQ blocks in ${files.length} file(s) pass (correct answer, ≥2 distinct choices, neutral explanations)`);
+  console.log(`✓ all MCQ blocks in ${files.length} file(s) pass (exactly one correct answer, ≥2 distinct choices, neutral explanations)`);
 }


### PR DESCRIPTION
## Summary

The `<MultipleChoice>` component auto-detected a multi-answer mode whenever 2+ choices were marked `[o]` — switching to checkboxes, a "Select all that apply" label, a partial-credit banner, a separate Submit button, and an action hint. Since every authored course question is single-answer, this PR removes that branch entirely so the component **only accepts one answer**.

## What changed

**Component (`MultipleChoiceQuestion.tsx`)**
- Always a radio group. Picking a choice auto-submits and reveals per-choice feedback (no separate Submit step).
- Removed the checkbox input, Submit button, action hint, multi-answer mode label, and the `"partial"` result state. `summariseResult` collapsed to inline pass/fail.
- Selection state is now a single `string | null` instead of a `Set`.

**Parser (`parseQuestion.ts`)**
- Replaced `multiAnswer: boolean` + `correctIds: string[]` with a single `correctId: string | null`.

**Styles (`MultipleChoiceQuestion.module.css`)**
- Removed checkbox input styles, the `partial` banner state (light + dark), Submit-button styles, the action-hint rule, and the now-orphaned `--mc-accent-hover` / `--mc-accent-disabled` tokens. Consolidated the radio rules. (-100 lines)

**Linter (`scripts/check-mcq.mjs`)**
- Now enforces **exactly one** `[o]` per question via a new `multiple-correct` rule (previously "at least one, multi-answer allowed"). This is wired into `npm test` (`mcqContent.test.ts`) and `npm run check:mcq`.

**Content**
- Of 2,354 MCQ blocks across 716 files, only 3 used multiple correct answers. The one genuine course question (`practical-r-for-beginners › your-first-r-program`) was **split into two single-answer questions** (one for auto-printing, one for explicit `print()`), preserving the lesson's "two kinds of output" pedagogy. The two multi-answer examples in the `/learn/multiple-choice` docs page were removed and the page renumbered.

**Tests**
- Updated `multipleChoiceParse.test.ts` to the `correctId` API; replaced the multi-answer-detection test with a `null` correctId case.

## Verification

- `npm run check:mcq` → ✓ all MCQ blocks in 716 files pass (exactly one correct answer).
- Re-scan confirms **0** blocks with >1 (or 0) correct answers.
- Parser validated against every unit-test fixture via a standalone harness (16/16 checks pass), including fenced code-block choices and the null-correct case.

> Note: `node_modules` was not installed in the execution environment, so `vitest`/`tsc`/`eslint` could not be run here. The parser and linter (both dependency-free) were executed directly; the component and CSS changes were reviewed manually.

> Out of scope: the ad-hoc audit scripts under `scripts/audit/` (`mcq-lint.mjs`, `interact.mjs`) still reference multi-answer but are historical, not wired into CI, and won't error.

https://claude.ai/code/session_01CuV6kD3ZTWUDM2q66aA35t

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuV6kD3ZTWUDM2q66aA35t)_