### PR TITLE
Add illustration placeholders to the C programming course

### DIFF
--- a/app/_components/mdx/illustration.module.css
+++ b/app/_components/mdx/illustration.module.css
@@ -1,0 +1,101 @@
+/* Styling for <Illustration> (app/_components/mdx/illustration.tsx).
+ *
+ * Two states share one <figure>:
+ *   1. The generated SVG (.image) — rendered once `src` is supplied.
+ *   2. The .placeholder frame — a dashed card that surfaces the generation
+ *      prompt while the artwork is still pending.
+ *
+ * All chrome is built from Fumadocs theme tokens (--color-fd-*) so the frame
+ * tracks light/dark automatically, with brand-hue accents from brand.css
+ * (--ds-blue-500 etc.) for the palette hint. */
+
+.figure {
+  margin: 1.75rem 0;
+}
+
+/* ── Real artwork ─────────────────────────────────────────────────────── */
+.image {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin-inline: auto;
+  border-radius: 12px;
+}
+
+/* ── Placeholder frame ────────────────────────────────────────────────── */
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 1.5rem 1.75rem;
+  box-sizing: border-box;
+  text-align: center;
+
+  border: 2px dashed
+    var(--color-fd-border, color-mix(in srgb, currentColor 20%, transparent));
+  border-radius: 12px;
+  background: var(
+    --color-fd-muted,
+    color-mix(in srgb, currentColor 4%, transparent)
+  );
+  color: var(--color-fd-muted-foreground, currentColor);
+}
+
+.frameIcon {
+  color: var(--color-fd-muted-foreground, currentColor);
+  opacity: 0.9;
+  line-height: 0;
+}
+
+.kicker {
+  font-family: var(--font-sans), system-ui, sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-fd-muted-foreground, currentColor);
+  opacity: 0.85;
+}
+
+/* The generation prompt. Mono, compact, capped width so longer prompts stay
+   readable. Sits in its own subtle card with a brand-blue accent edge. */
+.prompt {
+  margin: 0;
+  max-width: 46ch;
+  font-family: var(--font-mono), "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: var(--color-fd-foreground, currentColor);
+
+  padding: 0.6rem 0.8rem;
+  border-radius: 8px;
+  border-left: 3px solid var(--ds-blue-500);
+  background: var(
+    --color-fd-card,
+    color-mix(in srgb, currentColor 5%, transparent)
+  );
+  text-align: left;
+}
+
+/* Four-dot reminder of the allowed brand palette. */
+.palette {
+  display: inline-flex;
+  gap: 6px;
+}
+.palette i {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+}
+
+/* ── Caption ──────────────────────────────────────────────────────────── */
+.caption {
+  margin-top: 0.6rem;
+  text-align: center;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-fd-muted-foreground, currentColor);
+}

--- a/app/_components/mdx/illustration.tsx
+++ b/app/_components/mdx/illustration.tsx
@@ -1,0 +1,97 @@
+import styles from "./illustration.module.css";
+
+/**
+ * `<Illustration>` — a decorative / informative vector figure for lessons.
+ *
+ * The illustrations themselves are generated externally (e.g. with Recraft)
+ * as SVGs and dropped into `public/illustrations/<course>/…`. Until a file is
+ * generated, the component renders a **placeholder frame** that shows the
+ * generation `prompt`, so authors can scaffold a whole course with the right
+ * art direction first and fill in the real artwork later.
+ *
+ * Authoring (in MDX, no import needed — registered in `mdx-components.tsx`):
+ *
+ * ```mdx
+ * <Illustration
+ *   prompt="Flat abstract vector illustration of a row of numbered mailboxes…"
+ *   alt="A row of memory cells, each holding one byte"
+ *   caption="RAM as a long row of numbered, byte-sized boxes."
+ *   ratio="16 / 9"
+ * />
+ * ```
+ *
+ * Props:
+ *   - `prompt`  (required) the image-generation prompt. Shown in the
+ *               placeholder; ignored once `src` is supplied.
+ *   - `src`     path to the generated SVG (served from `/public`). When set,
+ *               the real artwork renders instead of the placeholder.
+ *   - `alt`     accessible description for the final `<img>`. Omit (or pass
+ *               `""`) for purely decorative art so screen readers skip it.
+ *   - `caption` optional visible caption rendered as a `<figcaption>`.
+ *   - `ratio`   CSS `aspect-ratio` for the frame (default `16 / 9`).
+ *
+ * Art-direction guidance for the prompt lives in `docs/illustrations.md`; in
+ * short: flat vector, no strokes/borders on shapes, must read on both light
+ * and dark backgrounds, and stick to the brand blue/green/yellow/red 500s.
+ */
+
+export interface IllustrationProps {
+  prompt: string;
+  src?: string;
+  alt?: string;
+  caption?: string;
+  ratio?: string;
+}
+
+export function Illustration({
+  prompt,
+  src,
+  alt = "",
+  caption,
+  ratio = "16 / 9",
+}: IllustrationProps) {
+  return (
+    <figure className={styles.figure}>
+      {src ? (
+        // Real artwork. SVGs sit in /public; a plain <img> keeps them
+        // theme-agnostic (the SVG itself carries the dual-mode palette).
+        // Vector SVGs gain nothing from next/image's raster optimization.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          className={styles.image}
+          src={src}
+          alt={alt}
+          style={{ aspectRatio: ratio }}
+          loading="lazy"
+        />
+      ) : (
+        <div
+          className={styles.placeholder}
+          style={{ aspectRatio: ratio }}
+          role="img"
+          aria-label={alt || "Illustration placeholder"}
+        >
+          <div className={styles.frameIcon} aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" width="28" height="28">
+              <rect x="3" y="4" width="18" height="16" rx="2" fill="currentColor" opacity="0.12" />
+              <circle cx="8.5" cy="9" r="1.8" fill="var(--ds-yellow-500)" />
+              <path d="M4 18l5-5 3 3 4-4 4 4v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1z" fill="var(--ds-blue-500)" />
+              <path d="M11 16l4-4 3 3v1a1 1 0 0 1-1 1h-7z" fill="var(--ds-green-500)" />
+            </svg>
+          </div>
+          <span className={styles.kicker}>Illustration · placeholder</span>
+          <p className={styles.prompt}>{prompt}</p>
+          <span className={styles.palette} aria-hidden="true">
+            <i style={{ background: "var(--ds-blue-500)" }} />
+            <i style={{ background: "var(--ds-green-500)" }} />
+            <i style={{ background: "var(--ds-yellow-500)" }} />
+            <i style={{ background: "var(--ds-red-500)" }} />
+          </span>
+        </div>
+      )}
+      {caption && <figcaption className={styles.caption}>{caption}</figcaption>}
+    </figure>
+  );
+}
+
+export default Illustration;

--- a/content/learn/c-programming-for-beginners/arrays.mdx
+++ b/content/learn/c-programming-for-beginners/arrays.mdx
@@ -9,6 +9,11 @@ sequence of temperatures, a row of pixels. C's most basic answer is
 the **array**: a contiguous block of memory holding many values of
 the same type.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for arrays: a clean horizontal row of identical rounded boxes butting together with no gaps, each holding a small value token, with tiny index numbers 0, 1, 2, 3 beneath the first few. Conveys a contiguous row of same-type cells. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — small index numbers 0, 1, 2 acceptable.`}
+  ratio="16 / 9"
+/>
+
 ## Declaring and indexing
 
 ```c
@@ -60,6 +65,12 @@ Each `int` is (say) 4 bytes. The five cells sit **next to each
 other** in memory. `primes[i]` is shorthand for "the cell at address
 `primes + i * sizeof(int)`". This contiguity is the secret to why
 arrays are fast: predicting the next address is one addition.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of an array's memory layout: five equal cells side by side holding 2, 3, 5, 7, 11, with faint consecutive addresses beneath and a small bracket showing each cell is the same fixed width apart. Conveys contiguous, evenly spaced storage. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — the small numbers inside the cells are acceptable.`}
+  alt="Five array elements stored in contiguous, evenly spaced memory cells"
+  ratio="5 / 2"
+/>
 
 ## The size is fixed at declaration
 
