### PR TITLE
Wrap mermaid expressions, SQL, edge labels & entity names in monospace `<code>`

### DIFF
--- a/content/learn/beginners-javascript/conditionals.mdx
+++ b/content/learn/beginners-javascript/conditionals.mdx
@@ -61,7 +61,7 @@ Visually:
 
 ```mermaid
 flowchart TD
-    A[Start] --> B{age >= 18?}
+    A[Start] --> B{"<code>age &gt;= 18</code>?"}
     B -- yes --> C["Print 'can vote'"]
     B -- no  --> D["Print 'cannot vote yet'"]
     C --> E[Done]
@@ -106,15 +106,15 @@ condition) catches everything left over.
 
 ```mermaid
 flowchart TD
-    A[Start] --> B{score >= 90?}
-    B -- yes --> R1[return 'A']
-    B -- no  --> C{score >= 80?}
-    C -- yes --> R2[return 'B']
-    C -- no  --> D{score >= 70?}
-    D -- yes --> R3[return 'C']
-    D -- no  --> E{score >= 60?}
-    E -- yes --> R4[return 'D']
-    E -- no  --> R5[return 'F']
+    A[Start] --> B{"<code>score &gt;= 90</code>?"}
+    B -- yes --> R1["<code>return 'A'</code>"]
+    B -- no  --> C{"<code>score &gt;= 80</code>?"}
+    C -- yes --> R2["<code>return 'B'</code>"]
+    C -- no  --> D{"<code>score &gt;= 70</code>?"}
+    D -- yes --> R3["<code>return 'C'</code>"]
+    D -- no  --> E{"<code>score &gt;= 60</code>?"}
+    E -- yes --> R4["<code>return 'D'</code>"]
+    E -- no  --> R5["<code>return 'F'</code>"]
 ```
 
 **Order matters.** If you wrote the conditions starting from

--- a/content/learn/beginners-javascript/how-javascript-runs.mdx
+++ b/content/learn/beginners-javascript/how-javascript-runs.mdx
@@ -121,7 +121,7 @@ A simplified picture:
 
 ```mermaid
 flowchart TD
-    JS[JS Engine + Call Stack] -->|"calls e.g. setTimeout(fn, 100)"| HOST[Host]
+    JS[JS Engine + Call Stack] -->|"calls e.g. <code>setTimeout(fn, 100)</code>"| HOST[Host]
     HOST -->|after 100ms| Q[Task Queue]
     Q -->|when stack is empty| JS
     MQ[Microtask Queue] -->|drained between every task| JS

--- a/content/learn/beginners-javascript/loops-and-iteration.mdx
+++ b/content/learn/beginners-javascript/loops-and-iteration.mdx
@@ -335,9 +335,9 @@ classic `for (let i = 0; i < N; i++) { ... }`:
 ```mermaid
 flowchart TD
     A["Initialise <code>i = 0</code>"]
-    B{i < N?}
+    B{"<code>i &lt; N</code>?"}
     C[Body: do something with i]
-    D[i = i + 1]
+    D["<code>i = i + 1</code>"]
     A --> B
     B -- yes --> C --> D --> B
     B -- no --> E[After the loop]

--- a/content/learn/beginners-javascript/map-filter-reduce.mdx
+++ b/content/learn/beginners-javascript/map-filter-reduce.mdx
@@ -245,8 +245,8 @@ Each step takes the previous output as input.
 
 ```mermaid
 flowchart TD
-    A[orders] --> B["filter: status === 'paid'"]
-    B --> C["map: o => o.amount"]
+    A[orders] --> B["filter: <code>status === 'paid'</code>"]
+    B --> C["map: <code>o =&gt; o.amount</code>"]
     C --> D["reduce: sum"]
     D --> E[revenue: number]
 ```

--- a/content/learn/c-programming-for-beginners/conditionals.mdx
+++ b/content/learn/c-programming-for-beginners/conditionals.mdx
@@ -280,13 +280,13 @@ Three things to remember:
 
 ```mermaid
 flowchart TD
-    A{score >= 90?}
+    A{"<code>score &gt;= 90</code>?"}
     A -- yes --> A1[Grade: A]
-    A -- no --> B{score >= 80?}
+    A -- no --> B{"<code>score &gt;= 80</code>?"}
     B -- yes --> B1[Grade: B]
-    B -- no --> C{score >= 70?}
+    B -- no --> C{"<code>score &gt;= 70</code>?"}
     C -- yes --> C1[Grade: C]
-    C -- no --> D{score >= 60?}
+    C -- no --> D{"<code>score &gt;= 60</code>?"}
     D -- yes --> D1[Grade: D]
     D -- no --> E[Grade: F]
 ```

--- a/content/learn/c-programming-for-beginners/loops.mdx
+++ b/content/learn/c-programming-for-beginners/loops.mdx
@@ -251,9 +251,9 @@ A classic countdown.
 
 ```mermaid
 flowchart TD
-    A["init: <code>i = 1</code>"] --> B{i <= 5?}
+    A["init: <code>i = 1</code>"] --> B{"<code>i &lt;= 5</code>?"}
     B -- yes --> C[body: print i]
-    C --> D[increment: i = i + 1]
+    C --> D["increment: <code>i = i + 1</code>"]
     D --> B
     B -- no --> E[exit loop]
 ```

--- a/content/learn/csharp-linq-functional/birth-of-linq.mdx
+++ b/content/learn/csharp-linq-functional/birth-of-linq.mdx
@@ -117,7 +117,7 @@ There are two kinds of LINQ, and the difference matters.
 ```mermaid
 flowchart TB
     subgraph LinqToObjects[LINQ to Objects]
-        Q1["<code>IEnumerable&lt;T&gt;</code>"] -->|"Func&lt;T,bool&gt;"| F1[Pipeline executes locally]
+        Q1["<code>IEnumerable&lt;T&gt;</code>"] -->|"<code>Func&lt;T,bool&gt;</code>"| F1[Pipeline executes locally]
     end
     subgraph LinqToProviders[LINQ to a provider]
         Q2["<code>IQueryable&lt;T&gt;</code>"] -->|"Expression&lt;Func&lt;T,bool&gt;&gt;"| F2[Pipeline is *translated* to SQL/HTTP/etc.]

--- a/content/learn/csharp-linq-functional/filtering-and-projection.mdx
+++ b/content/learn/csharp-linq-functional/filtering-and-projection.mdx
@@ -175,8 +175,8 @@ pipeline above:
 
 ```mermaid
 flowchart TD
-    O1["Order(Widget, 9.99, 3)"] --> W1{"Where: Product == 'Widget'"}
-    W1 -->|"pass"| W2{"Where: Quantity > 0"}
+    O1["Order(Widget, 9.99, 3)"] --> W1{"Where: <code>Product == 'Widget'</code>"}
+    W1 -->|"pass"| W2{"Where: <code>Quantity &gt; 0</code>"}
     W2 -->|"pass"| S["Select: new <code>{ Price=9.99, Total=29.97 }</code>"]
     S --> R[Output]
 ```

--- a/content/learn/csharp-linq-functional/generic-abstractions.mdx
+++ b/content/learn/csharp-linq-functional/generic-abstractions.mdx
@@ -25,8 +25,8 @@ necessary to *walk* a sequence.
 
 ```mermaid
 flowchart LR
-    A["<code>IEnumerable&lt;T&gt;</code>"] -->|GetEnumerator| B["<code>IEnumerator&lt;T&gt;</code>"]
-    B -->|MoveNext| C{has next?}
+    A["<code>IEnumerable&lt;T&gt;</code>"] -->|"<code>GetEnumerator</code>"| B["<code>IEnumerator&lt;T&gt;</code>"]
+    B -->|"<code>MoveNext</code>"| C{has next?}
     C -- yes --> D[Current] --> B
     C -- no --> E[done]
 ```

--- a/content/learn/csharp-linq-functional/ienumerable-and-iteration.mdx
+++ b/content/learn/csharp-linq-functional/ienumerable-and-iteration.mdx
@@ -49,8 +49,8 @@ arrays, files, network streams, and infinite sequences.
 
 ```mermaid
 flowchart TD
-    A["<code>IEnumerable&lt;T&gt;</code>"] -->|GetEnumerator| B["<code>IEnumerator&lt;T&gt;</code>"]
-    B -->|MoveNext| C{has next?}
+    A["<code>IEnumerable&lt;T&gt;</code>"] -->|"<code>GetEnumerator</code>"| B["<code>IEnumerator&lt;T&gt;</code>"]
+    B -->|"<code>MoveNext</code>"| C{has next?}
     C -->|yes| D[Current → consumer]
     D --> B
     C -->|no| E[done]

--- a/content/learn/csharp-linq-functional/lambdas-and-delegates.mdx
+++ b/content/learn/csharp-linq-functional/lambdas-and-delegates.mdx
@@ -209,10 +209,10 @@ language (SQL, BSON, an HTTP query).
 
 ```mermaid
 flowchart LR
