### PR TITLE
Add SVG vector illustrations to the Beginner's Guide to JavaScript

### DIFF
--- a/app/_components/mdx/illustrations/Illustration.tsx
+++ b/app/_components/mdx/illustrations/Illustration.tsx
@@ -1,0 +1,86 @@
+/**
+ * `<Illustration>` — the single MDX entry point for the course's SVG artwork.
+ *
+ * Registered globally in `mdx-components.tsx`, so any lesson can drop a graphic
+ * in by key with no import:
+ *
+ * ```mdx
+ * <Illustration name="types-as-tokens" />
+ * <Illustration name="closures-backpack" size="lg" caption="A function keeps its scope." />
+ * ```
+ *
+ * The component is a pure server component: it renders a static `<svg>` whose
+ * colors are CSS variables (see palette.ts), so it themes itself for light and
+ * dark mode with no client JavaScript. The artwork for each `name` lives in the
+ * section files under this folder and is wired up in `registry.tsx`.
+ */
+import type { IllustrationSize } from "./types";
+import { illustrations } from "./registry";
+import s from "./illustrations.module.css";
+
+interface IllustrationProps {
+  /** Registry key — see registry.tsx for the full list. */
+  name: string;
+  /** Frame width; falls back to the registry default, then `"md"`. */
+  size?: IllustrationSize;
+  /** Optional visible caption. Used sparingly — the art should carry meaning. */
+  caption?: string;
+  /** Wrap the art in a soft surface panel. */
+  framed?: boolean;
+  /** Override the built-in accessible label. */
+  label?: string;
+}
+
+export function Illustration({
+  name,
+  size,
+  caption,
+  framed,
+  label,
+}: IllustrationProps) {
+  const entry = illustrations[name];
+
+  if (!entry) {
+    // Authoring guard: a mistyped name shows a visible marker during
+    // development instead of silently rendering nothing. Not expected to ship.
+    if (process.env.NODE_ENV !== "production") {
+      return (
+        <figure className={`${s.figure} ${s.md}`}>
+          <div
+            style={{
+              border: "1px dashed var(--ds-red-500)",
+              color: "var(--ds-red-500)",
+              borderRadius: 8,
+              padding: "0.75rem 1rem",
+              font: "500 0.8125rem/1.4 var(--font-mono, monospace)",
+            }}
+          >
+            Unknown illustration: <code>{name}</code>
+          </div>
+        </figure>
+      );
+    }
+    return null;
+  }
+
+  const resolvedSize = size ?? entry.size ?? "md";
+  const a11yLabel = label ?? entry.label;
+
+  return (
+    <figure
+      className={`${s.figure} ${s[resolvedSize]} ${framed ? s.framed : ""}`}
+    >
+      <svg
+        className={s.art}
+        viewBox={entry.viewBox}
+        role="img"
+        aria-label={a11yLabel}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <title>{a11yLabel}</title>
+        {entry.render()}
+      </svg>
+      {caption ? <figcaption className={s.caption}>{caption}</figcaption> : null}
+    </figure>
+  );
+}

