### PR TITLE
Align running examples across all 27 courses (prose ↔ diagrams ↔ code ↔ challenges)

### DIFF
--- a/content/learn/c-programming-for-beginners/input-and-output.mdx
+++ b/content/learn/c-programming-for-beginners/input-and-output.mdx
@@ -227,7 +227,7 @@ We'll see more of `fgets` in the chapter on strings.
   instructions={`Two variables \`item\` (string) and \`qty\` (int) and \`unit_price\` (double) are set to \`"Widget"\`, \`5\`, and \`3.50\`. Print exactly:
 
 \`\`\`
-Item: Widget    Qty: 5  Unit: $3.50  Total: $17.50
+Item: Widget   Qty: 5  Unit: $3.50  Total: $17.50
 \`\`\`
 
 Use the field widths:

--- a/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
+++ b/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
@@ -38,11 +38,11 @@ The desired report:
 === Product B ===
   units sold:   12
   gross:        588.00
-  net (paid - refund): 539.00
+  net (paid - refund): 588.00
 === TOTAL ===
   units sold:   29
   gross:        927.83
-  net:          838.85
+  net:          887.85
 ```
 
 ## The architecture
@@ -267,7 +267,7 @@ public static class Pipeline
       name: "Full pipeline produces correct multi-product report",
       description: "Parse + group + summarize + total over the sample dataset",
       expect: {
-        stdoutEquals: "=== Product A ===\n  units sold:   17\n  gross:        339.83\n  net:          299.85\n=== Product B ===\n  units sold:   12\n  gross:        588.00\n  net:          539.00\n=== TOTAL ===\n  units sold:   29\n  gross:        927.83\n  net:          838.85\n",
+        stdoutEquals: "=== Product A ===\n  units sold:   17\n  gross:        339.83\n  net:          299.85\n=== Product B ===\n  units sold:   12\n  gross:        588.00\n  net:          588.00\n=== TOTAL ===\n  units sold:   29\n  gross:        927.83\n  net:          887.85\n",
       },
     },
   ]}

--- a/content/learn/csharp-linq-functional/generic-abstractions.mdx
+++ b/content/learn/csharp-linq-functional/generic-abstractions.mdx
@@ -272,7 +272,7 @@ public static class HistogramOp
       name: "Generic histogram handles ints and strings",
       description: "Same generic operator works on words-by-length and ints-by-parity",
       expect: {
-        stdoutEquals: "len 4: 1\nlen 5: 3\nlen 7: 2\n--\neven: 5\nodd: 5\n",
+        stdoutEquals: "len 4: 2\nlen 5: 3\nlen 7: 1\n--\neven: 5\nodd: 5\n",
       },
     },
   ]}

