### PR TITLE
Show course name as breadcrumb on /learn pages; drop Playwright MCP

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,11 +9,6 @@
       "command": "npx",
       "args": ["-y", "next-devtools-mcp@latest"]
     },
-    "playwright": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"]
-    },
     "duckdb": {
       "type": "stdio",
       "command": "uvx",

--- a/app/learn/[[...slug]]/page.tsx
+++ b/app/learn/[[...slug]]/page.tsx
@@ -49,7 +49,15 @@ export default async function LearnPage(props: LearnPageProps) {
   const githubUrl = `${GITHUB_BLOB_BASE}/${page.path}`;
 
   return (
-    <DocsPage toc={toc} full={page.data.full}>
+    // Each course folder's meta.json sets `root: true`, so Fumadocs scopes the
+    // sidebar and breadcrumb tree to that course (the root folder's title is the
+    // course name). `includeRoot: true` adds that root as the breadcrumb's
+    // leading crumb — linking to the course index — which surfaces the course
+    // name on every lesson page. Without it the breadcrumb excludes the root,
+    // and since the course is the only node in scope it would render nothing.
+    // Loose/demo pages under `content/learn` aren't inside a `root` folder, so
+    // they simply get no breadcrumb.
+    <DocsPage toc={toc} full={page.data.full} breadcrumb={{ includeRoot: true }}>
       <DocsTitle>{page.data.title}</DocsTitle>
       {page.data.description ? (
         <DocsDescription>{page.data.description}</DocsDescription>


### PR DESCRIPTION
Two small, independent changes (one commit each).

## 1. Remove Playwright from `.mcp.json`
Drops the `playwright` MCP server entry. `mermaid`, `next-devtools`, and `duckdb` are untouched; the file remains valid JSON.

## 2. Breadcrumbs on `/learn` showing the course name
Surfaces the **course name** as a breadcrumb on every lesson page, linking back to the course index.

**Why a one-line prop does it:** every course folder's `meta.json` sets `"root": true`, so Fumadocs scopes the sidebar/breadcrumb tree to that course and the root folder's `title` is the course name. `DocsPage` already renders a breadcrumb by default, but with the default `includeRoot: false` it *excludes* the root folder — and since the course root is the only node in scope on a lesson page, the breadcrumb was rendering nothing. Passing `breadcrumb={{ includeRoot: true }}` adds that root as the leading crumb.

This is the native Fumadocs breadcrumb (`getBreadcrumbItemsFromPath` with `includeRoot`), so it will also render deeper trails correctly if a course ever adds nested folders.

```tsx
<DocsPage toc={toc} full={page.data.full} breadcrumb={{ includeRoot: true }}>
```

### Behavior
- **Course lesson pages** → breadcrumb shows the course name (the root `meta.json` title), linked to the course index.
- **Loose/demo pages** under `content/learn` (e.g. `code-blocks-*`, `multiple-choice`, `mermaid-test`) aren't inside a `root` folder, so they render no breadcrumb — unchanged.

### Notes
- Styling uses Fumadocs' default breadcrumb styles. `learn.css` already runs Tailwind over Fumadocs' dist (and a comment there already accounted for breadcrumb `<span>`s), so the crumb is styled without extra CSS.
- Verified against the published `fumadocs-ui@16.8.5` / `fumadocs-core@16.8.5` types and implementation. `node_modules` isn't installed in this environment (heavy wasm/pyodide/almostnode deps), so this wasn't built locally — the change is a single type-safe prop addition.

https://claude.ai/code/session_01KaEyuPLTWxnFQWh6uQfa66

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaEyuPLTWxnFQWh6uQfa66)_