### PR TITLE
Add SVG vector illustrations to the remaining 6 courses (Wave 4)

### DIFF
--- a/content/learn/sql-analytics-duckdb/aggregate-functions.mdx
+++ b/content/learn/sql-analytics-duckdb/aggregate-functions.mdx
@@ -10,6 +10,60 @@ have ever seen in a report is an aggregate. This page explains not just
 the five functions but *why* aggregation is the analyst's most important
 move.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A wide beam of faint rows strikes a translucent blue prism and fans out as five single colored values — one unreadable pile of data refracted into count, sum, average, minimum, and maximum"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="48" cy="78" r="3.5" />
+    <circle cx="76" cy="96" r="3.5" />
+    <circle cx="58" cy="118" r="3.5" />
+    <circle cx="92" cy="134" r="3.5" />
+    <circle cx="104" cy="84" r="3.5" />
+    <circle cx="128" cy="106" r="3.5" />
+    <circle cx="118" cy="128" r="3.5" />
+    <circle cx="148" cy="92" r="3.5" />
+    <circle cx="160" cy="116" r="3.5" />
+    <circle cx="178" cy="102" r="3.5" />
+    <circle cx="196" cy="118" r="3.5" />
+    <circle cx="208" cy="100" r="3.5" />
+    <circle cx="226" cy="110" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 312 42 L 374 168 L 250 168 Z" fillOpacity="0.25" />
+    <path d="M 312 74 L 352 156 L 272 156 Z" fillOpacity="0.25" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="404" cy="62" r="2.5" />
+    <circle cx="446" cy="48" r="2.5" />
+    <circle cx="408" cy="88" r="2.5" />
+    <circle cx="452" cy="80" r="2.5" />
+    <circle cx="412" cy="112" r="2.5" />
+    <circle cx="458" cy="112" r="2.5" />
+    <circle cx="408" cy="136" r="2.5" />
+    <circle cx="452" cy="144" r="2.5" />
+    <circle cx="404" cy="160" r="2.5" />
+    <circle cx="446" cy="176" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.55">
+    <circle cx="530" cy="34" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="548" cy="76" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="556" cy="112" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="548" cy="148" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="530" cy="188" r="9" />
+  </g>
+</svg>
+
 ## Why aggregation exists
 
 A human cannot comprehend a million rows. But "the average order was
@@ -139,6 +193,43 @@ Product A averages over its two real scores (5 and 3 → 4.0), ignoring the
 missing one. If `NULL` counted as 0, the average would be a misleading
 2.67. SQL's choice to skip NULLs is what makes aggregates trustworthy —
 but you must *know* it is happening.
+
+<svg
+  viewBox="0 0 640 160"
+  role="img"
+  aria-label="Solid green values roll into a blue averaging bowl while two hollow unknown values detour around it on a dotted path — aggregates skip NULLs rather than counting them as zero"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="66" cy="64" r="8" />
+    <circle cx="104" cy="64" r="8" />
+    <circle cx="142" cy="64" r="8" />
+    <circle cx="180" cy="64" r="8" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <path d="M 226 64 a 8 8 0 1 0 16 0 a 8 8 0 1 0 -16 0 M 230 64 a 4 4 0 1 1 8 0 a 4 4 0 1 1 -8 0" fillRule="evenodd" />
+    <path d="M 264 64 a 8 8 0 1 0 16 0 a 8 8 0 1 0 -16 0 M 268 64 a 4 4 0 1 1 8 0 a 4 4 0 1 1 -8 0" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="296" cy="92" r="2.5" />
+    <circle cx="312" cy="112" r="2.5" />
+    <circle cx="336" cy="126" r="2.5" />
+    <circle cx="364" cy="132" r="2.5" />
+    <circle cx="392" cy="126" r="2.5" />
+    <circle cx="414" cy="112" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 320 58 A 42 42 0 0 0 404 58 L 392 58 A 30 30 0 0 1 332 58 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="436" cy="64" r="2.5" />
+    <circle cx="454" cy="64" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="500" cy="64" r="18" fillOpacity="0.2" />
+    <circle cx="500" cy="64" r="10" />
+  </g>
+</svg>
 
 ## Aggregating a filtered slice
 

--- a/content/learn/sql-analytics-duckdb/analytical-vs-transactional-workloads.mdx
+++ b/content/learn/sql-analytics-duckdb/analytical-vs-transactional-workloads.mdx
@@ -10,6 +10,61 @@ Processing*. You do not need to memorize the acronyms, but understanding
 what each workload *demands* explains why analytical databases like
 DuckDB are built so differently from the database behind a typical app.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A narrow ledger tape records transactions tick by tick, with a fresh yellow entry still sliding in, while across a dotted trail the same history is condensed into an isometric analytics cube — OLTP records what happened, OLAP explains what it means"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="96" y="30" width="84" height="162" rx="10" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="110" y="46" width="44" height="5" rx="2.5" />
+    <rect x="110" y="64" width="52" height="5" rx="2.5" />
+    <rect x="110" y="82" width="38" height="5" rx="2.5" />
+    <rect x="110" y="100" width="50" height="5" rx="2.5" />
+    <rect x="110" y="118" width="42" height="5" rx="2.5" />
+    <rect x="110" y="136" width="54" height="5" rx="2.5" />
+    <rect x="110" y="154" width="40" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="166" cy="48" r="2.8" />
+    <circle cx="166" cy="84" r="2.8" />
+    <circle cx="166" cy="120" r="2.8" />
+    <circle cx="166" cy="156" r="2.8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="124" y="172" width="48" height="6" rx="3" />
+    <circle cx="184" cy="175" r="3" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="228" cy="110" r="3" />
+    <circle cx="258" cy="104" r="3.5" />
+    <circle cx="290" cy="100" r="4" />
+    <circle cx="324" cy="98" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 462 36 L 540 76 L 462 116 L 384 76 Z" fillOpacity="0.9" />
+    <path d="M 384 76 L 462 116 L 462 196 L 384 156 Z" fillOpacity="0.55" />
+    <path d="M 540 76 L 462 116 L 462 196 L 540 156 Z" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="462" cy="76" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="420" cy="140" r="5" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="504" cy="140" r="5" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="586" cy="48" r="3" />
+    <circle cx="350" cy="180" r="3" />
+    <circle cx="60" cy="70" r="3" />
+  </g>
+</svg>
+
 ## A transaction vs. an analysis
 
 A **transaction** is a small, complete unit of business activity: place
@@ -72,6 +127,85 @@ On a wide table that can mean reading 5% of the data instead of 100%.
 That single design choice is why purpose-built analytical engines crush
 row-oriented databases on summary queries. DuckDB is column-oriented,
 which is a big part of *why DuckDB exists* (more on that soon).
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="The same table stored two ways: on the left each row keeps its four mixed-color values side by side and one whole row is lit for a point read; on the right every column's values stand together as one vertical stripe and only the green amount stripe glows — a column store reads just what the question needs"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="56" y="36" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="56" y="60" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="56" y="84" width="44" height="16" rx="5" fillOpacity="0.9" />
+    <rect x="56" y="108" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="56" y="132" width="44" height="16" rx="5" fillOpacity="0.22" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="106" y="36" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="106" y="60" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="106" y="84" width="44" height="16" rx="5" fillOpacity="0.9" />
+    <rect x="106" y="108" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="106" y="132" width="44" height="16" rx="5" fillOpacity="0.22" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="156" y="36" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="156" y="60" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="156" y="84" width="44" height="16" rx="5" fillOpacity="0.9" />
+    <rect x="156" y="108" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="156" y="132" width="44" height="16" rx="5" fillOpacity="0.22" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="206" y="36" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="206" y="60" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="206" y="84" width="44" height="16" rx="5" fillOpacity="0.9" />
+    <rect x="206" y="108" width="44" height="16" rx="5" fillOpacity="0.22" />
+    <rect x="206" y="132" width="44" height="16" rx="5" fillOpacity="0.22" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="86" y="168" width="134" height="4" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="306" cy="92" r="2.5" />
+    <circle cx="320" cy="92" r="2.5" />
+    <circle cx="334" cy="92" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="388" y="36" width="40" height="112" rx="8" fillOpacity="0.14" />
+    <rect x="396" y="44" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="396" y="64" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="396" y="84" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="396" y="104" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="396" y="124" width="24" height="14" rx="4" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="438" y="30" width="44" height="124" rx="8" fillOpacity="0.3" />
+    <rect x="448" y="44" width="24" height="14" rx="4" />
+    <rect x="448" y="64" width="24" height="14" rx="4" />
+    <rect x="448" y="84" width="24" height="14" rx="4" />
+    <rect x="448" y="104" width="24" height="14" rx="4" />
+    <rect x="448" y="124" width="24" height="14" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="492" y="36" width="40" height="112" rx="8" fillOpacity="0.14" />
+    <rect x="500" y="44" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="500" y="64" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="500" y="84" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="500" y="104" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="500" y="124" width="24" height="14" rx="4" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="542" y="36" width="40" height="112" rx="8" fillOpacity="0.14" />
+    <rect x="550" y="44" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="550" y="64" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="550" y="84" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="550" y="104" width="24" height="14" rx="4" fillOpacity="0.3" />
+    <rect x="550" y="124" width="24" height="14" rx="4" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="448" y="168" width="24" height="4" rx="2" fillOpacity="0.7" />
+  </g>
+</svg>
 
 ## You write SQL the same way either way
 

--- a/content/learn/sql-analytics-duckdb/analytics-vs-application-development.mdx
+++ b/content/learn/sql-analytics-duckdb/analytics-vs-application-development.mdx
@@ -9,6 +9,57 @@ SQL — but it is a *different job* from what an analyst does, even though
 both use the word `SELECT`. This page makes that difference explicit,
 because almost every habit you build in this course flows from it.
 
+<svg
+  viewBox="0 0 640 215"
+  role="img"
+  aria-label="On the left a thin blue needle dives onto one highlighted cell among faint row strips; on the right a wide translucent net gathers a whole school of dots toward a single green summary value — application SQL finds one row fast, analytical SQL weighs the entire catch"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.11">
+    <rect x="48" y="58" width="172" height="13" rx="6.5" />
+    <rect x="48" y="80" width="172" height="13" rx="6.5" />
+    <rect x="48" y="102" width="172" height="13" rx="6.5" />
+    <rect x="48" y="124" width="172" height="13" rx="6.5" />
+    <rect x="48" y="146" width="172" height="13" rx="6.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="123" cy="108" r="16" fillOpacity="0.15" />
+    <rect x="106" y="102" width="34" height="13" rx="6.5" />
+    <path d="M 86 20 L 118 95 L 128 91 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="262" cy="106" r="2.5" />
+    <circle cx="276" cy="106" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <ellipse cx="392" cy="112" rx="112" ry="80" fillOpacity="0.1" />
+    <ellipse cx="392" cy="112" rx="86" ry="60" fillOpacity="0.1" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="330" cy="92" r="4" />
+    <circle cx="356" cy="132" r="4" />
+    <circle cx="384" cy="72" r="4" />
+    <circle cx="402" cy="150" r="4" />
+    <circle cx="428" cy="96" r="4" />
+    <circle cx="442" cy="136" r="4" />
+    <circle cx="368" cy="106" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="346" cy="78" r="4.5" fillOpacity="0.8" />
+    <circle cx="412" cy="118" r="4.5" fillOpacity="0.8" />
+    <circle cx="378" cy="142" r="4.5" fillOpacity="0.8" />
+    <circle cx="436" cy="70" r="4.5" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="514" cy="112" r="3" />
+    <circle cx="536" cy="112" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="580" cy="112" r="22" fillOpacity="0.18" />
+    <circle cx="580" cy="112" r="13" />
+  </g>
+</svg>
+
 ## Two jobs, one language
 
 Think of a busy online store.

--- a/content/learn/sql-analytics-duckdb/building-business-metrics.mdx
+++ b/content/learn/sql-analytics-duckdb/building-business-metrics.mdx
@@ -9,6 +9,58 @@ conversion rate, average revenue per user, retention, growth. The SQL is
 familiar by now; the new skill is **reasoning about what a number really
 means** and constructing it so it tells the truth.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="Faint raw rows at the bottom dissolve upward into four abstract dashboard tiles — a headline bar, a rising sparkline, a donut with one slice set apart, and a ratio of two bars — records becoming the numbers a business steers by"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.07">
+    <rect x="150" y="22" width="160" height="64" rx="12" />
+    <rect x="330" y="22" width="160" height="64" rx="12" />
+    <rect x="150" y="100" width="160" height="64" rx="12" />
+    <rect x="330" y="100" width="160" height="64" rx="12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="168" y="38" width="86" height="20" rx="7" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="168" y="66" width="40" height="7" rx="3.5" />
+    <rect x="216" y="66" width="26" height="7" rx="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="352" cy="72" r="4" />
+    <circle cx="378" cy="64" r="4" />
+    <circle cx="404" cy="66" r="4" />
+    <circle cx="430" cy="50" r="4" />
+    <circle cx="456" cy="40" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 206 132 m -24 0 a 24 24 0 1 0 48 0 a 24 24 0 1 0 -48 0 M 206 132 m -13 0 a 13 13 0 1 1 26 0 a 13 13 0 1 1 -26 0" fillRule="evenodd" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 236 106 A 26 26 0 0 1 262 132 L 245 132 A 15 15 0 0 0 230 119 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="350" y="116" width="118" height="14" rx="7" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="350" y="134" width="118" height="3" rx="1.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="350" y="141" width="66" height="14" rx="7" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="240" cy="182" r="2.5" />
+    <circle cx="320" cy="176" r="2.5" />
+    <circle cx="400" cy="182" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.13">
+    <rect x="128" y="198" width="384" height="9" rx="4.5" />
+    <rect x="160" y="216" width="320" height="9" rx="4.5" />
+  </g>
+</svg>
+
 ## A metric is a definition first, SQL second
 
 Before writing any query, an analyst pins down the **definition**. "Active
@@ -145,6 +197,60 @@ FROM
 both correct — for different questions. Quoting the wrong one, or not
 saying which, is how metrics mislead. The analytical skill is choosing the
 denominator that matches the decision.
+
+<svg
+  viewBox="0 0 640 195"
+  role="img"
+  aria-label="One green revenue disc is shared out two ways: spread across ten faint heads it becomes slim slivers, but across only the three who actually paid it becomes thick slabs — the same total, two denominators, two honest metrics"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="320" cy="44" r="26" />
+    <circle cx="320" cy="44" r="36" fillOpacity="0.15" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="270" cy="74" r="2.5" />
+    <circle cx="232" cy="94" r="2.5" />
+    <circle cx="198" cy="112" r="2.5" />
+    <circle cx="370" cy="74" r="2.5" />
+    <circle cx="408" cy="94" r="2.5" />
+    <circle cx="442" cy="112" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="56" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+    <rect x="80" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+    <rect x="104" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+    <rect x="128" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+    <rect x="152" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+    <rect x="176" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+    <rect x="200" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+    <rect x="224" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+    <rect x="248" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+    <rect x="272" y="132" width="14" height="8" rx="4" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="63" cy="160" r="6" />
+    <circle cx="87" cy="160" r="6" />
+    <circle cx="111" cy="160" r="6" />
+    <circle cx="135" cy="160" r="6" />
+    <circle cx="159" cy="160" r="6" />
+    <circle cx="183" cy="160" r="6" />
+    <circle cx="207" cy="160" r="6" />
+    <circle cx="231" cy="160" r="6" />
+    <circle cx="255" cy="160" r="6" />
+    <circle cx="279" cy="160" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="384" y="126" width="56" height="14" rx="7" />
+    <rect x="452" y="126" width="56" height="14" rx="7" />
+    <rect x="520" y="126" width="56" height="14" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="412" cy="162" r="8" />
+    <circle cx="480" cy="162" r="8" />
+    <circle cx="548" cy="162" r="8" />
+  </g>
+</svg>
 
 ## Period-over-period growth
 

--- a/content/learn/sql-analytics-duckdb/common-table-expressions.mdx
+++ b/content/learn/sql-analytics-duckdb/common-table-expressions.mdx
@@ -11,6 +11,50 @@ a sequence of named, readable steps, like a recipe. This is arguably the
 most important *style* skill in analytical SQL, so it gets a page of its
 own.
 
+<svg
+  viewBox="0 0 640 235"
+  role="img"
+  aria-label="Scaffolding rises in three named levels, each platform standing on posts planted in the one below, with a yellow flag flying from the top — a CTE pipeline that builds the final query step by step instead of nesting it inside out"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="80" y="208" width="480" height="6" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="158" y="166" width="9" height="42" rx="4" />
+    <rect x="473" y="166" width="9" height="42" rx="4" />
+    <rect x="198" y="114" width="9" height="44" rx="4" />
+    <rect x="433" y="114" width="9" height="44" rx="4" />
+    <rect x="238" y="62" width="9" height="44" rx="4" />
+    <rect x="393" y="62" width="9" height="44" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="140" y="158" width="360" height="9" rx="4.5" />
+    <rect x="180" y="106" width="280" height="9" rx="4.5" />
+    <rect x="220" y="54" width="200" height="9" rx="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="226" y="130" width="96" height="20" rx="10" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="266" y="78" width="96" height="20" rx="10" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="356" cy="124" r="2.5" />
+    <circle cx="366" cy="113" r="2.5" />
+    <circle cx="396" cy="72" r="2.5" />
+    <circle cx="406" cy="61" r="2.5" />
+    <circle cx="316" cy="176" r="2.5" />
+    <circle cx="326" cy="165" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="318" y="16" width="5" height="38" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 323 18 L 368 28 L 323 38 Z" />
+  </g>
+</svg>
+
 ## The problem: queries that nest inward
 
 Without CTEs, a multi-step analysis nests subqueries inside subqueries.
@@ -166,6 +210,41 @@ ORDER BY
 The `region_rev` step is computed once and reused; `overall` summarizes
 it; the final query compares them. Three small, verifiable steps replace
 one inscrutable nest.
+
+<svg
+  viewBox="0 0 640 165"
+  role="img"
+  aria-label="One solid green step sends copies of itself along two dotted trails into two waiting sockets downstream — a CTE is computed once and referenced as many times as the query needs"
+  style={{ display: "block", width: "100%", maxWidth: "500px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="64" y="66" width="110" height="32" rx="16" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="206" cy="68" r="2.5" />
+    <circle cx="234" cy="54" r="2.5" />
+    <circle cx="264" cy="44" r="2.5" />
+    <circle cx="296" cy="40" r="2.5" />
+    <circle cx="206" cy="96" r="2.5" />
+    <circle cx="234" cy="110" r="2.5" />
+    <circle cx="264" cy="120" r="2.5" />
+    <circle cx="296" cy="124" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="330" y="16" width="240" height="52" rx="12" />
+    <rect x="330" y="98" width="240" height="52" rx="12" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="348" y="30" width="74" height="24" rx="12" fillOpacity="0.45" />
+    <rect x="348" y="112" width="74" height="24" rx="12" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <rect x="436" y="36" width="56" height="12" rx="6" />
+    <rect x="500" y="36" width="40" height="12" rx="6" />
+    <rect x="436" y="118" width="42" height="12" rx="6" />
+    <rect x="486" y="118" width="62" height="12" rx="6" />
+  </g>
+</svg>
 
 ## A note on recursive CTEs
 

--- a/content/learn/sql-analytics-duckdb/conditional-logic.mdx
+++ b/content/learn/sql-analytics-duckdb/conditional-logic.mdx
@@ -11,6 +11,51 @@ how analysts reshape values on the fly. This page also introduces
 **conditional aggregation**, one of the most useful patterns in all of
 analytical SQL.
 
+<svg
+  viewBox="0 0 640 215"
+  role="img"
+  aria-label="Plain dots ride a single track into a yellow switch diamond that routes each one onto the first branch whose test it passes, coloring it on the way out — CASE turning raw values into clean categories"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="36" y="96" width="200" height="24" rx="12" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="70" cy="108" r="7" />
+    <circle cx="116" cy="108" r="7" />
+    <circle cx="162" cy="108" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 270 80 L 298 108 L 270 136 L 242 108 Z" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="322" cy="88" r="2.5" />
+    <circle cx="354" cy="72" r="2.5" />
+    <circle cx="386" cy="58" r="2.5" />
+    <circle cx="322" cy="108" r="2.5" />
+    <circle cx="354" cy="108" r="2.5" />
+    <circle cx="386" cy="108" r="2.5" />
+    <circle cx="322" cy="128" r="2.5" />
+    <circle cx="354" cy="144" r="2.5" />
+    <circle cx="386" cy="158" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="424" cy="46" r="7" />
+    <circle cx="468" cy="40" r="7" />
+    <rect x="506" y="30" width="34" height="18" rx="9" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="424" cy="108" r="7" />
+    <circle cx="468" cy="108" r="7" />
+    <circle cx="512" cy="108" r="7" />
+    <rect x="544" y="99" width="52" height="18" rx="9" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="424" cy="170" r="7" />
+    <rect x="460" y="161" width="70" height="18" rx="9" fillOpacity="0.45" />
+  </g>
+</svg>
+
 ## `CASE`: if/else for a column
 
 A `CASE` expression evaluates conditions in order and returns the value
@@ -216,6 +261,40 @@ Two small but constant companions of conditional logic:
   for filling in a default: `COALESCE(discount, 0)`.
 - **`NULLIF(a, b)`** returns `NULL` when `a = b` — most often used to
   avoid divide-by-zero: `amount / NULLIF(quantity, 0)`.
+
+<svg
+  viewBox="0 0 640 160"
+  role="img"
+  aria-label="Two divisions side by side: dividing by a raw red zero ends in a jagged burst, while NULLIF first softens the zero into a hollow ring so the same division lands as a calm, harmless NULL"
+  style={{ display: "block", width: "100%", maxWidth: "500px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="70" y="40" width="68" height="16" rx="8" fillOpacity="0.8" />
+    <rect x="70" y="104" width="68" height="16" rx="8" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="178" y="56" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle">÷</text>
+    <text x="178" y="120" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle">÷</text>
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <text x="232" y="57" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle" fontWeight="700">0</text>
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <path d="M 232 104 m -9 0 a 9 9 0 1 0 18 0 a 9 9 0 1 0 -18 0 M 232 104 m -5 0 a 5 5 0 1 1 10 0 a 5 5 0 1 1 -10 0" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="290" cy="48" r="2.5" />
+    <circle cx="316" cy="48" r="2.5" />
+    <circle cx="290" cy="112" r="2.5" />
+    <circle cx="316" cy="112" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 392 48 L 401 32 L 406 46 L 422 38 L 416 52 L 432 56 L 416 62 L 424 76 L 408 68 L 402 82 L 396 66 L 380 72 L 388 58 L 372 52 L 388 50 Z" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 402 112 m -13 0 a 13 13 0 1 0 26 0 a 13 13 0 1 0 -26 0 M 402 112 m -7 0 a 7 7 0 1 1 14 0 a 7 7 0 1 1 -14 0" fillRule="evenodd" />
+  </g>
+</svg>
 
 <SqlCodeBlock
   dialect="duckdb"

--- a/content/learn/sql-analytics-duckdb/filtering-and-slicing.mdx
+++ b/content/learn/sql-analytics-duckdb/filtering-and-slicing.mdx
@@ -10,6 +10,42 @@ categories. Carving out that part is **slicing**, and the tool is the
 sharpens your filtering vocabulary and explains *why* analysts filter as
 early as possible.
 
+<svg
+  viewBox="0 0 640 215"
+  role="img"
+  aria-label="A translucent yellow cutting plane passes through a faint isometric slab of data, and the carved slice slides out to the right in solid blue carrying its green rows — WHERE lifts out exactly the part the question is about"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor">
+    <path d="M 100 78 L 250 78 L 304 112 L 154 112 Z" opacity="0.16" />
+    <path d="M 154 112 L 304 112 L 304 178 L 154 178 Z" opacity="0.09" />
+    <path d="M 100 78 L 154 112 L 154 178 L 100 144 Z" opacity="0.2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 312 56 L 334 70 L 334 186 L 312 172 Z" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="362" cy="118" r="3" />
+    <circle cx="384" cy="118" r="3" />
+    <circle cx="406" cy="118" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 438 70 L 482 70 L 536 104 L 492 104 Z" fillOpacity="0.6" />
+    <path d="M 492 104 L 536 104 L 536 170 L 492 170 Z" fillOpacity="0.35" />
+    <path d="M 438 70 L 492 104 L 492 170 L 438 136 Z" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="514" cy="124" r="5" />
+    <circle cx="514" cy="146" r="5" />
+    <circle cx="465" cy="112" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="80" cy="40" r="3" />
+    <circle cx="580" cy="50" r="3" />
+    <circle cx="600" cy="190" r="3" />
+  </g>
+</svg>
+
 ## A slice is a question in disguise
 
 Every business question hides a filter. "How are sales in the West?" means
@@ -168,6 +204,41 @@ ORDER BY
 Without the parentheses, `amount > 100 AND region = 'West' OR region =
 'East'` would also return *every* East order regardless of amount — a
 classic, silent analytical bug.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="Dots flow along a lane toward a yellow filter gate, but a dotted bypass arc carries red dots up and over the gate back into the output — an ungrouped OR quietly lets rows skip the filter"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="40" y="98" width="560" height="30" rx="15" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="80" cy="113" r="6" />
+    <circle cx="124" cy="113" r="6" />
+    <circle cx="168" cy="113" r="6" />
+    <circle cx="212" cy="113" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="296" y="78" width="14" height="30" rx="5" />
+    <rect x="296" y="118" width="14" height="30" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="372" cy="113" r="6" />
+    <circle cx="420" cy="113" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="248" cy="92" r="4" fillOpacity="0.5" />
+    <circle cx="268" cy="64" r="4" fillOpacity="0.65" />
+    <circle cx="298" cy="44" r="4" fillOpacity="0.8" />
+    <circle cx="334" cy="50" r="4" fillOpacity="0.9" />
+    <circle cx="362" cy="72" r="4" />
+    <circle cx="382" cy="96" r="4" />
+    <circle cx="468" cy="113" r="6" />
+    <circle cx="516" cy="113" r="6" />
+  </g>
+</svg>
 
 ## Why analysts filter *early*
 

--- a/content/learn/sql-analytics-duckdb/filtering-groups.mdx
+++ b/content/learn/sql-analytics-duckdb/filtering-groups.mdx
@@ -10,6 +10,66 @@ filter that runs *after* aggregation, on the group summaries themselves.
 The hardest part is keeping it distinct from `WHERE`, so that is what this
 page nails down.
 
+<svg
+  viewBox="0 0 640 235"
+  role="img"
+  aria-label="Three jars of grouped dots ride spring platforms: the two full jars compress their springs and earn a green badge while the light jar rides high and is marked red — HAVING weighs whole groups only after they are formed"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="60" y="206" width="520" height="5" rx="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.07">
+    <rect x="98" y="92" width="84" height="62" rx="11" />
+    <rect x="278" y="34" width="84" height="62" rx="11" />
+    <rect x="458" y="106" width="84" height="62" rx="11" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="122" cy="136" r="7" />
+    <circle cx="142" cy="130" r="7" />
+    <circle cx="162" cy="136" r="7" />
+    <circle cx="132" cy="114" r="7" />
+    <circle cx="152" cy="112" r="7" />
+    <circle cx="306" cy="78" r="7" fillOpacity="0.45" />
+    <circle cx="334" cy="78" r="7" fillOpacity="0.45" />
+    <circle cx="482" cy="150" r="7" />
+    <circle cx="502" cy="144" r="7" />
+    <circle cx="522" cy="150" r="7" />
+    <circle cx="492" cy="128" r="7" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="122" y="162" width="36" height="6" rx="3" />
+    <rect x="122" y="176" width="36" height="6" rx="3" />
+    <rect x="122" y="190" width="36" height="6" rx="3" />
+    <rect x="302" y="104" width="36" height="6" rx="3" />
+    <rect x="302" y="124" width="36" height="6" rx="3" />
+    <rect x="302" y="144" width="36" height="6" rx="3" />
+    <rect x="302" y="164" width="36" height="6" rx="3" />
+    <rect x="302" y="184" width="36" height="6" rx="3" />
+    <rect x="482" y="176" width="36" height="6" rx="3" />
+    <rect x="482" y="190" width="36" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="48" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="70" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="200" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="222" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="244" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="380" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="402" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="424" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="560" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="582" y="98" width="12" height="5" rx="2.5" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="196" cy="84" r="9" />
+    <circle cx="556" cy="98" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="376" cy="26" r="9" fillOpacity="0.85" />
+  </g>
+</svg>
+
 ## Two filters, two moments
 
 `WHERE` and `HAVING` both filter — but at different stages of the query.
@@ -112,6 +172,61 @@ Read it as a pipeline: *"Of the **paid** orders, group by region, and show
 only regions whose paid revenue exceeds \$150."* The refunded rows never
 enter the groups at all — and that changes the totals `HAVING` then
 judges.
+
+<svg
+  viewBox="0 0 640 165"
+  role="img"
+  aria-label="Two checkpoints on one flow: loose dots pass a small yellow gate that turns two of them away, the survivors gather into jars, and the jars then face a taller gate where only the full one passes — WHERE filters rows, HAVING filters the groups they form"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="46" cy="80" r="5.5" />
+    <circle cx="74" cy="64" r="5.5" />
+    <circle cx="74" cy="96" r="5.5" />
+    <circle cx="102" cy="80" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="130" y="44" width="9" height="30" rx="4.5" />
+    <rect x="130" y="86" width="9" height="30" rx="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <circle cx="118" cy="124" r="4.5" />
+    <circle cx="112" cy="142" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="166" cy="80" r="5.5" fillOpacity="0.7" />
+    <circle cx="190" cy="80" r="5.5" fillOpacity="0.7" />
+  </g>
+  <g fill="currentColor" opacity="0.07">
+    <rect x="228" y="46" width="70" height="52" rx="10" />
+    <rect x="228" y="108" width="70" height="38" rx="10" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="248" cy="82" r="6" />
+    <circle cx="266" cy="76" r="6" />
+    <circle cx="282" cy="84" r="6" />
+    <circle cx="256" cy="62" r="6" />
+    <circle cx="252" cy="130" r="6" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="348" y="28" width="11" height="48" rx="5.5" />
+    <rect x="348" y="90" width="11" height="48" rx="5.5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="394" cy="82" r="3" />
+    <circle cx="414" cy="82" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="446" y="50" width="78" height="56" rx="11" fillOpacity="0.16" />
+    <circle cx="470" cy="88" r="6.5" />
+    <circle cx="490" cy="82" r="6.5" />
+    <circle cx="506" cy="90" r="6.5" />
+    <circle cx="480" cy="68" r="6.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="326" cy="124" r="6" fillOpacity="0.55" />
+  </g>
+</svg>
 
 ## The classic mistake
 

--- a/content/learn/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
+++ b/content/learn/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
@@ -10,6 +10,46 @@ multi-level summaries in a single query. This page covers `GROUP BY ALL`
 SETS`) for subtotals — the kind of thing you would otherwise stitch
 together with several queries.
 
+<svg
+  viewBox="0 0 640 215"
+  role="img"
+  aria-label="Six blue detail chips merge upward into two green subtotal chips and one yellow grand total, all inside a single soft outline — one rolled-up query returning every level of summary at once"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.05">
+    <rect x="64" y="18" width="512" height="184" rx="28" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="96" y="164" width="58" height="16" rx="8" fillOpacity="0.6" />
+    <rect x="166" y="164" width="58" height="16" rx="8" fillOpacity="0.6" />
+    <rect x="236" y="164" width="58" height="16" rx="8" fillOpacity="0.6" />
+    <rect x="330" y="164" width="58" height="16" rx="8" fillOpacity="0.6" />
+    <rect x="400" y="164" width="58" height="16" rx="8" fillOpacity="0.6" />
+    <rect x="470" y="164" width="58" height="16" rx="8" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="160" cy="142" r="2.5" />
+    <circle cx="195" cy="134" r="2.5" />
+    <circle cx="230" cy="142" r="2.5" />
+    <circle cx="394" cy="142" r="2.5" />
+    <circle cx="429" cy="134" r="2.5" />
+    <circle cx="464" cy="142" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="130" y="102" width="130" height="18" rx="9" fillOpacity="0.75" />
+    <rect x="364" y="102" width="130" height="18" rx="9" fillOpacity="0.75" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="240" cy="82" r="2.5" />
+    <circle cx="285" cy="72" r="2.5" />
+    <circle cx="384" cy="82" r="2.5" />
+    <circle cx="339" cy="72" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="222" y="40" width="180" height="20" rx="10" />
+  </g>
+</svg>
+
 ## `GROUP BY ALL` — stop repeating yourself
 
 A normal grouped query forces you to list the grouping columns *twice*:
@@ -155,6 +195,37 @@ ORDER BY
 
 You now have per-region subtotals, per-product subtotals, the detail, and
 the grand total — the full cross-tabulation, in one query.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A two-by-two grid of blue detail cells grows a green margin column, a yellow margin row, and a red corner total — CUBE computing the detail and every marginal subtotal in a single pass"
+  style={{ display: "block", width: "100%", maxWidth: "440px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="160" y="30" width="92" height="44" rx="9" fillOpacity="0.55" />
+    <rect x="262" y="30" width="92" height="44" rx="9" fillOpacity="0.4" />
+    <rect x="160" y="84" width="92" height="44" rx="9" fillOpacity="0.35" />
+    <rect x="262" y="84" width="92" height="44" rx="9" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="382" y="30" width="60" height="44" rx="9" fillOpacity="0.8" />
+    <rect x="382" y="84" width="60" height="44" rx="9" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="160" y="146" width="92" height="28" rx="9" fillOpacity="0.85" />
+    <rect x="262" y="146" width="92" height="28" rx="9" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="382" y="146" width="60" height="28" rx="9" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="368" cy="52" r="2.5" />
+    <circle cx="368" cy="106" r="2.5" />
+    <circle cx="206" cy="138" r="2.5" />
+    <circle cx="308" cy="138" r="2.5" />
+  </g>
+</svg>
 
 ## Distinguishing real NULLs from subtotal NULLs
 

--- a/content/learn/sql-analytics-duckdb/grouping-data.mdx
+++ b/content/learn/sql-analytics-duckdb/grouping-data.mdx
@@ -9,6 +9,60 @@ want more: "how much *per region*?", "average rating *per product*?",
 it is arguably the most-used construct in all of analytical SQL. This page
 builds a solid mental model of what grouping really does.
 
+<svg
+  viewBox="0 0 640 235"
+  role="img"
+  aria-label="One mixed stream of colored dots falls from a spout and sorts itself into three jars by color, and each jar condenses into a single solid bar sized to its contents — GROUP BY bins the rows, then summarizes every bin once"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="284" y="14" width="72" height="16" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="302" cy="40" r="5" />
+    <circle cx="268" cy="58" r="4" fillOpacity="0.7" />
+    <circle cx="226" cy="76" r="4" fillOpacity="0.5" />
+    <circle cx="188" cy="98" r="4" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="320" cy="52" r="5" />
+    <circle cx="320" cy="78" r="4" fillOpacity="0.6" />
+    <circle cx="320" cy="102" r="4" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="338" cy="40" r="5" />
+    <circle cx="372" cy="58" r="4" fillOpacity="0.7" />
+    <circle cx="414" cy="76" r="4" fillOpacity="0.5" />
+    <circle cx="452" cy="98" r="4" fillOpacity="0.4" />
+  </g>
+  <g fill="currentColor" opacity="0.07">
+    <rect x="102" y="118" width="96" height="84" rx="12" />
+    <rect x="272" y="118" width="96" height="84" rx="12" />
+    <rect x="442" y="118" width="96" height="84" rx="12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="128" cy="180" r="7" />
+    <circle cx="150" cy="184" r="7" />
+    <circle cx="172" cy="178" r="7" />
+    <circle cx="140" cy="160" r="7" />
+    <rect x="130" y="216" width="40" height="9" rx="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="304" cy="182" r="7" />
+    <circle cx="328" cy="180" r="7" />
+    <circle cx="316" cy="160" r="7" />
+    <rect x="305" y="216" width="30" height="9" rx="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="466" cy="182" r="7" />
+    <circle cx="488" cy="178" r="7" />
+    <circle cx="510" cy="184" r="7" />
+    <circle cx="478" cy="160" r="7" />
+    <circle cx="500" cy="162" r="7" />
+    <rect x="465" y="216" width="50" height="9" rx="4.5" />
+  </g>
+</svg>
+
 ## From one summary to many
 
 Without `GROUP BY`, an aggregate collapses the *whole* table to one row.
@@ -112,6 +166,42 @@ Grouping by two columns creates one row per **combination** that actually
 appears. Above, you get one row per `(region, product)` pair — a small
 matrix of the business. Adding a grouping column is exactly the
 **drill-down** move from earlier: more dimensions, finer detail.
+
+<svg
+  viewBox="0 0 640 175"
+  role="img"
+  aria-label="Six pill tiles arranged as a small quilt, each holding one of three region colors paired with either a solid or a hollow product mark — grouping by two columns yields one summary row per combination that appears"
+  style={{ display: "block", width: "100%", maxWidth: "440px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.07">
+    <rect x="116" y="28" width="190" height="36" rx="18" />
+    <rect x="334" y="28" width="190" height="36" rx="18" />
+    <rect x="116" y="78" width="190" height="36" rx="18" />
+    <rect x="334" y="78" width="190" height="36" rx="18" />
+    <rect x="116" y="128" width="190" height="36" rx="18" />
+    <rect x="334" y="128" width="190" height="36" rx="18" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="148" cy="46" r="9" />
+    <circle cx="366" cy="46" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="148" cy="96" r="9" />
+    <circle cx="366" cy="96" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="148" cy="146" r="9" />
+    <circle cx="366" cy="146" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.55">
+    <circle cx="272" cy="46" r="7" />
+    <circle cx="272" cy="96" r="7" />
+    <circle cx="272" cy="146" r="7" />
+    <path d="M 490 46 m -7 0 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 M 490 46 m -3.5 0 a 3.5 3.5 0 1 1 7 0 a 3.5 3.5 0 1 1 -7 0" fillRule="evenodd" />
+    <path d="M 490 96 m -7 0 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 M 490 96 m -3.5 0 a 3.5 3.5 0 1 1 7 0 a 3.5 3.5 0 1 1 -7 0" fillRule="evenodd" />
+    <path d="M 490 146 m -7 0 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 M 490 146 m -3.5 0 a 3.5 3.5 0 1 1 7 0 a 3.5 3.5 0 1 1 -7 0" fillRule="evenodd" />
+  </g>
+</svg>
 
 ## Grouping by an expression
 

--- a/content/learn/sql-analytics-duckdb/index.mdx
+++ b/content/learn/sql-analytics-duckdb/index.mdx
@@ -14,6 +14,64 @@ summarize ten million sales into a single trend line. Learning *how
 analysts wield SQL* — and *why* analytical queries are shaped the way
 they are — is the whole point of what follows.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="An abstract duck built from filled circles glides along a waterline under a yellow sun, and its reflection below the surface is a bar chart of columnar stripes — data turning into insight wherever DuckDB swims"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="86" cy="62" r="3" />
+    <circle cx="128" cy="34" r="2.5" />
+    <circle cx="178" cy="78" r="2" />
+    <circle cx="466" cy="96" r="2.5" />
+    <circle cx="598" cy="112" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="540" cy="48" r="26" fillOpacity="0.18" />
+    <circle cx="540" cy="48" r="16" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="36" y="146" width="568" height="4" rx="2" />
+    <rect x="64" y="160" width="92" height="3" rx="1.5" />
+    <rect x="470" y="160" width="110" height="3" rx="1.5" />
+    <rect x="104" y="172" width="58" height="3" rx="1.5" />
+    <rect x="506" y="174" width="64" height="3" rx="1.5" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="236" cy="140" r="3" />
+    <circle cx="210" cy="134" r="2.5" />
+    <circle cx="186" cy="140" r="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 276 104 L 242 82 L 260 116 Z" />
+    <circle cx="302" cy="116" r="34" />
+    <rect x="332" y="76" width="16" height="38" rx="8" />
+    <circle cx="344" cy="76" r="17" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <circle cx="296" cy="118" r="14" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 359 68 L 384 76 L 359 86 Z" />
+  </g>
+  <circle cx="349" cy="71" r="2.6" fill="var(--ds-white)" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="254" y="154" width="17" height="50" rx="5" fillOpacity="0.4" />
+    <rect x="277" y="154" width="17" height="30" rx="5" fillOpacity="0.28" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="300" y="154" width="17" height="68" rx="5" fillOpacity="0.5" />
+    <rect x="323" y="154" width="17" height="42" rx="5" fillOpacity="0.32" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="346" y="154" width="17" height="56" rx="5" fillOpacity="0.42" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="369" y="154" width="17" height="24" rx="5" fillOpacity="0.4" />
+  </g>
+</svg>
+
 <Callout type="info" title="Nothing to install">
 Every SQL example on every page runs **inside your browser** on a real
 DuckDB engine (DuckDB compiled to WebAssembly). There is no server, no

--- a/content/learn/sql-analytics-duckdb/loading-and-generating-data.mdx
+++ b/content/learn/sql-analytics-duckdb/loading-and-generating-data.mdx
@@ -9,6 +9,50 @@ introduces two DuckDB conveniences you will use constantly: the `range()`
 generator and `CREATE TABLE AS`. These let you build realistic practice
 datasets in seconds — no files required.
 
+<svg
+  viewBox="0 0 640 215"
+  role="img"
+  aria-label="From a single green seed, a fountain of dots arcs across the canvas and lands as a neat grid of table cells that grow more solid as they materialize — whole practice datasets conjured from one generator expression"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="72" cy="168" r="8" />
+    <path d="M 72 158 Q 64 142 74 132 Q 80 146 72 158 Z" fillOpacity="0.7" />
+    <circle cx="106" cy="130" r="3" fillOpacity="0.5" />
+    <circle cx="142" cy="96" r="3.5" fillOpacity="0.6" />
+    <circle cx="184" cy="68" r="4" fillOpacity="0.7" />
+    <circle cx="232" cy="50" r="4.5" fillOpacity="0.8" />
+    <circle cx="284" cy="42" r="5" fillOpacity="0.9" />
+    <circle cx="336" cy="46" r="5" />
+    <circle cx="382" cy="58" r="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <circle cx="124" cy="60" r="3" />
+    <circle cx="206" cy="110" r="3" />
+    <circle cx="300" cy="86" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="424" y="80" width="38" height="20" rx="5" fillOpacity="0.25" />
+    <rect x="468" y="80" width="38" height="20" rx="5" fillOpacity="0.45" />
+    <rect x="512" y="80" width="38" height="20" rx="5" fillOpacity="0.65" />
+    <rect x="556" y="80" width="38" height="20" rx="5" fillOpacity="0.85" />
+    <rect x="424" y="106" width="38" height="20" rx="5" fillOpacity="0.2" />
+    <rect x="468" y="106" width="38" height="20" rx="5" fillOpacity="0.4" />
+    <rect x="556" y="106" width="38" height="20" rx="5" fillOpacity="0.8" />
+    <rect x="424" y="132" width="38" height="20" rx="5" fillOpacity="0.15" />
+    <rect x="468" y="132" width="38" height="20" rx="5" fillOpacity="0.35" />
+    <rect x="512" y="132" width="38" height="20" rx="5" fillOpacity="0.55" />
+    <rect x="556" y="132" width="38" height="20" rx="5" fillOpacity="0.75" />
+    <rect x="424" y="158" width="38" height="20" rx="5" fillOpacity="0.1" />
+    <rect x="468" y="158" width="38" height="20" rx="5" fillOpacity="0.3" />
+    <rect x="512" y="158" width="38" height="20" rx="5" fillOpacity="0.5" />
+    <rect x="556" y="158" width="38" height="20" rx="5" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="512" y="106" width="38" height="20" rx="5" fillOpacity="0.9" />
+  </g>
+</svg>
+
 ## Four ways data arrives
 
 ```mermaid
@@ -76,6 +120,37 @@ ORDER BY
 you want 1 through 100, write `range(1, 101)`. This off-by-one is the most
 common `range()` mistake.
 </Callout>
+
+<svg
+  viewBox="0 0 640 140"
+  role="img"
+  aria-label="A translucent blue band covers a row of twelve solid dots from one to twelve, while a thirteenth dot waits ghosted in red just outside the band's right edge — range includes its start but excludes its end"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="48" y="46" width="468" height="44" rx="22" fillOpacity="0.14" />
+    <circle cx="80" cy="68" r="9" />
+    <circle cx="116" cy="68" r="9" />
+    <circle cx="152" cy="68" r="9" />
+    <circle cx="188" cy="68" r="9" />
+    <circle cx="224" cy="68" r="9" />
+    <circle cx="260" cy="68" r="9" />
+    <circle cx="296" cy="68" r="9" />
+    <circle cx="332" cy="68" r="9" />
+    <circle cx="368" cy="68" r="9" />
+    <circle cx="404" cy="68" r="9" />
+    <circle cx="440" cy="68" r="9" />
+    <circle cx="484" cy="68" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="556" cy="68" r="9" fillOpacity="0.3" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="80" y="118" fontFamily="ui-monospace, monospace" fontSize="14" textAnchor="middle">1</text>
+    <text x="484" y="118" fontFamily="ui-monospace, monospace" fontSize="14" textAnchor="middle">12</text>
+    <text x="556" y="118" fontFamily="ui-monospace, monospace" fontSize="14" textAnchor="middle">13</text>
+  </g>
+</svg>
 
 You can turn the integer into dates, categories, and amounts using
 arithmetic and DuckDB's list-indexing trick `['a','b','c'][n]`:
@@ -155,6 +230,36 @@ No import step, no schema declaration — DuckDB infers the columns and
 scans the file. This "query the file in place" ability is a big reason
 analysts love it. The browser sandbox here has no file system, so we
 generate data instead, but the **SQL you practice is identical**.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A file card with a folded blue corner whose stripes spill straight out of its bottom edge and widen into faint table rows, while a green query dot touches the card directly — the file is queried in place, with no import step in between"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.09">
+    <path d="M 240 28 L 366 28 L 400 62 L 400 134 L 240 134 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 366 28 L 400 62 L 366 62 Z" fillOpacity="0.8" />
+    <rect x="258" y="52" width="92" height="9" rx="4.5" fillOpacity="0.45" />
+    <rect x="258" y="72" width="116" height="9" rx="4.5" fillOpacity="0.45" />
+    <rect x="258" y="92" width="78" height="9" rx="4.5" fillOpacity="0.45" />
+    <rect x="258" y="112" width="104" height="9" rx="4.5" fillOpacity="0.45" />
+    <rect x="238" y="146" width="164" height="9" rx="4.5" fillOpacity="0.3" />
+    <rect x="218" y="164" width="204" height="9" rx="4.5" fillOpacity="0.2" />
+    <rect x="198" y="182" width="244" height="9" rx="4.5" fillOpacity="0.12" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="200" cy="80" r="22" fillOpacity="0.18" />
+    <circle cx="200" cy="80" r="11" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="468" cy="60" r="3" />
+    <circle cx="488" cy="110" r="3" />
+    <circle cx="462" cy="160" r="3" />
+  </g>
+</svg>
 
 ## Check your understanding
 

--- a/content/learn/sql-analytics-duckdb/next-steps.mdx
+++ b/content/learn/sql-analytics-duckdb/next-steps.mdx
@@ -10,6 +10,55 @@ readable pipelines, and turn raw rows into trustworthy business metrics.
 More importantly, you understand **why** each technique exists — which is
 the part that outlasts any one tool.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A line of solid green stepping stones crosses the water and fades into dotted ones, where a small sailboat sets off toward three islands on the horizon — the course behind you, the next territories within reach"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="40" y="100" width="560" height="4" rx="2" />
+    <rect x="80" y="132" width="90" height="3" rx="1.5" />
+    <rect x="240" y="150" width="70" height="3" rx="1.5" />
+    <rect x="420" y="128" width="84" height="3" rx="1.5" />
+    <rect x="150" y="186" width="110" height="3" rx="1.5" />
+    <rect x="480" y="170" width="70" height="3" rx="1.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 488 100 A 15 9 0 0 1 518 100 Z" fillOpacity="0.3" />
+    <path d="M 524 100 A 27 15 0 0 1 578 100 Z" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 584 100 A 19 11 0 0 1 622 100 Z" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="92" cy="188" r="11" />
+    <circle cx="152" cy="176" r="10" />
+    <circle cx="210" cy="164" r="9" />
+    <circle cx="266" cy="152" r="8" />
+    <circle cx="318" cy="142" r="7" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="364" cy="133" r="6" />
+    <circle cx="404" cy="126" r="5" />
+    <circle cx="440" cy="120" r="4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="412" y="48" width="4" height="40" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 420 50 L 420 86 L 448 86 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 392 90 L 444 90 Q 436 104 414 104 Q 398 104 392 90 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="120" cy="48" r="3" />
+    <circle cx="190" cy="30" r="2.5" />
+    <circle cx="560" cy="40" r="3" />
+  </g>
+</svg>
+
 ## What you built up
 
 The course moved deliberately from *mindset* to *technique* to *insight*:

--- a/content/learn/sql-analytics-duckdb/pivoting-and-reshaping.mdx
+++ b/content/learn/sql-analytics-duckdb/pivoting-and-reshaping.mdx
@@ -10,6 +10,58 @@ wide is great for reading. This page explains the two shapes, why they
 matter, and how to pivot in DuckDB both by hand and with the dedicated
 `PIVOT` syntax.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A tall one-value-per-row strip swings along a dotted arc around a yellow pivot pin and lands as a short wide grid, every colored cell finding its own column — the same data turned ninety degrees from long to wide"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="100" y="28" width="44" height="26" rx="6" fillOpacity="0.85" />
+    <rect x="100" y="118" width="44" height="26" rx="6" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="100" y="58" width="44" height="26" rx="6" fillOpacity="0.85" />
+    <rect x="100" y="148" width="44" height="26" rx="6" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="100" y="88" width="44" height="26" rx="6" fillOpacity="0.85" />
+    <rect x="100" y="178" width="44" height="26" rx="6" fillOpacity="0.4" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="186" cy="36" r="2.5" />
+    <circle cx="226" cy="24" r="2.5" />
+    <circle cx="268" cy="18" r="2.5" />
+    <circle cx="310" cy="20" r="2.5" />
+    <circle cx="350" cy="30" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="302" cy="120" r="13" fillOpacity="0.25" />
+    <circle cx="302" cy="120" r="7" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="368" y="64" width="32" height="26" rx="6" />
+    <rect x="368" y="100" width="32" height="26" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="410" y="64" width="56" height="26" rx="6" fillOpacity="0.85" />
+    <rect x="410" y="100" width="56" height="26" rx="6" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="476" y="64" width="56" height="26" rx="6" fillOpacity="0.85" />
+    <rect x="476" y="100" width="56" height="26" rx="6" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="542" y="64" width="56" height="26" rx="6" fillOpacity="0.85" />
+    <rect x="542" y="100" width="56" height="26" rx="6" fillOpacity="0.4" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="430" cy="170" r="3" />
+    <circle cx="62" cy="190" r="3" />
+    <circle cx="580" cy="170" r="3" />
+  </g>
+</svg>
+
 ## Long vs. wide: the same data, two layouts
 
 Imagine quarterly sales per region. In **long** form, each region-quarter
@@ -164,6 +216,39 @@ spreadsheet someone built for reading rather than computing.
   wide** at the end.
 
 A good rule: **compute in long, present in wide.**
+
+<svg
+  viewBox="0 0 640 165"
+  role="img"
+  aria-label="A tall strip of cells stands beside an italic function mark, while a wide row of cells rests beside an open eye — compute in long form, present in wide form"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="104" y="28" width="40" height="24" rx="6" fillOpacity="0.75" />
+    <rect x="104" y="58" width="40" height="24" rx="6" fillOpacity="0.55" />
+    <rect x="104" y="88" width="40" height="24" rx="6" fillOpacity="0.65" />
+    <rect x="104" y="118" width="40" height="24" rx="6" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <text x="200" y="98" fontFamily="Georgia, serif" fontSize="52" fontStyle="italic" textAnchor="middle">ƒ</text>
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="276" y="80" width="4" height="10" rx="2" />
+    <rect x="288" y="80" width="4" height="10" rx="2" />
+    <rect x="300" y="80" width="4" height="10" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="336" y="72" width="46" height="24" rx="6" fillOpacity="0.75" />
+    <rect x="388" y="72" width="46" height="24" rx="6" fillOpacity="0.55" />
+    <rect x="440" y="72" width="46" height="24" rx="6" fillOpacity="0.65" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <path d="M 516 84 Q 552 56 588 84 Q 552 112 516 84 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="552" cy="84" r="9" />
+  </g>
+</svg>
 
 ## Check your understanding
 

--- a/content/learn/sql-analytics-duckdb/profiling-a-dataset.mdx
+++ b/content/learn/sql-analytics-duckdb/profiling-a-dataset.mdx
@@ -10,6 +10,57 @@ Skipping this step is how analysts get fooled — by duplicates, missing
 values, or a date column that secretly stops in March. This page is the
 profiling checklist, expressed in SQL.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A blue magnifier hovers over one column of a faint table and blows it up into quick stats — a range bar, distinct-value dots, and a red ring around a hole where a value is missing — profiling a dataset before trusting it"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="70" y="40" width="38" height="20" rx="5" />
+    <rect x="70" y="68" width="38" height="20" rx="5" />
+    <rect x="70" y="96" width="38" height="20" rx="5" />
+    <rect x="70" y="124" width="38" height="20" rx="5" />
+    <rect x="70" y="152" width="38" height="20" rx="5" />
+    <rect x="122" y="40" width="38" height="20" rx="5" />
+    <rect x="122" y="68" width="38" height="20" rx="5" />
+    <rect x="122" y="96" width="38" height="20" rx="5" />
+    <rect x="122" y="124" width="38" height="20" rx="5" />
+    <rect x="122" y="152" width="38" height="20" rx="5" />
+    <rect x="174" y="40" width="38" height="20" rx="5" />
+    <rect x="174" y="68" width="38" height="20" rx="5" />
+    <rect x="174" y="96" width="38" height="20" rx="5" />
+    <rect x="174" y="124" width="38" height="20" rx="5" />
+    <rect x="174" y="152" width="38" height="20" rx="5" />
+    <rect x="226" y="40" width="38" height="20" rx="5" />
+    <rect x="226" y="68" width="38" height="20" rx="5" />
+    <rect x="226" y="124" width="38" height="20" rx="5" />
+    <rect x="226" y="152" width="38" height="20" rx="5" />
+  </g>
+  <g fill="currentColor" opacity="0.05">
+    <circle cx="400" cy="104" r="56" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 400 40 a 64 64 0 1 0 0.01 0 Z M 400 49 a 55 55 0 1 1 -0.01 0 Z" fillRule="evenodd" />
+    <path d="M 441 156 L 456 141 L 524 201 L 511 218 Z" />
+    <rect x="364" y="76" width="72" height="13" rx="6.5" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="372" cy="110" r="6" />
+    <circle cx="394" cy="110" r="6" />
+    <circle cx="416" cy="110" r="6" />
+    <circle cx="438" cy="110" r="6" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 400 124 a 12 12 0 1 0 0.01 0 Z M 400 130 a 6 6 0 1 1 -0.01 0 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="560" cy="60" r="3" />
+    <circle cx="590" cy="106" r="3" />
+    <circle cx="566" cy="150" r="3" />
+  </g>
+</svg>
+
 ## Why profile first
 
 A dataset can lie to you in quiet ways:
@@ -123,6 +174,31 @@ FROM
 
 Knowing *how many* values are missing tells you whether a column is
 trustworthy or needs cleaning before analysis.
+
+<svg
+  viewBox="0 0 640 130"
+  role="img"
+  aria-label="Two left-aligned measuring bars — every row in blue above, only the non-null values in green below — leave a red overhang where they differ: the exact count of missing values"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="80" y="34" width="400" height="22" rx="11" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="80" y="72" width="296" height="22" rx="11" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="384" y="72" width="96" height="22" rx="11" fillOpacity="0.25" />
+    <circle cx="412" cy="83" r="4" fillOpacity="0.85" />
+    <circle cx="432" cy="83" r="4" fillOpacity="0.85" />
+    <circle cx="452" cy="83" r="4" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="80" y="106" width="3" height="10" rx="1.5" />
+    <rect x="478" y="106" width="3" height="10" rx="1.5" />
+    <rect x="376" y="106" width="3" height="10" rx="1.5" />
+  </g>
+</svg>
 
 ## The shortcut: `SUMMARIZE`
 

--- a/content/learn/sql-analytics-duckdb/ranking-and-row-number.mdx
+++ b/content/learn/sql-analytics-duckdb/ranking-and-row-number.mdx
@@ -11,6 +11,44 @@ top-N pattern they unlock. Because ranking is foundational and the
 RANK/DENSE_RANK distinction trips people up, there are extra questions at
 the end.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Two green dots share the top step of a podium while the second step holds only a ghost ring and a blue dot stands on third — when rows tie, RANK hands out two golds and no silver"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor">
+    <rect x="148" y="128" width="116" height="76" rx="8" opacity="0.12" />
+    <rect x="264" y="92" width="116" height="112" rx="8" opacity="0.18" />
+    <rect x="380" y="152" width="116" height="52" rx="8" opacity="0.09" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="298" cy="72" r="11" />
+    <circle cx="344" cy="72" r="11" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="298" cy="50" r="3" fillOpacity="0.8" />
+    <circle cx="321" cy="44" r="3.5" fillOpacity="0.9" />
+    <circle cx="344" cy="50" r="3" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <path d="M 206 108 m -10 0 a 10 10 0 1 0 20 0 a 10 10 0 1 0 -20 0 M 206 108 m -6 0 a 6 6 0 1 1 12 0 a 6 6 0 1 1 -12 0" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="438" cy="132" r="10" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <text x="322" y="156" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle">1</text>
+    <text x="438" y="186" fontFamily="ui-monospace, monospace" fontSize="18" textAnchor="middle">3</text>
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <text x="206" y="172" fontFamily="ui-monospace, monospace" fontSize="20" textAnchor="middle">2</text>
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="120" y="210" width="400" height="5" rx="2.5" />
+  </g>
+</svg>
+
 ## Numbering rows with `ROW_NUMBER`
 
 `ROW_NUMBER()` assigns 1, 2, 3, ... to rows in the order you specify. It

--- a/content/learn/sql-analytics-duckdb/reproducible-analytical-workflows.mdx
+++ b/content/learn/sql-analytics-duckdb/reproducible-analytical-workflows.mdx
@@ -9,6 +9,55 @@ produce the same result, and you should be able to explain exactly how it
 was computed. This closing-technique page is about **reproducibility**:
 the habits that turn a one-off query into analysis others can rely on.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="Three colored stations sit on a dotted loop that can be run lap after lap, and every lap drops one more identical green chip onto the stack at the right — a reproducible workflow returns the same answer every time it runs"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="240" cy="38" r="3" />
+    <circle cx="277" cy="48" r="3" />
+    <circle cx="303" cy="74" r="3" />
+    <circle cx="312" cy="110" r="3" />
+    <circle cx="303" cy="146" r="3" />
+    <circle cx="277" cy="172" r="3" />
+    <circle cx="240" cy="182" r="3" />
+    <circle cx="203" cy="172" r="3" />
+    <circle cx="177" cy="146" r="3" />
+    <circle cx="168" cy="110" r="3" />
+    <circle cx="177" cy="74" r="3" />
+    <circle cx="203" cy="48" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="240" cy="38" r="12" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="303" cy="146" r="12" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="177" cy="146" r="12" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="352" cy="110" r="2.5" />
+    <circle cx="374" cy="110" r="2.5" />
+    <circle cx="396" cy="110" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <text x="424" y="118" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle">=</text>
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="452" y="62" width="116" height="20" rx="10" fillOpacity="0.85" />
+    <rect x="452" y="100" width="116" height="20" rx="10" fillOpacity="0.85" />
+    <rect x="452" y="138" width="116" height="20" rx="10" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="84" cy="60" r="3" />
+    <circle cx="64" cy="160" r="3" />
+    <circle cx="600" cy="190" r="3" />
+  </g>
+</svg>
+
 ## Why reproducibility is non-negotiable
 
 Analysis drives decisions, and decisions get questioned. "Where did this
@@ -155,6 +204,40 @@ ORDER BY
 The definition of "paid revenue by region" now lives in *one* place. If
 the business redefines it, you change the view once and every downstream
 query follows.
+
+<svg
+  viewBox="0 0 640 175"
+  role="img"
+  aria-label="Three readers draw from one yellow named definition along dotted rays, while below two faded copy-pasted chips have already drifted out of line — a view keeps everyone computing the same metric"
+  style={{ display: "block", width: "100%", maxWidth: "500px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="86" y="48" width="128" height="36" rx="18" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="248" cy="46" r="2.5" />
+    <circle cx="286" cy="36" r="2.5" />
+    <circle cx="324" cy="30" r="2.5" />
+    <circle cx="248" cy="66" r="2.5" />
+    <circle cx="290" cy="66" r="2.5" />
+    <circle cx="332" cy="66" r="2.5" />
+    <circle cx="248" cy="86" r="2.5" />
+    <circle cx="286" cy="96" r="2.5" />
+    <circle cx="324" cy="102" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="372" cy="28" r="11" />
+    <circle cx="380" cy="66" r="11" />
+    <circle cx="372" cy="104" r="11" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="118" y="128" width="84" height="16" rx="8" />
+    <rect x="232" y="138" width="84" height="16" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="206" y="124" width="34" height="6" rx="3" fillOpacity="0.6" />
+  </g>
+</svg>
 
 ## Structure for readability and auditability
 

--- a/content/learn/sql-analytics-duckdb/running-totals-and-moving-averages.mdx
+++ b/content/learn/sql-analytics-duckdb/running-totals-and-moving-averages.mdx
@@ -10,6 +10,51 @@ calculation accumulate or slide as it moves through the rows. This page
 covers running totals, moving averages, and the row-comparison functions
 `LAG`/`LEAD`, and finally explains the **window frame**.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A staircase of stacked bars climbs left to right, each step carrying the previous blue total with today's green slice added on top, while a yellow dot walks the rising edge — a running total accumulating row by row"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="80" y="204" width="490" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="104" y="176" width="56" height="26" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="196" y="176" width="56" height="26" rx="6" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="196" y="140" width="56" height="32" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="288" y="140" width="56" height="62" rx="6" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="288" y="116" width="56" height="20" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="380" y="116" width="56" height="86" rx="6" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="380" y="66" width="56" height="46" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="472" y="66" width="56" height="136" rx="6" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="472" y="36" width="56" height="26" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="132" cy="162" r="7" fillOpacity="0.35" />
+    <circle cx="224" cy="126" r="7" fillOpacity="0.5" />
+    <circle cx="316" cy="102" r="7" fillOpacity="0.65" />
+    <circle cx="408" cy="52" r="7" fillOpacity="0.8" />
+    <circle cx="500" cy="22" r="7" />
+  </g>
+</svg>
+
 ## A running total
 
 A running (cumulative) total adds each row's value to the sum of all rows
@@ -136,6 +181,47 @@ The first row's `prev_day` is `NULL` — there is no earlier row to look
 back to. That is expected, and it is why the first `change` is also
 `NULL`.
 
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="A blue row glances backward to its green predecessor and forward to its yellow successor along dotted arcs, while the very first row's backward glance finds only a hollow red ring — LAG and LEAD read neighboring rows, and the first row has nothing behind it"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 56 92 m -8 0 a 8 8 0 1 0 16 0 a 8 8 0 1 0 -16 0 M 56 92 m -4.5 0 a 4.5 4.5 0 1 1 9 0 a 4.5 4.5 0 1 1 -9 0" fillRule="evenodd" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="84" cy="74" r="2" />
+    <circle cx="98" cy="66" r="2" />
+    <circle cx="112" cy="62" r="2" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="124" cy="92" r="8" />
+    <circle cx="192" cy="92" r="8" />
+    <circle cx="464" cy="92" r="8" />
+    <circle cx="532" cy="92" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="260" cy="92" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="328" cy="92" r="12" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="396" cy="92" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="306" cy="66" r="2.5" fillOpacity="0.7" />
+    <circle cx="288" cy="58" r="2.5" fillOpacity="0.7" />
+    <circle cx="270" cy="66" r="2.5" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="350" cy="66" r="2.5" fillOpacity="0.8" />
+    <circle cx="368" cy="58" r="2.5" fillOpacity="0.8" />
+    <circle cx="386" cy="66" r="2.5" fillOpacity="0.8" />
+  </g>
+</svg>
+
 ## The window frame — moving averages
 
 So far an ordered `SUM` summed *everything up to the current row*. That
@@ -143,6 +229,43 @@ default is called the frame `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT
 ROW`. You can change the frame to a **sliding window** — say, the current
 row plus the two before it — to compute a **moving average** that smooths
 out noise.
+
+<svg
+  viewBox="0 0 640 185"
+  role="img"
+  aria-label="A translucent yellow frame slides along a row of jagged bars three at a time, leaving behind its ghost from the previous step, while a calm curve of green dots rises above the noise — a moving average smoothing the series"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.22">
+    <rect x="70" y="108" width="26" height="58" rx="5" />
+    <rect x="120" y="84" width="26" height="82" rx="5" />
+    <rect x="170" y="122" width="26" height="44" rx="5" />
+    <rect x="220" y="70" width="26" height="96" rx="5" />
+    <rect x="270" y="100" width="26" height="66" rx="5" />
+    <rect x="320" y="60" width="26" height="106" rx="5" />
+    <rect x="370" y="114" width="26" height="52" rx="5" />
+    <rect x="420" y="78" width="26" height="88" rx="5" />
+    <rect x="470" y="96" width="26" height="70" rx="5" />
+    <rect x="520" y="68" width="26" height="98" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="110" y="48" width="146" height="128" rx="14" fillOpacity="0.12" />
+    <rect x="260" y="42" width="146" height="134" rx="14" fillOpacity="0.32" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="133" cy="46" r="4" fillOpacity="0.5" />
+    <circle cx="183" cy="42" r="4" fillOpacity="0.6" />
+    <circle cx="233" cy="40" r="4.5" fillOpacity="0.7" />
+    <circle cx="283" cy="36" r="4.5" fillOpacity="0.8" />
+    <circle cx="333" cy="32" r="5" />
+    <circle cx="383" cy="30" r="4.5" fillOpacity="0.8" />
+    <circle cx="433" cy="32" r="4" fillOpacity="0.65" />
+    <circle cx="483" cy="30" r="4" fillOpacity="0.5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="60" y="170" width="500" height="4" rx="2" />
+  </g>
+</svg>
 
 <SqlCodeBlock
   dialect="duckdb"

--- a/content/learn/sql-analytics-duckdb/sorting-and-top-n.mdx
+++ b/content/learn/sql-analytics-duckdb/sorting-and-top-n.mdx
@@ -9,6 +9,68 @@ to *sort, then look at the head*. This page treats `ORDER BY` not as
 presentation but as a way to **find the rows that matter**, and introduces
 the per-group top-N pattern analysts use constantly.
 
+<svg
+  viewBox="0 0 640 235"
+  role="img"
+  aria-label="Loose dots pour into a vessel and settle into layers sorted by size, while a yellow ladle skims the three biggest green dots off the top — and an equally large red dot left in the layer below hints at the tie that almost made the cut"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="62" cy="44" r="5" />
+    <circle cx="96" cy="28" r="7" />
+    <circle cx="128" cy="52" r="4" />
+    <circle cx="158" cy="30" r="6" />
+    <circle cx="118" cy="84" r="3.5" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="184" cy="62" r="3" />
+    <circle cx="208" cy="84" r="3" />
+    <circle cx="228" cy="108" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.07">
+    <rect x="244" y="84" width="252" height="124" rx="16" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 252 58 Q 370 86 488 58 L 488 68 Q 370 96 252 68 Z" fillOpacity="0.55" />
+    <rect x="488" y="50" width="64" height="10" rx="5" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="306" cy="42" r="10" />
+    <circle cx="370" cy="48" r="10" />
+    <circle cx="434" cy="42" r="10" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="294" cy="110" r="7" fillOpacity="0.6" />
+    <circle cx="350" cy="110" r="7" fillOpacity="0.6" />
+    <circle cx="462" cy="110" r="7" fillOpacity="0.6" />
+    <circle cx="286" cy="140" r="5.5" fillOpacity="0.45" />
+    <circle cx="330" cy="140" r="5.5" fillOpacity="0.45" />
+    <circle cx="374" cy="140" r="5.5" fillOpacity="0.45" />
+    <circle cx="418" cy="140" r="5.5" fillOpacity="0.45" />
+    <circle cx="460" cy="140" r="5.5" fillOpacity="0.45" />
+    <circle cx="280" cy="166" r="4" fillOpacity="0.3" />
+    <circle cx="316" cy="166" r="4" fillOpacity="0.3" />
+    <circle cx="352" cy="166" r="4" fillOpacity="0.3" />
+    <circle cx="388" cy="166" r="4" fillOpacity="0.3" />
+    <circle cx="424" cy="166" r="4" fillOpacity="0.3" />
+    <circle cx="460" cy="166" r="4" fillOpacity="0.3" />
+    <circle cx="276" cy="190" r="3" fillOpacity="0.18" />
+    <circle cx="308" cy="190" r="3" fillOpacity="0.18" />
+    <circle cx="340" cy="190" r="3" fillOpacity="0.18" />
+    <circle cx="372" cy="190" r="3" fillOpacity="0.18" />
+    <circle cx="404" cy="190" r="3" fillOpacity="0.18" />
+    <circle cx="436" cy="190" r="3" fillOpacity="0.18" />
+    <circle cx="466" cy="190" r="3" fillOpacity="0.18" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="406" cy="110" r="9.5" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="560" cy="120" r="3" />
+    <circle cx="586" cy="160" r="3" />
+  </g>
+</svg>
+
 ## Sorting surfaces the extremes
 
 The fastest way to learn something about a dataset is to look at its
@@ -162,6 +224,41 @@ section explains them in full. For now, note the *shape* of the question:
 **rank within each group, then keep the top of each**. It is one of the
 most common analytical patterns there is, and `QUALIFY` expresses it
 without an extra subquery.
+
+<svg
+  viewBox="0 0 640 195"
+  role="img"
+  aria-label="Three vertical lanes of dots sorted by size, each with a translucent green band hugging its own two largest — top-N applied within every group instead of once across the whole result"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.06">
+    <rect x="98" y="24" width="92" height="156" rx="16" />
+    <rect x="274" y="24" width="92" height="156" rx="16" />
+    <rect x="450" y="24" width="92" height="156" rx="16" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="106" y="34" width="76" height="68" rx="13" fillOpacity="0.16" />
+    <rect x="282" y="34" width="76" height="62" rx="13" fillOpacity="0.16" />
+    <rect x="458" y="34" width="76" height="74" rx="13" fillOpacity="0.16" />
+    <circle cx="144" cy="54" r="10" />
+    <circle cx="144" cy="84" r="8" />
+    <circle cx="320" cy="52" r="9" />
+    <circle cx="320" cy="80" r="7.5" />
+    <circle cx="496" cy="56" r="11" />
+    <circle cx="496" cy="90" r="8.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="144" cy="116" r="6" fillOpacity="0.4" />
+    <circle cx="144" cy="142" r="4.5" fillOpacity="0.28" />
+    <circle cx="144" cy="163" r="3.5" fillOpacity="0.18" />
+    <circle cx="320" cy="108" r="6" fillOpacity="0.4" />
+    <circle cx="320" cy="134" r="4.5" fillOpacity="0.28" />
+    <circle cx="320" cy="156" r="3.5" fillOpacity="0.18" />
+    <circle cx="496" cy="122" r="6" fillOpacity="0.4" />
+    <circle cx="496" cy="148" r="4.5" fillOpacity="0.28" />
+    <circle cx="496" cy="168" r="3.5" fillOpacity="0.18" />
+  </g>
+</svg>
 
 ## Check your understanding
 

--- a/content/learn/sql-analytics-duckdb/subqueries-in-analytics.mdx
+++ b/content/learn/sql-analytics-duckdb/subqueries-in-analytics.mdx
@@ -9,6 +9,55 @@ moderation, though, subqueries are a precise, expressive tool. This page
 sorts the common kinds, shows where each shines in analysis, and gives you
 a rule for choosing between a subquery, a CTE, and a join.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Value dots float above and below a dashed yellow line whose height was forged inside a small medallion where miniature rows collapse to a single point — a subquery computes one number and every outer row is measured against it"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="84" cy="64" r="8" />
+    <circle cx="188" cy="48" r="8" />
+    <circle cx="292" cy="76" r="8" />
+    <circle cx="396" cy="56" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="136" cy="148" r="8" fillOpacity="0.45" />
+    <circle cx="240" cy="166" r="8" fillOpacity="0.45" />
+    <circle cx="344" cy="140" r="8" fillOpacity="0.45" />
+    <circle cx="422" cy="172" r="8" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="60" y="106" width="20" height="5" rx="2.5" />
+    <rect x="92" y="106" width="20" height="5" rx="2.5" />
+    <rect x="124" y="106" width="20" height="5" rx="2.5" />
+    <rect x="156" y="106" width="20" height="5" rx="2.5" />
+    <rect x="188" y="106" width="20" height="5" rx="2.5" />
+    <rect x="220" y="106" width="20" height="5" rx="2.5" />
+    <rect x="252" y="106" width="20" height="5" rx="2.5" />
+    <rect x="284" y="106" width="20" height="5" rx="2.5" />
+    <rect x="316" y="106" width="20" height="5" rx="2.5" />
+    <rect x="348" y="106" width="20" height="5" rx="2.5" />
+    <rect x="380" y="106" width="20" height="5" rx="2.5" />
+    <rect x="412" y="106" width="20" height="5" rx="2.5" />
+    <rect x="444" y="106" width="20" height="5" rx="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.07">
+    <circle cx="552" cy="104" r="60" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="524" y="72" width="32" height="6" rx="3" />
+    <rect x="536" y="86" width="32" height="6" rx="3" />
+    <rect x="524" y="100" width="32" height="6" rx="3" />
+    <rect x="536" y="114" width="32" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="548" cy="140" r="8" />
+    <circle cx="497" cy="116" r="2.5" fillOpacity="0.8" />
+    <circle cx="480" cy="110" r="2.5" fillOpacity="0.8" />
+  </g>
+</svg>
+
 ## Three kinds of subquery
 
 ```mermaid
@@ -213,6 +262,36 @@ ORDER BY
 
 Bo has no orders, so Bo is excluded. `EXISTS` stops at the first match,
 making it an efficient "has any" test.
+
+<svg
+  viewBox="0 0 640 155"
+  role="img"
+  aria-label="Three customer capsules are inspected for contents: the ones holding at least one yellow order dot earn a solid green lamp, while the empty capsule gets a hollow red ring — EXISTS asks only whether a match exists, never how many"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="84" y="56" width="136" height="66" rx="18" />
+    <rect x="252" y="56" width="136" height="66" rx="18" />
+    <rect x="420" y="56" width="136" height="66" rx="18" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="134" cy="89" r="9" />
+    <circle cx="166" cy="89" r="9" />
+    <circle cx="488" cy="89" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="296" y="86" width="12" height="6" rx="3" />
+    <rect x="316" y="86" width="12" height="6" rx="3" />
+    <rect x="336" y="86" width="12" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="152" cy="36" r="9" />
+    <circle cx="488" cy="36" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 320 36 m -9 0 a 9 9 0 1 0 18 0 a 9 9 0 1 0 -18 0 M 320 36 m -5 0 a 5 5 0 1 1 10 0 a 5 5 0 1 1 -10 0" fillRule="evenodd" fillOpacity="0.75" />
+  </g>
+</svg>
 
 ## Choosing: subquery vs. CTE vs. join
 

--- a/content/learn/sql-analytics-duckdb/thinking-in-datasets.mdx
+++ b/content/learn/sql-analytics-duckdb/thinking-in-datasets.mdx
@@ -10,6 +10,69 @@ shape** through summaries. This page is about that mindset: how to think
 when the data is too big to see, and how SQL becomes your instrument for
 "looking."
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A vast sea of faint dots runs past the edges of the frame, one red dot hiding in it, while a thought bubble above holds just four crisp summary chips — a dataset too big to see, held in mind as a handful of numbers"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor">
+    <circle cx="8" cy="138" r="3" opacity="0.1" />
+    <circle cx="34" cy="156" r="3" opacity="0.16" />
+    <circle cx="58" cy="132" r="3" opacity="0.2" />
+    <circle cx="84" cy="170" r="3" opacity="0.22" />
+    <circle cx="108" cy="146" r="3" opacity="0.25" />
+    <circle cx="132" cy="186" r="3" opacity="0.2" />
+    <circle cx="150" cy="128" r="3" opacity="0.26" />
+    <circle cx="176" cy="160" r="3" opacity="0.28" />
+    <circle cx="198" cy="196" r="3" opacity="0.22" />
+    <circle cx="214" cy="138" r="3" opacity="0.3" />
+    <circle cx="244" cy="172" r="3" opacity="0.28" />
+    <circle cx="262" cy="208" r="3" opacity="0.18" />
+    <circle cx="282" cy="146" r="3" opacity="0.3" />
+    <circle cx="306" cy="184" r="3" opacity="0.26" />
+    <circle cx="330" cy="132" r="3" opacity="0.3" />
+    <circle cx="352" cy="166" r="3" opacity="0.3" />
+    <circle cx="376" cy="202" r="3" opacity="0.24" />
+    <circle cx="396" cy="142" r="3" opacity="0.3" />
+    <circle cx="420" cy="178" r="3" opacity="0.26" />
+    <circle cx="448" cy="208" r="3" opacity="0.2" />
+    <circle cx="462" cy="136" r="3" opacity="0.26" />
+    <circle cx="488" cy="168" r="3" opacity="0.24" />
+    <circle cx="512" cy="198" r="3" opacity="0.18" />
+    <circle cx="530" cy="142" r="3" opacity="0.2" />
+    <circle cx="556" cy="176" r="3" opacity="0.16" />
+    <circle cx="582" cy="150" r="3" opacity="0.12" />
+    <circle cx="608" cy="186" r="3" opacity="0.1" />
+    <circle cx="632" cy="158" r="3" opacity="0.08" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="430" cy="152" r="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.09">
+    <ellipse cx="320" cy="58" rx="150" ry="44" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="252" cy="112" r="7" />
+    <circle cx="226" cy="130" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="216" y="46" width="74" height="16" rx="8" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="330" cy="54" r="11" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="362" y="46" width="42" height="16" rx="8" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="222" y="70" width="36" height="6" rx="3" />
+    <rect x="266" y="70" width="24" height="6" rx="3" />
+    <rect x="318" y="70" width="30" height="6" rx="3" />
+    <rect x="362" y="70" width="20" height="6" rx="3" />
+  </g>
+</svg>
+
 ## You cannot see a million rows — so you summarize
 
 Imagine someone hands you a spreadsheet with 2 million sales. Scrolling

--- a/content/learn/sql-analytics-duckdb/why-duckdb.mdx
+++ b/content/learn/sql-analytics-duckdb/why-duckdb.mdx
@@ -10,6 +10,60 @@ analysis. This page explains, concisely, *why it exists* and *why it has
 become so popular*, so the tool you are about to use stops feeling like a
 black box.
 
+<svg
+  viewBox="0 0 640 225"
+  role="img"
+  aria-label="A faraway server tower can only be reached along a long dotted arc interrupted by a red toll, while inside the laptop on the right a green engine glows in concentric rings next to the little files it queries in place — DuckDB runs where you already are"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="60" y="42" width="64" height="138" rx="10" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="72" y="58" width="40" height="8" rx="4" />
+    <rect x="72" y="76" width="40" height="8" rx="4" />
+    <rect x="72" y="94" width="40" height="8" rx="4" />
+    <circle cx="78" cy="156" r="3.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="148" cy="84" r="3" />
+    <circle cx="174" cy="68" r="3" />
+    <circle cx="202" cy="56" r="3" />
+    <circle cx="232" cy="48" r="3" />
+    <circle cx="296" cy="46" r="3" />
+    <circle cx="326" cy="52" r="3" />
+    <circle cx="354" cy="62" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="264" cy="44" r="7" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="392" y="48" width="206" height="124" rx="12" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="372" y="178" width="246" height="14" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="462" cy="110" r="34" fillOpacity="0.14" />
+    <circle cx="462" cy="110" r="22" fillOpacity="0.35" />
+    <circle cx="462" cy="110" r="11" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="524" y="76" width="32" height="40" rx="5" fillOpacity="0.4" />
+    <path d="M 548 76 L 556 84 L 548 84 Z" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="536" y="124" width="32" height="36" rx="5" fillOpacity="0.45" />
+    <path d="M 560 124 L 568 132 L 560 132 Z" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="500" cy="98" r="2.5" />
+    <circle cx="512" cy="106" r="2.5" />
+    <circle cx="506" cy="128" r="2.5" />
+    <circle cx="518" cy="136" r="2.5" />
+  </g>
+</svg>
+
 ## The problem DuckDB solves
 
 Organizations now generate **enormous** amounts of data almost by

--- a/content/learn/sql-analytics-duckdb/why-window-functions.mdx
+++ b/content/learn/sql-analytics-duckdb/why-window-functions.mdx
@@ -10,6 +10,61 @@ mechanics only make sense once you see the problem they solve. Because
 this is a foundational, often-confusing concept, this page has extra
 practice questions.
 
+<svg
+  viewBox="0 0 640 235"
+  role="img"
+  aria-label="The same five rows take two paths: down the left they collapse into a single green summary dot, down the right all five survive and each carries an identical small green badge — GROUP BY summarizes instead of the rows, a window function summarizes alongside them"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="230" cy="42" r="8" />
+    <circle cx="275" cy="42" r="8" />
+    <circle cx="320" cy="42" r="8" />
+    <circle cx="365" cy="42" r="8" />
+    <circle cx="410" cy="42" r="8" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="206" cy="76" r="2.5" />
+    <circle cx="184" cy="104" r="2.5" />
+    <circle cx="168" cy="132" r="2.5" />
+    <circle cx="244" cy="80" r="2.5" />
+    <circle cx="208" cy="112" r="2.5" />
+    <circle cx="182" cy="140" r="2.5" />
+    <circle cx="296" cy="84" r="2.5" />
+    <circle cx="234" cy="120" r="2.5" />
+    <circle cx="190" cy="148" r="2.5" />
+    <circle cx="404" cy="78" r="2.5" />
+    <circle cx="416" cy="108" r="2.5" />
+    <circle cx="430" cy="138" r="2.5" />
+    <circle cx="462" cy="84" r="2.5" />
+    <circle cx="486" cy="116" r="2.5" />
+    <circle cx="506" cy="142" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="160" cy="186" r="26" fillOpacity="0.2" />
+    <circle cx="160" cy="186" r="16" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="356" cy="186" r="9" />
+    <circle cx="408" cy="186" r="9" />
+    <circle cx="460" cy="186" r="9" />
+    <circle cx="512" cy="186" r="9" />
+    <circle cx="564" cy="186" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="366" cy="172" r="5" />
+    <circle cx="418" cy="172" r="5" />
+    <circle cx="470" cy="172" r="5" />
+    <circle cx="522" cy="172" r="5" />
+    <circle cx="574" cy="172" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="64" cy="60" r="3" />
+    <circle cx="592" cy="46" r="3" />
+    <circle cx="78" cy="200" r="3" />
+  </g>
+</svg>
+
 ## The problem `GROUP BY` cannot solve
 
 `GROUP BY` is powerful but it **destroys the individual rows**. When you
@@ -77,6 +132,36 @@ ORDER BY
 Notice all five rows survived, each carrying the grand total `505`. A
 plain `SUM(amount)` would have returned a single row. The `OVER ()` is the
 entire difference.
+
+<svg
+  viewBox="0 0 640 165"
+  role="img"
+  aria-label="Five faint rows of different lengths each end in an identical yellow chip stacked in one neat column — an empty OVER clause writes the same grand total onto every surviving row"
+  style={{ display: "block", width: "100%", maxWidth: "460px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.13">
+    <rect x="80" y="36" width="244" height="13" rx="6.5" />
+    <rect x="80" y="60" width="190" height="13" rx="6.5" />
+    <rect x="80" y="84" width="266" height="13" rx="6.5" />
+    <rect x="80" y="108" width="150" height="13" rx="6.5" />
+    <rect x="80" y="132" width="216" height="13" rx="6.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="396" y="22" width="60" height="141" rx="14" fillOpacity="0.12" />
+    <rect x="406" y="34" width="40" height="17" rx="8.5" />
+    <rect x="406" y="58" width="40" height="17" rx="8.5" />
+    <rect x="406" y="82" width="40" height="17" rx="8.5" />
+    <rect x="406" y="106" width="40" height="17" rx="8.5" />
+    <rect x="406" y="130" width="40" height="17" rx="8.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="358" cy="42" r="2.5" />
+    <circle cx="358" cy="66" r="2.5" />
+    <circle cx="358" cy="90" r="2.5" />
+    <circle cx="358" cy="114" r="2.5" />
+    <circle cx="358" cy="138" r="2.5" />
+  </g>
+</svg>
 
 ## `PARTITION BY` — windows per group
 

--- a/content/learn/sql-analytics-duckdb/working-with-dates.mdx
+++ b/content/learn/sql-analytics-duckdb/working-with-dates.mdx
@@ -10,6 +10,62 @@ This page builds the date toolkit analysts use daily — truncating,
 extracting, and computing with dates — and shows how to assemble a proper
 time series.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Day ticks along a timeline are gathered under three translucent domes that each collapse into one solid month chip below, while every seventh tick glows yellow across all of them — truncating dates into periods, extracting the weekday that repeats"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 64 96 A 93 42 0 0 1 250 96 Z" fillOpacity="0.1" />
+    <path d="M 258 96 A 93 42 0 0 1 444 96 Z" fillOpacity="0.1" />
+    <path d="M 452 96 A 70 36 0 0 1 592 96 Z" fillOpacity="0.1" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="48" y="96" width="556" height="5" rx="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="72" y="82" width="3" height="12" rx="1.5" />
+    <rect x="92" y="82" width="3" height="12" rx="1.5" />
+    <rect x="132" y="82" width="3" height="12" rx="1.5" />
+    <rect x="152" y="82" width="3" height="12" rx="1.5" />
+    <rect x="172" y="82" width="3" height="12" rx="1.5" />
+    <rect x="212" y="82" width="3" height="12" rx="1.5" />
+    <rect x="232" y="82" width="3" height="12" rx="1.5" />
+    <rect x="272" y="82" width="3" height="12" rx="1.5" />
+    <rect x="292" y="82" width="3" height="12" rx="1.5" />
+    <rect x="332" y="82" width="3" height="12" rx="1.5" />
+    <rect x="352" y="82" width="3" height="12" rx="1.5" />
+    <rect x="372" y="82" width="3" height="12" rx="1.5" />
+    <rect x="412" y="82" width="3" height="12" rx="1.5" />
+    <rect x="432" y="82" width="3" height="12" rx="1.5" />
+    <rect x="472" y="82" width="3" height="12" rx="1.5" />
+    <rect x="492" y="82" width="3" height="12" rx="1.5" />
+    <rect x="532" y="82" width="3" height="12" rx="1.5" />
+    <rect x="552" y="82" width="3" height="12" rx="1.5" />
+    <rect x="572" y="82" width="3" height="12" rx="1.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="111" y="78" width="4" height="16" rx="2" />
+    <rect x="251" y="78" width="4" height="16" rx="2" />
+    <rect x="391" y="78" width="4" height="16" rx="2" />
+    <rect x="531" y="78" width="4" height="16" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="157" cy="118" r="2.5" />
+    <circle cx="157" cy="134" r="2.5" />
+    <circle cx="351" cy="118" r="2.5" />
+    <circle cx="351" cy="134" r="2.5" />
+    <circle cx="522" cy="118" r="2.5" />
+    <circle cx="522" cy="134" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="117" y="150" width="80" height="18" rx="9" fillOpacity="0.85" />
+    <rect x="311" y="150" width="80" height="18" rx="9" fillOpacity="0.85" />
+    <rect x="482" y="150" width="80" height="18" rx="9" fillOpacity="0.85" />
+  </g>
+</svg>
+
 ## The core move: truncate to a period
 
 To summarize "by month", you do **not** group by the raw date — that would
@@ -126,6 +182,37 @@ simply **missing** from a grouped result — which makes a chart lie by
 skipping the gap. The fix is to generate a complete spine of dates with
 `generate_series` (or `range`) and `LEFT JOIN` the data onto it, so empty
 periods show up as zero.
+
+<svg
+  viewBox="0 0 640 175"
+  role="img"
+  aria-label="Green day-bars stand on a complete spine of seven dots, and the two silent days hold hollow zero rings instead of disappearing — a generated date spine keeps empty periods visible in the series"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="84" y="62" width="26" height="68" rx="7" fillOpacity="0.8" />
+    <rect x="228" y="42" width="26" height="88" rx="7" fillOpacity="0.8" />
+    <rect x="372" y="76" width="26" height="54" rx="7" fillOpacity="0.8" />
+    <rect x="444" y="54" width="26" height="76" rx="7" fillOpacity="0.8" />
+    <rect x="516" y="88" width="26" height="42" rx="7" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <path d="M 169 118 m -11 0 a 11 11 0 1 0 22 0 a 11 11 0 1 0 -22 0 M 169 118 m -6 0 a 6 6 0 1 1 12 0 a 6 6 0 1 1 -12 0" fillRule="evenodd" />
+    <path d="M 313 118 m -11 0 a 11 11 0 1 0 22 0 a 11 11 0 1 0 -22 0 M 313 118 m -6 0 a 6 6 0 1 1 12 0 a 6 6 0 1 1 -12 0" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="64" y="140" width="492" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="97" cy="158" r="4.5" fillOpacity="0.6" />
+    <circle cx="169" cy="158" r="4.5" fillOpacity="0.6" />
+    <circle cx="241" cy="158" r="4.5" fillOpacity="0.6" />
+    <circle cx="313" cy="158" r="4.5" fillOpacity="0.6" />
+    <circle cx="385" cy="158" r="4.5" fillOpacity="0.6" />
+    <circle cx="457" cy="158" r="4.5" fillOpacity="0.6" />
+    <circle cx="529" cy="158" r="4.5" fillOpacity="0.6" />
+  </g>
+</svg>
 
 <SqlCodeBlock
   dialect="duckdb"

--- a/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
+++ b/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
@@ -8,6 +8,58 @@ new syntax — it is about *re-seeing* those familiar tools through an
 analyst's eyes. The same `SELECT` that fetches a record in an app becomes,
 with a shift in intent, the first move of an exploration.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A blue wedge sliced out of a data disc streams its green rows along dotted arcs into a column sorted by size, where an open yellow ring picks out only the top of the stack — WHERE slices, ORDER BY sorts, LIMIT peeks"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <circle cx="130" cy="112" r="64" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="104" cy="86" r="3.5" />
+    <circle cx="132" cy="64" r="3.5" />
+    <circle cx="88" cy="124" r="3.5" />
+    <circle cx="118" cy="150" r="3.5" />
+    <circle cx="148" cy="132" r="3.5" />
+    <circle cx="100" cy="156" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 162 112 L 217 80 A 64 64 0 0 1 217 144 Z" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="186" cy="112" r="4.5" />
+    <circle cx="204" cy="100" r="4.5" />
+    <circle cx="204" cy="124" r="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="258" cy="96" r="3" />
+    <circle cx="296" cy="82" r="3" />
+    <circle cx="336" cy="72" r="3" />
+    <circle cx="378" cy="66" r="3" />
+    <circle cx="262" cy="130" r="3" />
+    <circle cx="302" cy="136" r="3" />
+    <circle cx="344" cy="146" r="3" />
+    <circle cx="384" cy="152" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="478" cy="56" r="12" />
+    <circle cx="478" cy="92" r="9.5" />
+    <circle cx="478" cy="124" r="7.5" />
+    <circle cx="478" cy="152" r="5.5" fillOpacity="0.55" />
+    <circle cx="478" cy="176" r="4" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 440 74 a 38 38 0 1 0 76 0 a 38 38 0 1 0 -76 0 M 447 74 a 31 31 0 1 1 62 0 a 31 31 0 1 1 -62 0" fillRule="evenodd" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="568" cy="48" r="3" />
+    <circle cx="586" cy="110" r="3" />
+    <circle cx="560" cy="170" r="3" />
+  </g>
+</svg>
+
 ## Reading a table is the analyst's "hello world"
 
 Before summarizing anything, an analyst usually takes a quick look at a
@@ -186,6 +238,42 @@ ORDER BY
 The column `fare_per_min` exists only inside this query — it is a
 *question*, not stored data. Inventing measures like this is most of what
 analytical `SELECT` lists are for.
+
+<svg
+  viewBox="0 0 640 160"
+  role="img"
+  aria-label="Two stored value bars meet at a division glyph and produce a glowing yellow chip that floats above a dotted shelf — a derived measure that exists only inside the query, never in the table"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="70" y="46" width="120" height="20" rx="10" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="70" y="92" width="84" height="20" rx="10" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="248" y="89" fontFamily="ui-monospace, monospace" fontSize="30" textAnchor="middle">÷</text>
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="296" cy="79" r="3" />
+    <circle cx="316" cy="79" r="3" />
+    <circle cx="336" cy="79" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="364" y="64" width="104" height="28" rx="14" fillOpacity="0.55" />
+    <circle cx="486" cy="58" r="3.5" fillOpacity="0.8" />
+    <circle cx="498" cy="74" r="2.5" fillOpacity="0.6" />
+    <circle cx="480" cy="100" r="2.5" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="364" y="118" width="10" height="4" rx="2" />
+    <rect x="382" y="118" width="10" height="4" rx="2" />
+    <rect x="400" y="118" width="10" height="4" rx="2" />
+    <rect x="418" y="118" width="10" height="4" rx="2" />
+    <rect x="436" y="118" width="10" height="4" rx="2" />
+    <rect x="454" y="118" width="10" height="4" rx="2" />
+  </g>
+</svg>
 
 ## The same keywords, a new purpose
 

--- a/content/learn/sqlite-for-beginners/aggregate-functions.mdx
+++ b/content/learn/sqlite-for-beginners/aggregate-functions.mdx
@@ -14,6 +14,54 @@ But many everyday questions are not detail questions. They are summary questions
 
 **Aggregate functions** answer questions like these by reading many rows and returning one summary value.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A whole bunch of grape dots feeds into a little press marked with a sigma, and a single drop falls into the waiting glass — an aggregate squeezes many row values down to one summary value"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="148" y="20" width="4" height="20" rx="2" fillOpacity="0.7" />
+    <ellipse cx="166" cy="28" rx="12" ry="6" transform="rotate(20 166 28)" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="124" cy="56" r="13" fillOpacity="0.85" />
+    <circle cx="152" cy="50" r="13" fillOpacity="0.7" />
+    <circle cx="180" cy="58" r="13" fillOpacity="0.85" />
+    <circle cx="110" cy="84" r="13" fillOpacity="0.6" />
+    <circle cx="138" cy="80" r="13" fillOpacity="0.9" />
+    <circle cx="166" cy="84" r="13" fillOpacity="0.65" />
+    <circle cx="124" cy="110" r="13" fillOpacity="0.8" />
+    <circle cx="152" cy="108" r="13" fillOpacity="0.55" />
+    <circle cx="138" cy="134" r="13" fillOpacity="0.75" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="216" cy="96" r="3" />
+    <circle cx="242" cy="88" r="3" />
+    <circle cx="268" cy="82" r="3" />
+    <circle cx="294" cy="78" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="330" y="16" width="44" height="10" rx="5" />
+    <rect x="347" y="24" width="10" height="20" rx="4" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="308" y="42" width="88" height="74" rx="12" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-white)" }} fill="currentColor">
+    <text x="352" y="90" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="30" fontWeight="700">Σ</text>
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 352 132 Q 340 152 352 162 Q 364 152 352 132 Z" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <path d="M 316 178 L 388 178 L 378 226 Q 377 232 371 232 L 333 232 Q 327 232 326 226 Z" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 322 206 L 382 206 L 378 226 Q 377 232 371 232 L 333 232 Q 327 232 326 226 Z" fillOpacity="0.45" />
+  </g>
+</svg>
+
 ## From many rows to one answer
 
 Think of an aggregate as a tiny summarizing machine. Many rows go in. One value comes out.
@@ -133,6 +181,31 @@ Aggregates are for summary questions, not row-by-row detail questions.`}
 ## Finding the smallest and largest values
 
 `MIN(column)` returns the smallest value. `MAX(column)` returns the largest value.
+
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="A line of pebbles of different sizes on a beach, with a green ring around the tiniest and a red ring around the biggest — MIN and MAX walk the whole column and point at its two extremes"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="70" y="112" width="500" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="130" cy="92" r="18" fillOpacity="0.6" />
+    <circle cx="208" cy="102" r="8" fillOpacity="0.8" />
+    <circle cx="282" cy="86" r="24" fillOpacity="0.5" />
+    <circle cx="368" cy="96" r="14" fillOpacity="0.7" />
+    <circle cx="452" cy="78" r="32" fillOpacity="0.6" />
+    <circle cx="532" cy="98" r="12" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 208 86 A 16 16 0 1 0 208 118 A 16 16 0 1 0 208 86 Z M 208 92 A 10 10 0 1 1 208 112 A 10 10 0 1 1 208 92 Z" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 452 36 A 42 42 0 1 0 452 120 A 42 42 0 1 0 452 36 Z M 452 44 A 34 34 0 1 1 452 112 A 34 34 0 1 1 452 44 Z" />
+  </g>
+</svg>
 
 <SqlCodeBlock
   dialect="sqlite"

--- a/content/learn/sqlite-for-beginners/creating-tables.mdx
+++ b/content/learn/sqlite-for-beginners/creating-tables.mdx
@@ -7,6 +7,41 @@ A database table is a place to store one kind of thing: books, customers, recipe
 
 Before a table can hold rows, you define its shape. In SQL, that job belongs to `CREATE TABLE`.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A cookie-cutter ring hovers over rolled dough where one row shape has already been cut, and finished row-cookies with their value dots cool on the right — CREATE TABLE defines the shape that every future row will be stamped from"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 96 28 Q 84 28 84 40 L 84 64 Q 84 76 96 76 L 280 76 Q 292 76 292 64 L 292 40 Q 292 28 280 28 Z M 100 38 Q 94 38 94 44 L 94 60 Q 94 66 100 66 L 276 66 Q 282 66 282 60 L 282 44 Q 282 38 276 38 Z" fillOpacity="0.85" />
+    <rect x="174" y="12" width="28" height="12" rx="6" fillOpacity="0.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="318" cy="44" r="2.5" />
+    <circle cx="332" cy="52" r="2.5" />
+    <circle cx="322" cy="62" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.1">
+    <path d="M 48 124 Q 40 188 110 196 L 320 200 Q 380 198 372 150 Q 368 116 300 112 L 110 110 Q 54 110 48 124 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <path fillRule="evenodd" d="M 102 134 Q 94 134 94 142 L 94 162 Q 94 170 102 170 L 256 170 Q 264 170 264 162 L 264 142 Q 264 134 256 134 Z M 106 141 Q 101 141 101 146 L 101 158 Q 101 163 106 163 L 252 163 Q 257 163 257 158 L 257 146 Q 257 141 252 141 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="416" y="108" width="186" height="40" rx="12" fillOpacity="0.3" />
+    <circle cx="440" cy="128" r="8" fillOpacity="0.95" />
+    <rect x="458" y="122" width="58" height="11" rx="5.5" fillOpacity="0.7" />
+    <rect x="526" y="122" width="38" height="11" rx="5.5" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="432" y="160" width="186" height="40" rx="12" fillOpacity="0.3" />
+    <circle cx="456" cy="180" r="8" fillOpacity="0.95" />
+    <rect x="474" y="174" width="58" height="11" rx="5.5" fillOpacity="0.7" />
+    <rect x="542" y="174" width="38" height="11" rx="5.5" fillOpacity="0.5" />
+  </g>
+</svg>
+
 ## The basic CREATE TABLE shape
 
 To create a table, give SQLite a table name and a list of columns. Each column has a name and a type.
@@ -141,6 +176,37 @@ A table can include rules called **constraints**. Two beginner-friendly constrai
 
 - `NOT NULL`: this column must have a value.
 - `DEFAULT`: if the insert omits this column, use a fallback value.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="A new row arrives with one cell left empty, and a little dispenser above drops a yellow zero token into the gap along a dotted trail — a DEFAULT quietly fills in what the insert left out"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="96" y="104" width="118" height="44" rx="8" />
+    <rect x="222" y="104" width="118" height="44" rx="8" />
+    <rect x="348" y="104" width="118" height="44" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="128" cy="126" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="244" y="120" width="74" height="12" rx="6" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="376" y="16" width="62" height="26" rx="7" fillOpacity="0.85" />
+    <rect x="396" y="42" width="22" height="8" rx="3" fillOpacity="0.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="407" cy="62" r="2.5" />
+    <circle cx="407" cy="78" r="2.5" />
+    <circle cx="407" cy="94" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 407 110 A 16 16 0 1 0 407 142 A 16 16 0 1 0 407 110 Z M 407 119 A 7 7 0 1 1 407 133 A 7 7 0 1 1 407 119 Z" fillOpacity="0.95" />
+  </g>
+</svg>
 
 <SqlCodeBlock
   dialect="sqlite"

--- a/content/learn/sqlite-for-beginners/data-exploration.mdx
+++ b/content/learn/sqlite-for-beginners/data-exploration.mdx
@@ -11,6 +11,59 @@ and methodically — before you write a single "real" query.
 This page gives you a repeatable routine. Think of it as the
 questions a careful analyst always asks first.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="A treasure-map of table islands joined by a dotted route, a compass rose in the corner, and a magnifying glass hovering over one island making its value dots crisp, while a red cross marks an oddity on another — exploring an unfamiliar database island by island"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <path d="M 80 92 Q 64 56 104 44 Q 152 30 176 58 Q 196 84 168 102 Q 124 122 80 92 Z" />
+    <path d="M 280 190 Q 258 160 296 144 Q 344 128 372 152 Q 396 178 360 198 Q 312 216 280 190 Z" />
+    <path d="M 472 84 Q 456 52 496 40 Q 548 28 570 56 Q 588 84 556 100 Q 508 116 472 84 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="196" cy="86" r="2.5" />
+    <circle cx="222" cy="102" r="2.5" />
+    <circle cx="246" cy="120" r="2.5" />
+    <circle cx="268" cy="138" r="2.5" />
+    <circle cx="396" cy="160" r="2.5" />
+    <circle cx="420" cy="140" r="2.5" />
+    <circle cx="442" cy="118" r="2.5" />
+    <circle cx="460" cy="98" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="116" cy="74" r="4" />
+    <circle cx="134" cy="74" r="4" />
+    <circle cx="116" cy="90" r="4" />
+    <circle cx="134" cy="90" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="306" cy="168" r="5" />
+    <circle cx="324" cy="168" r="5" fillOpacity="0.7" />
+    <circle cx="306" cy="184" r="5" fillOpacity="0.7" />
+    <circle cx="324" cy="184" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 315 132 A 44 44 0 1 0 315 220 A 44 44 0 1 0 315 132 Z M 315 142 A 34 34 0 1 1 315 210 A 34 34 0 1 1 315 142 Z" fillOpacity="0.85" />
+    <rect x="352" y="206" width="52" height="14" rx="7" transform="rotate(38 358 212)" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="500" y="58" width="34" height="9" rx="4.5" transform="rotate(45 517 62)" />
+    <rect x="500" y="58" width="34" height="9" rx="4.5" transform="rotate(-45 517 62)" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 86 184 L 94 204 L 86 224 L 78 204 Z" />
+    <path d="M 66 204 L 86 197 L 106 204 L 86 211 Z" fillOpacity="0.6" />
+    <circle cx="86" cy="204" r="4" style={{ color: "var(--ds-white)" }} />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="560" cy="184" r="4" />
+    <circle cx="588" cy="206" r="3" />
+    <circle cx="200" cy="206" r="3" />
+  </g>
+</svg>
+
 ## The exploration loop
 
 You rarely understand a dataset in one look. You **loop**: get the

--- a/content/learn/sqlite-for-beginners/data-organization.mdx
+++ b/content/learn/sqlite-for-beginners/data-organization.mdx
@@ -9,6 +9,65 @@ the opposite: splitting that big table into smaller, related ones so
 each fact is stored **once**. This page builds the intuition behind
 why that matters — the idea professionals call *normalization*.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="One overstuffed house crams in repeated copies of the same dots, one copy already drifted red; across the lane, a tidy row of three small houses gives each fact its own home, joined by dotted footpaths — organizing data means every fact lives in exactly one place"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="40" y="214" width="560" height="6" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="70" y="104" width="180" height="110" rx="6" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <path d="M 56 108 L 160 38 L 264 108 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="106" cy="136" r="11" fillOpacity="0.9" />
+    <circle cx="148" cy="142" r="11" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="192" cy="138" r="11" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="120" cy="176" r="11" fillOpacity="0.9" />
+    <circle cx="170" cy="180" r="11" fillOpacity="0.6" />
+    <circle cx="216" cy="174" r="11" fillOpacity="0.75" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="294" cy="180" r="2.5" />
+    <circle cx="318" cy="176" r="2.5" />
+    <circle cx="342" cy="174" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="382" y="150" width="70" height="64" rx="5" />
+    <rect x="486" y="150" width="70" height="64" rx="5" />
+    <rect x="434" y="64" width="70" height="56" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 374 152 L 417 122 L 460 152 Z" fillOpacity="0.8" />
+    <circle cx="417" cy="186" r="10" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 478 152 L 521 122 L 564 152 Z" fillOpacity="0.8" />
+    <circle cx="521" cy="186" r="10" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 426 66 L 469 36 L 512 66 Z" fillOpacity="0.8" />
+    <circle cx="469" cy="96" r="10" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="441" cy="138" r="2.5" />
+    <circle cx="452" cy="124" r="2.5" />
+    <circle cx="497" cy="138" r="2.5" />
+    <circle cx="486" cy="124" r="2.5" />
+    <circle cx="469" cy="186" r="2.5" />
+    <circle cx="486" cy="186" r="2.5" />
+  </g>
+</svg>
+
 ## The problem: one big table
 
 Imagine tracking orders in a single flat table. Every row repeats

--- a/content/learn/sqlite-for-beginners/data-types.mdx
+++ b/content/learn/sqlite-for-beginners/data-types.mdx
@@ -9,6 +9,60 @@ That sounds technical, but the beginner idea is simple:
 
 > In SQLite, the value itself has the strongest type. The column's declared type is a helpful preference, not always a strict wall.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Five pantry jars on a shelf hold SQLite's storage classes — whole-number dots, decimal dot pairs, text bars, one raw blob, and a jar holding nothing at all — while one stray text bar leans inside the number jar, because SQLite's typing is a preference, not a wall"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="40" y="190" width="560" height="8" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="62" y="94" width="92" height="96" rx="12" />
+    <rect x="172" y="94" width="92" height="96" rx="12" />
+    <rect x="282" y="94" width="92" height="96" rx="12" />
+    <rect x="392" y="94" width="92" height="96" rx="12" />
+    <rect x="502" y="94" width="92" height="96" rx="12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="72" y="80" width="72" height="15" rx="7" fillOpacity="0.9" />
+    <circle cx="88" cy="166" r="9" fillOpacity="0.85" />
+    <circle cx="112" cy="172" r="9" fillOpacity="0.6" />
+    <circle cx="134" cy="162" r="9" fillOpacity="0.75" />
+    <circle cx="98" cy="142" r="9" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="116" y="118" width="34" height="9" rx="4.5" transform="rotate(24 133 122)" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="182" y="80" width="72" height="15" rx="7" fillOpacity="0.9" />
+    <circle cx="202" cy="164" r="9" fillOpacity="0.8" />
+    <circle cx="215" cy="174" r="3.5" fillOpacity="0.8" />
+    <circle cx="234" cy="148" r="9" fillOpacity="0.55" />
+    <circle cx="247" cy="158" r="3.5" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="292" y="80" width="72" height="15" rx="7" fillOpacity="0.9" />
+    <rect x="296" y="166" width="56" height="9" rx="4.5" fillOpacity="0.8" />
+    <rect x="304" y="150" width="40" height="9" rx="4.5" fillOpacity="0.6" />
+    <rect x="298" y="134" width="48" height="9" rx="4.5" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="402" y="80" width="72" height="15" rx="7" fillOpacity="0.9" />
+    <path d="M 414 168 Q 408 144 430 138 Q 454 132 462 150 Q 470 170 448 176 Q 424 182 414 168 Z" fillOpacity="0.7" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="512" y="80" width="72" height="15" rx="7" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="532" cy="156" r="3" />
+    <circle cx="548" cy="146" r="3" />
+    <circle cx="564" cy="156" r="3" />
+    <circle cx="548" cy="166" r="3" />
+  </g>
+</svg>
+
 ## SQLite is flexible about types
 
 Some database systems are rigid: if a column is declared as a number, text that is not a number is rejected.
@@ -143,6 +197,43 @@ This does **not** mean types do not matter in SQLite. They still matter because 
 ## NULL means missing or unknown
 
 `NULL` means the value is missing, unknown, or not applicable. It is not the same as zero, an empty string, or the word `'NULL'`.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="Three display pedestals: one holds the number zero, one holds a real but empty text ribbon, and the third holds only a faint dotted ghost — zero and empty string are known values, NULL is the absence of a value"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="120" y="118" width="90" height="14" rx="5" />
+    <rect x="138" y="132" width="54" height="20" rx="4" />
+    <rect x="276" y="118" width="90" height="14" rx="5" />
+    <rect x="294" y="132" width="54" height="20" rx="4" />
+    <rect x="432" y="118" width="90" height="14" rx="5" />
+    <rect x="450" y="132" width="54" height="20" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 165 56 A 26 26 0 1 0 165 108 A 26 26 0 1 0 165 56 Z M 165 70 A 12 12 0 1 1 165 94 A 12 12 0 1 1 165 70 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="289" y="92" width="64" height="14" rx="7" fillOpacity="0.4" />
+    <rect x="297" y="78" width="10" height="14" rx="4" fillOpacity="0.9" />
+    <rect x="335" y="78" width="10" height="14" rx="4" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="477" cy="66" r="3" />
+    <circle cx="491" cy="70" r="3" />
+    <circle cx="499" cy="82" r="3" />
+    <circle cx="495" cy="96" r="3" />
+    <circle cx="483" cy="103" r="3" />
+    <circle cx="469" cy="100" r="3" />
+    <circle cx="460" cy="89" r="3" />
+    <circle cx="463" cy="74" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <text x="478" y="92" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="600">?</text>
+  </g>
+</svg>
 
 | Value | Meaning |
 | --- | --- |

--- a/content/learn/sqlite-for-beginners/expressions-and-aliases.mdx
+++ b/content/learn/sqlite-for-beginners/expressions-and-aliases.mdx
@@ -10,6 +10,56 @@ Those calculations are called **expressions**. An expression might
 multiply price by quantity, join two pieces of text, round a number, or
 make text uppercase. An **alias** gives the computed result a clear name.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="Two value dots tumble into a mixing bowl with a multiplication spark, and out comes a brand-new dot wearing a little name tag on a string — an expression computes a fresh value and an alias gives it a friendly name"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="172" cy="34" r="13" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="262" cy="28" r="13" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="217" y="44" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700">*</text>
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="180" cy="60" r="2.5" />
+    <circle cx="190" cy="78" r="2.5" />
+    <circle cx="200" cy="94" r="2.5" />
+    <circle cx="256" cy="54" r="2.5" />
+    <circle cx="248" cy="72" r="2.5" />
+    <circle cx="240" cy="90" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <path d="M 132 112 L 308 112 Q 304 178 220 178 Q 136 178 132 112 Z" />
+    <rect x="196" y="178" width="48" height="10" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 320 92 L 324 102 L 334 106 L 324 110 L 320 120 L 316 110 L 306 106 L 316 102 Z" fillOpacity="0.8" />
+    <path d="M 348 64 L 351 72 L 359 75 L 351 78 L 348 86 L 345 78 L 337 75 L 345 72 Z" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="372" cy="120" r="2.5" />
+    <circle cx="396" cy="116" r="2.5" />
+    <circle cx="420" cy="114" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="468" cy="118" r="20" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="486" cy="132" r="2" />
+    <circle cx="494" cy="140" r="2" />
+    <circle cx="502" cy="148" r="2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 506 148 L 568 148 L 580 160 L 568 172 L 506 172 Q 500 172 500 166 L 500 154 Q 500 148 506 148 Z" fillOpacity="0.3" />
+    <rect x="512" y="155" width="44" height="10" rx="5" fillOpacity="0.9" />
+  </g>
+</svg>
+
 ## Expressions create computed columns
 
 Anywhere you can select a column, you can also write a calculation.
@@ -138,6 +188,37 @@ flowchart LR
 
 In SQLite, `||` concatenates text. "Concatenate" means join pieces of
 text together.
+
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="Two separate text ribbons slide together and click into one continuous ribbon joined by a small knot — the double-bar operator threads pieces of text into a single value"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="96" y="34" width="120" height="18" rx="9" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="248" y="50" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="700">||</text>
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="282" y="34" width="96" height="18" rx="9" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="420" cy="62" r="2.5" />
+    <circle cx="404" cy="76" r="2.5" />
+    <circle cx="388" cy="90" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="142" y="100" width="120" height="18" rx="9" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="262" y="100" width="96" height="18" rx="9" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="262" cy="109" r="7" />
+  </g>
+</svg>
 
 <SqlCodeBlock
   dialect="sqlite"

--- a/content/learn/sqlite-for-beginners/filtering-groups.mdx
+++ b/content/learn/sqlite-for-beginners/filtering-groups.mdx
@@ -13,6 +13,58 @@ For example:
 
 These are not row-by-row conditions. They are conditions about **groups after aggregation**. That is what `HAVING` is for.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Three stacks of dots line up at a fairground measuring post with a dotted you-must-be-this-tall line; only the stack that reaches above the line earns the green check — HAVING measures each finished group and keeps the ones that qualify"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="70" y="208" width="500" height="7" rx="3.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="440" y="40" width="14" height="168" rx="5" />
+    <rect x="456" y="58" width="12" height="5" rx="2.5" />
+    <rect x="456" y="94" width="12" height="5" rx="2.5" />
+    <rect x="456" y="130" width="12" height="5" rx="2.5" />
+    <rect x="456" y="166" width="12" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 438 102 L 416 92 L 416 112 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="96" cy="102" r="2.5" />
+    <circle cx="124" cy="102" r="2.5" />
+    <circle cx="152" cy="102" r="2.5" />
+    <circle cx="180" cy="102" r="2.5" />
+    <circle cx="208" cy="102" r="2.5" />
+    <circle cx="236" cy="102" r="2.5" />
+    <circle cx="264" cy="102" r="2.5" />
+    <circle cx="292" cy="102" r="2.5" />
+    <circle cx="320" cy="102" r="2.5" />
+    <circle cx="348" cy="102" r="2.5" />
+    <circle cx="376" cy="102" r="2.5" />
+    <circle cx="404" cy="102" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="118" cy="194" r="14" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="226" cy="194" r="14" fillOpacity="0.45" />
+    <circle cx="226" cy="164" r="14" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="354" cy="194" r="14" />
+    <circle cx="354" cy="164" r="14" fillOpacity="0.85" />
+    <circle cx="354" cy="134" r="14" fillOpacity="0.7" />
+    <circle cx="354" cy="104" r="14" fillOpacity="0.9" />
+    <circle cx="354" cy="74" r="14" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 506 96 L 520 114 L 552 70 L 526 122 L 506 108 Z" />
+  </g>
+</svg>
+
 ## WHERE filters rows before groups exist
 
 `WHERE` runs before grouping. At that moment, there are only individual rows. There are no group totals yet, so `WHERE COUNT(*) > 2` does not make sense.

--- a/content/learn/sqlite-for-beginners/filtering-rows.mdx
+++ b/content/learn/sqlite-for-beginners/filtering-rows.mdx
@@ -9,6 +9,48 @@ That difference matters. A table may hold hundreds or millions of rows,
 but most questions only need some of them: books under a certain price,
 employees in one department, or customers in one city.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="Mixed dots rain into a yellow colander; only the small green ones fit through its holes and collect in the bowl below, while the big red ones stay caught — WHERE is a sieve that lets matching rows through"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="248" cy="22" r="5.5" fillOpacity="0.8" />
+    <circle cx="330" cy="14" r="5.5" fillOpacity="0.9" />
+    <circle cx="296" cy="44" r="5.5" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="368" cy="36" r="11" fillOpacity="0.8" />
+    <circle cx="222" cy="52" r="10" fillOpacity="0.7" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="394" cy="64" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 196 96 A 98 98 0 0 0 392 96 Z M 243 124 A 7 7 0 1 0 257 124 A 7 7 0 1 0 243 124 Z M 287 146 A 7 7 0 1 0 301 146 A 7 7 0 1 0 287 146 Z M 331 124 A 7 7 0 1 0 345 124 A 7 7 0 1 0 331 124 Z M 287 108 A 7 7 0 1 0 301 108 A 7 7 0 1 0 287 108 Z" fillOpacity="0.85" />
+    <rect x="162" y="90" width="36" height="11" rx="5.5" fillOpacity="0.85" />
+    <rect x="390" y="90" width="36" height="11" rx="5.5" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="262" cy="106" r="11" fillOpacity="0.85" />
+    <circle cx="322" cy="110" r="10" fillOpacity="0.7" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="294" cy="128" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="294" cy="158" r="5.5" fillOpacity="0.9" />
+    <circle cx="250" cy="178" r="5.5" fillOpacity="0.7" />
+    <circle cx="338" cy="172" r="5.5" fillOpacity="0.8" />
+    <circle cx="280" cy="196" r="5.5" fillOpacity="0.6" />
+    <circle cx="312" cy="206" r="5.5" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <path d="M 216 218 A 78 78 0 0 0 372 218 Z" />
+  </g>
+</svg>
+
 ## WHERE keeps matching rows
 
 A `WHERE` clause is a test that SQLite applies to each row. If the test
@@ -277,6 +319,47 @@ WHERE
 
 In SQLite, `LIKE` is case-insensitive for ordinary ASCII letters by
 default. That means `'sql%'` can match `SQL Street`.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A pattern card shows a solid blue start followed by trailing wildcard dots; below it, two text bars whose beginnings match glow green while the bar with a different start fades out — LIKE matches the shape of text, not the whole exact value"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="180" y="18" width="280" height="44" rx="10" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="198" y="32" width="84" height="16" rx="8" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="300" cy="40" r="4" />
+    <circle cx="320" cy="40" r="4" />
+    <circle cx="340" cy="40" r="4" />
+    <circle cx="360" cy="40" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="146" y="92" width="84" height="14" rx="7" />
+    <rect x="146" y="156" width="84" height="14" rx="7" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="238" y="92" width="120" height="14" rx="7" />
+    <rect x="238" y="156" width="56" height="14" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="146" y="124" width="84" height="14" rx="7" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="238" y="124" width="96" height="14" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="406" cy="99" r="8" />
+    <circle cx="406" cy="163" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="406" cy="131" r="8" fillOpacity="0.5" />
+  </g>
+</svg>
 
 <SqlCodeBlock
   dialect="sqlite"

--- a/content/learn/sqlite-for-beginners/first-queries.mdx
+++ b/content/learn/sqlite-for-beginners/first-queries.mdx
@@ -7,6 +7,51 @@ Welcome to your first hands-on SQLite page. You do not need to install anything 
 
 One important habit: each block is **independent**. If one block creates a table, the next block does not remember it. When a block needs a table that is already prepared for you, the hidden setup lives in `initSql`; the query you see is the part you practice.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="A tin-can telephone: a tiny sum is spoken into the left can, the string sags across the page, and the right can answers with a one-cell result holding the number four — your first query is a small friendly conversation with SQLite"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="66" y="96" width="78" height="48" rx="10" transform="rotate(8 105 120)" fillOpacity="0.8" />
+    <ellipse cx="140" cy="125" rx="9" ry="23" transform="rotate(8 140 125)" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="166" cy="136" r="2.5" />
+    <circle cx="196" cy="146" r="2.5" />
+    <circle cx="228" cy="153" r="2.5" />
+    <circle cx="262" cy="158" r="2.5" />
+    <circle cx="296" cy="161" r="2.5" />
+    <circle cx="330" cy="162" r="2.5" />
+    <circle cx="364" cy="161" r="2.5" />
+    <circle cx="398" cy="158" r="2.5" />
+    <circle cx="430" cy="153" r="2.5" />
+    <circle cx="460" cy="146" r="2.5" />
+    <circle cx="488" cy="138" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="500" y="98" width="78" height="48" rx="10" transform="rotate(-8 539 122)" fillOpacity="0.8" />
+    <ellipse cx="504" cy="127" rx="9" ry="23" transform="rotate(-8 504 127)" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <path d="M 60 22 Q 60 12 70 12 L 196 12 Q 206 12 206 22 L 206 56 Q 206 66 196 66 L 120 66 L 100 84 L 106 66 L 70 66 Q 60 66 60 56 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.55">
+    <text x="133" y="48" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="600">2+2</text>
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="452" y="14" width="64" height="58" rx="9" fillOpacity="0.3" />
+    <rect x="452" y="14" width="64" height="18" rx="9" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.6">
+    <text x="484" y="60" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="700">4</text>
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <path d="M 500 80 L 516 72 L 510 88 Z" />
+  </g>
+</svg>
+
 ## SQL can give back a value
 
 The keyword `SELECT` means: *compute something and show me the result.* You can use it even before you have any tables.

--- a/content/learn/sqlite-for-beginners/foreign-keys.mdx
+++ b/content/learn/sqlite-for-beginners/foreign-keys.mdx
@@ -36,6 +36,59 @@ This keeps data tidy:
 - Many orders can point to the same customer.
 - If Ada's name changes, the orders still point to customer `1`.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="A cloakroom rail with three numbered hooks holding coats, and below, claim tickets tied by dotted threads to their matching hooks — but the red ticket numbered seven points at a hook that does not exist, a dangling foreign key"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="90" y="24" width="460" height="9" rx="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="170" cy="44" r="6" />
+    <circle cx="320" cy="44" r="6" />
+    <circle cx="470" cy="44" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 150 58 Q 150 50 158 50 L 166 50 L 170 56 L 174 50 L 182 50 Q 190 50 190 58 L 187 106 Q 170 112 153 106 Z" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 300 58 Q 300 50 308 50 L 316 50 L 320 56 L 324 50 L 332 50 Q 340 50 340 58 L 337 106 Q 320 112 303 106 Z" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 450 58 Q 450 50 458 50 L 466 50 L 470 56 L 474 50 L 482 50 Q 490 50 490 58 L 487 106 Q 470 112 453 106 Z" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="172" cy="128" r="2.5" />
+    <circle cx="174" cy="146" r="2.5" />
+    <circle cx="176" cy="164" r="2.5" />
+    <circle cx="464" cy="128" r="2.5" />
+    <circle cx="452" cy="146" r="2.5" />
+    <circle cx="440" cy="164" r="2.5" />
+    <circle cx="560" cy="150" r="2.5" />
+    <circle cx="572" cy="128" r="2.5" />
+    <circle cx="580" cy="104" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="138" y="178" width="76" height="44" rx="7" transform="rotate(-5 176 200)" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="386" y="178" width="76" height="44" rx="7" transform="rotate(4 424 200)" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="508" y="166" width="76" height="44" rx="7" transform="rotate(-7 546 188)" fillOpacity="0.4" />
+  </g>
+  <g fill="currentColor" opacity="0.6">
+    <text x="176" y="207" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" transform="rotate(-5 176 200)">1</text>
+    <text x="424" y="207" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" transform="rotate(4 424 200)">3</text>
+    <text x="546" y="195" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" transform="rotate(-7 546 188)">7</text>
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <circle cx="588" cy="80" r="8" />
+  </g>
+</svg>
+
 <SqlCodeBlock
   dialect="sqlite"
   title="A foreign key stores another table's id"

--- a/content/learn/sqlite-for-beginners/grouping-data.mdx
+++ b/content/learn/sqlite-for-beginners/grouping-data.mdx
@@ -12,6 +12,65 @@ Aggregate functions can summarize a whole table into one answer. That is useful,
 
 `GROUP BY` is how you ask SQLite to split rows into groups first, then summarize each group.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="Mixed laundry dots tumble down dotted trails into three baskets sorted by color, and each basket wears a little tag with its count — GROUP BY sorts rows into piles first, then summarizes each pile"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="150" cy="30" r="10" fillOpacity="0.85" />
+    <circle cx="334" cy="22" r="10" fillOpacity="0.7" />
+    <circle cx="436" cy="40" r="10" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="238" cy="40" r="10" fillOpacity="0.85" />
+    <circle cx="498" cy="24" r="10" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="386" cy="30" r="10" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="160" cy="64" r="2.5" />
+    <circle cx="166" cy="84" r="2.5" />
+    <circle cx="170" cy="104" r="2.5" />
+    <circle cx="316" cy="56" r="2.5" />
+    <circle cx="306" cy="76" r="2.5" />
+    <circle cx="298" cy="96" r="2.5" />
+    <circle cx="396" cy="60" r="2.5" />
+    <circle cx="404" cy="80" r="2.5" />
+    <circle cx="410" cy="100" r="2.5" />
+    <circle cx="490" cy="52" r="2.5" />
+    <circle cx="480" cy="74" r="2.5" />
+    <circle cx="472" cy="96" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <path d="M 110 140 L 238 140 L 222 216 Q 220 224 212 224 L 136 224 Q 128 224 126 216 Z" />
+    <path d="M 274 140 L 402 140 L 386 216 Q 384 224 376 224 L 300 224 Q 292 224 290 216 Z" />
+    <path d="M 438 140 L 566 140 L 550 216 Q 548 224 540 224 L 464 224 Q 456 224 454 216 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="152" cy="172" r="11" fillOpacity="0.9" />
+    <circle cx="178" cy="180" r="11" fillOpacity="0.7" />
+    <circle cx="164" cy="200" r="11" fillOpacity="0.5" />
+    <rect x="206" y="124" width="26" height="22" rx="6" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="322" cy="176" r="11" fillOpacity="0.9" />
+    <circle cx="350" cy="186" r="11" fillOpacity="0.6" />
+    <rect x="370" y="124" width="26" height="22" rx="6" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="498" cy="184" r="11" fillOpacity="0.9" />
+    <rect x="534" y="124" width="26" height="22" rx="6" fillOpacity="0.35" />
+  </g>
+  <g fill="currentColor" opacity="0.55">
+    <text x="219" y="141" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">3</text>
+    <text x="383" y="141" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">2</text>
+    <text x="547" y="141" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">1</text>
+  </g>
+</svg>
+
 ## The big idea: split, then summarize
 
 Without `GROUP BY`, an aggregate gives one summary for all rows. With `GROUP BY`, SQLite makes one group for each distinct value, then runs the aggregate once per group.

--- a/content/learn/sqlite-for-beginners/how-applications-store-information.mdx
+++ b/content/learn/sqlite-for-beginners/how-applications-store-information.mdx
@@ -11,6 +11,57 @@ Applications use databases when they need to remember information after a screen
 
 With SQLite, that remembered information usually lives in a single ordinary database file on disk.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="An app window sits above the ground while a dotted trail carries a saved dot down to a little file cellar below — the database file is the invisible room under the app where facts keep living after the screen closes"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="150" y="20" width="240" height="130" rx="12" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <rect x="150" y="20" width="240" height="26" rx="12" />
+    <rect x="150" y="34" width="240" height="12" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="168" cy="33" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="184" cy="33" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="200" cy="33" r="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="170" y="62" width="130" height="7" rx="3.5" />
+    <rect x="170" y="78" width="96" height="7" rx="3.5" />
+    <rect x="170" y="94" width="148" height="7" rx="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="170" y="114" width="74" height="22" rx="11" fillOpacity="0.9" />
+    <circle cx="207" cy="125" r="5" style={{ color: "var(--ds-white)" }} />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="40" y="166" width="560" height="8" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="320" cy="152" r="3" />
+    <circle cx="330" cy="170" r="3" />
+    <circle cx="342" cy="186" r="3" />
+    <circle cx="358" cy="198" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="346" cy="178" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 388 186 L 478 186 L 500 208 L 500 238 Q 500 244 494 244 L 394 244 Q 388 244 388 238 Z" fillOpacity="0.3" />
+    <path d="M 478 186 L 478 202 Q 478 208 484 208 L 500 208 Z" fillOpacity="0.7" />
+    <rect x="402" y="214" width="56" height="6" rx="3" fillOpacity="0.8" />
+    <rect x="402" y="226" width="40" height="6" rx="3" fillOpacity="0.5" />
+  </g>
+</svg>
+
 ## The basic app and database loop
 
 Most application database work follows a simple loop:

--- a/content/learn/sqlite-for-beginners/index.mdx
+++ b/content/learn/sqlite-for-beginners/index.mdx
@@ -14,6 +14,66 @@ question of all — *what is a database, really?* — and build up,
 one small idea at a time, until you can read and write real SQL
 queries with confidence.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="Loose tilted paper scraps drift along a dotted trail into one friendly file with a folded corner, where they settle into three tidy glowing tables — a whole little database living inside a single SQLite file"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="38" y="52" width="52" height="38" rx="5" transform="rotate(-14 64 71)" />
+    <rect x="96" y="138" width="56" height="40" rx="5" transform="rotate(9 124 158)" />
+    <rect x="30" y="168" width="48" height="36" rx="5" transform="rotate(-7 54 186)" />
+    <rect x="120" y="28" width="46" height="34" rx="5" transform="rotate(18 143 45)" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="46" y="62" width="30" height="4" rx="2" transform="rotate(-14 64 71)" />
+    <rect x="46" y="72" width="22" height="4" rx="2" transform="rotate(-14 64 71)" />
+    <rect x="106" y="150" width="34" height="4" rx="2" transform="rotate(9 124 158)" />
+    <rect x="106" y="160" width="24" height="4" rx="2" transform="rotate(9 124 158)" />
+    <rect x="38" y="178" width="28" height="4" rx="2" transform="rotate(-7 54 186)" />
+    <rect x="128" y="38" width="26" height="4" rx="2" transform="rotate(18 143 45)" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="196" cy="118" r="3.5" />
+    <circle cx="226" cy="110" r="3.5" />
+    <circle cx="256" cy="106" r="3.5" />
+    <circle cx="286" cy="106" r="3.5" />
+    <circle cx="316" cy="110" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="236" y="58" width="44" height="32" rx="5" transform="rotate(12 258 74)" fillOpacity="0.85" />
+    <rect x="244" y="68" width="24" height="4" rx="2" transform="rotate(12 258 74)" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 366 36 L 516 36 L 556 76 L 556 214 Q 556 226 544 226 L 378 226 Q 366 226 366 214 Z" fillOpacity="0.14" />
+    <path d="M 516 36 L 516 64 Q 516 76 528 76 L 556 76 Z" fillOpacity="0.55" />
+    <rect x="386" y="92" width="64" height="12" rx="4" fillOpacity="0.8" />
+    <rect x="386" y="108" width="64" height="9" rx="3" fillOpacity="0.3" />
+    <rect x="386" y="121" width="64" height="9" rx="3" fillOpacity="0.3" />
+    <rect x="386" y="134" width="64" height="9" rx="3" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="462" y="92" width="74" height="12" rx="4" fillOpacity="0.8" />
+    <rect x="462" y="108" width="74" height="9" rx="3" fillOpacity="0.3" />
+    <rect x="462" y="121" width="74" height="9" rx="3" fillOpacity="0.3" />
+    <rect x="462" y="134" width="74" height="9" rx="3" fillOpacity="0.3" />
+    <rect x="462" y="147" width="74" height="9" rx="3" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="386" y="166" width="150" height="12" rx="4" fillOpacity="0.8" />
+    <rect x="386" y="182" width="150" height="9" rx="3" fillOpacity="0.3" />
+    <rect x="386" y="195" width="150" height="9" rx="3" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="345" cy="92" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="178" cy="206" r="5" fillOpacity="0.7" />
+    <circle cx="206" cy="196" r="4" fillOpacity="0.5" />
+  </g>
+</svg>
+
 <Callout type="info" title="Nothing to install">
 Every SQL example on every page runs **inside your browser** on a
 real SQLite engine (the official `@sqlite.org/sqlite-wasm` build —

--- a/content/learn/sqlite-for-beginners/inner-joins.mdx
+++ b/content/learn/sqlite-for-beginners/inner-joins.mdx
@@ -30,6 +30,57 @@ This data includes two unmatched things:
 - Linus is a customer with no order.
 - Order `104` points to customer `7`, who is not in the customers table.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="On a checkered dance floor two matched couples dance holding a shared yellow spark, while a blue dot and a green dot without partners sit out on the side benches — an inner join lets only matched pairs onto the floor"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.06">
+    <rect x="190" y="60" width="65" height="40" rx="4" />
+    <rect x="320" y="60" width="65" height="40" rx="4" />
+    <rect x="255" y="100" width="65" height="40" rx="4" />
+    <rect x="385" y="100" width="65" height="40" rx="4" />
+    <rect x="190" y="140" width="65" height="40" rx="4" />
+    <rect x="320" y="140" width="65" height="40" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="255" y="60" width="65" height="40" rx="4" />
+    <rect x="385" y="60" width="65" height="40" rx="4" />
+    <rect x="190" y="100" width="65" height="40" rx="4" />
+    <rect x="320" y="100" width="65" height="40" rx="4" />
+    <rect x="255" y="140" width="65" height="40" rx="4" />
+    <rect x="385" y="140" width="65" height="40" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="248" cy="92" r="13" />
+    <circle cx="352" cy="150" r="13" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="288" cy="92" r="13" />
+    <circle cx="392" cy="150" r="13" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="268" cy="78" r="6" />
+    <circle cx="372" cy="136" r="6" />
+    <path d="M 300 30 L 304 40 L 314 44 L 304 48 L 300 58 L 296 48 L 286 44 L 296 40 Z" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="60" y="178" width="90" height="10" rx="4" />
+    <rect x="68" y="188" width="8" height="22" rx="3" />
+    <rect x="134" y="188" width="8" height="22" rx="3" />
+    <rect x="490" y="178" width="90" height="10" rx="4" />
+    <rect x="498" y="188" width="8" height="22" rx="3" />
+    <rect x="564" y="188" width="8" height="22" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="105" cy="164" r="12" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="535" cy="164" r="12" fillOpacity="0.35" />
+  </g>
+</svg>
+
 <SqlCodeBlock
   dialect="sqlite"
   title="INNER JOIN keeps only matching rows"

--- a/content/learn/sqlite-for-beginners/inserting-data.mdx
+++ b/content/learn/sqlite-for-beginners/inserting-data.mdx
@@ -7,6 +7,59 @@ A table's structure is only the beginning. To make a table useful, you add rows.
 
 The SQL statement for adding rows is `INSERT INTO`.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A tilted seed packet scatters three seeds along a dotted arc into an empty garden furrow, while the furrow above already has a line of green sprouts and one ladybug resting on a leaf — INSERT plants new rows into the table bed"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="64" y="26" width="66" height="84" rx="9" transform="rotate(24 97 68)" fillOpacity="0.8" />
+    <path d="M 76 38 L 118 20 L 124 34 L 82 52 Z" transform="rotate(24 97 68)" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="172" cy="96" r="6" />
+    <circle cx="232" cy="120" r="6" />
+    <circle cx="296" cy="136" r="6" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="200" cy="108" r="2.5" />
+    <circle cx="262" cy="129" r="2.5" />
+    <circle cx="330" cy="141" r="2.5" />
+    <circle cx="364" cy="144" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.13">
+    <rect x="80" y="76" width="480" height="18" rx="9" />
+    <rect x="80" y="146" width="480" height="18" rx="9" />
+    <rect x="80" y="196" width="480" height="18" rx="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="128" y="48" width="4" height="28" rx="2" />
+    <ellipse cx="121" cy="52" rx="9" ry="5" transform="rotate(-28 121 52)" />
+    <ellipse cx="139" cy="52" rx="9" ry="5" transform="rotate(28 139 52)" />
+    <rect x="238" y="48" width="4" height="28" rx="2" />
+    <ellipse cx="231" cy="52" rx="9" ry="5" transform="rotate(-28 231 52)" />
+    <ellipse cx="249" cy="52" rx="9" ry="5" transform="rotate(28 249 52)" />
+    <rect x="348" y="48" width="4" height="28" rx="2" />
+    <ellipse cx="341" cy="52" rx="9" ry="5" transform="rotate(-28 341 52)" />
+    <ellipse cx="359" cy="52" rx="9" ry="5" transform="rotate(28 359 52)" />
+    <rect x="458" y="48" width="4" height="28" rx="2" />
+    <ellipse cx="451" cy="52" rx="9" ry="5" transform="rotate(-28 451 52)" />
+    <ellipse cx="469" cy="52" rx="9" ry="5" transform="rotate(28 469 52)" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="466" cy="46" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="428" y="122" width="4" height="24" rx="2" fillOpacity="0.7" />
+    <ellipse cx="421" cy="126" rx="8" ry="4.5" transform="rotate(-28 421 126)" fillOpacity="0.7" />
+    <ellipse cx="439" cy="126" rx="8" ry="4.5" transform="rotate(28 439 126)" fillOpacity="0.7" />
+    <rect x="508" y="126" width="4" height="20" rx="2" fillOpacity="0.45" />
+    <ellipse cx="502" cy="129" rx="7" ry="4" transform="rotate(-28 502 129)" fillOpacity="0.45" />
+    <ellipse cx="516" cy="129" rx="7" ry="4" transform="rotate(28 516 129)" fillOpacity="0.45" />
+  </g>
+</svg>
+
 ## INSERT adds rows
 
 An `INSERT` statement names the table, names the columns you are filling, and supplies matching values.
@@ -137,6 +190,48 @@ flowchart TB
 ## Column order matters
 
 The column list and values match by position. The first value goes into the first named column, the second value goes into the second named column, and so on.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Three value tokens drop straight down dotted lines into three labeled slots, first to first, second to second, third to third — insert values line up with the column list purely by position"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="118" y="22" width="96" height="26" rx="13" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="272" y="22" width="96" height="26" rx="13" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="426" y="22" width="96" height="26" rx="13" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="166" cy="64" r="2.5" />
+    <circle cx="166" cy="80" r="2.5" />
+    <circle cx="166" cy="96" r="2.5" />
+    <circle cx="320" cy="64" r="2.5" />
+    <circle cx="320" cy="80" r="2.5" />
+    <circle cx="320" cy="96" r="2.5" />
+    <circle cx="474" cy="64" r="2.5" />
+    <circle cx="474" cy="80" r="2.5" />
+    <circle cx="474" cy="96" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="110" y="112" width="112" height="44" rx="8" />
+    <rect x="264" y="112" width="112" height="44" rx="8" />
+    <rect x="418" y="112" width="112" height="44" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="126" y="126" width="80" height="16" rx="8" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="280" y="126" width="80" height="16" rx="8" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="434" y="126" width="80" height="16" rx="8" fillOpacity="0.3" />
+  </g>
+</svg>
 
 <SqlCodeBlock
   dialect="sqlite"

--- a/content/learn/sqlite-for-beginners/many-to-many.mdx
+++ b/content/learn/sqlite-for-beginners/many-to-many.mdx
@@ -16,6 +16,73 @@ flowchart LR
 
 Ada connects to more than one course. Math connects to more than one student. A single foreign-key column on either table cannot describe all those crossings.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="An old telephone switchboard: student jacks on the left and course jacks on the right are connected by dotted cords, and every cord plugs through its own yellow socket on the central panel — each socket is one row of the junction table, with one cord still waiting to be plugged in"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="250" y="28" width="140" height="184" rx="14" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="290" cy="196" r="5" />
+    <circle cx="320" cy="196" r="5" />
+    <circle cx="350" cy="196" r="5" />
+    <circle cx="350" cy="160" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 96 48 A 17 17 0 1 0 96 82 A 17 17 0 1 0 96 48 Z M 96 56 A 9 9 0 1 1 96 74 A 9 9 0 1 1 96 56 Z" />
+    <path fillRule="evenodd" d="M 96 104 A 17 17 0 1 0 96 138 A 17 17 0 1 0 96 104 Z M 96 112 A 9 9 0 1 1 96 130 A 9 9 0 1 1 96 112 Z" fillOpacity="0.8" />
+    <path fillRule="evenodd" d="M 96 160 A 17 17 0 1 0 96 194 A 17 17 0 1 0 96 160 Z M 96 168 A 9 9 0 1 1 96 186 A 9 9 0 1 1 96 168 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 544 48 A 17 17 0 1 0 544 82 A 17 17 0 1 0 544 48 Z M 544 56 A 9 9 0 1 1 544 74 A 9 9 0 1 1 544 56 Z" />
+    <path fillRule="evenodd" d="M 544 104 A 17 17 0 1 0 544 138 A 17 17 0 1 0 544 104 Z M 544 112 A 9 9 0 1 1 544 130 A 9 9 0 1 1 544 112 Z" fillOpacity="0.8" />
+    <path fillRule="evenodd" d="M 544 160 A 17 17 0 1 0 544 194 A 17 17 0 1 0 544 160 Z M 544 168 A 9 9 0 1 1 544 186 A 9 9 0 1 1 544 168 Z" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="136" cy="62" r="2.5" />
+    <circle cx="174" cy="58" r="2.5" />
+    <circle cx="212" cy="56" r="2.5" />
+    <circle cx="250" cy="56" r="2.5" />
+    <circle cx="136" cy="74" r="2.5" />
+    <circle cx="172" cy="86" r="2.5" />
+    <circle cx="208" cy="98" r="2.5" />
+    <circle cx="244" cy="108" r="2.5" />
+    <circle cx="136" cy="124" r="2.5" />
+    <circle cx="174" cy="116" r="2.5" />
+    <circle cx="212" cy="106" r="2.5" />
+    <circle cx="248" cy="92" r="2.5" />
+    <circle cx="390" cy="60" r="2.5" />
+    <circle cx="428" cy="58" r="2.5" />
+    <circle cx="466" cy="58" r="2.5" />
+    <circle cx="504" cy="60" r="2.5" />
+    <circle cx="390" cy="92" r="2.5" />
+    <circle cx="426" cy="100" r="2.5" />
+    <circle cx="464" cy="110" r="2.5" />
+    <circle cx="502" cy="118" r="2.5" />
+    <circle cx="392" cy="118" r="2.5" />
+    <circle cx="430" cy="124" r="2.5" />
+    <circle cx="468" cy="130" r="2.5" />
+    <circle cx="506" cy="142" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="290" cy="62" r="7" />
+    <circle cx="320" cy="88" r="7" />
+    <circle cx="290" cy="116" r="7" />
+    <circle cx="320" cy="124" r="7" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="136" cy="180" r="2.5" />
+    <circle cx="166" cy="190" r="2.5" />
+    <circle cx="194" cy="202" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="216" cy="212" r="7" fillOpacity="0.55" />
+  </g>
+</svg>
+
 ## Why one foreign key is not enough
 
 If you put `course_id` on `students`, each student could store only one course. If you put `student_id` on `courses`, each course could store only one student. Both designs lose information.

--- a/content/learn/sqlite-for-beginners/next-steps.mdx
+++ b/content/learn/sqlite-for-beginners/next-steps.mdx
@@ -8,6 +8,52 @@ you can reason about tables, keys, relationships, and queries — and,
 more importantly, you understand **why** each of those ideas exists.
 That conceptual foundation is the hard part, and you have it.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A paper boat folded from a sheet of table rows sails away from a little dock at sunrise, leaving a dotted wake and heading toward islands on the horizon — the foundations are folded and the voyage is just beginning"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="520" cy="120" r="34" fillOpacity="0.85" />
+    <circle cx="520" cy="120" r="48" fillOpacity="0.18" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <path d="M 560 146 Q 588 134 616 146 Q 604 156 580 156 Q 566 154 560 146 Z" />
+    <path d="M 440 152 Q 462 142 484 152 Q 474 160 458 160 Q 446 158 440 152 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="588" cy="136" r="5" fillOpacity="0.6" />
+    <circle cx="462" cy="144" r="4" fillOpacity="0.5" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <rect x="44" y="118" width="96" height="9" rx="4" />
+    <rect x="54" y="127" width="8" height="38" rx="3" />
+    <rect x="118" y="127" width="8" height="38" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 296 96 L 296 156 L 250 156 Z" fillOpacity="0.45" />
+    <path d="M 296 70 L 296 156 L 348 156 Z" fillOpacity="0.9" />
+    <path d="M 222 156 L 374 156 L 344 192 L 252 192 Z" fillOpacity="0.95" />
+  </g>
+  <g style={{ color: "var(--ds-white)" }} fill="currentColor">
+    <circle cx="310" cy="110" r="3" />
+    <circle cx="322" cy="122" r="3" />
+    <circle cx="310" cy="134" r="3" />
+    <circle cx="322" cy="146" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="206" cy="180" r="3" />
+    <circle cx="184" cy="186" r="3" />
+    <circle cx="162" cy="190" r="3" />
+    <circle cx="140" cy="192" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 40 204 Q 90 192 140 204 Q 190 216 240 204 Q 290 192 340 204 Q 390 216 440 204 Q 490 192 540 204 Q 570 211 600 206 L 600 226 L 40 226 Z" fillOpacity="0.18" />
+    <path d="M 40 218 Q 110 208 180 218 Q 250 228 320 218 Q 390 208 460 218 Q 530 228 600 220 L 600 240 L 40 240 Z" fillOpacity="0.12" />
+  </g>
+</svg>
+
 ## What you've built up
 
 The course moved deliberately from "why" to "how" to "how to think":

--- a/content/learn/sqlite-for-beginners/outer-joins.mdx
+++ b/content/learn/sqlite-for-beginners/outer-joins.mdx
@@ -11,6 +11,47 @@ An inner join hides rows with no match. Sometimes those missing matches are exac
 
 For those questions, beginners should reach first for **LEFT JOIN**.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Three couples promenade along a path: two are complete pairs, and in the third a blue dot strolls beside a dotted ghost circle where its partner would be — LEFT JOIN keeps every left row and fills the missing side with NULL"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.08">
+    <path d="M 40 150 Q 320 110 600 150 L 600 184 Q 320 144 40 184 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="136" cy="124" r="14" />
+    <circle cx="306" cy="112" r="14" />
+    <circle cx="476" cy="118" r="14" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="172" cy="120" r="14" />
+    <circle cx="342" cy="108" r="14" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="154" cy="104" r="5" />
+    <circle cx="324" cy="92" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="512" cy="103" r="2.5" />
+    <circle cx="521" cy="110" r="2.5" />
+    <circle cx="524" cy="121" r="2.5" />
+    <circle cx="520" cy="132" r="2.5" />
+    <circle cx="511" cy="138" r="2.5" />
+    <circle cx="501" cy="136" r="2.5" />
+    <circle cx="495" cy="127" r="2.5" />
+    <circle cx="497" cy="115" r="2.5" />
+    <circle cx="504" cy="106" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="222" cy="48" r="4" />
+    <circle cx="414" cy="40" r="4" />
+    <circle cx="568" cy="62" r="4" />
+    <circle cx="76" cy="58" r="4" />
+  </g>
+</svg>
+
 ## LEFT JOIN keeps every row from the left table
 
 A `LEFT JOIN` keeps all rows from the first table you name. If a matching row exists on the right, SQLite includes it. If not, the right-side columns become `NULL`.

--- a/content/learn/sqlite-for-beginners/primary-keys.mdx
+++ b/content/learn/sqlite-for-beginners/primary-keys.mdx
@@ -7,6 +7,62 @@ Imagine two people have the same name. If your table only stores names, how can 
 
 That is the job of a **primary key**: it gives each row a reliable identity.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A hotel key board holds three keys, each cut with its own teeth, above two guest cards that look exactly alike — only the numbered key each card holds tells the look-alike rows apart"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="150" y="14" width="340" height="120" rx="12" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="220" cy="34" r="5" />
+    <circle cx="320" cy="34" r="5" />
+    <circle cx="420" cy="34" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 220 28 A 14 14 0 1 0 220 56 A 14 14 0 1 0 220 28 Z M 220 36 A 6 6 0 1 1 220 48 A 6 6 0 1 1 220 36 Z" />
+    <rect x="216" y="54" width="8" height="48" rx="3" />
+    <rect x="224" y="86" width="10" height="6" rx="2" />
+    <rect x="224" y="96" width="7" height="6" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 320 28 A 14 14 0 1 0 320 56 A 14 14 0 1 0 320 28 Z M 320 36 A 6 6 0 1 1 320 48 A 6 6 0 1 1 320 36 Z" />
+    <rect x="316" y="54" width="8" height="48" rx="3" />
+    <rect x="324" y="78" width="8" height="6" rx="2" />
+    <rect x="324" y="92" width="12" height="6" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path fillRule="evenodd" d="M 420 28 A 14 14 0 1 0 420 56 A 14 14 0 1 0 420 28 Z M 420 36 A 6 6 0 1 1 420 48 A 6 6 0 1 1 420 36 Z" />
+    <rect x="416" y="54" width="8" height="48" rx="3" />
+    <rect x="424" y="84" width="11" height="6" rx="2" />
+    <rect x="424" y="96" width="6" height="6" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="150" y="158" width="160" height="66" rx="9" />
+    <rect x="330" y="158" width="160" height="66" rx="9" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <rect x="200" y="172" width="92" height="7" rx="3.5" />
+    <rect x="200" y="188" width="70" height="7" rx="3.5" />
+    <rect x="200" y="204" width="82" height="7" rx="3.5" />
+    <rect x="380" y="172" width="92" height="7" rx="3.5" />
+    <rect x="380" y="188" width="70" height="7" rx="3.5" />
+    <rect x="380" y="204" width="82" height="7" rx="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="177" cy="190" r="13" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="357" cy="190" r="13" />
+  </g>
+  <g style={{ color: "var(--ds-white)" }} fill="currentColor">
+    <text x="177" y="196" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700">1</text>
+    <text x="357" y="196" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700">2</text>
+  </g>
+</svg>
+
 ## The identity problem
 
 Two rows can look almost the same:

--- a/content/learn/sqlite-for-beginners/query-execution-order.mdx
+++ b/content/learn/sqlite-for-beginners/query-execution-order.mdx
@@ -9,6 +9,85 @@ but SQLite does **not** run it in that order. SQL has a hidden
 of confusing errors — like *"why can't I use an alias in `WHERE`?"*
 This is one of the most clarifying ideas in all of SQL.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="Rows ride a factory conveyor past numbered stations: a loose pile is gathered, a reject drops into the scrap bin at station two, survivors merge into group stacks, get their colors at station four, and only the first one passes the end gate — a query runs as an ordered assembly line, not in the order it is written"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="40" y="150" width="560" height="16" rx="8" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="80" cy="176" r="6" />
+    <circle cx="180" cy="176" r="6" />
+    <circle cx="280" cy="176" r="6" />
+    <circle cx="380" cy="176" r="6" />
+    <circle cx="480" cy="176" r="6" />
+    <circle cx="560" cy="176" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="96" y="40" width="30" height="30" rx="8" fillOpacity="0.95" />
+    <rect x="206" y="40" width="30" height="30" rx="8" fillOpacity="0.9" />
+    <rect x="316" y="40" width="30" height="30" rx="8" fillOpacity="0.85" />
+    <rect x="426" y="40" width="30" height="30" rx="8" fillOpacity="0.8" />
+    <rect x="536" y="40" width="30" height="30" rx="8" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-white)" }} fill="currentColor">
+    <text x="111" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">1</text>
+    <text x="221" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">2</text>
+    <text x="331" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">3</text>
+    <text x="441" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">4</text>
+    <text x="551" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">5</text>
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="108" y="70" width="6" height="80" rx="3" />
+    <rect x="218" y="70" width="6" height="80" rx="3" />
+    <rect x="328" y="70" width="6" height="80" rx="3" />
+    <rect x="438" y="70" width="6" height="80" rx="3" />
+    <rect x="548" y="70" width="6" height="80" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="56" cy="136" r="7" />
+    <circle cx="72" cy="128" r="7" />
+    <circle cx="66" cy="142" r="7" />
+    <circle cx="84" cy="140" r="7" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="142" cy="140" r="7" />
+    <circle cx="162" cy="140" r="7" />
+    <circle cx="182" cy="140" r="7" />
+    <circle cx="202" cy="140" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="248" cy="196" r="7" fillOpacity="0.7" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <path d="M 230 214 L 268 214 L 264 238 Q 263 244 257 244 L 241 244 Q 235 244 234 238 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="262" cy="140" r="7" />
+    <circle cx="282" cy="140" r="7" />
+    <circle cx="302" cy="140" r="7" />
+    <circle cx="368" cy="143" r="7" />
+    <circle cx="368" cy="128" r="7" />
+    <circle cx="396" cy="143" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="476" cy="143" r="7" />
+    <circle cx="476" cy="128" r="7" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="504" cy="143" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="580" y="108" width="10" height="46" rx="5" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="612" cy="143" r="7" />
+  </g>
+</svg>
+
 ## Written order vs. execution order
 
 The order you type is for human readability. The order the database

--- a/content/learn/sqlite-for-beginners/relationships-intro.mdx
+++ b/content/learn/sqlite-for-beginners/relationships-intro.mdx
@@ -7,6 +7,58 @@ A relational database is powerful because tables can **relate** to each other.
 
 Instead of storing every fact in one giant table, you store each kind of thing in its own table, then connect the tables with key values.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="A corkboard where one pinned customer card is tied by threads to two order cards, while a fourth card waits in the corner with a pin and no thread yet — tables become a story when key values connect their rows"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <path fillRule="evenodd" d="M 60 16 L 580 16 L 580 234 L 60 234 Z M 74 30 L 566 30 L 566 220 L 74 220 Z" fill="currentColor" opacity="0.14" />
+  <rect x="74" y="30" width="492" height="190" fill="currentColor" opacity="0.05" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="112" y="62" width="138" height="88" rx="8" transform="rotate(-3 181 106)" fillOpacity="0.22" />
+    <circle cx="146" cy="98" r="16" transform="rotate(-3 181 106)" fillOpacity="0.8" />
+    <rect x="172" y="86" width="58" height="9" rx="4.5" transform="rotate(-3 181 106)" fillOpacity="0.6" />
+    <rect x="172" y="102" width="44" height="9" rx="4.5" transform="rotate(-3 181 106)" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="181" cy="64" r="6.5" />
+    <circle cx="455" cy="56" r="6.5" />
+    <circle cx="475" cy="148" r="6.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="400" y="52" width="112" height="58" rx="8" transform="rotate(2 456 81)" fillOpacity="0.22" />
+    <circle cx="420" cy="78" r="7" transform="rotate(2 456 81)" fillOpacity="0.85" />
+    <rect x="434" y="73" width="56" height="9" rx="4.5" transform="rotate(2 456 81)" fillOpacity="0.5" />
+    <rect x="420" y="144" width="112" height="58" rx="8" transform="rotate(-2 476 173)" fillOpacity="0.22" />
+    <circle cx="440" cy="170" r="7" transform="rotate(-2 476 173)" fillOpacity="0.85" />
+    <rect x="454" y="165" width="56" height="9" rx="4.5" transform="rotate(-2 476 173)" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="194" cy="60" r="2.5" />
+    <circle cx="230" cy="52" r="2.5" />
+    <circle cx="268" cy="46" r="2.5" />
+    <circle cx="306" cy="44" r="2.5" />
+    <circle cx="344" cy="44" r="2.5" />
+    <circle cx="382" cy="47" r="2.5" />
+    <circle cx="420" cy="51" r="2.5" />
+    <circle cx="440" cy="54" r="2.5" />
+    <circle cx="196" cy="74" r="2.5" />
+    <circle cx="234" cy="88" r="2.5" />
+    <circle cx="274" cy="102" r="2.5" />
+    <circle cx="314" cy="116" r="2.5" />
+    <circle cx="354" cy="128" r="2.5" />
+    <circle cx="394" cy="138" r="2.5" />
+    <circle cx="434" cy="145" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="110" y="170" width="96" height="42" rx="7" transform="rotate(4 158 191)" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="158" cy="174" r="5" />
+  </g>
+</svg>
+
 ## Why not one giant table?
 
 Imagine an orders table that repeats the customer's details on every order.

--- a/content/learn/sqlite-for-beginners/select-basics.mdx
+++ b/content/learn/sqlite-for-beginners/select-basics.mdx
@@ -10,6 +10,64 @@ choose which **columns** you want from a table.
 A helpful first idea: a `SELECT` query does **not** change the stored
 table. It creates a temporary result table for you to look at.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A garden bed grows four columns of flowers, one color per column, and a vase on the right holds a bouquet picked from just the blue and yellow columns while the garden keeps every flower — SELECT chooses columns to look at without changing the stored table"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="56" y="196" width="300" height="14" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="88" y="92" width="3.5" height="104" rx="1.75" fillOpacity="0.4" />
+    <rect x="158" y="104" width="3.5" height="92" rx="1.75" fillOpacity="0.4" />
+    <rect x="228" y="92" width="3.5" height="104" rx="1.75" fillOpacity="0.4" />
+    <rect x="298" y="104" width="3.5" height="92" rx="1.75" fillOpacity="0.4" />
+    <rect x="118" y="128" width="3.5" height="68" rx="1.75" fillOpacity="0.4" />
+    <rect x="188" y="136" width="3.5" height="60" rx="1.75" fillOpacity="0.4" />
+    <rect x="258" y="128" width="3.5" height="68" rx="1.75" fillOpacity="0.4" />
+    <rect x="328" y="136" width="3.5" height="60" rx="1.75" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="90" cy="86" r="9" />
+    <circle cx="120" cy="122" r="7" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="160" cy="98" r="9" />
+    <circle cx="190" cy="130" r="7" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="230" cy="86" r="9" />
+    <circle cx="260" cy="122" r="7" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="300" cy="98" r="9" />
+    <circle cx="330" cy="130" r="7" fillOpacity="0.75" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="380" cy="92" r="2.5" />
+    <circle cx="404" cy="80" r="2.5" />
+    <circle cx="430" cy="72" r="2.5" />
+    <circle cx="456" cy="68" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <path d="M 478 142 L 562 142 L 548 218 Q 547 226 539 226 L 501 226 Q 493 226 492 218 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="506" y="84" width="3.5" height="62" rx="1.75" transform="rotate(-14 508 115)" fillOpacity="0.45" />
+    <rect x="530" y="78" width="3.5" height="68" rx="1.75" transform="rotate(8 532 112)" fillOpacity="0.45" />
+    <rect x="518" y="92" width="3.5" height="54" rx="1.75" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="498" cy="78" r="9" />
+    <circle cx="520" cy="86" r="7" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="540" cy="72" r="9" />
+  </g>
+</svg>
+
 ## SELECT chooses columns
 
 Imagine a table like a spreadsheet. It has rows going down and columns
@@ -181,6 +239,39 @@ FROM
 
 There are five books, but only three genres. `DISTINCT` is perfect for
 questions like "what categories exist?"
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="Five stamps in a row include the same blue design three times; below the dotted drop, each design appears exactly once — DISTINCT keeps one copy of every different value"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="130" cy="40" r="15" />
+    <circle cx="290" cy="40" r="15" fillOpacity="0.85" />
+    <circle cx="450" cy="40" r="15" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="195" y="26" width="30" height="28" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 370 26 L 384 54 L 356 54 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="240" cy="84" r="2.5" />
+    <circle cx="290" cy="88" r="2.5" />
+    <circle cx="340" cy="84" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="210" cy="130" r="15" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="275" y="116" width="30" height="28" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 370 116 L 384 144 L 356 144 Z" />
+  </g>
+</svg>
 
 `DISTINCT` works on the whole selected row. If you select two columns,
 SQLite keeps each unique combination of those two columns.

--- a/content/learn/sqlite-for-beginners/sorting-and-limiting.mdx
+++ b/content/learn/sqlite-for-beginners/sorting-and-limiting.mdx
@@ -11,6 +11,55 @@ After the rows are ordered, `LIMIT` and `OFFSET` let you take a smaller
 piece of the result. Together, they answer questions like "which books
 are cheapest?" and "show the next page."
 
+<svg
+  viewBox="0 0 640 260"
+  role="img"
+  aria-label="A jumbled top shelf of books, one leaning at an angle, is rearranged on the lower shelf from shortest to tallest, where an L-shaped bookend stops after the first three and the rest fade — ORDER BY lines rows up and LIMIT keeps just the front of the line"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="100" y="106" width="440" height="8" rx="4" />
+    <rect x="100" y="232" width="440" height="8" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="128" y="50" width="26" height="56" rx="4" fillOpacity="0.85" />
+    <rect x="288" y="58" width="26" height="48" rx="4" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="162" y="68" width="26" height="38" rx="4" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="206" y="46" width="26" height="64" rx="4" transform="rotate(9 219 78)" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="252" y="76" width="26" height="30" rx="4" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="404" cy="128" r="2.5" />
+    <circle cx="384" cy="142" r="2.5" />
+    <circle cx="364" cy="156" r="2.5" />
+    <circle cx="344" cy="170" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="128" y="202" width="26" height="30" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="162" y="194" width="26" height="38" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="196" y="184" width="26" height="48" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <path d="M 236 232 L 236 178 L 248 178 L 248 220 L 274 220 L 274 232 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="288" y="176" width="26" height="56" rx="4" fillOpacity="0.25" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="322" y="168" width="26" height="64" rx="4" fillOpacity="0.25" />
+  </g>
+</svg>
+
 ## ORDER BY sorts rows
 
 `ORDER BY` sorts the result by a column. Use `ASC` for ascending order

--- a/content/learn/sqlite-for-beginners/spreadsheets-vs-databases.mdx
+++ b/content/learn/sqlite-for-beginners/spreadsheets-vs-databases.mdx
@@ -11,6 +11,80 @@ Spreadsheets are wonderful tools. They are visual, flexible, and easy to start u
 
 Databases solve a different problem: keeping structured information reliable when software, rules, relationships, history, and multiple users matter.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="Two grids side by side: in the spreadsheet anything lands anywhere — a bar straddles two cells, a value escapes the edge, a red blob ignores the lines — while in the database every value sits in its column's slot, each column holding one kind of thing"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="56" y="40" width="52" height="36" rx="4" />
+    <rect x="114" y="40" width="52" height="36" rx="4" />
+    <rect x="172" y="40" width="52" height="36" rx="4" />
+    <rect x="56" y="82" width="52" height="36" rx="4" />
+    <rect x="114" y="82" width="52" height="36" rx="4" />
+    <rect x="172" y="82" width="52" height="36" rx="4" />
+    <rect x="56" y="124" width="52" height="36" rx="4" />
+    <rect x="114" y="124" width="52" height="36" rx="4" />
+    <rect x="172" y="124" width="52" height="36" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="82" cy="58" r="8" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="96" y="92" width="84" height="12" rx="6" transform="rotate(-9 138 98)" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="111" cy="142" r="8" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 206 130 Q 232 118 244 140 Q 252 158 230 164 Q 204 168 200 150 Q 198 138 206 130 Z" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="240" cy="52" r="8" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="310" cy="100" r="3" />
+    <circle cx="324" cy="100" r="3" />
+    <circle cx="338" cy="100" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="376" y="36" width="62" height="16" rx="5" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="444" y="36" width="62" height="16" rx="5" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="512" y="36" width="62" height="16" rx="5" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="376" y="58" width="62" height="34" rx="4" />
+    <rect x="444" y="58" width="62" height="34" rx="4" />
+    <rect x="512" y="58" width="62" height="34" rx="4" />
+    <rect x="376" y="98" width="62" height="34" rx="4" />
+    <rect x="444" y="98" width="62" height="34" rx="4" />
+    <rect x="512" y="98" width="62" height="34" rx="4" />
+    <rect x="376" y="138" width="62" height="34" rx="4" />
+    <rect x="444" y="138" width="62" height="34" rx="4" />
+    <rect x="512" y="138" width="62" height="34" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="407" cy="75" r="7" fillOpacity="0.7" />
+    <circle cx="407" cy="115" r="7" fillOpacity="0.7" />
+    <circle cx="407" cy="155" r="7" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="456" y="70" width="38" height="10" rx="5" fillOpacity="0.7" />
+    <rect x="456" y="110" width="30" height="10" rx="5" fillOpacity="0.7" />
+    <rect x="456" y="150" width="42" height="10" rx="5" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="543" cy="75" r="7" fillOpacity="0.7" />
+    <circle cx="543" cy="115" r="7" fillOpacity="0.7" />
+    <circle cx="543" cy="155" r="7" fillOpacity="0.7" />
+  </g>
+</svg>
+
 ## A spreadsheet is a flexible workspace
 
 A spreadsheet is like a digital workbench.
@@ -207,6 +281,41 @@ WHERE
 />
 
 ## Which should you use?
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A dotted path forks: one branch leads to a loose freeform sheet for quick exploring, the other to a tidy structured table for dependable storage — neither tool is better, the path depends on the job"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="320" cy="156" r="10" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="306" cy="132" r="3" />
+    <circle cx="290" cy="112" r="3" />
+    <circle cx="270" cy="94" r="3" />
+    <circle cx="246" cy="80" r="3" />
+    <circle cx="334" cy="132" r="3" />
+    <circle cx="350" cy="112" r="3" />
+    <circle cx="370" cy="94" r="3" />
+    <circle cx="394" cy="80" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="118" y="22" width="100" height="56" rx="8" transform="rotate(-5 168 50)" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="146" cy="42" r="6" transform="rotate(-5 168 50)" fillOpacity="0.85" />
+    <rect x="160" y="54" width="40" height="8" rx="4" transform="rotate(-5 168 50)" fillOpacity="0.6" />
+    <circle cx="200" cy="38" r="4" transform="rotate(-5 168 50)" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="424" y="18" width="98" height="14" rx="4" fillOpacity="0.8" />
+    <rect x="424" y="36" width="98" height="11" rx="3" fillOpacity="0.35" />
+    <rect x="424" y="51" width="98" height="11" rx="3" fillOpacity="0.35" />
+    <rect x="424" y="66" width="98" height="11" rx="3" fillOpacity="0.35" />
+  </g>
+</svg>
 
 Use a spreadsheet when:
 

--- a/content/learn/sqlite-for-beginners/tables-rows-columns.mdx
+++ b/content/learn/sqlite-for-beginners/tables-rows-columns.mdx
@@ -42,6 +42,61 @@ Read one row as a sentence:
 
 That sentence works because the table is organized around one kind of thing: pets.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="One row slides out of a soft grid like a tray, and a speech bubble above repeats its four values in order — a single row is one complete record that reads like a sentence about one pet"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.09">
+    <rect x="100" y="86" width="64" height="34" rx="5" />
+    <rect x="170" y="86" width="110" height="34" rx="5" />
+    <rect x="286" y="86" width="86" height="34" rx="5" />
+    <rect x="378" y="86" width="64" height="34" rx="5" />
+    <rect x="100" y="168" width="64" height="34" rx="5" />
+    <rect x="170" y="168" width="110" height="34" rx="5" />
+    <rect x="286" y="168" width="86" height="34" rx="5" />
+    <rect x="378" y="168" width="64" height="34" rx="5" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="132" y="127" width="64" height="34" rx="5" />
+    <rect x="202" y="127" width="110" height="34" rx="5" />
+    <rect x="318" y="127" width="86" height="34" rx="5" />
+    <rect x="410" y="127" width="64" height="34" rx="5" />
+    <path d="M 484 136 L 504 144 L 484 152 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="164" cy="144" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="222" y="138" width="70" height="12" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="361" cy="144" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="442" cy="144" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <path d="M 150 18 Q 150 8 160 8 L 480 8 Q 490 8 490 18 L 490 52 Q 490 62 480 62 L 250 62 L 226 80 L 232 62 L 160 62 Q 150 62 150 52 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="186" cy="35" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="208" y="30" width="56" height="10" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="292" cy="35" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="322" cy="35" r="7" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="352" cy="42" r="2.5" />
+  </g>
+</svg>
+
 ## Rows are records
 
 A **row** is one complete record. In the `pets` table, one row means one pet.

--- a/content/learn/sqlite-for-beginners/understanding-joins.mdx
+++ b/content/learn/sqlite-for-beginners/understanding-joins.mdx
@@ -56,6 +56,64 @@ FROM
 
 Read the `ON` line as: "match an order to a customer when the order's `customer_id` equals the customer's `id`."
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="Two train cars roll toward each other, each carrying its own cargo bars, with matching yellow couplers reaching out; on the track below they have clicked into one long car sharing a single coupler — a join snaps two rows together where their key values meet"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="50" y="106" width="540" height="5" rx="2.5" />
+    <rect x="50" y="226" width="540" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="84" y="38" width="160" height="56" rx="10" fillOpacity="0.3" />
+    <circle cx="112" cy="66" r="9" fillOpacity="0.95" />
+    <rect x="130" y="60" width="64" height="12" rx="6" fillOpacity="0.7" />
+    <rect x="244" y="60" width="22" height="12" rx="4" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="272" cy="66" r="9" />
+    <circle cx="362" cy="66" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="112" cy="100" r="8" />
+    <circle cx="216" cy="100" r="8" />
+    <circle cx="422" cy="100" r="8" />
+    <circle cx="526" cy="100" r="8" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="304" cy="66" r="2.5" />
+    <circle cx="317" cy="66" r="2.5" />
+    <circle cx="330" cy="66" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="394" y="38" width="160" height="56" rx="10" fillOpacity="0.3" />
+    <rect x="368" y="60" width="22" height="12" rx="4" fillOpacity="0.5" />
+    <rect x="412" y="60" width="50" height="12" rx="6" fillOpacity="0.7" />
+    <rect x="472" y="60" width="62" height="12" rx="6" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="158" y="160" width="166" height="54" rx="10" fillOpacity="0.3" />
+    <circle cx="186" cy="187" r="9" fillOpacity="0.95" />
+    <rect x="204" y="181" width="64" height="12" rx="6" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="324" y="160" width="160" height="54" rx="10" fillOpacity="0.3" />
+    <rect x="348" y="181" width="50" height="12" rx="6" fillOpacity="0.7" />
+    <rect x="408" y="181" width="62" height="12" rx="6" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="324" cy="187" r="10" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="190" cy="220" r="8" />
+    <circle cx="290" cy="220" r="8" />
+    <circle cx="356" cy="220" r="8" />
+    <circle cx="452" cy="220" r="8" />
+  </g>
+</svg>
+
 ## The row-matching picture
 
 A useful beginner mental model is **cartesian then filter**:

--- a/content/learn/sqlite-for-beginners/understanding-tables.mdx
+++ b/content/learn/sqlite-for-beginners/understanding-tables.mdx
@@ -9,6 +9,58 @@ A table is more than a grid. A good table is a clear statement:
 
 That sentence is one of the most important habits in database design. Before you worry about SQL syntax, learn to ask: **what does one row mean?**
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="One overstuffed box holds circles, triangles, and squares all jumbled together with one shape tipping out, while on the right each shape kind has its own tidy box — a good table keeps exactly one kind of thing"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.14">
+    <path d="M 56 88 L 232 88 L 220 196 Q 219 204 211 204 L 77 204 Q 69 204 68 196 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="106" cy="140" r="16" fillOpacity="0.8" />
+    <circle cx="188" cy="172" r="13" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 148 118 L 168 152 L 128 152 Z" fillOpacity="0.8" />
+    <path d="M 96 168 L 114 196 L 78 196 Z" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="158" y="120" width="28" height="28" rx="5" transform="rotate(14 172 134)" fillOpacity="0.8" />
+    <rect x="124" y="160" width="24" height="24" rx="5" transform="rotate(-10 136 172)" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="226" cy="84" r="13" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="272" cy="146" r="3" />
+    <circle cx="292" cy="146" r="3" />
+    <circle cx="312" cy="146" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <path d="M 348 116 L 432 116 L 426 196 Q 425 204 417 204 L 363 204 Q 355 204 354 196 Z" />
+    <path d="M 452 116 L 536 116 L 530 196 Q 529 204 521 204 L 467 204 Q 459 204 458 196 Z" />
+    <path d="M 556 116 L 640 116 L 634 196 Q 633 204 625 204 L 571 204 Q 563 204 562 196 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="374" cy="158" r="11" fillOpacity="0.85" />
+    <circle cx="404" cy="158" r="11" fillOpacity="0.6" />
+    <circle cx="389" cy="184" r="11" fillOpacity="0.4" />
+    <circle cx="390" cy="92" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 480 146 L 496 172 L 464 172 Z" fillOpacity="0.85" />
+    <path d="M 510 158 L 524 182 L 496 182 Z" fillOpacity="0.55" />
+    <path d="M 494 70 L 506 90 L 482 90 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="576" y="146" width="22" height="22" rx="4" fillOpacity="0.85" />
+    <rect x="602" y="160" width="20" height="20" rx="4" fillOpacity="0.55" />
+    <rect x="590" y="80" width="16" height="16" rx="3" />
+  </g>
+</svg>
+
 ## One table, one kind of thing
 
 A well-shaped table stores facts about one kind of thing: one customer, one pet, one book, one order, one city.

--- a/content/learn/sqlite-for-beginners/what-is-a-database.mdx
+++ b/content/learn/sqlite-for-beginners/what-is-a-database.mdx
@@ -11,6 +11,55 @@ A notebook can store information. A spreadsheet can store information. A folder 
 
 SQLite is a real database management system. It may be small enough to live inside an app, but it still stores structured data, answers SQL questions, protects saved changes, and manages a real database file.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A card-catalog box with neatly tabbed cards standing in order, and one card lifted out along a dotted trail exactly when needed — a database is an organized place where facts can be stored, found again, and trusted"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.22">
+    <rect x="172" y="118" width="296" height="14" rx="6" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="196" y="70" width="46" height="52" rx="4" />
+    <rect x="252" y="76" width="46" height="46" rx="4" />
+    <rect x="308" y="72" width="46" height="50" rx="4" />
+    <rect x="364" y="78" width="46" height="44" rx="4" />
+    <rect x="412" y="74" width="46" height="48" rx="4" transform="rotate(7 435 98)" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="202" y="60" width="24" height="12" rx="4" />
+    <path d="M 160 126 L 480 126 L 466 204 Q 464 212 456 212 L 184 212 Q 176 212 174 204 Z" fillOpacity="0.22" />
+    <rect x="160" y="120" width="320" height="12" rx="6" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="258" y="66" width="24" height="12" rx="4" />
+    <rect x="370" y="68" width="24" height="12" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="424" y="62" width="24" height="12" rx="4" transform="rotate(7 436 68)" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="350" cy="96" r="3" />
+    <circle cx="362" cy="76" r="3" />
+    <circle cx="378" cy="58" r="3" />
+    <circle cx="398" cy="44" r="3" />
+    <circle cx="422" cy="34" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="448" y="14" width="120" height="74" rx="8" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <rect x="462" y="40" width="78" height="5" rx="2.5" />
+    <rect x="462" y="52" width="92" height="5" rx="2.5" />
+    <rect x="462" y="64" width="58" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="456" y="4" width="26" height="13" rx="4" />
+    <circle cx="548" cy="28" r="6" />
+  </g>
+</svg>
+
 ## A database stores facts
 
 Imagine a small online bookstore. It needs to remember things like:

--- a/content/learn/sqlite-for-beginners/what-sql-does.mdx
+++ b/content/learn/sqlite-for-beginners/what-sql-does.mdx
@@ -11,6 +11,62 @@ It is the language most relational databases understand, including SQLite.
 
 Instead of telling the computer every tiny step, SQL lets you describe the result you want.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="An order slip with a wish written on it passes over a counter with a service bell; behind the hatch, gears turn out of sight, and a plate of neatly arranged results slides out — SQL describes what you want and the database quietly works out how"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="48" y="48" width="104" height="76" rx="8" transform="rotate(-6 100 86)" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <rect x="62" y="66" width="62" height="6" rx="3" transform="rotate(-6 100 86)" />
+    <rect x="62" y="96" width="70" height="6" rx="3" transform="rotate(-6 100 86)" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="62" y="80" width="76" height="9" rx="4.5" transform="rotate(-6 100 86)" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="178" cy="120" r="3" />
+    <circle cx="202" cy="128" r="3" />
+    <circle cx="226" cy="134" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 256 150 L 256 78 Q 256 30 320 30 Q 384 30 384 78 L 384 150 Z" fillOpacity="0.2" />
+    <rect x="240" y="150" width="160" height="16" rx="6" fillOpacity="0.6" />
+    <rect x="248" y="166" width="144" height="36" rx="6" fillOpacity="0.3" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <circle cx="300" cy="92" r="20" />
+    <rect x="296" y="64" width="8" height="12" rx="2" />
+    <rect x="296" y="108" width="8" height="12" rx="2" />
+    <rect x="272" y="88" width="12" height="8" rx="2" />
+    <rect x="316" y="88" width="12" height="8" rx="2" />
+    <circle cx="344" cy="116" r="13" />
+    <rect x="341" y="98" width="6" height="9" rx="2" />
+    <rect x="341" y="124" width="6" height="9" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 404 142 Q 404 126 422 126 Q 440 126 440 142 Z" />
+    <rect x="417" y="118" width="10" height="8" rx="4" />
+    <rect x="398" y="142" width="48" height="7" rx="3.5" fillOpacity="0.7" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="462" cy="148" r="3" />
+    <circle cx="486" cy="152" r="3" />
+    <circle cx="510" cy="156" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <path d="M 524 176 Q 524 160 568 160 Q 612 160 612 176 Q 612 188 568 188 Q 524 188 524 176 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="550" cy="168" r="7" />
+    <circle cx="568" cy="164" r="7" fillOpacity="0.75" />
+    <circle cx="586" cy="168" r="7" fillOpacity="0.5" />
+  </g>
+</svg>
+
 ## A shared language
 
 Before a database can answer questions, people and programs need a way to express those questions clearly.

--- a/content/learn/sqlite-for-beginners/why-databases-exist.mdx
+++ b/content/learn/sqlite-for-beginners/why-databases-exist.mdx
@@ -11,6 +11,61 @@ But as soon as more people, more rules, more history, and more questions appear,
 
 Databases were invented to help with that.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A balloon carrying a fact drifts away and a sticky note peels off a wall losing its dot, while the same facts rest safely in a sturdy chest on the right — fragile ways of remembering versus a database built to keep them"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="120" cy="58" r="26" fillOpacity="0.45" />
+    <path d="M 113 82 L 127 82 L 120 92 Z" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="120" cy="58" r="8" fillOpacity="0.35" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="122" cy="102" r="2.5" />
+    <circle cx="128" cy="116" r="2.5" />
+    <circle cx="126" cy="130" r="2.5" />
+    <circle cx="118" cy="143" r="2.5" />
+    <circle cx="112" cy="156" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 240 96 L 304 90 L 310 146 L 268 152 Q 244 132 240 96 Z" fillOpacity="0.5" />
+    <path d="M 268 152 Q 262 134 240 130 Q 252 144 268 152 Z" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="290" cy="176" r="7" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="60" y="196" width="520" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 408 116 L 568 116 L 568 190 Q 568 196 562 196 L 414 196 Q 408 196 408 190 Z" fillOpacity="0.3" />
+    <path d="M 408 116 Q 408 88 488 88 Q 568 88 568 116 Z" fillOpacity="0.55" />
+    <rect x="478" y="108" width="20" height="16" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="438" cy="156" r="8" />
+    <circle cx="463" cy="156" r="8" fillOpacity="0.75" />
+    <circle cx="488" cy="156" r="8" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="513" cy="156" r="8" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="538" cy="156" r="8" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="438" cy="176" r="2.5" />
+    <circle cx="463" cy="176" r="2.5" />
+    <circle cx="488" cy="176" r="2.5" />
+    <circle cx="513" cy="176" r="2.5" />
+    <circle cx="538" cy="176" r="2.5" />
+  </g>
+</svg>
+
 ## The simple version
 
 A database helps an application:
@@ -255,6 +310,45 @@ Sometimes files are exactly right.
 A profile photo, a PDF receipt, a configuration file, or a short note may belong in a regular file.
 
 The question is not "files or databases forever?"
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A single photo card hangs happily from one clip while a grid of interrelated facts sits on the other side of a question diamond — some information is fine as a plain file, and structured facts belong in a database"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="60" y="22" width="520" height="5" rx="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="142" y="27" width="6" height="22" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="100" y="48" width="90" height="104" rx="6" transform="rotate(-4 145 100)" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 110 116 L 134 84 L 152 104 L 168 88 L 184 112 L 184 124 L 110 124 Z" transform="rotate(-4 145 100)" fillOpacity="0.55" />
+    <circle cx="126" cy="70" r="8" transform="rotate(-4 145 100)" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="296" y="76" width="48" height="48" rx="9" transform="rotate(45 320 100)" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="320" y="108" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="700">?</text>
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="430" y="48" width="44" height="30" rx="5" fillOpacity="0.75" />
+    <rect x="482" y="48" width="44" height="30" rx="5" fillOpacity="0.35" />
+    <rect x="430" y="86" width="44" height="30" rx="5" fillOpacity="0.35" />
+    <rect x="482" y="86" width="44" height="30" rx="5" fillOpacity="0.55" />
+    <rect x="430" y="124" width="44" height="30" rx="5" fillOpacity="0.45" />
+    <rect x="482" y="124" width="44" height="30" rx="5" fillOpacity="0.25" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="478" cy="82" r="3" />
+    <circle cx="478" cy="120" r="3" />
+  </g>
+</svg>
 
 The better question is:
 

--- a/content/learn/sqlite-for-beginners/why-relational-databases.mdx
+++ b/content/learn/sqlite-for-beginners/why-relational-databases.mdx
@@ -9,6 +9,67 @@ That may sound small, but it changes how reliably software can work with informa
 
 SQLite is a relational database system. It stores data in tables and lets you connect rows using keys.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="On the left, three cards each carry their own copy of the same yellow fact and one copy has drifted red; on the right, the fact lives once on a central card and small order chips simply hold a thread to it — store a fact one time and point to it"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="48" y="38" width="120" height="44" rx="7" />
+    <rect x="48" y="92" width="120" height="44" rx="7" />
+    <rect x="48" y="146" width="120" height="44" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="62" y="54" width="74" height="11" rx="5.5" fillOpacity="0.8" />
+    <rect x="62" y="108" width="74" height="11" rx="5.5" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="62" y="162" width="74" height="11" rx="5.5" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="216" cy="114" r="3" />
+    <circle cx="234" cy="114" r="3" />
+    <circle cx="252" cy="114" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <rect x="358" y="80" width="140" height="68" rx="9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="374" y="96" width="88" height="12" rx="6" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="380" cy="126" r="8" />
+    <rect x="396" y="121" width="48" height="9" rx="4.5" fillOpacity="0.35" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="345" cy="62" r="2.5" />
+    <circle cx="332" cy="48" r="2.5" />
+    <circle cx="320" cy="34" r="2.5" />
+    <circle cx="528" cy="62" r="2.5" />
+    <circle cx="548" cy="48" r="2.5" />
+    <circle cx="568" cy="34" r="2.5" />
+    <circle cx="528" cy="168" r="2.5" />
+    <circle cx="548" cy="182" r="2.5" />
+    <circle cx="568" cy="196" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="262" y="6" width="74" height="34" rx="8" fillOpacity="0.3" />
+    <rect x="560" y="6" width="74" height="34" rx="8" fillOpacity="0.3" />
+    <rect x="560" y="190" width="74" height="34" rx="8" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="278" cy="23" r="6" />
+    <circle cx="576" cy="23" r="6" />
+    <circle cx="576" cy="207" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="290" y="19" width="34" height="8" rx="4" fillOpacity="0.6" />
+    <rect x="588" y="19" width="34" height="8" rx="4" fillOpacity="0.6" />
+    <rect x="588" y="203" width="34" height="8" rx="4" fillOpacity="0.6" />
+  </g>
+</svg>
+
 ## The problem: repeated facts drift apart
 
 Imagine tracking bookstore orders in one big list:

--- a/content/learn/sqlite-for-beginners/why-sqlite.mdx
+++ b/content/learn/sqlite-for-beginners/why-sqlite.mdx
@@ -9,6 +9,69 @@ It is one of the most widely used database engines in the world. You may use it 
 
 SQLite is not a toy database. It is a real relational DBMS that understands SQL and stores durable data.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="Tall faded server racks loom on the left while the same colored data dots sit packed in a small bright suitcase on the right — SQLite carries a whole database in one little file, no server room required"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="72" y="24" width="78" height="186" rx="8" />
+    <rect x="162" y="44" width="78" height="166" rx="8" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="84" y="40" width="54" height="9" rx="4.5" />
+    <rect x="84" y="58" width="54" height="9" rx="4.5" />
+    <rect x="84" y="76" width="54" height="9" rx="4.5" />
+    <rect x="84" y="94" width="54" height="9" rx="4.5" />
+    <rect x="174" y="60" width="54" height="9" rx="4.5" />
+    <rect x="174" y="78" width="54" height="9" rx="4.5" />
+    <rect x="174" y="96" width="54" height="9" rx="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="96" cy="126" r="5" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="120" cy="146" r="5" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="198" cy="130" r="5" fillOpacity="0.35" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="270" cy="160" r="3" />
+    <circle cx="294" cy="156" r="3" />
+    <circle cx="318" cy="153" r="3" />
+    <circle cx="342" cy="152" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <rect x="40" y="210" width="560" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 478 100 Q 478 84 494 84 L 522 84 Q 538 84 538 100 L 538 108 L 524 108 L 524 102 Q 524 98 520 98 L 496 98 Q 492 98 492 102 L 492 108 L 478 108 Z" fillOpacity="0.9" />
+    <rect x="430" y="106" width="156" height="104" rx="14" fillOpacity="0.3" />
+    <rect x="430" y="106" width="156" height="22" rx="11" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="460" cy="152" r="8" />
+    <circle cx="460" cy="182" r="8" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="490" cy="152" r="8" />
+    <circle cx="490" cy="182" r="8" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="520" cy="152" r="8" />
+    <circle cx="520" cy="182" r="8" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="550" cy="152" r="8" />
+    <circle cx="550" cy="182" r="8" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 600 70 L 605 82 L 617 87 L 605 92 L 600 104 L 595 92 L 583 87 L 595 82 Z" fillOpacity="0.8" />
+  </g>
+</svg>
+
 ## SQLite is embedded
 
 Many database systems run as a separate server process. An application connects to that server.
@@ -122,6 +185,36 @@ flowchart TB
 SQLite is public-domain software, which makes it unusually easy for projects to use.
 
 It is also famous for careful testing. Beginners do not need to understand the testing details yet. The beginner version is:
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="A small database file stands calmly in the middle of an orbit of green check marks — SQLite has earned trust through an enormous amount of careful testing"
+  style={{ display: "block", width: "100%", maxWidth: "420px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 286 56 L 344 56 L 364 76 L 364 132 Q 364 138 358 138 L 292 138 Q 286 138 286 132 Z" fillOpacity="0.3" />
+    <path d="M 344 56 L 344 70 Q 344 76 350 76 L 364 76 Z" fillOpacity="0.7" />
+    <rect x="298" y="90" width="36" height="6" rx="3" fillOpacity="0.8" />
+    <rect x="298" y="102" width="26" height="6" rx="3" fillOpacity="0.5" />
+    <rect x="298" y="114" width="42" height="6" rx="3" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 318 18 L 324 26 L 338 8 L 330 30 L 318 26 Z" fillOpacity="0.9" />
+    <path d="M 416 44 L 422 52 L 436 34 L 428 56 L 416 52 Z" fillOpacity="0.6" />
+    <path d="M 444 104 L 450 112 L 464 94 L 456 116 L 444 112 Z" fillOpacity="0.8" />
+    <path d="M 386 152 L 392 160 L 406 142 L 398 164 L 386 160 Z" fillOpacity="0.5" />
+    <path d="M 244 152 L 250 160 L 264 142 L 256 164 L 244 160 Z" fillOpacity="0.7" />
+    <path d="M 192 96 L 198 104 L 212 86 L 204 108 L 192 104 Z" fillOpacity="0.55" />
+    <path d="M 218 40 L 224 48 L 238 30 L 230 52 L 218 48 Z" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="172" cy="140" r="3" />
+    <circle cx="470" cy="60" r="3" />
+    <circle cx="480" cy="148" r="3" />
+    <circle cx="166" cy="48" r="3" />
+  </g>
+</svg>
 
 > SQLite is trusted because a huge amount of software relies on it to store important local data correctly.
 

--- a/content/learn/sqlite-for-beginners/why-structured-data.mdx
+++ b/content/learn/sqlite-for-beginners/why-structured-data.mdx
@@ -9,6 +9,49 @@ Instead of one long note, the facts are separated into named pieces. In a relati
 
 This structure is powerful because software can understand it.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="Loose eggs roll free on the left — one already cracked — while on the right each egg rests in its own carton dimple, sorted by color column by column, with one dimple left empty — structure gives every fact a predictable place, even a missing one"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.22">
+    <ellipse cx="78" cy="96" rx="17" ry="22" transform="rotate(-18 78 96)" />
+    <ellipse cx="142" cy="64" rx="16" ry="21" transform="rotate(12 142 64)" />
+    <ellipse cx="186" cy="128" rx="17" ry="22" transform="rotate(28 186 128)" />
+    <ellipse cx="104" cy="166" rx="16" ry="21" transform="rotate(74 104 166)" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <ellipse cx="232" cy="76" rx="16" ry="21" transform="rotate(-30 232 76)" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 222 62 L 230 70 L 224 78 L 234 86 L 228 92 L 238 84 L 230 76 L 236 68 Z" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.28">
+    <circle cx="290" cy="110" r="3" />
+    <circle cx="308" cy="106" r="3" />
+    <circle cx="326" cy="104" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 358 96 L 600 96 L 592 178 Q 591 186 583 186 L 375 186 Q 367 186 366 178 Z" fillOpacity="0.22" />
+    <rect x="358" y="90" width="242" height="12" rx="6" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <ellipse cx="402" cy="92" rx="15" ry="19" fillOpacity="0.85" />
+    <ellipse cx="402" cy="148" rx="15" ry="19" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <ellipse cx="479" cy="92" rx="15" ry="19" fillOpacity="0.85" />
+    <ellipse cx="479" cy="148" rx="15" ry="19" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <ellipse cx="556" cy="92" rx="15" ry="19" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <ellipse cx="556" cy="152" rx="16" ry="11" />
+  </g>
+</svg>
+
 ## Messy notes are easy for people, hard for computers
 
 Imagine a teacher writes this note:

--- a/content/learn/sqlite-for-beginners/working-with-null.mdx
+++ b/content/learn/sqlite-for-beginners/working-with-null.mdx
@@ -10,6 +10,68 @@ calculations behave. Many beginner SQL bugs come from treating `NULL`
 like a normal value. It is not zero. It is not an empty string. It is
 missing or unknown.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A tiled mosaic where most tiles hold a colored dot, one tile is present but empty, and one tile is missing entirely with only dotted corners marking the gap — an empty value is still a value, but NULL is the tile that was never placed"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="130" y="24" width="70" height="40" rx="7" />
+    <rect x="210" y="24" width="70" height="40" rx="7" />
+    <rect x="290" y="24" width="70" height="40" rx="7" />
+    <rect x="370" y="24" width="70" height="40" rx="7" />
+    <rect x="450" y="24" width="70" height="40" rx="7" />
+    <rect x="130" y="74" width="70" height="40" rx="7" />
+    <rect x="210" y="74" width="70" height="40" rx="7" />
+    <rect x="290" y="74" width="70" height="40" rx="7" />
+    <rect x="450" y="74" width="70" height="40" rx="7" />
+    <rect x="130" y="124" width="70" height="40" rx="7" />
+    <rect x="210" y="124" width="70" height="40" rx="7" />
+    <rect x="290" y="124" width="70" height="40" rx="7" />
+    <rect x="370" y="124" width="70" height="40" rx="7" />
+    <rect x="450" y="124" width="70" height="40" rx="7" />
+    <rect x="130" y="174" width="70" height="40" rx="7" />
+    <rect x="210" y="174" width="70" height="40" rx="7" />
+    <rect x="290" y="174" width="70" height="40" rx="7" />
+    <rect x="370" y="174" width="70" height="40" rx="7" />
+    <rect x="450" y="174" width="70" height="40" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="165" cy="44" r="8" fillOpacity="0.8" />
+    <circle cx="325" cy="44" r="8" fillOpacity="0.6" />
+    <circle cx="165" cy="144" r="8" fillOpacity="0.7" />
+    <circle cx="485" cy="194" r="8" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="245" cy="44" r="8" fillOpacity="0.7" />
+    <circle cx="485" cy="94" r="8" fillOpacity="0.8" />
+    <circle cx="245" cy="194" r="8" fillOpacity="0.6" />
+    <circle cx="405" cy="144" r="8" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="485" cy="44" r="8" fillOpacity="0.8" />
+    <circle cx="165" cy="94" r="8" fillOpacity="0.6" />
+    <circle cx="325" cy="94" r="8" fillOpacity="0.75" />
+    <circle cx="325" cy="194" r="8" fillOpacity="0.6" />
+    <circle cx="405" cy="44" r="8" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="485" cy="144" r="8" fillOpacity="0.7" />
+    <circle cx="245" cy="94" r="8" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="374" cy="78" r="2.5" />
+    <circle cx="406" cy="78" r="2.5" />
+    <circle cx="436" cy="78" r="2.5" />
+    <circle cx="374" cy="94" r="2.5" />
+    <circle cx="436" cy="94" r="2.5" />
+    <circle cx="374" cy="110" r="2.5" />
+    <circle cx="406" cy="110" r="2.5" />
+    <circle cx="436" cy="110" r="2.5" />
+  </g>
+</svg>
+
 ## NULL is not zero or empty text
 
 These three values mean different things:
@@ -218,6 +280,42 @@ Linus has `NULL` reward points, so adding 5 still gives `NULL`.
 `COALESCE` returns the first value in its list that is not `NULL`. It is
 one of the most useful tools for displaying or calculating with missing
 values.
+
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="A hopping dotted trail checks a line of cups: the first two are empty holes, the third holds a green value, and the trail stops there and carries it to the result — COALESCE takes the first value that is not NULL"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.14">
+    <path d="M 80 80 L 144 80 L 136 122 Q 135 128 129 128 L 95 128 Q 89 128 88 122 Z" />
+    <path d="M 196 80 L 260 80 L 252 122 Q 251 128 245 128 L 211 128 Q 205 128 204 122 Z" />
+    <path d="M 312 80 L 376 80 L 368 122 Q 367 128 361 128 L 327 128 Q 321 128 320 122 Z" />
+    <path d="M 428 80 L 492 80 L 484 122 Q 483 128 477 128 L 443 128 Q 437 128 436 122 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="96" cy="56" r="2.5" />
+    <circle cx="112" cy="44" r="2.5" />
+    <circle cx="128" cy="56" r="2.5" />
+    <circle cx="180" cy="44" r="2.5" />
+    <circle cx="212" cy="56" r="2.5" />
+    <circle cx="228" cy="44" r="2.5" />
+    <circle cx="244" cy="56" r="2.5" />
+    <circle cx="296" cy="44" r="2.5" />
+    <circle cx="328" cy="56" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="344" cy="104" r="11" />
+    <circle cx="344" cy="32" r="8" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="460" cy="104" r="9" fillOpacity="0.4" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <text x="122" y="112" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="600">?</text>
+    <text x="238" y="112" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="600">?</text>
+  </g>
+</svg>
 
 <SqlCodeBlock
   dialect="sqlite"

--- a/content/learn/statistics-for-data-science-python/ab-testing.mdx
+++ b/content/learn/statistics-for-data-science-python/ab-testing.mdx
@@ -20,6 +20,60 @@ The full arc, start to finish:
 
 **Hypothesis + primary metric → Randomize users to A/B → Pick sample size (power) in advance → Run to plan (no peeking) → Analyze (lift, CI, effect size, p) → Decide: ship? (significance *and* size)**
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A stream of user dots reaches a yellow coin-flip diamond and splits into two lanes — a blue control panel and a green variant panel of identical crowds, the variant lighting up more converted dots and growing a longer result pill — randomize the split, and the only difference left to credit is the change itself"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="56" cy="112" r="5" />
+    <circle cx="80" cy="112" r="5" />
+    <circle cx="104" cy="112" r="5" />
+    <circle cx="128" cy="112" r="5" />
+    <circle cx="152" cy="112" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 200 88 L 224 112 L 200 136 L 176 112 Z" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="238" cy="92" r="2.5" />
+    <circle cx="258" cy="76" r="2.5" />
+    <circle cx="278" cy="63" r="2.5" />
+    <circle cx="238" cy="132" r="2.5" />
+    <circle cx="258" cy="148" r="2.5" />
+    <circle cx="278" cy="161" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="296" y="30" width="180" height="64" rx="12" fillOpacity="0.13" />
+    <circle cx="322" cy="52" r="5" fillOpacity="0.3" />
+    <circle cx="354" cy="52" r="5" fillOpacity="0.3" />
+    <circle cx="386" cy="52" r="5" />
+    <circle cx="418" cy="52" r="5" fillOpacity="0.3" />
+    <circle cx="450" cy="52" r="5" fillOpacity="0.3" />
+    <circle cx="322" cy="76" r="5" fillOpacity="0.3" />
+    <circle cx="354" cy="76" r="5" />
+    <circle cx="386" cy="76" r="5" fillOpacity="0.3" />
+    <circle cx="418" cy="76" r="5" fillOpacity="0.3" />
+    <circle cx="450" cy="76" r="5" fillOpacity="0.3" />
+    <rect x="500" y="56" width="44" height="10" rx="5" fillOpacity="0.65" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="296" y="134" width="180" height="64" rx="12" fillOpacity="0.13" />
+    <circle cx="322" cy="156" r="5" />
+    <circle cx="354" cy="156" r="5" fillOpacity="0.3" />
+    <circle cx="386" cy="156" r="5" fillOpacity="0.3" />
+    <circle cx="418" cy="156" r="5" />
+    <circle cx="450" cy="156" r="5" fillOpacity="0.3" />
+    <circle cx="322" cy="180" r="5" fillOpacity="0.3" />
+    <circle cx="354" cy="180" r="5" fillOpacity="0.3" />
+    <circle cx="386" cy="180" r="5" />
+    <circle cx="418" cy="180" r="5" fillOpacity="0.3" />
+    <circle cx="450" cy="180" r="5" fillOpacity="0.3" />
+    <rect x="500" y="160" width="66" height="10" rx="5" fillOpacity="0.75" />
+  </g>
+</svg>
+
 ## Design comes first (and is where most tests are won or lost)
 
 The analysis is the easy part. A test that wasn't *designed* properly
@@ -347,6 +401,42 @@ of two *identical* arms will cross p < 0.05 *at some point* surprisingly
 often if you keep peeking. Pre-commit to your stopping rule, or use a
 method designed for continuous monitoring.
 </Callout>
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A wandering trail of daily p-value dots dips below the red significance line exactly once, where a yellow stop flag is eagerly planted, while the fainter future of the trail climbs right back up — peek long enough and noise alone will hand you a lucky dip to stop on"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="70" y="130" width="500" height="4" rx="2" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.85">
+    <circle cx="90" cy="60" r="4.5" />
+    <circle cx="120" cy="84" r="4.5" />
+    <circle cx="150" cy="70" r="4.5" />
+    <circle cx="180" cy="96" r="4.5" />
+    <circle cx="210" cy="110" r="4.5" />
+    <circle cx="240" cy="122" r="4.5" />
+    <circle cx="270" cy="142" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.3">
+    <circle cx="300" cy="126" r="4.5" />
+    <circle cx="330" cy="98" r="4.5" />
+    <circle cx="360" cy="108" r="4.5" />
+    <circle cx="390" cy="86" r="4.5" />
+    <circle cx="420" cy="96" r="4.5" />
+    <circle cx="450" cy="76" r="4.5" />
+    <circle cx="480" cy="88" r="4.5" />
+    <circle cx="510" cy="70" r="4.5" />
+    <circle cx="540" cy="80" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M256 142 a14 14 0 1 0 28 0 a14 14 0 1 0 -28 0 M261 142 a9 9 0 1 0 18 0 a9 9 0 1 0 -18 0" fillRule="evenodd" fillOpacity="0.9" />
+    <rect x="268" y="158" width="4" height="28" rx="2" fillOpacity="0.8" />
+    <path d="M 272 158 L 294 164 L 272 170 Z" fillOpacity="0.8" />
+  </g>
+</svg>
 
 ## Practice
 

--- a/content/learn/statistics-for-data-science-python/anova-and-chi-square.mdx
+++ b/content/learn/statistics-for-data-science-python/anova-and-chi-square.mdx
@@ -19,6 +19,31 @@ This page covers the two tools that handle these cases:
 Both are one-liners in `scipy.stats`. As always, the value is in picking
 the right one and reading the result honestly.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Three colored group humps stand on one shared axis, each raising a post to its own mean around a faint grand-mean line — ANOVA asks a single global question: are the posts farther apart than the width of the humps can explain?"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="160" width="520" height="4" rx="2" fill="currentColor" opacity="0.18" />
+  <rect x="100" y="93" width="420" height="3" rx="1.5" fill="currentColor" opacity="0.3" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 80 160 C 105 160 110 96 140 96 C 170 96 175 160 200 160 Z" fillOpacity="0.35" />
+    <rect x="137.5" y="100" width="5" height="60" rx="2.5" />
+    <circle cx="140" cy="92" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 230 160 C 255 160 260 78 290 78 C 320 78 325 160 350 160 Z" fillOpacity="0.35" />
+    <rect x="287.5" y="84" width="5" height="76" rx="2.5" />
+    <circle cx="290" cy="74" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 390 160 C 415 160 420 110 450 110 C 480 110 485 160 510 160 Z" fillOpacity="0.4" />
+    <rect x="447.5" y="114" width="5" height="46" rx="2.5" />
+    <circle cx="450" cy="106" r="5.5" />
+  </g>
+</svg>
+
 ## Part A — One-way ANOVA: comparing 3+ group means
 
 ### Why not just run a bunch of t-tests?
@@ -225,6 +250,36 @@ flowchart LR
 ```
 
 Let's test whether **device type** is associated with **churn**.
+
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A mosaic of device columns split into churn and stay tiles, each crossed by a thin yellow line where its count would sit if the variables were unrelated — the red mobile-churn tile bulging past its line is exactly the deviation a chi-square test adds up"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="120" y="60" width="200" height="36" rx="6" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fillOpacity="0.45">
+    <rect x="326" y="60" width="160" height="20" rx="6" />
+    <rect x="492" y="60" width="44" height="25" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.2">
+    <rect x="120" y="102" width="200" height="68" rx="6" />
+    <rect x="326" y="86" width="160" height="84" rx="6" />
+    <rect x="492" y="91" width="44" height="79" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor" fillOpacity="0.85">
+    <rect x="120" y="86" width="200" height="3" rx="1.5" />
+    <rect x="326" y="86" width="160" height="3" rx="1.5" />
+    <rect x="492" y="86" width="44" height="3" rx="1.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="220" cy="190" r="3" />
+    <circle cx="406" cy="190" r="3" />
+    <circle cx="514" cy="190" r="3" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/central-limit-theorem.mdx
+++ b/content/learn/statistics-for-data-science-python/central-limit-theorem.mdx
@@ -17,6 +17,41 @@ skewed, lumpy, or weird-shaped. Without it, every analysis would need a
 custom distribution for every dataset. The CLT says: don't bother — for
 the **mean**, things converge to the same familiar bell curve.
 
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Four small distributions morph from left to right — a red skewed slide, a yellow lopsided hump, a blue almost-bell, and a clean green bell — as the sample size beneath each grows from one to one hundred, the distribution of the mean forgets the parent's shape"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="44" y="130" width="556" height="4" rx="2" fill="currentColor" opacity="0.15" />
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 48 130 L 48 52 C 70 60 95 105 150 124 C 158 127 164 129 168 130 Z" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 198 130 C 210 130 212 80 232 76 C 260 70 286 112 318 126 L 322 130 Z" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 348 130 C 364 130 368 70 396 70 C 424 70 432 118 468 127 L 472 130 Z" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 498 130 C 518 130 522 62 548 62 C 574 62 578 130 598 130 Z" fillOpacity="0.5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="176" cy="94" r="2.5" />
+    <circle cx="186" cy="94" r="2.5" />
+    <circle cx="328" cy="94" r="2.5" />
+    <circle cx="338" cy="94" r="2.5" />
+    <circle cx="478" cy="94" r="2.5" />
+    <circle cx="488" cy="94" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="106" y="158" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">1</text>
+    <text x="258" y="158" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">5</text>
+    <text x="408" y="158" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">30</text>
+    <text x="548" y="158" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">100</text>
+  </g>
+</svg>
+
 ## The theorem in plain words
 
 Here is the whole idea, stated as plainly as possible:
@@ -128,6 +163,43 @@ different populations at it — right-skewed, flat uniform, and bimodal
 (two separated humps) — and confirm the *mean's* sampling distribution
 goes normal in every case at large `n`. A normal curve is overlaid for
 comparison.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Three wildly different parent shapes — a skewed slide, a flat slab, and a two-humped camel — all funnel along dotted trails into the same single green bell on the right — averaging washes out every parent's shape into one universal curve"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="50" y="62" width="150" height="4" rx="2" />
+    <rect x="50" y="124" width="150" height="4" rx="2" />
+    <rect x="50" y="186" width="150" height="4" rx="2" />
+    <rect x="420" y="170" width="170" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.4">
+    <path d="M 56 62 L 56 20 C 75 26 100 48 140 58 C 148 60 154 61 158 62 Z" />
+    <rect x="58" y="96" width="130" height="28" rx="5" />
+    <path d="M 58 186 C 70 186 72 152 86 152 C 100 152 98 176 108 176 C 118 176 116 152 130 152 C 144 152 146 186 158 186 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="240" cy="58" r="2.5" />
+    <circle cx="290" cy="80" r="2.5" />
+    <circle cx="340" cy="104" r="2.5" />
+    <circle cx="240" cy="124" r="2.5" />
+    <circle cx="290" cy="126" r="2.5" />
+    <circle cx="340" cy="128" r="2.5" />
+    <circle cx="240" cy="184" r="2.5" />
+    <circle cx="290" cy="168" r="2.5" />
+    <circle cx="340" cy="152" r="2.5" />
+    <circle cx="384" cy="130" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 424 170 C 460 170 466 64 504 64 C 542 64 548 170 584 170 Z" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="501.5" y="70" width="5" height="100" rx="2.5" fillOpacity="0.8" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/conditional-probability.mdx
+++ b/content/learn/statistics-for-data-science-python/conditional-probability.mdx
@@ -20,6 +20,67 @@ given A. By the end of this page you'll see exactly why a test that's
 people it flags — and you'll be able to compute the truth in a few lines
 of Python.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A faint full sample space with a small blue region inside it expands along dotted zoom lines into a world of its own, where four of twelve dots glow green — conditioning throws away everything outside B and recomputes the probability inside what is left"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="40" y="30" width="240" height="160" rx="16" fill="currentColor" opacity="0.06" />
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="64" cy="54" r="3" />
+    <circle cx="100" cy="44" r="3" />
+    <circle cx="138" cy="58" r="3" />
+    <circle cx="176" cy="44" r="3" />
+    <circle cx="218" cy="56" r="3" />
+    <circle cx="254" cy="44" r="3" />
+    <circle cx="62" cy="96" r="3" />
+    <circle cx="98" cy="84" r="3" />
+    <circle cx="132" cy="100" r="3" />
+    <circle cx="256" cy="86" r="3" />
+    <circle cx="64" cy="140" r="3" />
+    <circle cx="100" cy="128" r="3" />
+    <circle cx="128" cy="150" r="3" />
+    <circle cx="74" cy="174" r="3" />
+    <circle cx="110" cy="168" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="194" cy="128" r="44" fillOpacity="0.2" />
+    <circle cx="176" cy="124" r="3.5" />
+    <circle cx="192" cy="148" r="3.5" />
+    <circle cx="212" cy="132" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="196" cy="106" r="3.5" />
+    <circle cx="212" cy="112" r="3.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="244" cy="74" r="2.5" />
+    <circle cx="294" cy="62" r="2.5" />
+    <circle cx="344" cy="50" r="2.5" />
+    <circle cx="246" cy="178" r="2.5" />
+    <circle cx="296" cy="184" r="2.5" />
+    <circle cx="346" cy="190" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="462" cy="112" r="82" fillOpacity="0.12" />
+    <circle cx="408" cy="112" r="6" />
+    <circle cx="428" cy="142" r="6" />
+    <circle cx="458" cy="152" r="6" />
+    <circle cx="492" cy="138" r="6" />
+    <circle cx="516" cy="112" r="6" />
+    <circle cx="418" cy="78" r="6" />
+    <circle cx="528" cy="86" r="6" />
+    <circle cx="474" cy="124" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="432" cy="82" r="6" />
+    <circle cx="470" cy="70" r="6" />
+    <circle cx="450" cy="110" r="6" />
+    <circle cx="496" cy="92" r="6" />
+  </g>
+</svg>
+
 ## What conditioning means
 
 The notation P(A | B) reads "the probability of A **given** B" —
@@ -217,6 +278,58 @@ The killer is in the leaves: only **100** people are actually sick, but
 healthy people, 1% of a huge number (999) dwarfs the 99 true positives
 from the tiny sick group. So most positives are false alarms. Let's
 verify both by direct calculation and by simulating a population.
+
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="In a large grid of faint people exactly one red dot is truly sick, yet the flagged group gathered at the right holds nine yellow false alarms beside that single red case — when a condition is rare, even an accurate test's positives are mostly healthy people"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="60" cy="40" r="4" /><circle cx="84" cy="40" r="4" /><circle cx="108" cy="40" r="4" /><circle cx="132" cy="40" r="4" /><circle cx="156" cy="40" r="4" /><circle cx="180" cy="40" r="4" /><circle cx="204" cy="40" r="4" /><circle cx="228" cy="40" r="4" /><circle cx="276" cy="40" r="4" /><circle cx="300" cy="40" r="4" /><circle cx="324" cy="40" r="4" /><circle cx="348" cy="40" r="4" /><circle cx="372" cy="40" r="4" /><circle cx="396" cy="40" r="4" /><circle cx="420" cy="40" r="4" />
+    <circle cx="60" cy="64" r="4" /><circle cx="108" cy="64" r="4" /><circle cx="132" cy="64" r="4" /><circle cx="156" cy="64" r="4" /><circle cx="180" cy="64" r="4" /><circle cx="204" cy="64" r="4" /><circle cx="228" cy="64" r="4" /><circle cx="252" cy="64" r="4" /><circle cx="276" cy="64" r="4" /><circle cx="324" cy="64" r="4" /><circle cx="348" cy="64" r="4" /><circle cx="372" cy="64" r="4" /><circle cx="396" cy="64" r="4" /><circle cx="420" cy="64" r="4" />
+    <circle cx="60" cy="88" r="4" /><circle cx="84" cy="88" r="4" /><circle cx="108" cy="88" r="4" /><circle cx="132" cy="88" r="4" /><circle cx="156" cy="88" r="4" /><circle cx="180" cy="88" r="4" /><circle cx="204" cy="88" r="4" /><circle cx="228" cy="88" r="4" /><circle cx="252" cy="88" r="4" /><circle cx="276" cy="88" r="4" /><circle cx="300" cy="88" r="4" /><circle cx="324" cy="88" r="4" /><circle cx="348" cy="88" r="4" /><circle cx="372" cy="88" r="4" /><circle cx="420" cy="88" r="4" />
+    <circle cx="84" cy="112" r="4" /><circle cx="108" cy="112" r="4" /><circle cx="132" cy="112" r="4" /><circle cx="156" cy="112" r="4" /><circle cx="204" cy="112" r="4" /><circle cx="228" cy="112" r="4" /><circle cx="252" cy="112" r="4" /><circle cx="276" cy="112" r="4" /><circle cx="300" cy="112" r="4" /><circle cx="324" cy="112" r="4" /><circle cx="348" cy="112" r="4" /><circle cx="372" cy="112" r="4" /><circle cx="396" cy="112" r="4" /><circle cx="420" cy="112" r="4" />
+    <circle cx="60" cy="136" r="4" /><circle cx="84" cy="136" r="4" /><circle cx="108" cy="136" r="4" /><circle cx="132" cy="136" r="4" /><circle cx="156" cy="136" r="4" /><circle cx="180" cy="136" r="4" /><circle cx="204" cy="136" r="4" /><circle cx="228" cy="136" r="4" /><circle cx="252" cy="136" r="4" /><circle cx="276" cy="136" r="4" /><circle cx="300" cy="136" r="4" /><circle cx="348" cy="136" r="4" /><circle cx="372" cy="136" r="4" /><circle cx="396" cy="136" r="4" /><circle cx="420" cy="136" r="4" />
+    <circle cx="60" cy="160" r="4" /><circle cx="84" cy="160" r="4" /><circle cx="132" cy="160" r="4" /><circle cx="156" cy="160" r="4" /><circle cx="180" cy="160" r="4" /><circle cx="204" cy="160" r="4" /><circle cx="228" cy="160" r="4" /><circle cx="252" cy="160" r="4" /><circle cx="276" cy="160" r="4" /><circle cx="300" cy="160" r="4" /><circle cx="324" cy="160" r="4" /><circle cx="348" cy="160" r="4" /><circle cx="372" cy="160" r="4" /><circle cx="396" cy="160" r="4" /><circle cx="420" cy="160" r="4" />
+    <circle cx="60" cy="184" r="4" /><circle cx="84" cy="184" r="4" /><circle cx="108" cy="184" r="4" /><circle cx="132" cy="184" r="4" /><circle cx="156" cy="184" r="4" /><circle cx="180" cy="184" r="4" /><circle cx="228" cy="184" r="4" /><circle cx="252" cy="184" r="4" /><circle cx="276" cy="184" r="4" /><circle cx="300" cy="184" r="4" /><circle cx="324" cy="184" r="4" /><circle cx="396" cy="184" r="4" /><circle cx="420" cy="184" r="4" />
+    <circle cx="60" cy="208" r="4" /><circle cx="84" cy="208" r="4" /><circle cx="108" cy="208" r="4" /><circle cx="132" cy="208" r="4" /><circle cx="156" cy="208" r="4" /><circle cx="180" cy="208" r="4" /><circle cx="228" cy="208" r="4" /><circle cx="252" cy="208" r="4" /><circle cx="276" cy="208" r="4" /><circle cx="300" cy="208" r="4" /><circle cx="324" cy="208" r="4" /><circle cx="348" cy="208" r="4" /><circle cx="372" cy="208" r="4" /><circle cx="396" cy="208" r="4" /><circle cx="420" cy="208" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="84" cy="64" r="4.5" />
+    <circle cx="252" cy="40" r="4.5" />
+    <circle cx="396" cy="88" r="4.5" />
+    <circle cx="108" cy="160" r="4.5" />
+    <circle cx="324" cy="136" r="4.5" />
+    <circle cx="204" cy="208" r="4.5" />
+    <circle cx="372" cy="184" r="4.5" />
+    <circle cx="60" cy="112" r="4.5" />
+    <circle cx="300" cy="64" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="180" cy="112" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="444" cy="122" r="2.5" />
+    <circle cx="458" cy="122" r="2.5" />
+    <circle cx="472" cy="122" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="490" y="44" width="112" height="156" rx="20" fillOpacity="0.1" />
+    <circle cx="524" cy="94" r="6" />
+    <circle cx="568" cy="94" r="6" />
+    <circle cx="524" cy="122" r="6" />
+    <circle cx="568" cy="122" r="6" />
+    <circle cx="524" cy="150" r="6" />
+    <circle cx="568" cy="150" r="6" />
+    <circle cx="524" cy="178" r="6" />
+    <circle cx="568" cy="178" r="6" />
+    <circle cx="568" cy="66" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="524" cy="66" r="6.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/confidence-intervals.mdx
+++ b/content/learn/statistics-for-data-science-python/confidence-intervals.mdx
@@ -19,6 +19,39 @@ that intuition, then spends most of its energy on the single most
 misunderstood sentence in all of applied statistics: what "95%
 confidence" actually means.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="Nine horizontal interval pills stack beside one fixed yellow truth line, each centered somewhere a little different yet almost all crossing the line, while a single red interval floats clear of it — 95 percent confidence is the recipe's long-run hit rate, and yours might be the unlucky one"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="318" y="20" width="4" height="200" rx="2" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="250" y="33" width="130" height="7" rx="3.5" fillOpacity="0.35" />
+    <circle cx="315" cy="36.5" r="4" />
+    <rect x="270" y="54" width="110" height="7" rx="3.5" fillOpacity="0.35" />
+    <circle cx="325" cy="57.5" r="4" />
+    <rect x="216" y="75" width="150" height="7" rx="3.5" fillOpacity="0.35" />
+    <circle cx="291" cy="78.5" r="4" />
+    <rect x="296" y="96" width="96" height="7" rx="3.5" fillOpacity="0.35" />
+    <circle cx="344" cy="99.5" r="4" />
+    <rect x="232" y="117" width="124" height="7" rx="3.5" fillOpacity="0.35" />
+    <circle cx="294" cy="120.5" r="4" />
+    <rect x="262" y="159" width="126" height="7" rx="3.5" fillOpacity="0.35" />
+    <circle cx="325" cy="162.5" r="4" />
+    <rect x="204" y="180" width="132" height="7" rx="3.5" fillOpacity="0.35" />
+    <circle cx="270" cy="183.5" r="4" />
+    <rect x="286" y="201" width="104" height="7" rx="3.5" fillOpacity="0.35" />
+    <circle cx="338" cy="204.5" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="352" y="138" width="118" height="7" rx="3.5" fillOpacity="0.5" />
+    <circle cx="411" cy="141.5" r="4.5" />
+  </g>
+</svg>
+
 ## A point estimate alone hides its own uncertainty
 
 You sample 50 users, the mean is \$48.20. That's your **point
@@ -315,6 +348,48 @@ responds to exactly three levers:
   margin. (The same diminishing return from *Standard Error*.)
 - **Variability `s` ↑ → wider.** Noisier data gives a noisier estimate.
   You don't control this directly, but cleaner measurement helps.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Three lever panels, each squeezing or stretching an interval pill: piling on more data dots narrows the blue pill, demanding a higher confidence percentage widens the green pill, and noisier jittered data widens the red pill — the three levers that set a confidence interval's width"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.06">
+    <rect x="48" y="26" width="170" height="140" rx="14" />
+    <rect x="234" y="26" width="170" height="140" rx="14" />
+    <rect x="420" y="26" width="170" height="140" rx="14" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="118" cy="50" r="3" />
+    <circle cx="133" cy="50" r="3" />
+    <circle cx="148" cy="50" r="3" />
+    <circle cx="110" cy="62" r="3" />
+    <circle cx="125" cy="62" r="3" />
+    <circle cx="140" cy="62" r="3" />
+    <circle cx="155" cy="62" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="68" y="88" width="130" height="8" rx="4" fillOpacity="0.3" />
+    <rect x="103" y="126" width="60" height="8" rx="4" fillOpacity="0.75" />
+  </g>
+  <text x="319" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fill="currentColor" opacity="0.5">%</text>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="289" y="88" width="60" height="8" rx="4" fillOpacity="0.75" />
+    <rect x="254" y="126" width="130" height="8" rx="4" fillOpacity="0.3" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="478" cy="44" r="3" />
+    <circle cx="492" cy="58" r="3" />
+    <circle cx="506" cy="42" r="3" />
+    <circle cx="520" cy="60" r="3" />
+    <circle cx="534" cy="46" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="475" y="88" width="60" height="8" rx="4" fillOpacity="0.75" />
+    <rect x="440" y="126" width="130" height="8" rx="4" fillOpacity="0.35" />
+  </g>
+</svg>
 
 Let's watch the first two levers move.
 

--- a/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
@@ -19,6 +19,27 @@ for continuous variables lives in **intervals**, and it's computed as
 **area under a curve**. Internalize that and the rest of this page falls
 into place.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Three density silhouettes stand along one baseline — a flat plateau, a decaying slide, and a bell — with one green interval slice holding real probability and a red hairline at a single point holding none — for continuous variables probability is area, and a point has zero width"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="160" width="540" height="5" rx="2.5" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.3">
+    <rect x="70" y="96" width="120" height="64" rx="6" />
+    <path d="M 228 160 L 228 72 C 268 76 300 120 360 148 C 380 155 396 158 410 160 Z" />
+    <path d="M 440 160 C 472 160 478 84 510 84 C 542 84 548 160 580 160 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 268 160 L 268 86 C 290 96 310 124 330 140 L 330 160 Z" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="129" y="96" width="2.5" height="64" fillOpacity="0.9" />
+    <text x="130" y="86" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">0</text>
+  </g>
+</svg>
+
 ## The big idea: probability is area under the PDF
 
 A continuous distribution is described by a **probability density
@@ -264,6 +285,32 @@ print(f"90th percentile score  = {scores.ppf(0.9):.1f}")
     },
   ]}
 />
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A bell curve with most of its area filled green up to a yellow cutoff post, and a small percent badge pointing down at the post along a dotted trail — the ppf question runs in reverse: name the probability, get back the value that traps it"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="80" y="150" width="480" height="4" rx="2" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 120 150 C 200 150 210 54 320 54 C 430 54 440 150 520 150 Z" fillOpacity="0.18" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 120 150 C 200 150 210 54 320 54 C 380 54 402 90 430 122 L 430 150 Z" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="427" y="116" width="5" height="44" rx="2.5" />
+    <circle cx="429.5" cy="166" r="6" />
+    <circle cx="478" cy="48" r="17" fillOpacity="0.2" />
+  </g>
+  <text x="478" y="54" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fill="currentColor" opacity="0.6">%</text>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="466" cy="74" r="2.5" />
+    <circle cx="454" cy="92" r="2.5" />
+    <circle cx="442" cy="108" r="2.5" />
+  </g>
+</svg>
 
 <Callout type="tip" title="cdf and ppf are inverses">
 `cdf` takes a value and returns a probability (area to the left). `ppf`

--- a/content/learn/statistics-for-data-science-python/correlation-and-nonparametric.mdx
+++ b/content/learn/statistics-for-data-science-python/correlation-and-nonparametric.mdx
@@ -15,6 +15,39 @@ Both keep the same mindset as the rest of the course: get a number (an
 effect size or a statistic), get a p-value, and — above all — interpret
 it honestly.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A scatter of blue dots climbs steeply then flattens while one red outlier sits far off the pattern; the straight yellow line the outlier dragged misses the bend that the green rank-following band hugs — Pearson measures straight lines, Spearman follows any monotonic climb"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="80" y="180" width="480" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <rect x="80" y="40" width="4" height="144" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 100 138 L 530 96 L 530 106 L 100 148 Z" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 105 150 C 200 102 320 68 480 50 L 480 60 C 320 78 200 114 105 162 Z" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.85">
+    <circle cx="110" cy="160" r="5" />
+    <circle cx="140" cy="142" r="5" />
+    <circle cx="170" cy="122" r="5" />
+    <circle cx="200" cy="106" r="5" />
+    <circle cx="235" cy="92" r="5" />
+    <circle cx="270" cy="82" r="5" />
+    <circle cx="305" cy="74" r="5" />
+    <circle cx="340" cy="68" r="5" />
+    <circle cx="375" cy="64" r="5" />
+    <circle cx="410" cy="60" r="5" />
+    <circle cx="445" cy="58" r="5" />
+    <circle cx="480" cy="56" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="522" cy="166" r="6" />
+  </g>
+</svg>
+
 ## Part A — Correlation: how two variables move together
 
 A **correlation coefficient** condenses the relationship between two
@@ -292,6 +325,42 @@ flowchart TD
 The pairing logic mirrors the t-tests in *t-Tests*: **Mann–Whitney U**
 is the rank-based cousin of the **independent** two-sample t-test, and
 **Wilcoxon signed-rank** is the cousin of the **paired** t-test.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A top row of wildly different sized dots — one enormous red outlier among small blue values — funnels down into a bottom row of identical evenly spaced dots numbered one to five — converting values to ranks keeps their order but strips the outlier of its size"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="120" cy="56" r="6" />
+    <circle cx="210" cy="56" r="9" />
+    <circle cx="300" cy="56" r="12" />
+    <circle cx="390" cy="56" r="15" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="500" cy="56" r="26" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="310" cy="92" r="2.5" />
+    <circle cx="310" cy="104" r="2.5" />
+    <circle cx="310" cy="116" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fillOpacity="0.8">
+    <circle cx="120" cy="146" r="8" />
+    <circle cx="215" cy="146" r="8" />
+    <circle cx="310" cy="146" r="8" />
+    <circle cx="405" cy="146" r="8" />
+    <circle cx="500" cy="146" r="8" />
+  </g>
+  <g fill="currentColor" opacity="0.55">
+    <text x="120" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">1</text>
+    <text x="215" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">2</text>
+    <text x="310" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">3</text>
+    <text x="405" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">4</text>
+    <text x="500" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">5</text>
+  </g>
+</svg>
 
 ### Mann–Whitney U: independent groups, robustly
 

--- a/content/learn/statistics-for-data-science-python/discrete-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/discrete-distributions.mdx
@@ -19,6 +19,64 @@ important, *which one fits which situation*. Picking the wrong model is
 the most common way these tools go wrong, so we'll spend real time on
 when each one applies and when it doesn't.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A single yes-or-no Bernoulli pair at the top branches down into three children — a lollipop hill of success counts, a timeline of irregularly spaced event ticks, and a row of misses ending in the first green hit — binomial, Poisson, and geometric all grown from one tiny atom"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="304" cy="44" r="12" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="336" cy="44" r="12" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="262" cy="76" r="2.5" />
+    <circle cx="216" cy="104" r="2.5" />
+    <circle cx="174" cy="132" r="2.5" />
+    <circle cx="320" cy="84" r="2.5" />
+    <circle cx="320" cy="114" r="2.5" />
+    <circle cx="320" cy="144" r="2.5" />
+    <circle cx="378" cy="76" r="2.5" />
+    <circle cx="424" cy="104" r="2.5" />
+    <circle cx="466" cy="132" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="64" y="200" width="180" height="4" rx="2" />
+    <rect x="250" y="200" width="140" height="4" rx="2" />
+    <rect x="430" y="200" width="160" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="86" y="172" width="4" height="28" rx="2" fillOpacity="0.5" />
+    <circle cx="88" cy="166" r="5.5" />
+    <rect x="120" y="142" width="4" height="58" rx="2" fillOpacity="0.5" />
+    <circle cx="122" cy="136" r="7" />
+    <rect x="154" y="126" width="4" height="74" rx="2" fillOpacity="0.5" />
+    <circle cx="156" cy="120" r="8" />
+    <rect x="188" y="150" width="4" height="50" rx="2" fillOpacity="0.5" />
+    <circle cx="190" cy="144" r="6.5" />
+    <rect x="222" y="178" width="4" height="22" rx="2" fillOpacity="0.5" />
+    <circle cx="224" cy="172" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="262" y="184" width="4" height="14" rx="2" />
+    <rect x="288" y="184" width="4" height="14" rx="2" />
+    <rect x="296" y="184" width="4" height="14" rx="2" />
+    <rect x="342" y="184" width="4" height="14" rx="2" />
+    <rect x="376" y="184" width="4" height="14" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="448" cy="190" r="7" />
+    <circle cx="480" cy="190" r="7" />
+    <circle cx="512" cy="190" r="7" />
+    <circle cx="544" cy="190" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="578" cy="190" r="8.5" />
+  </g>
+</svg>
+
 <Callout type="info" title="Discrete means countable">
 A distribution is **discrete** when the outcomes are separate, countable
 values — 0, 1, 2, 3 tickets; never 2.7 tickets. The function that gives
@@ -292,6 +350,35 @@ flowchart TD
 Suppose your queue gets about **3 support tickets per hour** on average,
 arriving independently. What's the chance a single hour brings **8 or
 more** — a spike worth staffing for?
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="One long timeline of irregularly arriving yellow event ticks sliced into three equal translucent windows that capture two, five, and one events — a fixed interval, a constant average rate, and a count that varies window to window is exactly the Poisson setting"
+  style={{ display: "block", width: "100%", maxWidth: "620px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="108" width="520" height="5" rx="2.5" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.12">
+    <rect x="66" y="44" width="160" height="84" rx="12" />
+    <rect x="240" y="44" width="160" height="84" rx="12" />
+    <rect x="414" y="44" width="160" height="84" rx="12" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="96" y="84" width="5" height="24" rx="2.5" />
+    <rect x="178" y="84" width="5" height="24" rx="2.5" />
+    <rect x="252" y="84" width="5" height="24" rx="2.5" />
+    <rect x="268" y="84" width="5" height="24" rx="2.5" />
+    <rect x="300" y="84" width="5" height="24" rx="2.5" />
+    <rect x="338" y="84" width="5" height="24" rx="2.5" />
+    <rect x="382" y="84" width="5" height="24" rx="2.5" />
+    <rect x="500" y="84" width="5" height="24" rx="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.55">
+    <text x="146" y="68" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17">2</text>
+    <text x="320" y="68" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17">5</text>
+    <text x="494" y="68" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17">1</text>
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/effect-sizes.mdx
+++ b/content/learn/statistics-for-data-science-python/effect-sizes.mdx
@@ -22,6 +22,31 @@ collected. This page is about measuring magnitude — and about why, with
 a big enough sample, *everything* becomes significant whether it matters
 or not.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="A tiny blue speck surrounded by loud concentric yellow broadcast rings faces a massive green boulder wearing barely a whisper of a ring — a huge sample can make a microscopic effect scream with significance while a big effect on little data hardly registers"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="166" width="520" height="4" rx="2" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M114 120 a66 66 0 1 0 132 0 a66 66 0 1 0 -132 0 M118 120 a62 62 0 1 0 124 0 a62 62 0 1 0 -124 0" fillRule="evenodd" fillOpacity="0.2" />
+    <path d="M132 120 a48 48 0 1 0 96 0 a48 48 0 1 0 -96 0 M136 120 a44 44 0 1 0 88 0 a44 44 0 1 0 -88 0" fillRule="evenodd" fillOpacity="0.4" />
+    <path d="M150 120 a30 30 0 1 0 60 0 a30 30 0 1 0 -60 0 M154 120 a26 26 0 1 0 52 0 a26 26 0 1 0 -52 0" fillRule="evenodd" fillOpacity="0.65" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="180" cy="120" r="5" />
+  </g>
+  <rect x="166" y="158" width="28" height="8" rx="4" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="470" cy="122" r="38" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <path d="M420 122 a50 50 0 1 0 100 0 a50 50 0 1 0 -100 0 M424 122 a46 46 0 1 0 92 0 a46 46 0 1 0 -92 0" fillRule="evenodd" />
+  </g>
+  <rect x="436" y="158" width="68" height="8" rx="4" fill="currentColor" opacity="0.25" />
+</svg>
+
 ## The problem: significance is not importance
 
 Here is the uncomfortable truth that motivates this entire page. The
@@ -229,6 +254,37 @@ flowchart LR
 
 Let's verify it. We fix a true `d` of about 0.3 and watch what happens
 to the p-value versus the estimated `d` as `n` grows.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Three panels with ever taller stacks of data dots: beneath them the green effect-size bar stays exactly the same height in every panel while the red p-value bar collapses to a sliver — more data sharpens the magnitude but makes significance nearly automatic"
+  style={{ display: "block", width: "100%", maxWidth: "620px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="56" y="160" width="528" height="4" rx="2" fill="currentColor" opacity="0.18" />
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="120" cy="52" r="4" />
+    <circle cx="310" cy="52" r="4" />
+    <circle cx="322" cy="52" r="4" />
+    <circle cx="316" cy="42" r="4" />
+    <circle cx="500" cy="52" r="4" />
+    <circle cx="512" cy="52" r="4" />
+    <circle cx="524" cy="52" r="4" />
+    <circle cx="506" cy="42" r="4" />
+    <circle cx="518" cy="42" r="4" />
+    <circle cx="512" cy="32" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fillOpacity="0.7">
+    <rect x="92" y="112" width="26" height="48" rx="5" />
+    <rect x="282" y="112" width="26" height="48" rx="5" />
+    <rect x="472" y="112" width="26" height="48" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor" fillOpacity="0.7">
+    <rect x="126" y="84" width="26" height="76" rx="5" />
+    <rect x="316" y="124" width="26" height="36" rx="5" />
+    <rect x="506" y="152" width="26" height="8" rx="4" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/errors-and-power.mdx
+++ b/content/learn/statistics-for-data-science-python/errors-and-power.mdx
@@ -15,6 +15,29 @@ significant difference, so the treatment doesn't work." "The p-value was
 below 0.05, so who cares about power?" Both are dangerously wrong, and by
 the end of this page you'll be able to simulate exactly why.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A two-by-two grid of outcomes: two calm green cells on the diagonal, a red exclamation cell where a false alarm rejects a true null, and a yellow crescent cell asleep while a real effect slips past — Type one cries wolf, Type two misses the wolf, and power is escaping the sleepy cell"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="140" y="30" width="160" height="86" rx="14" fillOpacity="0.12" />
+    <circle cx="220" cy="73" r="10" fillOpacity="0.8" />
+    <rect x="330" y="130" width="160" height="86" rx="14" fillOpacity="0.15" />
+    <path d="M 392 172 L 404 184 L 424 156 L 430 162 L 405 194 L 386 178 Z" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="330" y="30" width="160" height="86" rx="14" fillOpacity="0.15" />
+    <rect x="406" y="48" width="7" height="32" rx="3.5" />
+    <circle cx="409.5" cy="94" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="140" y="130" width="160" height="86" rx="14" fillOpacity="0.15" />
+    <path d="M206 173 a16 16 0 1 0 32 0 a16 16 0 1 0 -32 0 M216 167 a14 14 0 1 0 28 0 a14 14 0 1 0 -28 0" fillRule="evenodd" fillOpacity="0.9" />
+  </g>
+</svg>
+
 ## The 2x2 decision matrix
 
 Every test has an unknowable **truth** (H₀ is really true, or it's
@@ -168,6 +191,28 @@ before reading a null result as evidence of absence.
 Two of the four levers are the ones you reason about most. Let's watch
 power climb as we increase `n`, and separately as we increase the true
 effect. We'll draw both curves with Plotly.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Two overlapping bells — the blue no-effect world and the green real-effect world — split by a red decision post: the yellow slice of the green bell stranded left of the post is a missed effect, and the green mass beyond it is power, the chance of catching what is really there"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="170" width="520" height="4" rx="2" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 80 170 C 140 170 150 60 230 60 C 310 60 320 170 380 170 Z" fillOpacity="0.25" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 260 170 C 320 170 330 60 410 60 C 490 60 500 170 560 170 Z" fillOpacity="0.2" />
+    <path d="M 330 170 L 330 116 C 346 88 372 62 410 62 C 488 62 498 170 558 170 Z" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 262 170 C 292 170 306 142 330 118 L 330 170 Z" fillOpacity="0.65" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="328" y="52" width="4.5" height="118" rx="2.25" fillOpacity="0.85" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
+++ b/content/learn/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
@@ -18,6 +18,59 @@ Exploration **generates** hypotheses; it must never be mistaken for
 **confirming** them. The single most important habit in all of applied
 statistics is to keep those two activities on opposite sides of a wall.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A messy playground of little charts and a question badge on one side of a brick wall, a single clean interval with a green check on the other, and one yellow hypothesis dot arcing over the top — explore freely, then confirm on data that never saw the exploring"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="310" y="44" width="22" height="30" rx="4" />
+    <rect x="310" y="80" width="22" height="30" rx="4" />
+    <rect x="310" y="116" width="22" height="30" rx="4" />
+    <rect x="310" y="152" width="22" height="30" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.5">
+    <rect x="70" y="122" width="10" height="34" rx="3" />
+    <rect x="84" y="108" width="10" height="48" rx="3" />
+    <rect x="98" y="130" width="10" height="26" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 142 100 C 156 100 158 70 174 70 C 190 70 192 100 206 100 Z" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="92" cy="62" r="3.5" />
+    <circle cx="114" cy="48" r="3.5" />
+    <circle cx="136" cy="58" r="3.5" />
+    <circle cx="158" cy="42" r="3.5" />
+    <circle cx="130" cy="172" r="3.5" />
+    <circle cx="156" cy="160" r="3.5" />
+    <circle cx="182" cy="170" r="3.5" />
+    <circle cx="208" cy="156" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="244" cy="120" r="11" fillOpacity="0.25" />
+  </g>
+  <text x="244" y="126" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.6">?</text>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="262" cy="88" r="2.5" />
+    <circle cx="286" cy="56" r="2.5" />
+    <circle cx="320" cy="36" r="2.5" />
+    <circle cx="354" cy="56" r="2.5" />
+    <circle cx="378" cy="88" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="320" cy="30" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="420" y="128" width="130" height="9" rx="4.5" fillOpacity="0.4" />
+    <rect x="418" y="122" width="5" height="21" rx="2.5" fillOpacity="0.85" />
+    <rect x="547" y="122" width="5" height="21" rx="2.5" fillOpacity="0.85" />
+    <circle cx="485" cy="132.5" r="5.5" />
+    <path d="M 466 84 L 480 98 L 502 68 L 510 74 L 481 112 L 458 92 Z" fillOpacity="0.85" />
+  </g>
+</svg>
+
 ## Exploratory vs confirmatory: the wall you must not cross
 
 There are two fundamentally different modes of data analysis, and
@@ -264,6 +317,63 @@ where the tip went unrecorded, so `dropna()` would silently bias your
 average tip downward. Always ask *why* a value is missing before
 deciding how to handle it — the mechanism matters more than the count.
 </Callout>
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A data grid of solid blue cells pocked with empty holes: in the left block the holes scatter randomly, but in the rightmost column they stack up together, ringed in red — missingness with a pattern is information, and dropping those rows would quietly bias everything"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.45">
+    <rect x="100" y="36" width="34" height="20" rx="5" />
+    <rect x="142" y="36" width="34" height="20" rx="5" />
+    <rect x="184" y="36" width="34" height="20" rx="5" />
+    <rect x="226" y="36" width="34" height="20" rx="5" />
+    <rect x="268" y="36" width="34" height="20" rx="5" />
+    <rect x="310" y="36" width="34" height="20" rx="5" />
+    <rect x="352" y="36" width="34" height="20" rx="5" />
+    <rect x="394" y="36" width="34" height="20" rx="5" />
+    <rect x="436" y="36" width="34" height="20" rx="5" />
+    <rect x="100" y="64" width="34" height="20" rx="5" />
+    <rect x="184" y="64" width="34" height="20" rx="5" />
+    <rect x="226" y="64" width="34" height="20" rx="5" />
+    <rect x="268" y="64" width="34" height="20" rx="5" />
+    <rect x="310" y="64" width="34" height="20" rx="5" />
+    <rect x="352" y="64" width="34" height="20" rx="5" />
+    <rect x="394" y="64" width="34" height="20" rx="5" />
+    <rect x="436" y="64" width="34" height="20" rx="5" />
+    <rect x="436" y="92" width="34" height="20" rx="5" />
+    <rect x="100" y="92" width="34" height="20" rx="5" />
+    <rect x="142" y="92" width="34" height="20" rx="5" />
+    <rect x="184" y="92" width="34" height="20" rx="5" />
+    <rect x="268" y="92" width="34" height="20" rx="5" />
+    <rect x="310" y="92" width="34" height="20" rx="5" />
+    <rect x="352" y="92" width="34" height="20" rx="5" />
+    <rect x="394" y="92" width="34" height="20" rx="5" />
+    <rect x="100" y="120" width="34" height="20" rx="5" />
+    <rect x="142" y="120" width="34" height="20" rx="5" />
+    <rect x="184" y="120" width="34" height="20" rx="5" />
+    <rect x="226" y="120" width="34" height="20" rx="5" />
+    <rect x="310" y="120" width="34" height="20" rx="5" />
+    <rect x="352" y="120" width="34" height="20" rx="5" />
+    <rect x="394" y="120" width="34" height="20" rx="5" />
+    <rect x="436" y="120" width="34" height="20" rx="5" />
+  </g>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="142" y="64" width="34" height="20" rx="5" />
+    <rect x="226" y="92" width="34" height="20" rx="5" />
+    <rect x="268" y="120" width="34" height="20" rx="5" />
+    <rect x="478" y="36" width="34" height="20" rx="5" />
+    <rect x="478" y="64" width="34" height="20" rx="5" />
+    <rect x="478" y="92" width="34" height="20" rx="5" />
+    <rect x="478" y="120" width="34" height="20" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="472" y="28" width="46" height="120" rx="12" fillOpacity="0.14" />
+    <rect x="472" y="28" width="46" height="5" rx="2.5" fillOpacity="0.7" />
+    <rect x="472" y="143" width="46" height="5" rx="2.5" fillOpacity="0.7" />
+  </g>
+</svg>
 
 ## Step 4: outliers
 

--- a/content/learn/statistics-for-data-science-python/hypothesis-testing.mdx
+++ b/content/learn/statistics-for-data-science-python/hypothesis-testing.mdx
@@ -19,6 +19,40 @@ question is the one this whole page is about:
 It is the engine underneath A/B tests, clinical trials, quality control,
 and almost every "is this real?" decision a data scientist makes.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A tilted balance: the blue null block rides high on one pan while a pile of green evidence dots drags the other pan down past a dotted red doubt threshold — assume nothing is going on, and reject only when the evidence outweighs that presumption"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <path d="M 320 186 L 294 208 L 346 208 Z" fill="currentColor" opacity="0.35" />
+  <rect x="316" y="100" width="8" height="92" rx="4" fill="currentColor" opacity="0.3" />
+  <g transform="rotate(9 320 104)">
+    <rect x="150" y="100" width="340" height="8" rx="4" fill="currentColor" opacity="0.45" />
+    <rect x="156" y="108" width="4" height="24" fill="currentColor" opacity="0.35" />
+    <path d="M 132 132 A 26 26 0 0 0 184 132 Z" fill="currentColor" opacity="0.2" />
+    <rect x="476" y="108" width="4" height="24" fill="currentColor" opacity="0.35" />
+    <path d="M 452 132 A 26 26 0 0 0 504 132 Z" fill="currentColor" opacity="0.2" />
+    <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+      <rect x="146" y="108" width="24" height="24" rx="6" />
+    </g>
+    <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+      <circle cx="464" cy="124" r="6" />
+      <circle cx="478" cy="124" r="6" />
+      <circle cx="492" cy="124" r="6" />
+      <circle cx="471" cy="112" r="6" />
+      <circle cx="485" cy="112" r="6" />
+    </g>
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor" fillOpacity="0.7">
+    <circle cx="430" cy="140" r="2.5" />
+    <circle cx="450" cy="140" r="2.5" />
+    <circle cx="470" cy="140" r="2.5" />
+    <circle cx="490" cy="140" r="2.5" />
+    <circle cx="510" cy="140" r="2.5" />
+  </g>
+</svg>
+
 ## The core idea: assume nothing is going on, then look for a contradiction
 
 Hypothesis testing flips the burden of proof. Instead of trying to prove
@@ -292,6 +326,29 @@ scientific reason, in advance, or stay two-sided. `scipy.stats` tests are
 two-sided by default; you opt into one-sided with `alternative='greater'`
 or `alternative='less'`.
 </Callout>
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Two small bell curves: the left one shades a yellow half-slice of surprise into each tail, the right one pours its whole green slice into a single tail — a two-sided test splits its skepticism both ways, a one-sided test spends it all in one direction"
+  style={{ display: "block", width: "100%", maxWidth: "620px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="56" y="138" width="240" height="4" rx="2" />
+    <rect x="344" y="138" width="240" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.2">
+    <path d="M 66 138 C 116 138 126 48 176 48 C 226 48 236 138 286 138 Z" />
+    <path d="M 354 138 C 404 138 414 48 464 48 C 514 48 524 138 574 138 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor" fillOpacity="0.7">
+    <path d="M 66 138 C 84 138 92 124 100 110 L 104 138 Z" />
+    <path d="M 286 138 C 268 138 260 124 252 110 L 248 138 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fillOpacity="0.7">
+    <path d="M 574 138 C 552 138 542 118 532 98 L 526 138 Z" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/index.mdx
+++ b/content/learn/statistics-for-data-science-python/index.mdx
@@ -15,6 +15,74 @@ conclusions — one ships a feature, the other kills it — because one
 of them mistook a random wiggle for a real signal. Statistics is the
 discipline that keeps you from fooling yourself.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A faint field of population dots fills the frame while a small ringed handful glows blue; a dotted trail climbs from the sample into a green bell curve over a confidence pill whose yellow true-value dot sits inside but off center — reasoning honestly from the sample you have to the population you care about"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.16">
+    <circle cx="38" cy="42" r="3" />
+    <circle cx="84" cy="68" r="2.5" />
+    <circle cx="58" cy="118" r="3" />
+    <circle cx="34" cy="182" r="2.5" />
+    <circle cx="108" cy="28" r="3" />
+    <circle cx="146" cy="58" r="2.5" />
+    <circle cx="190" cy="36" r="3" />
+    <circle cx="235" cy="52" r="2.5" />
+    <circle cx="330" cy="44" r="2.5" />
+    <circle cx="372" cy="26" r="3" />
+    <circle cx="420" cy="40" r="2.5" />
+    <circle cx="468" cy="28" r="3" />
+    <circle cx="515" cy="46" r="2.5" />
+    <circle cx="560" cy="30" r="3" />
+    <circle cx="600" cy="58" r="2.5" />
+    <circle cx="610" cy="110" r="3" />
+    <circle cx="598" cy="170" r="2.5" />
+    <circle cx="586" cy="212" r="3" />
+    <circle cx="250" cy="120" r="3" />
+    <circle cx="300" cy="152" r="2.5" />
+    <circle cx="262" cy="186" r="3" />
+    <circle cx="220" cy="168" r="2.5" />
+    <circle cx="90" cy="210" r="3" />
+    <circle cx="165" cy="218" r="2.5" />
+    <circle cx="225" cy="214" r="3" />
+    <circle cx="310" cy="216" r="2.5" />
+    <circle cx="62" cy="156" r="2.5" />
+    <circle cx="288" cy="74" r="3" />
+  </g>
+  <rect x="60" y="196" width="520" height="4" rx="2" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="282" cy="30" r="4" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="150" cy="150" r="46" fillOpacity="0.12" />
+    <circle cx="130" cy="134" r="4.5" />
+    <circle cx="152" cy="121" r="4.5" />
+    <circle cx="173" cy="139" r="4.5" />
+    <circle cx="122" cy="156" r="4.5" />
+    <circle cx="143" cy="148" r="4.5" />
+    <circle cx="165" cy="158" r="4.5" />
+    <circle cx="136" cy="172" r="4.5" />
+    <circle cx="158" cy="176" r="4.5" />
+    <circle cx="210" cy="128" r="2.5" fillOpacity="0.5" />
+    <circle cx="240" cy="110" r="2.5" fillOpacity="0.5" />
+    <circle cx="270" cy="95" r="2.5" fillOpacity="0.5" />
+    <circle cx="300" cy="83" r="2.5" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 330 196 C 390 196 405 74 450 74 C 495 74 510 196 570 196 Z" fillOpacity="0.3" />
+    <path d="M 362 196 C 412 196 420 104 450 104 C 480 104 488 196 538 196 Z" fillOpacity="0.25" />
+    <rect x="398" y="210" width="104" height="10" rx="5" fillOpacity="0.45" />
+    <rect x="396" y="204" width="5" height="22" rx="2.5" fillOpacity="0.85" />
+    <rect x="499" y="204" width="5" height="22" rx="2.5" fillOpacity="0.85" />
+    <rect x="447" y="206" width="5" height="18" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="474" cy="215" r="6" />
+  </g>
+</svg>
+
 <Callout type="info" title="What we assume you already know">
 You can write basic Python, use Pandas (`read_csv`, filtering,
 `groupby`, `merge`), and make a chart. You do **not** need any prior

--- a/content/learn/statistics-for-data-science-python/measures-of-center.mdx
+++ b/content/learn/statistics-for-data-science-python/measures-of-center.mdx
@@ -16,6 +16,33 @@ number that's supposed to stand in for "the middle." The trouble is
 that "the middle" isn't one idea. This page is about knowing which
 center you're actually asking for, and when each one quietly lies.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Seven dots rest on a plank with the green median dot among them while one heavy yellow value sits far down the beam, dragging the balance-point fulcrum into empty space where no data lives — the mean is a balance point, and outliers drag it"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="70" y="166" width="500" height="4" rx="2" fill="currentColor" opacity="0.15" />
+  <rect x="80" y="120" width="480" height="8" rx="4" fill="currentColor" opacity="0.3" />
+  <path d="M 350 130 L 372 166 L 328 166 Z" fill="currentColor" opacity="0.45" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="120" cy="109" r="7" />
+    <circle cx="146" cy="109" r="7" />
+    <circle cx="172" cy="109" r="7" />
+    <circle cx="224" cy="109" r="7" />
+    <circle cx="250" cy="109" r="7" />
+    <circle cx="276" cy="109" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="198" cy="109" r="7" />
+    <rect x="195.5" y="74" width="5" height="24" rx="2.5" fillOpacity="0.7" />
+    <circle cx="198" cy="68" r="6" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="520" cy="104" r="13" />
+  </g>
+</svg>
+
 ## The three centers, and what each one means
 
 - **Mean** (the arithmetic average): add everything up, divide by the
@@ -209,6 +236,38 @@ percent changes, fold-changes), the *arithmetic* mean overstates
 typical growth. The geometric mean multiplies the values and takes the
 nth root, which is the correct "average factor" for things that
 compound.
+
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="A sorted row of dots with its two extreme ends caught inside translucent red trim zones, and a green marker resting below the center of the surviving dots — the trimmed mean averages only what is left after the extremes are chopped"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="66" width="520" height="4" rx="2" fill="currentColor" opacity="0.15" />
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor" fillOpacity="0.18">
+    <rect x="66" y="38" width="92" height="60" rx="12" />
+    <rect x="482" y="38" width="92" height="60" rx="12" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor" fillOpacity="0.6">
+    <circle cx="92" cy="68" r="7" />
+    <circle cx="128" cy="68" r="7" />
+    <circle cx="512" cy="68" r="7" />
+    <circle cx="548" cy="68" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="192" cy="68" r="7" />
+    <circle cx="232" cy="68" r="7" />
+    <circle cx="272" cy="68" r="7" />
+    <circle cx="312" cy="68" r="7" />
+    <circle cx="352" cy="68" r="7" />
+    <circle cx="392" cy="68" r="7" />
+    <circle cx="432" cy="68" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="288" y="104" width="48" height="9" rx="4.5" fillOpacity="0.4" />
+    <circle cx="312" cy="108" r="7" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/measures-of-spread.mdx
+++ b/content/learn/statistics-for-data-science-python/measures-of-spread.mdx
@@ -18,6 +18,42 @@ all of these are spread, not center. This page builds the vocabulary:
 **MAD**, and the **coefficient of variation**, plus the one divisor
 detail (`n−1`) that trips up almost everyone.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Two strips of deliveries share one yellow average line: the top row's green dots huddle tightly around it while the bottom row's blue dots scatter from edge to edge, their range pills wildly different widths — same center, completely different spread"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="318" y="28" width="4" height="144" rx="2" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="100" y="66" width="440" height="4" rx="2" />
+    <rect x="100" y="136" width="440" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="298" cy="68" r="6" fillOpacity="0.8" />
+    <circle cx="306" cy="68" r="6" fillOpacity="0.8" />
+    <circle cx="314" cy="68" r="6" fillOpacity="0.8" />
+    <circle cx="321" cy="68" r="6" fillOpacity="0.8" />
+    <circle cx="328" cy="68" r="6" fillOpacity="0.8" />
+    <circle cx="336" cy="68" r="6" fillOpacity="0.8" />
+    <circle cx="343" cy="68" r="6" fillOpacity="0.8" />
+    <rect x="292" y="84" width="58" height="6" rx="3" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="110" cy="138" r="6" fillOpacity="0.85" />
+    <circle cx="180" cy="138" r="6" fillOpacity="0.85" />
+    <circle cx="250" cy="138" r="6" fillOpacity="0.85" />
+    <circle cx="305" cy="138" r="6" fillOpacity="0.85" />
+    <circle cx="332" cy="138" r="6" fillOpacity="0.85" />
+    <circle cx="410" cy="138" r="6" fillOpacity="0.85" />
+    <circle cx="480" cy="138" r="6" fillOpacity="0.85" />
+    <circle cx="545" cy="138" r="6" fillOpacity="0.85" />
+    <rect x="104" y="154" width="448" height="6" rx="3" fillOpacity="0.25" />
+  </g>
+</svg>
+
 ## Same center, different spread
 
 Let's make the delivery story concrete. Both services have a mean of
@@ -174,6 +210,41 @@ population mean. So squared deviations from the sample mean are
 the values, the last value is determined, so only `n−1` deviations are
 truly free to vary.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Five scattered points joined by dotted spokes to the blue ring of the center they define themselves, while the yellow true center floats a little way off to the side — data always hugs its own mean most tightly, which is why sample spread divides by n minus one to push the estimate back up"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="185" cy="72" r="6" />
+    <circle cx="315" cy="80" r="6" />
+    <circle cx="195" cy="142" r="6" />
+    <circle cx="308" cy="138" r="6" />
+    <circle cx="252" cy="165" r="6" />
+    <path d="M241 119 a10 10 0 1 0 20 0 a10 10 0 1 0 -20 0 M246 119 a5 5 0 1 0 10 0 a5 5 0 1 0 -10 0" fillRule="evenodd" />
+    <circle cx="234" cy="107" r="2" fillOpacity="0.6" />
+    <circle cx="218" cy="96" r="2" fillOpacity="0.6" />
+    <circle cx="202" cy="84" r="2" fillOpacity="0.6" />
+    <circle cx="267" cy="109" r="2" fillOpacity="0.6" />
+    <circle cx="283" cy="100" r="2" fillOpacity="0.6" />
+    <circle cx="299" cy="90" r="2" fillOpacity="0.6" />
+    <circle cx="237" cy="125" r="2" fillOpacity="0.6" />
+    <circle cx="223" cy="131" r="2" fillOpacity="0.6" />
+    <circle cx="209" cy="136" r="2" fillOpacity="0.6" />
+    <circle cx="265" cy="124" r="2" fillOpacity="0.6" />
+    <circle cx="280" cy="129" r="2" fillOpacity="0.6" />
+    <circle cx="294" cy="133" r="2" fillOpacity="0.6" />
+    <circle cx="251" cy="131" r="2" fillOpacity="0.6" />
+    <circle cx="252" cy="142" r="2" fillOpacity="0.6" />
+    <circle cx="252" cy="154" r="2" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="372" cy="90" r="16" fillOpacity="0.15" />
+    <circle cx="372" cy="90" r="7" />
+  </g>
+</svg>
+
 <Callout type="info" title="ddof = 'delta degrees of freedom'">
 In NumPy, `ddof` is what gets subtracted from `n` in the divisor.
 `ddof=0` divides by `n` (the **population** formula). `ddof=1` divides
@@ -259,6 +330,38 @@ print("The lone 9000 barely touches the IQR but explodes the std.")
     },
   ]}
 />
+
+<svg
+  viewBox="0 0 640 160"
+  role="img"
+  aria-label="Sorted dots on a line with the middle half wrapped in a green capsule that one far-flung red value cannot stretch, while the thin red band of the standard deviation below runs all the way out to reach it — the IQR shrugs off the outlier that wrecks the std"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="78" width="520" height="4" rx="2" fill="currentColor" opacity="0.12" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="144" y="62" width="156" height="36" rx="18" fillOpacity="0.18" />
+    <rect x="144" y="64" width="6" height="32" rx="3" fillOpacity="0.7" />
+    <rect x="294" y="64" width="6" height="32" rx="3" fillOpacity="0.7" />
+    <rect x="216" y="66" width="5" height="28" rx="2.5" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="100" cy="80" r="6" />
+    <circle cx="130" cy="80" r="6" />
+    <circle cx="330" cy="80" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="158" cy="80" r="6" />
+    <circle cx="183" cy="80" r="6" />
+    <circle cx="208" cy="80" r="6" />
+    <circle cx="233" cy="80" r="6" />
+    <circle cx="258" cy="80" r="6" />
+    <circle cx="285" cy="80" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="560" cy="80" r="7" />
+    <rect x="96" y="118" width="470" height="6" rx="3" fillOpacity="0.3" />
+  </g>
+</svg>
 
 <Callout type="tip" title="Std vs IQR: which spread to report">
 Mirror your center choice. If the data is roughly symmetric and you're

--- a/content/learn/statistics-for-data-science-python/next-steps.mdx
+++ b/content/learn/statistics-for-data-science-python/next-steps.mdx
@@ -9,6 +9,53 @@ who work with data never quite acquire. This closing page looks back at
 the path, names what you can now do, and points honestly toward what
 comes next without pretending to teach it here.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A dotted path winds up over translucent hills past tiny milestone badges — a little bell curve, an interval pill, a scatter trio — where a green traveler dot walks toward a yellow sun on the horizon — the course ends here, and the road of practice carries on"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 444 122 A 40 40 0 0 1 524 122 Z" fillOpacity="0.85" />
+    <circle cx="424" cy="86" r="3" fillOpacity="0.5" />
+    <circle cx="484" cy="62" r="3" fillOpacity="0.5" />
+    <circle cx="544" cy="86" r="3" fillOpacity="0.5" />
+  </g>
+  <g fill="currentColor" opacity="0.08">
+    <path d="M 40 122 C 140 70 240 112 340 119 C 420 124 520 122 600 122 L 600 198 L 40 198 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 40 198 C 120 150 240 140 360 162 C 460 180 560 188 600 190 L 600 198 Z" fillOpacity="0.18" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <circle cx="80" cy="190" r="3" />
+    <circle cx="120" cy="182" r="3" />
+    <circle cx="158" cy="172" r="3" />
+    <circle cx="196" cy="164" r="3" />
+    <circle cx="268" cy="152" r="3" />
+    <circle cx="304" cy="148" r="3" />
+    <circle cx="340" cy="142" r="3" />
+    <circle cx="376" cy="138" r="3" />
+    <circle cx="412" cy="133" r="3" />
+    <circle cx="446" cy="128" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="232" cy="156" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 162 148 C 170 148 171 132 180 132 C 189 132 190 148 198 148 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="288" y="122" width="30" height="6" rx="3" fillOpacity="0.5" />
+    <circle cx="303" cy="125" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor" fillOpacity="0.7">
+    <circle cx="382" cy="112" r="3" />
+    <circle cx="392" cy="104" r="3" />
+    <circle cx="400" cy="114" r="3" />
+  </g>
+</svg>
+
 ## The journey you just took
 
 Every page built on the last. Step back and the shape is clear: you went

--- a/content/learn/statistics-for-data-science-python/p-values.mdx
+++ b/content/learn/statistics-for-data-science-python/p-values.mdx
@@ -15,6 +15,73 @@ curve. Second, it relentlessly clears away every classic misreading,
 because knowing what a p-value is *not* is just as important as knowing
 what it is.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A bell-shaped pile of faint dots records every gap pure noise produced in a no-effect world; a red post marks the gap actually observed, and the few yellow dots at or beyond it are the p-value — the fraction of the boring world at least as extreme as you"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="90" y="184" width="440" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="130" cy="172" r="5.5" />
+    <circle cx="162" cy="172" r="5.5" />
+    <circle cx="162" cy="158" r="5.5" />
+    <circle cx="194" cy="172" r="5.5" />
+    <circle cx="194" cy="158" r="5.5" />
+    <circle cx="194" cy="144" r="5.5" />
+    <circle cx="226" cy="172" r="5.5" />
+    <circle cx="226" cy="158" r="5.5" />
+    <circle cx="226" cy="144" r="5.5" />
+    <circle cx="226" cy="130" r="5.5" />
+    <circle cx="226" cy="116" r="5.5" />
+    <circle cx="258" cy="172" r="5.5" />
+    <circle cx="258" cy="158" r="5.5" />
+    <circle cx="258" cy="144" r="5.5" />
+    <circle cx="258" cy="130" r="5.5" />
+    <circle cx="258" cy="116" r="5.5" />
+    <circle cx="258" cy="102" r="5.5" />
+    <circle cx="258" cy="88" r="5.5" />
+    <circle cx="290" cy="172" r="5.5" />
+    <circle cx="290" cy="158" r="5.5" />
+    <circle cx="290" cy="144" r="5.5" />
+    <circle cx="290" cy="130" r="5.5" />
+    <circle cx="290" cy="116" r="5.5" />
+    <circle cx="290" cy="102" r="5.5" />
+    <circle cx="290" cy="88" r="5.5" />
+    <circle cx="290" cy="74" r="5.5" />
+    <circle cx="322" cy="172" r="5.5" />
+    <circle cx="322" cy="158" r="5.5" />
+    <circle cx="322" cy="144" r="5.5" />
+    <circle cx="322" cy="130" r="5.5" />
+    <circle cx="322" cy="116" r="5.5" />
+    <circle cx="322" cy="102" r="5.5" />
+    <circle cx="322" cy="88" r="5.5" />
+    <circle cx="322" cy="74" r="5.5" />
+    <circle cx="354" cy="172" r="5.5" />
+    <circle cx="354" cy="158" r="5.5" />
+    <circle cx="354" cy="144" r="5.5" />
+    <circle cx="354" cy="130" r="5.5" />
+    <circle cx="354" cy="116" r="5.5" />
+    <circle cx="354" cy="102" r="5.5" />
+    <circle cx="386" cy="172" r="5.5" />
+    <circle cx="386" cy="158" r="5.5" />
+    <circle cx="386" cy="144" r="5.5" />
+    <circle cx="386" cy="130" r="5.5" />
+    <circle cx="418" cy="172" r="5.5" />
+    <circle cx="418" cy="158" r="5.5" />
+    <circle cx="418" cy="144" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor" fillOpacity="0.9">
+    <circle cx="450" cy="172" r="5.5" />
+    <circle cx="450" cy="158" r="5.5" />
+    <circle cx="482" cy="172" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="434" y="78" width="4.5" height="106" rx="2.25" />
+    <circle cx="436" cy="70" r="6" />
+  </g>
+</svg>
+
 ## The one-sentence definition
 
 > A **p-value** is the probability of observing data **at least as
@@ -414,6 +481,51 @@ p-value is essentially a uniform random number between 0 and 1. So if you
 test **20 independent things** that are all truly null, you *expect* one
 of them to come up "significant" at α = 0.05 — by pure luck. Hunt
 through enough comparisons and you will always find a "discovery."
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A wall of identical test tiles, every one of them pure noise, with exactly one glowing green and crowned by a celebratory yellow star — scan enough comparisons and luck alone will hand you a discovery to misreport"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="110" y="40" width="64" height="50" rx="10" />
+    <rect x="186" y="40" width="64" height="50" rx="10" />
+    <rect x="262" y="40" width="64" height="50" rx="10" />
+    <rect x="338" y="40" width="64" height="50" rx="10" />
+    <rect x="414" y="40" width="64" height="50" rx="10" />
+    <rect x="110" y="102" width="64" height="50" rx="10" />
+    <rect x="186" y="102" width="64" height="50" rx="10" />
+    <rect x="338" y="102" width="64" height="50" rx="10" />
+    <rect x="414" y="102" width="64" height="50" rx="10" />
+    <rect x="34" y="40" width="64" height="50" rx="10" />
+    <rect x="34" y="102" width="64" height="50" rx="10" />
+    <rect x="490" y="40" width="64" height="50" rx="10" />
+    <rect x="490" y="102" width="64" height="50" rx="10" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="66" cy="65" r="4" />
+    <circle cx="142" cy="65" r="4" />
+    <circle cx="218" cy="65" r="4" />
+    <circle cx="294" cy="65" r="4" />
+    <circle cx="370" cy="65" r="4" />
+    <circle cx="446" cy="65" r="4" />
+    <circle cx="522" cy="65" r="4" />
+    <circle cx="66" cy="127" r="4" />
+    <circle cx="142" cy="127" r="4" />
+    <circle cx="218" cy="127" r="4" />
+    <circle cx="370" cy="127" r="4" />
+    <circle cx="446" cy="127" r="4" />
+    <circle cx="522" cy="127" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="262" y="102" width="64" height="50" rx="10" fillOpacity="0.5" />
+    <circle cx="294" cy="127" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 294 84 L 298 94 L 308 94 L 300 100 L 303 110 L 294 104 L 285 110 L 288 100 L 280 94 L 290 94 Z" fillOpacity="0.9" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/populations-and-samples.mdx
+++ b/content/learn/statistics-for-data-science-python/populations-and-samples.mdx
@@ -17,6 +17,101 @@ reporting a sample average as if it were the population's, expecting a
 bigger sample to "change" the answer, or forgetting that a statistic
 wobbles every time you collect new data. Let's pin them down.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A vast faint dot field hides a yellow ring at its heart while nine scattered dots glow blue; the same nine reappear gathered in a small tray whose green summary dot is the only number you can actually compute — a sample statistic estimating a population parameter you never see"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="36" y="22" width="380" height="186" rx="18" fill="currentColor" opacity="0.05" />
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="60" cy="50" r="3.5" />
+    <circle cx="92" cy="38" r="3.5" />
+    <circle cx="124" cy="56" r="3.5" />
+    <circle cx="156" cy="40" r="3.5" />
+    <circle cx="188" cy="52" r="3.5" />
+    <circle cx="220" cy="38" r="3.5" />
+    <circle cx="252" cy="54" r="3.5" />
+    <circle cx="284" cy="42" r="3.5" />
+    <circle cx="316" cy="56" r="3.5" />
+    <circle cx="348" cy="40" r="3.5" />
+    <circle cx="380" cy="54" r="3.5" />
+    <circle cx="56" cy="86" r="3.5" />
+    <circle cx="88" cy="74" r="3.5" />
+    <circle cx="120" cy="92" r="3.5" />
+    <circle cx="152" cy="78" r="3.5" />
+    <circle cx="216" cy="76" r="3.5" />
+    <circle cx="248" cy="90" r="3.5" />
+    <circle cx="312" cy="80" r="3.5" />
+    <circle cx="344" cy="92" r="3.5" />
+    <circle cx="376" cy="78" r="3.5" />
+    <circle cx="64" cy="122" r="3.5" />
+    <circle cx="96" cy="110" r="3.5" />
+    <circle cx="128" cy="126" r="3.5" />
+    <circle cx="192" cy="112" r="3.5" />
+    <circle cx="256" cy="124" r="3.5" />
+    <circle cx="288" cy="110" r="3.5" />
+    <circle cx="320" cy="126" r="3.5" />
+    <circle cx="384" cy="112" r="3.5" />
+    <circle cx="58" cy="158" r="3.5" />
+    <circle cx="90" cy="146" r="3.5" />
+    <circle cx="122" cy="162" r="3.5" />
+    <circle cx="154" cy="148" r="3.5" />
+    <circle cx="186" cy="160" r="3.5" />
+    <circle cx="218" cy="146" r="3.5" />
+    <circle cx="250" cy="162" r="3.5" />
+    <circle cx="282" cy="148" r="3.5" />
+    <circle cx="314" cy="160" r="3.5" />
+    <circle cx="346" cy="146" r="3.5" />
+    <circle cx="378" cy="158" r="3.5" />
+    <circle cx="72" cy="190" r="3.5" />
+    <circle cx="104" cy="178" r="3.5" />
+    <circle cx="168" cy="182" r="3.5" />
+    <circle cx="200" cy="192" r="3.5" />
+    <circle cx="232" cy="178" r="3.5" />
+    <circle cx="264" cy="190" r="3.5" />
+    <circle cx="296" cy="180" r="3.5" />
+    <circle cx="328" cy="192" r="3.5" />
+    <circle cx="360" cy="180" r="3.5" />
+    <circle cx="392" cy="190" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M210 112 a16 16 0 1 0 32 0 a16 16 0 1 0 -32 0 M218 112 a8 8 0 1 0 16 0 a8 8 0 1 0 -16 0" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="110" cy="60" r="4.5" />
+    <circle cx="300" cy="64" r="4.5" />
+    <circle cx="76" cy="104" r="4.5" />
+    <circle cx="360" cy="120" r="4.5" />
+    <circle cx="170" cy="136" r="4.5" />
+    <circle cx="264" cy="72" r="4.5" />
+    <circle cx="140" cy="180" r="4.5" />
+    <circle cx="330" cy="168" r="4.5" />
+    <circle cx="212" cy="170" r="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="430" cy="100" r="2.5" />
+    <circle cx="447" cy="106" r="2.5" />
+    <circle cx="463" cy="112" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="478" y="66" width="124" height="98" rx="14" fillOpacity="0.1" />
+    <circle cx="504" cy="92" r="4.5" />
+    <circle cx="540" cy="92" r="4.5" />
+    <circle cx="576" cy="92" r="4.5" />
+    <circle cx="504" cy="116" r="4.5" />
+    <circle cx="540" cy="116" r="4.5" />
+    <circle cx="576" cy="116" r="4.5" />
+    <circle cx="504" cy="140" r="4.5" />
+    <circle cx="540" cy="140" r="4.5" />
+    <circle cx="576" cy="140" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="478" y="178" width="124" height="6" rx="3" fillOpacity="0.3" />
+    <circle cx="546" cy="181" r="6.5" />
+  </g>
+</svg>
+
 ## Population vs. sample
 
 The **population** is the entire collection of units you actually care
@@ -69,6 +164,41 @@ pointless:
   course: a modest, representative sample estimates a population
   parameter with quantifiable precision. You don't need everything —
   you need enough, collected well.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="A shelf of identical batteries, two of them snapped in half by lifetime testing with a small yellow data spark above each — when measurement destroys the unit, you can only ever test a sample, never the whole shipment"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="132" width="500" height="5" rx="2.5" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.55">
+    <rect x="90" y="56" width="14" height="6" rx="2" />
+    <rect x="80" y="62" width="34" height="64" rx="6" />
+    <rect x="150" y="56" width="14" height="6" rx="2" />
+    <rect x="140" y="62" width="34" height="64" rx="6" />
+    <rect x="270" y="56" width="14" height="6" rx="2" />
+    <rect x="260" y="62" width="34" height="64" rx="6" />
+    <rect x="330" y="56" width="14" height="6" rx="2" />
+    <rect x="320" y="62" width="34" height="64" rx="6" />
+    <rect x="450" y="56" width="14" height="6" rx="2" />
+    <rect x="440" y="62" width="34" height="64" rx="6" />
+    <rect x="510" y="56" width="14" height="6" rx="2" />
+    <rect x="500" y="62" width="34" height="64" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor" fillOpacity="0.8">
+    <rect x="210" y="56" width="14" height="6" rx="2" />
+    <rect x="200" y="62" width="34" height="26" rx="6" />
+    <rect x="208" y="98" width="34" height="28" rx="6" />
+    <rect x="390" y="56" width="14" height="6" rx="2" />
+    <rect x="380" y="62" width="34" height="26" rx="6" />
+    <rect x="372" y="98" width="34" height="28" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="217" cy="38" r="5" />
+    <circle cx="397" cy="38" r="5" />
+  </g>
+</svg>
 
 <Callout type="tip" title="Sampling is a feature, not a compromise">
 Sampling isn't a sad approximation you settle for. It's the entire

--- a/content/learn/statistics-for-data-science-python/probability-basics.mdx
+++ b/content/learn/statistics-for-data-science-python/probability-basics.mdx
@@ -17,6 +17,46 @@ what *could* happen, or how surprising what *did* happen really is. That
 interval, p-value, and A/B test later in this course. This page builds
 the vocabulary and the handful of rules everything else rests on.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A six-wedge wheel with the three even faces lit blue under a yellow pointer, beside a fraction built from dots — three blue outcomes over six possible ones — probability as the share of the sample space an event covers"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <path d="M 200 110 L 200 32 A 78 78 0 0 1 267.5 71 Z" />
+    <path d="M 200 110 L 267.5 149 A 78 78 0 0 1 200 188 Z" />
+    <path d="M 200 110 L 132.5 149 A 78 78 0 0 1 132.5 71 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.55">
+    <path d="M 200 110 L 267.5 71 A 78 78 0 0 1 267.5 149 Z" />
+    <path d="M 200 110 L 200 188 A 78 78 0 0 1 132.5 149 Z" />
+    <path d="M 200 110 L 132.5 71 A 78 78 0 0 1 200 32 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.7">
+    <text x="246" y="116" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15">2</text>
+    <text x="172" y="162" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15">4</text>
+    <text x="172" y="72" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15">6</text>
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 190 12 L 210 12 L 200 32 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="444" cy="82" r="7" />
+    <circle cx="480" cy="82" r="7" />
+    <circle cx="516" cy="82" r="7" />
+  </g>
+  <rect x="412" y="100" width="136" height="5" rx="2.5" fill="currentColor" opacity="0.4" />
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="420" cy="126" r="7" />
+    <circle cx="444" cy="126" r="7" />
+    <circle cx="468" cy="126" r="7" />
+    <circle cx="492" cy="126" r="7" />
+    <circle cx="516" cy="126" r="7" />
+    <circle cx="540" cy="126" r="7" />
+  </g>
+</svg>
+
 ## Sample spaces and events
 
 Before you can assign a probability to anything, you have to be clear
@@ -228,6 +268,39 @@ flowchart TD
 Let's watch it happen. We'll flip a fair coin 5,000 times and plot the
 **running proportion** of heads after each flip. Early on it lurches
 around; as the flip count climbs it homes in on 0.5.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A trail of coin-flip dots lurches far above and below the yellow one-half line at first, then settles into a tight hug of it as the flips pile up — the Law of Large Numbers stabilizes the long run without ever fixing the short run"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="80" y="108" width="500" height="4" rx="2" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.8">
+    <circle cx="90" cy="40" r="4.5" />
+    <circle cx="120" cy="170" r="4.5" />
+    <circle cx="150" cy="60" r="4.5" />
+    <circle cx="180" cy="150" r="4.5" />
+    <circle cx="210" cy="80" r="4.5" />
+    <circle cx="240" cy="135" r="4.5" />
+    <circle cx="270" cy="92" r="4.5" />
+    <circle cx="300" cy="126" r="4.5" />
+    <circle cx="330" cy="99" r="4.5" />
+    <circle cx="360" cy="120" r="4.5" />
+    <circle cx="390" cy="104" r="4.5" />
+    <circle cx="420" cy="116" r="4.5" />
+    <circle cx="450" cy="106" r="4.5" />
+    <circle cx="480" cy="113" r="4.5" />
+    <circle cx="510" cy="108" r="4.5" />
+    <circle cx="540" cy="112" r="4.5" />
+    <circle cx="570" cy="110" r="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <path d="M 80 30 C 240 30 380 96 580 102 L 580 118 C 380 124 240 190 80 190 Z" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/random-variables.mdx
+++ b/content/learn/statistics-for-data-science-python/random-variables.mdx
@@ -19,6 +19,56 @@ variable. This page is about describing them with two summary numbers
 (**expectation** and **variance**) and using the first one to make
 real-world decisions.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Four coin-pair outcomes funnel through a function box marked with an italic f and land as numbered dots on a line, two different outcomes stacking onto the same middle number — a random variable is the rule that turns whatever happened into a number you can do math on"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="90" cy="50" r="9" />
+    <circle cx="114" cy="50" r="9" />
+    <circle cx="90" cy="95" r="9" />
+    <circle cx="114" cy="140" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="114" cy="95" r="9" />
+    <circle cx="90" cy="140" r="9" />
+    <circle cx="90" cy="185" r="9" />
+    <circle cx="114" cy="185" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="172" cy="72" r="2.5" />
+    <circle cx="222" cy="96" r="2.5" />
+    <circle cx="172" cy="103" r="2.5" />
+    <circle cx="222" cy="110" r="2.5" />
+    <circle cx="172" cy="132" r="2.5" />
+    <circle cx="222" cy="122" r="2.5" />
+    <circle cx="172" cy="162" r="2.5" />
+    <circle cx="222" cy="136" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="266" y="80" width="72" height="72" rx="14" fillOpacity="0.18" />
+    <text x="302" y="128" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="34">ƒ</text>
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="358" cy="120" r="2.5" />
+    <circle cx="374" cy="126" r="2.5" />
+    <circle cx="390" cy="132" r="2.5" />
+  </g>
+  <rect x="408" y="150" width="192" height="4" rx="2" fill="currentColor" opacity="0.3" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="436" cy="138" r="6" />
+    <circle cx="504" cy="134" r="9" />
+    <circle cx="572" cy="138" r="6" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="436" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">0</text>
+    <text x="504" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">1</text>
+    <text x="572" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">2</text>
+  </g>
+</svg>
+
 ## A random variable maps outcomes to numbers
 
 The mental model: the world rolls some dice you can't control, and the
@@ -96,6 +146,38 @@ function (pdf)** describes probability as **area**: the chance that `X`
 falls *in an interval* is the area under the pdf curve over that
 interval. Density is not probability — it's "probability per unit of
 `x`," and only becomes probability once you integrate over a range.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="On the left, discrete lollipop masses you can point at and read; on the right, a smooth density curve where only the shaded green slice between two points carries probability — masses for countable values, area under a curve for continuous ones"
+  style={{ display: "block", width: "100%", maxWidth: "620px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="56" y="148" width="220" height="4" rx="2" />
+    <rect x="336" y="148" width="248" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="88" y="106" width="5" height="42" rx="2.5" fillOpacity="0.5" />
+    <circle cx="90.5" cy="100" r="8" />
+    <rect x="136" y="66" width="5" height="82" rx="2.5" fillOpacity="0.5" />
+    <circle cx="138.5" cy="60" r="11" />
+    <rect x="184" y="84" width="5" height="64" rx="2.5" fillOpacity="0.5" />
+    <circle cx="186.5" cy="78" r="9.5" />
+    <rect x="232" y="120" width="5" height="28" rx="2.5" fillOpacity="0.5" />
+    <circle cx="234.5" cy="114" r="6.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 340 148 C 380 148 392 56 460 56 C 528 56 540 148 580 148 Z" fillOpacity="0.22" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 432 148 L 432 72 C 442 63 452 59 460 59 C 468 59 478 63 488 72 L 488 148 Z" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <rect x="430" y="148" width="4" height="14" rx="2" />
+    <rect x="486" y="148" width="4" height="14" rx="2" />
+  </g>
+</svg>
 
 <Callout type="warn" title="Misconception: a pdf gives the probability of a single value">
 For continuous variables, P(X = exact value) = 0, always.

--- a/content/learn/statistics-for-data-science-python/sampling-and-bias.mdx
+++ b/content/learn/statistics-for-data-science-python/sampling-and-bias.mdx
@@ -17,6 +17,79 @@ an error that *no amount of extra rows removes*. Learning to see that
 error — and to choose samples that avoid it — is one of the highest-value
 skills in applied statistics.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A well-mixed field of blue and green dots is sampled by a yellow scoop that covers only one green-heavy corner, filling the tray with an unbalanced handful whose red estimate lands away from the yellow truth mark — a biased scoop stays wrong no matter how much it scoops"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="40" y="24" width="400" height="176" rx="16" fill="currentColor" opacity="0.05" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.75">
+    <circle cx="70" cy="50" r="4" />
+    <circle cx="130" cy="40" r="4" />
+    <circle cx="200" cy="56" r="4" />
+    <circle cx="270" cy="40" r="4" />
+    <circle cx="340" cy="52" r="4" />
+    <circle cx="400" cy="44" r="4" />
+    <circle cx="90" cy="96" r="4" />
+    <circle cx="160" cy="90" r="4" />
+    <circle cx="230" cy="104" r="4" />
+    <circle cx="300" cy="88" r="4" />
+    <circle cx="370" cy="100" r="4" />
+    <circle cx="415" cy="140" r="4" />
+    <circle cx="250" cy="150" r="4" />
+    <circle cx="330" cy="160" r="4" />
+    <circle cx="390" cy="184" r="4" />
+    <circle cx="210" cy="184" r="4" />
+    <circle cx="152" cy="136" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fillOpacity="0.75">
+    <circle cx="100" cy="60" r="4" />
+    <circle cx="170" cy="64" r="4" />
+    <circle cx="240" cy="76" r="4" />
+    <circle cx="310" cy="64" r="4" />
+    <circle cx="380" cy="72" r="4" />
+    <circle cx="60" cy="106" r="4" />
+    <circle cx="415" cy="80" r="4" />
+    <circle cx="280" cy="120" r="4" />
+    <circle cx="350" cy="130" r="4" />
+    <circle cx="180" cy="158" r="4" />
+    <circle cx="290" cy="184" r="4" />
+    <circle cx="105" cy="140" r="4" />
+    <circle cx="140" cy="150" r="4" />
+    <circle cx="120" cy="172" r="4" />
+    <circle cx="155" cy="178" r="4" />
+    <circle cx="96" cy="160" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="128" cy="158" r="52" fillOpacity="0.14" />
+    <path d="M76 158 a52 52 0 1 0 104 0 a52 52 0 1 0 -104 0 M82 158 a46 46 0 1 0 92 0 a46 46 0 1 0 -92 0" fillRule="evenodd" fillOpacity="0.7" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="450" cy="112" r="2.5" />
+    <circle cx="464" cy="112" r="2.5" />
+    <circle cx="478" cy="112" r="2.5" />
+  </g>
+  <rect x="490" y="70" width="110" height="86" rx="14" fill="currentColor" opacity="0.06" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="515" cy="96" r="5" />
+    <circle cx="545" cy="96" r="5" />
+    <circle cx="575" cy="96" r="5" />
+    <circle cx="530" cy="126" r="5" />
+    <circle cx="560" cy="126" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="515" cy="126" r="5" />
+  </g>
+  <rect x="490" y="176" width="110" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="543" y="168" width="4" height="20" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="582" cy="178" r="5.5" />
+  </g>
+</svg>
+
 ## Why the sampling method is everything
 
 Almost every method in this course assumes your sample is a *fair draw*
@@ -252,6 +325,46 @@ moves you *leftward* (less variance) but **cannot move you downward**
 collect more data" is the right instinct for noise and the *wrong*
 instinct for bias.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Two dartboards: on the left a loose blue cluster centered on the yellow bullseye, on the right a tight red cluster parked stubbornly away from it — noisy but honest beats consistent but wrong, because more darts tighten a cluster yet never move its center"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor">
+    <circle cx="180" cy="115" r="62" opacity="0.07" />
+    <circle cx="180" cy="115" r="40" opacity="0.1" />
+    <circle cx="460" cy="115" r="62" opacity="0.07" />
+    <circle cx="460" cy="115" r="40" opacity="0.1" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="180" cy="115" r="9" />
+    <circle cx="460" cy="115" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="150" cy="85" r="5" />
+    <circle cx="215" cy="100" r="5" />
+    <circle cx="165" cy="148" r="5" />
+    <circle cx="206" cy="142" r="5" />
+    <circle cx="140" cy="120" r="5" />
+    <circle cx="190" cy="68" r="5" />
+    <circle cx="182" cy="118" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="492" cy="76" r="5" />
+    <circle cx="504" cy="86" r="5" />
+    <circle cx="494" cy="92" r="5" />
+    <circle cx="506" cy="72" r="5" />
+    <circle cx="500" cy="80" r="5" />
+    <circle cx="488" cy="84" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="470" cy="105" r="2" />
+    <circle cx="479" cy="97" r="2" />
+    <circle cx="488" cy="90" r="2" />
+  </g>
+</svg>
+
 <CodeBlock
   adapter="python"
   files={[
@@ -389,6 +502,32 @@ survivors. "Successful founders dropped out of college" ignores the vast
 graveyard of dropouts whose startups failed and who were never
 interviewed. Any time your dataset is "the ones still here," ask what the
 *absent* ones would have told you.
+
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A top-view bomber silhouette speckled with red bullet holes along its wings and tail while a yellow ring marks the untouched nose — the holes only show where planes survived being hit, and the clean spot is where the lost planes were struck"
+  style={{ display: "block", width: "100%", maxWidth: "460px", height: "auto", margin: "2.5rem auto" }}
+>
+  <path d="M 320 28 C 332 40 330 60 330 80 L 330 102 L 424 132 L 424 154 L 332 134 L 332 168 L 364 184 L 364 200 L 322 192 L 280 200 L 280 184 L 312 168 L 312 134 L 220 154 L 220 132 L 314 102 L 314 80 C 314 60 312 40 320 28 Z" fill="currentColor" opacity="0.15" />
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor" fillOpacity="0.85">
+    <circle cx="240" cy="143" r="4" />
+    <circle cx="262" cy="140" r="4" />
+    <circle cx="284" cy="135" r="4" />
+    <circle cx="298" cy="148" r="4" />
+    <circle cx="356" cy="136" r="4" />
+    <circle cx="378" cy="140" r="4" />
+    <circle cx="400" cy="144" r="4" />
+    <circle cx="322" cy="148" r="4" />
+    <circle cx="318" cy="162" r="4" />
+    <circle cx="326" cy="175" r="4" />
+    <circle cx="296" cy="190" r="4" />
+    <circle cx="346" cy="190" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M292 58 a28 28 0 1 0 56 0 a28 28 0 1 0 -56 0 M299 58 a21 21 0 1 0 42 0 a21 21 0 1 0 -42 0" fillRule="evenodd" fillOpacity="0.75" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/sampling-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/sampling-distributions.mdx
@@ -16,6 +16,51 @@ about inference traces back to that collapse. So we're going to slow
 down, name all three, and build the third one with our own hands in code
 until it's concrete.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="Three stacked shapes share one yellow truth line: the population's wide hump, one sample's scruffy dots whose own blue mean tick lands slightly off the line, and at the bottom the slim green hump of the means themselves — the sampling distribution that inference actually lives on"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="318" y="16" width="4" height="222" rx="2" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="100" y="80" width="440" height="4" rx="2" />
+    <rect x="100" y="153" width="440" height="4" rx="2" />
+    <rect x="100" y="226" width="440" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 120 80 C 200 80 220 28 320 28 C 420 28 440 80 520 80 Z" fillOpacity="0.3" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="150" cy="148" r="3.5" />
+    <circle cx="180" cy="142" r="3.5" />
+    <circle cx="205" cy="135" r="3.5" />
+    <circle cx="225" cy="144" r="3.5" />
+    <circle cx="248" cy="128" r="3.5" />
+    <circle cx="262" cy="140" r="3.5" />
+    <circle cx="280" cy="122" r="3.5" />
+    <circle cx="300" cy="133" r="3.5" />
+    <circle cx="312" cy="118" r="3.5" />
+    <circle cx="332" cy="126" r="3.5" />
+    <circle cx="348" cy="116" r="3.5" />
+    <circle cx="366" cy="130" r="3.5" />
+    <circle cx="390" cy="138" r="3.5" />
+    <circle cx="412" cy="128" r="3.5" />
+    <circle cx="440" cy="144" r="3.5" />
+    <circle cx="470" cy="148" r="3.5" />
+    <circle cx="295" cy="146" r="3.5" />
+    <circle cx="338" cy="142" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 334 160 L 342 172 L 326 172 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 268 226 C 294 226 300 170 320 170 C 340 170 346 226 372 226 Z" fillOpacity="0.5" />
+  </g>
+</svg>
+
 ## The three distributions you must keep separate
 
 Here are the three. Read them slowly — the differences are the whole
@@ -363,6 +408,32 @@ maximum has a sampling distribution, the standard deviation has one, a
 proportion has one. Whenever you summarize a sample into a number and
 imagine repeating the sampling, you get a sampling distribution for that
 number.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="Three little sampling distributions side by side — a slim blue hump for the mean, a green hump for the median, and a yellow lopsided hump for the maximum leaning against its wall — every statistic you can compute has its own distribution across repeated samples"
+  style={{ display: "block", width: "100%", maxWidth: "620px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="56" y="130" width="160" height="4" rx="2" />
+    <rect x="240" y="130" width="160" height="4" rx="2" />
+    <rect x="424" y="130" width="160" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 96 130 C 116 130 120 64 136 64 C 152 64 156 130 176 130 Z" fillOpacity="0.45" />
+    <circle cx="136" cy="146" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 272 130 C 294 130 298 72 318 72 C 338 72 342 130 364 130 Z" fillOpacity="0.45" />
+    <circle cx="318" cy="146" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 438 130 C 470 130 500 118 522 92 C 534 78 540 66 544 56 L 548 130 Z" fillOpacity="0.5" />
+    <rect x="548" y="44" width="5" height="90" rx="2.5" fillOpacity="0.8" />
+    <circle cx="540" cy="146" r="4.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/shape-and-outliers.mdx
+++ b/content/learn/statistics-for-data-science-python/shape-and-outliers.mdx
@@ -16,6 +16,31 @@ The headline you should carry in: an outlier is a *question*, not a
 verdict. "This point is far from the others" tells you to look, not to
 delete.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="A dune-shaped distribution peaks on the left and drags a long tail to the right, its green median post standing nearer the peak than the yellow mean post the tail has pulled away, while one red point sits far down the tail — skew is named for the tail, and an outlier is a question, not a verdict"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="170" width="540" height="5" rx="2.5" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 70 170 C 90 170 100 60 160 60 C 240 60 280 150 400 162 C 470 168 520 170 560 170 Z" fillOpacity="0.3" />
+    <path d="M 92 170 C 108 170 118 96 162 96 C 222 96 252 158 360 166 C 400 169 420 170 440 170 Z" fillOpacity="0.25" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="186" y="92" width="5" height="78" rx="2.5" />
+    <circle cx="188.5" cy="84" r="5.5" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="244" y="118" width="5" height="52" rx="2.5" />
+    <circle cx="246.5" cy="110" r="5.5" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="548" cy="161" r="10" fillOpacity="0.2" />
+    <circle cx="548" cy="161" r="5.5" />
+  </g>
+</svg>
+
 ## Skewness: which way the tail leans
 
 A distribution is **symmetric** if its left and right halves mirror
@@ -91,6 +116,35 @@ response times split between cache-hit and cache-miss, purchase amounts
 from two customer segments. When you see two peaks, the right move is
 usually to *split the groups*, because no single center or spread
 honestly describes a two-humped distribution.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Two translucent humps, one blue and one green, hide inside a single column of data while the yellow mean post stands in the empty valley between them — a bimodal shape means two groups got mixed together, and one center describes nobody"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="70" y="152" width="500" height="4" rx="2" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 100 152 C 140 152 150 70 200 70 C 250 70 260 152 300 152 Z" fillOpacity="0.35" />
+    <circle cx="170" cy="166" r="3" />
+    <circle cx="186" cy="166" r="3" />
+    <circle cx="202" cy="166" r="3" />
+    <circle cx="218" cy="166" r="3" />
+    <circle cx="234" cy="166" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 290 152 C 335 152 345 62 400 62 C 455 62 465 152 510 152 Z" fillOpacity="0.35" />
+    <circle cx="370" cy="166" r="3" />
+    <circle cx="386" cy="166" r="3" />
+    <circle cx="402" cy="166" r="3" />
+    <circle cx="418" cy="166" r="3" />
+    <circle cx="434" cy="166" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="297" y="86" width="6" height="66" rx="3" />
+    <circle cx="300" cy="78" r="6" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"
@@ -194,6 +248,36 @@ for opposite responses:
    case, a real record-breaking day. These are often the **most
    important rows in the dataset** — deleting them throws away the
    signal you're being paid to find.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="A cluster of ordinary dots on the left and one red point far away on the right, held under a blue magnifying lens with a small question mark — an outlier is simply far away, which earns it an investigation, not a deletion"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="90" cy="120" r="4" />
+    <circle cx="120" cy="95" r="4" />
+    <circle cx="150" cy="130" r="4" />
+    <circle cx="180" cy="105" r="4" />
+    <circle cx="210" cy="125" r="4" />
+    <circle cx="240" cy="100" r="4" />
+    <circle cx="270" cy="118" r="4" />
+    <circle cx="300" cy="108" r="4" />
+    <circle cx="150" cy="80" r="4" />
+    <circle cx="220" cy="142" r="4" />
+    <circle cx="115" cy="142" r="4" />
+    <circle cx="255" cy="135" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="430" cy="80" r="6.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M396 80 a34 34 0 1 0 68 0 a34 34 0 1 0 -68 0 M404 80 a26 26 0 1 0 52 0 a26 26 0 1 0 -52 0" fillRule="evenodd" />
+    <rect x="448" y="98" width="14" height="56" rx="7" transform="rotate(-45 455 105)" />
+  </g>
+  <text x="430" y="66" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fill="currentColor" opacity="0.55">?</text>
+</svg>
 
 <Callout type="danger" title="Misconception: outliers are errors you should delete">
 The single most damaging habit in data cleaning. Auto-deleting outliers

--- a/content/learn/statistics-for-data-science-python/standard-error.mdx
+++ b/content/learn/statistics-for-data-science-python/standard-error.mdx
@@ -17,6 +17,36 @@ question about your *estimate's* reliability. Keeping those two apart is
 the heart of this page, because conflating them is, without exaggeration,
 the most common quantitative mistake in data science.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Around one shared yellow center line, the raw data dots above scatter wide under a broad blue band, while the sample means below huddle tight inside a slim green band — the standard deviation describes the data, the standard error describes the estimate"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="318" y="26" width="4" height="148" rx="2" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="128" cy="64" r="5" fillOpacity="0.8" />
+    <circle cx="185" cy="58" r="5" fillOpacity="0.8" />
+    <circle cx="236" cy="68" r="5" fillOpacity="0.8" />
+    <circle cx="284" cy="56" r="5" fillOpacity="0.8" />
+    <circle cx="332" cy="66" r="5" fillOpacity="0.8" />
+    <circle cx="382" cy="58" r="5" fillOpacity="0.8" />
+    <circle cx="438" cy="68" r="5" fillOpacity="0.8" />
+    <circle cx="498" cy="60" r="5" fillOpacity="0.8" />
+    <rect x="118" y="82" width="392" height="8" rx="4" fillOpacity="0.25" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="300" cy="128" r="5" fillOpacity="0.85" />
+    <circle cx="313" cy="122" r="5" fillOpacity="0.85" />
+    <circle cx="326" cy="130" r="5" fillOpacity="0.85" />
+    <circle cx="338" cy="124" r="5" fillOpacity="0.85" />
+    <circle cx="320" cy="134" r="5" fillOpacity="0.85" />
+    <rect x="290" y="146" width="60" height="8" rx="4" fillOpacity="0.4" />
+  </g>
+</svg>
+
 ## Standard deviation vs. standard error
 
 These two are constantly confused, often even in published papers and
@@ -187,6 +217,29 @@ the precision, you need **100x** the sample. Precision gets expensive fast.
 
 Let's watch the SE fall as `n` grows and feel the diminishing returns.
 The curve drops steeply at first, then flattens into a long, slow crawl.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Three bars trade width for height: each is four times wider than the one before yet only half as tall — to halve the standard error you must quadruple the sample, so precision gets expensive fast"
+  style={{ display: "block", width: "100%", maxWidth: "620px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="170" width="540" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="60" y="74" width="24" height="96" rx="5" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="122" y="122" width="96" height="48" rx="5" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="256" y="146" width="330" height="24" rx="5" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="72" y="192" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">25</text>
+    <text x="170" y="192" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">100</text>
+    <text x="421" y="192" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">400</text>
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
+++ b/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
@@ -15,6 +15,37 @@ This page is a field guide to the classics. For each one: **what it is**,
 fancy math to understand. All of them have ended real projects, shipped
 real bad features, and made it into real headlines.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="Two dot clusters each climb upward inside their own blue and green trend bands, yet one red band drawn through everything together slopes firmly downward — Simpson's paradox in miniature: the combined trend can contradict every group it contains"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="80" y="196" width="480" height="4" rx="2" fill="currentColor" opacity="0.18" />
+  <rect x="80" y="36" width="4" height="160" rx="2" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 100 56 L 510 152 L 510 164 L 100 68 Z" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 112 92 L 226 54 L 226 46 L 112 84 Z" fillOpacity="0.35" />
+    <circle cx="122" cy="84" r="5.5" />
+    <circle cx="152" cy="76" r="5.5" />
+    <circle cx="182" cy="68" r="5.5" />
+    <circle cx="212" cy="58" r="5.5" />
+    <circle cx="140" cy="94" r="5.5" />
+    <circle cx="172" cy="86" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 372 178 L 486 140 L 486 132 L 372 170 Z" fillOpacity="0.35" />
+    <circle cx="382" cy="170" r="5.5" />
+    <circle cx="412" cy="162" r="5.5" />
+    <circle cx="442" cy="154" r="5.5" />
+    <circle cx="472" cy="144" r="5.5" />
+    <circle cx="400" cy="180" r="5.5" />
+    <circle cx="432" cy="172" r="5.5" />
+  </g>
+</svg>
+
 Even with a correct calculation, the reasoning can still spring one of
 these leaks:
 
@@ -350,6 +381,39 @@ looks like a decline. The same logic explains why "punishing the worst
 performers seems to work" and "rewarding the best seems to backfire":
 both groups were partly lucky/unlucky and drift back regardless.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Dots from a first measurement drift along faint trails toward a second column: the ringed high flyers sink back toward the yellow mean line and the ringed strugglers float up to it, with no intervention anywhere — extreme readings carry luck, and luck does not repeat"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="120" y="106" width="400" height="4" rx="2" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="180" cy="38" r="7" />
+    <path d="M166 38 a14 14 0 1 0 28 0 a14 14 0 1 0 -28 0 M170 38 a10 10 0 1 0 20 0 a10 10 0 1 0 -20 0" fillRule="evenodd" fillOpacity="0.4" />
+    <circle cx="180" cy="84" r="6" fillOpacity="0.6" />
+    <circle cx="180" cy="132" r="6" fillOpacity="0.6" />
+    <circle cx="180" cy="178" r="7" />
+    <path d="M166 178 a14 14 0 1 0 28 0 a14 14 0 1 0 -28 0 M170 178 a10 10 0 1 0 20 0 a10 10 0 1 0 -20 0" fillRule="evenodd" fillOpacity="0.4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="250" cy="48" r="2.5" />
+    <circle cx="320" cy="62" r="2.5" />
+    <circle cx="390" cy="74" r="2.5" />
+    <circle cx="250" cy="170" r="2.5" />
+    <circle cx="320" cy="156" r="2.5" />
+    <circle cx="390" cy="144" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="460" cy="84" r="7" />
+    <circle cx="460" cy="134" r="7" />
+    <circle cx="460" cy="70" r="6" fillOpacity="0.6" />
+    <circle cx="460" cy="148" r="6" fillOpacity="0.6" />
+  </g>
+</svg>
+
 <CodeBlock
   adapter="python"
   files={[
@@ -434,6 +498,41 @@ chance, and zooming in on the worst one *after the fact* (drawing the
 target around it) manufactures a story from noise. The same logic powers
 "this stock-picking strategy would have crushed the market" when the
 strategy was tuned on the very history it's tested against.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Bullet holes scattered at random across a faint barn wall, with bright red and yellow target rings painted afterwards around the one chance cluster — the Texas sharpshooter draws the bullseye after the shooting, and so does an analyst who builds the hypothesis around the pattern"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="24" width="520" height="166" rx="14" fill="currentColor" opacity="0.06" />
+  <g fill="currentColor" opacity="0.45">
+    <circle cx="110" cy="60" r="4.5" />
+    <circle cx="170" cy="140" r="4.5" />
+    <circle cx="240" cy="52" r="4.5" />
+    <circle cx="300" cy="160" r="4.5" />
+    <circle cx="350" cy="86" r="4.5" />
+    <circle cx="520" cy="60" r="4.5" />
+    <circle cx="545" cy="150" r="4.5" />
+    <circle cx="92" cy="168" r="4.5" />
+    <circle cx="262" cy="112" r="4.5" />
+    <circle cx="386" cy="170" r="4.5" />
+    <circle cx="438" cy="96" r="4.5" />
+    <circle cx="450" cy="110" r="4.5" />
+    <circle cx="466" cy="98" r="4.5" />
+    <circle cx="456" cy="84" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M412 97 a40 40 0 1 0 80 0 a40 40 0 1 0 -80 0 M419 97 a33 33 0 1 0 66 0 a33 33 0 1 0 -66 0" fillRule="evenodd" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M430 97 a22 22 0 1 0 44 0 a22 22 0 1 0 -44 0 M436 97 a16 16 0 1 0 32 0 a16 16 0 1 0 -32 0" fillRule="evenodd" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="500" y="148" width="8" height="34" rx="4" transform="rotate(-35 504 165)" fillOpacity="0.9" />
+    <path d="M 488 144 L 500 138 L 506 150 L 494 156 Z" fillOpacity="0.55" />
+  </g>
+</svg>
 
 **How to avoid it.** State the hypothesis and the analysis window
 *before* looking, report *all* the comparisons you ran (not just the

--- a/content/learn/statistics-for-data-science-python/statistical-thinking.mdx
+++ b/content/learn/statistics-for-data-science-python/statistical-thinking.mdx
@@ -20,6 +20,45 @@ useful. The mistake — the expensive, career-defining mistake — is
 using deterministic thinking on a question that needs statistical
 thinking.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A soft green process emits a string of draws that wobble around its yellow true level; the one draw you actually observed is ringed in blue and sits clearly off the line — a number is one noisy output of a process, not the truth itself"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="90" cy="100" r="42" fillOpacity="0.1" />
+    <circle cx="90" cy="100" r="27" fillOpacity="0.18" />
+    <circle cx="90" cy="100" r="11" />
+    <circle cx="90" cy="62" r="3.5" fillOpacity="0.6" />
+    <circle cx="117" cy="73" r="3.5" fillOpacity="0.6" />
+    <circle cx="128" cy="100" r="3.5" fillOpacity="0.6" />
+    <circle cx="117" cy="127" r="3.5" fillOpacity="0.6" />
+    <circle cx="90" cy="138" r="3.5" fillOpacity="0.6" />
+    <circle cx="63" cy="127" r="3.5" fillOpacity="0.6" />
+    <circle cx="52" cy="100" r="3.5" fillOpacity="0.6" />
+    <circle cx="63" cy="73" r="3.5" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="148" y="100" width="432" height="4" rx="2" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor">
+    <circle cx="160" cy="96" r="4" opacity="0.35" />
+    <circle cx="205" cy="114" r="4" opacity="0.35" />
+    <circle cx="250" cy="88" r="4" opacity="0.35" />
+    <circle cx="295" cy="106" r="4" opacity="0.35" />
+    <circle cx="340" cy="118" r="4" opacity="0.35" />
+    <circle cx="430" cy="104" r="4" opacity="0.35" />
+    <circle cx="475" cy="86" r="4" opacity="0.18" />
+    <circle cx="520" cy="112" r="4" opacity="0.18" />
+    <circle cx="565" cy="98" r="4" opacity="0.18" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="385" cy="78" r="14" fillOpacity="0.18" />
+    <circle cx="385" cy="78" r="6.5" />
+  </g>
+</svg>
+
 <Callout type="info" title="What this page is and isn't">
 This is a *mindset* page, not a techniques page. There are no formulas
 to memorize. The goal is to install a handful of reflexes — variation
@@ -109,6 +148,40 @@ patterns that look exactly like real findings** — trends, gaps,
 
 Watch a fake trend appear from data where, by construction, there is no
 trend whatsoever.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Scattered dots jitter evenly around a flat yellow truth line while a red arrow ribbon sweeps upward through one lucky run of them — the rising trend is a story the noise told, not a thing the process did"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="70" y="118" width="500" height="5" rx="2.5" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="90" cy="108" r="3.5" />
+    <circle cx="118" cy="132" r="3.5" />
+    <circle cx="146" cy="114" r="3.5" />
+    <circle cx="174" cy="126" r="3.5" />
+    <circle cx="202" cy="98" r="3.5" />
+    <circle cx="230" cy="134" r="3.5" />
+    <circle cx="258" cy="120" r="3.5" />
+    <circle cx="286" cy="104" r="3.5" />
+    <circle cx="314" cy="128" r="3.5" />
+    <circle cx="342" cy="112" r="3.5" />
+    <circle cx="370" cy="140" r="3.5" />
+    <circle cx="398" cy="96" r="3.5" />
+    <circle cx="426" cy="122" r="3.5" />
+    <circle cx="454" cy="108" r="3.5" />
+    <circle cx="482" cy="130" r="3.5" />
+    <circle cx="510" cy="100" r="3.5" />
+    <circle cx="538" cy="124" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 226 144 L 396 98 L 396 88 L 226 134 Z" fillOpacity="0.45" />
+    <path d="M 398 78 L 420 92 L 398 102 Z" fillOpacity="0.85" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"
@@ -277,6 +350,52 @@ Statistical thinking says: "average handle time is *somewhere around*
 200, and here's the range of values that are consistent with what I
 saw." The second is not vaguer — it's *more honest and more useful*,
 because it carries its own error bars.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A single yellow point estimate caps a bell-shaped pile of translucent blue dots, each dot a value the same process could just as easily have produced — the reported number is one member of a distribution, not the distribution itself"
+  style={{ display: "block", width: "100%", maxWidth: "460px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="210" y="170" width="228" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.5">
+    <circle cx="244" cy="158" r="6" />
+    <circle cx="264" cy="158" r="6" />
+    <circle cx="264" cy="142" r="6" />
+    <circle cx="284" cy="158" r="6" />
+    <circle cx="284" cy="142" r="6" />
+    <circle cx="284" cy="126" r="6" />
+    <circle cx="284" cy="110" r="6" />
+    <circle cx="304" cy="158" r="6" />
+    <circle cx="304" cy="142" r="6" />
+    <circle cx="304" cy="126" r="6" />
+    <circle cx="304" cy="110" r="6" />
+    <circle cx="304" cy="94" r="6" />
+    <circle cx="304" cy="78" r="6" />
+    <circle cx="324" cy="158" r="6" />
+    <circle cx="324" cy="142" r="6" />
+    <circle cx="324" cy="126" r="6" />
+    <circle cx="324" cy="110" r="6" />
+    <circle cx="324" cy="94" r="6" />
+    <circle cx="324" cy="78" r="6" />
+    <circle cx="344" cy="158" r="6" />
+    <circle cx="344" cy="142" r="6" />
+    <circle cx="344" cy="126" r="6" />
+    <circle cx="344" cy="110" r="6" />
+    <circle cx="344" cy="94" r="6" />
+    <circle cx="344" cy="78" r="6" />
+    <circle cx="364" cy="158" r="6" />
+    <circle cx="364" cy="142" r="6" />
+    <circle cx="364" cy="126" r="6" />
+    <circle cx="364" cy="110" r="6" />
+    <circle cx="384" cy="158" r="6" />
+    <circle cx="384" cy="142" r="6" />
+    <circle cx="404" cy="158" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="324" cy="58" r="7.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/t-tests.mdx
+++ b/content/learn/statistics-for-data-science-python/t-tests.mdx
@@ -22,6 +22,46 @@ This page is about picking the right one, running it with `scipy.stats`,
 and — the part that actually matters — reading the result like a careful
 analyst instead of a p-value vending machine.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Two jittered dot columns with their mean bars at different heights and a yellow bracket measuring the gap, beside a literal fraction of that yellow gap pill over a row of noisy dots — the t statistic is just signal divided by noise"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="140" cy="60" r="5.5" fillOpacity="0.8" />
+    <circle cx="158" cy="76" r="5.5" fillOpacity="0.8" />
+    <circle cx="146" cy="94" r="5.5" fillOpacity="0.8" />
+    <circle cx="162" cy="110" r="5.5" fillOpacity="0.8" />
+    <circle cx="150" cy="128" r="5.5" fillOpacity="0.8" />
+    <rect x="120" y="92" width="64" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="272" cy="96" r="5.5" fillOpacity="0.8" />
+    <circle cx="288" cy="112" r="5.5" fillOpacity="0.8" />
+    <circle cx="276" cy="130" r="5.5" fillOpacity="0.8" />
+    <circle cx="292" cy="148" r="5.5" fillOpacity="0.8" />
+    <circle cx="280" cy="164" r="5.5" fillOpacity="0.8" />
+    <rect x="252" y="128" width="64" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="348" y="94" width="5" height="39" rx="2.5" />
+    <rect x="338" y="90" width="25" height="4" rx="2" />
+    <rect x="338" y="133" width="25" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="470" y="80" width="70" height="10" rx="5" />
+  </g>
+  <rect x="452" y="106" width="106" height="4" rx="2" fill="currentColor" opacity="0.4" />
+  <g fill="currentColor" opacity="0.45">
+    <circle cx="472" cy="126" r="3.5" />
+    <circle cx="489" cy="121" r="3.5" />
+    <circle cx="506" cy="128" r="3.5" />
+    <circle cx="523" cy="122" r="3.5" />
+    <circle cx="540" cy="127" r="3.5" />
+  </g>
+</svg>
+
 ## The t-statistic is signal divided by noise
 
 Every t-test boils your data down to a single number, the **t-statistic**.
@@ -322,6 +362,52 @@ flowchart TD
 A paired t-test is *literally* a one-sample t-test on the column of
 differences, with the target being **zero** ("no change"). Let's prove
 that to ourselves.
+
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="Six people's before dots on the left connect by faint trails to their after dots on the right; the two columns overlap so much their group means almost match, yet every single trail tilts upward — pairing each unit with itself reveals the change that group comparison drowns in noise"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="250" cy="55" r="2" />
+    <circle cx="320" cy="51" r="2" />
+    <circle cx="390" cy="47" r="2" />
+    <circle cx="250" cy="83" r="2" />
+    <circle cx="320" cy="79" r="2" />
+    <circle cx="390" cy="75" r="2" />
+    <circle cx="250" cy="111" r="2" />
+    <circle cx="320" cy="107" r="2" />
+    <circle cx="390" cy="103" r="2" />
+    <circle cx="250" cy="139" r="2" />
+    <circle cx="320" cy="135" r="2" />
+    <circle cx="390" cy="131" r="2" />
+    <circle cx="250" cy="167" r="2" />
+    <circle cx="320" cy="163" r="2" />
+    <circle cx="390" cy="159" r="2" />
+    <circle cx="250" cy="195" r="2" />
+    <circle cx="320" cy="191" r="2" />
+    <circle cx="390" cy="187" r="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="200" cy="58" r="6.5" />
+    <circle cx="200" cy="86" r="6.5" />
+    <circle cx="200" cy="114" r="6.5" />
+    <circle cx="200" cy="142" r="6.5" />
+    <circle cx="200" cy="170" r="6.5" />
+    <circle cx="200" cy="198" r="6.5" />
+    <rect x="168" y="124" width="64" height="4" rx="2" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="440" cy="44" r="6.5" />
+    <circle cx="440" cy="72" r="6.5" />
+    <circle cx="440" cy="100" r="6.5" />
+    <circle cx="440" cy="128" r="6.5" />
+    <circle cx="440" cy="156" r="6.5" />
+    <circle cx="440" cy="184" r="6.5" />
+    <rect x="408" y="110" width="64" height="4" rx="2" fillOpacity="0.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/the-bootstrap.mdx
+++ b/content/learn/statistics-for-data-science-python/the-bootstrap.mdx
@@ -19,6 +19,67 @@ data with replacement**. With a few lines of NumPy you get a standard
 error and a confidence interval for almost any statistic — no calculus,
 no distributional assumptions, no lookup tables.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="One row of sample dots is copied into three resamples below, where touching pairs reveal observations drawn twice while others vanish, and each resample drops a green statistic dot that piles into a small hump — resampling your own data with replacement fakes the sampling distribution you cannot collect"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="150" cy="44" r="7" fillOpacity="0.95" />
+    <circle cx="180" cy="44" r="7" fillOpacity="0.7" />
+    <circle cx="210" cy="44" r="7" fillOpacity="0.5" />
+    <circle cx="240" cy="44" r="7" fillOpacity="0.3" />
+    <circle cx="270" cy="44" r="7" fillOpacity="0.85" />
+    <circle cx="300" cy="44" r="7" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="118" cy="64" r="2.5" />
+    <circle cx="106" cy="90" r="2.5" />
+    <circle cx="102" cy="118" r="2.5" />
+    <circle cx="106" cy="146" r="2.5" />
+    <circle cx="112" cy="170" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="150" cy="120" r="7" fillOpacity="0.95" />
+    <circle cx="166" cy="120" r="7" fillOpacity="0.95" />
+    <circle cx="210" cy="120" r="7" fillOpacity="0.5" />
+    <circle cx="240" cy="120" r="7" fillOpacity="0.3" />
+    <circle cx="290" cy="120" r="7" fillOpacity="0.45" />
+    <circle cx="306" cy="120" r="7" fillOpacity="0.45" />
+    <circle cx="150" cy="152" r="7" fillOpacity="0.7" />
+    <circle cx="196" cy="152" r="7" fillOpacity="0.5" />
+    <circle cx="212" cy="152" r="7" fillOpacity="0.5" />
+    <circle cx="256" cy="152" r="7" fillOpacity="0.85" />
+    <circle cx="272" cy="152" r="7" fillOpacity="0.85" />
+    <circle cx="320" cy="152" r="7" fillOpacity="0.45" />
+    <circle cx="150" cy="184" r="7" fillOpacity="0.95" />
+    <circle cx="180" cy="184" r="7" fillOpacity="0.7" />
+    <circle cx="226" cy="184" r="7" fillOpacity="0.3" />
+    <circle cx="242" cy="184" r="7" fillOpacity="0.3" />
+    <circle cx="286" cy="184" r="7" fillOpacity="0.85" />
+    <circle cx="316" cy="184" r="7" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="352" cy="120" r="2" />
+    <circle cx="368" cy="120" r="2" />
+    <circle cx="384" cy="120" r="2" />
+    <circle cx="352" cy="152" r="2" />
+    <circle cx="368" cy="152" r="2" />
+    <circle cx="384" cy="152" r="2" />
+    <circle cx="352" cy="184" r="2" />
+    <circle cx="368" cy="184" r="2" />
+    <circle cx="384" cy="184" r="2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="408" cy="120" r="5.5" />
+    <circle cx="408" cy="152" r="5.5" />
+    <circle cx="408" cy="184" r="5.5" />
+    <path d="M 470 196 C 494 196 498 144 520 144 C 542 144 546 196 570 196 Z" fillOpacity="0.45" />
+  </g>
+  <rect x="450" y="196" width="140" height="4" rx="2" fill="currentColor" opacity="0.15" />
+</svg>
+
 ## The core idea: your sample stands in for the population
 
 Recall the fundamental problem from *Sampling Distributions*: to know how

--- a/content/learn/statistics-for-data-science-python/the-normal-distribution.mdx
+++ b/content/learn/statistics-for-data-science-python/the-normal-distribution.mdx
@@ -18,6 +18,34 @@ the normal is the wrong model*, because assuming normality on skewed or
 heavy-tailed data is one of the most expensive mistakes in applied
 statistics.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A bell curve built from three nested translucent layers — a wide base, a middle shell, and a tight core around the yellow center post — with tick posts marking one, two, and three standard deviations and a lone red dot stranded beyond the last — the 68, 95, and 99.7 percent zones of the normal"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="180" width="520" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 100 180 C 190 180 205 40 320 40 C 435 40 450 180 540 180 Z" fillOpacity="0.12" />
+    <path d="M 180 180 C 235 180 240 60 320 60 C 400 60 405 180 460 180 Z" fillOpacity="0.18" />
+    <path d="M 245 180 C 280 180 285 86 320 86 C 355 86 360 180 395 180 Z" fillOpacity="0.26" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="243" y="184" width="4" height="12" rx="2" />
+    <rect x="393" y="184" width="4" height="12" rx="2" />
+    <rect x="178" y="184" width="4" height="12" rx="2" />
+    <rect x="458" y="184" width="4" height="12" rx="2" />
+    <rect x="98" y="184" width="4" height="12" rx="2" />
+    <rect x="538" y="184" width="4" height="12" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="317.5" y="48" width="5" height="132" rx="2.5" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="588" cy="176" r="5" />
+  </g>
+</svg>
+
 ## Why the normal shows up everywhere
 
 The normal isn't common by coincidence. It's what you get when many
@@ -242,6 +270,48 @@ print("\\nSame answer: standardizing and using norm.cdf are equivalent.")
   ]}
 />
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A blue test score and a green height each drop from their own differently scaled rulers onto one shared z ruler below, landing at the same tick two standard deviations out — standardizing strips the units so unlike things can be compared on a common scale"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="70" y="46" width="220" height="4" rx="2" />
+    <rect x="350" y="46" width="220" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="252" cy="38" r="7" />
+    <circle cx="256" cy="66" r="2.5" fillOpacity="0.5" />
+    <circle cx="264" cy="90" r="2.5" fillOpacity="0.5" />
+    <circle cx="274" cy="114" r="2.5" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="532" cy="38" r="7" />
+    <circle cx="500" cy="66" r="2.5" fillOpacity="0.5" />
+    <circle cx="436" cy="90" r="2.5" fillOpacity="0.5" />
+    <circle cx="362" cy="114" r="2.5" fillOpacity="0.5" />
+  </g>
+  <rect x="80" y="140" width="480" height="5" rx="2.5" fill="currentColor" opacity="0.3" />
+  <g fill="currentColor" opacity="0.35">
+    <rect x="118" y="148" width="4" height="12" rx="2" />
+    <rect x="184" y="148" width="4" height="12" rx="2" />
+    <rect x="250" y="148" width="4" height="12" rx="2" />
+    <rect x="318" y="148" width="4" height="12" rx="2" />
+    <rect x="384" y="148" width="4" height="12" rx="2" />
+    <rect x="450" y="148" width="4" height="12" rx="2" />
+    <rect x="516" y="148" width="4" height="12" rx="2" />
+  </g>
+  <text x="320" y="182" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.5">0</text>
+  <text x="452" y="182" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.5">+2</text>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="446" cy="132" r="6.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="459" cy="132" r="6.5" />
+  </g>
+</svg>
+
 <Callout type="danger" title="Misconception: a z-score IS a probability">
 A z-score is a **position** (distance in standard deviations), not a
 probability. A z of 2 doesn't mean "2%" or "0.02." To turn a z-score
@@ -429,6 +499,23 @@ produces confidently wrong answers:
 - **Bounded / discrete**: proportions live in [0, 1]; counts are
   non-negative integers. A symmetric, unbounded bell can't honestly
   represent them, especially near the boundaries.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A symmetric blue bell mask laid over red skewed data that does not fit it — the red bulk leans left of the bell's center and a long red tail escapes far beyond the bell's edge — assuming normality hides exactly the tail that hurts you"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="152" width="540" height="4" rx="2" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 90 152 C 110 152 116 56 168 56 C 240 56 264 130 360 144 C 450 154 530 150 584 151 L 584 152 Z" fillOpacity="0.3" />
+    <circle cx="560" cy="146" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 130 152 C 190 152 200 48 270 48 C 340 48 350 152 410 152 Z" fillOpacity="0.25" />
+    <rect x="267" y="56" width="5" height="96" rx="2.5" fillOpacity="0.6" />
+  </g>
+</svg>
 
 Let's *see* the misfit by forcing a normal onto right-skewed income data.
 

--- a/content/learn/statistics-for-data-science-python/types-of-data.mdx
+++ b/content/learn/statistics-for-data-science-python/types-of-data.mdx
@@ -17,6 +17,54 @@ is nonsense, because those numbers are labels, not quantities. This
 page is about telling those apart — by eye and in pandas — so you never
 ship a 1.8-flavored conclusion.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A four-tile mosaic of data types: unordered mixed shapes for nominal labels, circles growing along unevenly spaced steps for ordinal, separate countable dots for discrete with a faint red ghost where no in-between value exists, and a smooth continuous ramp carrying a yellow marker at an arbitrary value"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.06">
+    <rect x="56" y="28" width="256" height="88" rx="14" />
+    <rect x="328" y="28" width="256" height="88" rx="14" />
+    <rect x="56" y="128" width="256" height="88" rx="14" />
+    <rect x="328" y="128" width="256" height="88" rx="14" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="112" cy="72" r="13" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="160" y="59" width="26" height="26" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 225 85 L 239 59 L 253 85 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="362" y="94" width="36" height="7" rx="3.5" />
+    <rect x="408" y="86" width="40" height="7" rx="3.5" />
+    <rect x="488" y="76" width="44" height="7" rx="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="380" cy="86" r="6" />
+    <circle cx="428" cy="76" r="8.5" />
+    <circle cx="510" cy="64" r="11" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="100" cy="180" r="7" />
+    <circle cx="140" cy="180" r="7" />
+    <circle cx="220" cy="180" r="7" />
+    <circle cx="260" cy="180" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="180" cy="180" r="5" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 350 192 C 420 192 470 156 562 150 L 562 160 C 470 166 420 202 350 202 Z" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="470" cy="173" r="6.5" />
+  </g>
+</svg>
+
 <Callout type="info" title="Why this page comes before the statistics">
 Every later technique assumes you've classified your variables
 correctly. *Measures of Center* asks "mean or mode?" — the answer is a
@@ -220,6 +268,43 @@ The averaged zip code (~48,705) isn't a place; it's the centroid of
 four arbitrary labels. The rating mean is *less* wrong but still rests
 on assuming equal spacing. Only `price_usd` — a true ratio quantity —
 earns its mean.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Four blue code tags pinned at scattered spots on a faint map, with dotted trails converging on a red diamond in the middle of nowhere — averaging labels lands you at a point that means nothing"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="70" y="20" width="500" height="150" rx="16" fill="currentColor" opacity="0.05" />
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="110" cy="150" r="3" />
+    <circle cx="250" cy="40" r="3" />
+    <circle cx="540" cy="150" r="3" />
+    <circle cx="380" cy="32" r="3" />
+    <circle cx="96" cy="92" r="3" />
+    <circle cx="548" cy="76" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="112" y="38" width="46" height="24" rx="7" fillOpacity="0.8" />
+    <rect x="446" y="50" width="46" height="24" rx="7" fillOpacity="0.8" />
+    <rect x="148" y="118" width="46" height="24" rx="7" fillOpacity="0.8" />
+    <rect x="452" y="124" width="46" height="24" rx="7" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="190" cy="65" r="2.5" />
+    <circle cx="244" cy="78" r="2.5" />
+    <circle cx="416" cy="74" r="2.5" />
+    <circle cx="368" cy="84" r="2.5" />
+    <circle cx="224" cy="115" r="2.5" />
+    <circle cx="264" cy="105" r="2.5" />
+    <circle cx="412" cy="116" r="2.5" />
+    <circle cx="370" cy="106" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="316" cy="95" r="20" fillOpacity="0.15" />
+    <path d="M 316 81 L 329 95 L 316 109 L 303 95 Z" />
+  </g>
+</svg>
 
 <Callout type="danger" title="The numeric-looking ID trap">
 If a column's numbers are **identifiers or codes** — `user_id`,

--- a/content/learn/statistics-for-data-science-python/visualizing-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/visualizing-distributions.mdx
@@ -17,6 +17,38 @@ each answers a different question, and knowing which to reach for is a
 real skill. We'll use Plotly Express and the built-in `tips` dataset so
 every chart runs as-is.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Three distributions — a tidy bell, two separated humps, and a flat slab — each sit above the exact same yellow mean dot and green spread pill, joined by equals signs — identical summaries, completely different shapes, so plot before you summarize"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="60" y="128" width="160" height="4" rx="2" />
+    <rect x="240" y="128" width="160" height="4" rx="2" />
+    <rect x="420" y="128" width="160" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.35">
+    <path d="M 70 130 C 100 130 105 58 140 58 C 175 58 180 130 210 130 Z" />
+    <path d="M 250 130 C 268 130 270 78 290 78 C 310 78 308 118 320 118 C 332 118 330 78 350 78 C 370 78 372 130 390 130 Z" />
+    <rect x="430" y="88" width="140" height="42" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="140" cy="154" r="5" />
+    <circle cx="320" cy="154" r="5" />
+    <circle cx="500" cy="154" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fillOpacity="0.45">
+    <rect x="110" y="166" width="60" height="7" rx="3.5" />
+    <rect x="290" y="166" width="60" height="7" rx="3.5" />
+    <rect x="470" y="166" width="60" height="7" rx="3.5" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <text x="230" y="166" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20">=</text>
+    <text x="410" y="166" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20">=</text>
+  </g>
+</svg>
+
 ## Why summaries lie: always plot first
 
 The classic demonstration is **Anscombe's quartet** — four datasets
@@ -77,6 +109,50 @@ the **bin count** — and *the same data can tell different stories at
 different bin counts*. Too few bins hides structure (two peaks blur into
 one); too many bins turns signal into noise (every bin has one or two
 points). There is no single "objective" bin count.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="The same data binned three ways: two fat bars that blur the shape away, a six-bar version where the hump appears with a green dot of approval above it, and a forest of skinny one-count spikes — the bin knob decides which story a histogram tells"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="56" y="140" width="160" height="4" rx="2" />
+    <rect x="240" y="140" width="160" height="4" rx="2" />
+    <rect x="424" y="140" width="160" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.45">
+    <rect x="64" y="66" width="70" height="74" rx="6" />
+    <rect x="140" y="96" width="70" height="44" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.6">
+    <rect x="248" y="124" width="20" height="16" rx="3" />
+    <rect x="272" y="102" width="20" height="38" rx="3" />
+    <rect x="296" y="78" width="20" height="62" rx="3" />
+    <rect x="320" y="88" width="20" height="52" rx="3" />
+    <rect x="344" y="112" width="20" height="28" rx="3" />
+    <rect x="368" y="128" width="20" height="12" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.5">
+    <rect x="430" y="118" width="6" height="22" rx="2" />
+    <rect x="440" y="92" width="6" height="48" rx="2" />
+    <rect x="450" y="126" width="6" height="14" rx="2" />
+    <rect x="460" y="74" width="6" height="66" rx="2" />
+    <rect x="470" y="110" width="6" height="30" rx="2" />
+    <rect x="480" y="84" width="6" height="56" rx="2" />
+    <rect x="490" y="120" width="6" height="20" rx="2" />
+    <rect x="500" y="98" width="6" height="42" rx="2" />
+    <rect x="510" y="130" width="6" height="10" rx="2" />
+    <rect x="520" y="88" width="6" height="52" rx="2" />
+    <rect x="530" y="116" width="6" height="24" rx="2" />
+    <rect x="540" y="102" width="6" height="38" rx="2" />
+    <rect x="550" y="126" width="6" height="14" rx="2" />
+    <rect x="560" y="108" width="6" height="32" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="320" cy="52" r="7" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/statistics-for-data-science-python/why-statistics-matters.mdx
+++ b/content/learn/statistics-for-data-science-python/why-statistics-matters.mdx
@@ -16,6 +16,59 @@ differently?" "Is churn going up, or did we just have a noisy month?"
 For those, the data in front of you is a *clue*, not the answer. This
 short page is about why.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A small bright window frames a handful of solid blue dots inside a vast faint field of dots; a red dot waits just outside the frame and the ringed yellow point you actually care about sits far away — your dataset is one lit slice of a much larger world"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="40" y="24" width="560" height="172" rx="16" fill="currentColor" opacity="0.06" />
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="70" cy="50" r="3" />
+    <circle cx="90" cy="110" r="3" />
+    <circle cx="70" cy="170" r="3" />
+    <circle cx="270" cy="50" r="3" />
+    <circle cx="300" cy="95" r="3" />
+    <circle cx="282" cy="152" r="3" />
+    <circle cx="330" cy="180" r="3" />
+    <circle cx="360" cy="62" r="3" />
+    <circle cx="390" cy="122" r="3" />
+    <circle cx="420" cy="172" r="3" />
+    <circle cx="450" cy="45" r="3" />
+    <circle cx="472" cy="148" r="3" />
+    <circle cx="530" cy="62" r="3" />
+    <circle cx="556" cy="124" r="3" />
+    <circle cx="574" cy="176" r="3" />
+    <circle cx="170" cy="42" r="3" />
+    <circle cx="220" cy="44" r="3" />
+    <circle cx="132" cy="182" r="3" />
+    <circle cx="196" cy="184" r="3" />
+    <circle cx="496" cy="92" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="108" y="66" width="134" height="98" rx="10" fillOpacity="0.12" />
+    <rect x="108" y="66" width="134" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="108" y="159" width="134" height="5" rx="2.5" fillOpacity="0.8" />
+    <rect x="108" y="66" width="5" height="98" rx="2.5" fillOpacity="0.8" />
+    <rect x="237" y="66" width="5" height="98" rx="2.5" fillOpacity="0.8" />
+    <circle cx="130" cy="95" r="4" />
+    <circle cx="155" cy="85" r="4" />
+    <circle cx="180" cy="105" r="4" />
+    <circle cx="205" cy="90" r="4" />
+    <circle cx="140" cy="130" r="4" />
+    <circle cx="170" cy="140" r="4" />
+    <circle cx="200" cy="125" r="4" />
+    <circle cx="220" cy="147" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="258" cy="112" r="4" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="520" cy="108" r="14" fillOpacity="0.18" />
+    <circle cx="520" cy="108" r="7" />
+  </g>
+</svg>
+
 ## Why data alone is often not enough
 
 Raw data answers questions about *itself*. Statistics answers
@@ -125,6 +178,45 @@ variation manufactures fake differences for free.** Your job is to
 tell those apart from real ones — and that requires a model of how big
 "normal" random wiggles can get. That model is what probability and
 sampling distributions give you.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Five repeated experiments drawn from one identical process: paired blue and green dots wobble around the same center line, their yellow gaps flipping direction at random, and one run's red gap looks big enough to be a discovery — random variation manufactures differences for free"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="318" y="24" width="4" height="164" rx="2" fill="currentColor" opacity="0.25" />
+  <g fill="currentColor" opacity="0.1">
+    <rect x="170" y="38" width="300" height="4" rx="2" />
+    <rect x="170" y="70" width="300" height="4" rx="2" />
+    <rect x="170" y="102" width="300" height="4" rx="2" />
+    <rect x="170" y="134" width="300" height="4" rx="2" />
+    <rect x="170" y="166" width="300" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor" fillOpacity="0.55">
+    <rect x="306" y="38.5" width="24" height="3" rx="1.5" />
+    <rect x="314" y="70.5" width="26" height="3" rx="1.5" />
+    <rect x="320" y="102.5" width="6" height="3" rx="1.5" />
+    <rect x="324" y="166.5" width="8" height="3" rx="1.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="282" y="134.5" width="84" height="3" rx="1.5" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="300" cy="40" r="5.5" />
+    <circle cx="346" cy="72" r="5.5" />
+    <circle cx="326" cy="104" r="5.5" />
+    <circle cx="276" cy="136" r="5.5" />
+    <circle cx="338" cy="168" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="336" cy="40" r="5.5" />
+    <circle cx="308" cy="72" r="5.5" />
+    <circle cx="314" cy="104" r="5.5" />
+    <circle cx="372" cy="136" r="5.5" />
+    <circle cx="318" cy="168" r="5.5" />
+  </g>
+</svg>
 
 <Callout type="warn" title="The most common mistake in data work">
 Treating any difference as meaningful just because it's nonzero. With

--- a/content/learn/statistics-for-data-science-python/working-with-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/working-with-distributions.mdx
@@ -18,6 +18,53 @@ thresholds, simulations). The catch — and the part people skip — is the
 sanity check in between. A model that doesn't fit gives precise,
 authoritative, *wrong* answers.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A frozen distribution sits inside a translucent ice cube at the center while four small tool tiles orbit it on dotted spokes — a density hump, a rising accumulation ribbon, a yellow quantile cut post, and a spray of random draws — every scipy distribution answers the same four questions"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="265" y="80" width="110" height="86" rx="16" fillOpacity="0.15" />
+    <circle cx="282" cy="96" r="3" fillOpacity="0.5" />
+    <path d="M 280 152 C 300 152 302 104 320 104 C 338 104 340 152 360 152 Z" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor" opacity="0.07">
+    <rect x="80" y="28" width="96" height="64" rx="12" />
+    <rect x="464" y="28" width="96" height="64" rx="12" />
+    <rect x="80" y="148" width="96" height="64" rx="12" />
+    <rect x="464" y="148" width="96" height="64" rx="12" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="222" cy="98" r="2.5" />
+    <circle cx="200" cy="84" r="2.5" />
+    <circle cx="418" cy="98" r="2.5" />
+    <circle cx="440" cy="84" r="2.5" />
+    <circle cx="222" cy="150" r="2.5" />
+    <circle cx="200" cy="164" r="2.5" />
+    <circle cx="418" cy="150" r="2.5" />
+    <circle cx="440" cy="164" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 96 80 C 110 80 112 44 128 44 C 144 44 146 80 160 80 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 478 84 C 500 84 506 46 546 42 L 546 50 C 510 54 506 91 478 91 Z" fillOpacity="0.65" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="92" y="196" width="72" height="3.5" rx="1.75" fillOpacity="0.35" />
+    <rect x="136" y="166" width="4.5" height="32" rx="2.25" />
+    <circle cx="138" cy="160" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="488" cy="176" r="4" />
+    <circle cx="508" cy="192" r="4" />
+    <circle cx="528" cy="170" r="4" />
+    <circle cx="544" cy="188" r="4" />
+    <circle cx="498" cy="200" r="4" />
+  </g>
+</svg>
+
 ```mermaid
 flowchart LR
   A["Real data"] --> B["Fit a distribution<br/>(.fit -> parameters)"]
@@ -446,6 +493,43 @@ The tails of a fitted distribution are an *extrapolation* — they're
 governed by the assumed shape, not by observations you actually made. If
 your data tops out around 120, asking the fitted normal for P(X > 300) is
 answering a question the data never spoke to.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="A green fitted band runs solidly through the region where data dots actually live, then dissolves into fading ghost dots beyond the last observation, where a red diamond waits — past the data's edge a model is pure assumption, not evidence"
+  style={{ display: "block", width: "100%", maxWidth: "620px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="140" width="520" height="4" rx="2" fill="currentColor" opacity="0.15" />
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="100" cy="112" r="4" />
+    <circle cx="130" cy="96" r="4" />
+    <circle cx="160" cy="104" r="4" />
+    <circle cx="190" cy="84" r="4" />
+    <circle cx="220" cy="92" r="4" />
+    <circle cx="250" cy="74" r="4" />
+    <circle cx="280" cy="82" r="4" />
+    <circle cx="310" cy="66" r="4" />
+    <circle cx="336" cy="74" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 88 122 C 170 108 260 84 352 66 L 352 78 C 262 96 172 118 88 132 Z" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="378" cy="62" r="3.5" fillOpacity="0.45" />
+    <circle cx="404" cy="57" r="3.5" fillOpacity="0.35" />
+    <circle cx="430" cy="52" r="3.5" fillOpacity="0.26" />
+    <circle cx="456" cy="48" r="3.5" fillOpacity="0.18" />
+    <circle cx="482" cy="44" r="3.5" fillOpacity="0.12" />
+    <circle cx="508" cy="40" r="3.5" fillOpacity="0.07" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="354" y="100" width="4" height="52" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 552 36 L 564 48 L 552 60 L 540 48 Z" fillOpacity="0.85" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/systems-programming-c/arrays-and-pointers.mdx
+++ b/content/learn/systems-programming-c/arrays-and-pointers.mdx
@@ -7,6 +7,66 @@ C arrays are the most direct expression of "contiguous bytes in
 memory with a name." They are also surprisingly subtle: an array is
 not quite a pointer, but it *becomes* one almost any time you use it.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A six-car array train with a yellow length badge rolls under a function arch and emerges as ghost cars led by a single blue pointer flag — the badge drops off at the gate, because arrays decay to a bare pointer when passed in"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="40" y="158" width="560" height="5" rx="2.5" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="56" y="118" width="34" height="34" rx="5" fillOpacity="0.3" />
+    <rect x="94" y="118" width="34" height="34" rx="5" fillOpacity="0.3" />
+    <rect x="132" y="118" width="34" height="34" rx="5" fillOpacity="0.3" />
+    <rect x="170" y="118" width="34" height="34" rx="5" fillOpacity="0.3" />
+    <rect x="208" y="118" width="34" height="34" rx="5" fillOpacity="0.3" />
+    <rect x="246" y="118" width="34" height="34" rx="5" fillOpacity="0.3" />
+    <rect x="90" y="132" width="4" height="6" fillOpacity="0.5" />
+    <rect x="128" y="132" width="4" height="6" fillOpacity="0.5" />
+    <rect x="166" y="132" width="4" height="6" fillOpacity="0.5" />
+    <rect x="204" y="132" width="4" height="6" fillOpacity="0.5" />
+    <rect x="242" y="132" width="4" height="6" fillOpacity="0.5" />
+    <circle cx="73" cy="135" r="4" />
+    <circle cx="111" cy="135" r="4" />
+    <circle cx="149" cy="135" r="4" />
+    <circle cx="187" cy="135" r="4" />
+    <circle cx="225" cy="135" r="4" />
+    <circle cx="263" cy="135" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="73" cy="96" r="13" />
+    <circle cx="388" cy="140" r="10" fillOpacity="0.85" />
+  </g>
+  <text x="73" y="101" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14" fontWeight="700" fill="currentColor" opacity="0.75">6</text>
+  <g fill="currentColor" opacity="0.22">
+    <rect x="330" y="58" width="14" height="100" rx="4" />
+    <rect x="396" y="58" width="14" height="100" rx="4" />
+    <rect x="322" y="44" width="96" height="16" rx="8" />
+  </g>
+  <text x="370" y="58" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="15" fill="currentColor" opacity="0.55">ƒ</text>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="385" y="112" width="4" height="8" rx="2" />
+    <rect x="392" y="122" width="4" height="8" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="452" y="118" width="34" height="34" rx="5" />
+    <rect x="490" y="118" width="34" height="34" rx="5" />
+    <rect x="528" y="118" width="34" height="34" rx="5" />
+    <rect x="566" y="118" width="34" height="34" rx="5" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="469" cy="135" r="4" />
+    <circle cx="507" cy="135" r="4" />
+    <circle cx="545" cy="135" r="4" />
+    <circle cx="583" cy="135" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="467" y="74" width="4" height="38" rx="2" fillOpacity="0.7" />
+    <path d="M471 74 L497 82 L471 90 Z" />
+    <circle cx="469" cy="112" r="7" />
+  </g>
+</svg>
+
 ## A C array is contiguous memory
 
 `int nums[5] = {10, 20, 30, 40, 50};` reserves enough room for five
@@ -242,12 +302,117 @@ Row-major layout means `grid[r][c]` lives at offset
 (outer loop over rows, inner loop over columns) walks memory linearly
 and is cache-friendly.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A green thread visits a three-by-four grid row by row, and the same order lays the tiles out as one flat twelve-cell strip below — the yellow cell at row one, column two lands at flat offset six, row-major order"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.16">
+    <rect x="124" y="30" width="56" height="36" rx="7" />
+    <rect x="188" y="30" width="56" height="36" rx="7" />
+    <rect x="252" y="30" width="56" height="36" rx="7" />
+    <rect x="316" y="30" width="56" height="36" rx="7" />
+    <rect x="124" y="74" width="56" height="36" rx="7" />
+    <rect x="188" y="74" width="56" height="36" rx="7" />
+    <rect x="316" y="74" width="56" height="36" rx="7" />
+    <rect x="124" y="118" width="56" height="36" rx="7" />
+    <rect x="188" y="118" width="56" height="36" rx="7" />
+    <rect x="252" y="118" width="56" height="36" rx="7" />
+    <rect x="316" y="118" width="56" height="36" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="252" y="74" width="56" height="36" rx="7" fillOpacity="0.85" />
+    <rect x="328" y="186" width="30" height="22" rx="4" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="152" cy="48" r="3" fillOpacity="0.3" />
+    <circle cx="216" cy="48" r="3" fillOpacity="0.36" />
+    <circle cx="280" cy="48" r="3" fillOpacity="0.42" />
+    <circle cx="344" cy="48" r="3" fillOpacity="0.48" />
+    <circle cx="152" cy="92" r="3" fillOpacity="0.54" />
+    <circle cx="216" cy="92" r="3" fillOpacity="0.6" />
+    <circle cx="280" cy="92" r="4" />
+    <circle cx="344" cy="92" r="3" fillOpacity="0.72" />
+    <circle cx="152" cy="136" r="3" fillOpacity="0.78" />
+    <circle cx="216" cy="136" r="3" fillOpacity="0.84" />
+    <circle cx="280" cy="136" r="3" fillOpacity="0.9" />
+    <circle cx="344" cy="136" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="300" cy="118" r="2.5" />
+    <circle cx="318" cy="144" r="2.5" />
+    <circle cx="336" cy="170" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.16">
+    <rect x="124" y="186" width="30" height="22" rx="4" />
+    <rect x="158" y="186" width="30" height="22" rx="4" />
+    <rect x="192" y="186" width="30" height="22" rx="4" />
+    <rect x="226" y="186" width="30" height="22" rx="4" />
+    <rect x="260" y="186" width="30" height="22" rx="4" />
+    <rect x="294" y="186" width="30" height="22" rx="4" />
+    <rect x="362" y="186" width="30" height="22" rx="4" />
+    <rect x="396" y="186" width="30" height="22" rx="4" />
+    <rect x="430" y="186" width="30" height="22" rx="4" />
+    <rect x="464" y="186" width="30" height="22" rx="4" />
+    <rect x="498" y="186" width="30" height="22" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="139" cy="197" r="2.5" fillOpacity="0.3" />
+    <circle cx="173" cy="197" r="2.5" fillOpacity="0.36" />
+    <circle cx="207" cy="197" r="2.5" fillOpacity="0.42" />
+    <circle cx="241" cy="197" r="2.5" fillOpacity="0.48" />
+    <circle cx="275" cy="197" r="2.5" fillOpacity="0.54" />
+    <circle cx="309" cy="197" r="2.5" fillOpacity="0.6" />
+    <circle cx="343" cy="197" r="3.5" />
+    <circle cx="377" cy="197" r="2.5" fillOpacity="0.72" />
+    <circle cx="411" cy="197" r="2.5" fillOpacity="0.78" />
+    <circle cx="445" cy="197" r="2.5" fillOpacity="0.84" />
+    <circle cx="479" cy="197" r="2.5" fillOpacity="0.9" />
+    <circle cx="513" cy="197" r="2.5" />
+  </g>
+</svg>
+
 ## Bounds checking — there isn't any
 
 C arrays do not check bounds. Writing `a[100]` for a 10-element array
 will quietly stomp on whatever memory follows the array — a heap
 metadata structure, another variable, the return address on the
 stack. That is *the* C bug.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A red stamp comes down one slot past the array's last cell and its fence post, splattering over the green value that happened to live in the neighbouring memory — an out-of-bounds write"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.28">
+    <rect x="96" y="104" width="44" height="44" rx="6" />
+    <rect x="144" y="104" width="44" height="44" rx="6" />
+    <rect x="192" y="104" width="44" height="44" rx="6" />
+    <rect x="240" y="104" width="44" height="44" rx="6" />
+  </g>
+  <rect x="292" y="92" width="6" height="62" rx="3" fill="currentColor" opacity="0.45" />
+  <rect x="304" y="96" width="240" height="58" rx="10" fill="currentColor" opacity="0.07" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="336" cy="126" r="10" />
+    <circle cx="452" cy="126" r="8" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="330" y="18" width="12" height="52" rx="4" fillOpacity="0.8" />
+    <rect x="314" y="66" width="44" height="16" rx="5" />
+    <circle cx="336" cy="120" r="15" fillOpacity="0.55" />
+    <circle cx="336" cy="120" r="7" />
+    <path d="M310 108 L320 100 L322 112 Z" fillOpacity="0.6" />
+    <path d="M352 134 L364 130 L358 142 Z" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="118" cy="160" r="2" />
+    <circle cx="166" cy="160" r="2" />
+    <circle cx="214" cy="160" r="2" />
+    <circle cx="262" cy="160" r="2" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="c"

--- a/content/learn/systems-programming-c/c-toolchain.mdx
+++ b/content/learn/systems-programming-c/c-toolchain.mdx
@@ -28,6 +28,91 @@ flowchart TD
 In one `clang hello.c -o hello` command, the driver actually runs all
 four stages in sequence — but you can stop after any one of them.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A part rides a dotted conveyor through four inspection gates — preprocess, compile, assemble, link — morphing from a source sheet into pasted sheets, a jagged assembly shard, a grid of object-code dots with one unresolved hole, and finally one solid green runnable block as library dots drop in at the last gate"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="56" cy="160" r="2.5" />
+    <circle cx="84" cy="160" r="2.5" />
+    <circle cx="112" cy="160" r="2.5" />
+    <circle cx="140" cy="160" r="2.5" />
+    <circle cx="168" cy="160" r="2.5" />
+    <circle cx="196" cy="160" r="2.5" />
+    <circle cx="224" cy="160" r="2.5" />
+    <circle cx="252" cy="160" r="2.5" />
+    <circle cx="280" cy="160" r="2.5" />
+    <circle cx="308" cy="160" r="2.5" />
+    <circle cx="336" cy="160" r="2.5" />
+    <circle cx="364" cy="160" r="2.5" />
+    <circle cx="392" cy="160" r="2.5" />
+    <circle cx="420" cy="160" r="2.5" />
+    <circle cx="448" cy="160" r="2.5" />
+    <circle cx="476" cy="160" r="2.5" />
+    <circle cx="504" cy="160" r="2.5" />
+    <circle cx="532" cy="160" r="2.5" />
+    <circle cx="560" cy="160" r="2.5" />
+    <circle cx="588" cy="160" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="112" y="70" width="10" height="86" rx="3" />
+    <rect x="178" y="70" width="10" height="86" rx="3" />
+    <rect x="106" y="56" width="88" height="14" rx="7" />
+    <rect x="232" y="70" width="10" height="86" rx="3" />
+    <rect x="298" y="70" width="10" height="86" rx="3" />
+    <rect x="226" y="56" width="88" height="14" rx="7" />
+    <rect x="352" y="70" width="10" height="86" rx="3" />
+    <rect x="418" y="70" width="10" height="86" rx="3" />
+    <rect x="346" y="56" width="88" height="14" rx="7" />
+    <rect x="472" y="70" width="10" height="86" rx="3" />
+    <rect x="538" y="70" width="10" height="86" rx="3" />
+    <rect x="466" y="56" width="88" height="14" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="150" cy="63" r="5" />
+    <rect x="58" y="118" width="24" height="30" rx="3" fillOpacity="0.3" />
+    <rect x="62" y="126" width="14" height="3" rx="1.5" fillOpacity="0.55" />
+    <rect x="62" y="133" width="16" height="3" rx="1.5" fillOpacity="0.55" />
+    <rect x="62" y="140" width="10" height="3" rx="1.5" fillOpacity="0.55" />
+    <rect x="198" y="114" width="24" height="32" rx="3" fillOpacity="0.18" />
+    <rect x="206" y="118" width="24" height="30" rx="3" fillOpacity="0.38" />
+    <rect x="211" y="126" width="14" height="3" rx="1.5" fillOpacity="0.6" />
+    <rect x="211" y="133" width="13" height="3" rx="1.5" fillOpacity="0.6" />
+    <path d="M318 148 L326 116 L334 132 L342 112 L350 134 L344 148 Z" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="270" cy="63" r="5" />
+    <rect x="438" y="116" width="8" height="8" rx="2" fillOpacity="0.8" />
+    <rect x="450" y="116" width="8" height="8" rx="2" fillOpacity="0.5" />
+    <rect x="462" y="116" width="8" height="8" rx="2" fillOpacity="0.8" />
+    <rect x="438" y="128" width="8" height="8" rx="2" fillOpacity="0.5" />
+    <rect x="450" y="128" width="8" height="8" rx="2" fillOpacity="0.8" />
+    <rect x="462" y="128" width="8" height="8" rx="2" fillOpacity="0.5" />
+    <rect x="438" y="140" width="8" height="8" rx="2" fillOpacity="0.8" />
+    <rect x="450" y="140" width="8" height="8" rx="2" fillOpacity="0.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="462" y="140" width="8" height="8" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="390" cy="63" r="5" />
+    <circle cx="600" cy="100" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="510" cy="63" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="492" y="14" width="44" height="16" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="512" cy="40" r="3.5" />
+    <circle cx="510" cy="50" r="3.5" fillOpacity="0.7" />
+    <rect x="562" y="112" width="34" height="34" rx="9" />
+  </g>
+</svg>
+
 | Stage | Input | Output | Tool flag (clang/gcc) |
 | --- | --- | --- | --- |
 | Preprocess | `.c` | `.i` | `-E` |
@@ -144,6 +229,33 @@ undefined reference to `greet`
 `main.c`, but never compiled or passed `greet.c` (or its `.o`) to the
 linker.
 
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Three blue object pieces interlock into a binary with one empty outlined slot marked by a question mark — an undefined reference — while the matching green piece slides in along a dotted arc"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="150" y="46" width="110" height="52" rx="10" fillOpacity="0.35" />
+    <rect x="262" y="46" width="90" height="52" rx="10" fillOpacity="0.2" />
+    <rect x="150" y="100" width="90" height="52" rx="10" fillOpacity="0.25" />
+    <circle cx="260" cy="72" r="7" fillOpacity="0.55" />
+    <circle cx="205" cy="100" r="7" fillOpacity="0.55" />
+  </g>
+  <path d="M242 100 h110 v52 h-110 Z M248 106 h98 v40 h-98 Z" fillRule="evenodd" fill="currentColor" opacity="0.18" />
+  <text x="297" y="134" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="22" fill="currentColor" opacity="0.4">?</text>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="470" cy="116" r="2.5" />
+    <circle cx="440" cy="128" r="2.5" />
+    <circle cx="408" cy="134" r="2.5" />
+    <circle cx="376" cy="134" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="436" y="58" width="104" height="48" rx="10" />
+    <circle cx="436" cy="82" r="8" />
+  </g>
+</svg>
+
 <Callout type="info" title="The declaration / definition split">
 A **declaration** says "such a function exists somewhere" — that's
 what headers do. A **definition** is the actual body — that's what
@@ -213,6 +325,41 @@ Two flavors of library exist on most systems:
   the binary just records "I depend on `libfoo`"; the OS loads it at
   runtime and resolves the symbols. Smaller binaries; multiple
   programs share one copy in memory; but you must ship the library.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Static linking on the left copies the green library inside one big binary; dynamic linking on the right keeps a single green library outside, tethered by dotted lines to two slim binaries that share it"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="318" y="30" width="4" height="130" rx="2" fill="currentColor" opacity="0.12" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="70" y="46" width="200" height="104" rx="14" fillOpacity="0.18" />
+    <rect x="88" y="66" width="76" height="64" rx="8" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="176" y="66" width="76" height="64" rx="8" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="360" y="38" width="110" height="56" rx="10" fillOpacity="0.18" />
+    <rect x="372" y="48" width="56" height="36" rx="6" fillOpacity="0.5" />
+  </g>
+  <g fill="currentColor">
+    <rect x="360" y="118" width="110" height="56" rx="10" opacity="0.12" />
+    <rect x="372" y="128" width="56" height="36" rx="6" opacity="0.3" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="482" cy="70" r="2.5" />
+    <circle cx="496" cy="76" r="2.5" />
+    <circle cx="510" cy="82" r="2.5" />
+    <circle cx="482" cy="142" r="2.5" />
+    <circle cx="496" cy="134" r="2.5" />
+    <circle cx="510" cy="124" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="524" y="78" width="72" height="46" rx="10" fillOpacity="0.7" />
+  </g>
+</svg>
 
 `printf` lives in libc, which is dynamic on virtually every desktop
 system. That is why a "hello world" binary is so small.

--- a/content/learn/systems-programming-c/data-types-and-memory.mdx
+++ b/content/learn/systems-programming-c/data-types-and-memory.mdx
@@ -9,6 +9,51 @@ fixed number of bytes. That fixed size is both C's greatest strength
 of overflow bugs. This page builds the mental model you need to
 reason about *what is actually in memory*.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A circular gauge whose blue dots sweep clockwise toward a red boundary bar at twelve o'clock — one step past the maximum and the needle wraps to the green minimum just beyond it, because fixed-size integers roll over instead of growing"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <path d="M240 120 A80 80 0 1 1 400 120 A80 80 0 1 1 240 120 Z M258 120 A62 62 0 1 1 382 120 A62 62 0 1 1 258 120 Z" fillRule="evenodd" fill="currentColor" opacity="0.13" />
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="391" cy="120" r="2.5" />
+    <circle cx="381" cy="155" r="2.5" />
+    <circle cx="355" cy="181" r="2.5" />
+    <circle cx="320" cy="191" r="2.5" />
+    <circle cx="285" cy="181" r="2.5" />
+    <circle cx="259" cy="155" r="2.5" />
+    <circle cx="249" cy="120" r="2.5" />
+    <circle cx="259" cy="85" r="2.5" />
+    <circle cx="285" cy="59" r="2.5" />
+    <circle cx="355" cy="59" r="2.5" />
+    <circle cx="381" cy="85" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="320" cy="191" r="4.5" fillOpacity="0.25" />
+    <circle cx="290" cy="184" r="4.5" fillOpacity="0.35" />
+    <circle cx="266" cy="166" r="4.5" fillOpacity="0.45" />
+    <circle cx="251" cy="138" r="4.5" fillOpacity="0.55" />
+    <circle cx="250" cy="108" r="4.5" fillOpacity="0.65" />
+    <circle cx="262" cy="79" r="4.5" fillOpacity="0.78" />
+    <circle cx="285" cy="59" r="4.5" fillOpacity="0.9" />
+    <circle cx="302" cy="51" r="4.5" />
+    <path d="M320 120 L301 53 L312 49 Z" />
+    <circle cx="320" cy="120" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="316" y="32" width="9" height="52" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="322" cy="22" r="2" />
+    <circle cx="332" cy="20" r="2" />
+    <circle cx="342" cy="23" r="2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="338" cy="51" r="5.5" />
+  </g>
+</svg>
+
 ## The fundamental types
 
 | Type | Typical size | Range (signed) |
@@ -183,6 +228,59 @@ Little-endian:   0x78     0x56     0x34     0x12     (x86, WASI)
 Big-endian:      0x12     0x34     0x56     0x78
 ```
 
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="The same four byte dominoes mirrored across a line: read left to right, big-endian leads with the four-pip heavy byte while little-endian leads with the yellow-underlined one-pip byte — opposite orders, identical value"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fillOpacity="0.8">
+    <path d="M116 50 L132 58 L116 66 Z" />
+    <path d="M116 124 L132 132 L116 140 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="150" y="36" width="54" height="44" rx="8" />
+    <rect x="236" y="36" width="54" height="44" rx="8" />
+    <rect x="322" y="36" width="54" height="44" rx="8" />
+    <rect x="408" y="36" width="54" height="44" rx="8" />
+    <rect x="150" y="110" width="54" height="44" rx="8" />
+    <rect x="236" y="110" width="54" height="44" rx="8" />
+    <rect x="322" y="110" width="54" height="44" rx="8" />
+    <rect x="408" y="110" width="54" height="44" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="167" cy="49" r="3.5" />
+    <circle cx="187" cy="49" r="3.5" />
+    <circle cx="167" cy="67" r="3.5" />
+    <circle cx="187" cy="67" r="3.5" />
+    <circle cx="253" cy="50" r="3.5" />
+    <circle cx="263" cy="58" r="3.5" />
+    <circle cx="273" cy="66" r="3.5" />
+    <circle cx="341" cy="51" r="3.5" />
+    <circle cx="357" cy="65" r="3.5" />
+    <circle cx="435" cy="58" r="3.5" />
+    <circle cx="177" cy="132" r="3.5" />
+    <circle cx="255" cy="125" r="3.5" />
+    <circle cx="271" cy="139" r="3.5" />
+    <circle cx="339" cy="124" r="3.5" />
+    <circle cx="349" cy="132" r="3.5" />
+    <circle cx="359" cy="140" r="3.5" />
+    <circle cx="425" cy="123" r="3.5" />
+    <circle cx="445" cy="123" r="3.5" />
+    <circle cx="425" cy="141" r="3.5" />
+    <circle cx="445" cy="141" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="408" y="86" width="54" height="5" rx="2.5" />
+    <rect x="150" y="160" width="54" height="5" rx="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="110" y="93" width="420" height="4" rx="2" />
+    <path d="M98 95 L106 90 L114 95 L106 100 Z" />
+    <path d="M526 95 L534 90 L542 95 L534 100 Z" />
+  </g>
+</svg>
+
 You can *see* the byte order at runtime by reading the bytes of an
 integer through a `char *`:
 
@@ -226,6 +324,44 @@ The compiler enforces alignment automatically: local variables and
 struct members are placed at aligned addresses, sometimes with unused
 padding bytes in between. We will see padding clearly when we cover
 structs.
+
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="Typed blocks park against a kerb only at evenly spaced alignment ticks, leaving small padding gaps between them, while one red block hovers off-grid straddling a boundary it is not allowed to land on"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="118" width="520" height="6" rx="3" fill="currentColor" opacity="0.25" />
+  <g fill="currentColor" opacity="0.35">
+    <rect x="60" y="102" width="4" height="16" rx="2" />
+    <rect x="124" y="102" width="4" height="16" rx="2" />
+    <rect x="188" y="102" width="4" height="16" rx="2" />
+    <rect x="252" y="102" width="4" height="16" rx="2" />
+    <rect x="316" y="102" width="4" height="16" rx="2" />
+    <rect x="380" y="102" width="4" height="16" rx="2" />
+    <rect x="444" y="102" width="4" height="16" rx="2" />
+    <rect x="508" y="102" width="4" height="16" rx="2" />
+    <rect x="572" y="102" width="4" height="16" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="62" y="76" width="124" height="40" rx="8" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="190" y="76" width="60" height="40" rx="8" fillOpacity="0.55" />
+    <rect x="254" y="76" width="28" height="40" rx="6" fillOpacity="0.35" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="292" cy="96" r="2.5" />
+    <circle cx="304" cy="96" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="318" y="76" width="12" height="40" rx="4" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="398" y="28" width="60" height="28" rx="8" fillOpacity="0.7" />
+    <circle cx="446" cy="64" r="3.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="c"

--- a/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -12,6 +12,73 @@ return it later with `free`.
 Manual heap management is C's most distinctive (and most dangerous)
 feature. This page is the long, careful introduction.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A wall of storage lockers run from a small allocator kiosk: a yellow key arcs out to open one green locker, several others sit claimed, and one locker stays latched forever because its red key lies lost beneath the floor — malloc hands out space that only free can return"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="64" y="40" width="56" height="40" rx="5" />
+    <rect x="196" y="40" width="56" height="40" rx="5" />
+    <rect x="262" y="40" width="56" height="40" rx="5" />
+    <rect x="394" y="40" width="56" height="40" rx="5" />
+    <rect x="130" y="90" width="56" height="40" rx="5" />
+    <rect x="328" y="90" width="56" height="40" rx="5" />
+    <rect x="130" y="140" width="56" height="40" rx="5" />
+    <rect x="196" y="140" width="56" height="40" rx="5" />
+    <rect x="262" y="140" width="56" height="40" rx="5" />
+    <rect x="328" y="140" width="56" height="40" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="130" y="40" width="56" height="40" rx="5" fillOpacity="0.45" />
+    <rect x="328" y="40" width="56" height="40" rx="5" fillOpacity="0.45" />
+    <rect x="196" y="90" width="56" height="40" rx="5" fillOpacity="0.45" />
+    <rect x="64" y="140" width="56" height="40" rx="5" fillOpacity="0.45" />
+    <rect x="64" y="90" width="56" height="40" rx="5" fillOpacity="0.45" />
+    <rect x="262" y="90" width="56" height="40" rx="5" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="148" cy="60" r="3" />
+    <circle cx="346" cy="60" r="3" />
+    <circle cx="214" cy="110" r="3" />
+    <circle cx="82" cy="160" r="3" />
+    <circle cx="82" cy="110" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="394" y="140" width="56" height="40" rx="5" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <rect x="412" y="156" width="20" height="7" rx="3.5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="500" cy="92" r="2.5" />
+    <circle cx="470" cy="80" r="2.5" />
+    <circle cx="436" cy="76" r="2.5" />
+    <circle cx="400" cy="80" r="2.5" />
+    <circle cx="366" cy="90" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="326" cy="100" r="7" />
+    <rect x="333" y="97" width="16" height="6" rx="2" />
+    <rect x="343" y="103" width="4" height="7" rx="1.5" />
+    <rect x="337" y="103" width="3" height="5" rx="1.5" />
+  </g>
+  <circle cx="326" cy="100" r="3" fill="var(--ds-white)" />
+  <g fill="currentColor" opacity="0.12">
+    <rect x="488" y="68" width="104" height="122" rx="12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M508 130 A22 22 0 0 1 552 130 L552 152 L508 152 Z" fillOpacity="0.45" />
+    <rect x="500" y="156" width="60" height="8" rx="4" fillOpacity="0.25" />
+  </g>
+  <rect x="40" y="190" width="560" height="7" rx="3.5" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor" fillOpacity="0.55">
+    <circle cx="414" cy="208" r="6" />
+    <rect x="420" y="205" width="14" height="5" rx="2" />
+  </g>
+</svg>
+
 ## The four heap functions
 
 | Function | Purpose | Returns |
@@ -152,6 +219,47 @@ by `memset(p, 0, ...)`.
 - allocate a *new* block, copy the old contents, and free the old one,
 - or return `NULL` (the old block is **still valid** in this case).
 
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="Four dots move from a snug container along a dotted arc into a roomier one with four empty slots waiting — realloc copies the contents to a bigger block and retires the old one, marked with a red dot"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="70" y="62" width="128" height="56" rx="12" fillOpacity="0.12" />
+    <circle cx="96" cy="90" r="9" fillOpacity="0.4" />
+    <circle cx="120" cy="90" r="9" fillOpacity="0.4" />
+    <circle cx="144" cy="90" r="9" fillOpacity="0.4" />
+    <circle cx="168" cy="90" r="9" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="198" cy="62" r="5" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="222" cy="56" r="2.5" />
+    <circle cx="250" cy="44" r="2.5" />
+    <circle cx="282" cy="38" r="2.5" />
+    <circle cx="314" cy="40" r="2.5" />
+    <circle cx="344" cy="48" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="330" y="62" width="240" height="56" rx="12" fillOpacity="0.2" />
+    <circle cx="358" cy="90" r="9" />
+    <circle cx="384" cy="90" r="9" />
+    <circle cx="410" cy="90" r="9" />
+    <circle cx="436" cy="90" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <path d="M453 90 a9 9 0 1 1 18 0 a9 9 0 1 1 -18 0 Z M456 90 a6 6 0 1 1 12 0 a6 6 0 1 1 -12 0 Z" fillRule="evenodd" />
+    <path d="M479 90 a9 9 0 1 1 18 0 a9 9 0 1 1 -18 0 Z M482 90 a6 6 0 1 1 12 0 a6 6 0 1 1 -12 0 Z" fillRule="evenodd" />
+    <path d="M505 90 a9 9 0 1 1 18 0 a9 9 0 1 1 -18 0 Z M508 90 a6 6 0 1 1 12 0 a6 6 0 1 1 -12 0 Z" fillRule="evenodd" />
+    <path d="M531 90 a9 9 0 1 1 18 0 a9 9 0 1 1 -18 0 Z M534 90 a6 6 0 1 1 12 0 a6 6 0 1 1 -12 0 Z" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="570" cy="62" r="5" />
+  </g>
+</svg>
+
 <Callout type="warn" title="Never assign realloc's result back over the only pointer">
 `p = realloc(p, n);` leaks the original block if `realloc` fails. The
 safe pattern is to use a temporary.
@@ -261,6 +369,49 @@ int main(void) {
 
 Doubling the capacity each time gives amortized O(1) `push`. This is
 exactly how `std::vector<T>` in C++ and `Vec<T>` in Rust grow.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Capacity columns double from two to four to eight slots as green pushes fill them, with yellow arcs marking the occasional copy-everything resize — rare big moves that stay cheap on average"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="80" y="174" width="480" height="5" rx="2.5" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fillOpacity="0.85">
+    <rect x="120" y="152" width="40" height="14" rx="3" />
+    <rect x="120" y="134" width="40" height="14" rx="3" />
+    <rect x="240" y="152" width="40" height="14" rx="3" />
+    <rect x="240" y="134" width="40" height="14" rx="3" />
+    <rect x="240" y="116" width="40" height="14" rx="3" />
+    <rect x="240" y="98" width="40" height="14" rx="3" />
+    <rect x="400" y="152" width="40" height="14" rx="3" />
+    <rect x="400" y="134" width="40" height="14" rx="3" />
+    <rect x="400" y="116" width="40" height="14" rx="3" />
+    <rect x="400" y="98" width="40" height="14" rx="3" />
+    <rect x="400" y="80" width="40" height="14" rx="3" />
+    <rect x="400" y="62" width="40" height="14" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.15">
+    <rect x="400" y="44" width="40" height="14" rx="3" />
+    <rect x="400" y="26" width="40" height="14" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="176" cy="120" r="3" />
+    <circle cx="198" cy="106" r="3" />
+    <circle cx="220" cy="100" r="3" fillOpacity="0.7" />
+    <circle cx="298" cy="78" r="3" />
+    <circle cx="330" cy="58" r="3" />
+    <circle cx="364" cy="50" r="3" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="504" cy="44" r="6" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="488" cy="48" r="2" />
+    <circle cx="472" cy="50" r="2" />
+    <circle cx="456" cy="51" r="2" />
+  </g>
+</svg>
 
 ## Ownership: who frees what?
 

--- a/content/learn/systems-programming-c/index.mdx
+++ b/content/learn/systems-programming-c/index.mdx
@@ -17,6 +17,75 @@ language but a *model of the machine* — a small, honest model in which
 every byte has an address, every variable has a type with a known
 size, and every allocation is yours to manage.
 
+<svg
+  viewBox="0 0 640 280"
+  role="img"
+  aria-label="Isometric tower of a process address space: read-only code bedrock at the base, a globals floor above it, a green heap floor where a yellow hoist lowers a fresh block, then a stack floor of trays on top — with one red shard slipping out of the gap between heap and stack"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="60" cy="36" r="3" />
+    <circle cx="590" cy="210" r="4" />
+    <circle cx="566" cy="26" r="3" />
+    <circle cx="50" cy="250" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="86" y="60" width="10" height="3" rx="1.5" />
+    <rect x="86" y="86" width="10" height="3" rx="1.5" />
+    <rect x="86" y="112" width="10" height="3" rx="1.5" />
+    <rect x="86" y="138" width="10" height="3" rx="1.5" />
+    <rect x="86" y="164" width="10" height="3" rx="1.5" />
+    <rect x="86" y="190" width="10" height="3" rx="1.5" />
+    <rect x="86" y="216" width="10" height="3" rx="1.5" />
+    <rect x="86" y="242" width="10" height="3" rx="1.5" />
+  </g>
+  <g fill="currentColor">
+    <path d="M145 228 L310 262 L475 228 L475 242 L310 276 L145 242 Z" opacity="0.22" />
+    <path d="M145 228 L310 194 L475 228 L310 262 Z" opacity="0.12" />
+    <circle cx="250" cy="224" r="2.5" opacity="0.4" />
+    <circle cx="280" cy="219" r="2.5" opacity="0.4" />
+    <circle cx="310" cy="214" r="2.5" opacity="0.4" />
+    <circle cx="340" cy="219" r="2.5" opacity="0.4" />
+    <circle cx="370" cy="224" r="2.5" opacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M145 192 L310 226 L475 192 L475 206 L310 240 L145 206 Z" fillOpacity="0.38" />
+    <path d="M145 192 L310 158 L475 192 L310 226 Z" fillOpacity="0.22" />
+    <circle cx="260" cy="188" r="4" />
+    <circle cx="310" cy="180" r="4" />
+    <circle cx="360" cy="188" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M145 154 L310 188 L475 154 L475 168 L310 202 L145 168 Z" fillOpacity="0.45" />
+    <path d="M145 154 L310 120 L475 154 L310 188 Z" fillOpacity="0.25" />
+    <path d="M222 146 L250 158 L278 146 L278 153 L250 165 L222 153 Z" fillOpacity="0.6" />
+    <path d="M222 146 L250 134 L278 146 L250 158 Z" fillOpacity="0.9" />
+    <path d="M316 152 L340 162 L364 152 L364 159 L340 169 L316 159 Z" fillOpacity="0.6" />
+    <path d="M316 152 L340 142 L364 152 L340 162 Z" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M145 66 L310 100 L475 66 L475 80 L310 114 L145 80 Z" fillOpacity="0.5" />
+    <path d="M145 66 L310 32 L475 66 L310 100 Z" fillOpacity="0.32" />
+    <path d="M270 60 L310 76 L350 60 L310 44 Z" fillOpacity="0.65" />
+    <path d="M282 47 L310 58 L338 47 L310 36 Z" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="506" y="36" width="10" height="148" rx="3" />
+    <rect x="380" y="36" width="136" height="10" rx="5" />
+    <rect x="470" y="48" width="18" height="14" rx="3" fillOpacity="0.8" />
+    <rect x="496" y="180" width="30" height="8" rx="4" />
+    <rect x="398" y="46" width="4" height="56" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M382 110 L400 118 L418 110 L418 116 L400 124 L382 116 Z" fillOpacity="0.7" />
+    <path d="M382 110 L400 102 L418 110 L400 118 Z" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M150 110 L170 102 L160 122 Z" fillOpacity="0.85" />
+    <circle cx="178" cy="118" r="3" />
+  </g>
+</svg>
+
 ## What you will learn
 
 Each page mixes prose with three kinds of interactive widgets:

--- a/content/learn/systems-programming-c/memory-bugs.mdx
+++ b/content/learn/systems-programming-c/memory-bugs.mdx
@@ -23,6 +23,90 @@ These are not "exotic" bugs — they are the source of an enormous
 share of real-world security vulnerabilities (CVEs). Recognizing the
 patterns is half the battle.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="A collector's case of eight memory-bug specimens — a faded block still being touched, a twice-freed pair, a dripping leak, an overflowing vessel, a dot past the bracket, a question-mark cell, a string whose balloon is gone, and a square peg over a round hole"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="40" y="24" width="560" height="204" rx="14" fill="currentColor" opacity="0.05" />
+  <g fill="currentColor" opacity="0.08">
+    <rect x="64" y="44" width="116" height="80" rx="10" />
+    <rect x="196" y="44" width="116" height="80" rx="10" />
+    <rect x="328" y="44" width="116" height="80" rx="10" />
+    <rect x="460" y="44" width="116" height="80" rx="10" />
+    <rect x="64" y="136" width="116" height="80" rx="10" />
+    <rect x="196" y="136" width="116" height="80" rx="10" />
+    <rect x="328" y="136" width="116" height="80" rx="10" />
+    <rect x="460" y="136" width="116" height="80" rx="10" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="92" y="62" width="40" height="28" rx="6" fillOpacity="0.15" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="138" cy="92" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M140 66 L152 60 L150 74 Z" fillOpacity="0.8" />
+    <circle cx="240" cy="84" r="12" />
+    <path d="M252 76 a12 12 0 1 1 24 0 a12 12 0 1 1 -24 0 Z M256 76 a8 8 0 1 1 16 0 a8 8 0 1 1 -16 0 Z" fillRule="evenodd" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="362" y="58" width="36" height="26" rx="5" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="380" cy="94" r="4" />
+    <circle cx="386" cy="106" r="3" fillOpacity="0.7" />
+    <circle cx="377" cy="117" r="2.5" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="492" y="60" width="5" height="40" rx="2" />
+    <rect x="537" y="60" width="5" height="40" rx="2" />
+    <rect x="492" y="96" width="50" height="5" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="501" y="66" width="32" height="30" fillOpacity="0.5" />
+    <rect x="503" y="48" width="28" height="18" rx="4" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="517" cy="44" r="4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="84" y="160" width="3" height="11" />
+    <rect x="84" y="168" width="56" height="3" />
+    <rect x="137" y="160" width="3" height="11" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="94" cy="186" r="4" />
+    <circle cx="108" cy="186" r="4" />
+    <circle cx="122" cy="186" r="4" />
+    <circle cx="136" cy="186" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="154" cy="186" r="4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="232" cy="160" r="2.5" />
+    <circle cx="249" cy="158" r="2.5" />
+    <circle cx="266" cy="160" r="2.5" />
+    <circle cx="230" cy="178" r="2.5" />
+    <circle cx="268" cy="178" r="2.5" />
+    <circle cx="232" cy="196" r="2.5" />
+    <circle cx="249" cy="198" r="2.5" />
+    <circle cx="266" cy="196" r="2.5" />
+  </g>
+  <text x="249" y="186" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fill="currentColor" opacity="0.45">?</text>
+  <circle cx="386" cy="150" r="13" fill="currentColor" opacity="0.1" />
+  <path d="M384 204 Q378 190 384 176 Q390 165 386 152 L389 151 Q394 165 388 177 Q382 190 388 204 Z" fill="currentColor" opacity="0.4" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="386" cy="206" r="5" />
+  </g>
+  <path d="M504 174 a12 12 0 1 1 24 0 a12 12 0 1 1 -24 0 Z M509 174 a7 7 0 1 1 14 0 a7 7 0 1 1 -14 0 Z" fillRule="evenodd" fill="currentColor" opacity="0.3" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="528" y="142" width="24" height="24" rx="4" fillOpacity="0.85" />
+  </g>
+</svg>
+
 ## 1. Use-after-free
 
 After `free(p)` the memory is returned to the allocator and may be
@@ -159,6 +243,42 @@ Writing past the end of an allocation (stack or heap) is the canonical
 C bug. Depending on the layout it may corrupt neighboring variables,
 allocator metadata, or — historically, before stack protections — the
 function's return address, leading to remote code execution.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Liquid poured into the left vessel rises past its rim and spills over the shared wall onto the green value stored next door — a buffer overflow corrupting its neighbour"
+  style={{ display: "block", width: "100%", maxWidth: "500px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="180" cy="24" r="4" fillOpacity="0.8" />
+    <circle cx="184" cy="40" r="4" fillOpacity="0.8" />
+    <circle cx="180" cy="56" r="4" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="140" y="72" width="6" height="76" rx="3" />
+    <rect x="296" y="72" width="6" height="76" rx="3" />
+    <rect x="140" y="142" width="162" height="6" rx="3" />
+    <rect x="320" y="92" width="6" height="56" rx="3" />
+    <rect x="320" y="142" width="126" height="6" rx="3" />
+    <rect x="440" y="92" width="6" height="56" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="150" y="78" width="142" height="64" rx="4" fillOpacity="0.5" />
+    <rect x="150" y="64" width="142" height="16" rx="6" fillOpacity="0.65" />
+    <circle cx="305" cy="60" r="4" fillOpacity="0.8" />
+    <circle cx="316" cy="70" r="4" fillOpacity="0.7" />
+    <circle cx="324" cy="84" r="4" fillOpacity="0.6" />
+    <rect x="330" y="120" width="106" height="22" rx="4" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="383" cy="124" r="11" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="383" cy="98" r="5" />
+    <path d="M376 84 L383 72 L390 84 Z" fillOpacity="0.7" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="c"
@@ -350,6 +470,43 @@ a `union`. Do not cast unrelated pointer types and dereference them.
 
 C cannot give you safety, but you can build habits and tooling around
 the language:
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Red darts fly toward a green core and each is stopped at a different concentric shield ring — warnings, sanitizers, runtime checks — defense in depth for memory safety"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M240 105 a80 80 0 1 1 160 0 a80 80 0 1 1 -160 0 Z M246 105 a74 74 0 1 1 148 0 a74 74 0 1 1 -148 0 Z" fillRule="evenodd" fillOpacity="0.18" />
+    <path d="M264 105 a56 56 0 1 1 112 0 a56 56 0 1 1 -112 0 Z M270 105 a50 50 0 1 1 100 0 a50 50 0 1 1 -100 0 Z" fillRule="evenodd" fillOpacity="0.3" />
+    <path d="M288 105 a32 32 0 1 1 64 0 a32 32 0 1 1 -64 0 Z M294 105 a26 26 0 1 1 52 0 a26 26 0 1 1 -52 0 Z" fillRule="evenodd" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="320" cy="105" r="10" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="178" cy="105" r="2.5" />
+    <circle cx="196" cy="105" r="2.5" />
+    <circle cx="214" cy="105" r="2.5" />
+    <circle cx="416" cy="32" r="2.5" />
+    <circle cx="402" cy="42" r="2.5" />
+    <circle cx="388" cy="52" r="2.5" />
+    <circle cx="320" cy="188" r="2.5" />
+    <circle cx="320" cy="174" r="2.5" />
+    <circle cx="320" cy="160" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M222 99 L238 105 L222 111 Z" />
+    <path d="M374 50 L362 66 L380 62 Z" />
+    <path d="M314 156 L320 140 L326 156 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="242" cy="105" r="3.5" />
+    <circle cx="360" cy="68" r="3.5" />
+    <circle cx="320" cy="138" r="3.5" />
+  </g>
+</svg>
 
 | Defense | What it catches |
 | --- | --- |

--- a/content/learn/systems-programming-c/memory-layout.mdx
+++ b/content/learn/systems-programming-c/memory-layout.mdx
@@ -36,6 +36,59 @@ The WASI runtime uses a similar layout in linear memory; the
 addresses just happen to be inside the WebAssembly module's memory
 rather than your laptop's physical RAM.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="A cave cross-section of a process address space: read-only code bedrock and globals strata form the floor, green heap stalagmites grow upward, yellow stack stalactites grow down from the high-address ceiling, and a red spark marks the narrowing gap where the two would meet"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="40" y="28" width="560" height="14" rx="6" fill="currentColor" opacity="0.15" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M316 42 L344 42 L330 116 Z" fillOpacity="0.8" />
+    <path d="M380 42 L408 42 L394 100 Z" fillOpacity="0.65" />
+    <path d="M422 42 L448 42 L435 78 Z" fillOpacity="0.5" />
+    <path d="M462 42 L490 42 L476 108 Z" fillOpacity="0.7" />
+    <path d="M504 42 L530 42 L517 70 Z" fillOpacity="0.45" />
+    <path d="M544 42 L570 42 L557 90 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M76 158 L91 100 L106 158 Z" fillOpacity="0.6" />
+    <path d="M118 158 L131 124 L144 158 Z" fillOpacity="0.45" />
+    <path d="M156 158 L171 84 L186 158 Z" fillOpacity="0.7" />
+    <path d="M198 158 L210 132 L222 158 Z" fillOpacity="0.4" />
+    <path d="M236 158 L250 108 L264 158 Z" fillOpacity="0.55" />
+    <path d="M286 158 L302 80 L318 158 Z" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="320" cy="97" r="4" />
+    <path d="M310 88 L316 92 L308 96 Z" fillOpacity="0.7" />
+    <path d="M330 102 L336 99 L334 108 Z" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="40" y="158" width="560" height="22" rx="4" fillOpacity="0.12" />
+    <circle cx="370" cy="169" r="3" fillOpacity="0.3" />
+    <circle cx="430" cy="169" r="3" fillOpacity="0.3" />
+    <circle cx="490" cy="169" r="3" fillOpacity="0.3" />
+    <circle cx="550" cy="169" r="3" fillOpacity="0.3" />
+    <rect x="40" y="182" width="560" height="22" rx="4" fillOpacity="0.3" />
+    <circle cx="140" cy="193" r="3.5" />
+    <circle cx="240" cy="193" r="3.5" />
+    <circle cx="340" cy="193" r="3.5" />
+    <circle cx="460" cy="193" r="3.5" />
+  </g>
+  <g fill="currentColor">
+    <rect x="40" y="206" width="560" height="26" rx="6" opacity="0.3" />
+    <rect x="100" y="217" width="16" height="4" rx="2" opacity="0.5" />
+    <rect x="132" y="217" width="10" height="4" rx="2" opacity="0.5" />
+    <rect x="170" y="217" width="20" height="4" rx="2" opacity="0.5" />
+    <rect x="240" y="217" width="12" height="4" rx="2" opacity="0.5" />
+    <rect x="300" y="217" width="18" height="4" rx="2" opacity="0.5" />
+    <rect x="380" y="217" width="14" height="4" rx="2" opacity="0.5" />
+    <rect x="450" y="217" width="20" height="4" rx="2" opacity="0.5" />
+    <rect x="520" y="217" width="12" height="4" rx="2" opacity="0.5" />
+  </g>
+</svg>
+
 ## Seeing the regions
 
 You can roughly identify which region a variable lives in by printing
@@ -127,6 +180,43 @@ int main(void) {
 A common surprise: declaring a 10-million-element zero-initialized
 global does **not** make your binary 40 MB larger, because BSS is
 "described by metadata" rather than stored as bytes.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="On the cargo deck of the executable, initialized globals travel as solid crates with real contents, while zeroed globals are just ghost outlines plus one small yellow manifest tag — BSS ships as metadata, not bytes"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="136" width="520" height="8" rx="4" fill="currentColor" opacity="0.18" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="92" y="76" width="56" height="56" rx="8" fillOpacity="0.55" />
+    <rect x="156" y="76" width="56" height="56" rx="8" fillOpacity="0.4" />
+    <rect x="124" y="42" width="56" height="56" rx="8" fillOpacity="0.7" />
+    <circle cx="120" cy="104" r="5" />
+    <circle cx="184" cy="104" r="5" />
+    <circle cx="152" cy="70" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.16">
+    <path d="M330 76 h56 v56 h-56 Z M336 82 h44 v44 h-44 Z" fillRule="evenodd" />
+    <path d="M394 76 h56 v56 h-56 Z M400 82 h44 v44 h-44 Z" fillRule="evenodd" />
+    <path d="M458 76 h56 v56 h-56 Z M464 82 h44 v44 h-44 Z" fillRule="evenodd" />
+    <path d="M362 42 h56 v56 h-56 Z M368 48 h44 v44 h-44 Z" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="496" y="36" width="58" height="34" rx="6" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.55">
+    <circle cx="512" cy="48" r="2.5" />
+    <circle cx="525" cy="48" r="2.5" />
+    <circle cx="538" cy="48" r="2.5" />
+    <rect x="508" y="57" width="34" height="3" rx="1.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="524" cy="78" r="2" />
+    <circle cx="520" cy="88" r="2" />
+    <circle cx="514" cy="98" r="2" />
+  </g>
+</svg>
 
 ## Storage classes for variables
 

--- a/content/learn/systems-programming-c/next-steps.mdx
+++ b/content/learn/systems-programming-c/next-steps.mdx
@@ -16,6 +16,83 @@ alternatives that build on what C taught you.
 This page is a roadmap, not a tutorial. Each topic deserves its own
 course, and there are many great ones out there.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A transit map: from a blue you-are-here hub, dotted lines branch through station after station — processes, networking, tooling — and one faint line runs clean off the map's edge, because the journey keeps going"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M120 120 a20 20 0 1 1 40 0 a20 20 0 1 1 -40 0 Z M125 120 a15 15 0 1 1 30 0 a15 15 0 1 1 -30 0 Z" fillRule="evenodd" fillOpacity="0.3" />
+    <circle cx="140" cy="120" r="11" />
+    <circle cx="162" cy="114" r="2.5" fillOpacity="0.5" />
+    <circle cx="184" cy="109" r="2.5" fillOpacity="0.5" />
+    <circle cx="206" cy="103" r="2.5" fillOpacity="0.5" />
+    <circle cx="228" cy="98" r="2.5" fillOpacity="0.5" />
+    <circle cx="240" cy="95" r="5" />
+    <circle cx="262" cy="89" r="2.5" fillOpacity="0.5" />
+    <circle cx="284" cy="84" r="2.5" fillOpacity="0.5" />
+    <circle cx="306" cy="79" r="2.5" fillOpacity="0.5" />
+    <circle cx="330" cy="72" r="5" />
+    <circle cx="352" cy="67" r="2.5" fillOpacity="0.5" />
+    <circle cx="372" cy="63" r="2.5" fillOpacity="0.5" />
+    <circle cx="392" cy="60" r="2.5" fillOpacity="0.5" />
+    <circle cx="410" cy="58" r="5" />
+    <circle cx="432" cy="55" r="2.5" fillOpacity="0.5" />
+    <circle cx="450" cy="53" r="2.5" fillOpacity="0.5" />
+    <path d="M471 50 a9 9 0 1 1 18 0 a9 9 0 1 1 -18 0 Z M475 50 a5 5 0 1 1 10 0 a5 5 0 1 1 -10 0 Z" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="166" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="188" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="210" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="232" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="260" cy="120" r="5" />
+    <circle cx="284" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="308" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="332" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="356" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="380" cy="120" r="5" />
+    <circle cx="404" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="426" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="448" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="470" cy="120" r="5" />
+    <circle cx="494" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="516" cy="120" r="2.5" fillOpacity="0.5" />
+    <circle cx="538" cy="120" r="2.5" fillOpacity="0.5" />
+    <path d="M551 120 a9 9 0 1 1 18 0 a9 9 0 1 1 -18 0 Z M555 120 a5 5 0 1 1 10 0 a5 5 0 1 1 -10 0 Z" fillRule="evenodd" />
+  </g>
+  <path d="M371 120 a9 9 0 1 1 18 0 a9 9 0 1 1 -18 0 Z M375 120 a5 5 0 1 1 10 0 a5 5 0 1 1 -10 0 Z" fillRule="evenodd" fill="currentColor" opacity="0.3" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="162" cy="126" r="2.5" fillOpacity="0.6" />
+    <circle cx="184" cy="132" r="2.5" fillOpacity="0.6" />
+    <circle cx="206" cy="138" r="2.5" fillOpacity="0.6" />
+    <circle cx="228" cy="144" r="2.5" fillOpacity="0.6" />
+    <circle cx="250" cy="150" r="5" />
+    <circle cx="274" cy="155" r="2.5" fillOpacity="0.6" />
+    <circle cx="298" cy="160" r="2.5" fillOpacity="0.6" />
+    <circle cx="322" cy="165" r="2.5" fillOpacity="0.6" />
+    <circle cx="350" cy="170" r="5" />
+    <circle cx="374" cy="173" r="2.5" fillOpacity="0.6" />
+    <circle cx="398" cy="176" r="2.5" fillOpacity="0.6" />
+    <circle cx="422" cy="180" r="2.5" fillOpacity="0.6" />
+    <circle cx="446" cy="182" r="2.5" fillOpacity="0.6" />
+    <path d="M461 185 a9 9 0 1 1 18 0 a9 9 0 1 1 -18 0 Z M465 185 a5 5 0 1 1 10 0 a5 5 0 1 1 -10 0 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor">
+    <circle cx="496" cy="192" r="2.5" opacity="0.3" />
+    <circle cx="520" cy="199" r="2.5" opacity="0.24" />
+    <circle cx="544" cy="206" r="2.5" opacity="0.18" />
+    <circle cx="568" cy="212" r="2.5" opacity="0.12" />
+    <circle cx="592" cy="218" r="2.5" opacity="0.06" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="80" cy="50" r="3" />
+    <circle cx="600" cy="40" r="3" />
+    <circle cx="60" cy="190" r="3" />
+  </g>
+</svg>
+
 ## 1. Processes and signals
 
 A *process* is a running program: its address space, open files,
@@ -119,6 +196,67 @@ or a teaching OS like xv6.
 
 These are the tools that turn C from "trust the programmer" into
 "trust but verify."
+
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Mixed dots pour down through three stacked sieves; each sieve catches a different red defect while the clean green and blue dots fall through to the dish below — sanitizers layered over a C program"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="300" cy="16" r="4" fillOpacity="0.8" />
+    <circle cx="336" cy="20" r="4" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="318" cy="10" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="316" y="52" width="13" height="13" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="180" y="66" width="80" height="8" rx="4" />
+    <rect x="272" y="66" width="96" height="8" rx="4" />
+    <rect x="380" y="66" width="80" height="8" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="266" cy="88" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="374" cy="92" r="3.5" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M340 102 L354 102 L347 116 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="200" y="116" width="56" height="8" rx="4" />
+    <rect x="268" y="116" width="98" height="8" rx="4" />
+    <rect x="378" y="116" width="62" height="8" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="262" cy="138" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="372" cy="142" r="3.5" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="300" cy="158" r="6" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="220" y="166" width="40" height="8" rx="4" />
+    <rect x="272" y="166" width="92" height="8" rx="4" />
+    <rect x="376" y="166" width="46" height="8" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="266" cy="186" r="3.5" />
+    <circle cx="290" cy="198" r="4" />
+    <circle cx="346" cy="198" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="372" cy="188" r="3.5" fillOpacity="0.8" />
+    <circle cx="318" cy="198" r="4" fillOpacity="0.8" />
+  </g>
+  <rect x="240" y="206" width="160" height="8" rx="4" fill="currentColor" opacity="0.18" />
+</svg>
 
 | Tool | What it catches | How to enable |
 | --- | --- | --- |

--- a/content/learn/systems-programming-c/pointers.mdx
+++ b/content/learn/systems-programming-c/pointers.mdx
@@ -7,6 +7,74 @@ A pointer is just a variable whose value is the address of another
 piece of memory. That one sentence is the whole concept — and also
 the source of half the things that make C feel hard.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A street of houses, each door wearing a pip-numbered address plate; a held card bearing three green pips arcs to the matching third door, while the vacant lot next to it posts a red no-entry sign — a pointer is an address, and NULL points at nothing"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="600" cy="60" r="3" />
+    <circle cx="40" cy="120" r="3" />
+  </g>
+  <rect x="50" y="190" width="540" height="6" rx="3" fill="currentColor" opacity="0.2" />
+  <g fill="currentColor">
+    <path d="M114 130 L152 100 L190 130 Z" opacity="0.25" />
+    <rect x="120" y="130" width="64" height="60" opacity="0.13" />
+    <rect x="144" y="156" width="16" height="34" rx="3" opacity="0.3" />
+    <rect x="138" y="138" width="28" height="13" rx="4" opacity="0.12" />
+    <path d="M204 130 L242 100 L280 130 Z" opacity="0.25" />
+    <rect x="210" y="130" width="64" height="60" opacity="0.13" />
+    <rect x="234" y="156" width="16" height="34" rx="3" opacity="0.3" />
+    <rect x="228" y="138" width="28" height="13" rx="4" opacity="0.12" />
+    <path d="M294 130 L332 100 L370 130 Z" opacity="0.25" />
+    <rect x="300" y="130" width="64" height="60" opacity="0.13" />
+    <rect x="318" y="138" width="28" height="13" rx="4" opacity="0.12" />
+    <path d="M474 130 L512 100 L550 130 Z" opacity="0.25" />
+    <rect x="480" y="130" width="64" height="60" opacity="0.13" />
+    <rect x="504" y="156" width="16" height="34" rx="3" opacity="0.3" />
+    <rect x="498" y="138" width="28" height="13" rx="4" opacity="0.12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="152" cy="144.5" r="2.2" />
+    <circle cx="237" cy="144.5" r="2.2" />
+    <circle cx="247" cy="144.5" r="2.2" />
+    <circle cx="504" cy="144.5" r="2.2" />
+    <circle cx="509.5" cy="144.5" r="2.2" />
+    <circle cx="515" cy="144.5" r="2.2" />
+    <circle cx="520.5" cy="144.5" r="2.2" />
+    <rect x="56" y="44" width="74" height="46" rx="8" fillOpacity="0.16" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="324" y="156" width="16" height="34" rx="3" />
+    <circle cx="325" cy="144.5" r="2.2" />
+    <circle cx="332" cy="144.5" r="2.2" />
+    <circle cx="339" cy="144.5" r="2.2" />
+    <circle cx="78" cy="67" r="3.5" />
+    <circle cx="93" cy="67" r="3.5" />
+    <circle cx="108" cy="67" r="3.5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="150" cy="52" r="2.5" />
+    <circle cx="195" cy="42" r="2.5" />
+    <circle cx="243" cy="46" r="2.5" />
+    <circle cx="283" cy="62" r="2.5" />
+    <circle cx="312" cy="90" r="2.5" />
+    <circle cx="328" cy="118" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="392" cy="184" r="2" />
+    <circle cx="408" cy="180" r="2" />
+    <circle cx="430" cy="184" r="2" />
+    <circle cx="448" cy="181" r="2" />
+  </g>
+  <rect x="417" y="148" width="6" height="42" rx="2" fill="currentColor" opacity="0.3" />
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="420" cy="136" r="13" />
+  </g>
+  <rect x="411" y="133" width="18" height="6" rx="3" fill="var(--ds-white)" />
+</svg>
+
 ## Variables live at addresses
 
 When you write `int x = 42;`, the compiler picks a memory address for
@@ -131,6 +199,41 @@ Either give it a real address or set it to `NULL`.
 
 C passes arguments **by value**. If a function takes an `int`, it
 gets a copy. Modifying that copy does nothing to the caller.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Left: a function edits only a faded photocopy and the yellow sticker never reaches the original; right: it receives a green address tag tied to the real box, so the sticker lands on the original — pass by value versus pass by pointer"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="318" y="28" width="4" height="124" rx="2" fill="currentColor" opacity="0.12" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="84" y="56" width="56" height="56" rx="10" />
+    <rect x="180" y="56" width="56" height="56" rx="10" fillOpacity="0.2" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="148" cy="84" r="2.5" />
+    <circle cx="160" cy="84" r="2.5" />
+    <circle cx="172" cy="84" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="222" cy="66" r="7" />
+    <circle cx="426" cy="66" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="384" y="56" width="56" height="56" rx="10" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="450" cy="87" r="2" />
+    <circle cx="464" cy="87" r="2" />
+    <circle cx="478" cy="87" r="2" />
+    <circle cx="492" cy="87" r="2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="498" y="72" width="52" height="30" rx="8" fillOpacity="0.85" />
+  </g>
+  <circle cx="508" cy="87" r="4" fill="var(--ds-white)" />
+</svg>
 
 <CodeBlock
   adapter="c"
@@ -274,6 +377,41 @@ A pointer is a value, so you can take *its* address too. Patterns
 like this are how you write functions that allocate memory on behalf
 of the caller and store the new pointer in one of the caller's
 variables.
+
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="A card whose picture is another card, a dotted hop to that second card, and a final hop to the little green-doored house — pointer to pointer to value, two dereferences from the data"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="76" y="50" width="64" height="44" rx="8" fillOpacity="0.15" />
+    <rect x="94" y="62" width="28" height="20" rx="4" fillOpacity="0.45" />
+    <rect x="102" y="68" width="12" height="8" rx="2" fillOpacity="0.9" />
+    <rect x="266" y="50" width="64" height="44" rx="8" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="292" cy="72" r="4" />
+    <circle cx="304" cy="72" r="4" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="152" cy="66" r="2.5" />
+    <circle cx="182" cy="56" r="2.5" />
+    <circle cx="214" cy="52" r="2.5" />
+    <circle cx="246" cy="58" r="2.5" />
+    <circle cx="342" cy="66" r="2.5" />
+    <circle cx="374" cy="56" r="2.5" />
+    <circle cx="408" cy="52" r="2.5" />
+    <circle cx="442" cy="60" r="2.5" />
+  </g>
+  <g fill="currentColor">
+    <path d="M454 70 L492 44 L530 70 Z" opacity="0.25" />
+    <rect x="460" y="70" width="64" height="52" opacity="0.13" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="484" y="94" width="16" height="28" rx="3" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="c"

--- a/content/learn/systems-programming-c/real-world-disasters.mdx
+++ b/content/learn/systems-programming-c/real-world-disasters.mdx
@@ -34,6 +34,76 @@ time. It was the world's first major internet worm and led directly
 to the creation of CERT/CC, the first computer-emergency response
 team.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A constellation of networked machines: from one red node, infection ripples outward in rings, turning near neighbours red and the frontier yellow, while distant green nodes wait — the 1988 Morris worm crossing the early internet"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="165" cy="99" r="1.5" />
+    <circle cx="180" cy="88" r="1.5" />
+    <circle cx="169" cy="120" r="1.5" />
+    <circle cx="188" cy="130" r="1.5" />
+    <circle cx="218" cy="84" r="1.5" />
+    <circle cx="240" cy="90" r="1.5" />
+    <circle cx="223" cy="146" r="1.5" />
+    <circle cx="238" cy="152" r="1.5" />
+    <circle cx="291" cy="104" r="1.5" />
+    <circle cx="320" cy="112" r="1.5" />
+    <circle cx="373" cy="100" r="1.5" />
+    <circle cx="396" cy="80" r="1.5" />
+    <circle cx="363" cy="137" r="1.5" />
+    <circle cx="377" cy="153" r="1.5" />
+    <circle cx="457" cy="70" r="1.5" />
+    <circle cx="493" cy="80" r="1.5" />
+    <circle cx="490" cy="117" r="1.5" />
+    <circle cx="510" cy="103" r="1.5" />
+    <circle cx="417" cy="157" r="1.5" />
+    <circle cx="443" cy="143" r="1.5" />
+    <circle cx="553" cy="80" r="1.5" />
+    <circle cx="577" cy="70" r="1.5" />
+    <circle cx="540" cy="117" r="1.5" />
+    <circle cx="550" cy="143" r="1.5" />
+    <circle cx="114" cy="85" r="1.5" />
+    <circle cx="132" cy="97" r="1.5" />
+    <circle cx="129" cy="143" r="1.5" />
+    <circle cx="139" cy="127" r="1.5" />
+    <circle cx="189" cy="49" r="1.5" />
+    <circle cx="193" cy="63" r="1.5" />
+    <circle cx="307" cy="59" r="1.5" />
+    <circle cx="284" cy="77" r="1.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M116 110 a34 34 0 1 1 68 0 a34 34 0 1 1 -68 0 Z M122 110 a28 28 0 1 1 56 0 a28 28 0 1 1 -56 0 Z" fillRule="evenodd" fillOpacity="0.3" />
+    <path d="M88 110 a62 62 0 1 1 124 0 a62 62 0 1 1 -124 0 Z M94 110 a56 56 0 1 1 112 0 a56 56 0 1 1 -112 0 Z" fillRule="evenodd" fillOpacity="0.14" />
+    <circle cx="150" cy="110" r="9" />
+    <circle cx="196" cy="78" r="5" />
+    <circle cx="208" cy="140" r="5" />
+    <circle cx="118" cy="160" r="5" />
+    <circle cx="96" cy="72" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="262" cy="96" r="4.5" />
+    <circle cx="252" cy="158" r="4.5" />
+    <circle cx="186" cy="34" r="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <circle cx="350" cy="120" r="4" />
+    <circle cx="390" cy="170" r="4" />
+    <circle cx="330" cy="40" r="4" />
+    <circle cx="600" cy="60" r="4" />
+    <circle cx="430" cy="190" r="4" />
+    <circle cx="580" cy="30" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="420" cy="60" r="4" />
+    <circle cx="470" cy="130" r="4" />
+    <circle cx="530" cy="90" r="4" />
+    <circle cx="560" cy="170" r="4" />
+  </g>
+</svg>
+
 One of its key propagation vectors exploited a *stack buffer
 overflow* in the BSD `fingerd` daemon. `fingerd` read a request into
 a fixed-size local buffer using `gets()`:
@@ -106,6 +176,67 @@ implementation of the TLS Heartbeat extension. It did not corrupt
 memory or crash the server — it did something arguably worse: it
 let any attacker read up to ~64 KB of the server's process memory
 *per request*, with no authentication and no log trace.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A vault of memory dots leaks a long stream of secrets — yellow keys and green session dots among them — out through a small red heart-shaped opening in its wall toward a waiting attacker: Heartbleed"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="120" y="40" width="260" height="120" rx="12" fillOpacity="0.18" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="144" cy="62" r="2.5" />
+    <circle cx="172" cy="62" r="2.5" />
+    <circle cx="200" cy="62" r="2.5" />
+    <circle cx="228" cy="62" r="2.5" />
+    <circle cx="256" cy="62" r="2.5" />
+    <circle cx="284" cy="62" r="2.5" />
+    <circle cx="312" cy="62" r="2.5" />
+    <circle cx="144" cy="88" r="2.5" />
+    <circle cx="200" cy="88" r="2.5" />
+    <circle cx="228" cy="88" r="2.5" />
+    <circle cx="284" cy="88" r="2.5" />
+    <circle cx="340" cy="88" r="2.5" />
+    <circle cx="144" cy="114" r="2.5" />
+    <circle cx="172" cy="114" r="2.5" />
+    <circle cx="228" cy="114" r="2.5" />
+    <circle cx="284" cy="114" r="2.5" />
+    <circle cx="312" cy="114" r="2.5" />
+    <circle cx="144" cy="140" r="2.5" />
+    <circle cx="200" cy="140" r="2.5" />
+    <circle cx="256" cy="140" r="2.5" />
+    <circle cx="312" cy="140" r="2.5" />
+    <circle cx="340" cy="140" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="172" cy="88" r="4" />
+    <circle cx="340" cy="114" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="256" cy="114" r="4" />
+    <circle cx="312" cy="88" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M388 116 C376 102 368 96 368 84 C368 74 376 68 384 70 C387 71 388 74 388 76 C388 74 389 71 392 70 C400 68 408 74 408 84 C408 96 400 102 388 116 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="420" cy="96" r="3" />
+    <circle cx="438" cy="92" r="3" />
+    <circle cx="474" cy="94" r="3" />
+    <circle cx="510" cy="92" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="456" cy="98" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="492" cy="98" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M548 86 L568 95 L548 104 Z" fillOpacity="0.75" />
+  </g>
+</svg>
 
 The bug, distilled:
 
@@ -275,6 +406,48 @@ removing safety hardware on the assumption that the code is correct.
 On its maiden flight, the European Space Agency's Ariane 5 rocket
 self-destructed 37 seconds after launch, taking with it four
 scientific satellites and roughly $370 million.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="A dotted launch arc climbs steadily until a wide faint band must squeeze through a narrow yellow slot — the 64-to-16-bit conversion — where the trail kinks red and the abstract craft breaks into drifting shards: Ariane 5, flight 501"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="186" width="180" height="6" rx="3" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="90" cy="180" r="3" fillOpacity="0.3" />
+    <circle cx="110" cy="162" r="3" fillOpacity="0.38" />
+    <circle cx="132" cy="144" r="3" fillOpacity="0.46" />
+    <circle cx="156" cy="127" r="3" fillOpacity="0.54" />
+    <circle cx="182" cy="111" r="3" fillOpacity="0.62" />
+    <circle cx="210" cy="97" r="3" fillOpacity="0.7" />
+    <circle cx="240" cy="85" r="3" fillOpacity="0.8" />
+    <circle cx="272" cy="75" r="3" fillOpacity="0.9" />
+  </g>
+  <path d="M250 50 L332 38 L332 102 L250 122 Z" fill="currentColor" opacity="0.07" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor" fillOpacity="0.75">
+    <path d="M332 22 L374 22 L374 60 L332 44 Z" />
+    <path d="M332 116 L374 116 L374 78 L332 96 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M292 90 L316 70 L330 76 L306 96 Z" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="388" cy="72" r="3" />
+    <circle cx="402" cy="84" r="3" />
+    <circle cx="412" cy="100" r="3" />
+    <path d="M418 84 L432 80 L424 96 Z" fillOpacity="0.7" />
+    <path d="M430 110 L444 106 L436 122 Z" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M396 60 L410 54 L404 70 Z" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="452" cy="130" r="2.5" />
+    <circle cx="458" cy="150" r="2.5" />
+    <circle cx="462" cy="170" r="2.5" />
+  </g>
+</svg>
 
 The cause was not, strictly, a memory bug — but it is a textbook
 example of the kind of UB-adjacent disaster C programmers are

--- a/content/learn/systems-programming-c/stack-and-functions.mdx
+++ b/content/learn/systems-programming-c/stack-and-functions.mdx
@@ -13,6 +13,60 @@ This page makes that mechanism concrete enough that you can predict
 how recursion uses memory and where local pointers stop being safe to
 read.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A spring-loaded well of stacked trays — each call frame carrying its green locals and a yellow return token — with the top tray lifting off as its function returns"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="80" cy="60" r="3" />
+    <circle cx="560" cy="180" r="3" />
+    <circle cx="590" cy="48" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <rect x="200" y="84" width="14" height="118" rx="4" />
+    <rect x="426" y="84" width="14" height="118" rx="4" />
+    <rect x="200" y="196" width="240" height="10" rx="5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <path d="M260 192 L280 178 L300 192 Z" />
+    <path d="M300 192 L320 178 L340 192 Z" />
+    <path d="M340 192 L360 178 L380 192 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="224" y="158" width="192" height="18" rx="6" fillOpacity="0.25" />
+    <rect x="224" y="134" width="192" height="18" rx="6" fillOpacity="0.4" />
+    <rect x="224" y="110" width="192" height="18" rx="6" fillOpacity="0.55" />
+    <rect x="232" y="56" width="176" height="18" rx="6" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="248" cy="167" r="4" />
+    <circle cx="266" cy="167" r="4" />
+    <circle cx="248" cy="143" r="4" />
+    <circle cx="266" cy="143" r="4" />
+    <circle cx="284" cy="143" r="4" />
+    <circle cx="248" cy="119" r="4" />
+    <circle cx="254" cy="65" r="4" />
+    <circle cx="272" cy="65" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="392" y="162" width="11" height="11" rx="3" />
+    <rect x="392" y="138" width="11" height="11" rx="3" />
+    <rect x="392" y="114" width="11" height="11" rx="3" />
+    <rect x="384" y="60" width="11" height="11" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <path d="M260 92 Q320 82 380 92 L380 95 Q320 85 260 95 Z" />
+    <path d="M276 102 Q320 95 364 102 L364 105 Q320 98 276 105 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="452" cy="52" r="2.5" />
+    <circle cx="466" cy="42" r="2.5" />
+    <circle cx="482" cy="34" r="2.5" />
+  </g>
+</svg>
+
 ## Anatomy of a stack frame
 
 A typical frame contains:
@@ -118,6 +172,37 @@ When recursion is too deep — or a function declares a huge local
 array — you hit the end of the stack region and the program crashes
 with a stack overflow.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A tower of call-frame trays stacked past the red stack-limit line, with the topmost trays tipping and falling — recursion deep enough to overflow"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="240" y="196" width="160" height="8" rx="4" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="260" y="178" width="120" height="13" rx="5" fillOpacity="0.2" />
+    <rect x="260" y="161" width="120" height="13" rx="5" fillOpacity="0.27" />
+    <rect x="260" y="144" width="120" height="13" rx="5" fillOpacity="0.34" />
+    <rect x="260" y="127" width="120" height="13" rx="5" fillOpacity="0.41" />
+    <rect x="260" y="110" width="120" height="13" rx="5" fillOpacity="0.48" />
+    <rect x="260" y="93" width="120" height="13" rx="5" fillOpacity="0.56" />
+    <rect x="260" y="76" width="120" height="13" rx="5" fillOpacity="0.64" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="150" y="66" width="84" height="5" rx="2.5" fillOpacity="0.7" />
+    <rect x="252" y="66" width="136" height="5" rx="2.5" fillOpacity="0.35" />
+    <rect x="406" y="66" width="84" height="5" rx="2.5" fillOpacity="0.7" />
+    <rect x="262" y="50" width="120" height="13" rx="5" fillOpacity="0.55" />
+    <path d="M280 32 L398 40 L396 52 L278 44 Z" fillOpacity="0.7" />
+    <path d="M428 26 L482 48 L477 59 L423 37 Z" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="500" cy="74" r="2.5" />
+    <circle cx="512" cy="92" r="2.5" />
+    <circle cx="520" cy="112" r="2.5" />
+  </g>
+</svg>
+
 <Callout type="warn" title="Beware huge stack arrays">
 A local declaration like `char buf[16 * 1024 * 1024];` allocates 16 MB
 on the stack. On many platforms the entire stack is only 1 MB, and
@@ -220,6 +305,41 @@ The single most important stack rule:
 > A local variable lives only between the matching `{` and `}`. Any
 > pointer to it becomes invalid the instant control leaves that
 > scope.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A green walker has crossed a plank bridge that dissolves behind it — a dotted look-back arc points at a red gap where a plank no longer exists, like a pointer to a returned function's local"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <path d="M40 110 L150 110 L150 178 L40 178 Z" />
+    <path d="M490 110 L600 110 L600 178 L490 178 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="170" y="108" width="34" height="9" rx="4" fillOpacity="0.06" />
+    <rect x="216" y="108" width="34" height="9" rx="4" fillOpacity="0.12" />
+    <rect x="262" y="108" width="34" height="9" rx="4" fillOpacity="0.2" />
+    <rect x="354" y="108" width="34" height="9" rx="4" fillOpacity="0.45" />
+    <rect x="400" y="108" width="34" height="9" rx="4" fillOpacity="0.65" />
+    <rect x="446" y="108" width="34" height="9" rx="4" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M310 124 L324 116 L322 132 Z" fillOpacity="0.8" />
+    <circle cx="318" cy="142" r="3" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="463" cy="92" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="436" cy="76" r="2.5" />
+    <circle cx="408" cy="68" r="2.5" />
+    <circle cx="378" cy="66" r="2.5" />
+    <circle cx="348" cy="72" r="2.5" />
+    <circle cx="326" cy="86" r="2.5" />
+    <circle cx="318" cy="102" r="2.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="c"

--- a/content/learn/systems-programming-c/strings.mdx
+++ b/content/learn/systems-programming-c/strings.mdx
@@ -19,6 +19,50 @@ The character `'\0'` is the byte `0`, *not* the digit `'0'` (which is
 `0x30` in ASCII). Until the runtime finds it, every byte is still
 "part of the string."
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Two bead strings: the top one ends in a solid knot so the read stops there — the null terminator — while the bottom string is missing its knot and the read runs straight off the frayed end into junk shapes and a red crash"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <path d="M64 70 Q320 44 556 70 L556 74 Q320 48 64 74 Z" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="120" cy="65" r="9" />
+    <circle cx="164" cy="62" r="9" />
+    <circle cx="252" cy="58" r="9" />
+    <circle cx="340" cy="57" r="9" />
+    <circle cx="384" cy="58" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="208" cy="59" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="296" cy="57" r="9" />
+  </g>
+  <circle cx="428" cy="60" r="7" fill="currentColor" opacity="0.75" />
+  <path d="M64 150 Q260 128 440 150 L440 154 Q260 132 64 154 Z" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="120" cy="144" r="9" />
+    <circle cx="170" cy="141" r="9" />
+    <circle cx="220" cy="139" r="9" />
+    <circle cx="270" cy="139" r="9" />
+    <circle cx="320" cy="140" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="448" cy="150" r="2" />
+    <circle cx="454" cy="145" r="2" />
+    <circle cx="452" cy="156" r="2" />
+  </g>
+  <g fill="currentColor">
+    <rect x="470" y="146" width="12" height="12" rx="2" opacity="0.3" />
+    <path d="M500 158 L512 142 L522 158 Z" opacity="0.35" />
+    <circle cx="546" cy="152" r="6" opacity="0.25" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="574" y="145" width="13" height="13" rx="3" />
+  </g>
+</svg>
+
 <CodeBlock
   adapter="c"
   files={[
@@ -148,6 +192,39 @@ int main(void) {
 That second case is the bug factory. Many codebases now use
 `snprintf(dst, sizeof dst, "%s", src)` or platform-specific
 `strlcpy` instead.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="Two ribbons trimmed at the same length: snprintf finishes with a solid green end cap — always terminated — while the strncpy cut below is raw and fraying, so reads continue past it into junk and a red overrun"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="80" y="26" width="308" height="3" rx="1.5" />
+    <rect x="80" y="26" width="3" height="9" rx="1.5" />
+    <rect x="385" y="26" width="3" height="9" rx="1.5" />
+  </g>
+  <rect x="386" y="40" width="4" height="106" rx="2" fill="currentColor" opacity="0.12" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="80" y="52" width="294" height="24" rx="12" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="382" cy="64" r="12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M92 108 H388 V132 H92 Q80 132 80 120 Q80 108 92 108 Z" fillOpacity="0.55" />
+    <path d="M388 108 L402 113 L388 119 Z" fillOpacity="0.45" />
+    <path d="M388 121 L400 125 L388 130 Z" fillOpacity="0.45" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="416" cy="118" r="2.5" />
+    <circle cx="434" cy="122" r="2.5" />
+    <circle cx="452" cy="118" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="476" cy="120" r="6" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="c"

--- a/content/learn/systems-programming-c/structs-and-unions.mdx
+++ b/content/learn/systems-programming-c/structs-and-unions.mdx
@@ -11,6 +11,49 @@ bytes inserted to keep each member at a properly aligned address.
 This page is about both the language feature and the byte-level
 reality.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Two courses of the same bricks: declared char-int-char the top wall needs six ghost padding bricks and runs twelve bytes long; reordered largest-first below, it packs into eight, with the four saved bytes highlighted in yellow"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.6">
+    <rect x="176" y="56" width="22" height="34" rx="4" />
+    <rect x="368" y="56" width="22" height="34" rx="4" />
+    <rect x="272" y="130" width="22" height="34" rx="4" />
+    <rect x="296" y="130" width="22" height="34" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fillOpacity="0.65">
+    <rect x="272" y="56" width="94" height="34" rx="4" />
+    <rect x="176" y="130" width="94" height="34" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <path d="M200 56 h22 v34 h-22 Z M204 60 h14 v26 h-14 Z" fillRule="evenodd" />
+    <path d="M224 56 h22 v34 h-22 Z M228 60 h14 v26 h-14 Z" fillRule="evenodd" />
+    <path d="M248 56 h22 v34 h-22 Z M252 60 h14 v26 h-14 Z" fillRule="evenodd" />
+    <path d="M392 56 h22 v34 h-22 Z M396 60 h14 v26 h-14 Z" fillRule="evenodd" />
+    <path d="M416 56 h22 v34 h-22 Z M420 60 h14 v26 h-14 Z" fillRule="evenodd" />
+    <path d="M440 56 h22 v34 h-22 Z M444 60 h14 v26 h-14 Z" fillRule="evenodd" />
+    <path d="M320 130 h22 v34 h-22 Z M324 134 h14 v26 h-14 Z" fillRule="evenodd" />
+    <path d="M344 130 h22 v34 h-22 Z M348 134 h14 v26 h-14 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="176" y="96" width="288" height="3" rx="1.5" />
+    <rect x="176" y="91" width="2" height="8" />
+    <rect x="272" y="91" width="2" height="8" />
+    <rect x="368" y="91" width="2" height="8" />
+    <rect x="462" y="91" width="2" height="8" />
+    <rect x="176" y="170" width="192" height="3" rx="1.5" />
+    <rect x="176" y="165" width="2" height="8" />
+    <rect x="272" y="165" width="2" height="8" />
+    <rect x="366" y="165" width="2" height="8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="372" y="130" width="92" height="34" rx="6" fillOpacity="0.15" />
+    <rect x="372" y="170" width="92" height="3" rx="1.5" fillOpacity="0.8" />
+  </g>
+</svg>
+
 ## Defining and using a struct
 
 <CodeBlock
@@ -312,6 +355,44 @@ A `union` is a value that can hold *any one of* several types — but
 only one at a time. Every member shares the same storage; the
 union's size is the size of its largest member.
 
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Three translucent rooms of different sizes share one corner and the same floor space, a single occupant dot inside and only one roof tab active — a union stores any one member at a time in storage sized for the largest"
+  style={{ display: "block", width: "100%", maxWidth: "500px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="180" y="48" width="230" height="100" rx="10" fillOpacity="0.15" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="180" y="74" width="150" height="74" rx="10" fillOpacity="0.18" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="180" y="98" width="90" height="50" rx="10" fillOpacity="0.2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="196" y="36" width="36" height="12" rx="5" fillOpacity="0.2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="240" y="36" width="36" height="12" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="284" y="36" width="36" height="12" rx="5" fillOpacity="0.2" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="224" cy="122" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="180" y="158" width="230" height="3" rx="1.5" />
+    <rect x="180" y="153" width="2" height="8" />
+    <rect x="408" y="153" width="2" height="8" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="455" cy="70" r="3" />
+    <circle cx="120" cy="130" r="3" />
+  </g>
+</svg>
+
 <CodeBlock
   adapter="c"
   files={[
@@ -396,6 +477,46 @@ Sometimes you need to pack several small fields into a single
 integer — say, flags on a packet header or per-pixel data. C's
 *bitfield* syntax lets you declare members in widths smaller than a
 byte.
+
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="A single byte bar split into eight thin slots: three carry tiny flags — read raised, write lowered, execute raised — and the rest sit unused, the way bitfields pack booleans into one integer"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="140" y="88" width="360" height="34" rx="9" fill="currentColor" opacity="0.1" />
+  <g fill="currentColor" opacity="0.18">
+    <rect x="184" y="92" width="2" height="26" />
+    <rect x="229" y="92" width="2" height="26" />
+    <rect x="274" y="92" width="2" height="26" />
+    <rect x="319" y="92" width="2" height="26" />
+    <rect x="364" y="92" width="2" height="26" />
+    <rect x="409" y="92" width="2" height="26" />
+    <rect x="454" y="92" width="2" height="26" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="140" y="88" width="44" height="34" rx="9" fillOpacity="0.35" />
+    <rect x="160" y="34" width="3" height="54" fillOpacity="0.7" />
+    <path d="M163 34 L189 42 L163 50 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="186" y="88" width="43" height="34" rx="0" fillOpacity="0.18" />
+    <rect x="205" y="64" width="3" height="24" fillOpacity="0.5" />
+    <path d="M208 64 L230 71 L208 78 Z" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="231" y="88" width="43" height="34" fillOpacity="0.35" />
+    <rect x="250" y="34" width="3" height="54" fillOpacity="0.7" />
+    <path d="M253 34 L279 42 L253 50 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="297" cy="105" r="2.5" />
+    <circle cx="342" cy="105" r="2.5" />
+    <circle cx="387" cy="105" r="2.5" />
+    <circle cx="432" cy="105" r="2.5" />
+    <circle cx="477" cy="105" r="2.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="c"

--- a/content/learn/systems-programming-c/why-c-for-systems.mdx
+++ b/content/learn/systems-programming-c/why-c-for-systems.mdx
@@ -9,6 +9,70 @@ it is still the language that the world's most important systems are
 written in. Knowing why will help you understand what to expect from
 the language — and what *not* to expect.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="A skyline of software towers — kernels, runtimes, databases — every one standing on a single thin solid blue bedrock layer of C, with silicon substrate dots beneath and one green tower still under construction"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="600" cy="40" r="3" />
+    <circle cx="38" cy="98" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="76" cy="52" r="15" />
+  </g>
+  <g fill="currentColor">
+    <rect x="110" y="96" width="52" height="78" opacity="0.18" />
+    <rect x="176" y="64" width="40" height="110" opacity="0.28" />
+    <rect x="194" y="40" width="4" height="24" opacity="0.28" />
+    <rect x="230" y="110" width="64" height="64" opacity="0.14" />
+    <rect x="308" y="48" width="46" height="126" opacity="0.33" />
+    <rect x="368" y="92" width="58" height="82" opacity="0.2" />
+    <rect x="440" y="70" width="42" height="104" opacity="0.26" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="196" cy="36" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="188" cy="84" r="3" />
+    <circle cx="204" cy="84" r="3" />
+    <circle cx="188" cy="104" r="3" />
+    <circle cx="204" cy="104" r="3" />
+    <circle cx="322" cy="70" r="3" />
+    <circle cx="340" cy="70" r="3" />
+    <circle cx="322" cy="92" r="3" />
+    <circle cx="340" cy="92" r="3" />
+    <circle cx="454" cy="90" r="3" />
+    <circle cx="468" cy="90" r="3" />
+    <circle cx="454" cy="112" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="322" cy="114" r="3" />
+    <circle cx="124" cy="116" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="498" y="132" width="44" height="42" fillOpacity="0.5" />
+    <rect x="523" y="108" width="13" height="12" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="556" y="84" width="6" height="90" rx="2" />
+    <rect x="520" y="84" width="42" height="6" rx="3" />
+    <rect x="528" y="90" width="3" height="16" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="72" y="174" width="500" height="14" rx="7" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor">
+    <rect x="88" y="196" width="468" height="8" rx="4" opacity="0.1" />
+    <circle cx="140" cy="212" r="2.5" opacity="0.25" />
+    <circle cx="220" cy="210" r="2.5" opacity="0.25" />
+    <circle cx="320" cy="213" r="2.5" opacity="0.25" />
+    <circle cx="420" cy="210" r="2.5" opacity="0.25" />
+    <circle cx="500" cy="212" r="2.5" opacity="0.25" />
+  </g>
+</svg>
+
 ## C runs the world
 
 | Software | Written in |
@@ -124,6 +188,49 @@ A pragmatic course must be honest about C's costs:
 - **Undefined behavior is everywhere.** Signed overflow, reading
   uninitialized memory, strict aliasing violations — the compiler is
   allowed to do *anything* in response.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A blue walker balances along a thin high beam between two pylons with only a faint ghost of a safety net and a row of red spikes below — C's speed comes without bounds checks or a runtime to catch you"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="86" y="58" width="14" height="104" rx="4" />
+    <rect x="540" y="58" width="14" height="104" rx="4" />
+    <rect x="80" y="52" width="26" height="8" rx="4" />
+    <rect x="534" y="52" width="26" height="8" rx="4" />
+  </g>
+  <rect x="100" y="62" width="440" height="5" rx="2.5" fill="currentColor" opacity="0.35" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="140" cy="58" r="2" fillOpacity="0.15" />
+    <circle cx="180" cy="58" r="2" fillOpacity="0.25" />
+    <circle cx="225" cy="58" r="2" fillOpacity="0.35" />
+    <circle cx="264" cy="58" r="2" fillOpacity="0.45" />
+    <rect x="258" y="56" width="84" height="4" rx="2" fillOpacity="0.7" />
+    <circle cx="300" cy="50" r="8" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <circle cx="140" cy="120" r="3" />
+    <circle cx="190" cy="134" r="3" />
+    <circle cx="240" cy="144" r="3" />
+    <circle cx="290" cy="148" r="3" />
+    <circle cx="340" cy="148" r="3" />
+    <circle cx="390" cy="144" r="3" />
+    <circle cx="440" cy="134" r="3" />
+    <circle cx="490" cy="120" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor" fillOpacity="0.65">
+    <path d="M150 168 L168 142 L186 168 Z" />
+    <path d="M196 168 L214 142 L232 168 Z" />
+    <path d="M242 168 L260 142 L278 168 Z" />
+    <path d="M288 168 L306 142 L324 168 Z" />
+    <path d="M334 168 L352 142 L370 168 Z" />
+    <path d="M380 168 L398 142 L416 168 Z" />
+    <path d="M426 168 L444 142 L462 168 Z" />
+  </g>
+  <rect x="100" y="168" width="440" height="6" rx="3" fill="currentColor" opacity="0.15" />
+</svg>
 
 <Callout type="warn" title="Undefined behavior is not just &quot;crashes&quot;">
 "Undefined behavior" (UB) means the C standard imposes no

--- a/content/learn/time-series-analysis-python/acf-and-pacf.mdx
+++ b/content/learn/time-series-analysis-python/acf-and-pacf.mdx
@@ -10,6 +10,42 @@ model orders without brute-force search. Master these two plots and the
 otherwise-mysterious `(p, d, q)` of ARIMA becomes something you can often
 *read off a chart*.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Two rows of echoes spread from the same starting dot: the blue top row fades gradually lag by lag while the green bottom row sounds once and then falls silent into hollow rings — an ACF that tails off and a PACF that cuts off, the paired fingerprint that names a model"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="122" y="42" width="36" height="146" rx="13" fillOpacity="0.12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="80" cy="70" r="11" />
+    <circle cx="140" cy="70" r="8.5" fillOpacity="0.85" />
+    <circle cx="196" cy="70" r="7.5" fillOpacity="0.72" />
+    <circle cx="252" cy="70" r="6.6" fillOpacity="0.6" />
+    <circle cx="308" cy="70" r="5.8" fillOpacity="0.5" />
+    <circle cx="364" cy="70" r="5.1" fillOpacity="0.41" />
+    <circle cx="420" cy="70" r="4.5" fillOpacity="0.33" />
+    <circle cx="476" cy="70" r="4" fillOpacity="0.26" />
+    <circle cx="532" cy="70" r="3.6" fillOpacity="0.2" />
+    <circle cx="584" cy="70" r="3.2" fillOpacity="0.15" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="80" cy="160" r="11" />
+    <circle cx="140" cy="160" r="8.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <path d="M 191 160 a 5 5 0 1 0 10 0 a 5 5 0 1 0 -10 0 Z M 193.5 160 a 2.5 2.5 0 1 0 5 0 a 2.5 2.5 0 1 0 -5 0 Z" fillRule="evenodd" />
+    <path d="M 247 160 a 5 5 0 1 0 10 0 a 5 5 0 1 0 -10 0 Z M 249.5 160 a 2.5 2.5 0 1 0 5 0 a 2.5 2.5 0 1 0 -5 0 Z" fillRule="evenodd" />
+    <path d="M 303 160 a 5 5 0 1 0 10 0 a 5 5 0 1 0 -10 0 Z M 305.5 160 a 2.5 2.5 0 1 0 5 0 a 2.5 2.5 0 1 0 -5 0 Z" fillRule="evenodd" />
+    <path d="M 359 160 a 5 5 0 1 0 10 0 a 5 5 0 1 0 -10 0 Z M 361.5 160 a 2.5 2.5 0 1 0 5 0 a 2.5 2.5 0 1 0 -5 0 Z" fillRule="evenodd" />
+    <path d="M 415 160 a 5 5 0 1 0 10 0 a 5 5 0 1 0 -10 0 Z M 417.5 160 a 2.5 2.5 0 1 0 5 0 a 2.5 2.5 0 1 0 -5 0 Z" fillRule="evenodd" />
+    <path d="M 471 160 a 5 5 0 1 0 10 0 a 5 5 0 1 0 -10 0 Z M 473.5 160 a 2.5 2.5 0 1 0 5 0 a 2.5 2.5 0 1 0 -5 0 Z" fillRule="evenodd" />
+    <path d="M 527 160 a 5 5 0 1 0 10 0 a 5 5 0 1 0 -10 0 Z M 529.5 160 a 2.5 2.5 0 1 0 5 0 a 2.5 2.5 0 1 0 -5 0 Z" fillRule="evenodd" />
+  </g>
+</svg>
+
 ## Two kinds of correlation with the past
 
 - The **ACF** (Autocorrelation Function) measures the correlation between
@@ -26,6 +62,32 @@ correlated with `y(t-2)` too — through the chain — even though there's no
 direct link. The **ACF** at lag 2 sees that indirect echo and is nonzero;
 the **PACF** at lag 2 strips the chain away and reveals the truth: no direct
 lag-2 relationship.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Two solid links join three dots in a chain while a faint arc of small dots leaps directly from the first to the last; a green ring pins the middle dot in place — the ACF counts the leaping indirect echo, the PACF holds the middleman fixed and keeps only direct ties"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="158" width="520" height="4" rx="2" fill="currentColor" opacity="0.15" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="185" cy="88" r="3.5" fillOpacity="0.3" />
+    <circle cx="230" cy="66" r="3.5" fillOpacity="0.3" />
+    <circle cx="275" cy="52" r="3.5" fillOpacity="0.3" />
+    <circle cx="320" cy="48" r="3.5" fillOpacity="0.3" />
+    <circle cx="365" cy="52" r="3.5" fillOpacity="0.3" />
+    <circle cx="410" cy="66" r="3.5" fillOpacity="0.3" />
+    <circle cx="455" cy="88" r="3.5" fillOpacity="0.3" />
+    <rect x="162" y="115" width="136" height="10" rx="5" fillOpacity="0.35" />
+    <rect x="342" y="115" width="136" height="10" rx="5" fillOpacity="0.35" />
+    <circle cx="140" cy="120" r="10" />
+    <circle cx="320" cy="120" r="10" />
+    <circle cx="500" cy="120" r="10" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 303 120 a 17 17 0 1 0 34 0 a 17 17 0 1 0 -34 0 Z M 307 120 a 13 13 0 1 0 26 0 a 13 13 0 1 0 -26 0 Z" fillRule="evenodd" />
+  </g>
+</svg>
 
 <Callout type="tip" title="The intuition in one line">
 ACF asks "how related are values `k` apart, *however* that relationship
@@ -206,6 +268,35 @@ the band are statistically indistinguishable from zero — noise. Spikes
 *poking outside* are "significant." When we say a plot "cuts off after lag
 `p`," we mean the spikes are significant up through lag `p` and then duck
 inside the band.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Thin bars rise and dip around a shaded zero band: the first two clear it convincingly in blue, most hide inside it, and one lone red bar pokes out far down the row — spikes inside the band are noise, and an isolated far-out spike deserves suspicion"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="96" width="540" height="48" rx="10" fill="currentColor" opacity="0.08" />
+  <rect x="50" y="118" width="540" height="4" rx="2" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="78" y="50" width="9" height="68" rx="4.5" />
+    <rect x="116" y="66" width="9" height="52" rx="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="154" y="122" width="9" height="16" rx="4.5" />
+    <rect x="192" y="102" width="9" height="16" rx="4.5" />
+    <rect x="230" y="122" width="9" height="12" rx="4.5" />
+    <rect x="268" y="106" width="9" height="12" rx="4.5" />
+    <rect x="306" y="122" width="9" height="17" rx="4.5" />
+    <rect x="344" y="104" width="9" height="14" rx="4.5" />
+    <rect x="382" y="122" width="9" height="13" rx="4.5" />
+    <rect x="420" y="103" width="9" height="15" rx="4.5" />
+    <rect x="458" y="122" width="9" height="15" rx="4.5" />
+    <rect x="534" y="108" width="9" height="10" rx="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="496" y="46" width="9" height="72" rx="4.5" fillOpacity="0.9" />
+  </g>
+</svg>
 
 <Callout type="warn" title="Don't over-read the bands">
 With many lags plotted, a few spikes will breach the band *by chance* alone

--- a/content/learn/time-series-analysis-python/arima-models.mdx
+++ b/content/learn/time-series-analysis-python/arima-models.mdx
@@ -9,6 +9,64 @@ those skills into the workhorses of classical forecasting: **AR**, **MA**,
 **ARMA**, and their union **ARIMA**. By the end you'll fit one, read its
 output, and produce a forecast with honest uncertainty bands.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Three interlocking gears turn together — a blue one carrying a trail of recent values, a yellow one carrying a tiny staircase of differences, and a green one carrying fading shock dots, with one small red shock caught between the teeth — AR, I, and MA meshing into a single forecasting machine"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="163" y="50" width="14" height="18" rx="3" />
+    <rect x="163" y="50" width="14" height="18" rx="3" transform="rotate(45 170 112)" />
+    <rect x="163" y="50" width="14" height="18" rx="3" transform="rotate(90 170 112)" />
+    <rect x="163" y="50" width="14" height="18" rx="3" transform="rotate(135 170 112)" />
+    <rect x="163" y="50" width="14" height="18" rx="3" transform="rotate(180 170 112)" />
+    <rect x="163" y="50" width="14" height="18" rx="3" transform="rotate(225 170 112)" />
+    <rect x="163" y="50" width="14" height="18" rx="3" transform="rotate(270 170 112)" />
+    <rect x="163" y="50" width="14" height="18" rx="3" transform="rotate(315 170 112)" />
+    <path d="M 124 112 a 46 46 0 1 0 92 0 a 46 46 0 1 0 -92 0 Z M 150 112 a 20 20 0 1 0 40 0 a 20 20 0 1 0 -40 0 Z" fillRule="evenodd" />
+    <circle cx="158" cy="112" r="3.5" fillOpacity="0.4" />
+    <circle cx="170" cy="112" r="3.5" fillOpacity="0.65" />
+    <circle cx="182" cy="112" r="3.5" fillOpacity="0.95" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="293" y="94" width="13" height="18" rx="3" transform="rotate(22.5 300 150)" />
+    <rect x="293" y="94" width="13" height="18" rx="3" transform="rotate(67.5 300 150)" />
+    <rect x="293" y="94" width="13" height="18" rx="3" transform="rotate(112.5 300 150)" />
+    <rect x="293" y="94" width="13" height="18" rx="3" transform="rotate(157.5 300 150)" />
+    <rect x="293" y="94" width="13" height="18" rx="3" transform="rotate(202.5 300 150)" />
+    <rect x="293" y="94" width="13" height="18" rx="3" transform="rotate(247.5 300 150)" />
+    <rect x="293" y="94" width="13" height="18" rx="3" transform="rotate(292.5 300 150)" />
+    <rect x="293" y="94" width="13" height="18" rx="3" transform="rotate(337.5 300 150)" />
+    <path d="M 260 150 a 40 40 0 1 0 80 0 a 40 40 0 1 0 -80 0 Z M 283 150 a 17 17 0 1 0 34 0 a 17 17 0 1 0 -34 0 Z" fillRule="evenodd" />
+    <rect x="288" y="156" width="8" height="5" rx="1.5" />
+    <rect x="296" y="150" width="8" height="5" rx="1.5" />
+    <rect x="304" y="144" width="8" height="5" rx="1.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="425" y="48" width="14" height="18" rx="3" transform="rotate(22.5 432 108)" />
+    <rect x="425" y="48" width="14" height="18" rx="3" transform="rotate(67.5 432 108)" />
+    <rect x="425" y="48" width="14" height="18" rx="3" transform="rotate(112.5 432 108)" />
+    <rect x="425" y="48" width="14" height="18" rx="3" transform="rotate(157.5 432 108)" />
+    <rect x="425" y="48" width="14" height="18" rx="3" transform="rotate(202.5 432 108)" />
+    <rect x="425" y="48" width="14" height="18" rx="3" transform="rotate(247.5 432 108)" />
+    <rect x="425" y="48" width="14" height="18" rx="3" transform="rotate(292.5 432 108)" />
+    <rect x="425" y="48" width="14" height="18" rx="3" transform="rotate(337.5 432 108)" />
+    <path d="M 388 108 a 44 44 0 1 0 88 0 a 44 44 0 1 0 -88 0 Z M 413 108 a 19 19 0 1 0 38 0 a 19 19 0 1 0 -38 0 Z" fillRule="evenodd" />
+    <circle cx="420" cy="108" r="4" />
+    <circle cx="432" cy="108" r="3.5" fillOpacity="0.6" />
+    <circle cx="444" cy="108" r="3" fillOpacity="0.35" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="368" cy="128" r="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="80" cy="190" r="4" />
+    <circle cx="540" cy="186" r="4" />
+    <circle cx="566" cy="48" r="3" />
+  </g>
+</svg>
+
 ## The two ingredients: AR and MA
 
 An ARIMA model is built from two simple ideas about where the next value
@@ -206,6 +264,44 @@ stretching years into the future — is hiding how little it really knows.
 Always look at the bands, not just the central line.
 </Callout>
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A blue trail of observations climbs to a yellow post where the data ends, and a green cone fans wider and wider around the forecast dots beyond it, with the eventual actual values landing inside the band — uncertainty compounds with every step ahead, and an honest forecast admits it"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="44" y="174" width="552" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="56" cy="130" r="4.5" />
+    <circle cx="86" cy="138" r="4.5" />
+    <circle cx="116" cy="122" r="4.5" />
+    <circle cx="146" cy="130" r="4.5" />
+    <circle cx="176" cy="112" r="4.5" />
+    <circle cx="206" cy="120" r="4.5" />
+    <circle cx="236" cy="104" r="4.5" />
+    <circle cx="266" cy="112" r="4.5" />
+    <circle cx="296" cy="98" r="4.5" />
+    <circle cx="320" cy="102" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="332" y="56" width="7" height="118" rx="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 346 98 L 596 26 L 596 178 Z" fillOpacity="0.1" />
+    <path d="M 346 98 L 596 60 L 596 136 Z" fillOpacity="0.16" />
+    <circle cx="386" cy="94" r="4.5" fillOpacity="0.95" />
+    <circle cx="428" cy="91" r="4.5" fillOpacity="0.8" />
+    <circle cx="470" cy="89" r="4.5" fillOpacity="0.65" />
+    <circle cx="512" cy="87" r="4.5" fillOpacity="0.5" />
+    <circle cx="554" cy="85" r="4.5" fillOpacity="0.4" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <circle cx="428" cy="102" r="3.5" />
+    <circle cx="512" cy="70" r="3.5" />
+    <circle cx="576" cy="96" r="3.5" />
+  </g>
+</svg>
+
 ## Choosing orders with AIC (and its limits)
 
 ACF/PACF suggest candidate orders, but often several are plausible. The
@@ -316,6 +412,36 @@ ARIMA can't capture. That's the residual diagnostic doing its job: telling
 you the model is incomplete and pointing at *seasonality* as the culprit.
 The fix is a **seasonal** ARIMA (SARIMA), which adds seasonal AR/I/MA terms
 at the period — conceptually just "do the AR/I/MA trick at lag 12 too."
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="Residual dots hug the zero line quietly until the twelfth one leaps high in red with a halo around it — a lag-12 spike left in the residuals is the model confessing that it is missing a seasonal term"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="100" width="540" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g fill="currentColor" opacity="0.45">
+    <circle cx="70" cy="94" r="4" />
+    <circle cx="106" cy="106" r="4" />
+    <circle cx="142" cy="98" r="4" />
+    <circle cx="178" cy="104" r="4" />
+    <circle cx="214" cy="92" r="4" />
+    <circle cx="250" cy="108" r="4" />
+    <circle cx="286" cy="96" r="4" />
+    <circle cx="322" cy="102" r="4" />
+    <circle cx="358" cy="94" r="4" />
+    <circle cx="394" cy="106" r="4" />
+    <circle cx="430" cy="98" r="4" />
+    <circle cx="502" cy="104" r="4" />
+    <circle cx="538" cy="96" r="4" />
+    <circle cx="574" cy="102" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="463" y="46" width="6" height="52" rx="3" fillOpacity="0.3" />
+    <circle cx="466" cy="40" r="11" fillOpacity="0.25" />
+    <circle cx="466" cy="40" r="6" />
+  </g>
+</svg>
 
 <MultipleChoice
   markdown={`A teammate says, "I'll use an MA(2) model — that's just a 2-period moving average of the data, right?" What's the correction?

--- a/content/learn/time-series-analysis-python/capstone-forecasting-pipeline.mdx
+++ b/content/learn/time-series-analysis-python/capstone-forecasting-pipeline.mdx
@@ -102,6 +102,53 @@ Put the model to work, watch it on new data, and refit as the series evolves.
 Every forecast starts with eyes on the data. We name what we see *before*
 touching a model.
 
+<svg
+  viewBox="0 0 640 260"
+  role="img"
+  aria-label="A dotted trail climbs from a blue seasonal wave in the foothills, passes a red pitfall and a yellow gate partway up, and reaches a green summit flag where a beam of light fans into the sky — the whole forecasting pipeline as one journey from raw data to a validated forecast"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="90" cy="52" r="14" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.08">
+    <path d="M 40 210 C 120 170 200 190 280 170 C 360 150 440 170 520 140 C 560 126 580 130 600 122 L 600 230 L 40 230 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.13">
+    <path d="M 40 224 C 140 200 220 210 320 188 C 420 166 500 174 600 146 L 600 236 L 40 236 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 40 232 C 60 232 70 206 90 206 C 110 206 118 224 138 224 C 158 224 166 196 186 196 C 206 196 214 218 234 218 C 254 218 262 188 282 188 L 282 232 Z" fillOpacity="0.3" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <circle cx="120" cy="216" r="3.5" />
+    <circle cx="160" cy="208" r="3.5" />
+    <circle cx="200" cy="200" r="3.5" />
+    <circle cx="240" cy="192" r="3.5" />
+    <circle cx="280" cy="184" r="3.5" />
+    <circle cx="316" cy="172" r="3.5" />
+    <circle cx="352" cy="160" r="3.5" />
+    <circle cx="388" cy="148" r="3.5" />
+    <circle cx="424" cy="136" r="3.5" />
+    <circle cx="460" cy="124" r="3.5" />
+    <circle cx="496" cy="112" r="3.5" />
+    <circle cx="524" cy="100" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="362" y="128" width="7" height="44" rx="3" />
+    <rect x="386" y="120" width="7" height="44" rx="3" />
+    <rect x="356" y="114" width="44" height="7" rx="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="302" cy="200" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 550 62 L 604 12 L 632 48 Z" fillOpacity="0.12" />
+    <rect x="544" y="64" width="5" height="56" rx="2.5" />
+    <path d="M 549 64 L 583 76 L 549 88 Z" />
+  </g>
+</svg>
+
 <CodeBlock
   adapter="python"
   files={[
@@ -409,6 +456,28 @@ errors, so it trails the seasonal model. The gap between them is precisely the
 seasonality that plain ARIMA's lag-12 residual spike warned about on the ARIMA
 page — the residual diagnostic, paid off in hard numbers.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Three error columns stand against a yellow line set by the baseline: the neutral baseline column reaches it exactly, the blue model only just dips beneath it, and the green seasonal model sits far lower with a small medal dot above — an error score only means something when it beats the baseline on the same honest test"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="170" width="540" height="5" rx="2.5" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="60" y="78" width="500" height="6" rx="3" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="100" y="84" width="64" height="86" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="268" y="96" width="64" height="74" rx="7" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="436" y="130" width="64" height="40" rx="7" />
+    <circle cx="468" cy="112" r="5.5" />
+  </g>
+</svg>
+
 ## Step 8 — Visualize the forecast against reality
 
 <CodeBlock
@@ -502,6 +571,41 @@ In production, a forecast is a living thing:
 - **Respect the horizon.** Short-horizon forecasts are trustworthy; far-out
   ones come with wide bands for a reason. Don't promise precision the
   uncertainty doesn't support.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Around a continuous loop, a blue gear-like model node hands off to green monitoring pulse dots and yellow retraining arrows, while one red dot drifts away from the orbit trailing a fading tail — in production a forecast lives in a cycle of monitoring, drift detection, and refitting"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <path d="M 248 105 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0 Z M 254 105 a 66 66 0 1 0 132 0 a 66 66 0 1 0 -132 0 Z" fillRule="evenodd" fill="currentColor" opacity="0.15" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="315" y="14" width="10" height="10" rx="2" />
+    <rect x="315" y="42" width="10" height="10" rx="2" />
+    <rect x="301" y="28" width="10" height="10" rx="2" />
+    <rect x="329" y="28" width="10" height="10" rx="2" />
+    <circle cx="320" cy="33" r="12" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="382" cy="142" r="6.5" />
+    <circle cx="392" cy="118" r="5" fillOpacity="0.7" />
+    <circle cx="390" cy="92" r="4" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="244" y="152" width="20" height="8" rx="4" transform="rotate(32 254 156)" />
+    <rect x="222" y="132" width="20" height="8" rx="4" transform="rotate(52 232 136)" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="394" cy="64" r="3" fillOpacity="0.35" />
+    <circle cx="406" cy="54" r="3.5" fillOpacity="0.55" />
+    <circle cx="420" cy="44" r="5.5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="120" cy="60" r="4" />
+    <circle cx="520" cy="160" r="4" />
+    <circle cx="150" cy="170" r="3" />
+  </g>
+</svg>
 
 ## Practice
 

--- a/content/learn/time-series-analysis-python/chronological-validation.mdx
+++ b/content/learn/time-series-analysis-python/chronological-validation.mdx
@@ -10,6 +10,56 @@ separates a real forecaster from someone with a good-looking notebook is
 future it has never seen. Get this wrong and every accuracy number you report
 is a comfortable fiction.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A yellow fence divides the timeline into blue past dots for training and green future dots for testing, while below a small interleaved blue-and-green row is struck through in red — the chronological split is the law, and the shuffled split is the forbidden alternative"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="44" y="148" width="552" height="5" rx="2.5" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="64" cy="128" r="5" />
+    <circle cx="96" cy="136" r="5" />
+    <circle cx="128" cy="122" r="5" />
+    <circle cx="160" cy="130" r="5" />
+    <circle cx="192" cy="114" r="5" />
+    <circle cx="224" cy="124" r="5" />
+    <circle cx="256" cy="108" r="5" />
+    <circle cx="288" cy="118" r="5" />
+    <circle cx="320" cy="104" r="5" />
+    <circle cx="348" cy="110" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="374" y="82" width="9" height="70" rx="4" />
+    <rect x="398" y="82" width="9" height="70" rx="4" />
+    <rect x="366" y="94" width="50" height="7" rx="3.5" fillOpacity="0.8" />
+    <rect x="366" y="122" width="50" height="7" rx="3.5" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="440" cy="100" r="5" />
+    <circle cx="472" cy="108" r="5" />
+    <circle cx="504" cy="94" r="5" />
+    <circle cx="536" cy="102" r="5" />
+    <circle cx="568" cy="88" r="5" />
+    <circle cx="592" cy="96" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="220" cy="198" r="4" fillOpacity="0.6" />
+    <circle cx="260" cy="198" r="4" fillOpacity="0.6" />
+    <circle cx="300" cy="198" r="4" fillOpacity="0.6" />
+    <circle cx="340" cy="198" r="4" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="240" cy="198" r="4" fillOpacity="0.6" />
+    <circle cx="280" cy="198" r="4" fillOpacity="0.6" />
+    <circle cx="320" cy="198" r="4" fillOpacity="0.6" />
+    <circle cx="360" cy="198" r="4" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="286" y="170" width="8" height="58" rx="4" transform="rotate(52 290 199)" fillOpacity="0.85" />
+  </g>
+</svg>
+
 <Callout type="danger" title="The cardinal rule, one more time">
 **You may only use the past to predict the future, never the reverse.** Every
 validation technique on this page is a mechanism for enforcing that rule.
@@ -178,6 +228,39 @@ net flows). When in doubt, report MAE *and* RMSE, and add MAPE only when a
 percentage genuinely makes sense.
 </Callout>
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Two forecast records around the same truth line: on the left, green dots miss by small even amounts; on the right, blue dots sit perfectly except for one towering red blunder under a yellow magnifier — squared-error metrics like RMSE make that single blunder dominate the score"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="108" width="230" height="4" rx="2" fill="currentColor" opacity="0.25" />
+  <rect x="360" y="108" width="230" height="4" rx="2" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="66" cy="100" r="4.5" />
+    <circle cx="102" cy="120" r="4.5" />
+    <circle cx="138" cy="102" r="4.5" />
+    <circle cx="174" cy="118" r="4.5" />
+    <circle cx="210" cy="101" r="4.5" />
+    <circle cx="246" cy="119" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="376" cy="110" r="4.5" />
+    <circle cx="412" cy="110" r="4.5" />
+    <circle cx="448" cy="110" r="4.5" />
+    <circle cx="484" cy="110" r="4.5" />
+    <circle cx="556" cy="110" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="517" y="48" width="6" height="60" rx="3" fillOpacity="0.3" />
+    <circle cx="520" cy="42" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 504 42 a 16 16 0 1 0 32 0 a 16 16 0 1 0 -32 0 Z M 508 42 a 12 12 0 1 0 24 0 a 12 12 0 1 0 -24 0 Z" fillRule="evenodd" />
+    <rect x="529" y="51" width="7" height="20" rx="3.5" transform="rotate(-45 532.5 61)" />
+  </g>
+</svg>
+
 ## Beyond one split: walk-forward backtesting
 
 A single train/test split gives *one* estimate of forecast skill — and one
@@ -197,6 +280,34 @@ set grows each fold while the test window marches forward. A **rolling-window**
 scheme instead keeps the training window a fixed *size* and slides it — useful
 when old history stops being relevant. Either way, you get several honest
 out-of-sample scores instead of one.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Three stacked timelines show a blue training bar growing longer in each fold while a green test block marches further into the future past a yellow cut mark — walk-forward backtesting, where training always ends before testing begins"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="60" y="48" width="200" height="28" rx="8" fillOpacity="0.55" />
+    <rect x="60" y="104" width="284" height="28" rx="8" fillOpacity="0.55" />
+    <rect x="60" y="160" width="368" height="28" rx="8" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="263" y="44" width="5" height="36" rx="2.5" />
+    <rect x="347" y="100" width="5" height="36" rx="2.5" />
+    <rect x="431" y="156" width="5" height="36" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="271" y="48" width="84" height="28" rx="8" />
+    <rect x="355" y="104" width="84" height="28" rx="8" />
+    <rect x="439" y="160" width="84" height="28" rx="8" />
+  </g>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="363" y="48" width="217" height="28" rx="8" />
+    <rect x="447" y="104" width="133" height="28" rx="8" />
+    <rect x="531" y="160" width="49" height="28" rx="8" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"
@@ -296,6 +407,45 @@ it won't have at prediction time:
   and keeping the one with the best *test* score, the test set has trained
   your choices. You need a separate **validation** set (or nested CV); the
   final test set is looked at **once**.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="The yellow fence guards the split above the ground, but a red trail of dots tunnels beneath it from the future side back into training, surfacing among the blue past dots — preprocessing computed on the whole series leaks the future even when the split itself looks correct"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="44" y="130" width="552" height="5" rx="2.5" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="80" cy="112" r="5" />
+    <circle cx="130" cy="104" r="5" />
+    <circle cx="180" cy="112" r="5" />
+    <circle cx="230" cy="102" r="5" />
+    <circle cx="280" cy="110" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="310" y="68" width="9" height="62" rx="4" />
+    <rect x="334" y="68" width="9" height="62" rx="4" />
+    <rect x="302" y="80" width="50" height="6" rx="3" fillOpacity="0.8" />
+    <rect x="302" y="104" width="50" height="6" rx="3" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="372" cy="104" r="5" />
+    <circle cx="422" cy="112" r="5" />
+    <circle cx="472" cy="100" r="5" />
+    <circle cx="522" cy="110" r="5" />
+    <circle cx="572" cy="102" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="462" cy="142" r="3.5" fillOpacity="0.7" />
+    <circle cx="420" cy="164" r="3.5" fillOpacity="0.7" />
+    <circle cx="378" cy="178" r="3.5" fillOpacity="0.7" />
+    <circle cx="330" cy="182" r="3.5" fillOpacity="0.7" />
+    <circle cx="282" cy="178" r="3.5" fillOpacity="0.7" />
+    <circle cx="240" cy="164" r="3.5" fillOpacity="0.7" />
+    <circle cx="198" cy="142" r="3.5" fillOpacity="0.7" />
+    <circle cx="190" cy="120" r="5.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/time-series-analysis-python/decomposition-trend-seasonality.mdx
+++ b/content/learn/time-series-analysis-python/decomposition-trend-seasonality.mdx
@@ -25,6 +25,45 @@ The honest way to trust a tool is to feed it data whose answer you already
 know. We'll *construct* a series from a known trend, a known seasonal sine,
 and known noise, then ask `seasonal_decompose` to hand the pieces back.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="A blue observed ridge sits above three translucent strata that add up to it — a rising green trend ramp, a steady yellow seasonal wave, and a dusting of residual noise dots — decomposition pulls one series apart into trend, season, and remainder"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 90 92 C 105 80 118 62 140 62 C 162 62 168 80 190 80 C 212 80 218 52 240 52 C 262 52 268 72 290 72 C 312 72 318 44 340 44 C 362 44 368 64 390 64 C 412 64 418 34 440 34 C 462 34 470 56 492 56 C 514 56 530 40 550 36 L 550 92 Z" fillOpacity="0.28" />
+    <circle cx="140" cy="62" r="4" />
+    <circle cx="240" cy="52" r="4" />
+    <circle cx="340" cy="44" r="4" />
+    <circle cx="440" cy="34" r="4" />
+  </g>
+  <text x="60" y="124" fontFamily="ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">=</text>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 90 130 L 550 96 L 550 104 L 90 138 Z" fillOpacity="0.55" />
+  </g>
+  <text x="60" y="182" fontFamily="ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">+</text>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 90 176 C 113 158 136 158 159 176 C 182 194 205 194 228 176 C 251 158 274 158 297 176 C 320 194 343 194 366 176 C 389 158 412 158 435 176 C 458 194 481 194 504 176 C 527 158 538 158 550 166 L 550 176 C 538 168 527 168 504 186 C 481 204 458 204 435 186 C 412 168 389 168 366 186 C 343 204 320 204 297 186 C 274 168 251 168 228 186 C 205 204 182 204 159 186 C 136 168 113 168 90 186 Z" fillOpacity="0.55" />
+  </g>
+  <text x="60" y="232" fontFamily="ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">+</text>
+  <g fill="currentColor" opacity="0.45">
+    <circle cx="104" cy="228" r="3" />
+    <circle cx="140" cy="220" r="3" />
+    <circle cx="176" cy="232" r="3" />
+    <circle cx="212" cy="224" r="3" />
+    <circle cx="248" cy="230" r="3" />
+    <circle cx="284" cy="218" r="3" />
+    <circle cx="320" cy="234" r="3" />
+    <circle cx="356" cy="226" r="3" />
+    <circle cx="392" cy="220" r="3" />
+    <circle cx="428" cy="232" r="3" />
+    <circle cx="464" cy="222" r="3" />
+    <circle cx="500" cy="230" r="3" />
+    <circle cx="536" cy="224" r="3" />
+  </g>
+</svg>
+
 <CodeBlock
   adapter="python"
   files={[
@@ -90,6 +129,29 @@ The choice between the two models isn't a coin flip — the data tells you:
 - **Multiplicative** (`Observed = Trend x Seasonal x Residual`): use it when
   the seasonal swings **grow with the level**. The summer bump is "+30%" — so
   it's small when the series is low and large when it's high.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Two waves climb side by side: the green one swings by the same amount all the way up, while the blue one swings wider and wider inside a faint red funnel as its level rises — constant-size swings are additive, swings that grow with the level are multiplicative"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="52" y="176" width="244" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <rect x="344" y="176" width="244" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 60 150 C 68 138 74 132 82 132 C 94 132 112 152 127 152 C 142 152 158 116 172 116 C 186 116 202 137 217 137 C 232 137 248 101 262 101 C 272 101 280 104 288 108 L 288 117 C 280 113 272 110 262 110 C 248 110 232 146 217 146 C 202 146 186 125 172 125 C 158 125 142 161 127 161 C 112 161 94 141 82 141 C 74 141 68 147 60 159 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 350 142 L 580 66 L 580 166 L 350 158 Z" fillOpacity="0.1" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 350 150 C 358 142 364 138 372 138 C 384 138 402 152 417 152 C 432 152 446 109 462 109 C 478 109 492 153 507 153 C 522 153 536 77 552 77 C 562 77 570 82 580 88 L 580 97 C 570 91 562 86 552 86 C 536 86 522 162 507 162 C 492 162 478 118 462 118 C 446 118 432 161 417 161 C 402 161 384 147 372 147 C 364 147 358 151 350 159 Z" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="318" cy="60" r="3" />
+    <circle cx="318" cy="120" r="3" />
+  </g>
+</svg>
 
 The airline series is the textbook multiplicative case: its summer-to-winter
 swing is tiny in 1949 and huge by 1960. Watch what additive does with that.
@@ -178,6 +240,30 @@ There's an elegant shortcut. Taking the **logarithm** of a multiplicative
 series makes it *additive*, because `log(T x S x R) = log T + log S + log R`.
 A log compresses the big late-period swings and stretches the small early
 ones until they're the same size — exactly what an additive model wants.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A wave whose swings grow ever larger flows into a yellow lens marked ln and emerges on the other side with calm, equal swings — the log transform turns multiplicative growth into the additive world classical models live in"
+  style={{ display: "block", width: "100%", maxWidth: "600px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 50 100 C 60 94 70 92 80 92 C 95 92 110 114 125 114 C 140 114 155 78 170 78 C 185 78 200 130 215 130 C 230 130 244 76 258 70 L 258 79 C 244 85 230 139 215 139 C 200 139 185 87 170 87 C 155 87 140 123 125 123 C 110 123 95 101 80 101 C 70 101 60 103 50 109 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 286 100 a 34 34 0 1 0 68 0 a 34 34 0 1 0 -68 0 Z M 294 100 a 26 26 0 1 0 52 0 a 26 26 0 1 0 -52 0 Z" fillRule="evenodd" />
+  </g>
+  <text x="320" y="107" fontFamily="Georgia, serif" fontStyle="italic" fontSize="20" fill="currentColor" opacity="0.55" textAnchor="middle">ln</text>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 370 100 C 380 88 390 84 400 84 C 415 84 430 116 445 116 C 460 116 475 84 490 84 C 505 84 520 116 535 116 C 550 116 562 96 580 92 L 580 101 C 562 105 550 125 535 125 C 520 125 505 93 490 93 C 475 93 460 125 445 125 C 430 125 415 93 400 93 C 390 93 380 97 370 109 Z" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="320" cy="34" r="3" />
+    <circle cx="320" cy="166" r="3" />
+    <circle cx="80" cy="160" r="3" />
+    <circle cx="560" cy="44" r="3" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/time-series-analysis-python/differencing.mdx
+++ b/content/learn/time-series-analysis-python/differencing.mdx
@@ -10,6 +10,39 @@ the operation hiding behind the `d` in **ARIMA**. This page is about *why*
 it works, how far to take it, and the classic mistake of taking it one step
 too far.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="A blue staircase climbs steadily on the left while on the right its risers have been laid out as five identical green tiles on level ground beneath a small delta sign — differencing turns a rising level into a constant step, and the trend vanishes"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="48" y="184" width="556" height="5" rx="2.5" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="60" y="162" width="52" height="22" rx="4" fillOpacity="0.75" />
+    <rect x="112" y="140" width="52" height="44" rx="4" fillOpacity="0.75" />
+    <rect x="164" y="118" width="52" height="66" rx="4" fillOpacity="0.75" />
+    <rect x="216" y="96" width="52" height="88" rx="4" fillOpacity="0.75" />
+    <rect x="268" y="74" width="52" height="110" rx="4" fillOpacity="0.75" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="344" cy="128" r="3.5" />
+    <circle cx="360" cy="128" r="3.5" />
+    <circle cx="376" cy="128" r="3.5" />
+  </g>
+  <text x="497" y="140" fontFamily="ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">Δ</text>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="396" y="164" width="34" height="20" rx="5" fillOpacity="0.85" />
+    <rect x="438" y="164" width="34" height="20" rx="5" fillOpacity="0.85" />
+    <rect x="480" y="164" width="34" height="20" rx="5" fillOpacity="0.85" />
+    <rect x="522" y="164" width="34" height="20" rx="5" fillOpacity="0.85" />
+    <rect x="564" y="164" width="34" height="20" rx="5" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="80" cy="50" r="4" />
+    <circle cx="580" cy="56" r="3" />
+  </g>
+</svg>
+
 ## What differencing is
 
 First differencing replaces each value with the **change since the previous
@@ -250,6 +283,43 @@ structure and inflates the variance. The fingerprint of over-differencing is
 a strong **negative lag-1 autocorrelation** (around `-0.5`) and a variance
 that went *up* instead of down.
 
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A calm, already-stationary band of blue dots passes through one needless extra difference and emerges as a violent red sawtooth swinging alternately high and low with twice the spread — over-differencing manufactures negative correlation instead of removing anything"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="50" y="86" width="222" height="28" rx="14" fillOpacity="0.12" />
+    <circle cx="62" cy="96" r="4" />
+    <circle cx="80" cy="106" r="4" />
+    <circle cx="98" cy="98" r="4" />
+    <circle cx="116" cy="104" r="4" />
+    <circle cx="134" cy="94" r="4" />
+    <circle cx="152" cy="106" r="4" />
+    <circle cx="170" cy="100" r="4" />
+    <circle cx="188" cy="96" r="4" />
+    <circle cx="206" cy="104" r="4" />
+    <circle cx="224" cy="98" r="4" />
+    <circle cx="242" cy="103" r="4" />
+    <circle cx="260" cy="97" r="4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="296" cy="100" r="3.5" />
+    <circle cx="314" cy="100" r="3.5" />
+    <circle cx="332" cy="100" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 364 95 L 388 53 L 424 137 L 460 53 L 496 137 L 532 53 L 568 137 L 588 95 L 588 105 L 568 147 L 532 63 L 496 147 L 460 63 L 424 147 L 388 63 L 364 105 Z" fillOpacity="0.5" />
+    <circle cx="388" cy="58" r="4.5" />
+    <circle cx="424" cy="142" r="4.5" />
+    <circle cx="460" cy="58" r="4.5" />
+    <circle cx="496" cy="142" r="4.5" />
+    <circle cx="532" cy="58" r="4.5" />
+    <circle cx="568" cy="142" r="4.5" />
+  </g>
+</svg>
+
 <CodeBlock
   adapter="python"
   files={[
@@ -309,6 +379,52 @@ differencing is a **cumulative sum** plus the starting value — a process
 called **integration**. That's literally what the "I" in AR**I**MA stands
 for: *Integrated*, meaning the model works on a differenced series and
 integrates its forecasts back up.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="From a yellow starting dot, flat green change-tiles are stacked one atop another, column by column, until the blue staircase silhouette reappears on the right — integration, the cumulative sum plus the starting value, undoes differencing and is the I in ARIMA"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="48" y="182" width="556" height="5" rx="2.5" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="70" cy="169" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="94" y="160" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="136" y="160" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="178" y="160" width="34" height="18" rx="5" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="238" cy="130" r="3.5" />
+    <circle cx="254" cy="130" r="3.5" />
+    <circle cx="270" cy="130" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 296 178 L 296 158 L 340 158 L 340 138 L 384 138 L 384 118 L 428 118 L 428 98 L 472 98 L 472 78 L 516 78 L 516 178 Z" fillOpacity="0.15" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="300" y="160" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="344" y="160" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="344" y="140" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="388" y="160" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="388" y="140" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="388" y="120" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="432" y="160" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="432" y="140" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="432" y="120" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="432" y="100" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="476" y="160" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="476" y="140" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="476" y="120" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="476" y="100" width="34" height="18" rx="5" fillOpacity="0.85" />
+    <rect x="476" y="80" width="34" height="18" rx="5" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="560" cy="60" r="4" />
+    <circle cx="588" cy="120" r="3" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/time-series-analysis-python/handling-missing-temporal-data.mdx
+++ b/content/learn/time-series-analysis-python/handling-missing-temporal-data.mdx
@@ -11,6 +11,46 @@ question is rarely "drop or keep?" but "**what do I believe happened
 during the gap?**" — and every fill method is a different answer to that
 question.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A dotted ribbon runs along the timeline with two torn gaps — one stitched closed by green interpolated dots on a mending strip, the other still a row of hollow red rings — a missing stretch of temporal data is either repaired by an assumption or left honestly empty"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="44" y="86" width="172" height="48" rx="20" />
+    <rect x="312" y="86" width="100" height="48" rx="20" />
+    <rect x="500" y="86" width="96" height="48" rx="20" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="60" cy="114" r="5" />
+    <circle cx="94" cy="104" r="5" />
+    <circle cx="128" cy="116" r="5" />
+    <circle cx="162" cy="106" r="5" />
+    <circle cx="196" cy="98" r="5" />
+    <circle cx="328" cy="110" r="5" />
+    <circle cx="362" cy="100" r="5" />
+    <circle cx="396" cy="112" r="5" />
+    <circle cx="516" cy="108" r="5" />
+    <circle cx="550" cy="98" r="5" />
+    <circle cx="582" cy="110" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 196 95 L 328 107 L 328 113 L 196 101 Z" fillOpacity="0.35" />
+    <circle cx="240" cy="102" r="4.5" fillOpacity="0.9" />
+    <circle cx="284" cy="106" r="4.5" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 423 104 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 426.5 104 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" fillOpacity="0.8" />
+    <path d="M 457 104 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 460.5 104 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="80" cy="40" r="3" />
+    <circle cx="560" cy="166" r="3" />
+    <circle cx="340" cy="170" r="3" />
+  </g>
+</svg>
+
 <Callout type="info" title="Two kinds of 'missing' in time series">
 1. **A missing value at a present timestamp** — the row exists, but the
    value is `NaN` (the sensor returned nothing at 14:00).
@@ -124,6 +164,42 @@ print("Three different stories about the same two unknown days.")
 - **Linear interpolation** — "the value **glided smoothly** between the two
   knowns." Ideal for *continuous physical* quantities sampled with dropouts:
   temperature, sensor voltage, a slowly drifting measurement.
+
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Three copies of the same gap between a low known dot and a high known dot: yellow holds the last value flat, red drags the next value backwards, and green glides evenly between them — forward-fill, back-fill, and interpolation are three different beliefs about the unseen"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="110" cy="56" r="6" />
+    <circle cx="470" cy="32" r="6" />
+    <circle cx="110" cy="132" r="6" />
+    <circle cx="470" cy="108" r="6" />
+    <circle cx="110" cy="208" r="6" />
+    <circle cx="470" cy="184" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="118" y="53" width="234" height="6" rx="3" fillOpacity="0.45" />
+    <circle cx="230" cy="56" r="5" />
+    <circle cx="350" cy="56" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="222" y="105" width="240" height="6" rx="3" fillOpacity="0.4" />
+    <circle cx="230" cy="108" r="5" />
+    <circle cx="350" cy="108" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 116 205 L 464 181 L 464 187 L 116 211 Z" fillOpacity="0.45" />
+    <circle cx="230" cy="200" r="5" />
+    <circle cx="350" cy="192" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="540" cy="56" r="3.5" />
+    <circle cx="540" cy="108" r="3.5" />
+    <circle cx="540" cy="184" r="3.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"
@@ -250,6 +326,34 @@ a sensor that's off, a holiday with no trading — these are *zeros or
 genuine absences*, not values to interpolate. Decide what the gap *means*
 first; only then pick a fill.
 </Callout>
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Six solid blue sales columns finish the week, and in Sunday's empty slot a hollow red phantom bar looms at the height interpolation would invent while the true value — a flat green zero tile — sits on the floor; a closed shop is a real zero, not a gap to fill"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="56" y="170" width="528" height="5" rx="2.5" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="72" y="106" width="36" height="64" rx="6" fillOpacity="0.8" />
+    <rect x="138" y="114" width="36" height="56" rx="6" fillOpacity="0.8" />
+    <rect x="204" y="100" width="36" height="70" rx="6" fillOpacity="0.8" />
+    <rect x="270" y="110" width="36" height="60" rx="6" fillOpacity="0.8" />
+    <rect x="336" y="84" width="36" height="86" rx="6" fillOpacity="0.8" />
+    <rect x="402" y="64" width="36" height="106" rx="6" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 468 60 L 504 60 L 504 170 L 468 170 Z M 474 66 L 498 66 L 498 164 L 474 164 Z" fillRule="evenodd" fillOpacity="0.55" />
+    <circle cx="486" cy="44" r="4" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="468" y="162" width="36" height="8" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="546" cy="150" r="4" />
+    <circle cx="566" cy="160" r="4" />
+  </g>
+</svg>
 
 ## When dropping is actually fine
 

--- a/content/learn/time-series-analysis-python/index.mdx
+++ b/content/learn/time-series-analysis-python/index.mdx
@@ -16,6 +16,53 @@ passage of time. Reorder the rows of an ordinary table and you lose
 nothing. Reorder the rows of a time series and you have **destroyed the
 data** — because in a time series, the *order is the information*.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A seasonal wave grows along a timeline of dots toward a yellow now-post, a green forecast cone fans wider into the future beyond it, and the same points lie scattered as dust beneath the axis — in time series the order is the information, and honest forecasts carry widening uncertainty"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="36" y="186" width="568" height="5" rx="2.5" fill="currentColor" opacity="0.25" />
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="64" cy="38" r="4" />
+    <circle cx="600" cy="210" r="3" />
+    <circle cx="336" cy="30" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 48 186 C 70 186 78 168 96 168 C 114 168 120 183 138 183 C 156 183 164 148 184 148 C 204 148 210 178 228 178 C 246 178 256 118 280 118 C 304 118 310 172 328 172 C 346 172 356 84 384 84 L 384 186 Z" fillOpacity="0.2" />
+    <circle cx="96" cy="168" r="4" />
+    <circle cx="138" cy="183" r="4" />
+    <circle cx="184" cy="148" r="4.5" />
+    <circle cx="228" cy="178" r="4.5" />
+    <circle cx="280" cy="118" r="5" />
+    <circle cx="328" cy="172" r="5" />
+    <circle cx="384" cy="84" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="396" y="96" width="8" height="90" rx="4" />
+    <circle cx="400" cy="82" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 410 96 L 600 24 L 600 164 Z" fillOpacity="0.1" />
+    <path d="M 410 96 L 600 56 L 600 124 Z" fillOpacity="0.16" />
+    <circle cx="446" cy="92" r="4.5" fillOpacity="0.95" />
+    <circle cx="486" cy="87" r="4.5" fillOpacity="0.8" />
+    <circle cx="526" cy="83" r="4.5" fillOpacity="0.65" />
+    <circle cx="566" cy="79" r="4.5" fillOpacity="0.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="76" cy="206" r="3" />
+    <circle cx="118" cy="222" r="3" />
+    <circle cx="164" cy="210" r="3" />
+    <circle cx="246" cy="224" r="3" />
+    <circle cx="298" cy="206" r="3" />
+    <circle cx="352" cy="219" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="206" cy="215" r="3.5" />
+  </g>
+</svg>
+
 <Callout type="info" title="What we assume you already know">
 You can write basic Python (slicing, list comprehensions), use pandas
 (`DataFrame`, `Series`, filtering), make a simple line chart, and you

--- a/content/learn/time-series-analysis-python/resampling-and-aggregation.mdx
+++ b/content/learn/time-series-analysis-python/resampling-and-aggregation.mdx
@@ -36,6 +36,76 @@ waits for you to tell it how to aggregate each bucket. The frequency string
 names the summary.
 </Callout>
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Twenty-eight small day tiles merge into four green week bars and then into one yellow month block, a single red day leaving a fading trace at every scale — resampling rolls a fine calendar up into a coarser one, carrying its days' influence along"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="56" y="46" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="81" y="46" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="106" y="46" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="131" y="46" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="156" y="46" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="181" y="46" width="18" height="18" rx="4" fillOpacity="0.22" />
+    <rect x="206" y="46" width="18" height="18" rx="4" fillOpacity="0.22" />
+    <rect x="56" y="71" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="81" y="71" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="106" y="71" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="131" y="71" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="156" y="71" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="181" y="71" width="18" height="18" rx="4" fillOpacity="0.22" />
+    <rect x="206" y="71" width="18" height="18" rx="4" fillOpacity="0.22" />
+    <rect x="56" y="96" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="81" y="96" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="106" y="96" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="156" y="96" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="181" y="96" width="18" height="18" rx="4" fillOpacity="0.22" />
+    <rect x="206" y="96" width="18" height="18" rx="4" fillOpacity="0.22" />
+    <rect x="56" y="121" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="81" y="121" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="106" y="121" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="131" y="121" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="156" y="121" width="18" height="18" rx="4" fillOpacity="0.55" />
+    <rect x="181" y="121" width="18" height="18" rx="4" fillOpacity="0.22" />
+    <rect x="206" y="121" width="18" height="18" rx="4" fillOpacity="0.22" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="131" y="96" width="18" height="18" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="246" cy="92" r="3" />
+    <circle cx="261" cy="92" r="3" />
+    <circle cx="276" cy="92" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="296" y="46" width="88" height="18" rx="9" fillOpacity="0.75" />
+    <rect x="296" y="71" width="88" height="18" rx="9" fillOpacity="0.75" />
+    <rect x="296" y="96" width="88" height="18" rx="9" fillOpacity="0.75" />
+    <rect x="296" y="121" width="88" height="18" rx="9" fillOpacity="0.75" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="334" y="100" width="10" height="10" rx="3" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="404" cy="92" r="3" />
+    <circle cx="419" cy="92" r="3" />
+    <circle cx="434" cy="92" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="454" y="46" width="96" height="93" rx="14" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="532" cy="124" r="4" fillOpacity="0.55" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="582" cy="60" r="4" />
+    <circle cx="80" cy="180" r="4" />
+    <circle cx="560" cy="180" r="3" />
+  </g>
+</svg>
+
 ## Downsampling: summarizing to a coarser grid
 
 Let's build a daily series — website visits with a slow upward trend and a
@@ -92,6 +162,35 @@ This is the choice beginners get wrong most often. The rule:
   temperature, price, CPU utilization, a stock's closing level. The monthly
   "temperature" is the *average* of its days, never their sum (summing 30
   daily temperatures of 20°C into "600°C for the month" is nonsense).
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Green drops fall and stack into one tall column beside a sigma sign, while blue dots scatter around a steady horizontal band on the right — flows like rainfall add up to a sum, but levels like temperature summarize as a mean"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="80" y="172" width="200" height="4" rx="2" fill="currentColor" opacity="0.25" />
+  <rect x="360" y="172" width="200" height="4" rx="2" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="166" cy="42" r="4" fillOpacity="0.55" />
+    <circle cx="198" cy="60" r="4" fillOpacity="0.7" />
+    <circle cx="178" cy="80" r="4" fillOpacity="0.85" />
+    <rect x="158" y="152" width="44" height="16" rx="4" />
+    <rect x="158" y="134" width="44" height="16" rx="4" fillOpacity="0.85" />
+    <rect x="158" y="116" width="44" height="16" rx="4" fillOpacity="0.7" />
+    <rect x="158" y="98" width="44" height="16" rx="4" fillOpacity="0.55" />
+  </g>
+  <text x="116" y="128" fontFamily="ui-monospace, monospace" fontSize="22" fill="currentColor" opacity="0.45">Σ</text>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="368" y="124" width="184" height="9" rx="4.5" fillOpacity="0.35" />
+    <circle cx="380" cy="112" r="5" />
+    <circle cx="412" cy="142" r="5" />
+    <circle cx="444" cy="106" r="5" />
+    <circle cx="476" cy="148" r="5" />
+    <circle cx="508" cy="114" r="5" />
+    <circle cx="540" cy="136" r="5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"
@@ -301,6 +400,37 @@ observations is a guess whose quality depends entirely on whether your
 fill assumption matches reality. Never report upsampled points as if they
 were measured.
 </Callout>
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Three solid monthly dots stand above a row of hollow daily slots, joined by two invented routes — a yellow forward-fill staircase and a green interpolated glide — upsampling lays down the finer grid, but every in-between value is an assumption rather than a measurement"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="60" y="176" width="520" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g fill="currentColor" opacity="0.35">
+    <path d="M 133 176 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 136.5 176 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" />
+    <path d="M 193 176 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 196.5 176 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" />
+    <path d="M 253 176 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 256.5 176 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" />
+    <path d="M 373 176 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 376.5 176 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" />
+    <path d="M 433 176 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 436.5 176 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" />
+    <path d="M 493 176 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 496.5 176 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="86" y="143" width="228" height="6" rx="3" fillOpacity="0.6" />
+    <rect x="317" y="89" width="6" height="57" rx="3" fillOpacity="0.6" />
+    <rect x="326" y="83" width="228" height="6" rx="3" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M 86 143 L 314 83 L 314 89 L 86 149 Z" fillOpacity="0.6" />
+    <path d="M 326 83 L 554 113 L 554 119 L 326 89 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="80" cy="146" r="6.5" />
+    <circle cx="320" cy="86" r="6.5" />
+    <circle cx="560" cy="116" r="6.5" />
+  </g>
+</svg>
 
 <MultipleChoice
   markdown={`A colleague upsamples a **monthly** revenue series to **daily** with linear interpolation and announces, "Now we have daily revenue figures." What's the problem?

--- a/content/learn/time-series-analysis-python/rolling-and-expanding-windows.mdx
+++ b/content/learn/time-series-analysis-python/rolling-and-expanding-windows.mdx
@@ -11,6 +11,47 @@ three closely related tools: **`shift`** (look at the past), **`rolling`**
 everything so far). It also covers the two ways people quietly cheat with
 them.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="A glowing yellow pane slides along a row of dim noisy dots, lighting the few inside it blue, while a calm green trail of averages forms beneath the positions it has already visited — a rolling window summarizes a sliding stretch of the recent past"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="86" y="62" width="150" height="104" rx="14" fillOpacity="0.07" />
+    <rect x="206" y="62" width="150" height="104" rx="14" fillOpacity="0.12" />
+    <rect x="326" y="62" width="150" height="104" rx="14" fillOpacity="0.24" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="60" cy="118" r="5" />
+    <circle cx="96" cy="96" r="5" />
+    <circle cx="132" cy="132" r="5" />
+    <circle cx="168" cy="104" r="5" />
+    <circle cx="204" cy="142" r="5" />
+    <circle cx="240" cy="98" r="5" />
+    <circle cx="276" cy="126" r="5" />
+    <circle cx="312" cy="92" r="5" />
+    <circle cx="512" cy="100" r="5" />
+    <circle cx="548" cy="134" r="5" />
+    <circle cx="584" cy="108" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="348" cy="136" r="5.5" />
+    <circle cx="382" cy="88" r="5.5" />
+    <circle cx="416" cy="122" r="5.5" />
+    <circle cx="450" cy="104" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="161" cy="184" r="3.5" fillOpacity="0.45" />
+    <circle cx="201" cy="184" r="3.5" fillOpacity="0.55" />
+    <circle cx="241" cy="184" r="3.5" fillOpacity="0.65" />
+    <circle cx="281" cy="184" r="3.5" fillOpacity="0.75" />
+    <circle cx="321" cy="184" r="3.5" fillOpacity="0.85" />
+    <circle cx="361" cy="184" r="3.5" fillOpacity="0.95" />
+    <circle cx="401" cy="184" r="6" />
+  </g>
+</svg>
+
 ## First, looking backward: `shift`
 
 Almost every time series operation needs to compare *now* to *then*.
@@ -244,6 +285,37 @@ already have**. It describes the *past*. It has no machinery to project
 stops. People see a smooth upward moving-average curve and imagine it
 "continuing," but the moving average itself predicts nothing.
 
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="A smooth blue average ribbon glides upward and halts at a red post where the data ends, leaving only hollow slots and a question mark in the space beyond — a moving average describes the past and cannot step into the future"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="44" y="156" width="552" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="70" cy="122" r="3.5" fillOpacity="0.35" />
+    <circle cx="106" cy="106" r="3.5" fillOpacity="0.35" />
+    <circle cx="142" cy="118" r="3.5" fillOpacity="0.35" />
+    <circle cx="178" cy="92" r="3.5" fillOpacity="0.35" />
+    <circle cx="214" cy="104" r="3.5" fillOpacity="0.35" />
+    <circle cx="250" cy="80" r="3.5" fillOpacity="0.35" />
+    <circle cx="286" cy="92" r="3.5" fillOpacity="0.35" />
+    <circle cx="322" cy="70" r="3.5" fillOpacity="0.35" />
+    <circle cx="358" cy="82" r="3.5" fillOpacity="0.35" />
+    <circle cx="394" cy="62" r="3.5" fillOpacity="0.35" />
+    <path d="M 64 120 C 150 110 200 96 280 84 C 340 75 380 68 424 62 L 425 74 C 381 80 341 87 282 96 C 202 108 152 122 66 132 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="434" y="44" width="7" height="112" rx="3.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <path d="M 466 68 a 6 6 0 1 0 12 0 a 6 6 0 1 0 -12 0 Z M 469 68 a 3 3 0 1 0 6 0 a 3 3 0 1 0 -6 0 Z" fillRule="evenodd" />
+    <path d="M 502 62 a 6 6 0 1 0 12 0 a 6 6 0 1 0 -12 0 Z M 505 62 a 3 3 0 1 0 6 0 a 3 3 0 1 0 -6 0 Z" fillRule="evenodd" />
+    <path d="M 538 56 a 6 6 0 1 0 12 0 a 6 6 0 1 0 -12 0 Z M 541 56 a 3 3 0 1 0 6 0 a 3 3 0 1 0 -6 0 Z" fillRule="evenodd" />
+  </g>
+  <text x="500" y="124" fontFamily="ui-monospace, monospace" fontSize="30" fill="currentColor" opacity="0.45" textAnchor="middle">?</text>
+</svg>
+
 <CodeBlock
   adapter="python"
   files={[
@@ -368,6 +440,42 @@ Where `rolling(N)` looks back a fixed `N` steps, **`expanding`** looks back
 running (cumulative) average — "the average of everything up to and
 including now." It's the honest, leakage-free way to say "the typical value
 *so far*," because at each point it only knows the past.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="On the left a fixed-width blue pane slides along its dots, trailing a ghost of where it just was; on the right green panes grow from one anchored dot, each wider than the last — a rolling window forgets old data while an expanding window remembers everything so far"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="70" cy="106" r="4.5" />
+    <circle cx="102" cy="92" r="4.5" />
+    <circle cx="134" cy="112" r="4.5" />
+    <circle cx="166" cy="96" r="4.5" />
+    <circle cx="198" cy="116" r="4.5" />
+    <circle cx="230" cy="100" r="4.5" />
+    <circle cx="262" cy="88" r="4.5" />
+    <circle cx="404" cy="108" r="4.5" />
+    <circle cx="436" cy="94" r="4.5" />
+    <circle cx="468" cy="114" r="4.5" />
+    <circle cx="500" cy="98" r="4.5" />
+    <circle cx="532" cy="118" r="4.5" />
+    <circle cx="564" cy="102" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="92" y="66" width="92" height="78" rx="12" fillOpacity="0.1" />
+    <rect x="156" y="66" width="92" height="78" rx="12" fillOpacity="0.26" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="362" y="74" width="96" height="62" rx="12" fillOpacity="0.12" />
+    <rect x="362" y="68" width="160" height="74" rx="12" fillOpacity="0.12" />
+    <rect x="362" y="62" width="224" height="86" rx="12" fillOpacity="0.12" />
+    <circle cx="372" cy="102" r="6.5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="318" y="58" width="4" height="96" rx="2" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="python"

--- a/content/learn/time-series-analysis-python/stationarity.mdx
+++ b/content/learn/time-series-analysis-python/stationarity.mdx
@@ -9,6 +9,46 @@ you skip the check, you'll fit a model to conditions that won't hold and get
 a confident, wrong forecast. The good news: the idea is far more intuitive
 than its intimidating name.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="On the left ten dots jitter inside a flat green band around a steady center line; on the right the same number of dots drift upward and fan apart inside a widening red cloud — a stationary series keeps its rules fixed while a non-stationary one keeps changing them"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="180" width="540" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="50" y="92" width="250" height="54" rx="20" fillOpacity="0.14" />
+    <rect x="58" y="116" width="234" height="5" rx="2.5" fillOpacity="0.5" />
+    <circle cx="66" cy="108" r="4.5" />
+    <circle cx="90" cy="128" r="4.5" />
+    <circle cx="114" cy="102" r="4.5" />
+    <circle cx="138" cy="134" r="4.5" />
+    <circle cx="162" cy="112" r="4.5" />
+    <circle cx="186" cy="126" r="4.5" />
+    <circle cx="210" cy="100" r="4.5" />
+    <circle cx="234" cy="130" r="4.5" />
+    <circle cx="258" cy="110" r="4.5" />
+    <circle cx="284" cy="122" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 340 134 L 596 28 L 596 118 L 340 146 Z" fillOpacity="0.1" />
+    <circle cx="356" cy="138" r="4.5" />
+    <circle cx="382" cy="128" r="4.5" />
+    <circle cx="408" cy="133" r="4.5" />
+    <circle cx="434" cy="114" r="4.5" />
+    <circle cx="460" cy="124" r="4.5" />
+    <circle cx="486" cy="98" r="4.5" />
+    <circle cx="512" cy="114" r="4.5" />
+    <circle cx="538" cy="84" r="4.5" />
+    <circle cx="564" cy="102" r="4.5" />
+    <circle cx="588" cy="64" r="4.5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="320" cy="56" r="3" />
+    <circle cx="320" cy="160" r="3" />
+  </g>
+</svg>
+
 ## What "stationary" actually means
 
 A series is **stationary** when its *statistical properties don't change
@@ -113,6 +153,58 @@ the same through time, which is exactly what stationarity guarantees. Point
 a fixed-coefficient model at a trending series and it's like fitting one
 straight line through data whose true level keeps moving — the coefficients
 describe an average of conditions that never actually occur.
+
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="The same blue stencil frame fits a flat dot series wherever it is placed, but on a rising series the second placement misses and the dots spill out above it in red — fixed model coefficients can only describe a relationship that holds still over time"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="70" cy="64" r="4" />
+    <circle cx="102" cy="54" r="4" />
+    <circle cx="134" cy="66" r="4" />
+    <circle cx="166" cy="56" r="4" />
+    <circle cx="198" cy="62" r="4" />
+    <circle cx="230" cy="52" r="4" />
+    <circle cx="262" cy="64" r="4" />
+    <circle cx="294" cy="56" r="4" />
+    <circle cx="326" cy="62" r="4" />
+    <circle cx="358" cy="54" r="4" />
+    <circle cx="390" cy="64" r="4" />
+    <circle cx="422" cy="58" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 56 38 L 212 38 L 212 82 L 56 82 Z M 62 44 L 206 44 L 206 76 L 62 76 Z" fillRule="evenodd" fillOpacity="0.8" />
+    <path d="M 300 38 L 456 38 L 456 82 L 300 82 Z M 306 44 L 450 44 L 450 76 L 306 76 Z" fillRule="evenodd" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="70" cy="182" r="4" />
+    <circle cx="102" cy="176" r="4" />
+    <circle cx="134" cy="184" r="4" />
+    <circle cx="166" cy="172" r="4" />
+    <circle cx="198" cy="178" r="4" />
+    <circle cx="230" cy="168" r="4" />
+    <circle cx="262" cy="174" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="294" cy="162" r="4" />
+    <circle cx="326" cy="150" r="4" />
+    <circle cx="358" cy="140" r="4" />
+    <circle cx="390" cy="128" r="4" />
+    <circle cx="422" cy="118" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 56 156 L 212 156 L 212 200 L 56 200 Z M 62 162 L 206 162 L 206 194 L 62 194 Z" fillRule="evenodd" fillOpacity="0.8" />
+    <path d="M 300 156 L 456 156 L 456 200 L 300 200 Z M 306 162 L 450 162 L 450 194 L 306 194 Z" fillRule="evenodd" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="494" cy="60" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 487 171 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 490.5 171 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" />
+  </g>
+</svg>
 
 <Callout type="info" title="Stationarity is what makes the past usable">
 Forecasting is, at bottom, the bet that *the future will behave like the
@@ -239,6 +331,31 @@ alone barely helps (it fixes *variance*, not the *trend*). A single
 at the threshold because strong seasonality remains. It takes a **seasonal**
 difference, on the next page, to push it firmly into stationary territory.
 That preview is the entire motivation for what comes next.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="Red dots float high above a yellow threshold band and green dots settle well below it, but one haloed blue dot rests exactly on the line — the airline series after a single difference is the famous borderline case, hovering right at the 0.05 decision boundary"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="70" y="90" width="500" height="10" rx="5" fillOpacity="0.45" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="140" cy="44" r="6" />
+    <circle cx="262" cy="58" r="6" />
+    <circle cx="384" cy="36" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="186" cy="138" r="6" />
+    <circle cx="322" cy="126" r="6" />
+    <circle cx="452" cy="144" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="512" cy="95" r="13" fillOpacity="0.2" />
+    <circle cx="512" cy="95" r="7" />
+  </g>
+</svg>
 
 <MultipleChoice
   markdown={`You run \`adfuller\` on a series and get a p-value of **0.78**. What do you conclude?

--- a/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
+++ b/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
@@ -11,6 +11,46 @@ weekly, roll a 7-day average, and — the quiet hero of this page —
 off-by-one error again. This page is about getting your data onto that
 timeline correctly.
 
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Tilted scraps of date text drift above an evenly spaced timeline and rain down into clean blue dots, but one red scrap that will not parse leaves only a hollow ring on the spine — to_datetime turns messy strings into a DatetimeIndex, marking the unparseable as NaT"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="50" y="172" width="540" height="5" rx="2.5" fill="currentColor" opacity="0.25" />
+  <g fill="currentColor" opacity="0.3">
+    <rect x="70" y="40" width="64" height="12" rx="6" transform="rotate(-12 102 46)" />
+    <rect x="180" y="68" width="52" height="12" rx="6" transform="rotate(8 206 74)" />
+    <rect x="300" y="36" width="70" height="12" rx="6" transform="rotate(-5 335 42)" />
+    <rect x="430" y="60" width="56" height="12" rx="6" transform="rotate(14 458 66)" />
+    <rect x="512" y="40" width="48" height="12" rx="6" transform="rotate(-10 536 46)" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="214" y="98" width="58" height="13" rx="6.5" transform="rotate(4 243 104)" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="244" cy="124" r="3" fillOpacity="0.4" />
+    <circle cx="243" cy="140" r="3" fillOpacity="0.55" />
+    <circle cx="242" cy="156" r="3" fillOpacity="0.7" />
+    <circle cx="86" cy="174" r="5.5" />
+    <circle cx="138" cy="174" r="5.5" />
+    <circle cx="190" cy="174" r="5.5" />
+    <circle cx="242" cy="174" r="5.5" />
+    <circle cx="294" cy="174" r="5.5" />
+    <circle cx="346" cy="174" r="5.5" />
+    <circle cx="450" cy="174" r="5.5" />
+    <circle cx="502" cy="174" r="5.5" />
+    <circle cx="554" cy="174" r="5.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="336" y="92" width="66" height="13" rx="6.5" transform="rotate(-16 369 98)" fillOpacity="0.85" />
+    <circle cx="394" cy="122" r="3" fillOpacity="0.35" />
+    <circle cx="396" cy="138" r="3" fillOpacity="0.45" />
+    <circle cx="397" cy="153" r="3" fillOpacity="0.55" />
+    <path d="M 391 174 a 7 7 0 1 0 14 0 a 7 7 0 1 0 -14 0 Z M 394.5 174 a 3.5 3.5 0 1 0 7 0 a 3.5 3.5 0 1 0 -7 0 Z" fillRule="evenodd" />
+  </g>
+</svg>
+
 ## From strings to timestamps: `pd.to_datetime`
 
 Dates almost always arrive as **text**. The first job of any time series
@@ -231,6 +271,38 @@ unlike normal Python slicing, which excludes the stop. That's deliberate:
 you asked for "through September," so you get September. This partial-string
 slicing is the single most convenient thing about a `DatetimeIndex`.
 
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="A translucent yellow band settles over a run of dots on a long timeline, and the dots at both edges of the band glow with halos fully inside it — partial-string slicing selects the whole span you name, inclusive of the end label"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="46" y="84" width="548" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="198" y="56" width="244" height="60" rx="18" fillOpacity="0.18" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="60" cy="86" r="4.5" />
+    <circle cx="100" cy="86" r="4.5" />
+    <circle cx="140" cy="86" r="4.5" />
+    <circle cx="180" cy="86" r="4.5" />
+    <circle cx="460" cy="86" r="4.5" />
+    <circle cx="500" cy="86" r="4.5" />
+    <circle cx="540" cy="86" r="4.5" />
+    <circle cx="580" cy="86" r="4.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="220" cy="86" r="10" fillOpacity="0.2" />
+    <circle cx="220" cy="86" r="5.5" />
+    <circle cx="260" cy="86" r="5.5" />
+    <circle cx="300" cy="86" r="5.5" />
+    <circle cx="340" cy="86" r="5.5" />
+    <circle cx="380" cy="86" r="5.5" />
+    <circle cx="420" cy="86" r="10" fillOpacity="0.2" />
+    <circle cx="420" cy="86" r="5.5" />
+  </g>
+</svg>
+
 <MultipleChoice
   markdown={`With a \`DatetimeIndex\`, what does \`air.loc["1955-06":"1955-09"]\` return?
 
@@ -303,6 +375,39 @@ Grouping by `date.dt.month` already reveals the yearly seasonal shape —
 summer months tower over winter ones. We'll formalize that into a proper
 *seasonal component* later; for now, notice how `.dt` turns timestamps into
 ordinary grouping keys.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="One solid blue timestamp capsule travels into a yellow prism and fans out into three separate small tiles — the dt accessor splits a single datetime into calendar parts like year, month, and weekday"
+  style={{ display: "block", width: "100%", maxWidth: "540px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="60" y="82" width="130" height="36" rx="18" />
+    <circle cx="212" cy="100" r="3.5" fillOpacity="0.6" />
+    <circle cx="234" cy="100" r="3.5" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M 258 62 L 258 138 L 322 100 Z" fillOpacity="0.9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="344" cy="84" r="3" />
+    <circle cx="366" cy="64" r="3" />
+    <circle cx="348" cy="100" r="3" />
+    <circle cx="374" cy="96" r="3" />
+    <circle cx="344" cy="116" r="3" />
+    <circle cx="366" cy="136" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="396" y="34" width="72" height="26" rx="9" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="420" y="84" width="72" height="26" rx="9" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="396" y="134" width="72" height="26" rx="9" fillOpacity="0.85" />
+  </g>
+</svg>
 
 ## Timestamp vs Period: a point versus a span
 

--- a/content/learn/time-series-analysis-python/what-makes-time-series-unique.mdx
+++ b/content/learn/time-series-analysis-python/what-makes-time-series-unique.mdx
@@ -9,6 +9,45 @@ have a date column.** It is a fundamentally different object, and almost
 every mistake beginners make comes from forgetting that. This page is the
 "why" the rest of the course rests on.
 
+<svg
+  viewBox="0 0 640 220"
+  role="img"
+  aria-label="Eleven dots ride an ordered blue wave-band with the newest glowing yellow at its tip, while below the same eleven lie scattered with no shape and one stray dot flushed red — a time series is a sequence whose order carries the signal, and shuffling turns it into dust"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 64 80 C 100 56 130 56 166 80 C 202 104 232 104 268 80 C 304 56 334 56 370 80 C 406 104 436 104 472 80 C 508 56 538 56 574 80 L 574 94 C 538 70 508 70 472 94 C 436 118 406 118 370 94 C 334 70 304 70 268 94 C 232 118 202 118 166 94 C 130 70 100 70 64 94 Z" fillOpacity="0.16" />
+    <circle cx="64" cy="87" r="5" />
+    <circle cx="115" cy="69" r="5" />
+    <circle cx="166" cy="87" r="5" />
+    <circle cx="217" cy="105" r="5" />
+    <circle cx="268" cy="87" r="5" />
+    <circle cx="319" cy="69" r="5" />
+    <circle cx="370" cy="87" r="5" />
+    <circle cx="421" cy="105" r="5" />
+    <circle cx="472" cy="87" r="5" />
+    <circle cx="523" cy="69" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="574" cy="87" r="6.5" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="96" cy="170" r="5" />
+    <circle cx="141" cy="193" r="5" />
+    <circle cx="187" cy="159" r="5" />
+    <circle cx="243" cy="186" r="5" />
+    <circle cx="282" cy="166" r="5" />
+    <circle cx="372" cy="158" r="5" />
+    <circle cx="431" cy="189" r="5" />
+    <circle cx="469" cy="171" r="5" />
+    <circle cx="525" cy="161" r="5" />
+    <circle cx="560" cy="186" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="336" cy="197" r="5.5" />
+  </g>
+</svg>
+
 ## What actually is a time series?
 
 A **time series** is a sequence of observations recorded in time order —
@@ -372,6 +411,31 @@ In every case the failure is the same: the order of the data was the most
 important variable, and it got thrown away — either by shuffling, or by an
 evaluation that pretended the future was available.
 
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A gentle weekly traffic wave ripples beneath a green band of forecast comfort until one red spike erupts straight through it with alarm ticks flying — a model validated with a leaky split looks calm right up until the real future arrives unannounced"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="40" y="170" width="560" height="5" rx="2.5" fill="currentColor" opacity="0.25" />
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="50" y="118" width="540" height="20" rx="10" fillOpacity="0.16" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M 50 158 C 62 158 70 134 82 134 C 94 134 102 158 114 158 C 126 158 134 134 146 134 C 158 134 166 158 178 158 C 190 158 198 134 210 134 C 222 134 230 158 242 158 C 254 158 262 134 274 134 C 286 134 294 158 306 158 C 318 158 326 134 338 134 C 350 134 358 158 370 158 C 382 158 390 134 402 134 C 414 134 422 158 434 158 L 434 170 L 50 170 Z" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M 462 170 C 474 168 478 60 492 60 C 506 60 510 168 522 170 Z" fillOpacity="0.85" />
+    <rect x="470" y="40" width="4" height="13" rx="2" transform="rotate(-28 472 46)" />
+    <rect x="490" y="32" width="4" height="13" rx="2" />
+    <rect x="510" y="40" width="4" height="13" rx="2" transform="rotate(28 512 46)" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="556" cy="152" r="4" />
+    <circle cx="578" cy="158" r="4" />
+  </g>
+</svg>
+
 <Callout type="info" title="Where time series shows up in jobs">
 "Demand forecasting," "capacity planning," "anomaly detection on metrics,"
 "churn *timing*," "sensor / IoT analytics," and most of "operations
@@ -390,6 +454,49 @@ baseline.** Two are classic:
   one full season ago (`ŷₜ = yₜ₋ₘ`, with `m = 12` for monthly data with
   yearly seasonality). For strongly seasonal series, this is the baseline
   to beat.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Two echo trails converge on tomorrow's yellow dot along a timeline: a short blue hop from yesterday and a long green arc from the same month one year back — the naive and seasonal-naive baselines that every real model must beat"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <rect x="44" y="162" width="556" height="4" rx="2" fill="currentColor" opacity="0.2" />
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="60" cy="150" r="4" />
+    <circle cx="140" cy="150" r="4" />
+    <circle cx="180" cy="150" r="4" />
+    <circle cx="220" cy="150" r="4" />
+    <circle cx="260" cy="150" r="4" />
+    <circle cx="300" cy="150" r="4" />
+    <circle cx="340" cy="150" r="4" />
+    <circle cx="380" cy="150" r="4" />
+    <circle cx="420" cy="150" r="4" />
+    <circle cx="460" cy="150" r="4" />
+    <circle cx="500" cy="150" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="540" cy="150" r="6" />
+    <circle cx="552" cy="135" r="3" fillOpacity="0.85" />
+    <circle cx="564" cy="130" r="3" fillOpacity="0.7" />
+    <circle cx="574" cy="138" r="3" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="100" cy="150" r="6" />
+    <circle cx="148" cy="117" r="3.5" fillOpacity="0.9" />
+    <circle cx="196" cy="91" r="3.5" fillOpacity="0.85" />
+    <circle cx="244" cy="73" r="3.5" fillOpacity="0.8" />
+    <circle cx="292" cy="62" r="3.5" fillOpacity="0.75" />
+    <circle cx="340" cy="58" r="3.5" fillOpacity="0.7" />
+    <circle cx="388" cy="62" r="3.5" fillOpacity="0.65" />
+    <circle cx="436" cy="73" r="3.5" fillOpacity="0.6" />
+    <circle cx="484" cy="91" r="3.5" fillOpacity="0.55" />
+    <circle cx="532" cy="117" r="3.5" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="580" cy="150" r="7.5" />
+  </g>
+</svg>
 
 If your fancy ARIMA can't beat "same as last year," the ARIMA is not
 adding value. Let's compute both baselines so the idea is concrete.

--- a/content/learn/typescript-from-scratch/any-unknown-never.mdx
+++ b/content/learn/typescript-from-scratch/any-unknown-never.mdx
@@ -14,6 +14,78 @@ This chapter answers: **What is `any` and when should you (not) use it?**
 **How is `unknown` different?** **What does `never` represent?** **How do
 these types relate to each other?**
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Three stalls side by side: a wild storm of dots that leaks across its own boundary, a locked blue crate with a keyhole while a visitor hovers above, and a spot where only a dotted outline with a faint afterglow remains — any ignores the rules, unknown demands a check first, never holds nothing at all"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="235" cy="36" r="2" />
+    <circle cx="235" cy="62" r="2" />
+    <circle cx="235" cy="88" r="2" />
+    <circle cx="235" cy="114" r="2" />
+    <circle cx="235" cy="140" r="2" />
+    <circle cx="235" cy="166" r="2" />
+    <circle cx="235" cy="192" r="2" />
+    <circle cx="425" cy="36" r="2" />
+    <circle cx="425" cy="62" r="2" />
+    <circle cx="425" cy="88" r="2" />
+    <circle cx="425" cy="114" r="2" />
+    <circle cx="425" cy="140" r="2" />
+    <circle cx="425" cy="166" r="2" />
+    <circle cx="425" cy="192" r="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M70 130 C80 86 140 70 170 96 C196 118 180 160 140 162 C112 164 96 146 104 126" fillOpacity="0.14" />
+    <circle cx="100" cy="80" r="5" />
+    <circle cx="156" cy="64" r="4" fillOpacity="0.8" />
+    <circle cx="186" cy="110" r="6" fillOpacity="0.9" />
+    <circle cx="80" cy="140" r="4" fillOpacity="0.7" />
+    <circle cx="140" cy="172" r="5" fillOpacity="0.8" />
+    <circle cx="196" cy="160" r="3.5" fillOpacity="0.6" />
+    <circle cx="60" cy="100" r="3" fillOpacity="0.5" />
+    <circle cx="252" cy="74" r="4" fillOpacity="0.7" />
+    <circle cx="266" cy="180" r="3" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="124" cy="108" r="6" fillOpacity="0.85" />
+    <circle cx="170" cy="140" r="3.5" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="92" cy="174" r="4" fillOpacity="0.7" />
+    <circle cx="206" cy="76" r="4" fillOpacity="0.6" />
+    <rect x="276" y="90" width="110" height="78" rx="10" />
+    <rect x="276" y="78" width="110" height="20" rx="9" fillOpacity="0.75" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="331" cy="122" r="6" />
+    <path d="M331 126 L337 144 L325 144 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="331" cy="40" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="331" cy="58" r="2.5" />
+    <circle cx="331" cy="68" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="538" cy="115" r="2.5" />
+    <circle cx="533.4" cy="127.7" r="2.5" />
+    <circle cx="520" cy="133" r="2.5" />
+    <circle cx="506.6" cy="127.7" r="2.5" />
+    <circle cx="502" cy="115" r="2.5" />
+    <circle cx="506.6" cy="102.3" r="2.5" />
+    <circle cx="520" cy="97" r="2.5" />
+    <circle cx="533.4" cy="102.3" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="520" cy="115" r="3.5" fillOpacity="0.25" />
+    <circle cx="547" cy="86" r="2" fillOpacity="0.3" />
+    <circle cx="556" cy="76" r="1.8" fillOpacity="0.2" />
+  </g>
+</svg>
+
 ## The type hierarchy: top and bottom
 
 Imagine the type system as a lattice. At the very top sits a type that
@@ -425,6 +497,51 @@ console.log("Type relationships demonstrated");
     },
   ]}
 />
+
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A fountain of basins: values rain from the wide top pool into the middle pools, the tiny basin at the bottom receives nothing, yet faint streams rise from it back to every pool above — anything fits in unknown, nothing fits in never, and never fits anywhere"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <path d="M120 40 L520 40 L504 78 L136 78 Z" />
+    <path d="M150 120 L300 120 L288 152 L162 152 Z" />
+    <path d="M340 120 L490 120 L478 152 L352 152 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.14">
+    <path d="M290 196 L350 196 L344 218 L296 218 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="200" cy="60" r="7" />
+    <circle cx="380" cy="58" r="7" />
+    <circle cx="400" cy="136" r="7" />
+    <circle cx="430" cy="136" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="260" cy="58" r="7" />
+    <circle cx="440" cy="60" r="7" />
+    <circle cx="200" cy="136" r="7" />
+    <circle cx="240" cy="136" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="320" cy="62" r="7" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="225" cy="92" r="2.5" />
+    <circle cx="225" cy="106" r="2.5" />
+    <circle cx="415" cy="92" r="2.5" />
+    <circle cx="415" cy="106" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="284" cy="186" r="2" />
+    <circle cx="272" cy="170" r="2" />
+    <circle cx="260" cy="154" r="2" />
+    <circle cx="356" cy="186" r="2" />
+    <circle cx="368" cy="170" r="2" />
+    <circle cx="380" cy="154" r="2" />
+  </g>
+</svg>
 
 ## Practice: a safe JSON parser
 

--- a/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
+++ b/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
@@ -7,6 +7,45 @@ As systems grow, they're split into modules, services, and teams. Each boundary 
 
 TypeScript offers a better way: **types as contracts**. By modeling your API surfaces with precise types, you move entire classes of integration bugs to compile time. In this chapter, you'll learn to design contracts that span module boundaries, model request/response cycles, separate domain logic from transport concerns, and build systems where the compiler enforces compatibility.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="Two halves of a bridge built from opposite cliffs meet mid-air in interlocking fingers and a parcel rolls across, while a faint earlier attempt below never met and lets a red drop fall through the gap — a shared type contract makes both sides meet exactly"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.08">
+    <path d="M40 128 L240 128 L240 232 L40 232 Z" />
+    <path d="M400 128 L600 128 L600 232 L400 232 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="120" y="84" width="180" height="32" rx="6" />
+    <rect x="300" y="84" width="22" height="10" />
+    <rect x="300" y="106" width="22" height="10" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="342" y="84" width="180" height="32" rx="6" />
+    <rect x="320" y="94" width="22" height="12" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="250" cy="72" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="180" cy="72" r="2.5" />
+    <circle cx="210" cy="72" r="2.5" />
+    <circle cx="288" cy="72" r="2.5" />
+    <circle cx="318" cy="72" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="160" y="176" width="120" height="20" rx="5" />
+    <rect x="360" y="176" width="120" height="20" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="320" cy="206" r="6" fillOpacity="0.7" />
+    <circle cx="320" cy="188" r="2.5" fillOpacity="0.4" />
+    <circle cx="320" cy="222" r="2.5" fillOpacity="0.3" />
+  </g>
+</svg>
+
 ---
 
 ## The Problem: Implicit Contracts
@@ -207,6 +246,34 @@ This pattern:
 ## Generic API Response Envelopes
 
 You can generalize the response pattern with a generic `Result<T, E>` or `ApiResponse<T>` type:
+
+<svg
+  viewBox="0 0 640 150"
+  role="img"
+  aria-label="Two identical envelopes differ only in their edge stripe: the green-striped one carries a blue payload disc, the red-striped one carries an error diamond — one generic envelope wraps every response with a status the caller must inspect"
+  style={{ display: "block", width: "100%", maxWidth: "460px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="110" y="40" width="180" height="70" rx="16" />
+    <rect x="350" y="40" width="180" height="70" rx="16" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="110" y="40" width="14" height="70" rx="7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="350" y="40" width="14" height="70" rx="7" />
+    <path d="M452 58 L466 75 L452 92 L438 75 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="212" cy="75" r="15" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="248" cy="75" r="3" />
+    <circle cx="262" cy="75" r="3" />
+    <circle cx="490" cy="75" r="3" />
+    <circle cx="504" cy="75" r="3" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="typescript"

--- a/content/learn/typescript-from-scratch/arrays-and-tuples.mdx
+++ b/content/learn/typescript-from-scratch/arrays-and-tuples.mdx
@@ -19,6 +19,49 @@ the bounds of a known-length sequence.
 This chapter answers: **How do you type arrays?** **What's the difference
 between arrays and tuples?** **What bugs does this prevent?**
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="An open rail threads identical blue beads that fade off toward more of the same, while an egg-carton tray below holds exactly three cups — square, circle, and triangle each in its own slot — and a red extra shape waits with no cup to fit — arrays are any length of one type, tuples are fixed positions with a type each"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="60" y="60" width="470" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="90" cy="63" r="11" />
+    <circle cx="140" cy="63" r="11" />
+    <circle cx="190" cy="63" r="11" />
+    <circle cx="240" cy="63" r="11" />
+    <circle cx="290" cy="63" r="11" />
+    <circle cx="340" cy="63" r="11" />
+    <circle cx="390" cy="63" r="11" />
+    <circle cx="435" cy="63" r="11" fillOpacity="0.55" />
+    <circle cx="472" cy="63" r="11" fillOpacity="0.3" />
+    <circle cx="507" cy="63" r="11" fillOpacity="0.15" />
+  </g>
+  <g fill="currentColor">
+    <rect x="170" y="150" width="300" height="70" rx="16" opacity="0.1" />
+    <circle cx="220" cy="185" r="26" opacity="0.16" />
+    <circle cx="320" cy="185" r="26" opacity="0.16" />
+    <circle cx="420" cy="185" r="26" opacity="0.16" />
+    <circle cx="505" cy="188" r="2.5" opacity="0.25" />
+    <circle cx="488" cy="187" r="2.5" opacity="0.25" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="202" y="167" width="36" height="36" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="320" cy="185" r="18" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M420 165 L442 203 L398 203 Z" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="535" cy="190" r="12" />
+  </g>
+</svg>
+
 ## Array types: homogeneous collections
 
 The simplest array type is `T[]`, meaning "an array whose elements are
@@ -139,6 +182,37 @@ makes that contract explicit. The compiler ensures that the function
 doesn't accidentally call a mutating method. This is especially valuable
 in large codebases where function signatures act as machine-checked
 documentation.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="A row of beads rests under a translucent green display dome while a red ball arriving from outside stops at the glass — a readonly array can be viewed and iterated but never mutated"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="140" y="128" width="360" height="6" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="100" y="138" width="440" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="180" cy="120" r="10" />
+    <circle cx="230" cy="120" r="10" />
+    <circle cx="280" cy="120" r="10" />
+    <circle cx="330" cy="120" r="10" />
+    <circle cx="380" cy="120" r="10" />
+    <circle cx="430" cy="120" r="10" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M120 132 A200 90 0 0 1 520 132 L504 132 A184 76 0 0 0 136 132 Z" fillOpacity="0.7" />
+    <path d="M136 132 A184 76 0 0 1 504 132 Z" fillOpacity="0.08" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="468" cy="66" r="8" />
+    <circle cx="494" cy="52" r="3.5" fillOpacity="0.45" />
+    <circle cx="516" cy="42" r="3" fillOpacity="0.25" />
+  </g>
+</svg>
 
 Alternatively, you can use the `ReadonlyArray<T>` generic:
 
@@ -305,6 +379,34 @@ console.log(\`\${aliceName}'s scores:\`, aliceScores);
 
 The rest element must be last. It behaves like a normal array, so you can
 iterate over it, `push` to it (if the tuple is mutable), etc.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="A single egg-carton slot holds one fixed green square, then a coupling joins an open rail of blue beads stretching away and fading out — a tuple's required head followed by a rest element of any length"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor">
+    <rect x="50" y="62" width="140" height="76" rx="14" opacity="0.1" />
+    <circle cx="120" cy="100" r="28" opacity="0.16" />
+    <circle cx="196" cy="100" r="4" opacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="101" y="81" width="38" height="38" rx="8" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="204" y="97" width="356" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="240" cy="100" r="11" />
+    <circle cx="290" cy="100" r="11" />
+    <circle cx="340" cy="100" r="11" />
+    <circle cx="390" cy="100" r="11" />
+    <circle cx="438" cy="100" r="11" fillOpacity="0.55" />
+    <circle cx="482" cy="100" r="11" fillOpacity="0.3" />
+    <circle cx="522" cy="100" r="11" fillOpacity="0.15" />
+  </g>
+</svg>
 
 ## Variadic tuple types (a glimpse)
 

--- a/content/learn/typescript-from-scratch/birth-of-typescript.mdx
+++ b/content/learn/typescript-from-scratch/birth-of-typescript.mdx
@@ -13,6 +13,48 @@ Developers felt the pain acutely:
 
 The tools didn't help. JavaScript's dynamism — its greatest strength for quick prototyping — made it nearly impossible for editors to provide reliable autocomplete, refactoring, or go-to-definition. The language itself offered no way to declare contracts or constraints.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="An island map: the solid JavaScript island keeps all its blue city blocks while a larger translucent landmass grows around it, one yellow block straddles the old coastline and a dotted ferry route arrives from open water — TypeScript as a strict superset that leaves everything in place"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M85 130 C90 70 180 38 300 36 C420 34 520 70 522 125 C525 180 430 215 295 216 C175 218 80 190 85 130 Z" fillOpacity="0.16" />
+    <circle cx="442" cy="92" r="6" />
+    <circle cx="468" cy="134" r="5" />
+    <circle cx="424" cy="172" r="5" />
+    <circle cx="158" cy="70" r="5" />
+    <circle cx="122" cy="142" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M170 130 C175 95 220 75 270 78 C330 70 375 95 378 125 C380 155 330 175 275 178 C220 180 168 162 170 130 Z" fillOpacity="0.3" />
+    <rect x="222" y="108" width="26" height="18" rx="4" />
+    <rect x="260" y="130" width="30" height="16" rx="4" />
+    <rect x="298" y="104" width="22" height="22" rx="4" />
+    <rect x="234" y="148" width="24" height="14" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="360" y="116" width="30" height="20" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="42" cy="216" r="3" />
+    <circle cx="76" cy="206" r="3" />
+    <circle cx="110" cy="198" r="3" />
+    <circle cx="144" cy="190" r="3" />
+    <circle cx="178" cy="180" r="3" />
+    <circle cx="206" cy="166" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="580" cy="200" r="4" />
+    <circle cx="606" cy="96" r="4" />
+    <circle cx="48" cy="56" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="588" cy="38" r="5.5" />
+  </g>
+</svg>
+
 ## The early experiments
 
 Several teams tried to bring types to JavaScript:
@@ -22,6 +64,51 @@ Several teams tried to bring types to JavaScript:
 **Facebook's Flow** (2014) was a true static type checker for JavaScript. You added type annotations (`let x: number = 5`), and Flow checked them. It was fast, pragmatic, and integrated well with React. But it required a build step, the ecosystem was small, and Facebook's internal priorities meant external users often felt like second-class citizens.
 
 Both tools pointed toward the same insight: **JavaScript developers wanted types, but they wanted them to feel like a natural extension of the language, not a bolt-on.** The syntax had to be clean. The tooling had to be excellent. The migration path had to be gradual — you couldn't force a million-line codebase to convert overnight.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Three dotted trails set off up the same hillside: a yellow one and a red one fade out partway up, while the blue trail climbs all the way to the summit flag — earlier attempts at typing JavaScript pointed the way without reaching the top"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.07">
+    <path d="M30 192 C160 56 360 26 612 192 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <path d="M330 192 C420 110 520 96 626 192 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="70" cy="180" r="4" />
+    <circle cx="100" cy="170" r="4" fillOpacity="0.8" />
+    <circle cx="128" cy="159" r="4" fillOpacity="0.55" />
+    <circle cx="154" cy="149" r="4" fillOpacity="0.35" />
+    <circle cx="178" cy="141" r="4" fillOpacity="0.16" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="92" cy="188" r="4" />
+    <circle cx="132" cy="180" r="4" fillOpacity="0.75" />
+    <circle cx="170" cy="170" r="4" fillOpacity="0.5" />
+    <circle cx="208" cy="161" r="4" fillOpacity="0.3" />
+    <circle cx="242" cy="155" r="4" fillOpacity="0.14" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="58" cy="174" r="4" />
+    <circle cx="94" cy="162" r="4" />
+    <circle cx="130" cy="148" r="4" />
+    <circle cx="165" cy="134" r="4" />
+    <circle cx="200" cy="120" r="4" />
+    <circle cx="235" cy="106" r="4" />
+    <circle cx="268" cy="93" r="4" />
+    <circle cx="300" cy="81" r="4" />
+    <circle cx="330" cy="70" r="4" />
+    <circle cx="356" cy="61" r="4" />
+    <circle cx="372" cy="52" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="384" y="14" width="4" height="34" rx="2" />
+    <path d="M388 16 L412 24 L388 32 Z" />
+  </g>
+</svg>
 
 ## Enter Anders Hejlsberg
 

--- a/content/learn/typescript-from-scratch/branded-types.mdx
+++ b/content/learn/typescript-from-scratch/branded-types.mdx
@@ -21,6 +21,56 @@ getUser(orderId); // Oops! No error — both are just strings.
 
 TypeScript can't tell them apart because they're structurally identical. This chapter introduces **branded types** (also called **opaque types** or **nominal types**) — a technique to tag values with phantom properties that make them incompatible at compile time, even though they're the same at runtime.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Two otherwise identical envelopes differ only by their wax seal: the green-sealed one glides toward the wall slot under a green reader light, while the yellow-sealed one is turned back below with a red light — a brand makes look-alike values distinguishable to the checker"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="250" y="50" width="120" height="74" rx="8" />
+    <rect x="80" y="148" width="120" height="74" rx="8" />
+  </g>
+  <g fill="currentColor" opacity="0.1">
+    <path d="M252 52 L310 96 L368 52 Z" />
+    <path d="M82 150 L140 194 L198 150 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="310" cy="92" r="11" />
+    <circle cx="479" cy="70" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="140" cy="190" r="11" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="310" cy="92" r="3" />
+    <circle cx="140" cy="190" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="470" y="30" width="18" height="52" rx="8" />
+    <rect x="470" y="98" width="18" height="102" rx="8" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="170" cy="88" r="2.5" />
+    <circle cx="200" cy="88" r="2.5" />
+    <circle cx="230" cy="88" r="2.5" />
+    <circle cx="392" cy="88" r="2.5" />
+    <circle cx="420" cy="88" r="2.5" />
+    <circle cx="446" cy="88" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="230" cy="186" r="2.5" />
+    <circle cx="270" cy="186" r="2.5" />
+    <circle cx="310" cy="186" r="2.5" />
+    <circle cx="350" cy="186" r="2.5" />
+    <circle cx="390" cy="186" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="448" cy="186" r="6" />
+    <circle cx="479" cy="166" r="5" fillOpacity="0.85" />
+  </g>
+</svg>
+
 ---
 
 ## The Problem: Structural Typing's Blind Spot
@@ -180,6 +230,43 @@ Now, if you accidentally pass an `OrderId` to `getUser`, the compiler catches it
 ## Combining Brands with Validation
 
 Smart constructors are also the perfect place to validate input. You can ensure that branded values are always valid:
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Plain values queue at a stamping press: the one that passes inspection leaves wearing a small green seal while a bad one drops away in red — a smart constructor validates first and only then applies the brand"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="60" y="102" width="520" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="110" cy="88" r="13" />
+    <circle cx="180" cy="88" r="13" />
+    <circle cx="470" cy="88" r="13" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="296" y="18" width="22" height="12" rx="4" />
+    <rect x="303" y="30" width="8" height="22" rx="3" />
+    <rect x="284" y="52" width="46" height="10" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="292" y="62" width="30" height="8" rx="4" />
+    <path d="M470 64 A9 9 0 1 1 488 64 A9 9 0 1 1 470 64 Z M474 64 A5 5 0 1 0 484 64 A5 5 0 1 0 474 64 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="230" cy="88" r="2.5" />
+    <circle cx="258" cy="88" r="2.5" />
+    <circle cx="352" cy="88" r="2.5" />
+    <circle cx="384" cy="88" r="2.5" />
+    <circle cx="416" cy="88" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="307" cy="142" r="9" fillOpacity="0.8" />
+    <circle cx="307" cy="118" r="2.5" fillOpacity="0.4" />
+    <circle cx="307" cy="162" r="2.5" fillOpacity="0.3" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="typescript"

--- a/content/learn/typescript-from-scratch/discriminated-unions.mdx
+++ b/content/learn/typescript-from-scratch/discriminated-unions.mdx
@@ -9,6 +9,58 @@ The idea: define a union of object types, each with a **discriminant** field (a 
 
 This is how you model state machines, API responses, domain events, parser results, and anything else with "one of several possibilities." Let's see why discriminated unions are so powerful.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="Identical parcels ride a belt, each bearing one small colored corner tag; at a junction an arm reads the tag and routes every parcel into its matching tinted bin, while one untagged parcel waits aside under a red alert — the discriminant field tells the compiler exactly which variant it holds"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="50" y="92" width="330" height="6" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="70" y="58" width="40" height="32" rx="5" />
+    <rect x="150" y="58" width="40" height="32" rx="5" />
+    <rect x="230" y="58" width="40" height="32" rx="5" />
+    <rect x="96" y="150" width="40" height="32" rx="5" />
+    <rect x="500" y="32" width="40" height="28" rx="5" />
+    <rect x="500" y="102" width="40" height="28" rx="5" />
+    <rect x="500" y="172" width="40" height="28" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="104" cy="64" r="5" />
+    <rect x="480" y="20" width="110" height="50" rx="10" fillOpacity="0.12" />
+    <circle cx="534" cy="38" r="5" />
+    <path d="M390 71 L448 50 L451 58 L392 79 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M178 67 L190 67 L184 57 Z" />
+    <rect x="480" y="90" width="110" height="50" rx="10" fillOpacity="0.12" />
+    <path d="M528 116 L540 116 L534 106 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="258" y="59" width="10" height="10" rx="2" />
+    <rect x="480" y="160" width="110" height="50" rx="10" fillOpacity="0.12" />
+    <rect x="529" y="176" width="10" height="10" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <path d="M390 55 L412 75 L390 95 L368 75 Z" />
+    <circle cx="424" cy="62" r="2.5" />
+    <circle cx="444" cy="50" r="2.5" />
+    <circle cx="464" cy="42" r="2.5" />
+    <circle cx="424" cy="84" r="2.5" />
+    <circle cx="446" cy="98" r="2.5" />
+    <circle cx="466" cy="110" r="2.5" />
+    <circle cx="412" cy="100" r="2.5" />
+    <circle cx="430" cy="132" r="2.5" />
+    <circle cx="450" cy="160" r="2.5" />
+    <circle cx="466" cy="178" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="144" cy="146" r="5.5" />
+  </g>
+</svg>
+
 ## The discriminant field
 
 A discriminated union is a union of object types that share a common property — the **discriminant** — with distinct literal values for each variant.
@@ -70,6 +122,52 @@ You can name the discriminant field anything you want, but `kind` and `type` are
 The real power of discriminated unions is **exhaustiveness checking**: the compiler can verify you've handled *every* variant. If you add a new variant later and forget to update a `switch` statement, the compiler catches it.
 
 Here's the trick: assign the unhandled case to `never`. If you've covered all variants, the code is unreachable and `never` is satisfied. If you missed a variant, the compiler complains that the leftover type isn't assignable to `never`.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="Three tinted bins each hold a parcel matching their tag, but a newly arrived parcel with a red diamond tag hovers in front of a bin that exists only as a dotted outline — exhaustiveness checking complains until every variant has a place to go"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="50" y="60" width="110" height="60" rx="10" fillOpacity="0.12" />
+    <circle cx="105" cy="78" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="190" y="60" width="110" height="60" rx="10" fillOpacity="0.12" />
+    <path d="M239 84 L251 84 L245 74 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="330" y="60" width="110" height="60" rx="10" fillOpacity="0.12" />
+    <rect x="380" y="73" width="10" height="10" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="71" y="74" width="40" height="30" rx="5" />
+    <rect x="211" y="74" width="40" height="30" rx="5" />
+    <rect x="351" y="74" width="40" height="30" rx="5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="470" cy="62" r="2" />
+    <circle cx="494" cy="62" r="2" />
+    <circle cx="518" cy="62" r="2" />
+    <circle cx="542" cy="62" r="2" />
+    <circle cx="566" cy="62" r="2" />
+    <circle cx="470" cy="90" r="2" />
+    <circle cx="470" cy="118" r="2" />
+    <circle cx="566" cy="90" r="2" />
+    <circle cx="566" cy="118" r="2" />
+    <circle cx="494" cy="118" r="2" />
+    <circle cx="518" cy="118" r="2" />
+    <circle cx="542" cy="118" r="2" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="498" y="20" width="40" height="30" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M530 18 L537 25 L530 32 L523 25 Z" />
+    <circle cx="554" cy="14" r="5" fillOpacity="0.8" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="typescript"

--- a/content/learn/typescript-from-scratch/error-handling-with-types.mdx
+++ b/content/learn/typescript-from-scratch/error-handling-with-types.mdx
@@ -9,6 +9,55 @@ TypeScript inherits this problem. But there's a better way, borrowed from functi
 
 In this chapter, you'll learn the **`Result<T, E>` pattern**, a type-safe alternative to exceptions. You'll build combinators that compose error-prone operations, and you'll see when to use `Result` vs. when to still throw.
 
+<svg
+  viewBox="0 0 640 270"
+  role="img"
+  aria-label="Two corridors: in the upper one a walker strolls toward a trapdoor already swinging open beneath an unbroken-looking floor, while the lower corridor ends honestly at two marked doors, one green and one red — exceptions hide failure in the floor, Result puts both outcomes in plain sight"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="80" y="88" width="270" height="6" rx="3" />
+    <rect x="408" y="88" width="152" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="180" cy="76" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="216" cy="76" r="2.5" />
+    <circle cx="244" cy="76" r="2.5" />
+    <circle cx="272" cy="76" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M350 90 L406 90 L390 126 L334 126 Z" fillOpacity="0.3" />
+    <circle cx="376" cy="150" r="5" fillOpacity="0.55" />
+    <circle cx="378" cy="168" r="2.5" fillOpacity="0.35" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="80" y="185" width="240" height="6" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="250" cy="173" r="9" />
+    <rect x="430" y="138" width="44" height="58" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="430" y="208" width="44" height="56" rx="8" fillOpacity="0.85" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="464" cy="168" r="3.5" />
+    <circle cx="464" cy="236" r="3.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="332" cy="178" r="2.5" />
+    <circle cx="358" cy="168" r="2.5" />
+    <circle cx="384" cy="158" r="2.5" />
+    <circle cx="408" cy="152" r="2.5" />
+    <circle cx="332" cy="194" r="2.5" />
+    <circle cx="358" cy="204" r="2.5" />
+    <circle cx="384" cy="216" r="2.5" />
+    <circle cx="408" cy="226" r="2.5" />
+  </g>
+</svg>
+
 ---
 
 ## The Problem with Exceptions
@@ -224,6 +273,39 @@ Useful when you want a fallback without explicitly checking `.ok`.
 ## Composing Operations with `Result`
 
 Let's build a pipeline that parses input, validates it, and computes a result:
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A green value hops from station to station along the upper success rail, but the moment a hop turns red it slides onto the bypass rail and coasts past every remaining station to the red exit — andThen short-circuits the rest of the chain on the first failure"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="100" y="50" width="80" height="40" rx="12" fillOpacity="0.8" />
+    <rect x="260" y="50" width="80" height="40" rx="12" fillOpacity="0.8" />
+    <rect x="420" y="50" width="80" height="40" rx="12" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="62" cy="70" r="8" />
+    <circle cx="205" cy="70" r="3" fillOpacity="0.6" />
+    <circle cx="228" cy="70" r="3" fillOpacity="0.6" />
+    <path d="M548 70 A12 12 0 1 1 572 70 A12 12 0 1 1 548 70 Z M553 70 A7 7 0 1 0 567 70 A7 7 0 1 0 553 70 Z" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="320" cy="108" r="7" fillOpacity="0.9" />
+    <circle cx="348" cy="124" r="2.5" fillOpacity="0.5" />
+    <circle cx="380" cy="136" r="2.5" fillOpacity="0.5" />
+    <circle cx="414" cy="144" r="2.5" fillOpacity="0.5" />
+    <circle cx="448" cy="148" r="2.5" fillOpacity="0.5" />
+    <circle cx="482" cy="150" r="2.5" fillOpacity="0.5" />
+    <circle cx="514" cy="150" r="2.5" fillOpacity="0.5" />
+    <path d="M548 150 A12 12 0 1 1 572 150 A12 12 0 1 1 548 150 Z M553 150 A7 7 0 1 0 567 150 A7 7 0 1 0 553 150 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="365" cy="70" r="3" />
+    <circle cx="388" cy="70" r="3" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="typescript"

--- a/content/learn/typescript-from-scratch/evolution-of-javascript.mdx
+++ b/content/learn/typescript-from-scratch/evolution-of-javascript.mdx
@@ -9,6 +9,42 @@ Netscape hired a programmer named **Brendan Eich** and gave him ten days to crea
 
 In May 1995, Eich delivered **Mocha** (soon renamed JavaScript), a small, dynamic language inspired by Scheme, Self, and Java. It was never meant to scale beyond a few hundred lines of form validation. It was a *prototype*, and it showed.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Geological cross-section: sediment layers laid down era by era thicken into a tall wedge, a tiny lightning-bolt fossil rests in the oldest thin band, and a red fissure cracks the newest, heaviest layers — JavaScript's growth outpacing its scripting foundations"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor">
+    <rect x="28" y="202" width="584" height="5" rx="2.5" opacity="0.25" />
+    <circle cx="48" cy="36" r="3" opacity="0.18" />
+    <circle cx="200" cy="52" r="2.5" opacity="0.18" />
+    <circle cx="300" cy="30" r="3" opacity="0.18" />
+    <circle cx="170" cy="196" r="3" opacity="0.3" />
+    <circle cx="230" cy="180" r="3" opacity="0.3" />
+    <circle cx="350" cy="166" r="3" opacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M40 202 L600 202 L600 182 C410 178 200 188 40 194 Z" fillOpacity="0.15" />
+    <path d="M90 190.5 C260 185 430 179 600 182 L600 160 C430 156 270 168 90 190.5 Z" fillOpacity="0.24" />
+    <path d="M160 184 C320 174 460 158 600 160 L600 136 C460 132 330 148 160 184 Z" fillOpacity="0.34" />
+    <path d="M240 172 C380 156 480 134 600 136 L600 110 C490 106 390 124 240 172 Z" fillOpacity="0.48" />
+    <path d="M330 158 C440 136 500 108 600 110 L600 82 C510 78 450 96 330 158 Z" fillOpacity="0.65" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M100 188 L110 188 L104 194 L110 194 L97 204 L102 196 L96 196 Z" />
+    <circle cx="84" cy="64" r="9" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="402" cy="150" r="3.5" />
+    <circle cx="416" cy="145" r="3.5" />
+    <circle cx="430" cy="140" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M556 84 L548 110 L558 134 L546 160 L554 184 L549 202 L559 202 L564 184 L556 160 L568 134 L558 110 L565 86 Z" fillOpacity="0.9" />
+  </g>
+</svg>
+
 ## The first decade: scripting toy to DOM workhorse
 
 JavaScript's initial decade was marked by chaos. The language had quirks — `==` vs `===`, automatic semicolon insertion, the infamous `this` binding rules, a prototype chain that confused most programmers. But it had one killer advantage: it was *the only* language that ran in every browser.
@@ -103,6 +139,57 @@ function getUserDetails(id, includeOrders) {
 ```
 
 In JavaScript, the **50 call sites** scattered across your codebase still compile and run. They just pass `undefined` for the second argument. Some code paths work. Some don't. You won't know until a user reports a bug — or worse, until data gets corrupted silently.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="A function bar gains a third yellow socket while the six caller chips below still supply only two filled dots each; in two of them the empty third slot glows red — call sites that silently break after a signature change"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="240" y="20" width="160" height="36" rx="12" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="362" cy="38" r="7" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="278" cy="38" r="6" />
+    <circle cx="320" cy="38" r="6" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="135" cy="92" r="2.5" />
+    <circle cx="228" cy="92" r="2.5" />
+    <circle cx="320" cy="92" r="2.5" />
+    <circle cx="412" cy="92" r="2.5" />
+    <circle cx="505" cy="92" r="2.5" />
+    <rect x="62" y="118" width="76" height="30" rx="10" />
+    <rect x="155" y="118" width="76" height="30" rx="10" />
+    <rect x="248" y="118" width="76" height="30" rx="10" />
+    <rect x="341" y="118" width="76" height="30" rx="10" />
+    <rect x="434" y="118" width="76" height="30" rx="10" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="82" cy="133" r="5" />
+    <circle cx="100" cy="133" r="5" />
+    <circle cx="175" cy="133" r="5" />
+    <circle cx="193" cy="133" r="5" />
+    <circle cx="268" cy="133" r="5" />
+    <circle cx="286" cy="133" r="5" />
+    <circle cx="361" cy="133" r="5" />
+    <circle cx="379" cy="133" r="5" />
+    <circle cx="454" cy="133" r="5" />
+    <circle cx="472" cy="133" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="118" cy="133" r="5" />
+    <circle cx="304" cy="133" r="5" />
+    <circle cx="490" cy="133" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="211" cy="133" r="5" fillOpacity="0.85" />
+    <circle cx="397" cy="133" r="5" fillOpacity="0.85" />
+  </g>
+</svg>
 
 ## The search for safety
 

--- a/content/learn/typescript-from-scratch/functions-and-signatures.mdx
+++ b/content/learn/typescript-from-scratch/functions-and-signatures.mdx
@@ -16,6 +16,57 @@ This chapter covers: **parameter and return types**, **optional and
 default parameters**, **rest parameters**, **function type expressions**,
 **call signatures**, **overloads**, and **contextual typing**.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A solid blue panel bears one opening per parameter — a circle, a square, and a dotted optional triangle; matching shapes glide in on guide dots, a green result pops out the far side, and a red extra argument below finds no opening — a function signature enforced at the call site"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="250" y="60" width="140" height="120" rx="16" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="285" cy="92" r="11" />
+    <rect x="274" y="121" width="22" height="22" rx="4" />
+    <circle cx="287" cy="152" r="2" />
+    <circle cx="297" cy="170" r="2" />
+    <circle cx="277" cy="170" r="2" />
+    <circle cx="292" cy="161" r="2" />
+    <circle cx="282" cy="161" r="2" />
+    <circle cx="287" cy="170" r="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="120" cy="92" r="11" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="109" y="121" width="22" height="22" rx="4" />
+    <circle cx="430" cy="120" r="13" />
+    <circle cx="454" cy="120" r="3.5" fillOpacity="0.45" />
+    <circle cx="472" cy="120" r="3" fillOpacity="0.25" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="160" cy="92" r="2.5" />
+    <circle cx="190" cy="92" r="2.5" />
+    <circle cx="220" cy="92" r="2.5" />
+    <circle cx="160" cy="132" r="2.5" />
+    <circle cx="190" cy="132" r="2.5" />
+    <circle cx="220" cy="132" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <circle cx="190" cy="163" r="2.5" />
+    <circle cx="220" cy="163" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="290" y="192" width="20" height="5" rx="2.5" fillOpacity="0.7" />
+    <path d="M300 204 L312 224 L288 224 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="540" cy="60" r="3" />
+    <circle cx="70" cy="210" r="3" />
+    <circle cx="586" cy="186" r="3" />
+  </g>
+</svg>
+
 ## Parameter and return types
 
 The simplest function signature specifies the type of each parameter and
@@ -350,6 +401,42 @@ console.log("format('hello'):", format("hello"));
 The **overload signatures** (the first two lines) describe the public
 API. The **implementation signature** (the third line) handles all cases.
 Callers see only the overloads; the implementation is hidden.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Two solid faceplates with different openings both feed one faint capsule holding a circle and a square, which emits a single green result — overload signatures are the public faces of one hidden implementation"
+  style={{ display: "block", width: "100%", maxWidth: "460px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="90" y="30" width="100" height="56" rx="12" />
+    <rect x="90" y="110" width="100" height="56" rx="12" fillOpacity="0.8" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="130" cy="58" r="9" />
+    <rect x="120" y="127" width="22" height="22" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="215" cy="66" r="2.5" />
+    <circle cx="240" cy="74" r="2.5" />
+    <circle cx="265" cy="82" r="2.5" />
+    <circle cx="215" cy="132" r="2.5" />
+    <circle cx="240" cy="124" r="2.5" />
+    <circle cx="265" cy="116" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="295" y="68" width="185" height="62" rx="31" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="352" cy="99" r="9" fillOpacity="0.7" />
+    <rect x="382" y="90" width="18" height="18" rx="4" fillOpacity="0.7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="508" cy="99" r="10" />
+    <circle cx="530" cy="99" r="3.5" fillOpacity="0.45" />
+    <circle cx="546" cy="99" r="3" fillOpacity="0.25" />
+  </g>
+</svg>
 
 **When to use overloads:** When a function has *distinct* parameter
 patterns that can't be expressed with a single union type. Overloads make

--- a/content/learn/typescript-from-scratch/generic-constraints.mdx
+++ b/content/learn/typescript-from-scratch/generic-constraints.mdx
@@ -7,6 +7,47 @@ In [Generics Basics](./generics-basics), we saw how unconstrained type parameter
 
 This is where **generic constraints** come in. You can restrict a type parameter to types that satisfy certain conditions using the `extends` keyword. This unlocks richer operations: accessing properties, calling methods, indexing into objects, and more — all while keeping the code generic and type-safe.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Wildly different shapes all hang from one rail by the same small ring, while a shape born without a ring lies fallen on the floor below — a constraint lets any type in, as long as it brings the required part"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="60" y="40" width="520" height="8" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <path d="M123 58 A7 7 0 1 1 137 58 A7 7 0 1 1 123 58 Z M126 58 A4 4 0 1 0 134 58 A4 4 0 1 0 126 58 Z" fillRule="evenodd" />
+    <path d="M233 58 A7 7 0 1 1 247 58 A7 7 0 1 1 233 58 Z M236 58 A4 4 0 1 0 244 58 A4 4 0 1 0 236 58 Z" fillRule="evenodd" />
+    <path d="M353 58 A7 7 0 1 1 367 58 A7 7 0 1 1 353 58 Z M356 58 A4 4 0 1 0 364 58 A4 4 0 1 0 356 58 Z" fillRule="evenodd" />
+    <path d="M463 58 A7 7 0 1 1 477 58 A7 7 0 1 1 463 58 Z M466 58 A4 4 0 1 0 474 58 A4 4 0 1 0 466 58 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="128" y="64" width="4" height="12" rx="2" />
+    <rect x="238" y="64" width="4" height="12" rx="2" />
+    <rect x="358" y="64" width="4" height="12" rx="2" />
+    <rect x="468" y="64" width="4" height="12" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="130" cy="98" r="22" />
+    <path d="M470 76 L496 124 L444 124 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="218" y="76" width="44" height="44" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="342" y="76" width="36" height="70" rx="10" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="60" y="214" width="520" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="560" cy="196" r="18" />
+    <circle cx="540" cy="162" r="2.5" fillOpacity="0.4" />
+    <circle cx="549" cy="176" r="2.5" fillOpacity="0.3" />
+  </g>
+</svg>
+
 ## The problem: operations on unconstrained types
 
 Suppose you want a function that logs the length of an array or a string. With an unconstrained type parameter, this doesn't work:
@@ -242,6 +283,50 @@ console.log(\`Ages: \${ages.join(", ")}\`);
 />
 
 The `pluck` function is generic over both the object type (`T`) and the key type (`K`). The constraint `K extends keyof T` ensures the key exists, and the return type `T[K][]` gives you an array of the property's type.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Three record cards each carry the same three slots; a translucent band lifts the middle slot out of every card into one tidy green column — pluck extracts a single keyed property from every object, and the constraint guarantees the key exists"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="80" y="30" width="280" height="40" rx="10" />
+    <rect x="80" y="84" width="280" height="40" rx="10" />
+    <rect x="80" y="138" width="280" height="40" rx="10" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="186" y="18" width="56" height="170" rx="12" fillOpacity="0.13" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="120" cy="50" r="9" />
+    <circle cx="120" cy="104" r="9" />
+    <circle cx="120" cy="158" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="202" y="41" width="24" height="18" rx="5" />
+    <rect x="202" y="95" width="24" height="18" rx="5" />
+    <rect x="202" y="149" width="24" height="18" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="310" cy="50" r="9" />
+    <circle cx="310" cy="104" r="9" />
+    <circle cx="310" cy="158" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="396" cy="50" r="2.5" />
+    <circle cx="424" cy="50" r="2.5" />
+    <circle cx="396" cy="104" r="2.5" />
+    <circle cx="424" cy="104" r="2.5" />
+    <circle cx="396" cy="158" r="2.5" />
+    <circle cx="424" cy="158" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="460" y="41" width="24" height="18" rx="5" />
+    <rect x="460" y="95" width="24" height="18" rx="5" />
+    <rect x="460" y="149" width="24" height="18" rx="5" />
+  </g>
+</svg>
 
 ## A practical example: typed `pick`
 

--- a/content/learn/typescript-from-scratch/generics-basics.mdx
+++ b/content/learn/typescript-from-scratch/generics-basics.mdx
@@ -23,6 +23,49 @@ function identity<T>(x: T): T {
 
 Now `identity(42)` returns `number`, `identity("hello")` returns `string`, and the compiler tracks the exact type through the function. This is the power of generics: **abstraction without information loss**.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A pantograph linkage rests its tracer on a blue triangle while its pen reproduces the very same triangle across the desk, and a circle and a square wait in line to be traced next — one generic mechanism that works for any shape without forgetting which it was given"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="60" y="232" width="520" height="4" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="306" y="26" width="28" height="12" rx="6" />
+    <rect x="317" y="36" width="6" height="58" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <path d="M177 183 L317 93 L325 103 L185 194 Z" />
+    <path d="M323 93 L463 183 L455 194 L315 103 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.5">
+    <circle cx="320" cy="99" r="7" />
+    <path d="M170 187 A11 11 0 1 1 192 187 A11 11 0 1 1 170 187 Z M175 187 A6 6 0 1 0 187 187 A6 6 0 1 0 175 187 Z" fillRule="evenodd" />
+    <circle cx="459" cy="188" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M181 198 L203 232 L159 232 Z" />
+    <path d="M459 198 L481 232 L437 232 Z" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="466" cy="196" r="2.5" fillOpacity="0.8" />
+    <circle cx="474" cy="190" r="2" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="80" cy="220" r="11" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="106" y="210" width="22" height="22" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="560" cy="60" r="3" />
+    <circle cx="600" cy="140" r="3" />
+    <circle cx="60" cy="110" r="3" />
+  </g>
+</svg>
+
 ## Why generics matter
 
 Without generics, you face a painful trade-off:
@@ -305,6 +348,36 @@ The inference flows in one direction: **`map(array, fn)` → infer `T` from the 
 
 This is the power of generics: you write one function, and the compiler figures out the specific types for every call site.
 
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Four blue circles pass through a translucent transformation band marked with a function symbol and emerge as four green squares in exactly the same order and count — map changes the element type while the shape of the array survives"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="160" cy="46" r="13" />
+    <circle cx="250" cy="46" r="13" />
+    <circle cx="340" cy="46" r="13" />
+    <circle cx="430" cy="46" r="13" />
+  </g>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="120" y="76" width="440" height="28" rx="14" />
+  </g>
+  <text x="96" y="99" fontFamily="Georgia, serif" fontStyle="italic" fontSize="22" fill="currentColor" fillOpacity="0.45" textAnchor="middle">ƒ</text>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="160" cy="90" r="2.5" />
+    <circle cx="250" cy="90" r="2.5" />
+    <circle cx="340" cy="90" r="2.5" />
+    <circle cx="430" cy="90" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="148" y="122" width="24" height="24" rx="5" />
+    <rect x="238" y="122" width="24" height="24" rx="5" />
+    <rect x="328" y="122" width="24" height="24" rx="5" />
+    <rect x="418" y="122" width="24" height="24" rx="5" />
+  </g>
+</svg>
+
 ## Type parameter flow
 
 Understanding how type parameters flow through a function is key to using generics effectively. Let's trace through an example:
@@ -334,6 +407,46 @@ console.log(\`Empty array first: \${nope}\`); // undefined
 />
 
 The type parameter `T` is inferred from the input array. If you pass `number[]`, `T = number`, so the return type is `number | undefined`. The `| undefined` is there because the array might be empty.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Two runs of the same capsule: whatever color enters, a thread of that color runs through the inside and the very same color exits — the type parameter is a thread tying the output type to the input type"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="260" y="38" width="160" height="44" rx="22" />
+    <rect x="260" y="110" width="160" height="44" rx="22" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="140" cy="60" r="13" />
+    <circle cx="278" cy="60" r="2.5" fillOpacity="0.5" />
+    <circle cx="304" cy="60" r="2.5" fillOpacity="0.5" />
+    <circle cx="330" cy="60" r="2.5" fillOpacity="0.5" />
+    <circle cx="356" cy="60" r="2.5" fillOpacity="0.5" />
+    <circle cx="382" cy="60" r="2.5" fillOpacity="0.5" />
+    <circle cx="404" cy="60" r="2.5" fillOpacity="0.5" />
+    <circle cx="500" cy="60" r="13" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="128" y="120" width="24" height="24" rx="5" />
+    <circle cx="278" cy="132" r="2.5" fillOpacity="0.5" />
+    <circle cx="304" cy="132" r="2.5" fillOpacity="0.5" />
+    <circle cx="330" cy="132" r="2.5" fillOpacity="0.5" />
+    <circle cx="356" cy="132" r="2.5" fillOpacity="0.5" />
+    <circle cx="382" cy="132" r="2.5" fillOpacity="0.5" />
+    <circle cx="404" cy="132" r="2.5" fillOpacity="0.5" />
+    <rect x="488" y="120" width="24" height="24" rx="5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="190" cy="60" r="2.5" />
+    <circle cx="220" cy="60" r="2.5" />
+    <circle cx="448" cy="60" r="2.5" />
+    <circle cx="190" cy="132" r="2.5" />
+    <circle cx="220" cy="132" r="2.5" />
+    <circle cx="448" cy="132" r="2.5" />
+  </g>
+</svg>
 
 ## Challenge: Generic container
 

--- a/content/learn/typescript-from-scratch/how-typescript-works.mdx
+++ b/content/learn/typescript-from-scratch/how-typescript-works.mdx
@@ -7,6 +7,53 @@ TypeScript is often described as "JavaScript with types." But what does that act
 
 This page takes you inside TypeScript's architecture — from the relationship between TypeScript and JavaScript, through the compiler's internal pipeline, to the language service that powers VS Code, WebStorm, and every other modern editor.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Twin block towers: the left one is wrapped in green scaffolding with a red bug pinned on a beam, the right one stands identical but bare while the scaffold dissolves into drifting dots beside a play button — types support the build, then erase before the code runs"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="90" y="190" width="470" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="130" y="152" width="64" height="36" rx="6" />
+    <rect x="130" y="112" width="64" height="36" rx="6" fillOpacity="0.9" />
+    <rect x="130" y="72" width="64" height="36" rx="6" fillOpacity="0.8" />
+    <rect x="430" y="152" width="64" height="36" rx="6" />
+    <rect x="430" y="112" width="64" height="36" rx="6" fillOpacity="0.9" />
+    <rect x="430" y="72" width="64" height="36" rx="6" fillOpacity="0.8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="112" y="52" width="6" height="136" rx="3" />
+    <rect x="206" y="52" width="6" height="136" rx="3" />
+    <rect x="106" y="60" width="112" height="5" rx="2.5" />
+    <rect x="106" y="100" width="112" height="5" rx="2.5" />
+    <rect x="106" y="140" width="112" height="5" rx="2.5" />
+    <circle cx="412" cy="160" r="3" fillOpacity="0.25" />
+    <circle cx="416" cy="120" r="3" fillOpacity="0.18" />
+    <circle cx="414" cy="84" r="2.5" fillOpacity="0.12" />
+    <circle cx="508" cy="150" r="3" fillOpacity="0.22" />
+    <circle cx="512" cy="108" r="3" fillOpacity="0.15" />
+    <circle cx="510" cy="76" r="2.5" fillOpacity="0.1" />
+    <circle cx="446" cy="58" r="2.5" fillOpacity="0.14" />
+    <circle cx="478" cy="50" r="2.5" fillOpacity="0.1" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="200" cy="96" r="5.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="270" cy="128" r="3" />
+    <circle cx="292" cy="128" r="3" />
+    <circle cx="314" cy="128" r="3" />
+    <circle cx="336" cy="128" r="3" />
+    <path d="M348 120 L364 128 L348 136 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M540 158 L558 169 L540 180 Z" />
+  </g>
+</svg>
+
 ## The JavaScript ↔ TypeScript relationship
 
 Here's the most important fact about TypeScript: **TypeScript is a syntactic superset of JavaScript.** That means every valid JavaScript program is a valid TypeScript program. If you take a `.js` file and rename it to `.ts`, it compiles. You don't have to change a single character.
@@ -155,6 +202,44 @@ LET_KEYWORD  IDENTIFIER("x")  COLON  IDENTIFIER("number")  EQUALS  NUMERIC_LITER
 
 The scanner doesn't understand *meaning* yet. It just recognizes keywords (`let`, `function`, `if`), identifiers (`x`, `myFunction`), operators (`+`, `=`), and literals (`42`, `"hello"`).
 
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="A continuous flowing ribbon of source text falls apart into a neat row of small colored chips and beads — the scanner chopping raw characters into discrete tokens"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.18">
+    <path d="M60 50 C140 34 220 62 300 48 C380 36 460 60 580 44 L580 58 C460 74 380 50 300 62 C220 76 140 48 60 64 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="110" cy="84" r="2.5" />
+    <circle cx="190" cy="88" r="2.5" />
+    <circle cx="270" cy="84" r="2.5" />
+    <circle cx="350" cy="88" r="2.5" />
+    <circle cx="430" cy="84" r="2.5" />
+    <circle cx="510" cy="88" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="60" y="106" width="46" height="20" rx="10" />
+    <rect x="240" y="106" width="38" height="20" rx="10" />
+    <circle cx="398" cy="116" r="9" />
+    <rect x="480" y="106" width="46" height="20" rx="10" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="130" cy="116" r="9" />
+    <circle cx="212" cy="116" r="9" />
+    <rect x="328" y="106" width="46" height="20" rx="10" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="158" y="106" width="30" height="20" rx="10" />
+    <circle cx="300" cy="116" r="9" />
+    <rect x="426" y="106" width="30" height="20" rx="10" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="550" cy="116" r="4" />
+  </g>
+</svg>
+
 ### 2. Parser
 
 The **parser** takes the stream of tokens and builds an **Abstract Syntax Tree (AST)** — a tree structure representing the program's syntactic structure. For the line above, the AST node might look like:
@@ -297,6 +382,43 @@ Type-checking a large codebase (tens of thousands of files) would be slow if Typ
 **Project references** (for monorepos): If you have multiple TypeScript projects in one repository, you can configure them as "project references." TypeScript builds each project once, emits `.d.ts` files, and then other projects import those declarations instead of re-checking the source.
 
 These optimizations are why TypeScript scales to massive codebases (Microsoft's internal repos have hundreds of thousands of TypeScript files) while still providing instant feedback in editors.
+
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A grid of file tiles stays dim except one yellow edited file and the two blue files that import it, joined by dotted edges — incremental compilation re-checks only what changed"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="60" y="24" width="80" height="44" rx="9" />
+    <rect x="168" y="24" width="80" height="44" rx="9" />
+    <rect x="276" y="24" width="80" height="44" rx="9" />
+    <rect x="492" y="24" width="80" height="44" rx="9" />
+    <rect x="60" y="92" width="80" height="44" rx="9" />
+    <rect x="168" y="92" width="80" height="44" rx="9" />
+    <rect x="384" y="92" width="80" height="44" rx="9" />
+    <rect x="492" y="92" width="80" height="44" rx="9" />
+    <rect x="60" y="160" width="80" height="44" rx="9" />
+    <rect x="168" y="160" width="80" height="44" rx="9" />
+    <rect x="276" y="160" width="80" height="44" rx="9" />
+    <rect x="492" y="160" width="80" height="44" rx="9" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="276" y="92" width="80" height="44" rx="9" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="384" y="24" width="80" height="44" rx="9" fillOpacity="0.78" />
+    <rect x="384" y="160" width="80" height="44" rx="9" fillOpacity="0.78" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="366" cy="100" r="2.5" />
+    <circle cx="376" cy="84" r="2.5" />
+    <circle cx="384" cy="66" r="2.5" />
+    <circle cx="366" cy="128" r="2.5" />
+    <circle cx="375" cy="144" r="2.5" />
+    <circle cx="382" cy="158" r="2.5" />
+  </g>
+</svg>
 
 ## What the compiler can't do
 

--- a/content/learn/typescript-from-scratch/index.mdx
+++ b/content/learn/typescript-from-scratch/index.mdx
@@ -14,6 +14,48 @@ shape of modules. From there, we build up the *why* and *how* of
 TypeScript layer by layer, all the way to advanced type modeling and
 type-driven architecture.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="Drafting-table scene: solid shapes snap into matching silhouettes cut into a translucent template sheet, a compass arc and ruler ticks frame the work, and one red shape fits no opening — the type system as a design language for programs"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor">
+    <rect x="52" y="36" width="360" height="178" rx="16" opacity="0.06" />
+    <circle cx="128" cy="92" r="27" opacity="0.14" />
+    <rect x="196" y="136" width="54" height="54" rx="10" opacity="0.14" />
+    <path d="M312 70 L348 130 L276 130 Z" opacity="0.14" />
+    <rect x="600" y="44" width="8" height="148" rx="4" opacity="0.15" />
+    <rect x="586" y="58" width="11" height="3" rx="1.5" opacity="0.3" />
+    <rect x="586" y="84" width="11" height="3" rx="1.5" opacity="0.3" />
+    <rect x="586" y="110" width="11" height="3" rx="1.5" opacity="0.3" />
+    <rect x="586" y="136" width="11" height="3" rx="1.5" opacity="0.3" />
+    <rect x="586" y="162" width="11" height="3" rx="1.5" opacity="0.3" />
+    <circle cx="334" cy="76" r="2.5" opacity="0.3" />
+    <circle cx="326" cy="87" r="2.5" opacity="0.3" />
+    <circle cx="319" cy="98" r="2.5" opacity="0.3" />
+    <circle cx="470" cy="34" r="3" opacity="0.18" />
+    <circle cx="36" cy="222" r="3" opacity="0.18" />
+    <circle cx="558" cy="216" r="3" opacity="0.18" />
+    <circle cx="42" cy="24" r="3" opacity="0.18" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="128" cy="92" r="21" />
+    <path d="M490 30 A66 66 0 0 1 556 96 L542 96 A52 52 0 0 0 490 44 Z" fillOpacity="0.35" />
+    <circle cx="544" cy="120" r="5" fillOpacity="0.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="201" y="141" width="44" height="44" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M352 18 L380 64 L324 64 Z" />
+    <circle cx="490" cy="96" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M470 160 L489 174 L482 197 L458 197 L451 174 Z" />
+  </g>
+</svg>
+
 <Callout type="info" title="Who this course is for">
 You should be comfortable writing small JavaScript programs and reading
 modern ES syntax. You do **not** need any prior experience with
@@ -70,6 +112,39 @@ framework you adopt later.
 
 The pages are designed to be read in order. Each one stands on its
 own, but later chapters lean on earlier ideas.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Seven slab steps climb from left to right, each resting on the one before; a green dot stands partway up the stack and a yellow flag waits on the highest step — chapters that build on earlier chapters"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="30" y="190" width="150" height="15" rx="7.5" fillOpacity="0.2" />
+    <rect x="88" y="164" width="150" height="15" rx="7.5" fillOpacity="0.3" />
+    <rect x="146" y="138" width="150" height="15" rx="7.5" fillOpacity="0.4" />
+    <rect x="204" y="112" width="150" height="15" rx="7.5" fillOpacity="0.55" />
+    <rect x="262" y="86" width="150" height="15" rx="7.5" fillOpacity="0.7" />
+    <rect x="320" y="60" width="150" height="15" rx="7.5" fillOpacity="0.85" />
+    <rect x="378" y="34" width="150" height="15" rx="7.5" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="190" cy="148" r="2.5" />
+    <circle cx="225" cy="134" r="2.5" />
+    <circle cx="258" cy="122" r="2.5" />
+    <circle cx="292" cy="108" r="2.5" />
+    <circle cx="326" cy="94" r="2.5" />
+    <circle cx="360" cy="80" r="2.5" />
+    <circle cx="394" cy="66" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="142" cy="156" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="468" y="6" width="4" height="28" rx="2" />
+    <path d="M472 8 L496 15 L472 22 Z" />
+  </g>
+</svg>
 
 ### 1. The story of TypeScript
 How JavaScript outgrew its scripting roots, the maintainability

--- a/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
+++ b/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
@@ -11,6 +11,56 @@ You've learned how to transform and filter types with [mapped and conditional ty
 
 Together, these tools let you derive types from your code's structure, ensuring that types and values stay in sync automatically. You'll build event systems, configuration validators, and API contracts where the types are generated from your data, not manually duplicated.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A cabinet wears three shaped keyholes — circle, square, and triangle — and the ring beside it holds exactly three matching keys, with only a dotted ghost where a fourth would hang — keyof lifts an object's true keys into a type, no more and no fewer"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="80" y="40" width="200" height="160" rx="14" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="135" cy="85" r="14" />
+    <rect x="191" y="71" width="28" height="28" rx="5" />
+    <path d="M135 138 L151 166 L119 166 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <path d="M394 70 A26 26 0 1 1 446 70 A26 26 0 1 1 394 70 Z M400 70 A20 20 0 1 0 440 70 A20 20 0 1 0 400 70 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="402" cy="104" r="2.5" />
+    <circle cx="420" cy="101" r="2.5" />
+    <circle cx="442" cy="104" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="390" cy="122" r="11" />
+    <rect x="386" y="132" width="8" height="40" rx="3" />
+    <rect x="394" y="158" width="8" height="6" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="409" y="112" width="22" height="22" rx="5" />
+    <rect x="416" y="134" width="8" height="42" rx="3" />
+    <rect x="424" y="162" width="8" height="6" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M470 110 L483 132 L457 132 Z" />
+    <rect x="466" y="132" width="8" height="40" rx="3" />
+    <rect x="474" y="158" width="8" height="6" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="540" cy="112" r="2.5" />
+    <circle cx="550" cy="120" r="2.5" />
+    <circle cx="552" cy="132" r="2.5" />
+    <circle cx="546" cy="143" r="2.5" />
+    <circle cx="534" cy="146" r="2.5" />
+    <circle cx="526" cy="138" r="2.5" />
+    <circle cx="526" cy="124" r="2.5" />
+    <circle cx="540" cy="158" r="2.5" />
+    <circle cx="540" cy="172" r="2.5" />
+  </g>
+</svg>
+
 ---
 
 ## `keyof T`: The Keys of a Type
@@ -92,6 +142,43 @@ console.log(newConfig);
 
 `typeof config` produces `{ apiUrl: string; timeout: number; retries: number }`. If you add or remove properties from `config`, the type automatically reflects the change.
 
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A solid green square on the ground projects a beam up through the dotted cloud line, where its hollow twin appears in the type sky — typeof lifts a runtime value into the world of types"
+  style={{ display: "block", width: "100%", maxWidth: "460px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="100" y="170" width="440" height="4" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="120" cy="92" r="2.5" />
+    <circle cx="150" cy="92" r="2.5" />
+    <circle cx="180" cy="92" r="2.5" />
+    <circle cx="210" cy="92" r="2.5" />
+    <circle cx="240" cy="92" r="2.5" />
+    <circle cx="270" cy="92" r="2.5" />
+    <circle cx="300" cy="92" r="2.5" />
+    <circle cx="330" cy="92" r="2.5" />
+    <circle cx="360" cy="92" r="2.5" />
+    <circle cx="390" cy="92" r="2.5" />
+    <circle cx="420" cy="92" r="2.5" />
+    <circle cx="450" cy="92" r="2.5" />
+    <circle cx="480" cy="92" r="2.5" />
+    <circle cx="510" cy="92" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M282 170 L318 170 L342 36 L258 36 Z" fillOpacity="0.1" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="282" y="134" width="36" height="36" rx="6" />
+    <path d="M278 18 L322 18 L322 62 L278 62 Z M286 26 L314 26 L314 54 L286 54 Z" fillRule="evenodd" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="560" cy="36" r="10" />
+  </g>
+</svg>
+
 You can also use `typeof` with functions:
 
 <CodeBlock
@@ -167,6 +254,44 @@ console.log(msg1, msg2);
 />
 
 When you interpolate a union, TypeScript distributes over it, producing all combinations:
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Two blue prefix chips cross three yellow suffix chips in a small multiplication table, minting six two-tone combination chips — a template literal type generates every pairing automatically"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="210" y="24" width="64" height="24" rx="12" />
+    <rect x="306" y="24" width="64" height="24" rx="12" />
+    <rect x="402" y="24" width="64" height="24" rx="12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="90" y="84" width="64" height="24" rx="12" />
+    <rect x="90" y="144" width="64" height="24" rx="12" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="180" cy="36" r="3" />
+    <circle cx="180" cy="96" r="3" />
+    <circle cx="180" cy="156" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M222 84 L242 84 L242 108 L222 108 A12 12 0 0 1 222 84 Z" />
+    <path d="M318 84 L338 84 L338 108 L318 108 A12 12 0 0 1 318 84 Z" />
+    <path d="M414 84 L434 84 L434 108 L414 108 A12 12 0 0 1 414 84 Z" />
+    <path d="M222 144 L242 144 L242 168 L222 168 A12 12 0 0 1 222 144 Z" />
+    <path d="M318 144 L338 144 L338 168 L318 168 A12 12 0 0 1 318 144 Z" />
+    <path d="M414 144 L434 144 L434 168 L414 168 A12 12 0 0 1 414 144 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M242 84 L262 84 A12 12 0 0 1 262 108 L242 108 Z" />
+    <path d="M338 84 L358 84 A12 12 0 0 1 358 108 L338 108 Z" />
+    <path d="M434 84 L454 84 A12 12 0 0 1 454 108 L434 108 Z" />
+    <path d="M242 144 L262 144 A12 12 0 0 1 262 168 L242 168 Z" />
+    <path d="M338 144 L358 144 A12 12 0 0 1 358 168 L338 168 Z" />
+    <path d="M434 144 L454 144 A12 12 0 0 1 454 168 L434 168 Z" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="typescript"

--- a/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
+++ b/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
@@ -7,6 +7,58 @@ You've learned how to build generic types that work with any input. But what if 
 
 These questions lead us to **mapped types** and **conditional types**, two of TypeScript's most powerful metaprogramming tools. They let you write type-level functions that inspect, filter, and reshape other types. They're the building blocks behind the standard library's utility types (which we'll tour in the next chapter), and they're essential for modeling complex, real-world constraints.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A loom: five key threads hang from a beam and pass through a single blue heddle bar; below it every surviving thread wears an identical green ring while one thread simply ends at the bar — a mapped type transforms every property uniformly and can drop keys as it goes"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="120" y="30" width="400" height="12" rx="6" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="158" y="42" width="4" height="66" rx="2" />
+    <rect x="238" y="42" width="4" height="66" rx="2" />
+    <rect x="318" y="42" width="4" height="66" rx="2" />
+    <rect x="398" y="42" width="4" height="66" rx="2" />
+    <rect x="478" y="42" width="4" height="66" rx="2" />
+    <rect x="158" y="130" width="4" height="56" rx="2" />
+    <rect x="238" y="130" width="4" height="56" rx="2" />
+    <rect x="318" y="130" width="4" height="56" rx="2" />
+    <rect x="398" y="130" width="4" height="56" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="160" cy="36" r="6" />
+    <circle cx="400" cy="36" r="6" />
+    <rect x="120" y="108" width="400" height="22" rx="11" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="240" cy="36" r="6" />
+    <circle cx="480" cy="36" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="320" cy="36" r="6" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="160" cy="119" r="4" />
+    <circle cx="240" cy="119" r="4" />
+    <circle cx="320" cy="119" r="4" />
+    <circle cx="400" cy="119" r="4" />
+    <circle cx="480" cy="119" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M151 162 A9 9 0 1 1 169 162 A9 9 0 1 1 151 162 Z M154.5 162 A5.5 5.5 0 1 0 165.5 162 A5.5 5.5 0 1 0 154.5 162 Z" fillRule="evenodd" />
+    <path d="M231 162 A9 9 0 1 1 249 162 A9 9 0 1 1 231 162 Z M234.5 162 A5.5 5.5 0 1 0 245.5 162 A5.5 5.5 0 1 0 234.5 162 Z" fillRule="evenodd" />
+    <path d="M311 162 A9 9 0 1 1 329 162 A9 9 0 1 1 311 162 Z M314.5 162 A5.5 5.5 0 1 0 325.5 162 A5.5 5.5 0 1 0 314.5 162 Z" fillRule="evenodd" />
+    <path d="M391 162 A9 9 0 1 1 409 162 A9 9 0 1 1 391 162 Z M394.5 162 A5.5 5.5 0 1 0 405.5 162 A5.5 5.5 0 1 0 394.5 162 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="480" cy="140" r="2.5" />
+    <circle cx="480" cy="152" r="2" />
+    <rect x="120" y="196" width="400" height="14" rx="7" />
+  </g>
+</svg>
+
 ---
 
 ## Mapped Types
@@ -215,6 +267,46 @@ console.log(a, b);
 
 Conditional types become powerful when combined with generics. You can build type-level logic that branches based on the input.
 
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="A dotted track reaches a blue gate pierced by a diamond window: the piece that fits the window rides the upper rail to the green terminal, the round one curves down to the yellow terminal — a conditional type picks one of two branches with an extends test"
+  style={{ display: "block", width: "100%", maxWidth: "500px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="60" cy="95" r="2.5" />
+    <circle cx="90" cy="95" r="2.5" />
+    <circle cx="120" cy="95" r="2.5" />
+    <circle cx="150" cy="95" r="2.5" />
+    <circle cx="180" cy="95" r="2.5" />
+    <circle cx="210" cy="95" r="2.5" />
+    <circle cx="310" cy="80" r="2.5" />
+    <circle cx="340" cy="68" r="2.5" />
+    <circle cx="370" cy="56" r="2.5" />
+    <circle cx="400" cy="47" r="2.5" />
+    <circle cx="430" cy="42" r="2.5" />
+    <circle cx="310" cy="110" r="2.5" />
+    <circle cx="340" cy="122" r="2.5" />
+    <circle cx="370" cy="134" r="2.5" />
+    <circle cx="400" cy="143" r="2.5" />
+    <circle cx="430" cy="148" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M260 58 L297 95 L260 132 L223 95 Z" />
+  </g>
+  <g fill="var(--ds-white)">
+    <path d="M260 80 L275 95 L260 110 L245 95 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M348 56 L358 66 L348 76 L338 66 Z" />
+    <rect x="452" y="136" width="26" height="26" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="356" cy="126" r="9" />
+    <circle cx="468" cy="40" r="13" />
+  </g>
+</svg>
+
 ---
 
 ## Distributive Conditional Types
@@ -287,6 +379,32 @@ console.log(x, y);
 ## The `infer` Keyword
 
 The `infer` keyword lets you **extract** parts of a type inside a conditional. It's like pattern matching for types.
+
+<svg
+  viewBox="0 0 640 160"
+  role="img"
+  aria-label="Tweezers reach into a blue capsule and lift out its green pearl, leaving a pale hollow behind — infer names the type packed inside a wrapper so you can carry it away"
+  style={{ display: "block", width: "100%", maxWidth: "440px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="120" y="64" width="150" height="54" rx="27" fillOpacity="0.9" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="195" cy="91" r="13" />
+  </g>
+  <g fill="currentColor" opacity="0.4">
+    <path d="M352 18 L228 80 L233 90 L357 28 Z" />
+    <path d="M352 18 L262 108 L270 114 L359 26 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="300" cy="74" r="2.5" />
+    <circle cx="350" cy="64" r="2.5" />
+    <circle cx="400" cy="58" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="452" cy="56" r="14" />
+  </g>
+</svg>
 
 For example, here's how to extract the return type of a function:
 

--- a/content/learn/typescript-from-scratch/modeling-domains-with-types.mdx
+++ b/content/learn/typescript-from-scratch/modeling-domains-with-types.mdx
@@ -7,6 +7,53 @@ The difference between mediocre TypeScript and great TypeScript often comes down
 
 This chapter is the capstone of type-driven design. We'll take sloppy, bug-prone type definitions and evolve them into precise, self-documenting structures that use discriminated unions, literal types, and careful narrowing to eliminate invalid states. By the end, you'll see how the compiler can enforce your business logic at compile time, long before any code runs.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="An archipelago of state islands joined only by the bridges the domain allows: a traveler dot crosses a legal bridge, a red route attempted over open water ends in a splash, and one outlying islet has no bridge at all — illegal states and transitions have nowhere to exist"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <circle cx="60" cy="180" r="3" />
+    <circle cx="90" cy="226" r="3" />
+    <circle cx="300" cy="120" r="3" />
+    <circle cx="560" cy="50" r="3" />
+    <circle cx="600" cy="220" r="3" />
+    <circle cx="400" cy="210" r="3" />
+    <circle cx="160" cy="30" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M70 84 C72 58 104 44 130 48 C158 42 178 62 176 84 C178 106 150 120 116 118 C88 120 68 106 70 84 Z" fillOpacity="0.85" />
+    <circle cx="225" cy="68" r="6.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M292 62 C294 38 326 26 352 30 C380 24 400 44 398 64 C400 86 372 100 338 98 C310 100 290 86 292 62 Z" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M436 150 C438 126 470 112 496 116 C524 110 544 130 542 150 C544 172 516 186 482 184 C454 186 434 172 436 150 Z" fillOpacity="0.85" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <path d="M176 196 C178 182 196 174 212 176 C228 172 240 184 238 196 C240 208 224 216 204 215 C188 216 175 208 176 196 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.45">
+    <circle cx="192" cy="76" r="4" />
+    <circle cx="222" cy="71" r="4" />
+    <circle cx="252" cy="67" r="4" />
+    <circle cx="280" cy="64" r="4" />
+    <circle cx="408" cy="82" r="4" />
+    <circle cx="424" cy="102" r="4" />
+    <circle cx="436" cy="122" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="160" cy="130" r="3.5" fillOpacity="0.8" />
+    <circle cx="196" cy="150" r="3.5" fillOpacity="0.65" />
+    <circle cx="234" cy="166" r="3.5" fillOpacity="0.5" />
+    <path d="M262 182 A10 10 0 1 1 282 182 A10 10 0 1 1 262 182 Z M266 182 A6 6 0 1 0 278 182 A6 6 0 1 0 266 182 Z" fillRule="evenodd" fillOpacity="0.6" />
+    <circle cx="288" cy="168" r="2" fillOpacity="0.5" />
+    <circle cx="258" cy="166" r="2" fillOpacity="0.5" />
+  </g>
+</svg>
+
 ## The problem: boolean soup
 
 Let's start with a common anti-pattern. Suppose you're modeling a user in a multi-tenant application:
@@ -383,6 +430,55 @@ console.log(
 />
 
 Each payment method is a distinct variant with its own fields. No optional properties, no runtime checks for "is this a credit card or a bank account?" — the type tells you.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Three independent toggles spawn a ghost grid of eight combinations with several glowing red, while a single dial offers exactly three positions and nothing in between — replacing boolean soup with one variant field leaves illegal mixes no place to live"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="70" y="40" width="44" height="20" rx="10" />
+    <rect x="70" y="76" width="44" height="20" rx="10" />
+    <rect x="70" y="112" width="44" height="20" rx="10" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="82" cy="50" r="8" />
+    <circle cx="102" cy="86" r="8" />
+    <circle cx="82" cy="122" r="8" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="160" y="42" width="26" height="26" rx="5" />
+    <rect x="196" y="42" width="26" height="26" rx="5" />
+    <rect x="232" y="42" width="26" height="26" rx="5" />
+    <rect x="268" y="42" width="26" height="26" rx="5" />
+    <rect x="160" y="106" width="26" height="26" rx="5" />
+    <rect x="268" y="106" width="26" height="26" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="196" y="106" width="26" height="26" rx="5" fillOpacity="0.4" />
+    <rect x="232" y="106" width="26" height="26" rx="5" fillOpacity="0.4" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="330" cy="88" r="2.5" />
+    <circle cx="348" cy="88" r="2.5" />
+    <circle cx="366" cy="88" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <path d="M420 88 A48 48 0 1 1 516 88 A48 48 0 1 1 420 88 Z M428 88 A40 40 0 1 0 508 88 A40 40 0 1 0 428 88 Z" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="468" cy="44" r="7" />
+    <path d="M464 88 L468 48 L472 88 Z" />
+    <circle cx="468" cy="88" r="8" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="430" cy="110" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="506" cy="110" r="7" />
+  </g>
+</svg>
 
 ## Literal types for constrained values
 

--- a/content/learn/typescript-from-scratch/next-steps.mdx
+++ b/content/learn/typescript-from-scratch/next-steps.mdx
@@ -7,6 +7,54 @@ You've completed the TypeScript from Scratch course. You started with the story 
 
 But this is just the beginning. TypeScript is a vast ecosystem, and there's always more to learn. This chapter outlines the natural next steps: frameworks, runtimes, ecosystem-specific patterns, and resources for continued learning.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A rail turntable with the engine's bridge already swung to line up with one of several radiating tracks — the green line climbing to its station — while other destinations wait on dotted rails and the track behind fades out — the course ends at a junction where you choose the next line"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <path d="M185 130 A75 75 0 1 1 335 130 A75 75 0 1 1 185 130 Z M200 130 A60 60 0 1 0 320 130 A60 60 0 1 0 200 130 Z" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M316.6 80.2 L324.8 91.6 L203.4 179.8 L195.2 168.4 Z" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="282" cy="114" r="11" />
+    <circle cx="338" cy="73" r="3.5" fillOpacity="0.6" />
+    <circle cx="356" cy="60" r="3.5" fillOpacity="0.6" />
+    <circle cx="374" cy="47" r="3.5" fillOpacity="0.6" />
+    <circle cx="392" cy="34" r="3.5" fillOpacity="0.6" />
+    <circle cx="412" cy="24" r="12" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="352" cy="130" r="3" />
+    <circle cx="378" cy="130" r="3" />
+    <circle cx="404" cy="130" r="3" />
+    <circle cx="430" cy="130" r="3" />
+    <circle cx="334" cy="192" r="3" />
+    <circle cx="352" cy="205" r="3" />
+    <circle cx="370" cy="217" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="452" y="118" width="24" height="24" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="390" cy="226" r="9" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="150" cy="130" r="3" />
+    <circle cx="124" cy="130" r="3" />
+    <circle cx="98" cy="130" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <circle cx="74" cy="130" r="9" />
+    <circle cx="560" cy="60" r="3" />
+    <circle cx="580" cy="190" r="3" />
+    <circle cx="60" cy="40" r="3" />
+  </g>
+</svg>
+
 ---
 
 ## What You've Learned

--- a/content/learn/typescript-from-scratch/objects-and-interfaces.mdx
+++ b/content/learn/typescript-from-scratch/objects-and-interfaces.mdx
@@ -16,6 +16,68 @@ difference between `interface` and `type`, and how TypeScript's
 **structural type system** makes objects compatible based on their shape,
 not their declared name.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="A workshop shadow board: painted silhouettes mark each required tool, a blue bar and a green disc hang over their matching outlines, a triangle outline waits empty beside a red alert dot, and a yellow extra tool hangs off the board — an interface as the painted shape an object must fill"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.06">
+    <rect x="70" y="30" width="400" height="180" rx="16" />
+  </g>
+  <g fill="currentColor" opacity="0.1">
+    <circle cx="100" cy="58" r="2" />
+    <circle cx="148" cy="58" r="2" />
+    <circle cx="196" cy="58" r="2" />
+    <circle cx="244" cy="58" r="2" />
+    <circle cx="292" cy="58" r="2" />
+    <circle cx="340" cy="58" r="2" />
+    <circle cx="388" cy="58" r="2" />
+    <circle cx="436" cy="58" r="2" />
+    <circle cx="100" cy="106" r="2" />
+    <circle cx="148" cy="106" r="2" />
+    <circle cx="196" cy="106" r="2" />
+    <circle cx="244" cy="106" r="2" />
+    <circle cx="292" cy="106" r="2" />
+    <circle cx="340" cy="106" r="2" />
+    <circle cx="388" cy="106" r="2" />
+    <circle cx="436" cy="106" r="2" />
+    <circle cx="100" cy="154" r="2" />
+    <circle cx="148" cy="154" r="2" />
+    <circle cx="196" cy="154" r="2" />
+    <circle cx="244" cy="154" r="2" />
+    <circle cx="292" cy="154" r="2" />
+    <circle cx="340" cy="154" r="2" />
+    <circle cx="388" cy="154" r="2" />
+    <circle cx="436" cy="154" r="2" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <rect x="117" y="85" width="90" height="22" rx="11" />
+    <circle cx="307" cy="99" r="24" />
+    <path d="M200 132 L232 186 L168 186 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="110" y="78" width="90" height="22" rx="11" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="300" cy="92" r="24" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="246" cy="140" r="5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="518" y="68" width="4" height="20" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="498" y="88" width="42" height="42" rx="9" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="560" cy="190" r="3" />
+    <circle cx="38" cy="120" r="3" />
+    <circle cx="600" cy="40" r="3" />
+  </g>
+</svg>
+
 ## Object type literals
 
 The simplest way to type an object is an **object type literal** — a
@@ -170,6 +232,37 @@ The type of `bob.age` is `number | undefined`, so you must narrow before
 treating it as a pure `number`. This forces you to handle the "missing
 property" case explicitly, preventing `TypeError`s at runtime.
 
+<svg
+  viewBox="0 0 640 160"
+  role="img"
+  aria-label="On a small shadow board two solid outlines hold their tools while a third outline drawn only in dots stands empty and raises no alarm — optional properties may be filled or left absent"
+  style={{ display: "block", width: "100%", maxWidth: "460px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.06">
+    <rect x="110" y="24" width="420" height="112" rx="14" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="196" cy="86" r="22" />
+    <rect x="438" y="64" width="44" height="44" rx="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="188" cy="78" r="22" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="430" y="56" width="44" height="44" rx="9" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="364" cy="80" r="2.5" />
+    <circle cx="357" cy="97" r="2.5" />
+    <circle cx="340" cy="104" r="2.5" />
+    <circle cx="323" cy="97" r="2.5" />
+    <circle cx="316" cy="80" r="2.5" />
+    <circle cx="323" cy="63" r="2.5" />
+    <circle cx="340" cy="56" r="2.5" />
+    <circle cx="357" cy="63" r="2.5" />
+  </g>
+</svg>
+
 ## Readonly properties
 
 A `readonly` property can be set once (during initialization) but not
@@ -270,6 +363,54 @@ console.log("apple:", data.apple);
 be compatible with it. In the example above, `count` is a `number`, which
 matches the index signature `[key: string]: number`. If `count` were a
 `string`, the compiler would reject it.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A wall of identical pigeonholes accepts only green discs: one tinted slot is reserved by name, several wait empty, and a red triangle hovering outside fits none — an index signature gives every key the same value type"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <rect x="80" y="36" width="56" height="44" rx="8" />
+    <rect x="148" y="36" width="56" height="44" rx="8" />
+    <rect x="216" y="36" width="56" height="44" rx="8" />
+    <rect x="352" y="36" width="56" height="44" rx="8" />
+    <rect x="420" y="36" width="56" height="44" rx="8" />
+    <rect x="80" y="92" width="56" height="44" rx="8" />
+    <rect x="148" y="92" width="56" height="44" rx="8" />
+    <rect x="216" y="92" width="56" height="44" rx="8" />
+    <rect x="284" y="92" width="56" height="44" rx="8" />
+    <rect x="352" y="92" width="56" height="44" rx="8" />
+    <rect x="420" y="92" width="56" height="44" rx="8" />
+    <rect x="80" y="148" width="56" height="44" rx="8" />
+    <rect x="148" y="148" width="56" height="44" rx="8" />
+    <rect x="216" y="148" width="56" height="44" rx="8" />
+    <rect x="284" y="148" width="56" height="44" rx="8" />
+    <rect x="352" y="148" width="56" height="44" rx="8" />
+    <rect x="420" y="148" width="56" height="44" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="284" y="36" width="56" height="44" rx="8" fillOpacity="0.3" />
+    <circle cx="292" cy="44" r="3.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="108" cy="58" r="13" />
+    <circle cx="244" cy="58" r="13" />
+    <circle cx="312" cy="58" r="13" />
+    <circle cx="176" cy="114" r="13" />
+    <circle cx="380" cy="114" r="13" />
+    <circle cx="108" cy="170" r="13" />
+    <circle cx="312" cy="170" r="13" />
+    <circle cx="448" cy="170" r="13" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M560 96 L578 126 L542 126 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="524" cy="114" r="2.5" />
+    <circle cx="506" cy="114" r="2.5" />
+  </g>
+</svg>
 
 ## Interface extension
 
@@ -387,6 +528,42 @@ confusing, so use it sparingly. Declaration merging is one of the main
 reasons to prefer `interface` over `type` for public APIs — if users need
 to extend your types, they can re-declare the interface in their own
 code.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Two capsules each carrying one porthole slide down and fuse into a single two-tone capsule with both portholes — declaring the same interface name twice merges its members into one shape"
+  style={{ display: "block", width: "100%", maxWidth: "440px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="120" y="36" width="140" height="44" rx="22" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="380" y="36" width="140" height="44" rx="22" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="190" cy="58" r="6.5" />
+    <circle cx="450" cy="58" r="6.5" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="216" cy="92" r="2.5" />
+    <circle cx="244" cy="106" r="2.5" />
+    <circle cx="272" cy="118" r="2.5" />
+    <circle cx="424" cy="92" r="2.5" />
+    <circle cx="396" cy="106" r="2.5" />
+    <circle cx="368" cy="118" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M254 130 L320 130 L320 178 L254 178 C240.7 178 230 167.3 230 154 C230 140.7 240.7 130 254 130 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M320 130 L386 130 C399.3 130 410 140.7 410 154 C410 167.3 399.3 178 386 178 L320 178 Z" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="285" cy="154" r="6.5" />
+    <circle cx="355" cy="154" r="6.5" />
+  </g>
+</svg>
 
 ## `interface` vs `type`: when to use which
 

--- a/content/learn/typescript-from-scratch/primitive-types.mdx
+++ b/content/learn/typescript-from-scratch/primitive-types.mdx
@@ -13,6 +13,55 @@ number never accidentally receives a string.
 This chapter answers three questions: **What are the primitive types?**
 **How does the compiler track them?** **What bugs does this prevent?**
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="Seven atoms drift in a field: blue, green, and yellow nuclei with orbiting electrons, a double-ringed heavyweight, a one-of-a-kind red atom with a sparkle, a deliberately hollow ring, and a barely-there ghost — the primitive types as the indivisible atoms of the type system"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="60" cy="40" r="3" />
+    <circle cx="600" cy="60" r="3" />
+    <circle cx="330" cy="20" r="2.5" />
+    <circle cx="610" cy="214" r="3" />
+    <circle cx="40" cy="120" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M120 84 A30 30 0 1 1 180 84 A30 30 0 1 1 120 84 Z M123 84 A27 27 0 1 0 177 84 A27 27 0 1 0 123 84 Z" fillRule="evenodd" fillOpacity="0.3" />
+    <circle cx="150" cy="84" r="15" />
+    <circle cx="171" cy="63" r="4" />
+    <circle cx="129" cy="105" r="4" />
+    <path d="M186 178 A34 34 0 1 1 254 178 A34 34 0 1 1 186 178 Z M189 178 A31 31 0 1 0 251 178 A31 31 0 1 0 189 178 Z" fillRule="evenodd" fillOpacity="0.25" />
+    <path d="M174 178 A46 46 0 1 1 266 178 A46 46 0 1 1 174 178 Z M177 178 A43 43 0 1 0 263 178 A43 43 0 1 0 177 178 Z" fillRule="evenodd" fillOpacity="0.14" />
+    <circle cx="220" cy="178" r="17" fillOpacity="0.85" />
+    <circle cx="266" cy="178" r="4" />
+    <circle cx="220" cy="132" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M303 76 A27 27 0 1 1 357 76 A27 27 0 1 1 303 76 Z M306 76 A24 24 0 1 0 354 76 A24 24 0 1 0 306 76 Z" fillRule="evenodd" fillOpacity="0.3" />
+    <circle cx="330" cy="76" r="13" />
+    <circle cx="352" cy="58" r="3.5" />
+    <circle cx="366" cy="46" r="3" />
+    <circle cx="380" cy="36" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M446 64 A24 24 0 1 1 494 64 A24 24 0 1 1 446 64 Z M449 64 A21 21 0 1 0 491 64 A21 21 0 1 0 449 64 Z" fillRule="evenodd" fillOpacity="0.35" />
+    <circle cx="470" cy="64" r="11" />
+    <circle cx="494" cy="64" r="4.5" />
+    <circle cx="446" cy="64" r="4.5" />
+  </g>
+  <g fill="currentColor">
+    <path d="M376 170 A14 14 0 1 1 404 170 A14 14 0 1 1 376 170 Z M382 170 A8 8 0 1 0 398 170 A8 8 0 1 0 382 170 Z" fillRule="evenodd" opacity="0.45" />
+    <circle cx="96" cy="190" r="8" opacity="0.1" />
+    <path d="M80 190 A16 16 0 1 1 112 190 A16 16 0 1 1 80 190 Z M82 190 A14 14 0 1 0 110 190 A14 14 0 1 0 82 190 Z" fillRule="evenodd" opacity="0.07" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M500 170 A20 20 0 1 1 540 170 A20 20 0 1 1 500 170 Z M503 170 A17 17 0 1 0 537 170 A17 17 0 1 0 503 170 Z" fillRule="evenodd" fillOpacity="0.3" />
+    <circle cx="520" cy="170" r="9" />
+    <path d="M551 142 L554 150 L562 153 L554 156 L551 164 L548 156 L540 153 L548 150 Z" />
+  </g>
+</svg>
+
 ## The seven primitive types
 
 JavaScript has seven primitive types. TypeScript provides a corresponding
@@ -167,6 +216,40 @@ In practice, `undefined` means "never initialized" or "missing property,"
 while `null` means "intentionally empty." By giving each its own type,
 TypeScript forces you to be explicit about which kind of emptiness you
 expect.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Two kinds of nothing: on the left a solid pedestal holds an empty bowl with a green placed marker, on the right only a dotted outline shows where a bowl would stand — null is emptiness on purpose, undefined is a value that never arrived"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M120 70 L220 70 C218 102 196 118 170 118 C144 118 122 102 120 70 Z" fillOpacity="0.85" />
+    <rect x="160" y="118" width="20" height="22" rx="4" fillOpacity="0.6" />
+    <rect x="130" y="140" width="80" height="10" rx="5" fillOpacity="0.4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M156 50 A14 14 0 1 1 184 50 A14 14 0 1 1 156 50 Z M162 50 A8 8 0 1 0 178 50 A8 8 0 1 0 162 50 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <circle cx="420" cy="70" r="3" />
+    <circle cx="446" cy="74" r="3" />
+    <circle cx="470" cy="84" r="3" />
+    <circle cx="488" cy="100" r="3" />
+    <circle cx="496" cy="116" r="3" />
+    <circle cx="500" cy="70" r="3" />
+    <circle cx="474" cy="74" r="3" />
+    <circle cx="424" cy="100" r="3" />
+    <circle cx="432" cy="116" r="3" />
+    <circle cx="460" cy="120" r="3" />
+    <circle cx="460" cy="140" r="3" />
+    <circle cx="436" cy="150" r="2.5" />
+    <circle cx="484" cy="150" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="80" y="160" width="480" height="4" rx="2" />
+  </g>
+</svg>
 
 **Strict null checks:** By default (in `strict` mode), TypeScript does
 *not* allow `null` or `undefined` to inhabit other types. A variable of

--- a/content/learn/typescript-from-scratch/scalable-architecture.mdx
+++ b/content/learn/typescript-from-scratch/scalable-architecture.mdx
@@ -7,6 +7,54 @@ As codebases grow, they become harder to navigate, test, and change. Functions d
 
 This chapter introduces **layered architecture** — a pattern for organizing code into distinct layers (domain, application, infrastructure) with clear boundaries and dependencies flowing in one direction. You'll learn how to use **TypeScript's type system** to enforce these boundaries, prevent circular dependencies, and make large systems understandable and maintainable.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="A temple in cross-section: the yellow roof of infrastructure rests on blue application columns standing on a deep green domain foundation, weather dots kept outside; one column is only a dotted outline — a port — with its green implementation sliding in from the side — layers depend downward and the foundation knows nothing above it"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="200" cy="24" r="3" />
+    <circle cx="320" cy="12" r="3" />
+    <circle cx="440" cy="24" r="3" />
+    <circle cx="566" cy="60" r="3" />
+    <circle cx="76" cy="60" r="3" />
+    <circle cx="600" cy="140" r="3" />
+    <circle cx="40" cy="160" r="3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M104 100 L320 38 L536 100 Z" fillOpacity="0.85" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="164" y="100" width="40" height="12" rx="4" fillOpacity="0.5" />
+    <rect x="254" y="100" width="40" height="12" rx="4" fillOpacity="0.5" />
+    <rect x="344" y="100" width="40" height="12" rx="4" fillOpacity="0.5" />
+    <rect x="434" y="100" width="40" height="12" rx="4" fillOpacity="0.5" />
+    <rect x="170" y="112" width="28" height="78" rx="6" fillOpacity="0.8" />
+    <rect x="260" y="112" width="28" height="78" rx="6" fillOpacity="0.8" />
+    <rect x="440" y="112" width="28" height="78" rx="6" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="364" cy="120" r="2.5" />
+    <circle cx="364" cy="136" r="2.5" />
+    <circle cx="364" cy="152" r="2.5" />
+    <circle cx="364" cy="168" r="2.5" />
+    <circle cx="364" cy="184" r="2.5" />
+    <circle cx="352" cy="120" r="2.5" />
+    <circle cx="352" cy="136" r="2.5" />
+    <circle cx="352" cy="152" r="2.5" />
+    <circle cx="352" cy="168" r="2.5" />
+    <circle cx="352" cy="184" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="404" cy="152" r="8" />
+    <circle cx="422" cy="152" r="2.5" fillOpacity="0.5" />
+    <circle cx="436" cy="152" r="2.5" fillOpacity="0.35" />
+    <rect x="120" y="190" width="400" height="30" rx="8" fillOpacity="0.85" />
+    <rect x="100" y="220" width="440" height="14" rx="7" fillOpacity="0.5" />
+  </g>
+</svg>
+
 ---
 
 ## The Problem: Tangled Dependencies
@@ -315,6 +363,48 @@ Notice:
 ## Barrel Files for Clean Exports
 
 A **barrel file** (`index.ts`) re-exports only the public API of a module, hiding internal details:
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Three scattered trails of exports pour into one barrel that has a single tap, from which one green stream leaves; a faint extra trail stops outside the barrel wall — a barrel file gathers a module's public surface into one import path and keeps internals inside"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="80" cy="44" r="6" />
+    <circle cx="118" cy="52" r="5" fillOpacity="0.7" />
+    <circle cx="156" cy="62" r="4" fillOpacity="0.5" />
+    <circle cx="80" cy="90" r="6" />
+    <circle cx="122" cy="90" r="5" fillOpacity="0.7" />
+    <circle cx="164" cy="90" r="4" fillOpacity="0.5" />
+    <circle cx="80" cy="136" r="6" />
+    <circle cx="118" cy="128" r="5" fillOpacity="0.7" />
+    <circle cx="156" cy="118" r="4" fillOpacity="0.5" />
+    <circle cx="194" cy="80" r="3.5" fillOpacity="0.4" />
+    <circle cx="194" cy="100" r="3.5" fillOpacity="0.4" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <path d="M250 40 C242 40 236 46 236 54 L236 126 C236 134 242 140 250 140 L350 140 C358 140 364 134 364 126 L364 54 C364 46 358 40 350 40 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <rect x="236" y="62" width="128" height="6" rx="3" />
+    <rect x="236" y="112" width="128" height="6" rx="3" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="364" y="82" width="22" height="14" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="412" cy="89" r="6" />
+    <circle cx="448" cy="89" r="5" fillOpacity="0.7" />
+    <circle cx="484" cy="89" r="4" fillOpacity="0.5" />
+    <circle cx="518" cy="89" r="3.5" fillOpacity="0.35" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <circle cx="280" cy="160" r="3" />
+    <circle cx="310" cy="164" r="3" />
+    <circle cx="340" cy="160" r="3" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="typescript"

--- a/content/learn/typescript-from-scratch/setup-and-tsconfig.mdx
+++ b/content/learn/typescript-from-scratch/setup-and-tsconfig.mdx
@@ -7,6 +7,48 @@ Now that you understand *why* TypeScript exists and *how* it works, let's get pr
 
 We'll keep it minimal. You don't need a complex build pipeline, a framework, or a bundler to learn TypeScript. The in-browser playground on this site is enough for most lessons. But if you want to experiment locally, this page shows you how.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="A mixer console of five faders and two dials: the large master fader is pushed all the way up and glows green while one neglected fader sits low above a red light — tsconfig as a panel of strictness controls"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor">
+    <rect x="70" y="28" width="500" height="174" rx="18" opacity="0.06" />
+    <rect x="120" y="50" width="8" height="120" rx="4" opacity="0.18" />
+    <rect x="180" y="50" width="8" height="120" rx="4" opacity="0.18" />
+    <rect x="240" y="50" width="8" height="120" rx="4" opacity="0.18" />
+    <rect x="300" y="50" width="8" height="120" rx="4" opacity="0.18" />
+    <rect x="360" y="50" width="8" height="120" rx="4" opacity="0.18" />
+    <rect x="438" y="42" width="10" height="132" rx="5" opacity="0.22" />
+    <path d="M504 70 A16 16 0 1 1 536 70 A16 16 0 1 1 504 70 Z M510 70 A10 10 0 1 0 530 70 A10 10 0 1 0 510 70 Z" fillRule="evenodd" opacity="0.25" />
+    <path d="M504 130 A16 16 0 1 1 536 130 A16 16 0 1 1 504 130 Z M510 130 A10 10 0 1 0 530 130 A10 10 0 1 0 510 130 Z" fillRule="evenodd" opacity="0.25" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="110" y="80" width="28" height="14" rx="7" />
+    <rect x="170" y="114" width="28" height="14" rx="7" />
+    <rect x="230" y="60" width="28" height="14" rx="7" />
+    <rect x="290" y="98" width="28" height="14" rx="7" />
+    <rect x="350" y="148" width="28" height="14" rx="7" />
+    <circle cx="531" cy="59" r="4" />
+    <circle cx="509" cy="141" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="425" y="46" width="36" height="16" rx="8" />
+    <circle cx="443" cy="32" r="4" fillOpacity="0.6" />
+    <circle cx="124" cy="186" r="5" />
+    <circle cx="184" cy="186" r="5" />
+    <circle cx="304" cy="186" r="5" />
+    <circle cx="443" cy="186" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="244" cy="186" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="364" cy="186" r="5" />
+  </g>
+</svg>
+
 ## Installing TypeScript
 
 TypeScript is distributed as an npm package. You can install it globally (available everywhere) or per-project (recommended for real applications).
@@ -257,6 +299,51 @@ if (name !== null) {
 ```
 
 This eliminates the "billion-dollar mistake" — `TypeError: Cannot read property 'x' of null/undefined` — which plagues JavaScript.
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Two plank walkways with the same missing plank: on the upper one a walking dot is a single step from the unmarked hole, on the lower one a green ramp arcs over the gap and the dot is already safely across — strictNullChecks makes the null hole visible and handled"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="70" y="58" width="46" height="12" rx="6" />
+    <rect x="124" y="58" width="46" height="12" rx="6" />
+    <rect x="178" y="58" width="46" height="12" rx="6" />
+    <rect x="232" y="58" width="46" height="12" rx="6" />
+    <rect x="286" y="58" width="46" height="12" rx="6" />
+    <rect x="394" y="58" width="46" height="12" rx="6" />
+    <rect x="448" y="58" width="46" height="12" rx="6" />
+    <rect x="502" y="58" width="46" height="12" rx="6" />
+    <rect x="70" y="150" width="46" height="12" rx="6" />
+    <rect x="124" y="150" width="46" height="12" rx="6" />
+    <rect x="178" y="150" width="46" height="12" rx="6" />
+    <rect x="232" y="150" width="46" height="12" rx="6" />
+    <rect x="286" y="150" width="46" height="12" rx="6" />
+    <rect x="394" y="150" width="46" height="12" rx="6" />
+    <rect x="448" y="150" width="46" height="12" rx="6" />
+    <rect x="502" y="150" width="46" height="12" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="340" y="58" width="46" height="12" rx="6" fillOpacity="0.22" />
+    <circle cx="363" cy="86" r="4" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="314" cy="46" r="9" />
+    <circle cx="524" cy="138" r="9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M330 150 C348 116 378 116 396 150 L382 150 C370 128 356 128 344 150 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="120" cy="40" r="2.5" />
+    <circle cx="172" cy="40" r="2.5" />
+    <circle cx="224" cy="40" r="2.5" />
+    <circle cx="276" cy="40" r="2.5" />
+    <circle cx="430" cy="132" r="2.5" />
+    <circle cx="468" cy="132" r="2.5" />
+  </g>
+</svg>
 
 ### `noUncheckedIndexedAccess` — Safer array/object indexing
 

--- a/content/learn/typescript-from-scratch/static-analysis-in-action.mdx
+++ b/content/learn/typescript-from-scratch/static-analysis-in-action.mdx
@@ -7,6 +7,50 @@ You've written types, modeled domains, and structured architectures. But what do
 
 This chapter reveals the compiler's inner workings: how it catches bugs at compile time, enables refactoring with confidence, proves exhaustiveness, and drives the language service that powers autocomplete, go-to-definition, and instant feedback in your editor.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Parcels ride a belt through a translucent scanning arch on their way to the departure flag: inside the arch one parcel turns see-through and reveals a red flaw, while cleared parcels carry green rings — static analysis inspects code before it ever ships"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="50" y="160" width="540" height="8" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="90" cy="178" r="4" />
+    <circle cx="170" cy="178" r="4" />
+    <circle cx="250" cy="178" r="4" />
+    <circle cx="330" cy="178" r="4" />
+    <circle cx="410" cy="178" r="4" />
+    <circle cx="490" cy="178" r="4" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="110" y="118" width="52" height="42" rx="6" />
+    <rect x="190" y="126" width="44" height="34" rx="6" />
+    <rect x="430" y="118" width="48" height="42" rx="6" />
+    <rect x="510" y="126" width="40" height="34" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M260 160 L260 60 Q260 36 284 36 L356 36 Q380 36 380 60 L380 160 L352 160 L352 64 Q352 60 348 60 L292 60 Q288 60 288 64 L288 160 Z" fillOpacity="0.35" />
+    <rect x="288" y="60" width="64" height="100" fillOpacity="0.08" />
+    <rect x="288" y="102" width="64" height="5" fillOpacity="0.3" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="296" y="118" width="48" height="42" rx="6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M320 128 L324 136 L333 137 L326 143 L329 152 L320 147 L311 152 L314 143 L307 137 L316 136 Z" fillOpacity="0.9" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M445 100 A9 9 0 1 1 463 100 A9 9 0 1 1 445 100 Z M448.5 100 A5.5 5.5 0 1 0 459.5 100 A5.5 5.5 0 1 0 448.5 100 Z" fillRule="evenodd" />
+    <circle cx="530" cy="108" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="586" y="118" width="4" height="42" rx="2" />
+    <path d="M590 120 L612 127 L590 134 Z" />
+  </g>
+</svg>
+
 ---
 
 ## What the Compiler Proves
@@ -303,6 +347,41 @@ console.log(processValue(0));
 />
 
 If you add another `else` after the `value === 0` case, it's unreachable, and the compiler can warn you.
+
+<svg
+  viewBox="0 0 640 170"
+  role="img"
+  aria-label="A bright dotted route runs straight through, while a faint spur drops away to a node nothing ever reaches, ringed in red — the compiler proves that code after a return or an impossible branch can never run"
+  style={{ display: "block", width: "100%", maxWidth: "460px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="70" cy="70" r="4" />
+    <circle cx="115" cy="70" r="4" />
+    <circle cx="160" cy="70" r="4" />
+    <circle cx="205" cy="70" r="4" />
+    <circle cx="250" cy="70" r="4" />
+    <circle cx="295" cy="70" r="4" />
+    <circle cx="340" cy="70" r="4" />
+    <circle cx="385" cy="70" r="4" />
+    <circle cx="430" cy="70" r="4" />
+    <circle cx="475" cy="70" r="4" />
+    <circle cx="520" cy="70" r="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="565" cy="70" r="9" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="312" cy="96" r="3" />
+    <circle cx="336" cy="116" r="3" />
+    <circle cx="358" cy="134" r="3" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <circle cx="390" cy="144" r="10" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M376 144 A14 14 0 1 1 404 144 A14 14 0 1 1 376 144 Z M379 144 A11 11 0 1 0 401 144 A11 11 0 1 0 379 144 Z" fillRule="evenodd" fillOpacity="0.45" />
+  </g>
+</svg>
 
 ---
 

--- a/content/learn/typescript-from-scratch/structural-typing.mdx
+++ b/content/learn/typescript-from-scratch/structural-typing.mdx
@@ -9,6 +9,44 @@ TypeScript takes a different approach. It uses **structural typing** (also calle
 
 This makes TypeScript remarkably flexible and composable. You can reuse types across unrelated modules without needing a shared base class or interface. But it also has surprising edge cases, especially around object literals. Let's explore how structural typing works and when it bites.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="Two completely different builds — one stacked from blocks, one molded in a single piece — cast exactly the same notched shadow, joined by a dotted trail of equivalence, while a third object's plain shadow matches nothing — the compiler compares the shapes things cast, not what they are called"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="320" cy="32" r="11" />
+    <circle cx="344" cy="18" r="2.5" fillOpacity="0.6" />
+    <circle cx="296" cy="18" r="2.5" fillOpacity="0.6" />
+    <circle cx="320" cy="6" r="2.5" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.22">
+    <rect x="60" y="190" width="520" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="120" y="150" width="64" height="40" rx="8" />
+    <circle cx="152" cy="130" r="20" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M420 190 L420 158 C420 132 436 118 452 118 C468 118 484 132 484 158 L484 190 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <path d="M116 198 L140 198 A12 7 0 0 0 164 198 L200 198 L200 210 L116 210 Z" />
+    <path d="M412 198 L436 198 A12 7 0 0 0 460 198 L496 198 L496 210 L412 210 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="240" cy="204" r="2.5" fillOpacity="0.6" />
+    <circle cx="280" cy="204" r="2.5" fillOpacity="0.6" />
+    <circle cx="320" cy="204" r="2.5" fillOpacity="0.6" />
+    <circle cx="360" cy="204" r="2.5" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="548" y="158" width="52" height="32" rx="6" />
+    <path d="M544 198 L606 198 L606 210 L544 210 Z" fillOpacity="0.25" />
+  </g>
+</svg>
+
 ## Shape-based compatibility
 
 In TypeScript, a type is compatible with another if it has *at least* the required properties, with the correct types. The name doesn't matter.
@@ -164,6 +202,45 @@ So TypeScript adds a **freshness** check: when you pass an object literal direct
 <Callout type="warning" title="Fresh vs. non-fresh">
 An object literal is "fresh" when it's created inline as an argument or assignment. Once you store it in a variable (even without a type annotation), it loses freshness and reverts to structural compatibility. This is why `myConfig` above works — by the time it reaches `connect`, it's no longer a fresh literal.
 </Callout>
+
+<svg
+  viewBox="0 0 640 210"
+  role="img"
+  aria-label="Two journeys for the same parcel with an extra yellow ribbon: handed straight to the blue portal it is stopped by a red bar, but after first resting on a pallet it glides through untouched — fresh object literals get strict excess-property checks while stored variables do not"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="180" cy="70" r="2.5" />
+    <circle cx="220" cy="70" r="2.5" />
+    <circle cx="260" cy="70" r="2.5" />
+    <circle cx="300" cy="70" r="2.5" />
+    <circle cx="244" cy="150" r="2.5" />
+    <circle cx="284" cy="150" r="2.5" />
+    <circle cx="324" cy="150" r="2.5" />
+    <circle cx="364" cy="150" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="352" y="52" width="36" height="36" rx="6" />
+    <rect x="148" y="132" width="36" height="36" rx="6" />
+    <rect x="488" y="132" width="36" height="36" rx="6" />
+    <circle cx="556" cy="124" r="5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="352" y="64" width="36" height="8" rx="4" />
+    <rect x="148" y="144" width="36" height="8" rx="4" />
+    <rect x="488" y="144" width="36" height="8" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="402" y="50" width="6" height="40" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M424 70 A26 26 0 1 1 476 70 A26 26 0 1 1 424 70 Z M431 70 A19 19 0 1 0 469 70 A19 19 0 1 0 431 70 Z" fillRule="evenodd" />
+    <path d="M424 150 A26 26 0 1 1 476 150 A26 26 0 1 1 424 150 Z M431 150 A19 19 0 1 0 469 150 A19 19 0 1 0 431 150 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <rect x="136" y="170" width="72" height="10" rx="5" />
+  </g>
+</svg>
 
 ### Bypassing excess property checking
 

--- a/content/learn/typescript-from-scratch/type-aliases-and-literals.mdx
+++ b/content/learn/typescript-from-scratch/type-aliases-and-literals.mdx
@@ -11,6 +11,48 @@ express that a value is not just *any* string or number, but a
 *specific* string or number. This chapter shows you how to harness these
 features to build self-documenting, precise type systems.
 
+<svg
+  viewBox="0 0 640 250"
+  role="img"
+  aria-label="A gauge with a faint band of every possible value: only three exact notches are marked in red, green, and blue, the needle rests precisely on one, and a small name tag hangs from the pivot — literal types pick exact points and an alias names the chosen set"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.1">
+    <path d="M170 190 A150 150 0 0 1 470 190 L440 190 A120 120 0 0 0 200 190 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="189.6" cy="155.1" r="2.5" />
+    <circle cx="203.1" cy="122.5" r="2.5" />
+    <circle cx="252.5" cy="73.1" r="2.5" />
+    <circle cx="285.1" cy="59.6" r="2.5" />
+    <circle cx="354.9" cy="59.6" r="2.5" />
+    <circle cx="387.5" cy="73.1" r="2.5" />
+    <circle cx="436.9" cy="122.5" r="2.5" />
+    <circle cx="450.4" cy="155.1" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="224.5" cy="94.5" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="320" cy="55" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="415.5" cy="94.5" r="7" />
+    <path d="M313.5 190 L320 70 L326.5 190 Z" />
+    <circle cx="320" cy="190" r="10" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <circle cx="334" cy="198" r="2.5" />
+    <circle cx="346" cy="204" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="358" y="198" width="64" height="26" rx="8" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="370" cy="211" r="4" />
+  </g>
+</svg>
+
 ## Type aliases: naming types
 
 A **type alias** binds a name to a type. It's like a variable, but for
@@ -315,6 +357,47 @@ handleStatus(STATUS_CODES.NOT_FOUND); // ✅
 The `typeof STATUS_CODES[keyof typeof STATUS_CODES]` idiom extracts a
 union of all the *values* in the object. This is a common pattern for
 creating enums from objects.
+
+<svg
+  viewBox="0 0 640 190"
+  role="img"
+  aria-label="Three beads blur inside wide halos of possible values, then reappear frozen inside a translucent slab with no halos at all — as const narrows every member to its exact literal and locks it readonly"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="170" cy="56" r="24" fillOpacity="0.12" />
+    <circle cx="170" cy="56" r="12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="320" cy="56" r="26" fillOpacity="0.12" />
+    <circle cx="320" cy="56" r="12" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="470" cy="56" r="24" fillOpacity="0.12" />
+    <circle cx="470" cy="56" r="12" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="196" cy="38" r="2.5" />
+    <circle cx="148" cy="76" r="2.5" />
+    <circle cx="348" cy="40" r="2.5" />
+    <circle cx="294" cy="76" r="2.5" />
+    <circle cx="496" cy="40" r="2.5" />
+    <circle cx="444" cy="74" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="120" y="118" width="400" height="56" rx="14" fillOpacity="0.12" />
+    <path d="M139 124 L141.5 130.5 L148 133 L141.5 135.5 L139 142 L136.5 135.5 L130 133 L136.5 130.5 Z" fillOpacity="0.6" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="170" cy="146" r="12" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="320" cy="146" r="12" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="470" cy="146" r="12" />
+  </g>
+</svg>
 
 ## Literal types as lightweight enums
 

--- a/content/learn/typescript-from-scratch/type-inference.mdx
+++ b/content/learn/typescript-from-scratch/type-inference.mdx
@@ -7,6 +7,51 @@ TypeScript's compiler doesn't just check types — it can **infer** them. When y
 
 Good inference means you write fewer annotations while keeping full type safety. The trick is knowing when the compiler can figure it out on its own and when you should step in with an explicit type.
 
+<svg
+  viewBox="0 0 640 230"
+  role="img"
+  aria-label="Shapes standing in low sunlight cast their exact silhouettes onto the ground without anyone drawing them, while one square also wears a hand-dotted outline — the compiler infers a type from each value, and annotations are simply drawn on top"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="80" cy="50" r="16" />
+    <circle cx="110" cy="34" r="3" fillOpacity="0.6" />
+    <circle cx="116" cy="58" r="3" fillOpacity="0.6" />
+    <circle cx="96" cy="78" r="3" fillOpacity="0.6" />
+    <circle cx="54" cy="78" r="3" fillOpacity="0.6" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <rect x="60" y="180" width="520" height="4" rx="2" />
+  </g>
+  <g fill="currentColor" opacity="0.18">
+    <path d="M252 182 L296 182 L338 192 L274 192 Z" />
+    <path d="M352 182 L396 182 L430 192 L386 192 Z" />
+    <path d="M446 182 L496 182 L544 192 L478 192 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="250" cy="158" r="22" />
+    <path d="M470 110 L498 180 L442 180 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="350" y="136" width="44" height="44" rx="6" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <circle cx="344" cy="130" r="2" />
+    <circle cx="372" cy="128" r="2" />
+    <circle cx="400" cy="130" r="2" />
+    <circle cx="402" cy="158" r="2" />
+    <circle cx="400" cy="186" r="2" />
+    <circle cx="344" cy="186" r="2" />
+    <circle cx="342" cy="158" r="2" />
+    <circle cx="372" cy="188" r="2" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <circle cx="560" cy="50" r="3" />
+    <circle cx="600" cy="110" r="3" />
+    <circle cx="180" cy="60" r="3" />
+  </g>
+</svg>
+
 ## Variable initializer inference
 
 The simplest case: when you declare a variable with an initial value, TypeScript looks at that value and assigns a type.
@@ -172,6 +217,36 @@ if (result !== null) {
 ## Best-common-type inference for arrays
 
 When you initialize an array with mixed values, the compiler tries to find a **best common type** that accommodates all elements.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="A jar holds blue circles and a yellow square, and its lid label shows one chip of each kind; a green triangle hovering outside appears nowhere on the label — the inferred element type is the union of exactly what the array was given"
+  style={{ display: "block", width: "100%", maxWidth: "420px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.08">
+    <rect x="250" y="60" width="140" height="100" rx="18" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="262" y="40" width="116" height="20" rx="8" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="290" cy="128" r="13" />
+    <circle cx="352" cy="132" r="12" />
+    <circle cx="306" cy="50" r="6" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="320" y="100" width="26" height="26" rx="5" />
+    <rect x="326" y="44" width="12" height="12" rx="3" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M470 100 L488 136 L452 136 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="432" cy="120" r="2.5" />
+    <circle cx="412" cy="118" r="2.5" />
+  </g>
+</svg>
 
 <CodeBlock
   adapter="typescript"

--- a/content/learn/typescript-from-scratch/type-narrowing.mdx
+++ b/content/learn/typescript-from-scratch/type-narrowing.mdx
@@ -15,6 +15,48 @@ This chapter covers: **`typeof` guards**, **`instanceof` guards**,
 narrowing**, **user-defined type predicates**, and **assertion
 functions**.
 
+<svg
+  viewBox="0 0 640 260"
+  role="img"
+  aria-label="A mixed batch of shapes drops through two sieve trays: a triangle and a red pentagon are held by the first, the square is caught by the second, and only blue circles reach the cup at the bottom — each type guard lets fewer possibilities through"
+  style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="140" y="90" width="80" height="10" rx="5" fillOpacity="0.5" />
+    <rect x="260" y="90" width="90" height="10" rx="5" fillOpacity="0.5" />
+    <rect x="390" y="90" width="110" height="10" rx="5" fillOpacity="0.5" />
+    <rect x="140" y="170" width="100" height="10" rx="5" fillOpacity="0.5" />
+    <rect x="280" y="170" width="70" height="10" rx="5" fillOpacity="0.5" />
+    <rect x="410" y="170" width="90" height="10" rx="5" fillOpacity="0.5" />
+    <circle cx="240" cy="40" r="11" />
+    <circle cx="240" cy="132" r="11" />
+    <circle cx="316" cy="236" r="10" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="350" y="32" width="22" height="22" rx="4" />
+    <rect x="310" y="148" width="22" height="22" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M300 62 L316 90 L284 90 Z" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <path d="M450 64 L462.4 73 L457.6 87.6 L442.4 87.6 L437.6 73 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="240" cy="68" r="2.5" />
+    <circle cx="240" cy="108" r="2.5" />
+    <circle cx="240" cy="156" r="2.5" />
+    <circle cx="252" cy="196" r="2.5" />
+    <circle cx="268" cy="212" r="2.5" />
+    <circle cx="361" cy="76" r="2.5" />
+    <circle cx="361" cy="106" r="2.5" />
+    <circle cx="345" cy="130" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.15">
+    <path d="M250 232 L390 232 L378 254 L262 254 Z" />
+  </g>
+</svg>
+
 ## The narrowing problem
 
 Given a union type, you can only access properties or call methods that
@@ -367,6 +409,39 @@ The return type `value is string` tells the compiler: "If this function
 returns `true`, then `value` is a `string` in the caller's scope." This
 is more powerful than returning `boolean`, because it lets you encapsulate
 complex checks in a reusable function.
+
+<svg
+  viewBox="0 0 640 180"
+  role="img"
+  aria-label="Shapes ride a belt under a magnifying lens: circles emerge wearing a green certification ring while squares pass unmarked — a user-defined type predicate teaches the compiler which values to trust as the narrowed type"
+  style={{ display: "block", width: "100%", maxWidth: "480px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="60" y="120" width="520" height="5" rx="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="110" cy="107" r="11" />
+    <circle cx="300" cy="107" r="11" />
+    <circle cx="430" cy="107" r="11" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="168" y="85" width="22" height="22" rx="4" />
+    <rect x="498" y="85" width="22" height="22" rx="4" />
+  </g>
+  <g fill="currentColor" opacity="0.35">
+    <path d="M270 98 A30 30 0 1 1 330 98 A30 30 0 1 1 270 98 Z M276 98 A24 24 0 1 0 324 98 A24 24 0 1 0 276 98 Z" fillRule="evenodd" />
+    <path d="M320 122 L348 150 L338 160 L310 132 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M413 107 A17 17 0 1 1 447 107 A17 17 0 1 1 413 107 Z M417 107 A13 13 0 1 0 443 107 A13 13 0 1 0 417 107 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="240" cy="107" r="2.5" />
+    <circle cx="262" cy="107" r="2.5" />
+    <circle cx="362" cy="107" r="2.5" />
+    <circle cx="384" cy="107" r="2.5" />
+  </g>
+</svg>
 
 Another example with custom objects:
 

--- a/content/learn/typescript-from-scratch/unions-and-intersections.mdx
+++ b/content/learn/typescript-from-scratch/unions-and-intersections.mdx
@@ -15,6 +15,46 @@ This chapter covers: **union types**, **intersection types**,
 **set-theoretic intuition**, **when intersections produce `never`**, and
 **designing APIs with unions**.
 
+<svg
+  viewBox="0 0 640 240"
+  role="img"
+  aria-label="Two streams, one blue and one yellow, fork together into a single broad channel that carries beads of both colors downstream while a red bead hovers outside the banks — a union accepts values from either branch and nothing else"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <path d="M40 30 C150 34 220 86 320 96 L320 132 C220 122 150 60 40 56 Z" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M40 210 C150 206 220 154 320 144 L320 108 C220 118 150 180 40 184 Z" fillOpacity="0.3" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <path d="M320 96 L600 96 L600 144 L320 144 Z" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="350" cy="112" r="7" />
+    <circle cx="420" cy="116" r="7" />
+    <circle cx="490" cy="112" r="7" />
+    <circle cx="558" cy="118" r="7" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="385" cy="128" r="7" />
+    <circle cx="455" cy="124" r="7" />
+    <circle cx="525" cy="126" r="7" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="330" cy="52" r="8" />
+    <circle cx="312" cy="40" r="3" fillOpacity="0.35" />
+    <circle cx="298" cy="32" r="2.5" fillOpacity="0.2" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <circle cx="80" cy="120" r="3" />
+    <circle cx="130" cy="116" r="3" />
+    <circle cx="180" cy="120" r="3" />
+    <circle cx="590" cy="60" r="3" />
+    <circle cx="560" cy="190" r="3" />
+  </g>
+</svg>
+
 ## Union types: "this or that"
 
 A **union type** `A | B` represents a value that is *either* type `A`
@@ -143,6 +183,42 @@ console.log("age:", alice.age);
 
 The type `Person` has *both* the `name` property from `Named` *and* the
 `age` property from `Aged`. Intersections merge object types.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="Shapes ride two rails toward two punched plates: the green circle fits the cutouts in both plates and sails through, while the red square passes the first plate only to be stopped flat by the second — an intersection admits only what satisfies every constraint"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.12">
+    <rect x="80" y="94" width="500" height="4" rx="2" />
+    <rect x="80" y="152" width="500" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="210" y="36" width="46" height="140" rx="10" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <rect x="380" y="36" width="46" height="140" rx="10" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="233" cy="80" r="16" />
+    <rect x="219" y="124" width="28" height="28" rx="4" />
+    <circle cx="403" cy="80" r="16" />
+    <path d="M403 116 L419 146 L387 146 Z" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <circle cx="120" cy="80" r="13" />
+    <circle cx="318" cy="80" r="13" fillOpacity="0.75" />
+    <circle cx="540" cy="80" r="13" />
+    <circle cx="505" cy="80" r="3" fillOpacity="0.4" />
+    <circle cx="480" cy="80" r="2.5" fillOpacity="0.25" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <rect x="350" y="124" width="28" height="28" rx="4" />
+    <circle cx="322" cy="138" r="2.5" fillOpacity="0.35" />
+    <circle cx="296" cy="138" r="2.5" fillOpacity="0.2" />
+  </g>
+</svg>
 
 Intersections are useful for **mixins** — combining multiple interfaces
 or types into one:
@@ -456,6 +532,34 @@ console.log("Conflict type is uninhabited");
 The property `value` must be both `string` and `number`, which is
 impossible. So `Conflict` is effectively `never`. The compiler will catch
 this at declaration time in most cases.
+
+<svg
+  viewBox="0 0 640 160"
+  role="img"
+  aria-label="A blue disc and a yellow disc strain toward each other, but where their overlap should be there is only a dotted empty ring — conflicting constraints intersect to never, the type with no values"
+  style={{ display: "block", width: "100%", maxWidth: "420px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="200" cy="80" r="48" fillOpacity="0.3" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="440" cy="80" r="48" fillOpacity="0.3" />
+  </g>
+  <g fill="currentColor" opacity="0.2">
+    <path d="M268 72 L282 80 L268 88 Z" />
+    <path d="M372 72 L358 80 L372 88 Z" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="336" cy="80" r="2.5" />
+    <circle cx="331.3" cy="91.3" r="2.5" />
+    <circle cx="320" cy="96" r="2.5" />
+    <circle cx="308.7" cy="91.3" r="2.5" />
+    <circle cx="304" cy="80" r="2.5" />
+    <circle cx="308.7" cy="68.7" r="2.5" />
+    <circle cx="320" cy="64" r="2.5" />
+    <circle cx="331.3" cy="68.7" r="2.5" />
+  </g>
+</svg>
 
 ## Designing APIs with unions: flexibility and safety
 

--- a/content/learn/typescript-from-scratch/utility-types.mdx
+++ b/content/learn/typescript-from-scratch/utility-types.mdx
@@ -7,6 +7,71 @@ TypeScript ships with a rich set of **utility types** — pre-built generic type
 
 These utilities aren't magic. They're all built from the primitives you've learned: mapped types, conditional types, `keyof`, indexed access, and `infer`. By the end of this chapter, you'll see that you could write them yourself — and you'll know when to reach for them in real code.
 
+<svg
+  viewBox="0 0 640 260"
+  role="img"
+  aria-label="A workbench: one solid blue plate with four portholes sits under a press, and dotted rays lead out to four stamped variants — ghosted optional holes, a narrower two-hole cut, a hole patched over in red, and a plate sealed with a green ring — utility types mint new shapes from a single original"
+  style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.35">
+    <rect x="310" y="46" width="20" height="12" rx="4" />
+    <rect x="316" y="58" width="8" height="20" rx="3" />
+    <rect x="296" y="78" width="48" height="10" rx="5" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <rect x="250" y="100" width="140" height="64" rx="12" />
+    <rect x="80" y="32" width="120" height="48" rx="10" fillOpacity="0.25" />
+    <rect x="440" y="32" width="90" height="48" rx="10" />
+    <rect x="90" y="182" width="120" height="48" rx="10" />
+    <rect x="440" y="182" width="120" height="48" rx="10" />
+  </g>
+  <g fill="var(--ds-white)">
+    <circle cx="278" cy="132" r="6" />
+    <circle cx="306" cy="132" r="6" />
+    <circle cx="334" cy="132" r="6" />
+    <circle cx="362" cy="132" r="6" />
+    <circle cx="468" cy="56" r="6" />
+    <circle cx="498" cy="56" r="6" />
+    <circle cx="112" cy="206" r="5" />
+    <circle cx="136" cy="206" r="5" />
+    <circle cx="160" cy="206" r="5" />
+    <circle cx="184" cy="206" r="5" />
+    <circle cx="462" cy="206" r="6" />
+    <circle cx="490" cy="206" r="6" />
+    <circle cx="518" cy="206" r="6" />
+  </g>
+  <g fill="currentColor" opacity="0.3">
+    <path d="M100 56 A6 6 0 1 1 112 56 A6 6 0 1 1 100 56 Z M102.5 56 A3.5 3.5 0 1 0 109.5 56 A3.5 3.5 0 1 0 102.5 56 Z" fillRule="evenodd" />
+    <path d="M124 56 A6 6 0 1 1 136 56 A6 6 0 1 1 124 56 Z M126.5 56 A3.5 3.5 0 1 0 133.5 56 A3.5 3.5 0 1 0 126.5 56 Z" fillRule="evenodd" />
+    <path d="M148 56 A6 6 0 1 1 160 56 A6 6 0 1 1 148 56 Z M150.5 56 A3.5 3.5 0 1 0 157.5 56 A3.5 3.5 0 1 0 150.5 56 Z" fillRule="evenodd" />
+    <path d="M172 56 A6 6 0 1 1 184 56 A6 6 0 1 1 172 56 Z M174.5 56 A3.5 3.5 0 1 0 181.5 56 A3.5 3.5 0 1 0 174.5 56 Z" fillRule="evenodd" />
+  </g>
+  <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
+    <circle cx="544" cy="206" r="8" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <path d="M186 184 A10 10 0 1 1 206 184 A10 10 0 1 1 186 184 Z M190 184 A6 6 0 1 0 202 184 A6 6 0 1 0 190 184 Z" fillRule="evenodd" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="230" cy="96" r="2.5" />
+    <circle cx="206" cy="80" r="2.5" />
+    <circle cx="182" cy="66" r="2.5" />
+    <circle cx="404" cy="96" r="2.5" />
+    <circle cx="424" cy="80" r="2.5" />
+    <circle cx="442" cy="66" r="2.5" />
+    <circle cx="230" cy="168" r="2.5" />
+    <circle cx="202" cy="180" r="2.5" />
+    <circle cx="176" cy="190" r="2.5" />
+    <circle cx="404" cy="168" r="2.5" />
+    <circle cx="426" cy="180" r="2.5" />
+    <circle cx="446" cy="192" r="2.5" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <circle cx="352" cy="68" r="3" fillOpacity="0.8" />
+    <circle cx="362" cy="58" r="2.5" fillOpacity="0.6" />
+  </g>
+</svg>
+
 ---
 
 ## Object Transformation Utilities
@@ -225,6 +290,44 @@ A mapped type that iterates over `K` (a union of keys) and assigns type `T` to e
 ## Union Filtering Utilities
 
 These types filter or extract members from unions.
+
+<svg
+  viewBox="0 0 640 200"
+  role="img"
+  aria-label="A yellow magnet hovers over a line of mixed beads and pulls every triangle down into a tray while the circles and squares continue along the wire — Extract collects the matching members of a union and Exclude is the line that carries on without them"
+  style={{ display: "block", width: "100%", maxWidth: "520px", height: "auto", margin: "2.5rem auto" }}
+>
+  <g fill="currentColor" opacity="0.15">
+    <rect x="50" y="66" width="540" height="4" rx="2" />
+  </g>
+  <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
+    <circle cx="90" cy="68" r="10" />
+    <circle cx="230" cy="68" r="10" />
+    <circle cx="450" cy="68" r="10" />
+  </g>
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
+    <rect x="150" y="58" width="20" height="20" rx="4" />
+    <rect x="500" y="58" width="20" height="20" rx="4" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M298 90 A22 22 0 1 1 342 90 L328 90 A8 8 0 1 0 312 90 Z" />
+    <path d="M276 56 L288 56 L282 66 Z" fillOpacity="0.8" />
+    <path d="M352 56 L364 56 L358 66 Z" fillOpacity="0.8" />
+  </g>
+  <g fill="currentColor" opacity="0.25">
+    <circle cx="296" cy="112" r="2.5" />
+    <circle cx="306" cy="130" r="2.5" />
+    <circle cx="334" cy="112" r="2.5" />
+    <circle cx="328" cy="130" r="2.5" />
+  </g>
+  <g fill="currentColor" opacity="0.12">
+    <path d="M270 168 L370 168 L360 186 L280 186 Z" />
+  </g>
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+    <path d="M300 146 L314 146 L307 158 Z" />
+    <path d="M326 146 L340 146 L333 158 Z" />
+  </g>
+</svg>
 
 ### `Exclude<UnionType, ExcludedMembers>`
 


### PR DESCRIPTION
Picks up where #477 left off and illustrates the **remaining 6 courses** of the catalog — with this wave, all 27 courses now have illustrations.

**147 pages, 297 hand-crafted inline SVGs (147 chapter openers + 150 mid-page extras); 12,773 insertions, 0 deletions.**

| Course | Pages | SVGs | Flavor |
|---|---|---|---|
| `time-series-analysis-python` | 13 | 38 | timelines reimagined per page: calendar quilts, a lit rolling-window pane, a train/test fence, ARIMA gears, a forecast cone |
| `sql-analytics-duckdb` | 25 | 46 | a circle-built duck whose reflection is a bar chart, ledger vs OLAP cube, coin-sorter GROUP BY, jars on weighbridges for HAVING, pivot swinging 90° |
| `sqlite-for-beginners` | 34 | 45 | warm storybook pictograms: hotel key board, cloakroom claim tickets, grape-press aggregates, tin-can telephone, paper boat folded from a table-sheet |
| `systems-programming-c` | 14 | 36 | isometric address-space tower, cave of heap stalagmites & stack stalactites, locker-wall allocator with a lost key, eight-specimen bug case |
| `statistics-for-data-science-python` | 33 | 69 | inference-first data-art: CI forest with one red miss, Wald's bomber, Simpson's paradox bands, Texas-sharpshooter target, peeking p-value walk |
| `typescript-from-scratch` | 28 | 63 | drafting-table silhouettes, superset island map, strictness fader console, sieve-tray narrowing, loom-heddle mapped types, wax-seal branded types |

## Design system (same as #477)

- **Fills only, no strokes** — shapes have no borders; rings/outlines are layered fills or `fillRule="evenodd"`
- **Brand tokens, almost exclusively the four 500s** — applied via `<g style={{ color: "var(--ds-*-500)" }}>` + `fill="currentColor"` since `var()` doesn't resolve in SVG presentation attributes; depth comes from `fillOpacity` layering, not extra ramp steps
- **Light & dark mode** — structural/neutral shapes are low-opacity `currentColor`, so every illustration adapts to the page theme
- **Accessibility** — `role="img"` + a descriptive `aria-label` on every SVG; text limited to single glyphs (digits, Σ, Δ, ƒ, ÷, %)
- **One chapter opener per page** plus mid-page extras where a section begs for a visual; every composition distinct, with explicit dedupe passes against the motifs of overlapping #477 courses (C beginners, JS/FP-TS, the Postgres SQL courses) and against chart-type clichés from the seaborn/scientific-computing waves

## Validation

- `scripts/audit/validate-mdx.mjs` — all 781 content files compile through the site's remark/rehype pipeline
- Session-local SVG design-system linter (a11y attributes, stroke ban, color-token allowlist, text-length cap, per-page coverage): **0 errors** across all 297 SVGs; the only warnings are the pilot-sanctioned `var(--ds-white)` tiny cutouts on solid 500 shapes
- `git diff` verified **insertions only** — existing mermaid diagrams, React components, and prose are untouched

https://claude.ai/code/session_01QCttttB3H8pLxTK4a7HBCi