--- a/content/learn/csharp-linq-functional/rise-of-declarative.mdx
+++ b/content/learn/csharp-linq-functional/rise-of-declarative.mdx
@@ -111,7 +111,7 @@ Console.WriteLine("v4: " + v4);
 `}
 />
 
-All four print `2, 4, 8, 12`. They are **operationally equivalent**.
+All four print `4, 8, 12`. They are **operationally equivalent**.
 They are not **cognitively equivalent**. Each version, top to bottom,
 moves further from "I am driving a CPU" toward "I am describing a
 result".

--- a/content/learn/csharp-linq-functional/side-effect-management.mdx
+++ b/content/learn/csharp-linq-functional/side-effect-management.mdx
@@ -292,7 +292,7 @@ public static class Report
       name: "Pure Report.Build returns deterministic, time-injected total",
       description: "Date and window are arguments, so output is fully predictable",
       expect: {
-        stdoutEquals: "PAID in last 10 days: 340\n",
+        stdoutEquals: "PAID in last 10 days: 40\n",
       },
     },
   ]}

--- a/content/learn/data-analysis-python-pandas/messy-data-overview.mdx
+++ b/content/learn/data-analysis-python-pandas/messy-data-overview.mdx
@@ -157,8 +157,9 @@ What did you spot?
 - **Casing** ("DIEGO", "uk").
 - **Country inconsistency** (USA / U.S.A. / United States / U.S.).
 - **Date format chaos** (ISO, slash, MM/DD).
-- **An impossible date** (Feb 29, 2024 is real, but Feb 30 is
-  not — example of values that *look* fine but break).
+- **A date worth double-checking** (`2024-02-29` looks like a typo
+  but is real — 2024 is a leap year; a value like Feb 30 would be
+  the kind that *looks* fine but breaks).
 - **`spend` as strings** (because `"abc"` and `""` poison the
   type inference).
 - **`spend` outlier** (9,999,999 is probably wrong).

--- a/content/learn/data-analysis-python-pandas/string-operations.mdx
+++ b/content/learn/data-analysis-python-pandas/string-operations.mdx
@@ -126,7 +126,7 @@ logs = pd.Series(
 )
 
 parsed = logs.str.extract(
-    r"(?P<date>d{4}-d{2}-d{2}) (?P<time>d{2}:d{2}:d{2}) (?P<level>w+)s+(?P<msg>.*)"
+    r"(?P<date>\\d{4}-\\d{2}-\\d{2}) (?P<time>\\d{2}:\\d{2}:\\d{2}) (?P<level>\\w+)\\s+(?P<msg>.*)"
 )
 print(parsed)
 `}
@@ -144,7 +144,7 @@ turning log files into a real DataFrame.
 s = pd.Series(["(555) 123-4567", "(555) 987-6543", "(212) 555-0100"])
 
 # Strip non-digits to get a clean phone number
-clean = s.str.replace(r"\D", "", regex=True)
+clean = s.str.replace(r"\\D", "", regex=True)
 print(clean)
 `}
 />
@@ -213,7 +213,7 @@ raw = pd.Series(
 
 clean = (
     raw.str.strip()  # outer spaces
-    .str.replace(r"s+", " ", regex=True)  # collapse internal whitespace
+    .str.replace(r"\\s+", " ", regex=True)  # collapse internal whitespace
     .str.title()  # nice casing
     .replace("", pd.NA)  # empties → missing
 )
@@ -276,7 +276,7 @@ print(clean)
 
 clean = (
     titles.str.strip()
-    .str.replace(r"s+", " ", regex=True)
+    .str.replace(r"\\s+", " ", regex=True)
     .str.title()
     .replace({"Data Scientists": "Data Scientist"})
     .replace("", pd.NA)

--- a/content/learn/data-analysis-python-pandas/the-analyst-mindset.mdx
+++ b/content/learn/data-analysis-python-pandas/the-analyst-mindset.mdx
@@ -191,7 +191,7 @@ just take the mean. Look first.
 satisfaction = pd.DataFrame(
     {
         "customer_id": range(1, 16),
-        "score": [5, 4, 5, 5, 1, 5, 4, 5, 5, 1, 5, 5, 4, 5, 1],
+        "score": [5, 5, 5, 5, 5, 4, 5, 5, 4, 5, 5, 4, 1, 1, 1],
         "submitted_via": ["email"] * 12 + ["phone"] * 3,
     }
 )

--- a/content/learn/database-design-postgresql/many-to-many.mdx
+++ b/content/learn/database-design-postgresql/many-to-many.mdx
@@ -107,8 +107,8 @@ erDiagram
         text title
     }
     enrollments {
-        int student_id FK
-        int course_id FK
+        int student_id PK, FK
+        int course_id PK, FK
     }
 ```
 

