### PR TITLE
Add Copy Markdown + Open page-action buttons to /learn pages

### DIFF
--- a/app/learn/[[...slug]]/page.tsx
+++ b/app/learn/[[...slug]]/page.tsx
@@ -13,8 +13,17 @@ import {
   DocsPage,
   DocsTitle,
 } from "fumadocs-ui/page";
+import {
+  MarkdownCopyButton,
+  ViewOptionsPopover,
+} from "fumadocs-ui/layouts/docs/page";
 import { source } from "@/lib/source";
 import { getMDXComponents } from "@/mdx-components";
+
+// Lessons live at `content/learn/<page.path>` on the default branch, so the
+// "Open in GitHub" action links straight to the page source.
+const GITHUB_BLOB_BASE =
+  "https://github.com/dataslope/dataslope/blob/main/content/learn";
 
 interface LearnPageProps {
   params: Promise<{ slug?: string[] }>;
@@ -31,12 +40,37 @@ export default async function LearnPage(props: LearnPageProps) {
   // remain available directly on `page.data`.
   const { body: MDX, toc } = await page.data.load();
 
+  // `markdownUrl` is rewritten to the raw-Markdown route handler (see
+  // `next.config.ts` and `app/llms/learn/[[...slug]]/route.ts`). The
+  // `MarkdownCopyButton` fetches it for the clipboard; `ViewOptionsPopover`
+  // links to it ("View as Markdown") and builds the "Open in ChatGPT/Claude"
+  // shortcuts, alongside the GitHub source link.
+  const markdownUrl = `${page.url}.md`;
+  const githubUrl = `${GITHUB_BLOB_BASE}/${page.path}`;
+
   return (
     <DocsPage toc={toc} full={page.data.full}>
       <DocsTitle>{page.data.title}</DocsTitle>
       {page.data.description ? (
         <DocsDescription>{page.data.description}</DocsDescription>
       ) : null}
+      {/* Inline styles (not Tailwind utilities) on purpose: `learn.css` runs
+          Tailwind with `source(none)` and only scans Fumadocs's own dist, so
+          utility classes authored here would never be generated. The buttons
+          themselves are Fumadocs components and keep their compiled styles. */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          gap: "0.5rem",
+          paddingBottom: "1rem",
+          borderBottom: "1px solid var(--color-fd-border)",
+        }}
+      >
+        <MarkdownCopyButton markdownUrl={markdownUrl} />
+        <ViewOptionsPopover markdownUrl={markdownUrl} githubUrl={githubUrl} />
+      </div>
       <DocsBody>
         <MDX components={getMDXComponents()} />
       </DocsBody>

--- a/app/llms/learn/[[...slug]]/route.ts
+++ b/app/llms/learn/[[...slug]]/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Raw Markdown endpoint for `/learn` pages.
+ *
+ * Serves the unprocessed `.mdx` source of each lesson as `text/markdown`,
+ * giving the page-action buttons (see `app/learn/[[...slug]]/page.tsx`) a
+ * URL to point at:
+ *   - "Copy Markdown" fetches this and writes it to the clipboard.
+ *   - "View as Markdown" in the "Open" dropdown links here directly.
+ *
+ * Reached via the `/learn/:path*.md` → `/llms/learn/:path*` rewrite in
+ * `next.config.ts`, so the public URL is just `${page.url}.md`. The handler
+ * is statically generated from the same params as the page route, so no
+ * filesystem access happens at request time in production.
+ *
+ * We return the raw file (frontmatter + MDX body) rather than compiling it:
+ * the docs collection runs in `dynamic` mode (see `source.config.ts`) to
+ * keep ~800 lessons out of the bundler, and a plain file read keeps this
+ * endpoint just as cheap while still handing LLMs the full authored source.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { source } from "@/lib/source";
+
+export const revalidate = false;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug?: string[] }> },
+) {
+  const { slug } = await params;
+  const page = source.getPage(slug);
+  if (!page) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const filePath =
+    page.absolutePath ??
+    path.join(process.cwd(), "content", "learn", page.path);
+  const content = await readFile(filePath, "utf8");
+
+  return new Response(content, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}
+
+export function generateStaticParams() {
+  return source.generateParams();
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -30,6 +30,18 @@ const nextConfig: NextConfig = {
       permanent: false,
     },
   ],
+  // Expose every `/learn` lesson as raw Markdown at `${page.url}.md`, served
+  // by the route handler in `app/llms/learn/[[...slug]]/`. The page-action
+  // buttons (Copy Markdown / View as Markdown) point at these URLs. Using
+  // `beforeFiles` guarantees the `.md` suffix is intercepted before the
+  // `/learn/[[...slug]]` page route gets a chance to match it. The bare
+  // `/learn.md` entry covers the course index (content/learn/index.mdx).
+  rewrites: async () => ({
+    beforeFiles: [
+      { source: "/learn.md", destination: "/llms/learn" },
+      { source: "/learn/:path*.md", destination: "/llms/learn/:path*" },
+    ],
+  }),
 };
 
 const withMDX = createMDX();


