### PR TITLE
Clean up Mermaid diagrams across courses: remove redundant, simplify wide/tall

### DIFF
--- a/content/learn/beginners-javascript/javascript-beyond-the-browser.mdx
+++ b/content/learn/beginners-javascript/javascript-beyond-the-browser.mdx
@@ -30,22 +30,15 @@ and that is why "JavaScript in a browser" and "JavaScript on a
 server" feel like slightly different worlds, even though it is the
 same language.
 
-```mermaid
-flowchart TB
-    subgraph Lang["The JavaScript language (ECMAScript)"]
-        L1["Numbers, strings, booleans"]
-        L2["Variables, functions, loops"]
-        L3["Arrays, objects"]
-        L4["Promises, async/await"]
-    end
-    subgraph Runtimes["Runtimes layer different capabilities on top"]
-        R1["Browser<br/>DOM, fetch, localStorage"]
-        R2["Node.js<br/>fs, http, child processes"]
-        R3["Deno / Bun<br/>fs, http, native fetch"]
-        R4["Embedded engines<br/>game scripting, IoT"]
-    end
-    Lang --> Runtimes
-```
+The **language** (ECMAScript) is the same everywhere — numbers, strings,
+booleans, variables, functions, loops, arrays, objects, promises and
+`async`/`await`. Each **runtime** then layers its own capabilities on
+top:
+
+- **Browser**: DOM, `fetch`, `localStorage`.
+- **Node.js**: filesystem, HTTP, child processes.
+- **Deno / Bun**: filesystem, HTTP, native `fetch`.
+- **Embedded engines**: game scripting, IoT.
 
 The same `if`/`for`/`function` works everywhere. What changes is the
 *environment*: the set of built-in objects available, and what those

--- a/content/learn/beginners-javascript/javascript-today.mdx
+++ b/content/learn/beginners-javascript/javascript-today.mdx
@@ -149,26 +149,9 @@ JavaScript" is sometimes used to mean three quite different things:
    ever-changing landscape of libraries built **on top of** the
    language.
 
-```mermaid
-flowchart TB
-    subgraph L1["1. The language (this course)"]
-        A["JavaScript syntax, types, control flow, functions, async/await"]
-    end
-    subgraph L2["2. The platform APIs (per-runtime)"]
-        B1["Browser:<br/>DOM, fetch, localStorage"]
-        B2["Node.js:<br/>fs, http, processes"]
-        B3["Mobile:<br/>native bridges"]
-    end
-    subgraph L3["3. Frameworks and tools"]
-        C1[React, Vue, Svelte]
-        C2[Express, Next.js]
-        C3[Bundlers, linters, test runners]
-    end
-    L1 --> L2
-    L2 --> L3
-```
-
-Layer 1 is the foundation. The things in layer 3 change every few
+Each layer builds on the one before it: the platform APIs assume the
+language, and the frameworks and tools assume both. Layer 1 is the
+foundation. The things in layer 3 change every few
 years. The things in layer 1 essentially never change. By focusing
 this course on layer 1, we are giving you a skill that will not
 expire.

--- a/content/learn/beginners-javascript/modular-organization.mdx
+++ b/content/learn/beginners-javascript/modular-organization.mdx
@@ -24,7 +24,7 @@ clashing, because each name only exists inside its own file. That
 isolation is the entire point.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph users.js
         U1[users array]
         U2[getUser]

--- a/content/learn/beginners-javascript/rise-of-scripting-languages.mdx
+++ b/content/learn/beginners-javascript/rise-of-scripting-languages.mdx
@@ -52,17 +52,18 @@ A **scripting language** has, traditionally, a few common traits:
 - **Good at gluing things together.** Strings, files, processes,
   network requests — the bread and butter of automation.
 
-```mermaid
-flowchart TD
-    subgraph CL["Compiled language (e.g. C)"]
-        A1[Edit source] --> A2[Compile]
-        A2 --> A3[Link]
-        A3 --> A4[Run program]
-    end
-    subgraph SL["Scripting language (e.g. JS)"]
-        B1[Edit source] --> B2[Run interpreter on source]
-    end
-```
+The difference shows up in how many steps stand between editing and
+running. A **compiled language** (e.g. C) makes you:
+
+1. Edit source.
+2. Compile.
+3. Link.
+4. Run the program.
+
+A **scripting language** (e.g. JS) collapses that to:
+
+1. Edit source.
+2. Run the interpreter on the source.
 
 That last bullet — *gluing things together* — is why scripting
 languages exploded. A scripting language is rarely the *centre* of a

--- a/content/learn/beginners-javascript/values-and-types.mdx
+++ b/content/learn/beginners-javascript/values-and-types.mdx
@@ -107,23 +107,12 @@ The types divide into two large families:
 We will spend the next several pages on the primitives, then build
 up to objects later.
 
-```mermaid
-flowchart TB
-    V[Values]
-    V --> P[Primitives]
-    V --> O[Objects]
-    P --> N[number]
-    P --> S[string]
-    P --> B[boolean]
-    P --> NU[null]
-    P --> U[undefined]
-    P --> SY[symbol]
-    P --> BI[bigint]
-    O --> OB["plain {} objects"]
-    O --> AR["arrays []"]
-    O --> FN["functions"]
-    O --> DT["dates, regexes, Maps, Sets, ..."]
-```
+Every value falls into one of these two families:
+
+- **Primitives**: `number`, `string`, `boolean`, `null`, `undefined`,
+  `symbol`, `bigint`.
+- **Objects**: plain `{}` objects, `[]` arrays, functions, and the
+  rest (dates, regexes, `Map`s, `Set`s, ...).
 
 ## What "immutable" means for primitives
 

--- a/content/learn/c-programming-for-beginners/arrays.mdx
+++ b/content/learn/c-programming-for-beginners/arrays.mdx
@@ -201,17 +201,12 @@ int main(void) {
 `}
 />
 
-Visualize one swap:
+Visualize the result, comparing each position before and after:
 
-```mermaid
-flowchart LR
-    subgraph before
-      A1[1] --- A2[2] --- A3[3] --- A4[4] --- A5[5]
-    end
-    subgraph after
-      B1[5] --- B2[4] --- B3[3] --- B4[2] --- B5[1]
-    end
-```
+| Index  | 0 | 1 | 2 | 3 | 4 |
+| ------ | - | - | - | - | - |
+| Before | 1 | 2 | 3 | 4 | 5 |
+| After  | 5 | 4 | 3 | 2 | 1 |
 
 ### Count occurrences
 

--- a/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
@@ -11,15 +11,7 @@ to one specific stage.
 
 ## The four stages
 
-```mermaid
-flowchart TD
-    SRC["hello.c<br/>source text"] --> PP[Preprocessor]
-    PP --> CC[Compiler]
-    CC --> AS[Assembler]
-    AS --> LD[Linker]
-    LD --> EXE[Executable]
-    EXE --> RUN["Operating system<br/>loads and runs it"]
-```
+The pipeline runs **`hello.c` → Preprocessor → Compiler → Assembler → Linker → Executable**, and then the operating system loads and runs that executable.
 
 | Stage         | Input              | Output             | Job                                                  |
 |---------------|--------------------|--------------------|------------------------------------------------------|

--- a/content/learn/c-programming-for-beginners/computational-thinking.mdx
+++ b/content/learn/c-programming-for-beginners/computational-thinking.mdx
@@ -25,14 +25,10 @@ overlapping habits:
 4. **Algorithm design** — write down a precise, step-by-step recipe
    for solving the problem.
 
-```mermaid
-flowchart TD
-    P[Real-world<br/>problem] --> D[Decompose<br/>into steps]
-    D --> R[Recognize<br/>patterns]
-    R --> A[Abstract<br/>away noise]
-    A --> AL[Write a clear<br/>algorithm]
-    AL --> CODE[Translate to<br/>C source code]
-```
+Put together, these habits carry you from a problem to a program:
+**Real-world problem → decompose into steps → recognize patterns →
+abstract away noise → write a clear algorithm → translate to C source
+code.**
 
 Let's walk through a tiny, concrete example.
 

--- a/content/learn/c-programming-for-beginners/data-types.mdx
+++ b/content/learn/c-programming-for-beginners/data-types.mdx
@@ -228,22 +228,15 @@ int main(void) {
 
 You may still see older code use `int` for boolean values. Both work.
 
-## A picture: types and the bits they reserve
+## Types and the bits they reserve
 
-```mermaid
-flowchart LR
-    subgraph char
-      C0[1 byte]
-    end
-    subgraph int
-      I0[4 bytes]
-    end
-    subgraph double
-      D0[8 bytes]
-    end
-```
+| Type     | Size     |
+| -------- | -------- |
+| `char`   | 1 byte   |
+| `int`    | 4 bytes  |
+| `double` | 8 bytes  |
 
-Same memory, different sized boxes, different bit interpretations.
+Same memory, different sized chunks, different bit interpretations.
 The CPU has separate instructions for integer arithmetic and
 floating-point arithmetic — the type tells the compiler which to
 emit.

--- a/content/learn/c-programming-for-beginners/dynamic-memory.mdx
+++ b/content/learn/c-programming-for-beginners/dynamic-memory.mdx
@@ -12,17 +12,15 @@ That's what the **heap** is for. The heap is a big pool of memory
 your program can grab chunks from and give back as it sees fit. The
 controls are `malloc` and `free`.
 
-## Stack vs heap, in one picture
+## Stack vs heap
 
-```mermaid
-flowchart TB
-    subgraph "Process memory"
-      CODE["Code (your compiled instructions)"]
-      DATA["Globals & constants"]
-      HEAP["Heap (grows downward in this picture)<br/>malloc lives here"]
-      STACK["Stack (grows upward in this picture)<br/>function locals live here"]
-    end
-```
+A running program's memory is split into a few regions:
+
+- **Code** — your compiled instructions.
+- **Globals & constants** — values that live for the whole program.
+- **Heap** — a large pool you grab from with `malloc` and return with
+  `free`.
+- **Stack** — where function locals live, one frame per call.
 
 | Stack                                | Heap                              |
 |--------------------------------------|-----------------------------------|

--- a/content/learn/c-programming-for-beginners/index.mdx
+++ b/content/learn/c-programming-for-beginners/index.mdx
@@ -37,16 +37,10 @@ We are going to do the opposite. We will start with **stories**:
 
 Only after that foundation do we open a code editor.
 
-```mermaid
-flowchart TD
-    A[Real-world<br/>problem] --> B[Computational<br/>thinking]
-    B --> C[Algorithm<br/>steps]
-    C --> D[C source<br/>code]
-    D --> E[Compiler]
-    E --> F[Machine<br/>instructions]
-    F --> G[CPU executes<br/>and uses memory]
-    G --> H[Output you<br/>can observe]
-```
+The whole journey, end to end, is this: a **real-world problem →
+computational thinking → algorithm steps → C source code → compiler →
+machine instructions → CPU executes and uses memory → output you can
+observe.** Every page in this course lives somewhere on that path.
 
 ## How the interactive widgets work
 

--- a/content/learn/c-programming-for-beginners/pointers-and-arrays.mdx
+++ b/content/learn/c-programming-for-beginners/pointers-and-arrays.mdx
@@ -58,14 +58,13 @@ it adds the size of one element of the pointed-to type. So `p + 1`
 on an `int *` advances `4` bytes (on a typical system), landing on
 the next `int`.
 
-```mermaid
-flowchart LR
-    P0[p ] --> A0["a[0] = 10"]
-    P1["p+1"] --> A1["a[1] = 20"]
-    P2["p+2"] --> A2["a[2] = 30"]
-    P3["p+3"] --> A3["a[3] = 40"]
-    P4["p+4"] --> A4["a[4] = 50"]
-```
+| Expression | Points to     |
+| ---------- | ------------- |
+| `p`        | `a[0] = 10`   |
+| `p + 1`    | `a[1] = 20`   |
+| `p + 2`    | `a[2] = 30`   |
+| `p + 3`    | `a[3] = 40`   |
+| `p + 4`    | `a[4] = 50`   |
 
 This is why arrays and pointers fit so neatly together. Walking an
 array with a pointer is just incrementing the pointer.

--- a/content/learn/c-programming-for-beginners/your-first-program.mdx
+++ b/content/learn/c-programming-for-beginners/your-first-program.mdx
@@ -92,18 +92,15 @@ the program finished successfully. Reach the closing `}` without an
 explicit `return` and (since C99) `main` returns `0` automatically,
 but explicit is better than implicit.
 
-## What just happened, in pictures
+## What just happened, step by step
 
-```mermaid
-flowchart TB
-    A[Your text file<br/>hello.c] --> B[Compiler]
-    B --> C[Machine code<br/>executable]
-    C --> D[Operating system<br/>loads it into memory]
-    D --> E[CPU jumps to<br/>address of main]
-    E --> F[Execute printf:<br/>write bytes to stdout]
-    F --> G[Operating system<br/>delivers bytes to terminal]
-    G --> H[You see<br/>Hello, world!]
-```
+1. Your text file `hello.c` goes into the **compiler**.
+2. The compiler produces a **machine-code executable**.
+3. The **operating system** loads that executable into memory.
+4. The **CPU** jumps to the address of `main`.
+5. `printf` executes: it **writes bytes to stdout**.
+6. The operating system **delivers those bytes to the terminal**.
+7. You see **`Hello, world!`**.
 
 In our browser sandbox, every step still happens — the compiler is
 just bundled into the same web page you are reading, and the

--- a/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
+++ b/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
@@ -47,14 +47,7 @@ The desired report:
 
 ## The architecture
 
-```mermaid
-flowchart TD
-    R[Raw CSV lines] --> P[Parse]
-    P --> V[Valid rows]
-    V --> G[Group by product]
-    G --> S[Summarize per product]
-    S --> RPT[Render report]
-```
+**Raw CSV lines → Parse → Valid rows → Group by product → Summarize per product → Render report**
 
 Each stage is a pure function from one shape of data to another.
 Each stage uses LINQ. Each stage is independently testable.
@@ -304,14 +297,7 @@ If you completed the challenge, look back over your code and notice:
 
 ## How this generalizes
 
-```mermaid
-flowchart LR
-    Raw[Raw input] --> Parse --> Validate --> Transform --> Summarize --> Render
-    style Parse     fill:#e0f2fe,stroke:#0284c7
-    style Validate  fill:#e0f2fe,stroke:#0284c7
-    style Transform fill:#e0f2fe,stroke:#0284c7
-    style Summarize fill:#e0f2fe,stroke:#0284c7
-```
+**Raw input → Parse → Validate → Transform → Summarize → Render**
 
 Almost every batch data program — analytics, ETL, report
 generation, log processing, billing, search indexing — fits this

--- a/content/learn/csharp-linq-functional/functional-design-patterns.mdx
+++ b/content/learn/csharp-linq-functional/functional-design-patterns.mdx
@@ -298,17 +298,12 @@ These patterns are *tools*, not laws. In real C# code:
 - Use discriminated unions when you have a *closed* set of states.
 - Use combinators when you're writing a small DSL.
 
-```mermaid
-flowchart TB
-    P[Need to model missing data?] --> Q{Reach for}
-    Q --> N1[Nullable types: string?, int?]
-    P2[Need to model failure?] --> Q2{Reach for}
-    Q2 --> N2[Result&lt;T, E&gt;]
-    P3[Need to model a closed set of states?] --> Q3{Reach for}
-    Q3 --> N3[Discriminated union: sealed records]
-    P4[Need to build complex things from simple ones?] --> Q4{Reach for}
-    Q4 --> N4[Combinators]
-```
+| Need to model… | Reach for |
+| --- | --- |
+| Missing data | Nullable types: `string?`, `int?` |
+| Failure | `Result<T, E>` |
+| A closed set of states | Discriminated union: sealed records |
+| Complex things built from simple ones | Combinators |
 
 When chosen carefully, these patterns make C# code dramatically more
 expressive *without* abandoning the strengths of the OO model.

--- a/content/learn/csharp-linq-functional/higher-order-functions.mdx
+++ b/content/learn/csharp-linq-functional/higher-order-functions.mdx
@@ -194,18 +194,13 @@ ever writing a `for` loop.
 
 Every LINQ operator is a higher-order function:
 
-```mermaid
-flowchart LR
-    subgraph LINQ
-        W["Where(predicate)"]
-        S["Select(selector)"]
-        O["OrderBy(keySelector)"]
-        A["Aggregate(seed, accumulator)"]
-        G["GroupBy(keySelector)"]
-    end
-```
+- `Where(predicate)`
+- `Select(selector)`
+- `OrderBy(keySelector)`
+- `Aggregate(seed, accumulator)`
+- `GroupBy(keySelector)`
 
-Each box accepts a function and uses it to drive its behavior over a
+Each operator accepts a function and uses it to drive its behavior over a
 sequence. The sequence itself is just data; the *behavior* is
 parameterized.
 

--- a/content/learn/csharp-linq-functional/immutability.mdx
+++ b/content/learn/csharp-linq-functional/immutability.mdx
@@ -176,14 +176,12 @@ profiler proves it matters.**
 
 ## A small map of "mutability levels"
 
-```mermaid
-flowchart TB
-    A[Most immutable] --> B["record / record struct (with init properties)"]
-    B --> C["class with all init/readonly + ImmutableList"]
-    C --> D["class with readonly fields, but holds mutable List"]
-    D --> E[Mutable class]
-    E --> F[Most mutable]
-```
+From most immutable to most mutable:
+
+1. `record` / `record struct` (with `init` properties)
+2. `class` with all `init`/`readonly` + `ImmutableList`
+3. `class` with `readonly` fields, but holds a mutable `List`
+4. Mutable `class`
 
 The closer to the top, the easier it is to reason about. A `record`
 that contains a mutable `List<int>` is *not really* immutable — you

--- a/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
+++ b/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
@@ -155,19 +155,11 @@ Method syntax also wins when you need operators that have no query
 keyword: `Take`, `Skip`, `Distinct`, `Count`, `First`, `Aggregate`,
 `Zip`, `Concat`, `Reverse`, `Chunk`, and many more.
 
-```mermaid
-flowchart TB
-    subgraph "Use Query Syntax When"
-      QS1[Multiple from / cross joins]
-      QS2[let bindings carry state forward]
-      QS3[Visually similar to SQL]
-    end
-    subgraph "Use Method Syntax When"
-      MS1[Mostly Where + Select pipelines]
-      MS2[You need operators query syntax lacks]
-      MS3[The query ends with an aggregation]
-    end
-```
+| Use query syntax when | Use method syntax when |
+| --- | --- |
+| Multiple `from` / cross joins | Mostly `Where` + `Select` pipelines |
+| `let` bindings carry state forward | You need operators query syntax lacks |
+| Visually similar to SQL | The query ends with an aggregation |
 
 ## What the compiler actually does
 

--- a/content/learn/data-analysis-python-pandas/choosing-the-right-chart.mdx
+++ b/content/learn/data-analysis-python-pandas/choosing-the-right-chart.mdx
@@ -7,31 +7,20 @@ The right chart depends on *the question you're answering*.
 This page is a practical decision flow plus a tour of common
 charts and their failure modes.
 
-## The decision flow
+## The decision guide
 
-```mermaid
-flowchart TB
-  Q["What do I want<br/>to show?"]
-  Q --> D1{"Distribution<br/>of one variable?"}
-  D1 -- "Numeric" --> H["Histogram<br/>or box plot"]
-  D1 -- "Categorical" --> B1["Bar chart of counts"]
+Start from the question you want to answer, then read across:
 
-  Q --> D2{"Comparing categories<br/>by a numeric metric?"}
-  D2 --> B2["Bar chart<br/>(sorted)"]
-
-  Q --> D3{"Relationship between<br/>two numerics?"}
-  D3 --> S["Scatter plot"]
-  D3 -- "+ a third numeric" --> SS["Scatter + color or size"]
-
-  Q --> D4{"Change over time?"}
-  D4 --> L["Line chart"]
-
-  Q --> D5{"Composition<br/>(parts of whole)?"}
-  D5 --> ST["Stacked bar<br/>(avoid pies)"]
-
-  Q --> D6{"Many small charts<br/>by category?"}
-  D6 --> FA["Facet / small multiples"]
-```
+| What do you want to show? | Reach for |
+| --- | --- |
+| Distribution of one **numeric** variable | Histogram or box plot |
+| Distribution of one **categorical** variable | Bar chart of counts |
+| Comparing categories by a numeric metric | Sorted bar chart |
+| Relationship between two numerics | Scatter plot |
+| …plus a third numeric | Scatter + color or size |
+| Change over time | Line chart |
+| Composition (parts of a whole) | Stacked bar (avoid pies) |
+| Many small charts by category | Facets / small multiples |
 
 Print it. Reference it. Internalize it.
 
@@ -103,14 +92,13 @@ better.
 
 ## Bad choices and their consequences
 
-```mermaid
-flowchart LR
-  X1["Pie chart with 12 slices"] --> Y1["Eye cannot rank<br/>angles accurately"]
-  X2["3D bar chart"] --> Y2["Perspective distorts<br/>true heights"]
-  X3["Line on categorical axis"] --> Y3["Suggests false trend<br/>between unordered items"]
-  X4["Truncated y-axis"] --> Y4["Tiny changes<br/>look enormous"]
-  X5["Rainbow color scale"] --> Y5["Non-uniform perception<br/>creates false features"]
-```
+| Bad choice | Why it misleads |
+| --- | --- |
+| Pie chart with 12 slices | The eye can't rank angles accurately |
+| 3D bar chart | Perspective distorts true heights |
+| Line on a categorical axis | Suggests a false trend between unordered items |
+| Truncated y-axis | Tiny changes look enormous |
+| Rainbow color scale | Non-uniform perception creates false features |
 
 ## A practical anti-checklist
 

--- a/content/learn/data-analysis-python-pandas/debugging-analysis-code.mdx
+++ b/content/learn/data-analysis-python-pandas/debugging-analysis-code.mdx
@@ -216,14 +216,15 @@ Most bugs come from skipping step 1.
 
 ## A debugging checklist
 
-```mermaid
-flowchart TB
-  C1["Did you check .shape before & after?"] --> C2
-  C2["Are dtypes what you expect?"] --> C3
-  C3["Did the row count change unexpectedly?"] --> C4
-  C4["Are there NaNs you didn't account for?"] --> C5
-  C5["Can you reproduce in 5 rows?"] --> R["Now fix it"]
-```
+Before you change any code, run through:
+
+- Did you check `.shape` before **and** after?
+- Are the dtypes what you expect?
+- Did the row count change unexpectedly?
+- Are there `NaN`s you didn't account for?
+- Can you reproduce it in 5 rows?
+
+*Then* fix it.
 
 ## Check your understanding
 

--- a/content/learn/data-analysis-python-pandas/eda-workflow.mdx
+++ b/content/learn/data-analysis-python-pandas/eda-workflow.mdx
@@ -13,15 +13,15 @@ This page outlines a workflow you can apply to any new dataset.
 
 ## Why a workflow?
 
-```mermaid
-flowchart TD
-  A["New dataset"] --> B{"What questions<br/>can we ask?"}
-  B --> C["Discover<br/>shape & types"]
-  C --> D["Discover<br/>quality issues"]
-  D --> E["Discover<br/>distributions"]
-  E --> F["Discover<br/>relationships"]
-  F --> G["Now you can<br/>ask real questions"]
-```
+You discover a new dataset in layers, and each layer makes the
+next one trustworthy:
+
+1. **Shape & types** — what are we even looking at?
+2. **Quality issues** — what's missing, duplicated, or wrong?
+3. **Distributions** — how is each column shaped?
+4. **Relationships** — how do columns move together?
+
+Only *then* can you ask real questions with confidence.
 
 Without this scaffolding, beginners jump straight to `groupby`
 and chart-making, only to realize halfway through that one
@@ -164,16 +164,14 @@ it. Your notes should grow over the life of the project.
 
 ## An EDA checklist
 
-```mermaid
-flowchart TB
-  S1["1. Shape and dtypes"] --> S2
-  S2["2. head / sample"] --> S3
-  S3["3. Missing values"] --> S4
-  S4["4. Numeric describe"] --> S5
-  S5["5. Categorical value_counts"] --> S6
-  S6["6. Correlations / group summaries"] --> S7
-  S7["7. Write notes"] --> S8["8. Now ask your real questions"]
-```
+1. Shape and dtypes
+2. `head` / sample
+3. Missing values
+4. Numeric `describe`
+5. Categorical `value_counts`
+6. Correlations / group summaries
+7. Write notes
+8. Now ask your real questions
 
 Print it. Tape it to your wall. Use it on every new dataset.
 

--- a/content/learn/data-analysis-python-pandas/exporting-cleaned-data.mdx
+++ b/content/learn/data-analysis-python-pandas/exporting-cleaned-data.mdx
@@ -133,14 +133,13 @@ for sharing with humans.**
 
 Before you `df.to_csv(...)`:
 
-```mermaid
-flowchart TB
-  C1["Have you dropped truly internal columns?"] --> C2
-  C2["Are column names final / human-friendly?"] --> C3
-  C3["Did you set index=False (unless meaningful)?"] --> C4
-  C4["Did you choose a clear filename (with date)?"] --> C5
-  C5["Will this file overwrite something important?"] --> R["Now export"]
-```
+- Have you dropped truly internal columns?
+- Are the column names final and human-friendly?
+- Did you set `index=False` (unless the index is meaningful)?
+- Did you choose a clear filename (with a date)?
+- Will this file overwrite something important?
+
+*Then* export.
 
 ### Date-stamped filenames
 

--- a/content/learn/data-analysis-python-pandas/how-computers-see-data.mdx
+++ b/content/learn/data-analysis-python-pandas/how-computers-see-data.mdx
@@ -144,18 +144,20 @@ modern analytical systems — including Pandas — store data
   (`mean of salary`, `count of department`), not many columns
   of a few rows. Column storage makes those queries fast.
 
-```mermaid
-flowchart LR
-    subgraph "Row-store (think: a notebook)"
-        R1[Aiko 29 Tokyo]
-        R2[Bilal 42 Karachi]
-        R3[Chen 35 Shanghai]
-    end
-    subgraph "Column-store (Pandas, DuckDB, Parquet)"
-        C1[name: Aiko Bilal Chen]
-        C2[age: 29 42 35]
-        C3[city: Tokyo Karachi Shanghai]
-    end
+A **row-store** (think: a notebook) keeps each *record* together:
+
+```text
+Aiko,  29, Tokyo
+Bilal, 42, Karachi
+Chen,  35, Shanghai
+```
+
+A **column-store** (Pandas, DuckDB, Parquet) keeps each *column* together:
+
+```text
+name: Aiko, Bilal, Chen
+age:  29, 42, 35
+city: Tokyo, Karachi, Shanghai
 ```
 
 This is one of the reasons Pandas is fast on operations like

--- a/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
+++ b/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
@@ -146,14 +146,13 @@ data. **Significance is not the same as importance.**
 
 Before you celebrate or panic about a difference, ask:
 
-```mermaid
-flowchart TB
-  Q1["Is the difference larger than typical wiggle?"] --> Q2
-  Q2["How big is the sample?"] --> Q3
-  Q3["Is the effect size practically meaningful?"] --> Q4
-  Q4["Could a confounding variable explain it?"] --> Q5
-  Q5["Have I checked for data quality issues?"] --> A["Then you can act on it"]
-```
+- Is the difference larger than the typical wiggle?
+- How big is the sample?
+- Is the effect size practically meaningful?
+- Could a confounding variable explain it?
+- Have I checked for data-quality issues?
+
+Only then can you act on it.
 
 This is more important than any one statistical test.
 

--- a/content/learn/data-analysis-python-pandas/index.mdx
+++ b/content/learn/data-analysis-python-pandas/index.mdx
@@ -59,22 +59,6 @@ By the end of the course you will be able to:
 
 ## How the course is organized
 
-```mermaid
-flowchart TD
-    A[The Story<br/>of Data] --> B[What Data<br/>Analysis Is]
-    B --> C[Python for<br/>Analysis]
-    C --> D[Loading &<br/>Inspecting]
-    D --> E[DataFrames<br/>& Series]
-    E --> F[Filter, Sort,<br/>Rank]
-    F --> G[Aggregation<br/>& GroupBy]
-    G --> H[Cleaning<br/>Messy Data]
-    H --> I[Combining<br/>Datasets]
-    I --> J[Reshaping]
-    J --> K[Exploratory<br/>Analysis]
-    K --> L[Visualization]
-    L --> M[Reproducible<br/>Workflows]
-```
-
 We start with **a story**, not with syntax. The first chapters walk
 through where data came from, how spreadsheets shaped business
 analysis, and why a young economist named Wes McKinney decided to

--- a/content/learn/data-analysis-python-pandas/merging-and-joining.mdx
+++ b/content/learn/data-analysis-python-pandas/merging-and-joining.mdx
@@ -9,21 +9,12 @@ with the `how` parameter.
 
 ## The four join types
 
-```mermaid
-flowchart TB
-  subgraph Inner
-    I["Only rows whose key<br/>appears in BOTH tables"]
-  end
-  subgraph Left
-    L["All rows from LEFT table.<br/>Right columns filled with NaN<br/>where no match exists."]
-  end
-  subgraph Right
-    R["All rows from RIGHT table.<br/>Left columns filled with NaN<br/>where no match exists."]
-  end
-  subgraph Outer
-    O["Every row from EITHER table.<br/>NaN wherever the other side<br/>has no match."]
-  end
-```
+| `how=` | What you get |
+| --- | --- |
+| `inner` | Only rows whose key appears in **both** tables |
+| `left` | All rows from the **left** table; right columns are `NaN` where no match exists |
+| `right` | All rows from the **right** table; left columns are `NaN` where no match exists |
+| `outer` | Every row from **either** table; `NaN` wherever the other side has no match |
 
 ## Setting the stage
 

--- a/content/learn/data-analysis-python-pandas/next-steps.mdx
+++ b/content/learn/data-analysis-python-pandas/next-steps.mdx
@@ -80,16 +80,13 @@ These habits will keep paying off forever:
 
 ## A self-guided practice plan
 
-```mermaid
-flowchart TB
-  S1["Pick a real dataset<br/>(govt, sports, finance)"] --> S2
-  S2["Define one clear question"] --> S3
-  S3["Do EDA before any modeling"] --> S4
-  S4["Clean and document"] --> S5
-  S5["Produce one chart that answers the question"] --> S6
-  S6["Write a one-paragraph conclusion"] --> S7
-  S7["Repeat with a new dataset"]
-```
+1. Pick a real dataset (government, sports, finance).
+2. Define one clear question.
+3. Do EDA *before* any modeling.
+4. Clean and document.
+5. Produce one chart that answers the question.
+6. Write a one-paragraph conclusion.
+7. Repeat with a new dataset.
 
 Three or four of these projects will move you from
 "competent" to "comfortable" with the workflow.

--- a/content/learn/data-analysis-python-pandas/notebooks-and-environments.mdx
+++ b/content/learn/data-analysis-python-pandas/notebooks-and-environments.mdx
@@ -47,16 +47,11 @@ Notebooks are great for:
 - Anything that produces interesting plots you want to keep next
   to the code that made them.
 
-```mermaid
-flowchart LR
-    subgraph "Script"
-        S1[my_script.py] --> S2[Run top to bottom] --> S3[Outputs go to console / files]
-    end
-    subgraph "Notebook"
-        N1[analysis.ipynb] --> N2[Run cells interactively]
-        N2 --> N3[Output stays beside code]
-    end
-```
+- A **script** (`my_script.py`) runs top to bottom; output goes to
+  the console or to files.
+- A **notebook** (`analysis.ipynb`) runs cell by cell,
+  interactively, and keeps each output right beside the code that
+  produced it.
 
 The dominant notebook tool today is **Jupyter** (formerly IPython
 Notebook). Variants include JupyterLab, VS Code's notebook view,

--- a/content/learn/data-analysis-python-pandas/reproducible-analysis.mdx
+++ b/content/learn/data-analysis-python-pandas/reproducible-analysis.mdx
@@ -121,10 +121,7 @@ file or environment variables.
 
 A typical analysis notebook reads like a recipe:
 
-```mermaid
-flowchart LR
-  A["1. Imports"] --> B["2. Load"] --> C["3. Clean"] --> D["4. Transform"] --> E["5. Analyze"] --> F["6. Visualize"] --> G["7. Export"]
-```
+**Imports → Load → Clean → Transform → Analyze → Visualize → Export**
 
 Each section should produce a clearly named intermediate
 variable so you can pick up at any step.

--- a/content/learn/data-analysis-python-pandas/rows-and-columns.mdx
+++ b/content/learn/data-analysis-python-pandas/rows-and-columns.mdx
@@ -18,28 +18,14 @@ conceptual unlock for Pandas.
 - The **cell** at row $r$, column $c$ is *that thing's value of
   that attribute*.
 
-```mermaid
-flowchart TB
-    subgraph "DataFrame: 4 employees × 3 attributes"
-        direction LR
-        H1[name]:::hdr
-        H2[department]:::hdr
-        H3[salary]:::hdr
-        R1[Aiko]
-        R2[Eng]
-        R3[120]
-        S1[Bilal]
-        S2[Sales]
-        S3[95]
-        T1[Chen]
-        T2[Eng]
-        T3[140]
-        U1[Diego]
-        U2[Ops]
-        U3[80]
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-```
+A DataFrame of 4 employees (rows) × 3 attributes (columns):
+
+| name  | department | salary |
+| ----- | ---------- | ------ |
+| Aiko  | Eng        | 120    |
+| Bilal | Sales      | 95     |
+| Chen  | Eng        | 140    |
+| Diego | Ops        | 80     |
 
 When you read a Pandas tutorial and see `df.shape == (1470, 35)`,
 that means "1,470 things, each with 35 attributes." When you see

--- a/content/learn/data-analysis-python-pandas/spreadsheets-and-business.mdx
+++ b/content/learn/data-analysis-python-pandas/spreadsheets-and-business.mdx
@@ -132,18 +132,17 @@ spreadsheet horror stories:
   of the largest trading losses in JPMorgan's history (the 2012
   "London Whale" affair).
 
-```mermaid
-flowchart TB
-    R[Raw data] --> S1[Excel sheet 1<br/>manual cleanup]
-    S1 --> S2[Excel sheet 2<br/>copy-pasted by Alice]
-    S2 --> S3[Excel sheet 3<br/>VLOOKUPs into a CSV<br/>Steve emailed last week]
-    S3 --> S4[Excel sheet 4<br/>charts for the<br/>board deck]
-    S4 --> D[Decision]
-    style S2 fill:#fee2e2,stroke:#dc2626
-    style S3 fill:#fee2e2,stroke:#dc2626
-```
+A typical "analysis" flows through a chain of hand-edited sheets
+before anyone makes a decision:
 
-The red boxes are the points where, in a real company, *nobody
+1. Raw data
+2. Excel sheet 1 — manual cleanup
+3. ⚠️ Excel sheet 2 — copy-pasted by Alice
+4. ⚠️ Excel sheet 3 — VLOOKUPs into a CSV Steve emailed last week
+5. Excel sheet 4 — charts for the board deck
+6. Decision
+
+The ⚠️ steps are the points where, in a real company, *nobody
 remembers what was done or how*. The chain is **not
 reproducible**. Six months later, when an auditor asks "show me
 exactly how this number was computed," the honest answer is "we

--- a/content/learn/data-analysis-python-pandas/spreadsheets-vs-code.mdx
+++ b/content/learn/data-analysis-python-pandas/spreadsheets-vs-code.mdx
@@ -53,20 +53,21 @@ df.groupby("region")["revenue"].sum().plot.bar()
 
 Save the file as `weekly_report.py`. **Next Monday: re-run.**
 