--- a/content/learn/database-design-postgresql/second-normal-form.mdx
+++ b/content/learn/database-design-postgresql/second-normal-form.mdx
@@ -23,7 +23,7 @@ erDiagram
     products ||--o{ order_items : appears
     orders {
         int id PK
-        text order_date
+        date order_date
     }
     products {
         int id PK
@@ -128,7 +128,7 @@ erDiagram
     products ||--o{ order_items : appears
     orders {
         int id PK
-        text order_date
+        date order_date
     }
     products {
         int id PK

--- a/content/learn/functional-programming-typescript/function-composition.mdx
+++ b/content/learn/functional-programming-typescript/function-composition.mdx
@@ -340,7 +340,7 @@ arguments to `pipe` — no reshuffling of loops.
 
 - \`trim(s)\` — strip surrounding whitespace
 - \`lower(s)\` — lowercase
-- \`stripPunct(s)\` — remove non-alphanumeric, non-space characters
+- \`stripPunct(s)\` — replace non-alphanumeric, non-space characters with a space
 - \`collapseSpaces(s)\` — collapse runs of whitespace to one
 - \`hyphenate(s)\` — replace spaces with hyphens
 - \`slug(s)\` — pipeline of the above, in this order
@@ -386,7 +386,7 @@ export const slug = (s: string): string => s; // TODO: pipe the above
 export const trim = (s: string): string => s.trim();
 export const lower = (s: string): string => s.toLowerCase();
 export const stripPunct = (s: string): string =>
-  s.replace(/[^\\p{L}\\p{N}\\s]/gu, "");
+  s.replace(/[^\\p{L}\\p{N}\\s]/gu, " ");
 export const collapseSpaces = (s: string): string => s.replace(/\\s+/g, " ");
 export const hyphenate = (s: string): string => s.replace(/ /g, "-");
 

--- a/content/learn/functional-programming-typescript/option-and-result.mdx
+++ b/content/learn/functional-programming-typescript/option-and-result.mdx
@@ -307,8 +307,8 @@ provided.
 **Expected output**
 
 \`\`\`
-u3 -> linus@example.com
-u2 -> ada@example.com
+u3 -> ada@example.com
+u2 -> grace@example.com
 u1 -> none
 ux -> none
 \`\`\``}
@@ -402,7 +402,7 @@ export function emailOfManagerOf(id: string): Option<string> {
       id: "manager-email",
       name: "Chained Option lookups",
       description: "Compose findUser/managerOf/findUser/emailOf via flatMap.",
-      expect: { stdoutEquals: "u3 -> linus@example.com\nu2 -> ada@example.com\nu1 -> none\nux -> none" },
+      expect: { stdoutEquals: "u3 -> ada@example.com\nu2 -> grace@example.com\nu1 -> none\nux -> none" },
     },
   ]}
 />

--- a/content/learn/intro-data-viz-plotly/exploratory-workflow.mdx
+++ b/content/learn/intro-data-viz-plotly/exploratory-workflow.mdx
@@ -81,8 +81,9 @@ for col in df.select_dtypes("number").columns:
 `}
 />
 
-You'll see four histograms. In about 15 seconds you know the
-distribution of every numeric column.
+You'll see three histograms — one each for `total_bill`, `tip`, and
+`size`. In about 15 seconds you know the distribution of every numeric
+column.
 
 ## Step 3: Ask a real question
 

--- a/content/learn/intro-data-viz-plotly/storytelling-with-data.mdx
+++ b/content/learn/intro-data-viz-plotly/storytelling-with-data.mdx
@@ -79,7 +79,7 @@ fig1 = px.line(
     color="channel",
     markers=True,
     template="simple_white",
-    title="Mobile sales tripled while desktop sales fell by half",
+    title="Mobile sales more than quadrupled while desktop sales fell by half",
     labels={"sales": "Sales (units)", "year": "Year"},
 )
 fig1.add_annotation(

--- a/content/learn/intro-data-viz-plotly/why-charts-exist.mdx
+++ b/content/learn/intro-data-viz-plotly/why-charts-exist.mdx
@@ -78,7 +78,7 @@ fig.show()
 Now the questions are *trivial*:
 
 - **Largest gain** = steepest line. China and Brazil leap up;
-  Afghanistan is the most modest gain.
+  Norway (already high in 1952) barely rises.
 - **Already over 60 in 1952** = the dots above 60 on the left.
   Germany, Japan, Norway.
 - **Grew faster than China** = a line steeper than China's. Brazil

--- a/content/learn/intro-sql-postgres/understanding-joins.mdx
+++ b/content/learn/intro-sql-postgres/understanding-joins.mdx
@@ -52,7 +52,7 @@ CREATE TABLE orders (
   id SERIAL PRIMARY KEY, customer_id INTEGER REFERENCES customers(id), amount NUMERIC
 );
 INSERT INTO customers (name) VALUES ('Ada'), ('Grace');
-INSERT INTO orders (customer_id, amount) VALUES (1, 42), (2, 99);`}
+INSERT INTO orders (id, customer_id, amount) VALUES (101, 1, 42), (102, 2, 99);`}
   starterCode={`SELECT
   orders.id AS order_id,
   customers.name AS customer,