### PR DESCRIPTION
## What & why

Adds the two Fumadocs page-action buttons to every `/learn` lesson, matching the Fumadocs docs site (e.g. https://www.fumadocs.dev/docs/ui):

1. **Copy Markdown** — copies the page's raw Markdown to the clipboard.
2. **Open** dropdown — links to the **GitHub** source, **ChatGPT**, and **Claude** (plus the default **View as Markdown / Scira / Cursor** shortcuts).

Fumadocs UI 16.9 already ships these as built-ins (`MarkdownCopyButton` + `ViewOptionsPopover`), so the buttons themselves are just wired in rather than reimplemented. The `ViewOptionsPopover` ships its dropdown with a fixed 6-item set and no filtering prop — per the follow-up note in the thread, I used the default set (which already includes the requested GitHub / ChatGPT / Claude links) instead of forking the component.

## How it works

Both the Copy button and the "View as Markdown" link need a same-origin raw-Markdown URL, so:

- **`app/llms/learn/[[...slug]]/route.ts`** (new) serves each lesson's authored `.mdx` as `text/markdown`. It reads the raw file (no MDX compile) to stay cheap and consistent with the collection's `dynamic` mode, and is statically generated from the same params as the page route (no request-time filesystem access in prod).
- **`next.config.ts`** adds a `beforeFiles` rewrite from `/learn/:path*.md` → `/llms/learn/:path*` (plus `/learn.md` for the course index), so the public URL is just `${page.url}.md` and the `.md` suffix is intercepted before the `/learn/[[...slug]]` page route.
- **`app/learn/[[...slug]]/page.tsx`** renders the button row under the description with `markdownUrl = ${page.url}.md` and `githubUrl` pointing at `content/learn/<page.path>` on `main`. The wrapper uses inline styles on purpose — `learn.css` runs Tailwind with `source(none)` scanning only Fumadocs's dist, so utility classes authored in app code wouldn't be generated.

## Verification

- `eslint` and `tsc --noEmit` both clean.
- Dev server, real browser:
  - Both buttons render below the description with a divider, matching the reference screenshot.
  - Dropdown resolves to: GitHub → `…/blob/main/content/learn/python-basics/booleans.mdx`, View as Markdown → `/learn/python-basics/booleans.md`, and ChatGPT / Claude / Scira / Cursor prompt links.
- `curl` of the new route: nested page `200 text/markdown`, course index `/learn.md` `200`, unknown slug `404`.

## Note

If you'd rather the **Open** dropdown show *only* GitHub / ChatGPT / Claude, that's a small follow-up: swap `ViewOptionsPopover` for a trimmed local copy of Fumadocs's `page-actions` component. Happy to do that if you prefer the 3-item version.


---
_Generated by [Claude Code](https://claude.ai/code/session_018uEvUAJvofL5RpD6QZ4Uva)_