### PR TITLE
Improve solution modal action bars for challenge cards

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -351,13 +351,14 @@
 }
 
 /* Vertical hairline that separates the Copy button from the Load
-   Solution button in the action bar. */
+   Solution button in the action bar. Uses the same `--ch-border` color as
+   the main toolbar's `.btnGroupUtilSep` so the two separators match. */
 .solutionActionSeparator {
   width: 1px;
   height: 18px;
   flex-shrink: 0;
   margin: 0 4px;
-  background: var(--ch-border-light);
+  background: var(--ch-border);
 }
 
 /* Filename inside the "Copy <file>" button, rendered in the mono stack so

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -350,6 +350,58 @@
   border-top: 1px solid var(--ch-border-light);
 }
 
+/* Vertical hairline that separates the Copy button from the Load
+   Solution button in the action bar. */
+.solutionActionSeparator {
+  width: 1px;
+  height: 18px;
+  flex-shrink: 0;
+  margin: 0 4px;
+  background: var(--ch-border-light);
+}
+
+/* Filename inside the "Copy <file>" button, rendered in the mono stack so
+   it reads as code. Scoped under `.solutionActionBar` (specificity 0,2,0)
+   so it overrides the ambient Tailwind-Typography `code` styling — pill
+   background, padding, and the backtick ::before/::after — the card may
+   inherit when embedded inside a `.prose` region. */
+.solutionActionBar .solutionActionFileName {
+  font-family: var(--font-mono, var(--ch-font-mono));
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
+  background: none;
+  padding: 0;
+  border: none;
+  white-space: nowrap;
+}
+
+.solutionActionBar .solutionActionFileName::before,
+.solutionActionBar .solutionActionFileName::after {
+  content: none;
+}
+
+/* Subtle note shown between the file tab bar and the read-only editor in
+   a multi-file solution modal when the active file's solution is identical
+   to its starter, signalling that the tab needs no edits. */
+.solutionUnchangedNote {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-shrink: 0;
+  padding: 8px 14px;
+  font-size: 12.5px;
+  font-family: var(--ch-font-ui);
+  line-height: 1.4;
+  color: var(--ch-text-muted);
+  background: var(--ch-bg-subtle);
+  border-bottom: 1px solid var(--ch-border-light);
+}
+
+.solutionUnchangedNote svg {
+  flex-shrink: 0;
+}
+
 /* ─── Instructions ────────────────────────────────────────────────── */
 
 .instructions {

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -2061,7 +2061,7 @@ function SolutionModal({
       >
         <div className={styles.modalHeader}>
           <div className={styles.badge}>
-            <Terminal size={9} aria-hidden /> Solution
+            <Terminal size={9} aria-hidden />
           </div>
           <div className={styles.modalTitleArea}>
             <div className={styles.modalTitle}>Reference solution</div>

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -30,7 +30,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, ChevronUp, Eye, File, FileInput, Play, Terminal } from "lucide-react";
+import { RotateCcw, Check, X, ChevronDown, ChevronUp, Eye, File, FileInput, Info, Play, Terminal } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   CopyIcon,
@@ -155,6 +155,12 @@ interface SolutionFile {
    *  labels these "(unchanged)" so the learner can tell the file apart
    *  from one they should edit. */
   hasSolution: boolean;
+  /** True when the displayed solution is byte-for-byte identical to the
+   *  file's `starterCode` — either because the file supplied no
+   *  `solutionCode` (scaffold) or because its `solutionCode` matches the
+   *  starter. In a multi-file workspace the modal surfaces a subtle note
+   *  for these files so the learner knows the tab needs no edits. */
+  isUnchanged: boolean;
 }
 
 export interface ChallengeCardProps {
@@ -343,11 +349,15 @@ export default function ChallengeCard({
   // the learner is not expected to change). The modal opens iff at least
   // one file actually has a solution.
   const solutionFiles: SolutionFile[] = useMemo(() => {
-    return workspaceFiles.map((file) => ({
-      filename: file.filename,
-      source: file.solutionCode ?? file.starterCode,
-      hasSolution: file.solutionCode !== undefined,
-    }));
+    return workspaceFiles.map((file) => {
+      const source = file.solutionCode ?? file.starterCode;
+      return {
+        filename: file.filename,
+        source,
+        hasSolution: file.solutionCode !== undefined,
+        isUnchanged: source === file.starterCode,
+      };
+    });
   }, [workspaceFiles]);
   const hasSolution = solutionFiles.some((f) => f.hasSolution);
 
@@ -2015,6 +2025,12 @@ function SolutionModal({
     () => files.find((f) => f.filename === activeFilename)?.source ?? source,
     [files, activeFilename, source],
   );
+  // Whether the active file's solution is identical to its starter — used
+  // to surface a subtle "no edits needed" note in multi-file workspaces.
+  const activeIsUnchanged = useMemo(
+    () => files.find((f) => f.filename === activeFilename)?.isUnchanged ?? false,
+    [files, activeFilename],
+  );
   const handleCopy = useCallback(async () => {
     try {
       if (!navigator.clipboard?.writeText) return;
@@ -2112,6 +2128,15 @@ function SolutionModal({
             })}
           </div>
         )}
+        {showTabs && activeIsUnchanged && (
+          <div className={styles.solutionUnchangedNote} role="note">
+            <Info size={13} strokeWidth={2} aria-hidden />
+            <span>
+              This file is unchanged from the starter code — no edits are
+              needed here.
+            </span>
+          </div>
+        )}
         <div
           ref={editorHostRef}
           className={styles.modalEditor}
@@ -2131,8 +2156,20 @@ function SolutionModal({
             ) : (
               <CopyIcon />
             )}
-            <span>{copied ? "Copied!" : `Copy ${activeFilename}`}</span>
+            <span>
+              {copied ? (
+                "Copied!"
+              ) : (
+                <>
+                  Copy{" "}
+                  <code className={styles.solutionActionFileName}>
+                    {activeFilename}
+                  </code>
+                </>
+              )}
+            </span>
           </button>
+          <span className={styles.solutionActionSeparator} aria-hidden />
           <button
             type="button"
             className={styles.utilBtn}

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -35,7 +35,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, Eye, Play, Database, Table, List } from "lucide-react";
+import { RotateCcw, Check, X, ChevronDown, Eye, Play, Database, Table, List, FileInput } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   createColumnHelper,
@@ -1521,6 +1521,28 @@ export default function SqlChallengeCard({
     toasts.show("Reset to starter SQL.");
   }, [starterCode, persistedKey, ensureEngine, refreshTableViewer, clearTableViewer, tableViewerEnabled, toasts]);
 
+  // ─── Apply solution ─────────────────────────────────────────────────
+  // Load the reference SQL into the learner's editor (the "Load Solution
+  // into Editor" button in the solution modal), mirroring <ChallengeCard>.
+  const applySolutionToEditor = useCallback(() => {
+    if (!solutionSql) return;
+    const view = editorRef.current;
+    if (view) {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: solutionSql },
+      });
+    }
+    // Persist immediately and cancel the debounced save the dispatch above
+    // just scheduled, so closing the modal right away doesn't drop it.
+    if (persistSaveTimerRef.current !== null) {
+      window.clearTimeout(persistSaveTimerRef.current);
+      persistSaveTimerRef.current = null;
+    }
+    savePersistedCode(persistedKey, solutionSql);
+    setSolutionOpen(false);
+    toasts.show("Solution loaded into your editor.");
+  }, [solutionSql, persistedKey, toasts]);
+
   const copyCode = useCallback(async () => {
     const code = editorRef.current?.state.doc.toString() ?? "";
     try {
@@ -2004,6 +2026,7 @@ export default function SqlChallengeCard({
           onClose={() => setSolutionOpen(false)}
           editorHostRef={solutionEditorHostRef}
           source={solutionSql}
+          onApplySolution={applySolutionToEditor}
         />
       )}
 
@@ -2015,11 +2038,16 @@ function SolutionModal({
   onClose,
   editorHostRef,
   source,
+  onApplySolution,
 }: {
   onClose: () => void;
   editorHostRef: React.RefObject<HTMLDivElement | null>;
   source: string;
+  onApplySolution: () => void;
 }) {
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<number | null>(null);
+
   // Trap-free modal: click on backdrop to close, Esc to close.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -2028,14 +2056,28 @@ function SolutionModal({
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [onClose]);
+  // Tidy the "Copied!" reset timer on unmount.
+  useEffect(
+    () => () => {
+      if (copiedTimerRef.current !== null)
+        window.clearTimeout(copiedTimerRef.current);
+    },
+    [],
+  );
 
-  const copySolution = useCallback(async () => {
+  const handleCopy = useCallback(async () => {
     try {
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(source);
-      }
+      if (!navigator.clipboard?.writeText) return;
+      await navigator.clipboard.writeText(source);
+      setCopied(true);
+      if (copiedTimerRef.current !== null)
+        window.clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = window.setTimeout(() => {
+        setCopied(false);
+        copiedTimerRef.current = null;
+      }, 1500);
     } catch {
-      /* ignore */
+      /* clipboard blocked — leave the label unchanged */
     }
   }, [source]);
 
@@ -2064,7 +2106,7 @@ function SolutionModal({
           <div className={styles.modalActions}>
             <button
               type="button"
-              onClick={() => void copySolution()}
+              onClick={() => void handleCopy()}
               aria-label="Copy solution"
               title="Copy solution"
               className={styles.modalIconBtn}
@@ -2087,6 +2129,33 @@ function SolutionModal({
           className={styles.modalEditor}
           aria-label="Solution editor (read-only)"
         />
+        {/* Action bar pinned below the read-only editor. Borderless utility
+            buttons mirror <ChallengeCard>'s solution modal. */}
+        <div className={styles.solutionActionBar}>
+          <button
+            type="button"
+            className={styles.utilBtn}
+            onClick={() => void handleCopy()}
+            title="Copy solution query to clipboard"
+          >
+            {copied ? (
+              <Check size={13} strokeWidth={2.4} aria-hidden />
+            ) : (
+              <CopyIcon />
+            )}
+            <span>{copied ? "Copied!" : "Copy Solution Query"}</span>
+          </button>
+          <span className={styles.solutionActionSeparator} aria-hidden />
+          <button
+            type="button"
+            className={styles.utilBtn}
+            onClick={onApplySolution}
+            title="Replace your editor's code with this solution"
+          >
+            <FileInput size={13} strokeWidth={2} aria-hidden />
+            <span>Load Solution into Editor</span>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -2095,7 +2095,7 @@ function SolutionModal({
       >
         <div className={styles.modalHeader}>
           <div className={styles.badge}>
-            <Database size={9} aria-hidden /> Solution
+            <Database size={9} aria-hidden />
           </div>
           <div className={styles.modalTitleArea}>
             <div className={styles.modalTitle}>Reference solution</div>


### PR DESCRIPTION
## Summary

Polishes the **Reference solution** modal for both challenge-card flavors (`<ChallengeCard>` and `<SqlChallengeCard>`) so they share one consistent action bar, plus a couple of header/visibility refinements.

## Changes

### Action bar
- **Separator between buttons** — Added a vertical hairline between the **Copy** and **Load Solution into Editor** buttons in the non-SQL action bar, and gave the SQL modal the same action bar.
- **Separator visibility** — The separator now uses `--ch-border` (the same color as the main toolbar's `.btnGroupUtilSep`) instead of the near-invisible `--ch-border-light`.
- **Monospace filename (non-SQL)** — The filename in the "Copy `utils.ts`" button is wrapped in `<code>` and rendered with `var(--font-mono)`. The rule is scoped under `.solutionActionBar` so it overrides the ambient Tailwind-Typography inline-`code` decorations (backtick `::before`/`::after`, pill background) the card inherits inside a `.prose` region.

### SQL action-bar parity
The SQL solution modal now has the same action bar, same styles:
- **Copy Solution Query** — copies the reference SQL, with the same "Copied!" confirmation as the non-SQL card.
- **Load Solution into Editor** — loads the reference SQL into the learner's editor and persists it (new `applySolutionToEditor`, mirroring `<ChallengeCard>`).

### Header
- **Removed the redundant "Solution" badge text** from the modal header in both cards. The terminal/database icon stays; the "Reference solution" title already names the dialog.

### Multi-file "unchanged" note (non-SQL)
- Added an `isUnchanged` flag per solution file (`source === starterCode`) and a subtle note between the file tab bar and the editor: *"This file is unchanged from the starter code — no edits are needed here."* It appears only for multi-file workspaces on a file whose solution matches its starter (a scaffold file, or a `solutionCode` equal to the starter).

## Files
- `app/_components/ChallengeCard.tsx` — separator, `<code>` filename, `isUnchanged` + note, header badge text removed.
- `app/_components/SqlChallengeCard.tsx` — action bar, `applySolutionToEditor`, copy-confirmation state, header badge text removed.
- `app/_components/ChallengeCard.module.css` — `.solutionActionSeparator` (incl. color fix), `.solutionActionFileName`, `.solutionUnchangedNote`.

## Verification
- `npx tsc --noEmit` — no errors in application code (only pre-existing env-only test errors from dev deps not installed in this environment).
- `npx eslint app/_components/ChallengeCard.tsx app/_components/SqlChallengeCard.tsx` — clean.
- No test/e2e selectors reference the changed strings or class names.

## Notes
- For the "Solution" badge, I removed only the text and kept the icon, per the request. Happy to drop the lone icon too if you'd prefer.
- The "unchanged" note fires both for true scaffold files (no `solutionCode`) and for files whose `solutionCode` equals the starter, since both mean "starter and solution identical." Can restrict to one case if desired.

https://claude.ai/code/session_01VCSw3CYSv5P2f3jdnC8wmM