@@ -131,6 +142,12 @@ program may:
 This is called a **buffer overflow**, and it has been responsible for
 an astonishing fraction of all software security flaws since the
 1980s.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of an array bounds overflow: a tidy row of cells with a token stepping one box past the final cell onto unmarked ground beyond the array, the out-of-bounds step flagged with a subtle red accent. Cautionary but clean. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Stepping one element past the end of an array, into memory that is not yours"
+  ratio="16 / 9"
+/>
 
 <CodeBlock
   adapter="c"
@@ -258,6 +275,12 @@ int main(void) {
 `grid[3][4]` is laid out as 12 consecutive integers in **row-major**
 order — row 0, then row 1, then row 2. Knowing the layout helps you
 reason about cache performance and pointer arithmetic later.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of a 2D array stored in row-major order: a 3-by-4 grid on top, and below it the same twelve cells unrolled into one long single row, with soft solid arrows showing row 0, then row 1, then row 2 laid end to end. Conveys that a 2D shape is a flat region underneath. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No words; tiny indices optional.`}
+  alt="A 3x4 grid laid out in memory as twelve consecutive cells, row by row"
+  ratio="3 / 2"
+/>
 
 ## Passing arrays to functions
 

--- a/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
@@ -9,6 +9,11 @@ pipeline called the **C toolchain**. Understanding it will save you
 hours of confusion later, because most "weird" errors in C trace back
 to one specific stage.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for the C toolchain: a clean assembly-line conveyor belt carrying a source-code document that is transformed step by step into a finished executable cube at the far end, with a few small machine-and-gear stations along the belt. Industrious but tidy. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## The four stages
 
 The pipeline runs **`hello.c` → Preprocessor → Compiler → Assembler → Linker → Executable**, and then the operating system loads and runs that executable.
@@ -24,6 +29,12 @@ In real life, you usually invoke all four stages with one command,
 like `clang hello.c -o hello`. The compiler driver runs the rest
 behind the scenes. But each stage has its own kind of error message.
 Recognizing which stage is angry at you is half the debugging battle.
+
+<Illustration
+  prompt={`Informative flat-vector pipeline of four labeled stages connected left-to-right by solid arrows, each a distinct rounded station with a simple emblem: preprocessor (two documents merging, paste motif), compiler (a gear with a small branching tree), assembler (a tile of 0 and 1 glyphs), and linker (two puzzle pieces joining), ending in a finished executable block. Each stage a different brand color. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No words; tiny 0 and 1 glyphs on a single tile only.`}
+  alt="The four toolchain stages: preprocessor, compiler, assembler, and linker, producing an executable"
+  ratio="5 / 2"
+/>
 
 ## Stage 1: the preprocessor
 
@@ -146,6 +157,11 @@ Real programs are split across many files. The convention is:
 
 The header is the *interface*. The source file is the
 *implementation*.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of interface versus implementation: a clean storefront-window panel in front (the header — the public interface, showing a few simple labeled slots) with a busier machine-room panel behind it (the source file, full of gears doing the real work). Conveys a tidy public surface hiding private detail. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 The browser sandbox supports multi-file builds. Edit any tab below
 and click *Run* — both files are compiled and linked together.

--- a/content/learn/c-programming-for-beginners/computational-thinking.mdx
+++ b/content/learn/c-programming-for-beginners/computational-thinking.mdx
@@ -12,6 +12,11 @@ This skill is called **computational thinking**, and it long predates
 computers themselves. Once you have it, every programming language
 becomes easier.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for computational thinking: a tangled scribble-knot on the left gradually untangles into a clean, ordered sequence of numbered step-tiles on the right, suggesting a messy problem turning into a precise recipe. A small brain or gear motif sits near the transition point. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## The four habits of computational thinking
 
 Researchers usually break computational thinking into four
@@ -30,6 +35,12 @@ Put together, these habits carry you from a problem to a program:
 abstract away noise → write a clear algorithm → translate to C source
 code.**
 
+<Illustration
+  prompt={`Informative flat-vector illustration of the four habits of computational thinking as a balanced 2x2 grid of distinct icons: decomposition (one big block splitting into smaller blocks), pattern recognition (two matching shapes highlighted among several different ones), abstraction (a detailed shape simplifying into a clean silhouette), and algorithm design (a short numbered list of steps). Each quadrant uses a different brand color. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="The four habits: decomposition, pattern recognition, abstraction, and algorithm design"
+  ratio="3 / 2"
+/>
+
 Let's walk through a tiny, concrete example.
 
 ## Example: "Tell me the largest test score"
@@ -40,6 +51,11 @@ me which student got the highest score."*
 A human can do this without thinking. But let's pretend you have to
 explain it to a small, very fast, very literal robot named **Cee**
 who knows nothing about students, paper, or numbers.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of a small, friendly, very literal robot named Cee examining a stack of paper test sheets and holding up one highlighted sheet, as if remembering the largest score seen so far. The robot is built from simple rounded geometric shapes. Cute and clean. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ### Step 1: Decompose
 
@@ -122,6 +138,12 @@ Notice the line-by-line match with the pseudocode:
 If you can write the pseudocode, the C is mostly translation.
 
 ## A second example: rock, paper, scissors
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of rock, paper, scissors as three simple geometric icons — a rounded rock, a folded sheet of paper, and an open pair of scissors — arranged in a friendly triangular cycle with soft solid arrows showing what beats what. Playful and clean. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Rock, paper, scissors arranged in a cycle showing which beats which"
+  ratio="16 / 9"
+/>
 
 Let's design a tiny game. **Plain English first**:
 

--- a/content/learn/c-programming-for-beginners/conditionals.mdx
+++ b/content/learn/c-programming-for-beginners/conditionals.mdx
@@ -7,6 +7,11 @@ A program that always does the same thing isn't very interesting.
 **Conditionals** let a program look at a value and decide what to do
 next. They are the second pillar of computation, after sequence.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for conditionals: a path that reaches a fork and splits into two diverging routes, with a simple diamond decision marker at the junction and small directional arrows down each branch. Conveys a program choosing between paths. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## The `if` statement
 
 The basic form is:
@@ -148,6 +153,12 @@ evaluated**. This lets you write safe checks like
 `if (p != NULL && p->value == 0)` — the dereference on the right
 never runs when `p` is null.
 
+<Illustration
+  prompt={`Informative flat-vector illustration of the three logical operators as simple gate-like tiles: AND (two inputs, both lit, produce a lit output), OR (either input lit produces a lit output), and NOT (a single input flipped to its opposite). Use lit-versus-dim states, green for true and red for false. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No words; tiny symbols only.`}
+  alt="The AND, OR, and NOT logical operators shown as simple gates"
+  ratio="16 / 9"
+/>
+
 ## Truth values: what counts as true?
 
 In C, anything non-zero is true. `0` is false. There is no separate
@@ -275,6 +286,11 @@ Three things to remember:
   fall-through.
 - `default` runs if none of the cases matched. It is optional but
   good practice to include one.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of a switch statement as a railway junction: a single incoming track meeting a multi-way track switch that routes a little train car onto one of several parallel sidings, with one siding set apart as the default. Clean and playful. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ## Decision tree, visualized
 

--- a/content/learn/c-programming-for-beginners/data-types.mdx
+++ b/content/learn/c-programming-for-beginners/data-types.mdx
@@ -13,6 +13,11 @@ time. The type controls three things:
 - **What operations are legal** (you can add two `int`s; you can't
   add a function to a string).
 
+<Illustration
+  prompt={`Decorative flat-vector hero for C data types: a tidy family of differently sized rounded containers lined up — a tiny 1-byte cube, a medium 4-byte box, and a larger 8-byte box — each a different brand color, each with a small distinguishing emblem (a letter glyph, a whole-number dot cluster, a decimal-point sparkle). Clean and friendly. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No words; a single small emblem per box only.`}
+  ratio="16 / 9"
+/>
+
 ## The fundamental types
 
 | Type      | Typical size | What it stores                                                    |
@@ -104,6 +109,12 @@ int main(void) {
 variable are identical either way — it is the *format string* that
 decides how to display them.
 
+<Illustration
+  prompt={`Decorative flat-vector illustration showing that a char is secretly a small integer: a single tile flipping between two faces — one face shows a letter glyph, the other shows a number — joined by a small rotate/flip arrow, hinting that the same bits read either as a character or as its ASCII code. Arrow as a solid filled shape, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — a single letter and a single number are acceptable.`}
+  alt="The same byte read either as a character or as its numeric ASCII code"
+  ratio="16 / 9"
+/>
+
 ## Floating-point numbers
 
 For numbers with a fractional part, use `float` (less precision) or
@@ -136,6 +147,11 @@ in base 10. The number you store is a *very close approximation*.
 This is why \`0.1 + 0.2\` is famously not exactly \`0.3\` in almost
 every programming language.
 </Callout>
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of floating-point approximation: a clean number line or ruler where a target point sits just slightly off a tidy gridline, with a small magnifier highlighting the tiny gap, suggesting a value that is very close but not exact. Calm and precise-feeling. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 <CodeBlock
   adapter="c"
@@ -240,6 +256,12 @@ Same memory, different sized chunks, different bit interpretations.
 The CPU has separate instructions for integer arithmetic and
 floating-point arithmetic — the type tells the compiler which to
 emit.
+
+<Illustration
+  prompt={`Informative flat-vector illustration comparing how many bytes each type reserves: three horizontal bars built from small byte-squares — one square, four squares, and eight squares — stacked and left-aligned so the differing widths are obvious, each bar a different brand color. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No words; tiny size numbers optional.`}
+  alt="char reserves 1 byte, int reserves 4 bytes, and double reserves 8 bytes"
+  ratio="5 / 2"
+/>
 
 ## Challenge: average of three numbers
 

--- a/content/learn/c-programming-for-beginners/debugging-and-reasoning.mdx
+++ b/content/learn/c-programming-for-beginners/debugging-and-reasoning.mdx
@@ -11,6 +11,11 @@ and fix them faster.
 That speed comes from a few habits. None of them are magic. All of
 them can be practiced.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for debugging: a friendly magnifying glass hovering over a small stylized bug sitting on a line of code, with a faint checklist and lightbulb nearby suggesting calm, methodical investigation rather than panic. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Step 1: read the error message
 
 The single biggest improvement a new programmer can make is to
@@ -100,6 +105,12 @@ Two bugs are now obvious from the table:
 You would have stared at the code for a long time before seeing
 either. The trace table reveals both within a minute.
 
+<Illustration
+  prompt={`Informative flat-vector illustration of a trace table: a small neat grid tracking how a couple of variables change across successive steps, with one row subtly highlighted where a value exposes a bug. Conveys writing down variable values step by step. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — small numbers in the cells acceptable, no words.`}
+  alt="A trace table tracking variable values across steps, surfacing a bug"
+  ratio="3 / 2"
+/>
+
 ## Step 4: print debugging
 
 The humble `printf` is the workhorse of C debugging. Insert prints
@@ -139,6 +150,12 @@ The same idea works with code: if you can't tell which function is
 the culprit, **comment out** half of them and see if the bug
 persists.
 
+<Illustration
+  prompt={`Informative flat-vector illustration of shrinking a failing input by halving: a large input bar repeatedly cut in half, each remaining piece still flagged with a small red bug marker, narrowing down to a tiny snippet that still fails. Conveys binary-search input minimization. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Halving a failing input repeatedly until a tiny reproducer remains"
+  ratio="16 / 9"
+/>
+
 ## Step 6: rubber-duck explanation
 
 Out loud (or in writing), explain the code to an inanimate object,
@@ -147,6 +164,11 @@ the time, you'll hear yourself say something that doesn't make
 sense — "and here we increment `i`, then we add it to `total`, then
 we... wait, why did I subtract `1` here?" — and the bug is found
 without anyone else needing to look.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of rubber-duck debugging: a simple cheerful rubber duck (a yellow body is fine) beside a line of code with a small speech bubble, suggesting explaining the code out loud line by line. Light and playful. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ## Memory bugs: the special category
 

--- a/content/learn/c-programming-for-beginners/dynamic-memory.mdx
+++ b/content/learn/c-programming-for-beginners/dynamic-memory.mdx
@@ -12,6 +12,11 @@ That's what the **heap** is for. The heap is a big pool of memory
 your program can grab chunks from and give back as it sees fit. The
 controls are `malloc` and `free`.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for dynamic memory: a large pool or reservoir of memory from which a claw grabs a right-sized chunk on one side (malloc) and returns a chunk back into the pool on the other (free), with a few chunks floating in the pool. Conveys borrowing and returning memory at runtime. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Stack vs heap
 
 A running program's memory is split into a few regions:
@@ -33,6 +38,12 @@ A running program's memory is split into a few regions:
 If a value is small and short-lived, put it on the stack. If a value
 must outlive the function that created it, or must be sized at
 runtime, put it on the heap.
+
+<Illustration
+  prompt={`Informative flat-vector side-by-side comparison of stack versus heap: on the left, a neat vertical stack of function-frame plates growing and shrinking in order; on the right, a loose pool of variously sized blocks scattered in a larger reservoir. Two contrasting memory regions, each a different brand color. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="The stack as orderly function frames versus the heap as a flexible pool of blocks"
+  ratio="16 / 9"
+/>
 
 ## `malloc` and `free`
 
@@ -140,6 +151,12 @@ Every `_new` call must be balanced by exactly one `_free` call.
 
 These are the classics. Every C programmer will write them at some
 point. The skill is recognizing them quickly.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of the three classic memory bugs as three small vignettes in a row: a memory leak (a chunk drifting away from the program, never returned), a use-after-free (a claw grabbing a chunk already returned to the pool), and a double-free (the same chunk returned to the pool twice). Each vignette tagged with a subtle red accent. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Three memory bugs: memory leak, use-after-free, and double-free"
+  ratio="5 / 2"
+/>
 
 ### 1. Memory leak
 
@@ -348,6 +365,12 @@ void da_free(DynArr *a) {
 The doubling strategy is what `std::vector` does in C++ and what
 Python's `list` does. Allocating one element at a time would make
 every push O(n); doubling makes each push amortized O(1).
+
+<Illustration
+  prompt={`Informative flat-vector illustration of a growable buffer doubling its capacity: a left-to-right sequence of buffers, each twice as wide as the last, with filled cells carried over and fresh empty capacity added each time the previous buffer fills up. Conveys the capacity-doubling growth strategy. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No words; tiny capacity numbers optional.`}
+  alt="A dynamic array doubling its capacity as it fills"
+  ratio="5 / 2"
+/>
 
 <MultipleChoice
   markdown={`What is wrong with this code?

--- a/content/learn/c-programming-for-beginners/functions.mdx
+++ b/content/learn/c-programming-for-beginners/functions.mdx
@@ -15,6 +15,11 @@ programming language. They let you:
 You already met one function: `main`. Every C program starts there.
 Now let's write our own.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for functions: a friendly machine box with an input chute on the left receiving a value token and an output spout on the right emitting a result token, a couple of gears turning inside, and a small name-tag on the box. Conveys a named, reusable block — value in, result out. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Anatomy of a function
 
 ```c
@@ -81,6 +86,12 @@ int main(void) {
 copy of the value. To actually modify a caller's variable, you would
 pass a **pointer** to it — which is exactly what pointers are for,
 and what we'll explore in a few chapters.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of pass-by-value: a caller's variable box on the left and a photocopier-style motif producing a separate copy that travels into a function box on the right; a small scribble made on the copy leaves the original untouched. Conveys that the function works on its own copy. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="A function receives a copy of its argument, so changes inside do not affect the caller"
+  ratio="16 / 9"
+/>
 
 ## `void` — when a function returns nothing
 
@@ -271,6 +282,11 @@ Forget the base case and the program will recurse forever — until it
 runs out of stack space and crashes with a *stack overflow*. Recursion
 is powerful but also restrained: prefer a loop unless the problem is
 naturally recursive (trees, divide-and-conquer, parsing).
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of recursion: a set of nested self-similar shapes — like russian-doll boxes, each containing a smaller copy of itself a few times over — with a slim solid arrow spiraling inward toward a tiny base-case shape at the center. Calm and hypnotic. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ## Challenge: is it prime?
 

--- a/content/learn/c-programming-for-beginners/how-computers-execute-programs.mdx
+++ b/content/learn/c-programming-for-beginners/how-computers-execute-programs.mdx
@@ -10,6 +10,11 @@ predict what your code will do** before pressing Run.
 
 This chapter builds that picture.
 
+<Illustration
+  prompt={`Decorative flat-vector hero showing a simple mental model of a computer: a friendly rounded CPU square with a subtle gear or pulse motif on the left, connected by two soft solid arrows (one for read, one for write) to a tall stack of numbered memory cells on the right. Clean and diagrammatic but warm. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## A computer has two main parts (for us)
 
 For our purposes, every computer is made of two cooperating parts:
@@ -45,6 +50,12 @@ Contents:   42   00    00    00    'H'   'i'   '!'   00    ...
 Each mailbox holds one byte (a number between 0 and 255, or a
 character). Larger values like a 32-bit integer occupy several
 consecutive mailboxes — typically 4 bytes for an `int`.
+
+<Illustration
+  prompt={`Flat-vector illustration of RAM as a long horizontal row of numbered mailbox cells, each a small rounded rectangle butting against the next with no gaps. A few cells hold simple value blobs, and one run of four adjacent cells is highlighted together to show a single integer spanning several bytes. Friendly and orderly. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — small sparse address numbers optional.`}
+  alt="Memory as a contiguous row of numbered byte-sized cells, with four cells grouped into one integer"
+  ratio="5 / 2"
+/>
 
 When your C program declares a variable `int score = 42;`, the
 compiler arranges for four mailboxes somewhere in RAM to hold the
@@ -168,6 +179,11 @@ that confuse beginners become obvious:
 Programming is the art of **arranging a sequence of small operations
 in memory** such that, when the CPU walks through them, something
 useful happens at the end.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of programming as arranging small operations in memory: a neat left-to-right sequence of small colored instruction tiles laid inside a faint memory strip, with a tiny CPU marker walking along them and leaving a soft motion trail, ending in a small spark of useful output. Abstract and tidy. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 Every language we use — Python, JavaScript, Rust, C — ultimately
 exists to make it easier for humans to describe such arrangements.

--- a/content/learn/c-programming-for-beginners/index.mdx
+++ b/content/learn/c-programming-for-beginners/index.mdx
@@ -13,6 +13,11 @@ contest, and not to ship the next big web app. We will learn C because
 it is the language that most clearly reveals **how a computer
 actually works**.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for an introductory C programming course. An abstract, friendly scene: a stylized microchip square with concentric circuit traces on the left gently morphs into soft rounded code brackets and a blinking cursor on the right, with a few small geometric shapes (circle, triangle, square) drifting between them to suggest the journey from hardware to code. Airy, balanced composition. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 <Callout type="info" title="Who is this course for?">
 - People who have never programmed before.
 - Students who can write a few lines of Python or JavaScript but get
@@ -41,6 +46,13 @@ The whole journey, end to end, is this: a **real-world problem →
 computational thinking → algorithm steps → C source code → compiler →
 machine instructions → CPU executes and uses memory → output you can
 observe.** Every page in this course lives somewhere on that path.
+
+<Illustration
+  prompt={`Informative flat-vector horizontal flow showing a learning pipeline as a gentle left-to-right path of rounded stepping-stone nodes connected by soft solid arrows: a real-world problem (lightbulb blob), a thinking/brain node, a short stacked list of steps, a code-brackets node, a gear (compiler), a microchip (CPU), ending in a small output panel with a checkmark. Each node a different brand color, evenly spaced and friendly. Arrows drawn as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="The path from a real-world problem through thinking, code, the compiler, and the CPU to observable output"
+  caption="Every lesson lives somewhere along this path."
+  ratio="5 / 2"
+/>
 
 ## How the interactive widgets work
 
@@ -91,3 +103,8 @@ By the time you reach the last page, you will:
   moment to learn.
 - **Draw pictures.** Memory diagrams, arrows, boxes. Programming is a
   visual subject hiding inside a text editor.
+
+<Illustration
+  prompt={`Decorative flat-vector spot illustration of programming as a visual craft. An abstract boxes-and-arrows memory sketch (a few rounded boxes joined by solid arrows) overlaps a soft code window, with a simple pencil motif suggesting the diagrams are hand-drawn. Playful and light. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>

--- a/content/learn/c-programming-for-beginners/input-and-output.mdx
+++ b/content/learn/c-programming-for-beginners/input-and-output.mdx
@@ -12,6 +12,11 @@ C provides I/O through the standard library `<stdio.h>`. The
 philosophy is *small, simple, and printable*. Everything you read or
 write is a stream of bytes.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for input and output: a central program box with a stream of small byte-tokens flowing in from a keyboard motif on the left and another stream flowing out to a terminal panel on the right. Conveys reading and writing streams of bytes. Streams drawn as flowing rows of small filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Printing with `printf`
 
 You've used `printf` since the first chapter. Time to look at it
@@ -24,6 +29,12 @@ printf(format_string, args...);
 The **format string** is text with embedded **conversion
 specifications** like `%d`, `%s`, `%f`, each of which is replaced by
 the corresponding argument.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of a printf format string being filled in: a long template bar with a few empty slot-shaped placeholders, and matching value tokens dropping down by solid arrows into their slots to complete the line. Conveys placeholders replaced by arguments in order. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — tiny percent-style slot markers acceptable, no words.`}
+  alt="A format string with placeholder slots being filled by argument values in order"
+  ratio="5 / 2"
+/>
 
 | Spec  | Type                             | Example                  |
 |-------|----------------------------------|--------------------------|
@@ -200,6 +211,12 @@ Every C program automatically has three streams open:
 `printf` writes to `stdout`. `scanf` reads from `stdin`. For error
 messages, use `fprintf(stderr, "oops: %s\n", msg);`. Separating
 errors lets a user redirect them differently from normal output.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of the three standard streams: a program box with one inbound pipe from a small inbox motif (stdin) and two outbound pipes — one to a normal output panel (stdout) and one to a separate error panel marked with a subtle red accent (stderr). Three clearly distinct channels. Pipes drawn as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="The three standard streams: stdin in, stdout and stderr out"
+  ratio="16 / 9"
+/>
 
 ## Formatted vs unformatted I/O
 

--- a/content/learn/c-programming-for-beginners/linked-lists.mdx
+++ b/content/learn/c-programming-for-beginners/linked-lists.mdx
@@ -13,6 +13,11 @@ canonical "you actually understand pointers now" exercise. Each
 element of the list is a **node** on the heap, and each node holds a
 pointer to the next node.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for linked lists: an abstract chain of connected beads or links flowing across the frame, each link a rounded node with a small arrow tab joining it to the next, the final link trailing off into a tiny null badge. Stylized and friendly rather than strictly diagrammatic. Links and arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## The shape of a node
 
 ```c
@@ -167,6 +172,12 @@ The temptation is to write `cur = cur->next` *after* `free(cur)`.
 But that reads memory that has just been freed — undefined behavior.
 Always remember "save then free".
 
+<Illustration
+  prompt={`Informative flat-vector illustration of safely freeing a linked list: a traversal where, at each node, a small bookmark first saves the next pointer (marking the following node) and only then removes the current node, so the rest of the chain is never lost. Conveys the save-then-free rule. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Freeing a list by saving each node's next pointer before freeing the node"
+  ratio="16 / 9"
+/>
+
 ## Inserting in the middle
 
 To insert a new node *after* an existing one called `prev`:
@@ -207,6 +218,12 @@ If those two pictures aren't crystal clear, the program crashes or
 leaks. If they are, every operation is just rearranging arrows. Once
 you can write `list_free` from scratch without looking it up, you
 have internalized pointers.
+
+<Illustration
+  prompt={`Informative flat-vector illustration contrasting an array with a linked list: on one side, a tidy contiguous block of adjacent cells (fast indexing, cache-friendly); on the other, scattered nodes spread across memory joined by pointer arrows (flexible inserts, but jumping around). Two contrasting layouts side by side, each a different brand color. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="An array as one contiguous block versus a linked list as scattered nodes joined by pointers"
+  ratio="16 / 9"
+/>
 
 ## Multi-file challenge: a complete linked-list module
 

--- a/content/learn/c-programming-for-beginners/loops.mdx
+++ b/content/learn/c-programming-for-beginners/loops.mdx
@@ -12,6 +12,11 @@ theorem* — but you don't have to take a class to feel it.)
 C has three loop forms. They differ in style; the substance is the
 same.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for loops: a smooth circular arrow cycle made of a few segments, each segment a different brand color, with a small token traveling around the loop and a tiny exit ramp peeling off where the condition becomes false. Conveys repetition with a way out. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## The `while` loop
 
 ```c
@@ -203,6 +208,12 @@ int main(void) {
 
 Expected output: `1 2 4 5 7 8`.
 
+<Illustration
+  prompt={`Informative flat-vector illustration contrasting break and continue inside a loop cycle: a circular loop track where one token hits a barrier and exits the circle entirely (break, red accent) while a second token skips a segment and jumps straight back to the top of the loop (continue, blue accent). Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="break exits the loop entirely while continue skips to the next iteration"
+  ratio="16 / 9"
+/>
+
 ## Nested loops
 
 You can put a loop inside a loop. The inner loop runs in full for
@@ -227,6 +238,12 @@ int main(void) {
 Nested loops are how you walk a 2D grid: rows and columns, x and y,
 month and day.
 
+<Illustration
+  prompt={`Informative flat-vector illustration of nested loops walking a 2D grid: a small grid of cells with a path snaking through it row by row (left to right across a row, then down to the next), the current cell highlighted, with an outer row-counter and inner column-counter hinted along the edges. Clean and orderly. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No words; tiny edge tick numbers optional.`}
+  alt="Nested loops traversing a grid row by row, column by column"
+  ratio="3 / 2"
+/>
+
 ## Counting up vs counting down
 
 You can run a loop backwards. It's the same idea, just flipped:
@@ -246,6 +263,11 @@ int main(void) {
 />
 
 A classic countdown.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of a countdown loop: a descending row of numbered tiles shrinking from left to right, ending in a small rocket lifting off with a soft exhaust plume. Playful and energetic. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — small descending numbers optional.`}
+  ratio="16 / 9"
+/>
 
 ## Flowchart view
 

--- a/content/learn/c-programming-for-beginners/next-steps.mdx
+++ b/content/learn/c-programming-for-beginners/next-steps.mdx
@@ -12,6 +12,11 @@ behavior" is a phrase to take seriously.
 
 That's a real foundation. So — what's next?
 
+<Illustration
+  prompt={`Decorative flat-vector hero for a where-to-go-next roadmap: a single path that branches into several forward routes, each ending in a small distinct destination marker (a book, a tool wrench, a rocket), with a friendly forward-momentum feel. Conveys many directions to grow after the course. Paths and arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Solidify the basics
 
 Before sprinting toward new languages and frameworks, spend time
@@ -62,6 +67,12 @@ section. You don't need to memorize anything; just know what's
 
 C is a small language with a big ecosystem of tools. Three are
 indispensable:
+
+<Illustration
+  prompt={`Informative flat-vector illustration of three essential C tools as three labeled emblem tiles: a build system (stacked blocks assembling), a debugger (a pause/step control over code with an inspection marker), and a sanitizer (a shield catching a bug). Each tile a different brand color. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Three essential tools: a build system, a debugger, and a sanitizer"
+  ratio="3 / 2"
+/>
 
 ### A real build system
 
@@ -122,6 +133,11 @@ If you only read one, read K&R. It's a rite of passage.
 
 C is one of the best languages to *start* with, but rarely the best
 language to *finish* with. A few natural follow-ups:
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of languages to explore after C: a central C node with several friendly stepping-stone routes leading outward to abstract emblem tokens for neighboring languages (a fast low-level gear, a memory-safe shield, a concurrency motif, a high-level scripting spark), arranged as a welcoming constellation. Connectors as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ### C++
 

--- a/content/learn/c-programming-for-beginners/pointers-and-arrays.mdx
+++ b/content/learn/c-programming-for-beginners/pointers-and-arrays.mdx
@@ -9,11 +9,22 @@ admission. The payoff is a unified model in which traversing an
 array, walking a string, and scanning a region of memory are all the
 same idea.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for pointers and arrays: a row of array cells with a single pointer arrow gliding along them left to right, leaving a soft trail, suggesting that walking an array is just moving a pointer. Unified and smooth. Arrow as a solid filled shape, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Array name as a pointer
 
 When you mention an array name in most expressions, the compiler
 silently converts it to **a pointer to its first element**. This is
 called *array-to-pointer decay*.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of array-to-pointer decay: an array name-tag dissolving into a single pointer arrow aimed at the array's first cell, with faint motion lines showing the name becoming a pointer to element zero. Arrow as a solid filled shape, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="An array name decays into a pointer to its first element"
+  ratio="16 / 9"
+/>
 
 ```c
 int a[5] = {10, 20, 30, 40, 50};
@@ -128,6 +139,12 @@ Each iteration:
 2. If it's `\0`, stop.
 3. Otherwise print it.
 4. Advance the pointer to the next character.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of walking a null-terminated string with a pointer: a row of character cells ending in a null badge, a pointer arrow advancing one cell at a time, a small printed character emerging at each step, and the walk halting at the null terminator. Arrow as a solid filled shape, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — single letters and a 0 acceptable.`}
+  alt="A pointer advancing through a string one character at a time until the null terminator"
+  ratio="5 / 2"
+/>
 
 The famous one-liner `while (*s) putchar(*s++);` does the same thing
 even more compactly. *Familiarize yourself with the long form first*

--- a/content/learn/c-programming-for-beginners/pointers.mdx
+++ b/content/learn/c-programming-for-beginners/pointers.mdx
@@ -12,6 +12,11 @@ The trick is to keep the picture in front of you at all times.
 Every pointer is just a **box that holds an address**. Once you draw
 the boxes, everything else falls into place.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for pointers: one small box labeled as a pointer holding an address value, with a clear solid arrow reaching across to a separate target box that holds the real value. The whole idea in one image — a box that points at another box. Arrow as a solid filled shape, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## What a pointer is
 
 Every byte of RAM has an address — a number. A **pointer** is a
@@ -83,6 +88,12 @@ things:
 | `int *p = &n;` | declare `p`, initialize it with the address of `n`              |
 
 Once you internalize that, half of pointer confusion vanishes.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of the two pointer operators: on one side, an address-of motif taking a value box and producing a little address tag; on the other, a dereference motif following an address arrow back to the value it points at. Two complementary actions side by side. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — the symbols & and * are acceptable.`}
+  alt="The address-of operator produces an address; the dereference operator follows an address to its value"
+  ratio="16 / 9"
+/>
 
 ## Pictures, always pictures
 
@@ -202,6 +213,11 @@ if (p != NULL) {
 
 A common idiom is `if (p)` / `if (!p)`, since `NULL` is zero (false).
 
+<Illustration
+  prompt={`Decorative flat-vector illustration of a null pointer: a small pointer box whose arrow points at nothing — an empty void or crossed-out marker instead of a target box — with a subtle red accent as a gentle warning. Conveys a pointer that points to nothing valid. Arrow as a solid filled shape, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## What happens if you forget to initialize a pointer
 
 An uninitialized pointer holds whatever bits were in those bytes
@@ -263,6 +279,12 @@ should see that `tmp` (a local variable inside `swap`) holds `x`'s
 value, then `x` is overwritten by `y`, then `y` is overwritten from
 `tmp`. The pointers `a` and `b` give `swap` access to `main`'s
 variables without copying them.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of swapping two variables through pointers: two value boxes x and y in a caller, two pointer arrows reaching in from a function, and a small temporary holding one value mid-swap as curved solid arrows exchange the contents. Conveys a function reaching into the caller's boxes without copying them. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — single letters x, y acceptable.`}
+  alt="Two pointers let a function swap the caller's x and y variables in place"
+  ratio="16 / 9"
+/>
 
 ## Challenge: in-place addition
 

--- a/content/learn/c-programming-for-beginners/reading-code.mdx
+++ b/content/learn/c-programming-for-beginners/reading-code.mdx
@@ -11,6 +11,11 @@ you is C itself.
 
 Reading code well is a skill. Like any skill, it has a method.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for reading code: an eye or magnifier gliding over a stack of code panels, with a few panels gently lifting to reveal the structure beneath, suggesting understanding code by skimming for shape first. Calm and orderly. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Read top-down, then top-down again
 
 The most common mistake is to start at line 1 and try to understand
@@ -35,6 +40,12 @@ This is a *recursive zoom*: stay zoomed out until forced to zoom in,
 then zoom back out. You're never trying to hold every detail in your
 head at once.
 
+<Illustration
+  prompt={`Informative flat-vector illustration of recursive-zoom reading: three nested framing levels — a whole-file overview, then a single function in focus, then a few lines in close-up — joined by soft zoom-in and zoom-out arrows, suggesting staying zoomed out until you must dive in. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Reading code by zooming from a whole-file overview to a function to a few lines, then back out"
+  ratio="16 / 9"
+/>
+
 ## Follow the types
 
 C is a statically typed language. The type of a value tells you an
@@ -49,6 +60,11 @@ You instantly know: `head` is presumably a `Node *` (a list), and
 the result is a `Node *` (or `NULL`). Half the structure of the
 program is encoded in the types.
 
+<Illustration
+  prompt={`Decorative flat-vector illustration of following the types while reading code: a few value tokens each wearing a small colored type-badge, with soft connector lines linking matching badges across a snippet, suggesting that types reveal the program's structure. Connectors as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 Tools like `ctags`, `clangd`-aware editors, and IDE "go to
 definition" let you jump from a use to the declaration. **Use
 them**. Reading C without the ability to jump to definitions is
@@ -58,6 +74,12 @@ reading C with one hand tied.
 
 C is small. The same idioms recur. Recognizing them on sight is
 half of fluent reading.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of recurring code patterns as a small set of recognizable shape-cards: a loop cycle, a string scan ending in a null badge, a do-or-fail branch with a red accent, and a line-by-line read. Four tidy idiom tiles a reader learns to spot on sight. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Common C idioms: traversal loop, string scan, do-or-fail, and line-by-line read"
+  ratio="3 / 2"
+/>
 
 ### The traversal loop
 

--- a/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
+++ b/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
@@ -13,10 +13,21 @@ in one file. To grow, you need two skills:
 These are the engineering disciplines that turn working code into
 **maintainable** code.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for scope and modularity: on one side, concentric nested rounded frames representing the regions where names live; on the other, a few interlocking modular blocks or puzzle pieces forming a larger whole, joined by a slim seam. Conveys both nested visibility and building from pieces. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## What is a scope?
 
 A **scope** is a region of source code in which a name (a variable, a
 function) is meaningful. C's scopes are nested like Russian dolls.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of nested scopes as russian-doll-style concentric containers: an outermost file-scope frame containing a function-scope frame containing a small block-scope frame, each a different brand color, with a tiny name-token visible only inside its own layer. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Nested scopes: file scope contains function scope contains block scope"
+  ratio="3 / 2"
+/>
 
 ```c
 int g = 10;                   // file scope (a.k.a. "global")
@@ -89,6 +100,11 @@ int main(void) {
 Shadowing is occasionally useful (e.g. a tiny temporary) but more
 often a source of bugs. Most real codebases adopt the rule: **don't
 shadow**.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of variable shadowing: two stacked name-tokens carrying the same label, where a nearer inner token casts a soft shadow over a farther outer token of the same name, temporarily hiding it. A subtle eclipse-like motif. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ## Local variables are born and die
 
@@ -253,6 +269,11 @@ Several rules of the craft are visible here:
 If you later replaced `stats.c` with a faster implementation,
 nothing in `main.c` would need to change — as long as the header
 contract stayed the same. That is the power of modularity.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of modular code: several distinct rounded module blocks, each with a small public connector slot on top representing its header, snapping together through those slots into a clean larger assembly. Conveys files that hide their internals behind a public interface. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ## A challenge: split a calculator across files
 

--- a/content/learn/c-programming-for-beginners/story-of-c.mdx
+++ b/content/learn/c-programming-for-beginners/story-of-c.mdx
@@ -17,6 +17,11 @@ help from a colleague named **Dennis Ritchie**. They jokingly named it
 That side project — half operating system, half playground — went on
 to change computing forever.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for the birth of C and UNIX. An abstract refrigerator-sized minicomputer block with two reel-to-reel tape circles and a small glowing terminal screen sits beside flowing rounded code brackets and a stylized letter C formed from a single simple arc. Clean, slightly retro research-lab mood. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59; sparing neutral grays allowed. Minimal text — a single stylized letter C is acceptable.`}
+  ratio="16 / 9"
+/>
+
 ## Why a new language was needed
 
 The first version of UNIX was written entirely in **assembly
@@ -111,6 +116,12 @@ every day is written in C — or in something built on top of C:
 When you load a web page, dozens of C programs collaborate to make
 that happen.
 
+<Illustration
+  prompt={`Flat-vector illustration of C powering everything beneath modern software. A central simple letter-C arc (or small chip) from which thin solid connector lines radiate to abstract icons arranged in a balanced constellation: an operating-system kernel ring, a database cylinder, a network globe node, a tiny embedded chip, and a browser window. Conveys the idea that C sits underneath it all. Connectors as thin solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="C at the center of operating systems, databases, networks, embedded devices, and browsers"
+  ratio="16 / 9"
+/>
+
 ## How C influenced everything that came after
 
 Almost every popular language in use today inherits ideas — and
@@ -169,6 +180,11 @@ C is the layer where the cleanly abstracted world of "variables and
 functions" meets the messy physical world of "wires and voltages".
 Learning C lets you stand on that border and look in both directions.
 </Callout>
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of standing at the border between two worlds. On one side, a clean abstract realm of floating rounded shapes representing variables and functions; on the other, a physical realm of circuit traces and wire/voltage motifs. A simple seam or slim bridge down the middle joins the two halves. Calm and conceptual. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ## A short word from Dennis Ritchie
 

--- a/content/learn/c-programming-for-beginners/story-of-computers.mdx
+++ b/content/learn/c-programming-for-beginners/story-of-computers.mdx
@@ -9,6 +9,11 @@ quickly. To appreciate why C exists — and why programming languages
 exist at all — we need to understand the long, surprising road that
 brought us here.
 
+<Illustration
+  prompt={`Decorative flat-vector hero on the history of computing shown as a left-to-right progression. Interlocking brass-like gears (the mechanical era) transition into glowing vacuum-tube and switch shapes, then into a clean modern microchip square with circuit traces. A subtle timeline feel, no dates. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59; sparing neutral grays only if needed. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Computing before electricity
 
 For most of human history, "computing" meant moving beads on an abacus
@@ -62,6 +67,12 @@ floors.
 Inside a computer, every signal is either **on** or **off** — a 1 or a
 0. A group of 8 bits is a **byte**, and bytes are how we measure
 memory.
+
+<Illustration
+  prompt={`Flat-vector illustration of binary and bytes: a tidy grid of small rounded square bit-tiles, some switched on (filled bright blue or green) and some off (faint, low-opacity), grouped into clusters of eight to suggest bytes, with a couple of clusters glowing as if active. Abstract, rhythmic, pattern-like. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — only sparse 0 and 1 glyphs, if any.`}
+  alt="Bits drawn as on/off tiles grouped into bytes of eight"
+  ratio="16 / 9"
+/>
 
 A CPU is a piece of silicon that can do a small set of operations:
 add two numbers, compare two numbers, jump to a different instruction,
@@ -126,6 +137,11 @@ Assembly for an Intel chip will not run on an ARM chip. And you still
 have to think in tiny, one-instruction-at-a-time steps. There is no
 "if statement". There is no "function". You have to *build* those
 ideas yourself out of jumps and labels.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of rising abstraction levels: three or four stacked translucent platforms floating one above another, connected by soft steps and upward solid arrows. The lowest platform feels like raw hardware (a chip motif), the middle like assembly (small mnemonic blocks), the top like a friendly high-level language (rounded brackets and a flowing curve). A sense of climbing upward, away from the machine. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ## The dream of a high-level language
 

--- a/content/learn/c-programming-for-beginners/strings.mdx
+++ b/content/learn/c-programming-for-beginners/strings.mdx
@@ -11,6 +11,11 @@ character" `\0`.
 This page is about how to think about that, and how not to shoot
 yourself in the foot.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for C strings: a row of letter-tiles spelling a short friendly word, capped at the end by a distinct small terminator marker (a tiny stop or zero badge) showing where the string ends. Conveys a string as characters plus a hidden end marker. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — a few simple letters acceptable.`}
+  ratio="16 / 9"
+/>
+
 ## The null-terminated string
 
 ```c
@@ -32,6 +37,12 @@ There is no metadata. The convention is: walk until you see a `\0`.
 This convention is fast and compact, but it shifts a lot of
 responsibility onto the programmer. Forget the terminator and
 everything goes wrong.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of a null-terminated string: six adjacent cells holding h, e, l, l, o and a final distinct cell marked as the null terminator (a small zero or stop badge in a contrasting color), with a tiny walking marker reading left to right and halting at the terminator. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — single letters and a 0 acceptable.`}
+  alt="A string stored as characters followed by a null terminator that marks the end"
+  ratio="5 / 2"
+/>
 
 ## String literals
 
@@ -105,6 +116,12 @@ buffer **without checking how big it is**. If your destination is
 too small, you trash whatever memory is next to it. This was the
 mechanism behind the **Morris worm** (1988), countless web-server
 exploits, and many of the CVEs you read about today.
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of a buffer overflow: a small fixed-size container being overfilled so excess content spills over its edge onto neighboring cells, the spilled region flagged with a subtle red accent. Conveys writing past the end of a too-small buffer. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Writing more characters than a buffer can hold spills into neighboring memory"
+  ratio="16 / 9"
+/>
 
 ```c
 char buf[8];

--- a/content/learn/c-programming-for-beginners/structs.mdx
+++ b/content/learn/c-programming-for-beginners/structs.mdx
@@ -13,6 +13,11 @@ parameter lists and praying nothing fell out of sync. With structs,
 each "thing" becomes a single, named, typed value you can move
 around as a unit.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for structs: several distinct little field tokens — a number, a tiny name-tag, a small decimal — gathered and bundled together inside one larger labeled container box, like related items packed into a single parcel. Conveys grouping related values into one named thing. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Declaring a struct
 
 ```c
@@ -242,6 +247,12 @@ int main(void) {
 Read `box.top_left.x` as "the `x` of the `top_left` of `box`". Dot
 chains work just like in everyday English.
 
+<Illustration
+  prompt={`Informative flat-vector illustration of nested structs: a large container box holding two smaller point-boxes inside it, each of those holding two tiny field tokens — boxes within boxes. Conveys structs containing other structs. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="A struct containing other structs, like boxes nested inside a box"
+  ratio="16 / 9"
+/>
+
 ## Struct assignment copies
 
 Assigning one struct to another copies every field:
@@ -257,6 +268,12 @@ pointer copies the *pointer*, not the thing it points to. Both
 copies would then "own" the same heap allocation, which is a recipe
 for double-frees. We'll meet this pattern again in the linked-list
 chapter.
+
+<Illustration
+  prompt={`Informative flat-vector illustration of struct assignment making a full copy: one labeled struct box duplicated into a second independent struct box, every field copied across; alongside, a note that a contained pointer copies only the address — shown as two boxes whose pointer arrows aim at the same shared heap chunk. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="Struct assignment copies every field; a contained pointer is copied as an address, not deeply"
+  ratio="16 / 9"
+/>
 
 ## Challenge: rectangle area
 

--- a/content/learn/c-programming-for-beginners/variables-and-memory.mdx
+++ b/content/learn/c-programming-for-beginners/variables-and-memory.mdx
@@ -9,6 +9,11 @@ the friendly name is a fixed-size box of bytes at a specific address.
 That mental model — *variable = labelled box in memory* — will guide
 every chapter from now on.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for variables and memory: a friendly labelled box — a rounded container with a small name-tag — sitting in a row of memory cells, a value blob resting inside it. A gentle sticky-note label connects a human-friendly name on top to a faint numbered address below. Warm and simple. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
+
 ## Declaring a variable
 
 The minimum recipe for a variable is:
@@ -58,6 +63,12 @@ Address      Variable          Value (decimal)
 Each box is 4 bytes. The actual addresses are not predictable across
 runs — they depend on the OS, the architecture, and security
 features like ASLR. But the **shape** is reliable.
+
+<Illustration
+  prompt={`Informative flat-vector memory diagram: two stacked 4-byte boxes labelled by small name-tags, the upper holding the value 30 and the lower holding 1995, each sitting at a numbered address shown faintly to the left. Clean, aligned, grid-like. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — the small numbers 30 and 1995 are acceptable.`}
+  alt="Two variables shown as labelled 4-byte boxes at consecutive memory addresses"
+  ratio="3 / 2"
+/>
 
 ## Assignment versus declaration
 
@@ -218,6 +229,12 @@ temporary — but by the time the second line runs, `a` already holds
 the new value, so you copy it back into `b` and lose the original.
 Always think *what's in each box, right now?*
 
+<Illustration
+  prompt={`Informative flat-vector illustration of swapping two variables using a temporary: three labelled boxes a, b, and tmp, with curved solid arrows showing values moving in three steps — a into tmp, then b into a, then tmp into b. Clear and choreographed, like a small dance. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — single letters a, b, tmp only.`}
+  alt="Swapping two values a and b using a temporary box tmp, in three steps"
+  ratio="16 / 9"
+/>
+
 ## Why memory matters even for `int`
 
 A `int` on most systems is 4 bytes. That means it can hold values
@@ -237,6 +254,11 @@ int main(void) {
   return 0;
 }
 `}
+/>
+
+<Illustration
+  prompt={`Decorative flat-vector illustration of integer overflow: a fixed-width container of bits filled to the very top, with one extra unit tipping it past the edge so the value wraps from the far positive end back to the far negative end — shown as an odometer-style ring or a number line that loops back on itself. A subtle red accent marks the wrap point. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
 />
 
 This is a small but profound lesson: in C, **every variable has a

--- a/content/learn/c-programming-for-beginners/your-first-program.mdx
+++ b/content/learn/c-programming-for-beginners/your-first-program.mdx
@@ -6,6 +6,11 @@ description: Read, run, and modify your first C program — and understand every
 It is time. We have talked about hardware, history, and thinking.
 Now let's write code.
 
+<Illustration
+  prompt={`Decorative flat-vector hero for a learner's first program: a friendly terminal output window with a soft speech bubble rising from it containing a small waving-hand or smiley motif, suggesting a greeting to the world, surrounded by a few floating code brackets and a blinking cursor block. Welcoming and bright. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. Minimal text — a single exclamation mark at most, no words.`}
+  ratio="16 / 9"
+/>
+
 The traditional first program in any language is one that prints the
 words *"Hello, world!"*. This tradition started in **1974**, in an
 internal memo by Brian Kernighan at Bell Labs, and it has remained
@@ -102,6 +107,12 @@ but explicit is better than implicit.
 6. The operating system **delivers those bytes to the terminal**.
 7. You see **`Hello, world!`**.
 
+<Illustration
+  prompt={`Informative flat-vector left-to-right flow of what happens when a program runs: a small source-file document flows by a solid arrow into a gear (the compiler), producing an executable block, which the operating system loads into a memory strip, where a CPU marker runs it and emits little bytes into a small output window. Evenly spaced stages, each a different brand color. Arrows as solid filled shapes, no outline strokes. Transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  alt="From source file to compiler to executable, loaded by the OS and run by the CPU to produce output"
+  ratio="5 / 2"
+/>
+
 In our browser sandbox, every step still happens — the compiler is
 just bundled into the same web page you are reading, and the
 "terminal" is a panel to the right of the editor.
@@ -111,6 +122,11 @@ just bundled into the same web page you are reading, and the
 The fastest way to learn syntax is to break it on purpose. Try each
 of these in turn in the code block above; run; observe what the
 compiler or runtime tells you; then fix it.
+
+<Illustration
+  prompt={`Decorative flat-vector spot illustration of learning by breaking code on purpose: a small code-window tile with a playful crack or a missing puzzle-piece gap, a tiny wrench or bandage motif nearby suggesting fix-and-retry, and a subtle red accent marking the error spot. Encouraging rather than alarming. Flat vector, no outlines or strokes, transparent background, legible in both light and dark mode. Palette: blue #148CFF, green #20C621, yellow #FFDD6C, red #FF4F59. No text.`}
+  ratio="16 / 9"
+/>
 
 ### Experiment 1 — remove the semicolon
 

--- a/docs/illustrations.md
+++ b/docs/illustrations.md
@@ -1,0 +1,59 @@
+# Lesson illustrations
+
+Decorative and informative vector illustrations for `/learn` courses. Art is
+generated externally (e.g. with [Recraft](https://www.recraft.ai/)) as SVG,
+committed under `public/illustrations/<course>/…`, and placed in lessons with
+the `<Illustration>` MDX component.
+
+This started as a pilot in **`c-programming-for-beginners`**: every lesson has
+prompt-bearing placeholders ready to be turned into artwork.
+
+## The `<Illustration>` component
+
+Registered globally in `mdx-components.tsx`, so no import is needed in MDX.
+
+```mdx
+<Illustration
+  prompt="Flat abstract vector illustration of a row of numbered mailboxes, each a small rounded rectangle, a few holding tiny digit glyphs. Soft, friendly, no outlines."
+  alt="RAM pictured as a row of numbered, byte-sized boxes"
+  caption="Memory is just a long row of numbered cells."
+  ratio="16 / 9"
+/>
+```
+
+| Prop      | Required | Purpose                                                                 |
+| --------- | :------: | ----------------------------------------------------------------------- |
+| `prompt`  |   yes    | Generation prompt. Shown in the placeholder; ignored once `src` is set. |
+| `src`     |    no    | Path to the generated SVG (served from `/public`). Swaps in the artwork. |
+| `alt`     |    no    | Alt text for the final image. Omit / `""` for purely decorative art.    |
+| `caption` |    no    | Visible caption (`<figcaption>`).                                       |
+| `ratio`   |    no    | CSS `aspect-ratio` of the frame. Default `16 / 9`.                       |
+
+### Workflow
+
+1. Author places `<Illustration prompt="…" />` where art helps. The site shows
+   a dashed placeholder frame that surfaces the prompt.
+2. Generate the SVG from that prompt and save it, e.g.
+   `public/illustrations/c-programming-for-beginners/memory-mailboxes.svg`.
+3. Add `src="/illustrations/c-programming-for-beginners/memory-mailboxes.svg"`
+   to the placeholder. The real artwork replaces the frame; the prompt stays in
+   the source as a record of how the art was made.
+
+## Prompt / art-direction guidelines
+
+These constraints keep the set coherent and legible on both themes.
+
+- **Style** — flat vector; abstract, artistic, or lightly informative. Decorative
+  is fine; not everything needs to teach.
+- **No borders/strokes on shapes.** Let fills carry the form.
+- **Dual-mode.** Must read on **both** light and dark backgrounds. Avoid pure
+  white or pure black fills and large solid backgrounds; prefer transparent
+  backgrounds and mid-tone, saturated brand colors that hold up either way.
+- **Palette.** Use mainly the brand 500s:
+  - blue `#148CFF`, green `#20C621`, yellow `#FFDD6C`, red `#FF4F59`.
+  - Other shades (100–900) only when genuinely necessary.
+  - Teal / purple / orange: rare, decorative accents only.
+- **Text.** Avoid text in the artwork unless it is very simple (a single digit,
+  a `+`, a short label).
+
+The four-dot swatch on each placeholder frame is a reminder of the core palette.

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -19,6 +19,7 @@ import MdxSqlChallengeCard from "@/app/_components/MdxSqlChallengeCard";
 import MdxSqlCodeBlock from "@/app/_components/MdxSqlCodeBlock";
 import MdxMultipleChoiceQuestion from "@/app/_components/multipleChoice/MdxMultipleChoiceQuestion";
 import { Mermaid } from "@/app/_components/mdx/mermaid";
+import { Illustration } from "@/app/_components/mdx/illustration";
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
@@ -29,6 +30,10 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     SqlCodeBlock: MdxSqlCodeBlock,
     MultipleChoice: MdxMultipleChoiceQuestion,
     Mermaid,
+    // Decorative / informative vector figures. Renders a prompt-bearing
+    // placeholder until a generated SVG `src` is supplied. See
+    // app/_components/mdx/illustration.tsx and docs/illustrations.md.
+    Illustration,
     // Fumadocs Steps/Step — a numbered vertical walkthrough. Registered
     // globally so lessons can drop `<Steps>…<Step>` in without an import,
     // matching the convention used by the components above.

--- a/public/illustrations/c-programming-for-beginners/.gitkeep
+++ b/public/illustrations/c-programming-for-beginners/.gitkeep
@@ -1,0 +1,3 @@
+Generated SVG illustrations for the C course land here.
+See docs/illustrations.md and the <Illustration> placeholders in
+content/learn/c-programming-for-beginners/*.mdx.


### PR DESCRIPTION
## Summary

Pilot for generating **decorative and informative vector illustrations** (via Recraft) across `/learn/c-programming-for-beginners`. Introduces a reusable `<Illustration>` MDX component and seeds **82 prompt-bearing placeholders** — a hero plus several concept illustrations in every one of the 24 lessons.

Each placeholder carries its own **context-specific prompt** derived from the surrounding lesson content. Until a generated SVG is supplied, the component renders a tidy dashed frame that surfaces the prompt, so the spots and art direction can be reviewed first and the artwork filled in later.

## What's here

- **`app/_components/mdx/illustration.tsx`** + CSS module — renders a placeholder frame (icon, "Illustration · placeholder" label, the prompt, and a 4-dot brand-palette reminder) when no `src` is set; swaps in the real SVG once `src` is provided. All chrome is built from Fumadocs theme tokens, so it tracks **light/dark** automatically.
- **`mdx-components.tsx`** — registers `<Illustration>` globally (no import needed in MDX).
- **`docs/illustrations.md`** — workflow + art-direction guidelines.
- **`public/illustrations/c-programming-for-beginners/`** — home for the generated SVGs.
- **24 lesson `.mdx` files** — 82 `<Illustration>` placeholders inserted at natural spots (after intros, key concepts, before recaps).

## Prompt conventions (per request)

Every prompt encodes the constraints so it's usable standalone in Recraft:
- Flat vector, **no outlines/strokes** on shapes; abstract, artistic, or informative.
- Reads on **both light and dark** backgrounds (transparent background, mid-tone fills).
- Palette limited to brand **blue / green / yellow / red 500s**; other shades only when necessary; teal/purple/orange avoided.
- **Minimal or no text** (single digits/letters at most).

## Component API

```mdx
<Illustration
  prompt={`Flat vector illustration of …`}
  alt="accessible description (omit for purely decorative)"
  caption="optional visible caption"
  src="/illustrations/c-programming-for-beginners/foo.svg"  // optional; empty = placeholder
  ratio="16 / 9"
/>
```

To go live: generate each SVG from its prompt, drop it under `public/illustrations/c-programming-for-beginners/`, and add the `src`. The prompt stays in the source as a record.

## Validation

- `npm run build` passes — TypeScript clean, all **1580** static pages (every C lesson) prerender with the placeholders.
- Verified in the prerendered HTML: prompts/captions render, no raw `<Illustration>` tags leak, palette swatches present.

https://claude.ai/code/session_01VwfQgPEHT9J7eDvHj666z3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwfQgPEHT9J7eDvHj666z3)_