-```mermaid
-flowchart TD
-    subgraph "Spreadsheet workflow"
-        A1[Open CSV] --> A2[Manual import]
-        A2 --> A3[Eyeball + fix types]
-        A3 --> A4[Manual sort/filter/sum]
-        A4 --> A5[Manual chart]
-        A5 --> A6[Save with date<br/>in filename]
-        A6 --> A7[Repeat next week]
-    end
-    subgraph "Code workflow"
-        B1[python report.py] --> B2[Done]
-    end
-```
+The asymmetry is the whole point. **Every week**, the spreadsheet
+path is:
+
+1. Open the CSV
+2. Manual import
+3. Eyeball and fix column types
+4. Manual sort / filter / sum
+5. Build a chart by hand
+6. Save with the date in the filename
+7. …repeat it all next week
+
+…while the code path is:
+
+1. `python report.py`
+2. Done.
 
 ## What the comparison actually proves
 
@@ -223,20 +224,12 @@ the audience can read it.
 
 ## Conceptual comparison: manual vs reproducible
 
-```mermaid
-flowchart TB
-    subgraph "Manual (spreadsheet)"
-        M1[Steve opens file] --> M2[Steve clicks around]
-        M2 --> M3[Steve copies numbers]
-        M3 --> M4[Steve emails result]
-        M4 --> M5[Nobody can audit]
-    end
-    subgraph "Reproducible (code)"
-        C1[Run script] --> C2[Same inputs<br/>= same outputs]
-        C2 --> C3[Source in git]
-        C3 --> C4[Anyone can audit<br/>and rerun]
-    end
-```
+| Manual (spreadsheet) | Reproducible (code) |
+| --- | --- |
+| Steve opens the file and clicks around | Run one script |
+| Steve copies numbers by hand | Same inputs → same outputs |
+| Steve emails the result | Source lives in git |
+| Nobody can audit what he did | Anyone can audit and rerun |
 
 That right-hand pipeline — *same inputs, same outputs, audit
 trail* — is the whole game. Pandas is the most popular tool for

--- a/content/learn/data-analysis-python-pandas/statistical-summaries.mdx
+++ b/content/learn/data-analysis-python-pandas/statistical-summaries.mdx
@@ -65,12 +65,11 @@ is \$52K — much more representative. **For skewed
 distributions, prefer median.** Income, prices, durations, and
 file sizes are almost always skewed.
 
-```mermaid
-flowchart LR
-  A["Symmetric distribution<br/>(e.g. exam scores)"] --> M["Mean ≈ Median"]
-  B["Right-skewed distribution<br/>(e.g. income)"] --> N["Mean >> Median<br/>Use median"]
-  C["Outliers present"] --> O["Mean misleading<br/>Use median"]
-```
+| Distribution | Mean vs. median | Prefer |
+| --- | --- | --- |
+| Symmetric (e.g. exam scores) | Mean ≈ median | Either |
+| Right-skewed (e.g. income) | Mean ≫ median | **Median** |
+| Outliers present | Mean is misleading | **Median** |
 
 ## Quantiles — beyond the median
 

