### PR TITLE
Style non-SQL Run dropdown to match the SQL playground

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -801,6 +801,10 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   // Latest run handler in a ref so the editor's keymap can call into it
   // without being re-bound on every render.
   const runRef = useRef<() => void>(() => undefined);
+  // Secondary run action (⌘/Ctrl+Shift+Enter) — runs the Run dropdown's
+  // first/canonical entry. Kept as a ref so the CodeMirror keymap stays
+  // stable while the target entry updates as tabs/files change.
+  const runSecondaryRef = useRef<() => void>(() => undefined);
 
   // The id of the first output cell produced by the most recent run.
   // The auto-scroll effect uses it to scroll that cell into view rather
@@ -1337,6 +1341,13 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
               },
             },
             {
+              key: "Mod-Shift-Enter",
+              run: () => {
+                runSecondaryRef.current();
+                return true;
+              },
+            },
+            {
               key: "Ctrl-Space",
               run: (v) => {
                 startCompletion(v);
@@ -1868,6 +1879,16 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       computeRunButtonState(adapter, files, activeFileId, fileContentsByPath),
     [adapter, files, activeFileId, fileContentsByPath],
   );
+
+  // Keep the ⌘/Ctrl+Shift+Enter handler pointed at the Run dropdown's
+  // first entry (the canonical/default file, runnable from any tab).
+  // No-op when there's no secondary entry to run.
+  useEffect(() => {
+    runSecondaryRef.current = () => {
+      const secondary = runButtonState.dropdownItems[0];
+      if (secondary) void runCode(secondary.entryFilename);
+    };
+  }, [runButtonState, runCode]);
 
   // ─── File tab management ────────────────────────────────────────────────
 
@@ -3777,7 +3798,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                     <Menu.Portal>
                       <Menu.Positioner sideOffset={6} align="end">
                         <Menu.Popup className="bui-popup playground-run-multi-dropdown">
-                          {runButtonState.dropdownItems.map((item) => (
+                          {runButtonState.dropdownItems.map((item, idx) => (
                             <Menu.Item
                               key={item.entryFilename}
                               className="playground-run-multi-item"
@@ -3785,7 +3806,14 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                                 void runCode(item.entryFilename);
                               }}
                             >
-                              {item.label}
+                              <span className="playground-run-multi-item-label">
+                                {item.label}
+                              </span>
+                              {idx === 0 && (
+                                <span className="playground-run-multi-item-kbd">
+                                  {isMac ? "⌘⇧Enter" : "Ctrl+Shift+Enter"}
+                                </span>
+                              )}
                             </Menu.Item>
                           ))}
                         </Menu.Popup>

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1105,6 +1105,9 @@ body.playground-active {
   background: color-mix(in srgb, currentColor 18%, transparent);
   border-radius: 3px;
   padding: 0.05em 0.35em;
+  /* Breathing room between the "Run" verb and the entry-file chip so
+     the two don't read as one crammed token (e.g. Run · index). */
+  margin-left: 0.25em;
 }
 .playground-run-multi-chevron {
   background: transparent !important;
@@ -1134,6 +1137,8 @@ body.playground-active {
 .playground-run-multi-item {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   padding: 8px 12px;
   font-family: var(--font-ui);
   font-size: 13px;
@@ -1144,6 +1149,16 @@ body.playground-active {
 .playground-run-multi-item[data-highlighted],
 .playground-run-multi-item:hover {
   background: var(--bg3);
+}
+.playground-run-multi-item-label {
+  flex: 1 1 auto;
+}
+/* Right-aligned, muted keyboard-shortcut hint inside a Run dropdown
+   row — mirrors the SQL playground's `.run-split-item-kbd`. */
+.playground-run-multi-item-kbd {
+  color: var(--text-dim);
+  font-size: 11px;
+  flex-shrink: 0;
 }
 
 .editor-wrap {


### PR DESCRIPTION
## What

Brings the non-SQL playground's Run split-button in line with the SQL playground's run button, per the reference screenshot.

### Changes
1. **Spacing** — Added a small left margin to the entry-file chip (`.playground-run-entry`) so the "Run" verb and the filename no longer read as one crammed token (e.g. `Run` · `index`). Applies to the primary button label, the dropdown rows, and the hover popover.
2. **Dropdown style** — Run dropdown rows now use the same layout as the SQL playground's `.run-split-item`: label on the left, a muted right-aligned keyboard-shortcut hint, on the existing white menu with the existing gray hover.
3. **Keyboard shortcut** — The dropdown's canonical entry row shows `⌘⇧Enter` / `Ctrl+Shift+Enter`, and that shortcut is **actually wired** (new `Mod-Shift-Enter` keymap entry → runs the dropdown's first/canonical entry from any tab), mirroring the SQL editor's secondary run action rather than displaying a dead hint. The primary button stays on `⌘/Ctrl+Enter` (active file), unchanged.

### Notes
- For multi-entry-point languages (C/C++/Java/C#) the shortcut hint is shown only on the first/canonical dropdown row — the one `⌘⇧Enter` triggers — so it's never misleading.
- `tsc --noEmit` and `eslint` are clean for the changed files.

https://claude.ai/code/session_01Qqza8hZWwZCmHTjAEmknjS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qqza8hZWwZCmHTjAEmknjS)_