@@ -83,7 +83,7 @@ CREATE TABLE orders (
   id SERIAL PRIMARY KEY, customer_id INTEGER REFERENCES customers(id), amount NUMERIC
 );
 INSERT INTO customers (name) VALUES ('Ada'), ('Grace');
-INSERT INTO orders (customer_id, amount) VALUES (1, 42), (2, 99);`}
+INSERT INTO orders (id, customer_id, amount) VALUES (101, 1, 42), (102, 2, 99);`}
   starterCode={`SELECT
   o.id AS order_id,
   c.name AS customer,

--- a/content/learn/intro-sql-postgres/why-relational-databases.mdx
+++ b/content/learn/intro-sql-postgres/why-relational-databases.mdx
@@ -26,7 +26,7 @@ erDiagram
     ORDER {
         int id PK
         int customer_id FK
-        numeric amount
+        text item
     }
 ```
 

--- a/content/learn/java-collections-and-generics-deep-dive/data-modeling-with-collections.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/data-modeling-with-collections.mdx
@@ -243,9 +243,9 @@ information that comments and convention used to carry.
 Expected output:
 
 \`\`\`
-alice: [Order[id=1, total=100], Order[id=3, total=70]]
-bob: [Order[id=2, total=40]]
-carol: [Order[id=4, total=200]]
+alice: [Order[id=1, customerId=alice, total=100], Order[id=3, customerId=alice, total=70]]
+bob: [Order[id=2, customerId=bob, total=40]]
+carol: [Order[id=4, customerId=carol, total=200]]
 \`\`\``}
   entryFilename="Main.java"
   files={[

--- a/content/learn/java-programming-for-beginners/problem-solving.mdx
+++ b/content/learn/java-programming-for-beginners/problem-solving.mdx
@@ -241,15 +241,15 @@ where N is the number of vowels.`}
       id: "vowel-count",
       name: "Counts vowels correctly",
       expect: {
-        stdoutLines: ["vowels = 9"],
+        stdoutLines: ["vowels = 8"],
         stdoutLinesExact: true,
       },
     },
   ]}
 />
 
-(For *Hello, beautiful World!* the vowels are e, o, e, a, u, i, u, o,
-o — nine of them.)
+(For *Hello, beautiful World!* the vowels are e, o, e, a, u, i, u,
+o — eight of them.)
 
 <MultipleChoice
   markdown={`What is "rubber duck debugging"?

--- a/content/learn/java-programming-for-beginners/the-type-system.mdx
+++ b/content/learn/java-programming-for-beginners/the-type-system.mdx
@@ -284,7 +284,7 @@ where F is the \`double\` value and R is the cast-to-int value.`}
       id: "temp",
       name: "Converts and rounds correctly",
       expect: {
-        stdoutLines: ["fahrenheit = 97.88", "rounded = 97"],
+        stdoutLines: ["fahrenheit = 97.88000000000001", "rounded = 97"],
         stdoutLinesExact: true,
       },
     },

