### PR TITLE
Fix JS/TS code blocks leaking the previous block's output

### DIFF
--- a/__tests__/almostnodeRunner.test.ts
+++ b/__tests__/almostnodeRunner.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Per-run isolation for the almostnode-backed JS/TS workers.
+ *
+ * On a /learn page every `<CodeBlock>` and `<ChallengeCard>` of the same
+ * language shares ONE worker instance (via runtimeRegistry), so the
+ * worker's filesystem is long-lived. `AlmostNodeRunner` is what keeps one
+ * block's run from leaking into the next on that shared worker; these
+ * tests pin the contract down by exercising the real runner against the
+ * real almostnode runtime (no mocks).
+ *
+ * Regression: a single-file block used to re-run the PREVIOUS block's
+ * entry file, because the run handler preferred whatever sat at the entry
+ * path in the shared VFS over the freshly-passed code. Running a counter
+ * snippet right after a greeter snippet printed the greeter's output.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  AlmostNodeRunner,
+  type ConsoleSink,
+} from "../app/_components/runtime/almostnode-worker-shared";
+
+const encoder = new TextEncoder();
+
+/** Collect stdout/stderr from a run into plain strings. */
+function makeSink(): { sink: ConsoleSink; stdout: () => string; stderr: () => string } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    sink: {
+      stdout: (c) => out.push(c),
+      stderr: (e) => err.push(e),
+    },
+    stdout: () => out.join("\n"),
+    stderr: () => err.join("\n"),
+  };
+}
+
+/** Mirror the JavaScript worker's single-file run: the inline `code` is
+ *  always the authoritative entry source. */
+async function runSingleFileJs(
+  runner: AlmostNodeRunner,
+  code: string,
+): Promise<{ stdout: string; stderr: string }> {
+  const s = makeSink();
+  await runner.run("/index.js", () => code, s.sink);
+  return { stdout: s.stdout(), stderr: s.stderr() };
+}
+
+describe("AlmostNodeRunner per-run isolation", () => {
+  it("runs a single-file snippet", async () => {
+    const runner = new AlmostNodeRunner();
+    const { stdout } = await runSingleFileJs(
+      runner,
+      `console.log("Hello, Ada!");`,
+    );
+    expect(stdout).toBe("Hello, Ada!");
+  });
+
+  // The reported bug, distilled: block A defines a greeter and prints
+  // greetings; block B (run next on the SAME runner) defines a counter.
+  // B must print the counter output, never A's greetings.
+  it("does not leak the previous block's output into the next", async () => {
+    const runner = new AlmostNodeRunner();
+
+    const greeter = await runSingleFileJs(
+      runner,
+      `
+      function makeGreeter(greeting) {
+        return (name) => greeting + ", " + name + "!";
+      }
+      const hello = makeGreeter("Hello");
+      console.log(hello("Ada"));
+      console.log(hello("Linus"));
+      `,
+    );
+    expect(greeter.stdout).toBe("Hello, Ada!\nHello, Linus!");
+
+    const counter = await runSingleFileJs(
+      runner,
+      `
+      function makeCounter() {
+        let count = 0;
+        return () => (count += 1);
+      }
+      const tick = makeCounter();
+      console.log(tick());
+      console.log(tick());
+      console.log(tick());
+      `,
+    );
+    // The counter's own output…
+    expect(counter.stdout).toBe("1\n2\n3");
+    // …and crucially NOT the greeter block's output.
+    expect(counter.stdout).not.toContain("Hello");
+    expect(counter.stdout).not.toContain("Ada");
+  });
+
+  it("isolates top-level declarations across consecutive runs", async () => {
+    const runner = new AlmostNodeRunner();
+    await runSingleFileJs(runner, `const secret = 42; globalThis.__x = 1;`);
+    const second = await runSingleFileJs(
+      runner,
+      `
+      try { console.log(secret); } catch { console.log("secret-not-visible"); }
+      `,
+    );
+    expect(second.stdout).toContain("secret-not-visible");
+    expect(second.stdout).not.toContain("42");
+  });
+
+  // A multi-file block stages helper modules for one run; a single-file
+  // block that runs next must NOT be able to see those staged files.
+  it("does not leak staged helper files into a later single-file run", async () => {
+    const runner = new AlmostNodeRunner();
+
+    // Run 1: multi-file. Stage index.js + utils.js, then run.
+    runner.stage([
+      ["index.js", encoder.encode(`console.log(require("./utils").tag);`)],
+      ["utils.js", encoder.encode(`exports.tag = "from-utils";`)],
+    ]);
+    const first = makeSink();
+    await runner.run(
+      "/index.js",
+      () => `console.log(require("./utils").tag);`,
+      first.sink,
+    );
+    expect(first.stdout()).toBe("from-utils");
+
+    // Run 2: single-file (no stage). utils.js must be gone.
+    const second = await runSingleFileJs(
+      runner,
+      `
+      try {
+        require("./utils");
+        console.log("LEAKED");
+      } catch {
+        console.log("no-utils");
+      }
+      `,
+    );
+    expect(second.stdout).toBe("no-utils");
+    expect(second.stdout).not.toContain("LEAKED");
+  });
+
+  // Guard the multi-file happy path so the isolation fix doesn't break
+  // legitimate require() resolution within a single staged run.
+  it("resolves require() against freshly-staged files within a run", async () => {
+    const runner = new AlmostNodeRunner();
+    runner.stage([
+      ["index.js", encoder.encode(`console.log(require("./math").add(2, 3));`)],
+      ["math.js", encoder.encode(`exports.add = (a, b) => a + b;`)],
+    ]);
+    const s = makeSink();
+    await runner.run(
+      "/index.js",
+      () => `console.log(require("./math").add(2, 3));`,
+      s.sink,
+    );
+    expect(s.stdout()).toBe("5");
+  });
+
+  // The TypeScript worker resolves its entry via `vfs.existsSync(...)`
+  // (prefer the staged, transpiled copy; otherwise transpile inline).
+  // That check is only safe because each run gets a fresh VFS — verify a
+  // single-file run never observes a stale entry from the previous run.
+  it("hands each un-staged run a VFS with no stale entry file", async () => {
+    const runner = new AlmostNodeRunner();
+
+    await runSingleFileJs(runner, `console.log("first");`);
+
+    let secondRunSawStaleEntry = true;
+    const s = makeSink();
+    await runner.run(
+      "/index.js",
+      (vfs) => {
+        // In the buggy shared-VFS worker this was `true` (the previous
+        // run's /index.js lingered); with per-run isolation it's `false`.
+        secondRunSawStaleEntry = vfs.existsSync("/index.js");
+        return `console.log("second");`;
+      },
+      s.sink,
+    );
+
+    expect(secondRunSawStaleEntry).toBe(false);
+    expect(s.stdout()).toBe("second");
+  });
+});

