### PR TITLE
Add SVG vector illustrations to the JavaScript course (pilot)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,11 +9,6 @@
       "command": "npx",
       "args": ["-y", "next-devtools-mcp@latest"]
     },
-    "playwright": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"]
-    },
     "duckdb": {
       "type": "stdio",
       "command": "uvx",

--- a/app/_components/mdx/illustrations/Illustration.module.css
+++ b/app/_components/mdx/illustrations/Illustration.module.css
@@ -1,0 +1,111 @@
+/* ============================================================================
+ * Illustration.module.css — theme-aware token layer for lesson SVG art
+ * ----------------------------------------------------------------------------
+ * Every illustration is a server-rendered inline <svg> that paints itself from
+ * the `--il-*` custom properties declared here. The properties are defined on
+ * the `.figure` wrapper and overridden under the `.dark` / `[data-theme=dark]`
+ * ancestors, so a single set of SVGs renders correctly in BOTH color schemes
+ * with no JavaScript and no theme-flash — the cascade does the work.
+ *
+ * Colors are sourced from the brand system (app/brand.css):
+ *   - Neutrals come from the --ds-gray ramp (ink / surfaces / hairlines).
+ *   - Accents come from the seven categorical brand hues. We use the 500 step
+ *     in light mode and the brighter 400 step in dark mode so each accent keeps
+ *     a comfortable contrast against the surface it sits on.
+ *   - Soft tints are mixed at call sites with
+ *     `color-mix(in srgb, var(--il-…) <pct>%, transparent)`, which yields a
+ *     light wash over a white page and a subtle hue-tinted shade over the dark
+ *     page from the SAME declaration (color-mix is already used across the app).
+ * ========================================================================== */
+
+.figure {
+  /* Respond to the article column width, not the viewport. */
+  container-type: inline-size;
+  display: block;
+  margin: 2rem auto;
+  max-width: var(--il-max-width, 30rem);
+
+  /* ── Neutrals — LIGHT ─────────────────────────────────────────────── */
+  --il-ink: var(--ds-gray-800); /* primary linework / labels            */
+  --il-ink-2: var(--ds-gray-600); /* secondary lines                     */
+  --il-muted: var(--ds-gray-400); /* faint glyphs / de-emphasised text   */
+  --il-hair: var(--ds-gray-300); /* hairline guides, connectors, grids   */
+  --il-paper: var(--ds-white); /* primary object fill ("paper")          */
+  --il-surface-2: var(--ds-gray-100); /* secondary panel fill            */
+  --il-surface-3: var(--ds-gray-200); /* tertiary / iso side faces       */
+
+  /* ── Accents — LIGHT (500 step) ───────────────────────────────────── */
+  --il-blue: var(--ds-blue-500);
+  --il-teal: var(--ds-teal-500);
+  --il-purple: var(--ds-purple-500);
+  --il-orange: var(--ds-orange-500);
+  --il-green: var(--ds-green-500);
+  --il-yellow: var(--ds-yellow-500);
+  --il-red: var(--ds-red-500);
+}
+
+/* ── Dark overrides ───────────────────────────────────────────────────
+ * Targets BOTH theme hooks used in the repo (.dark for /learn via
+ * next-themes, [data-theme=dark] for /playground), mirroring brand.css. */
+:global(.dark) .figure,
+:global([data-theme="dark"]) .figure {
+  /* Neutrals — DARK */
+  --il-ink: var(--ds-gray-200);
+  --il-ink-2: var(--ds-gray-300);
+  --il-muted: var(--ds-gray-500);
+  --il-hair: var(--ds-gray-700);
+  --il-paper: var(--ds-gray-800); /* lifted card on the ~#121212 page    */
+  --il-surface-2: var(--ds-gray-700);
+  --il-surface-3: var(--ds-gray-600);
+
+  /* Accents — DARK (brighter 400 step) */
+  --il-blue: var(--ds-blue-400);
+  --il-teal: var(--ds-teal-400);
+  --il-purple: var(--ds-purple-400);
+  --il-orange: var(--ds-orange-400);
+  --il-green: var(--ds-green-400);
+  --il-yellow: var(--ds-yellow-400);
+  --il-red: var(--ds-red-400);
+}
+
+.svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  /* Anchor `currentColor` (used for incidental strokes) to the ink token. */
+  color: var(--il-ink);
+  overflow: visible;
+}
+
+/* Inline labels baked into the art. The /learn prose rules deliberately skip
+   `svg *`, so SVG text keeps these values instead of the article serif. */
+.svg text {
+  font-family: var(--font-sans, system-ui, sans-serif);
+  fill: var(--il-ink);
+}
+
+.svg .mono {
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+/* Visible fallback for an unknown illustration name (authoring typo). */
+.missing {
+  padding: 1.25rem;
+  border: 2px dashed var(--il-red, #ef4444);
+  border-radius: 0.75rem;
+  text-align: center;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.85rem;
+  color: var(--il-red, #ef4444);
+}
+
+.caption {
+  margin: 0.85rem auto 0;
+  max-width: 34rem;
+  text-align: center;
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  letter-spacing: -0.006em;
+  color: var(--color-fd-muted-foreground, var(--il-muted));
+}

--- a/app/_components/mdx/illustrations/Illustration.tsx
+++ b/app/_components/mdx/illustrations/Illustration.tsx
@@ -1,0 +1,64 @@
+/**
+ * <Illustration> — renders a registered lesson illustration as an inline,
+ * server-rendered <svg> wrapped in a captioned <figure>.
+ *
+ * The art paints itself from the `--il-*` tokens declared in
+ * `Illustration.module.css`, which are overridden under `.dark`, so a single
+ * piece renders correctly in both light and dark mode with no client JS.
+ *
+ * Usage in MDX:
+ *   <Illustration
+ *     name="closure-backpack"
+ *     caption="A returned function carries a backpack of the variables it closed over."
+ *   />
+ */
+import type { CSSProperties, ReactNode } from "react";
+import styles from "./Illustration.module.css";
+import { ART } from "./registry";
+
+export interface IllustrationProps {
+  /** Registry key, e.g. "closure-backpack" (see registry.ts). */
+  name: string;
+  /** Optional caption shown beneath the art. */
+  caption?: ReactNode;
+  /** Override the accessible label (defaults to the registry's description). */
+  alt?: string;
+  /** Override the natural max width (CSS length). */
+  maxWidth?: string;
+}
+
+export default function Illustration({ name, caption, alt, maxWidth }: IllustrationProps) {
+  const entry = ART[name];
+
+  if (!entry) {
+    // Never crash the page on an authoring typo — render a visible, obvious
+    // placeholder and log the available names instead.
+    if (typeof console !== "undefined") {
+      console.error(`<Illustration>: unknown name "${name}". Known names: ${Object.keys(ART).join(", ")}`);
+    }
+    return (
+      <figure className={styles.figure}>
+        <div className={styles.missing}>missing illustration: {name}</div>
+      </figure>
+    );
+  }
+
+  const { viewBox, defaultAlt, Art } = entry;
+  const width = maxWidth ?? entry.maxWidth;
+  const style = width ? ({ "--il-max-width": width } as CSSProperties) : undefined;
+
+  return (
+    <figure className={styles.figure} style={style}>
+      <svg
+        className={styles.svg}
+        viewBox={viewBox}
+        role="img"
+        aria-label={alt ?? defaultAlt}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <Art />
+      </svg>
+      {caption ? <figcaption className={styles.caption}>{caption}</figcaption> : null}
+    </figure>
+  );
+}

--- a/app/_components/mdx/illustrations/art/duotone.tsx
+++ b/app/_components/mdx/illustrations/art/duotone.tsx
@@ -1,0 +1,192 @@
+/**
+ * Duotone / editorial illustrations — an accent paired with a soft tint of the
+ * same hue, layered for depth. Each export renders the inner content of an
+ * <svg>; the wrapper supplies the <svg>, viewBox and a11y.
+ *
+ * Two fill helpers, both theme-aware from one declaration:
+ *   tint() mixes the accent toward `--il-paper` → an OPAQUE surface that reads
+ *          as a tint on the light page and a subtle shade on the dark page.
+ *   wash() mixes the accent toward transparent → an ambient glaze that lets the
+ *          page show through (used only for large background shapes).
+ */
+
+const tint = (accent: string, pct: number) => `color-mix(in srgb, ${accent} ${pct}%, var(--il-paper))`;
+const wash = (accent: string, pct: number) => `color-mix(in srgb, ${accent} ${pct}%, transparent)`;
+
+/* Welcome — learning to think in code as a climb: a rising slope (a nod to
+ * "DataSlope") past milestones to a goal, over an ambient field of code. */
+export function WelcomeJourneyArt() {
+  const dots = [
+    { x: 120, y: 188, accent: "var(--il-blue)" },
+    { x: 210, y: 150, accent: "var(--il-teal)" },
+    { x: 300, y: 116, accent: "var(--il-purple)" },
+    { x: 388, y: 84, accent: "var(--il-orange)" },
+  ];
+  const slope = "M44 214 C 150 206, 168 168, 240 150 S 360 104, 430 64";
+  return (
+    <>
+      {/* ambient blobs + faint code motifs */}
+      <circle cx={120} cy={90} r={66} fill={wash("var(--il-blue)", 14)} />
+      <circle cx={332} cy={84} r={82} fill={wash("var(--il-teal)", 12)} />
+      <circle cx={410} cy={186} r={58} fill={wash("var(--il-purple)", 12)} />
+      <text className="mono" x={120} y={104} fontSize={52} fontWeight={700} textAnchor="middle" fill={wash("var(--il-blue)", 22)}>
+        {"{ }"}
+      </text>
+      <text className="mono" x={336} y={96} fontSize={40} fontWeight={700} textAnchor="middle" fill={wash("var(--il-teal)", 22)}>
+        {"=>"}
+      </text>
+
+      {/* the slope: a filled hill under a bright ridge line */}
+      <path d={`${slope} L430 232 L44 232 Z`} fill={wash("var(--il-blue)", 12)} stroke="none" />
+      <path d={slope} fill="none" stroke="var(--il-blue)" strokeWidth={4} strokeLinecap="round" />
+
+      {/* milestones */}
+      {dots.map((d, i) => (
+        <circle key={i} cx={d.x} cy={d.y} r={6.5} fill="var(--il-paper)" stroke={d.accent} strokeWidth={3} />
+      ))}
+
+      {/* start: a small code prompt the path grows from */}
+      <rect x={18} y={196} width={56} height={34} rx={9} fill="var(--il-paper)" stroke="var(--il-teal)" strokeWidth={2.5} />
+      <text className="mono" x={46} y={218} fontSize={15} fontWeight={700} textAnchor="middle" fill="var(--il-teal)">
+        {"</>"}
+      </text>
+
+      {/* summit: flag + spark */}
+      <line x1={430} y1={64} x2={430} y2={34} stroke="var(--il-ink)" strokeWidth={2.5} strokeLinecap="round" />
+      <path d="M430 36 L460 44 L430 52 Z" fill="var(--il-orange)" stroke="var(--il-ink)" strokeWidth={1.5} strokeLinejoin="round" />
+      <path
+        d="M450 18 L453 28 L463 31 L453 34 L450 44 L447 34 L437 31 L447 28 Z"
+        fill="var(--il-yellow)"
+        stroke="var(--il-orange)"
+        strokeWidth={1.25}
+        strokeLinejoin="round"
+      />
+    </>
+  );
+}
+
+/* Objects — a bag of named values: keys on the left mapped to values on the
+ * right, inside one labelled record. */
+export function ObjectKeyValueArt() {
+  const rows = [
+    { y: 108, key: "name", value: '"Ada"', accent: "var(--il-purple)" },
+    { y: 156, key: "age", value: "28", accent: "var(--il-orange)" },
+    { y: 204, key: "isAdmin", value: "true", accent: "var(--il-green)" },
+  ];
+  return (
+    <>
+      {/* card */}
+      <rect x={66} y={32} width={268} height={208} rx={18} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      {/* header band */}
+      <path d="M66 50 a18 18 0 0 1 18 -18 h232 a18 18 0 0 1 18 18 v26 h-268 Z" fill={tint("var(--il-blue)", 18)} />
+      <line x1={66} y1={76} x2={334} y2={76} stroke="var(--il-ink)" strokeWidth={1.5} />
+      <text className="mono" x={200} y={61} fontSize={15} fontWeight={700} textAnchor="middle" fill="var(--il-ink)">
+        {"{ user }"}
+      </text>
+
+      {rows.map((r, i) => (
+        <g key={i}>
+          {/* key chip */}
+          <rect x={86} y={r.y - 17} width={96} height={34} rx={9} fill={tint("var(--il-teal)", 20)} stroke="var(--il-teal)" strokeWidth={2} />
+          <text className="mono" x={134} y={r.y + 5} fontSize={13} textAnchor="middle" fill="var(--il-ink)">
+            {r.key}
+          </text>
+          {/* colon connector */}
+          <circle cx={203} cy={r.y - 4} r={1.8} fill="var(--il-muted)" />
+          <circle cx={203} cy={r.y + 4} r={1.8} fill="var(--il-muted)" />
+          {/* value chip */}
+          <rect x={218} y={r.y - 17} width={96} height={34} rx={9} fill={tint(r.accent, 20)} stroke={r.accent} strokeWidth={2} />
+          <text className="mono" x={266} y={r.y + 5} fontSize={13} textAnchor="middle" fill="var(--il-ink)">
+            {r.value}
+          </text>
+        </g>
+      ))}
+    </>
+  );
+}
+
+/* Closures — a function, returned from the scope it was born in, carries a
+ * "backpack" of the variables it closed over. */
+export function ClosureBackpackArt() {
+  return (
+    <>
+      {/* the scope it was born in */}
+      <rect x={26} y={40} width={308} height={214} rx={22} fill={wash("var(--il-purple)", 7)} stroke="var(--il-muted)" strokeWidth={2} strokeDasharray="4 5" />
+      <text x={180} y={62} fontSize={11} textAnchor="middle" fill="var(--il-muted)">
+        the scope it was born in
+      </text>
+
+      {/* backpack (drawn first → sits behind, on the function's back) */}
+      <path d="M150 132 C 150 110, 210 110, 210 132" fill="none" stroke="var(--il-orange)" strokeWidth={5} strokeLinecap="round" />
+      <rect x={92} y={132} width={86} height={96} rx={20} fill={tint("var(--il-orange)", 24)} stroke="var(--il-orange)" strokeWidth={3} />
+      <rect x={92} y={152} width={86} height={34} rx={10} fill={tint("var(--il-orange)", 40)} stroke="var(--il-orange)" strokeWidth={2} />
+      <circle cx={135} cy={170} r={6} fill="var(--il-paper)" stroke="var(--il-orange)" strokeWidth={2} />
+      {/* captured-variable tag peeking out of the pack */}
+      <rect x={96} y={112} width={78} height={26} rx={7} fill="var(--il-paper)" stroke="var(--il-orange)" strokeWidth={2} />
+      <text className="mono" x={135} y={129} fontSize={11} fontWeight={600} textAnchor="middle" fill="var(--il-ink)">
+        greeting
+      </text>
+
+      {/* the function */}
+      <rect x={158} y={120} width={120} height={112} rx={26} fill={tint("var(--il-purple)", 20)} stroke="var(--il-purple)" strokeWidth={3} />
+      <text x={218} y={190} fontSize={40} fontWeight={800} textAnchor="middle" fill="var(--il-purple)">
+        fn
+      </text>
+      <text x={218} y={212} fontSize={10.5} textAnchor="middle" fill="var(--il-muted)">
+        remembers
+      </text>
+    </>
+  );
+}
+
+/* Promises — a placeholder you hold now for a value that settles later, into
+ * either fulfilled (a value) or rejected (an error). */
+export function PromisePlaceholderArt() {
+  return (
+    <>
+      {/* the promise "ticket" with a perforated stub + pending spinner */}
+      <rect x={36} y={84} width={140} height={72} rx={14} fill={tint("var(--il-blue)", 14)} stroke="var(--il-blue)" strokeWidth={2.5} />
+      <line x1={74} y1={92} x2={74} y2={148} stroke="var(--il-blue)" strokeWidth={1.75} strokeDasharray="3 4" />
+      <path d="M55 108 A 13 13 0 1 1 46 130" fill="none" stroke="var(--il-orange)" strokeWidth={3} strokeLinecap="round" />
+      <circle cx={55} cy={108} r={2.5} fill="var(--il-orange)" />
+      <text x={128} y={114} fontSize={13} fontWeight={700} textAnchor="middle" fill="var(--il-blue)">
+        Promise
+      </text>
+      <text x={128} y={134} fontSize={11} textAnchor="middle" fill="var(--il-muted)">
+        pending…
+      </text>
+
+      {/* time → it settles, exactly once */}
+      <text x={214} y={110} fontSize={10.5} textAnchor="middle" fill="var(--il-muted)">
+        later
+      </text>
+      <path d="M176 120 L250 120" fill="none" stroke="var(--il-ink-2)" strokeWidth={2.5} />
+      <path d="M250 120 C 272 120, 280 80, 300 80" fill="none" stroke="var(--il-ink-2)" strokeWidth={2.5} />
+      <path d="M250 120 C 272 120, 280 162, 300 162" fill="none" stroke="var(--il-ink-2)" strokeWidth={2.5} />
+      <path d="M312 80 L300 74 L300 86 Z" fill="var(--il-ink-2)" />
+      <path d="M312 162 L300 156 L300 168 Z" fill="var(--il-ink-2)" />
+
+      {/* fulfilled */}
+      <rect x={312} y={58} width={104} height={44} rx={12} fill={tint("var(--il-green)", 20)} stroke="var(--il-green)" strokeWidth={2.5} />
+      <circle cx={332} cy={80} r={9} fill="var(--il-green)" />
+      <path d="M327 80 L331 84 L338 76" fill="none" stroke="var(--il-paper)" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+      <text x={350} y={77} fontSize={12} fontWeight={700} fill="var(--il-green)">
+        fulfilled
+      </text>
+      <text className="mono" x={350} y={91} fontSize={10} fill="var(--il-muted)">
+        value
+      </text>
+
+      {/* rejected */}
+      <rect x={312} y={140} width={104} height={44} rx={12} fill={tint("var(--il-red)", 18)} stroke="var(--il-red)" strokeWidth={2.5} />
+      <circle cx={332} cy={162} r={9} fill="var(--il-red)" />
+      <path d="M328 158 L336 166 M336 158 L328 166" fill="none" stroke="var(--il-paper)" strokeWidth={2} strokeLinecap="round" />
+      <text x={350} y={159} fontSize={12} fontWeight={700} fill="var(--il-red)">
+        rejected
+      </text>
+      <text className="mono" x={350} y={173} fontSize={10} fill="var(--il-muted)">
+        error
+      </text>
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/art/flat.tsx
+++ b/app/_components/mdx/illustrations/art/flat.tsx
@@ -1,0 +1,264 @@
+/**
+ * Flat-geometric illustrations — solid accent fills, rounded shapes, ink
+ * outlines. Each export renders the inner content of an <svg>; the wrapper in
+ * `Illustration.tsx` supplies the <svg>, viewBox and a11y.
+ *
+ * `--il-paper` doubles as the "on-accent" text color: it is white in light
+ * mode (legible on a mid-tone 500 fill) and dark in dark mode (legible on the
+ * brighter 400 fill), so labels stay readable on colored shapes in both modes.
+ */
+
+/** A small right-pointing arrowhead with its tip at (x, y). */
+function ArrowRight({ x, y, color, s = 6 }: { x: number; y: number; color: string; s?: number }) {
+  return <path d={`M${x} ${y} L${x - s * 1.7} ${y - s} L${x - s * 1.7} ${y + s} Z`} fill={color} />;
+}
+
+/* Birth of JavaScript — a language designed in ten days: a calendar racing an
+ * alarm clock. */
+export function TenDaySprintArt() {
+  return (
+    <>
+      {/* speed lines behind the clock */}
+      <g stroke="var(--il-orange)" strokeWidth={3} strokeLinecap="round" opacity={0.85}>
+        <line x1={348} y1={156} x2={372} y2={156} />
+        <line x1={352} y1={170} x2={380} y2={170} />
+        <line x1={348} y1={184} x2={372} y2={184} />
+      </g>
+
+      {/* calendar bindings */}
+      <rect x={86} y={42} width={9} height={20} rx={4} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <rect x={186} y={42} width={9} height={20} rx={4} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={2.5} />
+
+      {/* calendar card */}
+      <rect x={40} y={50} width={200} height={150} rx={16} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={3} />
+      <path d="M40 66 a16 16 0 0 1 16 -16 h168 a16 16 0 0 1 16 16 v28 h-200 Z" fill="var(--il-blue)" />
+      <text x={140} y={78} fontSize={12} fontWeight={700} letterSpacing={3} textAnchor="middle" fill="var(--il-paper)">
+        APRIL 1995
+      </text>
+      <text x={125} y={172} fontSize={58} fontWeight={800} textAnchor="middle" fill="var(--il-blue)">
+        10
+      </text>
+      <text x={125} y={192} fontSize={12} fontWeight={700} letterSpacing={4} textAnchor="middle" fill="var(--il-ink-2)">
+        DAYS
+      </text>
+
+      {/* alarm clock */}
+      <rect x={283} y={111} width={14} height={9} rx={3} fill="var(--il-orange)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <ellipse cx={267} cy={132} rx={12} ry={11} fill="var(--il-orange)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <ellipse cx={313} cy={132} rx={12} ry={11} fill="var(--il-orange)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <circle cx={290} cy={170} r={46} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={3} />
+      <g stroke="var(--il-orange)" strokeWidth={2.5} strokeLinecap="round">
+        <line x1={290} y1={132} x2={290} y2={140} />
+        <line x1={290} y1={200} x2={290} y2={208} />
+        <line x1={252} y1={170} x2={260} y2={170} />
+        <line x1={320} y1={170} x2={328} y2={170} />
+      </g>
+      <g stroke="var(--il-ink)" strokeWidth={3} strokeLinecap="round">
+        <line x1={290} y1={170} x2={290} y2={142} />
+        <line x1={290} y1={170} x2={270} y2={154} />
+      </g>
+      <circle cx={290} cy={170} r={4.5} fill="var(--il-orange)" stroke="var(--il-ink)" strokeWidth={1.5} />
+      {/* feet */}
+      <line x1={262} y1={212} x2={252} y2={224} stroke="var(--il-ink)" strokeWidth={3} strokeLinecap="round" />
+      <line x1={318} y1={212} x2={328} y2={224} stroke="var(--il-ink)" strokeWidth={3} strokeLinecap="round" />
+    </>
+  );
+}
+
+/* Functions — inputs go in, work happens, an output comes out. */
+export function FunctionMachineArt() {
+  const gx = 225;
+  const gy = 72;
+  const teeth = Array.from({ length: 8 }, (_, i) => i * 45);
+  return (
+    <>
+      {/* input tokens */}
+      <circle cx={46} cy={96} r={17} fill="var(--il-blue)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <text className="mono" x={46} y={101} fontSize={14} fontWeight={600} textAnchor="middle" fill="var(--il-paper)">
+        a
+      </text>
+      <circle cx={46} cy={148} r={17} fill="var(--il-teal)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <text className="mono" x={46} y={153} fontSize={14} fontWeight={600} textAnchor="middle" fill="var(--il-paper)">
+        b
+      </text>
+      <text x={46} y={186} fontSize={11} textAnchor="middle" fill="var(--il-muted)">
+        inputs
+      </text>
+
+      {/* feed arrows */}
+      <path d="M65 98 C 110 102, 110 112, 146 112" fill="none" stroke="var(--il-ink-2)" strokeWidth={2.5} />
+      <path d="M65 146 C 110 142, 110 132, 146 132" fill="none" stroke="var(--il-ink-2)" strokeWidth={2.5} />
+      <ArrowRight x={150} y={112} color="var(--il-ink-2)" />
+      <ArrowRight x={150} y={132} color="var(--il-ink-2)" />
+
+      {/* machine body */}
+      <rect x={150} y={74} width={150} height={100} rx={18} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={3} />
+
+      {/* gear on top */}
+      {teeth.map((a) => (
+        <rect
+          key={a}
+          x={gx - 4}
+          y={gy - 21}
+          width={8}
+          height={9}
+          rx={2}
+          fill="var(--il-purple)"
+          stroke="var(--il-ink)"
+          strokeWidth={1.5}
+          transform={`rotate(${a} ${gx} ${gy})`}
+        />
+      ))}
+      <circle cx={gx} cy={gy} r={13} fill="var(--il-purple)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <circle cx={gx} cy={gy} r={4.5} fill="var(--il-paper)" />
+
+      <text x={225} y={134} fontSize={34} fontWeight={800} textAnchor="middle" fill="var(--il-purple)">
+        fn
+      </text>
+      <text x={225} y={156} fontSize={10.5} textAnchor="middle" fill="var(--il-muted)">
+        do some work
+      </text>
+
+      {/* output */}
+      <line x1={300} y1={124} x2={356} y2={124} stroke="var(--il-ink-2)" strokeWidth={2.5} />
+      <ArrowRight x={360} y={124} color="var(--il-ink-2)" />
+      <circle cx={392} cy={124} r={22} fill="var(--il-green)" stroke="var(--il-ink)" strokeWidth={3} />
+      <text className="mono" x={392} y={129} fontSize={14} fontWeight={600} textAnchor="middle" fill="var(--il-paper)">
+        out
+      </text>
+      <text x={392} y={166} fontSize={11} textAnchor="middle" fill="var(--il-muted)">
+        output
+      </text>
+    </>
+  );
+}
+
+/* Loops — repeat the body, advancing a counter each time around. */
+export function LoopCycleArt() {
+  return (
+    <>
+      {/* step ticks on the ring */}
+      <g fill="var(--il-teal)">
+        <circle cx={65} cy={150} r={4} />
+        <circle cx={160} cy={245} r={4} />
+        <circle cx={255} cy={150} r={4} />
+      </g>
+
+      {/* the loop arrow (clockwise, gap at the top) */}
+      <path
+        d="M122 64 A 95 95 0 1 1 198 64"
+        fill="none"
+        stroke="var(--il-blue)"
+        strokeWidth={5}
+        strokeLinecap="round"
+      />
+      <path d="M198 64 L182 56 L188 74 Z" fill="var(--il-blue)" />
+
+      {/* the repeated work — a small deck of cards */}
+      <rect x={118} y={130} width={92} height={34} rx={9} fill="var(--il-surface-2)" stroke="var(--il-ink)" strokeWidth={2} />
+      <rect x={110} y={143} width={92} height={34} rx={9} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={2} />
+      <rect x={102} y={156} width={92} height={34} rx={9} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <rect x={108} y={161} width={6} height={24} rx={3} fill="var(--il-teal)" />
+      <text x={156} y={177} fontSize={13} textAnchor="middle" fill="var(--il-ink)">
+        body
+      </text>
+
+      {/* counter badge sitting in the gap */}
+      <rect x={138} y={42} width={44} height={26} rx={13} fill="var(--il-orange)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <text className="mono" x={160} y={59} fontSize={13} fontWeight={700} textAnchor="middle" fill="var(--il-paper)">
+        i++
+      </text>
+    </>
+  );
+}
+
+/* Map / filter / reduce — a data pipeline: transform every item, drop some,
+ * then combine the rest into a single value. */
+export function TransformPipelineArt() {
+  const y = 100;
+  return (
+    <>
+      {/* lane line */}
+      <line x1={16} y1={y} x2={462} y2={y} stroke="var(--il-hair)" strokeWidth={1.5} strokeDasharray="2 6" />
+
+      {/* input set: four squares */}
+      <g fill="var(--il-blue)" stroke="var(--il-ink)" strokeWidth={1.5}>
+        <rect x={14} y={y - 6} width={12} height={12} rx={2} />
+        <rect x={30} y={y - 6} width={12} height={12} rx={2} />
+        <rect x={46} y={y - 6} width={12} height={12} rx={2} />
+        <rect x={62} y={y - 6} width={12} height={12} rx={2} />
+      </g>
+      <text x={44} y={y + 28} fontSize={10} textAnchor="middle" fill="var(--il-muted)">
+        input
+      </text>
+
+      <ArrowRight x={90} y={y} color="var(--il-ink-2)" />
+      <line x1={78} y1={y} x2={86} y2={y} stroke="var(--il-ink-2)" strokeWidth={2} />
+
+      {/* map */}
+      <rect x={92} y={y - 24} width={68} height={48} rx={12} fill="var(--il-paper)" stroke="var(--il-blue)" strokeWidth={2.5} />
+      <text x={126} y={y - 2} fontSize={14} fontWeight={700} textAnchor="middle" fill="var(--il-blue)">
+        map
+      </text>
+      <text className="mono" x={126} y={y + 13} fontSize={9} textAnchor="middle" fill="var(--il-muted)">
+        n→n²
+      </text>
+
+      <ArrowRight x={178} y={y} color="var(--il-ink-2)" />
+      <line x1={162} y1={y} x2={174} y2={y} stroke="var(--il-ink-2)" strokeWidth={2} />
+
+      {/* mapped set: four circles */}
+      <g fill="var(--il-teal)" stroke="var(--il-ink)" strokeWidth={1.5}>
+        <circle cx={192} cy={y} r={6} />
+        <circle cx={208} cy={y} r={6} />
+        <circle cx={224} cy={y} r={6} />
+        <circle cx={240} cy={y} r={6} />
+      </g>
+
+      <ArrowRight x={250} y={y} color="var(--il-ink-2)" />
+      <line x1={248} y1={y} x2={250} y2={y} stroke="var(--il-ink-2)" strokeWidth={2} />
+
+      {/* filter */}
+      <rect x={252} y={y - 24} width={68} height={48} rx={12} fill="var(--il-paper)" stroke="var(--il-orange)" strokeWidth={2.5} />
+      <text x={286} y={y - 2} fontSize={13} fontWeight={700} textAnchor="middle" fill="var(--il-orange)">
+        filter
+      </text>
+      <text className="mono" x={286} y={y + 13} fontSize={9} textAnchor="middle" fill="var(--il-muted)">
+        n&gt;0
+      </text>
+
+      <ArrowRight x={338} y={y} color="var(--il-ink-2)" />
+      <line x1={322} y1={y} x2={334} y2={y} stroke="var(--il-ink-2)" strokeWidth={2} />
+
+      {/* filtered set: two kept, two dropped (ghosted) */}
+      <g fill="var(--il-teal)" stroke="var(--il-ink)" strokeWidth={1.5}>
+        <circle cx={350} cy={y} r={6} />
+        <circle cx={366} cy={y} r={6} />
+      </g>
+      <g fill="none" stroke="var(--il-muted)" strokeWidth={1.5} strokeDasharray="2 3">
+        <circle cx={350} cy={y + 24} r={6} />
+        <circle cx={366} cy={y + 24} r={6} />
+      </g>
+
+      <ArrowRight x={380} y={y} color="var(--il-ink-2)" />
+      <line x1={378} y1={y} x2={380} y2={y} stroke="var(--il-ink-2)" strokeWidth={2} />
+
+      {/* reduce */}
+      <rect x={382} y={y - 24} width={64} height={48} rx={12} fill="var(--il-paper)" stroke="var(--il-purple)" strokeWidth={2.5} />
+      <text x={414} y={y - 2} fontSize={12.5} fontWeight={700} textAnchor="middle" fill="var(--il-purple)">
+        reduce
+      </text>
+      <text className="mono" x={414} y={y + 13} fontSize={9} textAnchor="middle" fill="var(--il-muted)">
+        a+b
+      </text>
+
+      <line x1={448} y1={y} x2={456} y2={y} stroke="var(--il-ink-2)" strokeWidth={2} />
+      <ArrowRight x={460} y={y} color="var(--il-ink-2)" />
+      {/* the single reduced value */}
+      <circle cx={480} cy={y} r={14} fill="var(--il-purple)" stroke="var(--il-ink)" strokeWidth={2.5} />
+      <text x={480} y={y + 5} fontSize={15} fontWeight={700} textAnchor="middle" fill="var(--il-paper)">
+        Σ
+      </text>
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/art/iso.tsx
+++ b/app/_components/mdx/illustrations/art/iso.tsx
@@ -1,0 +1,186 @@
+/**
+ * Isometric illustrations — extruded blocks with shaded faces for depth. Face
+ * shading is built from the accent mixed toward `--il-paper`, so the tints
+ * stay light over the light page and turn into subtle dark shades over the
+ * dark page from a single declaration. Each export renders the inner content
+ * of an <svg>; the wrapper supplies the <svg>, viewBox and a11y.
+ */
+
+const mix = (accent: string, pct: number) => `color-mix(in srgb, ${accent} ${pct}%, var(--il-paper))`;
+
+/** One flat isometric slab (a thin box) with a centered label on its top face. */
+function IsoSlab({
+  cx,
+  cy,
+  a,
+  b,
+  t,
+  accent,
+  label,
+  labelSize,
+}: {
+  cx: number;
+  cy: number;
+  a: number;
+  b: number;
+  t: number;
+  accent: string;
+  label: string;
+  labelSize: number;
+}) {
+  const top = `${cx},${cy - b} ${cx + a},${cy} ${cx},${cy + b} ${cx - a},${cy}`;
+  // Front-left and front-right faces drop straight down by the thickness `t`.
+  const right = `${cx + a},${cy} ${cx + a},${cy + t} ${cx},${cy + b + t} ${cx},${cy + b}`;
+  const left = `${cx - a},${cy} ${cx - a},${cy + t} ${cx},${cy + b + t} ${cx},${cy + b}`;
+  return (
+    <g>
+      <polygon points={left} fill={mix(accent, 58)} stroke={accent} strokeWidth={2} strokeLinejoin="round" />
+      <polygon points={right} fill={mix(accent, 44)} stroke={accent} strokeWidth={2} strokeLinejoin="round" />
+      <polygon points={top} fill={mix(accent, 26)} stroke={accent} strokeWidth={2} strokeLinejoin="round" />
+      <text x={cx} y={cy + labelSize * 0.34} fontSize={labelSize} fontWeight={600} textAnchor="middle" fill="var(--il-ink)">
+        {label}
+      </text>
+    </g>
+  );
+}
+
+/* Variables — a named box that holds a value, whose contents can be reassigned
+ * (with `let`). */
+export function VariableBoxArt() {
+  // Isometric box (closed) with three visible faces.
+  const T_back = "140,78";
+  const T_right = "212,114";
+  const T_front = "140,150";
+  const T_left = "68,114";
+  const B_front = "140,214";
+  const B_right = "212,178";
+  const B_left = "68,178";
+  return (
+    <>
+      {/* current value chip */}
+      <rect x={110} y={24} width={76} height={34} rx={10} fill="var(--il-paper)" stroke="var(--il-blue)" strokeWidth={2.5} />
+      <text className="mono" x={148} y={47} fontSize={18} fontWeight={700} textAnchor="middle" fill="var(--il-blue)">
+        28
+      </text>
+      {/* it drops into the box */}
+      <line x1={148} y1={58} x2={144} y2={74} stroke="var(--il-ink-2)" strokeWidth={2} />
+      <path d="M144 78 L139 67 L150 69 Z" fill="var(--il-ink-2)" />
+
+      {/* reassignment: 28 → 29 (let) */}
+      <path d="M188 38 C 206 26, 218 26, 226 36" fill="none" stroke="var(--il-orange)" strokeWidth={2.5} strokeLinecap="round" />
+      <path d="M226 36 L214 34 L221 25 Z" fill="var(--il-orange)" />
+      <text x={210} y={16} fontSize={10} fontWeight={600} textAnchor="middle" fill="var(--il-orange)">
+        let
+      </text>
+      <rect x={216} y={24} width={64} height={34} rx={10} fill="none" stroke="var(--il-muted)" strokeWidth={2} strokeDasharray="3 3" />
+      <text className="mono" x={248} y={47} fontSize={18} fontWeight={700} textAnchor="middle" fill="var(--il-muted)">
+        29
+      </text>
+
+      {/* the box (the variable) */}
+      <polygon points={`${T_left} ${T_front} ${B_front} ${B_left}`} fill="var(--il-surface-2)" stroke="var(--il-ink)" strokeWidth={2.5} strokeLinejoin="round" />
+      <polygon points={`${T_front} ${T_right} ${B_right} ${B_front}`} fill="var(--il-surface-3)" stroke="var(--il-ink)" strokeWidth={2.5} strokeLinejoin="round" />
+      <polygon points={`${T_back} ${T_right} ${T_front} ${T_left}`} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={2.5} strokeLinejoin="round" />
+      {/* name plate on the right face */}
+      <text x={176} y={170} fontSize={17} fontWeight={700} textAnchor="middle" fill="var(--il-ink)">
+        age
+      </text>
+    </>
+  );
+}
+
+/* Arrays — a contiguous run of indexed slots; indices are zero-based. */
+export function IndexedArrayArt() {
+  const cells = [0, 1, 2, 3, 4];
+  const W = 70;
+  const H = 54;
+  const d = 22; // iso depth
+  const x0 = 40;
+  const yTop = 86;
+  const values = ["10", "20", "30", "40", "50"];
+  const frontRight = x0 + cells.length * W; // 390
+  return (
+    <>
+      {/* whole-bar top face */}
+      <polygon
+        points={`${x0},${yTop} ${x0 + d},${yTop - d} ${frontRight + d},${yTop - d} ${frontRight},${yTop}`}
+        fill="var(--il-surface-2)"
+        stroke="var(--il-ink)"
+        strokeWidth={2.5}
+        strokeLinejoin="round"
+      />
+      {/* end cap (right face) */}
+      <polygon
+        points={`${frontRight},${yTop} ${frontRight + d},${yTop - d} ${frontRight + d},${yTop + H - d} ${frontRight},${yTop + H}`}
+        fill="var(--il-surface-3)"
+        stroke="var(--il-ink)"
+        strokeWidth={2.5}
+        strokeLinejoin="round"
+      />
+      {/* front face */}
+      <rect x={x0} y={yTop} width={cells.length * W} height={H} fill="var(--il-paper)" stroke="var(--il-ink)" strokeWidth={2.5} />
+
+      {/* cell dividers (front + matching top slant) and values */}
+      {cells.map((i) => {
+        const fx = x0 + i * W;
+        const cxFront = fx + W / 2;
+        return (
+          <g key={i}>
+            {i > 0 && (
+              <>
+                <line x1={fx} y1={yTop} x2={fx} y2={yTop + H} stroke="var(--il-ink)" strokeWidth={1.5} />
+                <line x1={fx} y1={yTop} x2={fx + d} y2={yTop - d} stroke="var(--il-ink)" strokeWidth={1.5} />
+              </>
+            )}
+            <text x={cxFront} y={yTop + 34} fontSize={16} fontWeight={600} textAnchor="middle" fill="var(--il-ink)">
+              {values[i]}
+            </text>
+            {/* index badge floating above the cell */}
+            <line x1={cxFront} y1={51} x2={cxFront - d / 2} y2={yTop - d / 2} stroke="var(--il-ink-2)" strokeWidth={1.25} />
+            <circle cx={cxFront} cy={40} r={11} fill="var(--il-teal)" stroke="var(--il-ink)" strokeWidth={2} />
+            <text className="mono" x={cxFront} y={44} fontSize={12} fontWeight={700} textAnchor="middle" fill="var(--il-paper)">
+              {i}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* label above the first (index 0) cell */}
+      <text x={x0 + W / 2} y={18} fontSize={10.5} textAnchor="middle" fill="var(--il-muted)">
+        index starts at 0
+      </text>
+      <text x={frontRight + d} y={yTop + H + 18} fontSize={11} textAnchor="end" fill="var(--il-muted)">
+        length 5
+      </text>
+    </>
+  );
+}
+
+/* Scope — names are resolved by walking outward through nested scopes (block →
+ * function → global) until a match is found. */
+export function ScopeNestingArt() {
+  return (
+    <>
+      {/* slabs: global (largest) at the bottom, block (smallest) on top */}
+      <IsoSlab cx={171} cy={236} a={128} b={52} t={13} accent="var(--il-blue)" label="global" labelSize={13} />
+      <IsoSlab cx={171} cy={176} a={94} b={40} t={13} accent="var(--il-teal)" label="function" labelSize={12} />
+      <IsoSlab cx={171} cy={120} a={62} b={27} t={13} accent="var(--il-purple)" label="block" labelSize={11} />
+
+      {/* the name being looked up (sits above the innermost scope) */}
+      <rect x={154} y={48} width={34} height={28} rx={8} fill="var(--il-paper)" stroke="var(--il-purple)" strokeWidth={2.5} />
+      <text className="mono" x={171} y={68} fontSize={15} fontWeight={700} textAnchor="middle" fill="var(--il-purple)">
+        x
+      </text>
+
+      {/* lookup chain: routed right of the labels, down/outward through `block`
+          until a match is found in the `function` scope */}
+      <path d="M189 62 C 248 84, 248 150, 204 174" fill="none" stroke="var(--il-ink-2)" strokeWidth={2} strokeDasharray="3 4" />
+      <path d="M204 174 L210 163 L214 173 Z" fill="var(--il-ink-2)" />
+      <text x={262} y={120} fontSize={10.5} textAnchor="middle" fill="var(--il-muted)">
+        look outward
+      </text>
+      {/* found marker on the function scope */}
+      <circle cx={201} cy={176} r={4.5} fill="var(--il-green)" stroke="var(--il-ink)" strokeWidth={1.5} />
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/art/lineArt.tsx
+++ b/app/_components/mdx/illustrations/art/lineArt.tsx
@@ -1,0 +1,153 @@
+/**
+ * Line-art illustrations — thin `--il-ink` strokes, generous whitespace, a
+ * single accent per piece. Each export renders the *inner* content of an
+ * <svg>; the surrounding <svg> (viewBox, sizing, a11y) is supplied by
+ * `Illustration.tsx`.
+ */
+
+/* Values & Types — a value can take any of several typed forms, drawn as a
+ * small constellation of labelled chips converging on one node. */
+export function TypedValuesArt() {
+  const W = 150;
+  const H = 54;
+  const cx = 210;
+  const cy = 120;
+  const chips = [
+    { x: 24, y: 32, side: "right", accent: "var(--il-blue)", value: "42", type: "number" },
+    { x: 246, y: 28, side: "left", accent: "var(--il-teal)", value: '"hi"', type: "string" },
+    { x: 18, y: 152, side: "right", accent: "var(--il-green)", value: "true", type: "boolean" },
+    { x: 240, y: 156, side: "left", accent: "var(--il-purple)", value: "[1, 2, 3]", type: "array" },
+  ] as const;
+
+  return (
+    <>
+      {/* connectors from the central node to each chip */}
+      {chips.map((c, i) => {
+        const ax = c.side === "right" ? c.x + W : c.x;
+        const ay = c.y + H / 2;
+        return (
+          <line
+            key={`l${i}`}
+            x1={cx}
+            y1={cy}
+            x2={ax}
+            y2={ay}
+            stroke="var(--il-hair)"
+            strokeWidth={1.5}
+          />
+        );
+      })}
+
+      {/* central node */}
+      <circle cx={cx} cy={cy} r={15} fill="none" stroke="var(--il-hair)" strokeWidth={1.5} />
+      <circle cx={cx} cy={cy} r={5} fill="var(--il-ink-2)" />
+
+      {/* chips */}
+      {chips.map((c, i) => (
+        <g key={`c${i}`}>
+          <rect
+            x={c.x}
+            y={c.y}
+            width={W}
+            height={H}
+            rx={H / 2}
+            fill="var(--il-paper)"
+            stroke="var(--il-ink)"
+            strokeWidth={2}
+          />
+          <circle cx={c.x + 28} cy={c.y + H / 2} r={7} fill={c.accent} />
+          <text
+            className="mono"
+            x={c.x + 50}
+            y={c.y + 26}
+            fontSize={17}
+            fontWeight={600}
+            fill="var(--il-ink)"
+          >
+            {c.value}
+          </text>
+          <text x={c.x + 50} y={c.y + 43} fontSize={11} fill="var(--il-muted)">
+            {c.type}
+          </text>
+        </g>
+      ))}
+    </>
+  );
+}
+
+/* Conditionals — control flow forks at a decision diamond into a taken
+ * (highlighted) branch and a skipped (muted) branch. */
+export function BranchingPathArt() {
+  return (
+    <>
+      {/* incoming path */}
+      <circle cx={26} cy={116} r={5} fill="var(--il-ink-2)" />
+      <line x1={26} y1={116} x2={160} y2={116} stroke="var(--il-ink)" strokeWidth={2.5} />
+
+      {/* decision diamond */}
+      <path
+        d="M190 86 L220 116 L190 146 L160 116 Z"
+        fill="var(--il-paper)"
+        stroke="var(--il-ink)"
+        strokeWidth={2.5}
+        strokeLinejoin="round"
+      />
+      <text className="mono" x={190} y={120} fontSize={11} textAnchor="middle" fill="var(--il-ink)">
+        x &gt; 0
+      </text>
+
+      {/* TRUE branch — taken, accented green */}
+      <path
+        d="M220 116 C 252 116, 262 72, 296 72"
+        fill="none"
+        stroke="var(--il-green)"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+      />
+      <path d="M308 72 L296 66 L296 78 Z" fill="var(--il-green)" />
+      <text x={250} y={58} fontSize={11} fontWeight={600} fill="var(--il-green)">
+        true
+      </text>
+      <rect
+        x={308}
+        y={50}
+        width={96}
+        height={44}
+        rx={12}
+        fill="var(--il-paper)"
+        stroke="var(--il-green)"
+        strokeWidth={2.5}
+      />
+      <text x={356} y={77} fontSize={13} textAnchor="middle" fill="var(--il-ink)">
+        run this
+      </text>
+
+      {/* FALSE branch — skipped, muted + dashed */}
+      <path
+        d="M190 146 C 190 178, 262 174, 296 174"
+        fill="none"
+        stroke="var(--il-muted)"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeDasharray="2 6"
+      />
+      <path d="M308 174 L296 168 L296 180 Z" fill="var(--il-muted)" />
+      <text x={250} y={196} fontSize={11} fontWeight={600} fill="var(--il-muted)">
+        false
+      </text>
+      <rect
+        x={308}
+        y={152}
+        width={96}
+        height={44}
+        rx={12}
+        fill="var(--il-paper)"
+        stroke="var(--il-muted)"
+        strokeWidth={2}
+      />
+      <text x={356} y={179} fontSize={13} textAnchor="middle" fill="var(--il-muted)">
+        skip / else
+      </text>
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/index.ts
+++ b/app/_components/mdx/illustrations/index.ts
@@ -1,0 +1,4 @@
+export { default as Illustration } from "./Illustration";
+export type { IllustrationProps } from "./Illustration";
+export { ART } from "./registry";
+export type { ArtEntry } from "./registry";

--- a/app/_components/mdx/illustrations/registry.ts
+++ b/app/_components/mdx/illustrations/registry.ts
@@ -1,0 +1,141 @@
+/**
+ * Registry of lesson illustrations.
+ *
+ * Maps a stable kebab-case `name` (used in MDX, e.g. `<Illustration
+ * name="closure-backpack" />`) to the inner SVG `Art`, its `viewBox`, a default
+ * accessible label, and an optional natural max width. Keeping this lookup in
+ * one place means `mdx-components.tsx` registers a single `<Illustration>`
+ * component, and new art can be added without touching MDX wiring.
+ */
+import type { FC } from "react";
+import { TypedValuesArt, BranchingPathArt } from "./art/lineArt";
+import { TenDaySprintArt, FunctionMachineArt, LoopCycleArt, TransformPipelineArt } from "./art/flat";
+import { VariableBoxArt, IndexedArrayArt, ScopeNestingArt } from "./art/iso";
+import { WelcomeJourneyArt, ObjectKeyValueArt, ClosureBackpackArt, PromisePlaceholderArt } from "./art/duotone";
+
+export interface ArtEntry {
+  /** SVG viewBox, e.g. "0 0 420 240". */
+  viewBox: string;
+  /** Default `aria-label` describing the illustration. */
+  defaultAlt: string;
+  /** Renders the inner content of the <svg>. */
+  Art: FC;
+  /** Natural max width (CSS length) so the piece isn't blown up too large. */
+  maxWidth?: string;
+  /** Short note on the visual style — for documentation / a future gallery. */
+  style: "line-art" | "flat" | "isometric" | "duotone";
+}
+
+export const ART: Record<string, ArtEntry> = {
+  // ── Duotone / editorial ──────────────────────────────────────────────
+  "welcome-journey": {
+    viewBox: "0 0 480 250",
+    defaultAlt:
+      "A rising slope past four milestone markers to a flag at the summit, over an ambient field of code symbols — learning to program as a climb.",
+    Art: WelcomeJourneyArt,
+    maxWidth: "34rem",
+    style: "duotone",
+  },
+  "object-keyvalue": {
+    viewBox: "0 0 400 268",
+    defaultAlt:
+      "A record card labelled 'user' with three rows mapping keys (name, age, isAdmin) to their values.",
+    Art: ObjectKeyValueArt,
+    maxWidth: "23rem",
+    style: "duotone",
+  },
+  "closure-backpack": {
+    viewBox: "0 28 360 226",
+    defaultAlt:
+      "A function drawn as a labelled block carrying a backpack that holds a captured variable named 'greeting', inside a dashed boundary marking the scope it was born in.",
+    Art: ClosureBackpackArt,
+    maxWidth: "24rem",
+    style: "duotone",
+  },
+  "promise-placeholder": {
+    viewBox: "0 40 440 164",
+    defaultAlt:
+      "A 'Promise' ticket in a pending state with a spinner, settling later into either a fulfilled value or a rejected error.",
+    Art: PromisePlaceholderArt,
+    maxWidth: "32rem",
+    style: "duotone",
+  },
+
+  // ── Flat geometric ───────────────────────────────────────────────────
+  "ten-day-sprint": {
+    viewBox: "0 22 420 216",
+    defaultAlt:
+      "A calendar reading 'APRIL 1995 — 10 DAYS' beside a running alarm clock, evoking JavaScript designed in ten days.",
+    Art: TenDaySprintArt,
+    maxWidth: "27rem",
+    style: "flat",
+  },
+  "function-machine": {
+    viewBox: "0 30 440 176",
+    defaultAlt:
+      "Two inputs feeding into a labelled 'fn' machine with a gear on top, producing a single output.",
+    Art: FunctionMachineArt,
+    maxWidth: "30rem",
+    style: "flat",
+  },
+  "loop-cycle": {
+    viewBox: "0 0 320 290",
+    defaultAlt:
+      "A circular arrow looping around a small deck of cards labelled 'body', with a counter badge reading 'i++' in the gap.",
+    Art: LoopCycleArt,
+    maxWidth: "19rem",
+    style: "flat",
+  },
+  "transform-pipeline": {
+    viewBox: "0 60 504 92",
+    defaultAlt:
+      "A pipeline: four input squares pass through map (becoming circles), filter (dropping two), then reduce (combining into one value).",
+    Art: TransformPipelineArt,
+    maxWidth: "34rem",
+    style: "flat",
+  },
+
+  // ── Isometric ────────────────────────────────────────────────────────
+  "variable-box": {
+    viewBox: "40 0 280 230",
+    defaultAlt:
+      "An isometric box labelled 'age' holding the value 28, with an arrow showing it being reassigned to 29 via 'let'.",
+    Art: VariableBoxArt,
+    maxWidth: "20rem",
+    style: "isometric",
+  },
+  "indexed-array": {
+    viewBox: "0 0 452 176",
+    defaultAlt:
+      "A row of five contiguous slots holding 10, 20, 30, 40, 50 with zero-based index badges 0 to 4 above them, and a 'length 5' label.",
+    Art: IndexedArrayArt,
+    maxWidth: "33rem",
+    style: "isometric",
+  },
+  "scope-nesting": {
+    viewBox: "0 24 342 288",
+    defaultAlt:
+      "Three stacked isometric platforms — global, function, block — with a name 'x' looked up by walking outward until it is found in the function scope.",
+    Art: ScopeNestingArt,
+    maxWidth: "21rem",
+    style: "isometric",
+  },
+
+  // ── Line art ─────────────────────────────────────────────────────────
+  "typed-values": {
+    viewBox: "0 10 416 218",
+    defaultAlt:
+      "Four labelled value chips — 42 (number), \"hi\" (string), true (boolean), [1, 2, 3] (array) — converging on a single node.",
+    Art: TypedValuesArt,
+    maxWidth: "27rem",
+    style: "line-art",
+  },
+  "branching-path": {
+    viewBox: "0 30 420 188",
+    defaultAlt:
+      "A path reaching a decision diamond and splitting into a highlighted 'true' branch that runs a block and a muted 'false' branch that is skipped.",
+    Art: BranchingPathArt,
+    maxWidth: "29rem",
+    style: "line-art",
+  },
+};

--- a/content/learn/beginners-javascript/arrays.mdx
+++ b/content/learn/beginners-javascript/arrays.mdx
@@ -8,6 +8,11 @@ enough. Most real-world data is a *collection* — a list of users,
 a row of pixels, a stack of moves. JavaScript's most fundamental
 collection is the **array**.
 
+<Illustration
+  name="indexed-array"
+  caption="An array is an ordered run of slots. Every element has an index, and indices start at 0."
+/>
+
 ## Creating arrays
 
 An array is written with square brackets and commas:

--- a/content/learn/beginners-javascript/birth-of-javascript.mdx
+++ b/content/learn/beginners-javascript/birth-of-javascript.mdx
@@ -20,6 +20,11 @@ language design. He liked elegant, mathematically grounded languages
 like **Scheme** (a tiny, beautiful descendant of Lisp). He was about
 to invent something very different.
 
+<Illustration
+  name="ten-day-sprint"
+  caption="Under real deadline pressure, Brendan Eich designed and built the first JavaScript prototype in just ten days in April 1995."
+/>
+
 ## The constraints, in detail
 
 Several decisions had already been made for him before he wrote a

--- a/content/learn/beginners-javascript/closures.mdx
+++ b/content/learn/beginners-javascript/closures.mdx
@@ -9,6 +9,11 @@ scope has finished. Closures are one of the most powerful and
 useful ideas in JavaScript, and once you see them clearly, an
 enormous amount of real-world code starts to make sense.
 
+<Illustration
+  name="closure-backpack"
+  caption="A closure is a function plus a backpack of the variables from the scope where it was born — it carries them wherever it goes."
+/>
+
 ## The simplest closure
 
 Watch this carefully:

--- a/content/learn/beginners-javascript/conditionals.mdx
+++ b/content/learn/beginners-javascript/conditionals.mdx
@@ -11,6 +11,11 @@ otherwise show 'Sign in'"* — it starts looking like real software.
 That capacity for decision-making is called **control flow**, and
 the most fundamental tool for it is the `if` statement.
 
+<Illustration
+  name="branching-path"
+  caption="A conditional is a fork in the road: the program tests a condition and takes exactly one branch."
+/>
+
 ## The `if` statement
 
 The basic shape:

--- a/content/learn/beginners-javascript/functions-basics.mdx
+++ b/content/learn/beginners-javascript/functions-basics.mdx
@@ -14,11 +14,10 @@ A **function** is a named, reusable piece of code that takes some
 **inputs** (arguments) and produces an **output** (a return value).
 You define it once. You call it many times.
 
-```mermaid
-flowchart LR
-    I1((inputs)) --> F[Function: do something with the inputs]
-    F --> O((output))
-```
+<Illustration
+  name="function-machine"
+  caption="A function takes inputs, does some work, and returns an output. Define it once, then call it as many times as you like."
+/>
 
 That picture is the entire mental model. Inputs in, work happens,
 output out.

--- a/content/learn/beginners-javascript/index.mdx
+++ b/content/learn/beginners-javascript/index.mdx
@@ -14,6 +14,11 @@ have heard of variables, loops, or functions. You don't need to know
 how a website is built. We will build everything from the ground up,
 one idea at a time.
 
+<Illustration
+  name="welcome-journey"
+  caption="Programming is a climb — each idea builds on the one before it. This course is the path from your very first line of code to thinking like a programmer."
+/>
+
 <Callout type="info" title="Who this course is for">
 You should be able to use a computer, open a web browser, and read
 English. That is all. No prior programming experience is assumed —

--- a/content/learn/beginners-javascript/loops-and-iteration.mdx
+++ b/content/learn/beginners-javascript/loops-and-iteration.mdx
@@ -13,6 +13,11 @@ syntactic tools for it are called **loops**.
 JavaScript has several kinds of loop. We will learn each one and,
 just as importantly, when to use which.
 
+<Illustration
+  name="loop-cycle"
+  caption="A loop runs the same body over and over, advancing a counter each time, until its condition tells it to stop."
+/>
+
 ## The `while` loop
 
 The simplest loop. While the condition is truthy, run the body. Then

--- a/content/learn/beginners-javascript/map-filter-reduce.mdx
+++ b/content/learn/beginners-javascript/map-filter-reduce.mdx
@@ -12,6 +12,11 @@ half the loops you would otherwise write disappear.
 These three methods together are sometimes called the **functional
 core** of array processing.
 
+<Illustration
+  name="transform-pipeline"
+  caption="Map, filter, and reduce form a pipeline: transform every item, keep the ones you want, then combine them into a single value."
+/>
+
 ## The shift in mindset
 
 A `for` loop says *how* to walk the array. The three methods say

--- a/content/learn/beginners-javascript/objects.mdx
+++ b/content/learn/beginners-javascript/objects.mdx
@@ -12,6 +12,11 @@ title.
 Objects are the most important compound type in JavaScript. The
 language itself is built around them.
 
+<Illustration
+  name="object-keyvalue"
+  caption="An object is a bag of named values: each key maps to a value, modelling a real-world thing with properties."
+/>
+
 ## Creating objects
 
 The classic syntax — **object literal** notation:

--- a/content/learn/beginners-javascript/promises-and-async-await.mdx
+++ b/content/learn/beginners-javascript/promises-and-async-await.mdx
@@ -14,6 +14,11 @@ much nicer tools:
 By the end of this chapter, you'll be able to read and write
 real-world async code.
 
+<Illustration
+  name="promise-placeholder"
+  caption="A Promise is a placeholder you hold right away for a value that arrives later — settling eventually as either fulfilled or rejected."
+/>
+
 ## A Promise is a placeholder
 
 When you start a slow operation, a Promise is the thing you

--- a/content/learn/beginners-javascript/scope-and-scope-chain.mdx
+++ b/content/learn/beginners-javascript/scope-and-scope-chain.mdx
@@ -28,6 +28,11 @@ Variables declared with `let` and `const` respect *block* scope.
 Variables declared with the old `var` only respect *function*
 scope, which is one of the reasons we avoid `var`.
 
+<Illustration
+  name="scope-nesting"
+  caption="A name is resolved by searching outward — block, then function, then global — stopping at the first scope that defines it."
+/>
+
 ## A first example
 
 <CodeBlock

--- a/content/learn/beginners-javascript/values-and-types.mdx
+++ b/content/learn/beginners-javascript/values-and-types.mdx
@@ -23,6 +23,11 @@ moment. Some examples:
 - A list of three things, `[1, 2, 3]`.
 - A small record, `{ name: "Ada", age: 28 }`.
 
+<Illustration
+  name="typed-values"
+  caption="Every value has a type — a number, a string, a boolean, an array — and its type decides what you can do with it."
+/>
+
 A value, on its own, just *is*. It is the runtime's job to keep
 track of values, and your job as a programmer to decide what to do
 with them.

--- a/content/learn/beginners-javascript/variables-and-state.mdx
+++ b/content/learn/beginners-javascript/variables-and-state.mdx
@@ -7,6 +7,11 @@ A program made only of values would be useless. The interesting
 thing programs do is **remember**. A variable is how a program
 remembers a value and gives it a name.
 
+<Illustration
+  name="variable-box"
+  caption="A variable is a named box that holds a value, and the value inside can change as the program runs."
+/>
+
 ## What a variable really is
 
 A **variable** is a named slot that holds a value. You can think of

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -18,6 +18,7 @@ import MdxSqlChallengeCard from "@/app/_components/MdxSqlChallengeCard";
 import MdxSqlCodeBlock from "@/app/_components/MdxSqlCodeBlock";
 import MdxMultipleChoiceQuestion from "@/app/_components/multipleChoice/MdxMultipleChoiceQuestion";
 import { Mermaid } from "@/app/_components/mdx/mermaid";
+import { Illustration } from "@/app/_components/mdx/illustrations";
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
@@ -28,6 +29,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     SqlCodeBlock: MdxSqlCodeBlock,
     MultipleChoice: MdxMultipleChoiceQuestion,
     Mermaid,
+    Illustration,
     ...components,
   };
 }


### PR DESCRIPTION
## What

A pilot adding **SVG vector illustrations** to lessons, starting with the **Beginner's Guide to JavaScript**. Introduces a reusable `<Illustration>` MDX component and **13 hero illustrations across four distinct styles**.

These are *conceptual hero art* — the lessons already use Mermaid for precise structural diagrams, so the illustrations reinforce the core metaphor of each lesson rather than duplicating those.

## Light + dark mode

Every illustration is a **server-rendered inline `<svg>`** painted from theme-aware `--il-*` CSS tokens that map to the existing brand palette (`app/brand.css`), with `.dark` overrides. So a single piece renders correctly in **both** modes with **no client JS and no theme flash** — the cascade does the work. Soft tints use `color-mix()` (already used across the app) so they wash light over the light page and shade subtly over the dark page from one declaration.

## The illustrations (one per lesson)

| Style | Lessons |
| --- | --- |
| **Duotone / editorial** | welcome (`index`), objects, closures (backpack metaphor), promises |
| **Flat geometric** | birth-of-JS (10-day sprint), functions, loops, map/filter/reduce |
| **Isometric** | variables, arrays (zero-based slots), scope chain |
| **Line art** | values & types, conditionals |

The functions lesson's bare Mermaid `inputs → output` flowchart is replaced by the richer `function-machine` illustration.

## How it's wired

- `app/_components/mdx/illustrations/` — `Illustration.tsx` wrapper (figure + caption + a11y), `Illustration.module.css` (the `--il-*` token layer + `.dark` overrides), `registry.ts` (name → art), and `art/{lineArt,flat,iso,duotone}.tsx`.
- Registered once in `mdx-components.tsx`; authored in MDX as `<Illustration name="closure-backpack" caption="…" />`.
- Adding more art needs no MDX-wiring changes. An unknown `name` renders a visible placeholder instead of crashing the page, and each `<svg>` carries a descriptive `aria-label`.

## Verification

- ✅ `tsc --noEmit` clean, `eslint` clean on new code.
- ✅ Rendered every affected lesson against `next dev` (SSR) — all `200`, correct `aria-label`s / in-art text, and `var(--il-*)` tokens present in the markup. No runtime errors.
- ⏭️ Per request, skipped the Playwright screenshot pass. Easy to eyeball locally by toggling the theme on any of the listed `/learn/beginners-javascript/*` pages — happy to add before/after captures if useful.

## Also (unrelated, requested in-session)

Removes the `playwright` entry from `.mcp.json`.

https://claude.ai/code/session_01JHTPm35oTtinKzUMmBpgNy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHTPm35oTtinKzUMmBpgNy)_