-    L["x => x.Age > 30"] -->|"compiled as Func"| D[Delegate: callable in C#]
+    L["<code>x =&gt; x.Age &gt; 30</code>"] -->|"compiled as Func"| D[Delegate: callable in C#]
     L -->|"compiled as Expression"| T[Tree of nodes: translatable]
-    T --> S["SELECT * FROM ... WHERE Age > 30"]
-    T --> M["{ Age: <code>{ $gt: 30 }</code> }"]
+    T --> S["<code>SELECT * FROM ... WHERE Age &gt; 30</code>"]
+    T --> M["<code>{ Age: { $gt: 30 } }</code>"]
 ```
 
 We're not going to write a LINQ provider in this course, but it is

--- a/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
+++ b/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
@@ -51,8 +51,8 @@ calls.
 
 ```mermaid
 flowchart LR
-    Q["from p in xs<br/>where p.A &gt; 0<br/>select p.B"]
-      -->|compiler rewrite| M["<code>xs.Where(p =&gt; p.A &gt; 0)</code><br/>.Select(p =&gt; p.B)"]
+    Q["<code>from p in xs<br/>where p.A &gt; 0<br/>select p.B</code>"]
+      -->|compiler rewrite| M["<code>xs.Where(p =&gt; p.A &gt; 0)</code><br/><code>.Select(p =&gt; p.B)</code>"]
     M --> IL[Same IL bytecode]
 ```
 

--- a/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
+++ b/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
@@ -81,7 +81,7 @@ them all into a single sequence.
 
 ```mermaid
 flowchart LR
-    A["Departments: [Eng, Sales, Finance]"] --> S["Select(d ⇒ d.Employees)"]
+    A["Departments: [Eng, Sales, Finance]"] --> S["<code>Select(d ⇒ d.Employees)</code>"]
     S --> N["[[Ada, Bilal], [Chiara, Dmitri, Esther], [Farah]]"]
     A --> M["<code>SelectMany(d ⇒ d.Employees)</code>"]
     M --> F["[Ada, Bilal, Chiara, Dmitri, Esther, Farah]"]

--- a/content/learn/data-analysis-python-pandas/pivot-tables.mdx
+++ b/content/learn/data-analysis-python-pandas/pivot-tables.mdx
@@ -11,7 +11,7 @@ rows, product to columns, sum of sales to values — Pandas's
 
 ```mermaid
 flowchart LR
-  L["Long DataFrame<br/>region, product, sales"] -->|pivot_table| W["Wide grid<br/>rows=region<br/>cols=product<br/>cells=<code>sum(sales)</code>"]
+  L["Long DataFrame<br/>region, product, sales"] -->|"<code>pivot_table</code>"| W["Wide grid<br/>rows=region<br/>cols=product<br/>cells=<code>sum(sales)</code>"]
 ```
 
 You're saying: "I want a grid. The rows come from this column,

--- a/content/learn/data-analysis-python-pandas/rows-and-columns.mdx
+++ b/content/learn/data-analysis-python-pandas/rows-and-columns.mdx
@@ -188,7 +188,7 @@ type, different axis — is a recurring theme.
 ```mermaid
 flowchart LR
     DF[("<code>DataFrame<br/>5 × 4</code>")] -->|df see column| C[Series of<br/>5 values<br/>indexed by row]
-    DF -->|df.iloc see row| R[Series of<br/>4 values<br/>indexed by column]
+    DF -->|"<code>df.iloc</code> see row"| R[Series of<br/>4 values<br/>indexed by column]
 ```
 
 We will study Series and DataFrames in depth in the *DataFrames

--- a/content/learn/database-design-postgresql/case-study-blog.mdx
+++ b/content/learn/database-design-postgresql/case-study-blog.mdx
@@ -42,11 +42,11 @@ table: `post_tags`.
 
 ```mermaid
 flowchart LR
-    Users["users"] --> Posts["posts"]
-    Users --> Comments["comments"]
+    Users["<code>users</code>"] --> Posts["<code>posts</code>"]
+    Users --> Comments["<code>comments</code>"]
     Posts --> Comments
     Posts --> PostTags["<code>post_tags</code>"]
-    Tags["tags"] --> PostTags
+    Tags["<code>tags</code>"] --> PostTags
 ```
 
 `post_tags` is not just a technical trick. It represents the fact
@@ -73,13 +73,13 @@ Each attribute belongs with the entity it describes.
 
 ```mermaid
 flowchart TD
-    User["users"] --> Email["email"]
+    User["<code>users</code>"] --> Email["email"]
     User --> Display["<code>display_name</code>"]
-    Post["posts"] --> Title["title"]
+    Post["<code>posts</code>"] --> Title["title"]
     Post --> Body["body"]
     Post --> Status["status"]
-    Comment["comments"] --> CommentBody["body"]
-    Tag["tags"] --> Name["name"]
+    Comment["<code>comments</code>"] --> CommentBody["body"]
+    Tag["<code>tags</code>"] --> Name["name"]
 ```
 
 The post does not store the author's email. It stores `author_id`, a

--- a/content/learn/database-design-postgresql/case-study-ecommerce.mdx
+++ b/content/learn/database-design-postgresql/case-study-ecommerce.mdx
@@ -43,11 +43,11 @@ The core entities are `customers`, `products`, `categories`, and
 
 ```mermaid
 flowchart LR
-    Customers["customers"] --> Orders["orders"]
+    Customers["<code>customers</code>"] --> Orders["<code>orders</code>"]
     Orders --> Items["<code>order_items</code>"]
-    Products["products"] --> Items
+    Products["<code>products</code>"] --> Items
     Products --> ProductCategories["<code>product_categories</code>"]
-    Categories["categories"] --> ProductCategories
+    Categories["<code>categories</code>"] --> ProductCategories
 ```
 
 <MultipleChoice

--- a/content/learn/database-design-postgresql/check-constraints.mdx
+++ b/content/learn/database-design-postgresql/check-constraints.mdx
@@ -38,7 +38,7 @@ business into a rule the database can enforce.
 
 ```mermaid
 flowchart TB
-    B["Business rule<br/>A product price cannot be negative"] --> S["Schema rule<br/>CHECK (price >= 0)"]
+    B["Business rule<br/>A product price cannot be negative"] --> S["Schema rule<br/>CHECK (<code>price &gt;= 0</code>)"]
     S --> E["Every insert and update<br/>must obey it"]
 ```
 

--- a/content/learn/database-design-postgresql/choosing-data-types.mdx
+++ b/content/learn/database-design-postgresql/choosing-data-types.mdx
@@ -196,7 +196,7 @@ Types are broad constraints. Other constraints narrow the rule.
 
 ```mermaid
 flowchart LR
-    Broad["NUMERIC<br/>any exact number"] --> Narrow["CHECK (price >= 0)<br/>valid price"]
+    Broad["NUMERIC<br/>any exact number"] --> Narrow["CHECK (<code>price &gt;= 0</code>)<br/>valid price"]
     Narrow --> Required["NOT NULL<br/>required valid price"]
 ```
 

--- a/content/learn/database-design-postgresql/foreign-keys.mdx
+++ b/content/learn/database-design-postgresql/foreign-keys.mdx
@@ -62,10 +62,10 @@ the stable identity on related rows.
 
 ```mermaid
 flowchart TB
-    subgraph customers["customers"]
+    subgraph customers["<code>customers</code>"]
         C1["<code>customer_id</code> = 7<br/>name = Mina<br/>email = mina@new.example"]
     end
-    subgraph orders["orders"]
+    subgraph orders["<code>orders</code>"]
         O1["<code>order_id = 101<br/>customer_id = 7</code>"]
         O2["<code>order_id = 102<br/>customer_id = 7</code>"]
     end
@@ -156,7 +156,7 @@ When discussing foreign keys, people often say **parent table** and
 flowchart TB
     P["Parent table<br/>customers"]:::parent
     C["Child table<br/>orders"]:::child
-    C -->|"customer_id references customer_id"| P
+    C -->|"<code>customer_id</code> references <code>customer_id</code>"| P
     classDef parent fill:#dbeafe,stroke:#1d4ed8
     classDef child fill:#fef3c7,stroke:#b45309
 ```

--- a/content/learn/database-design-postgresql/how-design-shapes-software.mdx
+++ b/content/learn/database-design-postgresql/how-design-shapes-software.mdx
@@ -23,10 +23,10 @@ schema choices become the foundation every feature stands on.
 flowchart TB
     A["Feature:<br/>customer order history"] --> B["Application query"]
     B --> C["Schema contract"]
-    C --> D["customers"]
-    C --> E["orders"]
+    C --> D["<code>customers</code>"]
+    C --> E["<code>orders</code>"]
     C --> F["<code>order_items</code>"]
-    C --> G["products"]
+    C --> G["<code>products</code>"]
     D --> H["Reliable result"]
     E --> H
     F --> H
@@ -44,7 +44,7 @@ creates data that must obey the schema.
 
 ```mermaid
 flowchart LR
-    A["Application code"] -->|"INSERT, UPDATE, SELECT"| B["Database schema"]
+    A["Application code"] -->|"<code>INSERT, UPDATE, SELECT</code>"| B["Database schema"]
     B -->|"columns, keys, constraints"| A
     B --> C["Stored data"]
     C -->|"query results"| A

--- a/content/learn/database-design-postgresql/one-to-many.mdx
+++ b/content/learn/database-design-postgresql/one-to-many.mdx
@@ -150,9 +150,9 @@ flowchart LR
     Parent["Parent row<br/><code>customers.id = 1</code>"] --> ChildA["Child row<br/>order 101"]
     Parent --> ChildB["Child row<br/>order 102"]
     Parent --> ChildC["Child row<br/>order 103"]
-    ChildA -->|"stores customer_id"| Parent
-    ChildB -->|"stores customer_id"| Parent
-    ChildC -->|"stores customer_id"| Parent
+    ChildA -->|"stores <code>customer_id</code>"| Parent
+    ChildB -->|"stores <code>customer_id</code>"| Parent
+    ChildC -->|"stores <code>customer_id</code>"| Parent
 ```
 
 The parent can exist without children: a new customer may not have

--- a/content/learn/database-design-postgresql/one-to-one.mdx
+++ b/content/learn/database-design-postgresql/one-to-one.mdx
@@ -145,7 +145,7 @@ foreign key. Choose the table whose row is dependent or optional.
 ```mermaid
 flowchart TB
     User["users<br/>core identity"] --> Profile["<code>user_profiles</code><br/>optional details"]
-    Profile -->|"user_id FK + UNIQUE"| User
+    Profile -->|"<code>user_id</code> FK + UNIQUE"| User
     Choice["Put the FK on the dependent table"] --> Profile
 ```
 

--- a/content/learn/database-design-postgresql/reading-er-diagrams.mdx
+++ b/content/learn/database-design-postgresql/reading-er-diagrams.mdx
@@ -54,9 +54,9 @@ The entity boxes are `customers`, `orders`, `products`, and
 
 ```mermaid
 flowchart LR
-    Diagram["ER diagram"] --> Customers["customers"]
-    Diagram --> Orders["orders"]
-    Diagram --> Products["products"]
+    Diagram["ER diagram"] --> Customers["<code>customers</code>"]
+    Diagram --> Orders["<code>orders</code>"]
+    Diagram --> Products["<code>products</code>"]
     Diagram --> Items["<code>order_items</code>"]
 ```
 
@@ -71,7 +71,7 @@ Inside each box are attributes. For example, `customers` has `id`,
 
 ```mermaid
 flowchart TB
-    Entity["orders"] --> ID["id PK"]
+    Entity["<code>orders</code>"] --> ID["id PK"]
     Entity --> CustomerID["<code>customer_id</code> FK"]
     Entity --> Placed["<code>placed_on</code>"]
     Entity --> Status["status"]

--- a/content/learn/database-design-postgresql/the-design-process.mdx
+++ b/content/learn/database-design-postgresql/the-design-process.mdx
@@ -150,12 +150,12 @@ belongs.
 
 ```mermaid
 flowchart TD
-    Event["events"] --> Title["title"]
+    Event["<code>events</code>"] --> Title["title"]
     Event --> Starts["<code>starts_at</code>"]
     Event --> VenueId["<code>venue_id</code>"]
-    Venue["venues"] --> VenueName["name"]
+    Venue["<code>venues</code>"] --> VenueName["name"]
     Venue --> Address["address"]
-    Attendee["attendees"] --> Email["email"]
+    Attendee["<code>attendees</code>"] --> Email["email"]
 ```
 
 Ask whether each attribute describes the row itself. A venue address

--- a/content/learn/database-design-postgresql/thinking-in-entities.mdx
+++ b/content/learn/database-design-postgresql/thinking-in-entities.mdx
@@ -21,7 +21,7 @@ type becomes **one row**.
 
 ```mermaid
 flowchart LR
-    E["Entity type<br/>customer"] --> T["Table<br/>customers"]
+    E["Entity type<br/><code>customer</code>"] --> T["Table<br/><code>customers</code>"]
     R["One real customer<br/>Ada Lovelace"] --> Row["One row<br/><code>id = 1</code>"]
     T --> Row
 ```
@@ -40,11 +40,11 @@ excellent candidates.
 
 ```mermaid
 flowchart TB
-    S["Sentence:<br/>Customers place orders for products"] --> N["Nouns:<br/>customers, orders, products"]
+    S["Sentence:<br/>Customers place orders for products"] --> N["Nouns:<br/><code>customers</code>, <code>orders</code>, <code>products</code>"]
     N --> C["Candidate entities"]
-    C --> Customers["customers"]
-    C --> Orders["orders"]
-    C --> Products["products"]
+    C --> Customers["<code>customers</code>"]
+    C --> Orders["<code>orders</code>"]
+    C --> Products["<code>products</code>"]
 ```
 
 The verbs matter too. "Place" hints that `customers` and `orders` are
@@ -170,10 +170,10 @@ Good entity names are ordinary words from the domain. Prefer
 
 ```mermaid
 flowchart TB
-    Bad["Vague table<br/>items"] --> Problem["Could mean products,<br/>order lines, tasks, or anything"]
-    Good["Clear tables"] --> A["products"]
+    Bad["Vague table<br/><code>items</code>"] --> Problem["Could mean products,<br/>order lines, tasks, or anything"]
+    Good["Clear tables"] --> A["<code>products</code>"]
     Good --> B["<code>order_items</code>"]
-    Good --> C["tasks"]
+    Good --> C["<code>tasks</code>"]
 ```
 
 Clear names make the design easier to discuss. If the team cannot

--- a/content/learn/database-design-postgresql/what-are-relationships.mdx
+++ b/content/learn/database-design-postgresql/what-are-relationships.mdx
@@ -18,8 +18,8 @@ a student **enrolls in** a course.
 
 ```mermaid
 flowchart LR
-    Customer["Customer"] -->|places| Order["Order"]
-    Order -->|contains| Product["Product"]
+    Customer["<code>Customer</code>"] -->|places| Order["<code>Order</code>"]
+    Order -->|contains| Product["<code>Product</code>"]
 ```
 
 Those labels are plain English, but they are serious design clues.

--- a/content/learn/database-design-postgresql/why-structured-data.mdx
+++ b/content/learn/database-design-postgresql/why-structured-data.mdx
@@ -198,9 +198,9 @@ flowchart LR
     B["Admin tool"] --> S
     C["Reporting job"] --> S
     D["Email service"] --> S
-    S --> E["customers"]
-    S --> F["orders"]
-    S --> G["products"]
+    S --> E["<code>customers</code>"]
+    S --> F["<code>orders</code>"]
+    S --> G["<code>products</code>"]
 ```
 
 The schema gives these programs a common language. The checkout app

--- a/content/learn/from-zero-to-cpp/pointers-and-references.mdx
+++ b/content/learn/from-zero-to-cpp/pointers-and-references.mdx
@@ -167,9 +167,9 @@ flowchart LR
     subgraph "int a[5] in memory"
         A0[10] --- A1[20] --- A2[30] --- A3[40] --- A4[50]
     end
-    P[p = &a 0] --> A0
-    PP1[p + 1] --> A1
-    PP2[p + 2] --> A2
+    P["<code>p = &amp;a</code> 0"] --> A0
+    PP1["<code>p + 1</code>"] --> A1
+    PP2["<code>p + 2</code>"] --> A2
 ```
 
 <CodeBlock

--- a/content/learn/from-zero-to-cpp/smart-pointers.mdx
+++ b/content/learn/from-zero-to-cpp/smart-pointers.mdx
@@ -60,8 +60,8 @@ std::unique_ptr<Widget> c = std::move(a);   // OK: ownership transferred
 
 ```mermaid
 flowchart LR
-    Before["a -> Widget<br/>b = nullptr"]
-    After["a = nullptr<br/>c -> Widget"]
+    Before["<code>a -&gt; Widget</code><br/><code>b = nullptr</code>"]
+    After["<code>a = nullptr</code><br/><code>c -&gt; Widget</code>"]
     Before -- std::move --> After
 ```
 

--- a/content/learn/intro-modern-csharp/control-flow.mdx
+++ b/content/learn/intro-modern-csharp/control-flow.mdx
@@ -211,7 +211,7 @@ A `for` loop has three parts in its header:
 ```mermaid
 flowchart TB
     S([Start]) --> Init["<code>i = 0</code>"]
-    Init --> Cond{i < 5?}
+    Init --> Cond{"<code>i &lt; 5</code>?"}
     Cond -- no --> End([End])
     Cond -- yes --> Body["run body"]
     Body --> Inc["i++"]

--- a/content/learn/intro-modern-csharp/rise-of-oop.mdx
+++ b/content/learn/intro-modern-csharp/rise-of-oop.mdx
@@ -36,8 +36,8 @@ flowchart LR
         S2[Ship B<br/>position, speed, cargo]
         D[Dock<br/>capacity, queue]
     end
-    S1 -->|"requestDock()"| D
-    S2 -->|"requestDock()"| D
+    S1 -->|"<code>requestDock()</code>"| D
+    S2 -->|"<code>requestDock()</code>"| D
 ```
 
 Dahl and Nygaard's insight was: let's just *say that* in the

--- a/content/learn/intro-sql-postgres/aggregate-functions.mdx
+++ b/content/learn/intro-sql-postgres/aggregate-functions.mdx
@@ -100,7 +100,7 @@ WHERE
 
 ```mermaid
 flowchart LR
-    T[("employees")] --> W["WHERE<br/><code>dept = 'Engineering'</code>"]
+    T[("<code>employees</code>")] --> W["WHERE<br/><code>dept = 'Engineering'</code>"]
     W --> A["AVG(salary)"]
     A --> R["one number"]
 ```

--- a/content/learn/intro-sql-postgres/expressions-and-aliases.mdx
+++ b/content/learn/intro-sql-postgres/expressions-and-aliases.mdx
@@ -51,7 +51,7 @@ value by name.
 
 ```mermaid
 flowchart LR
-    E["price * qty"] -->|"AS line_total"| C["a clearly<br/>named column"]
+    E["price * qty"] -->|"AS <code>line_total</code>"| C["a clearly<br/>named column"]
 ```
 
 <Callout type="info" title="The word AS is optional, but be kind">

--- a/content/learn/intro-sql-postgres/filtering-groups.mdx
+++ b/content/learn/intro-sql-postgres/filtering-groups.mdx
@@ -18,9 +18,9 @@ has been added up.
 
 ```mermaid
 flowchart LR
-    T[("rows")] --> W["WHERE<br/>(per-row filter)<br/>no totals exist yet"]
-    W --> G["GROUP BY<br/>totals computed here"]
-    G --> H["HAVING<br/>(per-group filter)<br/>can see the totals"]
+    T[("rows")] --> W["<code>WHERE</code><br/>(per-row filter)<br/>no totals exist yet"]
+    W --> G["<code>GROUP BY</code><br/>totals computed here"]
+    G --> H["<code>HAVING</code><br/>(per-group filter)<br/>can see the totals"]
     H --> R["Result"]
 ```
 

--- a/content/learn/intro-sql-postgres/filtering-rows.mdx
+++ b/content/learn/intro-sql-postgres/filtering-rows.mdx
@@ -15,7 +15,7 @@ the test comes out **true**.
 
 ```mermaid
 flowchart LR
-    A["All rows"] --> T{"WHERE<br/>condition true?"}
+    A["All rows"] --> T{"<code>WHERE</code><br/>condition true?"}
     T -->|"true"| K["Kept in result"]
     T -->|"false"| D["Dropped"]
 ```
@@ -154,8 +154,8 @@ surviving rows.
 
 ```mermaid
 flowchart LR
-    T[("table")] --> W["WHERE<br/>keep matching rows"]
-    W --> S["SELECT<br/>pick columns"]
+    T[("table")] --> W["<code>WHERE</code><br/>keep matching rows"]
+    W --> S["<code>SELECT</code><br/>pick columns"]
     S --> R["Result"]
 ```
 

--- a/content/learn/intro-sql-postgres/first-queries.mdx
+++ b/content/learn/intro-sql-postgres/first-queries.mdx
@@ -53,8 +53,8 @@ parts named:
 
 ```mermaid
 flowchart LR
-    K["SELECT"] --> C["which columns<br/>or values you want"]
-    C --> F["FROM"]
+    K["<code>SELECT</code>"] --> C["which columns<br/>or values you want"]
+    C --> F["<code>FROM</code>"]
     F --> T["which table<br/>to read from"]
 ```
 
@@ -81,7 +81,7 @@ will always include it as a good habit.
 
 ```mermaid
 flowchart LR
-    S1["SELECT 1;"] --> S2["SELECT 2;"] --> S3["SELECT 3;"]
+    S1["<code>SELECT 1;</code>"] --> S2["<code>SELECT 2;</code>"] --> S3["<code>SELECT 3;</code>"]
 ```
 
 ## A first look at reading from a table

--- a/content/learn/intro-sql-postgres/foreign-keys.mdx
+++ b/content/learn/intro-sql-postgres/foreign-keys.mdx
@@ -109,11 +109,11 @@ appears:
 
 ```mermaid
 flowchart TB
-    subgraph customers["customers"]
+    subgraph customers["<code>customers</code>"]
         C1["<code>id = 1</code> (PK)<br/>name = Ada"]
         C2["<code>id = 2</code> (PK)<br/>name = Grace"]
     end
-    subgraph orders["orders"]
+    subgraph orders["<code>orders</code>"]
         O1["id = 101<br/><code>customer_id</code> = 1 (FK)"]
         O2["id = 102<br/><code>customer_id</code> = 1 (FK)"]
         O3["id = 103<br/><code>customer_id</code> = 2 (FK)"]

--- a/content/learn/intro-sql-postgres/grouping-data.mdx
+++ b/content/learn/intro-sql-postgres/grouping-data.mdx
@@ -17,7 +17,7 @@ group** instead of once for the whole table.
 
 ```mermaid
 flowchart TB
-    All["All employees"] --> G{"GROUP BY dept"}
+    All["All employees"] --> G{"<code>GROUP BY dept</code>"}
     G --> E["Engineering<br/>group"]
     G --> S["Sales<br/>group"]
     G --> M["Marketing<br/>group"]
@@ -148,7 +148,7 @@ ORDER BY
 
 ```mermaid
 flowchart LR
-    T[("rows")] --> W["WHERE<br/>drop interns"] --> G["GROUP BY dept<br/>form groups"] --> A["AVG per group"]
+    T[("rows")] --> W["<code>WHERE</code><br/>drop interns"] --> G["<code>GROUP BY dept</code><br/>form groups"] --> A["AVG per group"]
 ```
 
 `WHERE` thins the rows first; *then* the survivors are grouped and

--- a/content/learn/intro-sql-postgres/how-applications-use-databases.mdx
+++ b/content/learn/intro-sql-postgres/how-applications-use-databases.mdx
@@ -89,10 +89,10 @@ learning the language that powers the software world.
 ```mermaid
 flowchart TB
     Q["Skills you'll learn"]
-    Q --> S1["SELECT / WHERE<br/>→ fetch the right rows"]
-    Q --> S2["JOIN<br/>→ combine related tables"]
-    Q --> S3["GROUP BY<br/>→ summarize and report"]
-    Q --> S4["INSERT / UPDATE / DELETE<br/>→ record changes"]
+    Q --> S1["<code>SELECT</code> / <code>WHERE</code><br/>→ fetch the right rows"]
+    Q --> S2["<code>JOIN</code><br/>→ combine related tables"]
+    Q --> S3["<code>GROUP BY</code><br/>→ summarize and report"]
+    Q --> S4["<code>INSERT</code> / <code>UPDATE</code> / <code>DELETE</code><br/>→ record changes"]
     S1 --> R["= how real apps<br/>work with data"]
     S2 --> R
     S3 --> R

--- a/content/learn/intro-sql-postgres/inserting-data.mdx
+++ b/content/learn/intro-sql-postgres/inserting-data.mdx
@@ -11,10 +11,10 @@ application ever does to data.
 
 ```mermaid
 flowchart LR
-    I["INSERT<br/>add rows"] --> T[("A table")]
-    U["UPDATE<br/>change rows"] --> T
-    D["DELETE<br/>remove rows"] --> T
-    S["SELECT<br/>read rows"] --> T
+    I["<code>INSERT</code><br/>add rows"] --> T[("A table")]
+    U["<code>UPDATE</code><br/>change rows"] --> T
+    D["<code>DELETE</code><br/>remove rows"] --> T
+    S["<code>SELECT</code><br/>read rows"] --> T
 ```
 
 ## INSERT: adding rows
@@ -136,7 +136,7 @@ accidentally destroy data.
 ```mermaid
 flowchart TB
     D1["DELETE FROM tasks<br/>WHERE <code>id = 5</code>;"] --> R1["Removes 1 row<br/>(good)"]
-    D2["DELETE FROM tasks;"] --> R2["Removes EVERY row<br/>(usually a disaster)"]
+    D2["<code>DELETE FROM tasks;</code>"] --> R2["Removes EVERY row<br/>(usually a disaster)"]
 ```
 
 <Callout type="warn" title="Always think about WHERE first">

--- a/content/learn/intro-sql-postgres/query-execution-order.mdx
+++ b/content/learn/intro-sql-postgres/query-execution-order.mdx
@@ -126,9 +126,9 @@ rows*. `HAVING` (step 4) runs **after** grouping, so it filters
 
 ```mermaid
 flowchart LR
-    R["rows"] --> W["WHERE<br/>filter rows<br/>(before grouping)"]
-    W --> G["GROUP BY<br/>form groups"]
-    G --> H["HAVING<br/>filter groups<br/>(after grouping)"]
+    R["rows"] --> W["<code>WHERE</code><br/>filter rows<br/>(before grouping)"]
+    W --> G["<code>GROUP BY</code><br/>form groups"]
+    G --> H["<code>HAVING</code><br/>filter groups<br/>(after grouping)"]
 ```
 
 You cannot filter on `SUM(amount)` in `WHERE`, because the sum does

--- a/content/learn/intro-sql-postgres/relationships-intro.mdx
+++ b/content/learn/intro-sql-postgres/relationships-intro.mdx
@@ -27,7 +27,7 @@ flowchart LR
     subgraph Good["Two related tables"]
         C["customers<br/>(details once)"]
         O["orders<br/>(linked by id)"]
-        O -->|"customer_id"| C
+        O -->|"<code>customer_id</code>"| C
     end
     Bad -->|"better as"| Good
 ```

--- a/content/learn/intro-sql-postgres/select-basics.mdx
+++ b/content/learn/intro-sql-postgres/select-basics.mdx
@@ -73,7 +73,7 @@ untouched, ready for the next question.
 
 ```mermaid
 flowchart LR
-    T[("employees<br/>(stored table)")] -->|"SELECT name, salary"| R["Result set<br/>name + salary<br/>(a new table)"]
+    T[("employees<br/>(stored table)")] -->|"<code>SELECT name, salary</code>"| R["Result set<br/>name + salary<br/>(a new table)"]
     T -.->|"unchanged"| T
 ```
 

--- a/content/learn/intro-sql-postgres/sorting-and-limiting.mdx
+++ b/content/learn/intro-sql-postgres/sorting-and-limiting.mdx
@@ -142,10 +142,10 @@ So far you have met four clauses. They must appear in this order:
 
 ```mermaid
 flowchart LR
-    S["SELECT<br/>columns"] --> F["FROM<br/>table"]
-    F --> W["WHERE<br/>filter rows"]
-    W --> O["ORDER BY<br/>sort"]
-    O --> L["LIMIT / OFFSET<br/>trim"]
+    S["<code>SELECT</code><br/>columns"] --> F["<code>FROM<br/>table</code>"]
+    F --> W["<code>WHERE</code><br/>filter rows"]
+    W --> O["<code>ORDER BY</code><br/>sort"]
+    O --> L["<code>LIMIT</code> / <code>OFFSET</code><br/>trim"]
 ```
 
 You can leave out the middle ones, but whichever you include must

--- a/content/learn/intro-sql-postgres/subqueries.mdx
+++ b/content/learn/intro-sql-postgres/subqueries.mdx
@@ -16,7 +16,7 @@ its answer.
 
 ```mermaid
 flowchart TB
-    Inner["Inner query:<br/>SELECT AVG(amount) FROM orders"] -->|"produces a value"| Outer["Outer query:<br/>SELECT ... WHERE amount > (that value)"]
+    Inner["Inner query:<br/><code>SELECT AVG(amount) FROM orders</code>"] -->|"produces a value"| Outer["Outer query:<br/><code>SELECT ... WHERE amount &gt; (that value)</code>"]
     Outer --> Result["Final rows"]
 ```
 

--- a/content/learn/intro-sql-postgres/understanding-joins.mdx
+++ b/content/learn/intro-sql-postgres/understanding-joins.mdx
@@ -19,16 +19,16 @@ them together:
 
 ```mermaid
 flowchart LR
-    subgraph C["customers"]
+    subgraph C["<code>customers</code>"]
         C1["1 · Ada"]
         C2["2 · Grace"]
     end
-    subgraph O["orders"]
+    subgraph O["<code>orders</code>"]
         O1["101 · cust 1 · $42"]
         O2["102 · cust 2 · $99"]
     end
-    O1 -->|"match on<br/>customer_id = id"| C1
-    O2 -->|"match on<br/>customer_id = id"| C2
+    O1 -->|"match on<br/><code>customer_id</code> = id"| C1
+    O2 -->|"match on<br/><code>customer_id</code> = id"| C2
     C1 --> R1["Ada · $42"]
     C2 --> R2["Grace · $99"]
 ```

--- a/content/learn/java-collections-and-generics-deep-dive/immutable-collections.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/immutable-collections.mdx
@@ -192,8 +192,8 @@ That's a 12-line class with no bugs.
 ```mermaid
 flowchart LR
     A[Mutable original] -->|publish raw| B[Mutable, shared - dangerous]
-    A -->|Collections.unmodifiableList| C[Unmodifiable view - still backed by mutable]
-    A -->|List.copyOf| D[Immutable snapshot - safe forever]
+    A -->|"<code>Collections.unmodifiableList</code>"| C[Unmodifiable view - still backed by mutable]
+    A -->|"<code>List.copyOf</code>"| D[Immutable snapshot - safe forever]
 ```
 
 The further right you go, the safer your API.

--- a/content/learn/java-collections-and-generics-deep-dive/lists.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/lists.mdx
@@ -73,7 +73,7 @@ flowchart LR
     subgraph Heap
       direction LR
       A["<code>ArrayList<br/>size=4<br/>capacity=8</code>"]
-      A -->|elementData| ARR["Object[]<br/>[a][b][c][d][_][_][_][_]"]
+      A -->|"<code>elementData</code>"| ARR["Object[]<br/>[a][b][c][d][_][_][_][_]"]
     end
 ```
 

--- a/content/learn/machine-learning-scikit-learn/decision-trees.mdx
+++ b/content/learn/machine-learning-scikit-learn/decision-trees.mdx
@@ -60,10 +60,10 @@ together as possible (it minimizes squared error).
 
 ```mermaid
 flowchart TD
-    A["All flowers<br/>(mixed species)"] -->|"petal width <= 0.8 cm?"| B["Yes"]
-    A -->|"no"| C["petal width > 0.8 cm"]
+    A["All flowers<br/>(mixed species)"] -->|"petal <code>width &lt;= 0.8</code> cm?"| B["Yes"]
+    A -->|"no"| C["petal <code>width &gt; 0.8</code> cm"]
     B --> D["Pure leaf<br/>all setosa"]
-    C -->|"petal width <= 1.75 cm?"| E["mostly versicolor"]
+    C -->|"petal <code>width &lt;= 1.75</code> cm?"| E["mostly versicolor"]
     C -->|"no"| F["mostly virginica"]
 ```
 

--- a/content/learn/machine-learning-scikit-learn/logistic-regression.mdx
+++ b/content/learn/machine-learning-scikit-learn/logistic-regression.mdx
@@ -124,8 +124,8 @@ main limitation, as we will see.
 ```mermaid
 flowchart TD
     A["Feature space<br/>(points of two classes)"] --> B["Linear boundary<br/>(a straight line where <code>z = 0</code>)"]
-    B --> C["Class 1 side<br/>(p >= 0.5)"]
-    B --> D["Class 0 side<br/>(p < 0.5)"]
+    B --> C["Class 1 side<br/>(<code>p &gt;= 0.5</code>)"]
+    B --> D["Class 0 side<br/>(<code>p &lt; 0.5</code>)"]
 ```
 
 ## Logistic regression in practice: breast cancer

--- a/content/learn/machine-learning-scikit-learn/the-scikit-learn-api.mdx
+++ b/content/learn/machine-learning-scikit-learn/the-scikit-learn-api.mdx
@@ -51,8 +51,8 @@ on training data, then `predict` (or `transform`, or `score`) on new data.
 
 ```mermaid
 flowchart LR
-    A["Raw training data<br/>(<code>X_train</code>, <code>y_train</code>)"] -->|"fit(X_train, y_train)"| B["Fitted estimator<br/>(holds what it learned)"]
-    C["New data<br/>(<code>X_new</code>)"] -->|"predict(X_new)"| B
+    A["Raw training data<br/>(<code>X_train</code>, <code>y_train</code>)"] -->|"<code>fit(X_train, y_train)</code>"| B["Fitted estimator<br/>(holds what it learned)"]
+    C["New data<br/>(<code>X_new</code>)"] -->|"<code>predict(X_new)</code>"| B
     B --> D["Predictions<br/>(numbers, labels, or groups)"]
     B -. "score(X_test, y_test)" .-> E["A quality number"]
 ```

--- a/content/learn/mastering-dsa-cpp/heaps.mdx
+++ b/content/learn/mastering-dsa-cpp/heaps.mdx
@@ -177,7 +177,7 @@ flowchart TD
     A["build max heap"] --> B["swap max with last unsorted item"]
     B --> C["shrink heap size"]
     C --> D["sift down root"]
-    D --> E{"heap size > 1?"}
+    D --> E{"heap <code>size &gt; 1</code>?"}
     E -- "yes" --> B
     E -- "no" --> F["array sorted ascending"]
 ```

--- a/content/learn/mastering-dsa-cpp/searching.mdx
+++ b/content/learn/mastering-dsa-cpp/searching.mdx
@@ -37,8 +37,8 @@ Binary search only works on sorted data. It keeps a search interval, checks the 
 
 ```mermaid
 flowchart TD
-    A["[1,3,5,7,9,11,13,15]"] --> B["<code>low=0 high=7 mid=3 value=7</code>"]
-    B --> C["11 > 7, search right half"]
+    A["<code>[1,3,5,7,9,11,13,15]</code>"] --> B["<code>low=0 high=7 mid=3 value=7</code>"]
+    B --> C["<code>11 &gt; 7</code>, search right half"]
     C --> D["<code>low=4 high=7 mid=5 value=11</code>"]
     D --> E["found index 5"]
 ```

--- a/content/learn/mastering-dsa-cpp/sorting-efficient.mdx
+++ b/content/learn/mastering-dsa-cpp/sorting-efficient.mdx
@@ -15,12 +15,12 @@ mergeSort(a): if size <= 1 return; sort left; sort right; merge
 
 ```mermaid
 graph TD
-    A["[5,2,8,1,9,3,7,4]"] --> B["[5,2,8,1]"]
-    A --> C["[9,3,7,4]"]
-    B --> D["[5,2]"]
-    B --> E["[8,1]"]
-    C --> F["[9,3]"]
-    C --> G["[7,4]"]
+    A["<code>[5,2,8,1,9,3,7,4]</code>"] --> B["<code>[5,2,8,1]</code>"]
+    A --> C["<code>[9,3,7,4]</code>"]
+    B --> D["<code>[5,2]</code>"]
+    B --> E["<code>[8,1]</code>"]
+    C --> F["<code>[9,3]</code>"]
+    C --> G["<code>[7,4]</code>"]
 ```
 
 <CodeBlock

--- a/content/learn/mastering-ggplot2/flipping-and-polar-coordinates.mdx
+++ b/content/learn/mastering-ggplot2/flipping-and-polar-coordinates.mdx
@@ -82,7 +82,7 @@ stacked bar, re-expressed in polar coordinates.
 
 ```mermaid
 flowchart LR
-    SB["Stacked bar<br/>height = count"] -->|"coord_polar(theta = y)"| PIE["Pie chart<br/>angle = count"]
+    SB["Stacked bar<br/>height = count"] -->|"<code>coord_polar(theta = y)</code>"| PIE["Pie chart<br/>angle = count"]
 ```
 
 In Cartesian space, a count became a *height*. In polar space, that

--- a/content/learn/oop-blueprint-java/objects-in-memory.mdx
+++ b/content/learn/oop-blueprint-java/objects-in-memory.mdx
@@ -136,7 +136,7 @@ either an arrow into the heap, or it is `null`.
 ```mermaid
 flowchart LR
     subgraph Stack
-        N["d : Dog ref = null"]
+        N["d : Dog <code>ref = null</code>"]
     end
     subgraph Heap[" "]
     end

--- a/content/learn/practical-r-for-beginners/logical-and-character-vectors.mdx
+++ b/content/learn/practical-r-for-beginners/logical-and-character-vectors.mdx
@@ -137,7 +137,7 @@ whole library click.
 ```mermaid
 flowchart LR
   v["values: [82, 91, 76, 100, 65, 88, 79, 93, 71, 85]"]
-  cond["condition: scores >= 90"]
+  cond["condition: <code>scores &gt;= 90</code>"]
   mask["[F, T, F, T, F, F, F, T, F, F]"]
   out["filtered: [91, 100, 93]"]
   v --> cond --> mask --> out

--- a/content/learn/practical-r-for-beginners/reshaping-data.mdx
+++ b/content/learn/practical-r-for-beginners/reshaping-data.mdx
@@ -37,8 +37,8 @@ flowchart LR
     l5["UK      | 2021 |  85"]
     l6["UK      | 2022 |  90"]
   end
-  wide -->|pivot_longer| long
-  long -->|pivot_wider| wide
+  wide -->|"<code>pivot_longer</code>"| long
+  long -->|"<code>pivot_wider</code>"| wide
   style wide fill:#fde68a
   style long fill:#dcfce7
 ```

--- a/content/learn/practical-r-for-beginners/scripts-and-projects.mdx
+++ b/content/learn/practical-r-for-beginners/scripts-and-projects.mdx
@@ -187,9 +187,9 @@ Git turns "I overwrote yesterday's file" from a tragedy into
 
 ```mermaid
 flowchart TD
-  edit["Edit files"] --> stage["git add ."]
-  stage --> commit["git commit -m 'why'"]
-  commit --> push["git push"]
+  edit["Edit files"] --> stage["<code>git add .</code>"]
+  stage --> commit["<code>git commit -m 'why'</code>"]
+  commit --> push["<code>git push</code>"]
   push --> remote[("Remote repo / backup")]
 ```
 

--- a/content/learn/practical-r-for-beginners/vectors-everywhere.mdx
+++ b/content/learn/practical-r-for-beginners/vectors-everywhere.mdx
@@ -54,7 +54,7 @@ is a vector of length one whose first element is 42.
 flowchart LR
   subgraph other["Many languages"]
     A1["<code>x = 42</code> (scalar)"]
-    A2["xs = [42, 43, 44] (array)"]
+    A2["<code>xs = [42, 43, 44]</code> (array)"]
     A1 -.different type.-> A2
   end
   subgraph R["R"]

--- a/content/learn/python-basics/comprehensions.mdx
+++ b/content/learn/python-basics/comprehensions.mdx
@@ -13,7 +13,7 @@ Comprehensions are everywhere in production Python. Every data pipeline maps and
 
 ```mermaid
 flowchart TD
-    A["Input: [1, 2, 3, 4, 5]"] --> B["Filter: x % 2 == 0"]
+    A["Input: [1, 2, 3, 4, 5]"] --> B["Filter: <code>x % 2 == 0</code>"]
     B --> C["Transform: x * x"]
     C --> D["Output: [4, 16]"]
 ```

--- a/content/learn/python-basics/control-flow.mdx
+++ b/content/learn/python-basics/control-flow.mdx
@@ -13,11 +13,11 @@ Conditionals are not just syntax — they are the logical heart of every program
 
 ```mermaid
 flowchart TD
-    A[Start] --> B{score >= 90?}
+    A[Start] --> B{"<code>score &gt;= 90</code>?"}
     B -- Yes --> C[Grade: A]
-    B -- No --> D{score >= 80?}
+    B -- No --> D{"<code>score &gt;= 80</code>?"}
     D -- Yes --> E[Grade: B]
-    D -- No --> F{score >= 70?}
+    D -- No --> F{"<code>score &gt;= 70</code>?"}
     F -- Yes --> G[Grade: C]
     F -- No --> H[Grade: F]
 ```

--- a/content/learn/sql-analytics-duckdb/aggregate-functions.mdx
+++ b/content/learn/sql-analytics-duckdb/aggregate-functions.mdx
@@ -171,7 +171,7 @@ WHERE
 
 ```mermaid
 flowchart LR
-    T[("orders")] --> W["WHERE amount > 50"]
+    T[("orders")] --> W["<code>WHERE amount &gt; 50</code>"]
     W --> A["AVG(amount),<br/>COUNT(*)"]
     A --> R["summary of the<br/>filtered slice"]
 ```

--- a/content/learn/sql-analytics-duckdb/filtering-and-slicing.mdx
+++ b/content/learn/sql-analytics-duckdb/filtering-and-slicing.mdx
@@ -18,7 +18,7 @@ Learning to *hear* the filter inside a question is half of analytical SQL.
 
 ```mermaid
 flowchart LR
-    All[("Whole dataset")] --> F["WHERE<br/>(the slice)"]
+    All[("Whole dataset")] --> F["<code>WHERE</code><br/>(the slice)"]
     F --> Sub[("Just the rows<br/>the question is about")]
     Sub --> A["Summarize / inspect"]
 ```

--- a/content/learn/sql-analytics-duckdb/filtering-groups.mdx
+++ b/content/learn/sql-analytics-duckdb/filtering-groups.mdx
@@ -134,7 +134,7 @@ grouping step.
 ```mermaid
 flowchart LR
     Cond1["Condition on a raw column<br/>(<code>status = 'paid'</code>)"] --> Where["belongs in WHERE"]
-    Cond2["Condition on an aggregate<br/>(SUM(amount) > 150)"] --> Having["belongs in HAVING"]
+    Cond2["Condition on an aggregate<br/>(<code>SUM(amount) &gt; 150</code>)"] --> Having["belongs in HAVING"]
 ```
 
 ## A quick decision rule

--- a/content/learn/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
+++ b/content/learn/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
@@ -59,7 +59,7 @@ one of the small ergonomics that make DuckDB pleasant for fast analysis.
 
 ```mermaid
 flowchart LR
-    S["SELECT region, product,<br/>channel, SUM(amount)"] --> A["GROUP BY ALL"]
+    S["<code>SELECT region, product,<br/>channel, SUM(amount)</code>"] --> A["<code>GROUP BY ALL</code>"]
     A --> G["Groups by the three<br/>non-aggregated columns"]
 ```
 

--- a/content/learn/sql-analytics-duckdb/grouping-data.mdx
+++ b/content/learn/sql-analytics-duckdb/grouping-data.mdx
@@ -17,7 +17,7 @@ the aggregate **once per bin**. One total becomes one total *per group*.
 
 ```mermaid
 flowchart TB
-    All[("All orders")] --> G["GROUP BY region"]
+    All[("All orders")] --> G["<code>GROUP BY region</code>"]
     G --> W["West bin"]
     G --> E["East bin"]
     G --> N["North bin"]
@@ -73,7 +73,7 @@ refuses. The column must either *define* the group (`region`) or be
 
 ```mermaid
 flowchart LR
-    Q["SELECT region, id, SUM(amount)"] --> X["id is neither grouped<br/>nor aggregated"]
+    Q["<code>SELECT region, id, SUM(amount)</code>"] --> X["id is neither grouped<br/>nor aggregated"]
     X --> Err["Ambiguous:<br/>which row's id?"]
 ```
 
@@ -162,10 +162,10 @@ aggregate, then sort.
 
 ```mermaid
 flowchart LR
-    F["FROM rows"] --> W["WHERE<br/>(filter rows)"]
-    W --> G["GROUP BY<br/>(form bins)"]
+    F["FROM rows"] --> W["<code>WHERE</code><br/>(filter rows)"]
+    W --> G["<code>GROUP BY</code><br/>(form bins)"]
     G --> A["aggregate<br/>(one value per bin)"]
-    A --> O["ORDER BY<br/>(sort the summary)"]
+    A --> O["<code>ORDER BY</code><br/>(sort the summary)"]
 ```
 
 `WHERE` filters *individual rows* before grouping — it cannot see group

--- a/content/learn/sql-analytics-duckdb/sorting-and-top-n.mdx
+++ b/content/learn/sql-analytics-duckdb/sorting-and-top-n.mdx
@@ -116,9 +116,9 @@ Two subtleties that quietly trip up analysts:
 
 ```mermaid
 flowchart LR
-    R[("Rows")] --> O["ORDER BY amount DESC,<br/>id ASC (tiebreaker)"]
+    R[("Rows")] --> O["<code>ORDER BY amount DESC,<br/>id ASC (tiebreaker)</code>"]
     O --> S["Stable, reproducible<br/>ordering"]
-    S --> L["LIMIT N"]
+    S --> L["<code>LIMIT N</code>"]
 ```
 
 ## Per-group top-N with `QUALIFY`

--- a/content/learn/sql-analytics-duckdb/working-with-dates.mdx
+++ b/content/learn/sql-analytics-duckdb/working-with-dates.mdx
@@ -162,7 +162,7 @@ most common ways an analyst's trend chart misleads.
 
 ```mermaid
 flowchart LR
-    Spine["Generated date spine<br/>(every day)"] --> J["LEFT JOIN orders"]
+    Spine["Generated date spine<br/>(every day)"] --> J["<code>LEFT JOIN orders</code>"]
     J --> S["Days with no orders<br/>become 0, not missing"]
 ```
 

--- a/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
+++ b/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
@@ -101,9 +101,9 @@ one is an `ORDER BY` followed by a glance at the head of the result.
 
 ```mermaid
 flowchart LR
-    T[("All rows")] --> W["WHERE<br/>(choose a slice)"]
-    W --> O["ORDER BY<br/>(surface extremes)"]
-    O --> L["LIMIT<br/>(look at the top)"]
+    T[("All rows")] --> W["<code>WHERE</code><br/>(choose a slice)"]
+    W --> O["<code>ORDER BY</code><br/>(surface extremes)"]
+    O --> L["<code>LIMIT</code><br/>(look at the top)"]
 ```
 
 This three-step rhythm — **slice, sort, peek** — is the analyst's

--- a/content/learn/sqlite-for-beginners/creating-tables.mdx
+++ b/content/learn/sqlite-for-beginners/creating-tables.mdx
@@ -28,7 +28,7 @@ Read the statement as: *create a table called `books` with an integer `id`, text
 
 ```mermaid
 flowchart TB
-    S["CREATE TABLE books"] --> P["column list"]
+    S["<code>CREATE TABLE books</code>"] --> P["column list"]
     P --> C1["id INTEGER"]
     P --> C2["title TEXT"]
     P --> C3["author TEXT"]
@@ -41,7 +41,7 @@ The table definition becomes an empty grid. The columns are ready; rows come lat
 
 ```mermaid
 flowchart LR
-    A["CREATE TABLE books<br/>id, title, author, year"] --> B["books grid"]
+    A["<code>CREATE TABLE books<br/>id, title, author, year</code>"] --> B["books grid"]
     B --> C["columns exist<br/>rows are empty"]
 ```
 
@@ -131,7 +131,7 @@ Notice that the `INSERT` statement did not provide `id` values. SQLite filled th
 
 ```mermaid
 flowchart LR
-    I["INSERT title and author"] --> S["SQLite assigns id"]
+    I["<code>INSERT</code> title and author"] --> S["SQLite assigns id"]
     S --> R["stored row<br/>id, title, author"]
 ```
 

--- a/content/learn/sqlite-for-beginners/filtering-groups.mdx
+++ b/content/learn/sqlite-for-beginners/filtering-groups.mdx
@@ -19,10 +19,10 @@ These are not row-by-row conditions. They are conditions about **groups after ag
 
 ```mermaid
 flowchart LR
-    From["FROM<br/>read rows"] --> Where["WHERE<br/>filter individual rows"]
-    Where --> Group["GROUP BY<br/>form groups"]
-    Group --> Having["HAVING<br/>filter groups"]
-    Having --> Select["SELECT<br/>show results"]
+    From["<code>FROM</code><br/>read rows"] --> Where["<code>WHERE</code><br/>filter individual rows"]
+    Where --> Group["<code>GROUP BY</code><br/>form groups"]
+    Group --> Having["<code>HAVING</code><br/>filter groups"]
+    Having --> Select["<code>SELECT</code><br/>show results"]
 ```
 
 Think of it like making piles of receipts:
@@ -71,7 +71,7 @@ flowchart TB
     Groups["Department groups"] --> Eng["Engineering<br/><code>COUNT = 3</code>"]
     Groups --> Sales["Sales<br/><code>COUNT = 2</code>"]
     Groups --> Mkt["Marketing<br/><code>COUNT = 1</code>"]
-    Eng --> Keep["HAVING COUNT(*) > 2<br/>keep"]
+    Eng --> Keep["<code>HAVING COUNT(*) &gt; 2</code><br/>keep"]
     Sales --> Drop["drop"]
     Mkt --> Drop
 ```

--- a/content/learn/sqlite-for-beginners/first-queries.mdx
+++ b/content/learn/sqlite-for-beginners/first-queries.mdx
@@ -61,7 +61,7 @@ A SQL statement is one complete instruction. We end statements with a semicolon 
 
 ```mermaid
 flowchart TB
-    A["SELECT"] --> B["what you want back"]
+    A["<code>SELECT</code>"] --> B["what you want back"]
     B --> C["AS <code>optional_name</code>"]
     C --> D["semicolon<br/>end of statement"]
 ```
@@ -111,7 +111,7 @@ Read the final query like a sentence: *select the `name` and `species` columns f
 
 ```mermaid
 flowchart LR
-    Q["SELECT name, species<br/>FROM pets;"] --> T["pets table"]
+    Q["<code>SELECT name, species<br/>FROM pets;</code>"] --> T["pets table"]
     T --> R["name column<br/>species column"]
 ```
 

--- a/content/learn/sqlite-for-beginners/foreign-keys.mdx
+++ b/content/learn/sqlite-for-beginners/foreign-keys.mdx
@@ -178,11 +178,11 @@ The join follows the foreign-key arrows and shows readable customer names next t
 
 ```mermaid
 flowchart TB
-    subgraph C["customers"]
+    subgraph C["<code>customers</code>"]
         C1["<code>id = 1</code><br/>Ada"]
         C2["<code>id = 2</code><br/>Grace"]
     end
-    subgraph O["orders"]
+    subgraph O["<code>orders</code>"]
         O1["<code>101<br/>customer_id = 1</code>"]
         O2["<code>102<br/>customer_id = 1</code>"]
         O3["<code>103<br/>customer_id = 2</code>"]

--- a/content/learn/sqlite-for-beginners/grouping-data.mdx
+++ b/content/learn/sqlite-for-beginners/grouping-data.mdx
@@ -18,7 +18,7 @@ Without `GROUP BY`, an aggregate gives one summary for all rows. With `GROUP BY`
 
 ```mermaid
 flowchart TB
-    Rows["All employee rows"] --> Group{"GROUP BY dept"}
+    Rows["All employee rows"] --> Group{"<code>GROUP BY dept</code>"}
     Group --> Eng["Engineering group"]
     Group --> Sales["Sales group"]
     Group --> Mkt["Marketing group"]
@@ -68,9 +68,9 @@ The `dept` column appears in the result because it labels each group. Without it
 
 ```mermaid
 flowchart LR
-    F["FROM employees"] --> G["GROUP BY dept"]
-    G --> S["SELECT dept,<br/>COUNT(*), AVG(salary)"]
-    S --> O["ORDER BY dept"]
+    F["<code>FROM employees</code>"] --> G["<code>GROUP BY dept</code>"]
+    G --> S["<code>SELECT dept,<br/>COUNT(*), AVG(salary)</code>"]
+    S --> O["<code>ORDER BY dept</code>"]
 ```
 
 ## One result row per group
@@ -279,7 +279,7 @@ The intern row is removed first. Then SQLite groups the remaining rows by depart
 ```mermaid
 flowchart LR
     Raw["Raw employee rows"] --> Where["WHERE <code>is_intern</code> = 0<br/>keep full-time rows"]
-    Where --> Group["GROUP BY dept<br/>make department groups"]
+    Where --> Group["<code>GROUP BY dept</code><br/>make department groups"]
     Group --> Avg["AVG(salary)<br/>inside each group"]
     Avg --> Result["One row per department"]
 ```

--- a/content/learn/sqlite-for-beginners/inner-joins.mdx
+++ b/content/learn/sqlite-for-beginners/inner-joins.mdx
@@ -189,8 +189,8 @@ You can chain inner joins. Each `JOIN ... ON ...` adds another table and another
 
 ```mermaid
 flowchart LR
-    C["customers"] -->|"c.id = o.customer_id"| O["orders"]
-    O -->|"o.product_id = p.id"| P["products"]
+    C["<code>customers</code>"] -->|"c.id = o.<code>customer_id</code>"| O["<code>orders</code>"]
+    O -->|"o.<code>product_id</code> = p.id"| P["<code>products</code>"]
     P --> R["customer + product result"]
 ```
 

--- a/content/learn/sqlite-for-beginners/inserting-data.mdx
+++ b/content/learn/sqlite-for-beginners/inserting-data.mdx
@@ -13,9 +13,9 @@ An `INSERT` statement names the table, names the columns you are filling, and su
 
 ```mermaid
 flowchart LR
-    A["INSERT INTO"] --> B["which table"]
+    A["<code>INSERT INTO</code>"] --> B["which table"]
     B --> C["which columns"]
-    C --> D["VALUES"]
+    C --> D["<code>VALUES</code>"]
     D --> E["new row data"]
 ```
 
@@ -75,7 +75,7 @@ The insert only gave `title`. SQLite supplied `id`, and `DEFAULT 0` supplied `do
 
 ```mermaid
 flowchart LR
-    V["VALUES<br/>'Water plants'"] --> T["tasks table"]
+    V["<code>VALUES<br/>'Water plants'</code>"] --> T["tasks table"]
     T --> R["id assigned<br/>done defaults to 0"]
 ```
 
@@ -126,7 +126,7 @@ Each parenthesized group becomes one new row.
 
 ```mermaid
 flowchart TB
-    I["INSERT INTO tasks"] --> R1["row 1<br/>Buy milk, 0"]
+    I["<code>INSERT INTO tasks</code>"] --> R1["row 1<br/>Buy milk, 0"]
     I --> R2["row 2<br/>Walk the dog, 1"]
     I --> R3["row 3<br/>Call dentist, 0"]
     R1 --> T["tasks table"]

--- a/content/learn/sqlite-for-beginners/many-to-many.mdx
+++ b/content/learn/sqlite-for-beginners/many-to-many.mdx
@@ -127,8 +127,8 @@ The primary key is the pair `(student_id, course_id)`. That means the same stude
 
 ```mermaid
 flowchart LR
-    S["students"] -->|"student_id"| E["enrollments<br/>one row per link"]
-    E -->|"course_id"| C["courses"]
+    S["<code>students</code>"] -->|"<code>student_id</code>"| E["enrollments<br/>one row per link"]
+    E -->|"<code>course_id</code>"| C["<code>courses</code>"]
 ```
 
 ## Join across the bridge
@@ -169,8 +169,8 @@ ORDER BY
 
 ```mermaid
 flowchart TB
-    E1["enrollment<br/><code>student_id</code> 1<br/><code>course_id</code> 10"] -->|"student_id = id"| S1["Ada"]
-    E1 -->|"course_id = id"| C1["Math"]
+    E1["enrollment<br/><code>student_id</code> 1<br/><code>course_id</code> 10"] -->|"<code>student_id</code> = id"| S1["Ada"]
+    E1 -->|"<code>course_id</code> = id"| C1["Math"]
     S1 --> R["Ada takes Math"]
     C1 --> R
 ```

--- a/content/learn/sqlite-for-beginners/outer-joins.mdx
+++ b/content/learn/sqlite-for-beginners/outer-joins.mdx
@@ -116,7 +116,7 @@ A `LEFT JOIN` plus `WHERE right_table.id IS NULL` is the classic pattern for "sh
 flowchart TB
     A["<code>LEFT JOIN</code><br/>keep all customers"] --> B["matched customers<br/>order id present"]
     A --> C["unmatched customers<br/>order id is NULL"]
-    C -->|"WHERE o.id IS NULL"| D["customers with no orders"]
+    C -->|"<code>WHERE o.id IS NULL</code>"| D["customers with no orders"]
     B -->|"filtered out"| X["not returned"]
 ```
 

--- a/content/learn/sqlite-for-beginners/outer-joins.mdx
+++ b/content/learn/sqlite-for-beginners/outer-joins.mdx
@@ -114,7 +114,7 @@ A `LEFT JOIN` plus `WHERE right_table.id IS NULL` is the classic pattern for "sh
 
 ```mermaid
 flowchart TB
-    A["LEFT JOIN<br/>keep all customers"] --> B["matched customers<br/>order id present"]
+    A["<code>LEFT JOIN</code><br/>keep all customers"] --> B["matched customers<br/>order id present"]
     A --> C["unmatched customers<br/>order id is NULL"]
     C -->|"WHERE o.id IS NULL"| D["customers with no orders"]
     B -->|"filtered out"| X["not returned"]
@@ -205,9 +205,9 @@ For beginners, `LEFT JOIN` is the most important outer join. Recent SQLite versi
 
 ```mermaid
 flowchart LR
-    I["INNER JOIN<br/>only matches"] --- L["LEFT JOIN<br/>all left rows"]
-    L --- R["RIGHT JOIN<br/>all right rows"]
-    R --- F["FULL OUTER JOIN<br/>all rows from both sides"]
+    I["<code>INNER JOIN</code><br/>only matches"] --- L["<code>LEFT JOIN</code><br/>all left rows"]
+    L --- R["<code>RIGHT JOIN</code><br/>all right rows"]
+    R --- F["<code>FULL OUTER JOIN</code><br/>all rows from both sides"]
 ```
 
 <Callout type="info" title="How to choose">

--- a/content/learn/sqlite-for-beginners/query-execution-order.mdx
+++ b/content/learn/sqlite-for-beginners/query-execution-order.mdx
@@ -128,9 +128,9 @@ rows*. `HAVING` (step 4) runs **after** grouping, so it filters
 
 ```mermaid
 flowchart LR
-    R["rows"] --> W["WHERE<br/>filter rows<br/>(before grouping)"]
-    W --> G["GROUP BY<br/>form groups"]
-    G --> H["HAVING<br/>filter groups<br/>(after grouping)"]
+    R["rows"] --> W["<code>WHERE</code><br/>filter rows<br/>(before grouping)"]
+    W --> G["<code>GROUP BY</code><br/>form groups"]
+    G --> H["<code>HAVING</code><br/>filter groups<br/>(after grouping)"]
 ```
 
 You cannot filter on `SUM(amount)` in `WHERE`, because the sum does

--- a/content/learn/sqlite-for-beginners/relationships-intro.mdx
+++ b/content/learn/sqlite-for-beginners/relationships-intro.mdx
@@ -25,7 +25,7 @@ flowchart LR
     BAD["Repeated customer details<br/>inside order rows"] --> GOOD["Separate tables"]
     GOOD --> C["customers<br/>customer details once"]
     GOOD --> O["orders<br/>order facts only"]
-    O -->|"customer_id points to id"| C
+    O -->|"<code>customer_id</code> points to id"| C
 ```
 
 ## Tables connect through keys
@@ -156,8 +156,8 @@ The helper table stores the pairs: which student is in which course.
 
 ```mermaid
 flowchart TB
-    S["students"] --> E["enrollments<br/><code>student_id</code> plus <code>course_id</code>"]
-    C["courses"] --> E
+    S["<code>students</code>"] --> E["enrollments<br/><code>student_id</code> plus <code>course_id</code>"]
+    C["<code>courses</code>"] --> E
     E --> PAIR["One row means<br/>one student-course pairing"]
 ```
 

--- a/content/learn/sqlite-for-beginners/select-basics.mdx
+++ b/content/learn/sqlite-for-beginners/select-basics.mdx
@@ -18,7 +18,7 @@ names the table that holds them.
 
 ```mermaid
 flowchart LR
-    T[("books table<br/>stored data")] --> C["SELECT title, author<br/>choose columns"]
+    T[("books table<br/>stored data")] --> C["<code>SELECT title, author</code><br/>choose columns"]
     C --> R["result table<br/>title + author"]
     T -.-> T
 ```
@@ -122,7 +122,7 @@ of the result you receive.
 
 ```mermaid
 flowchart TB
-    A["stored row<br/>id, title, author, genre, price"] --> B["SELECT price, title, genre"]
+    A["stored row<br/>id, title, author, genre, price"] --> B["<code>SELECT price, title, genre</code>"]
     B --> C["result row<br/>price, title, genre"]
 ```
 

--- a/content/learn/sqlite-for-beginners/sorting-and-limiting.mdx
+++ b/content/learn/sqlite-for-beginners/sorting-and-limiting.mdx
@@ -71,7 +71,7 @@ ORDER BY
 
 ```mermaid
 flowchart LR
-    A["unsorted result rows"] --> B["ORDER BY price DESC<br/>sort high to low"]
+    A["unsorted result rows"] --> B["<code>ORDER BY price DESC</code><br/>sort high to low"]
     B --> C["ordered result rows"]
 ```
 
@@ -140,7 +140,7 @@ ORDER BY
 
 ```mermaid
 flowchart TB
-    A["ORDER BY genre ASC, price DESC"] --> B["first key<br/>genre A to Z"]
+    A["<code>ORDER BY genre ASC, price DESC</code>"] --> B["first key<br/>genre A to Z"]
     B --> C["tie breaker<br/>price high to low"]
     C --> D["final sorted result"]
 ```
@@ -193,9 +193,9 @@ with `LIMIT`, it is how websites make pages of results.
 
 ```mermaid
 flowchart LR
-    A["all matching rows"] --> S["ORDER BY<br/>sort rows"]
-    S --> O["OFFSET 2<br/>skip two"]
-    O --> L["LIMIT 2<br/>take two"]
+    A["all matching rows"] --> S["<code>ORDER BY</code><br/>sort rows"]
+    S --> O["<code>OFFSET 2</code><br/>skip two"]
+    O --> L["<code>LIMIT 2</code><br/>take two"]
     L --> R["page result"]
 ```
 
@@ -238,9 +238,9 @@ When these clauses appear together, write them in this order:
 
 ```mermaid
 flowchart LR
-    A["SELECT<br/>columns"] --> B["FROM<br/>table"]
-    B --> C["WHERE<br/>filter rows"]
-    C --> D["ORDER BY<br/>sort rows"]
+    A["<code>SELECT</code><br/>columns"] --> B["<code>FROM<br/>table</code>"]
+    B --> C["<code>WHERE</code><br/>filter rows"]
+    C --> D["<code>ORDER BY</code><br/>sort rows"]
     D --> E["LIMIT and OFFSET<br/>trim result"]
 ```
 

--- a/content/learn/sqlite-for-beginners/spreadsheets-vs-databases.mdx
+++ b/content/learn/sqlite-for-beginners/spreadsheets-vs-databases.mdx
@@ -113,9 +113,9 @@ A relational database can separate those ideas:
 
 ```mermaid
 flowchart LR
-    C["customers"] --> O["orders"]
+    C["<code>customers</code>"] --> O["<code>orders</code>"]
     O --> I["<code>order_items</code>"]
-    I --> P["products"]
+    I --> P["<code>products</code>"]
 ```
 
 ## Types and integrity

--- a/content/learn/sqlite-for-beginners/understanding-joins.mdx
+++ b/content/learn/sqlite-for-beginners/understanding-joins.mdx
@@ -9,16 +9,16 @@ For example, `orders` knows the amount. `customers` knows the name. A join lets 
 
 ```mermaid
 flowchart LR
-    subgraph C["customers"]
+    subgraph C["<code>customers</code>"]
         C1["id 1<br/>Ada"]
         C2["id 2<br/>Grace"]
     end
-    subgraph O["orders"]
+    subgraph O["<code>orders</code>"]
         O1["order 101<br/><code>customer_id</code> 1<br/>42"]
         O2["order 102<br/><code>customer_id</code> 2<br/>99"]
     end
-    O1 -->|"customer_id = id"| C1
-    O2 -->|"customer_id = id"| C2
+    O1 -->|"<code>customer_id</code> = id"| C1
+    O2 -->|"<code>customer_id</code> = id"| C2
     C1 -->|"combine columns"| R1["Ada<br/>order 101<br/>42"]
     C2 -->|"combine columns"| R2["Grace<br/>order 102<br/>99"]
 ```

--- a/content/learn/sqlite-for-beginners/what-sql-does.mdx
+++ b/content/learn/sqlite-for-beginners/what-sql-does.mdx
@@ -83,9 +83,9 @@ flowchart LR
 
 ```mermaid
 flowchart TB
-    A["What you write"] --> B["SELECT name"]
-    A --> C["FROM products"]
-    A --> D["WHERE price < 20"]
+    A["What you write"] --> B["<code>SELECT name</code>"]
+    A --> C["<code>FROM products</code>"]
+    A --> D["<code>WHERE price &lt; 20</code>"]
     B --> E["What you want"]
     C --> E
     D --> E
@@ -120,10 +120,10 @@ These match the basic things applications do with stored information.
 ```mermaid
 flowchart TB
     A["Application request"] --> B{"What kind of job?"}
-    B --> C["SELECT<br/>read"]
-    B --> D["INSERT<br/>add"]
-    B --> E["UPDATE<br/>change"]
-    B --> F["DELETE<br/>remove"]
+    B --> C["<code>SELECT</code><br/>read"]
+    B --> D["<code>INSERT</code><br/>add"]
+    B --> E["<code>UPDATE</code><br/>change"]
+    B --> F["<code>DELETE</code><br/>remove"]
 ```
 
 ```mermaid

--- a/content/learn/sqlite-for-beginners/why-relational-databases.mdx
+++ b/content/learn/sqlite-for-beginners/why-relational-databases.mdx
@@ -68,7 +68,7 @@ Now if Maya changes her email, there is one customer row to update.
 
 ```mermaid
 flowchart LR
-    C["customers"] -->|"customer id"| O["orders"]
+    C["<code>customers</code>"] -->|"customer id"| O["<code>orders</code>"]
 ```
 
 ```mermaid

--- a/content/learn/sqlite-for-beginners/why-structured-data.mdx
+++ b/content/learn/sqlite-for-beginners/why-structured-data.mdx
@@ -52,7 +52,7 @@ A column name tells you what a value means.
 ```mermaid
 flowchart TB
     A["Value 92"] --> B{"Which column?"}
-    B -->|"quiz_score"| C["A quiz result"]
+    B -->|"<code>quiz_score</code>"| C["A quiz result"]
     B -->|"temperature"| D["A weather reading"]
     B -->|"quantity"| E["A count of items"]
 ```

--- a/content/learn/sqlite-for-beginners/working-with-null.mdx
+++ b/content/learn/sqlite-for-beginners/working-with-null.mdx
@@ -134,7 +134,7 @@ possible outcomes: true, false, and unknown.
 
 ```mermaid
 flowchart LR
-    A["comparison<br/>phone = NULL"] --> U["unknown<br/>not true"]
+    A["comparison<br/><code>phone = NULL</code>"] --> U["unknown<br/>not true"]
     U --> W["WHERE keeps only true rows"]
     W --> D["row is not kept"]
 ```

--- a/content/learn/statistics-for-data-science-python/ab-testing.mdx
+++ b/content/learn/statistics-for-data-science-python/ab-testing.mdx
@@ -267,7 +267,7 @@ significance-vs-importance distinction from *Effect Sizes*.
 
 ```mermaid
 flowchart TD
-  A["Test result"] --> B{"Significant?<br/>(p <= alpha, CI excludes 0)"}
+  A["Test result"] --> B{"Significant?<br/>(<code>p &lt;= alpha</code>, CI excludes 0)"}
   B -->|"no"| C["Don't ship on this evidence<br/>(maybe underpowered -<br/>was n big enough?)"]
   B -->|"yes"| D{"Is the lift big enough<br/>to matter in practice?"}
   D -->|"no, trivial"| E["Don't ship<br/>(real but not worth it)"]

--- a/content/learn/statistics-for-data-science-python/anova-and-chi-square.mdx
+++ b/content/learn/statistics-for-data-science-python/anova-and-chi-square.mdx
@@ -209,7 +209,7 @@ are linked.
 flowchart LR
   A["Two categorical columns<br/>(e.g. device, churned)"] --> B["pandas crosstab<br/>(contingency table of COUNTS)"]
   B --> C["<code>chi2_contingency</code><br/>compares observed vs expected"]
-  C --> D{"p <= alpha?"}
+  C --> D{"<code>p &lt;= alpha</code>?"}
   D -->|"yes"| E["Variables are associated"]
   D -->|"no"| F["No evidence of association"]
 ```

--- a/content/learn/statistics-for-data-science-python/errors-and-power.mdx
+++ b/content/learn/statistics-for-data-science-python/errors-and-power.mdx
@@ -524,8 +524,8 @@ flowchart TD
   D --> E
   E --> F["Run the study at that n"]
   F --> G{"Result"}
-  G -->|"p <= alpha"| H["Detected: report effect SIZE + CI,<br/>check it replicates"]
-  G -->|"p > alpha"| I["Not detected: was power adequate?<br/>If low, 'no effect' is unjustified"]
+  G -->|"<code>p &lt;= alpha</code>"| H["Detected: report effect SIZE + CI,<br/>check it replicates"]
+  G -->|"<code>p &gt; alpha</code>"| I["Not detected: was power adequate?<br/>If low, 'no effect' is unjustified"]
 ```
 
 Notice that **power analysis happens before you collect data**, not after.

--- a/content/learn/statistics-for-data-science-python/errors-and-power.mdx
+++ b/content/learn/statistics-for-data-science-python/errors-and-power.mdx
@@ -519,7 +519,7 @@ flowchart TD
   A["Design the study"] --> B["Pick alpha<br/>(false-positive risk)"]
   A --> C["Estimate the effect size<br/>you care about detecting"]
   A --> D["Estimate variance<br/>from pilot data"]
-  B --> E["Solve for required n<br/>to reach power >= 0.80"]
+  B --> E["Solve for required n<br/>to reach <code>power &gt;= 0.80</code>"]
   C --> E
   D --> E
   E --> F["Run the study at that n"]

--- a/content/learn/statistics-for-data-science-python/hypothesis-testing.mdx
+++ b/content/learn/statistics-for-data-science-python/hypothesis-testing.mdx
@@ -107,8 +107,8 @@ flowchart TD
   C --> D["4. Collect data,<br/>compute a test statistic"]
   D --> E["5. Get the p-value<br/>(how extreme is the data under H0?)"]
   E --> F{"p-value vs alpha"}
-  F -->|"p <= alpha"| G["Reject H0<br/>(result is 'significant')"]
-  F -->|"p > alpha"| H["Fail to reject H0<br/>(insufficient evidence)"]
+  F -->|"<code>p &lt;= alpha</code>"| G["Reject H0<br/>(result is 'significant')"]
+  F -->|"<code>p &gt; alpha</code>"| H["Fail to reject H0<br/>(insufficient evidence)"]
 ```
 
 Let's unpack the two pieces that trip people up.

--- a/content/learn/statistics-for-data-science-python/p-values.mdx
+++ b/content/learn/statistics-for-data-science-python/p-values.mdx
@@ -368,7 +368,7 @@ honest.
 
 ```mermaid
 flowchart TD
-  A["You have a p-value"] --> B{"p <= alpha?"}
+  A["You have a p-value"] --> B{"<code>p &lt;= alpha</code>?"}
   B -->|"yes"| C["Reject H0:<br/>data is surprising under H0"]
   B -->|"no"| D["Fail to reject H0:<br/>data is compatible with H0"]
   C --> E["Now ask: how BIG is the effect?<br/>(effect size + confidence interval)"]

--- a/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
+++ b/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
@@ -87,11 +87,11 @@ numbers, opposite story.
 ```mermaid
 flowchart LR
   subgraph WITHIN["Within each group"]
-    W1["Women > Men<br/>in Dept Easy"]
-    W2["Women > Men<br/>in Dept Hard"]
+    W1["<code>Women &gt; Men</code><br/>in Dept Easy"]
+    W2["<code>Women &gt; Men</code><br/>in Dept Hard"]
   end
   subgraph POOLED["Pooled together"]
-    P1["Men > Women<br/>overall (!)"]
+    P1["<code>Men &gt; Women</code><br/>overall (!)"]
   end
   WITHIN -->|"ignore the lurking<br/>variable (department)"| POOLED
 ```

--- a/content/learn/statistics-for-data-science-python/the-normal-distribution.mdx
+++ b/content/learn/statistics-for-data-science-python/the-normal-distribution.mdx
@@ -195,8 +195,8 @@ arguments.
 ```mermaid
 flowchart LR
   A["raw value x<br/>(score, height, ...)"] -->|"z = (x − mu) / sigma"| B["z-score<br/>(SDs from the mean)"]
-  B -->|"norm.cdf(z)"| C["percentile<br/>(fraction below)"]
-  C -->|"norm.ppf(p)"| B
+  B -->|"<code>norm.cdf(z)</code>"| C["percentile<br/>(fraction below)"]
+  C -->|"<code>norm.ppf(p)</code>"| B
   B -->|"x = mu + z·sigma"| A
 ```
 

--- a/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -25,10 +25,10 @@ They all live in `<stdlib.h>`.
 
 ```mermaid
 flowchart LR
-    A[Program] -->|"malloc(n)"| B[Allocator]
+    A[Program] -->|"<code>malloc(n)</code>"| B[Allocator]
     B -->|"void *"| A
     A -->|"writes / reads"| C["Heap block<br/>(n bytes)"]
-    A -->|"free(p)"| B
+    A -->|"<code>free(p)</code>"| B
     B -->|"block reclaimed"| D[Free list / arena]
 ```
 

--- a/content/learn/time-series-analysis-python/stationarity.mdx
+++ b/content/learn/time-series-analysis-python/stationarity.mdx
@@ -274,8 +274,8 @@ statistics, never instead of them:
 ```mermaid
 flowchart TD
     A["Raw series"] --> B{"Constant mean,<br/>variance, and<br/>autocorrelation?"}
-    B -->|"yes (ADF p < 0.05)"| C["Stationary: ready to model"]
-    B -->|"no (ADF p >= 0.05)"| D["Non-stationary"]
+    B -->|"yes (ADF <code>p &lt; 0.05</code>)"| C["Stationary: ready to model"]
+    B -->|"no (ADF <code>p &gt;= 0.05</code>)"| D["Non-stationary"]
     D --> E["Stabilize variance with a log"]
     D --> F["Remove trend/season by differencing"]
     E --> G["Re-test with ADF"]

--- a/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
+++ b/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
@@ -387,7 +387,7 @@ timeline, and the rest of pandas' time tooling switches on.
 
 ```mermaid
 flowchart LR
-    S["Raw date strings"] -->|"pd.to_datetime()"| T["<code>DatetimeIndex</code>"]
+    S["Raw date strings"] -->|"<code>pd.to_datetime()</code>"| T["<code>DatetimeIndex</code>"]
     T --> SL["Partial-string slicing<br/><code>df.loc</code>['1955']"]
     T --> RS["<code>resample()</code><br/>(next page)"]
     T --> RW["<code>rolling()</code>"]

--- a/scripts/audit/code-shapes.mjs
+++ b/scripts/audit/code-shapes.mjs
@@ -291,12 +291,14 @@ const SQL_FUNC = new Set([
 // names in these courses (amount, price, dept, orders, …) are never in this set,
 // so a real clause runs through them.
 const SQL_PROSE = new Set(
-  ("filter rows row keep keeps drop choose pick show read change remove add sort " +
-    "trim form groups grouping result results columns column tables only matches " +
-    "matched totals no can see here computed individual full make department take " +
-    "skip two high low surface extremes top look bins slice value condition true " +
-    "false the before after early late combine related record changes fetch right " +
-    "and or of pairs query final per into nothing")
+  ("filter filters rows row keep keeps drop drops choose chooses pick picks show " +
+    "shows read reads change changes remove removes add adds sort sorts trim trims " +
+    "form forms join joins return returns write writes group grouping groups result " +
+    "results columns column tables only matches matched totals no can see here " +
+    "computed individual full make makes department take takes skip skips two high " +
+    "low surface extremes top look bins slice value condition true false the before " +
+    "after early late combine related record fetch right and or of pairs query " +
+    "final per into nothing")
     .split(/\s+/),
 );
 const sep = (ch) => ch === "" || ":/|,(".includes(ch);
@@ -483,23 +485,24 @@ function isStrongExpr(m) {
 function wrapExprSpans(chunk, tags) {
   return chunk.replace(EXPR_SPAN, (m, ...args) => {
     const offset = args[args.length - 2];
+    const before = chunk.slice(0, offset);
     if (/[A-Za-z_]\w*<[A-Za-z_]/.test(m) && !/\s<\s/.test(m)) return m; // generic, not a comparison
-    // Math interval / inequality notation over single-letter operands (a < X < b,
-    // 0 <= p <= 1) reads as math, not code — same call the first pass made for
-    // y(t) and AR(p). A single comparison (i < N, score >= 90) still wraps.
-    if ((m.match(/[<>]=?/g) || []).length >= 2 && !/[A-Za-z_]{2,}/.test(m)) return m;
     if (!isStrongExpr(m)) return m;
     // For an assignment, the strength must be on the RIGHT of "=" — so "b =
     // nullptr" and "i = i + 1" wrap, but a prose gloss like "null = no effect"
     // (strong only because of the keyword on the left) does not.
     const asg = m.match(/^[A-Za-z_][\w.]*\s*=(?!=)\s*([\s\S]+)$/);
-    if (asg && !isStrongExpr(asg[1])) return m;
-    // A bare single < / > comparison sitting mid-phrase is usually a compound
-    // noun + threshold ("petal width > 0.8 cm", "heap size > 1") whose real
-    // operand is the words before it — wrap it only when it leads the chunk or
-    // follows a separator, never straight after another word.
-    const onlyAngle = /[<>]/.test(m) && !/[=!]=|[<>]=|=>|⇒|=|\breturn\b|\(|\[/.test(m);
-    if (onlyAngle && /\w\s$/.test(chunk.slice(0, offset))) return m;
+    if (asg) {
+      if (!isStrongExpr(asg[1])) return m;
+    } else if (/[<>]=?|[=!]==?/.test(m) && !/=>|⇒/.test(m)) {
+      // Math / probability notation over single-letter operands — a chained
+      // inequality (a < X < b) or one inside a function call P(X <= x) — reads as
+      // math, not code; same call the first pass made for y(t) and AR(p). A real
+      // condition (i < N, score >= 90, ADF p >= 0.05, width <= 0.8) still wraps.
+      const ops = (m.match(/[<>]=?|[=!]==?/g) || []).length;
+      const singleLetters = !/[A-Za-z_]{2,}|\d/.test(m);
+      if (singleLetters && (ops >= 2 || /\($/.test(before))) return m;
+    }
     tags.push(m);
     return `<code>${escHtml(m)}</code>`;
   });
@@ -589,6 +592,37 @@ function rewriteLabel(rawLabel) {
   return { label: `"${out.replace(/"/g, "&quot;")}"`, tags };
 }
 
+// Find edge labels — the text inside the `|…|` of `A -->|"INSERT, UPDATE"| B`.
+// Tracks shape-bracket depth and quotes so a pipe *inside* a node label (e.g.
+// the linked-list cell `["a | next"]`) is never mistaken for an edge label.
+function findEdgeLabels(line) {
+  const out = [];
+  const N = line.length;
+  let depth = 0;
+  let i = 0;
+  while (i < N) {
+    const ch = line[i];
+    if (ch === '"') {
+      i++;
+      while (i < N && line[i] !== '"') { if (line[i] === "\\") i++; i++; }
+      i++;
+      continue;
+    }
+    if (ch === "[" || ch === "{" || ch === "(") { depth++; i++; continue; }
+    if (ch === "]" || ch === "}" || ch === ")") { if (depth > 0) depth--; i++; continue; }
+    if (ch === "|" && depth === 0) {
+      let j = i + 1;
+      while (j < N && line[j] !== "|") {
+        if (line[j] === '"') { j++; while (j < N && line[j] !== '"') { if (line[j] === "\\") j++; j++; } }
+        j++;
+      }
+      if (j < N) { out.push({ contentStart: i + 1, contentEnd: j }); i = j + 1; continue; }
+    }
+    i++;
+  }
+  return out;
+}
+
 function processLine(line, isFlow) {
   if (!isFlow) return { line, tags: [] };
   // Bare subgraph title (`subgraph users.js`): wrap a code-like title, rewriting
@@ -602,22 +636,27 @@ function processLine(line, isFlow) {
     return { line, tags: [] };
   }
   if (SKIP_LINE.test(line)) return { line, tags: [] };
-  const nodes = findNodes(line);
-  if (!nodes.length) return { line, tags: [] };
+  // Node labels and edge labels are disjoint (nodes live inside shape brackets,
+  // edge labels between pipes at bracket depth 0); rewrite each span in place.
+  const spans = [
+    ...findNodes(line).map((n) => ({ start: n.contentStart, end: n.contentEnd })),
+    ...findEdgeLabels(line).map((e) => ({ start: e.contentStart, end: e.contentEnd })),
+  ].sort((a, b) => a.start - b.start);
+  if (!spans.length) return { line, tags: [] };
   const tags = [];
   let out = "";
   let pos = 0;
-  for (const n of nodes) {
-    const raw = line.slice(n.contentStart, n.contentEnd);
+  for (const s of spans) {
+    const raw = line.slice(s.start, s.end);
     const res = rewriteLabel(raw);
-    out += line.slice(pos, n.contentStart);
+    out += line.slice(pos, s.start);
     if (res.tags.length && res.label !== raw) {
       out += res.label;
       tags.push(...res.tags);
     } else {
       out += raw;
     }
-    pos = n.contentEnd;
+    pos = s.end;
   }
   out += line.slice(pos);
   return { line: out, tags };

--- a/scripts/audit/code-shapes.mjs
+++ b/scripts/audit/code-shapes.mjs
@@ -10,9 +10,14 @@
 //   node scripts/audit/code-shapes.mjs --apply    # rewrite the .mdx files
 //
 // Conservative by design: only flowchart/graph blocks, and only spans with a
-// strong, unambiguous code signal (scope `::`, a call `f(…)`, a template `<T>`,
-// a member call `a.b()`, or snake_case). Bare words, proper nouns (JavaScript),
-// math notation (AR(p), y(t)) and prose-with-a-parenthetical are left alone.
+// strong, unambiguous code signal. The first group of rules covers identifiers
+// and calls (scope `::`, a call `f(…)`, a template `<T>`, a member call `a.b()`,
+// snake_case); a second continuation group (below `escHtml`) covers the *other*
+// shapes of code that read as prose to those rules — expressions (lambdas,
+// comparisons, assignments, returns), SQL clauses and keyword stage-boxes, and
+// literals (shell commands, LINQ queries, numeric arrays). Bare words, proper
+// nouns (JavaScript), math notation (AR(p), y(t), a < X < b) and prose-with-a-
+// parenthetical are left alone.
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -253,6 +258,295 @@ function escHtml(t) {
     .join("");
 }
 
+// ─── Continuation pass: expressions, SQL, and literals ─────────────────────
+//
+// The patterns above catch identifiers, calls and templates. This second group
+// catches the *other* shapes of code that read as prose to those rules but are
+// still things you'd type into an editor, a SQL console or a shell:
+//   • expressions — lambdas (x => x.Age > 30), comparisons/conditions
+//     (score >= 90?), assignments (i = i + 1), method chains (.Select(p => p.B)),
+//     return statements, pointer arrows (a -> Widget);
+//   • SQL — clauses and statements (SELECT name, salary; WHERE price < 20), down
+//     to bare keyword stage-boxes (SELECT, FROM, WHERE), with any trailing prose
+//     description left in the sans body font;
+//   • literals — shell commands (git push), LINQ query syntax, numeric arrays.
+
+// SQL keywords that open a clause (longest first so "GROUP BY" beats "GROUP").
+// Matched only when UPPERCASE, the convention these courses write SQL in — so a
+// prose "join the tables" or "select a row" is never mistaken for code.
+const SQL_OPENERS = [
+  "FULL OUTER JOIN", "CREATE TABLE AS", "DELETE FROM", "INSERT INTO", "GROUP BY",
+  "ORDER BY", "INNER JOIN", "LEFT JOIN", "RIGHT JOIN", "CROSS JOIN", "FULL JOIN",
+  "CREATE TABLE", "UNION ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "HAVING",
+  "VALUES", "OFFSET", "UNION", "WHERE", "LIMIT", "JOIN", "FROM",
+];
+// SQL functions: the only names allowed to pull a "(" into a clause (so COUNT(*)
+// continues, but WHERE (a prose aside) stops before the paren).
+const SQL_FUNC = new Set([
+  "COUNT", "SUM", "AVG", "MIN", "MAX", "COALESCE", "ABS", "ROUND", "UPPER",
+  "LOWER", "LENGTH", "CAST", "EXTRACT", "NOW", "DATE", "RANK", "ROW_NUMBER",
+]);
+// Lowercase words that mark the start of a prose description trailing a clause
+// (WHERE filter rows → keyword is code, "filter rows" is prose). Column/table
+// names in these courses (amount, price, dept, orders, …) are never in this set,
+// so a real clause runs through them.
+const SQL_PROSE = new Set(
+  ("filter rows row keep keeps drop choose pick show read change remove add sort " +
+    "trim form groups grouping result results columns column tables only matches " +
+    "matched totals no can see here computed individual full make department take " +
+    "skip two high low surface extremes top look bins slice value condition true " +
+    "false the before after early late combine related record changes fetch right " +
+    "and or of pairs query final per into nothing")
+    .split(/\s+/),
+);
+const sep = (ch) => ch === "" || ":/|,(".includes(ch);
+
+// Tokenize a label segment for the SQL scanner: words, numbers, strings, the
+// ellipsis placeholder, multi-char operators, and single punctuation.
+function sqlTokenize(s) {
+  const re = /\s+|[A-Za-z_]\w*|0x[0-9a-fA-F]+|\d[\d.]*|'[^']*'|"[^"]*"|\.\.\.|<=|>=|<>|!=|[(),.;*=<>%]|\S/g;
+  const toks = [];
+  let m;
+  while ((m = re.exec(s))) toks.push({ t: m[0], i: m.index, end: m.index + m[0].length });
+  return toks;
+}
+
+// Keyword enumerations — UPPERCASE SQL keywords joined by "/" or "," (SELECT /
+// WHERE, INSERT / UPDATE / DELETE). Wrap each keyword, leaving the separators.
+const SQL_KW_ALT = SQL_OPENERS.join("|"); // longest-first, so "GROUP BY" wins
+function wrapSqlKeywordLists(seg, tags) {
+  const list = new RegExp(`(?:${SQL_KW_ALT})(?:\\s*[/,]\\s*(?:${SQL_KW_ALT}))+`, "g");
+  const one = new RegExp(`(?:${SQL_KW_ALT})`, "g");
+  return seg.replace(list, (run) =>
+    run.replace(one, (kw) => {
+      tags.push(kw);
+      return `<code>${kw}</code>`;
+    }),
+  );
+}
+
+// Wrap maximal SQL clauses in a segment. A clause starts at an UPPERCASE SQL
+// keyword that leads the segment or follows a separator (: / | , (), then runs
+// through SQL tokens — identifiers, numbers, strings, operators, commas,
+// function calls — until a prose word, a separator, a colon, or an arrow. The
+// clause is wrapped only if it extends past the keyword (e.g. WHERE price < 20)
+// or *is* the whole label (a bare SELECT / FROM stage-box) — so a lone keyword
+// trailed by prose ("UPDATE: move each center…", "WHERE filter rows") is left be.
+function wrapSqlClause(seg, tags) {
+  if (!/[A-Z]/.test(seg)) return seg;
+  const toks = sqlTokenize(seg);
+  let out = "";
+  let lastFlushed = 0; // index into `seg` up to which we've emitted
+  let prevSig = ""; // previous significant (non-space) token text
+  for (let k = 0; k < toks.length; k++) {
+    const tok = toks[k];
+    if (/^\s+$/.test(tok.t)) continue;
+    // Try to match a SQL opener (possibly two words) at this position.
+    let opener = null;
+    let span = 1;
+    for (const kw of SQL_OPENERS) {
+      const parts = kw.split(" ");
+      const slice = toks
+        .slice(k, k + parts.length * 2)
+        .filter((x) => !/^\s+$/.test(x.t))
+        .slice(0, parts.length)
+        .map((x) => x.t)
+        .join(" ");
+      if (slice === kw) {
+        opener = kw;
+        let need = parts.length;
+        let j = k;
+        while (need > 0 && j < toks.length) {
+          if (!/^\s+$/.test(toks[j].t)) need--;
+          j++;
+        }
+        span = j - k; // raw tokens (incl. interleaved spaces) the opener spans
+        break;
+      }
+    }
+    if (!opener || !sep(prevSig === "" ? "" : prevSig.slice(-1))) {
+      prevSig = tok.t;
+      continue;
+    }
+    // Walk forward consuming SQL-continuation tokens. Track paren depth so a
+    // function call's parens are kept (COUNT(*)) but a closing paren that merely
+    // wraps the clause in the prose ("(VALUES)", "(CREATE TABLE AS)") stops it.
+    let end = k + span; // first index after the opener
+    let lastSig = k + span - 1; // last non-space token index kept
+    let depth = 0;
+    while (end < toks.length) {
+      const x = toks[end];
+      if (/^\s+$/.test(x.t)) { end++; continue; }
+      const w = x.t;
+      const prevKept = toks[lastSig].t;
+      if (w === ")") {
+        if (depth === 0) break;
+        depth--;
+        lastSig = end;
+        end++;
+        continue;
+      }
+      const stop =
+        w === "/" || w === "|" || w === "→" || w === "-" || w === ":" ||
+        (w === "(" && !SQL_FUNC.has(prevKept.toUpperCase())) ||
+        (/^[a-z]/.test(w) && SQL_PROSE.has(w.toLowerCase()));
+      if (stop) break;
+      if (w === "(") depth++;
+      lastSig = end;
+      end++;
+    }
+    // Build the clause text, trimming trailing operators/punctuation (but never
+    // a closing ), * or ; that legitimately ends a statement).
+    let clause = seg.slice(toks[k].i, toks[lastSig].end);
+    const trimmed = clause.replace(/[\s,.<>=!%(+-]+$/, "");
+    const drop = clause.length - trimmed.length;
+    clause = trimmed;
+    // Only commit if the clause runs past the opener, or is the whole label.
+    const extends_ = lastSig >= k + span;
+    if (!extends_ && clause !== seg.trim()) {
+      prevSig = tok.t;
+      continue;
+    }
+    out += seg.slice(lastFlushed, toks[k].i) + `<code>${escHtml(clause)}</code>`;
+    tags.push(clause);
+    lastFlushed = toks[lastSig].end - drop;
+    k = lastSig; // resume scanning after the kept clause
+    prevSig = toks[lastSig].t;
+  }
+  return out + seg.slice(lastFlushed);
+}
+
+// Keyword enumerations first, then maximal clauses in whatever's left outside.
+function wrapSqlClauses(seg, tags) {
+  const listed = wrapSqlKeywordLists(seg, tags);
+  return wrapOutsideCode(listed, (chunk) => wrapSqlClause(chunk, tags));
+}
+
+// Run `fn` only on the parts of `s` that lie OUTSIDE existing <code> spans, so a
+// second pass can't wrap text already wrapped by an earlier one.
+function wrapOutsideCode(s, fn) {
+  return s
+    .split(/(<code>[\s\S]*?<\/code>)/i)
+    .map((part) => (/^<code>/i.test(part) ? part : fn(part)))
+    .join("");
+}
+
+// An operand in an expression: a (possibly member) identifier or call, a number,
+// a string, or a code keyword like nullptr/NULL/true/false.
+const OPERAND =
+  "(?:[&*]?[A-Za-z_]\\w*(?:\\.[A-Za-z_]\\w*)*(?:\\([^()]*\\))?" +
+  "|-?\\d[\\w.]*|'[^']*'|\"[^\"]*\"|nullptr|NULL|null|None|true|false|TRUE|FALSE)";
+const CMP = "(?:===?|!==?|>=|<=|<|>)";
+const LAMBDA = "(?:=>|⇒)";
+// A term is an operand or an arithmetic chain of them (a + b, slope * x), so a
+// comparison like "x % 2 == 0" is captured whole, not split at the %.
+const TERM = `${OPERAND}(?:\\s*[-+*/%]\\s*${OPERAND})*`;
+const EXPR_SPAN = new RegExp(
+  // a method/extension call whose args hold a lambda: Select(d => d.Employees)
+  `[A-Za-z_]\\w*\\([^()]*${LAMBDA}[^()]*\\)` +
+    // lambda: x => x.Age > 30 , (a, b) => a + b
+    `|(?:\\([^()]*\\)|[A-Za-z_]\\w*)\\s*${LAMBDA}\\s*${OPERAND}(?:\\s*(?:${CMP}|[-+*/%]|&&|\\|\\|)\\s*${OPERAND})*` +
+    // a leading method chain: .Select(p => p.B).Where(...)
+    `|\\.[A-Za-z_]\\w*\\([^()]*\\)(?:\\.[A-Za-z_]\\w*\\([^()]*\\))*` +
+    // return statement: return 'A'
+    `|\\breturn\\s+${OPERAND}` +
+    // comparison / condition: x.Age > 30 , Product == 'Widget' , x % 2 == 0
+    `|${TERM}\\s*${CMP}\\s*${TERM}(?:\\s*(?:${CMP}|&&|\\|\\|)\\s*${TERM})*` +
+    // assignment to a literal / expression (spaces around = so a linked-list box
+    // field "prev=null" isn't caught): i = i + 1 , xs = [1, 2, 3] , b = nullptr
+    `|[A-Za-z_][\\w.]*\\s+=\\s+(?:\\[[^\\]]*\\]|${OPERAND})(?:\\s*[-+*/%]\\s*${OPERAND})*` +
+    // arithmetic against an explicit number, spaces required so a hyphenated
+    // name or date (Therac-25, Jan-01) isn't mistaken for subtraction: p + 1
+    `|[A-Za-z_]\\w*\\s+[-+*/%]\\s+-?\\d[\\w.]*`,
+  "g",
+);
+
+// Does a matched span carry a *strong* code signal, or is it just English words
+// joined by an operator (a prose formula like "Residual = actual - predicted" or
+// "y = intercept + slope * x")? Comparisons, lambdas, calls, member access,
+// literals, numbers-in-arithmetic, address-of and code keywords qualify; a bare
+// word * word / word + word does not.
+function isStrongExpr(m) {
+  if (/===?|!==?|>=|<=|<|>|=>|⇒|&&|\|\|/.test(m)) return true; // comparison / lambda / logical
+  if (/['"]/.test(m)) return true; // string literal
+  if (/\d/.test(m) && /[-+*/%=]/.test(m)) return true; // arithmetic with a number
+  if (/[A-Za-z_]\w*\([^()]*\)/.test(m)) return true; // call
+  if (/[A-Za-z_]\w*\.[A-Za-z_]/.test(m)) return true; // member access
+  if (/\b(?:nullptr|NULL|null|None|true|false|TRUE|FALSE)\b/.test(m)) return true;
+  if (/&\s*[A-Za-z_]/.test(m)) return true; // address-of: &a
+  if (/\[[^\]]*\]/.test(m)) return true; // array literal
+  return false;
+}
+
+// Wrap expression spans inside one chunk of prose. Skips generic-type lookalikes
+// (Func<T,bool>) and weak prose equations via isStrongExpr.
+function wrapExprSpans(chunk, tags) {
+  return chunk.replace(EXPR_SPAN, (m, ...args) => {
+    const offset = args[args.length - 2];
+    if (/[A-Za-z_]\w*<[A-Za-z_]/.test(m) && !/\s<\s/.test(m)) return m; // generic, not a comparison
+    // Math interval / inequality notation over single-letter operands (a < X < b,
+    // 0 <= p <= 1) reads as math, not code — same call the first pass made for
+    // y(t) and AR(p). A single comparison (i < N, score >= 90) still wraps.
+    if ((m.match(/[<>]=?/g) || []).length >= 2 && !/[A-Za-z_]{2,}/.test(m)) return m;
+    if (!isStrongExpr(m)) return m;
+    // For an assignment, the strength must be on the RIGHT of "=" — so "b =
+    // nullptr" and "i = i + 1" wrap, but a prose gloss like "null = no effect"
+    // (strong only because of the keyword on the left) does not.
+    const asg = m.match(/^[A-Za-z_][\w.]*\s*=(?!=)\s*([\s\S]+)$/);
+    if (asg && !isStrongExpr(asg[1])) return m;
+    // A bare single < / > comparison sitting mid-phrase is usually a compound
+    // noun + threshold ("petal width > 0.8 cm", "heap size > 1") whose real
+    // operand is the words before it — wrap it only when it leads the chunk or
+    // follows a separator, never straight after another word.
+    const onlyAngle = /[<>]/.test(m) && !/[=!]=|[<>]=|=>|⇒|=|\breturn\b|\(|\[/.test(m);
+    if (onlyAngle && /\w\s$/.test(chunk.slice(0, offset))) return m;
+    tags.push(m);
+    return `<code>${escHtml(m)}</code>`;
+  });
+}
+
+// SQL clauses first (they own their inner comparisons), then expression spans in
+// whatever prose is left outside the wrapped clauses.
+function wrapNewSpans(seg, tags) {
+  let s = wrapSqlClauses(seg, tags);
+  s = wrapOutsideCode(s, (chunk) => wrapExprSpans(chunk, tags));
+  return s;
+}
+
+// Is the whole label a single SQL statement (possibly wrapped over <br/> lines)?
+// Starts with a clause keyword and every token is SQL — a keyword, a column/table
+// name (lowercase, not a prose word), a number, string, function call, operator
+// or comma. Lets a multi-line statement wrap as ONE span instead of per line.
+const SQL_OPEN_RE = new RegExp(`^(?:${SQL_OPENERS.join("|")})\\b`);
+function isWholeSql(s) {
+  if (!SQL_OPEN_RE.test(s)) return false;
+  for (const tok of sqlTokenize(s)) {
+    const t = tok.t;
+    if (/^\s+$/.test(t)) continue;
+    if (/^[A-Za-z_]\w*$/.test(t)) {
+      if (/[a-z]/.test(t) && SQL_PROSE.has(t.toLowerCase())) return false; // prose word
+      continue; // keyword, function, or column/table name
+    }
+    if (/^-?\d/.test(t) || /^0x/i.test(t) || /^['"]/.test(t) || t === "...") continue;
+    if (/^[(),.;*%]$/.test(t) || /^(?:===?|!==?|>=|<=|<>|[<>=])$/.test(t)) continue;
+    return false; // :, ?, →, /, |, -, or any other non-SQL token
+  }
+  return true;
+}
+
+// Whole-label code the conservative isWholeCode misses: shell commands, numeric
+// array literals, LINQ query syntax (reads as English but is code), and complete
+// SQL statements.
+function isWholeCodeExtra(raw) {
+  const s = normalize(raw);
+  if (!s) return false;
+  if (/^(git|npm|npx|yarn|pnpm|pip3?|cd|cargo|dotnet|node|docker)\s+\S/.test(s)) return true;
+  if (/^\[\s*-?\d[\d\s,.]*\]$/.test(s)) return true; // [1, 2, 3]
+  if (/^from\s+\w+\s+in\s+\S.*\bselect\b/i.test(s)) return true; // LINQ query
+  if (isWholeSql(s)) return true;
+  return false;
+}
+
 // Rewrite one label, returning { label, tags }. Wraps the whole label if it is
 // pure code, else wraps embedded code spans (segment by segment so a span can't
 // cross or swallow a <br/>). Returns the label unchanged if nothing matched or
@@ -265,26 +559,30 @@ function rewriteLabel(rawLabel) {
 
   const tags = [];
   let out;
-  if (isWholeCode(inner)) {
+  if (isWholeCode(inner) || isWholeCodeExtra(inner)) {
     out = `<code>${escHtml(inner)}</code>`;
     tags.push(normalize(inner));
   } else {
     let any = false;
     out = inner
       .split(/(<br\s*\/?>)/i)
-      .map((seg) =>
-        /^<br/i.test(seg)
-          ? seg
-          : seg.replace(SPAN, (s) => {
-              const plain = s.match(/^([A-Za-z_]\w*)\(([^()]*)\)$/);
-              if (plain && (!isCodeName(plain[1]) || plain[2].trim() === "s"))
-                return s; // math notation / "word(s)" pluralization
-              if (isProseName(s)) return s; // product name / domain
-              any = true;
-              tags.push(s);
-              return `<code>${escHtml(s)}</code>`;
-            }),
-      )
+      .map((seg) => {
+        if (/^<br/i.test(seg)) return seg;
+        const coded = seg.replace(SPAN, (s) => {
+          const plain = s.match(/^([A-Za-z_]\w*)\(([^()]*)\)$/);
+          if (plain && (!isCodeName(plain[1]) || plain[2].trim() === "s"))
+            return s; // math notation / "word(s)" pluralization
+          if (isProseName(s)) return s; // product name / domain
+          any = true;
+          tags.push(s);
+          return `<code>${escHtml(s)}</code>`;
+        });
+        // Then the continuation pass (SQL clauses + expression spans) on the
+        // prose still left outside any <code> the conservative rules wrapped.
+        const next = wrapOutsideCode(coded, (chunk) => wrapNewSpans(chunk, tags));
+        if (next !== seg) any = true;
+        return next;
+      })
       .join("");
     if (!any) return { label: rawLabel, tags: [] };
   }


### PR DESCRIPTION
## What

Continues the code-in-diagrams work from #467. That pass rendered **identifier and call** shapes (`std::unique_ptr`, `value_counts()`, `vector<int>`) in `var(--font-mono)`, but it was conservative and skipped the *other* shapes of code that read as prose to its rules. This PR catches those across all ~1,250 flowchart diagrams — in node labels, **edge labels**, and the **entity-modeling** diagrams — for **~290 new `<code>` spans across 100 files**.

The motivating C# LINQ diagram had three labels that are code but weren't mono:

```
x => x.Age > 30                  (a lambda expression)
SELECT * FROM ... WHERE Age > 30 (SQL)
{ Age: { $gt: 30 } }             (a query/object literal)
```

## Newly rendered in monospace

- **Expressions** (node + edge labels) — lambdas (`x => x.Age > 30`), comparisons & conditions (`score >= 90?`, `i < N?`, `Product == 'Widget'`, `p <= alpha`), assignments (`i = i + 1`, `b = nullptr`), returns (`return 'A'`), method chains (`.Select(p => p.B)`, `norm.cdf(z)`), pointer arrows (`a -> Widget`).
- **SQL** — statements & clauses (`SELECT name, species FROM pets;`, `WHERE price < 20`, `GROUP BY dept`), bare keyword stage-boxes (`SELECT`, `FROM`, `WHERE`) and keyword lists — including on **edge labels** (`A -->|"INSERT, UPDATE, SELECT"| B`). A clause's trailing prose description stays sans:

  ```
  W["<code>WHERE</code><br/>filter rows<br/>(before grouping)"]
  ```
- **Literals** — shell commands (`git push`), LINQ query syntax (`from p in xs where p.A > 0 select p.B`), numeric arrays (`[5,2,8,1]`), and the `{ Age: { $gt: 30 } }` object.
- **Entity / table names** — in the entity-modeling diagrams (`thinking-in-entities`, `what-are-relationships`, the ER / join / case-study flowcharts) a node whose label **is** a table name — `customers`, `orders`, `products`, `users`, `posts`, `tags`, … — now matches the snake_case join tables (`order_items`, `post_tags`) the first pass already wrapped.

## How

Two passes:

1. **`scripts/audit/code-shapes.mjs`** (the reproducible fixer — `node scripts/audit/code-shapes.mjs [--apply]`) gained a second rule group for expressions / SQL / literals, plus edge-label scanning with a bracket/quote-aware finder so a pipe *inside* a node label (`["a | next"]`) isn't mistaken for an edge. The fixer is **idempotent**.
2. The **entity** wrap was a targeted edit scoped to the database courses and exact table-name labels — table names are ordinary words, so there's no safe global rule to add to the audit script.

Kept conservative — these are **left in the body font**:

- prose formulas — `Residual = actual - predicted`, `y = intercept + slope * x`
- math / probability notation — `a < X < b`, `P(X <= x)`, `O(n log n)`
- generic-type lookalikes mid-word, and hyphenated names / dates — `Therac-25`, `Jan-01`
- a SQL keyword followed by a prose description — `UPDATE: move each center…`, `INNER JOIN keeps`
- entity names inside a sentence (`"Customers place orders for products"`) and attribute / column nodes (`title`, `name`, `email`) — the entity ask was specifically about table names

## Validation

- `fumadocs-mdx` + `scripts/audit/validate-mdx.mjs` → **781 files compile cleanly**
- `<code>` tags balanced on every changed line; no double-wrapping
- re-running `code-shapes.mjs --apply` wraps **0** (idempotent)

https://claude.ai/code/session_01RnMah2ZK7uHWg9TnxUUTT2