--- a/content/learn/database-design-postgresql/attributes-and-domains.mdx
+++ b/content/learn/database-design-postgresql/attributes-and-domains.mdx
@@ -25,21 +25,8 @@ flowchart TB
 ```
 
 In a table, each attribute usually becomes one column. Each row then
-stores the values for one real entity.
-
-```mermaid
-flowchart LR
-    subgraph customers["Table: customers"]
-        direction LR
-        A["id"]:::pk
-        B["name"]:::hdr
-        C["email"]:::hdr
-        D["joined_on"]:::hdr
-        E["status"]:::hdr
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-    classDef pk fill:#fde68a,stroke:#b45309
-```
+stores the values for one real entity. A `customers` table might have
+the columns `id`, `name`, `email`, `joined_on`, and `status`.
 
 ## Domains say what values are allowed
 

--- a/content/learn/database-design-postgresql/cardinality.mdx
+++ b/content/learn/database-design-postgresql/cardinality.mdx
@@ -181,15 +181,9 @@ relationships.
 Cardinality also includes the minimum number of related rows. This is
 sometimes called **participation**.
 
-- **Optional** means zero is allowed.
-- **Mandatory** means at least one is required.
-
-```mermaid
-flowchart LR
-    Optional["o<br/>zero allowed"] --> Meaning1["optional participation"]
-    Mandatory["|<br/>one required"] --> Meaning2["mandatory participation"]
-    Many["{<br/>many allowed"] --> Meaning3["maximum is many"]
-```
+- **Optional** means zero is allowed, shown by `o` on the line.
+- **Mandatory** means at least one is required, shown by `|` on the line.
+- **Many** is the crow's foot, `{`, marking the maximum as many.
 
 Crow's-foot symbols combine minimum and maximum. `o{` means zero or
 many. `||` means exactly one. `o|` means zero or one.

--- a/content/learn/database-design-postgresql/choosing-data-types.mdx
+++ b/content/learn/database-design-postgresql/choosing-data-types.mdx
@@ -61,17 +61,7 @@ all.
 ## Choosing common types
 
 You do not need every PostgreSQL type on day one. Start with the common
-modeling choices.
-
-```mermaid
-flowchart TB
-    V["What kind of value?"] --> Text["Words or codes<br/>TEXT or VARCHAR"]
-    V --> Whole["Whole number<br/>INTEGER or BIGINT"]
-    V --> Money["Exact decimal<br/>NUMERIC"]
-    V --> Bool["True or false<br/>BOOLEAN"]
-    V --> Day["Calendar date<br/>DATE"]
-    V --> Moment["Moment in time<br/>TIMESTAMP or TIMESTAMPTZ"]
-```
+modeling choices, matched to the kind of value you are storing.
 
 - Use `TEXT` for ordinary strings. `VARCHAR(n)` is useful when the
   length limit is a real business rule, not just habit.

--- a/content/learn/database-design-postgresql/cost-of-poor-design.mdx
+++ b/content/learn/database-design-postgresql/cost-of-poor-design.mdx
@@ -22,15 +22,15 @@ flat table. The first report works because there are only three rows.
 Then customers change emails, product names change, and new features
 need order history by product.
 
-```mermaid
-flowchart LR
-    A["Day 1:<br/>one flat table"] --> B["Feature works"]
-    B --> C["More rows arrive"]
-    C --> D["Repeated facts drift"]
-    D --> E["Bug fixes and cleanup"]
-    E --> F["Slower feature work"]
-    F --> G["Design debt compounds"]
-```
+The shortcut follows a predictable arc:
+
+1. Day 1: everything lives in one flat table.
+2. The first feature works.
+3. More rows arrive.
+4. Repeated facts start to drift apart.
+5. Bug fixes and cleanup scripts pile up.
+6. Feature work slows down.
+7. Design debt compounds.
 
 The schema did not suddenly become worse. The system simply grew large
 enough for the original shortcuts to matter.
@@ -211,15 +211,17 @@ They may need cleanup before the feature can even begin.
 A better design stores products once and order items point to them.
 Then the feature is mostly a query.
 
-```mermaid
-flowchart LR
-    A["New feature request"] --> B{"Schema has clear entities?"}
-    B -->|"yes"| C["Write focused query"]
-    B -->|"no"| D["Clean duplicates"]
-    D --> E["Patch application code"]
-    E --> F["Migrate old rows"]
-    F --> G["Then write query"]
-```
+The same request lands very differently depending on the schema. When
+the schema has clear entities:
+
+1. Write a focused query.
+
+When it does not:
+
+1. Clean up the duplicate values.
+2. Patch the application code that produced them.
+3. Migrate the old rows.
+4. Only then write the query.
 
 The difference is not developer talent. It is whether the schema has
 already answered the modeling questions the feature depends on.

--- a/content/learn/database-design-postgresql/denormalization.mdx
+++ b/content/learn/database-design-postgresql/denormalization.mdx
@@ -14,17 +14,13 @@ shortcut around design; it is a trade-off you make with your eyes open.
 ## Normalize first
 
 Start with the clean design. Give each fact one home. Use keys and
-relationships to connect the facts.
+relationships to connect the facts. The normal forms build on each other:
 
-```mermaid
-flowchart LR
-    UNF["UNF<br/>mixed and repeated facts"] --> NF1["1NF<br/>atomic values"]
-    NF1 --> NF2["2NF<br/>whole key"]
-    NF2 --> NF3["3NF<br/>nothing but the key"]
-    NF3 --> Decision{"Need a deliberate<br/>read model?"}
-    Decision -->|"no"| Keep["Keep normalized design"]
-    Decision -->|"yes"| Denorm["Add controlled<br/>denormalized data"]
-```
+**UNF (mixed and repeated facts) → 1NF (atomic values) → 2NF (whole key) → 3NF (nothing but the key)**
+
+Only once you reach a clean, normalized design do you ask whether you
+need a deliberate read model. If not, keep the normalized design. If you
+do, add controlled denormalized data on top of it.
 
 A normalized design is easier to trust because updates happen in one
 place. If Ada changes her city, the `customers` row changes once. Every

--- a/content/learn/database-design-postgresql/design-and-data-quality.mdx
+++ b/content/learn/database-design-postgresql/design-and-data-quality.mdx
@@ -80,13 +80,6 @@ must be unique.
 `NOT NULL` protects required facts. `CHECK` protects allowed values.
 Foreign keys protect relationships.
 
-```mermaid
-flowchart LR
-    Required["Required fact"] --> NotNull["NOT NULL"]
-    Allowed["Allowed values"] --> Check["CHECK"]
-    Relationship["Valid relationship"] --> ForeignKey["FOREIGN KEY"]
-```
-
 A task status should not be any random text. If the design knows the
 allowed states, the schema can enforce them.
 

--- a/content/learn/database-design-postgresql/evolving-schemas-safely.mdx
+++ b/content/learn/database-design-postgresql/evolving-schemas-safely.mdx
@@ -7,17 +7,15 @@ Changing a schema is easy when no one uses it yet. It is harder after
 real rows, real queries, and real application code depend on it.
 
 A safe schema change treats the migration as a sequence of deliberate
-steps, not one dramatic rewrite.
+steps, not one dramatic rewrite:
 
-```mermaid
-flowchart TD
-    Need["New requirement"] --> Plan["Plan migration"]
-    Plan --> Add["Add compatible structure"]
-    Add --> Backfill["Backfill existing rows"]
-    Backfill --> Verify["Verify data matches rule"]
-    Verify --> Tighten["Tighten constraint"]
-    Tighten --> Cleanup["Remove old structure later"]
-```
+1. Start from the new requirement.
+2. Plan the migration.
+3. Add compatible structure.
+4. Backfill existing rows.
+5. Verify the data matches the new rule.
+6. Tighten the constraint.
+7. Remove the old structure later.
 
 ## Migrations are ordered changes
 

--- a/content/learn/database-design-postgresql/how-design-shapes-software.mdx
+++ b/content/learn/database-design-postgresql/how-design-shapes-software.mdx
@@ -189,17 +189,18 @@ misspellings, decide whether `notebook` and `notebooks` match, and hope
 old notes use the same pattern. The feature is no longer just a query.
 It is data cleanup, parsing logic, and risk.
 
-```mermaid
-flowchart LR
-    A["Clean schema"] --> B["New question"]
-    B --> C["Small join"]
+With a clean schema, a new question is short:
 
-    D["Messy schema"] --> E["New question"]
-    E --> F["Parse text"]
-    F --> G["Clean old values"]
-    G --> H["Patch edge cases"]
-    H --> I["Maybe answer"]
-```
+1. New question arrives.
+2. Write a small join.
+
+With a messy schema, the same question turns into a project:
+
+1. New question arrives.
+2. Parse the free text.
+3. Clean up old values.
+4. Patch the edge cases.
+5. Maybe get an answer.
 
 Good schema design does not remove all application work. It makes the
 work about the feature instead of about recovering meaning from messy

--- a/content/learn/database-design-postgresql/index.mdx
+++ b/content/learn/database-design-postgresql/index.mdx
@@ -76,20 +76,6 @@ By the end of the course you will be able to:
 
 ## How the course is organized
 
-```mermaid
-flowchart TB
-    A["Why Database<br/>Design Matters"] --> B["Entities and<br/>Attributes"]
-    B --> C["Relationships<br/>and Cardinality"]
-    C --> D["Keys and<br/>Identity"]
-    D --> E["Relationship<br/>Patterns"]
-    E --> F["Constraints and<br/>Data Integrity"]
-    F --> G["Normalization"]
-    G --> H["Designing<br/>Real Systems"]
-    H --> I["Schema<br/>Evolution"]
-    I --> J["Design, Quality,<br/>and Scale"]
-    J --> K["Wrapping Up"]
-```
-
 We begin with *ideas, not syntax*. The first section answers the
 question most tutorials skip entirely: **why does database design
 even matter?** From there we build the vocabulary of modeling —

--- a/content/learn/database-design-postgresql/next-steps.mdx
+++ b/content/learn/database-design-postgresql/next-steps.mdx
@@ -15,18 +15,6 @@ to insert.
 You started with the reason design matters, then built up the tools for
 making design decisions deliberately.
 
-```mermaid
-flowchart TD
-    Start["Why design matters"] --> Entities["Entities and attributes"]
-    Entities --> Relationships["Relationships and cardinality"]
-    Relationships --> Keys["Primary and foreign keys"]
-    Keys --> Constraints["Constraints and integrity"]
-    Constraints --> Normalization["Normalization"]
-    Normalization --> CaseStudies["Case studies"]
-    CaseStudies --> Evolution["Schema evolution"]
-    Evolution --> Quality["Quality and scale"]
-```
-
 Each topic answers a different question:
 
 - What things do we track?

--- a/content/learn/database-design-postgresql/not-null-and-defaults.mdx
+++ b/content/learn/database-design-postgresql/not-null-and-defaults.mdx
@@ -131,12 +131,11 @@ also unknown.
 
 Use `IS NULL` and `IS NOT NULL` when you want to test for missing data.
 
-```mermaid
-flowchart TB
-    A["email = NULL"] --> U["Unknown<br/>not true"]
-    B["email IS NULL"] --> T["True when<br/>missing"]
-    C["email IS NOT NULL"] --> F["True when<br/>present"]
-```
+| Comparison         | Result                  |
+| ------------------ | ----------------------- |
+| `email = NULL`     | Unknown, never true     |
+| `email IS NULL`    | True when the value is missing |
+| `email IS NOT NULL` | True when a value is present  |
 
 This is called **three-valued logic**: SQL conditions can be true,
 false, or unknown. You do not need the formal theory yet. Just remember

--- a/content/learn/database-design-postgresql/one-to-many.mdx
+++ b/content/learn/database-design-postgresql/one-to-many.mdx
@@ -68,13 +68,10 @@ one customer. The customer row does **not** need a list of order ids.
 That would break the table shape: a cell would have to hold many
 values, and every new order would require editing the parent row.
 
-```mermaid
-flowchart TB
-    Bad["Bad idea:<br/>customers.order_ids = 101, 102, 103"] --> Problem["One cell now stores a list"]
-    Problem --> Hard["Hard to validate, query, and update"]
-    Good["Good idea:<br/>orders.customer_id"] --> Simple["One child row stores one parent id"]
-    Simple --> Join["A join rebuilds the full picture"]
-```
+| Approach | Where the link lives | Result |
+| --- | --- | --- |
+| Bad idea | `customers.order_ids = 101, 102, 103` | One cell stores a list; hard to validate, query, and update. |
+| Good idea | `orders.customer_id` | One child row stores one parent id; a join rebuilds the full picture. |
 
 The many side can repeat the same parent id safely. That repetition is
 not a duplication problem; it is the relationship itself.

--- a/content/learn/database-design-postgresql/primary-keys.mdx
+++ b/content/learn/database-design-postgresql/primary-keys.mdx
@@ -29,23 +29,12 @@ flowchart TB
 A **primary key** is the table's answer to this problem. It is the
 column, or group of columns, whose job is to identify each row.
 
-```mermaid
-flowchart TB
-    subgraph customers["Table: customers"]
-        direction LR
-        H1["customer_id (PK)"]:::pk
-        H2["name"]:::hdr
-        H3["city"]:::hdr
-        A1["101"]:::pk
-        A2["Taylor Kim"]
-        A3["Portland"]
-        B1["102"]:::pk
-        B2["Taylor Kim"]
-        B3["Portland"]
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-    classDef pk fill:#fde68a,stroke:#b45309
-```
+Table: `customers`
+
+| customer_id (PK) | name       | city     |
+| ---------------- | ---------- | -------- |
+| 101              | Taylor Kim | Portland |
+| 102              | Taylor Kim | Portland |
 
 Now there are not two vague Taylors. There is customer `101` and
 customer `102`. The values can look similar everywhere else, but the
@@ -177,11 +166,10 @@ The key is the combination: student `7` in course `42`. That design says
 A primary key should rarely, ideally never, change. If many other tables
 point to it, changing the key means changing every reference too.
 
-```mermaid
-flowchart LR
-    A["Stable key"] --> B["Safe references"] --> C["Reliable joins"]
-    X["Changing key"] --> Y["References must change"] --> Z["Broken links risk"]
-```
+| Key behavior | Consequence | Outcome |
+| --- | --- | --- |
+| Stable key | References stay valid | Reliable joins |
+| Changing key | Every reference must change too | Risk of broken links |
 
 That is why many designs use an artificial `id`: not because numbers are
 magical, but because a generated id can stay stable even when human data

--- a/content/learn/database-design-postgresql/reading-er-diagrams.mdx
+++ b/content/learn/database-design-postgresql/reading-er-diagrams.mdx
@@ -85,12 +85,11 @@ must be unique.
 
 Every relationship line can become an English sentence.
 
-```mermaid
-flowchart TB
-    A["customers ||--o{ orders"] --> S1["One customer places zero or many orders"]
-    B["orders ||--|{ order_items"] --> S2["One order contains one or many order items"]
-    C["products ||--o{ order_items"] --> S3["One product appears in zero or many order items"]
-```
+| Relationship | In plain English |
+| --- | --- |
+| `customers \|\|--o{ orders` | One customer places zero or many orders. |
+| `orders \|\|--\|{ order_items` | One order contains one or many order items. |
+| `products \|\|--o{ order_items` | One product appears in zero or many order items. |
 
 The words are just as important as the symbols. If the sentence sounds
 wrong to the business, the diagram needs work.
@@ -120,14 +119,7 @@ The relationship lines are stored using foreign keys:
 - `order_items.order_id` points to `orders.id`.
 - `order_items.product_id` points to `products.id`.
 
-```mermaid
-flowchart LR
-    O["orders.customer_id<br/>FK"] --> C["customers.id<br/>PK"]
-    I1["order_items.order_id<br/>FK"] --> OID["orders.id<br/>PK"]
-    I2["order_items.product_id<br/>FK"] --> P["products.id<br/>PK"]
-```
-
-The diagram tells you where joins will happen, but it also tells you
+Those keys tell you where joins will happen, but they also tell you
 where integrity rules should exist.
 
 <SqlCodeBlock
@@ -199,14 +191,12 @@ only has meaning within its parent order.
 
 When you meet a new ER diagram, use this order:
 
-```mermaid
-flowchart TB
-    A["1. Find entity boxes"] --> B["2. Read attributes"]
-    B --> C["3. Mark PK, FK, UK"]
-    C --> D["4. Turn lines into sentences"]
-    D --> E["5. Check cardinality<br/>in both directions"]
-    E --> F["6. Imagine the joins"]
-```
+1. Find the entity boxes.
+2. Read the attributes.
+3. Mark `PK`, `FK`, and `UK`.
+4. Turn the lines into sentences.
+5. Check cardinality in both directions.
+6. Imagine the joins.
 
 This keeps you from staring at symbols randomly. You are translating a
 picture into plain English and then into schema rules.

--- a/content/learn/database-design-postgresql/thinking-in-entities.mdx
+++ b/content/learn/database-design-postgresql/thinking-in-entities.mdx
@@ -58,39 +58,36 @@ entity, but `email` is probably a column on `customers`.
 ## Candidate entities are boxes
 
 Designers often sketch entities as boxes before deciding exact columns
-or SQL syntax. The box says, "this is a kind of thing we may need to
-store."
+or SQL syntax. Each box says, "this is a kind of thing we may need to
+store." An online shop might begin with:
 
-```mermaid
-flowchart LR
-    subgraph Shop["Online shop"]
-        Customer["Customer"]
-        Order["Order"]
-        Product["Product"]
-        Payment["Payment"]
-        Shipment["Shipment"]
-    end
-```
+- Customer
+- Order
+- Product
+- Payment
+- Shipment
 
-At this stage, the boxes are intentionally simple. You are building a
-map of the domain, not a finished schema.
+At this stage, the candidates are intentionally simple. You are building
+a map of the domain, not a finished schema.
 
 ## One entity type, one table
 
 Once an entity is real enough to track, it usually gets its own table.
 A table should hold rows that are all the same kind of thing.
 
-```mermaid
-flowchart TB
-    subgraph customers["Table: customers"]
-        C1["id = 1<br/>Ada"]
-        C2["id = 2<br/>Grace"]
-    end
-    subgraph products["Table: products"]
-        P1["id = 10<br/>Notebook"]
-        P2["id = 11<br/>Pen"]
-    end
-```
+Table: `customers`
+
+| id | name  |
+| -- | ----- |
+| 1  | Ada   |
+| 2  | Grace |
+
+Table: `products`
+
+| id | name     |
+| -- | -------- |
+| 10 | Notebook |
+| 11 | Pen      |
 
 Mixing different entity types into one table creates confusion. A
 customer row and a product row do not have the same meaning, the same

--- a/content/learn/database-design-postgresql/what-are-constraints.mdx
+++ b/content/learn/database-design-postgresql/what-are-constraints.mdx
@@ -122,16 +122,6 @@ same answer: no.
 PostgreSQL gives you several common kinds of constraints. Each protects
 a different part of the design.
 
-```mermaid
-flowchart TB
-    C["Constraint family"] --> NN["NOT NULL<br/>value required"]
-    C --> D["DEFAULT<br/>fill missing value"]
-    C --> U["UNIQUE<br/>no duplicates"]
-    C --> CH["CHECK<br/>domain rule"]
-    C --> PK["PRIMARY KEY<br/>row identity"]
-    C --> FK["FOREIGN KEY<br/>valid reference"]
-```
-
 - **NOT NULL** means a column must have a value.
 - **DEFAULT** supplies a value when the insert does not provide one.
 - **UNIQUE** prevents duplicate values such as repeated usernames.

--- a/content/learn/database-design-postgresql/what-is-database-design.mdx
+++ b/content/learn/database-design-postgresql/what-is-database-design.mdx
@@ -207,16 +207,11 @@ possibly old data.
 Design first does not mean you must predict everything. It means you
 pause long enough to model the core facts that are already visible.
 
-```mermaid
-flowchart TB
-    A["Model core facts"] --> B["Create tables and constraints"]
-    B --> C["Write application code"]
-    C --> D["Add features on stable meaning"]
-
-    E["Skip modeling"] --> F["Code invents assumptions"]
-    F --> G["Data grows around shortcuts"]
-    G --> H["Expensive redesign"]
-```
+| Design first | Skip modeling |
+| --- | --- |
+| Model core facts | Code invents assumptions |
+| Create tables and constraints | Data grows around shortcuts |
+| Write application code on stable meaning | Expensive redesign later |
 
 The schema becomes a contract. It is much easier to make that contract
 clear before many callers depend on it.

--- a/content/learn/database-design-postgresql/why-schemas-change.mdx
+++ b/content/learn/database-design-postgresql/why-schemas-change.mdx
@@ -41,17 +41,14 @@ the model must change too.
 
 ## Common kinds of change
 
-Schema changes usually fall into a few patterns.
+Schema changes usually fall into a few patterns:
 
-```mermaid
-flowchart TD
-    Change["Schema change"] --> Attribute["New attribute"]
-    Change --> Entity["New entity"]
-    Change --> Relationship["New relationship"]
-    Change --> Split["Split a table"]
-    Change --> Merge["Merge tables"]
-    Change --> Tighten["Tighten constraints"]
-```
+- a new attribute
+- a new entity
+- a new relationship
+- splitting a table
+- merging tables
+- tightening constraints
 
 ### New attributes
 

--- a/content/learn/from-zero-to-cpp/algorithms-intuition.mdx
+++ b/content/learn/from-zero-to-cpp/algorithms-intuition.mdx
@@ -24,10 +24,8 @@ algorithm's *time complexity*.
 | O(n²) | "n squared" | Doubling n quadruples the work. Fine for n=1000, painful for n=100,000. |
 | O(2ⁿ) | "exponential" | Adding one input element doubles the time. Only tractable for tiny n. |
 
-```mermaid
-flowchart LR
-    A[O 1 ] --> B[O log n ] --> C[O n ] --> D[O n log n ] --> E[O n squared ] --> F[O 2 to the n ]
-```
+The rows are ordered from cheapest to most expensive: each step down
+the table grows faster than the one above it.
 
 You don't need to be a theorist. Just learn to recognize the
 shape: nested loops over the same data are usually quadratic; a

--- a/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
+++ b/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
@@ -12,16 +12,15 @@ errors come from confusing one stage with another.
 
 ## A four-step pipeline
 
-The traditional C++ toolchain has four steps:
+The traditional C++ toolchain takes your source code (`.cpp` + `.h`)
+and runs it through four steps to produce an executable (`a.out` /
+`.exe`):
 
-```mermaid
-flowchart TD
-    A[Source code<br/>.cpp + .h] --> P[1. Preprocess<br/>expand #include,<br/>#define, ifdef]
-    P --> C[2. Compile<br/>parse, type-check,<br/>generate assembly]
-    C --> AS[3. Assemble<br/>assembly to<br/>object code .o]
-    AS --> L[4. Link<br/>combine .o files +<br/>libraries into one<br/>executable]
-    L --> E[Executable<br/>a.out / .exe]
-```
+1. **Preprocess** — expand `#include`, `#define`, and `#ifdef`.
+2. **Compile** — parse, type-check, and generate assembly.
+3. **Assemble** — turn assembly into object code (`.o`).
+4. **Link** — combine the `.o` files and libraries into one
+   executable.
 
 Each step produces a real artifact you can sometimes inspect. Each
 step has its own kind of error message. Let's walk through them.
@@ -62,18 +61,18 @@ to `5`, not `9`. This is one big reason modern C++ prefers
 
 The actual **compiler** takes one translation unit and turns it into
 **assembly**, the human-readable form of machine code for your target
-CPU. Inside, the compiler runs many sub-passes:
+CPU. Inside, the compiler runs many sub-passes over the translation
+unit, in order:
 
-```mermaid
-flowchart TD
-    A[Translation unit] --> L[Lexer:<br/>text to tokens]
-    L --> Pa[Parser:<br/>tokens to syntax tree]
-    Pa --> Sm[Semantic analysis:<br/>type-check, lookup names]
-    Sm --> IR[Intermediate<br/>representation IR]
-    IR --> Op[Optimizer:<br/>fold constants,<br/>inline, vectorize]
-    Op --> Cg[Code generator:<br/>IR to assembly]
-    Cg --> Out[.s assembly file]
-```
+1. **Lexer** — text to tokens.
+2. **Parser** — tokens to a syntax tree.
+3. **Semantic analysis** — type-check and look up names.
+4. **Intermediate representation (IR)** — a lower-level form the
+   compiler can reason about.
+5. **Optimizer** — fold constants, inline, vectorize.
+6. **Code generator** — IR to assembly.
+
+The result is a `.s` assembly file.
 
 This is the stage where almost all of your *type errors* are caught.
 If you write

--- a/content/learn/from-zero-to-cpp/data-structures-intuition.mdx
+++ b/content/learn/from-zero-to-cpp/data-structures-intuition.mdx
@@ -14,23 +14,16 @@ each — without diving into their implementations.
 
 ## A map of the standard containers
 
-```mermaid
-flowchart TB
-    subgraph "Sequence containers"
-        V[std::vector<br/>contiguous, grow at end]
-        D[std::deque<br/>like vector, grow at both ends]
-        L[std::list<br/>doubly linked]
-        A[std::array<br/>fixed size]
-    end
-    subgraph "Associative ordered"
-        M[std::map<br/>sorted key->value]
-        S[std::set<br/>sorted unique keys]
-    end
-    subgraph "Associative hashed"
-        UM[std::unordered_map<br/>hash key->value]
-        US[std::unordered_set<br/>hash unique keys]
-    end
-```
+| Family | Container | What it is |
+| --- | --- | --- |
+| Sequence | `std::vector` | contiguous, grow at the end |
+| Sequence | `std::deque` | like vector, grow at both ends |
+| Sequence | `std::list` | doubly linked |
+| Sequence | `std::array` | fixed size |
+| Associative, ordered | `std::map` | sorted key → value |
+| Associative, ordered | `std::set` | sorted unique keys |
+| Associative, hashed | `std::unordered_map` | hash key → value |
+| Associative, hashed | `std::unordered_set` | hash unique keys |
 
 ## Sequence containers
 

--- a/content/learn/from-zero-to-cpp/dynamic-memory.mdx
+++ b/content/learn/from-zero-to-cpp/dynamic-memory.mdx
@@ -14,21 +14,11 @@ control: the **heap**.
 
 ## Stack vs. heap, one more time
 
-```mermaid
-flowchart LR
-    subgraph Stack
-        direction TB
-        S1[Automatic variables]
-        S2[Function frames]
-        S3[Tiny, fixed-size, super fast]
-    end
-    subgraph Heap
-        direction TB
-        H1[Manually requested storage]
-        H2[Lifetime decided by program]
-        H3[Large, flexible, slower]
-    end
-```
+| Stack | Heap |
+| --- | --- |
+| Automatic variables | Manually requested storage |
+| Function frames | Lifetime decided by the program |
+| Tiny, fixed-size, super fast | Large, flexible, slower |
 
 Asking for heap memory used to be done with raw `new` and `delete`.
 Modern C++ has *much* better tools (we'll meet them in the smart

--- a/content/learn/from-zero-to-cpp/how-computers-execute.mdx
+++ b/content/learn/from-zero-to-cpp/how-computers-execute.mdx
@@ -141,17 +141,6 @@ Within its address space, your program organises memory into a few
 distinct regions. You will hear about these for the rest of the
 course, so it helps to meet them now:
 
-```mermaid
-flowchart TB
-    subgraph "Program address space"
-        T["Text / code<br/>the compiled instructions"]
-        D["Data<br/>global and static variables"]
-        H["Heap<br/>grows upward as you<br/>allocate dynamically"]
-        Sp[ ]
-        S["Stack<br/>grows downward<br/>function call frames"]
-    end
-```
-
 - **Text / code** — the actual machine instructions of your program.
   Usually read-only.
 - **Data** — global variables, string literals, and other things that

--- a/content/learn/from-zero-to-cpp/index.mdx
+++ b/content/learn/from-zero-to-cpp/index.mdx
@@ -53,19 +53,6 @@ confidence of someone who knows *why* their code works.
 The course is organized into ten short sections. Each builds on the
 previous one, but every page also stands on its own.
 
-```mermaid
-flowchart TD
-    H[A Story of Programming] --> R[How Computers Run Programs]
-    R --> T[Computational Thinking]
-    T --> F[Control Flow & Functions]
-    F --> M[Memory, Pointers & References]
-    M --> S[Aggregates & Structured Data]
-    S --> O[Object-Oriented Programming]
-    O --> RM[Resource Management & Modern C++]
-    RM --> AD[Algorithms & Data Structures Intuition]
-    AD --> D[Debugging & Maintainable Software]
-```
-
 You will see three kinds of interactive widgets on most pages:
 
 1. **Executable code blocks.** Every C++ snippet compiles with

--- a/content/learn/from-zero-to-cpp/memory-model.mdx
+++ b/content/learn/from-zero-to-cpp/memory-model.mdx
@@ -14,16 +14,12 @@ questions:
    end of program, never)
 3. **Who is responsible for it?** (the compiler, you, or the OS)
 
-```mermaid
-flowchart TB
-    subgraph "Process address space"
-        T[Text segment<br/>compiled machine code<br/>read-only]
-        D[Data segment<br/>globals + statics + string literals<br/>lives for whole program]
-        H[Heap<br/>'new' allocates here<br/>YOU manage lifetime]
-        Gap[(...unused address space...)]
-        S[Stack<br/>function calls + locals<br/>auto-managed]
-    end
-```
+| Region | What lives there | Lifetime / owner |
+| --- | --- | --- |
+| Text segment | compiled machine code | whole program, read-only |
+| Data segment | globals, statics, string literals | whole program |
+| Heap | whatever `new` allocates | until you free it — **you** manage it |
+| Stack | function calls and locals | end of scope — auto-managed |
 
 ## The four regions, one by one
 

--- a/content/learn/from-zero-to-cpp/the-call-stack.mdx
+++ b/content/learn/from-zero-to-cpp/the-call-stack.mdx
@@ -208,16 +208,10 @@ rewrite it as a loop.
 We saw this in the "How Computers Run Programs" chapter. The stack
 is one of several regions:
 
-```mermaid
-flowchart TB
-    subgraph "Program memory"
-        T[Text / code]
-        D[Data: globals, statics, string literals]
-        H[Heap: grows upward as you 'new' things]
-        Gap[(unused address space)]
-        S[Stack: grows downward as you call functions]
-    end
-```
+- **Text / code** — the compiled instructions.
+- **Data** — globals, statics, string literals.
+- **Heap** — grows upward as you `new` things.
+- **Stack** — grows downward as you call functions.
 
 The stack grows toward the heap; the heap grows toward the stack.
 On 32-bit systems they could in principle meet. On modern 64-bit

--- a/content/learn/from-zero-to-cpp/types-and-values.mdx
+++ b/content/learn/from-zero-to-cpp/types-and-values.mdx
@@ -34,22 +34,18 @@ flowchart LR
 
 C++ types break down into a small family of categories:
 
-```mermaid
-flowchart TD
-    T[Types]
-    T --> Fund[Fundamental]
-    T --> Comp[Compound]
-    Fund --> Int[Integral<br/>int, char, bool, ...]
-    Fund --> Flt[Floating-point<br/>float, double, long double]
-    Fund --> Void[void<br/>'no value']
-    Fund --> Nptr[std::nullptr_t<br/>just for nullptr]
-    Comp --> Ptr[Pointer T*]
-    Comp --> Ref[Reference T&]
-    Comp --> Arr[Array T n]
-    Comp --> Fn[Function int int]
-    Comp --> Cls[Class / Struct]
-    Comp --> Enum[Enumeration]
-```
+- **Fundamental**
+  - Integral — `int`, `char`, `bool`, ...
+  - Floating-point — `float`, `double`, `long double`
+  - `void` — "no value"
+  - `std::nullptr_t` — just for `nullptr`
+- **Compound**
+  - Pointer — `T*`
+  - Reference — `T&`
+  - Array — `T[n]`
+  - Function — `int(int)`
+  - Class / struct
+  - Enumeration
 
 Most of your day will be spent with `int`, `double`, `bool`,
 `std::string`, `std::vector`, and your own classes — but it helps

--- a/content/learn/functional-programming-typescript/declarative-thinking.mdx
+++ b/content/learn/functional-programming-typescript/declarative-thinking.mdx
@@ -99,16 +99,14 @@ sort.* There's no index, no mutation, no `seen` set, no `for` loop.
 
 ## What "declarative" actually means
 
-```mermaid
-flowchart LR
-    subgraph Imperative
-      A1["loop variables"] --> A2["mutate accumulators"] --> A3["control flow"] --> A4["result"]
-    end
-    subgraph Declarative
-      B1["data"] --> B2["transformations"] --> B3["data"]
-    end
-    style B2 fill:#e6f7e6
-```
+The two styles build a result along very different paths:
+
+| Imperative | Declarative |
+| --- | --- |
+| loop variables | data |
+| mutate accumulators | transformations |
+| control flow | data |
+| result | |
 
 Declarative code:
 

--- a/content/learn/functional-programming-typescript/evolution-of-complexity.mdx
+++ b/content/learn/functional-programming-typescript/evolution-of-complexity.mdx
@@ -221,16 +221,14 @@ single, radical claim:
 The rest of this course is about how to actually do that, in
 TypeScript, for real applications.
 
-```mermaid
-flowchart LR
-    subgraph Imperative
-      A[Step 1: mutate x] --> B[Step 2: mutate y] --> C[Step 3: side effect]
-    end
-    subgraph Functional
-      D[value] --> E[pure transformation] --> F[new value] --> G[edge effect]
-    end
-    style E fill:#e6f7e6
-```
+The shape of a computation changes accordingly:
+
+| Imperative | Functional |
+| --- | --- |
+| mutate `x` | a value |
+| mutate `y` | a pure transformation |
+| side effect | a new value |
+| | the effect, at the edge |
 
 The next chapter looks at where these ideas *came from* — the
 mathematical and historical roots of functional programming, from

--- a/content/learn/functional-programming-typescript/generic-abstractions-and-type-classes.mdx
+++ b/content/learn/functional-programming-typescript/generic-abstractions-and-type-classes.mdx
@@ -185,15 +185,12 @@ orderings algebraically.
 
 ## Type-class hierarchies (briefly)
 
-Some classes extend others. The classical hierarchy from FP looks
-like:
+Some classes extend others. The classical hierarchy from FP forms a
+few independent lineages:
 
-```mermaid
-flowchart TD
-    Functor --> Applicative --> Monad
-    Semigroup --> Monoid
-    Eq --> Ord
-```
+- `Functor` → `Applicative` → `Monad`
+- `Semigroup` → `Monoid`
+- `Eq` → `Ord`
 
 The arrows mean "extends" — every `Ord` instance is also an `Eq`
 (it can decide equality from "neither less nor greater"). Every

--- a/content/learn/intro-data-viz-plotly/box-plots.mdx
+++ b/content/learn/intro-data-viz-plotly/box-plots.mdx
@@ -11,17 +11,14 @@ key summary statistics — and that compactness lets you compare
 
 ## Anatomy of a box plot
 
-```mermaid
-flowchart TB
-    Min["Min<br/>(or lower fence)"]
-    Q1["Q1<br/>(25th percentile)"]
-    Med["Median<br/>(50th percentile)"]
-    Q3["Q3<br/>(75th percentile)"]
-    Max["Max<br/>(or upper fence)"]
-    Out["Outliers<br/>(beyond fences)"]
-    Min --> Q1 --> Med --> Q3 --> Max
-    Q3 --> Out
-```
+A box plot is built from a handful of ordered summary statistics:
+
+- **Min** (or lower fence)
+- **Q1** — 25th percentile
+- **Median** — 50th percentile
+- **Q3** — 75th percentile
+- **Max** (or upper fence)
+- **Outliers** — points beyond the fences
 
 The box itself spans from **Q1** (25th percentile) to **Q3** (75th
 percentile). The line inside is the **median**. The "whiskers"

--- a/content/learn/intro-data-viz-plotly/color-scales-and-aesthetics.mdx
+++ b/content/learn/intro-data-viz-plotly/color-scales-and-aesthetics.mdx
@@ -14,13 +14,11 @@ sometimes lies about it.
 There are essentially three families. Knowing which family fits
 which kind of data is 80% of the battle.
 
-```mermaid
-flowchart TB
-    D[Data] --> A{What kind?}
-    A -->|Categories<br/>no order| QUAL[Qualitative<br/>distinct hues]
-    A -->|Ordered low to high<br/>no special midpoint| SEQ[Sequential<br/>light to dark of one hue]
-    A -->|Diverging from a midpoint<br/>e.g. positive vs negative| DIV[Diverging<br/>two hues + white in middle]
-```
+| Kind of data | Family | What it looks like |
+| --- | --- | --- |
+| Categories, no order | Qualitative | Distinct hues |
+| Ordered low to high, no special midpoint | Sequential | Light to dark of one hue |
+| Diverging from a midpoint (e.g. positive vs. negative) | Diverging | Two hues + white in the middle |
 
 ### Qualitative (categorical) palettes
 

--- a/content/learn/intro-data-viz-plotly/dashboard-intuition.mdx
+++ b/content/learn/intro-data-viz-plotly/dashboard-intuition.mdx
@@ -45,16 +45,14 @@ The classic dashboard failure mode is the **wall of charts**: 30+
 small panels, each showing a different metric, with no apparent
 priority. The user opens it, freezes, and closes it.
 
-```mermaid
-flowchart TB
-    B[Bad dashboard]
-    B --> M[Too many charts]
-    B --> NP[No visual priority]
-    B --> NC[No clear question]
-    B --> SS[Stale data]
-    B --> NL[Unlabeled axes]
-    B --> NA[No annotations]
-```
+A bad dashboard usually has several of these traits at once:
+
+- Too many charts.
+- No visual priority.
+- No clear question.
+- Stale data.
+- Unlabeled axes.
+- No annotations.
 
 Why does this happen? Because dashboards are *cheap* to build and
 *expensive* to delete. Every stakeholder who ever wanted "their

--- a/content/learn/intro-data-viz-plotly/faceting-and-small-multiples.mdx
+++ b/content/learn/intro-data-viz-plotly/faceting-and-small-multiples.mdx
@@ -14,12 +14,9 @@ visualization, and Plotly Express makes it almost free.
 
 ## The pitch
 
-```mermaid
-flowchart TD
-    O[One messy chart<br/>30 overlapping lines] --> F[Facet by category]
-    F --> M[30 small charts<br/>one per category<br/>shared axes]
-    M --> C[Compare like-with-like<br/>at a glance]
-```
+**One messy chart of 30 overlapping lines → facet by category → 30 small
+charts (one per category, shared axes) → compare like-with-like at a
+glance.**
 
 Small multiples leverage a deep fact about perception: **the eye
 compares parallel pictures faster than it parses one busy picture.**

--- a/content/learn/intro-data-viz-plotly/filtering-before-plotting.mdx
+++ b/content/learn/intro-data-viz-plotly/filtering-before-plotting.mdx
@@ -22,13 +22,9 @@ Most analytic questions are about a **subset** of the data:
 If you skip the filter, the chart drowns in noise. Worse, the
 chart may *technically* be correct but answer the wrong question.
 
-```mermaid
-flowchart TD
-    R[Raw data<br/>2M rows] --> F[Filter to<br/>relevant slice]
-    F --> A[Aggregate if needed]
-    A --> P[Plot]
-    P --> RD[Read]
-```
+The pre-chart pipeline is almost always the same: **raw data (say, 2M
+rows) → filter to the relevant slice → aggregate if needed → plot →
+read.**
 
 ## The big four operations
 

--- a/content/learn/intro-data-viz-plotly/florence-nightingale.mdx
+++ b/content/learn/intro-data-viz-plotly/florence-nightingale.mdx
@@ -35,13 +35,9 @@ comparison. Anyone who looked at the chart — a politician, a queen,
 a newspaper editor — could see in a single glance that **soldiers
 were not dying of war; they were dying of dirt**.
 
-```mermaid
-flowchart TD
-    D[Monthly death<br/>statistics] --> E[Coxcomb<br/>rose diagram]
-    E --> P[Politicians<br/>understand instantly]
-    P --> R[Sanitary Commission<br/>sent to Scutari]
-    R --> O[Mortality<br/>drops dramatically]
-```
+The causal chain was direct: **monthly death statistics → a coxcomb rose
+diagram → politicians understand instantly → a Sanitary Commission sent
+to Scutari → mortality drops dramatically.**
 
 The chart did its job. The British government created a Sanitary
 Commission, the hospitals were cleaned, mortality plummeted, and

--- a/content/learn/intro-data-viz-plotly/geographic-visualization.mdx
+++ b/content/learn/intro-data-viz-plotly/geographic-visualization.mdx
@@ -102,15 +102,6 @@ sphere onto a flat page. *Every* projection distorts *something*
   exaggerates the size of regions near the poles (Greenland looks
   the same size as Africa, but Africa is 14× bigger).
 
-```mermaid
-flowchart TB
-    G[3-D globe] --> P[Project to 2-D]
-    P --> A[Equirectangular<br/>simple, distorted poles]
-    P --> B[Mercator<br/>preserves angles, lies about size]
-    P --> C[Natural Earth<br/>compromise, nice default]
-    P --> D[Orthographic<br/>realistic, half a globe]
-```
-
 <Callout type="warn" title="Mercator distortion is a real visualization problem">
 The Mercator projection famously makes Greenland look as large as
 Africa, even though Africa is ~14× larger by area. If your map's

--- a/content/learn/intro-data-viz-plotly/heatmaps.mdx
+++ b/content/learn/intro-data-viz-plotly/heatmaps.mdx
@@ -132,15 +132,6 @@ This is the single most important decision when making a heatmap.
   bright cyan and yellow bands look like ridges in the data even
   where there aren't any. `Viridis` is its modern replacement.
 
-```mermaid
-flowchart TB
-    D[Data]
-    D --> H1{One-sided<br/>e.g. counts}
-    H1 --> SEQ[Sequential palette<br/>Viridis, Blues, Plasma]
-    D --> H2{Diverging<br/>e.g. correlation}
-    H2 --> DIV[Diverging palette<br/>RdBu, PiYG, centered at 0]
-```
-
 ## Pitfalls of heatmaps
 
 - **Too many cells** (1000×1000) make individual cells invisible.

--- a/content/learn/intro-data-viz-plotly/histograms.mdx
+++ b/content/learn/intro-data-viz-plotly/histograms.mdx
@@ -19,12 +19,8 @@ A histogram chops the range of a numeric variable into **bins**
 that fall into each bin. The result looks like a bar chart, but
 the bars represent *intervals*, not categories.
 
-```mermaid
-flowchart TD
-    V["Numeric column<br/>(values)"] --> B["Cut into bins<br/>e.g. 0-10, 10-20, ..."]
-    B --> C["Count per bin"]
-    C --> P["Plot as bars"]
-```
+In short: **a numeric column → cut into bins (e.g. 0-10, 10-20, ...) →
+count per bin → plot as bars.**
 
 ## The simplest histogram
 

--- a/content/learn/intro-data-viz-plotly/history-of-visual-communication.mdx
+++ b/content/learn/intro-data-viz-plotly/history-of-visual-communication.mdx
@@ -72,13 +72,6 @@ popularized three chart types we still use today:
 - A few years later, the **pie chart**, for showing parts of a
   whole.
 
-```mermaid
-flowchart LR
-    P[William Playfair<br/>1759-1823] --> L[Line chart<br/>change over time]
-    P --> B[Bar chart<br/>category comparison]
-    P --> Pi[Pie chart<br/>parts of a whole]
-```
-
 Playfair's leap was philosophical. He argued that **economic and
 political data could be *seen***, not just *read*. To a generation
 raised on tables of numbers, this was strange and a little

--- a/content/learn/intro-data-viz-plotly/how-humans-perceive-visuals.mdx
+++ b/content/learn/intro-data-viz-plotly/how-humans-perceive-visuals.mdx
@@ -29,18 +29,14 @@ intensity) is a pre-attentive feature.
 The same is true for many other visual properties. Here are the
 ones most relevant to data visualization:
 
-```mermaid
-flowchart TB
-    PA["Pre-attentive features"]
-    PA --> POS["Position<br/>(2D location)"]
-    PA --> LEN["Length"]
-    PA --> ORI["Orientation"]
-    PA --> COL["Color hue"]
-    PA --> INT["Color intensity"]
-    PA --> SIZ["Size"]
-    PA --> SHP["Shape"]
-    PA --> MOT["Motion"]
-```
+- Position (2D location)
+- Length
+- Orientation
+- Color hue
+- Color intensity
+- Size
+- Shape
+- Motion
 
 ## The Cleveland-McGill ranking
 

--- a/content/learn/intro-data-viz-plotly/index.mdx
+++ b/content/learn/intro-data-viz-plotly/index.mdx
@@ -49,16 +49,6 @@ This course **is**:
 
 ## What you will learn
 
-```mermaid
-flowchart TD
-    A[The Story] --> B[Visual<br/>Reasoning]
-    B --> C[Plotly Express<br/>Fundamentals]
-    C --> D[Chart Types]
-    D --> E[Encodings &<br/>Color]
-    E --> F[Domain<br/>Workflows]
-    F --> G[Storytelling<br/>& Ethics]
-```
-
 The course is organized as a journey:
 
 1. **The story** — How humans went from carving tally marks on bone

--- a/content/learn/intro-data-viz-plotly/introducing-plotly-express.mdx
+++ b/content/learn/intro-data-viz-plotly/introducing-plotly-express.mdx
@@ -131,14 +131,6 @@ When you call `fig.show()`, Plotly Express does the following:
 3. Plotly.js renders the chart as interactive SVG or WebGL,
    wrapped in HTML.
 
-```mermaid
-flowchart TD
-    Code["Python code<br/>px.bar(...)"] --> Fig["Figure object<br/>(JSON spec)"]
-    Fig --> Show["fig.show()"]
-    Show --> JS["Plotly.js<br/>in browser"]
-    JS --> Render["Interactive chart"]
-```
-
 You don't normally need to think about this pipeline. But it
 explains why Plotly charts are interactive *for free*: the chart
 *is* a small JavaScript application.

--- a/content/learn/intro-data-viz-plotly/storytelling-with-data.mdx
+++ b/content/learn/intro-data-viz-plotly/storytelling-with-data.mdx
@@ -23,13 +23,8 @@ The chart is the *evidence*; the argument is what the chart is
 *for*. Storytelling is the discipline of making the chart match
 the argument so well that the reader can't miss it.
 
-```mermaid
-flowchart TD
-    Q[Question /<br/>Argument] --> D[Data]
-    D --> C[Chart]
-    C --> R[Reader]
-    R --> A[Acts /<br/>Believes]
-```
+The whole arc runs one way: **a question or argument → the data → a
+chart → the reader → who then acts or believes.**
 
 ## Three ingredients of a good story-chart
 

--- a/content/learn/intro-data-viz-plotly/the-rise-of-plotly.mdx
+++ b/content/learn/intro-data-viz-plotly/the-rise-of-plotly.mdx
@@ -145,15 +145,10 @@ chart libraries:
 3. **It produces interactive charts by default.** Every output is
    pannable, zoomable, hoverable. You don't have to opt in.
 
-```mermaid
-flowchart TD
-    DF[(DataFrame)] --> PX["px.bar / px.line / px.scatter / ..."]
-    PX --> Args["x= y= color= size= facet_col= ..."]
-    Args --> Fig[Interactive Plotly figure]
-    Fig --> H[Hover]
-    Fig --> Z[Zoom]
-    Fig --> D[Download]
-```
+The whole flow is one line: a **DataFrame** goes into a call like
+`px.bar` / `px.line` / `px.scatter`, encodings ride along as arguments
+(`x=`, `y=`, `color=`, `size=`, `facet_col=`, ...), and out comes an
+interactive Plotly figure you can hover, zoom, and download.
 
 ## Plotly Express's place in the ecosystem
 

--- a/content/learn/intro-data-viz-plotly/the-simple-white-template.mdx
+++ b/content/learn/intro-data-viz-plotly/the-simple-white-template.mdx
@@ -25,11 +25,9 @@ Templates are *purely cosmetic*. They do not change which data is
 plotted, which encodings you use, or any analytical content. They
 only change how the chart *looks*.
 
-```mermaid
-flowchart LR
-    PX["px.bar(df, x=..., y=...,<br/>template='simple_white')"] --> S["Plotly resolves<br/>'simple_white' to a<br/>full styling spec"]
-    S --> R["Render with<br/>those defaults"]
-```
+Passing `template='simple_white'` to `px.bar(df, x=..., y=...)` tells
+Plotly to resolve that name to a full styling spec, then render the
+chart with those defaults.
 
 ## The built-in templates
 

--- a/content/learn/intro-data-viz-plotly/what-is-data-visualization.mdx
+++ b/content/learn/intro-data-viz-plotly/what-is-data-visualization.mdx
@@ -31,13 +31,8 @@ A visualization is a *mapping* from data to visual properties.
 Numbers become positions. Categories become colors. Time becomes a
 horizontal axis. The map is called an **encoding**.
 
-```mermaid
-flowchart TD
-    D["Data<br/>(rows + columns)"] --> E["Encoding<br/>(rules)"]
-    E --> P["Picture<br/>(positions, colors, sizes)"]
-    P --> H["Human eye"]
-    H --> I["Insight"]
-```
+The chain runs: **data (rows + columns) → encoding (the rules) → a
+picture (positions, colors, sizes) → the human eye → insight.**
 
 The encoding is the *design decision*. There is no "neutral" or
 "default" encoding. Every chart you make is the result of choices

--- a/content/learn/intro-data-viz-plotly/why-charts-exist.mdx
+++ b/content/learn/intro-data-viz-plotly/why-charts-exist.mdx
@@ -102,15 +102,15 @@ Several things are happening at once that the table cannot do:
 These are all things the visual cortex is built for and the
 conscious arithmetic part of the brain is *terrible* at.
 
-```mermaid
-flowchart TD
-    T["Table<br/>(numbers)"] --> R["Read each number"]
-    R --> M["Hold in memory"]
-    M --> A["Mentally compute"]
-    A --> Slow["Slow, error-prone"]
-    C["Chart<br/>(positions, lines)"] --> V["Perceive structure"]
-    V --> Fast["Fast, parallel, unconscious"]
-```
+Reading a **table of numbers** is a serial chore:
+
+1. Read each number.
+2. Hold it in memory.
+3. Mentally compute the comparison.
+
+The result is *slow and error-prone*. Reading a **chart** collapses
+that to a single step — perceive the structure in the positions and
+lines — which is *fast, parallel, and unconscious*.
 
 ## When tables are actually better
 

--- a/content/learn/intro-modern-csharp/evolution-of-dotnet.mdx
+++ b/content/learn/intro-modern-csharp/evolution-of-dotnet.mdx
@@ -113,16 +113,14 @@ C# has had its own steady release cadence, and in modern .NET each
 new language version ships alongside a new runtime version. A few
 features you will actually use:
 
-```mermaid
-flowchart TB
-    C7["C# 7<br/>tuples, pattern matching"]
-    C8["C# 8<br/>nullable reference types"]
-    C9["C# 9<br/>records, top-level statements"]
-    C10["C# 10<br/>file-scoped namespaces"]
-    C11["C# 11<br/>raw string literals"]
-    C12["C# 12<br/>primary constructors"]
-    C7 --> C8 --> C9 --> C10 --> C11 --> C12
-```
+| Version | Adds |
+| --- | --- |
+| C# 7 | Tuples, pattern matching |
+| C# 8 | Nullable reference types |
+| C# 9 | Records, top-level statements |
+| C# 10 | File-scoped namespaces |
+| C# 11 | Raw string literals |
+| C# 12 | Primary constructors |
 
 The thread connecting all these additions: **let the programmer
 write less ceremony around the same ideas.** Compare an old-style

--- a/content/learn/intro-modern-csharp/how-programs-execute.mdx
+++ b/content/learn/intro-modern-csharp/how-programs-execute.mdx
@@ -14,17 +14,9 @@ CPU instructions, just build the mental model.
 
 ## The big picture
 
-```mermaid
-flowchart TD
-    A["Source code<br/>(.cs files)"] --> B["Compiler<br/>(Roslyn)"]
-    B --> C["Intermediate Language<br/>(CIL / IL)"]
-    C --> D["Runtime<br/>(.NET CLR or WebAssembly)"]
-    D --> E["JIT compiler<br/>(translates IL to CPU code<br/>on the fly)"]
-    E --> F["CPU<br/>+ memory"]
-    F --> G[Output to console / files / screen]
-```
+**Source code (`.cs` files) → Compiler (Roslyn) → Intermediate Language (CIL / IL) → Runtime (.NET CLR or WebAssembly) → JIT compiler → CPU + memory → Output to console / files / screen**
 
-There are five real "things" in that diagram, plus the CPU. Let's
+There are five real "things" in that pipeline, plus the CPU. Let's
 walk through them.
 
 ## 1. Source code
@@ -242,20 +234,15 @@ Console.WriteLine($"now a list of length {nums.Count}");
 
 ## 8. The full lifecycle, one more time
 
-Let's redraw the whole picture, now with the pieces named.
+Here is the whole picture, now with the pieces named.
 
-```mermaid
-flowchart TB
-    A["1. You write .cs source"]
-    B["2. Roslyn compiles to IL (.dll)"]
-    C["3. Runtime loads .dll, type-checks, sets up stack and heap"]
-    D["4. JIT compiles IL to CPU machine code on demand"]
-    E["5. CPU executes; stack holds calls, heap holds objects"]
-    F["6. GC reclaims unreferenced heap objects"]
-    G["7. Program exits, OS frees all memory"]
-
-    A --> B --> C --> D --> E --> F --> G
-```
+1. You write `.cs` source.
+2. Roslyn compiles it to IL (`.dll`).
+3. The runtime loads the `.dll`, type-checks it, and sets up the stack and heap.
+4. The JIT compiles IL to CPU machine code on demand.
+5. The CPU executes; the stack holds calls, the heap holds objects.
+6. The GC reclaims unreferenced heap objects.
+7. The program exits, and the OS frees all memory.
 
 That is the *entire* journey of one C# program. Every later
 chapter in this course is just a closer look at some piece of this

--- a/content/learn/intro-modern-csharp/microsoft-dotnet-vision.mdx
+++ b/content/learn/intro-modern-csharp/microsoft-dotnet-vision.mdx
@@ -18,15 +18,12 @@ described publicly in 2000 and shipped as **.NET Framework 1.0** in
 Microsoft's pitch for .NET had four pillars. Each one was a direct
 response to a problem from the previous chapters.
 
-```mermaid
-flowchart TB
-    subgraph Goals["The .NET vision"]
-        G1["1. A managed runtime (CLR)<br/>fewer memory bugs"]
-        G2["2. A common type system (CTS)<br/>languages can share types"]
-        G3["3. A large standard library (BCL)<br/>'batteries included'"]
-        G4["4. Tooling: Visual Studio + MSBuild<br/>productivity-first"]
-    end
-```
+| Pillar | Why it mattered |
+| --- | --- |
+| A managed runtime (CLR) | Fewer memory bugs |
+| A common type system (CTS) | Languages can share types |
+| A large standard library (BCL) | "Batteries included" |
+| Tooling: Visual Studio + MSBuild | Productivity-first |
 
 Let's unpack each one.
 

--- a/content/learn/intro-modern-csharp/variables-and-memory.mdx
+++ b/content/learn/intro-modern-csharp/variables-and-memory.mdx
@@ -90,17 +90,14 @@ Imagine memory as a long strip of numbered cells. When you write
 `int age = 30;`, the compiler picks a cell (or a few cells), labels
 it `age`, and writes the number `30` into it.
 
-```mermaid
-flowchart LR
-    subgraph Memory
-        A["age<br/>30"]
-        B["price<br/>19.99"]
-        C["name<br/>'Ada'"]
-        D["isAdmin<br/>true"]
-    end
-```
+| Variable | Value |
+| --- | --- |
+| `age` | `30` |
+| `price` | `19.99` |
+| `name` | `'Ada'` |
+| `isAdmin` | `true` |
 
-That picture is slightly oversimplified — strings and lists
+That is slightly oversimplified — strings and lists
 actually live on the *heap*, with a small reference on the stack
 pointing to them — but for value types like `int` and `bool` it's
 exactly right.

--- a/content/learn/intro-modern-csharp/windows-and-enterprise-software.mdx
+++ b/content/learn/intro-modern-csharp/windows-and-enterprise-software.mdx
@@ -70,22 +70,8 @@ later make.
 ## The Microsoft developer toolchain before .NET
 
 By the late 1990s, Microsoft offered three major tools for building
-software on Windows:
-
-```mermaid
-flowchart TB
-    subgraph Tools["Microsoft developer tools, ~1998"]
-        VC["Visual C++<br/>(power, but unsafe)"]
-        VB["Visual Basic<br/>(easy, but limited)"]
-        VJ["Visual J++<br/>(Microsoft's Java)"]
-    end
-    subgraph Goal["What enterprises wanted"]
-        G["A language that was<br/>both safe AND powerful,<br/>with great Windows tools"]
-    end
-    Tools -.does not exist yet.-> Goal
-```
-
-Each tool had real strengths and real weaknesses:
+software on Windows — Visual C++, Visual Basic, and Visual J++.
+Each had real strengths and real weaknesses:
 
 - **Visual C++** gave you raw, fast access to Windows. But C++ is
   notoriously unsafe: pointer bugs, memory leaks, and crashes were

--- a/content/learn/intro-sql-postgres/creating-tables.mdx
+++ b/content/learn/intro-sql-postgres/creating-tables.mdx
@@ -31,15 +31,6 @@ integer `id`, a text `title`, a text `author`, and an integer
 `year`."* The parentheses hold a comma-separated list of
 `column_name TYPE` pairs. That is the core of the whole statement.
 
-```mermaid
-flowchart TB
-    K["CREATE TABLE books ("] --> C1["id INTEGER,"]
-    C1 --> C2["title TEXT,"]
-    C2 --> C3["author TEXT,"]
-    C3 --> C4["year INTEGER"]
-    C4 --> E[")"]
-```
-
 ## Adding rules with constraints
 
 Beyond a name and type, each column can carry **constraints** —

--- a/content/learn/intro-sql-postgres/data-types.mdx
+++ b/content/learn/intro-sql-postgres/data-types.mdx
@@ -56,12 +56,11 @@ what you can *do* with the values:
 - You can compare and subtract `DATE`s to get a number of days.
 - You can filter `BOOLEAN` columns directly (`WHERE is_active`).
 
-```mermaid
-flowchart TB
-    NUM["Numbers<br/>(INTEGER, NUMERIC)"] --> M1["add, subtract,<br/>average, sum"]
-    TXT["Text (TEXT)"] --> M2["join, search,<br/>change case"]
-    DT["Dates (DATE,<br/>TIMESTAMP)"] --> M3["compare, find<br/>differences in days"]
-```
+| Type | Natural operations |
+| --- | --- |
+| Numbers (`INTEGER`, `NUMERIC`) | add, subtract, average, sum |
+| Text (`TEXT`) | join, search, change case |
+| Dates (`DATE`, `TIMESTAMP`) | compare, find differences in days |
 
 Choosing the right type up front means the natural operations are
 available and the nonsensical ones (like multiplying two names) are

--- a/content/learn/intro-sql-postgres/filtering-groups.mdx
+++ b/content/learn/intro-sql-postgres/filtering-groups.mdx
@@ -111,10 +111,7 @@ grouping step.
 You have now met the core query clauses. Here is their fixed order —
 and, helpfully, roughly the order the database executes them:
 
-```mermaid
-flowchart LR
-    F["FROM"] --> W["WHERE"] --> G["GROUP BY"] --> H["HAVING"] --> S["SELECT"] --> O["ORDER BY"] --> L["LIMIT"]
-```
+**`FROM` → `WHERE` → `GROUP BY` → `HAVING` → `SELECT` → `ORDER BY` → `LIMIT`**
 
 We will revisit this execution order in detail in the **Composing
 Queries** section — for now, knowing where `HAVING` fits is the key

--- a/content/learn/intro-sql-postgres/how-data-is-stored.mdx
+++ b/content/learn/intro-sql-postgres/how-data-is-stored.mdx
@@ -23,30 +23,17 @@ The relational database's big idea is to group facts into neat
   a price.
 - A **cell** (one row, one column) holds a single value.
 
-```mermaid
-flowchart TB
-    subgraph customers["Table: customers"]
-        direction LR
-        H1["id"]:::hdr
-        H2["name"]:::hdr
-        H3["city"]:::hdr
-        R1["1"]
-        R2["Ada"]
-        R3["Toronto"]
-        S1["2"]
-        S2["Linus"]
-        S3["Helsinki"]
-        T1["3"]
-        T2["Grace"]
-        T3["New York"]
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-```
+Table: `customers`
 
-That picture — a labeled grid of rows and columns — is the single
-most important image in this entire course. Almost everything we do
-is either *reading* such a grid, *changing* it, or *combining* two
-of them.
+| id | name | city |
+| --- | --- | --- |
+| 1 | Ada | Toronto |
+| 2 | Linus | Helsinki |
+| 3 | Grace | New York |
+
+That labeled grid of rows and columns is the single most important
+image in this entire course. Almost everything we do is either
+*reading* such a grid, *changing* it, or *combining* two of them.
 
 ## Why a grid?
 

--- a/content/learn/intro-sql-postgres/index.mdx
+++ b/content/learn/intro-sql-postgres/index.mdx
@@ -71,18 +71,6 @@ more sense *after* you understand the ideas taught here.
 
 ## How the course is organized
 
-```mermaid
-flowchart TB
-    A["Why Databases<br/>Exist"] --> B["Relational<br/>Foundations"]
-    B --> C["Getting Started<br/>with PostgreSQL"]
-    C --> D["Querying<br/>Data"]
-    D --> E["Summarizing<br/>Data"]
-    E --> F["Connecting<br/>Tables (Joins)"]
-    F --> G["Data<br/>Modeling"]
-    G --> H["Composing<br/>Queries"]
-    H --> I["Wrapping<br/>Up"]
-```
-
 We start with **ideas, not syntax**. The first section answers the
 questions most tutorials skip: what a database is, why it exists,
 how data is stored, and why SQL and PostgreSQL became so popular.

--- a/content/learn/intro-sql-postgres/next-steps.mdx
+++ b/content/learn/intro-sql-postgres/next-steps.mdx
@@ -12,15 +12,13 @@ That conceptual foundation is the hard part, and you have it.
 
 The course moved deliberately from "why" to "how" to "how to think":
 
-```mermaid
-flowchart TB
-    A["Why databases exist<br/>(beyond spreadsheets)"] --> B["Relational foundations<br/>(tables, keys, types)"]
-    B --> C["Querying data<br/>(SELECT, WHERE, ORDER BY)"]
-    C --> D["Summarizing data<br/>(aggregates, GROUP BY, HAVING)"]
-    D --> E["Connecting tables<br/>(foreign keys, joins, many-to-many)"]
-    E --> F["Data modeling<br/>(entities, ER diagrams, normalization)"]
-    F --> G["Composing queries<br/>(subqueries, CTEs, execution order)"]
-```
+1. **Why databases exist** — beyond spreadsheets.
+2. **Relational foundations** — tables, keys, types.
+3. **Querying data** — `SELECT`, `WHERE`, `ORDER BY`.
+4. **Summarizing data** — aggregates, `GROUP BY`, `HAVING`.
+5. **Connecting tables** — foreign keys, joins, many-to-many.
+6. **Data modeling** — entities, ER diagrams, normalization.
+7. **Composing queries** — subqueries, CTEs, execution order.
 
 Each layer rested on the one before it. Joins only made sense once
 keys did; normalization only made sense once you felt the pain of

--- a/content/learn/intro-sql-postgres/primary-keys.mdx
+++ b/content/learn/intro-sql-postgres/primary-keys.mdx
@@ -33,23 +33,12 @@ A **primary key** is a column (or set of columns) whose value
 **uniquely identifies each row** in a table. No two rows may share
 the same primary key value, and it is never empty.
 
-```mermaid
-flowchart TB
-    subgraph customers["Table: customers"]
-        direction LR
-        H1["id (PK)"]:::pk
-        H2["name"]:::hdr
-        H3["city"]:::hdr
-        A1["1"]:::pk
-        A2["John Smith"]
-        A3["Springfield"]
-        B1["2"]:::pk
-        B2["John Smith"]
-        B3["Springfield"]
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-    classDef pk fill:#fde68a,stroke:#b45309
-```
+Table: `customers`
+
+| id (PK) | name | city |
+| --- | --- | --- |
+| 1 | John Smith | Springfield |
+| 2 | John Smith | Springfield |
 
 Now the two John Smiths are clearly different: one is customer `1`,
 the other is customer `2`. The `id` column is the primary key, and

--- a/content/learn/intro-sql-postgres/query-execution-order.mdx
+++ b/content/learn/intro-sql-postgres/query-execution-order.mdx
@@ -14,18 +14,14 @@ This is one of the most clarifying ideas in all of SQL.
 The order you type is for human readability. The order the database
 *reasons* about the query is different:
 
-```mermaid
-flowchart TB
-    F["1. FROM / JOIN<br/>gather and combine tables"]
-    W["2. WHERE<br/>filter individual rows"]
-    G["3. GROUP BY<br/>form groups"]
-    H["4. HAVING<br/>filter groups"]
-    S["5. SELECT<br/>choose columns, compute aliases"]
-    D["6. DISTINCT<br/>remove duplicates"]
-    O["7. ORDER BY<br/>sort"]
-    L["8. LIMIT<br/>keep the first N"]
-    F --> W --> G --> H --> S --> D --> O --> L
-```
+1. **`FROM` / `JOIN`** — gather and combine tables.
+2. **`WHERE`** — filter individual rows.
+3. **`GROUP BY`** — form groups.
+4. **`HAVING`** — filter groups.
+5. **`SELECT`** — choose columns, compute aliases.
+6. **`DISTINCT`** — remove duplicates.
+7. **`ORDER BY`** — sort.
+8. **`LIMIT`** — keep the first N.
 
 Read the numbers: `FROM` is first, `SELECT` is near the **end**, and
 `LIMIT` is last. The clause you *write* first (`SELECT`) is among the

--- a/content/learn/intro-sql-postgres/tables-rows-columns.mdx
+++ b/content/learn/intro-sql-postgres/tables-rows-columns.mdx
@@ -10,29 +10,13 @@ becomes mostly common sense.
 
 ## The three words
 
-```mermaid
-flowchart TB
-    subgraph students["Table: students"]
-        direction LR
-        H1["id"]:::hdr
-        H2["name"]:::hdr
-        H3["grade"]:::hdr
-        H4["gpa"]:::hdr
-        A1["1"]
-        A2["Ana"]
-        A3["9"]
-        A4["3.8"]
-        B1["2"]
-        B2["Ben"]
-        B3["10"]
-        B4["3.4"]
-        C1["3"]
-        C2["Cara"]
-        C3["11"]
-        C4["2.9"]
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-```
+The `students` table:
+
+| id | name | grade | gpa |
+| --- | --- | --- | --- |
+| 1 | Ana | 9 | 3.8 |
+| 2 | Ben | 10 | 3.4 |
+| 3 | Cara | 11 | 2.9 |
 
 - **Table** — a named grid that holds data about one kind of thing.
   This one holds *students*.

--- a/content/learn/intro-sql-postgres/thinking-in-entities.mdx
+++ b/content/learn/intro-sql-postgres/thinking-in-entities.mdx
@@ -45,12 +45,11 @@ The nouns — bookstore, book, customer, order — are candidate
 entities. Now ask of each: *what do we need to know about it?* Those
 become attributes (columns):
 
-```mermaid
-flowchart TB
-    Books["books"] --> BA["title<br/>author<br/>price"]
-    Customers["customers"] --> CA["name<br/>email"]
-    Orders["orders"] --> OA["order date<br/>total"]
-```
+| Entity | Attributes |
+| --- | --- |
+| `books` | title, author, price |
+| `customers` | name, email |
+| `orders` | order date, total |
 
 Notice attributes describe **one** instance of the entity: one book
 has one title and one price. If a "fact" really describes *many*

--- a/content/learn/intro-sql-postgres/why-postgresql.mdx
+++ b/content/learn/intro-sql-postgres/why-postgresql.mdx
@@ -62,22 +62,13 @@ performance tuning, security roles, clustering, and more. Those
 belong to the world of **database administration** and production
 operations.
 
-```mermaid
-flowchart LR
-    subgraph This["This course (the foundation)"]
-        F1["Writing SQL"]
-        F2["Relational thinking"]
-        F3["Modeling & joins"]
-    end
-    subgraph Later["Not this course (operations)"]
-        L1["Deployment & scaling"]
-        L2["Replication & backups"]
-        L3["Tuning & security"]
-    end
-    This --> Later
-```
+| This course (the foundation) | Not this course (operations) |
+| --- | --- |
+| Writing SQL | Deployment & scaling |
+| Relational thinking | Replication & backups |
+| Modeling & joins | Tuning & security |
 
-This course stays firmly on the **left** side: the SQL and
+This course stays firmly in the **foundation** column: the SQL and
 relational foundations that everything else is built on. You will
 be far better prepared for the operational topics later precisely
 because you took the time to build this base now.

--- a/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
@@ -208,15 +208,16 @@ the *consumer* (we write into it): `? super T`.
 
 ## Picture: variance on a number line
 
-```mermaid
-flowchart TD
-    A[List of Object] --- B[List ? super Integer]
-    B --- C[List of Integer]
-    C --- D[List ? extends Number]
-    D --- E[List of Number]
-    E --- F[List ? extends Object]
-    F --- G[List ? unbounded]
-```
+Line the wildcard forms up from the widest supertype down to the most
+permissive bound:
+
+1. `List<Object>`
+2. `List<? super Integer>`
+3. `List<Integer>`
+4. `List<? extends Number>`
+5. `List<Number>`
+6. `List<? extends Object>`
+7. `List<?>` (unbounded)
 
 `? extends T` shrinks toward subtypes (read-only side). `? super T`
 shrinks toward supertypes (write-only side). Plain `T` is the fixed

--- a/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
@@ -50,14 +50,13 @@ Hashing turns an arbitrary object into an `int` "fingerprint." A
 the bucket where the element should live — instead of scanning all
 buckets.
 
-```mermaid
-flowchart TD
-    A["new Customer('ada@…')"] --> H["hashCode()<br/>= 8132917"]
-    H --> M["bucket = 8132917 mod N<br/>= 5"]
-    M --> B5["bucket 5<br/>1–2 candidates"]
-    B5 --> EQ["walk candidates,<br/>call equals(x)"]
-    EQ --> R["hit or miss<br/>in O(1) average"]
-```
+A lookup for `new Customer("ada@…")` flows through these stages:
+
+1. `hashCode()` returns the fingerprint, say `8132917`.
+2. `bucket = 8132917 mod N` picks the bucket, say `5`.
+3. Bucket `5` holds only 1–2 candidates.
+4. Walk those candidates, calling `equals(x)` on each.
+5. Hit or miss — in `O(1)` on average.
 
 So a hash collection's lookup is two steps:
 

--- a/content/learn/java-collections-and-generics-deep-dive/index.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/index.mdx
@@ -143,14 +143,14 @@ Three things to notice — they will reappear on almost every page:
 
 ## What you'll be able to do by the end
 
-```mermaid
-flowchart TD
-    A["A vague requirement<br/>track unique users<br/>by login order"] --> B["Recognize<br/>the right container<br/>LinkedHashSet"]
-    B --> C["Model it with<br/>a generic API"]
-    C --> D["Reason about<br/>Big-O and memory"]
-    D --> E["Layer behind<br/>an interface"]
-    E --> F["Compose into<br/>larger architecture"]
-```
+Take a vague requirement — *track unique users by login order* — and
+carry it all the way down:
+
+1. **Recognize** the right container (here, a `LinkedHashSet`).
+2. **Model** it with a generic API.
+3. **Reason** about its Big-O and memory.
+4. **Layer** it behind an interface.
+5. **Compose** it into a larger architecture.
 
 Let's start where every interesting story about software starts: with
 the problem that the tools we had weren't enough.

--- a/content/learn/java-collections-and-generics-deep-dive/the-collections-framework.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-collections-framework.mdx
@@ -16,15 +16,13 @@ makes the JCF feel coherent even today, almost three decades later.
 
 ## The two big ideas
 
-```mermaid
-flowchart LR
-    subgraph Goals["Goals of the JCF"]
-        G1[Program to<br/>interfaces, not<br/>implementations]
-        G2[A small,<br/>uniform vocabulary<br/>of container shapes]
-        G3[High-quality<br/>default implementations<br/>for each interface]
-        G4["Algorithms<br/>(sort, shuffle, search)<br/>that work on any<br/>matching container"]
-    end
-```
+The JCF was built around four goals:
+
+- Program to **interfaces**, not implementations.
+- A small, uniform **vocabulary** of container shapes.
+- High-quality **default implementations** for each interface.
+- **Algorithms** (sort, shuffle, search) that work on any matching
+  container.
 
 That is it. From those four goals everything else follows: the
 interface hierarchy, the `Collections` static-utility class, the

--- a/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
@@ -59,16 +59,11 @@ a new *language* feature with two distinct ideas:
    `List<String>`, the *compile* fails — before the program even
    runs.
 
-```mermaid
-flowchart LR
-    A[List names<br/>= new ArrayList<br/><br/>Java 1.4]
-      --> B[List of Object<br/>compile-time:<br/>no type checks]
-    B --> C[Runtime cast<br/>+ ClassCastException]
-
-    D[List String names<br/>= new ArrayList String<br/><br/>Java 5+]
-      --> E[List of String<br/>compile-time:<br/>type checked]
-    E --> F[No cast in source<br/>compiler inserts<br/>and proves safe]
-```
+|  | Pre-generics (Java 1.4) | Generics (Java 5+) |
+| --- | --- | --- |
+| **Declaration** | `List names = new ArrayList()` | `List<String> names = new ArrayList<>()` |
+| **Compile time** | holds `Object`; no type checks | element type checked |
+| **Runtime** | manual cast, risking `ClassCastException` | no cast in source — the compiler inserts one and proves it safe |
 
 That is the entire story. The JCF you already know does not change
 shape — the *types* on every method now carry the element type, so

--- a/content/learn/java-collections-and-generics-deep-dive/type-erasure.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/type-erasure.mdx
@@ -46,11 +46,10 @@ That is the whole trick. Generics give you compile-time guarantees;
 at runtime, they look like the old `Object`-based code, with the
 casts written for you.
 
-```mermaid
-flowchart LR
-    A[Source<br/>List String] --> B[javac<br/>type-checks] --> C[Bytecode<br/>List of Object]
-    A2[Source<br/>String s = list.get 0] --> B2[javac<br/>inserts cast] --> C2[Bytecode<br/>String s = String list.get 0]
-```
+| Source | What `javac` does | Bytecode |
+| --- | --- | --- |
+| `List<String>` | type-checks the element type | `List` (of `Object`) |
+| `String s = list.get(0)` | inserts the cast | `String s = (String) list.get(0)` |
 
 ## Consequence 1: you cannot ask for the type parameter at runtime
 

--- a/content/learn/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
+++ b/content/learn/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
@@ -52,15 +52,11 @@ at the middle element. If it matches, done. If your target is
 smaller, search the left half. Otherwise the right half. Each step
 eliminates *half* of what is left.
 
-```mermaid
-flowchart TB
-    A["search 17 in 2 5 8 11 17 23 31 42"]
-    A --> B["mid is 11<br/>17 > 11 → search right half"]
-    B --> C["search 17 in 17 23 31 42"]
-    C --> D["mid is 23<br/>17 < 23 → search left half"]
-    D --> E["search 17 in 17"]
-    E --> F[found!]
-```
+Searching for `17` in `[2, 5, 8, 11, 17, 23, 31, 42]`:
+
+1. Middle of the whole list is `11`. `17 > 11`, so search the right half: `[17, 23, 31, 42]`.
+2. Middle is `23`. `17 < 23`, so search the left half: `[17]`.
+3. Middle is `17`. Match — found it.
 
 A list of 1 million elements is fully searched in **20** comparisons
 (2^20 ≈ 1M). A list of 1 billion: about **30** comparisons.

--- a/content/learn/java-programming-for-beginners/computational-thinking.mdx
+++ b/content/learn/java-programming-for-beginners/computational-thinking.mdx
@@ -13,14 +13,9 @@ The term was popularized by Jeannette Wing in 2006, but the habits
 are far older. There are four of them. Each is worth a lifetime of
 practice.
 
-```mermaid
-flowchart TD
-    Vague[Vague problem<br/>in English] --> D[1. Decompose]
-    D --> P[2. Find patterns]
-    P --> A[3. Abstract]
-    A --> Algo[4. Design algorithm]
-    Algo --> Code[Code it]
-```
+The path from a fuzzy idea to running code:
+
+**Vague problem in English → Decompose → Find patterns → Abstract → Design algorithm → Code it**
 
 ## 1. Decomposition: break it into pieces
 

--- a/content/learn/java-programming-for-beginners/constructors-and-lifecycle.mdx
+++ b/content/learn/java-programming-for-beginners/constructors-and-lifecycle.mdx
@@ -152,14 +152,7 @@ hours later when something downstream blows up.
 
 ## The lifecycle of an object
 
-```mermaid
-flowchart TD
-    A[1. allocated<br/>on heap] --> B[2. fields default-initialized<br/>0 / null / false]
-    B --> C[3. constructor runs]
-    C --> D[4. object is alive<br/>methods can be called]
-    D --> E[5. no references left]
-    E --> F[6. garbage-collected]
-```
+An object moves through six stages, from creation to reclamation:
 
 1. **Allocation.** `new Point(3, 4)` finds free memory on the heap.
 2. **Default initialization.** Java fills every field with its

--- a/content/learn/java-programming-for-beginners/encapsulation-and-abstraction.mdx
+++ b/content/learn/java-programming-for-beginners/encapsulation-and-abstraction.mdx
@@ -136,18 +136,13 @@ That is the **abstraction**. The fact that the balance is stored as
 is the **implementation**. We can change the implementation without
 breaking any caller, as long as the abstraction stays the same.
 
-```mermaid
-flowchart TB
-    subgraph A[Abstraction <br/>what the world sees]
-        AB1[owner, balance, deposit, withdraw]
-    end
-    subgraph I[Implementation <br/>how it really works]
-        IB1[balanceCents: long]
-        IB2[validation rules]
-        IB3[possibly a transaction log, etc.]
-    end
-    A -. hides .-> I
-```
+The abstraction hides the implementation:
+
+| Abstraction (what the world sees) | Implementation (how it really works) |
+| --- | --- |
+| `owner`, `balance`, `deposit`, `withdraw` | `balanceCents: long` |
+| | validation rules |
+| | possibly a transaction log, etc. |
 
 A class is *well designed* to the extent that its abstraction is
 small, clean, and stable while its implementation can change freely.

--- a/content/learn/java-programming-for-beginners/evolution-of-java.mdx
+++ b/content/learn/java-programming-for-beginners/evolution-of-java.mdx
@@ -15,15 +15,12 @@ pages. A Java **applet** was a small program (a `.class` file) that
 the browser downloaded and ran in a sandbox. Applets did simple
 animations, calculators, simple games, and proof-of-concept demos.
 
-```mermaid
-flowchart TD
-    Page[Web page HTML]
-    Page -->|<applet> tag| Browser
-    Browser -->|download| Server[Web server: .class]
-    Server --> Applet[Applet bytecode]
-    Applet --> JVM[Plug-in JVM inside browser]
-    JVM --> UI[Pixels in the page]
-```
+How an applet reached the screen:
+
+1. A web page's HTML contained an `<applet>` tag.
+2. The browser downloaded the `.class` file from the web server.
+3. A plug-in JVM inside the browser ran that applet bytecode.
+4. The applet drew pixels directly into the page.
 
 For a brief window in the late 1990s, applets looked like the future
 of interactive content on the web. They never quite lived up to that
@@ -115,14 +112,16 @@ Recent versions have added:
 We will not use most of these advanced features in this course, but
 it is worth knowing they exist. Java is not standing still.
 
-```mermaid
-flowchart TD
-    A[Java 1<br/>1996<br/>Applets] --> B[Java 5<br/>2004<br/>Generics, enums]
-    B --> C[Java 8<br/>2014<br/>Lambdas, streams]
-    C --> D[Java 11<br/>2018<br/>Modern LTS]
-    D --> E[Java 17<br/>2021<br/>Records, sealed]
-    E --> F[Java 21<br/>2023<br/>Virtual threads]
-```
+The major milestones at a glance:
+
+| Version | Year | Headline additions |
+| --- | --- | --- |
+| Java 1 | 1996 | Applets |
+| Java 5 | 2004 | Generics, enums |
+| Java 8 | 2014 | Lambdas, streams |
+| Java 11 | 2018 | Modern LTS |
+| Java 17 | 2021 | Records, sealed classes |
+| Java 21 | 2023 | Virtual threads |
 
 ## What got dropped
 

--- a/content/learn/java-programming-for-beginners/gosling-and-java.mdx
+++ b/content/learn/java-programming-for-beginners/gosling-and-java.mdx
@@ -81,21 +81,14 @@ This conservatism is the reason Java looks "boring" to fans of
 exotic languages. It is also exactly why Java still runs banks,
 airlines, and stock exchanges thirty years later.
 
-```mermaid
-flowchart LR
-    subgraph in[Kept]
-        S1[C-style syntax]
-        S2[Classes / OOP]
-        S3[Strong typing]
-        S4[Threads]
-    end
-    subgraph out[Removed]
-        R1[Pointer arithmetic]
-        R2[Manual memory]
-        R3[Multiple inheritance]
-        R4[Operator overloading]
-    end
-```
+In short, what Gosling kept and what he threw away:
+
+| Kept | Removed |
+| --- | --- |
+| C-style syntax | Pointer arithmetic |
+| Classes / OOP | Manual memory management |
+| Strong typing | Multiple inheritance |
+| Threads | Operator overloading |
 
 <MultipleChoice
   markdown={`What was Java originally designed for?

--- a/content/learn/java-programming-for-beginners/jvm-conceptually.mdx
+++ b/content/learn/java-programming-for-beginners/jvm-conceptually.mdx
@@ -106,30 +106,17 @@ For a beginner, three regions are worth knowing:
 - **Method area / metaspace.** Holds loaded classes themselves —
   their fields, methods, bytecode, constants.
 
-```mermaid
-flowchart TB
-    subgraph Memory[JVM Memory]
-        subgraph S[Stack per thread]
-            F3["frame: add(a=2, b=3)"]
-            F2["frame: main(args)"]
-            F1[main thread bottom]
-            F1 --> F2 --> F3
-        end
-        subgraph H[Heap shared]
-            O1[Account #1<br/>balance=500]
-            O2[Account #2<br/>balance=250]
-            O3[String 'Ada']
-        end
-        subgraph M[Method Area]
-            C1[class Account]
-            C2[class String]
-            C3[class Main]
-        end
-    end
-```
+A snapshot of what each region holds while `main` is calling `add`:
+
+- **Stack** (per thread) — a pile of frames, newest on top:
+  `main thread bottom` → `frame: main(args)` → `frame: add(a=2, b=3)`.
+- **Heap** (shared) — the live objects: `Account #1 (balance=500)`,
+  `Account #2 (balance=250)`, `String 'Ada'`.
+- **Method area** — the loaded classes themselves: `class Account`,
+  `class String`, `class Main`.
 
 We dedicate the next page entirely to stack vs heap — for now, the
-shape is what matters.
+three regions are what matter.
 
 ## Garbage collection, intuitively
 

--- a/content/learn/java-programming-for-beginners/maintainable-software.mdx
+++ b/content/learn/java-programming-for-beginners/maintainable-software.mdx
@@ -102,24 +102,15 @@ sentence *without using the word "and"*? If you need "and," the
 class probably has more than one responsibility and wants to be
 two classes.
 
-```mermaid
-flowchart LR
-    subgraph Bad["OrderManager (does too much)"]
-        B1[parse orders]
-        B2[validate orders]
-        B3[save to DB]
-        B4[send email]
-        B5[render PDF]
-    end
-    subgraph Good["Separate, focused classes"]
-        G1[OrderParser]
-        G2[OrderValidator]
-        G3[OrderRepository]
-        G4[OrderEmailer]
-        G5[InvoicePdfRenderer]
-    end
-    Bad --> Good
-```
+One `OrderManager` that does too much splits into a focused class per job:
+
+| Responsibility | Focused class |
+| --- | --- |
+| Parse orders | `OrderParser` |
+| Validate orders | `OrderValidator` |
+| Save to DB | `OrderRepository` |
+| Send email | `OrderEmailer` |
+| Render PDF | `InvoicePdfRenderer` |
 
 You don't have to split early. But when you notice the "and" in
 your description, refactor toward focused classes.

--- a/content/learn/java-programming-for-beginners/maps-and-sets.mdx
+++ b/content/learn/java-programming-for-beginners/maps-and-sets.mdx
@@ -89,12 +89,13 @@ A `HashMap<K, V>`:
   average.
 - Iteration order is **not** guaranteed.
 
-```mermaid
-flowchart LR
-    K1["key 'Ada'"] --> V1["value 36"]
-    K2["key 'Grace'"] --> V2["value 85"]
-    K3["key 'Linus'"] --> V3["value 54"]
-```
+Each key maps to exactly one value:
+
+| Key | Value |
+| --- | --- |
+| `"Ada"` | `36` |
+| `"Grace"` | `85` |
+| `"Linus"` | `54` |
 
 ## Choosing between List, Set, Map
 

--- a/content/learn/java-programming-for-beginners/variables-and-memory.mdx
+++ b/content/learn/java-programming-for-beginners/variables-and-memory.mdx
@@ -99,18 +99,6 @@ We will rarely worry about exact sizes. The key idea is that the
 type tells Java **how big the box is and how to interpret its
 contents**.
 
-```mermaid
-flowchart LR
-    A["int x<br/>= 42"]:::ibox
-    B["double pi<br/>= 3.14"]:::dbox
-    C["boolean<br/>done = true"]:::bbox
-    D["char c<br/>= 'A'"]:::cbox
-    classDef ibox fill:#dee,stroke:#066
-    classDef dbox fill:#fed,stroke:#660
-    classDef bbox fill:#efe,stroke:#060
-    classDef cbox fill:#fee,stroke:#600
-```
-
 ## Reference types: the box holds a pointer
 
 Not everything fits in a tiny box. A `String` like

--- a/content/learn/machine-learning-scikit-learn/decision-trees.mdx
+++ b/content/learn/machine-learning-scikit-learn/decision-trees.mdx
@@ -280,12 +280,11 @@ dip. Once the gap between the two columns yawns open, the extra depth is
 buying memorization, not understanding. The sweet spot is a depth where
 test accuracy is high *and* close to train accuracy.
 
-```mermaid
-flowchart LR
-    A["Shallow tree<br/>(depth 1-2)"] -->|"too simple"| B["Underfit<br/>high bias"]
-    C["Medium tree<br/>(depth 3-5)"] -->|"just right"| D["Generalizes well"]
-    E["Deep tree<br/>(no limit)"] -->|"too complex"| F["Overfit<br/>high variance"]
-```
+| Tree depth | Behavior | Result |
+| --- | --- | --- |
+| Shallow (depth 1-2) | Too simple to capture the pattern | Underfit — high bias |
+| Medium (depth 3-5) | Captures structure without chasing noise | Generalizes well |
+| Deep (no limit) | Carves out a region for nearly every row | Overfit — high variance |
 
 <Callout type="danger" title="An unlimited tree will memorize its training data">
 The default `DecisionTreeClassifier()` has **no depth limit**. On most

--- a/content/learn/machine-learning-scikit-learn/ensembles-and-random-forests.mdx
+++ b/content/learn/machine-learning-scikit-learn/ensembles-and-random-forests.mdx
@@ -241,14 +241,11 @@ essentially settled. The lesson: pick `n_estimators` large enough to reach
 the plateau (often a few hundred) and spend your real tuning effort on
 `max_depth`, `max_features`, or `min_samples_leaf` instead.
 
-```mermaid
-flowchart LR
-    A["Few trees<br/>(1-10)"] -->|"big gains per tree"| B["Accuracy rising fast"]
-    B --> C["Many trees<br/>(50-200)"]
-    C -->|"benefit flattens"| D["Plateau:<br/>more trees barely help"]
-    D --> E["Very many trees<br/>(1000+)"]
-    E -->|"more compute, ~same score"| F["Diminishing returns"]
-```
+| Number of trees | What happens |
+| --- | --- |
+| Few (1-10) | Big gains per tree — accuracy rises fast |
+| Many (50-200) | Benefit flattens — more trees barely help |
+| Very many (1000+) | Diminishing returns — more compute, roughly the same score |
 
 <Callout type="warn" title="More trees is not more overfitting">
 A common confusion: people assume that since a deeper *single* tree

--- a/content/learn/machine-learning-scikit-learn/features-and-targets.mdx
+++ b/content/learn/machine-learning-scikit-learn/features-and-targets.mdx
@@ -35,31 +35,19 @@ to the answer in the first slot of `y`. If that correspondence ever breaks,
 your model learns nonsense — so we always split `X` and `y` *together*, never
 separately.
 
-```mermaid
-flowchart LR
-    subgraph DATA["One labeled dataset"]
-        direction LR
-        subgraph XMAT["X  -  feature matrix"]
-            direction TB
-            X1["row 1: features of example 1"]
-            X2["row 2: features of example 2"]
-            X3["row 3: features of example 3"]
-        end
-        subgraph YVEC["y  -  target"]
-            direction TB
-            Y1["answer 1"]
-            Y2["answer 2"]
-            Y3["answer 3"]
-        end
-    end
-    X1 -. "same example" .-> Y1
-    X2 -. "same example" .-> Y2
-    X3 -. "same example" .-> Y3
-```
+In one labeled dataset, the rows of the feature matrix `X` line up one-for-one
+with the entries of the target `y`:
 
-Read the diagram across, not down: each row of `X` lines up with one entry of
-`y`. Columns of `X` are features; the single column `y` is what we predict.
-Hold this picture in mind and the abstract letters become concrete.
+| `X` — feature matrix (one row per example) | `y` — target |
+| --- | --- |
+| row 1: features of example 1 | answer 1 |
+| row 2: features of example 2 | answer 2 |
+| row 3: features of example 3 | answer 3 |
+
+Read the table across, not down: each row of `X` lines up with one entry of
+`y` — they describe the same example. Columns of `X` are features; the single
+column `y` is what we predict. Hold this picture in mind and the abstract
+letters become concrete.
 
 <Callout type="info" title="Why these exact letters?">
 The convention comes from the math: a model is a function `y = f(X)`, just

--- a/content/learn/machine-learning-scikit-learn/hyperparameter-tuning.mdx
+++ b/content/learn/machine-learning-scikit-learn/hyperparameter-tuning.mdx
@@ -203,19 +203,17 @@ one hyperparameter and 2 of another, that is 3 × 2 = 6 combinations, and
 with 5-fold cross-validation that is 6 × 5 = 30 model fits. Keep grids
 small — the work multiplies fast.
 
-```mermaid
-flowchart LR
-    subgraph Grid["Hyperparameter grid (C × max_depth)"]
-        direction TB
-        G1["C=0.1, depth=2"]
-        G2["C=0.1, depth=4"]
-        G3["C=1.0, depth=2"]
-        G4["C=1.0, depth=4"]
-    end
-    Grid --> CV["5-fold CV<br/>for each cell"]
-    CV --> Best["Pick highest<br/>mean CV score"]
-    Best --> Refit["best_estimator_<br/>(refit on all training data)"]
-```
+A grid over two hyperparameters — say `C` and `max_depth` — is every
+combination of their values:
+
+| | `max_depth=2` | `max_depth=4` |
+| --- | --- | --- |
+| `C=0.1` | `C=0.1, depth=2` | `C=0.1, depth=4` |
+| `C=1.0` | `C=1.0, depth=2` | `C=1.0, depth=4` |
+
+`GridSearchCV` runs 5-fold cross-validation for each cell, picks the
+combination with the highest mean CV score, and exposes it as
+`best_estimator_`, refit on all of the training data.
 
 Here is the smallest honest example: a tiny grid over a single
 hyperparameter, wrapped around a small model, judged by cross-validation.

--- a/content/learn/machine-learning-scikit-learn/k-nearest-neighbors.mdx
+++ b/content/learn/machine-learning-scikit-learn/k-nearest-neighbors.mdx
@@ -111,12 +111,11 @@ it directly controls the **bias-variance tradeoff** you met earlier.
   toward the overall majority class, ignoring local structure. This is
   **high bias, low variance**: the model **underfits**.
 
-```mermaid
-flowchart LR
-    A["k = 1<br/>jagged boundary"] -->|"too sensitive"| B["Overfit<br/>high variance"]
-    C["k = 5 to 15<br/>balanced"] -->|"local but smooth"| D["Generalizes well"]
-    E["k = very large<br/>over-smoothed"] -->|"ignores local detail"| F["Underfit<br/>high bias"]
-```
+| Value of `k` | Decision boundary | Result |
+| --- | --- | --- |
+| `k = 1` | Jagged, wraps tightly around individual points | Overfit — high variance |
+| `k = 5` to `15` | Local but smooth | Generalizes well |
+| `k` very large | Over-smoothed, ignores local detail | Underfit — high bias |
 
 Let us watch test accuracy respond to `k`.
 

--- a/content/learn/machine-learning-scikit-learn/logistic-regression.mdx
+++ b/content/learn/machine-learning-scikit-learn/logistic-regression.mdx
@@ -49,18 +49,10 @@ output into the 0-to-1 range** so it reads as a genuine probability.
 
 ## The intuition: linear score, then a squash
 
-Logistic regression works in three steps. Hold this picture in your head and
-the whole algorithm follows.
+Logistic regression works in three steps. Hold this pipeline in your head and
+the whole algorithm follows:
 
-```mermaid
-flowchart LR
-    A["Features<br/>x1, x2, x3, ..."] --> B["Linear score<br/>z = b + w1*x1 + w2*x2 + ..."]
-    B --> C["Sigmoid squash<br/>p = 1 / (1 + e^-z)"]
-    C --> D["Probability p<br/>(between 0 and 1)"]
-    D --> E{"p >= 0.5 ?"}
-    E -. yes .-> F["Predict class 1"]
-    E -. no .-> G["Predict class 0"]
-```
+**Features → linear score `z` → sigmoid squash → probability `p` → threshold at 0.5 → class 1 or class 0**
 
 **Step 1 — a linear score.** Exactly like linear regression, the model
 computes a weighted sum of the features plus a constant:

--- a/content/learn/machine-learning-scikit-learn/regression-classification-clustering.mdx
+++ b/content/learn/machine-learning-scikit-learn/regression-classification-clustering.mdx
@@ -228,27 +228,14 @@ meaning.
 
 ## The three side by side
 
-Here is the whole page in one table-like view. Same library, three different
-shapes of problem and output.
+Here is the whole page in one view. Same library, three different shapes of
+problem and output.
 
-```mermaid
-flowchart LR
-    subgraph RG["Regression"]
-        direction TB
-        r1["Input: features"] --> r2["Output: a NUMBER"]
-        r3["e.g. predict price"]
-    end
-    subgraph CF["Classification"]
-        direction TB
-        c1["Input: features"] --> c2["Output: a CATEGORY"]
-        c3["e.g. spam or not"]
-    end
-    subgraph CL["Clustering"]
-        direction TB
-        l1["Input: features only"] --> l2["Output: DISCOVERED groups"]
-        l3["e.g. customer segments"]
-    end
-```
+| Task | Input | Output | Example |
+| --- | --- | --- | --- |
+| Regression | Features | a NUMBER | predict price |
+| Classification | Features | a CATEGORY | spam or not |
+| Clustering | Features only | DISCOVERED groups | customer segments |
 
 And the code signatures, distilled:
 

--- a/content/learn/machine-learning-scikit-learn/the-bias-variance-tradeoff.mdx
+++ b/content/learn/machine-learning-scikit-learn/the-bias-variance-tradeoff.mdx
@@ -184,12 +184,11 @@ This single idea reframes much of the course:
   while keeping their low bias. That is *why* a forest usually beats a
   single deep tree.
 
-```mermaid
-flowchart TD
-    A["Model too simple"] -->|"high bias, low variance"| U["Underfitting"]
-    B["Model too flexible"] -->|"low bias, high variance"| O["Overfitting"]
-    C["Average many flexible models"] -->|"keeps low bias, cuts variance"| E["Ensembles win"]
-```
+| Model | Bias / variance | Result |
+| --- | --- | --- |
+| Too simple | High bias, low variance | Underfitting |
+| Too flexible | Low bias, high variance | Overfitting |
+| Average many flexible models | Keeps low bias, cuts variance | Ensembles win |
 
 ## More data changes the picture
 

--- a/content/learn/machine-learning-scikit-learn/train-test-split.mdx
+++ b/content/learn/machine-learning-scikit-learn/train-test-split.mdx
@@ -38,7 +38,7 @@ We train on the rest (the **training set**), and only at the very end do we
 unlock the drawer and measure performance on those held-out rows.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Full dataset<br/>(all rows)"] --> B{"random split"}
     B --> C["Training set<br/>(about 70-80%)"]
     B --> D["Test set<br/>(about 20-30%)"]

--- a/content/learn/mastering-dsa-cpp/complexity-analysis.mdx
+++ b/content/learn/mastering-dsa-cpp/complexity-analysis.mdx
@@ -63,16 +63,7 @@ The `sum` function is Θ(n): it must inspect every element, and it does constant
 
 ## Growth rates hierarchy
 
-```mermaid
-flowchart TD
-    A["O(1)"] --> B["O(log n)"]
-    B --> C["O(sqrt n)"]
-    C --> D["O(n)"]
-    D --> E["O(n log n)"]
-    E --> F["O(n^2)"]
-    F --> G["O(2^n)"]
-    G --> H["O(n!)"]
-```
+From slowest- to fastest-growing: **O(1) → O(log n) → O(sqrt n) → O(n) → O(n log n) → O(n^2) → O(2^n) → O(n!)**.
 
 | Complexity | Example |
 | --- | --- |

--- a/content/learn/mastering-dsa-cpp/next-steps.mdx
+++ b/content/learn/mastering-dsa-cpp/next-steps.mdx
@@ -9,16 +9,6 @@ Congratulations. You have traveled from foundations to linear structures, recurs
 You now have the toolkit to read serious algorithmic code, solve interview-style problems, and build systems that depend on efficient data structures. Thank you for learning with this course.
 </Callout>
 
-```mermaid
-flowchart TD
-    A[Foundations] --> B[Linear structures]
-    B --> C[Recursion, search, sort]
-    C --> D[Hashing and trees]
-    D --> E[Graphs]
-    E --> F[DP, greedy, backtracking]
-    F --> G[Advanced topics]
-```
-
 ## Advanced data structures
 
 Explore segment trees, Fenwick trees (BIT), suffix arrays, sparse tables, treaps, and splay trees.

--- a/content/learn/mastering-dsa-cpp/stacks.mdx
+++ b/content/learn/mastering-dsa-cpp/stacks.mdx
@@ -16,14 +16,13 @@ The abstract operations are small:
 | `top()` | Read the top item |
 | `empty()` | Check whether the stack has no items |
 
-```mermaid
-flowchart TD
-    A["push 10"] --> B["top: 10"]
-    B --> C["push 20"]
-    C --> D["top: 20"]
-    D --> E["pop"]
-    E --> F["top: 10"]
-```
+A short trace, where each operation acts on the top:
+
+| Operation | Stack top after |
+| --- | --- |
+| `push(10)` | 10 |
+| `push(20)` | 20 |
+| `pop()` | 10 |
 
 ## `std::stack<T>`
 

--- a/content/learn/mastering-dsa-cpp/trees.mdx
+++ b/content/learn/mastering-dsa-cpp/trees.mdx
@@ -207,12 +207,13 @@ int main() {
 `}
 />
 
-```mermaid
-flowchart LR
-    P["pre-order"] --> PR["root"] --> PL["left"] --> PX["right"]
-    I["in-order"] --> IL["left"] --> IR["root"] --> IX["right"]
-    O["post-order"] --> OL["left"] --> OR["right"] --> OO["root"]
-```
+The three depth-first orders differ only in when the root is visited relative to its subtrees:
+
+| Traversal | Visit order |
+| --- | --- |
+| Pre-order | root → left → right |
+| In-order | left → root → right |
+| Post-order | left → right → root |
 
 ## Level-order traversal
 

--- a/content/learn/mastering-dsa-cpp/tries.mdx
+++ b/content/learn/mastering-dsa-cpp/tries.mdx
@@ -125,10 +125,11 @@ int main() {
 
 Insertion creates missing nodes along the word path, then marks the final node as a complete word.
 
-```mermaid
-flowchart LR
-    A["root"] --> B["read c"] --> C["create/find c"] --> D["read a"] --> E["create/find a"] --> F["mark last node isWord"]
-```
+Starting at the root, for each character:
+
+1. Read the next character.
+2. Create the child node for it if missing, otherwise follow the existing one.
+3. After the last character, mark that node with `isWord`.
 
 <CodeBlock
   adapter="cpp"

--- a/content/learn/mastering-dsa-cpp/why-cpp-for-dsa.mdx
+++ b/content/learn/mastering-dsa-cpp/why-cpp-for-dsa.mdx
@@ -78,13 +78,10 @@ int main() {
 
 Many data structure tradeoffs are really memory-layout tradeoffs. A `std::vector<int>` stores integers contiguously, so walking through it usually benefits from CPU cache locality. A `std::list<int>` stores nodes separately, so traversal follows pointers from one allocation to the next.
 
-```mermaid
-flowchart LR
-    V["std::vector<int>"] --> C["contiguous memory"]
-    C --> F["fast iteration and random access"]
-    L["std::list<int>"] --> N["separate heap nodes"]
-    N --> P["cheap splicing, slower traversal"]
-```
+| Container | Memory layout | Consequence |
+| --- | --- | --- |
+| `std::vector<int>` | Contiguous memory | Fast iteration and random access |
+| `std::list<int>` | Separate heap nodes | Cheap splicing, slower traversal |
 
 That is why a vector can beat a list even when both have O(n) traversal: Big-O describes growth, but cache locality changes the constant factor dramatically.
 

--- a/content/learn/mastering-ggplot2/a-complete-workflow.mdx
+++ b/content/learn/mastering-ggplot2/a-complete-workflow.mdx
@@ -72,13 +72,11 @@ Time to make it presentable.
 
 ## The exploration-to-polish pipeline
 
-```mermaid
-flowchart LR
-    Q["Question"] --> E["Explore<br/>minimal plots, fast"]
-    E --> I["Iterate<br/>add color / facets / stats"]
-    I --> R["Refine<br/>scales, labels, theme"]
-    R --> S["Share<br/>final figure"]
-```
+1. **Question** — what do you want to learn from the data?
+2. **Explore** — minimal plots, fast.
+3. **Iterate** — add color, facets, and stats.
+4. **Refine** — scales, labels, theme.
+5. **Share** — the final figure.
 
 The first three stages are *exploration* — bare and quick. Only now, at
 *refinement*, do we spend effort on scales, labels, and theme.

--- a/content/learn/mastering-ggplot2/aesthetic-mappings.mdx
+++ b/content/learn/mastering-ggplot2/aesthetic-mappings.mdx
@@ -23,29 +23,16 @@ An **aesthetic mapping** is a *correspondence between a data column and
 one of these visual properties*. "Map `displ` to x." "Map `class` to
 color." You declare mappings inside `aes()`.
 
-```mermaid
-flowchart LR
-    subgraph Data columns
-      A["displ"]
-      B["hwy"]
-      C["class"]
-      D["cty"]
-    end
-    subgraph Aesthetics
-      X["x position"]
-      Y["y position"]
-      COL["color"]
-      SZ["size"]
-    end
-    A --> X
-    B --> Y
-    C --> COL
-    D --> SZ
-```
+| Data column | Aesthetic |
+| --- | --- |
+| `displ` | x position |
+| `hwy` | y position |
+| `class` | color |
+| `cty` | size |
 
-That diagram *is* a call to
-`aes(x = displ, y = hwy, color = class, size = cty)`. The arrows are
-the mappings.
+Those four rows *are* a call to
+`aes(x = displ, y = hwy, color = class, size = cty)`. Each row is one
+mapping.
 
 ## Aesthetics are information channels
 

--- a/content/learn/mastering-ggplot2/anatomy-of-a-complete-plot.mdx
+++ b/content/learn/mastering-ggplot2/anatomy-of-a-complete-plot.mdx
@@ -34,18 +34,6 @@ ggplot(mpg, aes(x = displ, y = hwy, color = drv)) +
 Walk down the code and name the **component** each line belongs to.
 This is the skill the whole course has been building:
 
-```mermaid
-flowchart TD
-    A["ggplot(mpg, ...)"] --> A1["DATA: the mpg table"]
-    B["aes(displ, hwy, color = drv)"] --> B1["MAPPINGS: x, y, color channels"]
-    C["geom_point(alpha = 0.7)"] --> C1["GEOMETRY 1: raw points<br/>(alpha SET, not mapped)"]
-    D["geom_smooth(method = lm)"] --> D1["GEOMETRY 2 + STAT: a fitted line per drv"]
-    E["scale_color_brewer(...)"] --> E1["SCALE: the categorical palette"]
-    F["facet_wrap(~ class)"] --> F1["FACETS: one panel per class"]
-    G["labs(...)"] --> G1["LABELS: title, axes, legend"]
-    H["theme_minimal()"] --> H1["THEME: non-data styling"]
-```
-
 | Code | Component | What it contributes |
 | --- | --- | --- |
 | `ggplot(mpg, ...)` | **Data** | The table being shown |

--- a/content/learn/mastering-ggplot2/bars-and-histograms.mdx
+++ b/content/learn/mastering-ggplot2/bars-and-histograms.mdx
@@ -14,12 +14,8 @@ A histogram answers: *how is one continuous variable distributed?* The
 stat slices the range of x into equal **bins** and counts how many
 values land in each.
 
-```mermaid
-flowchart LR
-    X["Continuous hwy<br/>values 12 to 44"] --> BIN["stat_bin<br/>cut into equal bins"]
-    BIN --> CNT["count per bin"]
-    CNT --> BARS["geom_histogram<br/>one bar per bin"]
-```
+**Continuous `hwy` (values 12 to 44) → `stat_bin` cuts the range into
+equal bins → count per bin → `geom_histogram` draws one bar per bin.**
 
 The single most important knob is the **bin width** — it changes the
 story the histogram tells:
@@ -63,12 +59,14 @@ now we must decide *how* the sub-bars share space. That decision is the
 When bars (or their sub-pieces) would occupy the same place, a
 **position** controls the arrangement:
 
-```mermaid
-flowchart TD
-    R["fill = drv on each class bar"] --> S["position = stack<br/>sub-bars piled vertically<br/>(default)"]
-    R --> D["position = dodge<br/>sub-bars side by side"]
-    R --> F["position = fill<br/>stacked to 100 percent<br/>shows proportions"]
-```
+With `fill = drv` on each `class` bar, the position adjustment decides
+how the sub-bars share that space:
+
+| `position =` | Arrangement | Best for |
+| --- | --- | --- |
+| `stack` (default) | Sub-bars piled vertically | Totals, with parts visible |
+| `dodge` | Sub-bars side by side | Comparing groups within a category |
+| `fill` | Stacked to 100 percent | Proportions, ignoring totals |
 
 See all three on the same data:
 

--- a/content/learn/mastering-ggplot2/cartesian-and-beyond.mdx
+++ b/content/learn/mastering-ggplot2/cartesian-and-beyond.mdx
@@ -42,13 +42,9 @@ space** — they change values. Coordinates operate on the **final
 space** — they reshape where already-computed marks land, *after* the
 stats and scales have run.
 
-```mermaid
-flowchart LR
-    DATA["Data"] --> STAT["Stat<br/>(data space)"]
-    STAT --> SCALE["Scale<br/>(data space)"]
-    SCALE --> COORD["Coordinate system<br/>(arranges final space)"]
-    COORD --> DRAW["Rendered marks"]
-```
+The pipeline runs in this order: **Data → Stat → Scale** (all in data
+space) **→ Coordinate system** (arranges the final space) **→ rendered
+marks**.
 
 This ordering is exactly why `coord_cartesian(xlim = ...)` *zooms*
 rather than *filters*: the coordinate step happens last, after the

--- a/content/learn/mastering-ggplot2/choosing-geometries.mdx
+++ b/content/learn/mastering-ggplot2/choosing-geometries.mdx
@@ -12,17 +12,12 @@ vocabulary. The goal is not to memorize a list but to develop a reflex:
 A reliable way to pick a geom is to count and classify the variables
 you want to show:
 
-```mermaid
-flowchart TD
-    Q1["How many variables?<br/>What types?"] --> A["1 continuous"]
-    Q1 --> B["1 categorical"]
-    Q1 --> C["2 continuous"]
-    Q1 --> D["1 categorical + 1 continuous"]
-    A --> A1["geom_histogram<br/>geom_density"]
-    B --> B1["geom_bar"]
-    C --> C1["geom_point<br/>geom_line"]
-    D --> D1["geom_boxplot<br/>geom_col<br/>geom_violin"]
-```
+| Variables | Reach for |
+| --- | --- |
+| 1 continuous | `geom_histogram`, `geom_density` |
+| 1 categorical | `geom_bar` |
+| 2 continuous | `geom_point`, `geom_line` |
+| 1 categorical + 1 continuous | `geom_boxplot`, `geom_col`, `geom_violin` |
 
 This is a starting point, not a law — but it resolves most "which geom
 do I use?" questions.

--- a/content/learn/mastering-ggplot2/color-and-fill-scales.mdx
+++ b/content/learn/mastering-ggplot2/color-and-fill-scales.mdx
@@ -36,13 +36,12 @@ ggplot(mpg, aes(class, fill = drv)) +
 The single biggest fork: is the mapped variable **categorical** or
 **continuous**? It determines the *kind* of color scale entirely.
 
-```mermaid
-flowchart TD
-    Q["What type is the variable<br/>mapped to color?"] --> D["Discrete / categorical"]
-    Q --> C["Continuous / numeric"]
-    D --> DP["Qualitative palette<br/>distinct hues<br/>scale_color_brewer"]
-    C --> CP["Gradient<br/>low-to-high lightness<br/>scale_color_viridis_c"]
-```
+The type of the variable mapped to color decides the kind of scale:
+
+| Variable mapped to color | Scale to use | Example |
+| --- | --- | --- |
+| Discrete / categorical | Qualitative palette (distinct hues) | `scale_color_brewer` |
+| Continuous / numeric | Gradient (low-to-high lightness) | `scale_color_viridis_c` |
 
 ### Discrete: distinct hues for distinct categories
 

--- a/content/learn/mastering-ggplot2/every-geom-has-a-stat.mdx
+++ b/content/learn/mastering-ggplot2/every-geom-has-a-stat.mdx
@@ -34,13 +34,9 @@ height. The geom draws bars; the stat invented the y-values.
 Every layer is really **data → stat → geom**. The stat sits between
 your raw data and the drawn marks:
 
-```mermaid
-flowchart LR
-    D["Raw data<br/>234 rows of mpg"] --> ST["stat_count<br/>group by class, count"]
-    ST --> C["Computed data<br/>7 rows: class + count"]
-    C --> G["geom_bar<br/>draw a bar per row"]
-    G --> P["Bar chart"]
-```
+**Raw data (234 rows of `mpg`) → `stat_count` groups by `class` and
+counts → computed data (7 rows: `class` + `count`) → `geom_bar` draws a
+bar per row → bar chart.**
 
 For a scatter plot the stat is `stat_identity` — it passes the data
 through *unchanged*, which is why `geom_point()` needs you to supply

--- a/content/learn/mastering-ggplot2/index.mdx
+++ b/content/learn/mastering-ggplot2/index.mdx
@@ -40,17 +40,7 @@ scatter plot to a publication figure with faceting, custom scales, and
 a hand-built theme, is assembled from the *same* small set of
 components:
 
-```mermaid
-flowchart LR
-    D["Data"] --> M["Aesthetic<br/>mappings"]
-    M --> G["Geometries"]
-    G --> S["Statistics"]
-    S --> SC["Scales"]
-    SC --> C["Coordinates"]
-    C --> F["Facets"]
-    F --> T["Theme"]
-    T --> P["Rendered<br/>plot"]
-```
+**Data → Aesthetic mappings → Geometries → Statistics → Scales → Coordinates → Facets → Theme → Rendered plot**
 
 Learn the components once, and every chart becomes a *combination* you
 can reason about — including charts you have never seen before.

--- a/content/learn/mastering-ggplot2/layering-multiple-geoms.mdx
+++ b/content/learn/mastering-ggplot2/layering-multiple-geoms.mdx
@@ -31,13 +31,10 @@ them.*
 ## Inheritance: layers borrow from the base by default
 
 A key rule: **layers inherit the data and mappings declared in
-`ggplot()`** unless you override them. This diagram shows the flow:
-
-```mermaid
-flowchart TD
-    G["ggplot(data = mpg,<br/>aes(displ, hwy, color = drv))"] --> P["geom_point()<br/>inherits all three"]
-    G --> S["geom_smooth()<br/>inherits all three<br/>-> one line per drv"]
-```
+`ggplot()`** unless you override them. So from a base of
+`ggplot(data = mpg, aes(displ, hwy, color = drv))`, both `geom_point()`
+and `geom_smooth()` inherit all three — and `geom_smooth()` draws one
+line per `drv`.
 
 So a `color = drv` mapping in `ggplot()` reaches *every* layer:
 

--- a/content/learn/mastering-ggplot2/next-steps.mdx
+++ b/content/learn/mastering-ggplot2/next-steps.mdx
@@ -12,17 +12,7 @@ what you have learned and point you toward where to take it.
 You can decompose **any** visualization into the components of the
 Grammar of Graphics:
 
-```mermaid
-flowchart TD
-    D["Data"] --> M["Aesthetic mappings"]
-    M --> G["Geometries"]
-    G --> S["Statistics"]
-    S --> SC["Scales"]
-    SC --> C["Coordinates"]
-    C --> F["Facets"]
-    F --> T["Theme"]
-    T --> O["A communicative plot"]
-```
+**Data → Aesthetic mappings → Geometries → Statistics → Scales → Coordinates → Facets → Theme → A communicative plot**
 
 And you understand the *ideas* that make those components powerful:
 

--- a/content/learn/mastering-ggplot2/origins-of-the-grammar.mdx
+++ b/content/learn/mastering-ggplot2/origins-of-the-grammar.mdx
@@ -18,15 +18,10 @@ number of sentences, including ones nobody has ever spoken before.
 
 Wilkinson asked: *what if charts worked the same way?*
 
-```mermaid
-flowchart LR
-    subgraph Language
-      W["Words +<br/>grammar rules"] --> SS["Infinite<br/>sentences"]
-    end
-    subgraph Graphics
-      C["Graphical components<br/>+ combination rules"] --> GG["Infinite<br/>charts"]
-    end
-```
+| Domain | A small set of... | Produces... |
+| --- | --- | --- |
+| Language | Words + grammar rules | Infinitely many sentences |
+| Graphics | Graphical components + combination rules | Infinitely many charts |
 
 Instead of a **catalogue** of chart types — "bar chart," "pie chart,"
 "scatter plot," each a separate special case — Wilkinson proposed a

--- a/content/learn/mastering-ggplot2/position-scales.mdx
+++ b/content/learn/mastering-ggplot2/position-scales.mdx
@@ -71,11 +71,8 @@ ggplot(df, aes(size, score)) +
 Same data, same mapping, same geom. Only the **scale's
 transformation** changed — and the chart went from unreadable to clear.
 
-```mermaid
-flowchart LR
-    DATA["Skewed data<br/>1 ... 100000"] --> T["scale_x_log10<br/>transform spacing"]
-    T --> EVEN["Evenly spread axis<br/>equal gaps = 10x steps"]
-```
+**Skewed data (1 ... 100000) → `scale_x_log10` transforms the spacing →
+an evenly spread axis where equal gaps mean 10x steps.**
 
 <Callout type="info" title="Transform the scale, not the data">
 You *could* create a new column `log10(size)` and plot that. But then

--- a/content/learn/mastering-ggplot2/small-multiples-with-facets.mdx
+++ b/content/learn/mastering-ggplot2/small-multiples-with-facets.mdx
@@ -39,11 +39,9 @@ ggplot(mpg, aes(displ, hwy)) +
 `}
 />
 
-```mermaid
-flowchart LR
-    M["One busy panel<br/>7 overlapping groups"] -->|"facet_wrap(~ class)"| G["7 small panels<br/>shared axes<br/>one group each"]
-    G --> C["Differences between panels<br/>= differences in the data"]
-```
+One busy panel with 7 overlapping groups becomes, via
+`facet_wrap(~ class)`, 7 small panels on shared axes — one group each.
+Differences *between* panels are then differences in the *data*.
 
 ## Why shared scales are the secret
 

--- a/content/learn/mastering-ggplot2/smoothers-and-summaries.mdx
+++ b/content/learn/mastering-ggplot2/smoothers-and-summaries.mdx
@@ -44,12 +44,9 @@ ggplot(mpg, aes(displ, hwy)) +
 `}
 />
 
-```mermaid
-flowchart LR
-    D["Raw points<br/>(displ, hwy)"] --> SM["stat_smooth<br/>fit model (lm or loess)"]
-    SM --> CURVE["Fitted values<br/>+ confidence band"]
-    CURVE --> G["geom_smooth<br/>draw line + ribbon"]
-```
+**Raw points `(displ, hwy)` → `stat_smooth` fits a model (`lm` or
+`loess`) → fitted values + a confidence band → `geom_smooth` draws the
+line + ribbon.**
 
 Switching `method` swaps the *statistic's* model while the *geom*
 (line + ribbon) stays the same — yet another instance of separating

--- a/content/learn/mastering-ggplot2/the-birth-of-ggplot2.mdx
+++ b/content/learn/mastering-ggplot2/the-birth-of-ggplot2.mdx
@@ -39,7 +39,7 @@ that makes the grammar pleasant to use day to day:
   so the bookkeeping that base R made you do disappears.
 
 ```mermaid
-flowchart LR
+flowchart TD
     W["Wilkinson<br/>1999<br/>the theory"] --> H["Wickham<br/>2007<br/>the R package"]
     H --> L["Layered syntax<br/>built with +"]
     H --> DF["Smart defaults<br/>stats, scales, legends"]

--- a/content/learn/mastering-ggplot2/the-data-layer.mdx
+++ b/content/learn/mastering-ggplot2/the-data-layer.mdx
@@ -37,11 +37,9 @@ ggplot2 works best with **tidy** data, where:
 This matters because **mappings refer to columns**. If the variable
 you want to put on the x-axis is not a column, you cannot map it.
 
-```mermaid
-flowchart LR
-    W["Wide / messy<br/>year columns: 2019, 2020, 2021"] -->|reshape| T["Tidy / long<br/>columns: year, value"]
-    T --> P["Now 'year' is a column<br/>you can map to x"]
-```
+Reshaping wide, messy data (separate `2019`, `2020`, `2021` columns)
+into tidy, long data (a `year` column and a `value` column) makes `year`
+a column you can map to x.
 
 ### A concrete reshaping example
 

--- a/content/learn/mastering-ggplot2/the-seven-components.mdx
+++ b/content/learn/mastering-ggplot2/the-seven-components.mdx
@@ -8,19 +8,9 @@ slowly. Everything after this is a deep dive into one of these
 components.
 
 The Grammar of Graphics says that **every** chart is assembled from a
-small set of components. ggplot2 organizes them like this:
+small set of components. ggplot2 stacks them in a fixed order:
 
-```mermaid
-flowchart TD
-    D["1 - Data<br/>the table of values"] --> M["2 - Mappings<br/>columns to aesthetics"]
-    M --> G["3 - Geometries<br/>the marks drawn"]
-    G --> S["4 - Statistics<br/>transform before drawing"]
-    S --> SC["5 - Scales<br/>data values to visual values"]
-    SC --> C["6 - Coordinates<br/>the space marks live in"]
-    C --> F["7 - Facets<br/>split into small panels"]
-    F --> T["Theme<br/>non-data styling"]
-    T --> OUT["Rendered plot"]
-```
+**Data → Mappings → Geometries → Statistics → Scales → Coordinates → Facets → Theme → Rendered plot**
 
 Let us meet each one with a single sentence and a concrete example
 using the built-in `mpg` data set (fuel-economy records for 234 cars).

--- a/content/learn/mastering-ggplot2/themes-and-styling.mdx
+++ b/content/learn/mastering-ggplot2/themes-and-styling.mdx
@@ -18,13 +18,7 @@ Every plot is made of two kinds of "ink":
 - **Non-data ink** — axes, gridlines, background, labels, legend
   styling. Controlled by the **theme**.
 
-```mermaid
-flowchart TD
-    P["A ggplot"] --> D["Data ink<br/>points, bars, lines<br/>geoms + scales"]
-    P --> N["Non-data ink<br/>background, grid, fonts,<br/>legend position<br/>THEME"]
-```
-
-The theme owns the entire right branch. You can hand the same data plot
+The theme owns all of the non-data ink. You can hand the same data plot
 to ten different themes and get ten different looks with identical
 meaning.
 

--- a/content/learn/mastering-ggplot2/thinking-in-layers.mdx
+++ b/content/learn/mastering-ggplot2/thinking-in-layers.mdx
@@ -15,12 +15,12 @@ statistic it uses**. When you write `+ geom_point()`, you add a layer.
 When you add `+ geom_smooth()`, you add another. They render in order,
 bottom to top:
 
-```mermaid
-flowchart TD
-    B["Base: ggplot(data, aes)<br/>coordinate space + scales"] --> L1["Layer 1: geom_point<br/>draw the raw points"]
-    L1 --> L2["Layer 2: geom_smooth<br/>draw a trend line on top"]
-    L2 --> R["Final composited plot"]
-```
+They render from the bottom up:
+
+1. **Base** — `ggplot(data, aes)` sets up the coordinate space + scales.
+2. **Layer 1** — `geom_point` draws the raw points.
+3. **Layer 2** — `geom_smooth` draws a trend line on top.
+4. The **final composited plot**.
 
 The base `ggplot()` call sets up the shared space; each `+ geom_*()`
 paints a transparent sheet over it.

--- a/content/learn/mastering-ggplot2/what-is-a-geom.mdx
+++ b/content/learn/mastering-ggplot2/what-is-a-geom.mdx
@@ -15,13 +15,13 @@ variables relate to what visual channels*. The geom decides *how those
 relationships are drawn*. Swap the geom and you get a different chart
 **from the same description**.
 
-```mermaid
-flowchart TD
-    DM["Same data + mappings<br/>aes(x = displ, y = hwy)"] --> P["geom_point<br/>scatter"]
-    DM --> L["geom_line<br/>connected line"]
-    DM --> B["geom_bin2d<br/>2-D density"]
-    DM --> S["geom_smooth<br/>trend + band"]
-```
+From the *same* data and mappings — `aes(x = displ, y = hwy)` — each
+geom draws a different chart:
+
+- `geom_point` — a scatter plot.
+- `geom_line` — a connected line.
+- `geom_bin2d` — a 2-D density.
+- `geom_smooth` — a trend line + band.
 
 Watch the geom change while everything else stays fixed:
 

--- a/content/learn/mastering-ggplot2/your-first-ggplot.mdx
+++ b/content/learn/mastering-ggplot2/your-first-ggplot.mdx
@@ -9,15 +9,7 @@ any basic ggplot as an English sentence.
 
 ## The skeleton
 
-Almost every ggplot follows the same shape:
-
-```mermaid
-flowchart LR
-    A["ggplot(data, aes(...))"] --> B["+ geom_something()"]
-    B --> C["+ optional<br/>scales / facets /<br/>theme"]
-```
-
-Three pieces:
+Almost every ggplot follows the same shape — three pieces:
 
 1. `ggplot(data, aes(...))` — name the **data** and the **mappings**.
 2. `+ geom_*()` — add at least one **geometry**.

--- a/content/learn/natural-language-processing-python/bag-of-words.mdx
+++ b/content/learn/natural-language-processing-python/bag-of-words.mdx
@@ -20,14 +20,12 @@ just a vector of numbers, which is exactly what an algorithm can work with.
 Bag-of-words turns a whole collection of documents into a table of numbers in
 a fixed sequence of steps.
 
-```mermaid
-flowchart TB
-    D["Documents<br/>doc1, doc2, doc3"] --> P["Tokenize + clean<br/>each document"]
-    P --> V["Build the vocabulary<br/>(all distinct words across the corpus)"]
-    V --> M["Count each vocabulary word<br/>in each document"]
-    M --> X["Document-term matrix<br/>rows = documents, columns = words, cells = counts"]
-    X --> C["Feed the matrix to a classifier"]
-```
+1. **Documents** come in (`doc1`, `doc2`, `doc3`).
+2. **Tokenize and clean** each document.
+3. **Build the vocabulary** — all distinct words across the corpus.
+4. **Count** each vocabulary word in each document.
+5. **Document-term matrix** — rows = documents, columns = words, cells = counts.
+6. **Feed the matrix** to a classifier.
 
 The output is a **document-term matrix**: one row per document, one column per
 vocabulary word, and each cell holding how many times that word appeared in

--- a/content/learn/natural-language-processing-python/choosing-your-pipeline.mdx
+++ b/content/learn/natural-language-processing-python/choosing-your-pipeline.mdx
@@ -20,16 +20,15 @@ step does to your data and matching it to what your task needs.
 Picture the steps as a menu of optional transformations. Only tokenization is
 nearly mandatory; everything after it is a decision.
 
-```mermaid
-flowchart TD
-    T["Tokenize<br/>(almost always)"] --> C1{"Lowercase?"}
-    C1 --> C2{"Remove stopwords?"}
-    C2 --> C3{"Stem or lemmatize?"}
-    C3 --> C4{"Add n-grams?"}
-    C4 --> A["Analysis"]
-```
+You almost always **tokenize** first. After that, every step is a question
+with no default answer:
 
-Each diamond is a question with no default answer. To answer it, apply a
+- Lowercase?
+- Remove stopwords?
+- Stem or lemmatize?
+- Add n-grams?
+
+Answer all four and you arrive at **analysis**. To answer each one, apply a
 single guiding principle.
 
 <Callout type="info" title="The one question to ask at every step">

--- a/content/learn/natural-language-processing-python/next-steps.mdx
+++ b/content/learn/natural-language-processing-python/next-steps.mdx
@@ -11,20 +11,12 @@ understanding, and it is the part of NLP that does not go out of date.
 
 ## What you can now do
 
-Look back at the journey. Each stage is something you can now reason about, not
-just run.
+Look back at the journey — the whole pipeline in one line:
 
-```mermaid
-flowchart LR
-    A["Raw text"] --> B["Tokenize<br/>(words, sentences)"]
-    B --> C["Normalize<br/>(case, punctuation)"]
-    C --> D["Filter / reduce<br/>(stopwords, stem, lemmatize)"]
-    D --> E["Analyze<br/>(frequencies, POS, n-grams)"]
-    E --> F["Features<br/>(bag-of-words)"]
-    F --> G["Decision<br/>(classify)"]
-```
+**Raw text → Tokenize → Normalize → Filter / reduce → Analyze → Features → Decision**
 
-Concretely, you can now:
+Each stage is something you can now reason about, not just run. Concretely, you
+can now:
 
 - Explain **why** raw text is hard — ambiguity and missing structure — and what
   a pipeline is for.

--- a/content/learn/natural-language-processing-python/the-nlp-pipeline.mdx
+++ b/content/learn/natural-language-processing-python/the-nlp-pipeline.mdx
@@ -14,20 +14,20 @@ once, because the shape will repeat on nearly every page that follows.
 Here is the canonical flow. Almost every classic NLP project is some subset
 of these steps, in roughly this order.
 
-```mermaid
-flowchart TD
-    A["Raw text<br/>(a string)"] --> B["Sentence tokenization<br/>split into sentences (optional)"]
-    B --> C["Word tokenization<br/>split into words and punctuation"]
-    C --> D["Case folding<br/>lowercase the tokens"]
-    D --> E["Cleaning<br/>drop punctuation and non-words"]
-    E --> F["Stopword removal<br/>drop ultra-common words (optional)"]
-    F --> G["Stemming or lemmatization<br/>reduce words to a root (optional)"]
-    G --> H["Analysis<br/>counts, n-grams, POS tags, features"]
-```
+| # | Step | What it does |
+| - | ---- | ------------ |
+| 1 | Raw text | A single string comes in. |
+| 2 | Sentence tokenization | Split into sentences (optional). |
+| 3 | Word tokenization | Split into words and punctuation. |
+| 4 | Case folding | Lowercase the tokens. |
+| 5 | Cleaning | Drop punctuation and non-words. |
+| 6 | Stopword removal | Drop ultra-common words (optional). |
+| 7 | Stemming or lemmatization | Reduce words to a root (optional). |
+| 8 | Analysis | Counts, n-grams, POS tags, features. |
 
 Read it top to bottom. Raw text comes in; a clean, normalized list of units
 comes out, ready to be counted or fed into a model. Three things about this
-picture matter more than the picture itself.
+sequence matter more than the steps themselves.
 
 **First, it is a pipeline of transformations.** At each step you are holding
 a value — first a string, then a list of tokens — and you apply one
@@ -61,7 +61,7 @@ transformations to apply.
 Let us make "a pipeline is a sequence of list transformations" concrete. The
 block below runs the standard steps and prints the list after each one, so
 you can watch it shrink and change. Read each printed line against the
-diagram above.
+table above.
 
 <CodeBlock
   adapter="python"
@@ -122,7 +122,7 @@ print("5. lemmatized:", tokens)
 `}
 />
 
-Each `print` is one row of the pipeline diagram. The list started as nine
+Each `print` is one row of the pipeline table. The list started as nine
 tokens including punctuation and shrank to a handful of meaningful roots. Try
 commenting out step 4 (stopword removal) and re-running — notice how much
 longer the final list becomes, and ask yourself whether those extra words
@@ -140,21 +140,18 @@ The stopword list is all lowercase, so comparing un-lowercased tokens like
 
 It helps to mentally split the pipeline into two halves.
 
-```mermaid
-flowchart LR
-    subgraph PRE["Preprocessing (cleaning)"]
-        direction TB
-        p1["Tokenize"] --> p2["Normalize"] --> p3["Filter / reduce"]
-    end
-    subgraph ANA["Analysis (extracting value)"]
-        direction TB
-        a1["Count frequencies"]
-        a2["Tag parts of speech"]
-        a3["Build n-grams"]
-        a4["Make features"]
-    end
-    PRE --> ANA
-```
+**Preprocessing (cleaning)** — a fixed sequence:
+
+1. Tokenize
+2. Normalize
+3. Filter / reduce
+
+**Analysis (extracting value)** — pick what your goal needs:
+
+- Count frequencies
+- Tag parts of speech
+- Build n-grams
+- Make features
 
 The **preprocessing** half turns raw text into clean, comparable units. It is
 mostly mechanical and mostly the same from project to project. The

--- a/content/learn/natural-language-processing-python/what-is-nlp.mdx
+++ b/content/learn/natural-language-processing-python/what-is-nlp.mdx
@@ -234,18 +234,11 @@ behind modern assistants) infer their behavior from large quantities of
 example text instead of hand-written rules. They are powerful but opaque, and
 they assume you already understand the structure of text.
 
-```mermaid
-flowchart TD
-    subgraph RB["Rule-based / classic NLP (this course)"]
-        direction LR
-        r1["Human-written rules<br/>and word lists"] --> r2["Transparent result"]
-    end
-    subgraph LB["Learning-based NLP (later study)"]
-        direction LR
-        l1["Lots of example text"] --> l2["Trained model"]
-    end
-    RB -.-> LB
-```
+|                 | Rule-based / classic NLP (this course)   | Learning-based NLP (later study)        |
+| --------------- | ---------------------------------------- | --------------------------------------- |
+| **Built from**  | Human-written rules and word lists       | Lots of labeled example text            |
+| **Produces**    | A transparent, inspectable result        | A trained model                         |
+| **You get**     | Read exactly why it did what it did       | Power, at the cost of opacity           |
 
 We focus on classic, rule-based and count-based NLP because it is where the
 durable intuition lives. Once you understand *why* text needs tokenizing,

--- a/content/learn/oop-blueprint-java/enums.mdx
+++ b/content/learn/oop-blueprint-java/enums.mdx
@@ -16,12 +16,11 @@ in Java to use.
 
 ## The problem enums solve
 
-```mermaid
-flowchart LR
-    A["Using a String<br/>'red' / 'amber' / 'green'<br/>(or 'Red' or 'RED' or 'gren'!)"] -->|risk| B["Typos<br/>Invalid values<br/>No autocomplete"]
-    C["Using an int<br/>0 / 1 / 2"] -->|risk| D["Magic numbers<br/>No meaning<br/>Out-of-range values"]
-    E["Using an enum<br/>RED, AMBER, GREEN"] -->|wins| F["Type-safe<br/>Self-documenting<br/>Exhaustive"]
-```
+| Representation | What you get |
+| --- | --- |
+| A `String` — `"red"` / `"amber"` / `"green"` (or `"Red"`, `"RED"`, `"gren"`!) | Typos, invalid values, no autocomplete |
+| An `int` — `0` / `1` / `2` | Magic numbers, no meaning, out-of-range values |
+| An `enum` — `RED`, `AMBER`, `GREEN` | Type-safe, self-documenting, exhaustive |
 
 <CodeBlock
   adapter="java"
@@ -203,13 +202,14 @@ alternative to a giant `switch` over a `String` operator.
 | `name()` | Returns the constant's name as a `String` |
 | `ordinal()` | Returns the constant's position (0-based) — useful, but use sparingly |
 
-```mermaid
-flowchart LR
-    A["Light.values()"] --> B[["[RED, AMBER, GREEN]"]]
-    C["Light.valueOf('AMBER')"] --> D["AMBER"]
-    E["Light.RED.name()"] --> F["'RED'"]
-    G["Light.GREEN.ordinal()"] --> H["2"]
-```
+Concretely, for the `Light` enum:
+
+| Call | Result |
+| --- | --- |
+| `Light.values()` | `[RED, AMBER, GREEN]` |
+| `Light.valueOf("AMBER")` | `AMBER` |
+| `Light.RED.name()` | `"RED"` |
+| `Light.GREEN.ordinal()` | `2` |
 
 ## A small modeling example: payment methods
 

--- a/content/learn/practical-r-for-beginners/data-frames.mdx
+++ b/content/learn/practical-r-for-beginners/data-frames.mdx
@@ -33,17 +33,15 @@ When you `print` a data frame in WebR, you get a real rendered
 HTML table. Each column has its own type — `name` and `dept` are
 character, `salary` is numeric, `remote` is logical.
 
-```mermaid
-flowchart TB
-  subgraph DF["data frame: employees"]
-    direction LR
-    c1["name (chr): Ada, Ben, Cleo, Drew"]
-    c2["dept (chr): Eng, Sales, Eng, HR"]
-    c3["salary (num): 95000, 72000, 110000, 65000"]
-    c4["remote (lgl): T, F, T, T"]
-  end
-  style DF fill:#dcfce7
-```
+Each column is a vector, and the data frame stacks them
+side-by-side:
+
+| Column   | Type        | Values                       |
+| -------- | ----------- | ---------------------------- |
+| `name`   | chr         | Ada, Ben, Cleo, Drew         |
+| `dept`   | chr         | Eng, Sales, Eng, HR          |
+| `salary` | num         | 95000, 72000, 110000, 65000  |
+| `remote` | lgl         | T, F, T, T                   |
 
 The columns are vectors. The table just *displays* them
 side-by-side.

--- a/content/learn/practical-r-for-beginners/dplyr-verbs.mdx
+++ b/content/learn/practical-r-for-beginners/dplyr-verbs.mdx
@@ -45,18 +45,14 @@ Plus one helper: `group_by()`, which makes `summarise()`,
 `mutate()`, and friends operate **per group**. We'll meet that
 properly on the next page.
 
-```mermaid
-flowchart TD
-  raw["data frame"] -->|filter| rows["fewer rows"]
-  rows -->|select| cols["fewer/different columns"]
-  cols -->|mutate| derived["new columns added"]
-  derived -->|arrange| sorted["rows reordered"]
-  sorted -->|summarise| out["summary row(s)"]
-  style out fill:#bfdbfe
-```
+Each verb reshapes the data frame a little:
+**`filter` (fewer rows) → `select` (fewer columns) → `mutate`
+(new columns) → `arrange` (rows reordered) → `summarise`
+(summary rows)**.
 
-You almost never use all five at once. But every dplyr pipeline
-is some composition of these.
+You almost never use all five at once, and they don't have to
+run in that order. But every dplyr pipeline is some composition
+of these.
 
 ## The pipe: `|>`
 

--- a/content/learn/practical-r-for-beginners/from-s-to-r.mdx
+++ b/content/learn/practical-r-for-beginners/from-s-to-r.mdx
@@ -89,19 +89,16 @@ statisticians, and adopted in the statistics curriculum at one
 university after another through the 2000s. New PhDs entered
 industry already fluent in R, and brought it with them.
 
-```mermaid
-flowchart LR
-  Core[R Core: the language] --> CRAN[CRAN: package archive]
-  CRAN --> A[ggplot2: plotting]
-  CRAN --> B[dplyr: data wrangling]
-  CRAN --> C[caret: machine learning]
-  CRAN --> D[shiny: web apps]
-  CRAN --> E[lme4: mixed models]
-  CRAN --> F[Bioconductor: genomics]
-  CRAN --> G[...thousands more]
-  style Core fill:#a7f3d0,stroke:#047857
-  style CRAN fill:#bfdbfe,stroke:#1d4ed8
-```
+On top of **R Core** (the language itself) sits **CRAN**, and on
+top of CRAN sits everything else:
+
+- `ggplot2` — plotting
+- `dplyr` — data wrangling
+- `caret` — machine learning
+- `shiny` — web apps
+- `lme4` — mixed models
+- `Bioconductor` — genomics
+- ...thousands more
 
 By 2010, CRAN had over 2,000 packages. By 2020, over 16,000. Today
 there are more than 20,000. Whatever obscure statistical method you

--- a/content/learn/practical-r-for-beginners/index.mdx
+++ b/content/learn/practical-r-for-beginners/index.mdx
@@ -43,26 +43,10 @@ analyst actually asks: *What does this dataset look like? Are these
 two groups really different? Is this number more interesting than
 random chance?*
 
-```mermaid
-flowchart TD
-  A[The Story]:::story --> B[Computational Thinking]:::think
-  B --> C[Vectors]:::vec
-  C --> D[Tabular Data]:::tab
-  D --> E[Transformation]:::trans
-  E --> F[Exploration]:::eda
-  F --> G[Visualization]:::vis
-  G --> H[Statistical Reasoning]:::stat
-  H --> I[Mini Project]:::final
-  classDef story fill:#fde68a,stroke:#92400e,color:#7c2d12
-  classDef think fill:#bfdbfe,stroke:#1d4ed8,color:#1e3a8a
-  classDef vec fill:#bbf7d0,stroke:#15803d,color:#14532d
-  classDef tab fill:#fbcfe8,stroke:#be185d,color:#831843
-  classDef trans fill:#e9d5ff,stroke:#7c3aed,color:#581c87
-  classDef eda fill:#fed7aa,stroke:#c2410c,color:#7c2d12
-  classDef vis fill:#fecaca,stroke:#b91c1c,color:#7f1d1d
-  classDef stat fill:#a7f3d0,stroke:#047857,color:#064e3b
-  classDef final fill:#c7d2fe,stroke:#4338ca,color:#312e81
-```
+From there the path is steady: the story, then computational
+thinking, then vectors, tabular data, transformation, exploration,
+visualization, and statistical reasoning — closing with a mini
+project that ties every piece together.
 
 ## What you will be able to do
 

--- a/content/learn/practical-r-for-beginners/inspecting-a-dataset.mdx
+++ b/content/learn/practical-r-for-beginners/inspecting-a-dataset.mdx
@@ -17,21 +17,18 @@ This page is the ritual. Memorize it.
 
 ## The five-minute ritual
 
-```mermaid
-flowchart TB
-  s["Dataset arrives"]
-  s --> shape["1. Shape: dim(), nrow(), ncol()"]
-  shape --> peek["2. Peek: head(), tail()"]
-  peek --> types["3. Types & structure: str()"]
-  types --> stats["4. Summaries: summary()"]
-  stats --> missing["5. Missingness: colSums(is.na(...))"]
-  missing --> ready["Ready to start asking real questions"]
-  style ready fill:#dcfce7
-```
+The moment a dataset arrives, run these five steps before anything
+else:
 
-Each step takes seconds and gives you orientation. Skip any of
-them and you risk asking a meaningless question of a misunderstood
-dataset.
+1. **Shape** — `dim()`, `nrow()`, `ncol()`.
+2. **Peek** — `head()`, `tail()`.
+3. **Types and structure** — `str()`.
+4. **Summaries** — `summary()`.
+5. **Missingness** — `colSums(is.na(...))`.
+
+Only then are you ready to start asking real questions. Each step
+takes seconds and gives you orientation. Skip any of them and you
+risk asking a meaningless question of a misunderstood dataset.
 
 We'll use `airquality` — a built-in dataset of daily air quality
 measurements in New York, May–September 1973 — as our example.

--- a/content/learn/practical-r-for-beginners/interpreting-plots.mdx
+++ b/content/learn/practical-r-for-beginners/interpreting-plots.mdx
@@ -89,16 +89,13 @@ A chart is a *projection* — a few dimensions of a higher-dimensional
 truth. The skilled reader always asks what *other* dimensions
 might explain the picture.
 
-```mermaid
-flowchart TB
-  chart["You see a chart"]
-  chart --> a["Read the axes and legend"]
-  a --> b["Identify the encoding"]
-  b --> c["See the shape (direction, strength, outliers)"]
-  c --> d["Ask: what's NOT shown that could explain this?"]
-  d --> e["Form an interpretation — *with appropriate uncertainty*"]
-  style e fill:#dcfce7
-```
+So whenever you see a chart, work through it in order:
+
+1. Read the axes and legend.
+2. Identify the encoding.
+3. See the shape — direction, strength, outliers.
+4. Ask what's *not* shown that could explain this.
+5. Form an interpretation, *with appropriate uncertainty*.
 
 ## Anscombe revisited: four shapes, one summary
 

--- a/content/learn/practical-r-for-beginners/mini-project-walkthrough.mdx
+++ b/content/learn/practical-r-for-beginners/mini-project-walkthrough.mdx
@@ -40,16 +40,8 @@ What we learn:
 - `Month` is numeric (5 through 9) but conceptually categorical.
 - `Temp` is in degrees Fahrenheit.
 
-```mermaid
-flowchart TD
-  load["Load airquality"] --> insp["Inspect: dim, head, str, summary"]
-  insp --> tidy["Tidy: NAs, types, factor for Month"]
-  tidy --> trans["Transform: add °C, monthly summaries"]
-  trans --> viz["Visualize: scatter, box, line"]
-  viz --> interp["Interpret"]
-  style load fill:#dcfce7
-  style interp fill:#bfdbfe
-```
+The rest of the walkthrough follows the standard arc:
+**Load → Inspect → Tidy → Transform → Visualize → Interpret.**
 
 ## Step 2 — Tidy: handle NAs and fix types
 

--- a/content/learn/practical-r-for-beginners/next-steps.mdx
+++ b/content/learn/practical-r-for-beginners/next-steps.mdx
@@ -20,17 +20,17 @@ to explore next, organized by goal.
 
 ## Map of where to go next
 
-```mermaid
-flowchart TB
-  here["You are here:\\nFoundations of analysis in R"]
-  here --> tidy["Go deeper on tidyverse"]
-  here --> stats["Go deeper on statistics + modeling"]
-  here --> viz["Go deeper on visualization"]
-  here --> reports["Communicate: R Markdown / Quarto"]
-  here --> tools["Workflow tools: git, renv, testing"]
-  here --> domains["Domain skills: ML, time series, geospatial, text"]
-  style here fill:#dcfce7
-```
+You're standing on solid foundations of analysis in R. From here,
+each direction below is a goal you can pursue independently:
+
+- Go deeper on the **tidyverse**.
+- Go deeper on **statistics and modeling**.
+- Go deeper on **visualization**.
+- **Communicate** your work with R Markdown / Quarto.
+- Adopt **workflow tools**: git, renv, testing.
+- Build **domain skills**: ML, time series, geospatial, text.
+
+The rest of this page expands on each.
 
 ## 1. Master the tidyverse
 

--- a/content/learn/practical-r-for-beginners/principles-of-visualization.mdx
+++ b/content/learn/practical-r-for-beginners/principles-of-visualization.mdx
@@ -143,16 +143,15 @@ will absorb none of them. If you have two things to say, make
 two charts. The eye is a serial reader; charts are best when
 they are crisp and singular.
 
-```mermaid
-flowchart TB
-  goal{"What is the one thing you want the reader to take away?"}
-  goal --> single["A single, clear takeaway"]
-  single --> encode["Encode that takeaway in *position* if you can"]
-  encode --> declutter["Remove every drop of non-data ink"]
-  declutter --> label["Title and axis labels that name the takeaway"]
-  label --> done["A chart that doesn't need explaining"]
-  style done fill:#dcfce7
-```
+Start from a single question — *what is the one thing you want the
+reader to take away?* — and let it drive every decision:
+
+1. Settle on a single, clear takeaway.
+2. Encode that takeaway in *position* if you can.
+3. Remove every drop of non-data ink.
+4. Write a title and axis labels that name the takeaway.
+
+The result is a chart that doesn't need explaining.
 
 A bad chart and a good chart, same data — look at them and pick
 the one you'd put in a report.

--- a/content/learn/practical-r-for-beginners/sampling-and-distributions.mdx
+++ b/content/learn/practical-r-for-beginners/sampling-and-distributions.mdx
@@ -81,18 +81,11 @@ Big sample sizes shrink **variability** but not **bias**. A
 biased survey of 10 million people is still biased. This is why
 *how* you sample matters as much as *how much* you sample.
 
-```mermaid
-flowchart TB
-  subgraph good["Unbiased + low variance ✅"]
-    g[Estimates cluster near truth]
-  end
-  subgraph biased["Biased ❌"]
-    b[Estimates cluster — but not near truth]
-  end
-  subgraph noisy["Unbiased + high variance"]
-    n[Estimates centered on truth, but scattered]
-  end
-```
+| Sampling method | Where the estimates land |
+| --- | --- |
+| Unbiased + low variance ✅ | Cluster near the truth |
+| Biased ❌ | Cluster tightly — but not near the truth |
+| Unbiased + high variance | Centered on the truth, but scattered |
 
 ## The sampling distribution of the mean
 

--- a/content/learn/practical-r-for-beginners/scripts-and-projects.mdx
+++ b/content/learn/practical-r-for-beginners/scripts-and-projects.mdx
@@ -15,15 +15,16 @@ ways anyone (including future-you) can re-run.
 
 ## A minimal project layout
 
-```mermaid
-flowchart TB
-  root["my-analysis/"] --> data["data/raw — original files, never edited"]
-  root --> processed["data/processed — cleaned outputs"]
-  root --> R["R/ — your scripts"]
-  root --> out["output/ — plots, reports, summaries"]
-  root --> readme["README.md — what this project does"]
-  root --> renv["renv.lock or DESCRIPTION — package versions (optional)"]
-```
+A project folder collects a handful of well-defined parts:
+
+| Path | What it holds |
+| --- | --- |
+| `data/raw/` | Original files, never edited |
+| `data/processed/` | Cleaned outputs |
+| `R/` | Your scripts |
+| `output/` | Plots, reports, summaries |
+| `README.md` | What this project does |
+| `renv.lock` or `DESCRIPTION` | Package versions (optional) |
 
 A common starter layout:
 

--- a/content/learn/practical-r-for-beginners/statistics-before-computers.mdx
+++ b/content/learn/practical-r-for-beginners/statistics-before-computers.mdx
@@ -123,18 +123,19 @@ mathematicians doing arithmetic in parallel. NASA's early space
 programs ran this way well into the 1960s, as immortalized in the
 book and film *Hidden Figures*.
 
-```mermaid
-flowchart TD
-  A[Question] --> B[Design experiment]
-  B --> C[Collect data on paper forms]
-  C --> D[Transcribe into worksheet]
-  D --> E[Hand-compute statistics]
-  E --> F[Look up p-values in printed tables]
-  F --> G[Write up results]
-```
+A typical study ran top to bottom through these stages:
+
+1. Pose the question.
+2. Design the experiment.
+3. Collect data on paper forms.
+4. Transcribe it into a worksheet.
+5. Hand-compute the statistics.
+6. Look up p-values in printed tables.
+7. Write up the results.
 
 That whole pipeline — every step — was manual. If you found a
-transcription error at step E, you might have to redo hours of work.
+transcription error partway through, you might have to redo hours
+of work.
 
 ## A taste of "manual statistics" in R
 

--- a/content/learn/practical-r-for-beginners/thinking-in-data.mdx
+++ b/content/learn/practical-r-for-beginners/thinking-in-data.mdx
@@ -173,7 +173,7 @@ This is the "many in, one out" direction — the basic gesture of
 statistics.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph P1["Pattern 1: Map"]
     C1[collection] --> Op1[operation] --> R1[collection]
   end

--- a/content/learn/practical-r-for-beginners/tidy-data-principles.mdx
+++ b/content/learn/practical-r-for-beginners/tidy-data-principles.mdx
@@ -80,16 +80,17 @@ is messy:
 
 Almost any real-world messiness fits one of these.
 
-```mermaid
-flowchart TD
-  raw["Raw / messy data"] -->|"pivot_longer / pivot_wider"| reshape["Reshape"]
-  reshape -->|"separate / unite"| split["Split combined columns"]
-  split -->|"join / split into multiple tables"| sep["Separate observational units"]
-  sep --> tidy["Tidy data"]
-  tidy -->|"ggplot, dplyr, models"| insight["Insight"]
-  style tidy fill:#dcfce7
-  style insight fill:#bfdbfe
-```
+Getting from raw data to tidy data is a sequence of small moves,
+each with its own tool:
+
+| Move | Tool |
+| --- | --- |
+| Reshape between wide and long | `pivot_longer` / `pivot_wider` |
+| Split combined columns | `separate` / `unite` |
+| Separate observational units | `join` / split into multiple tables |
+
+Once the data is tidy, it flows straight into analysis — `ggplot`,
+`dplyr`, and models — and from there into insight.
 
 We'll meet the actual reshaping tools (`pivot_longer`,
 `pivot_wider`) on the "Reshaping Data" page later. For now, the

--- a/content/learn/practical-r-for-beginners/variables-and-assignment.mdx
+++ b/content/learn/practical-r-for-beginners/variables-and-assignment.mdx
@@ -176,7 +176,7 @@ When you later write `x + 1`, R:
 3. Evaluates the expression on that vector.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Workspace
     n1[x] -.points to.-> v1["vector (1, 2, 3)"]
     n2[y] -.points to.-> v2["string 'hello'"]

--- a/content/learn/practical-r-for-beginners/why-r-matters-today.mdx
+++ b/content/learn/practical-r-for-beginners/why-r-matters-today.mdx
@@ -102,24 +102,17 @@ things to millions of users, R is rarely the right pick.
 
 ## A snapshot of who uses R
 
-```mermaid
-flowchart LR
-  R[R]:::r --> A[Academic statistics]:::aca
-  R --> B[Biomedical & pharma research]:::aca
-  R --> C[Genomics & bioinformatics]:::aca
-  R --> D[Government statistical agencies]:::gov
-  R --> E[Central banks & economic policy]:::gov
-  R --> F[Data journalism]:::media
-  R --> G[Sports analytics]:::biz
-  R --> H[Marketing analytics]:::biz
-  R --> I[Insurance & actuarial science]:::biz
-  R --> J[Environmental science & climate]:::aca
-  classDef r fill:#a7f3d0,stroke:#047857
-  classDef aca fill:#bfdbfe,stroke:#1d4ed8
-  classDef gov fill:#fde68a,stroke:#92400e
-  classDef media fill:#fbcfe8,stroke:#be185d
-  classDef biz fill:#e9d5ff,stroke:#7c3aed
-```
+R turns up across a wide range of fields, which group roughly into
+four worlds:
+
+- **Academia and research** — academic statistics, biomedical and
+  pharma research, genomics and bioinformatics, environmental
+  science and climate.
+- **Government** — national statistical agencies, central banks and
+  economic policy.
+- **Media** — data journalism.
+- **Business** — sports analytics, marketing analytics, insurance
+  and actuarial science.
 
 - The **US Bureau of Labor Statistics**, **Statistics Canada**, the
   **UK Office for National Statistics**, and dozens of other

--- a/content/learn/python-basics/inheritance.mdx
+++ b/content/learn/python-basics/inheritance.mdx
@@ -111,15 +111,13 @@ print(Dog("Rex", "Labrador").describe())
 
 Without `super().__init__(name)`, `self.name` would never be set. `super()` lets you **reuse** the parent's initialization logic.
 
-```mermaid
-flowchart TD
-    A["Dog('Rex', 'Labrador')"] --> B["Dog.__init__ runs"]
-    B --> C["super().__init__('Rex')"]
-    C --> D["Animal.__init__ sets self.name"]
-    D --> E["Dog.__init__ sets self.breed"]
-    E --> F["Return initialized Dog instance"]
-    style C fill:#e1f5ff
-```
+When you write `Dog("Rex", "Labrador")`, initialization runs in order:
+
+1. `Dog.__init__` runs.
+2. **`super().__init__("Rex")`** hands off to the parent.
+3. `Animal.__init__` sets `self.name`.
+4. Control returns to `Dog.__init__`, which sets `self.breed`.
+5. The fully initialized `Dog` instance is returned.
 
 <Callout type="info" title="super() in multiple inheritance">
 In single inheritance, \`super()\` just calls the parent. In multiple inheritance, \`super()\` follows the **Method Resolution Order (MRO)**, which is computed by the C3 linearization algorithm. This ensures every class is called exactly once in a consistent order. See the MRO section below.

--- a/content/learn/scientific-computing-python/approximation-and-error.mdx
+++ b/content/learn/scientific-computing-python/approximation-and-error.mdx
@@ -134,13 +134,12 @@ A first-order method needs $10^6$ steps to gain $6$ digits of
 accuracy. A fourth-order method needs only $30$. **Order beats
 constants** for any problem accurate enough to matter.
 
-```mermaid
-graph LR
-    O1[Order 1<br/>error halves per step] --> H1[~50 steps<br/>per 15 digits]
-    O2[Order 2<br/>error /4 per step] --> H2[~25 steps]
-    O4[Order 4<br/>error /16 per step] --> H4[~13 steps]
-    O8[Order 8<br/>error /256 per step] --> H8[~6 steps]
-```
+| Method order | Error per step | Steps for ~15 digits |
+| --- | --- | --- |
+| 1 | halves | ~50 |
+| 2 | $\div 4$ | ~25 |
+| 4 | $\div 16$ | ~13 |
+| 8 | $\div 256$ | ~6 |
 
 This is why SciPy's `solve_ivp` defaults to `RK45` (a 4th–5th order
 Runge–Kutta pair) rather than to plain Euler.

--- a/content/learn/scientific-computing-python/limits-of-manual-calculation.mdx
+++ b/content/learn/scientific-computing-python/limits-of-manual-calculation.mdx
@@ -31,14 +31,9 @@ manage a few thousand arithmetic operations. Predicting Jupiter for
 a century needs **billions**. The arithmetic is not hard. The volume
 is impossible.
 
-```mermaid
-flowchart TD
-    A[Newton's laws] --> B[Three-body problem]
-    B --> C{Closed-form<br/>solution?}
-    C -->|No| D[Iterative<br/>integration]
-    D --> E[Billions of<br/>tiny steps]
-    E --> F[Beyond a<br/>human's lifetime]
-```
+**Newton's laws → three-body problem → no closed-form solution →
+iterative integration → billions of tiny steps → beyond a human's
+lifetime.**
 
 Let us simulate, in Python, exactly how fast the work piles up.
 

--- a/content/learn/scientific-computing-python/linear-algebra-essentials.mdx
+++ b/content/learn/scientific-computing-python/linear-algebra-essentials.mdx
@@ -18,13 +18,12 @@ eigenvalue by hand.
 
 ## The four problem types
 
-```mermaid
-flowchart LR
-    Q1["Solve A x = b"] --> S1[Linear system]
-    Q2["Find min ||Ax - b||"] --> S2[Least squares]
-    Q3["Find A v = λ v"] --> S3[Eigenproblem]
-    Q4["Decompose A = U Σ Vᵀ"] --> S4[SVD]
-```
+| Problem | Name |
+| --- | --- |
+| Solve $A x = b$ | Linear system |
+| Find $\min \lVert A x - b \rVert$ | Least squares |
+| Find $A v = \lambda v$ | Eigenproblem |
+| Decompose $A = U \Sigma V^\mathsf{T}$ | SVD |
 
 Most of scientific computing falls into one of these four buckets.
 The next chapter will cover the factorizations behind each. This

--- a/content/learn/seaborn-foundations/box-and-violin-plots.mdx
+++ b/content/learn/seaborn-foundations/box-and-violin-plots.mdx
@@ -17,18 +17,6 @@ A **box plot** (or box-and-whisker plot) compresses a distribution into a
 handful of robust summary numbers based on **quartiles** — the values that
 cut the sorted data into four equal parts.
 
-```mermaid
-flowchart LR
-    subgraph BOX["The box spans Q1 to Q3: the middle 50% of the data (IQR)"]
-        Q1["Q1<br/>25th percentile<br/>(near edge of box)"]
-        MED["Median<br/>50th percentile<br/>(line inside box)"]
-        Q3["Q3<br/>75th percentile<br/>(far edge of box)"]
-    end
-    LW["Lower whisker:<br/>reaches the furthest point<br/>within 1.5 IQR below Q1"] --> Q1
-    Q3 --> UW["Upper whisker:<br/>reaches the furthest point<br/>within 1.5 IQR above Q3"]
-    UW --> OUT["Outliers:<br/>points beyond the whiskers,<br/>drawn one by one"]
-```
-
 Reading the parts:
 
 - **The box** spans the first quartile (**Q1**, 25th percentile) to the

--- a/content/learn/seaborn-foundations/categorical-overview.mdx
+++ b/content/learn/seaborn-foundations/categorical-overview.mdx
@@ -24,18 +24,6 @@ let you see**. Every group of numbers has a full shape — where it clusters,
 how spread out it is, where the outliers sit. A categorical plot makes a
 choice about how much of that shape to draw versus boil away.
 
-```mermaid
-flowchart TD
-    CAT["catplot<br/>categorical x, usually numeric y"] --> RAW["Show every point"]
-    CAT --> SUM["Summarize the distribution"]
-    CAT --> EST["Show one estimate"]
-    CAT --> CNT["Count occurrences"]
-    RAW --> R1["strip, swarm"]
-    SUM --> S1["box, violin, boxen"]
-    EST --> E1["bar, point"]
-    CNT --> C1["count"]
-```
-
 | `kind` | What it draws | How much it reveals | Needs |
 | ------ | ------------- | ------------------- | ----- |
 | `"strip"` | Every point, with jitter | **All** observations | category + numeric |

--- a/content/learn/seaborn-foundations/color-palettes.mdx
+++ b/content/learn/seaborn-foundations/color-palettes.mdx
@@ -12,16 +12,7 @@ Seaborn gives you three families of palettes for three kinds of data.
 
 ## Three palette types for three kinds of data
 
-```mermaid
-flowchart TD
-    Q{"What does the color represent?"}
-    Q -->|"Unordered categories"| QUAL["QUALITATIVE palette<br/>distinct, equal-weight hues<br/>e.g. deep, colorblind, Set2"]
-    Q -->|"An amount, low to high"| SEQ["SEQUENTIAL palette<br/>one ramp, light to dark<br/>e.g. rocket, mako, viridis"]
-    Q -->|"A value around a midpoint"| DIV["DIVERGING palette<br/>two hues, neutral center<br/>e.g. vlag, coolwarm, RdBu"]
-    QUAL --> QU["For: species, day, region"]
-    SEQ --> SU["For: counts, magnitude, density"]
-    DIV --> DU["For: correlation, change vs. a baseline"]
-```
+Seaborn matches three palette families to three kinds of data:
 
 - **Qualitative** palettes use distinct hues of roughly equal visual weight.
   They're for **unordered categories** (species, day, region), where no color

--- a/content/learn/seaborn-foundations/continuous-vs-categorical.mdx
+++ b/content/learn/seaborn-foundations/continuous-vs-categorical.mdx
@@ -51,18 +51,9 @@ do arithmetic on the labels.
 ## How Seaborn maps each kind
 
 This is the crux. The *type* of a variable decides how Seaborn turns it into
-something you can see:
-
-```mermaid
-flowchart TD
-    V["A column in your data"] --> Q{"A number measured<br/>on a scale?"}
-    Q -->|Yes| C["CONTINUOUS<br/>e.g. body_mass_g, total_bill"]
-    Q -->|No| K["CATEGORICAL<br/>e.g. species, day, sex"]
-    C --> CA["Mapped to: a continuous axis,<br/>a color gradient (hue),<br/>or marker size"]
-    K --> KA["Mapped to: discrete positions,<br/>distinct colors,<br/>or separate facets"]
-    CA --> CP["Natural charts: scatter, line,<br/>histogram, KDE, ECDF"]
-    KA --> KP["Natural charts: bar, count,<br/>box, violin, strip, swarm"]
-```
+something you can see. A continuous variable is a number measured on a scale
+(`body_mass_g`, `total_bill`); a categorical one is a label (`species`,
+`day`, `sex`):
 
 | If the variable is... | Seaborn gives it... | Reach for... |
 | --------------------- | ------------------- | ------------ |

--- a/content/learn/seaborn-foundations/distributions-kde.mdx
+++ b/content/learn/seaborn-foundations/distributions-kde.mdx
@@ -24,12 +24,9 @@ places a small smooth **bump** — called a *kernel* (usually a tiny Gaussian)
 points cluster, the bumps pile up into a tall region; where points are
 sparse, the curve sags. The sum is one smooth **density** curve.
 
-```mermaid
-flowchart LR
-    D["Raw data points<br/>on the number line"] --> K["Place a smooth bump<br/>(a kernel) over each point"]
-    K --> S["Add all the bumps<br/>together"]
-    S --> C["One smooth curve:<br/>the KDE"]
-```
+In short: **raw data points on the number line → place a smooth bump (a
+kernel) over each point → add all the bumps together → one smooth curve, the
+KDE.**
 
 That's the whole idea: **a KDE is the sum of one little bump per data
 point**. A histogram is a *count* in bins; a KDE is a *smoothed* version of

--- a/content/learn/seaborn-foundations/facets-and-grids.mdx
+++ b/content/learn/seaborn-foundations/facets-and-grids.mdx
@@ -80,14 +80,13 @@ The figure-level functions do their faceting through a class called
 three-step workflow demystifies what `relplot` and friends are doing — and
 lets you build custom grids when you need them.
 
-```mermaid
-flowchart TD
-    DATA["Full tidy dataset"] --> SPLIT["Split by the facet variables<br/>col= and/or row="]
-    SPLIT --> GRID["An empty grid of axes:<br/>one cell per category combination"]
-    GRID --> MAP["map() a plotting function<br/>onto each data subset"]
-    MAP --> DRAW["Every cell draws the same plot<br/>for its slice of the data"]
-    DRAW --> LEG["add_legend() and final touches"]
-```
+Starting from the full tidy dataset, the workflow runs:
+
+1. **Split** by the facet variables (`col=` and/or `row=`).
+2. Lay out an **empty grid of axes** — one cell per category combination.
+3. **`map()`** a plotting function onto each data subset.
+4. Every cell **draws the same plot** for its slice of the data.
+5. **`add_legend()`** and final touches.
 
 In code, those steps look like this:
 

--- a/content/learn/seaborn-foundations/figure-level-vs-axes-level.mdx
+++ b/content/learn/seaborn-foundations/figure-level-vs-axes-level.mdx
@@ -28,41 +28,23 @@ Here's the key relationship: **each figure-level function is a wrapper
 around a family of axes-level functions**, and the `kind` argument picks
 which one to use.
 
-```mermaid
-flowchart TD
-    subgraph FL["FIGURE-LEVEL: manage a whole figure, can facet"]
-        REL["relplot"]
-        DIS["displot"]
-        CAT["catplot"]
-        LM["lmplot"]
-    end
-    subgraph AL["AXES-LEVEL: draw on one Axes, composable"]
-        SC["scatterplot"]
-        LN["lineplot"]
-        HI["histplot"]
-        KD["kdeplot"]
-        EC["ecdfplot"]
-        BX["boxplot"]
-        VI["violinplot"]
-        BR["barplot"]
-        CO["countplot"]
-        ST["stripplot"]
-        SW["swarmplot"]
-        RG["regplot"]
-    end
-    REL -->|"kind='scatter'"| SC
-    REL -->|"kind='line'"| LN
-    DIS -->|"kind='hist'"| HI
-    DIS -->|"kind='kde'"| KD
-    DIS -->|"kind='ecdf'"| EC
-    CAT -->|"kind='box'"| BX
-    CAT -->|"kind='violin'"| VI
-    CAT -->|"kind='bar'"| BR
-    CAT -->|"kind='count'"| CO
-    CAT -->|"kind='strip'"| ST
-    CAT -->|"kind='swarm'"| SW
-    LM --> RG
-```
+Each figure-level function (left) dispatches to a family of axes-level
+functions (right) according to its `kind` argument:
+
+| Figure-level function | `kind=` | Axes-level function it calls |
+| --- | --- | --- |
+| `relplot` | `"scatter"` (default) | `scatterplot` |
+| `relplot` | `"line"` | `lineplot` |
+| `displot` | `"hist"` (default) | `histplot` |
+| `displot` | `"kde"` | `kdeplot` |
+| `displot` | `"ecdf"` | `ecdfplot` |
+| `catplot` | `"strip"` (default) | `stripplot` |
+| `catplot` | `"swarm"` | `swarmplot` |
+| `catplot` | `"box"` | `boxplot` |
+| `catplot` | `"violin"` | `violinplot` |
+| `catplot` | `"bar"` | `barplot` |
+| `catplot` | `"count"` | `countplot` |
+| `lmplot` | — | `regplot` |
 
 So `sns.relplot(..., kind="scatter")` ends up calling `scatterplot` under
 the hood, and `sns.catplot(..., kind="box")` calls `boxplot`. The

--- a/content/learn/seaborn-foundations/index.mdx
+++ b/content/learn/seaborn-foundations/index.mdx
@@ -29,13 +29,10 @@ Seaborn does the grouping, the aggregation, the color mapping, the legend,
 and sensible defaults — so the code you write looks like the *question you
 are asking*.
 
-```mermaid
-flowchart LR
-    A["Tidy DataFrame"] --> B["Describe the chart<br/>(x, y, hue, col, ...)"]
-    B --> C["Seaborn maps columns<br/>to visual properties"]
-    C --> D["Statistical summary<br/>(counts, means, density, CI)"]
-    D --> E["A figure that answers<br/>your question"]
-```
+The flow is always the same: **a tidy DataFrame → describe the chart (`x`,
+`y`, `hue`, `col`, ...) → Seaborn maps columns to visual properties →
+a statistical summary (counts, means, density, CI) → a figure that answers
+your question.**
 
 This is the mental shift the course is built around: **you describe
 *what* you want to see; Seaborn figures out *how* to draw it.**

--- a/content/learn/seaborn-foundations/visual-storytelling.mdx
+++ b/content/learn/seaborn-foundations/visual-storytelling.mdx
@@ -39,22 +39,6 @@ groups" means bar, box, or violin — depending on how much of the
 distribution you want to show. The point is to let the *question* pick the
 chart, not habit or whichever function you remember first.
 
-The same mapping reads naturally as a decision flow — start from the
-question, and the chart family falls out:
-
-```mermaid
-flowchart TD
-    START{"What is your question?"}
-    START -->|"How are two numbers related?"| REL["Scatter / line<br/>relplot"]
-    START -->|"What does one variable look like?"| DIST["Histogram / KDE / ECDF<br/>displot"]
-    START -->|"Compare a number across categories?"| CAT["Bar / box / violin<br/>catplot"]
-    START -->|"How many in each category?"| CNT["Count plot<br/>catplot kind=count"]
-    START -->|"All pairwise relationships?"| PAIR["Pair plot<br/>pairplot"]
-    START -->|"How do variables correlate?"| HEAT["Heatmap of a<br/>correlation matrix"]
-```
-
-The point is to let the *question* pick the chart, not the other way around.
-
 ## Cut the clutter
 
 Once the chart type is right, the most reliable way to improve an

--- a/content/learn/sql-analytics-duckdb/analytical-vs-transactional-workloads.mdx
+++ b/content/learn/sql-analytics-duckdb/analytical-vs-transactional-workloads.mdx
@@ -19,24 +19,21 @@ be fast, and must be safe even if thousands happen at once.
 An **analysis** is the opposite in almost every dimension: it reads a
 huge slice of history and condenses it into understanding.
 
-```mermaid
-flowchart LR
-    subgraph OLTP["OLTP — transactional"]
-        direction TB
-        T1["Many small writes<br/>and point reads"]
-        T2["Touch a few rows"]
-        T3["Latency: milliseconds"]
-        T4["Keeps the business<br/>running"]
-    end
-    subgraph OLAP["OLAP — analytical"]
-        direction TB
-        O1["Few large reads"]
-        O2["Scan millions of rows,<br/>few columns"]
-        O3["Latency: seconds is fine"]
-        O4["Helps the business<br/>understand itself"]
-    end
-    OLTP -. "same data,<br/>different question" .-> OLAP
-```
+**OLTP — transactional:**
+
+- Many small writes and point reads
+- Touches a few rows
+- Latency measured in milliseconds
+- Keeps the business *running*
+
+**OLAP — analytical:**
+
+- Few large reads
+- Scans millions of rows, a few columns
+- Latency of seconds is fine
+- Helps the business *understand itself*
+
+It is the same data, asked a different question.
 
 A simple way to remember it: **OLTP records what happened; OLAP explains
 what it means.** Every order an OLTP system saves becomes a row that, much
@@ -54,23 +51,20 @@ feels fast for analysis. Databases can store a table in two ways.
   for OLAP: "average `amount` over 10 million orders" reads just the
   `amount` column and skips everything else.
 
-```mermaid
-flowchart TB
-    subgraph Row["Row store (good for OLTP)"]
-        direction LR
-        R1["order1: id, date, amount, region"]
-        R2["order2: id, date, amount, region"]
-        R3["order3: id, date, amount, region"]
-    end
-    subgraph Col["Column store (good for OLAP)"]
-        direction LR
-        C1["all ids"]
-        C2["all dates"]
-        C3["all amounts"]
-        C4["all regions"]
-    end
-    Row -- "analytics reads<br/>one column" --> Col
+Row store (good for OLTP) keeps each order's values together on disk:
+
+```text
+[id1 date1 amount1 region1] [id2 date2 amount2 region2] [id3 date3 amount3 region3]
 ```
+
+Column store (good for OLAP) keeps each column together instead:
+
+```text
+[id1 id2 id3] [date1 date2 date3] [amount1 amount2 amount3] [region1 region2 region3]
+```
+
+An analytical query for "average `amount`" reads only the third block and
+skips the rest.
 
 When an analytical query only needs `amount`, a **column store** reads
 *only* the amounts — not the ids, dates, or regions sitting beside them.

--- a/content/learn/sql-analytics-duckdb/analytics-vs-application-development.mdx
+++ b/content/learn/sql-analytics-duckdb/analytics-vs-application-development.mdx
@@ -22,19 +22,11 @@ Think of a busy online store.
   first-time buyers spend less than returning ones?"* Each sweeps across
   *millions* of rows to produce a *small* summary.
 
-```mermaid
-flowchart LR
-    subgraph App["Application SQL"]
-        direction TB
-        A1["Tiny, targeted queries"] --> A2["Read/write a few rows"]
-        A2 --> A3["Runs constantly,<br/>must be instant"]
-    end
-    subgraph Ana["Analytical SQL"]
-        direction TB
-        B1["Broad, exploratory queries"] --> B2["Scan millions of rows"]
-        B2 --> B3["Produce a small summary"]
-    end
-```
+**Application SQL:** tiny, targeted queries that read or write a few rows
+and run constantly, so they must be instant.
+
+**Analytical SQL:** broad, exploratory queries that scan millions of rows
+to produce a small summary.
 
 Same keywords. Opposite shape. An application query is a **needle**: find
 this one row, fast. An analytical query is a **net**: drag it across the

--- a/content/learn/sql-analytics-duckdb/filtering-groups.mdx
+++ b/content/learn/sql-analytics-duckdb/filtering-groups.mdx
@@ -19,19 +19,14 @@ page nails down.
 - **`HAVING`** runs **after** grouping. It filters whole *groups*, so it
   can see aggregates like `SUM(amount)`.
 
-```mermaid
-flowchart LR
-    R[("Rows")] --> W["WHERE<br/>(filter rows)"]
-    W --> G["GROUP BY<br/>(form groups)"]
-    G --> A["aggregate<br/>(per-group totals)"]
-    A --> H["HAVING<br/>(filter groups)"]
-    H --> O["ORDER BY"]
-```
+The clauses run in a fixed order:
 
-That single diagram is the whole mental model. `WHERE` is upstream of the
-groups; `HAVING` is downstream. A condition that mentions an aggregate
-*must* go in `HAVING`, because the aggregate does not exist yet when
-`WHERE` runs.
+**Rows → `WHERE` (filter rows) → `GROUP BY` (form groups) → aggregate
+(per-group totals) → `HAVING` (filter groups) → `ORDER BY`**
+
+That order is the whole mental model. `WHERE` is upstream of the groups;
+`HAVING` is downstream. A condition that mentions an aggregate *must* go in
+`HAVING`, because the aggregate does not exist yet when `WHERE` runs.
 
 ## `HAVING` in action
 

--- a/content/learn/sql-analytics-duckdb/index.mdx
+++ b/content/learn/sql-analytics-duckdb/index.mdx
@@ -73,37 +73,15 @@ concurrency, ORMs, query-planner internals, or cloud infrastructure.
 Those matter for *running* a database in production, but they are not
 what an analyst reaches for when asking questions of data.
 
-```mermaid
-flowchart LR
-    subgraph Focus["This course focuses on"]
-        F1["Analytical SQL"]
-        F2["Exploratory analysis"]
-        F3["Aggregation"]
-        F4["Window functions"]
-        F5["Data to insight"]
-    end
-    subgraph Skip["This course skips"]
-        S1["Administration"]
-        S2["Transactions"]
-        S3["Replication, HA"]
-        S4["Deployment"]
-        S5["ORMs, backends"]
-    end
-```
+| This course focuses on | This course skips |
+| --- | --- |
+| Analytical SQL | Administration |
+| Exploratory analysis | Transactions |
+| Aggregation | Replication, HA |
+| Window functions | Deployment |
+| Data to insight | ORMs, backends |
 
 ## How the course is organized
-
-```mermaid
-flowchart TB
-    A["Why Analytical<br/>SQL"] --> B["Getting Started<br/>with DuckDB"]
-    B --> C["Exploratory<br/>Data Analysis"]
-    C --> D["Aggregation and<br/>Summarization"]
-    D --> E["Window<br/>Functions"]
-    E --> F["Transforming<br/>Data"]
-    F --> G["Composing<br/>Queries"]
-    G --> H["From Data<br/>to Insight"]
-    H --> I["Wrapping<br/>Up"]
-```
 
 We start with **mindset, not syntax**. The first section explains how
 analytical thinking differs from the application-development SQL you may

--- a/content/learn/sql-analytics-duckdb/next-steps.mdx
+++ b/content/learn/sql-analytics-duckdb/next-steps.mdx
@@ -14,15 +14,13 @@ the part that outlasts any one tool.
 
 The course moved deliberately from *mindset* to *technique* to *insight*:
 
-```mermaid
-flowchart TB
-    A["Analytical mindset<br/>(OLAP, thinking in datasets)"] --> B["Exploration<br/>(profile, slice, sort)"]
-    B --> C["Summarization<br/>(aggregates, GROUP BY, HAVING)"]
-    C --> D["Window functions<br/>(rank, running totals)"]
-    D --> E["Transformation<br/>(CASE, dates, pivots)"]
-    E --> F["Composition<br/>(CTEs, subqueries)"]
-    F --> G["Insight<br/>(metrics, reproducibility)"]
-```
+1. **Analytical mindset** — OLAP, thinking in datasets.
+2. **Exploration** — profile, slice, sort.
+3. **Summarization** — aggregates, `GROUP BY`, `HAVING`.
+4. **Window functions** — rank, running totals.
+5. **Transformation** — `CASE`, dates, pivots.
+6. **Composition** — CTEs, subqueries.
+7. **Insight** — metrics, reproducibility.
 
 Each layer rested on the one before it. Window functions only made sense
 once aggregation did; metrics only made sense once you could compose

--- a/content/learn/sql-analytics-duckdb/running-totals-and-moving-averages.mdx
+++ b/content/learn/sql-analytics-duckdb/running-totals-and-moving-averages.mdx
@@ -49,14 +49,13 @@ instead put the grand total `650` on every row. **Ordering an aggregate
 window turns it from a total into a running total** — that is the single
 most important idea on this page.
 
-```mermaid
-flowchart LR
-    D1["Day 1: 100"] --> R1["100"]
-    D2["Day 2: 140"] --> R2["240"]
-    D3["Day 3: 90"] --> R3["330"]
-    D4["Day 4: 200"] --> R4["530"]
-    D5["Day 5: 120"] --> R5["650"]
-```
+| Day | Revenue | Running total |
+| --- | --- | --- |
+| 1 | 100 | 100 |
+| 2 | 140 | 240 |
+| 3 | 90 | 330 |
+| 4 | 200 | 530 |
+| 5 | 120 | 650 |
 
 ## Running totals per group
 

--- a/content/learn/sqlite-for-beginners/data-types.mdx
+++ b/content/learn/sqlite-for-beginners/data-types.mdx
@@ -144,12 +144,11 @@ This does **not** mean types do not matter in SQLite. They still matter because 
 
 `NULL` means the value is missing, unknown, or not applicable. It is not the same as zero, an empty string, or the word `'NULL'`.
 
-```mermaid
-flowchart LR
-    Z["0"] --> ZERO["Known number: zero"]
-    E["''"] --> EMPTY["Known text: empty string"]
-    N["NULL"] --> MISS["Unknown or missing value"]
-```
+| Value | Meaning |
+| --- | --- |
+| `0` | A known number: zero |
+| `''` | A known text value: the empty string |
+| `NULL` | An unknown or missing value |
 
 For example, if you do not know a customer's phone number yet, `NULL` is better than making up a fake value.
 

--- a/content/learn/sqlite-for-beginners/filtering-groups.mdx
+++ b/content/learn/sqlite-for-beginners/filtering-groups.mdx
@@ -141,15 +141,6 @@ Read it in stages:
 3. `AVG(salary)` calculates each group's average.
 4. `HAVING AVG(salary) > 80000` keeps only groups with a high average.
 
-```mermaid
-flowchart LR
-    A["All rows"] --> B["WHERE<br/>drop interns"]
-    B --> C["GROUP BY dept<br/>make groups"]
-    C --> D["AVG(salary)<br/>compute summaries"]
-    D --> E["HAVING<br/>keep avg over 80000"]
-    E --> F["Final result"]
-```
-
 ## Filtering by totals
 
 `HAVING` is also common with `SUM`. This query keeps only products whose total sales are at least `30`.
@@ -240,15 +231,7 @@ ORDER BY sort_columns;
 
 The logical flow is:
 
-```mermaid
-flowchart TB
-    F["FROM<br/>choose table"] --> W["WHERE<br/>filter rows"]
-    W --> G["GROUP BY<br/>build groups"]
-    G --> A["Aggregates<br/>COUNT, SUM, AVG"]
-    A --> H["HAVING<br/>filter groups"]
-    H --> S["SELECT<br/>choose output"]
-    S --> O["ORDER BY<br/>sort result"]
-```
+**`FROM` (choose table) → `WHERE` (filter rows) → `GROUP BY` (build groups) → aggregates like `COUNT`, `SUM`, `AVG` → `HAVING` (filter groups) → `SELECT` (choose output) → `ORDER BY` (sort result)**
 
 The most important part for this page is:
 

--- a/content/learn/sqlite-for-beginners/index.mdx
+++ b/content/learn/sqlite-for-beginners/index.mdx
@@ -71,17 +71,6 @@ ideas taught here.
 
 ## How the course is organized
 
-```mermaid
-flowchart TB
-    A["Why Databases<br/>Exist"] --> B["Relational<br/>Foundations"]
-    B --> C["Getting Started<br/>with SQLite"]
-    C --> D["Querying<br/>Data"]
-    D --> E["Summarizing<br/>Data"]
-    E --> F["Connecting<br/>Tables (Joins)"]
-    F --> G["Exploring &<br/>Organizing Data"]
-    G --> H["Wrapping<br/>Up"]
-```
-
 We start with **ideas, not syntax**. The first section answers the
 questions most tutorials skip: what a database is, why it exists,
 how applications store information, and why SQL and SQLite became

--- a/content/learn/sqlite-for-beginners/inserting-data.mdx
+++ b/content/learn/sqlite-for-beginners/inserting-data.mdx
@@ -164,12 +164,13 @@ ORDER BY
   id;`}
 />
 
-```mermaid
-flowchart LR
-    C1["name"] --> V1["'Maya'"]
-    C2["email"] --> V2["'maya@example.com'"]
-    C3["age"] --> V3["31"]
-```
+Each named column lines up with a value in the same position:
+
+| Column  | Value                |
+| ------- | -------------------- |
+| `name`  | `'Maya'`             |
+| `email` | `'maya@example.com'` |
+| `age`   | `31`                 |
 
 <MultipleChoice
   markdown={`In \`INSERT INTO contacts (name, email, age) VALUES ('Maya', 'maya@example.com', 31);\`, where does \`31\` go?

--- a/content/learn/sqlite-for-beginners/next-steps.mdx
+++ b/content/learn/sqlite-for-beginners/next-steps.mdx
@@ -12,15 +12,13 @@ That conceptual foundation is the hard part, and you have it.
 
 The course moved deliberately from "why" to "how" to "how to think":
 
-```mermaid
-flowchart TB
-    A["Why databases exist<br/>(beyond spreadsheets)"] --> B["Relational foundations<br/>(tables, keys, types)"]
-    B --> C["Getting started<br/>with SQLite"]
-    C --> D["Querying data<br/>(SELECT, WHERE, ORDER BY)"]
-    D --> E["Summarizing data<br/>(aggregates, GROUP BY, HAVING)"]
-    E --> F["Connecting tables<br/>(foreign keys, joins, many-to-many)"]
-    F --> G["Exploring & organizing data<br/>(profiling, single-source-of-truth)"]
-```
+1. **Why databases exist** — beyond spreadsheets.
+2. **Relational foundations** — tables, keys, types.
+3. **Getting started with SQLite.**
+4. **Querying data** — `SELECT`, `WHERE`, `ORDER BY`.
+5. **Summarizing data** — aggregates, `GROUP BY`, `HAVING`.
+6. **Connecting tables** — foreign keys, joins, many-to-many.
+7. **Exploring & organizing data** — profiling, single-source-of-truth.
 
 Each layer rested on the one before it. Joins only made sense once
 keys did; organizing data only made sense once you felt the pain of

--- a/content/learn/sqlite-for-beginners/primary-keys.mdx
+++ b/content/learn/sqlite-for-beginners/primary-keys.mdx
@@ -25,28 +25,13 @@ Names can repeat. Addresses can repeat. Phone numbers can change. A table needs 
 
 A **primary key** is a column, or sometimes a combination of columns, that uniquely identifies each row in a table.
 
-For beginners, the most common pattern in SQLite is a column named `id`:
+For beginners, the most common pattern in SQLite is a column named `id`, as in this `customers` table:
 
-```mermaid
-flowchart TB
-    subgraph Customers["Table: customers"]
-        direction LR
-        H1["id<br/>primary key"]:::pk
-        H2["name"]:::hdr
-        H3["city"]:::hdr
-        A1["1"]:::pk
-        A2["John Smith"]
-        A3["Springfield"]
-        B1["2"]:::pk
-        B2["John Smith"]
-        B3["Springfield"]
-        C1["3"]:::pk
-        C2["Maya Chen"]
-        C3["Denver"]
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-    classDef pk fill:#fde68a,stroke:#b45309
-```
+| id (primary key) | name | city |
+| --- | --- | --- |
+| 1 | John Smith | Springfield |
+| 2 | John Smith | Springfield |
+| 3 | Maya Chen | Denver |
 
 Now the two John Smith rows are not confused:
 

--- a/content/learn/sqlite-for-beginners/query-execution-order.mdx
+++ b/content/learn/sqlite-for-beginners/query-execution-order.mdx
@@ -14,18 +14,14 @@ This is one of the most clarifying ideas in all of SQL.
 The order you type is for human readability. The order the database
 *reasons* about the query is different:
 
-```mermaid
-flowchart TB
-    F["1. FROM / JOIN<br/>gather and combine tables"]
-    W["2. WHERE<br/>filter individual rows"]
-    G["3. GROUP BY<br/>form groups"]
-    H["4. HAVING<br/>filter groups"]
-    S["5. SELECT<br/>choose columns, compute aliases"]
-    D["6. DISTINCT<br/>remove duplicates"]
-    O["7. ORDER BY<br/>sort"]
-    L["8. LIMIT<br/>keep the first N"]
-    F --> W --> G --> H --> S --> D --> O --> L
-```
+1. **`FROM` / `JOIN`** — gather and combine tables.
+2. **`WHERE`** — filter individual rows.
+3. **`GROUP BY`** — form groups.
+4. **`HAVING`** — filter groups.
+5. **`SELECT`** — choose columns, compute aliases.
+6. **`DISTINCT`** — remove duplicates.
+7. **`ORDER BY`** — sort.
+8. **`LIMIT`** — keep the first N.
 
 Read the numbers: `FROM` is first, `SELECT` is near the **end**, and
 `LIMIT` is last. The clause you *write* first (`SELECT`) is among the
@@ -119,18 +115,9 @@ Trace it in execution order:
 
 This is the **query transformation pipeline**: each stage reshapes a
 table and passes it on. Every query you write — however complex —
-flows through these same steps.
+flows through these same steps:
 
-```mermaid
-flowchart LR
-    T["orders<br/>(all rows)"] --> W["WHERE"]
-    W --> G["GROUP BY"]
-    G --> H["HAVING"]
-    H --> S["SELECT"]
-    S --> O["ORDER BY"]
-    O --> L["LIMIT"]
-    L --> R["final result"]
-```
+**`orders` (all rows) → `WHERE` → `GROUP BY` → `HAVING` → `SELECT` → `ORDER BY` → `LIMIT` → final result**
 
 ## WHERE vs. HAVING, settled
 

--- a/content/learn/sqlite-for-beginners/relationships-intro.mdx
+++ b/content/learn/sqlite-for-beginners/relationships-intro.mdx
@@ -11,28 +11,10 @@ Instead of storing every fact in one giant table, you store each kind of thing i
 
 Imagine an orders table that repeats the customer's details on every order.
 
-```mermaid
-flowchart TB
-    subgraph Giant["One giant table"]
-        direction LR
-        H1["order_id"]:::bad
-        H2["order_date"]:::bad
-        H3["customer_name"]:::bad
-        H4["customer_phone"]:::bad
-        H5["total"]:::bad
-        A1["101"]
-        A2["2026-01-05"]
-        A3["Ada"]
-        A4["555-0101"]
-        A5["42.00"]
-        B1["102"]
-        B2["2026-01-12"]
-        B3["Ada"]
-        B4["555-0101"]
-        B5["18.00"]
-    end
-    classDef bad fill:#fee2e2,stroke:#b91c1c
-```
+| order_id | order_date | customer_name | customer_phone | total |
+| --- | --- | --- | --- | --- |
+| 101 | 2026-01-05 | Ada | 555-0101 | 42.00 |
+| 102 | 2026-01-12 | Ada | 555-0101 | 18.00 |
 
 Ada's phone number is copied in multiple rows. If it changes, you must find and update every copy. Miss one copy, and the database disagrees with itself.
 

--- a/content/learn/sqlite-for-beginners/tables-rows-columns.mdx
+++ b/content/learn/sqlite-for-beginners/tables-rows-columns.mdx
@@ -30,29 +30,11 @@ A **table** is a named grid. Each table has:
 
 Here is a small `pets` table:
 
-```mermaid
-flowchart TB
-    subgraph Pets["Table: pets"]
-        direction LR
-        H1["id"]:::hdr
-        H2["name"]:::hdr
-        H3["species"]:::hdr
-        H4["age"]:::hdr
-        A1["1"]
-        A2["Mochi"]
-        A3["cat"]
-        A4["3"]
-        B1["2"]
-        B2["Biscuit"]
-        B3["dog"]
-        B4["5"]
-        C1["3"]
-        C2["Sunny"]
-        C3["bird"]
-        C4["1"]
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-```
+| id | name | species | age |
+| --- | --- | --- | --- |
+| 1 | Mochi | cat | 3 |
+| 2 | Biscuit | dog | 5 |
+| 3 | Sunny | bird | 1 |
 
 Read one row as a sentence:
 

--- a/content/learn/sqlite-for-beginners/understanding-joins.mdx
+++ b/content/learn/sqlite-for-beginners/understanding-joins.mdx
@@ -114,13 +114,14 @@ ORDER BY
   o.id;`}
 />
 
-```mermaid
-flowchart LR
-    P1["101 with Ada<br/>1 = 1"] -->|"keep"| K1["Ada<br/>101<br/>42"]
-    P2["101 with Grace<br/>1 = 2"] -->|"discard"| X1["not a match"]
-    P3["102 with Ada<br/>2 = 1"] -->|"discard"| X2["not a match"]
-    P4["102 with Grace<br/>2 = 2"] -->|"keep"| K2["Grace<br/>102<br/>99"]
-```
+Each pairing is tested against `o.customer_id = c.id`, and only the matches survive:
+
+| Pairing          | Test    | Outcome | Result row          |
+| ---------------- | ------- | ------- | ------------------- |
+| order 101 + Ada  | `1 = 1` | keep    | Ada, 101, 42        |
+| order 101 + Grace | `1 = 2` | discard | —                   |
+| order 102 + Ada  | `2 = 1` | discard | —                   |
+| order 102 + Grace | `2 = 2` | keep    | Grace, 102, 99      |
 
 <MultipleChoice
   markdown={`What is the job of the \`ON\` clause in a join?

--- a/content/learn/sqlite-for-beginners/understanding-tables.mdx
+++ b/content/learn/sqlite-for-beginners/understanding-tables.mdx
@@ -24,25 +24,11 @@ flowchart TB
 
 For example, a `students` table should have one row per student:
 
-```mermaid
-flowchart TB
-    subgraph Students["Table: students"]
-        direction LR
-        H1["id"]:::hdr
-        H2["name"]:::hdr
-        H3["grade_level"]:::hdr
-        A1["1"]
-        A2["Ana"]
-        A3["9"]
-        B1["2"]
-        B2["Ben"]
-        B3["10"]
-        C1["3"]
-        C2["Cara"]
-        C3["9"]
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-```
+| id | name | grade_level |
+| --- | --- | --- |
+| 1 | Ana | 9 |
+| 2 | Ben | 10 |
+| 3 | Cara | 9 |
 
 Every row answers: **which student?**
 
@@ -86,25 +72,10 @@ If you cannot finish the sentence, the table may be trying to store too many kin
 
 Here is a focused `products` table. Every row is one product. Every column describes that product.
 
-```mermaid
-flowchart TB
-    subgraph Products["Good table: products"]
-        direction LR
-        P1["id"]:::hdr
-        P2["name"]:::hdr
-        P3["category"]:::hdr
-        P4["price"]:::hdr
-        A1["1"]
-        A2["Notebook"]
-        A3["school"]
-        A4["3.50"]
-        B1["2"]
-        B2["Mug"]
-        B3["kitchen"]
-        B4["8.00"]
-    end
-    classDef hdr fill:#dbeafe,stroke:#1d4ed8
-```
+| id | name | category | price |
+| --- | --- | --- | --- |
+| 1 | Notebook | school | 3.50 |
+| 2 | Mug | kitchen | 8.00 |
 
 This table is easy to understand because the columns all fit the same subject.
 
@@ -120,28 +91,10 @@ flowchart LR
 
 Now compare that with a table that mixes products, customers, and order facts into one place.
 
-```mermaid
-flowchart TB
-    subgraph Messy["Messy table: mixed_sales"]
-        direction LR
-        H1["product_name"]:::bad
-        H2["product_price"]:::bad
-        H3["customer_name"]:::bad
-        H4["customer_phone"]:::bad
-        H5["order_date"]:::bad
-        A1["Notebook"]
-        A2["3.50"]
-        A3["Ada"]
-        A4["555-0101"]
-        A5["2026-02-01"]
-        B1["Notebook"]
-        B2["3.50"]
-        B3["Ada"]
-        B4["555-0101"]
-        B5["2026-02-10"]
-    end
-    classDef bad fill:#fee2e2,stroke:#b91c1c
-```
+| product_name | product_price | customer_name | customer_phone | order_date |
+| --- | --- | --- | --- | --- |
+| Notebook | 3.50 | Ada | 555-0101 | 2026-02-01 |
+| Notebook | 3.50 | Ada | 555-0101 | 2026-02-10 |
 
 This table has problems:
 

--- a/content/learn/statistics-for-data-science-python/ab-testing.mdx
+++ b/content/learn/statistics-for-data-science-python/ab-testing.mdx
@@ -16,14 +16,9 @@ collect a single row, **analyze** it once it's done, and **decide**
 whether to ship — then catalog the **pitfalls** that quietly invalidate
 otherwise-fine tests.
 
-```mermaid
-flowchart LR
-  A["1. Hypothesis +<br/>primary metric"] --> B["2. Randomize<br/>users to A / B"]
-  B --> C["3. Pick sample size<br/>(power) IN ADVANCE"]
-  C --> D["4. Run to plan<br/>(no peeking)"]
-  D --> E["5. Analyze:<br/>lift, CI, effect size, p"]
-  E --> F["6. Decide: ship?<br/>(significance AND size)"]
-```
+The full arc, start to finish:
+
+**Hypothesis + primary metric → Randomize users to A/B → Pick sample size (power) in advance → Run to plan (no peeking) → Analyze (lift, CI, effect size, p) → Decide: ship? (significance *and* size)**
 
 ## Design comes first (and is where most tests are won or lost)
 

--- a/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
@@ -54,17 +54,11 @@ always an area, never a height.
 The contrast with the discrete world is worth pinning down, because the
 mental model is genuinely different.
 
-```mermaid
-flowchart LR
-  subgraph S1["Discrete (PMF)"]
-    A1["Bars at 0, 1, 2, ..."] --> A2["Height = P(X = k)<br/>directly a probability"]
-    A2 --> A3["P over a range =<br/>SUM of bar heights"]
-  end
-  subgraph S2["Continuous (PDF)"]
-    B1["Smooth curve"] --> B2["Height = density<br/>NOT a probability"]
-    B2 --> B3["P over a range =<br/>AREA under the curve"]
-  end
-```
+| | **Discrete (PMF)** | **Continuous (PDF)** |
+| --- | --- | --- |
+| Shape | Bars at 0, 1, 2, … | A smooth curve |
+| Height means | `P(X = k)` — directly a probability | A *density* — **not** a probability |
+| `P` over a range | **Sum** of bar heights | **Area** under the curve |
 
 <Callout type="info" title="Why P(X = x) = 0 isn't a paradox">
 "The probability of any exact value is zero" sounds like it means

--- a/content/learn/statistics-for-data-science-python/errors-and-power.mdx
+++ b/content/learn/statistics-for-data-science-python/errors-and-power.mdx
@@ -21,19 +21,6 @@ Every test has an unknowable **truth** (H₀ is really true, or it's
 really false) and a **decision** you make (reject H₀, or fail to
 reject). Cross them and you get four outcomes — two right, two wrong.
 
-```mermaid
-flowchart TD
-  subgraph M["Truth (unknown) x Your decision"]
-    direction TB
-    A["H0 TRUE + you FAIL TO REJECT<br/>= correct (no false alarm)"]
-    B["H0 TRUE + you REJECT<br/>= TYPE I ERROR (false positive)<br/>rate = alpha"]
-    C["H0 FALSE + you FAIL TO REJECT<br/>= TYPE II ERROR (false negative)<br/>rate = beta"]
-    D["H0 FALSE + you REJECT<br/>= correct DETECTION<br/>rate = power = 1 - beta"]
-  end
-```
-
-Read it as a table:
-
 | | **You fail to reject H₀** | **You reject H₀** |
 | --- | --- | --- |
 | **H₀ is true** | Correct (specificity) | **Type I error** — false positive, rate α |

--- a/content/learn/statistics-for-data-science-python/index.mdx
+++ b/content/learn/statistics-for-data-science-python/index.mdx
@@ -65,18 +65,6 @@ By the time you finish, you'll be able to:
 We move from *describing* data, to *modeling* uncertainty, to *making
 inferences* and *testing claims*, and finally to *applying* it all.
 
-```mermaid
-flowchart TD
-    A["Why Statistics<br/>(thinking under uncertainty)"] --> B["Describing Data<br/>(center, spread, shape)"]
-    B --> C["Probability<br/>(the language of chance)"]
-    C --> D["Distributions<br/>(models for data)"]
-    D --> E["Sampling & the CLT<br/>(samples speak for populations)"]
-    E --> F["Confidence Intervals<br/>(how precise is my estimate?)"]
-    F --> G["Hypothesis Testing<br/>(signal vs noise)"]
-    G --> H["Effect Sizes & Reasoning<br/>(does it matter? is it real?)"]
-    H --> I["Applied Statistics<br/>(EDA, A/B testing)"]
-```
-
 Each section builds on the one before it. The middle of the course —
 **sampling distributions**, the **central limit theorem**, **confidence
 intervals**, and **p-values** — is the conceptual heart. If those

--- a/content/learn/statistics-for-data-science-python/next-steps.mdx
+++ b/content/learn/statistics-for-data-science-python/next-steps.mdx
@@ -15,17 +15,15 @@ Every page built on the last. Step back and the shape is clear: you went
 from *describing* data, to *modeling* uncertainty, to *making
 inferences*, to *applying* it all.
 
-```mermaid
-flowchart TD
-  A["Statistical thinking<br/>(reason under uncertainty)"] --> B["Describing data<br/>(center, spread, shape)"]
-  B --> C["Probability<br/>(the language of chance)"]
-  C --> D["Distributions<br/>(models for data)"]
-  D --> E["Sampling & the CLT<br/>(samples speak for populations)"]
-  E --> F["Confidence intervals<br/>(how precise is my estimate?)"]
-  F --> G["Hypothesis testing & p-values<br/>(signal vs noise)"]
-  G --> H["Effect sizes & fallacies<br/>(does it matter? is it real?)"]
-  H --> I["Applied: EDA & A/B testing<br/>(put it all to work)"]
-```
+1. **Statistical thinking** — reason under uncertainty.
+2. **Describing data** — center, spread, shape.
+3. **Probability** — the language of chance.
+4. **Distributions** — models for data.
+5. **Sampling and the CLT** — samples speak for populations.
+6. **Confidence intervals** — how precise is my estimate?
+7. **Hypothesis testing and p-values** — signal vs noise.
+8. **Effect sizes and fallacies** — does it matter? is it real?
+9. **Applied: EDA and A/B testing** — put it all to work.
 
 The conceptual heart was the middle: **sampling distributions**, the
 **central limit theorem**, **confidence intervals**, and **p-values**. If

--- a/content/learn/statistics-for-data-science-python/p-values.mdx
+++ b/content/learn/statistics-for-data-science-python/p-values.mdx
@@ -219,22 +219,17 @@ The null distribution shows what "pure noise" looks like, and pure noise average
 This is the heart of the page. Every item below is a misreading you will
 hear from smart people. Burn the corrections in.
 
-```mermaid
-flowchart TD
-  P["p-value = P(data this extreme or more | H0 true)"]
-  P --> N1["NOT P(H0 is true)"]
-  P --> N2["NOT P(result was 'due to chance')"]
-  P --> N3["NOT the probability you are wrong"]
-  P --> N4["NOT 1 minus P(H1)"]
-  P --> N5["NOT the effect size or its importance"]
-  P --> N6["NOT the probability the result replicates"]
-  N1 --> R1["It ASSUMES H0; it cannot output a probability about H0"]
-  N2 --> R2["It already assumes chance-only; it can't also measure it"]
-  N3 --> R3["Being wrong depends on whether H0 is actually true, which p never uses"]
-  N4 --> R4["It says nothing about how likely the alternative is"]
-  N5 --> R5["A tiny effect + huge sample gives a tiny p"]
-  N6 --> R6["Replication depends on power and the true effect, not on p"]
-```
+A p-value is `P(data this extreme or more | H0 true)` — and nothing else.
+Each misreading below, with why it fails:
+
+| A p-value is NOT… | Why |
+| --- | --- |
+| `P(H0 is true)` | It *assumes* H₀; it cannot output a probability about H₀. |
+| `P(result was "due to chance")` | It already assumes chance-only; it can't also measure it. |
+| the probability you are wrong | Being wrong depends on whether H₀ is actually true, which `p` never uses. |
+| `1 − P(H1)` | It says nothing about how likely the alternative is. |
+| the effect size or its importance | A tiny effect plus a huge sample gives a tiny `p`. |
+| the probability the result replicates | Replication depends on power and the true effect, not on `p`. |
 
 Let's take the four most damaging ones in turn.
 

--- a/content/learn/statistics-for-data-science-python/populations-and-samples.mdx
+++ b/content/learn/statistics-for-data-science-python/populations-and-samples.mdx
@@ -102,23 +102,6 @@ Latin/hat = your best guess from data.** The statistic is the
 *estimator*; the parameter is the *estimand*. You use x̄ to
 estimate μ, p̂ to estimate `p`, and so on.
 
-```mermaid
-flowchart TD
-    subgraph POP["Population (unknown truth)"]
-      MU["mu — true mean"]
-      SIG["sigma — true sd"]
-      PP["p — true proportion"]
-    end
-    subgraph SAMP["Sample (what you compute)"]
-      XB["x-bar — sample mean"]
-      SS["s — sample sd"]
-      PH["p-hat — sample proportion"]
-    end
-    XB -. "estimates" .-> MU
-    SS -. "estimates" .-> SIG
-    PH -. "estimates" .-> PP
-```
-
 <Callout type="danger" title="The #1 confusion: reporting a statistic as a parameter">
 Writing "average revenue per user is \$48.20" — full stop — quietly
 claims you measured the *population*. You didn't. You measured

--- a/content/learn/statistics-for-data-science-python/sampling-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/sampling-distributions.mdx
@@ -21,22 +21,11 @@ until it's concrete.
 Here are the three. Read them slowly — the differences are the whole
 lesson.
 
-```mermaid
-flowchart TD
-    subgraph A["(a) Population distribution"]
-      A1["Spread of the RAW VALUES<br/>across the whole population"]
-      A2["Fixed. Has mean mu, sd sigma.<br/>Usually unknown."]
-    end
-    subgraph B["(b) Distribution of ONE sample"]
-      B1["Spread of the RAW VALUES<br/>in the n data points you collected"]
-      B2["A noisy snapshot of (a).<br/>Looks more like (a) as n grows."]
-    end
-    subgraph C["(c) Sampling distribution of a statistic"]
-      C1["Spread of a STATISTIC (e.g. x-bar)<br/>across MANY samples of size n"]
-      C2["Centered near mu, but MUCH narrower.<br/>This is what inference uses."]
-    end
-    A --> B --> C
-```
+| Distribution | What spreads | Key fact |
+| --- | --- | --- |
+| (a) Population | raw values across the whole population | Fixed, with mean μ and sd σ. Usually unknown. |
+| (b) One sample | raw values in the `n` points you collected | A noisy snapshot of (a); looks more like (a) as `n` grows. |
+| (c) Sampling distribution of a statistic | a statistic (e.g. x̄) across many samples of size `n` | Centered near μ but much narrower. This is what inference uses. |
 
 1. **The population distribution** is the spread of the raw values across
    the *entire population*: every customer's spend, every part's

--- a/content/learn/statistics-for-data-science-python/shape-and-outliers.mdx
+++ b/content/learn/statistics-for-data-science-python/shape-and-outliers.mdx
@@ -33,18 +33,11 @@ sits.
   pulled below the median**. Think exam scores with a ceiling, or age
   at death.
 
-```mermaid
-flowchart TD
-  subgraph L["Left-skewed (negative)"]
-    L1["long tail to the LEFT"] --> L2["mean &lt; median"]
-  end
-  subgraph S["Symmetric"]
-    S1["balanced tails"] --> S2["mean &asymp; median"]
-  end
-  subgraph R["Right-skewed (positive)"]
-    R1["long tail to the RIGHT"] --> R2["mean &gt; median"]
-  end
-```
+| Shape | Long tail | Mean vs median |
+| --- | --- | --- |
+| Left-skewed (negative) | to the left | mean &lt; median |
+| Symmetric | balanced tails | mean &asymp; median |
+| Right-skewed (positive) | to the right | mean &gt; median |
 
 <Callout type="warn" title="Misconception: 'right-skewed' means the peak is on the right">
 It's the opposite. Right-skewed means the *tail* points right, so the
@@ -211,13 +204,10 @@ deviations from the mean?" But it's built on the **mean and standard
 deviation**, which the outliers *themselves* inflate — so on skewed or
 contaminated data it can hide the very points it's meant to catch.
 
-```mermaid
-flowchart LR
-  A["1.5 x IQR rule"] --> A1["uses Q1, Q3, IQR<br/>robust to outliers"]
-  A1 --> A2["good on skewed data"]
-  B["z-score rule (|z| > 3)"] --> B1["uses mean and std<br/>outliers inflate both"]
-  B1 --> B2["assumes roughly normal<br/>can miss/over-flag on skew"]
-```
+| Rule | Built on | Behavior |
+| --- | --- | --- |
+| 1.5×IQR | `Q1`, `Q3`, `IQR` | Robust — outliers don't move the fences. Good on skewed data. |
+| z-score (`\|z\| > 3`) | mean and std | Outliers inflate both; assumes roughly normal, so it can miss or over-flag on skew. |
 
 The two rules **often disagree**, and seeing how is genuinely
 clarifying.

--- a/content/learn/statistics-for-data-science-python/standard-error.mdx
+++ b/content/learn/statistics-for-data-science-python/standard-error.mdx
@@ -31,18 +31,10 @@ dashboards. Burn the distinction in now:
   It's the standard deviation of the *sampling distribution*. It **shrinks
   as `n` grows**, because bigger samples give steadier estimates.
 
-```mermaid
-flowchart TD
-    subgraph DATA["Standard deviation (SD)"]
-      D1["Spread of the DATA<br/>(how individual values vary)"]
-      D2["Property of the population.<br/>Does NOT shrink with more data."]
-    end
-    subgraph EST["Standard error (SE)"]
-      E1["Spread of the ESTIMATE<br/>(how x-bar varies sample to sample)"]
-      E2["= SD of the sampling distribution.<br/>SHRINKS as n grows: s / sqrt(n)."]
-    end
-    DATA -->|"divide by sqrt(n)"| EST
-```
+|  | Standard deviation (SD) | Standard error (SE) |
+| --- | --- | --- |
+| Spread of… | the **data** (how individual values vary) | the **estimate** (how x̄ varies sample to sample) |
+| Behavior | a property of the population; does **not** shrink with more data | the SD of the sampling distribution; **shrinks** as `n` grows, since `SE = s / √n` |
 
 The formula linking them is short and worth memorizing: for the sample
 mean,
@@ -231,12 +223,11 @@ only improves precision by about √10 ≈ 3.2x, and going
 further buys even less. Knowing this saves real money and time when you
 plan how much data to collect.
 
-```mermaid
-flowchart LR
-    A["Want 2x the precision<br/>(halve the SE)"] --> B["Need 4x the data"]
-    C["Want 3x the precision"] --> D["Need 9x the data"]
-    E["Want 10x the precision"] --> F["Need 100x the data"]
-```
+| Precision you want | Data you need |
+| --- | --- |
+| 2× (halve the SE) | 4× the data |
+| 3× | 9× the data |
+| 10× | 100× the data |
 
 <MultipleChoice
   markdown={`Your estimate of a mean has a standard error of 2.0 from a sample of \`n = 500\`. Your manager wants the SE down to 1.0. Roughly how large must the new sample be?

--- a/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
+++ b/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
@@ -15,18 +15,19 @@ This page is a field guide to the classics. For each one: **what it is**,
 fancy math to understand. All of them have ended real projects, shipped
 real bad features, and made it into real headlines.
 
-```mermaid
-flowchart TD
-  A["A correct calculation"] --> B{"But is the<br/>reasoning sound?"}
-  B -->|"forgot a lurking group"| C["Simpson's paradox"]
-  B -->|"a third cause"| D["Confounding"]
-  B -->|"tested many things"| E["P-hacking /<br/>multiple comparisons"]
-  B -->|"ignored the prior"| F["Base-rate neglect"]
-  B -->|"only saw survivors"| G["Survivorship bias"]
-  B -->|"extreme bounces back"| H["Regression to the mean"]
-  B -->|"picked the nice data"| I["Cherry-picking"]
-  B -->|"drew the target after"| J["Texas sharpshooter"]
-```
+Even with a correct calculation, the reasoning can still spring one of
+these leaks:
+
+| The mistake | The fallacy |
+| --- | --- |
+| Forgot a lurking group | Simpson's paradox |
+| A third cause | Confounding |
+| Tested many things | P-hacking / multiple comparisons |
+| Ignored the prior | Base-rate neglect |
+| Only saw survivors | Survivorship bias |
+| Extreme bounces back | Regression to the mean |
+| Picked the nice data | Cherry-picking |
+| Drew the target after | Texas sharpshooter |
 
 ## Simpson's paradox: a trend that reverses when you split the data
 

--- a/content/learn/systems-programming-c/data-types-and-memory.mdx
+++ b/content/learn/systems-programming-c/data-types-and-memory.mdx
@@ -155,14 +155,12 @@ memory:
 - **Big-endian** (older PowerPC, network byte order): the *most*
   significant byte first — `12 34 56 78`.
 
-```mermaid
-flowchart LR
-    subgraph LE["Little-endian (x86, WASI)"]
-        A0["addr 0<br/>0x78"] --> A1["addr 1<br/>0x56"] --> A2["addr 2<br/>0x34"] --> A3["addr 3<br/>0x12"]
-    end
-    subgraph BE["Big-endian"]
-        B0["addr 0<br/>0x12"] --> B1["addr 1<br/>0x34"] --> B2["addr 2<br/>0x56"] --> B3["addr 3<br/>0x78"]
-    end
+Laid out byte by byte at increasing addresses:
+
+```text
+                addr 0   addr 1   addr 2   addr 3
+Little-endian:   0x78     0x56     0x34     0x12     (x86, WASI)
+Big-endian:      0x12     0x34     0x56     0x78
 ```
 
 You can *see* the byte order at runtime by reading the bytes of an

--- a/content/learn/systems-programming-c/memory-bugs.mdx
+++ b/content/learn/systems-programming-c/memory-bugs.mdx
@@ -8,17 +8,16 @@ things in spectacular ways. This page is a tour of the bug classes
 that every C programmer eventually meets, with runnable examples that
 *reproduce the bug* in the sandbox where possible.
 
-```mermaid
-flowchart TB
-    A[Common memory bugs] --> B[Use after free]
-    A --> C[Double free]
-    A --> D[Memory leak]
-    A --> E[Buffer overflow]
-    A --> F[Off-by-one]
-    A --> G[Uninitialized read]
-    A --> H[Dangling stack pointer]
-    A --> I[Type confusion / strict aliasing]
-```
+The bug classes we will cover:
+
+- Use-after-free
+- Double-free
+- Memory leak
+- Buffer overflow
+- Off-by-one
+- Uninitialized read
+- Dangling stack pointer
+- Type confusion / strict aliasing
 
 These are not "exotic" bugs — they are the source of an enormous
 share of real-world security vulnerabilities (CVEs). Recognizing the

--- a/content/learn/time-series-analysis-python/chronological-validation.mdx
+++ b/content/learn/time-series-analysis-python/chronological-validation.mdx
@@ -26,17 +26,15 @@ training set* by February and April. The model gets to peek at both sides of
 every test point. It will score brilliantly in evaluation and collapse in
 production, where the future genuinely doesn't exist yet.
 
-```mermaid
-flowchart TB
-    subgraph BAD["WRONG: random / k-fold split (test points time-surrounded by train)"]
-        direction LR
-        b1["Jan<br/>train"] --> b2["Feb<br/>TEST"] --> b3["Mar<br/>train"] --> b4["Apr<br/>TEST"] --> b5["May<br/>train"]
-    end
-    subgraph GOOD["RIGHT: chronological split (train is the past, test is the future)"]
-        direction LR
-        g1["Jan<br/>train"] --> g2["Feb<br/>train"] --> g3["Mar<br/>train"] --> g4["Apr<br/>TEST"] --> g5["May<br/>TEST"]
-    end
-```
+Line the two schemes up month by month and the flaw is obvious — under the
+random split, every `TEST` month is hemmed in by `train` months on both
+sides; under the chronological split, all training is in the past and all
+testing is in the future:
+
+| Split | Jan | Feb | Mar | Apr | May |
+| --- | --- | --- | --- | --- | --- |
+| **Random / k-fold** (wrong) | train | `TEST` | train | `TEST` | train |
+| **Chronological** (right) | train | train | train | `TEST` | `TEST` |
 
 Let's *measure* the leakage. We'll take a smooth-ish series and "predict"
 held-out points two ways: a random hold-out (where each test point still has
@@ -178,23 +176,13 @@ estimate is noisy. Maybe that particular tail happened to be easy or hard.
 *many* successive cut-off points and averages the skill. The iron rule holds
 in every fold: **train is always strictly before test.**
 
-```mermaid
-flowchart TB
-    subgraph F1["Fold 1"]
-        direction LR
-        a1["train: months 1-60"] --> p1["test: 61-72"]
-    end
-    subgraph F2["Fold 2 (train grows)"]
-        direction LR
-        a2["train: months 1-72"] --> p2["test: 73-84"]
-    end
-    subgraph F3["Fold 3 (train grows)"]
-        direction LR
-        a3["train: months 1-84"] --> p3["test: 85-96"]
-    end
-```
+| Fold | Train (the past) | Test (the future) |
+| --- | --- | --- |
+| 1 | months 1–60 | months 61–72 |
+| 2 | months 1–72 | months 73–84 |
+| 3 | months 1–84 | months 85–96 |
 
-The picture above is the **expanding-window** (anchored) scheme: the training
+This is the **expanding-window** (anchored) scheme: the training
 set grows each fold while the test window marches forward. A **rolling-window**
 scheme instead keeps the training window a fixed *size* and slides it — useful
 when old history stops being relevant. Either way, you get several honest

--- a/content/learn/time-series-analysis-python/handling-missing-temporal-data.mdx
+++ b/content/learn/time-series-analysis-python/handling-missing-temporal-data.mdx
@@ -61,24 +61,17 @@ prerequisite for filling them honestly.
 Once gaps are explicit `NaN`s, you choose how to fill. The three workhorses
 encode three different beliefs about the unseen interval:
 
-```mermaid
-flowchart TB
-    subgraph FFILL["Forward-fill: carry the LAST known value forward"]
-        direction LR
-        F1["10"] --> F2["10 (copied)"] --> F3["10 (copied)"] --> F4["40"]
-    end
-    subgraph BFILL["Back-fill: pull the NEXT known value backward (uses the future!)"]
-        direction LR
-        B1["10"] --> B2["40 (copied)"] --> B3["40 (copied)"] --> B4["40"]
-    end
-    subgraph INTERP["Linear interpolation: glide in a straight line between knowns"]
-        direction LR
-        I1["10"] --> I2["20 (computed)"] --> I3["30 (computed)"] --> I4["40"]
-    end
-```
+Take the same gap — two missing points between a known `10` and a known
+`40` — and watch each method fill the two interior slots differently
+(filled values in **bold**):
 
-The same gap — two missing points between a 10 and a 40 — gets three
-different answers. Let's compute exactly that:
+| Method | known | gap | gap | known |
+| --- | --- | --- | --- | --- |
+| **Forward-fill** — carry the LAST known value forward | 10 | **10** | **10** | 40 |
+| **Back-fill** — pull the NEXT known value backward (uses the future!) | 10 | **40** | **40** | 40 |
+| **Linear interpolation** — glide in a straight line between knowns | 10 | **20** | **30** | 40 |
+
+The same gap gets three different answers. Let's compute exactly that:
 
 <CodeBlock
   adapter="python"

--- a/content/learn/time-series-analysis-python/index.mdx
+++ b/content/learn/time-series-analysis-python/index.mdx
@@ -127,17 +127,11 @@ know which question you're asking and whether the answer makes sense.
 
 We move from *understanding* time, to *reshaping* it, to *modeling* its
 structure, and finally to *forecasting and honestly evaluating* the
-result.
-
-```mermaid
-flowchart TD
-    A["The Time Dimension<br/>(why order is information)"] --> B["Reshaping Time<br/>(resample, rolling, gaps)"]
-    B --> C["Structure & Stationarity<br/>(decompose, test, difference)"]
-    C --> D["Reading the Echoes<br/>(ACF and PACF)"]
-    D --> E["Classic Forecasting<br/>(AR, MA, ARIMA)"]
-    E --> F["Chronological Validation<br/>(backtesting without leakage)"]
-    F --> G["Capstone<br/>(an end-to-end pipeline)"]
-```
+result. The path runs through the time dimension, reshaping time
+(resample, rolling, gaps), structure and stationarity (decompose, test,
+difference), reading the echoes (ACF and PACF), classic forecasting (AR,
+MA, ARIMA), chronological validation (backtesting without leakage), and a
+capstone end-to-end pipeline.
 
 Each section builds on the one before it. The conceptual heart of the
 course is the run of pages on **stationarity**, **differencing**,

--- a/content/learn/time-series-analysis-python/rolling-and-expanding-windows.mdx
+++ b/content/learn/time-series-analysis-python/rolling-and-expanding-windows.mdx
@@ -65,17 +65,15 @@ series and computes a summary at each stop. The **moving average** —
 becomes the average of itself and its `N-1` predecessors, so random
 up-and-down jitter cancels out while the slow signal survives.
 
-```mermaid
-flowchart TB
-    subgraph ROLL["Rolling window = 3 (fixed size, slides forward)"]
-        direction LR
-        R1["mean of y1, y2, y3"] --> R2["mean of y2, y3, y4"] --> R3["mean of y3, y4, y5"]
-    end
-    subgraph EXP["Expanding window (grows from the start)"]
-        direction LR
-        E1["mean of y1"] --> E2["mean of y1, y2"] --> E3["mean of y1, y2, y3"]
-    end
-```
+A **rolling** window is a fixed size that slides forward; an **expanding**
+window is anchored at the start and grows. Watch what each averages as it
+advances:
+
+| Step | Rolling, window = 3 (fixed size, slides) | Expanding (grows from the start) |
+| --- | --- | --- |
+| 1 | mean of `y1, y2, y3` | mean of `y1` |
+| 2 | mean of `y2, y3, y4` | mean of `y1, y2` |
+| 3 | mean of `y3, y4, y5` | mean of `y1, y2, y3` |
 
 Watch a 12-month moving average dissolve the airline series' seasonal hump
 and lay its trend bare. **Change the `window` and re-run** to feel the

--- a/content/learn/time-series-analysis-python/what-makes-time-series-unique.mdx
+++ b/content/learn/time-series-analysis-python/what-makes-time-series-unique.mdx
@@ -118,22 +118,12 @@ the same fixed distribution (same mean, same variance, forever).
 
 A time series violates **both** halves, on purpose:
 
-```mermaid
-flowchart TB
-    subgraph CS["Cross-sectional data (i.i.d.)"]
-        direction LR
-        C1["obs 1"]
-        C2["obs 2"]
-        C3["obs 3"]
-        C4["obs 4"]
-    end
-    subgraph TS["Time series (dependent, evolving)"]
-        direction LR
-        T1["y at t-1"] --> T2["y at t"] --> T3["y at t+1"] --> T4["y at t+2"]
-    end
-    CS -. "rows are islands<br/>shuffle freely" .-> NOTE1["order does not matter"]
-    TS -. "each value leans on the last<br/>mean and variance drift" .-> NOTE2["order is everything"]
-```
+| | Cross-sectional data (i.i.d.) | Time series (dependent, evolving) |
+| --- | --- | --- |
+| The rows | independent islands: `obs 1`, `obs 2`, `obs 3`, … | a chain: `y` at `t-1` → `y` at `t` → `y` at `t+1` → … |
+| Each value | stands alone | leans on the one before it |
+| Distribution | the same for every row | mean and variance drift over time |
+| Order | does not matter — shuffle freely | is everything — shuffling destroys it |
 
 - **Not independent:** `y_t` depends on `y_{t-1}`. That's temporal
   dependence — the thing we just plotted.
@@ -254,19 +244,17 @@ Your model effectively gets to peek at the future on both sides of every
 test point. It will look brilliant in evaluation and then fall on its face
 in production, where the future is genuinely unavailable.
 
-```mermaid
-flowchart LR
-    R1["Jan<br/>train"] --> R2["Feb<br/>test"] --> R3["Mar<br/>train"] --> R4["Apr<br/>test"] --> R5["May<br/>train"] --> R6["Jun<br/>test"]
-```
+| Jan | Feb | Mar | Apr | May | Jun |
+| --- | --- | --- | --- | --- | --- |
+| train | test | train | test | train | test |
 
 *Random split (WRONG):* train and test are interleaved in time. To
 "predict" February the model is allowed to learn from January **and**
 March — it has seen the future. This is **data leakage**.
 
-```mermaid
-flowchart LR
-    B1["Jan<br/>train"] --> B2["Feb<br/>train"] --> B3["Mar<br/>train"] --> B4["Apr<br/>test"] --> B5["May<br/>test"] --> B6["Jun<br/>test"]
-```
+| Jan | Feb | Mar | Apr | May | Jun |
+| --- | --- | --- | --- | --- | --- |
+| train | train | train | test | test | test |
 
 *Chronological split (RIGHT):* train is the earlier block, test is the
 later block. The model only ever learns from the past to predict the

--- a/content/learn/typescript-from-scratch/generic-constraints.mdx
+++ b/content/learn/typescript-from-scratch/generic-constraints.mdx
@@ -179,15 +179,11 @@ By constraining `T extends readonly unknown[]`, we accept both mutable and reado
 When you preserve precise input types (readonly, literals, exact shapes), the compiler can give you more accurate autocomplete and catch more bugs. This is especially important in library code, where you don't control the input types.
 </Callout>
 
-```mermaid
-graph TD
-    A[Input: readonly array of literals] --> B[T extends readonly unknown]
-    B --> C[T binds to precise type]
-    C --> D[Return T 0: preserves literal]
-    E[Input: mutable array of strings] --> F[T extends readonly unknown]
-    F --> G[T binds to string array]
-    G --> H[Return T 0: string]
-```
+| Stage | Readonly array of literals | Mutable array of strings |
+| --- | --- | --- |
+| Input | `readonly ["red", "green", "blue"]` | `string[]` |
+| `T extends readonly unknown[]` | `T` binds to the precise tuple | `T` binds to `string[]` |
+| Return `T[0]` | `"red"` (literal preserved) | `string` |
 
 ## A practical example: typed `pluck`
 

--- a/content/learn/typescript-from-scratch/generics-basics.mdx
+++ b/content/learn/typescript-from-scratch/generics-basics.mdx
@@ -63,13 +63,10 @@ The `<T>` is a **type parameter** (also called a **type variable**). It's a plac
 By convention, single-letter names like `T`, `U`, `V` are used for generic type parameters. If the parameter has a more specific role, use a descriptive name like `TKey` or `TValue`. Avoid overly generic names like `Type` or `GenericType`.
 </Callout>
 
-```mermaid
-graph LR
-    A[identity call with 42] --> B[Compiler infers T = number]
-    B --> C[Return type: number]
-    D["identity call with 'hello'"] --> E[Compiler infers T = string]
-    E --> F[Return type: string]
-```
+| Call | Inferred `T` | Return type |
+| --- | --- | --- |
+| `identity(42)` | `number` | `number` |
+| `identity("hello")` | `string` | `string` |
 
 ## Generic functions
 
@@ -269,14 +266,7 @@ Notice how the compiler infers both `T` and `U`:
 
 For the second call, it infers `T = number` and `U = string` (from the callback returning a string), so the return type is `string[]`.
 
-```mermaid
-graph TD
-    A[map array, fn] --> B{Infer T from array}
-    B --> C[T = element type]
-    C --> D{Infer U from fn return}
-    D --> E[U = return type of fn]
-    E --> F[Return type: U array]
-```
+The inference flows in one direction: **`map(array, fn)` → infer `T` from the array's element type → infer `U` from the callback's return type → return type is `U[]`.**
 
 This is the power of generics: you write one function, and the compiler figures out the specific types for every call site.
 

--- a/content/learn/typescript-from-scratch/type-inference.mdx
+++ b/content/learn/typescript-from-scratch/type-inference.mdx
@@ -51,13 +51,10 @@ Why the difference? A `const` binding can never be reassigned, so the compiler c
 
 This is called **widening**: the compiler expands a narrow literal type into a broader one when the variable is mutable. It's a practical trade-off between precision and flexibility.
 
-```mermaid
-graph TD
-    A["const x = 'hello'"] --> B["Type: 'hello' literal"]
-    C["let y = 'hello'"] --> D[Type: string widened]
-    B --> E[Cannot reassign]
-    D --> F[Can reassign to any string]
-```
+| Binding | Inferred type | Why |
+| --- | --- | --- |
+| `const x = "hello"` | `"hello"` (literal) | Can never be reassigned, so the exact value is locked in |
+| `let y = "hello"` | `string` (widened) | Can be reassigned to any string, so the type broadens |
 
 ## Contextual typing
 
@@ -219,14 +216,11 @@ console.log(\`First feature: \${firstFeature}\`);
 
 Here's the inference chain:
 
-```mermaid
-graph TD
-    A[getConfig return literal] --> B[Inferred object type]
-    B --> C[config: inferred type]
-    C --> D[config.features: string array]
-    D --> E[features zero-index: string]
-    E --> F[firstFeature: string]
-```
+1. `getConfig`'s `return` literal gives the function an inferred object type.
+2. `config` takes that inferred type.
+3. `config.features` is `string[]`.
+4. `config.features[0]` is `string`.
+5. `firstFeature` is therefore `string`.
 
 Each expression's type is deduced from the types of its subexpressions. The compiler starts at the leaves (literal values) and propagates types upward through property accesses, function calls, and assignments.
 

--- a/scripts/audit/mermaid-audit.mjs
+++ b/scripts/audit/mermaid-audit.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+// One-off audit: extract and classify every mermaid block in the courses so we
+// can triage which diagrams are redundant / too wide / too tall vs. genuinely
+// useful structural diagrams. Not part of the build.
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "content/learn";
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) out.push(...walk(p));
+    else if (name.endsWith(".mdx")) out.push(p);
+  }
+  return out;
+}
+
+// Pull ```mermaid ... ``` fenced blocks with their start line.
+function extractBlocks(text) {
+  const lines = text.split("\n");
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    const m = lines[i].match(/^(\s*)```mermaid\s*$/);
+    if (m) {
+      const startLine = i + 1;
+      const body = [];
+      i++;
+      while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
+        body.push(lines[i]);
+        i++;
+      }
+      blocks.push({ startLine, text: body.join("\n") });
+    }
+    i++;
+  }
+  return blocks;
+}
+
+// Strip mermaid node-shape labels so edge parsing sees bare ids. Applied
+// repeatedly to peel nested shapes like [[..]], ((..)), [(..)], {{..}}.
+function stripLabels(line) {
+  let prev;
+  do {
+    prev = line;
+    line = line
+      .replace(/\[\[[^\]]*\]\]/g, "")
+      .replace(/\(\([^)]*\)\)/g, "")
+      .replace(/\[\([^)]*\)\]/g, "")
+      .replace(/\{\{[^}]*\}\}/g, "")
+      .replace(/\[[^\][]*\]/g, "")
+      .replace(/\([^()]*\)/g, "")
+      .replace(/\{[^{}]*\}/g, "")
+      .replace(/>[^\]]*\]/g, "") // asymmetric >text]
+      .replace(/:::[A-Za-z0-9_]+/g, ""); // class assignment
+  } while (line !== prev);
+  return line;
+}
+
+// Parse edges into (src,dst) pairs by normalizing every arrow form to a single
+// token, then walking chained `A --> B --> C` segments. Good enough for degree
+// stats, which is what drives the structural classification.
+function parseEdges(lines) {
+  const edges = [];
+  const nodes = new Set();
+  for (let raw of lines) {
+    if (/^(flowchart|graph)\b/i.test(raw)) continue;
+    if (/^(subgraph|end\b|classDef|class\s|click|style|direction|linkStyle|%%)/i.test(raw)) continue;
+    let line = stripLabels(raw);
+    line = line.replace(/\|[^|]*\|/g, " "); // edge labels |x|
+    // `-- label -->` / `-. label .->` / `== label ==>` (label survived strip)
+    line = line.replace(/[-.=]{2,}\s*[^-.=>&\n]*?\s*[-.=]{1,}>/g, " ~> ");
+    line = line.replace(/[xo<][-.=]{2,}[^-.=>&\n]*?[-.=]{1,}[xo>]/g, " ~> ");
+    // bare arrows / links
+    line = line.replace(/[-.=]{2,}>/g, " ~> ");
+    line = line.replace(/<[-.=]{2,}/g, " ~> ");
+    line = line.replace(/[-.=]{3,}/g, " ~> "); // open link --- / ===
+    if (!line.includes("~>")) {
+      // declaration-only line: capture its node id
+      const idm = raw.trim().match(/^([A-Za-z][\w]*)/);
+      if (idm && !/^(flowchart|graph|subgraph|end|classDef|class|direction|style|linkStyle|click)$/i.test(idm[1])) nodes.add(idm[1]);
+      continue;
+    }
+    const segs = line.split("~>").map((s) => s.trim()).filter(Boolean);
+    const ids = segs.map((s) => {
+      const m = s.match(/([A-Za-z][\w]*)\s*$/); // id closest to the arrow
+      return m ? m[1] : null;
+    });
+    for (let i = 0; i < ids.length - 1; i++) {
+      if (ids[i] && ids[i + 1]) {
+        edges.push([ids[i], ids[i + 1]]);
+        nodes.add(ids[i]);
+        nodes.add(ids[i + 1]);
+      }
+    }
+  }
+  return { edges, nodes };
+}
+
+function classify(chart) {
+  const norm = chart.replace(/\\n/g, "\n");
+  const lines = norm.split("\n").map((l) => l.trim()).filter(Boolean);
+  const first = lines[0] || "";
+  const typeMatch = first.match(/^(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram(?:-v2)?|erDiagram|timeline|mindmap|pie|gantt|journey|gitGraph|quadrantChart|requirementDiagram|C4Context|xychart(?:-beta)?|block(?:-beta)?|sankey(?:-beta)?)\b/i);
+  const type = typeMatch ? typeMatch[1] : first.split(/\s+/)[0] || "unknown";
+  const dirMatch = first.match(/\b(LR|RL|TB|TD|BT)\b/);
+  const direction = dirMatch ? dirMatch[1] : "";
+
+  const isTimeline = /^timeline\b/i.test(first);
+  const isStructural = /^(sequenceDiagram|classDiagram|stateDiagram|erDiagram|mindmap|pie|gantt|journey|gitGraph|quadrantChart|requirementDiagram|C4|xychart|sankey)/i.test(type);
+  const isFlow = /^(flowchart|graph)/i.test(type);
+
+  const { edges, nodes } = parseEdges(lines);
+  const nodeCount = nodes.size;
+  const edgeCount = edges.length;
+  const subgraphs = (norm.match(/^\s*subgraph\b/gim) || []).length;
+  const hasClassDef = /classDef/.test(norm);
+  const maxLineLen = Math.max(0, ...lines.map((l) => l.length));
+
+  // Degrees
+  const outDeg = new Map();
+  const inDeg = new Map();
+  for (const [s, d] of edges) {
+    outDeg.set(s, (outDeg.get(s) || 0) + 1);
+    inDeg.set(d, (inDeg.get(d) || 0) + 1);
+  }
+  const maxOut = Math.max(0, ...outDeg.values());
+  const maxIn = Math.max(0, ...inDeg.values());
+
+  // Cycle detection (DFS) — a back-edge means a decision/loop flow (keep).
+  const adj = new Map();
+  for (const [s, d] of edges) {
+    if (!adj.has(s)) adj.set(s, []);
+    adj.get(s).push(d);
+  }
+  let hasCycle = false;
+  const WHITE = 0, GRAY = 1, BLACK = 2;
+  const color = new Map([...nodes].map((n) => [n, WHITE]));
+  const dfs = (u) => {
+    color.set(u, GRAY);
+    for (const v of adj.get(u) || []) {
+      if (color.get(v) === GRAY) { hasCycle = true; return; }
+      if (color.get(v) === WHITE) dfs(v);
+    }
+    color.set(u, BLACK);
+  };
+  for (const n of nodes) if (color.get(n) === WHITE) dfs(n);
+
+  // Longest path (DAG) → horizontal extent in LR, vertical extent in TD.
+  let longestPath = nodeCount > 0 ? 1 : 0;
+  if (!hasCycle && edgeCount > 0) {
+    const memo = new Map();
+    const dp = (u) => {
+      if (memo.has(u)) return memo.get(u);
+      let best = 1;
+      for (const v of adj.get(u) || []) best = Math.max(best, 1 + dp(v));
+      memo.set(u, best);
+      return best;
+    };
+    for (const n of nodes) longestPath = Math.max(longestPath, dp(n));
+  }
+
+  // Structural shape of the flow graph
+  const isPath = isFlow && edgeCount > 0 && maxOut <= 1 && maxIn <= 1 && !hasCycle; // a chain
+  const isTree = isFlow && maxOut >= 2 && maxIn <= 1 && !hasCycle; // branches out
+  const isMerge = isFlow && maxIn >= 2; // converges (split-apply-combine etc.)
+  const noEdges = isFlow && edgeCount === 0;
+
+  // Width proxies. Side-by-side subgraphs each widen the layout; a long LR
+  // chain or a big TD fan-out also do.
+  const horiz =
+    direction === "LR" || direction === "RL"
+      ? longestPath
+      : Math.max(maxOut, subgraphs >= 2 ? subgraphs : 0);
+  const subgraphWidth = subgraphs >= 2 ? subgraphs : 0;
+
+  // ── Flags ──────────────────────────────────────────────────────────────
+  let flag = "ok";
+  if (isTimeline) flag = "timeline-skip";
+  else if (isStructural) flag = "structural-ok";
+  else if (noEdges && nodeCount >= 4) flag = "TABLE-LIKE";
+  else if (isPath && nodeCount >= 6) flag = "LONG-PATH"; // redundant linear chain
+  else if (isPath && nodeCount >= 3) flag = "short-path";
+  // wide: long horizontal chain, big fan, or ≥2 side-by-side subgraph columns
+  else if ((direction === "LR" || direction === "RL") && longestPath >= 6) flag = "WIDE-CHAIN";
+  else if (maxOut >= 6) flag = "WIDE-FANOUT";
+  else if (subgraphWidth >= 3) flag = "WIDE-SUBGRAPHS";
+  else if (isTree || isMerge) flag = "branchy-ok";
+
+  return {
+    type, direction, nodeCount, edgeCount, subgraphs, hasClassDef,
+    maxLineLen, lineCount: lines.length,
+    maxOut, maxIn, hasCycle, longestPath, horiz,
+    isPath, isTree, isMerge, noEdges, flag,
+  };
+}
+
+const files = walk(ROOT).sort();
+const rows = [];
+for (const f of files) {
+  const text = readFileSync(f, "utf8");
+  const blocks = extractBlocks(text);
+  for (const b of blocks) {
+    const c = classify(b.text);
+    rows.push({ file: f, line: b.startLine, ...c, chart: b.text });
+  }
+}
+
+// Summary
+const byFlag = {};
+const byType = {};
+for (const r of rows) {
+  byFlag[r.flag] = (byFlag[r.flag] || 0) + 1;
+  byType[r.type] = (byType[r.type] || 0) + 1;
+}
+
+const mode = process.argv[2] || "summary";
+if (mode === "summary") {
+  console.log("TOTAL BLOCKS:", rows.length);
+  console.log("\nBY FLAG:");
+  for (const [k, v] of Object.entries(byFlag).sort((a, b) => b[1] - a[1])) console.log(`  ${k.padEnd(16)} ${v}`);
+  console.log("\nBY TYPE:");
+  for (const [k, v] of Object.entries(byType).sort((a, b) => b[1] - a[1])) console.log(`  ${k.padEnd(20)} ${v}`);
+  console.log("\nBY COURSE (actionable = TABLE-LIKE|LONG-PATH|WIDE-*):");
+  const ACTION = ["TABLE-LIKE", "LONG-PATH", "WIDE-CHAIN", "WIDE-FANOUT", "WIDE-SUBGRAPHS"];
+  const byCourse = {};
+  for (const r of rows) {
+    const course = r.file.split("/")[2];
+    byCourse[course] = byCourse[course] || { total: 0, flagged: 0 };
+    byCourse[course].total++;
+    if (ACTION.includes(r.flag)) byCourse[course].flagged++;
+  }
+  for (const [k, v] of Object.entries(byCourse).sort((a, b) => b[1].flagged - a[1].flagged)) {
+    if (v.flagged > 0) console.log(`  ${k.padEnd(40)} actionable ${String(v.flagged).padStart(3)} / ${v.total}`);
+  }
+} else if (mode === "json") {
+  // Dump flagged rows (no chart text) for triage.
+  const flagged = rows.filter((r) => ["TABLE-LIKE", "LONG-LINEAR", "WIDE", "TALL"].includes(r.flag));
+  console.log(JSON.stringify(flagged.map(({ chart, ...r }) => r), null, 2));
+} else if (mode === "list") {
+  const want = process.argv[3];
+  for (const r of rows) {
+    if (want && r.flag !== want) continue;
+    if (!want && r.flag === "ok") continue;
+    console.log(`${r.flag.padEnd(14)} ${r.type.padEnd(10)} n=${String(r.nodeCount).padStart(2)} e=${String(r.edgeOps).padStart(2)} ${r.file}:${r.line}`);
+  }
+} else if (mode === "dump") {
+  const want = process.argv[3];
+  const limit = Number(process.argv[4] || 8);
+  const course = process.argv[5];
+  let shown = 0;
+  for (const r of rows) {
+    if (r.flag !== want) continue;
+    if (course && !r.file.includes(course)) continue;
+    if (shown++ >= limit) break;
+    console.log(`\n━━━ ${r.flag} | ${r.type} ${r.direction} n=${r.nodeCount} e=${r.edgeOps} sg=${r.subgraphs} | ${r.file}:${r.line}`);
+    console.log(r.chart);
+  }
+} else if (mode === "file") {
+  const want = process.argv[3];
+  for (const r of rows) {
+    if (!r.file.includes(want)) continue;
+    console.log(`\n━━━ ${r.flag} | ${r.type} ${r.direction} n=${r.nodeCount} e=${r.edgeCount} | ${r.file}:${r.line}`);
+    console.log(r.chart);
+  }
+} else if (mode === "course") {
+  // Actionable worklist for one course: file:line, flag, stats, chart text.
+  const want = process.argv[3];
+  const ACTION = ["TABLE-LIKE", "LONG-PATH", "WIDE-CHAIN", "WIDE-FANOUT", "WIDE-SUBGRAPHS"];
+  let n = 0;
+  for (const r of rows) {
+    if (!r.file.includes(want)) continue;
+    if (!ACTION.includes(r.flag)) continue;
+    n++;
+    console.log(`\n━━━ #${n} ${r.flag} | ${r.type} ${r.direction} nodes=${r.nodeCount} edges=${r.edgeCount} maxOut=${r.maxOut} maxIn=${r.maxIn} subgraphs=${r.subgraphs} longestPath=${r.longestPath}`);
+    console.log(`FILE: ${r.file}:${r.line}`);
+    console.log("```mermaid");
+    console.log(r.chart);
+    console.log("```");
+  }
+  console.log(`\nTOTAL actionable in ${want}: ${n}`);
+}

--- a/scripts/audit/validate-mdx.mjs
+++ b/scripts/audit/validate-mdx.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Compile MDX files through (approximately) the same remark/rehype pipeline the
+// site uses, to catch syntax breakage from the diagram edits. Pass file paths,
+// or nothing to validate the whole content/learn tree.
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { compile } from "@mdx-js/mdx";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import { remarkMdxMermaid } from "fumadocs-core/mdx-plugins";
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) out.push(...walk(p));
+    else if (name.endsWith(".mdx")) out.push(p);
+  }
+  return out;
+}
+
+const args = process.argv.slice(2);
+// Expand any directory args to the .mdx files within; keep file args as-is.
+const files = args.length
+  ? args.flatMap((a) => (statSync(a).isDirectory() ? walk(a) : [a]))
+  : walk("content/learn");
+
+let failures = 0;
+for (const file of files) {
+  let src = readFileSync(file, "utf8");
+  // Strip leading YAML frontmatter — the real loader parses it separately, so
+  // `<…>` in a description must not be compiled as MDX/JSX.
+  src = src.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, "");
+  try {
+    await compile(src, {
+      format: "mdx",
+      // Match the app: gfm tables, math, and the mermaid remark transform.
+      remarkPlugins: [remarkGfm, remarkMath, remarkMdxMermaid],
+    });
+  } catch (err) {
+    failures++;
+    const line = err?.line ? `:${err.line}:${err.column ?? ""}` : "";
+    console.log(`✗ ${file}${line}\n    ${err.message.split("\n")[0]}`);
+  }
+}
+
+if (failures === 0) console.log(`✓ ${files.length} file(s) compiled cleanly`);
+else {
+  console.log(`\n${failures} file(s) failed to compile`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What & why

Audited **every** Mermaid diagram in `content/learn/**` and removed/replaced the ones that hurt readability, while keeping the diagrams that earn their space.

Two problems motivated this (both raised in review):

1. **Redundant diagrams** — a straight list of steps, a table-of-contents outline, or an edgeless grid drawn with boxes. These read better as plain Markdown.
2. **Too wide / too tall** — long horizontal `LR` chains and big fan-outs shrink until the text is unreadable, forcing the reader to open the fullscreen modal just to read them.

## Approach

- Built a small classifier (`scripts/audit/mermaid-audit.mjs`) that parses each diagram's edge graph (in/out-degree, cycles, longest path, fan-out, subgraphs) to distinguish **simple paths / grids / hub-and-spoke fans / side-by-side comparisons** (convert) from **branching, merging, cyclic, and relational** diagrams (keep).
- Applied a consistent rubric:
  - simple path → ordered list or inline `A → B → C` text (or **deleted** if it was just a TOC / duplicated adjacent prose)
  - edgeless "table" grid → **GFM table**
  - hub-and-spoke fan / lookup-style decision tree → list or table
  - side-by-side comparison subgraphs → 2-column table
  - genuinely wide-but-structural diagrams → flipped `LR → TD` so they fit the column
- **Kept** all diagrams that show real structure: split/merge flows, decision trees with multi-step branches, control-flow cycles, type lattices, language-genealogy graphs, package-dependency architecture, and spatial pictures (memory layouts, array cells, pointers, hash-table chaining, circular buffers). `timeline` blocks (custom component) were never touched.
- Verified every edited file compiles through the site's MDX pipeline (`scripts/audit/validate-mdx.mjs`, added here and reusable as a content check).

## Result

- **246 diagrams** removed or converted to tables / lists / text; **223 lessons** updated (net −954 lines).
- Edgeless "table" grids: **35 → 0**. Long linear chains: **165 → 12**. Over-wide diagrams: **31 → 8**.
- The ~20 diagrams still flagged by the width/path heuristics are all **deliberate keeps** — spatial and merging diagrams (e.g. the `unknown → primitives → never` type lattice, memory-layout pictures, the C/Java genealogy graphs, package architecture) where the layout carries the meaning.
- All **781** content files compile cleanly.

## Notes

- The three visualization courses (ggplot2, Plotly, Seaborn) carried the most decorative diagrams and got a slightly deeper pass: diagrams that merely restated an adjacent table/list were removed (e.g. a "question → chart" decision fan sitting directly above the equivalent table).
- Adds two reusable scripts under `scripts/audit/` (diagram classifier + MDX compile-check). Happy to drop them if you'd prefer a content-only PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_019SYXKge2q4bxcfEF6P9XbW)_