--- a/app/_components/runtime/almostnode-worker-shared.ts
+++ b/app/_components/runtime/almostnode-worker-shared.ts
@@ -150,3 +150,69 @@ export async function runEntry(
     runtime.clearCache();
   }
 }
+
+// ─── Per-run isolation ──────────────────────────────────────────────
+//
+// The JavaScript and TypeScript workers are long-lived: every
+// `<CodeBlock>` and `<ChallengeCard>` on a /learn page (and every run in
+// a `<Playground>`) shares ONE worker instance per language via the
+// runtime registry. That means the worker's VirtualFS would, if reused,
+// persist files — including the entry file — from one block's run into
+// the next. A single-file block that doesn't stage its own files would
+// then execute whatever entry the *previous* block left behind, so
+// running block B right after block A printed block A's output. (See the
+// regression test in __tests__/almostnodeRunner.test.ts.)
+//
+// `AlmostNodeRunner` closes that hole: each run executes against a
+// VirtualFS that contains ONLY that run's files. Multi-file callers call
+// `stage()` immediately before `run()` (recreating the FS from their
+// current workspace snapshot); single-file callers skip `stage()` and
+// get a brand-new empty FS. Either way the staged snapshot is consumed
+// by the run, so nothing leaks into a subsequent un-staged run.
+
+export class AlmostNodeRunner {
+  // Files staged by the most recent `stage()` call, awaiting their run.
+  // `null` once a run consumes them (or if `stage()` was never called),
+  // so a run that isn't preceded by its own staging starts from a clean,
+  // empty filesystem and can't observe the previous run's files or entry.
+  private stagedVfs: VirtualFS | null = null;
+
+  /** Stage a complete workspace snapshot into a freshly-created
+   *  VirtualFS for the NEXT run. Rebuilt from scratch each call so
+   *  deletions/renames in the UI propagate. `transformFile` lets the
+   *  TypeScript worker transpile `.ts` sources to `.js` as they're
+   *  staged (see `stageFiles`). */
+  stage(
+    files: Array<[string, Uint8Array]>,
+    transformFile?: (
+      path: string,
+      bytes: Uint8Array,
+    ) => Array<[string, Uint8Array]>,
+  ): void {
+    this.stagedVfs = stageFiles(files, transformFile);
+  }
+
+  /** Execute the entry file against a VirtualFS holding only this run's
+   *  files — the freshly-staged snapshot if `stage()` was called since
+   *  the last run, otherwise a brand-new empty FS.
+   *
+   *  `resolveEntrySource` is handed that VFS and returns the entry's
+   *  source text: the JavaScript worker returns its inline `code`
+   *  verbatim (always the authoritative entry source); the TypeScript
+   *  worker prefers the staged, already-transpiled copy and falls back to
+   *  transpiling inline code. The returned source is wrapped (so
+   *  top-level `await` works) and written at `entryVfsPath` before
+   *  execution. The staged snapshot is consumed up front so the next
+   *  un-staged run is fully isolated even if this one throws. */
+  async run(
+    entryVfsPath: string,
+    resolveEntrySource: (vfs: VirtualFS) => string,
+    sink: ConsoleSink,
+  ): Promise<void> {
+    const vfs = this.stagedVfs ?? new VirtualFS();
+    this.stagedVfs = null;
+    const entrySource = resolveEntrySource(vfs);
+    vfs.writeFileSync(entryVfsPath, wrapEntryAsAsyncIIFE(entrySource));
+    await runEntry(vfs, entryVfsPath, sink);
+  }
+}