--- a/content/learn/machine-learning-scikit-learn/features-and-targets.mdx
+++ b/content/learn/machine-learning-scikit-learn/features-and-targets.mdx
@@ -115,7 +115,7 @@ print("Target name:    ", y.name)
 `}
 />
 
-That is the entire idea. `X.drop(columns=["price"])` keeps every input
+That is the entire idea. `houses.drop(columns=["price"])` keeps every input
 column; `houses["price"]` pulls out the one answer column. The shapes confirm
 the structure: `X` is `(6, 4)` — six examples, four features each — and `y` is
 `(6,)` — six answers. Notice `X` and `y` still have the *same number of

--- a/content/learn/natural-language-processing-python/frequency-distributions.mdx
+++ b/content/learn/natural-language-processing-python/frequency-distributions.mdx
@@ -267,8 +267,9 @@ print("Top 5 WITHOUT stopwords:", FreqDist(content).most_common(5))
 `}
 />
 
-With stopwords, the top words are "the", "a", "that" — useless for guessing
-the topic. Without them, "text", "words", "search", "user", and "engine" rise
+With stopwords, the most frequent word is "the" (7 times), with "a" close
+behind — function words useless for guessing the topic. Without them, "text",
+"words", "search", "user", and "engine" rise
 to the top — and you can immediately tell this passage is about search. This
 is *why* keyword extraction almost always removes stopwords first, and it is a
 concrete payoff of the choice you studied two pages ago.

--- a/content/learn/natural-language-processing-python/the-nlp-pipeline.mdx
+++ b/content/learn/natural-language-processing-python/the-nlp-pipeline.mdx
@@ -189,7 +189,7 @@ print("5. lemmatized:", tokens)
 `}
 />
 
-Each `print` is one row of the pipeline table. The list started as nine
+Each `print` is one row of the pipeline table. The list started as thirteen
 tokens including punctuation and shrank to a handful of meaningful roots. Try
 commenting out step 4 (stopword removal) and re-running — notice how much
 longer the final list becomes, and ask yourself whether those extra words

--- a/content/learn/oop-blueprint-java/methods-and-messages.mdx
+++ b/content/learn/oop-blueprint-java/methods-and-messages.mdx
@@ -209,7 +209,7 @@ use thousands of times.
 classDiagram
     class Cashier { +ringUp(items) total }
     class Item { +price() }
-    class Receipt { +addLine(item, price); +total() }
+    class Receipt { +addLine(item); +total() }
     Cashier ..> Item
     Cashier ..> Receipt
     Receipt o-- Item

--- a/content/learn/practical-r-for-beginners/tidy-data-principles.mdx
+++ b/content/learn/practical-r-for-beginners/tidy-data-principles.mdx
@@ -107,11 +107,11 @@ written two ways:
 tidy <- data.frame(
   city = c("NYC", "NYC", "LA", "LA"),
   year = c(2022, 2023, 2022, 2023),
-  pop  = c(8.3, 8.4, 3.9, 3.9)
+  population = c(8.3, 8.4, 3.9, 3.9)
 )
 
 # Computing per-city average is trivial
-aggregate(pop ~ city, data = tidy, FUN = mean)
+aggregate(population ~ city, data = tidy, FUN = mean)
 `}
 />
 
@@ -131,7 +131,7 @@ wide
 />
 
 Both produce the right answer. But the tidy version uses a
-*general* operation (`aggregate(pop ~ city)`) that scales to any
+*general* operation (`aggregate(population ~ city)`) that scales to any
 number of years; the wide version requires explicitly enumerating
 the year columns. Add a `y2024` column, and the wide solution
 breaks; the tidy solution does not.
