### PR TITLE
Render code-only mermaid shapes in monospace; convert step sequences to Steps

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -8,7 +8,7 @@
    is language-agnostic — the same component is meant to host R and
    TypeScript challenges later. */
 
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400..700&display=swap");
 
 .card {
   /* Light, paper-style chrome distinct from the dark-by-default

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -15,7 +15,7 @@
    tokens under the `--cb-*` names these rules consume, so the output
    area always tracks the surrounding card's light/dark theme. */
 
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400..700&display=swap");
 
 .outputScope {
   --cb-black: var(--ds-black);

--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -27,6 +27,9 @@
   font-family: var(--font-mono), "JetBrains Mono", "Fira Code", ui-monospace,
     SFMono-Regular, Menlo, monospace;
   font-size: 1em;
+  /* Inherit the node's label color (white on brand fills, set by adaptNodes)
+     instead of the app's default <code> color, which is near-black. */
+  color: inherit;
   background: none;
   padding: 0;
   border: 0;

--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -17,6 +17,22 @@
   stroke-width: 0 !important;
 }
 
+/* Inline code in diagram labels. Authors mark code-only shapes (type names,
+   identifiers, calls — e.g. `std::unique_ptr`, `value_counts()`) by wrapping the
+   text in a <code> tag in the MDX; render those spans in the app's mono face
+   (JetBrains Mono) instead of the browser's default monospace, with no inherited
+   prose-code background/padding. Applies to both the inline diagram and the
+   fullscreen stage (both use `.diagram`). */
+.diagram :global(code) {
+  font-family: var(--font-mono), "JetBrains Mono", "Fira Code", ui-monospace,
+    SFMono-Regular, Menlo, monospace;
+  font-size: 1em;
+  background: none;
+  padding: 0;
+  border: 0;
+  white-space: inherit;
+}
+
 /* Render the diagram at its natural (intrinsic) size, centered in the column.
    Mermaid emits the SVG with width="100%" plus an inline `max-width:<W>px`
    cap equal to the diagram's intrinsic width. Leaving that cap intact keeps

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -548,25 +548,6 @@ function adaptNodes(root: Element | null, isDark: boolean): void {
     const token = MINDMAP_BRANCHES[Number(m[1]) % MINDMAP_BRANCHES.length];
     e.style.setProperty("stroke", c(token as keyof typeof BRAND_FALLBACKS), "important");
   });
-
-  // JetBrains Mono renders 700 ("bolder") heavy, so soften every bold label to
-  // 580 wherever the mono face is used: the all-mono class/ER diagrams and inline
-  // <code> spans. Inline style beats Mermaid's id-scoped `.classTitle` rule, and
-  // the variable font (loaded 400–700) makes 580 a real weight.
-  const soften = (el: SVGElement | HTMLElement) => {
-    const weight = getComputedStyle(el).fontWeight;
-    if (weight === "bold" || Number(weight) >= 600) el.style.fontWeight = "580";
-  };
-  const codeSvg = root.querySelector(
-    'svg[aria-roledescription="class"], svg[aria-roledescription="er"]',
-  );
-  codeSvg
-    ?.querySelectorAll<HTMLElement>(
-      "foreignObject p, foreignObject span, foreignObject div",
-    )
-    .forEach(soften);
-  codeSvg?.querySelectorAll<SVGElement>("text, tspan").forEach(soften);
-  root.querySelectorAll<HTMLElement>("foreignObject code").forEach(soften);
 }
 
 function MermaidContent({ chart }: { chart: string }) {
@@ -600,7 +581,7 @@ function MermaidContent({ chart }: { chart: string }) {
         document.fonts.load("700 15px Inter"),
         document.fonts.load('400 15px "JetBrains Mono"'),
         document.fonts.load('500 15px "JetBrains Mono"'),
-        document.fonts.load('580 15px "JetBrains Mono"'),
+        document.fonts.load('700 15px "JetBrains Mono"'),
       ]);
       const prefix = isCodeDiagram(chart) ? MONO_DIRECTIVE : "";
       return mermaid.render(id, prefix + chart.replaceAll("\\n", "\n"));

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -75,12 +75,37 @@ function cachePromise<T>(key: string, setPromise: () => Promise<T>): Promise<T> 
 // so we resolve the brand tokens to hex at render time (brand.css stays the
 // source of truth) with literal fallbacks.
 
-// Inter for regular text. Code spans inside labels are wrapped in <code> by the
-// author and rendered in JetBrains Mono via mermaid.module.css. The CSS var
-// resolves in the DOM (defined on :root and on <html> via next/font); the literal
-// fallbacks keep text measurement correct if the var is ever missing.
+// Inter for regular text; JetBrains Mono for diagrams that are entirely code.
+// Inline <code> spans in flowchart labels are styled via mermaid.module.css; whole
+// class/ER diagrams (see isCodeDiagram) render in mono so Mermaid measures — and
+// therefore sizes the boxes — in the mono face. The CSS vars resolve in the DOM
+// (defined on :root and on <html> via next/font); the literal fallbacks keep text
+// measurement correct if a var is ever missing.
 const SANS =
   'var(--font-sans), Inter, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+const MONO =
+  'var(--font-mono), "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace';
+
+// Class diagrams (class names, fields, method signatures) and ER diagrams (tables,
+// typed columns, keys) are entirely code, so they render wholesale in mono. Other
+// types stay sans — flowcharts tag individual code spans with <code> instead, and
+// state/sequence/mindmap/timeline labels are prose. Detected from the first line.
+function isCodeDiagram(chart: string): boolean {
+  const first = chart
+    .replace(/\\n/g, "\n")
+    .split("\n")
+    .map((l) => l.trim())
+    .find(Boolean);
+  return first != null && /^(classDiagram(?:-v2)?|erDiagram)\b/.test(first);
+}
+
+// Mermaid init directive that switches a single diagram to the mono face. It
+// merges over the global brand theme; adaptNodes still owns fills and label
+// colors, so only the font changes.
+const MONO_DIRECTIVE = `%%{init: ${JSON.stringify({
+  fontFamily: MONO,
+  themeVariables: { fontFamily: MONO },
+})}}%%\n`;
 
 const BRAND_FALLBACKS: Record<string, string> = {
   "--ds-blue-300": "#8ABFFF",
@@ -557,7 +582,8 @@ function MermaidContent({ chart }: { chart: string }) {
         document.fonts.load('400 15px "JetBrains Mono"'),
         document.fonts.load('500 15px "JetBrains Mono"'),
       ]);
-      return mermaid.render(id, chart.replaceAll("\\n", "\n"));
+      const prefix = isCodeDiagram(chart) ? MONO_DIRECTIVE : "";
+      return mermaid.render(id, prefix + chart.replaceAll("\\n", "\n"));
     }),
   );
 

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -548,6 +548,25 @@ function adaptNodes(root: Element | null, isDark: boolean): void {
     const token = MINDMAP_BRANCHES[Number(m[1]) % MINDMAP_BRANCHES.length];
     e.style.setProperty("stroke", c(token as keyof typeof BRAND_FALLBACKS), "important");
   });
+
+  // JetBrains Mono renders 700 ("bolder") heavy, so soften every bold label to
+  // 580 wherever the mono face is used: the all-mono class/ER diagrams and inline
+  // <code> spans. Inline style beats Mermaid's id-scoped `.classTitle` rule, and
+  // the variable font (loaded 400–700) makes 580 a real weight.
+  const soften = (el: SVGElement | HTMLElement) => {
+    const weight = getComputedStyle(el).fontWeight;
+    if (weight === "bold" || Number(weight) >= 600) el.style.fontWeight = "580";
+  };
+  const codeSvg = root.querySelector(
+    'svg[aria-roledescription="class"], svg[aria-roledescription="er"]',
+  );
+  codeSvg
+    ?.querySelectorAll<HTMLElement>(
+      "foreignObject p, foreignObject span, foreignObject div",
+    )
+    .forEach(soften);
+  codeSvg?.querySelectorAll<SVGElement>("text, tspan").forEach(soften);
+  root.querySelectorAll<HTMLElement>("foreignObject code").forEach(soften);
 }
 
 function MermaidContent({ chart }: { chart: string }) {
@@ -581,6 +600,7 @@ function MermaidContent({ chart }: { chart: string }) {
         document.fonts.load("700 15px Inter"),
         document.fonts.load('400 15px "JetBrains Mono"'),
         document.fonts.load('500 15px "JetBrains Mono"'),
+        document.fonts.load('580 15px "JetBrains Mono"'),
       ]);
       const prefix = isCodeDiagram(chart) ? MONO_DIRECTIVE : "";
       return mermaid.render(id, prefix + chart.replaceAll("\\n", "\n"));

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -62,8 +62,8 @@ function cachePromise<T>(key: string, setPromise: () => Promise<T>): Promise<T> 
 //     fill, and `adaptNodes` additionally forces stroke-width to 0 after
 //     render (which also clears any author `stroke:` override).
 //   • The fonts come from the app's type system: Inter (`--font-sans`) for
-//     regular text and JetBrains Mono (`--font-mono`) for nodes the author
-//     tags as code with `:::code`.
+//     regular text and JetBrains Mono (`--font-mono`) for code spans the author
+//     wraps in a <code> tag (styled in mermaid.module.css).
 //
 // ~50 MDX diagrams hand-color nodes with `style`/`classDef` using light pastel
 // fills (e.g. `fill:#fee2e2`). To keep those on-brand, `adaptNodes` buckets
@@ -75,13 +75,12 @@ function cachePromise<T>(key: string, setPromise: () => Promise<T>): Promise<T> 
 // so we resolve the brand tokens to hex at render time (brand.css stays the
 // source of truth) with literal fallbacks.
 
-// Inter for regular text, JetBrains Mono for code. The CSS vars resolve in the
-// DOM (defined on :root and on <html> via next/font), and the literal fallbacks
-// keep text measurement correct if a var is ever missing.
+// Inter for regular text. Code spans inside labels are wrapped in <code> by the
+// author and rendered in JetBrains Mono via mermaid.module.css. The CSS var
+// resolves in the DOM (defined on :root and on <html> via next/font); the literal
+// fallbacks keep text measurement correct if the var is ever missing.
 const SANS =
   'var(--font-sans), Inter, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
-const MONO =
-  'var(--font-mono), "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace';
 
 const BRAND_FALLBACKS: Record<string, string> = {
   "--ds-blue-300": "#8ABFFF",
@@ -361,8 +360,8 @@ function snapToBrand(
 //      `divider`s (which Mermaid draws in the fill color, i.e. invisible).
 //   3. label color — white, except near-black on yellow (and the two lightest
 //      mindmap blues) where white is unreadable.
-//   4. for nodes tagged `:::code`, switch the label to monospace and grow the
-//      box so the wider mono glyphs aren't clipped.
+//   4. for labels containing an inline <code> span, grow the box so the mono
+//      face (styled via CSS) isn't clipped past Mermaid's measured size.
 // Runs post-render because fills can come from injected CSS classes, so
 // getComputedStyle is required. Idempotent.
 function adaptNodes(root: Element | null, isDark: boolean): void {
@@ -450,25 +449,26 @@ function adaptNodes(root: Element | null, isDark: boolean): void {
     });
 
     const textColor = fillHex ? (darkText ? DARK : LIGHT) : null;
-    const isCode = node.classList.contains("code");
+    // Inline <code> spans are styled in mono by mermaid.module.css; the label
+    // color still needs syncing (white on the brand fill) and inherits down to
+    // the <code> child. `hasCode` also drives the box-grow safety net below.
+    const hasCode = node.querySelector("foreignObject code") != null;
     const htmlLabels = node.querySelectorAll<HTMLElement>(
       "foreignObject div, foreignObject span, foreignObject p",
     );
     htmlLabels.forEach((el) => {
       if (textColor) el.style.color = textColor;
-      if (isCode) el.style.fontFamily = MONO;
     });
     node.querySelectorAll<SVGElement>("text, tspan").forEach((el) => {
       if (textColor) el.style.fill = textColor;
-      if (isCode) el.style.fontFamily = MONO;
     });
 
-    // Mermaid measured the box with Inter; monospace glyphs are wider and the
-    // relabelled code wraps taller, so it can overflow and clip. Grow the box
-    // to fit the mono text at full size, re-centering the shape and label so the
-    // node stays put (edges connect at the center, so they stay aligned). Falls
-    // back to shrinking the label if the shape isn't a simple rect.
-    if (isCode) {
+    // Mermaid measures a <code> span in the browser's default monospace; our mono
+    // face (JetBrains Mono) can be marginally wider, so the label may overflow and
+    // clip. Grow the box to fit at full size, re-centering the shape and label so
+    // the node stays put (edges connect at the center, so they stay aligned).
+    // Falls back to shrinking the label if the shape isn't a simple rect.
+    if (hasCode) {
       const fo = node.querySelector<SVGForeignObjectElement>("foreignObject");
       const content = fo?.firstElementChild as HTMLElement | null;
       const rect = node.querySelector<SVGRectElement>("rect");

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -9,7 +9,7 @@
    `--color-…` vars); brand colors come from the global `--ds-*` ramp
    (app/brand.css). */
 
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400..700&display=swap");
 
 .card {
   /* Local neutral palette (Tailwind) — kept in sync with ChallengeCard;

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1,7 +1,7 @@
 /* ─── Playground (Python / R) shared styles ─────────────────────────────── */
 /* Extracted from public/python.html so the React component can reuse them. */
 
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400..700&display=swap");
 
 :root {
   --bg: #0f1117;

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -16,7 +16,7 @@
    must precede the tailwind/fumadocs imports below — `@import` rules
    are required to come before any non-`@import`/`@layer`/`@charset`
    at-rule, including the inlined CSS pulled in by tailwindcss. */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400..700&display=swap");
 
 /* `source(none)` disables Tailwind v4's automatic content detection,
    which otherwise crawls the entire project on every CSS compile. In this

--- a/content/learn/beginners-javascript/closures.mdx
+++ b/content/learn/beginners-javascript/closures.mdx
@@ -41,14 +41,14 @@ over" the variable `greeting` from `makeGreeter`'s scope.
 
 ```mermaid
 flowchart LR
-    subgraph Call1["makeGreeter('Hello')"]
-        G1["greeting = 'Hello'"]
-        H["function (name) { ... }"]
+    subgraph Call1["<code>makeGreeter('Hello')</code>"]
+        G1["<code>greeting = 'Hello'</code>"]
+        H["<code>function (name) { ... }</code>"]
         H -- closes over --> G1
     end
-    subgraph Call2["makeGreeter('Howdy')"]
-        G2["greeting = 'Howdy'"]
-        K["function (name) { ... }"]
+    subgraph Call2["<code>makeGreeter('Howdy')</code>"]
+        G2["<code>greeting = 'Howdy'</code>"]
+        K["<code>function (name) { ... }</code>"]
         K -- closes over --> G2
     end
 ```
@@ -309,7 +309,7 @@ just from how closures work.
 
 ```mermaid
 flowchart TB
-    A["A function is defined inside another function (or in any block)"]
+    A["A function is defined inside another <code>function (or in any block)</code>"]
     B["The inner function refers to a variable from the outer scope"]
     C["The outer scope finishes (its call returns)"]
     D["The inner function continues to live somewhere<br/>(returned, stored, passed as a callback)"]

--- a/content/learn/beginners-javascript/how-computers-execute-programs.mdx
+++ b/content/learn/beginners-javascript/how-computers-execute-programs.mdx
@@ -72,7 +72,7 @@ a JavaScript program, here is roughly what happens:
 
 ```mermaid
 flowchart TB
-    A["Your source code<br/>(text, e.g. main.js)"]
+    A["Your source code<br/>(text, e.g. <code>main.js</code>)"]
     B["Parser<br/>(reads the text and builds a tree of meaning)"]
     C["Compiler / interpreter<br/>(turns that tree into something runnable)"]
     D["Machine instructions<br/>(what the CPU actually executes)"]
@@ -182,7 +182,7 @@ of address pointing to it.
 ```mermaid
 flowchart LR
     subgraph Stack["Stack (per running function)"]
-        S1["x = 5"]
+        S1["<code>x = 5</code>"]
         S2["list = (pointer)"]
     end
     subgraph Heap["Heap (long-lived objects)"]

--- a/content/learn/beginners-javascript/loops-and-iteration.mdx
+++ b/content/learn/beginners-javascript/loops-and-iteration.mdx
@@ -334,7 +334,7 @@ classic `for (let i = 0; i < N; i++) { ... }`:
 
 ```mermaid
 flowchart TD
-    A[Initialise i = 0]
+    A["Initialise <code>i = 0</code>"]
     B{i < N?}
     C[Body: do something with i]
     D[i = i + 1]

--- a/content/learn/beginners-javascript/modular-organization.mdx
+++ b/content/learn/beginners-javascript/modular-organization.mdx
@@ -27,12 +27,12 @@ isolation is the entire point.
 flowchart TD
     subgraph users.js
         U1[users array]
-        U2[getUser]
+        U2["<code>getUser</code>"]
         U3[private helper]
     end
     subgraph orders.js
         O1[orders array]
-        O2[createOrder]
+        O2["<code>createOrder</code>"]
         O3[private helper]
     end
     subgraph index.js
@@ -224,8 +224,8 @@ on B, B may depend on C, but C must not depend on A.
 
 ```mermaid
 flowchart LR
-    A[index.js] --> B[users.js]
-    A --> C[orders.js]
+    A["<code>index.js</code>"] --> B["<code>users.js</code>"]
+    A --> C["<code>orders.js</code>"]
     C --> D[shared/http.js]
     B --> D
     style D fill:#dff,stroke:#066

--- a/content/learn/beginners-javascript/modular-organization.mdx
+++ b/content/learn/beginners-javascript/modular-organization.mdx
@@ -25,17 +25,17 @@ isolation is the entire point.
 
 ```mermaid
 flowchart TD
-    subgraph users.js
+    subgraph users.js["<code>users.js</code>"]
         U1[users array]
         U2["<code>getUser</code>"]
         U3[private helper]
     end
-    subgraph orders.js
+    subgraph orders.js["<code>orders.js</code>"]
         O1[orders array]
         O2["<code>createOrder</code>"]
         O3[private helper]
     end
-    subgraph index.js
+    subgraph index.js["<code>index.js</code>"]
         I1[main]
     end
     I1 -->|imports| U2
@@ -226,7 +226,7 @@ on B, B may depend on C, but C must not depend on A.
 flowchart LR
     A["<code>index.js</code>"] --> B["<code>users.js</code>"]
     A --> C["<code>orders.js</code>"]
-    C --> D[shared/http.js]
+    C --> D["shared/<code>http.js</code>"]
     B --> D
     style D fill:#dff,stroke:#066
 ```

--- a/content/learn/beginners-javascript/scope-and-scope-chain.mdx
+++ b/content/learn/beginners-javascript/scope-and-scope-chain.mdx
@@ -81,9 +81,9 @@ sequence of nested scopes is called the **scope chain**.
 
 ```mermaid
 flowchart TB
-    G["Global scope<br/>const greeting = 'Hello'"]
-    F["Function scope (greet)<br/>let name = 'Ada'"]
-    B["Block scope (if true)<br/>let stamp = '<<>>'"]
+    G["Global scope<br/>const <code>greeting = 'Hello'</code>"]
+    F["Function scope (greet)<br/>let <code>name = 'Ada'</code>"]
+    B["Block scope (if true)<br/>let <code>stamp = '&lt;&lt;&gt;&gt;'</code>"]
     B -->|outer| F -->|outer| G
 ```
 

--- a/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
@@ -212,8 +212,8 @@ least one definition per used symbol — no more, no less.
 
 ```mermaid
 flowchart LR
-    H["greetings.h<br/>void <code>say_hello(...)</code>"] -->|included by| M[main.c]
-    H -->|included by| G[greetings.c]
+    H["greetings.h<br/>void <code>say_hello(...)</code>"] -->|included by| M["<code>main.c</code>"]
+    H -->|included by| G["<code>greetings.c</code>"]
     G -->|defines| BODY["body of<br/><code>say_hello</code>"]
     M -->|calls| BODY
 ```

--- a/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
@@ -212,9 +212,9 @@ least one definition per used symbol — no more, no less.
 
 ```mermaid
 flowchart LR
-    H["greetings.h<br/>void say_hello(...)"] -->|included by| M[main.c]
+    H["greetings.h<br/>void <code>say_hello(...)</code>"] -->|included by| M[main.c]
     H -->|included by| G[greetings.c]
-    G -->|defines| BODY["body of<br/>say_hello"]
+    G -->|defines| BODY["body of<br/><code>say_hello</code>"]
     M -->|calls| BODY
 ```
 

--- a/content/learn/c-programming-for-beginners/functions.mdx
+++ b/content/learn/c-programming-for-beginners/functions.mdx
@@ -189,10 +189,10 @@ nothing else, then returns. Right at the moment we're inside
 ```mermaid
 flowchart TB
     subgraph Top
-      F1["square's frame<br/>n = 3"]
+      F1["square's frame<br/><code>n = 3</code>"]
     end
     subgraph Below
-      F2["main's frame<br/>a = 7, b = ?"]
+      F2["main's frame<br/><code>a = 7</code>, b = ?"]
     end
     F1 --- F2
 ```

--- a/content/learn/c-programming-for-beginners/functions.mdx
+++ b/content/learn/c-programming-for-beginners/functions.mdx
@@ -168,9 +168,9 @@ a higher level.
 
 ```mermaid
 flowchart TD
-    M[main] --> R[read_input]
+    M[main] --> R["<code>read_input</code>"]
     M --> P[process]
-    M --> O[print_result]
+    M --> O["<code>print_result</code>"]
     P --> H1[helper 1]
     P --> H2[helper 2]
 ```

--- a/content/learn/c-programming-for-beginners/loops.mdx
+++ b/content/learn/c-programming-for-beginners/loops.mdx
@@ -251,7 +251,7 @@ A classic countdown.
 
 ```mermaid
 flowchart TD
-    A[init: i = 1] --> B{i <= 5?}
+    A["init: <code>i = 1</code>"] --> B{i <= 5?}
     B -- yes --> C[body: print i]
     C --> D[increment: i = i + 1]
     D --> B

--- a/content/learn/c-programming-for-beginners/pointers-and-arrays.mdx
+++ b/content/learn/c-programming-for-beginners/pointers-and-arrays.mdx
@@ -240,14 +240,14 @@ Most compilers will warn about this. Take the warning seriously.
 flowchart TB
     subgraph "int a[5] in memory"
       direction LR
-      C0["a[0] = 10<br/>addr 0x100"]
-      C1["a[1] = 20<br/>addr 0x104"]
-      C2["a[2] = 30<br/>addr 0x108"]
-      C3["a[3] = 40<br/>addr 0x10c"]
-      C4["a[4] = 50<br/>addr 0x110"]
+      C0["a[0] = 10<br/>addr <code>0x100</code>"]
+      C1["a[1] = 20<br/>addr <code>0x104</code>"]
+      C2["a[2] = 30<br/>addr <code>0x108</code>"]
+      C3["a[3] = 40<br/>addr <code>0x10c</code>"]
+      C4["a[4] = 50<br/>addr <code>0x110</code>"]
     end
-    P["int *p = a;<br/>p = 0x100"] --> C0
-    Q["p + 2 = 0x108"] --> C2
+    P["int *p = a;<br/><code>p = 0x100</code>"] --> C0
+    Q["p + 2 = <code>0x108</code>"] --> C2
 ```
 
 Each cell is 4 bytes apart, but `p + 1` *adds 1 element* — the

--- a/content/learn/c-programming-for-beginners/pointers.mdx
+++ b/content/learn/c-programming-for-beginners/pointers.mdx
@@ -26,8 +26,8 @@ int  *p = &n;     // a pointer that holds the address of n
 ```mermaid
 flowchart LR
     subgraph memory
-      N["address 0x100<br/>n = 42"]
-      P["address 0x200<br/>p = 0x100"]
+      N["address <code>0x100</code><br/><code>n = 42</code>"]
+      P["address <code>0x200</code><br/><code>p = 0x100</code>"]
     end
     P -->|points to| N
 ```

--- a/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
+++ b/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
@@ -163,13 +163,13 @@ constants. It says nothing about *how* those things are implemented.
 
 ```mermaid
 flowchart LR
-    M[main.c<br/>#include parser.h<br/>#include evaluator.h] -.uses.-> PH[parser.h]
-    M -.uses.-> EH[evaluator.h]
-    PH --- P[parser.c]
-    EH --- E[evaluator.c]
-    P -.uses.-> UH[util.h]
+    M["<code>main.c</code><br/>#include <code>parser.h</code><br/>#include <code>evaluator.h</code>"] -.uses.-> PH["<code>parser.h</code>"]
+    M -.uses.-> EH["<code>evaluator.h</code>"]
+    PH --- P["<code>parser.c</code>"]
+    EH --- E["<code>evaluator.c</code>"]
+    P -.uses.-> UH["<code>util.h</code>"]
     E -.uses.-> UH
-    UH --- U[util.c]
+    UH --- U["<code>util.c</code>"]
 ```
 
 ## A worked multi-file example

--- a/content/learn/c-programming-for-beginners/strings.mdx
+++ b/content/learn/c-programming-for-beginners/strings.mdx
@@ -206,7 +206,7 @@ We'll see why that pattern is so common in the pointers chapter.
 ```mermaid
 flowchart LR
     subgraph stack
-      A["buf[6]<br/>'h','e','l','l','o','\\0'"]
+      A["<code>buf[6]<br/>'h','e','l','l','o','\\0'</code>"]
     end
     subgraph "read-only data"
       L["'h','e','l','l','o','\\0'"]

--- a/content/learn/csharp-linq-functional/aggregations.mdx
+++ b/content/learn/csharp-linq-functional/aggregations.mdx
@@ -199,10 +199,10 @@ Let's trace `nums.Aggregate(0, (acc, n) => acc + n)` for
 
 ```mermaid
 flowchart TD
-    A["acc=0"] --> B["+3 → acc=3"]
-    B --> C["+1 → acc=4"]
-    C --> D["+4 → acc=8"]
-    D --> E["result = 8"]
+    A["<code>acc=0</code>"] --> B["<code>+3 → acc=3</code>"]
+    B --> C["<code>+1 → acc=4</code>"]
+    C --> D["<code>+4 → acc=8</code>"]
+    D --> E["<code>result = 8</code>"]
 ```
 
 The accumulator threads through, one element at a time. The seed is

--- a/content/learn/csharp-linq-functional/birth-of-linq.mdx
+++ b/content/learn/csharp-linq-functional/birth-of-linq.mdx
@@ -117,10 +117,10 @@ There are two kinds of LINQ, and the difference matters.
 ```mermaid
 flowchart TB
     subgraph LinqToObjects[LINQ to Objects]
-        Q1["IEnumerable&lt;T&gt;"] -->|"Func&lt;T,bool&gt;"| F1[Pipeline executes locally]
+        Q1["<code>IEnumerable&lt;T&gt;</code>"] -->|"Func&lt;T,bool&gt;"| F1[Pipeline executes locally]
     end
     subgraph LinqToProviders[LINQ to a provider]
-        Q2["IQueryable&lt;T&gt;"] -->|"Expression&lt;Func&lt;T,bool&gt;&gt;"| F2[Pipeline is *translated* to SQL/HTTP/etc.]
+        Q2["<code>IQueryable&lt;T&gt;</code>"] -->|"Expression&lt;Func&lt;T,bool&gt;&gt;"| F2[Pipeline is *translated* to SQL/HTTP/etc.]
     end
 ```
 

--- a/content/learn/csharp-linq-functional/filtering-and-projection.mdx
+++ b/content/learn/csharp-linq-functional/filtering-and-projection.mdx
@@ -177,7 +177,7 @@ pipeline above:
 flowchart TD
     O1["Order(Widget, 9.99, 3)"] --> W1{"Where: Product == 'Widget'"}
     W1 -->|"pass"| W2{"Where: Quantity > 0"}
-    W2 -->|"pass"| S["Select: new { Price=9.99, Total=29.97 }"]
+    W2 -->|"pass"| S["Select: new <code>{ Price=9.99, Total=29.97 }</code>"]
     S --> R[Output]
 ```
 

--- a/content/learn/csharp-linq-functional/generic-abstractions.mdx
+++ b/content/learn/csharp-linq-functional/generic-abstractions.mdx
@@ -25,7 +25,7 @@ necessary to *walk* a sequence.
 
 ```mermaid
 flowchart LR
-    A["IEnumerable&lt;T&gt;"] -->|GetEnumerator| B["IEnumerator&lt;T&gt;"]
+    A["<code>IEnumerable&lt;T&gt;</code>"] -->|GetEnumerator| B["<code>IEnumerator&lt;T&gt;</code>"]
     B -->|MoveNext| C{has next?}
     C -- yes --> D[Current] --> B
     C -- no --> E[done]

--- a/content/learn/csharp-linq-functional/ienumerable-and-iteration.mdx
+++ b/content/learn/csharp-linq-functional/ienumerable-and-iteration.mdx
@@ -49,7 +49,7 @@ arrays, files, network streams, and infinite sequences.
 
 ```mermaid
 flowchart TD
-    A["IEnumerable&lt;T&gt;"] -->|GetEnumerator| B["IEnumerator&lt;T&gt;"]
+    A["<code>IEnumerable&lt;T&gt;</code>"] -->|GetEnumerator| B["<code>IEnumerator&lt;T&gt;</code>"]
     B -->|MoveNext| C{has next?}
     C -->|yes| D[Current → consumer]
     D --> B

--- a/content/learn/csharp-linq-functional/lambdas-and-delegates.mdx
+++ b/content/learn/csharp-linq-functional/lambdas-and-delegates.mdx
@@ -212,7 +212,7 @@ flowchart LR
     L["x => x.Age > 30"] -->|"compiled as Func"| D[Delegate: callable in C#]
     L -->|"compiled as Expression"| T[Tree of nodes: translatable]
     T --> S["SELECT * FROM ... WHERE Age > 30"]
-    T --> M["{ Age: { $gt: 30 } }"]
+    T --> M["{ Age: <code>{ $gt: 30 }</code> }"]
 ```
 
 We're not going to write a LINQ provider in this course, but it is

--- a/content/learn/csharp-linq-functional/next-steps.mdx
+++ b/content/learn/csharp-linq-functional/next-steps.mdx
@@ -89,8 +89,8 @@ that `yield return`) make defining sources delightful.
 
 ```mermaid
 flowchart LR
-    A[IAsyncEnumerable&lt;T&gt;] --> W["WhereAwait / WhereAsync"]
-      --> S["SelectAwait / SelectAsync"]
+    A["<code>IAsyncEnumerable&lt;T&gt;</code>"] --> W["<code>WhereAwait / WhereAsync</code>"]
+      --> S["<code>SelectAwait / SelectAsync</code>"]
       --> AF["await foreach"]
 ```
 

--- a/content/learn/csharp-linq-functional/ordering-and-grouping.mdx
+++ b/content/learn/csharp-linq-functional/ordering-and-grouping.mdx
@@ -117,7 +117,7 @@ that also has a `Key` property*. That's it.
 ```mermaid
 flowchart LR
     A["[Ada/London, Bilal/Berlin, Chiara/Berlin, Dmitri/Paris, Esther/London]"]
-       --> G["GroupBy(p ⇒ p.City)"]
+       --> G["<code>GroupBy(p ⇒ p.City)</code>"]
     G --> R1["London → [Ada, Esther]"]
     G --> R2["Berlin → [Bilal, Chiara]"]
     G --> R3["Paris  → [Dmitri]"]

--- a/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
+++ b/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
@@ -52,7 +52,7 @@ calls.
 ```mermaid
 flowchart LR
     Q["from p in xs<br/>where p.A &gt; 0<br/>select p.B"]
-      -->|compiler rewrite| M["xs.Where(p =&gt; p.A &gt; 0)<br/>.Select(p =&gt; p.B)"]
+      -->|compiler rewrite| M["<code>xs.Where(p =&gt; p.A &gt; 0)</code><br/>.Select(p =&gt; p.B)"]
     M --> IL[Same IL bytecode]
 ```
 

--- a/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
+++ b/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
@@ -83,7 +83,7 @@ them all into a single sequence.
 flowchart LR
     A["Departments: [Eng, Sales, Finance]"] --> S["Select(d ⇒ d.Employees)"]
     S --> N["[[Ada, Bilal], [Chiara, Dmitri, Esther], [Farah]]"]
-    A --> M["SelectMany(d ⇒ d.Employees)"]
+    A --> M["<code>SelectMany(d ⇒ d.Employees)</code>"]
     M --> F["[Ada, Bilal, Chiara, Dmitri, Esther, Farah]"]
 ```
 

--- a/content/learn/data-analysis-python-pandas/first-look-at-a-dataset.mdx
+++ b/content/learn/data-analysis-python-pandas/first-look-at-a-dataset.mdx
@@ -13,13 +13,43 @@ later.
 Every analyst eventually develops a personal version of this
 ritual. Here is a solid one to start with.
 
-```mermaid
-flowchart TD
-    A[1. Shape<br/>and head] --> B[2. dtypes<br/>and memory]
-    B --> C[3. describe<br/>numeric + objects]
-    C --> D[4. Missing-value<br/>map]
-    D --> E[5. Unique-value<br/>counts for categoricals]
-```
+<Steps>
+<Step>
+
+**Shape and head**
+
+How big is the table, and what do the first rows look like?
+
+</Step>
+<Step>
+
+**Dtypes and memory**
+
+Did Pandas read each column as the right type — and will it fit in memory?
+
+</Step>
+<Step>
+
+**Describe (numeric + objects)**
+
+Summary statistics for the numeric columns, then the text/categorical ones.
+
+</Step>
+<Step>
+
+**Missing-value map**
+
+Where is data missing, and is the pattern random or structural?
+
+</Step>
+<Step>
+
+**Unique-value counts for categoricals**
+
+For every text-like column, what distinct values actually appear?
+
+</Step>
+</Steps>
 
 Let us walk each step on a real dataset.
 

--- a/content/learn/data-analysis-python-pandas/notebooks-and-environments.mdx
+++ b/content/learn/data-analysis-python-pandas/notebooks-and-environments.mdx
@@ -176,7 +176,7 @@ something is wrong.
 flowchart TD
     subgraph "Kernel = your Python session"
         V1[Variables in memory]
-        V1 -->|cell 1 ran| V2[df = read_csv]
+        V1 -->|cell 1 ran| V2["df = <code>read_csv</code>"]
         V2 -->|cell 3 ran| V3[summary = ...]
         V3 -->|cell 2 re-ran| V4[df = ... but summary is stale!]
     end

--- a/content/learn/data-analysis-python-pandas/pivot-tables.mdx
+++ b/content/learn/data-analysis-python-pandas/pivot-tables.mdx
@@ -11,7 +11,7 @@ rows, product to columns, sum of sales to values — Pandas's
 
 ```mermaid
 flowchart LR
-  L["Long DataFrame<br/>region, product, sales"] -->|pivot_table| W["Wide grid<br/>rows=region<br/>cols=product<br/>cells=sum(sales)"]
+  L["Long DataFrame<br/>region, product, sales"] -->|pivot_table| W["Wide grid<br/>rows=region<br/>cols=product<br/>cells=<code>sum(sales)</code>"]
 ```
 
 You're saying: "I want a grid. The rows come from this column,

--- a/content/learn/data-analysis-python-pandas/rise-of-digital-datasets.mdx
+++ b/content/learn/data-analysis-python-pandas/rise-of-digital-datasets.mdx
@@ -94,12 +94,12 @@ shapes. Five of the most common:
 
 ```mermaid
 flowchart LR
-    A[CSV] --> P[pandas.read_csv]
-    B[Excel<br/>.xlsx] --> P2[pandas.read_excel]
-    C[JSON<br/>API] --> P3[pandas.read_json]
-    D[Parquet] --> P4[pandas.read_parquet]
-    E[SQL DB] --> P5[pandas.read_sql]
-    P --> DF[(DataFrame)]
+    A[CSV] --> P["pandas.<code>read_csv</code>"]
+    B[Excel<br/>.xlsx] --> P2["pandas.<code>read_excel</code>"]
+    C[JSON<br/>API] --> P3["pandas.<code>read_json</code>"]
+    D[Parquet] --> P4["pandas.<code>read_parquet</code>"]
+    E[SQL DB] --> P5["pandas.<code>read_sql</code>"]
+    P --> DF[("<code>DataFrame</code>")]
     P2 --> DF
     P3 --> DF
     P4 --> DF

--- a/content/learn/data-analysis-python-pandas/rows-and-columns.mdx
+++ b/content/learn/data-analysis-python-pandas/rows-and-columns.mdx
@@ -187,7 +187,7 @@ type, different axis — is a recurring theme.
 
 ```mermaid
 flowchart LR
-    DF[(DataFrame<br/>5 × 4)] -->|df see column| C[Series of<br/>5 values<br/>indexed by row]
+    DF[("<code>DataFrame<br/>5 × 4</code>")] -->|df see column| C[Series of<br/>5 values<br/>indexed by row]
     DF -->|df.iloc see row| R[Series of<br/>4 values<br/>indexed by column]
 ```
 

--- a/content/learn/database-design-postgresql/attributes-and-domains.mdx
+++ b/content/learn/database-design-postgresql/attributes-and-domains.mdx
@@ -20,7 +20,7 @@ have an order date, status, and total amount.
 flowchart TB
     Customer["Entity: customer"] --> Name["Attribute: name"]
     Customer --> Email["Attribute: email"]
-    Customer --> Joined["Attribute: joined_on"]
+    Customer --> Joined["Attribute: <code>joined_on</code>"]
     Customer --> Status["Attribute: status"]
 ```
 
@@ -120,7 +120,7 @@ identity, attributes, or relationships?"
 flowchart TB
     Q{"Does it have its own details<br/>or many rows?"} -->|"no"| Attr["Keep as attribute"]
     Q -->|"yes"| Entity["Model as entity"]
-    Attr --> Email["customer.email"]
+    Attr --> Email["<code>customer.email</code>"]
     Entity --> Address["addresses table"]
 ```
 
@@ -151,7 +151,7 @@ unit matters.
 ```mermaid
 flowchart TB
     Vague["amount"] --> Question["Dollars? cents?<br/>subtotal? total?"]
-    Clear["total_cents"] --> Meaning["Integer number of cents"]
+    Clear["<code>total_cents</code>"] --> Meaning["Integer number of cents"]
 ```
 
 The name, type, and constraints work together. A column called

--- a/content/learn/database-design-postgresql/case-study-blog.mdx
+++ b/content/learn/database-design-postgresql/case-study-blog.mdx
@@ -45,7 +45,7 @@ flowchart LR
     Users["users"] --> Posts["posts"]
     Users --> Comments["comments"]
     Posts --> Comments
-    Posts --> PostTags["post_tags"]
+    Posts --> PostTags["<code>post_tags</code>"]
     Tags["tags"] --> PostTags
 ```
 
@@ -74,7 +74,7 @@ Each attribute belongs with the entity it describes.
 ```mermaid
 flowchart TD
     User["users"] --> Email["email"]
-    User --> Display["display_name"]
+    User --> Display["<code>display_name</code>"]
     Post["posts"] --> Title["title"]
     Post --> Body["body"]
     Post --> Status["status"]
@@ -248,7 +248,7 @@ The design choices come from the rules:
 
 ```mermaid
 flowchart LR
-    Rule["One tag per post only once"] --> Key["PRIMARY KEY on post_id and tag_id"]
+    Rule["One tag per post only once"] --> Key["PRIMARY KEY on <code>post_id</code> and <code>tag_id</code>"]
     Key --> Reject["Duplicate pair is rejected"]
 ```
 

--- a/content/learn/database-design-postgresql/case-study-ecommerce.mdx
+++ b/content/learn/database-design-postgresql/case-study-ecommerce.mdx
@@ -44,9 +44,9 @@ The core entities are `customers`, `products`, `categories`, and
 ```mermaid
 flowchart LR
     Customers["customers"] --> Orders["orders"]
-    Orders --> Items["order_items"]
+    Orders --> Items["<code>order_items</code>"]
     Products["products"] --> Items
-    Products --> ProductCategories["product_categories"]
+    Products --> ProductCategories["<code>product_categories</code>"]
     Categories["categories"] --> ProductCategories
 ```
 
@@ -117,8 +117,8 @@ purchased product.
 flowchart TD
     ManyMany["Many-to-many relationship"] --> Pure["No extra facts"]
     ManyMany --> WithFacts["Has quantity or price"]
-    Pure --> ProductCategories["product_categories"]
-    WithFacts --> OrderItems["order_items"]
+    Pure --> ProductCategories["<code>product_categories</code>"]
+    WithFacts --> OrderItems["<code>order_items</code>"]
 ```
 
 ## Why copy unit_price?
@@ -134,7 +134,7 @@ when a product's current price changes.
 flowchart LR
     ProductPrice["Product current price changes"] --> Catalog["Catalog updates"]
     ProductPrice -->|must not change| PastOrder["Past order total"]
-    PastOrder --> LinePrice["Stored unit_price"]
+    PastOrder --> LinePrice["Stored <code>unit_price</code>"]
 ```
 
 This is a design trade-off: a little duplication protects historical

--- a/content/learn/database-design-postgresql/check-constraints.mdx
+++ b/content/learn/database-design-postgresql/check-constraints.mdx
@@ -99,7 +99,7 @@ CHECK constraints can compare columns in the same row. For an event,
 
 ```mermaid
 flowchart LR
-    Start["start_date"] --> Rule{"end_date > start_date"}
+    Start["<code>start_date</code>"] --> Rule{"<code>end_date &gt; start_date</code>"}
     End["end_date"] --> Rule
     Rule -->|true| Valid["Valid event"]
     Rule -->|false| Invalid["Reject event"]

--- a/content/learn/database-design-postgresql/denormalization.mdx
+++ b/content/learn/database-design-postgresql/denormalization.mdx
@@ -44,8 +44,8 @@ particular read path benefits from having them ready.
 
 ```mermaid
 flowchart LR
-    N["Normalized tables<br/>customers, orders,<br/>order_items, products"] --> R["Derived read table<br/>daily_sales_summary"]
-    N --> C["Cached value<br/>comment_count"]
+    N["Normalized tables<br/>customers, orders,<br/><code>order_items</code>, products"] --> R["Derived read table<br/><code>daily_sales_summary</code>"]
+    N --> C["Cached value<br/><code>comment_count</code>"]
     R --> Benefit["Simpler reads"]
     C --> Benefit
 ```

--- a/content/learn/database-design-postgresql/design-and-scale.mdx
+++ b/content/learn/database-design-postgresql/design-and-scale.mdx
@@ -93,8 +93,8 @@ They also imply the paths software will use to find related data.
 
 ```mermaid
 flowchart TD
-    Customer["customers.id primary key"] --> OrderFK["orders.<code>customer_id</code> foreign key"]
-    Email["customers.email unique"] --> AccountLookup["find account by email"]
+    Customer["<code>customers.id</code> primary key"] --> OrderFK["orders.<code>customer_id</code> foreign key"]
+    Email["<code>customers.email</code> unique"] --> AccountLookup["find account by email"]
     OrderFK --> OrderHistory["find customer orders"]
 ```
 

--- a/content/learn/database-design-postgresql/design-and-scale.mdx
+++ b/content/learn/database-design-postgresql/design-and-scale.mdx
@@ -93,7 +93,7 @@ They also imply the paths software will use to find related data.
 
 ```mermaid
 flowchart TD
-    Customer["customers.id primary key"] --> OrderFK["orders.customer_id foreign key"]
+    Customer["customers.id primary key"] --> OrderFK["orders.<code>customer_id</code> foreign key"]
     Email["customers.email unique"] --> AccountLookup["find account by email"]
     OrderFK --> OrderHistory["find customer orders"]
 ```
@@ -111,7 +111,7 @@ fact across many rows for no good reason.
 flowchart LR
     Repeat["Product name copied into every order item"] --> ManyCopies["many copies"]
     ManyCopies --> ExpensiveChange["hard to change safely"]
-    Normalize["order_items references products"] --> OneCopy["product name stored once"]
+    Normalize["<code>order_items</code> references products"] --> OneCopy["product name stored once"]
 ```
 
 A normalized structure lets related data grow without copying every

--- a/content/learn/database-design-postgresql/evolving-schemas-safely.mdx
+++ b/content/learn/database-design-postgresql/evolving-schemas-safely.mdx
@@ -190,8 +190,8 @@ For example, a `customers.full_name` column might become separate
 
 ```mermaid
 flowchart TD
-    V1["v1: full_name"] --> V2["v2: full_name plus first_name and last_name"]
-    V2 --> V3["v3: first_name and last_name"]
+    V1["v1: <code>full_name</code>"] --> V2["v2: <code>full_name</code> plus <code>first_name</code> and <code>last_name</code>"]
+    V2 --> V3["v3: <code>first_name</code> and <code>last_name</code>"]
 ```
 
 The middle version is temporary, but important. It gives the product a

--- a/content/learn/database-design-postgresql/first-normal-form.mdx
+++ b/content/learn/database-design-postgresql/first-normal-form.mdx
@@ -24,7 +24,7 @@ Common warning signs:
 
 ```mermaid
 flowchart LR
-    B["Before<br/>order_id: 10<br/>items: Book, Pen"] --> A["After<br/>order_id: 10 item: Book<br/>order_id: 10 item: Pen"]
+    B["Before<br/><code>order_id</code>: 10<br/>items: Book, Pen"] --> A["After<br/><code>order_id</code>: 10 item: Book<br/><code>order_id</code>: 10 item: Pen"]
 ```
 
 The after version has more rows, but each row is simpler. SQL can
@@ -37,7 +37,7 @@ Suppose a school stores student phone numbers like this:
 
 ```mermaid
 flowchart TB
-    T["students<br/>student_id | name | phones"]
+    T["students<br/><code>student_id</code> | name | phones"]
     T --> R1["1 | Ada | 555-1000, 555-2000"]
     T --> R2["2 | Grace | 555-3000"]
 ```
@@ -56,7 +56,7 @@ Some designs avoid comma-separated lists by adding more columns:
 
 ```mermaid
 flowchart TB
-    S["students<br/>student_id | name | phone1 | phone2 | phone3"]
+    S["students<br/><code>student_id</code> | name | phone1 | phone2 | phone3"]
     S --> R["1 | Ada | 555-1000 | 555-2000 | null"]
 ```
 
@@ -171,7 +171,7 @@ list.
 
 ```mermaid
 flowchart LR
-    Bad["orders<br/>id | customer | items<br/>10 | Ada | Book, Pen"] --> Good["order_items<br/>order_id | product<br/>10 | Book<br/>10 | Pen"]
+    Bad["orders<br/>id | customer | items<br/>10 | Ada | Book, Pen"] --> Good["<code>order_items</code><br/><code>order_id</code> | product<br/>10 | Book<br/>10 | Pen"]
 ```
 
 A separate `order_items` table gives every item its own row. Later, when

--- a/content/learn/database-design-postgresql/foreign-keys.mdx
+++ b/content/learn/database-design-postgresql/foreign-keys.mdx
@@ -35,7 +35,7 @@ customer can have many orders, and each order belongs to one customer.
 
 ```mermaid
 flowchart LR
-    O["orders.customer_id = 7"] -->|"FK -> PK"| C["customers.customer_id = 7<br/>Mina Patel"]
+    O["orders.<code>customer_id</code> = 7"] -->|"FK -> PK"| C["customers.<code>customer_id</code> = 7<br/>Mina Patel"]
 ```
 
 That arrow is more than a drawing. When you declare the constraint,
@@ -63,11 +63,11 @@ the stable identity on related rows.
 ```mermaid
 flowchart TB
     subgraph customers["customers"]
-        C1["customer_id = 7<br/>name = Mina<br/>email = mina@new.example"]
+        C1["<code>customer_id</code> = 7<br/>name = Mina<br/>email = mina@new.example"]
     end
     subgraph orders["orders"]
-        O1["order_id = 101<br/>customer_id = 7"]
-        O2["order_id = 102<br/>customer_id = 7"]
+        O1["<code>order_id = 101<br/>customer_id = 7</code>"]
+        O2["<code>order_id = 102<br/>customer_id = 7</code>"]
     end
     O1 -->|"FK -> PK"| C1
     O2 -->|"FK -> PK"| C1
@@ -138,7 +138,7 @@ row does not exist.
 
 ```mermaid
 flowchart LR
-    O["Order 102<br/>customer_id = 99"] --> M["Missing customer 99"]:::bad
+    O["Order 102<br/><code>customer_id</code> = 99"] --> M["Missing customer 99"]:::bad
     M --> R["Rejected by FK constraint"]:::good
     classDef bad fill:#fee2e2,stroke:#b91c1c
     classDef good fill:#dcfce7,stroke:#15803d

--- a/content/learn/database-design-postgresql/foreign-keys.mdx
+++ b/content/learn/database-design-postgresql/foreign-keys.mdx
@@ -48,8 +48,8 @@ order. That feels simple until the data changes.
 
 ```mermaid
 flowchart TB
-    A["orders table with copied customer data"] --> B["Order 1<br/>Mina, mina@old.example"]
-    A --> C["Order 2<br/>Mina, mina@old.example"]
+    A["orders table with copied customer data"] --> B["Order 1<br/>Mina, mina@<code>old.example</code>"]
+    A --> C["Order 2<br/>Mina, mina@<code>old.example</code>"]
     D["Email changes"] --> E{"Update every copy?"}
     B --> E
     C --> E

--- a/content/learn/database-design-postgresql/how-design-shapes-software.mdx
+++ b/content/learn/database-design-postgresql/how-design-shapes-software.mdx
@@ -25,7 +25,7 @@ flowchart TB
     B --> C["Schema contract"]
     C --> D["customers"]
     C --> E["orders"]
-    C --> F["order_items"]
+    C --> F["<code>order_items</code>"]
     C --> G["products"]
     D --> H["Reliable result"]
     E --> H

--- a/content/learn/database-design-postgresql/how-design-shapes-software.mdx
+++ b/content/learn/database-design-postgresql/how-design-shapes-software.mdx
@@ -261,7 +261,7 @@ parsing and rewriting historical text.
 ```mermaid
 flowchart TB
     A["Add product SKU"] --> B{"Product has its own table?"}
-    B -->|"yes"| C["Add products.sku"]
+    B -->|"yes"| C["Add <code>products.sku</code>"]
     C --> D["Update product rows"]
     B -->|"no"| E["Find product text in many places"]
     E --> F["Clean inconsistent names"]

--- a/content/learn/database-design-postgresql/junction-tables.mdx
+++ b/content/learn/database-design-postgresql/junction-tables.mdx
@@ -58,7 +58,7 @@ foreign keys. In `enrollments`, the pair `(student_id, course_id)` says
 
 ```mermaid
 flowchart TB
-    Pair["Primary key:<br/>(student_id, course_id)"] --> One["1 and 10<br/>Ada in Math"]
+    Pair["Primary key:<br/>(<code>student_id</code>, <code>course_id</code>)"] --> One["1 and 10<br/>Ada in Math"]
     Pair --> Two["1 and 11<br/>Ada in History"]
     Pair --> Reject["1 and 10 again<br/>duplicate pairing"]
 ```
@@ -101,7 +101,7 @@ For an enrollment:
 
 ```mermaid
 flowchart LR
-    S["Student: Ada"] --> E["Enrollment:<br/>enrolled_on = 2025-01-15<br/>grade = A"]
+    S["Student: Ada"] --> E["Enrollment:<br/><code>enrolled_on</code> = 2025-01-15<br/>grade = A"]
     C["Course: Math"] --> E
     E --> Meaning["Facts about this pairing"]
 ```

--- a/content/learn/database-design-postgresql/many-to-many.mdx
+++ b/content/learn/database-design-postgresql/many-to-many.mdx
@@ -54,7 +54,7 @@ room for one course id.
 
 ```mermaid
 flowchart TB
-    StudentRow["students row<br/>Ada"] --> OneSlot["course_id = 10"]
+    StudentRow["students row<br/>Ada"] --> OneSlot["<code>course_id = 10</code>"]
     OneSlot --> Problem["Where does History go?"]
 ```
 
@@ -63,7 +63,7 @@ has room for one student id.
 
 ```mermaid
 flowchart TB
-    CourseRow["courses row<br/>Math"] --> OneSlot["student_id = 1"]
+    CourseRow["courses row<br/>Math"] --> OneSlot["<code>student_id = 1</code>"]
     OneSlot --> Problem["Where does Grace go?"]
 ```
 

--- a/content/learn/database-design-postgresql/natural-vs-surrogate-keys.mdx
+++ b/content/learn/database-design-postgresql/natural-vs-surrogate-keys.mdx
@@ -96,9 +96,9 @@ does not. Other tables can keep pointing at the same row.
 
 ```mermaid
 flowchart LR
-    U["users.user_id = 10"]:::pk --> O1["orders.user_id = 10"]
-    U --> O2["reviews.user_id = 10"]
-    U --> O3["addresses.user_id = 10"]
+    U["users.<code>user_id</code> = 10"]:::pk --> O1["orders.<code>user_id</code> = 10"]
+    U --> O2["reviews.<code>user_id</code> = 10"]
+    U --> O3["addresses.<code>user_id</code> = 10"]
     E["email changes"] --> U
     classDef pk fill:#fde68a,stroke:#b45309
 ```
@@ -140,8 +140,8 @@ future update.
 
 ```mermaid
 flowchart TB
-    A["users.email is the PK<br/>ada@old.example"]:::bad --> B["orders.user_email<br/>ada@old.example"]
-    A --> C["tickets.user_email<br/>ada@old.example"]
+    A["users.email is the PK<br/>ada@old.example"]:::bad --> B["orders.<code>user_email</code><br/>ada@old.example"]
+    A --> C["tickets.<code>user_email</code><br/>ada@old.example"]
     D["Email changes to<br/>ada@new.example"] --> E{"What about old references?"}
     B --> E
     C --> E
@@ -158,7 +158,7 @@ an identity.
 
 ```mermaid
 flowchart LR
-    ID["users.user_id = 10"]:::pk --> R["references keep user_id = 10"]
+    ID["users.<code>user_id</code> = 10"]:::pk --> R["references keep <code>user_id</code> = 10"]
     E1["email = ada@old.example"] --> E2["email = ada@new.example"]
     ID --> E2
     classDef pk fill:#fde68a,stroke:#b45309

--- a/content/learn/database-design-postgresql/natural-vs-surrogate-keys.mdx
+++ b/content/learn/database-design-postgresql/natural-vs-surrogate-keys.mdx
@@ -140,9 +140,9 @@ future update.
 
 ```mermaid
 flowchart TB
-    A["users.email is the PK<br/>ada@old.example"]:::bad --> B["orders.<code>user_email</code><br/>ada@old.example"]
+    A["<code>users.email</code> is the PK<br/>ada@<code>old.example</code>"]:::bad --> B["orders.<code>user_email</code><br/>ada@old.example"]
     A --> C["tickets.<code>user_email</code><br/>ada@old.example"]
-    D["Email changes to<br/>ada@new.example"] --> E{"What about old references?"}
+    D["Email changes to<br/>ada@<code>new.example</code>"] --> E{"What about old references?"}
     B --> E
     C --> E
     E --> F["Every referencing row must stay in sync"]:::bad
@@ -159,7 +159,7 @@ an identity.
 ```mermaid
 flowchart LR
     ID["users.<code>user_id</code> = 10"]:::pk --> R["references keep <code>user_id</code> = 10"]
-    E1["email = ada@old.example"] --> E2["email = ada@new.example"]
+    E1["email = ada@<code>old.example</code>"] --> E2["email = ada@<code>new.example</code>"]
     ID --> E2
     classDef pk fill:#fde68a,stroke:#b45309
 ```

--- a/content/learn/database-design-postgresql/one-to-many.mdx
+++ b/content/learn/database-design-postgresql/one-to-many.mdx
@@ -55,7 +55,7 @@ the **many** side.
 
 ```mermaid
 flowchart LR
-    C["customers.id = 1<br/>Ada"] --> O1["<code>orders.id = 101<br/>customer_id = 1</code>"]
+    C["<code>customers.id = 1</code><br/>Ada"] --> O1["<code>orders.id = 101<br/>customer_id = 1</code>"]
     C --> O2["<code>orders.id = 102<br/>customer_id = 1</code>"]
     C --> O3["<code>orders.id = 103<br/>customer_id = 1</code>"]
     O1 -->|"FK -> PK"| C
@@ -147,7 +147,7 @@ Designers often call the one side the **parent** and the many side the
 
 ```mermaid
 flowchart LR
-    Parent["Parent row<br/>customers.id = 1"] --> ChildA["Child row<br/>order 101"]
+    Parent["Parent row<br/><code>customers.id = 1</code>"] --> ChildA["Child row<br/>order 101"]
     Parent --> ChildB["Child row<br/>order 102"]
     Parent --> ChildC["Child row<br/>order 103"]
     ChildA -->|"stores customer_id"| Parent

--- a/content/learn/database-design-postgresql/one-to-many.mdx
+++ b/content/learn/database-design-postgresql/one-to-many.mdx
@@ -55,9 +55,9 @@ the **many** side.
 
 ```mermaid
 flowchart LR
-    C["customers.id = 1<br/>Ada"] --> O1["orders.id = 101<br/>customer_id = 1"]
-    C --> O2["orders.id = 102<br/>customer_id = 1"]
-    C --> O3["orders.id = 103<br/>customer_id = 1"]
+    C["customers.id = 1<br/>Ada"] --> O1["<code>orders.id = 101<br/>customer_id = 1</code>"]
+    C --> O2["<code>orders.id = 102<br/>customer_id = 1</code>"]
+    C --> O3["<code>orders.id = 103<br/>customer_id = 1</code>"]
     O1 -->|"FK -> PK"| C
     O2 -->|"FK -> PK"| C
     O3 -->|"FK -> PK"| C

--- a/content/learn/database-design-postgresql/one-to-one.mdx
+++ b/content/learn/database-design-postgresql/one-to-one.mdx
@@ -18,7 +18,7 @@ profile details. Some users have those details, many do not.
 
 ```mermaid
 flowchart TB
-    Wide["Wide users table<br/>id | email | display_name | bio | avatar_url | timezone | preferences"]
+    Wide["Wide users table<br/>id | email | <code>display_name</code> | bio | <code>avatar_url</code> | timezone | preferences"]
     Wide --> Sparse["Many optional columns are empty"]
     Wide --> Mixed["Login identity mixed with profile details"]
     Wide --> Split["Split stable identity from optional profile"]
@@ -144,7 +144,7 @@ foreign key. Choose the table whose row is dependent or optional.
 
 ```mermaid
 flowchart TB
-    User["users<br/>core identity"] --> Profile["user_profiles<br/>optional details"]
+    User["users<br/>core identity"] --> Profile["<code>user_profiles</code><br/>optional details"]
     Profile -->|"user_id FK + UNIQUE"| User
     Choice["Put the FK on the dependent table"] --> Profile
 ```

--- a/content/learn/database-design-postgresql/primary-keys.mdx
+++ b/content/learn/database-design-postgresql/primary-keys.mdx
@@ -145,14 +145,14 @@ erDiagram
 flowchart TB
     subgraph enrollments["Table: enrollments"]
         direction LR
-        S["student_id"]:::pk
-        C["course_id"]:::pk
-        D["enrolled_on"]:::hdr
+        S["<code>student_id</code>"]:::pk
+        C["<code>course_id</code>"]:::pk
+        D["<code>enrolled_on</code>"]:::hdr
         R1["7"]:::pk
         R2["42"]:::pk
         R3["2026-01-15"]
     end
-    K["Composite PK:<br/>(student_id, course_id)"]:::pk --> S
+    K["Composite PK:<br/>(<code>student_id</code>, <code>course_id</code>)"]:::pk --> S
     K --> C
     classDef hdr fill:#dbeafe,stroke:#1d4ed8
     classDef pk fill:#fde68a,stroke:#b45309

--- a/content/learn/database-design-postgresql/reading-er-diagrams.mdx
+++ b/content/learn/database-design-postgresql/reading-er-diagrams.mdx
@@ -57,7 +57,7 @@ flowchart LR
     Diagram["ER diagram"] --> Customers["customers"]
     Diagram --> Orders["orders"]
     Diagram --> Products["products"]
-    Diagram --> Items["order_items"]
+    Diagram --> Items["<code>order_items</code>"]
 ```
 
 Each box is a kind of thing the system tracks. Each will usually
@@ -72,8 +72,8 @@ Inside each box are attributes. For example, `customers` has `id`,
 ```mermaid
 flowchart TB
     Entity["orders"] --> ID["id PK"]
-    Entity --> CustomerID["customer_id FK"]
-    Entity --> Placed["placed_on"]
+    Entity --> CustomerID["<code>customer_id</code> FK"]
+    Entity --> Placed["<code>placed_on</code>"]
     Entity --> Status["status"]
 ```
 
@@ -179,7 +179,7 @@ inside the same order.
 
 ```mermaid
 flowchart TB
-    Key["Primary key:<br/>order_id + line_number"] --> Row1["order 101,<br/>line 1"]
+    Key["Primary key:<br/><code>order_id</code> + <code>line_number</code>"] --> Row1["order 101,<br/>line 1"]
     Key --> Row2["order 101,<br/>line 2"]
     Key --> Row3["order 102,<br/>line 1"]
 ```

--- a/content/learn/database-design-postgresql/referential-integrity.mdx
+++ b/content/learn/database-design-postgresql/referential-integrity.mdx
@@ -18,8 +18,8 @@ not exist.
 
 ```mermaid
 flowchart LR
-    O["orders<br/>order_id = 101<br/>customer_id = 7"] --> C["customers<br/>customer_id = 7"]
-    X["orders<br/>order_id = 102<br/>customer_id = 99"] --> M["missing customer 99"]:::bad
+    O["orders<br/><code>order_id</code> = 101<br/><code>customer_id</code> = 7"] --> C["customers<br/><code>customer_id</code> = 7"]
+    X["orders<br/><code>order_id</code> = 102<br/><code>customer_id</code> = 99"] --> M["missing customer 99"]:::bad
     M --> P["Orphan row"]:::bad
     classDef bad fill:#fee2e2,stroke:#b91c1c
 ```
@@ -123,7 +123,7 @@ whose optional editor was removed.
 
 ```mermaid
 flowchart LR
-    E["Delete employee"] --> T["ticket.assigned_employee_id = NULL"]
+    E["Delete employee"] --> T["ticket.<code>assigned_employee_id</code> = NULL"]
     T --> K["Ticket stays open"]
 ```
 

--- a/content/learn/database-design-postgresql/second-normal-form.mdx
+++ b/content/learn/database-design-postgresql/second-normal-form.mdx
@@ -49,7 +49,7 @@ Consider this 1NF table:
 
 ```mermaid
 flowchart TB
-    T["order_items_bad<br/>order_id | product_id | product_name | quantity"]
+    T["<code>order_items_bad</code><br/><code>order_id</code> | <code>product_id</code> | <code>product_name</code> | quantity"]
     T --> R1["100 | 10 | Notebook | 2"]
     T --> R2["100 | 20 | Pencil | 5"]
     T --> R3["101 | 10 | Notebook | 1"]
@@ -64,8 +64,8 @@ no matter which order it appears on.
 
 ```mermaid
 flowchart LR
-    K["Composite key<br/>order_id + product_id"] --> Q["quantity"]
-    P["product_id<br/>only part of key"] --> N["product_name"]
+    K["Composite key<br/><code>order_id</code> + <code>product_id</code>"] --> Q["quantity"]
+    P["<code>product_id</code><br/>only part of key"] --> N["<code>product_name</code>"]
     K -. whole key .-> Q
     P -. partial dependency .-> N
 ```
@@ -114,8 +114,8 @@ facts stay in `order_items`.
 
 ```mermaid
 flowchart LR
-    Bad["order_items_bad<br/>order_id<br/>product_id<br/>product_name<br/>quantity"] --> Items["order_items<br/>order_id<br/>product_id<br/>quantity"]
-    Bad --> Products["products<br/>product_id<br/>product_name"]
+    Bad["<code>order_items_bad</code><br/><code>order_id</code><br/><code>product_id</code><br/><code>product_name</code><br/>quantity"] --> Items["<code>order_items</code><br/><code>order_id</code><br/><code>product_id</code><br/>quantity"]
+    Bad --> Products["products<br/><code>product_id</code><br/><code>product_name</code>"]
 ```
 
 The split removes the repeated product name from the order-items table.

--- a/content/learn/database-design-postgresql/self-referencing-relationships.mdx
+++ b/content/learn/database-design-postgresql/self-referencing-relationships.mdx
@@ -46,7 +46,7 @@ happens to be the same table.
 
 ```mermaid
 flowchart LR
-    Child["employees.<code>manager_id</code> = 2<br/>Mina's row"] -->|"FK -> PK"| Parent["employees.id = 2<br/>Grace's row"]
+    Child["employees.<code>manager_id</code> = 2<br/>Mina's row"] -->|"FK -> PK"| Parent["<code>employees.id = 2</code><br/>Grace's row"]
 ```
 
 This design gives you a flexible hierarchy without creating separate

--- a/content/learn/database-design-postgresql/self-referencing-relationships.mdx
+++ b/content/learn/database-design-postgresql/self-referencing-relationships.mdx
@@ -31,9 +31,9 @@ different tables; it is one table used in two relationship roles.
 
 ```mermaid
 flowchart TB
-    CEO["Ada<br/>id = 1<br/>manager_id = NULL"] --> Eng["Grace<br/>id = 2<br/>manager_id = 1"]
-    CEO --> Ops["Linus<br/>id = 3<br/>manager_id = 1"]
-    Eng --> Dev["Mina<br/>id = 4<br/>manager_id = 2"]
+    CEO["Ada<br/>id = 1<br/><code>manager_id</code> = NULL"] --> Eng["Grace<br/>id = 2<br/><code>manager_id</code> = 1"]
+    CEO --> Ops["Linus<br/>id = 3<br/><code>manager_id</code> = 1"]
+    Eng --> Dev["Mina<br/>id = 4<br/><code>manager_id</code> = 2"]
 ```
 
 The top row often has no parent. In an org chart, the CEO has no
@@ -46,7 +46,7 @@ happens to be the same table.
 
 ```mermaid
 flowchart LR
-    Child["employees.manager_id = 2<br/>Mina's row"] -->|"FK -> PK"| Parent["employees.id = 2<br/>Grace's row"]
+    Child["employees.<code>manager_id</code> = 2<br/>Mina's row"] -->|"FK -> PK"| Parent["employees.id = 2<br/>Grace's row"]
 ```
 
 This design gives you a flexible hierarchy without creating separate
@@ -119,7 +119,7 @@ erDiagram
 
 ```mermaid
 flowchart TB
-    Root["Root category<br/>parent_id = NULL"] --> Data["Data"]
+    Root["Root category<br/><code>parent_id</code> = NULL"] --> Data["Data"]
     Data --> SQL["SQL"]
     Data --> Modeling["Modeling"]
     Root --> Tools["Tools"]

--- a/content/learn/database-design-postgresql/the-design-process.mdx
+++ b/content/learn/database-design-postgresql/the-design-process.mdx
@@ -151,8 +151,8 @@ belongs.
 ```mermaid
 flowchart TD
     Event["events"] --> Title["title"]
-    Event --> Starts["starts_at"]
-    Event --> VenueId["venue_id"]
+    Event --> Starts["<code>starts_at</code>"]
+    Event --> VenueId["<code>venue_id</code>"]
     Venue["venues"] --> VenueName["name"]
     Venue --> Address["address"]
     Attendee["attendees"] --> Email["email"]

--- a/content/learn/database-design-postgresql/thinking-in-entities.mdx
+++ b/content/learn/database-design-postgresql/thinking-in-entities.mdx
@@ -22,7 +22,7 @@ type becomes **one row**.
 ```mermaid
 flowchart LR
     E["Entity type<br/>customer"] --> T["Table<br/>customers"]
-    R["One real customer<br/>Ada Lovelace"] --> Row["One row<br/>id = 1"]
+    R["One real customer<br/>Ada Lovelace"] --> Row["One row<br/><code>id = 1</code>"]
     T --> Row
 ```
 

--- a/content/learn/database-design-postgresql/thinking-in-entities.mdx
+++ b/content/learn/database-design-postgresql/thinking-in-entities.mdx
@@ -172,7 +172,7 @@ Good entity names are ordinary words from the domain. Prefer
 flowchart TB
     Bad["Vague table<br/>items"] --> Problem["Could mean products,<br/>order lines, tasks, or anything"]
     Good["Clear tables"] --> A["products"]
-    Good --> B["order_items"]
+    Good --> B["<code>order_items</code>"]
     Good --> C["tasks"]
 ```
 

--- a/content/learn/database-design-postgresql/third-normal-form.mdx
+++ b/content/learn/database-design-postgresql/third-normal-form.mdx
@@ -19,7 +19,7 @@ Imagine an `orders` table like this:
 
 ```mermaid
 flowchart TB
-    T["orders<br/>order_id | customer_id | customer_name | customer_city"]
+    T["orders<br/><code>order_id</code> | <code>customer_id</code> | <code>customer_name</code> | <code>customer_city</code>"]
     T --> R1["100 | 1 | Ada | London"]
     T --> R2["101 | 1 | Ada | London"]
     T --> R3["102 | 2 | Grace | Baltimore"]
@@ -31,9 +31,9 @@ the order itself. They are facts about the customer.
 
 ```mermaid
 flowchart LR
-    K["order_id<br/>primary key"] --> C["customer_id<br/>non-key column"]
-    C --> City["customer_city<br/>non-key column"]
-    C --> Name["customer_name<br/>non-key column"]
+    K["<code>order_id</code><br/>primary key"] --> C["<code>customer_id</code><br/>non-key column"]
+    C --> City["<code>customer_city</code><br/>non-key column"]
+    C --> Name["<code>customer_name</code><br/>non-key column"]
 ```
 
 The dependency travels through another column: `order_id` determines
@@ -127,8 +127,8 @@ customer attributes.
 
 ```mermaid
 flowchart LR
-    Bad["orders_bad<br/>order_id<br/>customer_id<br/>customer_name<br/>customer_city"] --> Orders["orders<br/>order_id<br/>customer_id"]
-    Bad --> Customers["customers<br/>customer_id<br/>customer_name<br/>customer_city"]
+    Bad["<code>orders_bad<br/>order_id<br/>customer_id<br/>customer_name<br/>customer_city</code>"] --> Orders["orders<br/><code>order_id</code><br/><code>customer_id</code>"]
+    Bad --> Customers["customers<br/><code>customer_id</code><br/><code>customer_name</code><br/><code>customer_city</code>"]
 ```
 
 The customer facts now have one home. The order row keeps the fact that

--- a/content/learn/database-design-postgresql/what-are-relationships.mdx
+++ b/content/learn/database-design-postgresql/what-are-relationships.mdx
@@ -32,9 +32,9 @@ level, a specific customer row is connected to specific order rows.
 
 ```mermaid
 flowchart TB
-    C["customers row<br/>id = 1<br/>Ada"] -->|places| O1["orders row<br/>id = 101"]
-    C -->|places| O2["orders row<br/>id = 102"]
-    G["customers row<br/>id = 2<br/>Grace"] -->|places| O3["orders row<br/>id = 103"]
+    C["customers row<br/><code>id = 1</code><br/>Ada"] -->|places| O1["orders row<br/><code>id = 101</code>"]
+    C -->|places| O2["orders row<br/><code>id = 102</code>"]
+    G["customers row<br/><code>id = 2</code><br/>Grace"] -->|places| O3["orders row<br/><code>id = 103</code>"]
 ```
 
 That is why relationships are central to relational design. They make

--- a/content/learn/database-design-postgresql/what-are-relationships.mdx
+++ b/content/learn/database-design-postgresql/what-are-relationships.mdx
@@ -49,7 +49,7 @@ points to it.
 ```mermaid
 flowchart LR
     Real["Real world:<br/>Ada placed order 101"] --> Model["Model:<br/>customer relates to order"]
-    Model --> Schema["Schema:<br/>orders.customer_id points to customers.id"]
+    Model --> Schema["Schema:<br/>orders.<code>customer_id</code> points to customers.id"]
 ```
 
 The relationship is the idea. The foreign key is the database

--- a/content/learn/database-design-postgresql/what-is-database-design.mdx
+++ b/content/learn/database-design-postgresql/what-is-database-design.mdx
@@ -33,7 +33,7 @@ flowchart TB
     A --> D["Relationships"]
     A --> E["Constraints"]
     B --> F["books, copies, borrowers, loans"]
-    C --> G["title, barcode, due_on"]
+    C --> G["title, barcode, <code>due_on</code>"]
     D --> H["borrower has loans"]
     E --> I["loan needs existing copy"]
 ```

--- a/content/learn/database-design-postgresql/why-normalization.mdx
+++ b/content/learn/database-design-postgresql/why-normalization.mdx
@@ -18,9 +18,9 @@ Imagine a shop stores orders in one flat table:
 ```mermaid
 flowchart TB
     T["<code>orders_flat<br/>order_id | customer_name | customer_email | product_name | product_price</code>"]
-    T --> R1["1 | Ada | ada@old.test | Notebook | 8.00"]
-    T --> R2["2 | Ada | ada@old.test | Pencil | 1.50"]
-    T --> R3["3 | Grace | grace@test.test | Notebook | 8.00"]
+    T --> R1["1 | Ada | ada@<code>old.test</code> | Notebook | 8.00"]
+    T --> R2["2 | Ada | ada@<code>old.test</code> | Pencil | 1.50"]
+    T --> R3["3 | Grace | grace@<code>test.test</code> | Notebook | 8.00"]
 ```
 
 The table is easy to read, but look carefully. Ada's email appears in

--- a/content/learn/database-design-postgresql/why-normalization.mdx
+++ b/content/learn/database-design-postgresql/why-normalization.mdx
@@ -17,7 +17,7 @@ Imagine a shop stores orders in one flat table:
 
 ```mermaid
 flowchart TB
-    T["orders_flat<br/>order_id | customer_name | customer_email | product_name | product_price"]
+    T["<code>orders_flat<br/>order_id | customer_name | customer_email | product_name | product_price</code>"]
     T --> R1["1 | Ada | ada@old.test | Notebook | 8.00"]
     T --> R2["2 | Ada | ada@old.test | Pencil | 1.50"]
     T --> R3["3 | Grace | grace@test.test | Notebook | 8.00"]

--- a/content/learn/database-design-postgresql/why-schemas-change.mdx
+++ b/content/learn/database-design-postgresql/why-schemas-change.mdx
@@ -30,7 +30,7 @@ or rule.
 
 ```mermaid
 flowchart LR
-    V1["v1: tasks only"] --> V2["v2: add due_date"]
+    V1["v1: tasks only"] --> V2["v2: add <code>due_date</code>"]
     V2 --> V3["v3: add projects"]
     V3 --> V4["v4: add labels"]
     V4 --> V5["v5: add history"]
@@ -95,7 +95,7 @@ relationship into many-to-many.
 
 ```mermaid
 flowchart LR
-    One["tasks.owner_id"] --> Many["task_assignees"]
+    One["tasks.<code>owner_id</code>"] --> Many["<code>task_assignees</code>"]
     Many --> Team["many users per task"]
 ```
 
@@ -107,7 +107,7 @@ rules.
 
 ```mermaid
 flowchart LR
-    Wide["customers with billing columns"] --> Split["customers plus billing_profiles"]
+    Wide["customers with billing columns"] --> Split["customers plus <code>billing_profiles</code>"]
     Split --> Clear["separate rules and lifetimes"]
 ```
 

--- a/content/learn/database-design-postgresql/why-structured-data.mdx
+++ b/content/learn/database-design-postgresql/why-structured-data.mdx
@@ -38,8 +38,8 @@ flowchart LR
 
     subgraph clean["Structured tables"]
         D["customers<br/>id, name, email"]
-        E["orders<br/>id, customer_id, ordered_on"]
-        F["order_items<br/>order_id, product_id, quantity"]
+        E["orders<br/>id, <code>customer_id</code>, <code>ordered_on</code>"]
+        F["<code>order_items</code><br/><code>order_id</code>, <code>product_id</code>, quantity"]
     end
 
     A --> G["Human interpretation"]

--- a/content/learn/database-design-postgresql/why-structured-data.mdx
+++ b/content/learn/database-design-postgresql/why-structured-data.mdx
@@ -33,7 +33,7 @@ flowchart LR
     subgraph messy["Unstructured pile"]
         A["Sticky note:<br/>Ada bought a book"]
         B["Spreadsheet:<br/>A. Lovelace, book"]
-        C["JSON blob:<br/>{name, item}"]
+        C["JSON blob:<br/><code>{name, item}</code>"]
     end
 
     subgraph clean["Structured tables"]

--- a/content/learn/from-zero-to-cpp/arrays-and-strings.mdx
+++ b/content/learn/from-zero-to-cpp/arrays-and-strings.mdx
@@ -109,7 +109,7 @@ Under the hood:
 ```mermaid
 flowchart LR
     subgraph Stack
-        V["v: std::vector<int><br/>size=3, capacity=4<br/>data: 0x6020a0"]
+        V["v: <code>std::vector&lt;int&gt;</code><br/>size=3, capacity=4<br/>data: 0x6020a0"]
     end
     subgraph Heap
         H["[10][20][30][ ]<br/>at 0x6020a0"]

--- a/content/learn/from-zero-to-cpp/arrays-and-strings.mdx
+++ b/content/learn/from-zero-to-cpp/arrays-and-strings.mdx
@@ -112,7 +112,7 @@ flowchart LR
         V["v: <code>std::vector&lt;int&gt;</code><br/>size=3, capacity=4<br/>data: 0x6020a0"]
     end
     subgraph Heap
-        H["[10][20][30][ ]<br/>at 0x6020a0"]
+        H["[10][20][30][ ]<br/>at <code>0x6020a0</code>"]
     end
     V --> H
 ```

--- a/content/learn/from-zero-to-cpp/building-maintainable-software.mdx
+++ b/content/learn/from-zero-to-cpp/building-maintainable-software.mdx
@@ -49,13 +49,13 @@ C++ code is typically split across two kinds of file:
 
 ```mermaid
 flowchart LR
-    H1[geometry.h<br/>declarations]
-    C1[geometry.cpp<br/>definitions]
+    H1["<code>geometry.h</code><br/>declarations"]
+    C1["<code>geometry.cpp</code><br/>definitions"]
     M["<code>main.cpp</code>"]
     H1 -. include .-> M
     H1 -. include .-> C1
-    C1 -- compile --> O1[geometry.o]
-    M  -- compile --> OM[main.o]
+    C1 -- compile --> O1["<code>geometry.o</code>"]
+    M  -- compile --> OM["<code>main.o</code>"]
     O1 --> L[linker] --> APP[app]
     OM --> L
 ```

--- a/content/learn/from-zero-to-cpp/building-maintainable-software.mdx
+++ b/content/learn/from-zero-to-cpp/building-maintainable-software.mdx
@@ -51,7 +51,7 @@ C++ code is typically split across two kinds of file:
 flowchart LR
     H1[geometry.h<br/>declarations]
     C1[geometry.cpp<br/>definitions]
-    M[main.cpp]
+    M["<code>main.cpp</code>"]
     H1 -. include .-> M
     H1 -. include .-> C1
     C1 -- compile --> O1[geometry.o]

--- a/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
+++ b/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
@@ -176,7 +176,7 @@ must be matched against a "defines" entry in another.
 flowchart LR
     M[main.o<br/>defines: main<br/>needs: greet] --> L[Linker]
     G[greet.o<br/>defines: greet<br/>needs: printf] --> L
-    S[libc / libc++<br/>defines: printf,<br/>std::cout, ...] --> L
+    S["libc / libc++<br/>defines: printf,<br/><code>std::cout</code>, ..."] --> L
     L --> E[a.out / .exe<br/>complete, runnable]
 ```
 
@@ -256,9 +256,9 @@ header/implementation split exists to obey this rule even when many
 
 ```mermaid
 flowchart TD
-    H[mathx.h<br/>declarations only] -->|"#include"| M1[main.cpp]
-    H -->|"#include"| M2[other.cpp]
-    H -->|"#include"| M3[third.cpp]
+    H[mathx.h<br/>declarations only] -->|"#include"| M1["<code>main.cpp</code>"]
+    H -->|"#include"| M2["<code>other.cpp</code>"]
+    H -->|"#include"| M3["<code>third.cpp</code>"]
     Imp[mathx.cpp<br/>ONE definition of add and mul] --> Obj[mathx.o]
     M1 --> O1[main.o]
     M2 --> O2[other.o]

--- a/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
+++ b/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
@@ -80,9 +80,9 @@ handles every line that starts with `#`:
 
 ```mermaid
 flowchart LR
-    A[your.cpp<br/>#include &lt;iostream&gt;] --> P[Preprocessor]
+    A["<code>your.cpp</code><br/>#include &lt;iostream&gt;"] --> P[Preprocessor]
     B[iostream<br/>thousands of lines] --> P
-    P --> X[your.cpp.i<br/>tens of thousands of<br/>lines, all C++ text]
+    P --> X["<code>your.cpp.i</code><br/>tens of thousands of<br/>lines, all C++ text"]
 ```
 
 After preprocessing, your single short `.cpp` file may have ballooned
@@ -150,8 +150,8 @@ This step is essentially a one-to-one translation table.
 
 ```mermaid
 flowchart LR
-    A[file.s<br/>'mov eax, 42'] --> AS[Assembler]
-    AS --> B[file.o<br/>binary bytes:<br/>B8 2A 00 00 00 ...]
+    A["<code>file.s</code><br/>'mov eax, 42'"] --> AS[Assembler]
+    AS --> B["<code>file.o</code><br/>binary bytes:<br/>B8 2A 00 00 00 ..."]
 ```
 
 An object file contains:
@@ -174,8 +174,8 @@ must be matched against a "defines" entry in another.
 
 ```mermaid
 flowchart LR
-    M[main.o<br/>defines: main<br/>needs: greet] --> L[Linker]
-    G[greet.o<br/>defines: greet<br/>needs: printf] --> L
+    M["<code>main.o</code><br/>defines: main<br/>needs: greet"] --> L[Linker]
+    G["<code>greet.o</code><br/>defines: greet<br/>needs: printf"] --> L
     S["libc / libc++<br/>defines: printf,<br/><code>std::cout</code>, ..."] --> L
     L --> E[a.out / .exe<br/>complete, runnable]
 ```
@@ -256,13 +256,13 @@ header/implementation split exists to obey this rule even when many
 
 ```mermaid
 flowchart TD
-    H[mathx.h<br/>declarations only] -->|"#include"| M1["<code>main.cpp</code>"]
+    H["<code>mathx.h</code><br/>declarations only"] -->|"#include"| M1["<code>main.cpp</code>"]
     H -->|"#include"| M2["<code>other.cpp</code>"]
     H -->|"#include"| M3["<code>third.cpp</code>"]
-    Imp[mathx.cpp<br/>ONE definition of add and mul] --> Obj[mathx.o]
-    M1 --> O1[main.o]
-    M2 --> O2[other.o]
-    M3 --> O3[third.o]
+    Imp["<code>mathx.cpp</code><br/>ONE definition of add and mul"] --> Obj["<code>mathx.o</code>"]
+    M1 --> O1["<code>main.o</code>"]
+    M2 --> O2["<code>other.o</code>"]
+    M3 --> O3["<code>third.o</code>"]
     Obj --> Lk[Linker]
     O1 --> Lk
     O2 --> Lk

--- a/content/learn/from-zero-to-cpp/data-structures-intuition.mdx
+++ b/content/learn/from-zero-to-cpp/data-structures-intuition.mdx
@@ -83,8 +83,8 @@ Use it for almost everything. The CPU loves contiguous memory.
 ```mermaid
 flowchart LR
     Q[Need a key/value lookup?]
-    Q -- "Iterate in order?" --> M[std::map]
-    Q -- "Don't care about order?" --> UM[std::unordered_map]
+    Q -- "Iterate in order?" --> M["<code>std::map</code>"]
+    Q -- "Don't care about order?" --> UM["<code>std::unordered_map</code>"]
 ```
 
 ## A concrete comparison

--- a/content/learn/from-zero-to-cpp/dynamic-memory.mdx
+++ b/content/learn/from-zero-to-cpp/dynamic-memory.mdx
@@ -59,10 +59,10 @@ A picture of what happened:
 ```mermaid
 flowchart LR
     subgraph Stack
-        P["p: int*<br/>0x6020a0"]
+        P["p: int*<br/><code>0x6020a0</code>"]
     end
     subgraph Heap
-        H["int<br/>value 42<br/>at 0x6020a0"]
+        H["int<br/>value 42<br/>at <code>0x6020a0</code>"]
     end
     P --> H
 ```

--- a/content/learn/from-zero-to-cpp/encapsulation-and-abstraction.mdx
+++ b/content/learn/from-zero-to-cpp/encapsulation-and-abstraction.mdx
@@ -91,8 +91,8 @@ public method names and meanings — stays the same. Code that uses a
 ```mermaid
 flowchart TB
     UI[code using TextStorage] -->|append, get| I[Interface]
-    I --> A[Impl: std::string]
-    I --> B[Impl: std::vector char ]
+    I --> A["Impl: <code>std::string</code>"]
+    I --> B["Impl: <code>std::vector</code> char "]
     I --> C[Impl: rope]
     I --> D[Impl: file backed]
 ```

--- a/content/learn/from-zero-to-cpp/index.mdx
+++ b/content/learn/from-zero-to-cpp/index.mdx
@@ -34,7 +34,7 @@ access matters.
 
 ```mermaid
 flowchart TD
-    A[Your C++ source<br/>file.cpp] --> B[Compiler<br/>clang++ / g++]
+    A["Your C++ source<br/><code>file.cpp</code>"] --> B[Compiler<br/>clang++ / g++]
     B --> C[Machine code<br/>.exe / a.out]
     C --> D[Operating system<br/>loads + runs]
     D --> E[CPU executes<br/>instructions]

--- a/content/learn/from-zero-to-cpp/inheritance-and-polymorphism.mdx
+++ b/content/learn/from-zero-to-cpp/inheritance-and-polymorphism.mdx
@@ -127,8 +127,8 @@ function for that class. Each object of that class stores a
 
 ```mermaid
 flowchart LR
-    O1[Dog Rex<br/>vptr] --> VTD[Dog vtable<br/>sound -> Dog::sound]
-    O2[Cat Mochi<br/>vptr] --> VTC[Cat vtable<br/>sound -> Cat::sound]
+    O1[Dog Rex<br/>vptr] --> VTD["Dog vtable<br/>sound -> <code>Dog::sound</code>"]
+    O2[Cat Mochi<br/>vptr] --> VTC["Cat vtable<br/>sound -> <code>Cat::sound</code>"]
 ```
 
 When you call `a->sound()`, the compiler emits "look up `sound` in

--- a/content/learn/from-zero-to-cpp/memory-model.mdx
+++ b/content/learn/from-zero-to-cpp/memory-model.mdx
@@ -196,7 +196,7 @@ does its data live?
 ```mermaid
 flowchart LR
     subgraph Stack
-        V[v : std::vector&lt;int&gt;<br/>holds a pointer, a size,<br/>and a capacity]
+        V["v : <code>std::vector</code>&lt;int&gt;<br/>holds a pointer, a size,<br/>and a capacity"]
     end
     subgraph Heap
         A["[ 1 | 2 | 3 | 4 | 5 ]<br/>contiguous array on heap"]

--- a/content/learn/from-zero-to-cpp/move-semantics-intuition.mdx
+++ b/content/learn/from-zero-to-cpp/move-semantics-intuition.mdx
@@ -29,7 +29,7 @@ A **move** just steals the pointer:
 
 ```mermaid
 flowchart LR
-    A2["a: vector<br/>data ptr = nullptr<br/>size = 0"]
+    A2["a: vector<br/>data ptr = nullptr<br/><code>size = 0</code>"]
     B2["b: vector<br/>data ptr -> buffer A"] --> BA2["buffer A<br/>1,000,000 ints"]
 ```
 

--- a/content/learn/from-zero-to-cpp/pointers-and-references.mdx
+++ b/content/learn/from-zero-to-cpp/pointers-and-references.mdx
@@ -28,8 +28,8 @@ After the second line, two variables exist:
 ```mermaid
 flowchart LR
     subgraph Stack
-        N["n: int<br/>value 42<br/>at 0x7fff_4cf0"]
-        P["p: int*<br/>value 0x7fff_4cf0<br/>at 0x7fff_4cf8"]
+        N["n: int<br/>value 42<br/>at <code>0x7fff_4cf0</code>"]
+        P["p: int*<br/>value <code>0x7fff_4cf0</code><br/>at <code>0x7fff_4cf8</code>"]
     end
     P -- points to --> N
 ```

--- a/content/learn/from-zero-to-cpp/smart-pointers.mdx
+++ b/content/learn/from-zero-to-cpp/smart-pointers.mdx
@@ -116,7 +116,7 @@ destroyed — a **cycle leak**.
 
 ```mermaid
 flowchart LR
-    A[A<br/>shared_ptr to B] --> B[B<br/>shared_ptr to A]
+    A["A<br/><code>shared_ptr</code> to B"] --> B["B<br/><code>shared_ptr</code> to A"]
     B --> A
 ```
 
@@ -145,9 +145,9 @@ merely watches it.
 ```mermaid
 flowchart TB
     Q[Need to manage a heap object?]
-    Q -- "One clear owner?" --> U[std::unique_ptr]
-    Q -- "Truly shared ownership?" --> S[std::shared_ptr]
-    Q -- "Just want to observe it?" --> W[std::weak_ptr]
+    Q -- "One clear owner?" --> U["<code>std::unique_ptr</code>"]
+    Q -- "Truly shared ownership?" --> S["<code>std::shared_ptr</code>"]
+    Q -- "Just want to observe it?" --> W["<code>std::weak_ptr</code>"]
     Q -- "It's stored in a container that already owns it?" --> R[Raw pointer or reference]
 ```
 

--- a/content/learn/from-zero-to-cpp/variables-and-memory.mdx
+++ b/content/learn/from-zero-to-cpp/variables-and-memory.mdx
@@ -20,7 +20,7 @@ you are telling the compiler:
 ```mermaid
 flowchart LR
     subgraph "Stack frame for main()"
-        X["x : int<br/>4 bytes<br/>value = 42"]
+        X["x : int<br/>4 bytes<br/><code>value = 42</code>"]
     end
 ```
 
@@ -91,7 +91,7 @@ label; it tells the compiler:
 ```mermaid
 flowchart LR
     subgraph Memory
-        B["4 raw bytes<br/>0x2A 0x00 0x00 0x00"]
+        B["4 raw bytes<br/><code>0x2A</code> <code>0x00</code> <code>0x00</code> <code>0x00</code>"]
     end
     B -->|interpreted as int| I[42]
     B -->|interpreted as float| F[5.88e-44]
@@ -181,9 +181,9 @@ block.
 ```mermaid
 flowchart TB
     subgraph "main scope"
-        A["int a = 1;"]
+        A["int <code>a = 1</code>;"]
         subgraph "inner block"
-            B["int b = 2;"]
+            B["int <code>b = 2</code>;"]
         end
         C["a is visible here; b is NOT"]
     end

--- a/content/learn/from-zero-to-cpp/your-first-program.mdx
+++ b/content/learn/from-zero-to-cpp/your-first-program.mdx
@@ -81,7 +81,7 @@ A single C++ statement that does a *lot*.
 
 ```mermaid
 flowchart TD
-    L["'Hello, World!\\n'<br/>(literal bytes in<br/>read-only memory)"] -->|stream insertion <<| O["std::cout<br/>(an output stream object)"]
+    L["'Hello, World!\\n'<br/>(literal bytes in<br/>read-only memory)"] -->|stream insertion <<| O["<code>std::cout</code><br/>(an output stream object)"]
     O -->|delegates to| OS[Operating system]
     OS --> T[Terminal / browser console]
 ```

--- a/content/learn/functional-programming-typescript/category-theory-intuitions.mdx
+++ b/content/learn/functional-programming-typescript/category-theory-intuitions.mdx
@@ -76,8 +76,8 @@ identity law.
 
 ```mermaid
 flowchart LR
-    A["F<A>"] -- "map(f)" --> B["F<B>"]
-    B -- "map(g)" --> C["F<C>"]
+    A["<code>F&lt;A&gt;</code>"] -- "map(f)" --> B["<code>F&lt;B&gt;</code>"]
+    B -- "map(g)" --> C["<code>F&lt;C&gt;</code>"]
     A -- "map(g ∘ f)" --> C
 ```
 

--- a/content/learn/functional-programming-typescript/functional-state-management.mdx
+++ b/content/learn/functional-programming-typescript/functional-state-management.mdx
@@ -262,9 +262,9 @@ Treating state as a value gives you:
 
 ```mermaid
 flowchart LR
-    S0[State t=0] -- "reducer(s, a0)" --> S1[State t=1]
-    S1 -- "reducer(s, a1)" --> S2[State t=2]
-    S2 -- "reducer(s, a2)" --> S3[State t=3]
+    S0["State <code>t=0</code>"] -- "reducer(s, a0)" --> S1["State <code>t=1</code>"]
+    S1 -- "reducer(s, a1)" --> S2["State <code>t=2</code>"]
+    S2 -- "reducer(s, a2)" --> S3["State <code>t=3</code>"]
     H((history)) --> S0 & S1 & S2 & S3
 ```
 

--- a/content/learn/functional-programming-typescript/option-and-result.mdx
+++ b/content/learn/functional-programming-typescript/option-and-result.mdx
@@ -242,9 +242,9 @@ computation". Every later chapter will use it for some `M<A>`:
 
 ```mermaid
 flowchart LR
-    A["M<A>"] -- "flatMap(f)" --> B["M<B>"]
+    A["<code>M&lt;A&gt;</code>"] -- "flatMap(f)" --> B["<code>M&lt;B&gt;</code>"]
     A -.->|"if 'none'/'err' or empty"| B
-    A -->|"if 'some'/'ok' value a"| C["f(a) = M<B>"] --> B
+    A -->|"if 'some'/'ok' value a"| C["f(a) = <code>M&lt;B&gt;</code>"] --> B
 ```
 
 The diagram captures the idea exactly: `flatMap` *threads* the

--- a/content/learn/intro-data-viz-plotly/spreadsheets-to-interactive.mdx
+++ b/content/learn/intro-data-viz-plotly/spreadsheets-to-interactive.mdx
@@ -59,7 +59,7 @@ flowchart TD
     SVG[SVG] --> D3
     D3 --> NYT[NYT graphics]
     D3 --> Plotly[Plotly.js<br/>2012]
-    Plotly --> PyPlotly[plotly.py]
+    Plotly --> PyPlotly["<code>plotly.py</code>"]
     PyPlotly --> PX[Plotly Express<br/>2019]
 ```
 

--- a/content/learn/intro-data-viz-plotly/the-rise-of-plotly.mdx
+++ b/content/learn/intro-data-viz-plotly/the-rise-of-plotly.mdx
@@ -27,7 +27,7 @@ them interchangeably in confusing ways. Let's be precise:
 
 ```mermaid
 flowchart TB
-    PX["Plotly Express<br/>(2019, Python)"] --> PY["plotly.py<br/>(Python wrapper)"]
+    PX["Plotly Express<br/>(2019, Python)"] --> PY["<code>plotly.py</code><br/>(Python wrapper)"]
     PY --> JS["Plotly.js<br/>(2015, JavaScript)"]
     JS --> D3["D3.js"]
     JS --> WG["WebGL"]

--- a/content/learn/intro-modern-csharp/classes-and-objects.mdx
+++ b/content/learn/intro-modern-csharp/classes-and-objects.mdx
@@ -54,9 +54,9 @@ An **object** is an actual instance built from that blueprint.
 
 ```mermaid
 flowchart LR
-    A["class BankAccount<br/>(blueprint)"] --> O1["object: alice's account<br/>balance = 60"]
-    A --> O2["object: bob's account<br/>balance = 500"]
-    A --> O3["object: cara's account<br/>balance = 0"]
+    A["class BankAccount<br/>(blueprint)"] --> O1["object: alice's account<br/><code>balance = 60</code>"]
+    A --> O2["object: bob's account<br/><code>balance = 500</code>"]
+    A --> O3["object: cara's account<br/><code>balance = 0</code>"]
 ```
 
 The class is the *idea* of a bank account. The objects are the
@@ -114,8 +114,8 @@ Two objects, two independent balances, one class.
 
 ```mermaid
 flowchart LR
-    Stack["stack"] -->|alice ref| H1["heap: BankAccount<br/>Owner='Alice'<br/>Balance=60"]
-    Stack -->|bob ref| H2["heap: BankAccount<br/>Owner='Bob'<br/>Balance=500"]
+    Stack["stack"] -->|alice ref| H1["heap: BankAccount<br/><code>Owner='Alice'</code><br/><code>Balance=60</code>"]
+    Stack -->|bob ref| H2["heap: BankAccount<br/><code>Owner='Bob'</code><br/><code>Balance=500</code>"]
 ```
 
 `alice` and `bob` are *references* sitting on the stack. The

--- a/content/learn/intro-modern-csharp/collections.mdx
+++ b/content/learn/intro-modern-csharp/collections.mdx
@@ -136,12 +136,12 @@ much faster than scanning a list.
 ```mermaid
 flowchart TD
     Q1{"Do you need to look<br/>things up by a key<br/>(not just position)?"}
-    Q1 -- yes --> D["Dictionary&lt;TKey, TValue&gt;"]
+    Q1 -- yes --> D["<code>Dictionary&lt;TKey, TValue&gt;</code>"]
     Q1 -- no --> Q2{"Do you only care<br/>whether an item<br/>is present?"}
-    Q2 -- yes --> S["HashSet&lt;T&gt;"]
+    Q2 -- yes --> S["<code>HashSet&lt;T&gt;</code>"]
     Q2 -- no --> Q3{"Will the size change<br/>after creation?"}
     Q3 -- no --> A["T[ ] (array)"]
-    Q3 -- yes --> L["List&lt;T&gt;"]
+    Q3 -- yes --> L["<code>List&lt;T&gt;</code>"]
 ```
 
 Rough cost picture:

--- a/content/learn/intro-modern-csharp/control-flow.mdx
+++ b/content/learn/intro-modern-csharp/control-flow.mdx
@@ -210,7 +210,7 @@ A `for` loop has three parts in its header:
 
 ```mermaid
 flowchart TB
-    S([Start]) --> Init["i = 0"]
+    S([Start]) --> Init["<code>i = 0</code>"]
     Init --> Cond{i < 5?}
     Cond -- no --> End([End])
     Cond -- yes --> Body["run body"]

--- a/content/learn/intro-modern-csharp/early-programming-complexity.mdx
+++ b/content/learn/intro-modern-csharp/early-programming-complexity.mdx
@@ -122,11 +122,11 @@ flowchart LR
         G2[orders]
         G3[inventory]
     end
-    F1[shipOrder]
-    F2[applyDiscount]
+    F1["<code>shipOrder</code>"]
+    F2["<code>applyDiscount</code>"]
     F3[refund]
-    F4[reorderStock]
-    F5[printReport]
+    F4["<code>reorderStock</code>"]
+    F5["<code>printReport</code>"]
 
     F1 --> Globals
     F2 --> Globals

--- a/content/learn/intro-modern-csharp/how-programs-execute.mdx
+++ b/content/learn/intro-modern-csharp/how-programs-execute.mdx
@@ -89,7 +89,7 @@ sometimes "IL" for short).
 
 ```mermaid
 flowchart LR
-    S["Program.cs"] --> R["Roslyn compiler"]
+    S["<code>Program.cs</code>"] --> R["Roslyn compiler"]
     R --> D["Program.dll<br/>(contains CIL)"]
 ```
 

--- a/content/learn/intro-modern-csharp/how-programs-execute.mdx
+++ b/content/learn/intro-modern-csharp/how-programs-execute.mdx
@@ -90,7 +90,7 @@ sometimes "IL" for short).
 ```mermaid
 flowchart LR
     S["<code>Program.cs</code>"] --> R["Roslyn compiler"]
-    R --> D["Program.dll<br/>(contains CIL)"]
+    R --> D["<code>Program.dll</code><br/>(contains CIL)"]
 ```
 
 CIL is not the machine code your CPU runs. It is a portable, more

--- a/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
+++ b/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
@@ -34,8 +34,8 @@ Machine** (JVM).
 
 ```mermaid
 flowchart TD
-    S["Source code<br/>Hello.java"] --> C["Java compiler<br/>(javac)"]
-    C --> B["Java bytecode<br/>Hello.class"]
+    S["Source code<br/><code>Hello.java</code>"] --> C["Java compiler<br/>(javac)"]
+    C --> B["Java bytecode<br/><code>Hello.class</code>"]
     B --> JVM["Java Virtual Machine<br/>(JVM)"]
     JVM --> W["Windows"]
     JVM --> L["Linux"]
@@ -98,7 +98,7 @@ For most software, this trade — slight runtime overhead for
 
 ```mermaid
 flowchart LR
-    S["<code>MyApp.java</code>"] --> C["javac"] --> B["MyApp.class<br/>(bytecode)"]
+    S["<code>MyApp.java</code>"] --> C["javac"] --> B["<code>MyApp.class</code><br/>(bytecode)"]
     B --> JVMW["JVM on Windows"]
     B --> JVML["JVM on Linux"]
     B --> JVMS["JVM on Solaris"]

--- a/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
+++ b/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
@@ -98,7 +98,7 @@ For most software, this trade — slight runtime overhead for
 
 ```mermaid
 flowchart LR
-    S["MyApp.java"] --> C["javac"] --> B["MyApp.class<br/>(bytecode)"]
+    S["<code>MyApp.java</code>"] --> C["javac"] --> B["MyApp.class<br/>(bytecode)"]
     B --> JVMW["JVM on Windows"]
     B --> JVML["JVM on Linux"]
     B --> JVMS["JVM on Solaris"]

--- a/content/learn/intro-modern-csharp/managed-runtimes.mdx
+++ b/content/learn/intro-modern-csharp/managed-runtimes.mdx
@@ -155,7 +155,7 @@ flowchart TB
     C["C() throws<br/>InvalidOperationException"]
     C -.runtime unwinds.-> B
     B -.no catch here.-> A
-    A -.has catch.-> Handler["catch (InvalidOperationException)<br/>{ ... }"]
+    A -.has catch.-> Handler["catch (InvalidOperationException)<br/><code>{ ... }</code>"]
 ```
 
 You don't write the unwinding logic. The runtime does. All you
@@ -194,7 +194,7 @@ It can help to picture all the layers at once.
 ```mermaid
 flowchart TB
     Y["Your C# code"]
-    BCL["Base Class Library<br/>(System.*, System.Collections, etc.)"]
+    BCL["Base Class Library<br/>(System.*, <code>System.Collections</code>, etc.)"]
     R["Runtime (CLR)<br/>GC, JIT, type system, exceptions"]
     OS["Operating system<br/>(Windows / Linux / macOS / browser WASM)"]
     H["Hardware"]

--- a/content/learn/intro-modern-csharp/software-organization.mdx
+++ b/content/learn/intro-modern-csharp/software-organization.mdx
@@ -31,12 +31,12 @@ you don't want to grep — you want to open the file with that name.
 ```mermaid
 flowchart TD
     F["src/"]
-    F --> A["Program.cs"]
-    F --> B["BankAccount.cs"]
-    F --> C["Customer.cs"]
+    F --> A["<code>Program.cs</code>"]
+    F --> B["<code>BankAccount.cs</code>"]
+    F --> C["<code>Customer.cs</code>"]
     F --> D["Transactions/"]
-    D --> D1["Deposit.cs"]
-    D --> D2["Withdrawal.cs"]
+    D --> D1["<code>Deposit.cs</code>"]
+    D --> D2["<code>Withdrawal.cs</code>"]
 ```
 
 Sub-folders mirror your *conceptual* groupings — and conventionally

--- a/content/learn/intro-modern-csharp/type-system.mdx
+++ b/content/learn/intro-modern-csharp/type-system.mdx
@@ -163,8 +163,8 @@ a method.
 ```mermaid
 flowchart LR
     subgraph Stack
-        A["a = 5"]
-        B["b = 5"]
+        A["<code>a = 5</code>"]
+        B["<code>b = 5</code>"]
     end
     Note["b = a copies the bytes"]
 ```
@@ -298,7 +298,7 @@ flowchart LR
     subgraph Before["Before Reassign"]
         Cx["caller's xs"] --> L1["List [10, 20, 1]"]
     end
-    subgraph Inside["Inside Reassign (after 'list = new List<int>()')"]
+    subgraph Inside["Inside Reassign (after 'list = new <code>List&lt;int&gt;()</code>')"]
         Px["parameter 'list'"] --> L2["List [999]"]
         Cx2["caller's xs (unchanged)"] --> L1b["List [10, 20, 1]"]
     end

--- a/content/learn/intro-modern-csharp/type-system.mdx
+++ b/content/learn/intro-modern-csharp/type-system.mdx
@@ -196,7 +196,7 @@ flowchart LR
         B["b (reference)"]
     end
     subgraph Heap
-        O["List<int> { 1, 2, 3 }"]
+        O["<code>List&lt;int&gt; { 1, 2, 3 }</code>"]
     end
     A --> O
     B --> O

--- a/content/learn/intro-sql-postgres/aggregate-functions.mdx
+++ b/content/learn/intro-sql-postgres/aggregate-functions.mdx
@@ -100,7 +100,7 @@ WHERE
 
 ```mermaid
 flowchart LR
-    T[("employees")] --> W["WHERE<br/>dept = 'Engineering'"]
+    T[("employees")] --> W["WHERE<br/><code>dept = 'Engineering'</code>"]
     W --> A["AVG(salary)"]
     A --> R["one number"]
 ```

--- a/content/learn/intro-sql-postgres/common-table-expressions.mdx
+++ b/content/learn/intro-sql-postgres/common-table-expressions.mdx
@@ -16,7 +16,7 @@ table.
 
 ```mermaid
 flowchart TB
-    CTE["WITH big_orders AS (<br/>SELECT ... FROM orders WHERE amount > 50<br/>)"] -->|"named result"| Main["SELECT ... FROM big_orders"]
+    CTE["WITH <code>big_orders</code> AS (<br/>SELECT ... FROM orders WHERE amount > 50<br/>)"] -->|"named result"| Main["SELECT ... FROM <code>big_orders</code>"]
     Main --> Result["Final rows"]
 ```
 

--- a/content/learn/intro-sql-postgres/foreign-keys.mdx
+++ b/content/learn/intro-sql-postgres/foreign-keys.mdx
@@ -34,7 +34,7 @@ the `id` of some customer. Order 101 storing `customer_id = 1` means
 
 ```mermaid
 flowchart LR
-    O["orders.<code>customer_id</code> = 1"] -->|"refers to"| C["customers.id = 1<br/>(Ada)"]
+    O["orders.<code>customer_id</code> = 1"] -->|"refers to"| C["<code>customers.id = 1</code><br/>(Ada)"]
 ```
 
 ## Why store an id instead of the name?
@@ -110,8 +110,8 @@ appears:
 ```mermaid
 flowchart TB
     subgraph customers["customers"]
-        C1["id = 1 (PK)<br/>name = Ada"]
-        C2["id = 2 (PK)<br/>name = Grace"]
+        C1["<code>id = 1</code> (PK)<br/>name = Ada"]
+        C2["<code>id = 2</code> (PK)<br/>name = Grace"]
     end
     subgraph orders["orders"]
         O1["id = 101<br/><code>customer_id</code> = 1 (FK)"]

--- a/content/learn/intro-sql-postgres/foreign-keys.mdx
+++ b/content/learn/intro-sql-postgres/foreign-keys.mdx
@@ -34,7 +34,7 @@ the `id` of some customer. Order 101 storing `customer_id = 1` means
 
 ```mermaid
 flowchart LR
-    O["orders.customer_id = 1"] -->|"refers to"| C["customers.id = 1<br/>(Ada)"]
+    O["orders.<code>customer_id</code> = 1"] -->|"refers to"| C["customers.id = 1<br/>(Ada)"]
 ```
 
 ## Why store an id instead of the name?
@@ -114,9 +114,9 @@ flowchart TB
         C2["id = 2 (PK)<br/>name = Grace"]
     end
     subgraph orders["orders"]
-        O1["id = 101<br/>customer_id = 1 (FK)"]
-        O2["id = 102<br/>customer_id = 1 (FK)"]
-        O3["id = 103<br/>customer_id = 2 (FK)"]
+        O1["id = 101<br/><code>customer_id</code> = 1 (FK)"]
+        O2["id = 102<br/><code>customer_id</code> = 1 (FK)"]
+        O3["id = 103<br/><code>customer_id</code> = 2 (FK)"]
     end
     O1 -->|"FK → PK"| C1
     O2 -->|"FK → PK"| C1

--- a/content/learn/intro-sql-postgres/inserting-data.mdx
+++ b/content/learn/intro-sql-postgres/inserting-data.mdx
@@ -135,7 +135,7 @@ accidentally destroy data.
 
 ```mermaid
 flowchart TB
-    D1["DELETE FROM tasks<br/>WHERE id = 5;"] --> R1["Removes 1 row<br/>(good)"]
+    D1["DELETE FROM tasks<br/>WHERE <code>id = 5</code>;"] --> R1["Removes 1 row<br/>(good)"]
     D2["DELETE FROM tasks;"] --> R2["Removes EVERY row<br/>(usually a disaster)"]
 ```
 

--- a/content/learn/intro-sql-postgres/normalization.mdx
+++ b/content/learn/intro-sql-postgres/normalization.mdx
@@ -16,7 +16,7 @@ the customer's name and email, and even the product's price:
 
 ```mermaid
 flowchart TB
-    T["orders_flat<br/>order_id | customer_name | customer_email | product | price"]
+    T["<code>orders_flat</code><br/><code>order_id</code> | <code>customer_name</code> | <code>customer_email</code> | product | price"]
     T --> R1["1 | Ada | ada@x.com | Book | 20"]
     T --> R2["2 | Ada | ada@x.com | Pen  | 3"]
     T --> R3["3 | Grace | grace@x.com | Book | 20"]

--- a/content/learn/intro-sql-postgres/understanding-joins.mdx
+++ b/content/learn/intro-sql-postgres/understanding-joins.mdx
@@ -112,7 +112,7 @@ keeping the ones where the `ON` condition is true:
 
 ```mermaid
 flowchart TB
-    P["Consider pairings of<br/>(order, customer)"] --> T{"ON condition true?<br/>order.customer_id = customer.id"}
+    P["Consider pairings of<br/>(order, customer)"] --> T{"ON condition true?<br/>order.<code>customer_id</code> = customer.id"}
     T -->|"yes"| K["Combine into<br/>one wide row"]
     T -->|"no"| D["Discard pairing"]
 ```

--- a/content/learn/java-collections-and-generics-deep-dive/lists.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/lists.mdx
@@ -72,7 +72,7 @@ public class Main {
 flowchart LR
     subgraph Heap
       direction LR
-      A[ArrayList<br/>size=4<br/>capacity=8]
+      A["<code>ArrayList<br/>size=4<br/>capacity=8</code>"]
       A -->|elementData| ARR["Object[]<br/>[a][b][c][d][_][_][_][_]"]
     end
 ```

--- a/content/learn/java-collections-and-generics-deep-dive/maps.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/maps.mdx
@@ -73,7 +73,7 @@ Worth understanding the data structure once.
 
 ```mermaid
 flowchart LR
-    subgraph HashMap[HashMap]
+    subgraph HashMap["<code>HashMap</code>"]
       direction LR
       AR[Object table N slots]
       AR --> B0["[bucket 0]<br/>(empty)"]

--- a/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
@@ -227,20 +227,20 @@ always: hinted `ArrayList` fastest, then unhinted `ArrayList`, then
 flowchart TD
     Q[need a container] --> A{key/value?}
     A -- yes --> M{order matters?}
-    M -- "no" --> HM[HashMap]
-    M -- "insertion" --> LHM[LinkedHashMap]
-    M -- "sorted/range" --> TM[TreeMap]
+    M -- "no" --> HM["<code>HashMap</code>"]
+    M -- "insertion" --> LHM["<code>LinkedHashMap</code>"]
+    M -- "sorted/range" --> TM["<code>TreeMap</code>"]
 
     A -- no --> S{unique?}
     S -- "yes" --> SO{order matters?}
-    SO -- "no" --> HS[HashSet]
-    SO -- "insertion" --> LHS[LinkedHashSet]
-    SO -- "sorted/range" --> TS[TreeSet]
+    SO -- "no" --> HS["<code>HashSet</code>"]
+    SO -- "insertion" --> LHS["<code>LinkedHashSet</code>"]
+    SO -- "sorted/range" --> TS["<code>TreeSet</code>"]
 
     S -- "no, allow duplicates" --> E{access pattern?}
-    E -- "index / append" --> AL[ArrayList]
-    E -- "queue / stack / both ends" --> AD[ArrayDeque]
-    E -- "priority order" --> PQ[PriorityQueue]
+    E -- "index / append" --> AL["<code>ArrayList</code>"]
+    E -- "queue / stack / both ends" --> AD["<code>ArrayDeque</code>"]
+    E -- "priority order" --> PQ["<code>PriorityQueue</code>"]
 ```
 
 ## Test your understanding

--- a/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
@@ -53,12 +53,12 @@ element, very fast.
 
 ```mermaid
 flowchart LR
-    subgraph Buffer["circular buffer (capacity = 8)"]
+    subgraph Buffer["circular buffer (<code>capacity = 8</code>)"]
       direction LR
       S0["[_]"] --- S1["[_]"] --- S2["[a]"] --- S3["[b]"] --- S4["[c]"] --- S5["[d]"] --- S6["[_]"] --- S7["[_]"]
     end
-    head[head=2] --> S2
-    tail[tail=6] --> S6
+    head["<code>head=2</code>"] --> S2
+    tail["<code>tail=6</code>"] --> S6
 ```
 
 Front and back are pointers into the array; they wrap around. Both

--- a/content/learn/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
@@ -153,10 +153,10 @@ existed. Every module rolled its own.
 flowchart TB
     subgraph App["A medium-sized application"]
         UI["UI module<br/>String[] names<br/>+ size counter"] --> RAW[(raw arrays)]
-        ORD["Order module<br/>Order[] orders<br/>+ grow() helper"] --> RAW
+        ORD["Order module<br/>Order[] orders<br/>+ <code>grow()</code> helper"] --> RAW
         IDX["Lookup module<br/>String[] keys<br/>+ Order[] values<br/>+ linear search"] --> RAW
         AUD["Audit module<br/>Event[] log<br/>+ ring-buffer math"] --> RAW
-        UNI["Uniqueness module<br/>String[] seen<br/>+ contains() loop"] --> RAW
+        UNI["Uniqueness module<br/>String[] seen<br/>+ <code>contains()</code> loop"] --> RAW
     end
 ```
 

--- a/content/learn/java-programming-for-beginners/birth-of-oop.mdx
+++ b/content/learn/java-programming-for-beginners/birth-of-oop.mdx
@@ -83,12 +83,12 @@ open it.
 ```mermaid
 flowchart TB
     subgraph A[Account #1001]
-        D1[(balance = 100)]
+        D1[("<code>balance = 100</code>")]
         M1[deposit / withdraw]
         M1 --- D1
     end
     subgraph B[Account #1002]
-        D2[(balance = 50)]
+        D2[("<code>balance = 50</code>")]
         M2[deposit / withdraw]
         M2 --- D2
     end

--- a/content/learn/java-programming-for-beginners/classes-and-objects.mdx
+++ b/content/learn/java-programming-for-beginners/classes-and-objects.mdx
@@ -85,8 +85,8 @@ flowchart LR
         VL["Dog luna →"]
     end
     subgraph heap[Heap]
-        OR["Dog object<br/>name='Rex', age=4"]
-        OL["Dog object<br/>name='Luna', age=2"]
+        OR["Dog object<br/><code>name='Rex'</code>, <code>age=4</code>"]
+        OL["Dog object<br/><code>name='Luna'</code>, <code>age=2</code>"]
     end
     VR --> OR
     VL --> OL

--- a/content/learn/java-programming-for-beginners/computational-thinking.mdx
+++ b/content/learn/java-programming-for-beginners/computational-thinking.mdx
@@ -85,7 +85,7 @@ disturbing the callers.
 
 ```mermaid
 flowchart TB
-    Caller["Caller:<br/>gradeExam(...)"] -->|sees only this| API["gradeExam returns int"]
+    Caller["Caller:<br/><code>gradeExam(...)</code>"] -->|sees only this| API["gradeExam returns int"]
     API -. hides .-> Inside["Inside: loop, compare,<br/>count, maybe cache"]
 ```
 

--- a/content/learn/java-programming-for-beginners/early-programming.mdx
+++ b/content/learn/java-programming-for-beginners/early-programming.mdx
@@ -63,10 +63,10 @@ program would print a result.
 
 ```mermaid
 flowchart TD
-    Main[main] --> Read[read_input]
+    Main[main] --> Read["<code>read_input</code>"]
     Main --> Calc[calculate]
-    Calc --> Format[format_result]
-    Main --> Print[print_output]
+    Calc --> Format["<code>format_result</code>"]
+    Main --> Print["<code>print_output</code>"]
 ```
 
 For decades, this was *the* way to write software. And it worked —

--- a/content/learn/java-programming-for-beginners/how-programs-execute.mdx
+++ b/content/learn/java-programming-for-beginners/how-programs-execute.mdx
@@ -12,8 +12,8 @@ output."
 
 ```mermaid
 flowchart TD
-    A[1. Source<br/>Main.java] --> B[2. Compile<br/>javac]
-    B --> C[3. Bytecode<br/>Main.class]
+    A["1. Source<br/><code>Main.java</code>"] --> B[2. Compile<br/>javac]
+    B --> C["3. Bytecode<br/><code>Main.class</code>"]
     C --> D[4. Run<br/>JVM]
     D --> E[Output]
 ```

--- a/content/learn/java-programming-for-beginners/interfaces.mdx
+++ b/content/learn/java-programming-for-beginners/interfaces.mdx
@@ -234,10 +234,10 @@ the right to change your storage later.
 
 ```mermaid
 flowchart LR
-    A[ArrayList] -. implements .-> L[List]
-    B[LinkedList] -. implements .-> L
+    A["<code>ArrayList</code>"] -. implements .-> L[List]
+    B["<code>LinkedList</code>"] -. implements .-> L
     C[Stack] -. implements .-> L
-    L --> M["process(List orders)"]
+    L --> M["<code>process(List orders)</code>"]
 ```
 
 The method `process` doesn't care which arrow the data came down. It

--- a/content/learn/java-programming-for-beginners/jvm-conceptually.mdx
+++ b/content/learn/java-programming-for-beginners/jvm-conceptually.mdx
@@ -138,7 +138,7 @@ flowchart LR
     subgraph Heap
         A[Account]
         B[Customer]
-        C[OldThing]
+        C["<code>OldThing</code>"]
     end
     L --> A
     A --> B

--- a/content/learn/java-programming-for-beginners/maps-and-sets.mdx
+++ b/content/learn/java-programming-for-beginners/maps-and-sets.mdx
@@ -122,7 +122,7 @@ bucket, check what's there.
 
 ```mermaid
 flowchart TD
-    K["key 'Ada'"] --> H["hashCode() = 65823..."]
+    K["key 'Ada'"] --> H["<code>hashCode() = 65823...</code>"]
     H --> B["bucket index = hash % bucketCount"]
     B --> Bucket["bucket → key/value pair"]
 ```

--- a/content/learn/java-programming-for-beginners/methods-and-modularity.mdx
+++ b/content/learn/java-programming-for-beginners/methods-and-modularity.mdx
@@ -24,12 +24,12 @@ makes its intent obvious.
 
 ```mermaid
 flowchart TD
-    Main[main] --> Load[loadData]
+    Main[main] --> Load["<code>loadData</code>"]
     Main --> Process[process]
-    Main --> Report[printReport]
-    Process --> Filter[filterValid]
-    Process --> Sort[sortByScore]
-    Process --> Avg[computeAverage]
+    Main --> Report["<code>printReport</code>"]
+    Process --> Filter["<code>filterValid</code>"]
+    Process --> Sort["<code>sortByScore</code>"]
+    Process --> Avg["<code>computeAverage</code>"]
 ```
 
 This is **modularity**: each method is a small module that does one

--- a/content/learn/java-programming-for-beginners/problem-solving.mdx
+++ b/content/learn/java-programming-for-beginners/problem-solving.mdx
@@ -16,21 +16,39 @@ math.
 
 ## The four steps
 
-```mermaid
-flowchart TD
-    A[1. Understand<br/>the problem] --> B[2. Devise<br/>a plan]
-    B --> C[3. Carry out<br/>the plan]
-    C --> D[4. Look back<br/>and reflect]
-    D -. revise .-> B
-```
+<Steps>
+<Step>
 
-1. **Understand the problem.** Restate it. List the inputs. List the
-   outputs. Find an example. Find an *edge case* example.
-2. **Devise a plan.** What kind of problem is this? Is it like
-   something you've seen? Can you solve a smaller version first?
-3. **Carry out the plan.** Translate it into code, step by step.
-4. **Look back.** Does it actually work? Does it work on weird
-   inputs? Is it readable? Could it be simpler?
+**Understand the problem**
+
+Restate it. List the inputs. List the outputs. Find an example. Find an
+*edge case* example.
+
+</Step>
+<Step>
+
+**Devise a plan**
+
+What kind of problem is this? Is it like something you've seen? Can you
+solve a smaller version first?
+
+</Step>
+<Step>
+
+**Carry out the plan**
+
+Translate it into code, step by step.
+
+</Step>
+<Step>
+
+**Look back**
+
+Does it actually work? Does it work on weird inputs? Is it readable?
+Could it be simpler? If not, revise the plan and loop back.
+
+</Step>
+</Steps>
 
 These steps look obvious written down. But almost every beginner
 mistake comes from skipping one of them — usually by jumping

--- a/content/learn/java-programming-for-beginners/software-organization.mdx
+++ b/content/learn/java-programming-for-beginners/software-organization.mdx
@@ -152,11 +152,11 @@ ever written.
 ```mermaid
 flowchart LR
     subgraph H[High cohesion + Low coupling - good]
-        A1[Order] --> A2[OrderRepository]
-        A1 --> A3[PricingService]
+        A1[Order] --> A2["<code>OrderRepository</code>"]
+        A1 --> A3["<code>PricingService</code>"]
     end
     subgraph B[Low cohesion + High coupling - bad]
-        B1[OrderManager] --- B2[DB]
+        B1["<code>OrderManager</code>"] --- B2[DB]
         B1 --- B3[Email]
         B1 --- B4[PDF]
         B1 --- B5[HTTP]

--- a/content/learn/java-programming-for-beginners/stack-and-heap.mdx
+++ b/content/learn/java-programming-for-beginners/stack-and-heap.mdx
@@ -21,7 +21,7 @@ flowchart LR
     end
     subgraph Heap[Heap — shared]
         direction TB
-        O1[int array<br/>length=3, values=80,90,100]
+        O1["int array<br/><code>length=3</code>, <code>values=80</code>,90,100"]
         O2[String 'Ada']
         O3[Student object]
     end
@@ -53,7 +53,7 @@ String s = "hello";
 ```mermaid
 flowchart LR
     subgraph S[stack frame]
-        X["x = 42"]
+        X["<code>x = 42</code>"]
         SREF["s = ●─"]
     end
     subgraph H[heap]
@@ -133,11 +133,11 @@ Calling `factorial(4)` builds up a stack of frames:
 
 ```mermaid
 flowchart TB
-    M["main: n=4, result=?"]
-    F4["factorial: n=4"]
-    F3["factorial: n=3"]
-    F2["factorial: n=2"]
-    F1["factorial: n=1 returns 1"]
+    M["main: <code>n=4</code>, result=?"]
+    F4["factorial: <code>n=4</code>"]
+    F3["factorial: <code>n=3</code>"]
+    F2["factorial: <code>n=2</code>"]
+    F1["factorial: <code>n=1</code> returns 1"]
     M --> F4 --> F3 --> F2 --> F1
 ```
 

--- a/content/learn/java-programming-for-beginners/variables-and-memory.mdx
+++ b/content/learn/java-programming-for-beginners/variables-and-memory.mdx
@@ -15,7 +15,7 @@ and each box has **contents** (the data).
 
 ```mermaid
 flowchart LR
-    M0[0x1000<br/>?] --- M1[0x1004<br/>?] --- M2[0x1008<br/>?] --- M3[0x100C<br/>?] --- M4[0x1010<br/>?]
+    M0["<code>0x1000</code><br/>?"] --- M1["<code>0x1004</code><br/>?"] --- M2["<code>0x1008</code><br/>?"] --- M3["<code>0x100C</code><br/>?"] --- M4["<code>0x1010</code><br/>?"]
 ```
 
 When you write `int x = 5;`, three things happen:
@@ -26,7 +26,7 @@ When you write `int x = 5;`, three things happen:
 
 ```mermaid
 flowchart LR
-    M0[0x1000<br/>?] --- M1["0x1004<br/>5<br/>(x)"] --- M2[0x1008<br/>?] --- M3[0x100C<br/>?] --- M4[0x1010<br/>?]
+    M0["<code>0x1000</code><br/>?"] --- M1["<code>0x1004</code><br/>5<br/>(x)"] --- M2["<code>0x1008</code><br/>?"] --- M3["<code>0x100C</code><br/>?"] --- M4["<code>0x1010</code><br/>?"]
     style M1 fill:#efe
 ```
 

--- a/content/learn/java-programming-for-beginners/write-once-run-anywhere.mdx
+++ b/content/learn/java-programming-for-beginners/write-once-run-anywhere.mdx
@@ -24,7 +24,7 @@ have to compile it again, on (and for) that target.
 
 ```mermaid
 flowchart LR
-    Src["source.cpp"]
+    Src["<code>source.cpp</code>"]
     Src -->|compile on Windows| ExeW["program.exe<br/>(Windows / x86)"]
     Src -->|compile on Mac| BinM["program<br/>(macOS / ARM)"]
     Src -->|compile on Linux| BinL["program<br/>(Linux / x86)"]
@@ -48,7 +48,7 @@ JVM reads the bytecode and executes it.
 
 ```mermaid
 flowchart LR
-    Src["Hello.java"]
+    Src["<code>Hello.java</code>"]
     Src -->|javac| BC["Hello.class<br/>(bytecode)"]
     BC -->|run by JVM| W[JVM on Windows]
     BC -->|run by JVM| M[JVM on macOS]

--- a/content/learn/java-programming-for-beginners/write-once-run-anywhere.mdx
+++ b/content/learn/java-programming-for-beginners/write-once-run-anywhere.mdx
@@ -25,7 +25,7 @@ have to compile it again, on (and for) that target.
 ```mermaid
 flowchart LR
     Src["<code>source.cpp</code>"]
-    Src -->|compile on Windows| ExeW["program.exe<br/>(Windows / x86)"]
+    Src -->|compile on Windows| ExeW["<code>program.exe</code><br/>(Windows / x86)"]
     Src -->|compile on Mac| BinM["program<br/>(macOS / ARM)"]
     Src -->|compile on Linux| BinL["program<br/>(Linux / x86)"]
     ExeW -. cannot run on .-> Mac[Mac]
@@ -49,7 +49,7 @@ JVM reads the bytecode and executes it.
 ```mermaid
 flowchart LR
     Src["<code>Hello.java</code>"]
-    Src -->|javac| BC["Hello.class<br/>(bytecode)"]
+    Src -->|javac| BC["<code>Hello.class</code><br/>(bytecode)"]
     BC -->|run by JVM| W[JVM on Windows]
     BC -->|run by JVM| M[JVM on macOS]
     BC -->|run by JVM| L[JVM on Linux]

--- a/content/learn/machine-learning-scikit-learn/encoding-categorical-features.mdx
+++ b/content/learn/machine-learning-scikit-learn/encoding-categorical-features.mdx
@@ -132,9 +132,9 @@ in its column and `0` everywhere else.
 ```mermaid
 flowchart LR
     A["color<br/>(one text column)"] --> B["one-hot encode"]
-    B --> C["color_red<br/>1 or 0"]
-    B --> D["color_green<br/>1 or 0"]
-    B --> E["color_blue<br/>1 or 0"]
+    B --> C["<code>color_red</code><br/>1 or 0"]
+    B --> D["<code>color_green</code><br/>1 or 0"]
+    B --> E["<code>color_blue</code><br/>1 or 0"]
 ```
 
 So a single column of `["red", "green", "blue"]` becomes three columns:

--- a/content/learn/machine-learning-scikit-learn/evaluating-clusters.mdx
+++ b/content/learn/machine-learning-scikit-learn/evaluating-clusters.mdx
@@ -43,7 +43,7 @@ nearest other cluster**. For each point `i`:
 flowchart LR
     P["A point i in cluster C"] --> A["a(i) = mean distance to the<br/>other points in C (cohesion)"]
     P --> B["b(i) = mean distance to points in the<br/>nearest other cluster (separation)"]
-    A --> S["silhouette s(i) = (b - a) / max(a, b)"]
+    A --> S["silhouette s(i) = (b - a) / <code>max(a, b)</code>"]
     B --> S
     S --> R["near +1: snug and separated<br/>near 0: on a border<br/>negative: probably misassigned"]
 ```

--- a/content/learn/machine-learning-scikit-learn/hyperparameter-tuning.mdx
+++ b/content/learn/machine-learning-scikit-learn/hyperparameter-tuning.mdx
@@ -138,7 +138,7 @@ flowchart LR
     A --> C["Validation set<br/>(choose hyperparameters)"]
     A --> D["Test set<br/>(final, untouched estimate)"]
     B --> E["model learns<br/>slopes, splits, coefficients"]
-    C --> F["compare k=3 vs 5 vs 7,<br/>pick the best"]
+    C --> F["compare <code>k=3</code> vs 5 vs 7,<br/>pick the best"]
     D --> G["report ONCE,<br/>at the very end"]
 ```
 

--- a/content/learn/machine-learning-scikit-learn/k-nearest-neighbors.mdx
+++ b/content/learn/machine-learning-scikit-learn/k-nearest-neighbors.mdx
@@ -35,7 +35,7 @@ have similar outputs.**
 ```mermaid
 flowchart TD
     Q["New point<br/>(species unknown)"] --> M["Measure distance<br/>to every training point"]
-    M --> N["Keep the k = 5 closest"]
+    M --> N["Keep the <code>k = 5</code> closest"]
     N --> V["Among those 5 neighbors:<br/>3 class A, 2 class B"]
     V --> P["Predict class A<br/>(the majority vote)"]
 ```

--- a/content/learn/machine-learning-scikit-learn/logistic-regression.mdx
+++ b/content/learn/machine-learning-scikit-learn/logistic-regression.mdx
@@ -123,7 +123,7 @@ main limitation, as we will see.
 
 ```mermaid
 flowchart TD
-    A["Feature space<br/>(points of two classes)"] --> B["Linear boundary<br/>(a straight line where z = 0)"]
+    A["Feature space<br/>(points of two classes)"] --> B["Linear boundary<br/>(a straight line where <code>z = 0</code>)"]
     B --> C["Class 1 side<br/>(p >= 0.5)"]
     B --> D["Class 0 side<br/>(p < 0.5)"]
 ```

--- a/content/learn/machine-learning-scikit-learn/pipelines-and-columntransformer.mdx
+++ b/content/learn/machine-learning-scikit-learn/pipelines-and-columntransformer.mdx
@@ -68,7 +68,7 @@ set, because you never touch the steps individually.
 ```mermaid
 flowchart LR
     subgraph Training ["Training: pipeline.fit(X_train, y_train)"]
-        A["X_train"] --> B["StandardScaler<br/>fit + transform"]
+        A["<code>X_train</code>"] --> B["StandardScaler<br/>fit + transform"]
         B --> C["LogisticRegression<br/>fit"]
         C --> D["fitted pipeline"]
     end
@@ -77,7 +77,7 @@ flowchart LR
 ```mermaid
 flowchart LR
     subgraph Prediction ["Prediction: pipeline.predict(X_new)"]
-        E["X_new"] --> F["StandardScaler<br/>transform only"]
+        E["<code>X_new</code>"] --> F["StandardScaler<br/>transform only"]
         F --> G["LogisticRegression<br/>predict"]
         G --> H["predictions"]
     end
@@ -223,9 +223,9 @@ to its own transformer, then concatenates the results side by side.
 
 ```mermaid
 flowchart TD
-    R["raw DataFrame<br/>numeric + categorical columns"] --> CT{"ColumnTransformer"}
-    CT -->|"numeric columns"| S["StandardScaler"]
-    CT -->|"categorical columns"| O["OneHotEncoder"]
+    R["raw DataFrame<br/>numeric + categorical columns"] --> CT{"<code>ColumnTransformer</code>"}
+    CT -->|"numeric columns"| S["<code>StandardScaler</code>"]
+    CT -->|"categorical columns"| O["<code>OneHotEncoder</code>"]
     S --> J["concatenate side by side"]
     O --> J
     J --> M["one feature matrix<br/>(all numeric, ready for the model)"]

--- a/content/learn/machine-learning-scikit-learn/the-scikit-learn-api.mdx
+++ b/content/learn/machine-learning-scikit-learn/the-scikit-learn-api.mdx
@@ -51,8 +51,8 @@ on training data, then `predict` (or `transform`, or `score`) on new data.
 
 ```mermaid
 flowchart LR
-    A["Raw training data<br/>(X_train, y_train)"] -->|"fit(X_train, y_train)"| B["Fitted estimator<br/>(holds what it learned)"]
-    C["New data<br/>(X_new)"] -->|"predict(X_new)"| B
+    A["Raw training data<br/>(<code>X_train</code>, <code>y_train</code>)"] -->|"fit(X_train, y_train)"| B["Fitted estimator<br/>(holds what it learned)"]
+    C["New data<br/>(<code>X_new</code>)"] -->|"predict(X_new)"| B
     B --> D["Predictions<br/>(numbers, labels, or groups)"]
     B -. "score(X_test, y_test)" .-> E["A quality number"]
 ```

--- a/content/learn/machine-learning-scikit-learn/train-test-split.mdx
+++ b/content/learn/machine-learning-scikit-learn/train-test-split.mdx
@@ -42,9 +42,9 @@ flowchart TD
     A["Full dataset<br/>(all rows)"] --> B{"random split"}
     B --> C["Training set<br/>(about 70-80%)"]
     B --> D["Test set<br/>(about 20-30%)"]
-    C --> E["model.fit(...)"]
+    C --> E["<code>model.fit(...)</code>"]
     E --> G["Trained model"]
-    D --> F["model.score(...)"]
+    D --> F["<code>model.score(...)</code>"]
     G --> F
     F --> H["Honest estimate of<br/>real-world performance"]
 ```

--- a/content/learn/machine-learning-scikit-learn/what-is-machine-learning.mdx
+++ b/content/learn/machine-learning-scikit-learn/what-is-machine-learning.mdx
@@ -251,10 +251,10 @@ produces predictions; and we judge the whole thing on held-out data.
 ```mermaid
 flowchart TD
     A["Collect labeled examples<br/>(features X, answers y)"] --> B["Split off a test set"]
-    B --> C["Train on the training set<br/>model.fit(X_train, y_train)"]
+    B --> C["Train on the training set<br/><code>model.fit(X_train, y_train)</code>"]
     C --> D["Trained model"]
-    D --> E["Evaluate on the test set<br/>model.score(X_test, y_test)"]
-    D --> F["Predict on brand-new data<br/>model.predict(X_new)"]
+    D --> E["Evaluate on the test set<br/><code>model.score(X_test, y_test)</code>"]
+    D --> F["Predict on brand-new data<br/><code>model.predict(X_new)</code>"]
     E -. "good enough?" .-> F
 ```
 

--- a/content/learn/machine-learning-scikit-learn/your-first-model.mdx
+++ b/content/learn/machine-learning-scikit-learn/your-first-model.mdx
@@ -51,15 +51,15 @@ finally the finished model labels brand-new flowers.
 
 ```mermaid
 flowchart TD
-    A["Raw labeled data<br/>X (features), y (labels)"] --> B{"train_test_split"}
-    B --> C["X_train, y_train"]
-    B --> D["X_test, y_test"]
-    C --> E["model.fit(X_train, y_train)<br/>LEARN the pattern"]
+    A["Raw labeled data<br/>X (features), y (labels)"] --> B{"<code>train_test_split</code>"}
+    B --> C["<code>X_train, y_train</code>"]
+    B --> D["<code>X_test, y_test</code>"]
+    C --> E["<code>model.fit(X_train, y_train)</code><br/>LEARN the pattern"]
     E --> F["Trained model"]
-    D --> G["model.score(X_test, y_test)<br/>GRADE on unseen data"]
+    D --> G["<code>model.score(X_test, y_test)</code><br/>GRADE on unseen data"]
     F --> G
     G --> H["Accuracy:<br/>an honest estimate"]
-    F --> I["model.predict(new_flower)<br/>USE it in the wild"]
+    F --> I["<code>model.predict(new_flower)</code><br/>USE it in the wild"]
     I --> J["Predicted species"]
 ```
 

--- a/content/learn/mastering-dsa-cpp/dynamic-programming.mdx
+++ b/content/learn/mastering-dsa-cpp/dynamic-programming.mdx
@@ -201,7 +201,7 @@ For LCS, `dp[i][j]` is the best length for prefixes `a[0..i)` and `b[0..j)`. Exa
 flowchart TD
     R["rows: ABCBDAB"] --> G["DP grid"]
     C["cols: BDCABC"] --> G
-    G --> A["bottom-right = 4"]
+    G --> A["bottom-<code>right = 4</code>"]
 ```
 
 <CodeBlock adapter="cpp" starterCode={`#include <algorithm>

--- a/content/learn/mastering-dsa-cpp/dynamic-programming.mdx
+++ b/content/learn/mastering-dsa-cpp/dynamic-programming.mdx
@@ -42,12 +42,12 @@ int main() {
 
 ```mermaid
 graph TD
-    A["fib(5)"] --> B["fib(4)"]
-    A --> C["fib(3)"]
-    B --> D["fib(3)"]
-    B --> E["fib(2)"]
-    C --> F["fib(2)"]
-    C --> G["fib(1)"]
+    A["<code>fib(5)</code>"] --> B["<code>fib(4)</code>"]
+    A --> C["<code>fib(3)</code>"]
+    B --> D["<code>fib(3)</code>"]
+    B --> E["<code>fib(2)</code>"]
+    C --> F["<code>fib(2)</code>"]
+    C --> G["<code>fib(1)</code>"]
 ```
 
 <CodeBlock adapter="cpp" starterCode={`#include <iostream>

--- a/content/learn/mastering-dsa-cpp/hash-tables.mdx
+++ b/content/learn/mastering-dsa-cpp/hash-tables.mdx
@@ -9,7 +9,7 @@ A hash table stores key-value data in an array of buckets. A hash function conve
 
 ```mermaid
 flowchart TD
-    K["key: apple"] --> H["hash(key)"]
+    K["key: apple"] --> H["<code>hash(key)</code>"]
     H --> M["% capacity"]
     M --> B["bucket index"]
     B --> A["bucket array"]
@@ -80,7 +80,7 @@ Open addressing keeps entries in the array itself. If the home bucket is occupie
 
 ```mermaid
 flowchart TD
-    H["hash(key)=2"] --> B2["bucket 2 occupied"]
+    H["<code>hash(key)=2</code>"] --> B2["bucket 2 occupied"]
     B2 --> B3["linear probe bucket 3 occupied"]
     B3 --> B4["bucket 4 empty: insert"]
 ```

--- a/content/learn/mastering-dsa-cpp/linked-lists.mdx
+++ b/content/learn/mastering-dsa-cpp/linked-lists.mdx
@@ -34,7 +34,7 @@ flowchart TD
     H["head"] --> N1["Node 1 | data=10"]
     N1 --> N2["Node 2 | data=20"]
     N2 --> N3["Node 3 | data=30"]
-    N3 --> Z["nullptr"]
+    N3 --> Z["<code>nullptr</code>"]
 ```
 
 ## Build and traverse a list

--- a/content/learn/mastering-dsa-cpp/linked-lists.mdx
+++ b/content/learn/mastering-dsa-cpp/linked-lists.mdx
@@ -31,9 +31,9 @@ int main() {
 
 ```mermaid
 flowchart TD
-    H["head"] --> N1["Node 1 | data=10"]
-    N1 --> N2["Node 2 | data=20"]
-    N2 --> N3["Node 3 | data=30"]
+    H["head"] --> N1["Node 1 | <code>data=10</code>"]
+    N1 --> N2["Node 2 | <code>data=20</code>"]
+    N2 --> N3["Node 3 | <code>data=30</code>"]
     N3 --> Z["<code>nullptr</code>"]
 ```
 

--- a/content/learn/mastering-dsa-cpp/recursion.mdx
+++ b/content/learn/mastering-dsa-cpp/recursion.mdx
@@ -81,14 +81,14 @@ int main() {
 
 ```mermaid
 graph TD
-    A["fib(4)"] --> B["fib(3)"]
-    A --> C["fib(2)"]
-    B --> D["fib(2)"]
-    B --> E["fib(1)"]
-    C --> F["fib(1)"]
-    C --> G["fib(0)"]
-    D --> H["fib(1)"]
-    D --> I["fib(0)"]
+    A["<code>fib(4)</code>"] --> B["<code>fib(3)</code>"]
+    A --> C["<code>fib(2)</code>"]
+    B --> D["<code>fib(2)</code>"]
+    B --> E["<code>fib(1)</code>"]
+    C --> F["<code>fib(1)</code>"]
+    C --> G["<code>fib(0)</code>"]
+    D --> H["<code>fib(1)</code>"]
+    D --> I["<code>fib(0)</code>"]
 ```
 
 Repeated calls motivate **memoization**, a dynamic programming idea we will revisit later.

--- a/content/learn/mastering-dsa-cpp/searching.mdx
+++ b/content/learn/mastering-dsa-cpp/searching.mdx
@@ -37,9 +37,9 @@ Binary search only works on sorted data. It keeps a search interval, checks the 
 
 ```mermaid
 flowchart TD
-    A["[1,3,5,7,9,11,13,15]"] --> B["low=0 high=7 mid=3 value=7"]
+    A["[1,3,5,7,9,11,13,15]"] --> B["<code>low=0 high=7 mid=3 value=7</code>"]
     B --> C["11 > 7, search right half"]
-    C --> D["low=4 high=7 mid=5 value=11"]
+    C --> D["<code>low=4 high=7 mid=5 value=11</code>"]
     D --> E["found index 5"]
 ```
 

--- a/content/learn/mastering-dsa-cpp/sorting-efficient.mdx
+++ b/content/learn/mastering-dsa-cpp/sorting-efficient.mdx
@@ -109,7 +109,7 @@ Prefer `std::sort` unless you specifically need stability. It is an introsort-st
 
 ```mermaid
 flowchart TD
-    A["std::sort range"] --> B["quicksort-style partitioning"]
+    A["<code>std::sort</code> range"] --> B["quicksort-style partitioning"]
     B --> C{"recursion too deep?"}
     C -- "no" --> D["keep partitioning"]
     C -- "yes" --> E["heapsort fallback"]

--- a/content/learn/mastering-dsa-cpp/strings.mdx
+++ b/content/learn/mastering-dsa-cpp/strings.mdx
@@ -158,8 +158,8 @@ int main() {
 
 ```mermaid
 flowchart LR
-    A["std::string owns characters"] --> B["dynamic storage"]
-    C["std::string_view"] --> D["pointer + length"]
+    A["<code>std::string</code> owns characters"] --> B["dynamic storage"]
+    C["<code>std::string_view</code>"] --> D["pointer + length"]
     D --> E["does not own data"]
 ```
 

--- a/content/learn/mastering-dsa-cpp/union-find.mdx
+++ b/content/learn/mastering-dsa-cpp/union-find.mdx
@@ -72,7 +72,7 @@ Path compression rewires every node on a find path directly to the root. Future 
 
 ```mermaid
 graph LR
-    A["before: 4 -> 3 -> 2 -> 1 -> 0"] --> B["find(4)"] --> C["after: 4,3,2,1 all point to 0"]
+    A["before: 4 -> 3 -> 2 -> 1 -> 0"] --> B["<code>find(4)</code>"] --> C["after: 4,3,2,1 all point to 0"]
 ```
 
 <CodeBlock

--- a/content/learn/mastering-ggplot2/mapping-versus-setting.mdx
+++ b/content/learn/mastering-ggplot2/mapping-versus-setting.mdx
@@ -19,8 +19,8 @@ visual property like color:
 
 ```mermaid
 flowchart TD
-    Q["Do you want color (or size, shape...)<br/>to depend on the data?"] -->|"Yes, varies by a column"| M["MAP it<br/>inside aes()<br/>aes(color = drv)"]
-    Q -->|"No, a fixed constant"| S["SET it<br/>outside aes()<br/>geom_point(color = 'blue')"]
+    Q["Do you want color (or size, shape...)<br/>to depend on the data?"] -->|"Yes, varies by a column"| M["MAP it<br/>inside <code>aes()</code><br/><code>aes(color = drv)</code>"]
+    Q -->|"No, a fixed constant"| S["SET it<br/>outside <code>aes()</code><br/><code>geom_point(color = 'blue')</code>"]
     M --> ML["Legend appears,<br/>colors chosen by a scale"]
     S --> SL["No legend,<br/>your exact constant used"]
 ```

--- a/content/learn/mastering-ggplot2/themes-and-styling.mdx
+++ b/content/learn/mastering-ggplot2/themes-and-styling.mdx
@@ -104,8 +104,8 @@ more specific ones, unless the specific one overrides them.
 ```mermaid
 flowchart TD
     TEXT["text<br/>(all text)"] --> TITLE["title"]
-    TEXT --> AXISTXT["axis.text"]
-    TITLE --> AXISTITLE["axis.title"]
+    TEXT --> AXISTXT["<code>axis.text</code>"]
+    TITLE --> AXISTITLE["<code>axis.title</code>"]
     AXISTITLE --> AXISTITLEX["axis.title.x"]
     AXISTITLE --> AXISTITLEY["axis.title.y"]
     AXISTXT --> AXISTXTX["axis.text.x"]

--- a/content/learn/mastering-ggplot2/themes-and-styling.mdx
+++ b/content/learn/mastering-ggplot2/themes-and-styling.mdx
@@ -106,9 +106,9 @@ flowchart TD
     TEXT["text<br/>(all text)"] --> TITLE["title"]
     TEXT --> AXISTXT["<code>axis.text</code>"]
     TITLE --> AXISTITLE["<code>axis.title</code>"]
-    AXISTITLE --> AXISTITLEX["axis.title.x"]
-    AXISTITLE --> AXISTITLEY["axis.title.y"]
-    AXISTXT --> AXISTXTX["axis.text.x"]
+    AXISTITLE --> AXISTITLEX["<code>axis.title.x</code>"]
+    AXISTITLE --> AXISTITLEY["<code>axis.title.y</code>"]
+    AXISTXT --> AXISTXTX["<code>axis.text.x</code>"]
 ```
 
 Set the root `text` element's font once, and *every* text element

--- a/content/learn/mastering-ggplot2/what-scales-do.mdx
+++ b/content/learn/mastering-ggplot2/what-scales-do.mdx
@@ -16,7 +16,7 @@ describes intent; the other carries it out:
 
 ```mermaid
 flowchart LR
-    COL["Data column<br/>displ = 1.6 ... 7.0"] --> MAP["Mapping<br/><code>aes(x = displ)</code>"]
+    COL["Data column<br/><code>displ = 1.6</code> ... 7.0"] --> MAP["Mapping<br/><code>aes(x = displ)</code>"]
     MAP --> SCALE["Scale<br/><code>scale_x_continuous</code>"]
     SCALE --> PIX["Visual value<br/>pixel x-position"]
     SCALE --> AXIS["Axis<br/>(the visible scale)"]

--- a/content/learn/mastering-ggplot2/what-scales-do.mdx
+++ b/content/learn/mastering-ggplot2/what-scales-do.mdx
@@ -16,8 +16,8 @@ describes intent; the other carries it out:
 
 ```mermaid
 flowchart LR
-    COL["Data column<br/>displ = 1.6 ... 7.0"] --> MAP["Mapping<br/>aes(x = displ)"]
-    MAP --> SCALE["Scale<br/>scale_x_continuous"]
+    COL["Data column<br/>displ = 1.6 ... 7.0"] --> MAP["Mapping<br/><code>aes(x = displ)</code>"]
+    MAP --> SCALE["Scale<br/><code>scale_x_continuous</code>"]
     SCALE --> PIX["Visual value<br/>pixel x-position"]
     SCALE --> AXIS["Axis<br/>(the visible scale)"]
 ```

--- a/content/learn/natural-language-processing-python/frequency-distributions.mdx
+++ b/content/learn/natural-language-processing-python/frequency-distributions.mdx
@@ -20,7 +20,7 @@ distribution") that adds text-specific conveniences.
 flowchart LR
     A["Clean tokens:<br/>fox, dog, fox, run, fox, dog"] --> B["FreqDist<br/>(tally each word)"]
     B --> C["Counts:<br/>fox=3, dog=2, run=1"]
-    C --> D["most_common(2):<br/>[('fox', 3), ('dog', 2)]"]
+    C --> D["<code>most_common(2)</code>:<br/>[('fox', 3), ('dog', 2)]"]
 ```
 
 <CodeBlock

--- a/content/learn/natural-language-processing-python/frequency-distributions.mdx
+++ b/content/learn/natural-language-processing-python/frequency-distributions.mdx
@@ -19,7 +19,7 @@ distribution") that adds text-specific conveniences.
 ```mermaid
 flowchart LR
     A["Clean tokens:<br/>fox, dog, fox, run, fox, dog"] --> B["FreqDist<br/>(tally each word)"]
-    B --> C["Counts:<br/>fox=3, dog=2, run=1"]
+    B --> C["Counts:<br/><code>fox=3</code>, <code>dog=2</code>, <code>run=1</code>"]
     C --> D["<code>most_common(2)</code>:<br/>[('fox', 3), ('dog', 2)]"]
 ```
 

--- a/content/learn/natural-language-processing-python/tokenization.mdx
+++ b/content/learn/natural-language-processing-python/tokenization.mdx
@@ -31,8 +31,8 @@ nasty input.
 ```mermaid
 flowchart TB
     S["Input text: don't stop!"]
-    S --> SP["text.split()"]
-    S --> TK["word_tokenize(text)"]
+    S --> SP["<code>text.split()</code>"]
+    S --> TK["<code>word_tokenize(text)</code>"]
     SP --> SP1["['don't', 'stop!']<br/>contraction hidden,<br/>'!' glued to 'stop'"]
     TK --> TK1["['do', 'n't', 'stop', '!']<br/>negation 'n't' exposed,<br/>'!' separated cleanly"]
 ```
@@ -126,8 +126,8 @@ abbreviates "Dr." and "U.S.A.", and it marks the decimal in "2.5".
 ```mermaid
 flowchart TB
     T["Text: Dr. Lee earned 2.5 million. He smiled."]
-    T --> N["Naive: text.split('.')"]
-    T --> P["sent_tokenize() (Punkt)"]
+    T --> N["Naive: <code>text.split('.')</code>"]
+    T --> P["<code>sent_tokenize()</code> (Punkt)"]
     N --> N1["broken fragments:<br/>'Dr', ' Lee earned 2', '5 million', ' He smiled'<br/>split inside 'Dr.' and '2.5'"]
     P --> P1["2 clean sentences:<br/>'Dr. Lee earned 2.5 million.'<br/>'He smiled.'"]
 ```

--- a/content/learn/oop-blueprint-java/constructors-and-state.mdx
+++ b/content/learn/oop-blueprint-java/constructors-and-state.mdx
@@ -135,7 +135,7 @@ shorter one that fills in defaults by calling the real one with
 flowchart LR
     A["new Point()"] -->|delegates| C["new Point(0,0)"]
     B["new Point(5)"] -->|delegates| C
-    C --> S["sets this.x and this.y"]
+    C --> S["sets <code>this.x</code> and <code>this.y</code>"]
 ```
 
 <CodeBlock
@@ -224,8 +224,8 @@ work.
 
 ```mermaid
 flowchart LR
-    P["price : Money<br/>cents=1999<br/>currency='USD'"]
-    T["taxed : Money<br/>cents=2159<br/>currency='USD'"]
+    P["price : Money<br/><code>cents=1999</code><br/><code>currency='USD'</code>"]
+    T["taxed : Money<br/><code>cents=2159</code><br/><code>currency='USD'</code>"]
     O["new Money(160,'USD')"]
 
     P -. unchanged .-> P

--- a/content/learn/oop-blueprint-java/encapsulation.mdx
+++ b/content/learn/oop-blueprint-java/encapsulation.mdx
@@ -31,7 +31,7 @@ flowchart LR
     end
     subgraph Capsule["BankAccount object"]
         I["state: balance"]
-        M["public methods<br/>deposit(amount)<br/>withdraw(amount)<br/>balance()"]
+        M["public methods<br/><code>deposit(amount)</code><br/><code>withdraw(amount)</code><br/><code>balance()</code>"]
     end
 
     C1 --> M

--- a/content/learn/oop-blueprint-java/inheritance.mdx
+++ b/content/learn/oop-blueprint-java/inheritance.mdx
@@ -110,7 +110,7 @@ When you build a `Dog`, you build an `Animal` first, then add the
 ```mermaid
 flowchart LR
     subgraph Heap
-        Obj["Dog object<br/>(inherits Animal's name field)<br/>name = 'Rex'"]
+        Obj["Dog object<br/>(inherits Animal's name field)<br/><code>name = 'Rex'</code>"]
     end
 ```
 

--- a/content/learn/oop-blueprint-java/objects-in-memory.mdx
+++ b/content/learn/oop-blueprint-java/objects-in-memory.mdx
@@ -284,7 +284,7 @@ flowchart LR
     subgraph Heap
       P["Person<br/>name='Ada'"]
       A["Address<br/>city='Oslo'"]
-      L["List<Book>"]
+      L["<code>List&lt;Book&gt;</code>"]
       B1["Book<br/>'A'"]
       B2["Book<br/>'B'"]
     end

--- a/content/learn/oop-blueprint-java/objects-in-memory.mdx
+++ b/content/learn/oop-blueprint-java/objects-in-memory.mdx
@@ -34,7 +34,7 @@ flowchart LR
         V1["d : Dog ref ──┐"]
     end
     subgraph H["Heap"]
-        O1["Dog object<br/>name='Rex'<br/>age=4"]
+        O1["Dog object<br/><code>name='Rex'</code><br/><code>age=4</code>"]
     end
     V1 --> O1
 ```
@@ -77,7 +77,7 @@ flowchart LR
         B["b : Dog ref"]
     end
     subgraph Heap
-        O["Dog<br/>name='Max'"]
+        O["Dog<br/><code>name='Max'</code>"]
     end
     A --> O
     B --> O
@@ -116,8 +116,8 @@ flowchart LR
         C2["c : Dog ref"]
     end
     subgraph Heap
-        OA["Dog<br/>name='Rex'"]
-        OC["Dog<br/>name='Rex'"]
+        OA["Dog<br/><code>name='Rex'</code>"]
+        OC["Dog<br/><code>name='Rex'</code>"]
     end
     A2 --> OA
     C2 --> OC
@@ -282,8 +282,8 @@ ends up looking like a small map of your problem domain.
 ```mermaid
 flowchart LR
     subgraph Heap
-      P["Person<br/>name='Ada'"]
-      A["Address<br/>city='Oslo'"]
+      P["Person<br/><code>name='Ada'</code>"]
+      A["Address<br/><code>city='Oslo'</code>"]
       L["<code>List&lt;Book&gt;</code>"]
       B1["Book<br/>'A'"]
       B2["Book<br/>'B'"]

--- a/content/learn/oop-blueprint-java/packages-and-architecture.mdx
+++ b/content/learn/oop-blueprint-java/packages-and-architecture.mdx
@@ -31,16 +31,16 @@ name*. The class `java.util.ArrayList` lives in the package
 
 ```mermaid
 flowchart TB
-    P1["package com.bank.account"]
+    P1["package <code>com.bank.account</code>"]
     P1 --> C1[Account]
     P1 --> C2[Transaction]
     P1 --> C3[Statement]
 
-    P2["package com.bank.customer"]
+    P2["package <code>com.bank.customer</code>"]
     P2 --> C4[Customer]
     P2 --> C5[Address]
 
-    P3["package com.bank.payments"]
+    P3["package <code>com.bank.payments</code>"]
     P3 --> C6[Payment]
     P3 --> C7[Gateway]
 ```
@@ -98,12 +98,12 @@ class is part of your package's *external API*.
 
 ```mermaid
 flowchart LR
-    subgraph com.bank.account
+    subgraph com.bank.account["<code>com.bank.account</code>"]
         A[Account]
         T[Transaction]
         L[(package-private<br/>helper class<br/>TxValidator)]
     end
-    subgraph com.bank.payments
+    subgraph com.bank.payments["<code>com.bank.payments</code>"]
         P[Payment]
     end
     P -. cannot see .-> L
@@ -158,20 +158,20 @@ growth. Each file's first line would be a `package` declaration.
 
 ```mermaid
 flowchart TB
-    subgraph cli["com.shop.cli"]
+    subgraph cli["<code>com.shop.cli</code>"]
         CLI["<code>CafeCli</code>"]
     end
-    subgraph service["com.shop.service"]
+    subgraph service["<code>com.shop.service</code>"]
         OS["<code>OrderService</code>"]
     end
-    subgraph model["com.shop.model"]
+    subgraph model["<code>com.shop.model</code>"]
         D[Drink]
         L["<code>LineItem</code>"]
         O[Order]
         R[Receipt]
         M[Menu]
     end
-    subgraph payments["com.shop.payments"]
+    subgraph payments["<code>com.shop.payments</code>"]
         P[Payment]
         I[["<code>PaymentGateway</code>"]]
         S["<code>StripeGateway</code>"]

--- a/content/learn/oop-blueprint-java/packages-and-architecture.mdx
+++ b/content/learn/oop-blueprint-java/packages-and-architecture.mdx
@@ -159,23 +159,23 @@ growth. Each file's first line would be a `package` declaration.
 ```mermaid
 flowchart TB
     subgraph cli["com.shop.cli"]
-        CLI[CafeCli]
+        CLI["<code>CafeCli</code>"]
     end
     subgraph service["com.shop.service"]
-        OS[OrderService]
+        OS["<code>OrderService</code>"]
     end
     subgraph model["com.shop.model"]
         D[Drink]
-        L[LineItem]
+        L["<code>LineItem</code>"]
         O[Order]
         R[Receipt]
         M[Menu]
     end
     subgraph payments["com.shop.payments"]
         P[Payment]
-        I[[PaymentGateway]]
-        S[StripeGateway]
-        F[FakeGateway]
+        I[["<code>PaymentGateway</code>"]]
+        S["<code>StripeGateway</code>"]
+        F["<code>FakeGateway</code>"]
     end
 
     CLI --> OS

--- a/content/learn/oop-blueprint-java/polymorphism.mdx
+++ b/content/learn/oop-blueprint-java/polymorphism.mdx
@@ -93,7 +93,7 @@ flowchart LR
     F["A single function:<br/><code>renderAll(List of Shape)</code>"] --> S1["<code>Circle.draw</code>"]
     F --> S2["<code>Square.draw</code>"]
     F --> S3["<code>Triangle.draw</code>"]
-    F --> S4[NEW! Hexagon.draw added next year]
+    F --> S4["NEW! <code>Hexagon.draw</code> added next year"]
 ```
 
 That last node — **the new shape added next year** — is the whole

--- a/content/learn/oop-blueprint-java/polymorphism.mdx
+++ b/content/learn/oop-blueprint-java/polymorphism.mdx
@@ -90,9 +90,9 @@ types as long as they share the right interface.
 
 ```mermaid
 flowchart LR
-    F["A single function:<br/>renderAll(List of Shape)"] --> S1[Circle.draw]
-    F --> S2[Square.draw]
-    F --> S3[Triangle.draw]
+    F["A single function:<br/><code>renderAll(List of Shape)</code>"] --> S1["<code>Circle.draw</code>"]
+    F --> S2["<code>Square.draw</code>"]
+    F --> S3["<code>Triangle.draw</code>"]
     F --> S4[NEW! Hexagon.draw added next year]
 ```
 

--- a/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
+++ b/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
@@ -74,7 +74,7 @@ flowchart TB
     M["Menu"] -. lists .-> D["Drink"]
     C["Customer"] -. selects .-> D
     C -. creates .-> O["Order"]
-    O -. consists of .-> L["LineItem"]
+    O -. consists of .-> L["<code>LineItem</code>"]
     L -. references .-> D
     P["Payment"] -. settles .-> O
     R["Receipt"] -. summarizes .-> O
@@ -338,8 +338,8 @@ A classic shorthand:
 
 ```mermaid
 flowchart LR
-    Bad["account.getBalance() > 100<br/>→ ... do stuff externally"]
-    Good["account.tryWithdraw(100)"]
+    Bad["<code>account.getBalance()</code> > 100<br/>→ ... do stuff externally"]
+    Good["<code>account.tryWithdraw(100)</code>"]
     Bad -. refactor .-> Good
 ```
 

--- a/content/learn/oop-blueprint-java/software-crisis.mdx
+++ b/content/learn/oop-blueprint-java/software-crisis.mdx
@@ -121,17 +121,17 @@ flowchart TB
         D4[(branches)]
     end
 
-    P1[openAccount] --> D1
+    P1["<code>openAccount</code>"] --> D1
     P1 --> D2
     P2[deposit] --> D2
     P2 --> D3
     P3[withdraw] --> D2
     P3 --> D3
-    P4[applyFees] --> D2
+    P4["<code>applyFees</code>"] --> D2
     P4 --> D1
-    P5[transferBranch] --> D1
+    P5["<code>transferBranch</code>"] --> D1
     P5 --> D4
-    P6[monthlyReport] --> D1
+    P6["<code>monthlyReport</code>"] --> D1
     P6 --> D2
     P6 --> D3
     P6 --> D4

--- a/content/learn/oop-blueprint-java/static-and-utility.mdx
+++ b/content/learn/oop-blueprint-java/static-and-utility.mdx
@@ -22,7 +22,7 @@ and the same `static` method.
 flowchart TB
     subgraph C["Counter (class)"]
         S[("static int created<br/>shared by everyone")]
-        SM["static int totalCreated()"]
+        SM["static int <code>totalCreated()</code>"]
     end
     subgraph I["instances"]
         I1["c1<br/>id=1"]

--- a/content/learn/oop-blueprint-java/static-and-utility.mdx
+++ b/content/learn/oop-blueprint-java/static-and-utility.mdx
@@ -25,9 +25,9 @@ flowchart TB
         SM["static int <code>totalCreated()</code>"]
     end
     subgraph I["instances"]
-        I1["c1<br/>id=1"]
-        I2["c2<br/>id=2"]
-        I3["c3<br/>id=3"]
+        I1["c1<br/><code>id=1</code>"]
+        I2["c2<br/><code>id=2</code>"]
+        I3["c3<br/><code>id=3</code>"]
     end
     I1 --- S
     I2 --- S

--- a/content/learn/practical-r-for-beginners/ggplot-grammar.mdx
+++ b/content/learn/practical-r-for-beginners/ggplot-grammar.mdx
@@ -234,8 +234,8 @@ clean, gridded, modern.
 
 ```mermaid
 flowchart TB
-  d["data"] --> a["aes() mapping"] --> g["geom_*()"] --> s["scales / labs / theme"] --> chart["a chart"]
-  facet["facet_wrap / facet_grid"] --> chart
+  d["data"] --> a["<code>aes()</code> mapping"] --> g["<code>geom_*()</code>"] --> s["scales / labs / theme"] --> chart["a chart"]
+  facet["<code>facet_wrap / facet_grid</code>"] --> chart
   style chart fill:#bfdbfe
 ```
 

--- a/content/learn/practical-r-for-beginners/grouped-analysis.mdx
+++ b/content/learn/practical-r-for-beginners/grouped-analysis.mdx
@@ -19,9 +19,9 @@ flowchart TD
   data["Whole dataset"] -->|split| grp1["region A"]
   data --> grp2["region B"]
   data --> grp3["region C"]
-  grp1 -->|apply mean| s1["sales=120"]
-  grp2 -->|apply mean| s2["sales=98"]
-  grp3 -->|apply mean| s3["sales=145"]
+  grp1 -->|apply mean| s1["<code>sales=120</code>"]
+  grp2 -->|apply mean| s2["<code>sales=98</code>"]
+  grp3 -->|apply mean| s3["<code>sales=145</code>"]
   s1 -->|combine| out["summary table"]
   s2 --> out
   s3 --> out

--- a/content/learn/practical-r-for-beginners/missing-values.mdx
+++ b/content/learn/practical-r-for-beginners/missing-values.mdx
@@ -130,7 +130,7 @@ flowchart TB
   decide{"Is missingness informative?"}
   drop["na.rm = TRUE / na.omit"]
   impute["Impute carefully"]
-  flag["Record a 'was_missing' column"]
+  flag["Record a '<code>was_missing</code>' column"]
   raw --> inspect --> decide
   decide -->|"random, small"| drop
   decide -->|"systematic, structural"| flag

--- a/content/learn/practical-r-for-beginners/missing-values.mdx
+++ b/content/learn/practical-r-for-beginners/missing-values.mdx
@@ -128,7 +128,7 @@ flowchart TB
   raw["Raw dataset with NAs"]
   inspect["Inspect missingness"]
   decide{"Is missingness informative?"}
-  drop["na.rm = TRUE / na.omit"]
+  drop["<code>na.rm</code> = TRUE / <code>na.omit</code>"]
   impute["Impute carefully"]
   flag["Record a '<code>was_missing</code>' column"]
   raw --> inspect --> decide

--- a/content/learn/practical-r-for-beginners/reproducible-analysis.mdx
+++ b/content/learn/practical-r-for-beginners/reproducible-analysis.mdx
@@ -163,7 +163,7 @@ generated together*.
 
 ```mermaid
 flowchart LR
-  Doc[report.qmd<br/>prose + R code] --> Render[quarto render]
+  Doc["<code>report.qmd</code><br/>prose + R code"] --> Render[quarto render]
   Data[data files] --> Render
   Render --> HTML["<code>report.html</code>"]
   Render --> PDF["<code>report.pdf</code>"]

--- a/content/learn/practical-r-for-beginners/reproducible-analysis.mdx
+++ b/content/learn/practical-r-for-beginners/reproducible-analysis.mdx
@@ -165,9 +165,9 @@ generated together*.
 flowchart LR
   Doc[report.qmd<br/>prose + R code] --> Render[quarto render]
   Data[data files] --> Render
-  Render --> HTML[report.html]
-  Render --> PDF[report.pdf]
-  Render --> Word[report.docx]
+  Render --> HTML["<code>report.html</code>"]
+  Render --> PDF["<code>report.pdf</code>"]
+  Render --> Word["<code>report.docx</code>"]
   style Doc fill:#bfdbfe,stroke:#1d4ed8
   style Render fill:#a7f3d0,stroke:#047857
 ```

--- a/content/learn/practical-r-for-beginners/reshaping-data.mdx
+++ b/content/learn/practical-r-for-beginners/reshaping-data.mdx
@@ -220,8 +220,8 @@ A simple rule of thumb:
 ```mermaid
 flowchart TB
   q{"What are you doing?"}
-  q -->|"plotting / modeling / computing per-row stats"| L["pivot_longer"]
-  q -->|"display / between-column arithmetic"| W["pivot_wider"]
+  q -->|"plotting / modeling / computing per-row stats"| L["<code>pivot_longer</code>"]
+  q -->|"display / between-column arithmetic"| W["<code>pivot_wider</code>"]
   style L fill:#dcfce7
   style W fill:#fde68a
 ```

--- a/content/learn/practical-r-for-beginners/variables-and-assignment.mdx
+++ b/content/learn/practical-r-for-beginners/variables-and-assignment.mdx
@@ -68,7 +68,7 @@ never want to use these as variable names anyway.)
 
 ```mermaid
 flowchart TD
-  Name["A name (e.g. avg_price)"] -->|<-| Value["A value (e.g. 9.99)"]
+  Name["A name (e.g. <code>avg_price</code>)"] -->|<-| Value["A value (e.g. 9.99)"]
   Value -->|stored in environment| Env["Workspace"]
   User["Later code"] -->|references name| Env
   Env -->|returns value| User

--- a/content/learn/practical-r-for-beginners/vectorized-computation.mdx
+++ b/content/learn/practical-r-for-beginners/vectorized-computation.mdx
@@ -68,7 +68,7 @@ This is the heart of how data analysts think: you have
 ```mermaid
 flowchart LR
   q["quantities: [2, 1, 3, 4]"] --> mul
-  p["unit_prices: [9.99, 14.50, 24.00, 5.75]"] --> mul
+  p["<code>unit_prices: [9.99, 14.50, 24.00, 5.75]</code>"] --> mul
   mul["element-wise * "] --> r["totals: [19.98, 14.50, 72.00, 23.00]"]
   style mul fill:#fde68a
 ```
@@ -195,8 +195,8 @@ equivalent loop**, on top of being shorter and easier to read.
 
 ```mermaid
 flowchart TB
-  loop["for (i in 1:n) result[i] <- xs[i] + ys[i]"]:::code -->|interpreted per element| slow["Slow"]
-  vec["result <- xs + ys"]:::code -->|single C call| fast["Fast"]
+  loop["<code>for (i in 1:n) result[i] &lt;- xs[i] + ys[i]</code>"] -->|interpreted per element| slow["Slow"]
+  vec["<code>result &lt;- xs + ys</code>"] -->|single C call| fast["Fast"]
   style fast fill:#dcfce7
   style slow fill:#fee2e2
 ```

--- a/content/learn/practical-r-for-beginners/vectors-everywhere.mdx
+++ b/content/learn/practical-r-for-beginners/vectors-everywhere.mdx
@@ -53,7 +53,7 @@ is a vector of length one whose first element is 42.
 ```mermaid
 flowchart LR
   subgraph other["Many languages"]
-    A1["x = 42 (scalar)"]
+    A1["<code>x = 42</code> (scalar)"]
     A2["xs = [42, 43, 44] (array)"]
     A1 -.different type.-> A2
   end

--- a/content/learn/practical-r-for-beginners/writing-your-own-functions.mdx
+++ b/content/learn/practical-r-for-beginners/writing-your-own-functions.mdx
@@ -19,9 +19,9 @@ of a kitchen ("chop, chop, chop, stir, stir, chop, stir, …").
 
 ```mermaid
 flowchart TD
-  call["my_fun(x = 3, y = 4)"] --> args["Arguments bind to parameter names"]
+  call["<code>my_fun(x = 3, y = 4)</code>"] --> args["Arguments bind to parameter names"]
   args --> body["Function body runs"]
-  body --> ret["Last expression (or explicit return()) is returned"]
+  body --> ret["Last expression (or explicit <code>return()</code>) is returned"]
   ret --> out["Returned value flows back to caller"]
 ```
 

--- a/content/learn/python-basics/classes.mdx
+++ b/content/learn/python-basics/classes.mdx
@@ -68,7 +68,7 @@ When you call `Dog("Rex", 4)`, Python:
 flowchart TD
     A["Dog('Rex', 4)"] --> B[Python creates empty Dog instance]
     B --> C["<code>__init__(self, 'Rex', 4)</code> runs"]
-    C --> D["self.name = 'Rex'"]
+    C --> D["<code>self.name = 'Rex'</code>"]
     C --> E["<code>self.age = 4</code>"]
     D --> F[Return initialized instance]
     E --> F

--- a/content/learn/python-basics/classes.mdx
+++ b/content/learn/python-basics/classes.mdx
@@ -67,9 +67,9 @@ When you call `Dog("Rex", 4)`, Python:
 ```mermaid
 flowchart TD
     A["Dog('Rex', 4)"] --> B[Python creates empty Dog instance]
-    B --> C["__init__(self, 'Rex', 4) runs"]
+    B --> C["<code>__init__(self, 'Rex', 4)</code> runs"]
     C --> D["self.name = 'Rex'"]
-    C --> E["self.age = 4"]
+    C --> E["<code>self.age = 4</code>"]
     D --> F[Return initialized instance]
     E --> F
     style C fill:#e1f5ff

--- a/content/learn/python-basics/data-types.mdx
+++ b/content/learn/python-basics/data-types.mdx
@@ -55,7 +55,7 @@ graph TD
     object --> sequence[Sequence types]
     object --> mapping[Mapping types]
     object --> set_types[Set types]
-    object --> none[NoneType]
+    object --> none["<code>NoneType</code>"]
     
     numeric --> int
     numeric --> float

--- a/content/learn/python-basics/dictionaries.mdx
+++ b/content/learn/python-basics/dictionaries.mdx
@@ -13,7 +13,7 @@ Under the hood, a dict is a **hash table**: Python computes a hash of your key, 
 
 ```mermaid
 flowchart TD
-    A["Key: 'apple'"] --> B["hash('apple')"]
+    A["Key: 'apple'"] --> B["<code>hash('apple')</code>"]
     B --> C["Bucket index"]
     C --> D["Value: 1.0"]
 ```

--- a/content/learn/python-basics/exceptions.mdx
+++ b/content/learn/python-basics/exceptions.mdx
@@ -77,11 +77,11 @@ When an exception is raised, Python **unwinds the stack**, looking for a `try`/`
 
 ```mermaid
 flowchart TD
-    A["function_c() raises ValueError"] --> B["Is function_c inside a try block?"]
-    B -->|no| C["Propagate to function_b (caller)"]
-    C --> D["Is function_b inside a try block?"]
-    D -->|no| E["Propagate to function_a (caller)"]
-    E --> F["Is function_a inside a try block?"]
+    A["<code>function_c()</code> raises ValueError"] --> B["Is <code>function_c</code> inside a try block?"]
+    B -->|no| C["Propagate to <code>function_b</code> (caller)"]
+    C --> D["Is <code>function_b</code> inside a try block?"]
+    D -->|no| E["Propagate to <code>function_a</code> (caller)"]
+    E --> F["Is <code>function_a</code> inside a try block?"]
     F -->|yes| G["Caught! Execute except block."]
     F -->|no| H["Unhandled: print traceback, exit."]
 ```

--- a/content/learn/python-basics/files.mdx
+++ b/content/learn/python-basics/files.mdx
@@ -197,9 +197,9 @@ You can write your own context managers with `__enter__` and `__exit__`, or use 
 
 ```mermaid
 flowchart TD
-    A[Enter 'with' block] --> B["__enter__() called"]
+    A[Enter 'with' block] --> B["<code>__enter__()</code> called"]
     B --> C[Body executes]
-    C --> D["__exit__() called"]
+    C --> D["<code>__exit__()</code> called"]
     D --> E[File closed]
     C -->|Exception raised| D
     style D fill:#c8e6c9

--- a/content/learn/python-basics/functions.mdx
+++ b/content/learn/python-basics/functions.mdx
@@ -45,7 +45,7 @@ When you hear "functional programming," it means **prefer pure functions**: no s
 
 ```mermaid
 flowchart LR
-    A["caller: greet('Ada')"] --> B["function body executes"]
+    A["caller: <code>greet('Ada')</code>"] --> B["function body executes"]
     B --> C["return value: 'Hello, Ada!'"]
     C --> A
 ```

--- a/content/learn/python-basics/modules.mdx
+++ b/content/learn/python-basics/modules.mdx
@@ -93,11 +93,11 @@ for p in sys.path[:5]:  # show first 5
 
 ```mermaid
 flowchart TD
-    A["import foo"] --> B["Is foo in sys.modules cache?"]
+    A["import foo"] --> B["Is foo in <code>sys.modules</code> cache?"]
     B -->|yes| C["Return cached module"]
-    B -->|no| D["Search sys.path for foo.py or foo/__init__.py"]
+    B -->|no| D["Search <code>sys.path</code> for <code>foo.py</code> or foo/<code>__init__.py</code>"]
     D --> E["Execute module top to bottom"]
-    E --> F["Store in sys.modules"]
+    E --> F["Store in <code>sys.modules</code>"]
     F --> G["Bind to name foo"]
 ```
 

--- a/content/learn/python-basics/sets.mdx
+++ b/content/learn/python-basics/sets.mdx
@@ -13,9 +13,9 @@ Like dicts, sets are implemented as **hash tables**. A set is essentially a dict
 
 ```mermaid
 flowchart LR
-    A["Set: {1, 2, 3}"] --> B["hash(1) → bucket"]
-    A --> C["hash(2) → bucket"]
-    A --> D["hash(3) → bucket"]
+    A["Set: {1, 2, 3}"] --> B["<code>hash(1)</code> → bucket"]
+    A --> C["<code>hash(2)</code> → bucket"]
+    A --> D["<code>hash(3)</code> → bucket"]
 ```
 
 <Callout type="info">

--- a/content/learn/python-basics/sets.mdx
+++ b/content/learn/python-basics/sets.mdx
@@ -13,7 +13,7 @@ Like dicts, sets are implemented as **hash tables**. A set is essentially a dict
 
 ```mermaid
 flowchart LR
-    A["Set: {1, 2, 3}"] --> B["<code>hash(1)</code> → bucket"]
+    A["Set: <code>{1, 2, 3}</code>"] --> B["<code>hash(1)</code> → bucket"]
     A --> C["<code>hash(2)</code> → bucket"]
     A --> D["<code>hash(3)</code> → bucket"]
 ```
@@ -160,12 +160,12 @@ print("disjoint?", a.isdisjoint({99}))
 
 ```mermaid
 graph TD
-    A["Set A: {1, 2, 3, 4}"]
-    B["Set B: {3, 4, 5, 6}"]
-    C["Union: {1, 2, 3, 4, 5, 6}"]
-    D["Intersection: {3, 4}"]
-    E["Difference A-B: {1, 2}"]
-    F["Symmetric: {1, 2, 5, 6}"]
+    A["Set A: <code>{1, 2, 3, 4}</code>"]
+    B["Set B: <code>{3, 4, 5, 6}</code>"]
+    C["Union: <code>{1, 2, 3, 4, 5, 6}</code>"]
+    D["Intersection: <code>{3, 4}</code>"]
+    E["Difference A-B: <code>{1, 2}</code>"]
+    F["Symmetric: <code>{1, 2, 5, 6}</code>"]
     
     A --> C
     B --> C

--- a/content/learn/python-basics/variables.mdx
+++ b/content/learn/python-basics/variables.mdx
@@ -27,7 +27,7 @@ Variables are the foundation of every program. In a web app, you might have `use
 
 ```mermaid
 graph LR
-    x[name: x] --> obj1[object: list at 0x1a2b3c]
+    x[name: x] --> obj1["object: list at <code>0x1a2b3c</code>"]
     y[name: y] --> obj1
 ```
 

--- a/content/learn/scientific-computing-python/capstone-simulation.mdx
+++ b/content/learn/scientific-computing-python/capstone-simulation.mdx
@@ -39,7 +39,7 @@ $$
 
 ```mermaid
 flowchart TD
-    Cfg[Config:<br/>sweep over a] --> Sim[simulate.py:<br/>solve_ivp + event]
+    Cfg[Config:<br/>sweep over a] --> Sim["simulate.py:<br/><code>solve_ivp</code> + event"]
     Sim --> Res[results: time-series<br/>+ extinction flag]
     Res --> Agg[aggregate.py:<br/>per-config summary]
     Agg --> Viz[plot.py:<br/>small multiples + phase portrait]

--- a/content/learn/scientific-computing-python/capstone-simulation.mdx
+++ b/content/learn/scientific-computing-python/capstone-simulation.mdx
@@ -41,8 +41,8 @@ $$
 flowchart TD
     Cfg[Config:<br/>sweep over a] --> Sim["simulate.py:<br/><code>solve_ivp</code> + event"]
     Sim --> Res[results: time-series<br/>+ extinction flag]
-    Res --> Agg[aggregate.py:<br/>per-config summary]
-    Agg --> Viz[plot.py:<br/>small multiples + phase portrait]
+    Res --> Agg["<code>aggregate.py</code>:<br/>per-config summary"]
+    Agg --> Viz["<code>plot.py</code>:<br/>small multiples + phase portrait"]
     Sim -. seed .-> Sim
 ```
 

--- a/content/learn/scientific-computing-python/matrix-decompositions.mdx
+++ b/content/learn/scientific-computing-python/matrix-decompositions.mdx
@@ -338,13 +338,13 @@ flowchart TB
     Q --> Q1{"Solve A x = b?"}
     Q1 -- "A is SPD" --> CH[Cholesky]
     Q1 -- "A square general" --> LU
-    Q1 -- "A is sparse" --> SP["scipy.sparse.linalg"]
+    Q1 -- "A is sparse" --> SP["<code>scipy.sparse.linalg</code>"]
     Q --> Q2{"Minimize ||Ax-b||²?"}
     Q2 -- "rank deficient or ill-conditioned" --> SVD
     Q2 -- "full rank" --> QR
     Q --> Q3{"Need eigenvalues?"}
-    Q3 -- "symmetric" --> Eigh["np.linalg.eigh"]
-    Q3 -- "general" --> Eig["np.linalg.eig"]
+    Q3 -- "symmetric" --> Eigh["<code>np.linalg.eigh</code>"]
+    Q3 -- "general" --> Eig["<code>np.linalg.eig</code>"]
     Q --> Q4{"Need rank, compression, or PCA?"}
     Q4 --> SVD
 ```

--- a/content/learn/scientific-computing-python/root-finding-and-optimization.mdx
+++ b/content/learn/scientific-computing-python/root-finding-and-optimization.mdx
@@ -24,12 +24,12 @@ flowchart TB
     R -- "1-D, derivative" --> Newton1[newton]
     R -- "n-D" --> Hybr[fsolve / root]
     P --> O{"min F(x)?"}
-    O -- "1-D, bounded" --> Min1[minimize_scalar]
+    O -- "1-D, bounded" --> Min1["<code>minimize_scalar</code>"]
     O -- "n-D, smooth" --> BFGS["BFGS / L-BFGS-B"]
-    O -- "least squares" --> LS[least_squares / curve_fit]
+    O -- "least squares" --> LS["<code>least_squares / curve_fit</code>"]
     O -- "constrained" --> Con["SLSQP / trust-constr"]
-    O -- "no derivatives" --> NM[Nelder-Mead / differential_evolution]
-    O -- "global" --> Glob[differential_evolution / dual_annealing]
+    O -- "no derivatives" --> NM["Nelder-Mead / <code>differential_evolution</code>"]
+    O -- "global" --> Glob["<code>differential_evolution / dual_annealing</code>"]
 ```
 
 ## Root finding in one dimension

--- a/content/learn/scientific-computing-python/scientific-visualization.mdx
+++ b/content/learn/scientific-computing-python/scientific-visualization.mdx
@@ -24,7 +24,7 @@ flowchart TB
     Data --> Three{Three or more?}
     Three -- "x, y, value" --> Field[contour, imshow, pcolormesh]
     Three -- "vector field" --> Vec[quiver, streamplot]
-    Three -- 3D surface --> Surf[plot_surface, scatter3D]
+    Three -- 3D surface --> Surf["<code>plot_surface</code>, scatter3D"]
     Three -- "many series" --> Small[small multiples / facet grid]
 ```
 

--- a/content/learn/scientific-computing-python/vectorized-thinking.mdx
+++ b/content/learn/scientific-computing-python/vectorized-thinking.mdx
@@ -59,7 +59,7 @@ call, and the wrapping of a `float` into a `numpy.float64` and back.
 
 ```mermaid
 flowchart TD
-    Code["np.sin(xs) ** 2"] --> Ufunc["ufunc loop"]
+    Code["<code>np.sin(xs) ** 2</code>"] --> Ufunc["ufunc loop"]
     Ufunc --> C["compiled C loop"]
     C --> SIMD["CPU SIMD instructions"]
     SIMD --> Mem["contiguous memory"]

--- a/content/learn/sql-analytics-duckdb/common-table-expressions.mdx
+++ b/content/learn/sql-analytics-duckdb/common-table-expressions.mdx
@@ -95,7 +95,7 @@ month later and still understand.
 
 ```mermaid
 flowchart LR
-    A["WITH paid<br/>(filter)"] --> B["per_region<br/>(aggregate)"]
+    A["WITH paid<br/>(filter)"] --> B["<code>per_region</code><br/>(aggregate)"]
     B --> C["final SELECT<br/>(filter + sort)"]
 ```
 

--- a/content/learn/sql-analytics-duckdb/conditional-logic.mdx
+++ b/content/learn/sql-analytics-duckdb/conditional-logic.mdx
@@ -153,7 +153,7 @@ clause, which does the same thing more readably.
 flowchart LR
     R[("rows with<br/>status: paid / refunded")] --> C1["SUM(CASE WHEN paid)"]
     R --> C2["SUM(CASE WHEN refunded)"]
-    C1 --> Out["one row:<br/>paid_revenue | refunded_revenue"]
+    C1 --> Out["one row:<br/><code>paid_revenue</code> | <code>refunded_revenue</code>"]
     C2 --> Out
 ```
 

--- a/content/learn/sql-analytics-duckdb/filtering-groups.mdx
+++ b/content/learn/sql-analytics-duckdb/filtering-groups.mdx
@@ -133,7 +133,7 @@ grouping step.
 
 ```mermaid
 flowchart LR
-    Cond1["Condition on a raw column<br/>(status = 'paid')"] --> Where["belongs in WHERE"]
+    Cond1["Condition on a raw column<br/>(<code>status = 'paid'</code>)"] --> Where["belongs in WHERE"]
     Cond2["Condition on an aggregate<br/>(SUM(amount) > 150)"] --> Having["belongs in HAVING"]
 ```
 

--- a/content/learn/sql-analytics-duckdb/loading-and-generating-data.mdx
+++ b/content/learn/sql-analytics-duckdb/loading-and-generating-data.mdx
@@ -14,7 +14,7 @@ datasets in seconds — no files required.
 ```mermaid
 flowchart TB
     A["Typed-in rows<br/>(VALUES)"] --> DB[("DuckDB")]
-    B["Generated rows<br/>(range, generate_series)"] --> DB
+    B["Generated rows<br/>(range, <code>generate_series</code>)"] --> DB
     C["Files<br/>(CSV, Parquet)"] --> DB
     D["Query results<br/>(CREATE TABLE AS)"] --> DB
     DB --> Q["Analytical<br/>queries"]

--- a/content/learn/sql-analytics-duckdb/ranking-and-row-number.mdx
+++ b/content/learn/sql-analytics-duckdb/ranking-and-row-number.mdx
@@ -186,9 +186,9 @@ ORDER BY
 
 ```mermaid
 flowchart TB
-    T["Two players tie at 100,<br/>two tie at 80"] --> RN["ROW_NUMBER:<br/>1, 2, 3, 4, 5"]
+    T["Two players tie at 100,<br/>two tie at 80"] --> RN["<code>ROW_NUMBER:<br/>1, 2, 3, 4, 5</code>"]
     T --> R["RANK:<br/>1, 1, 3, 4, 4"]
-    T --> D["DENSE_RANK:<br/>1, 1, 2, 3, 3"]
+    T --> D["<code>DENSE_RANK:<br/>1, 1, 2, 3, 3</code>"]
 ```
 
 Choosing between them:

--- a/content/learn/sql-analytics-duckdb/working-with-dates.mdx
+++ b/content/learn/sql-analytics-duckdb/working-with-dates.mdx
@@ -40,7 +40,7 @@ ORDER BY
 
 ```mermaid
 flowchart LR
-    D1["2024-03-04"] --> M["date_trunc('month')"]
+    D1["2024-03-04"] --> M["<code>date_trunc('month')</code>"]
     D2["2024-03-18"] --> M
     D3["2024-03-29"] --> M
     M --> R["all become<br/>2024-03-01"]

--- a/content/learn/sqlite-for-beginners/aggregate-functions.mdx
+++ b/content/learn/sqlite-for-beginners/aggregate-functions.mdx
@@ -226,7 +226,7 @@ Read this as: "Keep only Ada's rows, then add their amounts."
 
 ```mermaid
 flowchart LR
-    T[("orders table")] --> W["WHERE customer = 'Ada'"]
+    T[("orders table")] --> W["WHERE <code>customer = 'Ada'</code>"]
     W --> S["SUM(amount)"]
     S --> R["one total"]
 ```

--- a/content/learn/sqlite-for-beginners/aggregate-functions.mdx
+++ b/content/learn/sqlite-for-beginners/aggregate-functions.mdx
@@ -62,7 +62,7 @@ The table has four order rows, so the answer is one row containing the number `4
 ```mermaid
 flowchart TB
     T[("orders table")] --> C["COUNT(*)<br/>count every row"]
-    C --> R["order_count = 4"]
+    C --> R["<code>order_count = 4</code>"]
 ```
 
 ## Adding values with SUM

--- a/content/learn/sqlite-for-beginners/creating-tables.mdx
+++ b/content/learn/sqlite-for-beginners/creating-tables.mdx
@@ -199,7 +199,7 @@ ORDER BY
 flowchart TB
     T["movies table"] --> I["id INTEGER PRIMARY KEY"]
     T --> N["title TEXT NOT NULL"]
-    T --> Y["release_year INTEGER"]
+    T --> Y["<code>release_year</code> INTEGER"]
     T --> D["rating REAL DEFAULT 0.0"]
 ```
 

--- a/content/learn/sqlite-for-beginners/data-organization.mdx
+++ b/content/learn/sqlite-for-beginners/data-organization.mdx
@@ -16,7 +16,7 @@ the customer's name and email, and even the product's price:
 
 ```mermaid
 flowchart TB
-    T["orders_flat<br/>order_id | customer_name | customer_email | product | price"]
+    T["<code>orders_flat</code><br/><code>order_id</code> | <code>customer_name</code> | <code>customer_email</code> | product | price"]
     T --> R1["1 | Ada | ada@x.com | Book | 20"]
     T --> R2["2 | Ada | ada@x.com | Pen | 3"]
     T --> R3["3 | Grace | grace@x.com | Book | 20"]

--- a/content/learn/sqlite-for-beginners/expressions-and-aliases.mdx
+++ b/content/learn/sqlite-for-beginners/expressions-and-aliases.mdx
@@ -18,7 +18,7 @@ SQLite evaluates that calculation for each row in the result.
 ```mermaid
 flowchart LR
     A["one row<br/>price 12.99<br/>quantity 2"] --> B["expression<br/>price * quantity"]
-    B --> C["new result column<br/>line_total 25.98"]
+    B --> C["new result column<br/><code>line_total</code> 25.98"]
 ```
 
 <SqlCodeBlock
@@ -130,7 +130,7 @@ This course uses `AS` because it makes your intent obvious.
 
 ```mermaid
 flowchart LR
-    E["price * quantity"] --> N["AS line_total"]
+    E["price * quantity"] --> N["AS <code>line_total</code>"]
     N --> R["clear result heading"]
 ```
 

--- a/content/learn/sqlite-for-beginners/filtering-groups.mdx
+++ b/content/learn/sqlite-for-beginners/filtering-groups.mdx
@@ -68,9 +68,9 @@ Only Engineering survives because it has 3 employees. Sales has 2 and Marketing 
 
 ```mermaid
 flowchart TB
-    Groups["Department groups"] --> Eng["Engineering<br/>COUNT = 3"]
-    Groups --> Sales["Sales<br/>COUNT = 2"]
-    Groups --> Mkt["Marketing<br/>COUNT = 1"]
+    Groups["Department groups"] --> Eng["Engineering<br/><code>COUNT = 3</code>"]
+    Groups --> Sales["Sales<br/><code>COUNT = 2</code>"]
+    Groups --> Mkt["Marketing<br/><code>COUNT = 1</code>"]
     Eng --> Keep["HAVING COUNT(*) > 2<br/>keep"]
     Sales --> Drop["drop"]
     Mkt --> Drop

--- a/content/learn/sqlite-for-beginners/first-queries.mdx
+++ b/content/learn/sqlite-for-beginners/first-queries.mdx
@@ -62,7 +62,7 @@ A SQL statement is one complete instruction. We end statements with a semicolon 
 ```mermaid
 flowchart TB
     A["SELECT"] --> B["what you want back"]
-    B --> C["AS optional_name"]
+    B --> C["AS <code>optional_name</code>"]
     C --> D["semicolon<br/>end of statement"]
 ```
 

--- a/content/learn/sqlite-for-beginners/foreign-keys.mdx
+++ b/content/learn/sqlite-for-beginners/foreign-keys.mdx
@@ -27,7 +27,7 @@ In this picture, order `101` does not copy Ada's whole customer record. It store
 
 ```mermaid
 flowchart LR
-    O["orders row<br/>id = 101<br/><code>customer_id</code> = 1"] -->|"points to"| C["customers row<br/>id = 1<br/>name = Ada"]
+    O["orders row<br/>id = 101<br/><code>customer_id</code> = 1"] -->|"points to"| C["customers row<br/><code>id = 1</code><br/>name = Ada"]
 ```
 
 This keeps data tidy:
@@ -89,7 +89,7 @@ A foreign key value is a reference to a row in another table.`}
 
 ```mermaid
 flowchart TB
-    Good["order.<code>customer_id</code> = 1"] -->|"exists"| Ada["customers.id = 1<br/>Ada"]
+    Good["order.<code>customer_id</code> = 1"] -->|"exists"| Ada["<code>customers.id = 1</code><br/>Ada"]
     Bad["order.<code>customer_id</code> = 99"] -->|"missing"| Missing["no customer 99"]
     Missing --> Warning["dangling reference"]
 ```
@@ -179,8 +179,8 @@ The join follows the foreign-key arrows and shows readable customer names next t
 ```mermaid
 flowchart TB
     subgraph C["customers"]
-        C1["id = 1<br/>Ada"]
-        C2["id = 2<br/>Grace"]
+        C1["<code>id = 1</code><br/>Ada"]
+        C2["<code>id = 2</code><br/>Grace"]
     end
     subgraph O["orders"]
         O1["<code>101<br/>customer_id = 1</code>"]

--- a/content/learn/sqlite-for-beginners/foreign-keys.mdx
+++ b/content/learn/sqlite-for-beginners/foreign-keys.mdx
@@ -27,7 +27,7 @@ In this picture, order `101` does not copy Ada's whole customer record. It store
 
 ```mermaid
 flowchart LR
-    O["orders row<br/>id = 101<br/>customer_id = 1"] -->|"points to"| C["customers row<br/>id = 1<br/>name = Ada"]
+    O["orders row<br/>id = 101<br/><code>customer_id</code> = 1"] -->|"points to"| C["customers row<br/>id = 1<br/>name = Ada"]
 ```
 
 This keeps data tidy:
@@ -89,8 +89,8 @@ A foreign key value is a reference to a row in another table.`}
 
 ```mermaid
 flowchart TB
-    Good["order.customer_id = 1"] -->|"exists"| Ada["customers.id = 1<br/>Ada"]
-    Bad["order.customer_id = 99"] -->|"missing"| Missing["no customer 99"]
+    Good["order.<code>customer_id</code> = 1"] -->|"exists"| Ada["customers.id = 1<br/>Ada"]
+    Bad["order.<code>customer_id</code> = 99"] -->|"missing"| Missing["no customer 99"]
     Missing --> Warning["dangling reference"]
 ```
 
@@ -183,9 +183,9 @@ flowchart TB
         C2["id = 2<br/>Grace"]
     end
     subgraph O["orders"]
-        O1["101<br/>customer_id = 1"]
-        O2["102<br/>customer_id = 1"]
-        O3["103<br/>customer_id = 2"]
+        O1["<code>101<br/>customer_id = 1</code>"]
+        O2["<code>102<br/>customer_id = 1</code>"]
+        O3["<code>103<br/>customer_id = 2</code>"]
     end
     O1 -->|"FK to PK"| C1
     O2 -->|"FK to PK"| C1

--- a/content/learn/sqlite-for-beginners/grouping-data.mdx
+++ b/content/learn/sqlite-for-beginners/grouping-data.mdx
@@ -278,7 +278,7 @@ The intern row is removed first. Then SQLite groups the remaining rows by depart
 
 ```mermaid
 flowchart LR
-    Raw["Raw employee rows"] --> Where["WHERE is_intern = 0<br/>keep full-time rows"]
+    Raw["Raw employee rows"] --> Where["WHERE <code>is_intern</code> = 0<br/>keep full-time rows"]
     Where --> Group["GROUP BY dept<br/>make department groups"]
     Group --> Avg["AVG(salary)<br/>inside each group"]
     Avg --> Result["One row per department"]

--- a/content/learn/sqlite-for-beginners/inner-joins.mdx
+++ b/content/learn/sqlite-for-beginners/inner-joins.mdx
@@ -67,11 +67,11 @@ Ada and Grace appear because they have matching orders. Linus disappears because
 
 ```mermaid
 flowchart LR
-    C1["customer 1<br/>Ada"] -->|"matches"| O1["order 101<br/>customer_id 1"]
-    C1 -->|"matches"| O2["order 102<br/>customer_id 1"]
-    C2["customer 2<br/>Grace"] -->|"matches"| O3["order 103<br/>customer_id 2"]
+    C1["customer 1<br/>Ada"] -->|"matches"| O1["order 101<br/><code>customer_id</code> 1"]
+    C1 -->|"matches"| O2["order 102<br/><code>customer_id</code> 1"]
+    C2["customer 2<br/>Grace"] -->|"matches"| O3["order 103<br/><code>customer_id</code> 2"]
     C3["customer 3<br/>Linus"] -.-> Drop1["dropped<br/>no matching order"]
-    O4["order 104<br/>customer_id 7"] -.-> Drop2["dropped<br/>no matching customer"]
+    O4["order 104<br/><code>customer_id</code> 7"] -.-> Drop2["dropped<br/>no matching customer"]
 ```
 
 <MultipleChoice

--- a/content/learn/sqlite-for-beginners/many-to-many.mdx
+++ b/content/learn/sqlite-for-beginners/many-to-many.mdx
@@ -22,8 +22,8 @@ If you put `course_id` on `students`, each student could store only one course. 
 
 ```mermaid
 flowchart TB
-    Bad1["students.course_id"] --> Problem1["one student row<br/>can point to only one course"]
-    Bad2["courses.student_id"] --> Problem2["one course row<br/>can point to only one student"]
+    Bad1["students.<code>course_id</code>"] --> Problem1["one student row<br/>can point to only one course"]
+    Bad2["courses.<code>student_id</code>"] --> Problem2["one course row<br/>can point to only one student"]
     Problem1 --> Need["need many links<br/>on both sides"]
     Problem2 --> Need
 ```
@@ -169,7 +169,7 @@ ORDER BY
 
 ```mermaid
 flowchart TB
-    E1["enrollment<br/>student_id 1<br/>course_id 10"] -->|"student_id = id"| S1["Ada"]
+    E1["enrollment<br/><code>student_id</code> 1<br/><code>course_id</code> 10"] -->|"student_id = id"| S1["Ada"]
     E1 -->|"course_id = id"| C1["Math"]
     S1 --> R["Ada takes Math"]
     C1 --> R

--- a/content/learn/sqlite-for-beginners/outer-joins.mdx
+++ b/content/learn/sqlite-for-beginners/outer-joins.mdx
@@ -85,7 +85,7 @@ When SQLite cannot find a matching right-side row, it cannot show a real `orders
 
 ```mermaid
 flowchart LR
-    C["customer<br/>Linus"] -->|"no matching order"| N["order_id = NULL<br/>amount = NULL"]
+    C["customer<br/>Linus"] -->|"no matching order"| N["<code>order_id</code> = NULL<br/>amount = NULL"]
 ```
 
 <SqlCodeBlock

--- a/content/learn/sqlite-for-beginners/relationships-intro.mdx
+++ b/content/learn/sqlite-for-beginners/relationships-intro.mdx
@@ -34,7 +34,7 @@ The customer table has a primary key: `customers.id`. The orders table stores a 
 
 ```mermaid
 flowchart LR
-    C["customers.id<br/>primary key"]:::pk --> O["orders.customer_id<br/>points to customer"]:::fk
+    C["customers.id<br/>primary key"]:::pk --> O["orders.<code>customer_id</code><br/>points to customer"]:::fk
     classDef pk fill:#fde68a,stroke:#b45309
     classDef fk fill:#dcfce7,stroke:#15803d
 ```
@@ -156,7 +156,7 @@ The helper table stores the pairs: which student is in which course.
 
 ```mermaid
 flowchart TB
-    S["students"] --> E["enrollments<br/>student_id plus course_id"]
+    S["students"] --> E["enrollments<br/><code>student_id</code> plus <code>course_id</code>"]
     C["courses"] --> E
     E --> PAIR["One row means<br/>one student-course pairing"]
 ```

--- a/content/learn/sqlite-for-beginners/relationships-intro.mdx
+++ b/content/learn/sqlite-for-beginners/relationships-intro.mdx
@@ -34,7 +34,7 @@ The customer table has a primary key: `customers.id`. The orders table stores a 
 
 ```mermaid
 flowchart LR
-    C["customers.id<br/>primary key"]:::pk --> O["orders.<code>customer_id</code><br/>points to customer"]:::fk
+    C["<code>customers.id</code><br/>primary key"]:::pk --> O["orders.<code>customer_id</code><br/>points to customer"]:::fk
     classDef pk fill:#fde68a,stroke:#b45309
     classDef fk fill:#dcfce7,stroke:#15803d
 ```

--- a/content/learn/sqlite-for-beginners/spreadsheets-vs-databases.mdx
+++ b/content/learn/sqlite-for-beginners/spreadsheets-vs-databases.mdx
@@ -114,7 +114,7 @@ A relational database can separate those ideas:
 ```mermaid
 flowchart LR
     C["customers"] --> O["orders"]
-    O --> I["order_items"]
+    O --> I["<code>order_items</code>"]
     I --> P["products"]
 ```
 

--- a/content/learn/sqlite-for-beginners/understanding-joins.mdx
+++ b/content/learn/sqlite-for-beginners/understanding-joins.mdx
@@ -14,8 +14,8 @@ flowchart LR
         C2["id 2<br/>Grace"]
     end
     subgraph O["orders"]
-        O1["order 101<br/>customer_id 1<br/>42"]
-        O2["order 102<br/>customer_id 2<br/>99"]
+        O1["order 101<br/><code>customer_id</code> 1<br/>42"]
+        O2["order 102<br/><code>customer_id</code> 2<br/>99"]
     end
     O1 -->|"customer_id = id"| C1
     O2 -->|"customer_id = id"| C2
@@ -67,7 +67,7 @@ A useful beginner mental model is **cartesian then filter**:
 ```mermaid
 flowchart TB
     A["Start with one order row"] --> B["Try pairing it with each customer row"]
-    B --> C{"Does<br/>order.customer_id = customer.id?"}
+    B --> C{"Does<br/>order.<code>customer_id</code> = customer.id?"}
     C -->|"yes"| D["keep this pair"]
     C -->|"no"| E["discard this pair"]
 ```

--- a/content/learn/sqlite-for-beginners/understanding-tables.mdx
+++ b/content/learn/sqlite-for-beginners/understanding-tables.mdx
@@ -109,7 +109,7 @@ A better design gives each kind of thing its own table.
 
 ```mermaid
 flowchart LR
-    MIX["mixed_sales<br/>one confusing table"] --> SPLIT["Split by kind of thing"]
+    MIX["<code>mixed_sales</code><br/>one confusing table"] --> SPLIT["Split by kind of thing"]
     SPLIT --> C["customers<br/>one row per customer"]
     SPLIT --> P["products<br/>one row per product"]
     SPLIT --> O["orders<br/>one row per order"]

--- a/content/learn/sqlite-for-beginners/why-sqlite.mdx
+++ b/content/learn/sqlite-for-beginners/why-sqlite.mdx
@@ -71,7 +71,7 @@ That file can contain many tables, indexes, and rows.
 
 ```mermaid
 flowchart TB
-    A[("app.db")]
+    A[("<code>app.db</code>")]
     A --> B["users table"]
     A --> C["orders table"]
     A --> D["settings table"]

--- a/content/learn/statistics-for-data-science-python/anova-and-chi-square.mdx
+++ b/content/learn/statistics-for-data-science-python/anova-and-chi-square.mdx
@@ -208,7 +208,7 @@ are linked.
 ```mermaid
 flowchart LR
   A["Two categorical columns<br/>(e.g. device, churned)"] --> B["pandas crosstab<br/>(contingency table of COUNTS)"]
-  B --> C["chi2_contingency<br/>compares observed vs expected"]
+  B --> C["<code>chi2_contingency</code><br/>compares observed vs expected"]
   C --> D{"p <= alpha?"}
   D -->|"yes"| E["Variables are associated"]
   D -->|"no"| F["No evidence of association"]

--- a/content/learn/statistics-for-data-science-python/conditional-probability.mdx
+++ b/content/learn/statistics-for-data-science-python/conditional-probability.mdx
@@ -203,7 +203,7 @@ flowchart TD
   D --> DN["Test -: 1<br/>(false negative)"]
   H --> HP["Test +: 999<br/>(false positives)"]
   H --> HN["Test -: 98,901<br/>(true negatives)"]
-  DP --> R["Positives total = 99 + 999 = 1,098<br/>Truly sick among them = 99<br/>P(disease | +) = 99 / 1,098 = 9%"]
+  DP --> R["Positives <code>total = 99</code> + 999 = 1,098<br/>Truly sick among <code>them = 99</code><br/>P(disease | +) = 99 / 1,098 = 9%"]
   HP --> R
 ```
 

--- a/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
@@ -221,7 +221,7 @@ percentile. It's the tool for setting thresholds, SLAs, and cutoffs.
 flowchart LR
   A["a value x"] -->|"cdf: P(X <= x)"| B["a probability"]
   B -->|"ppf: inverse"| A
-  C["ppf(0.9) = the value below<br/>which 90% of outcomes fall"]
+  C["<code>ppf(0.9)</code> = the value below<br/>which 90% of outcomes fall"]
 ```
 
 <CodeBlock

--- a/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
@@ -37,7 +37,7 @@ about ranges.
 flowchart TD
   A["Continuous variable X<br/>(wait time, salary, ...)"] --> B["Described by a PDF<br/>(a smooth density curve)"]
   B --> C["P(a < X < b) = AREA<br/>under the curve from a to b"]
-  C --> D["Total area = 1<br/>P(X = exact point) = 0"]
+  C --> D["Total <code>area = 1</code><br/>P(X = exact point) = 0"]
 ```
 
 <Callout type="danger" title="Misconception #1: the PDF height is a probability">

--- a/content/learn/statistics-for-data-science-python/correlation-and-nonparametric.mdx
+++ b/content/learn/statistics-for-data-science-python/correlation-and-nonparametric.mdx
@@ -47,7 +47,7 @@ flowchart TD
   A["Two numeric variables;<br/>want their association"] --> B{"Is the relationship<br/>roughly LINEAR<br/>with no wild outliers?"}
   B -->|"yes"| C["Pearson r<br/>pearsonr"]
   B -->|"no: curved-but-monotonic,<br/>ordinal, or outliers"| D["Spearman rho<br/>spearmanr"]
-  C --> E["Reports linear strength<br/>+ p-value vs r = 0"]
+  C --> E["Reports linear strength<br/>+ p-value vs <code>r = 0</code>"]
   D --> F["Reports monotonic strength<br/>on ranks + p-value"]
 ```
 

--- a/content/learn/statistics-for-data-science-python/effect-sizes.mdx
+++ b/content/learn/statistics-for-data-science-python/effect-sizes.mdx
@@ -36,7 +36,7 @@ information about whether you should care.
 ```mermaid
 flowchart LR
   A["Effect exists?"] -->|"p-value answers this"| B["Yes / can't tell"]
-  C["How big is it?"] -->|"effect size answers this"| D["d = 0.05? r = 0.6?<br/>+8% revenue?"]
+  C["How big is it?"] -->|"effect size answers this"| D["<code>d = 0.05</code>? <code>r = 0.6</code>?<br/>+8% revenue?"]
   B --> E{"Ship decision<br/>needs BOTH"}
   D --> E
 ```
@@ -60,10 +60,10 @@ apart — only an effect size can.
 
 ```mermaid
 flowchart TD
-  P["Both studies report<br/>p = 0.03"] --> S1["Study A:<br/>tiny effect, huge n"]
+  P["Both studies report<br/><code>p = 0.03</code>"] --> S1["Study A:<br/>tiny effect, huge n"]
   P --> S2["Study B:<br/>large effect, small n"]
-  S1 --> O1["Effect size d = 0.04<br/>(ignore it)"]
-  S2 --> O2["Effect size d = 0.9<br/>(act on it)"]
+  S1 --> O1["Effect size <code>d = 0.04</code><br/>(ignore it)"]
+  S2 --> O2["Effect size <code>d = 0.9</code><br/>(act on it)"]
 ```
 
 The p-value is a function of *signal divided by noise divided by

--- a/content/learn/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
+++ b/content/learn/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
@@ -71,16 +71,6 @@ A disciplined exploration moves through a rough sequence. It's iterative,
 not linear — findings send you back upstream — but the stages give you a
 checklist so you don't miss something basic.
 
-```mermaid
-flowchart TD
-  A["1. Understand the shape<br/>(rows, columns, dtypes)"] --> B["2. Each variable alone<br/>(distributions, summaries)"]
-  B --> C["3. Missingness<br/>(how much, where, why)"]
-  C --> D["4. Outliers<br/>(errors vs real extremes)"]
-  D --> E["5. Relationships<br/>(groupby, correlation)"]
-  E --> F["6. Form hypotheses<br/>(to confirm LATER)"]
-  F -. "iterate" .-> B
-```
-
 Here is that checklist as a walkthrough — the question each stage answers:
 
 <Steps>

--- a/content/learn/statistics-for-data-science-python/measures-of-spread.mdx
+++ b/content/learn/statistics-for-data-science-python/measures-of-spread.mdx
@@ -44,7 +44,7 @@ print("\\nIdentical means. The spread is the whole story.")
 
 ```mermaid
 flowchart TD
-  A["Both have mean = 30"] --> B["Consistent service<br/>values hug 30"]
+  A["Both have <code>mean = 30</code>"] --> B["Consistent service<br/>values hug 30"]
   A --> C["Erratic service<br/>values from 5 to 55"]
   B --> D["Low spread<br/>predictable, low risk"]
   C --> E["High spread<br/>unpredictable, high risk"]

--- a/content/learn/statistics-for-data-science-python/probability-basics.mdx
+++ b/content/learn/statistics-for-data-science-python/probability-basics.mdx
@@ -32,8 +32,8 @@ about the set of things that could happen. That set has a name.
 
 ```mermaid
 flowchart TD
-  S["Sample space S<br/>all 6 die faces"] --> E1["Event A: even<br/>{2, 4, 6}"]
-  S --> E2["Event B: greater than 4<br/>{5, 6}"]
+  S["Sample space S<br/>all 6 die faces"] --> E1["Event A: even<br/><code>{2, 4, 6}</code>"]
+  S --> E2["Event B: greater than 4<br/><code>{5, 6}</code>"]
   E1 --> O1["outcome 6 is in BOTH<br/>(A and B overlap)"]
   E2 --> O1
 ```

--- a/content/learn/statistics-for-data-science-python/random-variables.mdx
+++ b/content/learn/statistics-for-data-science-python/random-variables.mdx
@@ -28,10 +28,10 @@ take with lowercase `x`.
 
 ```mermaid
 flowchart LR
-  O1["Outcome: HH"] --> N2["X = 2"]
-  O2["Outcome: HT"] --> N1["X = 1"]
+  O1["Outcome: HH"] --> N2["<code>X = 2</code>"]
+  O2["Outcome: HT"] --> N1["<code>X = 1</code>"]
   O3["Outcome: TH"] --> N1
-  O4["Outcome: TT"] --> N0["X = 0"]
+  O4["Outcome: TT"] --> N0["<code>X = 0</code>"]
   N0 --> R["X = number of heads<br/>in 2 coin flips<br/>(a function: outcomes to numbers)"]
   N1 --> R
   N2 --> R

--- a/content/learn/statistics-for-data-science-python/t-tests.mdx
+++ b/content/learn/statistics-for-data-science-python/t-tests.mdx
@@ -70,10 +70,10 @@ data?** Getting this wrong is the single most common t-test mistake.
 ```mermaid
 flowchart TD
   A["You want to compare means"] --> B{"How many groups?"}
-  B -->|"one group vs a fixed number"| C["One-sample t-test<br/>ttest_1samp"]
+  B -->|"one group vs a fixed number"| C["One-sample t-test<br/><code>ttest_1samp</code>"]
   B -->|"two groups"| D{"Are the two columns<br/>the SAME units<br/>measured twice?"}
-  D -->|"yes (before/after,<br/>matched pairs)"| E["Paired t-test<br/>ttest_rel"]
-  D -->|"no (independent groups)"| F["Two-sample t-test<br/>ttest_ind, equal_var=False"]
+  D -->|"yes (before/after,<br/>matched pairs)"| E["Paired t-test<br/><code>ttest_rel</code>"]
+  D -->|"no (independent groups)"| F["Two-sample t-test<br/><code>ttest_ind</code>, <code>equal_var</code>=False"]
 ```
 
 We'll take them one at a time.

--- a/content/learn/statistics-for-data-science-python/the-bootstrap.mdx
+++ b/content/learn/statistics-for-data-science-python/the-bootstrap.mdx
@@ -87,7 +87,7 @@ flowchart LR
   B --> C["Compute statistic<br/>on each resample"]
   C --> D["Collect B values =<br/>bootstrap distribution"]
   D --> E1["std = standard error"]
-  D --> E2["2.5 / 97.5 pct = 95% CI"]
+  D --> E2["2.5 / 97.5 <code>pct = 95</code>% CI"]
 ```
 
 ## Bootstrapping a mean (and checking it)

--- a/content/learn/statistics-for-data-science-python/types-of-data.mdx
+++ b/content/learn/statistics-for-data-science-python/types-of-data.mdx
@@ -35,7 +35,7 @@ much* or *how many*). Each splits once more:
 flowchart TD
     V["A variable"] --> CAT["Categorical<br/>(labels / groups)"]
     V --> NUM["Numerical<br/>(quantities)"]
-    CAT --> NOM["Nominal<br/>(no order)<br/>e.g. country, color, user_id"]
+    CAT --> NOM["Nominal<br/>(no order)<br/>e.g. country, color, <code>user_id</code>"]
     CAT --> ORD["Ordinal<br/>(ordered, uneven gaps)<br/>e.g. S/M/L, ratings, education level"]
     NUM --> DISC["Discrete<br/>(countable, whole)<br/>e.g. logins, defects, children"]
     NUM --> CONT["Continuous<br/>(any value in a range)<br/>e.g. height, price, latency"]
@@ -114,7 +114,7 @@ type, the right summary and chart almost pick themselves.
 ```mermaid
 flowchart TD
     START["A column to summarize"] --> Q1{"Categorical or numerical?"}
-    Q1 -->|"categorical"| C1["Counts / proportions<br/>value_counts, mode"]
+    Q1 -->|"categorical"| C1["Counts / proportions<br/><code>value_counts</code>, mode"]
     C1 --> C2["Plot: bar chart"]
     Q1 -->|"numerical"| Q2{"Roughly symmetric,<br/>no big outliers?"}
     Q2 -->|"yes"| N1["Center: mean<br/>Spread: standard deviation"]

--- a/content/learn/systems-programming-c/arrays-and-pointers.mdx
+++ b/content/learn/systems-programming-c/arrays-and-pointers.mdx
@@ -34,7 +34,7 @@ no per-element header.
 ```mermaid
 flowchart LR
     subgraph Mem["Memory"]
-        A0["nums[0]<br/>10"] --> A1["nums[1]<br/>20"] --> A2["nums[2]<br/>30"] --> A3["nums[3]<br/>40"] --> A4["nums[4]<br/>50"]
+        A0["<code>nums[0]<br/>10</code>"] --> A1["<code>nums[1]<br/>20</code>"] --> A2["<code>nums[2]<br/>30</code>"] --> A3["<code>nums[3]<br/>40</code>"] --> A4["<code>nums[4]<br/>50</code>"]
     end
     N["nums<br/>(name for<br/>the start)"] --> A0
 ```

--- a/content/learn/systems-programming-c/c-toolchain.mdx
+++ b/content/learn/systems-programming-c/c-toolchain.mdx
@@ -13,14 +13,14 @@ to add `foo.c` to the link command.
 
 ```mermaid
 flowchart TD
-    A["hello.c<br/>(source)"] --> B[Preprocessor]
-    B --> C["hello.i<br/>(translation unit)"]
+    A["<code>hello.c</code><br/>(source)"] --> B[Preprocessor]
+    B --> C["<code>hello.i</code><br/>(translation unit)"]
     C --> D[Compiler]
-    D --> E["hello.s<br/>(assembly)"]
+    D --> E["<code>hello.s</code><br/>(assembly)"]
     E --> F[Assembler]
-    F --> G["hello.o<br/>(object file)"]
+    F --> G["<code>hello.o</code><br/>(object file)"]
     G --> H[Linker]
-    I["libc.a"] --> H
+    I["<code>libc.a</code>"] --> H
     J["other .o files"] --> H
     H --> K["a.out<br/>(executable)"]
 ```

--- a/content/learn/systems-programming-c/pointers.mdx
+++ b/content/learn/systems-programming-c/pointers.mdx
@@ -56,7 +56,7 @@ Two operators move between values and addresses:
 
 ```mermaid
 flowchart LR
-    P["pointer p<br/>(its value is<br/>0x7ffc1234)"] -->|*p reads /<br/>writes there| V["int value 42<br/>at 0x7ffc1234"]
+    P["pointer p<br/>(its value is<br/><code>0x7ffc1234</code>)"] -->|*p reads /<br/>writes there| V["int value 42<br/>at <code>0x7ffc1234</code>"]
     V -->|&x gives| P
 ```
 

--- a/content/learn/systems-programming-c/stack-and-functions.mdx
+++ b/content/learn/systems-programming-c/stack-and-functions.mdx
@@ -28,9 +28,9 @@ A typical frame contains:
 flowchart TB
     A["High addresses"]
     A --> F3["main's frame<br/>(locals + return addr<br/>to OS startup)"]
-    F3 --> F2["fib(5) frame<br/>(n=5, return addr to main)"]
-    F2 --> F1["fib(4) frame<br/>(n=4, return addr to fib(5))"]
-    F1 --> F0["fib(3) frame<br/>(n=3, return addr to fib(4))"]
+    F3 --> F2["<code>fib(5)</code> frame<br/>(n=5, return addr to main)"]
+    F2 --> F1["<code>fib(4)</code> frame<br/>(n=4, return addr to <code>fib(5)</code>)"]
+    F1 --> F0["<code>fib(3)</code> frame<br/>(n=3, return addr to <code>fib(4)</code>)"]
     F0 --> SP["stack pointer<br/>(top of stack — grows downward)"]
     SP --> Z["Low addresses"]
 ```

--- a/content/learn/systems-programming-c/structs-and-unions.mdx
+++ b/content/learn/systems-programming-c/structs-and-unions.mdx
@@ -74,7 +74,7 @@ that arrays of the struct stay aligned.
 
 ```mermaid
 flowchart LR
-    subgraph bad["struct Bad { char c; int i; char d; }"]
+    subgraph bad["struct Bad <code>{ char c; int i; char d; }</code>"]
         b0["c<br/>1 B"] --> b1["pad<br/>3 B"] --> b2["i<br/>4 B"] --> b3["d<br/>1 B"] --> b4["pad<br/>3 B"]
     end
 ```

--- a/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
+++ b/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
@@ -388,7 +388,7 @@ timeline, and the rest of pandas' time tooling switches on.
 ```mermaid
 flowchart LR
     S["Raw date strings"] -->|"pd.to_datetime()"| T["<code>DatetimeIndex</code>"]
-    T --> SL["Partial-string slicing<br/>df.loc['1955']"]
+    T --> SL["Partial-string slicing<br/><code>df.loc</code>['1955']"]
     T --> RS["<code>resample()</code><br/>(next page)"]
     T --> RW["<code>rolling()</code>"]
     T --> AL["Automatic alignment"]

--- a/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
+++ b/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
@@ -387,10 +387,10 @@ timeline, and the rest of pandas' time tooling switches on.
 
 ```mermaid
 flowchart LR
-    S["Raw date strings"] -->|"pd.to_datetime()"| T["DatetimeIndex"]
+    S["Raw date strings"] -->|"pd.to_datetime()"| T["<code>DatetimeIndex</code>"]
     T --> SL["Partial-string slicing<br/>df.loc['1955']"]
-    T --> RS["resample()<br/>(next page)"]
-    T --> RW["rolling()"]
+    T --> RS["<code>resample()</code><br/>(next page)"]
+    T --> RW["<code>rolling()</code>"]
     T --> AL["Automatic alignment"]
 ```
 

--- a/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
+++ b/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
@@ -120,8 +120,8 @@ Both `service.ts` and `client.ts` import from `types.ts`. If you add a field to 
 
 ```mermaid
 graph LR
-    A[types.ts<br/>Shared Contract] --> B[service.ts<br/>Producer]
-    A --> C[client.ts<br/>Consumer]
+    A["<code>types.ts</code><br/>Shared Contract"] --> B["<code>service.ts</code><br/>Producer"]
+    A --> C["<code>client.ts</code><br/>Consumer"]
     B --> D[Runtime]
     C --> D
     style A fill:#fffacd

--- a/content/learn/typescript-from-scratch/error-handling-with-types.mdx
+++ b/content/learn/typescript-from-scratch/error-handling-with-types.mdx
@@ -258,9 +258,9 @@ Notice:
 
 ```mermaid
 graph TD
-    A[Input: '5'] --> B[parseNumber]
+    A[Input: '5'] --> B["<code>parseNumber</code>"]
     B --> C{ok?}
-    C -->|yes| D[validatePositive]
+    C -->|yes| D["<code>validatePositive</code>"]
     C -->|no| E[Error: Invalid number]
     D --> F{ok?}
     F -->|yes| G[map: square]

--- a/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
+++ b/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
@@ -235,9 +235,9 @@ This pattern ensures that if you add a new event to `EventMap`, the correspondin
 
 ```mermaid
 graph TD
-    A["Value: EventMap<br/>{click: ..., keypress: ..., focus: ...}"] --> B["keyof EventMap<br/>'click' | 'keypress' | 'focus'"]
+    A["Value: EventMap<br/><code>{click: ..., keypress: ..., focus: ...}</code>"] --> B["keyof EventMap<br/>'click' | 'keypress' | 'focus'"]
     B --> C["Template Literal<br/>'onClick' | 'onKeypress' | 'onFocus'"]
-    C --> D["Mapped Type<br/>{onClick: ..., onKeypress: ..., onFocus: ...}"]
+    C --> D["Mapped Type<br/><code>{onClick: ..., onKeypress: ..., onFocus: ...}</code>"]
     style A fill:#e1f5ff
     style D fill:#d4edda
 ```

--- a/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
+++ b/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
@@ -144,9 +144,9 @@ The condition `T[K] extends string ? K : never` keeps only keys whose values are
 
 ```mermaid
 graph TD
-    A["Original Type<br/>{id: number, name: string, active: boolean}"] --> B["Mapped Type Transform"]
+    A["Original Type<br/><code>{id: number, name: string, active: boolean}</code>"] --> B["Mapped Type Transform"]
     B --> C["Filter: keep string props"]
-    C --> D["Result Type<br/>{name: string}"]
+    C --> D["Result Type<br/><code>{name: string}</code>"]
     style A fill:#e1f5ff
     style D fill:#d4edda
 ```

--- a/content/learn/typescript-from-scratch/objects-and-interfaces.mdx
+++ b/content/learn/typescript-from-scratch/objects-and-interfaces.mdx
@@ -293,9 +293,9 @@ compiler merges all the properties from all the extended interfaces.
 
 ```mermaid
 graph TD
-    Named["Named: { name: string }"]
-    Aged["Aged: { age: number }"]
-    Person["Person extends Named, Aged: { email: string }"]
+    Named["Named: <code>{ name: string }</code>"]
+    Aged["Aged: <code>{ age: number }</code>"]
+    Person["Person extends Named, Aged: <code>{ email: string }</code>"]
     
     Named --> Person
     Aged --> Person

--- a/content/learn/typescript-from-scratch/structural-typing.mdx
+++ b/content/learn/typescript-from-scratch/structural-typing.mdx
@@ -57,9 +57,9 @@ Even though `Point` and `Vector` have identical fields, Java rejects the call be
 
 ```mermaid
 graph LR
-    A["Type A: { x: number; y: number }"]
-    B["Type B: { x: number; y: number }"]
-    C["Type C: { x: number; y: number; z: number }"]
+    A["Type A: <code>{ x: number; y: number }</code>"]
+    B["Type B: <code>{ x: number; y: number }</code>"]
+    C["Type C: <code>{ x: number; y: number; z: number }</code>"]
     A -->|Compatible| B
     B -->|Compatible| A
     C -->|Compatible - extra property| A

--- a/content/learn/typescript-from-scratch/type-narrowing.mdx
+++ b/content/learn/typescript-from-scratch/type-narrowing.mdx
@@ -272,9 +272,9 @@ The `switch` on `result.status` narrows `result` in each `case`.
 ```mermaid
 graph TD
     Start["result: Result"]
-    CheckStatus{"switch result.status"}
-    Success["case 'success': result.data"]
-    Failure["case 'failure': result.error"]
+    CheckStatus{"switch <code>result.status</code>"}
+    Success["case 'success': <code>result.data</code>"]
+    Failure["case 'failure': <code>result.error</code>"]
     Pending["case 'pending': (no extra fields)"]
     
     Start --> CheckStatus

--- a/scripts/audit/code-shapes.mjs
+++ b/scripts/audit/code-shapes.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+// Audit / fixer: wrap code in flowchart labels with <code> tags so the Mermaid
+// component renders it in `var(--font-mono)` (see app/_components/mdx/mermaid.
+// module.css and mermaid.tsx). Two cases:
+//   • whole-label code  →  U[std::unique_ptr]      → U["<code>std::unique_ptr</code>"]
+//   • code inside prose →  B[Click execute() now]  → B["Click <code>execute()</code> now"]
+// Prose stays in the sans body font.
+//
+//   node scripts/audit/code-shapes.mjs            # dry-run report
+//   node scripts/audit/code-shapes.mjs --apply    # rewrite the .mdx files
+//
+// Conservative by design: only flowchart/graph blocks, and only spans with a
+// strong, unambiguous code signal (scope `::`, a call `f(…)`, a template `<T>`,
+// a member call `a.b()`, or snake_case). Bare words, proper nouns (JavaScript),
+// math notation (AR(p), y(t)) and prose-with-a-parenthetical are left alone.
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "content/learn";
+const APPLY = process.argv.includes("--apply");
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) out.push(...walk(p));
+    else if (name.endsWith(".mdx")) out.push(p);
+  }
+  return out;
+}
+
+const SKIP_LINE = /^\s*(flowchart|graph|subgraph|end\b|classDef|class\s|click|style|linkStyle|direction|%%)/i;
+
+// Shape openers (longest first) → their valid closing brackets.
+const SHAPES = [
+  ["[[", ["]]"]],
+  ["[(", [")]"]],
+  ["([", ["])"]],
+  ["((", ["))"]],
+  ["{{", ["}}"]],
+  ["[/", ["/]", "\\]"]],
+  ["[\\", ["\\]", "/]"]],
+  ["[", ["]"]],
+  ["(", [")"]],
+  ["{", ["}"]],
+  [">", ["]"]],
+];
+
+// Scan from `start` to the first closer (one of `closers`) lying OUTSIDE a
+// double-quoted region — so a quoted label can contain the bracket char, e.g.
+// `["unit_prices: [9.99, …]"]`. Returns { start, end } of the closer, or null.
+function scanClose(line, start, closers) {
+  const N = line.length;
+  let i = start;
+  while (i < N) {
+    if (line[i] === '"') {
+      i++;
+      while (i < N && line[i] !== '"') {
+        if (line[i] === "\\") i++;
+        i++;
+      }
+      i++;
+      continue;
+    }
+    for (const cl of closers) if (line.startsWith(cl, i)) return { start: i, end: i + cl.length };
+    i++;
+  }
+  return null;
+}
+
+// Find node declarations: an id immediately followed by a shape bracket. Returns
+// [{ contentStart, contentEnd, declEnd }] with the label spanning
+// [contentStart, contentEnd) (quotes included if present).
+function findNodes(line) {
+  const out = [];
+  const N = line.length;
+  const word = (ch) => /[A-Za-z0-9_]/.test(ch);
+  let i = 0;
+  while (i < N) {
+    // Skip quoted regions that aren't a node label — e.g. edge labels
+    // (`-->|"fit(x)"|`), where `fit(x)` must NOT be mistaken for a node.
+    if (line[i] === '"') {
+      i++;
+      while (i < N && line[i] !== '"') {
+        if (line[i] === "\\") i++;
+        i++;
+      }
+      i++;
+      continue;
+    }
+    // An id begins a node only at a boundary and not as a member access
+    // (`.fit` / `::x`), which would be a call inside a label, not a node.
+    const prev = line[i - 1];
+    if (word(line[i]) && (i === 0 || (!word(prev) && prev !== "." && prev !== ":"))) {
+      let j = i;
+      while (j < N && word(line[j])) j++;
+      let matched = null;
+      for (const [open, closers] of SHAPES) {
+        if (line.startsWith(open, j)) {
+          const cs = j + open.length;
+          const close = scanClose(line, cs, closers);
+          if (close) {
+            matched = { contentStart: cs, contentEnd: close.start, declEnd: close.end };
+            break;
+          }
+        }
+      }
+      if (matched) {
+        out.push(matched);
+        i = matched.declEnd;
+        continue;
+      }
+      i = j;
+    } else {
+      i++;
+    }
+  }
+  return out;
+}
+
+function normalize(label) {
+  return label
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#?\w+;/g, " ")
+    .replace(/^["'`]|["'`]$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// Single-token code keywords lacking `_`/camelCase but unambiguously code.
+const CODE_WORDS = new Set([
+  "nullptr", "malloc", "calloc", "realloc", "printf", "scanf", "sizeof",
+  "typedef", "stdout", "stderr", "stdin", "argc", "argv",
+]);
+
+// Proper nouns / product names that happen to match the camelCase or
+// member-path patterns (PostgreSQL → "eS", Plotly.js → member) but are NOT code.
+// Only these block a whole-label wrap; embedded spans never match bare names.
+const NOT_CODE = new Set([
+  "javascript", "typescript", "mysql", "postgresql", "duckdb", "numpy", "scipy",
+  "webgl", "macos", "ironpython", "ironruby", "plotly.js", "d3.js", "vb.net",
+]);
+
+// A function name that reads as a code identifier rather than math notation.
+// Excludes single letters and short all-caps tokens — so `fib(5)`, `resample()`
+// and `value_counts()` pass, but `y(t)`, `AR(p)`, `I(d)`, `O(n)` and
+// `Poisson(lambda)` (a capitalized distribution) do not.
+function isCodeName(n) {
+  return n.length >= 2 && (/_/.test(n) || /^[a-z]/.test(n) || /[a-z][A-Z]/.test(n));
+}
+
+// Is the WHOLE label pure code? Subtract every identifier-bearing construct;
+// if one was removed and no alphabetic prose residue remains, it was all code.
+// Numbers/operators are stripped but don't, alone, make a label "code".
+function isWholeCode(rawLabel) {
+  let s = normalize(rawLabel);
+  if (!s || /[?]/.test(s)) return false;
+  if (CODE_WORDS.has(s.toLowerCase())) return true;
+
+  let removedIdent = false;
+  const ident = [
+    /[A-Za-z_]\w*(?:::[A-Za-z_~]\w*)+(?:<[^<>]*>)?(?:\([^)]*\))?/g, // a::b<T>(…)
+    /[A-Za-z_]\w*<[A-Za-z_][^<>]*>(?:\([^)]*\))?/g, // vector<int>
+    /[A-Za-z_]\w*\[[^\]]*\]/g, // arr[i]
+    /\b[A-Za-z]\w*_\w+\b/g, // snake_case (any case)
+    /[*&]+[A-Za-z_]\w*|[A-Za-z_]\w*[*&]+/g, // *ptr / T&
+  ];
+  for (const re of ident) {
+    if (re.test(s)) {
+      removedIdent = true;
+      s = s.replace(re, " ");
+    }
+  }
+  // Member paths (df.head()) and camelCase names (DataFrame) — but skip proper
+  // nouns (Plotly.js, JavaScript) so a label that is *only* a product name
+  // isn't treated as code.
+  const removeGuarded = (re) => {
+    s = s.replace(re, (m) => {
+      if (NOT_CODE.has(m.toLowerCase())) return m;
+      removedIdent = true;
+      return " ";
+    });
+  };
+  removeGuarded(/[A-Za-z_]\w+(?:\.[A-Za-z_]\w+)+(?:\([^)]*\))?/g); // df.head()
+  removeGuarded(/\b\w*[a-z][A-Z]\w*\b/g); // camelCase / PascalCase-multiword
+  // Plain calls only when the callee reads as code (not math like AR(p), y(t)),
+  // and not a "word(s)" English pluralization.
+  s = s.replace(/([A-Za-z_]\w*)\(([^()]*)\)/g, (m, name, args) => {
+    if (isCodeName(name) && args.trim() !== "s") {
+      removedIdent = true;
+      return " ";
+    }
+    return m;
+  });
+  s = s
+    .replace(/->|=>|<-|<<|>>|&&|\|\||==|!=|<=|>=|\+\+|--|\+=|-=|%>%|\|>|:=/g, " ")
+    .replace(/[-+]?\b\d[\w.]*\b/g, " ");
+  return removedIdent && s.replace(/[^A-Za-z]+/g, " ").trim().length === 0;
+}
+
+// High-confidence code spans to wrap inside an otherwise-prose label.
+const SPAN = new RegExp(
+  "\\b[A-Za-z_]\\w*(?:::[A-Za-z_~]\\w*)+(?:<[A-Za-z_][^<>]*>)?(?:\\([^()]*\\))?" + // std::a<T>(…)
+    "|\\b[A-Za-z_]\\w+(?:\\.[A-Za-z_]\\w+)+\\([^()]*\\)" + // df.head()
+    "|\\b[A-Za-z_]\\w*<[A-Za-z_][^<>]*>(?:\\([^()]*\\))?" + // vector<int>
+    "|\\b[A-Za-z_]\\w*\\([^()]*\\)" + // value_counts()
+    "|\\b[A-Za-z]\\w*_\\w+\\b", // snake_case
+  "g",
+);
+
+// Escape a code string for an HTML mermaid label: <br/> is preserved (line
+// break), but other </>/& are entity-encoded so Mermaid's sanitizer doesn't
+// strip template brackets (std::vector<int>, IEnumerable<T>) as unknown tags.
+function escHtml(t) {
+  return t
+    .split(/(<br\s*\/?>)/i)
+    .map((p) =>
+      /^<br/i.test(p)
+        ? "<br/>"
+        : p
+            .replace(/&(?!(?:amp|lt|gt|quot|#\d+|#x[0-9a-fA-F]+);)/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;"),
+    )
+    .join("");
+}
+
+// Rewrite one label, returning { label, tags }. Wraps the whole label if it is
+// pure code, else wraps embedded code spans (segment by segment so a span can't
+// cross or swallow a <br/>). Returns the label unchanged if nothing matched or
+// it is already coded.
+function rewriteLabel(rawLabel) {
+  if (rawLabel == null || rawLabel === "") return { label: rawLabel, tags: [] };
+  const qm = rawLabel.match(/^(["'])([\s\S]*)\1$/);
+  const inner = qm ? qm[2] : rawLabel;
+  if (/<code/i.test(inner)) return { label: rawLabel, tags: [] };
+
+  const tags = [];
+  let out;
+  if (isWholeCode(inner)) {
+    out = `<code>${escHtml(inner)}</code>`;
+    tags.push(normalize(inner));
+  } else {
+    let any = false;
+    out = inner
+      .split(/(<br\s*\/?>)/i)
+      .map((seg) =>
+        /^<br/i.test(seg)
+          ? seg
+          : seg.replace(SPAN, (s) => {
+              const plain = s.match(/^([A-Za-z_]\w*)\(([^()]*)\)$/);
+              if (plain && (!isCodeName(plain[1]) || plain[2].trim() === "s"))
+                return s; // math notation / "word(s)" pluralization
+              any = true;
+              tags.push(s);
+              return `<code>${escHtml(s)}</code>`;
+            }),
+      )
+      .join("");
+    if (!any) return { label: rawLabel, tags: [] };
+  }
+  return { label: `"${out.replace(/"/g, "&quot;")}"`, tags };
+}
+
+function processLine(line, isFlow) {
+  if (!isFlow || SKIP_LINE.test(line)) return { line, tags: [] };
+  const nodes = findNodes(line);
+  if (!nodes.length) return { line, tags: [] };
+  const tags = [];
+  let out = "";
+  let pos = 0;
+  for (const n of nodes) {
+    const raw = line.slice(n.contentStart, n.contentEnd);
+    const res = rewriteLabel(raw);
+    out += line.slice(pos, n.contentStart);
+    if (res.tags.length && res.label !== raw) {
+      out += res.label;
+      tags.push(...res.tags);
+    } else {
+      out += raw;
+    }
+    pos = n.contentEnd;
+  }
+  out += line.slice(pos);
+  return { line: out, tags };
+}
+
+const files = walk(ROOT).sort();
+let totalTags = 0;
+let filesTouched = 0;
+const report = [];
+
+for (const f of files) {
+  const lines = readFileSync(f, "utf8").split("\n");
+  let inMermaid = false;
+  let isFlow = false;
+  let changed = false;
+  const fileTags = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*```mermaid\s*$/.test(lines[i])) {
+      inMermaid = true;
+      isFlow = false;
+      continue;
+    }
+    if (inMermaid && /^\s*```\s*$/.test(lines[i])) {
+      inMermaid = false;
+      continue;
+    }
+    if (!inMermaid) continue;
+    if (/^\s*(flowchart|graph)\b/i.test(lines[i])) isFlow = true;
+    const { line, tags } = processLine(lines[i], isFlow);
+    if (tags.length) {
+      fileTags.push({ line: i + 1, tags });
+      if (line !== lines[i]) {
+        lines[i] = line;
+        changed = true;
+      }
+    }
+  }
+  if (fileTags.length) {
+    filesTouched++;
+    for (const t of fileTags) totalTags += t.tags.length;
+    report.push({ f, fileTags });
+    if (APPLY && changed) writeFileSync(f, lines.join("\n"));
+  }
+}
+
+for (const { f, fileTags } of report) {
+  const all = fileTags.flatMap((t) => t.tags);
+  console.log(`\n${f}  (${all.length})`);
+  for (const t of fileTags) console.log(`  :${t.line}  ${t.tags.join("  ·  ")}`);
+}
+console.log(
+  `\n${APPLY ? "WRAPPED" : "WOULD WRAP"} ${totalTags} code spans across ${filesTouched} files.`,
+);

--- a/scripts/audit/code-shapes.mjs
+++ b/scripts/audit/code-shapes.mjs
@@ -30,7 +30,7 @@ function walk(dir) {
   return out;
 }
 
-const SKIP_LINE = /^\s*(flowchart|graph|subgraph|end\b|classDef|class\s|click|style|linkStyle|direction|%%)/i;
+const SKIP_LINE = /^\s*(flowchart|graph|end\b|classDef|class\s|click|style|linkStyle|direction|%%)/i;
 
 // Shape openers (longest first) → their valid closing brackets.
 const SHAPES = [
@@ -144,7 +144,16 @@ const CODE_WORDS = new Set([
 const NOT_CODE = new Set([
   "javascript", "typescript", "mysql", "postgresql", "duckdb", "numpy", "scipy",
   "webgl", "macos", "ironpython", "ironruby", "plotly.js", "d3.js", "vb.net",
+  // Product/library names that look like a `name.js` file but are prose.
+  "node.js", "next.js", "vue.js", "react.js", "three.js", "express.js", "deno.js",
 ]);
+
+// A dotted span that's really prose, not code: a denylisted product name, or a
+// web domain (example.com, python.org) rather than a source file (hello.c).
+const WEB_TLD = /\.(?:com|org|net|edu|gov)$/i;
+function isProseName(s) {
+  return NOT_CODE.has(s.toLowerCase()) || WEB_TLD.test(s);
+}
 
 // A function name that reads as a code identifier rather than math notation.
 // Excludes single letters and short all-caps tokens — so `fib(5)`, `resample()`
@@ -163,31 +172,33 @@ function isWholeCode(rawLabel) {
   if (CODE_WORDS.has(s.toLowerCase())) return true;
 
   let removedIdent = false;
-  const ident = [
-    /[A-Za-z_]\w*(?:::[A-Za-z_~]\w*)+(?:<[^<>]*>)?(?:\([^)]*\))?/g, // a::b<T>(…)
-    /[A-Za-z_]\w*<[A-Za-z_][^<>]*>(?:\([^)]*\))?/g, // vector<int>
-    /[A-Za-z_]\w*\[[^\]]*\]/g, // arr[i]
-    /\b[A-Za-z]\w*_\w+\b/g, // snake_case (any case)
-    /[*&]+[A-Za-z_]\w*|[A-Za-z_]\w*[*&]+/g, // *ptr / T&
-  ];
-  for (const re of ident) {
+  const mark = (re) => {
     if (re.test(s)) {
       removedIdent = true;
       s = s.replace(re, " ");
     }
-  }
-  // Member paths (df.head()) and camelCase names (DataFrame) — but skip proper
-  // nouns (Plotly.js, JavaScript) so a label that is *only* a product name
-  // isn't treated as code.
+  };
+  mark(/function\s*\([^()]*\)/g); // function (args)
+  mark(/[A-Za-z_]\w*(?:::[A-Za-z_~]\w*)+(?:<[^<>]*>)?(?:\([^)]*\))?/g); // a::b<T>(…)
+  mark(/[A-Za-z_]\w*<[A-Za-z_][^<>]*>(?:\([^)]*\))?/g); // vector<int>
+  mark(/[A-Za-z_]\w*\[[^\]]*\]/g); // arr[i]
+  // Assignment to a *literal* or call (p = 0x100, n = 42, greeting = 'Howdy',
+  // x = f()). A bare-word RHS is excluded so prose equations ("Pipeline = recipe",
+  // "Residual = actual", "A = L") aren't treated as code.
+  mark(
+    /[A-Za-z_][\w.]*\s*=\s*(?:'[^']*'|"[^"]*"|0x[0-9a-fA-F_]+|-?\d[\w.]*|[A-Za-z_][\w.]*\([^()]*\))/g,
+  );
+  // Member paths (df.head()), dotted file/module names (hello.c, users.js), and
+  // camelCase names (DataFrame) — but skip proper nouns (Plotly.js, JavaScript)
+  // so a label that is *only* a product name isn't treated as code.
   const removeGuarded = (re) => {
     s = s.replace(re, (m) => {
-      if (NOT_CODE.has(m.toLowerCase())) return m;
+      if (isProseName(m)) return m;
       removedIdent = true;
       return " ";
     });
   };
-  removeGuarded(/[A-Za-z_]\w+(?:\.[A-Za-z_]\w+)+(?:\([^)]*\))?/g); // df.head()
-  removeGuarded(/\b\w*[a-z][A-Z]\w*\b/g); // camelCase / PascalCase-multiword
+  removeGuarded(/[A-Za-z_]\w+(?:\.[A-Za-z_]\w+)+\([^()]*\)/g); // df.head()
   // Plain calls only when the callee reads as code (not math like AR(p), y(t)),
   // and not a "word(s)" English pluralization.
   s = s.replace(/([A-Za-z_]\w*)\(([^()]*)\)/g, (m, name, args) => {
@@ -197,6 +208,13 @@ function isWholeCode(rawLabel) {
     }
     return m;
   });
+  removeGuarded(/[A-Za-z_][\w-]+(?:\.[A-Za-z][\w-]*)+/g); // hello.c / users.js
+  removeGuarded(/\b\w*[a-z][A-Z]\w*\b/g); // camelCase / PascalCase-multiword
+  mark(/\b[A-Za-z]\w*_\w+\b/g); // snake_case (any case)
+  mark(/[*&]+[A-Za-z_]\w*|[A-Za-z_]\w*[*&]+/g); // *ptr / T&
+  mark(/\{[^{}]*\}/g); // { ... } brace block
+  mark(/0x[0-9a-fA-F][0-9a-fA-F_]*/g); // hex literal
+  mark(/'[^']*'|"[^"]*"/g); // string literal
   s = s
     .replace(/->|=>|<-|<<|>>|&&|\|\||==|!=|<=|>=|\+\+|--|\+=|-=|%>%|\|>|:=/g, " ")
     .replace(/[-+]?\b\d[\w.]*\b/g, " ");
@@ -205,11 +223,16 @@ function isWholeCode(rawLabel) {
 
 // High-confidence code spans to wrap inside an otherwise-prose label.
 const SPAN = new RegExp(
-  "\\b[A-Za-z_]\\w*(?:::[A-Za-z_~]\\w*)+(?:<[A-Za-z_][^<>]*>)?(?:\\([^()]*\\))?" + // std::a<T>(…)
+  "\\bfunction\\s*\\([^()]*\\)(?:\\s*\\{[^{}]*\\})?" + // function (name) { ... }
+    "|\\b[A-Za-z_]\\w*(?:::[A-Za-z_~]\\w*)+(?:<[A-Za-z_][^<>]*>)?(?:\\([^()]*\\))?" + // std::a<T>(…)
+    "|\\b[A-Za-z_][\\w.]*\\s*=\\s*(?:'[^']*'|\"[^\"]*\"|0x[0-9a-fA-F_]+|-?\\d[\\w.]*|[A-Za-z_][\\w.]*\\([^()]*\\))" + // x = val
     "|\\b[A-Za-z_]\\w+(?:\\.[A-Za-z_]\\w+)+\\([^()]*\\)" + // df.head()
     "|\\b[A-Za-z_]\\w*<[A-Za-z_][^<>]*>(?:\\([^()]*\\))?" + // vector<int>
     "|\\b[A-Za-z_]\\w*\\([^()]*\\)" + // value_counts()
-    "|\\b[A-Za-z]\\w*_\\w+\\b", // snake_case
+    "|\\b[A-Za-z_][\\w-]+(?:\\.[A-Za-z][\\w-]*)+" + // hello.c / users.js
+    "|\\b[A-Za-z]\\w*_\\w+\\b" + // snake_case
+    "|0x[0-9a-fA-F][0-9a-fA-F_]*" + // hex literal
+    "|\\{[^{}]*\\}", // { ... }
   "g",
 );
 
@@ -256,6 +279,7 @@ function rewriteLabel(rawLabel) {
               const plain = s.match(/^([A-Za-z_]\w*)\(([^()]*)\)$/);
               if (plain && (!isCodeName(plain[1]) || plain[2].trim() === "s"))
                 return s; // math notation / "word(s)" pluralization
+              if (isProseName(s)) return s; // product name / domain
               any = true;
               tags.push(s);
               return `<code>${escHtml(s)}</code>`;
@@ -268,7 +292,18 @@ function rewriteLabel(rawLabel) {
 }
 
 function processLine(line, isFlow) {
-  if (!isFlow || SKIP_LINE.test(line)) return { line, tags: [] };
+  if (!isFlow) return { line, tags: [] };
+  // Bare subgraph title (`subgraph users.js`): wrap a code-like title, rewriting
+  // to the `subgraph <id>["…"]` form (the id keeps the original token). Bracketed
+  // titles (`subgraph id["…"]`) fall through to findNodes below.
+  const sg = line.match(/^(\s*subgraph\s+)([^\s"\[][^"\[\n]*?)(\s*)$/);
+  if (sg) {
+    const res = rewriteLabel(sg[2]);
+    if (res.tags.length && res.label !== sg[2])
+      return { line: `${sg[1]}${sg[2]}[${res.label}]${sg[3]}`, tags: res.tags };
+    return { line, tags: [] };
+  }
+  if (SKIP_LINE.test(line)) return { line, tags: [] };
   const nodes = findNodes(line);
   if (!nodes.length) return { line, tags: [] };
   const tags = [];

--- a/scripts/audit/steps-candidates.mjs
+++ b/scripts/audit/steps-candidates.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// One-off audit: find mermaid blocks that are really an ORDERED SEQUENCE OF
+// STEPS drawn as boxes — the case the Fumadocs <Steps> component renders better
+// than a diagram. The signal is a *linear* flowchart (a simple A→B→C path, no
+// branches/merges/cycles) whose node labels are *numbered* ("1.", "Step 2",
+// "Phase 3", …). Spatial/structural diagrams (memory layouts, call stacks, JOIN
+// maps) are linear too but are NOT sequences, so numbering is what separates
+// them. Not part of the build.
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "content/learn";
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) out.push(...walk(p));
+    else if (name.endsWith(".mdx")) out.push(p);
+  }
+  return out;
+}
+
+function extractBlocks(text) {
+  const lines = text.split("\n");
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (/^(\s*)```mermaid\s*$/.test(lines[i])) {
+      const startLine = i + 1;
+      const body = [];
+      i++;
+      while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
+        body.push(lines[i]);
+        i++;
+      }
+      blocks.push({ startLine, text: body.join("\n") });
+    }
+    i++;
+  }
+  return blocks;
+}
+
+// Pull the human label out of a node declaration: A["1. Foo"], A[1. Foo],
+// A(1. Foo), A{1. Foo}. We first scrub arrow operators, `<br>` tags and edge
+// labels (|x|) so they don't get mistaken for node delimiters, then grab the
+// text inside each bracket pair.
+function labelsOn(rawLine) {
+  const line = rawLine
+    .replace(/<br\s*\/?>/gi, " ") // line breaks → space
+    .replace(/\|[^|]*\|/g, " ") // edge labels |x|
+    .replace(/[xo<]?[-.=]{2,}>?/g, " ") // arrows / links --> -.- ==>
+    .replace(/:::[A-Za-z0-9_]+/g, ""); // class assignment
+  const out = [];
+  const re = /(?:\[\[|\[\(|\[|\(\(|\(|\{\{|\{)\s*("?)(.*?)\1\s*(?:\]\]|\)\]|\]|\)\)|\)|\}\}|\})/g;
+  let m;
+  while ((m = re.exec(line))) {
+    const t = m[2].trim();
+    if (t) out.push(t);
+  }
+  return out;
+}
+
+// Is this a flowchart whose nodes are numbered steps?
+function analyze(chart) {
+  const norm = chart.replace(/\\n/g, "\n");
+  const lines = norm.split("\n").map((l) => l.trim()).filter(Boolean);
+  const first = lines[0] || "";
+  if (!/^(flowchart|graph)\b/i.test(first)) return null;
+
+  // No subgraphs — those are almost always spatial groupings, not step lists.
+  if (/^\s*subgraph\b/im.test(norm)) return { numbered: false, hasSubgraph: true, labels: [] };
+
+  const labels = [];
+  for (const l of lines) {
+    if (/^(flowchart|graph|classDef|class\s|click|style|linkStyle|direction|%%)/i.test(l)) continue;
+    labels.push(...labelsOn(l));
+  }
+  if (labels.length === 0) return { numbered: false, hasSubgraph: false, labels: [] };
+
+  // A label counts as "numbered" if it starts with 1./2)/Step 3/Phase 4 etc.
+  // (but NOT "0:50" index:value pairs — require the separator to be . ) : - and
+  // be followed by a letter/space, not another digit run that looks like data).
+  const numRe = /^(?:(?:step|phase|stage|part)\s*)?\d+\s*[\.\)\-–]\s*\D/i;
+  const numbered = labels.filter((t) => numRe.test(t));
+  // Require at least 3 numbered labels and that they dominate (≥ half) — a real
+  // ordered list, tolerant of a leading "You are here" / trailing node.
+  const isSeq = numbered.length >= 3 && numbered.length * 2 >= labels.length;
+
+  return {
+    numbered: isSeq,
+    hasSubgraph: false,
+    count: labels.length,
+    numCount: numbered.length,
+    labels,
+  };
+}
+
+const files = walk(ROOT).sort();
+const hits = [];
+for (const f of files) {
+  const text = readFileSync(f, "utf8");
+  for (const b of extractBlocks(text)) {
+    const a = analyze(b.text);
+    if (a && a.numbered) hits.push({ file: f, line: b.startLine, ...a, chart: b.text });
+  }
+}
+
+console.log(`NUMBERED-SEQUENCE flowcharts: ${hits.length}\n`);
+for (const h of hits) {
+  console.log(`━━━ ${h.file}:${h.line}  (${h.numCount}/${h.count} numbered)`);
+  console.log(h.chart);
+  console.log();
+}


### PR DESCRIPTION
## Summary

Audited every mermaid diagram (~1,250 across the courses) for two improvements the diagrams were a poor fit for.

### 1. Code-only shapes now render in monospace

Mermaid flowchart labels that are code — type names, identifiers, calls, templates (e.g. `std::unique_ptr`, `value_counts()`, `std::vector<int>`) — are wrapped in a `<code>` tag and rendered in `var(--font-mono)` (JetBrains Mono) via `mermaid.module.css`. **Mixed** labels get only their code spans wrapped, leaving prose in the sans body font:

| before | after |
| --- | --- |
| `std::unique_ptr` (sans) | `std::unique_ptr` (mono) |
| `v: std::vector<int>, size=3` (all sans) | `v:` + `size=3` sans, `std::vector<int>` mono |

This **replaces the earlier `:::code` directive** with the HTML `<code>` approach (per the request). `<code>` works under Mermaid's strict `securityLevel`, and because a `<code>` span is already measured as monospace at layout time it needs no box-grow hack — so the `:::code` handling was removed from `mermaid.tsx` and the one existing usage migrated.

Escaping the wrapped code (`&lt;`/`&gt;`) additionally **fixes a latent bug**: template brackets like `<int>` / `<T>` were previously stripped by the sanitizer (`std::vector<int>` rendered as `std::vector`).

### 2. Numbered step-sequences → `<Steps>`

Three flowcharts that were purely an ordered checklist the reader follows were converted to the Fumadocs `<Steps>` component:

- **pandas › first-look-at-a-dataset** — the "five-minute ritual" (the chart in the original request)
- **java › problem-solving** — Polya's four steps
- **stats › exploratory-statistical-analysis** — the EDA-pipeline chart, which already had a `<Steps>` block beside it (removed the redundant chart, kept Steps)

Decision trees, cycles (the debugging loop), branching roadmaps, and artifact pipelines were intentionally **left as diagrams** — their branching carries meaning a linear Steps list can't.

### Tooling

`scripts/audit/steps-candidates.mjs` and `scripts/audit/code-shapes.mjs` document and reproduce the audit + rewrite (conservative detection: scope `::`, calls, templates, member calls, snake_case; excludes prose, proper nouns like JavaScript, and math notation like `AR(p)`/`y(t)`).

## Verification

- All 193 changed diagrams render with no parse errors (headless Mermaid with the app's strict config).
- Playwright against the dev server confirms code spans resolve to JetBrains Mono and prose stays Inter; template brackets are visible; the Steps conversions render and the replaced charts are gone.
- `tsc`, ESLint, the MDX validator (781 files), and `vitest` (456 tests) all pass.

https://claude.ai/code/session_01DV1Bm4ynSQMrK9Lg1yWNZg