--- a/app/_components/runtime/javascript-worker.ts
+++ b/app/_components/runtime/javascript-worker.ts
@@ -18,13 +18,7 @@
 //                  { kind: "stderr"; id: number; content: string }
 //                  { kind: "done"; id: number }
 
-import { VirtualFS } from "almostnode";
-import {
-  normalizeVfsPath,
-  runEntry,
-  stageFiles,
-  wrapEntryAsAsyncIIFE,
-} from "./almostnode-worker-shared";
+import { AlmostNodeRunner, normalizeVfsPath } from "./almostnode-worker-shared";
 
 declare const self: DedicatedWorkerGlobalScope;
 
@@ -44,17 +38,17 @@ function post(msg: OutMessage): void {
   self.postMessage(msg);
 }
 
-// Module-scope VFS so `prepare-fs` and `run` see the same state across
-// messages. Recreated on every `prepare-fs` call so deletions/renames
-// from the editor flow through cleanly.
-let vfs: VirtualFS = new VirtualFS();
+// One runner shared across messages. It hands each run a VirtualFS that
+// reflects only that run's files, so the entry/file state from one
+// block's run can't leak into the next on this long-lived worker.
+const runner = new AlmostNodeRunner();
 
 async function handlePrepareFs(
   id: number,
   files: Array<[string, Uint8Array]>,
 ): Promise<void> {
   try {
-    vfs = stageFiles(files);
+    runner.stage(files);
     post({ kind: "prepare-fs-done", id });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -69,21 +63,13 @@ async function handleRun(
 ): Promise<void> {
   const entryVfsPath = normalizeVfsPath(entryPath);
 
-  // Prefer the staged copy of the entry file (Playground passes it via
-  // prepare-fs whenever multi-file mode is in use). If the worker is
-  // invoked single-file — no prepare-fs — fall back to the inline
-  // `code` argument. This lets the worker work for both flows without
-  // a separate code path on the caller side.
-  const decoder = new TextDecoder();
-  const entrySource = vfs.existsSync(entryVfsPath)
-    ? decoder.decode(vfs.readFileSync(entryVfsPath))
-    : code;
-
-  // Rewrite the entry file so top-level `await` is legal. See the wrap
-  // helper for the precise transform.
-  vfs.writeFileSync(entryVfsPath, wrapEntryAsAsyncIIFE(entrySource));
-
-  await runEntry(vfs, entryVfsPath, {
+  // The `code` argument is always the authoritative entry source: every
+  // caller passes the entry file's exact bytes here, and in multi-file
+  // mode stages those same bytes via prepare-fs. Using it directly (over
+  // whatever happens to sit at `entryVfsPath`) is what guarantees a
+  // single-file run executes its own code rather than the previous
+  // block's leftover entry file.
+  await runner.run(entryVfsPath, () => code, {
     stdout: (content) => post({ kind: "stdout", id, content }),
     stderr: (content) => post({ kind: "stderr", id, content }),
   });

--- a/app/_components/runtime/typescript-worker.ts
+++ b/app/_components/runtime/typescript-worker.ts
@@ -10,13 +10,7 @@
 // share the same message shapes.
 
 import * as ts from "typescript";
-import { VirtualFS } from "almostnode";
-import {
-  normalizeVfsPath,
-  runEntry,
-  stageFiles,
-  wrapEntryAsAsyncIIFE,
-} from "./almostnode-worker-shared";
+import { AlmostNodeRunner, normalizeVfsPath } from "./almostnode-worker-shared";
 
 declare const self: DedicatedWorkerGlobalScope;
 
@@ -81,7 +75,11 @@ function transpileTs(
   return { outputText: result.outputText, diagnostics };
 }
 
-let vfs: VirtualFS = new VirtualFS();
+// One runner shared across messages. It hands each run a VirtualFS that
+// reflects only that run's files (see AlmostNodeRunner), so neither the
+// transpiled entry nor the staged modules from one block's run leak into
+// the next on this long-lived worker.
+const runner = new AlmostNodeRunner();
 // Pending diagnostics from the most recent prepare-fs, replayed as
 // stderr on the next run so the user sees compile errors next to the
 // failed execution rather than in a void.
@@ -95,7 +93,7 @@ async function handlePrepareFs(
     pendingDiagnostics = [];
     const decoder = new TextDecoder();
     const encoder = new TextEncoder();
-    vfs = stageFiles(files, (path, bytes) => {
+    runner.stage(files, (path, bytes) => {
       if (!isTsPath(path)) return [[path, bytes]];
       const source = decoder.decode(bytes);
       const { outputText, diagnostics } = transpileTs(source, path);
@@ -133,26 +131,28 @@ async function handleRun(
   }
   pendingDiagnostics = [];
 
-  // Prefer the staged + transpiled copy of the entry file. Fall back
-  // to transpiling `code` inline if prepare-fs wasn't called (single-
-  // file mode).
-  let entrySource: string;
-  if (vfs.existsSync(entryVfsPath)) {
-    entrySource = new TextDecoder().decode(vfs.readFileSync(entryVfsPath));
-  } else {
-    const { outputText, diagnostics } = transpileTs(code, entryPath);
-    for (const d of diagnostics) {
-      post({ kind: "stderr", id, content: `TS: ${d}` });
-    }
-    entrySource = outputText;
-  }
-
-  vfs.writeFileSync(entryVfsPath, wrapEntryAsAsyncIIFE(entrySource));
-
-  await runEntry(vfs, entryVfsPath, {
-    stdout: (content) => post({ kind: "stdout", id, content }),
-    stderr: (content) => post({ kind: "stderr", id, content }),
-  });
+  await runner.run(
+    entryVfsPath,
+    (vfs) => {
+      // Prefer the staged + transpiled copy of the entry file (multi-
+      // file). Fall back to transpiling `code` inline when this run
+      // wasn't staged (single-file). The runner hands us an empty VFS in
+      // the single-file case, so `existsSync` can't pick up a stale entry
+      // left by a previous block's run.
+      if (vfs.existsSync(entryVfsPath)) {
+        return new TextDecoder().decode(vfs.readFileSync(entryVfsPath));
+      }
+      const { outputText, diagnostics } = transpileTs(code, entryPath);
+      for (const d of diagnostics) {
+        post({ kind: "stderr", id, content: `TS: ${d}` });
+      }
+      return outputText;
+    },
+    {
+      stdout: (content) => post({ kind: "stdout", id, content }),
+      stderr: (content) => post({ kind: "stderr", id, content }),
+    },
+  );
 
   post({ kind: "done", id });
 }


### PR DESCRIPTION
## The bug

Running one JavaScript code block right after another showed the **first block's output under the second block**. In the reported case, a `makeCounter` block printed `Hello, Ada! / Hello, Linus! / Howdy, Grace!` — the output of the `makeGreeter` block above it — instead of `1 / 2 / 3 …`.

## Root cause

Every `<CodeBlock>` and `<ChallengeCard>` of a given language on a `/learn` page shares **one** almostnode worker via the runtime registry (and a `<Playground>` reuses its worker across runs). That worker's `VirtualFS` is therefore long-lived.

The run handler resolved the entry source as *"use the file already staged at the entry path, otherwise fall back to the passed-in code"*:

```ts
const entrySource = vfs.existsSync(entryVfsPath)
  ? decode(vfs.readFileSync(entryVfsPath)) // ← stale: previous block's entry
  : code;
```

For single-file blocks (which never call `prepare-fs`), the first block left its wrapped entry at `/index.js` in the shared VFS. The next block found that stale file via `existsSync` and re-executed it, ignoring its own `code`.

## The fix

Introduce `AlmostNodeRunner` in `almostnode-worker-shared.ts`. It hands each run a `VirtualFS` containing **only that run's files**:

- multi-file callers `stage()` their workspace snapshot immediately before running → a freshly-built FS;
- single-file callers skip staging → a brand-new empty FS.

The staged snapshot is **consumed** by the run, so neither the entry file nor staged helper modules can leak into a subsequent un-staged run. The JavaScript worker now treats the inline `code` as the authoritative entry source; the TypeScript worker still prefers its staged, transpiled entry but — because each run starts from a fresh FS — can no longer pick up a stale one.

Both `javascript-worker.ts` and `typescript-worker.ts` go through the same runner, so the fix covers **both languages across all three surfaces** (code blocks, challenge cards, playgrounds).

## Tests

Added `__tests__/almostnodeRunner.test.ts` — an integration test that drives the real runner against the real almostnode runtime:

- consecutive single-file runs stay isolated (the greeter-then-counter regression);
- top-level declarations don't bleed across runs;
- staged helper files from a multi-file run don't leak into a later single-file run;
- multi-file `require()` still resolves within a run;
- each un-staged run gets a VFS with no stale entry file.

### Verification

- `npm test` — 24 files, 456 tests pass
- `npx tsc --noEmit` — clean
- `npm run lint` — no new warnings
- `npm run build:workers` — both workers bundle cleanly

https://claude.ai/code/session_01BA7vv1h3niqsmSGeHE1BPD

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA7vv1h3niqsmSGeHE1BPD)_