--- a/app/_components/mdx/illustrations/controlFlow.tsx
+++ b/app/_components/mdx/illustrations/controlFlow.tsx
@@ -1,0 +1,101 @@
+/**
+ * Illustrations for the "Control flow" chapter.
+ *
+ * conditionals → a decision diamond forking into a true/false branch;
+ * loops       → a circular "repeat" arrow with an exit.
+ */
+import { P } from "./palette";
+import { Arrow } from "./helpers";
+
+/* ── conditionals: a decision splits the path two ways ────────────────────── */
+export function BranchFork() {
+  return (
+    <>
+      {/* entry */}
+      <Arrow x1={180} y1={8} x2={180} y2={34} color={P.ink} width={2.5} />
+
+      {/* the decision diamond */}
+      <polygon
+        points="180,34 222,74 180,114 138,74"
+        style={{ fill: P.yellow }}
+      />
+      {/* a question mark drawn as a path, on the yellow diamond */}
+      <path
+        d="M171 64 a10 10 0 1 1 13 9 c-4 2 -4 4 -4 7"
+        style={{
+          fill: "none",
+          stroke: P.onLight,
+          strokeWidth: 3.4,
+          strokeLinecap: "round",
+        }}
+      />
+      <circle cx={180} cy={92} r={2.6} style={{ fill: P.onLight }} />
+
+      {/* branches */}
+      <Arrow x1={150} y1={98} x2={96} y2={150} color={P.green700} width={2.5} />
+      <Arrow x1={210} y1={98} x2={264} y2={150} color={P.red600} width={2.5} />
+
+      {/* true → green with a check */}
+      <rect x={36} y={150} width={104} height={52} rx={13} style={{ fill: P.green }} />
+      <path
+        d="M68 176 l10 11 l20 -24"
+        style={{ fill: "none", stroke: P.onFill, strokeWidth: 5, strokeLinecap: "round", strokeLinejoin: "round" }}
+      />
+
+      {/* false → red with a cross */}
+      <rect x={220} y={150} width={104} height={52} rx={13} style={{ fill: P.red }} />
+      <g style={{ stroke: P.onFill, strokeWidth: 5, strokeLinecap: "round" }}>
+        <line x1={258} y1={164} x2={286} y2={188} />
+        <line x1={286} y1={164} x2={258} y2={188} />
+      </g>
+    </>
+  );
+}
+
+/* ── loops-and-iteration: repeat the body, then exit ──────────────────────── */
+export function LoopCycle() {
+  const cx = 150;
+  const cy = 108;
+  const r = 60;
+  // A near-complete ring with a gap at the top-right where the arrow re-enters.
+  const a0 = -50; // start angle (deg)
+  const a1 = 270; // end angle, sweeping clockwise most of the way round
+  const rad = (d: number) => (d * Math.PI) / 180;
+  const sx = cx + r * Math.cos(rad(a0));
+  const sy = cy + r * Math.sin(rad(a0));
+  const ex = cx + r * Math.cos(rad(a1));
+  const ey = cy + r * Math.sin(rad(a1));
+  // three iteration ticks around the ring
+  const ticks = [40, 130, 210].map((d) => ({
+    x: cx + r * Math.cos(rad(d)),
+    y: cy + r * Math.sin(rad(d)),
+  }));
+  return (
+    <>
+      {/* the repeat ring */}
+      <path
+        d={`M ${sx} ${sy} A ${r} ${r} 0 1 1 ${ex} ${ey}`}
+        style={{ fill: "none", stroke: P.blue, strokeWidth: 7, strokeLinecap: "round" }}
+      />
+      {/* arrowhead closing the loop at the top */}
+      <Arrow x1={ex - 1} y1={ey + 14} x2={ex + 6} y2={ey - 6} color={P.blue} width={7} head={15} />
+
+      {/* iteration ticks */}
+      {ticks.map((t, i) => (
+        <circle key={i} cx={t.x} cy={t.y} r={6} style={{ fill: P.paper, stroke: P.blue, strokeWidth: 3 }} />
+      ))}
+
+      {/* the loop body in the middle */}
+      <rect x={cx - 24} y={cy - 20} width={48} height={40} rx={9} style={{ fill: P.blue, opacity: 0.18 }} />
+      <rect x={cx - 24} y={cy - 20} width={48} height={40} rx={9} style={{ fill: "none", stroke: P.blue, strokeWidth: 2.5 }} />
+
+      {/* exit when the condition fails */}
+      <Arrow x1={cx + r - 6} y1={cy + 30} x2={262} y2={150} color={P.green700} width={3} />
+      <rect x={256} y={150} width={56} height={44} rx={11} style={{ fill: P.green }} />
+      <path
+        d="M272 172 l7 8 l14 -17"
+        style={{ fill: "none", stroke: P.onFill, strokeWidth: 4.5, strokeLinecap: "round", strokeLinejoin: "round" }}
+      />
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/data.tsx
+++ b/app/_components/mdx/illustrations/data.tsx
@@ -1,0 +1,143 @@
+/**
+ * Illustrations for the "Composite data" chapter.
+ *
+ * arrays      → indexed cells holding values (zero-based);
+ * objects     → named slots (key → value), a small record card;
+ * nested-data → arrays and objects nested into a small tree.
+ */
+import { P } from "./palette";
+
+const MONO = "var(--font-mono, monospace)";
+const CELL_FILLS = [P.blue, P.green, P.yellow, P.red, P.purple];
+
+/* ── arrays: a row of indexed cells, value dots inside ────────────────────── */
+export function ArrayCells() {
+  const n = 5;
+  const size = 58;
+  const gap = 8;
+  const x0 = 18;
+  const y = 22;
+  return (
+    <>
+      {Array.from({ length: n }, (_, i) => {
+        const x = x0 + i * (size + gap);
+        const dotFill = CELL_FILLS[i % CELL_FILLS.length];
+        const onLight = dotFill === P.yellow;
+        return (
+          <g key={i}>
+            <rect x={x} y={y} width={size} height={size} rx={11} style={{ fill: P.surface, stroke: P.line, strokeWidth: 1.5 }} />
+            <circle cx={x + size / 2} cy={y + size / 2} r={15} style={{ fill: dotFill }} />
+            <circle cx={x + size / 2} cy={y + size / 2} r={5} style={{ fill: onLight ? P.onLight : P.onFill, opacity: 0.85 }} />
+            {/* index */}
+            <text x={x + size / 2} y={y + size + 22} textAnchor="middle" style={{ fill: P.muted, font: `600 14px ${MONO}` }}>
+              {i}
+            </text>
+          </g>
+        );
+      })}
+      {/* bracket framing to read as "one array" */}
+      <path d={`M10 ${y - 4} q-4 0 -4 6 v${size - 4} q0 6 4 6`} style={{ fill: "none", stroke: P.muted, strokeWidth: 2.5, strokeLinecap: "round" }} />
+      <path d={`M${x0 + n * (size + gap) - gap + 8} ${y - 4} q4 0 4 6 v${size - 4} q0 6 -4 6`} style={{ fill: "none", stroke: P.muted, strokeWidth: 2.5, strokeLinecap: "round" }} />
+    </>
+  );
+}
+
+/* ── objects: a record card of key → value rows ───────────────────────────── */
+export function ObjectRecord() {
+  const rows = [
+    { key: P.blue, val: "dot" as const, valFill: P.green },
+    { key: P.green, val: "bar" as const, valFill: P.yellow },
+    { key: P.yellow, val: "dot" as const, valFill: P.red },
+    { key: P.red, val: "bar" as const, valFill: P.purple },
+  ];
+  const x = 70;
+  const w = 232;
+  const top = 22;
+  const rh = 38;
+  return (
+    <>
+      {/* the card */}
+      <rect x={x} y={top} width={w} height={rows.length * rh + 20} rx={16} style={{ fill: P.surface, stroke: P.line, strokeWidth: 1.5 }} />
+      {/* brace on the left to read as an object literal */}
+      <path
+        d={`M58 ${top} q-12 0 -12 14 v${(rows.length * rh) / 2 - 8} q0 10 -8 12 q8 2 8 12 v${(rows.length * rh) / 2 - 8} q0 14 12 14`}
+        style={{ fill: "none", stroke: P.purple, strokeWidth: 3, strokeLinecap: "round" }}
+      />
+      {rows.map((r, i) => {
+        const cy = top + 28 + i * rh;
+        return (
+          <g key={i}>
+            {/* key pill */}
+            <rect x={x + 18} y={cy - 11} width={46} height={22} rx={11} style={{ fill: r.key }} />
+            {/* colon */}
+            <circle cx={x + 80} cy={cy} r={2.4} style={{ fill: P.muted }} />
+            {/* value */}
+            {r.val === "dot" ? (
+              <circle cx={x + 120} cy={cy} r={11} style={{ fill: r.valFill }} />
+            ) : (
+              <rect x={x + 104} y={cy - 8} width={96} height={16} rx={8} style={{ fill: r.valFill }} />
+            )}
+          </g>
+        );
+      })}
+    </>
+  );
+}
+
+/* ── nested-data: arrays and objects nested into a tree ───────────────────── */
+export function NestedTree() {
+  // root object → two children: an array (with leaves) and an object (with leaves)
+  const root = { x: 180, y: 30 };
+  const left = { x: 92, y: 104 };
+  const right = { x: 268, y: 104 };
+  const leaves = [
+    { x: 44, y: 176, fill: P.yellow },
+    { x: 100, y: 176, fill: P.yellow },
+    { x: 156, y: 176, fill: P.yellow },
+    { x: 240, y: 176, fill: P.red },
+    { x: 296, y: 176, fill: P.red },
+  ];
+  const node = (cx: number, cy: number, fill: string, kind: "obj" | "arr") => (
+    <g>
+      <rect x={cx - 22} y={cy - 18} width={44} height={36} rx={10} style={{ fill }} />
+      {kind === "obj" ? (
+        <g style={{ stroke: P.onFill, strokeWidth: 2.6, strokeLinecap: "round" }}>
+          <line x1={cx - 9} y1={cy} x2={cx + 9} y2={cy} />
+          <line x1={cx - 9} y1={cy - 7} x2={cx + 9} y2={cy - 7} />
+          <line x1={cx - 9} y1={cy + 7} x2={cx + 2} y2={cy + 7} />
+        </g>
+      ) : (
+        <g style={{ fill: "none", stroke: P.onLight, strokeWidth: 2.2 }}>
+          <rect x={cx - 13} y={cy - 6} width={8} height={12} rx={2} />
+          <rect x={cx - 4} y={cy - 6} width={8} height={12} rx={2} />
+          <rect x={cx + 5} y={cy - 6} width={8} height={12} rx={2} />
+        </g>
+      )}
+    </g>
+  );
+  return (
+    <>
+      {/* edges */}
+      {[left, right].map((c, i) => (
+        <line key={i} x1={root.x} y1={root.y + 16} x2={c.x} y2={c.y - 16} style={{ stroke: P.line, strokeWidth: 2.5 }} />
+      ))}
+      {leaves.slice(0, 3).map((l, i) => (
+        <line key={i} x1={left.x} y1={left.y + 16} x2={l.x} y2={l.y - 14} style={{ stroke: P.line, strokeWidth: 2.5 }} />
+      ))}
+      {leaves.slice(3).map((l, i) => (
+        <line key={i} x1={right.x} y1={right.y + 16} x2={l.x} y2={l.y - 14} style={{ stroke: P.line, strokeWidth: 2.5 }} />
+      ))}
+
+      {/* leaves */}
+      {leaves.map((l, i) => (
+        <circle key={i} cx={l.x} cy={l.y} r={13} style={{ fill: l.fill }} />
+      ))}
+
+      {/* branch nodes */}
+      {node(left.x, left.y, P.teal, "arr")}
+      {node(right.x, right.y, P.purple, "obj")}
+      {/* root */}
+      {node(root.x, root.y, P.blue, "obj")}
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/engineering.tsx
+++ b/app/_components/mdx/illustrations/engineering.tsx
@@ -1,0 +1,135 @@
+/**
+ * Illustrations for the "Engineering foundations" chapter.
+ *
+ * debugging-and-reasoning → a magnifier and a bug over a block of code;
+ * maintainable-code       → tangled vs. tidy, side by side;
+ * modular-organization    → modules that plug into one another;
+ * next-steps              → a road ahead with milestones.
+ */
+import { P } from "./palette";
+
+/* ── debugging-and-reasoning: hunt the bug in the code ────────────────────── */
+export function BugMagnifier() {
+  return (
+    <>
+      {/* code block */}
+      <rect x={24} y={28} width={210} height={144} rx={14} style={{ fill: P.surface, stroke: P.line, strokeWidth: 1.5 }} />
+      {[
+        { y: 52, w: 120, c: P.blue },
+        { y: 74, w: 150, c: P.green },
+        { y: 96, w: 96, c: P.yellow600 },
+        { y: 118, w: 140, c: P.blue },
+        { y: 140, w: 80, c: P.green },
+      ].map((l, i) => (
+        <g key={i}>
+          <circle cx={42} cy={l.y} r={3} style={{ fill: P.muted }} />
+          <rect x={54} y={l.y - 5} width={l.w} height={10} rx={5} style={{ fill: l.c, opacity: 0.55 }} />
+        </g>
+      ))}
+
+      {/* the bug */}
+      <g>
+        <ellipse cx={150} cy={120} rx={15} ry={18} style={{ fill: P.red }} />
+        <line x1={150} y1={104} x2={150} y2={136} style={{ stroke: P.red700, strokeWidth: 2 }} />
+        <g style={{ stroke: P.red, strokeWidth: 3, strokeLinecap: "round" }}>
+          <line x1={135} y1={112} x2={123} y2={106} />
+          <line x1={135} y1={122} x2={121} y2={122} />
+          <line x1={135} y1={132} x2={123} y2={140} />
+          <line x1={165} y1={112} x2={177} y2={106} />
+          <line x1={165} y1={122} x2={179} y2={122} />
+          <line x1={165} y1={132} x2={177} y2={140} />
+        </g>
+        <circle cx={144} cy={110} r={2.4} style={{ fill: P.onFill }} />
+        <circle cx={156} cy={110} r={2.4} style={{ fill: P.onFill }} />
+      </g>
+
+      {/* magnifier over the bug */}
+      <circle cx={150} cy={120} r={40} style={{ fill: P.blue, opacity: 0.08 }} />
+      <circle cx={150} cy={120} r={40} style={{ fill: "none", stroke: P.blue, strokeWidth: 5 }} />
+      <line x1={180} y1={150} x2={214} y2={184} style={{ stroke: P.blue, strokeWidth: 9, strokeLinecap: "round" }} />
+    </>
+  );
+}
+
+/* ── maintainable-code: tangled vs. tidy ──────────────────────────────────── */
+export function TangleVsTidy() {
+  return (
+    <>
+      {/* messy */}
+      <rect x={14} y={22} width={150} height={140} rx={14} style={{ fill: P.red, opacity: 0.06 }} />
+      <path
+        d="M40 60 C 120 30, 60 90, 130 70 S 50 120, 120 130 C 150 138, 70 150, 44 120 S 130 96, 60 96"
+        style={{ fill: "none", stroke: P.red, strokeWidth: 3.5, strokeLinecap: "round" }}
+      />
+
+      {/* tidy */}
+      <rect x={196} y={22} width={150} height={140} rx={14} style={{ fill: P.green, opacity: 0.06 }} />
+      {[44, 70, 96, 122].map((y, i) => (
+        <g key={i}>
+          <circle cx={216} cy={y} r={5} style={{ fill: P.green }} />
+          <rect x={230} y={y - 6} width={[96, 70, 104, 58][i]} height={12} rx={6} style={{ fill: P.green, opacity: 0.6 }} />
+        </g>
+      ))}
+    </>
+  );
+}
+
+/* ── modular-organization: modules that plug together ─────────────────────── */
+export function ModulesBlocks() {
+  // each module is a rounded block with a plug (export) on the right and a
+  // socket (import) on the left — except the ends.
+  const blockBody = (x: number, fill: string) => (
+    <g>
+      <rect x={x} y={50} width={86} height={76} rx={14} style={{ fill }} />
+      {[66, 82, 98].map((y, i) => (
+        <rect key={i} x={x + 14} y={y} width={[44, 58, 34][i]} height={8} rx={4} style={{ fill: P.onFill, opacity: 0.85 }} />
+      ))}
+    </g>
+  );
+  return (
+    <>
+      {/* module A — plug on right */}
+      {blockBody(24, P.blue)}
+      <rect x={110} y={78} width={16} height={20} rx={5} style={{ fill: P.blue }} />
+
+      {/* module B — socket on left, plug on right */}
+      <rect x={132} y={78} width={14} height={20} rx={5} style={{ fill: P.surface, stroke: P.green, strokeWidth: 2 }} />
+      {blockBody(146, P.green)}
+      <rect x={232} y={78} width={16} height={20} rx={5} style={{ fill: P.green }} />
+
+      {/* module C — socket on left */}
+      <rect x={254} y={78} width={14} height={20} rx={5} style={{ fill: P.surface, stroke: P.yellow600, strokeWidth: 2 }} />
+      {blockBody(268, P.yellow)}
+    </>
+  );
+}
+
+/* ── next-steps: the road ahead, with milestones ──────────────────────────── */
+export function Roadmap() {
+  const flag = (x: number, y: number, fill: string) => (
+    <g>
+      <line x1={x} y1={y} x2={x} y2={y - 30} style={{ stroke: P.muted, strokeWidth: 3, strokeLinecap: "round" }} />
+      <path d={`M${x} ${y - 30} h22 l-6 7 l6 7 h-22 z`} style={{ fill }} />
+      <circle cx={x} cy={y} r={6} style={{ fill }} />
+    </g>
+  );
+  return (
+    <>
+      {/* the road */}
+      <path
+        d="M16 178 C 90 178, 96 96, 170 96 S 250 40, 326 40"
+        style={{ fill: "none", stroke: P.surface, strokeWidth: 22, strokeLinecap: "round" }}
+      />
+      <path
+        d="M16 178 C 90 178, 96 96, 170 96 S 250 40, 326 40"
+        style={{ fill: "none", stroke: P.blue, strokeWidth: 3, strokeLinecap: "round", strokeDasharray: "2 16", opacity: 0.8 }}
+      />
+      {/* start */}
+      <circle cx={16} cy={178} r={8} style={{ fill: P.blue }} />
+      {/* milestones */}
+      {flag(118, 150, P.green)}
+      {flag(212, 78, P.yellow)}
+      {flag(312, 40, P.red)}
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/functions.tsx
+++ b/app/_components/mdx/illustrations/functions.tsx
@@ -1,0 +1,123 @@
+/**
+ * Illustrations for the "Functions and modularity" chapter.
+ *
+ * functions-basics      → a value goes into a machine, a value comes out;
+ * parameters-and-returns → several arguments funnel to one return value;
+ * scope-and-scope-chain  → nested scopes with an outward name lookup;
+ * closures               → a function carries its birth scope like a backpack.
+ */
+import { P } from "./palette";
+import { Arrow, Gear } from "./helpers";
+
+/* ── functions-basics: input → [machine] → output ─────────────────────────── */
+export function FunctionMachine() {
+  return (
+    <>
+      {/* input token */}
+      <rect x={14} y={78} width={40} height={40} rx={9} style={{ fill: P.green }} />
+      <Arrow x1={60} y1={98} x2={120} y2={98} color={P.ink} width={2.5} />
+
+      {/* the machine */}
+      <rect x={124} y={48} width={112} height={100} rx={18} style={{ fill: P.blue }} />
+      <Gear cx={180} cy={98} r={26} color={P.onFill} holeColor={P.blue} />
+
+      {/* output token */}
+      <Arrow x1={240} y1={98} x2={300} y2={98} color={P.ink} width={2.5} />
+      <circle cx={326} cy={98} r={22} style={{ fill: P.yellow }} />
+    </>
+  );
+}
+
+/* ── parameters-and-returns: many arguments in, one value out ─────────────── */
+export function ParamsFunnel() {
+  const ins = [
+    { y: 38, fill: P.blue },
+    { y: 92, fill: P.green },
+    { y: 146, fill: P.yellow },
+  ];
+  return (
+    <>
+      {ins.map((it, i) => (
+        <g key={i}>
+          <rect x={14} y={it.y - 16} width={36} height={32} rx={8} style={{ fill: it.fill }} />
+          <Arrow x1={56} y1={it.y} x2={132} y2={92} color={P.muted} width={2.2} />
+        </g>
+      ))}
+
+      {/* funnel */}
+      <path
+        d="M134 40 L214 40 L176 100 L176 144 L152 144 L152 100 Z"
+        style={{ fill: P.blue, opacity: 0.16 }}
+      />
+      <path
+        d="M134 40 L214 40 L176 100 L176 144 L152 144 L152 100 Z"
+        style={{ fill: "none", stroke: P.blue, strokeWidth: 2.5, strokeLinejoin: "round" }}
+      />
+
+      {/* single return value out */}
+      <Arrow x1={176} y1={146} x2={176} y2={176} color={P.ink} width={2.5} />
+      <circle cx={176} cy={176} r={2} style={{ fill: P.ink }} />
+      <Arrow x1={214} y1={92} x2={300} y2={92} color={P.ink} width={2.5} />
+      <circle cx={326} cy={92} r={22} style={{ fill: P.purple }} />
+    </>
+  );
+}
+
+/* ── scope-and-scope-chain: nested scopes, lookup walks outward ───────────── */
+export function NestedScopes() {
+  return (
+    <>
+      {/* global */}
+      <rect x={16} y={18} width={328} height={164} rx={20} style={{ fill: P.blue, opacity: 0.06 }} />
+      <rect x={16} y={18} width={328} height={164} rx={20} style={{ fill: "none", stroke: P.blue, strokeWidth: 2.5 }} />
+      {/* outer */}
+      <rect x={62} y={46} width={236} height={108} rx={16} style={{ fill: P.green, opacity: 0.07 }} />
+      <rect x={62} y={46} width={236} height={108} rx={16} style={{ fill: "none", stroke: P.green, strokeWidth: 2.5 }} />
+      {/* inner */}
+      <rect x={120} y={74} width={120} height={52} rx={12} style={{ fill: P.yellow, opacity: 0.12 }} />
+      <rect x={120} y={74} width={120} height={52} rx={12} style={{ fill: "none", stroke: P.yellow600, strokeWidth: 2.5 }} />
+
+      {/* a name resolved by walking outward through the chain */}
+      <circle cx={150} cy={100} r={6} style={{ fill: P.red }} />
+      <Arrow x1={158} y1={100} x2={300} y2={100} color={P.red} width={2.5} dashed />
+      <circle cx={310} cy={100} r={6} style={{ fill: "none", stroke: P.red, strokeWidth: 2.5 }} />
+    </>
+  );
+}
+
+/* ── closures: a function keeps its birth scope, carried like a backpack ──── */
+export function ClosureBackpack() {
+  return (
+    <>
+      {/* the scope it was born in (now left behind) */}
+      <rect
+        x={14}
+        y={40}
+        width={120}
+        height={120}
+        rx={18}
+        style={{ fill: "none", stroke: P.line, strokeWidth: 2.5, strokeDasharray: "6 7" }}
+      />
+      <circle cx={74} cy={100} r={12} style={{ fill: P.green, opacity: 0.4 }} />
+
+      {/* it moved away, carrying the value with it */}
+      <Arrow x1={140} y1={100} x2={196} y2={100} color={P.muted} width={2.2} />
+
+      {/* the function */}
+      <rect x={206} y={54} width={96} height={96} rx={20} style={{ fill: P.blue }} />
+      {/* a lambda-ish glyph drawn as strokes */}
+      <g style={{ stroke: P.onFill, strokeWidth: 5, strokeLinecap: "round", fill: "none" }}>
+        <path d="M242 78 q10 0 14 12 l12 36" />
+        <line x1={266} y1={82} x2={244} y2={126} />
+      </g>
+
+      {/* the backpack pouch holding the captured value */}
+      <path
+        d="M286 120 h26 a10 10 0 0 1 10 10 v22 a10 10 0 0 1 -10 10 h-26 a10 10 0 0 1 -10 -10 v-22 a10 10 0 0 1 10 -10 z"
+        style={{ fill: P.yellow }}
+      />
+      <path d="M292 120 v-6 a10 10 0 0 1 20 0 v6" style={{ fill: "none", stroke: P.yellow600, strokeWidth: 3 }} />
+      <circle cx={302} cy={142} r={9} style={{ fill: P.green }} />
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/helpers.tsx
+++ b/app/_components/mdx/illustrations/helpers.tsx
@@ -1,0 +1,112 @@
+/**
+ * Small SVG primitives shared across the illustration set.
+ *
+ * These deliberately carry no visual "style" of their own beyond geometry, so
+ * each illustration stays free to set its own look. The key constraint: NO
+ * `<defs>`/`<marker>` with shared ids — several illustrations can render into
+ * the same document, and a duplicated marker id would cross-wire them. Arrow
+ * heads are therefore drawn inline as polygons.
+ */
+import type { ReactNode } from "react";
+
+interface ArrowProps {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  color: string;
+  width?: number;
+  /** Arrowhead length in user units. */
+  head?: number;
+  dashed?: boolean;
+  /** Draw a head at the start too (double-headed). */
+  double?: boolean;
+}
+
+/** A straight line ending in a filled triangular arrowhead at (x2, y2). */
+export function Arrow({
+  x1,
+  y1,
+  x2,
+  y2,
+  color,
+  width = 2.5,
+  head = 9,
+  dashed = false,
+  double = false,
+}: ArrowProps): ReactNode {
+  const angle = Math.atan2(y2 - y1, x2 - x1);
+  const spread = 0.42;
+  // Pull each end of the shaft back to the base of its head so the stroke
+  // doesn't poke through the triangle's tip.
+  const ex = x2 - Math.cos(angle) * head * 0.85;
+  const ey = y2 - Math.sin(angle) * head * 0.85;
+  const sx = double ? x1 + Math.cos(angle) * head * 0.85 : x1;
+  const sy = double ? y1 + Math.sin(angle) * head * 0.85 : y1;
+  const headAt = (tipX: number, tipY: number, dir: number) => {
+    const a = dir < 0 ? angle + Math.PI : angle;
+    const lx = tipX - Math.cos(a - spread) * head;
+    const ly = tipY - Math.sin(a - spread) * head;
+    const rx = tipX - Math.cos(a + spread) * head;
+    const ry = tipY - Math.sin(a + spread) * head;
+    return `${tipX},${tipY} ${lx},${ly} ${rx},${ry}`;
+  };
+  return (
+    <g>
+      <line
+        x1={sx}
+        y1={sy}
+        x2={ex}
+        y2={ey}
+        style={{
+          stroke: color,
+          strokeWidth: width,
+          strokeLinecap: "round",
+          strokeDasharray: dashed ? "1 7" : undefined,
+        }}
+      />
+      <polygon points={headAt(x2, y2, 1)} style={{ fill: color }} />
+      {double && (
+        <polygon points={headAt(x1, y1, -1)} style={{ fill: color }} />
+      )}
+    </g>
+  );
+}
+
+/** An eight-tooth gear — shorthand for "a machine / a process". The hole is
+ *  punched in `holeColor` (pass the surrounding fill to make it read as a
+ *  ring). */
+export function Gear({
+  cx,
+  cy,
+  r,
+  color,
+  holeColor,
+}: {
+  cx: number;
+  cy: number;
+  r: number;
+  color: string;
+  holeColor: string;
+}): ReactNode {
+  const toothW = r * 0.27;
+  const toothH = r * 0.42;
+  return (
+    <g>
+      {[0, 45, 90, 135, 180, 225, 270, 315].map((d) => (
+        <rect
+          key={d}
+          x={cx - toothW / 2}
+          y={cy - r - toothH * 0.55}
+          width={toothW}
+          height={toothH}
+          rx={toothW * 0.3}
+          style={{ fill: color }}
+          transform={`rotate(${d} ${cx} ${cy})`}
+        />
+      ))}
+      <circle cx={cx} cy={cy} r={r} style={{ fill: color }} />
+      <circle cx={cx} cy={cy} r={r * 0.42} style={{ fill: holeColor }} />
+    </g>
+  );
+}

--- a/app/_components/mdx/illustrations/history.tsx
+++ b/app/_components/mdx/illustrations/history.tsx
@@ -1,0 +1,303 @@
+/**
+ * Illustrations for the "Story of JavaScript" chapter.
+ *
+ * Deliberately varied styles: a duotone abstraction ladder, a two-lane
+ * compiled/interpreted flow, a flat client–server exchange, a circular
+ * "made-in-10-days" emblem, a radiating ecosystem burst, a hub-and-spoke of
+ * runtimes, and a line-art globe.
+ */
+import { P } from "./palette";
+import { Arrow, Gear } from "./helpers";
+
+/* ── story-of-programming: machine code up to high-level languages ────────── */
+export function AbstractionLadder() {
+  // bottom (raw machine) → top (human-readable), one blue ramp = "levels".
+  const bands = [
+    { y: 150, fill: P.blue900, kind: "bits" as const, on: P.onFill },
+    { y: 102, fill: P.blue600, kind: "asm" as const, on: P.onFill },
+    { y: 54, fill: P.blue300, kind: "high" as const, on: P.onLight },
+  ];
+  const x = 70;
+  const w = 196;
+  return (
+    <>
+      {/* "more abstract →" up arrow */}
+      <Arrow x1={40} y1={178} x2={40} y2={48} color={P.green700} width={2.6} />
+
+      {bands.map((b, i) => (
+        <g key={i}>
+          <rect x={x} y={b.y} width={w} height={36} rx={9} style={{ fill: b.fill }} />
+          {b.kind === "bits" &&
+            [0, 1, 2, 3, 4, 5, 6, 7].map((j) => (
+              <circle key={j} cx={x + 24 + j * 21} cy={b.y + 18} r={4} style={{ fill: b.on, opacity: j % 2 ? 0.5 : 1 }} />
+            ))}
+          {b.kind === "asm" &&
+            [0, 1, 2].map((j) => (
+              <g key={j}>
+                <rect x={x + 22 + j * 60} y={b.y + 13} width={14} height={10} rx={2} style={{ fill: b.on }} />
+                <rect x={x + 40 + j * 60} y={b.y + 13} width={26} height={10} rx={2} style={{ fill: b.on, opacity: 0.55 }} />
+              </g>
+            ))}
+          {b.kind === "high" &&
+            [0, 1, 2].map((j) => (
+              <rect key={j} x={x + 22 + j * 58} y={b.y + 12} width={[40, 48, 34][j]} height={12} rx={6} style={{ fill: b.on }} />
+            ))}
+        </g>
+      ))}
+    </>
+  );
+}
+
+/* a small page/document glyph */
+function Doc({ x, y, color }: { x: number; y: number; color: string }) {
+  return (
+    <g>
+      <path d={`M${x} ${y} h26 l10 10 v34 a4 4 0 0 1 -4 4 h-32 a4 4 0 0 1 -4 -4 v-40 a4 4 0 0 1 4 -4 z`} style={{ fill: "none", stroke: color, strokeWidth: 2.4, strokeLinejoin: "round" }} />
+      <g style={{ stroke: color, strokeWidth: 2.2, strokeLinecap: "round" }}>
+        <line x1={x + 7} y1={y + 16} x2={x + 23} y2={y + 16} />
+        <line x1={x + 7} y1={y + 24} x2={x + 27} y2={y + 24} />
+        <line x1={x + 7} y1={y + 32} x2={x + 20} y2={y + 32} />
+      </g>
+    </g>
+  );
+}
+
+/* ── rise-of-scripting-languages: compiled vs interpreted ─────────────────── */
+export function CompiledVsInterpreted() {
+  const play = (x: number, y: number, fill: string) => (
+    <g>
+      <circle cx={x} cy={y} r={18} style={{ fill }} />
+      <polygon points={`${x - 5},${y - 8} ${x + 9},${y} ${x - 5},${y + 8}`} style={{ fill: P.onFill }} />
+    </g>
+  );
+  return (
+    <>
+      {/* compiled lane: source → compiler → binary → run */}
+      <Doc x={16} y={26} color={P.blue} />
+      <Arrow x1={64} y1={48} x2={92} y2={48} color={P.muted} width={2.2} />
+      <rect x={96} y={26} width={48} height={44} rx={10} style={{ fill: P.blue }} />
+      <Gear cx={120} cy={48} r={13} color={P.onFill} holeColor={P.blue} />
+      <Arrow x1={148} y1={48} x2={176} y2={48} color={P.muted} width={2.2} />
+      {/* binary block */}
+      <rect x={180} y={28} width={44} height={40} rx={8} style={{ fill: P.blue, opacity: 0.16 }} />
+      <g style={{ fill: P.blue }}>
+        {[0, 1, 2].map((r) => [0, 1, 2].map((c) => <rect key={`${r}-${c}`} x={188 + c * 11} y={36 + r * 9} width={6} height={5} rx={1} style={{ opacity: (r + c) % 2 ? 0.5 : 1 }} />))}
+      </g>
+      <Arrow x1={228} y1={48} x2={256} y2={48} color={P.muted} width={2.2} />
+      {play(282, 48, P.green)}
+
+      {/* interpreted lane: source → interpreter runs it directly */}
+      <Doc x={16} y={120} color={P.purple} />
+      <Arrow x1={64} y1={142} x2={104} y2={142} color={P.muted} width={2.2} />
+      <rect x={108} y={118} width={70} height={48} rx={12} style={{ fill: P.purple }} />
+      <polygon points="130,134 148,142 130,150" style={{ fill: P.onFill }} />
+      <Gear cx={162} cy={142} r={11} color={P.onFill} holeColor={P.purple} />
+      <Arrow x1={182} y1={142} x2={256} y2={142} color={P.muted} width={2.2} />
+      {play(282, 142, P.green)}
+    </>
+  );
+}
+
+/* ── internet-and-interactivity: browser requests, server responds ────────── */
+export function ClientServer() {
+  return (
+    <>
+      {/* browser window */}
+      <rect x={20} y={44} width={120} height={92} rx={12} style={{ fill: P.surface, stroke: P.blue, strokeWidth: 2.5 }} />
+      <path d="M20 64 h120" style={{ stroke: P.blue, strokeWidth: 2.5 }} />
+      {[34, 48, 62].map((cx, i) => (
+        <circle key={i} cx={cx} cy={54} r={3.4} style={{ fill: [P.red, P.yellow, P.green][i] }} />
+      ))}
+      <rect x={34} y={80} width={92} height={10} rx={5} style={{ fill: P.blue, opacity: 0.5 }} />
+      <rect x={34} y={98} width={64} height={10} rx={5} style={{ fill: P.blue, opacity: 0.3 }} />
+
+      {/* request / response */}
+      <Arrow x1={150} y1={74} x2={224} y2={74} color={P.blue} width={2.8} />
+      <Arrow x1={224} y1={106} x2={150} y2={106} color={P.green700} width={2.8} />
+
+      {/* server stack */}
+      {[44, 80, 116].map((y, i) => (
+        <g key={i}>
+          <rect x={236} y={y} width={104} height={28} rx={7} style={{ fill: P.blue, opacity: 0.85 - i * 0.12 }} />
+          <circle cx={252} cy={y + 14} r={4} style={{ fill: P.onFill }} />
+        </g>
+      ))}
+    </>
+  );
+}
+
+/* ── birth-of-javascript: a 10-day spark (emblem) ─────────────────────────── */
+export function TenDaySpark() {
+  const cx = 120;
+  const cy = 120;
+  const ticks = Array.from({ length: 10 }, (_, i) => {
+    // ten marks across the top arc, from ~200° to ~340°
+    const a = ((200 + i * (140 / 9)) * Math.PI) / 180;
+    return {
+      x1: cx + 88 * Math.cos(a),
+      y1: cy + 88 * Math.sin(a),
+      x2: cx + 78 * Math.cos(a),
+      y2: cy + 78 * Math.sin(a),
+    };
+  });
+  return (
+    <>
+      <circle cx={cx} cy={cy} r={92} style={{ fill: "none", stroke: P.blue, strokeWidth: 3 }} />
+      <circle cx={cx} cy={cy} r={70} style={{ fill: P.blue, opacity: 0.08 }} />
+      {ticks.map((t, i) => (
+        <line key={i} x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2} style={{ stroke: P.blue, strokeWidth: 3, strokeLinecap: "round" }} />
+      ))}
+      {/* lightning bolt */}
+      <polygon points={`${cx + 12},${cy - 46} ${cx - 22},${cy + 8} ${cx - 2},${cy + 8} ${cx - 14},${cy + 48} ${cx + 24},${cy - 10} ${cx + 2},${cy - 10}`} style={{ fill: P.yellow, stroke: P.yellow600, strokeWidth: 2, strokeLinejoin: "round" }} />
+    </>
+  );
+}
+
+/* ── ecosystem-explosion: one library bursts into a galaxy of packages ────── */
+export function EcosystemBurst() {
+  const cx = 160;
+  const cy = 120;
+  const hues = [P.blue, P.green, P.yellow, P.red, P.teal, P.purple, P.orange];
+  const spokes = Array.from({ length: 12 }, (_, i) => {
+    const a = (i * 30 * Math.PI) / 180;
+    const len = 64 + (i % 3) * 22;
+    const x = cx + len * Math.cos(a);
+    const y = cy + len * Math.sin(a);
+    return { x, y, fill: hues[i % hues.length], r: 6 + (i % 3) * 2, a, len };
+  });
+  return (
+    <>
+      {spokes.map((s, i) => (
+        <line key={i} x1={cx} y1={cy} x2={s.x} y2={s.y} style={{ stroke: P.line, strokeWidth: 1.6 }} />
+      ))}
+      {/* secondary buds on a few spokes */}
+      {spokes.filter((_, i) => i % 4 === 0).map((s, i) => {
+        const bx = s.x + 16 * Math.cos(s.a + 0.5);
+        const by = s.y + 16 * Math.sin(s.a + 0.5);
+        return (
+          <g key={i}>
+            <line x1={s.x} y1={s.y} x2={bx} y2={by} style={{ stroke: P.line, strokeWidth: 1.4 }} />
+            <circle cx={bx} cy={by} r={4} style={{ fill: s.fill, opacity: 0.7 }} />
+          </g>
+        );
+      })}
+      {spokes.map((s, i) => (
+        <circle key={i} cx={s.x} cy={s.y} r={s.r} style={{ fill: s.fill }} />
+      ))}
+      <circle cx={cx} cy={cy} r={20} style={{ fill: P.blue }} />
+      <circle cx={cx} cy={cy} r={8} style={{ fill: P.onFill, opacity: 0.9 }} />
+    </>
+  );
+}
+
+/* device glyphs for the runtime hub */
+function Device({ kind, x, y, color }: { kind: "browser" | "server" | "terminal" | "phone" | "chip"; x: number; y: number; color: string }) {
+  const s = { fill: "none", stroke: color, strokeWidth: 2.4, strokeLinejoin: "round" as const, strokeLinecap: "round" as const };
+  if (kind === "browser")
+    return (
+      <g style={s}>
+        <rect x={x - 22} y={y - 16} width={44} height={34} rx={5} />
+        <line x1={x - 22} y1={y - 6} x2={x + 22} y2={y - 6} />
+      </g>
+    );
+  if (kind === "server")
+    return (
+      <g style={s}>
+        <rect x={x - 20} y={y - 16} width={40} height={14} rx={3} />
+        <rect x={x - 20} y={y + 2} width={40} height={14} rx={3} />
+        <line x1={x - 13} y1={y - 9} x2={x - 8} y2={y - 9} />
+        <line x1={x - 13} y1={y + 9} x2={x - 8} y2={y + 9} />
+      </g>
+    );
+  if (kind === "terminal")
+    return (
+      <g style={s}>
+        <rect x={x - 22} y={y - 16} width={44} height={34} rx={5} />
+        <path d={`M${x - 12} ${y - 4} l7 6 l-7 6`} />
+        <line x1={x + 2} y1={y + 9} x2={x + 13} y2={y + 9} />
+      </g>
+    );
+  if (kind === "phone")
+    return (
+      <g style={s}>
+        <rect x={x - 12} y={y - 18} width={24} height={38} rx={5} />
+        <line x1={x - 3} y1={y - 13} x2={x + 3} y2={y - 13} />
+      </g>
+    );
+  // chip
+  return (
+    <g style={s}>
+      <rect x={x - 14} y={y - 14} width={28} height={28} rx={4} />
+      {[-7, 0, 7].map((d) => (
+        <g key={d}>
+          <line x1={x + d} y1={y - 14} x2={x + d} y2={y - 19} />
+          <line x1={x + d} y1={y + 14} x2={x + d} y2={y + 19} />
+          <line x1={x - 14} y1={y + d} x2={x - 19} y2={y + d} />
+          <line x1={x + 14} y1={y + d} x2={x + 19} y2={y + d} />
+        </g>
+      ))}
+    </g>
+  );
+}
+
+/* ── javascript-beyond-the-browser: one language, many runtimes ──────────── */
+export function RuntimeHub() {
+  const cx = 170;
+  const cy = 122;
+  const devices = [
+    { kind: "browser" as const, x: 170, y: 36, color: P.blue },
+    { kind: "server" as const, x: 292, y: 96, color: P.green },
+    { kind: "phone" as const, x: 256, y: 198, color: P.purple },
+    { kind: "terminal" as const, x: 84, y: 198, color: P.orange },
+    { kind: "chip" as const, x: 48, y: 96, color: P.red },
+  ];
+  return (
+    <>
+      {devices.map((d, i) => (
+        <line key={i} x1={cx} y1={cy} x2={d.x} y2={d.y} style={{ stroke: P.line, strokeWidth: 2 }} />
+      ))}
+      {/* the language at the hub */}
+      <rect x={cx - 30} y={cy - 26} width={60} height={52} rx={13} style={{ fill: P.blue }} />
+      <g style={{ stroke: P.onFill, strokeWidth: 4, strokeLinecap: "round", fill: "none" }}>
+        <path d={`M${cx - 12} ${cy - 12} q-7 0 -7 8 t-7 6 q7 0 7 6 t7 8`} />
+        <path d={`M${cx + 12} ${cy - 12} q7 0 7 8 t7 6 q-7 0 -7 6 t-7 8`} />
+      </g>
+      {devices.map((d, i) => (
+        <Device key={i} kind={d.kind} x={d.x} y={d.y} color={d.color} />
+      ))}
+    </>
+  );
+}
+
+/* ── javascript-today: a general-purpose, everywhere language (globe) ─────── */
+export function UbiquityGlobe() {
+  const cx = 120;
+  const cy = 120;
+  const r = 92;
+  return (
+    <>
+      <circle cx={cx} cy={cy} r={r} style={{ fill: P.blue, opacity: 0.06 }} />
+      <circle cx={cx} cy={cy} r={r} style={{ fill: "none", stroke: P.blue, strokeWidth: 2.5 }} />
+      {/* longitudes */}
+      {[0.45, 0.9].map((k, i) => (
+        <ellipse key={i} cx={cx} cy={cy} rx={r * k} ry={r} style={{ fill: "none", stroke: P.blue, strokeWidth: 1.8, opacity: 0.7 }} />
+      ))}
+      <line x1={cx} y1={cy - r} x2={cx} y2={cy + r} style={{ stroke: P.blue, strokeWidth: 1.8, opacity: 0.7 }} />
+      {/* latitudes */}
+      <line x1={cx - r} y1={cy} x2={cx + r} y2={cy} style={{ stroke: P.blue, strokeWidth: 1.8, opacity: 0.7 }} />
+      {[-46, 46].map((dy, i) => {
+        const half = Math.sqrt(r * r - dy * dy);
+        return <line key={i} x1={cx - half} y1={cy + dy} x2={cx + half} y2={cy + dy} style={{ stroke: P.blue, strokeWidth: 1.6, opacity: 0.55 }} />;
+      })}
+      {/* nodes lit up across it */}
+      {[
+        { x: cx - 34, y: cy - 40, fill: P.green },
+        { x: cx + 40, y: cy - 14, fill: P.yellow },
+        { x: cx - 6, y: cy + 46, fill: P.red },
+        { x: cx + 18, y: cy + 18, fill: P.green },
+      ].map((n, i) => (
+        <circle key={i} cx={n.x} cy={n.y} r={6} style={{ fill: n.fill }} />
+      ))}
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/illustrations.module.css
+++ b/app/_components/mdx/illustrations/illustrations.module.css
@@ -1,0 +1,56 @@
+/* Frame for the /learn SVG illustrations.
+ *
+ * The <figure> centers the artwork in the article column and caps its width
+ * so a decorative graphic never blows past the prose measure. The SVG itself
+ * is fluid (width:100%, height:auto driven by its viewBox), so these
+ * max-widths are the only sizing knob authors reach for via the `size` prop.
+ *
+ * Colors live entirely inside each SVG (see palette.ts); the frame is
+ * deliberately neutral so it disappears into the page in both themes. */
+
+.figure {
+  margin: 1.75rem auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+}
+
+.sm {
+  max-width: 240px;
+}
+.md {
+  max-width: 420px;
+}
+.lg {
+  max-width: 600px;
+}
+.full {
+  max-width: 100%;
+}
+
+/* Optional surface behind the art. Uses the Fumadocs muted token so it sits a
+   hair above the page in light mode and a hair below it in dark mode — framed
+   illustrations get a soft card without any hard border. */
+.framed {
+  background: var(--color-fd-muted);
+  border: 1px solid var(--color-fd-border);
+  border-radius: 14px;
+  padding: 1.1rem 1.25rem;
+}
+
+.art {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.caption {
+  margin: 0;
+  text-align: center;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: var(--color-fd-muted-foreground);
+}

--- a/app/_components/mdx/illustrations/palette.ts
+++ b/app/_components/mdx/illustrations/palette.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared color tokens for the `/learn` SVG illustrations.
+ *
+ * Every illustration is a pure, static SVG that themes itself with **CSS
+ * variables only** — no JavaScript, no `useTheme`, no flash on load. Two
+ * families of token make that work:
+ *
+ *   1. Brand hues (`--ds-blue-500` … and friends from app/brand.css) are
+ *      *mode-agnostic*: the exact same hex in light and dark mode. A blue
+ *      shape reads as the same blue on a white page or a near-black one, so
+ *      we can use them as flat fills without a light/dark variant.
+ *
+ *   2. Theme-aware neutrals (`currentColor` and the Fumadocs `--color-fd-*`
+ *      tokens) flip with the active theme. We route every *structural* part
+ *      of an illustration — outlines, hairlines, knockouts, incidental text —
+ *      through these so the line-art inverts cleanly between modes.
+ *
+ * Because the brand fills never change between modes, any detail drawn *on
+ * top* of a fill must use a FIXED ink chosen for that fill — not
+ * `currentColor`, which would invert and disappear in one mode:
+ *
+ *   • `onFill`   — white; legible on the saturated mid/dark hues (blue, red,
+ *                  teal, purple, orange, and the 600+ greens).
+ *   • `onLight`  — near-black; for the light fills (yellow-500, the 100–300
+ *                  tints, green-300/400) where white would vanish.
+ *
+ * Authoring rule of thumb:
+ *   – Flat brand shape            → `style={{ fill: P.blue }}`
+ *   – Line-art that must invert   → `style={{ stroke: P.ink }}` (currentColor)
+ *   – A "hole" punched in a shape  → `style={{ fill: P.paper }}`
+ *   – Glyph on a saturated fill    → `style={{ fill: P.onFill }}`
+ *   – Glyph on a yellow/light fill → `style={{ fill: P.onLight }}`
+ */
+export const P = {
+  // ── Brand primaries (mode-agnostic) ──────────────────────────────────
+  blue: "var(--ds-blue-500)",
+  green: "var(--ds-green-500)",
+  red: "var(--ds-red-500)",
+  yellow: "var(--ds-yellow-500)",
+
+  // ── Decorative / categorical hues (non-semantic) ─────────────────────
+  teal: "var(--ds-teal-500)",
+  purple: "var(--ds-purple-500)",
+  orange: "var(--ds-orange-500)",
+
+  // ── Selected tints & shades (use sparingly, for depth/duotone) ───────
+  blue100: "var(--ds-blue-100)",
+  blue200: "var(--ds-blue-200)",
+  blue300: "var(--ds-blue-300)",
+  blue400: "var(--ds-blue-400)",
+  blue600: "var(--ds-blue-600)",
+  blue700: "var(--ds-blue-700)",
+  blue800: "var(--ds-blue-800)",
+  blue900: "var(--ds-blue-900)",
+
+  green100: "var(--ds-green-100)",
+  green300: "var(--ds-green-300)",
+  green400: "var(--ds-green-400)",
+  green600: "var(--ds-green-600)",
+  green700: "var(--ds-green-700)",
+
+  red100: "var(--ds-red-100)",
+  red300: "var(--ds-red-300)",
+  red400: "var(--ds-red-400)",
+  red600: "var(--ds-red-600)",
+  red700: "var(--ds-red-700)",
+
+  yellow100: "var(--ds-yellow-100)",
+  yellow300: "var(--ds-yellow-300)",
+  yellow400: "var(--ds-yellow-400)",
+  yellow600: "var(--ds-yellow-600)",
+  yellow700: "var(--ds-yellow-700)",
+  yellow800: "var(--ds-yellow-800)",
+
+  teal300: "var(--ds-teal-300)",
+  teal700: "var(--ds-teal-700)",
+  purple300: "var(--ds-purple-300)",
+  purple700: "var(--ds-purple-700)",
+  orange300: "var(--ds-orange-300)",
+  orange700: "var(--ds-orange-700)",
+
+  // ── Theme-aware neutrals (flip with light/dark) ──────────────────────
+  ink: "currentColor", // inherits prose text color → inverts per theme
+  paper: "var(--color-fd-background)", // page background (knockouts)
+  surface: "var(--color-fd-muted)", // faint panel / framed background
+  line: "var(--color-fd-border)", // hairline dividers
+  muted: "var(--color-fd-muted-foreground)", // de-emphasised marks
+
+  // ── Fixed inks for drawing ON a mode-agnostic brand fill ─────────────
+  onFill: "#ffffff", // white — on blue/red/teal/purple/orange/green-600+
+  onLight: "var(--ds-gray-900)", // near-black — on yellow & light tints
+} as const;
+
+export type Ink = (typeof P)[keyof typeof P];

--- a/app/_components/mdx/illustrations/registry.tsx
+++ b/app/_components/mdx/illustrations/registry.tsx
@@ -1,0 +1,276 @@
+/**
+ * The illustration registry: maps each stable `name` used in MDX to its
+ * artwork, accessible label, SVG user-space, and default frame width.
+ *
+ * Add a new graphic by exporting a render function from a section file and
+ * registering it here. Keys are kebab-case and never change once an MDX page
+ * references them.
+ */
+import type { IllustrationRegistry } from "./types";
+import * as Values from "./values";
+import * as ControlFlow from "./controlFlow";
+import * as Functions from "./functions";
+import * as Data from "./data";
+import * as Transform from "./transform";
+import * as Thinking from "./thinking";
+import * as Runtime from "./runtime";
+import * as History from "./history";
+import * as Engineering from "./engineering";
+
+export const illustrations: IllustrationRegistry = {
+  // ── Values, variables, and types ──────────────────────────────────────
+  "types-as-tokens": {
+    label:
+      "Six rounded chips, one per JavaScript type — number, string, boolean, null, object, and array — each drawn with a small glyph.",
+    viewBox: "0 0 380 212",
+    size: "md",
+    render: Values.TypesAsTokens,
+  },
+  "variable-rebind": {
+    label:
+      "A name tag linked by a solid arrow to its current value and by a faded arrow to the previous value it no longer points at.",
+    viewBox: "0 0 372 196",
+    size: "md",
+    render: Values.VariableRebind,
+  },
+  "number-line": {
+    label:
+      "A number line running in both directions through zero, with a curved arc hopping three steps to the right.",
+    viewBox: "0 0 380 168",
+    size: "lg",
+    render: Values.NumberLine,
+  },
+  "string-cells": {
+    label:
+      "The characters of a word in a row of cells, numbered from zero underneath to show zero-based indexing.",
+    viewBox: "0 0 372 96",
+    size: "lg",
+    render: Values.StringCells,
+  },
+  "boolean-venn": {
+    label:
+      "Two overlapping circles whose shared lens highlights where both conditions are true at once.",
+    viewBox: "0 0 376 200",
+    size: "sm",
+    render: Values.BooleanVenn,
+  },
+
+  // ── Control flow ──────────────────────────────────────────────────────
+  "branch-fork": {
+    label:
+      "A path reaching a diamond-shaped decision and splitting two ways: a green branch with a check mark and a red branch with a cross.",
+    viewBox: "0 0 360 212",
+    size: "sm",
+    render: ControlFlow.BranchFork,
+  },
+  "loop-cycle": {
+    label:
+      "A circular arrow looping back on itself with iteration ticks, and a branch that exits to a green check when the condition stops holding.",
+    viewBox: "0 0 330 220",
+    size: "sm",
+    render: ControlFlow.LoopCycle,
+  },
+
+  // ── Functions and modularity ──────────────────────────────────────────
+  "function-machine": {
+    label:
+      "A value entering a gear-driven machine on the left and a transformed value leaving on the right.",
+    viewBox: "0 0 360 196",
+    size: "md",
+    render: Functions.FunctionMachine,
+  },
+  "params-funnel": {
+    label:
+      "Three differently coloured arguments funnelling into a function and a single return value coming out.",
+    viewBox: "0 0 360 196",
+    size: "md",
+    render: Functions.ParamsFunnel,
+  },
+  "nested-scopes": {
+    label:
+      "Three nested rounded rectangles — global, outer, and inner scope — with a dashed arrow showing a name resolved by walking outward.",
+    viewBox: "0 0 360 200",
+    size: "md",
+    render: Functions.NestedScopes,
+  },
+  "closure-backpack": {
+    label:
+      "A function that has moved away from the scope it was born in, still carrying a captured value in an attached pouch.",
+    viewBox: "0 0 336 200",
+    size: "md",
+    render: Functions.ClosureBackpack,
+  },
+
+  // ── Composite data ────────────────────────────────────────────────────
+  "array-cells": {
+    label:
+      "Five bracketed cells in a row, each holding a coloured value and numbered from zero to show zero-based indexing.",
+    viewBox: "0 0 340 96",
+    size: "lg",
+    render: Data.ArrayCells,
+  },
+  "object-record": {
+    label:
+      "A record card of key-and-value rows, each key a coloured pill paired with a value shape, wrapped in braces.",
+    viewBox: "0 0 330 196",
+    size: "md",
+    render: Data.ObjectRecord,
+  },
+  "nested-tree": {
+    label:
+      "A small tree: a root object branching to a nested array and a nested object, each ending in leaf values.",
+    viewBox: "0 0 340 206",
+    size: "md",
+    render: Data.NestedTree,
+  },
+
+  // ── Data transformation ───────────────────────────────────────────────
+  "mfr-pipeline": {
+    label:
+      "A pipeline reading left to right: map recolours every item, filter keeps only some, and reduce folds the survivors into one value.",
+    viewBox: "0 0 384 210",
+    size: "lg",
+    render: Transform.MfrPipeline,
+  },
+  "compose-pipes": {
+    label:
+      "A value flowing through two chained functions, changing shape and colour as it passes from the first into the second.",
+    viewBox: "0 0 380 140",
+    size: "lg",
+    render: Transform.ComposePipes,
+  },
+
+  // ── Thinking like a programmer ────────────────────────────────────────
+  "cpu-cycle": {
+    label:
+      "A processor chip at the centre of a three-step loop — fetch, decode, execute — repeating clockwise.",
+    viewBox: "0 0 320 210",
+    size: "md",
+    render: Thinking.CpuCycle,
+  },
+  "decomposition-split": {
+    label:
+      "One large problem block breaking apart into four smaller, independent pieces.",
+    viewBox: "0 0 360 192",
+    size: "md",
+    render: Thinking.DecompositionSplit,
+  },
+  "maze-path": {
+    label:
+      "A dotted route weaving past scattered obstacles from a start point to a goal flag.",
+    viewBox: "0 0 330 210",
+    size: "md",
+    render: Thinking.MazePath,
+  },
+
+  // ── Runtime and asynchrony ────────────────────────────────────────────
+  "call-stack": {
+    label:
+      "Function frames stacked on top of one another, with arrows pushing a new frame on and popping the top one off.",
+    viewBox: "0 0 300 210",
+    size: "sm",
+    render: Runtime.CallStack,
+  },
+  "event-loop": {
+    label:
+      "An event loop taking the next task from a waiting queue and running it on the call stack once the stack is empty.",
+    viewBox: "0 0 360 210",
+    size: "md",
+    render: Runtime.EventLoop,
+  },
+  "async-handoff": {
+    label:
+      "A main thread that hands a long task to a background lane and keeps working, with a callback returning the result later.",
+    viewBox: "0 0 360 180",
+    size: "lg",
+    render: Runtime.AsyncHandoff,
+  },
+  "promise-states": {
+    label:
+      "A pending promise settling either to a green fulfilled state or a red rejected state.",
+    viewBox: "0 0 330 200",
+    size: "md",
+    render: Runtime.PromiseStates,
+  },
+
+  // ── The story of JavaScript ───────────────────────────────────────────
+  "abstraction-ladder": {
+    label:
+      "Three stacked layers rising from raw binary at the bottom, through assembly, to human-readable high-level code at the top.",
+    viewBox: "0 0 290 210",
+    size: "sm",
+    render: History.AbstractionLadder,
+  },
+  "compiled-vs-interpreted": {
+    label:
+      "Two lanes: a compiled language turning source into a binary before running, and an interpreted language running source directly.",
+    viewBox: "0 0 320 190",
+    size: "md",
+    render: History.CompiledVsInterpreted,
+  },
+  "client-server": {
+    label:
+      "A browser window and a server exchanging a request and a response.",
+    viewBox: "0 0 360 170",
+    size: "md",
+    render: History.ClientServer,
+  },
+  "ten-day-spark": {
+    label:
+      "An emblem: a lightning bolt inside a ring marked with ten ticks, for a language prototyped in ten days.",
+    viewBox: "0 0 240 240",
+    size: "sm",
+    render: History.TenDaySpark,
+  },
+  "ecosystem-burst": {
+    label:
+      "A single library at the centre radiating outward into a galaxy of many colourful packages.",
+    viewBox: "0 0 320 240",
+    size: "md",
+    render: History.EcosystemBurst,
+  },
+  "runtime-hub": {
+    label:
+      "One language at the hub, with spokes out to a browser, a server, a phone, a terminal, and a hardware chip.",
+    viewBox: "0 0 340 240",
+    size: "md",
+    render: History.RuntimeHub,
+  },
+  "ubiquity-globe": {
+    label:
+      "A line-art globe with lit nodes scattered across it, for a language used everywhere.",
+    viewBox: "0 0 240 240",
+    size: "sm",
+    render: History.UbiquityGlobe,
+  },
+
+  // ── Engineering foundations ───────────────────────────────────────────
+  "bug-magnifier": {
+    label:
+      "A magnifying glass and a bug held over a block of code, for systematic debugging.",
+    viewBox: "0 0 240 200",
+    size: "md",
+    render: Engineering.BugMagnifier,
+  },
+  "tangle-vs-tidy": {
+    label:
+      "A tangled red scribble on the left beside neat, evenly stacked green lines on the right.",
+    viewBox: "0 0 360 180",
+    size: "md",
+    render: Engineering.TangleVsTidy,
+  },
+  "modules-blocks": {
+    label:
+      "Three code modules plugging into one another through export plugs and import sockets.",
+    viewBox: "0 0 360 150",
+    size: "md",
+    render: Engineering.ModulesBlocks,
+  },
+  roadmap: {
+    label:
+      "A road winding into the distance past three milestone flags.",
+    viewBox: "0 0 342 200",
+    size: "md",
+    render: Engineering.Roadmap,
+  },
+};

--- a/app/_components/mdx/illustrations/runtime.tsx
+++ b/app/_components/mdx/illustrations/runtime.tsx
@@ -1,0 +1,117 @@
+/**
+ * Illustrations for the "Runtime and asynchrony" chapter.
+ *
+ * how-javascript-runs   → the call stack (push/pop) and the event loop;
+ * asynchronous-thinking → work handed to a background lane while the main
+ *                         thread keeps going, then a callback returns;
+ * promises-and-async-await → a promise settling from pending to fulfilled
+ *                            or rejected.
+ */
+import { P } from "./palette";
+import { Arrow } from "./helpers";
+
+/* ── how-javascript-runs: frames pushed and popped on the call stack ──────── */
+export function CallStack() {
+  const w = 150;
+  const x = 86;
+  const frames = [
+    { fill: P.blue, y: 150 },
+    { fill: P.green, y: 112 },
+    { fill: P.yellow, y: 74 },
+  ];
+  return (
+    <>
+      {/* base line */}
+      <line x1={x - 12} y1={190} x2={x + w + 12} y2={190} style={{ stroke: P.line, strokeWidth: 3, strokeLinecap: "round" }} />
+
+      {frames.map((f, i) => (
+        <rect key={i} x={x} y={f.y} width={w} height={32} rx={8} style={{ fill: f.fill }} />
+      ))}
+
+      {/* incoming frame + push arrow */}
+      <rect x={x} y={20} width={w} height={32} rx={8} style={{ fill: P.yellow, opacity: 0.3 }} />
+      <Arrow x1={x - 26} y1={30} x2={x - 26} y2={70} color={P.green700} width={2.6} />
+      {/* pop arrow */}
+      <Arrow x1={x + w + 26} y1={70} x2={x + w + 26} y2={30} color={P.red600} width={2.6} />
+    </>
+  );
+}
+
+/* ── how-javascript-runs: the event loop feeds the stack from a queue ─────── */
+export function EventLoop() {
+  return (
+    <>
+      {/* call stack (left) */}
+      <rect x={26} y={40} width={86} height={120} rx={12} style={{ fill: "none", stroke: P.blue, strokeWidth: 2.5 }} />
+      <rect x={40} y={120} width={58} height={24} rx={6} style={{ fill: P.blue }} />
+      <rect x={40} y={92} width={58} height={24} rx={6} style={{ fill: P.blue, opacity: 0.5 }} />
+
+      {/* task queue (right) */}
+      {[0, 1, 2].map((i) => (
+        <rect key={i} x={250 + i * 34} y={44} width={28} height={28} rx={7} style={{ fill: P.yellow, opacity: 1 - i * 0.22 }} />
+      ))}
+      <path d="M244 36 h104" style={{ fill: "none", stroke: P.line, strokeWidth: 2 }} />
+      <path d="M244 80 h104" style={{ fill: "none", stroke: P.line, strokeWidth: 2 }} />
+
+      {/* the loop: take the next task and run it on the stack when it's empty */}
+      <path d="M250 58 C 180 58, 170 150, 120 150" style={{ fill: "none", stroke: P.green700, strokeWidth: 2.6 }} />
+      <Arrow x1={138} y1={150} x2={116} y2={150} color={P.green700} width={2.6} />
+      {/* circular hint */}
+      <path d="M150 178 a26 26 0 1 0 14 -22" style={{ fill: "none", stroke: P.green700, strokeWidth: 2.6 }} />
+      <Arrow x1={158} y1={150} x2={166} y2={158} color={P.green700} width={2.6} head={8} />
+    </>
+  );
+}
+
+/* ── asynchronous-thinking: main thread keeps going; work returns later ───── */
+export function AsyncHandoff() {
+  const mainY = 56;
+  const bgY = 138;
+  return (
+    <>
+      {/* main thread */}
+      <Arrow x1={20} y1={mainY} x2={344} y2={mainY} color={P.ink} width={2.5} />
+      {/* main-thread tasks */}
+      {[40, 150, 250].map((x, i) => (
+        <rect key={i} x={x} y={mainY - 12} width={56} height={24} rx={7} style={{ fill: [P.blue, P.green, P.purple][i] }} />
+      ))}
+
+      {/* background lane */}
+      <line x1={20} y1={bgY} x2={344} y2={bgY} style={{ stroke: P.line, strokeWidth: 2, strokeDasharray: "2 6", strokeLinecap: "round" }} />
+      {/* the long-running work, offloaded */}
+      <rect x={108} y={bgY - 12} width={150} height={24} rx={7} style={{ fill: P.yellow }} />
+
+      {/* hand-off down, callback back up */}
+      <Arrow x1={96} y1={mainY + 12} x2={120} y2={bgY - 14} color={P.muted} width={2.2} />
+      <Arrow x1={250} y1={bgY - 14} x2={278} y2={mainY + 12} color={P.green700} width={2.4} />
+    </>
+  );
+}
+
+/* ── promises-and-async-await: pending settles to fulfilled or rejected ───── */
+export function PromiseStates() {
+  return (
+    <>
+      {/* pending */}
+      <circle cx={80} cy={100} r={36} style={{ fill: P.yellow }} />
+      {/* a clock/spinner glyph */}
+      <g style={{ stroke: P.onLight, strokeWidth: 3.4, strokeLinecap: "round", fill: "none" }}>
+        <path d="M80 78 a22 22 0 1 1 -16 7" />
+        <path d="M80 88 v13 l9 6" />
+      </g>
+
+      {/* to fulfilled */}
+      <Arrow x1={116} y1={84} x2={244} y2={56} color={P.green700} width={2.6} />
+      <circle cx={282} cy={52} r={28} style={{ fill: P.green }} />
+      <path d="M270 52 l7 8 l15 -17" style={{ fill: "none", stroke: P.onFill, strokeWidth: 4.5, strokeLinecap: "round", strokeLinejoin: "round" }} />
+
+      {/* to rejected */}
+      <Arrow x1={116} y1={116} x2={244} y2={146} color={P.red600} width={2.6} />
+      <circle cx={282} cy={150} r={28} style={{ fill: P.red }} />
+      <g style={{ stroke: P.onFill, strokeWidth: 4.5, strokeLinecap: "round" }}>
+        <line x1={272} y1={140} x2={292} y2={160} />
+        <line x1={292} y1={140} x2={272} y2={160} />
+      </g>
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/thinking.tsx
+++ b/app/_components/mdx/illustrations/thinking.tsx
@@ -1,0 +1,127 @@
+/**
+ * Illustrations for the "Thinking like a programmer" chapter.
+ *
+ * how-computers-execute-programs → the fetch / decode / execute cycle;
+ * computational-thinking          → decomposition: a big problem into pieces;
+ * problem-solving                 → a clear path found through obstacles.
+ */
+import { P } from "./palette";
+import { Arrow } from "./helpers";
+
+function NodeGlyph({ kind, x, y, on }: { kind: "fetch" | "decode" | "execute"; x: number; y: number; on: string }) {
+  if (kind === "fetch")
+    return (
+      <g style={{ stroke: on, strokeWidth: 3, strokeLinecap: "round", fill: "none" }}>
+        <path d={`M${x} ${y - 9} v15`} />
+        <path d={`M${x - 6} ${y} l6 6 l6 -6`} style={{ fill: on, stroke: "none" }} />
+        <path d={`M${x - 9} ${y + 11} h18`} />
+      </g>
+    );
+  if (kind === "execute")
+    return <polygon points={`${x - 7},${y - 9} ${x + 9},${y} ${x - 7},${y + 9}`} style={{ fill: on }} />;
+  // decode → three offset bars
+  return (
+    <g style={{ stroke: on, strokeWidth: 3, strokeLinecap: "round" }}>
+      <line x1={x - 8} y1={y - 6} x2={x + 8} y2={y - 6} />
+      <line x1={x - 8} y1={y} x2={x + 4} y2={y} />
+      <line x1={x - 8} y1={y + 6} x2={x + 8} y2={y + 6} />
+    </g>
+  );
+}
+
+/* ── how-computers-execute-programs: the fetch-decode-execute loop ────────── */
+export function CpuCycle() {
+  const cx = 160;
+  const cy = 120;
+  // three stations around the centre chip
+  const nodes = [
+    { x: cx, y: 38, fill: P.blue, glyph: "fetch" as const }, // top
+    { x: cx + 78, y: 158, fill: P.green, glyph: "execute" as const }, // bottom-right
+    { x: cx - 78, y: 158, fill: P.yellow, glyph: "decode" as const }, // bottom-left
+  ];
+  return (
+    <>
+      {/* connecting arcs (clockwise) */}
+      <path d={`M${cx + 26} 52 A 96 96 0 0 1 ${cx + 70} 128`} style={{ fill: "none", stroke: P.muted, strokeWidth: 2.4 }} />
+      <Arrow x1={cx + 64} y1={116} x2={cx + 72} y2={132} color={P.muted} width={2.4} head={8} />
+      <path d={`M${cx + 58} 176 A 96 96 0 0 1 ${cx - 58} 176`} style={{ fill: "none", stroke: P.muted, strokeWidth: 2.4 }} />
+      <Arrow x1={cx - 44} y1={181} x2={cx - 62} y2={174} color={P.muted} width={2.4} head={8} />
+      <path d={`M${cx - 70} 128 A 96 96 0 0 1 ${cx - 26} 52`} style={{ fill: "none", stroke: P.muted, strokeWidth: 2.4 }} />
+      <Arrow x1={cx - 32} y1={64} x2={cx - 24} y2={48} color={P.muted} width={2.4} head={8} />
+
+      {/* centre chip */}
+      <g>
+        <rect x={cx - 26} y={cy - 26} width={52} height={52} rx={9} style={{ fill: P.blue, opacity: 0.12 }} />
+        <rect x={cx - 26} y={cy - 26} width={52} height={52} rx={9} style={{ fill: "none", stroke: P.blue, strokeWidth: 2.5 }} />
+        <rect x={cx - 12} y={cy - 12} width={24} height={24} rx={4} style={{ fill: P.blue }} />
+        {[-16, 0, 16].map((d) => (
+          <g key={d} style={{ stroke: P.blue, strokeWidth: 2.5, strokeLinecap: "round" }}>
+            <line x1={cx + d} y1={cy - 26} x2={cx + d} y2={cy - 33} />
+            <line x1={cx + d} y1={cy + 26} x2={cx + d} y2={cy + 33} />
+            <line x1={cx - 26} y1={cy + d} x2={cx - 33} y2={cy + d} />
+            <line x1={cx + 26} y1={cy + d} x2={cx + 33} y2={cy + d} />
+          </g>
+        ))}
+      </g>
+
+      {/* stations */}
+      {nodes.map((n, i) => (
+        <g key={i}>
+          <circle cx={n.x} cy={n.y} r={26} style={{ fill: n.fill }} />
+          <NodeGlyph kind={n.glyph} x={n.x} y={n.y} on={n.glyph === "fetch" ? P.onFill : P.onLight} />
+        </g>
+      ))}
+    </>
+  );
+}
+
+/* ── computational-thinking: decompose a big problem into smaller ones ────── */
+export function DecompositionSplit() {
+  const smalls = [
+    { x: 232, y: 36, fill: P.green },
+    { x: 304, y: 36, fill: P.yellow },
+    { x: 232, y: 108, fill: P.red },
+    { x: 304, y: 108, fill: P.purple },
+  ];
+  return (
+    <>
+      {/* the big problem */}
+      <rect x={24} y={48} width={96} height={96} rx={16} style={{ fill: P.blue }} />
+
+      {/* split into pieces */}
+      {smalls.map((s, i) => (
+        <g key={i}>
+          <Arrow x1={126} y1={96} x2={s.x - 6} y2={s.y + 24} color={P.muted} width={2.2} head={8} />
+          <rect x={s.x} y={s.y} width={48} height={48} rx={11} style={{ fill: s.fill }} />
+        </g>
+      ))}
+    </>
+  );
+}
+
+/* ── problem-solving: a clear path found through the obstacles ────────────── */
+export function MazePath() {
+  // scattered obstacles
+  const blocks = [
+    [70, 30], [150, 70], [60, 120], [210, 40], [250, 120], [140, 150], [30, 70],
+  ];
+  return (
+    <>
+      {blocks.map(([x, y], i) => (
+        <rect key={i} x={x} y={y} width={30} height={30} rx={7} style={{ fill: P.surface, stroke: P.line, strokeWidth: 1.5 }} />
+      ))}
+
+      {/* the worked-out path — a dotted trail from start to goal */}
+      <path
+        d="M24 176 C 90 176, 96 110, 150 120 S 230 180, 300 96"
+        style={{ fill: "none", stroke: P.blue, strokeWidth: 4.5, strokeLinecap: "round", strokeDasharray: "0.5 11" }}
+      />
+
+      {/* start */}
+      <circle cx={24} cy={176} r={9} style={{ fill: P.blue }} />
+      {/* goal flag */}
+      <line x1={300} y1={96} x2={300} y2={62} style={{ stroke: P.green700, strokeWidth: 3, strokeLinecap: "round" }} />
+      <path d="M300 64 h22 l-6 8 l6 8 h-22 z" style={{ fill: P.green }} />
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/transform.tsx
+++ b/app/_components/mdx/illustrations/transform.tsx
@@ -1,0 +1,101 @@
+/**
+ * Illustrations for the "Data transformation" chapter.
+ *
+ * map-filter-reduce  → a left-to-right pipeline: transform each, keep some,
+ *                      fold to one;
+ * functional-intuition → composition: a value flows through chained functions.
+ */
+import { P } from "./palette";
+import { Arrow } from "./helpers";
+
+// tiny stage glyphs drawn above each connector (no words)
+function MapGlyph({ x }: { x: number }) {
+  return (
+    <g style={{ stroke: P.muted, strokeWidth: 2, strokeLinecap: "round", fill: "none" }}>
+      <path d={`M${x - 8} 18 h12`} />
+      <path d={`M${x + 1} 14 l4 4 l-4 4`} style={{ fill: P.muted, stroke: "none" }} />
+      <path d={`M${x + 8} 30 h-12`} />
+      <path d={`M${x - 1} 26 l-4 4 l4 4`} style={{ fill: P.muted, stroke: "none" }} />
+    </g>
+  );
+}
+function FilterGlyph({ x }: { x: number }) {
+  return <path d={`M${x - 9} 14 h18 l-6 9 v8 l-6 4 v-12 z`} style={{ fill: P.muted }} />;
+}
+function ReduceGlyph({ x }: { x: number }) {
+  return (
+    <g style={{ stroke: P.muted, strokeWidth: 2, strokeLinecap: "round", fill: "none" }}>
+      <path d={`M${x - 9} 14 l9 9 l-9 9`} />
+      <path d={`M${x + 1} 23 h9`} />
+    </g>
+  );
+}
+
+/* ── map-filter-reduce: the three-stage pipeline ──────────────────────────── */
+export function MfrPipeline() {
+  const ys = [44, 88, 132, 176];
+  const inputFills = [P.blue, P.green, P.yellow, P.red];
+
+  return (
+    <>
+      {/* stage 1 — input */}
+      {ys.map((y, i) => (
+        <circle key={i} cx={32} cy={y} r={14} style={{ fill: inputFills[i] }} />
+      ))}
+
+      {/* map → recolor every item, same count */}
+      <MapGlyph x={84} />
+      {ys.map((y, i) => (
+        <Arrow key={i} x1={50} y1={y} x2={120} y2={y} color={P.line} width={2} head={7} />
+      ))}
+      {ys.map((y, i) => (
+        <rect key={i} x={124} y={y - 14} width={28} height={28} rx={7} style={{ fill: P.blue }} />
+      ))}
+
+      {/* filter → only some pass; two fall away */}
+      <FilterGlyph x={196} />
+      <Arrow x1={154} y1={ys[0]} x2={232} y2={70} color={P.line} width={2} head={7} />
+      <Arrow x1={154} y1={ys[2]} x2={232} y2={150} color={P.line} width={2} head={7} />
+      {/* dropped */}
+      <rect x={166} y={ys[1] + 18} width={20} height={20} rx={5} style={{ fill: P.blue, opacity: 0.25 }} transform={`rotate(20 176 ${ys[1] + 28})`} />
+      <rect x={166} y={ys[3] + 4} width={20} height={20} rx={5} style={{ fill: P.blue, opacity: 0.25 }} transform={`rotate(-15 176 ${ys[3] + 14})`} />
+      <rect x={236} y={70 - 14} width={28} height={28} rx={7} style={{ fill: P.green }} />
+      <rect x={236} y={150 - 14} width={28} height={28} rx={7} style={{ fill: P.green }} />
+
+      {/* reduce → fold to one */}
+      <ReduceGlyph x={308} />
+      <Arrow x1={266} y1={70} x2={332} y2={104} color={P.line} width={2} head={7} />
+      <Arrow x1={266} y1={150} x2={332} y2={116} color={P.line} width={2} head={7} />
+      <circle cx={352} cy={110} r={20} style={{ fill: P.purple }} />
+    </>
+  );
+}
+
+/* ── functional-intuition: composition, a value flowing through f then g ───── */
+export function ComposePipes() {
+  const y = 70;
+  const block = (x: number, fill: string) => (
+    <g>
+      <rect x={x} y={y - 34} width={56} height={68} rx={14} style={{ fill }} />
+      {/* a small "process" chevron */}
+      <path d={`M${x + 22} ${y - 12} l12 12 l-12 12`} style={{ fill: "none", stroke: P.onFill, strokeWidth: 4, strokeLinecap: "round", strokeLinejoin: "round" }} />
+    </g>
+  );
+  return (
+    <>
+      {/* in */}
+      <circle cx={28} cy={y} r={16} style={{ fill: P.green }} />
+      <Arrow x1={48} y1={y} x2={96} y2={y} color={P.ink} width={2.5} />
+      {/* f */}
+      {block(98, P.blue)}
+      {/* intermediate value */}
+      <Arrow x1={158} y1={y} x2={206} y2={y} color={P.ink} width={2.5} />
+      <circle cx={186} cy={y} r={13} style={{ fill: P.yellow }} />
+      {/* g */}
+      {block(214, P.purple)}
+      {/* out */}
+      <Arrow x1={274} y1={y} x2={322} y2={y} color={P.ink} width={2.5} />
+      <circle cx={348} cy={y} r={16} style={{ fill: P.red }} />
+    </>
+  );
+}

--- a/app/_components/mdx/illustrations/types.ts
+++ b/app/_components/mdx/illustrations/types.ts
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+/** Frame width presets (see illustrations.module.css). */
+export type IllustrationSize = "sm" | "md" | "lg" | "full";
+
+export interface IllustrationEntry {
+  /**
+   * Accessible description. Rendered as the SVG's `<title>` and `aria-label`
+   * — it is NOT drawn on the page. This is how an illustration stays
+   * text-free visually while remaining meaningful to screen readers and
+   * search, so write it as a short, plain-language summary of the graphic.
+   */
+  label: string;
+  /** Default frame width when the author doesn't pass `size`. */
+  size?: IllustrationSize;
+  /** The SVG user-space, e.g. `"0 0 400 240"`. */
+  viewBox: string;
+  /** The inner SVG nodes (the wrapper owns the `<svg>` element itself). */
+  render: () => ReactNode;
+}
+
+export type IllustrationRegistry = Record<string, IllustrationEntry>;

--- a/app/_components/mdx/illustrations/values.tsx
+++ b/app/_components/mdx/illustrations/values.tsx
@@ -1,0 +1,355 @@
+/**
+ * Illustrations for the "Values, variables, and types" chapter.
+ *
+ * Styles intentionally differ page to page: a flat token grid (types), a
+ * line-art tag-and-box rebind (variables), a blueprint number line (numbers),
+ * a filmstrip of indexed cells (strings), and a set-theory Venn (booleans).
+ */
+import { P } from "./palette";
+import { Arrow } from "./helpers";
+
+const MONO = "var(--font-mono, monospace)";
+
+/* ── values-and-types: the built-in types as flat, glyph-only chips ───────── */
+export function TypesAsTokens() {
+  const tiles = [
+    { x: 10, y: 12, fill: P.blue, glyph: "number" as const, on: P.onFill },
+    { x: 136, y: 12, fill: P.green, glyph: "string" as const, on: P.onLight },
+    { x: 262, y: 12, fill: P.yellow, glyph: "boolean" as const, on: P.onLight },
+    { x: 10, y: 116, fill: P.red, glyph: "null" as const, on: P.onFill },
+    { x: 136, y: 116, fill: P.purple, glyph: "object" as const, on: P.onFill },
+    { x: 262, y: 116, fill: P.teal, glyph: "array" as const, on: P.onLight },
+  ];
+  return (
+    <>
+      {tiles.map((t, i) => {
+        const cx = t.x + 54;
+        const cy = t.y + 42;
+        return (
+          <g key={i}>
+            <rect
+              x={t.x}
+              y={t.y}
+              width={108}
+              height={84}
+              rx={16}
+              style={{ fill: t.fill }}
+            />
+            <Glyph kind={t.glyph} cx={cx} cy={cy} color={t.on} />
+          </g>
+        );
+      })}
+    </>
+  );
+}
+
+function Glyph({
+  kind,
+  cx,
+  cy,
+  color,
+}: {
+  kind: "number" | "string" | "boolean" | "null" | "object" | "array";
+  cx: number;
+  cy: number;
+  color: string;
+}) {
+  const stroke = {
+    stroke: color,
+    strokeWidth: 4,
+    strokeLinecap: "round" as const,
+    fill: "none",
+  };
+  if (kind === "number") {
+    // A hash "#" drawn as four strokes.
+    return (
+      <g style={stroke}>
+        <line x1={cx - 7} y1={cy - 16} x2={cx - 11} y2={cy + 16} />
+        <line x1={cx + 11} y1={cy - 16} x2={cx + 7} y2={cy + 16} />
+        <line x1={cx - 17} y1={cy - 5} x2={cx + 17} y2={cy - 5} />
+        <line x1={cx - 17} y1={cy + 7} x2={cx + 17} y2={cy + 7} />
+      </g>
+    );
+  }
+  if (kind === "string") {
+    // Three "lines of text" of decreasing width.
+    return (
+      <g style={stroke}>
+        <line x1={cx - 18} y1={cy - 12} x2={cx + 18} y2={cy - 12} />
+        <line x1={cx - 18} y1={cy} x2={cx + 12} y2={cy} />
+        <line x1={cx - 18} y1={cy + 12} x2={cx + 4} y2={cy + 12} />
+      </g>
+    );
+  }
+  if (kind === "boolean") {
+    // A toggle switch in the "on" position.
+    return (
+      <g>
+        <rect
+          x={cx - 22}
+          y={cy - 12}
+          width={44}
+          height={24}
+          rx={12}
+          style={{ fill: "none", stroke: color, strokeWidth: 3.5 }}
+        />
+        <circle cx={cx + 10} cy={cy} r={7} style={{ fill: color }} />
+      </g>
+    );
+  }
+  if (kind === "null") {
+    // The empty-set sign: a ring with a slash.
+    return (
+      <g style={{ stroke: color, strokeWidth: 4, fill: "none" }}>
+        <circle cx={cx} cy={cy} r={16} />
+        <line
+          x1={cx - 13}
+          y1={cy + 13}
+          x2={cx + 13}
+          y2={cy - 13}
+          style={{ strokeLinecap: "round" }}
+        />
+      </g>
+    );
+  }
+  if (kind === "object") {
+    // Three key→value rows (a small record).
+    return (
+      <g>
+        {[-13, 0, 13].map((dy, i) => (
+          <g key={i}>
+            <circle cx={cx - 16} cy={cy + dy} r={3.2} style={{ fill: color }} />
+            <line
+              x1={cx - 7}
+              y1={cy + dy}
+              x2={cx + 17}
+              y2={cy + dy}
+              style={{ stroke: color, strokeWidth: 3, strokeLinecap: "round" }}
+            />
+          </g>
+        ))}
+      </g>
+    );
+  }
+  // array: three little cells in a row.
+  return (
+    <g style={{ fill: "none", stroke: color, strokeWidth: 3 }}>
+      <rect x={cx - 24} y={cy - 9} width={16} height={18} rx={3} />
+      <rect x={cx - 8} y={cy - 9} width={16} height={18} rx={3} />
+      <rect x={cx + 8} y={cy - 9} width={16} height={18} rx={3} />
+    </g>
+  );
+}
+
+/* ── variables-and-state: a name (tag) rebound from one value to another ──── */
+export function VariableRebind() {
+  return (
+    <>
+      {/* the name — a luggage tag */}
+      <g>
+        <path
+          d="M28 78 h74 a14 14 0 0 1 14 14 v16 a14 14 0 0 1 -14 14 h-74 l-16 -22 z"
+          style={{ fill: P.blue }}
+        />
+        <circle cx={28} cy={100} r={5} style={{ fill: P.paper }} />
+      </g>
+
+      {/* old binding — faded */}
+      <rect
+        x={250}
+        y={20}
+        width={104}
+        height={56}
+        rx={12}
+        style={{ fill: "none", stroke: P.line, strokeWidth: 2 }}
+      />
+      <circle cx={302} cy={48} r={15} style={{ fill: P.muted, opacity: 0.5 }} />
+      <Arrow x1={120} y1={92} x2={246} y2={56} color={P.muted} width={2} dashed />
+
+      {/* current binding */}
+      <rect
+        x={250}
+        y={120}
+        width={104}
+        height={56}
+        rx={12}
+        style={{ fill: "none", stroke: P.green, strokeWidth: 2.5 }}
+      />
+      <circle cx={302} cy={148} r={15} style={{ fill: P.green }} />
+      <Arrow x1={120} y1={108} x2={246} y2={148} color={P.blue} width={3} />
+    </>
+  );
+}
+
+/* ── numbers-and-arithmetic: a number line with one "+" hop (blueprint) ───── */
+export function NumberLine() {
+  const y = 112;
+  const x0 = 24;
+  const x1 = 356;
+  const step = (x1 - x0) / 10;
+  const ticks = Array.from({ length: 11 }, (_, i) => x0 + i * step);
+  const zeroX = ticks[5];
+  return (
+    <>
+      {/* faint blueprint grid */}
+      {ticks.map((tx, i) => (
+        <line
+          key={i}
+          x1={tx}
+          y1={28}
+          x2={tx}
+          y2={150}
+          style={{ stroke: P.line, strokeWidth: 1, opacity: 0.5 }}
+        />
+      ))}
+
+      {/* a "+3" hop above the line */}
+      <path
+        d={`M ${zeroX} ${y - 6} C ${zeroX + step} ${y - 56}, ${zeroX + 2 * step} ${y - 56}, ${zeroX + 3 * step} ${y - 6}`}
+        style={{ fill: "none", stroke: P.blue, strokeWidth: 3 }}
+      />
+      <Arrow
+        x1={zeroX + 3 * step - 12}
+        y1={y - 22}
+        x2={zeroX + 3 * step}
+        y2={y - 6}
+        color={P.blue}
+        width={3}
+        head={8}
+      />
+
+      {/* the axis */}
+      <Arrow
+        x1={x0}
+        y1={y}
+        x2={x1}
+        y2={y}
+        color={P.ink}
+        width={2.5}
+        double
+        head={10}
+      />
+      {ticks.map((tx, i) => (
+        <line
+          key={i}
+          x1={tx}
+          y1={y - (i === 5 ? 12 : 7)}
+          x2={tx}
+          y2={y + (i === 5 ? 12 : 7)}
+          style={{ stroke: P.ink, strokeWidth: i === 5 ? 3 : 2 }}
+        />
+      ))}
+      <text
+        x={zeroX}
+        y={y + 30}
+        textAnchor="middle"
+        style={{ fill: P.muted, font: `600 13px ${MONO}` }}
+      >
+        0
+      </text>
+    </>
+  );
+}
+
+/* ── strings-and-text: characters in indexed cells (filmstrip + ruler) ────── */
+export function StringCells() {
+  const chars = ["H", "e", "l", "l", "o"];
+  const size = 60;
+  const gap = 10;
+  const x0 = 22;
+  const y = 26;
+  return (
+    <>
+      {chars.map((ch, i) => {
+        const x = x0 + i * (size + gap);
+        return (
+          <g key={i}>
+            <rect
+              x={x}
+              y={y}
+              width={size}
+              height={size}
+              rx={10}
+              style={{ fill: P.blue, opacity: i === 0 ? 1 : 0.16 }}
+            />
+            <rect
+              x={x}
+              y={y}
+              width={size}
+              height={size}
+              rx={10}
+              style={{ fill: "none", stroke: P.blue, strokeWidth: 2 }}
+            />
+            <text
+              x={x + size / 2}
+              y={y + size / 2 + 9}
+              textAnchor="middle"
+              style={{
+                fill: i === 0 ? P.onFill : P.ink,
+                font: `500 26px ${MONO}`,
+              }}
+            >
+              {ch}
+            </text>
+            {/* index ruler */}
+            <line
+              x1={x + size / 2}
+              y1={y + size + 8}
+              x2={x + size / 2}
+              y2={y + size + 16}
+              style={{ stroke: P.muted, strokeWidth: 2 }}
+            />
+            <text
+              x={x + size / 2}
+              y={y + size + 33}
+              textAnchor="middle"
+              style={{ fill: P.muted, font: `600 13px ${MONO}` }}
+            >
+              {i}
+            </text>
+          </g>
+        );
+      })}
+    </>
+  );
+}
+
+/* ── booleans-and-logic: two conditions overlapping (set Venn) ────────────── */
+export function BooleanVenn() {
+  // Circles centered on the same y, the lens (AND) carved from their overlap.
+  const cyc = 100;
+  const r = 64;
+  const lx = 150;
+  const rx = 226;
+  // Intersection points (both circles share radius r): vertical line at the
+  // midpoint x, offset ±h in y.
+  const midX = (lx + rx) / 2;
+  const d = (rx - lx) / 2;
+  const h = Math.sqrt(r * r - d * d);
+  const top = `${midX} ${cyc - h}`;
+  const bot = `${midX} ${cyc + h}`;
+  return (
+    <>
+      <circle cx={lx} cy={cyc} r={r} style={{ fill: P.blue, opacity: 0.85 }} />
+      <circle cx={rx} cy={cyc} r={r} style={{ fill: P.green, opacity: 0.85 }} />
+      {/* the AND lens */}
+      <path
+        d={`M ${top} A ${r} ${r} 0 0 1 ${bot} A ${r} ${r} 0 0 1 ${top} Z`}
+        style={{ fill: P.teal }}
+      />
+      {/* thin definition so the shapes read on a white page */}
+      <circle
+        cx={lx}
+        cy={cyc}
+        r={r}
+        style={{ fill: "none", stroke: P.blue, strokeWidth: 1.5 }}
+      />
+      <circle
+        cx={rx}
+        cy={cyc}
+        r={r}
+        style={{ fill: "none", stroke: P.green, strokeWidth: 1.5 }}
+      />
+    </>
+  );
+}

--- a/content/learn/beginners-javascript/arrays.mdx
+++ b/content/learn/beginners-javascript/arrays.mdx
@@ -46,6 +46,8 @@ console.log([].length); // 0
 
 ## Indexing: zero-based
 
+<Illustration name="array-cells" />
+
 Read or write an element by its **index**, starting at `0`.
 
 <CodeBlock

--- a/content/learn/beginners-javascript/asynchronous-thinking.mdx
+++ b/content/learn/beginners-javascript/asynchronous-thinking.mdx
@@ -153,6 +153,8 @@ to flatten this.
 
 ## Concurrency without parallelism
 
+<Illustration name="async-handoff" />
+
 A subtle but important word distinction:
 
 - **Concurrent**: many tasks are *in progress* during overlapping

--- a/content/learn/beginners-javascript/birth-of-javascript.mdx
+++ b/content/learn/beginners-javascript/birth-of-javascript.mdx
@@ -45,6 +45,8 @@ incredibly successful* language gets designed.
 
 ## The first prototype
 
+<Illustration name="ten-day-spark" />
+
 Eich worked feverishly. In **ten days in May 1995**, he produced a
 working prototype. The language was internally called **Mocha**, then
 **LiveScript**, and finally — for marketing reasons, to ride Java's

--- a/content/learn/beginners-javascript/booleans-and-logic.mdx
+++ b/content/learn/beginners-javascript/booleans-and-logic.mdx
@@ -46,6 +46,8 @@ locale-aware methods like `"a".localeCompare("B")`.
 
 ## The three logical operators
 
+<Illustration name="boolean-venn" />
+
 Once you have boolean values, you combine them with three logical
 operators:
 

--- a/content/learn/beginners-javascript/closures.mdx
+++ b/content/learn/beginners-javascript/closures.mdx
@@ -89,6 +89,8 @@ no global variable.
 
 ## Why closures exist (the mechanics)
 
+<Illustration name="closure-backpack" />
+
 Earlier we said each call to a function creates a new scope, and
 the local variables vanish when the call returns. **That second
 part is not quite true.** A scope's variables vanish only when

--- a/content/learn/beginners-javascript/computational-thinking.mdx
+++ b/content/learn/beginners-javascript/computational-thinking.mdx
@@ -17,6 +17,8 @@ practice them on small JavaScript problems.
 > **Decomposition** is breaking a fuzzy, big problem into smaller,
 > well-defined problems you can actually solve.
 
+<Illustration name="decomposition-split" />
+
 Imagine someone says: *"Write a program that figures out a fair way
 to split a restaurant bill, including tip."*
 

--- a/content/learn/beginners-javascript/conditionals.mdx
+++ b/content/learn/beginners-javascript/conditionals.mdx
@@ -13,6 +13,8 @@ the most fundamental tool for it is the `if` statement.
 
 ## The `if` statement
 
+<Illustration name="branch-fork" />
+
 The basic shape:
 
 ```javascript

--- a/content/learn/beginners-javascript/debugging-and-reasoning.mdx
+++ b/content/learn/beginners-javascript/debugging-and-reasoning.mdx
@@ -15,6 +15,8 @@ This chapter covers two things:
 
 ## What debugging really is
 
+<Illustration name="bug-magnifier" />
+
 A bug exists because there's a gap between:
 
 - the **mental model** you have of what the program does, and

--- a/content/learn/beginners-javascript/ecosystem-explosion.mdx
+++ b/content/learn/beginners-javascript/ecosystem-explosion.mdx
@@ -13,6 +13,8 @@ That changed slowly, then suddenly.
 
 ## The middle years: pain and patience (1995–2005)
 
+<Illustration name="ecosystem-burst" />
+
 The first decade of JavaScript was, frankly, painful. Three browsers
 (Netscape, Internet Explorer, and later Firefox) had subtly
 different implementations. The same code might work in one browser

--- a/content/learn/beginners-javascript/functional-intuition.mdx
+++ b/content/learn/beginners-javascript/functional-intuition.mdx
@@ -192,6 +192,8 @@ A pipeline like `arr.filter(...).map(...).reduce(...)` is a form
 of **composition**: small functions stuck together to make a
 bigger one. You can compose at the function level too.
 
+<Illustration name="compose-pipes" />
+
 <CodeBlock
   adapter="javascript"
   starterCode={`const trim = (s) => s.trim();

--- a/content/learn/beginners-javascript/functions-basics.mdx
+++ b/content/learn/beginners-javascript/functions-basics.mdx
@@ -14,6 +14,8 @@ A **function** is a named, reusable piece of code that takes some
 **inputs** (arguments) and produces an **output** (a return value).
 You define it once. You call it many times.
 
+<Illustration name="function-machine" />
+
 ```mermaid
 flowchart LR
     I1((inputs)) --> F[Function: do something with the inputs]

--- a/content/learn/beginners-javascript/how-computers-execute-programs.mdx
+++ b/content/learn/beginners-javascript/how-computers-execute-programs.mdx
@@ -46,6 +46,8 @@ text.
 
 ## The fetch-decode-execute loop
 
+<Illustration name="cpu-cycle" />
+
 The CPU itself, ignoring all complexity, runs the same tiny loop
 forever:
 

--- a/content/learn/beginners-javascript/how-javascript-runs.mdx
+++ b/content/learn/beginners-javascript/how-javascript-runs.mdx
@@ -35,6 +35,8 @@ When the function returns, the frame is popped. That's it. The
 "stack" is just the list of "things in progress, most recent on
 top."
 
+<Illustration name="call-stack" />
+
 <CodeBlock
   adapter="javascript"
   starterCode={`function greet(name) {
@@ -118,6 +120,8 @@ other languages and *can* do work in parallel. When they finish,
 they hand a result back to JS by **scheduling a task**.
 
 A simplified picture:
+
+<Illustration name="event-loop" />
 
 ```mermaid
 flowchart TD

--- a/content/learn/beginners-javascript/internet-and-interactivity.mdx
+++ b/content/learn/beginners-javascript/internet-and-interactivity.mdx
@@ -47,6 +47,8 @@ server hands it.
 
 ## The pain of "talk to the server for everything"
 
+<Illustration name="client-server" />
+
 Now imagine building a form on a page from the early 1990s. The
 user types their name and email and clicks "Submit". The browser
 sends the entire form to the server. The server checks: *is the

--- a/content/learn/beginners-javascript/javascript-beyond-the-browser.mdx
+++ b/content/learn/beginners-javascript/javascript-beyond-the-browser.mdx
@@ -12,6 +12,8 @@ JavaScript is worth learning deeply.
 
 ## The idea of a "runtime"
 
+<Illustration name="runtime-hub" />
+
 Before we tour all the places JavaScript runs, let's pin down a word
 we have been using loosely: **runtime**.
 

--- a/content/learn/beginners-javascript/javascript-today.mdx
+++ b/content/learn/beginners-javascript/javascript-today.mdx
@@ -9,6 +9,8 @@ programming language to learn deeply.
 
 ## What JavaScript is, in one sentence
 
+<Illustration name="ubiquity-globe" />
+
 > **JavaScript is a dynamic, multi-paradigm, garbage-collected
 > programming language that runs almost everywhere, with first-class
 > functions, mutable objects, and a single-threaded asynchronous

--- a/content/learn/beginners-javascript/loops-and-iteration.mdx
+++ b/content/learn/beginners-javascript/loops-and-iteration.mdx
@@ -15,6 +15,8 @@ just as importantly, when to use which.
 
 ## The `while` loop
 
+<Illustration name="loop-cycle" />
+
 The simplest loop. While the condition is truthy, run the body. Then
 check the condition again.
 

--- a/content/learn/beginners-javascript/maintainable-code.mdx
+++ b/content/learn/beginners-javascript/maintainable-code.mdx
@@ -11,6 +11,8 @@ modify, and trust without re-deriving how it works.
 There's no magic formula, but there are a handful of habits that
 move you a long way. This chapter is a tour.
 
+<Illustration name="tangle-vs-tidy" />
+
 ## Names are documentation
 
 The single highest-leverage thing you can do is name things well.

--- a/content/learn/beginners-javascript/map-filter-reduce.mdx
+++ b/content/learn/beginners-javascript/map-filter-reduce.mdx
@@ -243,6 +243,8 @@ replace a hand-rolled loop with an early `return true`.
 A chain of `.filter().map().reduce()` is a small **data pipeline**.
 Each step takes the previous output as input.
 
+<Illustration name="mfr-pipeline" />
+
 ```mermaid
 flowchart TD
     A[orders] --> B["filter: status === 'paid'"]

--- a/content/learn/beginners-javascript/modular-organization.mdx
+++ b/content/learn/beginners-javascript/modular-organization.mdx
@@ -14,6 +14,8 @@ principles take you 90% of the way.
 
 ## What is a module?
 
+<Illustration name="modules-blocks" />
+
 A **module** is a file (or package) that:
 
 - has its own private scope, and

--- a/content/learn/beginners-javascript/nested-data.mdx
+++ b/content/learn/beginners-javascript/nested-data.mdx
@@ -11,6 +11,8 @@ just about anything.
 
 ## Mental model: shapes inside shapes
 
+<Illustration name="nested-tree" />
+
 Take a moment to read this object slowly:
 
 <CodeBlock

--- a/content/learn/beginners-javascript/next-steps.mdx
+++ b/content/learn/beginners-javascript/next-steps.mdx
@@ -29,6 +29,8 @@ That's a real skill. Now you grow it by *building things*.
 
 ## Three paths from here
 
+<Illustration name="roadmap" />
+
 ```mermaid
 flowchart TB
     Foundations[You are here:<br/>JavaScript fundamentals] --> A[Path A: The Browser & UI]

--- a/content/learn/beginners-javascript/numbers-and-arithmetic.mdx
+++ b/content/learn/beginners-javascript/numbers-and-arithmetic.mdx
@@ -36,6 +36,8 @@ ignore it for now.)
 
 ## Basic arithmetic
 
+<Illustration name="number-line" />
+
 The familiar operators all work as expected:
 
 | Operator | Meaning | Example | Result |

--- a/content/learn/beginners-javascript/objects.mdx
+++ b/content/learn/beginners-javascript/objects.mdx
@@ -14,6 +14,8 @@ language itself is built around them.
 
 ## Creating objects
 
+<Illustration name="object-record" />
+
 The classic syntax — **object literal** notation:
 
 <CodeBlock

--- a/content/learn/beginners-javascript/parameters-and-returns.mdx
+++ b/content/learn/beginners-javascript/parameters-and-returns.mdx
@@ -7,6 +7,8 @@ A function is a contract: *"if you give me these inputs, I will
 give you this output"*. The vocabulary around that contract is
 worth getting right.
 
+<Illustration name="params-funnel" />
+
 - **Parameters** are the names in the function declaration. They
   are the *placeholders*.
 - **Arguments** are the actual values passed in when the function

--- a/content/learn/beginners-javascript/problem-solving.mdx
+++ b/content/learn/beginners-javascript/problem-solving.mdx
@@ -15,6 +15,8 @@ the answer in one shot. There is a better way.
 
 ## The five steps
 
+<Illustration name="maze-path" />
+
 ```mermaid
 flowchart TD
     A[1. Understand] --> B[2. Plan]

--- a/content/learn/beginners-javascript/promises-and-async-await.mdx
+++ b/content/learn/beginners-javascript/promises-and-async-await.mdx
@@ -23,6 +23,8 @@ ready yet. Later, the Promise will either be:
 - **fulfilled** with a value, or
 - **rejected** with an error.
 
+<Illustration name="promise-states" />
+
 Once a Promise is settled (fulfilled or rejected), it never
 changes.
 

--- a/content/learn/beginners-javascript/rise-of-scripting-languages.mdx
+++ b/content/learn/beginners-javascript/rise-of-scripting-languages.mdx
@@ -31,6 +31,8 @@ useful programs?*
 
 ## What "scripting" actually means
 
+<Illustration name="compiled-vs-interpreted" />
+
 The word **script** comes from the theatre: a script is a sequence of
 lines an actor follows. In computing, a script is a sequence of
 instructions that some larger system (an operating system, a

--- a/content/learn/beginners-javascript/scope-and-scope-chain.mdx
+++ b/content/learn/beginners-javascript/scope-and-scope-chain.mdx
@@ -79,6 +79,8 @@ When a name is referenced and the runtime cannot find it in the
 scope enclosing that, and so on out to the global scope. That
 sequence of nested scopes is called the **scope chain**.
 
+<Illustration name="nested-scopes" />
+
 ```mermaid
 flowchart TB
     G["Global scope<br/>const greeting = 'Hello'"]

--- a/content/learn/beginners-javascript/story-of-programming.mdx
+++ b/content/learn/beginners-javascript/story-of-programming.mdx
@@ -72,6 +72,8 @@ We needed languages that were closer to how humans *think*.
 
 ## High-level languages: thinking, not bookkeeping
 
+<Illustration name="abstraction-ladder" />
+
 In the late 1950s, languages like **FORTRAN** and **COBOL** appeared.
 They let programmers write things like:
 

--- a/content/learn/beginners-javascript/strings-and-text.mdx
+++ b/content/learn/beginners-javascript/strings-and-text.mdx
@@ -116,6 +116,8 @@ will save you grief later.
 
 ## Length and indexing
 
+<Illustration name="string-cells" />
+
 A string has a `.length` property — the number of characters in
 it. You can read an individual character with bracket notation:
 

--- a/content/learn/beginners-javascript/values-and-types.mdx
+++ b/content/learn/beginners-javascript/values-and-types.mdx
@@ -47,6 +47,8 @@ in a sensible way for its kind.
 
 ## A type is "the kind of value"
 
+<Illustration name="types-as-tokens" />
+
 Every value has a **type** — the *kind* of value it is. JavaScript
 has a small set of built-in types, and you can ask the runtime
 what type any value has with the `typeof` operator:

--- a/content/learn/beginners-javascript/variables-and-state.mdx
+++ b/content/learn/beginners-javascript/variables-and-state.mdx
@@ -12,6 +12,8 @@ remembers a value and gives it a name.
 A **variable** is a named slot that holds a value. You can think of
 it as a labelled box:
 
+<Illustration name="variable-rebind" />
+
 ```mermaid
 flowchart LR
     subgraph Memory

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -19,6 +19,7 @@ import MdxSqlChallengeCard from "@/app/_components/MdxSqlChallengeCard";
 import MdxSqlCodeBlock from "@/app/_components/MdxSqlCodeBlock";
 import MdxMultipleChoiceQuestion from "@/app/_components/multipleChoice/MdxMultipleChoiceQuestion";
 import { Mermaid } from "@/app/_components/mdx/mermaid";
+import { Illustration } from "@/app/_components/mdx/illustrations/Illustration";
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
@@ -29,6 +30,10 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     SqlCodeBlock: MdxSqlCodeBlock,
     MultipleChoice: MdxMultipleChoiceQuestion,
     Mermaid,
+    // SVG vector illustrations for /learn lessons — a single dispatcher that
+    // renders themed, text-free artwork by name (see app/_components/mdx/
+    // illustrations/registry.tsx).
+    Illustration,
     // Fumadocs Steps/Step — a numbered vertical walkthrough. Registered
     // globally so lessons can drop `<Steps>…<Step>` in without an import,
     // matching the convention used by the components above.


### PR DESCRIPTION
## What this is

A pilot of decorative/informative **SVG vector illustrations** across the **Beginner's Guide to JavaScript** course — at least one per lesson (34 in total), in deliberately varied visual styles.

The change is **purely additive**: no Mermaid diagram or React component is replaced. On conceptual pages the illustration is placed **right next to the existing Mermaid chart** so the two visual approaches can be compared directly (as requested).

## How it works

A single globally-registered MDX component:

```mdx
<Illustration name="mfr-pipeline" />
```

- **`app/_components/mdx/illustrations/`** — `Illustration.tsx` (the dispatcher/`<figure>` frame), `registry.tsx` (name → artwork + accessible label + viewBox), `palette.ts` (shared color tokens), `helpers.tsx` (arrow/gear primitives), and one file per course chapter holding the SVGs.
- Registered once in `mdx-components.tsx`, alongside `Mermaid`, `CodeBlock`, etc.
- Each illustration is a **pure static SVG** (server component, **no client JS**).

### Light + dark mode

Every graphic themes itself with **CSS variables only**, so it adapts to the active theme with no JS and no flash:

- **Brand hues** (`--ds-blue-500` … from `app/brand.css`) — mode-agnostic, used as flat fills. Mostly the **blue/green/red/yellow 500s**, with the **occasional teal/purple/orange** and 100–900 shades for categorical variety.
- **Theme-aware neutrals** — `currentColor` plus the Fumadocs `--color-fd-*` tokens for outlines, hairlines, surfaces, and knockouts, which flip between light and dark.
- Fixed inks (white / near-black) are used only where a detail sits *on top of* a mode-agnostic brand fill.

### Minimal text

Visible text is avoided; meaning is carried by an `aria-label`/`<title>` on each SVG (good for screen readers + search). The only on-canvas text is where it's pedagogically required — zero-based index digits, a `0` on the number line, and a sample `Hello` string.

## Styles included

Flat type-token grid, line-art tag-and-box, blueprint number line, filmstrip cells, set Venn, decision fork, repeat ring, function machine, funnel, nested scopes, closure "backpack", indexed cells, record card, node tree, conveyor pipeline, composition pipes, call-stack plates, event-loop ring, two-lane async timeline, promise state machine, fetch/decode/execute cycle, decomposition split, maze path, duotone abstraction ladder, compiled-vs-interpreted lanes, client–server exchange, 10-day emblem, ecosystem burst, runtime hub-and-spoke, line-art globe, bug-and-magnifier, tangle-vs-tidy, plug-in modules, and a milestone roadmap.

## Verification

- `tsc --noEmit` ✅, `eslint` ✅ (illustrations + `mdx-components.tsx`)
- All 33 lesson pages + index compile (HTTP 200) with no runtime warnings
- Content tests (`contentTitles`, `mcqContent`) pass
- Every illustration rendered and visually checked in **both light and dark** mode
- Registry ↔ usage cross-checked: 34 names, 34 uses, no typos

https://claude.ai/code/session_01QX1t3oaXLKovbjipMmTG5U

---
_Generated by [Claude Code](https://claude.ai/code/session_01QX1t3oaXLKovbjipMmTG5U)_