### PR TITLE
Code-quality & UX hardening: playgrounds, code blocks, challenge cards & MCQ

### DIFF
--- a/__tests__/duckdbSplit.test.ts
+++ b/__tests__/duckdbSplit.test.ts
@@ -1,10 +1,65 @@
 import { describe, expect, it } from "vitest";
 import {
+  arrowTypeToSqlName,
   splitDuckDbStatements,
   toBindParam,
   parseDuckDbEnumValues,
   toDuckDbListLiteral,
 } from "../app/_components/runtime/duckdb";
+
+describe("arrowTypeToSqlName (result-header type labels)", () => {
+  it("maps integer widths to DuckDB names", () => {
+    expect(arrowTypeToSqlName("Int8")).toBe("TINYINT");
+    expect(arrowTypeToSqlName("Int16")).toBe("SMALLINT");
+    expect(arrowTypeToSqlName("Int32")).toBe("INTEGER");
+    expect(arrowTypeToSqlName("Int64")).toBe("BIGINT");
+    expect(arrowTypeToSqlName("Uint64")).toBe("UBIGINT");
+  });
+
+  it("maps floats, strings, booleans and binary", () => {
+    expect(arrowTypeToSqlName("Float32")).toBe("FLOAT");
+    expect(arrowTypeToSqlName("Float64")).toBe("DOUBLE");
+    expect(arrowTypeToSqlName("Utf8")).toBe("VARCHAR");
+    expect(arrowTypeToSqlName("LargeUtf8")).toBe("VARCHAR");
+    expect(arrowTypeToSqlName("Bool")).toBe("BOOLEAN");
+    expect(arrowTypeToSqlName("Binary")).toBe("BLOB");
+    expect(arrowTypeToSqlName("FixedSizeBinary[16]")).toBe("BLOB");
+  });
+
+  it("converts Arrow decimal notation to DECIMAL(p,s)", () => {
+    expect(arrowTypeToSqlName("Decimal[38e+2]")).toBe("DECIMAL(38,2)");
+    expect(arrowTypeToSqlName("Decimal[18e0]")).toBe("DECIMAL(18,0)");
+    expect(arrowTypeToSqlName("Decimal[10e+5]")).toBe("DECIMAL(10,5)");
+  });
+
+  it("maps temporal types, distinguishing timestamptz", () => {
+    expect(arrowTypeToSqlName("Date32<DAY>")).toBe("DATE");
+    expect(arrowTypeToSqlName("Date64<MILLISECOND>")).toBe("DATE");
+    expect(arrowTypeToSqlName("Time64<MICROSECOND>")).toBe("TIME");
+    expect(arrowTypeToSqlName("Timestamp<MICROSECOND>")).toBe("TIMESTAMP");
+    expect(arrowTypeToSqlName("Timestamp<MICROSECOND, UTC>")).toBe(
+      "TIMESTAMP WITH TIME ZONE",
+    );
+    expect(arrowTypeToSqlName("Interval<MONTH_DAY_NANO>")).toBe("INTERVAL");
+  });
+
+  it("maps lists to []-suffixed element types, recursively", () => {
+    expect(arrowTypeToSqlName("List<Int32>")).toBe("INTEGER[]");
+    expect(arrowTypeToSqlName("List<Utf8>")).toBe("VARCHAR[]");
+    expect(arrowTypeToSqlName("List<List<Int64>>")).toBe("BIGINT[][]");
+    expect(arrowTypeToSqlName("FixedSizeList[4]<Float64>")).toBe("DOUBLE[]");
+  });
+
+  it("maps enum dictionaries and nested containers", () => {
+    expect(arrowTypeToSqlName("Dictionary<Int8, Utf8>")).toBe("ENUM");
+    expect(arrowTypeToSqlName("Struct<{a:Int32, b:Utf8}>")).toBe("STRUCT");
+    expect(arrowTypeToSqlName("Map<{key:Utf8, value:Int32}>")).toBe("MAP");
+  });
+
+  it("passes unknown notations through unchanged", () => {
+    expect(arrowTypeToSqlName("SomeFutureType<X>")).toBe("SomeFutureType<X>");
+  });
+});
 
 describe("splitDuckDbStatements", () => {
   it("splits simple statements on `;`", () => {

--- a/__tests__/resultShape.test.ts
+++ b/__tests__/resultShape.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { sameResultShape } from "../app/_components/sql/components/ResultView";
+import type { QueryRunResult } from "../app/_components/sql/types";
+
+const run = (
+  sets: ({ columns: string[]; values: unknown[][] } | null)[],
+): QueryRunResult =>
+  ({
+    sets,
+    elapsedMs: 1,
+    source: "Query 1",
+  }) as QueryRunResult;
+
+describe("sameResultShape", () => {
+  it("matches re-runs of the same statements regardless of row data", () => {
+    const a = run([null, { columns: ["id", "name"], values: [[1, "a"]] }]);
+    const b = run([
+      null,
+      { columns: ["id", "name"], values: [[1, "edited"], [2, "b"]] },
+    ]);
+    expect(sameResultShape(a, b)).toBe(true);
+  });
+
+  it("rejects results with different set counts", () => {
+    const a = run([{ columns: ["id"], values: [] }]);
+    const b = run([{ columns: ["id"], values: [] }, null]);
+    expect(sameResultShape(a, b)).toBe(false);
+  });
+
+  it("rejects results whose per-set null-ness differs", () => {
+    const a = run([null, { columns: ["id"], values: [] }]);
+    const b = run([{ columns: ["id"], values: [] }, null]);
+    expect(sameResultShape(a, b)).toBe(false);
+  });
+
+  it("rejects results with different column names", () => {
+    const a = run([{ columns: ["id", "name"], values: [] }]);
+    const b = run([{ columns: ["id", "email"], values: [] }]);
+    expect(sameResultShape(a, b)).toBe(false);
+  });
+
+  it("treats a null previous result as a fresh run", () => {
+    const a = run([{ columns: ["id"], values: [] }]);
+    expect(sameResultShape(a, null)).toBe(false);
+    expect(sameResultShape(null, a)).toBe(false);
+    expect(sameResultShape(null, null)).toBe(false);
+  });
+});

--- a/agent-outputs/20260609-2235-playgrounds-code-quality-audit.md
+++ b/agent-outputs/20260609-2235-playgrounds-code-quality-audit.md
@@ -1,0 +1,94 @@
+# Playgrounds Code-Quality & Workflow Audit — SQL + non-SQL
+
+**Date:** 2026-06-09
+**Scope:** Code review of both playground families (`app/_components/sql/**`, `app/_components/postgres/**`, `app/_components/duckdb/**`, `app/_components/runtime/**`, `app/_components/Playground.tsx` + shared chrome), plus a live Playwright walkthrough of the SQL IDE workflows: create database → create table → insert → edit cell (commit/undo) → alter structure (add column) → create/drop index → create view → truncate → drop table → multi-statement runs.
+**Method:** Two parallel code-review passes over the sources, findings *verified against the code before acting* (several agent-reported "high severity" findings turned out to be false positives and were dropped — see §4), then a hands-on Chromium walkthrough with console-error capture on `/playground/{sqlite,postgres,duckdb,javascript}`. All fixes below were re-verified live and against the unit + e2e suites.
+
+> **Relationship to earlier audits.** The 2026-05-31 SQL UX audit and 2026-06-06 non-SQL UX audit closed most user-facing gaps. This pass is the code-quality/correctness sweep on top: everything it found was invisible to a quick glance but shows up in the console, in invalid HTML, or in IDE-fidelity details.
+
+---
+
+## 1. What was fixed (all verified live)
+
+### 1.1 Hydration mismatch on every Postgres/DuckDB load (UX-Q1 — previously deferred) 🔴
+React #418 fired on every load of `/playground/postgres` and `/playground/duckdb` ("2 Issues"/"1 Issue" dev overlay; a discarded SSR tree in prod). Root cause (already diagnosed in the 05-31 audit): `loadTabs()` runs in `useState` initializers with non-deterministic `newTabId()`s and render-time `localStorage` reads, so server and client markup never match. **Fix:** the three SQL playground pages now load their body with `next/dynamic(…, { ssr: false })` (option (a) from the audit). There is nothing meaningful to server-render in an IDE whose state lives in localStorage/OPFS; first client paint now renders the persisted tabs directly instead of flashing defaults and re-rendering. Page `<title>`/`description` metadata stays in the (still server-rendered) layouts. Files: `app/playground/{sqlite,postgres,duckdb}/page.tsx`.
+
+### 1.2 Invalid HTML from the result grid's row context menu 🔴
+Right-clicking a result row injected Base UI's hidden focus-guard `<span>`s as direct children of `<tbody>` (a `<span> cannot be a child of <tbody>` hydration-hazard error in the console — reproduced live). Each row also mounted its own `<ContextMenu.Root>` (N menu instances per grid). **Fix:** one delegated `ContextMenu.Root` now wraps the table-wrap `<div>`; rows are plain `<tr>`s whose `onContextMenu` records `{absoluteRow, values}` as the event bubbles to the wrap-level trigger, and the trigger only forwards right-clicks that landed on a real data row (headers keep their own menu; the virtualizer's spacer rows and empty space keep the native browser menu). The focus guards now land in a `<div>` (valid), and there is exactly one menu instance per result table. Verified: `tbody` children are only `<tr>`s with the menu open; row menu + header menu + "Copy row as JSON" all still work. File: `app/_components/sql/components/ResultView.tsx`.
+
+### 1.3 Base UI "not a native button" console error 🔴
+Running any query on a table with a PK logged `Base UI: A component that acts as a button was not rendered as a native <button>…`. `Popover.Trigger` defaults to a native button; seven hover-tooltip triggers render `<span>`/`<div>` without declaring it. **Fix:** `nativeButton={false}` on all seven (PK/FK header icons and disabled-Duplicate row in `ResultView`, history timestamps in `QueryHistoryPane`, truncated names in `SchemaItem`, PK/FK icons in `ErDiagramPane` ×2).
+
+### 1.4 Every toast logged a React `flushSync` error 🔴
+Common workflows (create table, commit a cell edit, save structure, drop) each logged `flushSync was called from inside a lifecycle method` — 12 errors in one walkthrough session. Root cause: the **RC** Base UI package (`@base-ui-components/react@1.0.0-rc.0`) calls `ReactDOM.flushSync` from a layout effect in `ToastRoot`; the stable rename (`@base-ui/react@1.5.0`, already a dependency) fixed it upstream. **Fix:** migrated all 11 Toast imports (one shared toast context) to `@base-ui/react/toast`. Verified: full create/edit/drop walkthrough now logs **0** console errors; toasts render on SQL and non-SQL playgrounds. (The other Base UI components stay on the RC package — migrating them wholesale is a separate, riskier change.)
+
+### 1.5 SQLite engine worker leaked OPFS access handles 🔴
+`createSqliteEngine` spawned a dedicated Worker that was **never terminated** — the boot effect's cleanup destroyed the editor but not the engine. A leftover worker keeps the workspace's exclusive `opfs-sahpool` access handles open, so the next boot (dev StrictMode remount; client-side route change away and back) failed acquisition with a burst of `NoModificationAllowedError`s + `removeVfs() failed with no recovery strategy`. **Fix:** the worker proxy now exposes `dispose()` (rejects in-flight calls, terminates the worker — which releases its OPFS handles); the boot effect's cleanup calls it; and `createSqliteEngine` defensively terminates a still-tracked predecessor before spawning (covers a boot still in flight at cleanup time). `SqliteEngine.dispose` is optional so the in-process engine used by /learn code blocks is unaffected. Verified: repeated mounts boot cleanly with 0 OPFS errors. Files: `app/_components/runtime/sqlite.ts`, `sqlite-core.ts`, `app/_components/sql/SqlPlayground.tsx`.
+
+### 1.6 Structure editor leaked `__tmp_rebuild` names into constraints (Postgres) 🟡
+Adding a column via View/Edit Structure rebuilds the table through `books__tmp_rebuild_1`; sequences were already renamed back, but **constraints weren't** — the sidebar then showed `books__tmp_rebuild_1_pkey` under INDEXES (looks broken, compounds on every edit). Postgres's `RENAME TO` does not rename constraints. **Fix:** after the rename, `rebuildTable` now renames every constraint carrying the temp prefix (`ALTER TABLE … RENAME CONSTRAINT`, which also renames the backing index), mirroring the existing sequence handling. Verified live: after an add-column rebuild the sidebar shows `books_pkey`. File: `app/_components/runtime/postgres.ts`. (DuckDB/SQLite were checked: neither surfaces auto-named constraint objects in the sidebar, so neither leaks.)
+
+### 1.7 DuckDB result headers showed raw Arrow type notation 🟡
+The DuckDB grid's type badges leaked Arrow's `toString()`: `decimal[38e+2]`, `int64`, `utf8`, `list<int32>`, `dictionary<…>` — not SQL. A SQL IDE should show `DECIMAL(38,2)`, `BIGINT`, `VARCHAR`, `INTEGER[]`, `ENUM`. **Fix:** new pure `arrowTypeToSqlName` maps Arrow notation (ints/floats/utf8/bool/binary/decimal/date/time/timestamp±tz/interval/list→`[]` recursively/dictionary→ENUM/struct/map) with unknown notations passing through. Downstream consumers were audited first: `classifyCellEditor` (matches `[]`, `timestamp`, `date`, `blob`, … — all compatible; `list<…>` kept as fallback), `DataTypeIcon` (now also gives VARCHAR a text icon — `utf8` previously matched nothing), and the array-editor write path (keys off `Array.isArray`, not the label). Bonus: a `STRUCT<{ts:TIMESTAMP}>` column no longer mis-classifies as a datetime editor. **+7 unit tests** (`__tests__/duckdbSplit.test.ts`). Verified live: headers read `VARCHAR / BIGINT / DECIMAL(38,2)`.
+
+### 1.8 Multi-statement runs landed on "no result set returned" 🟡
+`INSERT …; SELECT …;` (the most common script shape: setup, then query) opened with **Set 1** active — the INSERT's "Statement executed successfully — no result set returned" notice — hiding the data the user just queried. **Fix:** a fresh run now lands on the **first set that returned a result table**; reloads (edit/sort/filter re-fetches — including queued re-fetches that arrive without a preserve slot, detected via the new pure `sameResultShape`) keep the user's set, clamped, exactly as before. Verified live (`CREATE; INSERT; SELECT` lands on Set 3 with rows) and against `e2e/sql-multi-result-edit.spec.ts` (the queued-re-fetch stay-on-Set-2 behavior is asserted there and passes). **+5 unit tests** (`__tests__/resultShape.test.ts`).
+
+### 1.9 Error-state timer raced a quick re-run (all 9 non-SQL playgrounds) 🟡
+After a failed run, a 3-second timer flipped status `error → ready`. Re-running within those 3 s let the stale timer fire **mid-run**, flipping the status to "ready" (run button re-enabled, spinner gone) while code was still executing. **Fix:** the timer id is tracked in a ref, cancelled at the start of every run and on unmount. File: `app/_components/Playground.tsx`.
+
+### 1.10 Stale metadata 🟢
+`/playground/postgres`'s layout description still read "Mock PostgreSQL playground shell for future browser-based query execution" — updated to describe the real PGlite playground.
+
+---
+
+## 2. Workflow walkthrough results (the requested IDE flows)
+
+All driven live on Postgres (plus SQLite/DuckDB for engine-specific checks), screenshots in the session log. Verdicts after the fixes above:
+
+| Workflow | Verdict | Notes |
+|---|---|---|
+| Create database (DB selector → New Database) | ✅ solid | Clean menu (New / Import SQL Dump / Rename + samples with descriptions); workspace-choice dialog prevents accidental overwrite |
+| Create table (Add table drawer) | ✅ solid | Default `id` PK column, type combobox, FK columns, toast + sidebar refresh; auto `books_pkey` appears |
+| Insert + multi-statement run | ✅ fixed | Now lands on the SELECT's result set (was "no result set returned") |
+| Update a cell (double-click → commit → undo) | ✅ solid | Pending-edit highlight, "Update 1 cell…" commit, post-commit Undo bar re-applies prior values (verified round-trip) |
+| Add a column (View/Edit Structure → Save) | ✅ fixed | Works; no longer leaves `__tmp_rebuild` constraint names behind |
+| Create index (INDEXES "+") | ✅ solid | Whole row toggles the checkbox, order badge, auto-name, live SQL preview, disabled-until-valid |
+| Drop index (right-click → Drop) | ✅ solid | Clear confirm dialog; sidebar refreshes |
+| Create view (VIEWS "+") | ✅ solid | Name + SELECT body + dialect-aware replace + live SQL preview, disabled-until-valid |
+| Truncate | ✅ solid | Dialog disclosed `TRUNCATE … RESTART IDENTITY CASCADE` semantics (UX-05 fix holding) |
+| Drop table | ✅ solid | Dialog disclosed `CASCADE` ("objects that depend on it … are dropped too") |
+| Add row (sidebar "+") | ✅ solid | Per-column typed inputs, "Keep open to add another row" |
+| Run / Run All / error display | ✅ solid | Split Run button, Explain, engine-badged error block with Copy + hint |
+| Row/header context menus | ✅ fixed | Single delegated menu, valid HTML; View Data / Add Row / Structure / Count / DDL / Copy / Export / Truncate / Drop all present |
+
+Console errors across the whole walkthrough after fixes: **0** (was: hydration error + Base UI button error + 12 flushSync errors + 7 OPFS errors per comparable session).
+
+---
+
+## 3. Verification
+
+- `npx tsc --noEmit` — clean.
+- `npx vitest run` — **468/468** (463 before + 12 new − 7 superseded… net: 24 files, all green; new: `resultShape.test.ts` ×5, `arrowTypeToSqlName` ×7).
+- ESLint on every touched file — 0 errors (3 pre-existing warnings in untouched regions of ResultView).
+- e2e (against the live dev server): `sql-multi-result-edit` (3 engines — exercises the active-set change), `sql-edit-undo`, `sql-create-object`, `sql-edit-ergonomics`, `sql-edit-refetch`, `sql-result-filter`, `sql-explain`, `sql-run-statement-at-cursor`, `sql-saved-queries`, `sql-column-stats`, `sql-array-editor`, `sql-enum-editor`, `sql-duckdb-param-binding`, `playground-mobile` — all green.
+- Live Playwright re-walkthrough of the §2 flows on all three SQL engines + the JavaScript playground (toast + run + files + settings) — 0 console errors.
+
+---
+
+## 4. Reviewed and rejected (verified false positives — do not "re-fix")
+
+The parallel code-review agents reported these as high severity; each was checked against the actual code and dropped:
+
+- **"Autocomplete schema effect lacks cancellation"** — it has a `cancelled` flag checked before every dispatch (`SqlPlayground.tsx:1378-1427`).
+- **"DuckDB snapshot timer races destroy()"** — `destroy()` clears the timer and `takeSnapshot` checks `destroyed` (`duckdb.ts:1676-1681`, `:792`).
+- **"Workspace-id race in runCode/syncCreatedFiles"** — workspace switches do a full `window.location.reload()` (`WorkspaceBadge.tsx:667`); the race cannot occur.
+- **"Resizer listeners leak on unmount"** — cleanup removes all three listeners; only a cosmetic `document.body.style.cursor` could persist if unmounted mid-drag (not worth touching three files).
+- **"postgres importSqlDump destroy race"** — PG workers die with the page; the import dialog blocks conflicting actions; no user-reachable path.
+
+## 5. Known-good observations & remaining (deliberately untouched)
+
+- The structure editor's **rebuild strategy drops user-created indexes/triggers** on the rebuilt table (PG `DROP TABLE CASCADE` + recreate). Pre-existing product behavior, bigger than this pass; flagged for a future slice (recreate user indexes after rebuild, or switch to native `ALTER` for additive changes).
+- `UX-08` (multi-statement error attribution / partial results) remains deferred pending the PG transaction-semantics product decision documented in the 05-31 audit.
+- The remaining Base UI components still import from the RC package; a wholesale migration to `@base-ui/react` should be its own PR with visual regression checks.
+- Tab close affordances are `<span role="button" tabIndex={-1}>` inside the tab `<button>` — deliberate (nested interactive elements are invalid HTML); keyboard users close via the context menu, mirroring VS Code.

--- a/agent-outputs/20260610-0040-code-blocks-challenge-cards-mcq-audit.md
+++ b/agent-outputs/20260610-0040-code-blocks-challenge-cards-mcq-audit.md
@@ -1,0 +1,45 @@
+# Code Blocks, Challenge Cards & MCQ — Code-Quality & UX Audit
+
+**Date:** 2026-06-10
+**Scope:** The MDX lesson components: `CodeBlock` / `ChallengeCard` (9 WASM language runtimes), `SqlCodeBlock` / `SqlChallengeCard` (SQLite / DuckDB / PostgreSQL in-browser engines, incl. the shared `useSqlTableViewer` hook), and `MultipleChoiceQuestion` (+ `parseQuestion`). Companion to the 2026-06-09 playgrounds audit on the same branch/PR.
+**Method:** Two parallel code-review passes verified line-by-line against the source (several reported findings were rejected — §3), plus a live Playwright walkthrough on the kitchen-sink demo pages (`/learn/code-blocks-javascript`, `/learn/challenge-cards-javascript`, `/learn/sql-code-blocks-sqlite`, `/learn/sql-challenge-cards-sqlite`, `/learn/multiple-choice`) at desktop **1600×1000** and mobile **390×844** (touch emulation), with console-error capture and horizontal-overflow probes at every step.
+
+---
+
+## 1. UX walkthrough verdict
+
+Both viewports are in strong shape — no blocking findings:
+
+| Surface | Desktop | Mobile (390px) |
+|---|---|---|
+| CodeBlock run/output/Reset/Format/Copy | ✅ polished (badge + ready dot, kbd hint, timing) | ✅ Run collapses to icon, 0 overflow |
+| ChallengeCard submit/tests/solution modal | ✅ split-button, per-test verdicts, pass/fail banner, solution modal with Copy + Load-into-editor | ✅ fits, split-button collapses, 0 overflow |
+| SqlCodeBlock tables viewer + results | ✅ tabs above editor (documented design), seeded-table browser, timing | ✅ tables scroll within card, 0 overflow |
+| SqlChallengeCard submit/tests | ✅ result tab + per-test details with expected/got | ✅ 0 overflow |
+| MultipleChoice | ✅ select-to-submit (documented design), per-choice explanations | ✅ 0 overflow |
+
+Console errors across every page and interaction, both viewports: **0**.
+
+## 2. What was fixed
+
+1. **Stale-run races in all four block components (high).** `ChallengeCard.run()/check()`, `SqlChallengeCard.run()/check()`, and `SqlCodeBlock.run()` updated state after `await` without checking whether a newer run superseded them. The Run/Submit buttons are disabled while busy, but the **⌘/Ctrl+Enter keymap is not gated** — two quick presses start two concurrent executions whose final `setOutputs`/`setTestResults`/`setStatus` interleave, so the slower (older) run could overwrite the newer run's results. Fixed by hoisting the run-sequence capture (`++runSeqRef.current`) from the internal `execute`/`executeSql` helpers into the callers (the helpers now take `mySeq` as a parameter) and guarding every post-await state update — the exact pattern `CodeBlock.run()` already used. The `finally` spinner cleanup is sequence-guarded too, so a superseded run can't re-enable Submit mid-flight of its successor; `reset()` now clears `activeAction` itself since a superseded run deliberately skips that cleanup.
+2. **Table-viewer refresh race (SQL blocks, medium).** `useSqlTableViewer.refresh()` had no in-flight guard: Reset destroys the engine and refreshes against the fresh one, but a slower refresh already in flight (e.g. the mount-time boot on DuckDB, whose WASM download widens the window) could land last and show the pre-reset rows. Added a refresh sequence ref checked before `setEntries`; `clear()` (called by Reset) also invalidates in-flight refreshes. Covers both `SqlChallengeCard` and `SqlCodeBlock` (shared hook).
+3. **`valueEquals('' , 0)` was true (SQL test framework, medium).** The numeric-string coercion used `Number(b) === a`, and `Number("")` is `0` — an empty-string cell passed a test expecting `0`. Blank/whitespace-only strings are now excluded from numeric coercion. (The deliberate `"42" == 42` looseness across engines is kept and documented.)
+4. **`loadLanguage` chunk-load rejections (low).** A failed dynamic `import()` of a CodeMirror language package (flaky network on a deployed site) rejected through five un-caught call sites in CodeBlock/ChallengeCard as unhandled promise rejections. The loader now catches internally and resolves `null` (= plain-text rendering), covering every caller at once.
+5. **MCQ feedback order + screen-reader announcement (UX/a11y).** The card rendered *Try again* **above** the verdict banner and explanation — action before feedback. Reordered to choices → verdict banner → explanation → *Try again* (see → understand → act), and the banner now carries `role="status"` so the verdict is announced to assistive tech when it appears. Verified live on desktop + mobile.
+6. **`cmThemeNameRef` sync effect missing its dependency array (lint-level).** Ran on every render; now `[cmThemeName]`.
+
+## 3. Reviewed and rejected (verified against the code — do not "re-fix")
+
+- **"SqlCodeBlock Reset leaks the engine worker on rapid clicks"** — `reset()` swaps the promise ref and queues `oldEngine.then(e => e.destroy())`, which also covers boots still in flight; nothing leaks.
+- **"`valueEquals` makes `0` equal `false`"** — booleans never enter the numeric-coercion branches; `valueEquals(0, false)` is `false`. (The real gap was the empty-string case — fixed, §2.3.)
+- **"`fetchTablePage` interpolates unvalidated LIMIT/OFFSET"** — `pageSize` is `Math.max(1, Math.floor(...))` at the hook boundary and `offset` is an array length; both are always safe integers.
+- **"`expectedColumnsInclude` should be case-insensitive"** — deliberate: expected values are authored against actual engine output, the failure message shows expected vs got verbatim, and loosening comparison semantics could silently change the strictness of existing course tests.
+- **"Cap `VirtualizedResultTable` rows"** — rows are already materialized by `engine.exec()` before rendering and the DOM is virtualized; a display cap wouldn't reduce peak memory.
+- **O(n²) order-independent row comparison** — documented teaching-scale trade-off; result sets here are seeded small.
+
+## 4. Verification
+
+- `tsc --noEmit` clean; ESLint clean on every touched file; `vitest run` **468/468**.
+- e2e against the live dev server: `code-blocks-run` (every block on the 9 language pages), `sql-code-blocks-run` (every SQL block × 3 dialects), `csv-examples` (4 external-network tests auto-skip), and the `challenge-solutions` sweep for JavaScript, TypeScript, SQLite, DuckDB, PostgreSQL — **all passing** through the modified run/check paths.
+- Live re-verification: rapid double ⌘/Ctrl+Enter on a JS challenge and a SQL block — no stuck spinner, single coherent result; MCQ answer flow on desktop + mobile with `role="status"` present and 0 overflow.

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -494,7 +494,7 @@ export default function ChallengeCard({
   const cmThemeNameRef = useRef(cmThemeName);
   useEffect(() => {
     cmThemeNameRef.current = cmThemeName;
-  });
+  }, [cmThemeName]);
 
   const canCheck = canRunTests(adapter.id, tests);
 
@@ -841,8 +841,12 @@ export default function ChallengeCard({
     async (
       entrySource: string,
       filesSnapshot: Map<string, string>,
+      // The caller's run sequence (from `++runSeqRef.current`). Owning
+      // the increment in the caller lets it guard its own post-await
+      // state updates too — a newer run/check/reset supersedes both
+      // this execution's streaming updates and the caller's final ones.
+      mySeq: number,
     ): Promise<{ cells: OutputCell[]; elapsedMs: number }> => {
-      const mySeq = ++runSeqRef.current;
       setOutputs([]);
       setStatus("loading");
       setStatusMessage("Initializing runtime…");
@@ -970,18 +974,21 @@ export default function ChallengeCard({
 
   // ─── Run (no tests) ────────────────────────────────────────────────
   const run = useCallback(async () => {
+    const mySeq = ++runSeqRef.current;
     setActiveAction("run");
     const snapshot = snapshotAllFiles();
     const entryCode = snapshot.get(resolvedEntryFilename) ?? "";
     const combined = effectiveSourceFor(resolvedEntryFilename, entryCode);
     try {
-      const { cells, elapsedMs } = await execute(combined, snapshot);
+      const { cells, elapsedMs } = await execute(combined, snapshot, mySeq);
+      if (runSeqRef.current !== mySeq) return;
       setOutputs(cells);
       setElapsed(formatElapsed(elapsedMs));
       const erred = cells.some((c) => c.type === "stderr");
       setStatus(erred ? "error" : "ready");
       setStatusMessage(erred ? "Errored" : "Done");
     } catch (err) {
+      if (runSeqRef.current !== mySeq) return;
       const message = err instanceof Error ? err.message : String(err);
       setOutputs([
         {
@@ -994,13 +1001,17 @@ export default function ChallengeCard({
       setStatus("error");
       setStatusMessage(message);
     } finally {
-      setActiveAction(null);
+      // Only the latest run owns the busy spinner — a superseded run
+      // clearing it would re-enable Run/Submit mid-flight for its
+      // successor.
+      if (runSeqRef.current === mySeq) setActiveAction(null);
     }
   }, [execute, resolvedEntryFilename, snapshotAllFiles, effectiveSourceFor]);
 
   // ─── Check Answer (run + tests) ─────────────────────────────────────
   const check = useCallback(async () => {
     if (!canCheck) return;
+    const mySeq = ++runSeqRef.current;
     setActiveAction("submit");
     const snapshot = snapshotAllFiles();
     const entryCode = snapshot.get(resolvedEntryFilename) ?? "";
@@ -1025,7 +1036,8 @@ export default function ChallengeCard({
     setTestListOpen(true);
 
     try {
-      const { cells, elapsedMs } = await execute(combined, snapshot);
+      const { cells, elapsedMs } = await execute(combined, snapshot, mySeq);
+      if (runSeqRef.current !== mySeq) return;
 
       // Split stdout cells into "user-visible" + parsed harness results.
       // Non-stdout cells (html / image / plot / stderr) pass through
@@ -1091,6 +1103,7 @@ export default function ChallengeCard({
         allPass ? "All tests passed" : `${passed}/${displayed.length} passed`,
       );
     } catch (err) {
+      if (runSeqRef.current !== mySeq) return;
       const message = err instanceof Error ? err.message : String(err);
       setOutputs([
         { id: 1, type: "stderr", content: message, elapsed: "" },
@@ -1106,7 +1119,8 @@ export default function ChallengeCard({
       );
       setBannerState("fail");
     } finally {
-      setActiveAction(null);
+      // Only the latest submission owns the busy spinner (see `run`).
+      if (runSeqRef.current === mySeq) setActiveAction(null);
     }
   }, [
     adapter.id,
@@ -1191,6 +1205,9 @@ export default function ChallengeCard({
     setStatusMessage("");
     setTestResults([]);
     setBannerState(null);
+    // A run superseded by this reset skips its own spinner cleanup
+    // (its `finally` is sequence-guarded), so clear it here.
+    setActiveAction(null);
     toasts.show("Reset to starter code.");
   }, [persistedKeyForFile, toasts, workspaceFiles]);
 

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -11,7 +11,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { ChevronDown, ChevronUp, File, Lock, Play, RotateCcw } from "lucide-react";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import {
   LANGUAGE_ICONS,
   LANGUAGE_ICON_SIZE_FACTOR,

--- a/app/_components/ErDiagramPane.tsx
+++ b/app/_components/ErDiagramPane.tsx
@@ -156,6 +156,7 @@ function ErTableNode({ data }: NodeProps) {
                     openOnHover
                     delay={120}
                     closeDelay={80}
+                    nativeButton={false}
                     render={(triggerProps) => (
                       <span {...triggerProps} className="er-col-icon-trigger">
                         <MdOutlineKey
@@ -181,6 +182,7 @@ function ErTableNode({ data }: NodeProps) {
                     openOnHover
                     delay={120}
                     closeDelay={80}
+                    nativeButton={false}
                     render={(triggerProps) => (
                       <span {...triggerProps} className="er-col-icon-trigger">
                         <IoLink

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -64,7 +64,7 @@ import Link from "next/link";
 import { Menu } from "@base-ui-components/react/menu";
 import { Popover } from "@base-ui-components/react/popover";
 import { AlertDialog } from "@base-ui-components/react/alert-dialog";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import { Select } from "@base-ui-components/react/select";
 import { Drawer } from "@base-ui/react/drawer";
 import {
@@ -806,6 +806,19 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   // The auto-scroll effect uses it to scroll that cell into view rather
   // than jumping all the way to the end of the scroll container.
   const newRunFirstIdRef = useRef<number | null>(null);
+
+  // Pending error→ready status reset. Tracked so a new run can cancel it —
+  // otherwise failing a run and re-running within 3s would let the stale
+  // timer flip the status to "ready" while the new run is still executing.
+  const errorResetTimerRef = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (errorResetTimerRef.current !== null) {
+        window.clearTimeout(errorResetTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const scrollToLatestOutput = useCallback(() => {
     const el = outputBodyRef.current;
@@ -1670,6 +1683,10 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     }
     if (!code.trim()) return;
 
+    if (errorResetTimerRef.current !== null) {
+      window.clearTimeout(errorResetTimerRef.current);
+      errorResetTimerRef.current = null;
+    }
     setStatusState("running");
 
     if (clearBeforeRun) {
@@ -1806,7 +1823,8 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
         },
       ]);
       setStatusState("error");
-      window.setTimeout(() => {
+      errorResetTimerRef.current = window.setTimeout(() => {
+        errorResetTimerRef.current = null;
         setStatusState("ready");
       }, 3000);
     } finally {

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -309,12 +309,13 @@ function valueEquals(a: unknown, b: unknown): boolean {
   // return numeric-typed columns as JS numbers while sqlite-wasm
   // returns them as strings for INTEGER columns wider than 2^53. For a
   // learner-facing test framework, treating "42" and 42 as equal is
-  // the principle of least surprise.
+  // the principle of least surprise. Blank strings are excluded —
+  // Number("") is 0, which would make '' compare equal to 0.
   if (typeof a === "number" && typeof b === "string") {
-    return Number(b) === a;
+    return b.trim() !== "" && Number(b) === a;
   }
   if (typeof a === "string" && typeof b === "number") {
-    return Number(a) === b;
+    return a.trim() !== "" && Number(a) === b;
   }
   if (typeof a === "bigint" || typeof b === "bigint") {
     return String(a) === String(b);
@@ -682,10 +683,16 @@ export function useSqlTableViewer({
   // while one is already in flight (the scroll handler can fire many
   // times before React commits the `loadingMore` flag).
   const inFlightRef = useRef<Set<number>>(new Set());
+  // Invalidates in-flight refreshes: a Reset destroys the engine and
+  // immediately starts a refresh against the fresh one — without this,
+  // a slower refresh that was already in flight (e.g. the mount-time
+  // boot on DuckDB) could land last and show the pre-reset rows.
+  const refreshSeqRef = useRef(0);
 
   const refresh = useCallback(
     async (engine: SqlEngineLike) => {
       if (!enabled) return;
+      const mySeq = ++refreshSeqRef.current;
       const defaultSchema = defaultSchemaFor(dialect);
       let plan: { schema: string | null; table: string }[];
       if (Array.isArray(tables)) {
@@ -720,6 +727,7 @@ export function useSqlTableViewer({
           };
         }),
       );
+      if (refreshSeqRef.current !== mySeq) return;
       setEntries(next);
       setActiveIdx((idx) => (next.length === 0 ? 0 : Math.min(idx, next.length - 1)));
       setInitializing(false);
@@ -778,8 +786,10 @@ export function useSqlTableViewer({
   );
 
   /** Clear all entries and re-arm the loading skeleton — used by Reset,
-   *  which destroys and re-seeds the engine. */
+   *  which destroys and re-seeds the engine. Also invalidates any
+   *  refresh still in flight so it can't resurrect the cleared rows. */
   const clear = useCallback(() => {
+    refreshSeqRef.current++;
     inFlightRef.current.clear();
     setEntries([]);
     setInitializing(enabled);
@@ -1139,12 +1149,16 @@ export default function SqlChallengeCard({
   const executeSql = useCallback(
     async (
       sql: string,
+      // The caller's run sequence (from `++runSeqRef.current`). Owning
+      // the increment in the caller lets it guard its own post-await
+      // state updates too — a newer run/check/reset supersedes both
+      // this execution's streaming updates and the caller's final ones.
+      mySeq: number,
     ): Promise<{
       results: SqlResult[];
       last: SqlResult | null;
       elapsedMs: number;
     }> => {
-      const mySeq = ++runSeqRef.current;
       setStatus("loading");
       setStatusMessage("Initializing database…");
       const engine = await ensureEngine();
@@ -1188,6 +1202,7 @@ export default function SqlChallengeCard({
 
   // ─── Run (no tests) ─────────────────────────────────────────────────
   const run = useCallback(async () => {
+    const mySeq = ++runSeqRef.current;
     setResultRunSeq((s) => s + 1);
     setActiveAction("run");
     const userSql = editorRef.current?.state.doc.toString() ?? "";
@@ -1196,7 +1211,8 @@ export default function SqlChallengeCard({
     setResultError("");
     setResultMessage("");
     try {
-      const { results, last, elapsedMs } = await executeSql(userSql);
+      const { results, last, elapsedMs } = await executeSql(userSql, mySeq);
+      if (runSeqRef.current !== mySeq) return;
       setElapsed(formatElapsed(elapsedMs));
       setResultSet(last);
       if (!last || last.columns.length === 0) {
@@ -1220,19 +1236,23 @@ export default function SqlChallengeCard({
         }
       }
     } catch (err) {
+      if (runSeqRef.current !== mySeq) return;
       const message = err instanceof Error ? err.message : String(err);
       setResultSet(null);
       setResultError(message);
       setStatus("error");
       setStatusMessage(message);
     } finally {
-      setActiveAction(null);
+      // Only the latest run owns the busy spinner — a superseded run
+      // clearing it would re-enable Submit mid-flight for its successor.
+      if (runSeqRef.current === mySeq) setActiveAction(null);
     }
   }, [executeSql, ensureEngine, refreshTableViewer, tableViewerEnabled]);
 
   // ─── Check Answer (run + tests) ─────────────────────────────────────
   const check = useCallback(async () => {
     if (!canCheck) return;
+    const mySeq = ++runSeqRef.current;
     setResultRunSeq((s) => s + 1);
     setActiveAction("submit");
     try {
@@ -1256,6 +1276,7 @@ export default function SqlChallengeCard({
     try {
       engine = await ensureEngine();
     } catch (err) {
+      if (runSeqRef.current !== mySeq) return;
       const message = err instanceof Error ? err.message : String(err);
       setStatus("error");
       setStatusMessage(message);
@@ -1270,12 +1291,14 @@ export default function SqlChallengeCard({
       setBannerState("fail");
       return;
     }
+    if (runSeqRef.current !== mySeq) return;
 
     // Run the learner's SQL first, capturing the final result set.
     let last: SqlResult | null = null;
     let elapsedMs = 0;
     try {
-      const out = await executeSql(userSql);
+      const out = await executeSql(userSql, mySeq);
+      if (runSeqRef.current !== mySeq) return;
       last = out.last;
       elapsedMs = out.elapsedMs;
       setElapsed(formatElapsed(elapsedMs));
@@ -1290,6 +1313,7 @@ export default function SqlChallengeCard({
         setResultMessage("");
       }
     } catch (err) {
+      if (runSeqRef.current !== mySeq) return;
       const message = err instanceof Error ? err.message : String(err);
       setResultError(message);
       setStatus("error");
@@ -1336,6 +1360,7 @@ export default function SqlChallengeCard({
           if (r.columns.length > 0) solutionResult = r;
         }
       } catch (err) {
+        if (runSeqRef.current !== mySeq) return;
         const msg = err instanceof Error ? err.message : String(err);
         setTestResults(
           tests.map((t) => ({
@@ -1351,6 +1376,7 @@ export default function SqlChallengeCard({
         setBannerState("fail");
         return;
       }
+      if (runSeqRef.current !== mySeq) return;
     }
 
     // Evaluate every test against the captured state.
@@ -1380,6 +1406,7 @@ export default function SqlChallengeCard({
         });
       }
     }
+    if (runSeqRef.current !== mySeq) return;
     setTestResults(displayed);
     const passed = displayed.filter((d) => d.state === "pass").length;
     const allPass = passed === displayed.length && displayed.length > 0;
@@ -1396,7 +1423,8 @@ export default function SqlChallengeCard({
       }
     }
     } finally {
-      setActiveAction(null);
+      // Only the latest submission owns the busy spinner (see `run`).
+      if (runSeqRef.current === mySeq) setActiveAction(null);
     }
   }, [canCheck, ensureEngine, executeSql, refreshTableViewer, solutionSql, tableViewerEnabled, tests]);
 
@@ -1510,6 +1538,9 @@ export default function SqlChallengeCard({
     setStatusMessage("");
     setTestResults([]);
     setBannerState(null);
+    // A run superseded by this reset skips its own spinner cleanup
+    // (its `finally` is sequence-guarded), so clear it here.
+    setActiveAction(null);
     clearTableViewer();
     if (tableViewerEnabled) {
       void ensureEngine()

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -335,12 +335,16 @@ export default function SqlCodeBlock({
   const executeSql = useCallback(
     async (
       sql: string,
+      // The caller's run sequence (from `++runSeqRef.current`). Owning
+      // the increment in the caller lets it guard its own post-await
+      // state updates too — a newer run/reset supersedes both this
+      // execution's status updates and the caller's final ones.
+      mySeq: number,
     ): Promise<{
       results: SqlResult[];
       last: SqlResult | null;
       elapsedMs: number;
     }> => {
-      const mySeq = ++runSeqRef.current;
       setStatus("loading");
       setStatusMessage("Initializing database…");
       const engine = await ensureEngine();
@@ -378,12 +382,14 @@ export default function SqlCodeBlock({
 
   // ─── Run ────────────────────────────────────────────────────────────
   const run = useCallback(async () => {
+    const mySeq = ++runSeqRef.current;
     setResultRunSeq((s) => s + 1);
     const userSql = editorRef.current?.state.doc.toString() ?? "";
     setResultError("");
     setResultMessage("");
     try {
-      const { results, last, elapsedMs } = await executeSql(userSql);
+      const { results, last, elapsedMs } = await executeSql(userSql, mySeq);
+      if (runSeqRef.current !== mySeq) return;
       setElapsed(formatElapsed(elapsedMs));
       setResultSet(last);
       if (!last || last.columns.length === 0) {
@@ -407,6 +413,7 @@ export default function SqlCodeBlock({
         }
       }
     } catch (err) {
+      if (runSeqRef.current !== mySeq) return;
       const message = err instanceof Error ? err.message : String(err);
       setResultSet(null);
       setResultError(message);

--- a/app/_components/cmExtensions.ts
+++ b/app/_components/cmExtensions.ts
@@ -34,8 +34,18 @@ import {
 //
 // Returns `null` for unknown modes — callers should treat that as
 // "render plain text", which is how v5 behaved when a mode wasn't loaded.
+// A failed chunk load (flaky network on a deployed site) resolves `null`
+// too, so callers never see an unhandled rejection for a cosmetic feature.
 
 export async function loadLanguage(mode: string): Promise<Extension | null> {
+  try {
+    return await loadLanguageModule(mode);
+  } catch {
+    return null;
+  }
+}
+
+async function loadLanguageModule(mode: string): Promise<Extension | null> {
   switch (mode) {
     case "python": {
       const { python } = await import("@codemirror/lang-python");

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -31,7 +31,7 @@ import { Menu } from "@base-ui-components/react/menu";
 import { Popover } from "@base-ui-components/react/popover";
 import { Select } from "@base-ui-components/react/select";
 import { Switch } from "@base-ui-components/react/switch";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import {
   ArrowDownToLine,
   ArrowUpFromLine,

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -204,17 +204,13 @@ export default function MultipleChoiceQuestion({
         })}
       </div>
 
-      {submitted ? (
-        <div className={styles.actionBar}>
-          <button type="button" className={styles.retryBtn} onClick={onRetry}>
-            <RotateCcw size={13} aria-hidden />
-            Try again
-          </button>
-        </div>
-      ) : null}
-
+      {/* Feedback first, action last: the verdict banner and explanation
+          read before the "Try again" affordance, mirroring the usual
+          quiz flow (see what happened → understand why → act).
+          `role="status"` announces the verdict to screen readers when
+          it appears. */}
       {result ? (
-        <div className={styles.banner} data-state={result}>
+        <div className={styles.banner} data-state={result} role="status">
           <span className={styles.bannerIcon}>
             {result === "pass" ? (
               <Check size={14} strokeWidth={3} aria-hidden />
@@ -239,6 +235,15 @@ export default function MultipleChoiceQuestion({
           <div className={styles.overallBody}>
             <MarkdownInline source={parsed.explanation} />
           </div>
+        </div>
+      ) : null}
+
+      {submitted ? (
+        <div className={styles.actionBar}>
+          <button type="button" className={styles.retryBtn} onClick={onRetry}>
+            <RotateCcw size={13} aria-hidden />
+            Try again
+          </button>
         </div>
       ) : null}
     </section>

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -31,7 +31,7 @@ import { Menu } from "@base-ui-components/react/menu";
 import { Popover } from "@base-ui-components/react/popover";
 import { Select } from "@base-ui-components/react/select";
 import { Switch } from "@base-ui-components/react/switch";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import {
   ArrowDownToLine,
   ArrowUpFromLine,

--- a/app/_components/runtime/duckdb.ts
+++ b/app/_components/runtime/duckdb.ts
@@ -302,6 +302,61 @@ export function parseDuckDbEnumValues(
   return values.length > 0 ? values : null;
 }
 
+/** Map an Arrow result-field type string to the DuckDB SQL type name a SQL
+ *  IDE would show. Without this, the raw Arrow `toString()` notation leaks
+ *  into the result header: `Decimal[38e+2]` instead of `DECIMAL(38,2)`,
+ *  `Int64` instead of `BIGINT`, `Utf8` instead of `VARCHAR`, `Dictionary<…>`
+ *  instead of `ENUM`. Unknown notations pass through unchanged so new Arrow
+ *  types degrade to their raw name rather than an empty label. */
+export function arrowTypeToSqlName(arrowType: string): string {
+  const t = arrowType.trim();
+  const lower = t.toLowerCase();
+  const scalar: Record<string, string> = {
+    int8: "TINYINT",
+    int16: "SMALLINT",
+    int32: "INTEGER",
+    int64: "BIGINT",
+    uint8: "UTINYINT",
+    uint16: "USMALLINT",
+    uint32: "UINTEGER",
+    uint64: "UBIGINT",
+    float16: "FLOAT",
+    float32: "FLOAT",
+    float64: "DOUBLE",
+    utf8: "VARCHAR",
+    largeutf8: "VARCHAR",
+    bool: "BOOLEAN",
+    binary: "BLOB",
+    largebinary: "BLOB",
+  };
+  if (scalar[lower]) return scalar[lower];
+  // List<Int32> / FixedSizeList[4]<Int32> → INTEGER[]
+  let m =
+    lower.match(/^(?:large)?list<(.+)>$/) ??
+    lower.match(/^fixedsizelist\[\d+\]<(.+)>$/);
+  if (m) return `${arrowTypeToSqlName(m[1])}[]`;
+  // Decimal[38e+2] → DECIMAL(38,2); the exponent part is the scale.
+  m = lower.match(/^decimal\[(\d+)e([+-]?\d+)\]/);
+  if (m) return `DECIMAL(${m[1]},${Number(m[2])})`;
+  // Timestamp<MICROSECOND> → TIMESTAMP; a trailing ", <tz>" marks TIMESTAMPTZ.
+  if (lower.startsWith("timestamp")) {
+    return lower.includes(",")
+      ? "TIMESTAMP WITH TIME ZONE"
+      : "TIMESTAMP";
+  }
+  if (lower.startsWith("date")) return "DATE";
+  if (lower.startsWith("time")) return "TIME";
+  if (lower.startsWith("interval") || lower.startsWith("duration")) {
+    return "INTERVAL";
+  }
+  if (lower.startsWith("fixedsizebinary")) return "BLOB";
+  // DuckDB ENUM columns arrive as an Arrow dictionary of their labels.
+  if (lower.startsWith("dictionary<")) return "ENUM";
+  if (lower.startsWith("struct")) return "STRUCT";
+  if (lower.startsWith("map<")) return "MAP";
+  return t;
+}
+
 function arrowToQueryExecResult(
   table: DuckDbArrowTable,
 ): (QueryExecResult & { columnTypes?: string[] }) | null {
@@ -310,7 +365,7 @@ function arrowToQueryExecResult(
   const columns = fields.map((f) => f.name);
   const columnTypes = fields.map((f) => {
     try {
-      return String(f.type);
+      return arrowTypeToSqlName(String(f.type));
     } catch {
       return "";
     }

--- a/app/_components/runtime/postgres.ts
+++ b/app/_components/runtime/postgres.ts
@@ -771,6 +771,25 @@ export async function createPostgresEngine(
             `ALTER SEQUENCE ${schemaPrefix}${quoteIdent(oldSeq)} RENAME TO ${quoteIdent(newSeq)}`,
           );
         }
+        // Like the sequences above, constraints auto-named by CREATE TABLE
+        // (`<tmpName>_pkey`, `<tmpName>_<col>_key`, `<tmpName>_<col>_fkey`,
+        // …) keep the temp prefix after RENAME TO — which would surface in
+        // the sidebar as e.g. `books__tmp_rebuild_1_pkey`. Rename every
+        // constraint that carries the temp prefix; renaming a constraint
+        // also renames its backing index.
+        const likePattern = `${tmpName.replace(/([%_\\])/g, "\\$1")}%`;
+        const tmpConstraints = await db.query<{ conname: string }>(
+          `SELECT conname FROM pg_constraint
+           WHERE conrelid = $1::regclass AND conname LIKE $2`,
+          [`${schemaPrefix}${quoteIdent(finalName)}`, likePattern],
+        );
+        for (const { conname } of tmpConstraints.rows) {
+          const renamed = conname.replace(tmpName, finalName);
+          if (renamed === conname) continue;
+          await db.exec(
+            `ALTER TABLE ${schemaPrefix}${quoteIdent(finalName)} RENAME CONSTRAINT ${quoteIdent(conname)} TO ${quoteIdent(renamed)}`,
+          );
+        }
         await db.exec("COMMIT");
       } catch (err) {
         try {

--- a/app/_components/runtime/sqlite-core.ts
+++ b/app/_components/runtime/sqlite-core.ts
@@ -141,6 +141,11 @@ export interface TableRebuildSpec {
 }
 
 export interface SqliteEngine {
+  /** Release the engine's resources. Implemented by the worker-backed
+   *  engine (terminates the worker, which closes its OPFS access handles);
+   *  the in-process engine used by /learn code blocks has no out-of-band
+   *  resources, so the method is optional. */
+  dispose?: () => void;
   /** Replace the active in-memory database with a fresh build of the
    *  given sample. Returns the active sample for convenience. */
   loadSampleDatabase: (id: string) => Promise<SqliteSampleMetadata>;
@@ -626,8 +631,10 @@ export async function createSqliteEngineInProcess(
   initialSampleId: string,
   openOptions: SqliteEngineOpenOptions = {},
 ): Promise<{
-  [K in keyof SqliteEngine]: Awaited<ReturnType<SqliteEngine[K]>> extends infer R
-    ? (...args: Parameters<SqliteEngine[K]>) => R
+  [K in keyof SqliteEngine]: Awaited<
+    ReturnType<NonNullable<SqliteEngine[K]>>
+  > extends infer R
+    ? (...args: Parameters<NonNullable<SqliteEngine[K]>>) => R
     : never;
 }> {
   const sqlite3 = await loadSqlite3();

--- a/app/_components/runtime/sqlite.ts
+++ b/app/_components/runtime/sqlite.ts
@@ -31,10 +31,25 @@ type SqliteWorkerResponse =
   | { id: number; ok: true; result: unknown }
   | { id: number; ok: false; error: string };
 
+// The playground owns at most one worker-backed engine at a time. Track it
+// module-wide so a new boot can terminate a predecessor that was never
+// disposed (or whose boot is still in flight): a leftover worker keeps the
+// workspace's exclusive opfs-sahpool access handles open, which makes the
+// next engine's OPFS acquisition fail with NoModificationAllowedError —
+// seen on dev StrictMode remounts and client-side route changes.
+let activeWorker: Worker | null = null;
+let rejectActivePending: ((reason: Error) => void) | null = null;
+
 export async function createSqliteEngine(
   initialSampleId: string,
   workspaceId?: string | null,
 ): Promise<SqliteEngine> {
+  if (activeWorker) {
+    rejectActivePending?.(new Error("SQLite engine disposed"));
+    activeWorker.terminate();
+    activeWorker = null;
+    rejectActivePending = null;
+  }
   const worker = new Worker(new URL("./sqlite-worker.ts", import.meta.url));
   let nextId = 0;
   const pending = new Map<
@@ -44,6 +59,11 @@ export async function createSqliteEngine(
       reject: (reason?: unknown) => void;
     }
   >();
+
+  const rejectAllPending = (error: Error) => {
+    for (const callbacks of pending.values()) callbacks.reject(error);
+    pending.clear();
+  };
 
   worker.addEventListener("message", (ev: MessageEvent<SqliteWorkerResponse>) => {
     const msg = ev.data;
@@ -55,10 +75,11 @@ export async function createSqliteEngine(
   });
 
   worker.addEventListener("error", (ev) => {
-    const error = new Error(ev.message || "SQLite worker failed");
-    for (const callbacks of pending.values()) callbacks.reject(error);
-    pending.clear();
+    rejectAllPending(new Error(ev.message || "SQLite worker failed"));
   });
+
+  activeWorker = worker;
+  rejectActivePending = rejectAllPending;
 
   function call(method: SqliteEngineMethod, args: unknown[] = []): Promise<unknown> {
     const id = ++nextId;
@@ -75,6 +96,14 @@ export async function createSqliteEngine(
   await call("loadSampleDatabase", [initialSampleId, workspaceId ?? null]);
 
   return {
+    dispose: () => {
+      rejectAllPending(new Error("SQLite engine disposed"));
+      worker.terminate();
+      if (activeWorker === worker) {
+        activeWorker = null;
+        rejectActivePending = null;
+      }
+    },
     loadSampleDatabase: (id) => call("loadSampleDatabase", [id]) as Promise<SqliteSampleMetadata>,
     exec: (sql) => call("exec", [sql]) as Promise<QueryExecResult[]>,
     execAll: (sql) => call("execAll", [sql]) as Promise<(QueryExecResultWithTypes | null)[]>,

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -40,7 +40,7 @@ import { Popover } from "@base-ui-components/react/popover";
 import { AlertDialog } from "@base-ui-components/react/alert-dialog";
 import { Dialog } from "@base-ui-components/react/dialog";
 import { Tabs } from "@base-ui-components/react/tabs";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   ArrowDownToLine,
@@ -1344,6 +1344,14 @@ function SqlPlaygroundInner() {
     })();
     return () => {
       cancelled = true;
+      // Terminate the engine worker so its OPFS access handles are
+      // released — a zombie worker would otherwise keep the workspace's
+      // opfs-sahpool locked across StrictMode remounts and client-side
+      // route changes, failing the next boot's OPFS acquisition. A boot
+      // still in flight here is handled by createSqliteEngine itself,
+      // which terminates the previous worker before spawning a new one.
+      engineRef.current?.dispose?.();
+      engineRef.current = null;
       editorRef.current?.destroy();
       editorRef.current = null;
       themeCompRef.current = null;

--- a/app/_components/sql/components/QueryHistoryPane.tsx
+++ b/app/_components/sql/components/QueryHistoryPane.tsx
@@ -195,6 +195,7 @@ function HistoryEntryRow({
               openOnHover
               delay={200}
               closeDelay={80}
+              nativeButton={false}
               render={(triggerProps) => (
                 <span
                   {...triggerProps}

--- a/app/_components/sql/components/ResultView.tsx
+++ b/app/_components/sql/components/ResultView.tsx
@@ -18,7 +18,7 @@ import { ContextMenu } from "@base-ui-components/react/context-menu";
 import { Menu } from "@base-ui-components/react/menu";
 import { Select } from "@base-ui-components/react/select";
 import { Checkbox } from "@base-ui-components/react/checkbox";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import { ToggleGroup } from "@base-ui/react/toggle-group";
 import { Toggle } from "@base-ui/react/toggle";
 import {
@@ -438,6 +438,28 @@ export function sqlValueEqual(a: unknown, b: unknown): boolean {
   return false;
 }
 
+/** True when two results have the same statement *shape* — same set count,
+ *  same per-set has-result-ness and column names — i.e. they look like
+ *  re-runs of the same statements (an edit/sort/filter re-fetch, or the user
+ *  re-running the same tab) rather than a different query. Cheaper than
+ *  `queryResultsIdentical`, which also compares every cell. */
+export function sameResultShape(
+  a: QueryRunResult | null,
+  b: QueryRunResult | null,
+): boolean {
+  if (a === null || b === null) return false;
+  if (a.sets.length !== b.sets.length) return false;
+  for (let i = 0; i < a.sets.length; i++) {
+    const sa = a.sets[i];
+    const sb = b.sets[i];
+    if (sa === null && sb === null) continue;
+    if (sa === null || sb === null) return false;
+    if (sa.columns.length !== sb.columns.length) return false;
+    if (!sa.columns.every((col, j) => col === sb.columns[j])) return false;
+  }
+  return true;
+}
+
 export function queryResultsIdentical(
   a: QueryRunResult | null,
   b: QueryRunResult | null,
@@ -688,12 +710,24 @@ function ResultViewImpl({
     const cachedSorting = result ? sortingCacheRef.current.get(result) : undefined;
     setSortingByIndex(preserved?.sortingByIndex ?? cachedSorting ?? {});
     setActiveEditCellByIndex({});
-    // Keep the active result-set tab across reloads — clamped to the new set
-    // count. (Clamping rather than restoring from a single "preserved" slot is
-    // robust when an edit triggers more than one queued re-fetch, e.g. quickly
-    // editing Set 1 then Set 2: each re-fetch would otherwise reset to Set 1.)
-    const nextSetCount = result?.sets.length ?? 1;
-    setActiveSetIdx((prev) => Math.max(0, Math.min(prev, nextSetCount - 1)));
+    if (preserved || sameResultShape(result, prevResultRef.current)) {
+      // A reload of the same statements (edit/sort/filter re-fetch — which
+      // preserves state — or a same-shape re-run, including a queued
+      // re-fetch that arrives without a preserve slot): keep the active
+      // result-set tab, clamped to the new set count. (Clamping rather than
+      // restoring from a single "preserved" slot is robust when an edit
+      // triggers more than one queued re-fetch, e.g. quickly editing Set 1
+      // then Set 2: each re-fetch would otherwise reset to Set 1.)
+      const nextSetCount = result?.sets.length ?? 1;
+      setActiveSetIdx((prev) => Math.max(0, Math.min(prev, nextSetCount - 1)));
+    } else {
+      // Fresh run: land on the first set that actually returned a result
+      // table. A multi-statement script commonly ends in a SELECT after
+      // DDL/DML setup statements — defaulting to Set 1 would show the
+      // "no result set returned" notice instead of the data just queried.
+      const firstWithTable = (result?.sets ?? []).findIndex((s) => s !== null);
+      setActiveSetIdx(firstWithTable >= 0 ? firstWithTable : 0);
+    }
     // A fresh result (or a filter/sort/edit reload) settles any pending filter
     // overlay — the rows shown now already reflect the applied filter.
     setFilterPending(false);
@@ -2164,6 +2198,16 @@ export function ResultTableBody({
     colIdx: number;
     value: unknown;
   } | null>(null);
+  // One delegated context menu serves every row: a per-row <ContextMenu.Root>
+  // would make Base UI render its hidden focus-guard <span>s as direct
+  // children of <tbody> (invalid HTML that React flags as a hydration
+  // hazard), and would mount one menu instance per row. The right-clicked
+  // row is captured here as the event bubbles from the <tr> to the
+  // table-wrap trigger.
+  const [ctxMenuRow, setCtxMenuRow] = useState<{
+    absoluteRow: number;
+    values: QueryExecResult["values"][number];
+  } | null>(null);
 
   const [modalEditCell, setModalEditCell] = useState<{
     cellKey: string;
@@ -2378,6 +2422,7 @@ export function ResultTableBody({
                                   openOnHover
                                   delay={150}
                                   closeDelay={100}
+                                  nativeButton={false}
                                   render={(triggerProps) => (
                                     <span
                                       {...triggerProps}
@@ -2415,6 +2460,7 @@ export function ResultTableBody({
                                   openOnHover
                                   delay={150}
                                   closeDelay={100}
+                                  nativeButton={false}
                                   render={(triggerProps) => (
                                     <span
                                       {...triggerProps}
@@ -3070,20 +3116,28 @@ export function ResultTableBody({
       );
     });
     return (
-      <ContextMenu.Root key={absoluteRow}>
-        <ContextMenu.Trigger
-          render={(props) => (
-            <tr
-              {...props}
-              className={checked ? "sql-result-row-selected" : undefined}
-            >
-              {cells}
-            </tr>
-          )}
-        />
-        <ContextMenu.Portal>
-          <ContextMenu.Positioner sideOffset={4}>
-            <ContextMenu.Popup className="bui-popup examples-dropdown sql-row-context-menu">
+      <tr
+        className={checked ? "sql-result-row-selected" : undefined}
+        onContextMenu={() => {
+          setCtxMenuRow({ absoluteRow, values: rowValues });
+        }}
+      >
+        {cells}
+      </tr>
+    );
+  };
+
+  // Rendered once per table, inside the wrap-level <ContextMenu.Root>; the
+  // items close over the row captured by the <tr> onContextMenu above.
+  const rowContextMenu = (
+    <ContextMenu.Portal>
+      <ContextMenu.Positioner sideOffset={4}>
+        <ContextMenu.Popup className="bui-popup examples-dropdown sql-row-context-menu">
+          {ctxMenuRow !== null &&
+            (() => {
+              const { absoluteRow, values: rowValues } = ctxMenuRow;
+              return (
+                <>
               <ContextMenu.Item
                 className="example-item"
                 onClick={() => {
@@ -3226,6 +3280,7 @@ export function ResultTableBody({
                       delay={200}
                       closeDelay={100}
                       className="example-item sql-ctx-disabled"
+                      nativeButton={false}
                       render={<div />}
                       aria-disabled="true"
                     >
@@ -3249,16 +3304,38 @@ export function ResultTableBody({
                   <div className="ex-title">Delete row</div>
                 </ContextMenu.Item>
               )}
-            </ContextMenu.Popup>
-          </ContextMenu.Positioner>
-        </ContextMenu.Portal>
-      </ContextMenu.Root>
-    );
-  };
+                </>
+              );
+            })()}
+        </ContextMenu.Popup>
+      </ContextMenu.Positioner>
+    </ContextMenu.Portal>
+  );
 
   return (
     <div className="sql-result-set">
-      <div className="sql-result-table-wrap">
+      <ContextMenu.Root
+        onOpenChange={(open) => {
+          if (!open) setCtxMenuRow(null);
+        }}
+      >
+        <ContextMenu.Trigger
+          render={(props) => (
+            <div
+              {...props}
+              className="sql-result-table-wrap"
+              onContextMenu={(e) => {
+                // Open the row menu only for right-clicks on a data row —
+                // column headers have their own menu, and the virtualizer's
+                // aria-hidden spacer rows and empty space keep the native
+                // browser menu.
+                const row = (e.target as HTMLElement).closest(
+                  'tbody tr:not([aria-hidden="true"])',
+                );
+                if (!row) return;
+                props.onContextMenu?.(e);
+              }}
+            >
         <table className="sql-result-table">
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -3307,7 +3384,11 @@ export function ResultTableBody({
             )}
           </tbody>
         </table>
-      </div>
+            </div>
+          )}
+        />
+        {rowContextMenu}
+      </ContextMenu.Root>
       {tableRows.length === 0 && (
         <div className="sql-result-empty-msg">
           <SearchX size={14} aria-hidden="true" />

--- a/app/_components/sql/components/SchemaItem.tsx
+++ b/app/_components/sql/components/SchemaItem.tsx
@@ -68,6 +68,7 @@ function TruncatedText({
         openOnHover
         delay={180}
         closeDelay={80}
+        nativeButton={false}
         render={(props) => (
           <span {...props} className={className}>
             {display}

--- a/app/_components/sql/components/ToastList.tsx
+++ b/app/_components/sql/components/ToastList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 
 function CopyIcon() {
   return (

--- a/app/_components/sql/hooks/useDatabaseActions.ts
+++ b/app/_components/sql/hooks/useDatabaseActions.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { startTransition } from "react";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import type { EditorView } from "@codemirror/view";
 import type { SqliteEngine } from "../../runtime/sqlite";
 import type { QueryTab } from "../../sqlitePlaygroundTabs";

--- a/app/_components/sql/hooks/useQueryRunner.ts
+++ b/app/_components/sql/hooks/useQueryRunner.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef } from "react";
 import { startTransition } from "react";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import type { EditorView } from "@codemirror/view";
 import type { QueryExecResult } from "../../runtime/sqlite-wasm";
 import type { SqliteEngine } from "../../runtime/sqlite";

--- a/app/_components/sql/hooks/useSidebarActions.ts
+++ b/app/_components/sql/hooks/useSidebarActions.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { startTransition } from "react";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import type { SqliteEngine, ColumnSpec, ForeignKeyInfo } from "../../runtime/sqlite";
 import {
   exportResultToCsv,

--- a/app/_components/sql/hooks/useTabManagement.ts
+++ b/app/_components/sql/hooks/useTabManagement.ts
@@ -3,7 +3,7 @@
 import { useCallback } from "react";
 import { startTransition } from "react";
 import { flushSync } from "react-dom";
-import { Toast } from "@base-ui-components/react/toast";
+import { Toast } from "@base-ui/react/toast";
 import type { EditorView } from "@codemirror/view";
 import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";

--- a/app/_components/sql/utils/cellEditing.ts
+++ b/app/_components/sql/utils/cellEditing.ts
@@ -53,8 +53,9 @@ export function classifyCellEditor(sqlType: string | undefined): CellEditorKind 
   if (/^bool(ean)?$/.test(t)) return "boolean";
   // Arrays / lists get a dedicated JSON-array editor (checked before the
   // scalar temporal/json rules so an array of timestamps isn't mistaken for a
-  // single timestamp). Postgres reports `integer[]` / `text[]`; DuckDB result
-  // metadata uses Arrow notation, `list<int32>` / `list<utf8>`.
+  // single timestamp). Postgres and DuckDB report `integer[]` / `text[]`;
+  // raw Arrow notation (`list<int32>`) is kept as a fallback for callers
+  // that bypass `arrowTypeToSqlName`.
   if (t.endsWith("[]") || t.startsWith("list<") || t.startsWith("list(")) {
     return "array";
   }

--- a/app/playground/duckdb/page.tsx
+++ b/app/playground/duckdb/page.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import DuckDbPlayground from "../../_components/duckdb/DuckDbPlayground";
+import dynamic from "next/dynamic";
+
+// Client-only: the playground reads persisted state (tabs, active database)
+// from localStorage and generates per-session tab ids in render-time
+// initializers, so an SSR pass would always hydrate against different
+// markup. Skipping SSR renders the persisted state directly on first
+// client paint instead of flashing defaults and re-rendering.
+const DuckDbPlayground = dynamic(
+  () => import("../../_components/duckdb/DuckDbPlayground"),
+  { ssr: false },
+);
 
 export default function DuckDbPage() {
   return <DuckDbPlayground />;

--- a/app/playground/postgres/layout.tsx
+++ b/app/playground/postgres/layout.tsx
@@ -2,7 +2,8 @@ import type { ReactNode } from "react";
 
 export const metadata = {
   title: "PostgreSQL Playground",
-  description: "Mock PostgreSQL playground shell for future browser-based query execution.",
+  description:
+    "Browser-based PostgreSQL playground powered by PGlite — run real Postgres queries against sample databases entirely in your browser.",
 };
 
 export default function PostgresLayout({ children }: { children: ReactNode }) {

--- a/app/playground/postgres/page.tsx
+++ b/app/playground/postgres/page.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import PostgresPlayground from "../../_components/postgres/PostgresPlayground";
+import dynamic from "next/dynamic";
+
+// Client-only: the playground reads persisted state (tabs, active database)
+// from localStorage and generates per-session tab ids in render-time
+// initializers, so an SSR pass would always hydrate against different
+// markup. Skipping SSR renders the persisted state directly on first
+// client paint instead of flashing defaults and re-rendering.
+const PostgresPlayground = dynamic(
+  () => import("../../_components/postgres/PostgresPlayground"),
+  { ssr: false },
+);
 
 export default function PostgresPage() {
   return <PostgresPlayground />;

--- a/app/playground/sqlite/page.tsx
+++ b/app/playground/sqlite/page.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import SqlPlayground from "../../_components/SqlPlayground";
+import dynamic from "next/dynamic";
+
+// Client-only, matching the Postgres/DuckDB pages: the SQL playgrounds
+// restore tabs and per-database state from localStorage on the client, so
+// there is nothing useful to server-render and skipping SSR removes the
+// whole class of hydration mismatches.
+const SqlPlayground = dynamic(() => import("../../_components/SqlPlayground"), {
+  ssr: false,
+});
 
 export default function SqlitePage() {
   return <SqlPlayground />;


### PR DESCRIPTION
Code-quality and live-UX audit across the interactive learning surfaces, in two passes. Every fix was verified with Playwright against the dev server (desktop 1600×1000 + mobile 390×844) and the relevant unit/e2e suites. Full reports: `agent-outputs/20260609-2235-playgrounds-code-quality-audit.md` and `agent-outputs/20260610-0040-code-blocks-challenge-cards-mcq-audit.md` (each includes a "reviewed and rejected" section for findings that were verified false).

## Pass 1 — SQL + non-SQL playgrounds (`9f6e718`)

- **Hydration mismatch on every Postgres/DuckDB load (UX-Q1, previously deferred):** the SQL playground pages now load client-only via `next/dynamic(..., { ssr: false })` — tabs/db state come from localStorage and per-session ids, so SSR markup could never match. First paint now shows persisted tabs directly.
- **Invalid HTML from the result grid:** per-row `ContextMenu.Root`s made Base UI inject focus-guard `<span>`s directly into `<tbody>`. One delegated context menu per table now serves all rows (also N→1 menu instances).
- **`Popover.Trigger` rendered as `<span>`/`<div>` without `nativeButton={false}`** (7 sites) — silenced the recurring Base UI console error.
- **Every toast logged a React `flushSync` error:** the RC Base UI package calls `flushSync` from a layout effect; migrated the Toast subsystem (11 files, one shared context) to the stable `@base-ui/react` which fixed it upstream.
- **SQLite engine worker leaked its exclusive OPFS access-handle pool** across StrictMode remounts / SPA navigation — added `dispose()` (terminate worker → handles released) wired into the boot effect cleanup, plus a defensive previous-worker terminate in the factory.
- **Postgres structure edits leaked `__tmp_rebuild_N` into constraint names** (`books__tmp_rebuild_1_pkey` in the sidebar): `rebuildTable` now renames temp-prefixed constraints after the table rename, like it already did for sequences.
- **DuckDB result headers showed raw Arrow type notation** (`decimal[38e+2]`, `int64`, `utf8`, `list<int32>`): new `arrowTypeToSqlName` maps to real SQL names (`DECIMAL(38,2)`, `BIGINT`, `VARCHAR`, `INTEGER[]`, `ENUM`, …) with downstream consumers audited (+7 unit tests).
- **Multi-statement runs landed on "no result set returned":** a fresh run now opens the first set that returned a result table (`INSERT…; SELECT…` lands on the SELECT); reloads keep the user's set via the new `sameResultShape` (+5 unit tests). `e2e/sql-multi-result-edit` passes on all three engines.
- **Non-SQL playgrounds:** the 3s error→ready status timer is cancelled on re-run/unmount (it could flip status to "ready" mid-run); stale "Mock PostgreSQL playground" metadata updated.

## Pass 2 — Code blocks, challenge cards & MCQ (`ba9b045`)

- **Stale-run races in all four block components:** `ChallengeCard.run()/check()`, `SqlChallengeCard.run()/check()`, `SqlCodeBlock.run()` updated state after `await` without sequence guards — and the ⌘/Ctrl+Enter keymap isn't disabled while busy, so rapid presses raced and the older run could overwrite the newer one's results. Sequence ownership hoisted from `execute()/executeSql()` to callers (the pattern `CodeBlock` already used), with guarded `finally` cleanup and `reset()` clearing the busy state.
- **Table-viewer refresh race (shared `useSqlTableViewer`):** an in-flight refresh (e.g. DuckDB's slow mount boot) could land after Reset and show pre-reset rows — refreshes are now sequence-guarded and `clear()` invalidates in-flight ones.
- **SQL test framework:** `valueEquals("", 0)` no longer passes (`Number("")` is `0`); blank strings are excluded from numeric coercion.
- **`loadLanguage()`** resolves `null` on a failed CodeMirror chunk load instead of an unhandled rejection through 5 call sites.
- **MultipleChoice:** verdict banner + explanation now render before "Try again" (feedback → understanding → action) and the banner has `role="status"` so the verdict is announced to assistive tech.

## Verification

- `tsc` clean · ESLint clean on touched files · **468/468** unit tests
- e2e: all SQL playground specs (multi-result-edit, edit-undo, create-object, ergonomics, refetch, filter, explain, run-at-cursor, saved-queries, column-stats, array/enum editors, param-binding, mobile), `code-blocks-run`, `sql-code-blocks-run` ×3 dialects, `csv-examples`, `challenge-solutions` sweep (JS/TS/SQLite/DuckDB/PostgreSQL) — green
- Production build exit 0 (both passes)
- Console errors across all playgrounds, demo pages and workflows, both viewports: **0** (was: hydration + Base UI + 12 flushSync + 7 OPFS errors per session)

https://claude.ai/code/session_012qgAP4tRNeHWXvtESH74iP