@@ -174,12 +174,12 @@ data is tidy.
 Want a line chart of population over time, colored by city?
 
 ```r
-ggplot(tidy, aes(x = year, y = pop, color = city)) +
+ggplot(tidy, aes(x = year, y = population, color = city)) +
   geom_line()
 ```
 
-That single expression works because `year` is a column, `pop`
-is a column, and `city` is a column. Try doing the same with the
+That single expression works because `year` is a column,
+`population` is a column, and `city` is a column. Try doing the same with the
 wide form — you can't, without reshaping first.
 
 ## Two acid tests

--- a/content/learn/python-basics/files.mdx
+++ b/content/learn/python-basics/files.mdx
@@ -354,11 +354,11 @@ for row in data:
     },
     {
       filename: "sales.csv",
-      initialContent: `product, amount
-Laptop, 1200
-Mouse, 25
-Keyboard, 75
-Monitor, 300
+      initialContent: `product,amount
+Laptop,1200
+Mouse,25
+Keyboard,75
+Monitor,300
 `,
     },
     {

--- a/content/learn/python-basics/iterators-and-generators.mdx
+++ b/content/learn/python-basics/iterators-and-generators.mdx
@@ -393,7 +393,7 @@ assert list(islice(fib(), 10)) == [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]`,
     },
     {
       id: "twentieth",
-      name: "20th Fibonacci is 4181",
+      name: "20th Fibonacci is 6765",
       code: `from itertools import islice
 f = list(islice(fib(), 21))
 assert f[20] == 6765`,

--- a/content/learn/python-basics/syntax-and-indentation.mdx
+++ b/content/learn/python-basics/syntax-and-indentation.mdx
@@ -172,7 +172,10 @@ ways to span multiple lines:
 <CodeBlock
   adapter="python"
   starterCode={`# Preferred: implicit continuation inside parentheses.
-total = 1 + 2 + 3 + 4 + 5 + 6
+total = (
+    1 + 2 + 3
+    + 4 + 5 + 6
+)
 
 print("Total:", total)
 `}
@@ -181,7 +184,8 @@ print("Total:", total)
 <CodeBlock
   adapter="python"
   starterCode={`# Works but ugly: explicit backslash continuation.
-total2 = 1 + 2 + 3 + 4 + 5 + 6
+total2 = 1 + 2 + 3 \\
+    + 4 + 5 + 6
 
 print("Total2:", total2)
 `}
@@ -287,14 +291,17 @@ print(average([1, 2, 3, 4]))
 
 Do not change the function's behavior, just improve its style.`}
   starterCode={`def long_sum(a, b, c, d, e):
-    result = a + b + c + d + e
+    result = a + b + c + d \\
+        + e
     return result
 
 
 print(long_sum(1, 2, 3, 4, 5))
 `}
   solutionCode={`def long_sum(a, b, c, d, e):
-    result = a + b + c + d + e
+    result = (
+        a + b + c + d + e
+    )
     return result
 
 

--- a/content/learn/scientific-computing-python/arrays-and-tensors.mdx
+++ b/content/learn/scientific-computing-python/arrays-and-tensors.mdx
@@ -315,7 +315,7 @@ def weighted_centroid(points, weights):
 points = np.array([[0.0, 0.0], [2.0, 0.0], [0.0, 4.0]])
 weights = np.array([1.0, 1.0, 2.0])
 print("centroid =", weighted_centroid(points, weights))
-# Expected: (2*0 + 1*2 + 1*0)/4, (1*0 + 1*0 + 2*4)/4 = (0.5, 2.0)
+# Expected: (1*0 + 1*2 + 2*0)/4, (1*0 + 1*0 + 2*4)/4 = (0.5, 2.0)
 `}
   solutionCode={`import numpy as np
 

--- a/content/learn/scientific-computing-python/capstone-simulation.mdx
+++ b/content/learn/scientific-computing-python/capstone-simulation.mdx
@@ -224,7 +224,7 @@ import matplotlib.pyplot as plt
 from scipy.integrate import solve_ivp
 
 
-def rhs(t, z, r=1.0, K=200.0, a=0.015, e=0.1, m=0.4):
+def rhs(t, z, r=1.0, K=200.0, a=0.03, e=0.1, m=0.4):
     x, y = z
     return [r * x * (1 - x / K) - a * x * y, e * a * x * y - m * y]
 
@@ -238,8 +238,8 @@ for x0 in [20, 60, 120, 180]:
     ax.plot(x, y, lw=0.7, label=f"x₀ = {x0}")
 
 # Equilibrium point
-x_eq = 0.4 / (0.1 * 0.015)
-y_eq = 1.0 * (1 - x_eq / 200) / 0.015
+x_eq = 0.4 / (0.1 * 0.03)
+y_eq = 1.0 * (1 - x_eq / 200) / 0.03
 ax.plot(x_eq, y_eq, "k*", ms=14, label="equilibrium")
 
 ax.set_xlabel("prey x")

--- a/content/learn/scientific-computing-python/limits-of-manual-calculation.mdx
+++ b/content/learn/scientific-computing-python/limits-of-manual-calculation.mdx
@@ -60,8 +60,8 @@ print(f"Human-years required:        {human_years:,.0f}")
 `}
 />
 
-Tens of thousands of human-years for a problem your laptop will
-solve in a fraction of a second. This gap — between what is
+Nearly six human-years of nonstop arithmetic for a problem your laptop
+will solve in a fraction of a second. This gap — between what is
 *mathematically defined* and what is *humanly computable* — is the
 gap that scientific computing exists to close.
 

--- a/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
+++ b/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
@@ -447,10 +447,10 @@ Produce two variables:
 Conversion rate = \`conversions / visitors\`. A paradox exists when \`agg_winner != within_winner\`.`}
   initCode={`import pandas as pd
 df = pd.DataFrame([
-    ["mobile",  "A",  900, 270],   # 30.0%
-    ["mobile",  "B",  100,  33],   # 33.0%  (B higher)
-    ["desktop", "A",  100,  70],   # 70.0%
-    ["desktop", "B",  900, 657],   # 73.0%  (B higher)
+    ["mobile",  "A",  100,  30],   # 30.0%
+    ["mobile",  "B",  900, 297],   # 33.0%  (B higher)
+    ["desktop", "A",  900, 630],   # 70.0%
+    ["desktop", "B",  100,  73],   # 73.0%  (B higher)
 ], columns=["device", "group", "visitors", "conversions"])`}
   starterCode={`import pandas as pd
 

--- a/content/learn/time-series-analysis-python/handling-missing-temporal-data.mdx
+++ b/content/learn/time-series-analysis-python/handling-missing-temporal-data.mdx
@@ -215,7 +215,7 @@ print("Sunday is missing because the shop was CLOSED:")
 print(sales)
 print()
 
-wrong = sales.interpolate(method="linear")  # invents ~330 phantom Sunday sales
+wrong = sales.interpolate(method="linear")  # holds Saturday's 300 as phantom Sunday sales
 right = sales.fillna(0)  # closed means zero
 
 print(f"Interpolation invents Sunday sales of ~{wrong.iloc[-1]:.0f} (PHANTOM revenue).")


### PR DESCRIPTION
## Goal

Make each lesson's **running example consistent across all its elements** — the prose, Mermaid diagrams, code blocks, and challenge cards on a page should use the same dataset, variable/object names, and terminology, and any output a page states should match what its own code produces.

A recurring, higher-impact variant: **challenge cards asserting an expected output the provided solution doesn't produce** — i.e. the reference solution would fail its own test. Those are fixed so the solution passes (this also repairs `test:solutions` cases).

## Method

Every lesson page in all 27 courses was read in full and checked for within-page example agreement. Only high-confidence mismatches were changed; deliberately-distinct teaching examples, generic multiple-choice variables, and standalone re-declared datasets were left alone. Numeric/algorithm/query results were re-derived (or traced) by hand; random-seed outputs were not second-guessed.

One subtle bug class in Python pages: code inside `<CodeBlock>`/`<ChallengeCard>` template-literal props is delivered as the **cooked** template value, so a regex/string backslash must be doubled in source (`\\s`); a single `\s` silently breaks at runtime.

## Result — all 27 courses reviewed · 33 fixes across 17 courses

**Reviewed clean (10):** beginners-javascript, typescript-from-scratch, from-zero-to-cpp, mastering-dsa-cpp, systems-programming-c, intro-modern-csharp, mastering-ggplot2, seaborn-foundations, sql-analytics-duckdb, sqlite-for-beginners.

**Fixed (17):**

| Course | Fixes |
| --- | --- |
| csharp-linq-functional | 4 — `capstone-data-pipeline`, `generic-abstractions`, `rise-of-declarative`, `side-effect-management` |
| data-analysis-python-pandas | 3 — `string-operations`, `the-analyst-mindset`, `messy-data-overview` |
| intro-data-viz-plotly | 3 — `exploratory-workflow`, `why-charts-exist`, `storytelling-with-data` |
| python-basics | 3 — `files`, `iterators-and-generators`, `syntax-and-indentation` |
| scientific-computing-python | 3 — `limits-of-manual-calculation`, `capstone-simulation`, `arrays-and-tensors` |
| database-design-postgresql | 2 — `many-to-many`, `second-normal-form` |
| intro-sql-postgres | 2 — `why-relational-databases`, `understanding-joins` |
| java-programming-for-beginners | 2 — `problem-solving`, `the-type-system` |
| natural-language-processing-python | 2 — `the-nlp-pipeline`, `frequency-distributions` |
| functional-programming-typescript | 2 — `function-composition`, `option-and-result` |
| practical-r-for-beginners | 1 — `tidy-data-principles` |
| c-programming-for-beginners | 1 — `input-and-output` |
| machine-learning-scikit-learn | 1 — `features-and-targets` |
| statistics-for-data-science-python | 1 — `statistical-fallacies` |
| time-series-analysis-python | 1 — `handling-missing-temporal-data` |
| java-collections-and-generics-deep-dive | 1 — `data-modeling-with-collections` |
| oop-blueprint-java | 1 — `methods-and-messages` |

### Categories of fix

- **Challenge solutions that failed their own tests** (now pass): csharp-linq capstone/generic-abstractions/side-effect-management, pandas string-operations (cooked-regex), java problem-solving/the-type-system, python files (CSV whitespace → `DictReader` KeyError), fp-ts function-composition (slugger)/option-and-result (manager-email chain), statistics statistical-fallacies (data contained no Simpson's paradox).
- **Stated outputs vs the page's own code**: plotly (three columns / Norway / "more than quadrupled"), NLP (13 tokens; top-word list), sci-computing (~6 not "tens of thousands"; non-physical predator-prey equilibrium → bump attack rate; centroid comment), time-series (interp holds 300, comment said 330).
- **ER-diagram / classDiagram vs code**: db-design (`PK, FK`; `date`), intro-sql (`text item`; explicit order ids), java-collections (record `toString`), oop-java (`addLine` arity).
- **Same example, drifting names/values**: R `pop`→`population`, pandas analyst-mindset/messy-data, python continuation blocks, C invoice spacing, csharp `4, 8, 12`, ML `houses.drop`.

## Notes

- Scope is per-page example consistency, as agreed. The closed #470 was an unrelated layout change.
- Several fixes repair challenge solution tests that would otherwise fail in `test:solutions`.
- Out-of-scope heads-up (not changed): a few pandas pages load a remote `HR-dataset-v14.csv` whose current contents no longer match the IBM-attrition columns the code assumes — a shared data-source issue (each page is internally consistent).
