### PR TITLE
Make SQL playground autocomplete behave like a desktop SQL IDE

### DIFF
--- a/__tests__/sqlCompletion.test.ts
+++ b/__tests__/sqlCompletion.test.ts
@@ -13,26 +13,47 @@ const schema: SqlCompletionSchema = {
     {
       name: "customers",
       kind: "table",
-      columns: ["id", "name", "email"],
+      columns: [
+        { name: "id", type: "INTEGER" },
+        { name: "name", type: "TEXT" },
+        { name: "email", type: "TEXT" },
+      ],
     },
     {
       name: "orders",
       kind: "table",
-      columns: ["id", "customer_id", "total"],
+      columns: [
+        { name: "id", type: "INTEGER" },
+        { name: "customer_id", type: "INTEGER" },
+        { name: "total", type: "REAL" },
+      ],
+      foreignKeys: [
+        { column: "customer_id", refEntity: "customers", refColumn: "id" },
+      ],
     },
     {
       name: "recent_orders",
       kind: "view",
+      // Plain-string columns stay supported for callers without type info.
       columns: ["order_id", "total"],
     },
   ],
 };
 
 function makeComplete(options: SqlCompletionOptions = {}) {
-  return (doc: string, explicit = false): CompletionResult | null => {
+  // A `|` in the doc marks the cursor; without one the cursor sits at
+  // the end. This lets tests cover the IDE-critical "editing in the
+  // middle of a statement" scenarios.
+  return (docWithCursor: string, explicit = false): CompletionResult | null => {
+    const marker = docWithCursor.indexOf("|");
+    const doc =
+      marker === -1
+        ? docWithCursor
+        : docWithCursor.slice(0, marker) + docWithCursor.slice(marker + 1);
+    const pos = marker === -1 ? doc.length : marker;
     const state = EditorState.create({ doc });
     const source = createSqlCompletionSource(schema, options);
-    const result = source(new CompletionContext(state, doc.length, explicit));
+    const result = source(new CompletionContext(state, pos, explicit));
     if (result instanceof Promise) {
       throw new Error("SQL completion source should be synchronous");
     }
@@ -50,6 +71,50 @@ function findOption(result: CompletionResult | null, label: string) {
   return result?.options.find((option) => option.label === label);
 }
 
+function topKeywords(result: CompletionResult | null, n = 8): string[] {
+  return (result?.options ?? [])
+    .filter((option) => option.type === "keyword")
+    .slice()
+    .sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0))
+    .slice(0, n)
+    .map((option) => option.label);
+}
+
+// Replicates @codemirror/autocomplete's sortOptions for an empty typed
+// pattern: every option's fuzzy score is equal, so ordering is boost plus
+// the dynamic-section offset (sections sort by their best-scoring option).
+// This is the order users actually see in the dropdown — assertions on raw
+// `options` order or plain boosts can't catch section-level inversions.
+function renderedLabels(result: CompletionResult | null): string[] {
+  const options = result?.options ?? [];
+  const sectionBest = new Map<string, number>();
+  for (const option of options) {
+    const section = option.section;
+    const name =
+      typeof section === "string" ? section : (section?.name ?? "");
+    const score = option.boost ?? 0;
+    sectionBest.set(name, Math.max(sectionBest.get(name) ?? -Infinity, score));
+  }
+  const orderedSections = [...sectionBest.entries()]
+    .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))
+    .map(([name]) => name);
+  const offset = new Map(
+    orderedSections.map((name, index) => [name, -100000 * (index + 1)]),
+  );
+  return options
+    .slice()
+    .sort((a, b) => {
+      const sectionOf = (option: (typeof options)[number]) => {
+        const section = option.section;
+        return typeof section === "string" ? section : (section?.name ?? "");
+      };
+      const scoreA = (a.boost ?? 0) + (offset.get(sectionOf(a)) ?? 0);
+      const scoreB = (b.boost ?? 0) + (offset.get(sectionOf(b)) ?? 0);
+      return scoreB - scoreA || (a.label < b.label ? -1 : 1);
+    })
+    .map((option) => option.label);
+}
+
 describe("SQLite SQL completion source", () => {
   it("suggests tables after FROM", () => {
     const result = complete("SELECT * FROM ");
@@ -58,7 +123,6 @@ describe("SQLite SQL completion source", () => {
       "orders",
       "recent_orders",
     ]);
-    expect(result?.validFor).toBeInstanceOf(RegExp);
   });
 
   it("suggests scoped columns after WHERE", () => {
@@ -70,7 +134,7 @@ describe("SQLite SQL completion source", () => {
 
   it("suggests alias-qualified columns after dot", () => {
     const result = complete("SELECT * FROM customers c WHERE c.");
-    expect(labels(result)).toEqual(["id", "name", "email"]);
+    expect(labels(result)).toEqual(["*", "id", "name", "email"]);
   });
 
   it("falls back to SQL keywords for general prefixes", () => {
@@ -106,7 +170,7 @@ describe("SQLite SQL completion source", () => {
 
   it("suggests scoped columns from multiple referenced tables", () => {
     const result = complete(
-      "SELECT * FROM customers c JOIN orders o ON ",
+      "SELECT * FROM customers c JOIN orders o WHERE ",
     );
     const labelSet = new Set(labels(result));
     // Both sides of the JOIN are in scope. Ambiguous columns (id) get
@@ -137,7 +201,7 @@ describe("SQLite SQL completion source", () => {
     const result = complete(
       "WITH summary(total_count, latest) AS (SELECT 1, 2) SELECT summary.",
     );
-    expect(labels(result)).toEqual(["total_count", "latest"]);
+    expect(labels(result)).toEqual(["*", "total_count", "latest"]);
   });
 
   it("does not suggest existing tables in CREATE TABLE name slot", () => {
@@ -152,16 +216,18 @@ describe("SQLite SQL completion source", () => {
     expect(labels(result)).toEqual(["id", "customer_id", "total"]);
   });
 
-  it("suggests columns inside USING (...)", () => {
+  it("suggests shared bare column names inside USING (...)", () => {
     const result = complete(
       "SELECT * FROM customers JOIN orders USING (",
     );
-    const labelSet = new Set(labels(result));
-    // USING columns must be present in both joined tables. Even without
-    // a strict intersection filter, the suggestions should still include
-    // columns from the referenced tables.
-    expect(labelSet.has("customers.id")).toBe(true);
-    expect(labelSet.has("orders.id")).toBe(true);
+    // USING takes bare names that exist on both sides — `id` here. The
+    // shared column ranks above single-side columns; dotted names would
+    // be invalid in this slot and must not appear.
+    const idOption = findOption(result, "id");
+    expect(idOption).toBeDefined();
+    const nameOption = findOption(result, "name");
+    expect((idOption?.boost ?? 0) > (nameOption?.boost ?? 0)).toBe(true);
+    expect(labels(result)).not.toContain("customers.id");
   });
 
   it("does not suggest columns when no FROM clause provides scope", () => {
@@ -173,17 +239,66 @@ describe("SQLite SQL completion source", () => {
     expect(labelList).toContain("DISTINCT");
   });
 
-  function topKeywords(
-    result: CompletionResult | null,
-    n = 8,
-  ): string[] {
-    return (result?.options ?? [])
-      .filter((option) => option.type === "keyword")
-      .slice()
-      .sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0))
-      .slice(0, n)
-      .map((option) => option.label);
-  }
+  describe("rendered dropdown order (boost + dynamic sections)", () => {
+    it("renders columns above keywords and tables in a WHERE slot", () => {
+      const rendered = renderedLabels(
+        complete("SELECT * FROM customers WHERE "),
+      );
+      expect(rendered.indexOf("name")).toBeLessThan(rendered.indexOf("NOT"));
+      expect(rendered.indexOf("name")).toBeLessThan(
+        rendered.indexOf("customers"),
+      );
+    });
+
+    it("renders next-clause keywords above tables after a FROM reference", () => {
+      const rendered = renderedLabels(
+        complete("SELECT * FROM customers ", true),
+      );
+      expect(rendered.indexOf("WHERE")).toBeLessThan(
+        rendered.indexOf("customers"),
+      );
+      expect(rendered.indexOf("JOIN")).toBeLessThan(
+        rendered.indexOf("orders"),
+      );
+    });
+
+    it("renders tables above keywords after FROM", () => {
+      const rendered = renderedLabels(complete("SELECT * FROM "));
+      expect(rendered.indexOf("customers")).toBeLessThan(
+        rendered.indexOf("SELECT"),
+      );
+    });
+
+    it("renders the FK join condition first in the ON slot", () => {
+      const rendered = renderedLabels(
+        complete("SELECT * FROM customers c JOIN orders o ON "),
+      );
+      expect(rendered[0]).toBe("o.customer_id = c.id");
+    });
+  });
+
+  describe("full-statement awareness (cursor mid-statement)", () => {
+    it("suggests columns in the SELECT list when FROM appears after the cursor", () => {
+      const result = complete("SELECT | FROM customers");
+      const labelSet = new Set(labels(result));
+      expect(labelSet.has("name")).toBe(true);
+      expect(labelSet.has("email")).toBe(true);
+    });
+
+    it("resolves alias-qualified columns when the alias is declared after the cursor", () => {
+      const result = complete("SELECT c.| FROM customers c");
+      expect(labels(result)).toEqual(["*", "id", "name", "email"]);
+    });
+
+    it("scopes columns to the statement under the cursor in multi-statement docs", () => {
+      const result = complete(
+        "SELECT * FROM orders; SELECT | FROM customers; SELECT 1",
+      );
+      const labelSet = new Set(labels(result));
+      expect(labelSet.has("name")).toBe(true);
+      expect(labelSet.has("customer_id")).toBe(false);
+    });
+  });
 
   describe("context-aware keyword ranking", () => {
     it("ranks statement-starter keywords first at start of buffer", () => {
@@ -199,6 +314,12 @@ describe("SQLite SQL completion source", () => {
     it("ranks FROM after a SELECT list", () => {
       const result = complete("SELECT id ", true);
       const top = topKeywords(result, 6);
+      expect(top).toContain("FROM");
+    });
+
+    it("ranks FROM right after SELECT *", () => {
+      const result = complete("SELECT * ", true);
+      const top = topKeywords(result, 3);
       expect(top).toContain("FROM");
     });
 
@@ -231,6 +352,49 @@ describe("SQLite SQL completion source", () => {
       expect(top).toContain("IN");
     });
 
+    it("treats string literals as complete operands", () => {
+      const result = complete(
+        "SELECT * FROM customers WHERE name = 'Alice' ",
+        true,
+      );
+      const top = topKeywords(result, 8);
+      expect(top).toContain("AND");
+      expect(top).toContain("OR");
+    });
+
+    it("treats decimal numbers as complete operands", () => {
+      const result = complete(
+        "SELECT * FROM orders WHERE total > 1.5 ",
+        true,
+      );
+      const top = topKeywords(result, 8);
+      expect(top).toContain("AND");
+      expect(top).toContain("OR");
+    });
+
+    it("still offers OFFSET after LIMIT <n>", () => {
+      const result = complete("SELECT * FROM customers LIMIT 10 ", true);
+      const labelSet = new Set(labels(result));
+      expect(labelSet.has("OFFSET")).toBe(true);
+      expect(labelSet.has("WHERE")).toBe(false);
+    });
+
+    it("suggests JOIN after a join modifier", () => {
+      const result = complete("SELECT * FROM customers LEFT ", true);
+      const labelSet = new Set(labels(result));
+      expect(labelSet.has("JOIN")).toBe(true);
+      expect(labelSet.has("WHERE")).toBe(false);
+    });
+
+    it("suggests THEN after an open CASE WHEN condition", () => {
+      const result = complete(
+        "SELECT CASE WHEN total > 10 ",
+        true,
+      );
+      const top = topKeywords(result, 8);
+      expect(top).toContain("THEN");
+    });
+
     it("limits CREATE keyword to TABLE/VIEW/INDEX/TRIGGER family", () => {
       const result = complete("CREATE ", true);
       const top = topKeywords(result, 10);
@@ -251,7 +415,7 @@ describe("SQLite SQL completion source", () => {
       expect(labelSet.has("WHERE")).toBe(false);
     });
 
-    it("offers OFFSET after LIMIT <n>", () => {
+    it("offers OFFSET after LIMIT", () => {
       const result = complete("SELECT * FROM customers LIMIT ", true);
       const top = topKeywords(result, 5);
       expect(top).toContain("OFFSET");
@@ -275,6 +439,166 @@ describe("SQLite SQL completion source", () => {
     });
   });
 
+  describe("keyword casing follows typed case", () => {
+    it("inserts lowercase keywords for lowercase prefixes", () => {
+      const result = complete("sel");
+      expect(findOption(result, "SELECT")?.apply).toBe("select");
+    });
+
+    it("inserts uppercase keywords for uppercase prefixes", () => {
+      const result = complete("SEL");
+      // No apply override — the uppercase label itself is inserted.
+      expect(findOption(result, "SELECT")?.apply).toBeUndefined();
+    });
+
+    it("re-queries when the casing style changes mid-word", () => {
+      const result = complete("sel");
+      const validFor = result?.validFor;
+      expect(typeof validFor).toBe("function");
+      if (typeof validFor === "function") {
+        const valid = validFor as (
+          text: string,
+          from: number,
+          to: number,
+          state: EditorState,
+        ) => boolean;
+        const state = EditorState.create({ doc: "sel" });
+        expect(valid("sele", 0, 4, state)).toBe(true);
+        expect(valid("SELE", 0, 4, state)).toBe(false);
+      }
+    });
+  });
+
+  describe("JOIN intelligence", () => {
+    it("suggests a complete FK join condition after ON", () => {
+      const result = complete(
+        "SELECT * FROM customers c JOIN orders o ON ",
+      );
+      const condition = findOption(result, "o.customer_id = c.id");
+      expect(condition).toBeDefined();
+      // The ready-made condition outranks plain column suggestions.
+      const column = findOption(result, "name");
+      expect((condition?.boost ?? 0) > (column?.boost ?? 0)).toBe(true);
+    });
+
+    it("suggests the reversed FK condition when joining the parent table", () => {
+      const result = complete(
+        "SELECT * FROM orders o JOIN customers c ON ",
+      );
+      expect(findOption(result, "c.id = o.customer_id")).toBeDefined();
+    });
+
+    it("uses table names in conditions when no aliases are declared", () => {
+      const result = complete(
+        "SELECT * FROM customers JOIN orders ON ",
+      );
+      expect(
+        findOption(result, "orders.customer_id = customers.id"),
+      ).toBeDefined();
+    });
+
+    it("ranks FK-related tables first after JOIN", () => {
+      const result = complete("SELECT * FROM customers JOIN ");
+      const orders = findOption(result, "orders");
+      const view = findOption(result, "recent_orders");
+      expect((orders?.boost ?? 0) > (view?.boost ?? 0)).toBe(true);
+    });
+  });
+
+  describe("DDL-aware completion", () => {
+    it("suggests data types after a column name in CREATE TABLE", () => {
+      const result = complete("CREATE TABLE t (id ", true);
+      const labelList = labels(result);
+      expect(labelList).toContain("INTEGER");
+      expect(labelList).toContain("TEXT");
+      // No tables / statement keywords inside a column definition.
+      expect(labelList).not.toContain("customers");
+      expect(labelList).not.toContain("SELECT");
+    });
+
+    it("suggests constraints after a column type", () => {
+      const result = complete("CREATE TABLE t (id INTEGER ", true);
+      const top = topKeywords(result, 8);
+      expect(top).toContain("PRIMARY");
+      expect(top).toContain("NOT");
+      expect(labels(result)).not.toContain("SELECT");
+    });
+
+    it("requires KEY after PRIMARY in a column definition", () => {
+      const result = complete("CREATE TABLE t (id INTEGER PRIMARY ", true);
+      expect(labels(result)).toEqual(["KEY"]);
+    });
+
+    it("suggests existing tables after REFERENCES", () => {
+      const result = complete(
+        "CREATE TABLE t (customer_id INTEGER REFERENCES ",
+        true,
+      );
+      expect(labels(result)).toContain("customers");
+    });
+
+    it("suggests the parent table's columns inside REFERENCES (...)", () => {
+      const result = complete(
+        "CREATE TABLE t (customer_id INTEGER REFERENCES customers(",
+        true,
+      );
+      expect(labels(result)).toEqual(["id", "name", "email"]);
+    });
+
+    it("stays quiet inside nested parens like DECIMAL(10, …", () => {
+      const result = complete("CREATE TABLE t (price DECIMAL(10, ", true);
+      expect(result).toBeNull();
+    });
+
+    it("suggests tables after CREATE INDEX … ON", () => {
+      const result = complete("CREATE INDEX idx ON ", true);
+      expect(labels(result)).toContain("customers");
+    });
+
+    it("suggests the indexed table's columns inside CREATE INDEX … ON t (", () => {
+      const result = complete("CREATE INDEX idx ON customers (", true);
+      expect(labels(result)).toEqual(["id", "name", "email"]);
+    });
+
+    it("suggests existing columns after ALTER TABLE … DROP COLUMN", () => {
+      const result = complete("ALTER TABLE customers DROP COLUMN ", true);
+      const labelSet = new Set(labels(result));
+      expect(labelSet.has("name")).toBe(true);
+      expect(labelSet.has("email")).toBe(true);
+    });
+  });
+
+  describe("schema metadata in suggestions", () => {
+    it("shows column types in the detail", () => {
+      const result = complete("SELECT * FROM customers WHERE ");
+      expect(findOption(result, "name")?.detail).toBe("TEXT");
+    });
+
+    it("shows the owning table for multi-table scopes", () => {
+      const result = complete(
+        "SELECT * FROM customers JOIN orders ON customers.id = orders.customer_id WHERE ",
+      );
+      expect(findOption(result, "name")?.detail).toBe("customers · TEXT");
+    });
+
+    it("attaches a column-list preview to table suggestions", () => {
+      const result = complete("SELECT * FROM ");
+      const info = findOption(result, "customers")?.info;
+      expect(typeof info).toBe("string");
+      expect(info).toContain("id INTEGER");
+    });
+
+    it("completes tables after the main. schema qualifier", () => {
+      const result = complete("SELECT * FROM main.");
+      expect(labels(result)).toContain("customers");
+    });
+
+    it("resolves columns for schema-qualified table references", () => {
+      const result = complete("SELECT * FROM main.customers WHERE ");
+      expect(labels(result)).toContain("name");
+    });
+  });
+
   describe("dialect catalog filtering (SQLite)", () => {
     it("exposes SQLite-only keywords like PRAGMA and GLOB", () => {
       const result = complete("", true);
@@ -291,20 +615,18 @@ describe("SQLite SQL completion source", () => {
       const result = complete("SELECT ", true);
       expect(labels(result)).toContain("STRFTIME");
     });
+
+    it("includes SQLite window functions and GROUP_CONCAT", () => {
+      const result = complete("SELECT ", true);
+      const labelSet = new Set(labels(result));
+      expect(labelSet.has("ROW_NUMBER")).toBe(true);
+      expect(labelSet.has("GROUP_CONCAT")).toBe(true);
+    });
   });
 });
 
 describe("PostgreSQL SQL completion source", () => {
   const completePg = makeComplete({ dialect: "postgres" });
-
-  function topKw(result: CompletionResult | null, n = 8): string[] {
-    return (result?.options ?? [])
-      .filter((opt) => opt.type === "keyword")
-      .slice()
-      .sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0))
-      .slice(0, n)
-      .map((opt) => opt.label);
-  }
 
   it("offers ILIKE/SIMILAR after WHERE col and hides GLOB", () => {
     const result = completePg("SELECT * FROM customers WHERE name ", true);
@@ -326,7 +648,7 @@ describe("PostgreSQL SQL completion source", () => {
 
   it("offers RETURNING/FROM after UPDATE clause", () => {
     const result = completePg("UPDATE customers SET name = 'x' ", true);
-    const top = topKw(result, 10);
+    const top = topKeywords(result, 10);
     expect(top).toContain("WHERE");
     expect(top).toContain("RETURNING");
     expect(top).toContain("FROM");
@@ -337,14 +659,14 @@ describe("PostgreSQL SQL completion source", () => {
       "INSERT INTO customers (id, name) VALUES (1, 'a') ",
       true,
     );
-    const labelSet = new Set(labels(result));
-    expect(labelSet.has("ON")).toBe(true);
-    expect(labelSet.has("RETURNING")).toBe(true);
+    const top = topKeywords(result, 6);
+    expect(top).toContain("ON");
+    expect(top).toContain("RETURNING");
   });
 
   it("offers Postgres-flavored statement starters", () => {
     const result = completePg("", true);
-    const top = topKw(result, 12);
+    const top = topKeywords(result, 12);
     expect(top).toContain("SELECT");
     // Secondary set should include TRUNCATE/GRANT/REVOKE for Postgres.
     const labelSet = new Set(labels(result));
@@ -370,21 +692,25 @@ describe("PostgreSQL SQL completion source", () => {
 
   it("still completes table/column references correctly", () => {
     const result = completePg("SELECT * FROM customers c WHERE c.");
-    expect(labels(result)).toEqual(["id", "name", "email"]);
+    expect(labels(result)).toEqual(["*", "id", "name", "email"]);
+  });
+
+  it("completes tables after the public. schema qualifier", () => {
+    const result = completePg("SELECT * FROM public.");
+    expect(labels(result)).toContain("customers");
+  });
+
+  it("offers Postgres data types in CREATE TABLE column definitions", () => {
+    const result = completePg("CREATE TABLE t (id ", true);
+    const labelList = labels(result);
+    expect(labelList).toContain("SERIAL");
+    expect(labelList).toContain("TIMESTAMPTZ");
+    expect(labelList).not.toContain("AUTOINCREMENT");
   });
 });
 
 describe("DuckDB SQL completion source", () => {
   const completeDdb = makeComplete({ dialect: "duckdb" });
-
-  function topKw(result: CompletionResult | null, n = 8): string[] {
-    return (result?.options ?? [])
-      .filter((opt) => opt.type === "keyword")
-      .slice()
-      .sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0))
-      .slice(0, n)
-      .map((opt) => opt.label);
-  }
 
   it("offers QUALIFY after GROUP BY/ORDER BY", () => {
     const result = completeDdb(
@@ -437,12 +763,21 @@ describe("DuckDB SQL completion source", () => {
     expect(labelSet.has("JULIANDAY")).toBe(false);
   });
 
+  it("collapses keyword/function duplicates like LIST into one entry", () => {
+    const result = completeDdb("SELECT ", true);
+    const listEntries = (result?.options ?? []).filter(
+      (option) => option.label === "LIST",
+    );
+    expect(listEntries).toHaveLength(1);
+    expect(listEntries[0]?.type).toBe("function");
+  });
+
   it("uses ILIKE/SIMILAR for the after-NOT operator menu", () => {
     const result = completeDdb(
       "SELECT * FROM customers WHERE name NOT ",
       true,
     );
-    const top = topKw(result, 12);
+    const top = topKeywords(result, 12);
     expect(top).toContain("ILIKE");
     expect(top).toContain("SIMILAR");
     expect(top).not.toContain("GLOB");
@@ -450,7 +785,7 @@ describe("DuckDB SQL completion source", () => {
 
   it("offers CREATE OR REPLACE flavors for CREATE", () => {
     const result = completeDdb("CREATE ", true);
-    const top = topKw(result, 12);
+    const top = topKeywords(result, 12);
     expect(top).toContain("TABLE");
     expect(top).toContain("VIEW");
     expect(top).toContain("OR");

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -2061,18 +2061,40 @@ function DuckDbPlaygroundInner() {
     const completionComp = completionCompRef.current;
     if (!view || !langCompRef.current || !completionComp) return;
     const schema: Record<string, string[]> = {};
-    const completionSchema: SqlCompletionSchema = { entities: [] };
+    const completionSchema: SqlCompletionSchema = {
+      entities: [],
+      schemas,
+    };
     for (const name of tables) {
-      const cols = columnsByEntity[name]?.map((column) => column.name) ?? [];
-      schema[name] = cols;
-      completionSchema.entities.push({ name, columns: cols, kind: "table" });
+      const cols = columnsByEntity[name] ?? [];
+      schema[name] = cols.map((column) => column.name);
+      completionSchema.entities.push({
+        name,
+        columns: cols.map((column) => ({
+          name: column.name,
+          type: column.type,
+        })),
+        kind: "table",
+        foreignKeys: (foreignKeysByEntity[name] ?? []).map((fk) => ({
+          column: fk.from,
+          refEntity: fk.table,
+          refColumn: fk.to,
+        })),
+      });
     }
     for (const name of views) {
-      const cols = columnsByEntity[name]?.map((column) => column.name) ?? [];
-      schema[name] = cols;
-      completionSchema.entities.push({ name, columns: cols, kind: "view" });
+      const cols = columnsByEntity[name] ?? [];
+      schema[name] = cols.map((column) => column.name);
+      completionSchema.entities.push({
+        name,
+        columns: cols.map((column) => ({
+          name: column.name,
+          type: column.type,
+        })),
+        kind: "view",
+      });
     }
-    const key = JSON.stringify(completionSchema.entities);
+    const key = JSON.stringify(completionSchema);
     if (key === lastReconfigureKeyRef.current) return;
     // Dispatch the completion reconfigure immediately so user-defined
     // tables/views show up in autocomplete the moment the schema lands.
@@ -2104,7 +2126,7 @@ function DuckDbPlaygroundInner() {
     return () => {
       cancelled = true;
     };
-  }, [tables, views, columnsByEntity]);
+  }, [tables, views, columnsByEntity, foreignKeysByEntity, schemas]);
 
   // Drop result entries whose owning tab no longer exists.
   useEffect(() => {

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -1960,18 +1960,40 @@ function PostgresPlaygroundInner() {
     const completionComp = completionCompRef.current;
     if (!view || !langCompRef.current || !completionComp) return;
     const schema: Record<string, string[]> = {};
-    const completionSchema: SqlCompletionSchema = { entities: [] };
+    const completionSchema: SqlCompletionSchema = {
+      entities: [],
+      schemas,
+    };
     for (const name of tables) {
-      const cols = columnsByEntity[name]?.map((column) => column.name) ?? [];
-      schema[name] = cols;
-      completionSchema.entities.push({ name, columns: cols, kind: "table" });
+      const cols = columnsByEntity[name] ?? [];
+      schema[name] = cols.map((column) => column.name);
+      completionSchema.entities.push({
+        name,
+        columns: cols.map((column) => ({
+          name: column.name,
+          type: column.type,
+        })),
+        kind: "table",
+        foreignKeys: (foreignKeysByEntity[name] ?? []).map((fk) => ({
+          column: fk.from,
+          refEntity: fk.table,
+          refColumn: fk.to,
+        })),
+      });
     }
     for (const name of views) {
-      const cols = columnsByEntity[name]?.map((column) => column.name) ?? [];
-      schema[name] = cols;
-      completionSchema.entities.push({ name, columns: cols, kind: "view" });
+      const cols = columnsByEntity[name] ?? [];
+      schema[name] = cols.map((column) => column.name);
+      completionSchema.entities.push({
+        name,
+        columns: cols.map((column) => ({
+          name: column.name,
+          type: column.type,
+        })),
+        kind: "view",
+      });
     }
-    const key = JSON.stringify(completionSchema.entities);
+    const key = JSON.stringify(completionSchema);
     if (key === lastReconfigureKeyRef.current) return;
     view.dispatch({
       effects: [
@@ -1999,7 +2021,7 @@ function PostgresPlaygroundInner() {
     return () => {
       cancelled = true;
     };
-  }, [tables, views, columnsByEntity]);
+  }, [tables, views, columnsByEntity, foreignKeysByEntity, schemas]);
 
   // Drop result entries whose owning tab no longer exists.
   useEffect(() => {

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -1392,28 +1392,45 @@ function SqlPlaygroundInner() {
     let cancelled = false;
     void (async () => {
       const schema: Record<string, string[]> = {};
-      const completionSchema: SqlCompletionSchema = { entities: [] };
+      const completionSchema: SqlCompletionSchema = {
+        entities: [],
+        schemas: ["main", "temp"],
+      };
       for (const name of tables) {
+        let cols: Awaited<ReturnType<typeof engine.listColumns>> = [];
+        let fks: Awaited<ReturnType<typeof engine.listForeignKeys>> = [];
         try {
-          schema[name] = (await engine.listColumns(name)).map((c) => c.name);
+          [cols, fks] = await Promise.all([
+            engine.listColumns(name),
+            engine.listForeignKeys(name).catch(() => []),
+          ]);
         } catch {
-          schema[name] = [];
+          // Leave the entity in place with no columns so the table name
+          // itself still completes.
         }
+        schema[name] = cols.map((c) => c.name);
         completionSchema.entities.push({
           name,
-          columns: schema[name],
+          columns: cols.map((c) => ({ name: c.name, type: c.type })),
           kind: "table",
+          foreignKeys: fks.map((fk) => ({
+            column: fk.from,
+            refEntity: fk.table,
+            refColumn: fk.to,
+          })),
         });
       }
       for (const name of views) {
+        let cols: Awaited<ReturnType<typeof engine.listColumns>> = [];
         try {
-          schema[name] = (await engine.listColumns(name)).map((c) => c.name);
+          cols = await engine.listColumns(name);
         } catch {
-          schema[name] = [];
+          // Same fallback as tables: keep the view name completable.
         }
+        schema[name] = cols.map((c) => c.name);
         completionSchema.entities.push({
           name,
-          columns: schema[name],
+          columns: cols.map((c) => ({ name: c.name, type: c.type })),
           kind: "view",
         });
       }

--- a/app/_components/sql/shared/editorSetup.ts
+++ b/app/_components/sql/shared/editorSetup.ts
@@ -117,6 +117,12 @@ export function makeSqlAutocompletionExtension(
     activateOnTyping: true,
     activateOnTypingDelay: AUTOCOMPLETE_DELAY_MS,
     closeOnBlur: true,
+    // The extension's built-in keymap binds Enter → acceptCompletion at
+    // the highest precedence, which would shadow the Enter-less keymap
+    // assembled in `createSqlEditorExtensions` and hijack newlines
+    // whenever the (eagerly opened) popup is visible. We register the
+    // completion keys ourselves instead.
+    defaultKeymap: false,
     override: [createSqlCompletionSource(schema, { dialect })],
   });
 }
@@ -246,15 +252,19 @@ export function createSqlEditorExtensions(
         },
       },
       ...closeBracketsKeymap,
+      // Completion keys must come before `defaultKeymap`, otherwise
+      // ArrowUp/ArrowDown would move the cursor instead of the popup
+      // selection. Enter is removed so it always inserts a newline —
+      // Tab accepts the active completion instead (falling through to
+      // indentWithTab when no completion is shown). This only works
+      // because the autocompletion extension's own keymap is disabled
+      // (`defaultKeymap: false` above); that built-in copy binds Enter
+      // at the highest precedence and would override anything here.
+      ...completionKeymap.filter((b) => b.key !== "Enter"),
+      { key: "Tab", run: acceptCompletion },
       ...defaultKeymap,
       ...searchKeymap,
       ...historyKeymap,
-      // Remove Enter from the default completion keymap so that Enter
-      // always inserts a newline. Tab accepts the active completion
-      // instead, falling through to indentWithTab when no completion is
-      // shown.
-      ...completionKeymap.filter((b) => b.key !== "Enter"),
-      { key: "Tab", run: acceptCompletion },
       indentWithTab,
     ]),
   ];

--- a/app/_components/sql/sqlCompletion.ts
+++ b/app/_components/sql/sqlCompletion.ts
@@ -6,14 +6,42 @@ import {
   type CompletionSource,
 } from "@codemirror/autocomplete";
 
+/** Column metadata. Plain strings are accepted everywhere a column is
+ *  expected so lightweight callers (and CTE extraction, which only sees
+ *  names) don't have to wrap each name in an object. */
+export interface SqlColumnMeta {
+  name: string;
+  /** Declared type (e.g. `INTEGER`, `text`), shown as the completion
+   *  detail the way desktop SQL IDEs annotate column suggestions. */
+  type?: string;
+}
+
+export type SqlCompletionColumn = string | SqlColumnMeta;
+
+/** One column-level foreign-key edge, used to suggest complete
+ *  `a.col = b.col` join conditions and to rank join-related tables. */
+export interface SqlForeignKeyMeta {
+  /** Column on the owning entity. */
+  column: string;
+  /** Referenced table/view name. */
+  refEntity: string;
+  /** Referenced column name. */
+  refColumn: string;
+}
+
 export interface SqlCompletionEntity {
   name: string;
-  columns: string[];
+  columns: SqlCompletionColumn[];
   kind: "table" | "view" | "cte";
+  foreignKeys?: SqlForeignKeyMeta[];
 }
 
 export interface SqlCompletionSchema {
   entities: SqlCompletionEntity[];
+  /** Namespace (schema) names like `public` or `main`. Typing
+   *  `<schema>.` suggests tables, mirroring qualified completion in
+   *  desktop SQL IDEs. Defaults per dialect when omitted. */
+  schemas?: string[];
 }
 
 // The three SQL flavors the playground supports. Each shares the same
@@ -30,12 +58,28 @@ type SqlCompletionMode =
   | "tables"
   | "keywords"
   | "qualified-columns"
-  | "naming";
+  | "naming"
+  | "column-def";
 
 interface SqlCompletionContextInfo {
   mode: SqlCompletionMode;
   from: number;
   qualifier?: string;
+  /** Qualified mode entered via a literal `alias.` — adds the `*`
+   *  suggestion (`t.*`) the way SQL IDEs do. INSERT column lists and
+   *  `REFERENCES t(…)` reuse qualified mode but must not offer `*`. */
+  viaDot?: boolean;
+  /** `JOIN … ON |` slot — prepend ready-made join conditions derived
+   *  from foreign keys / matching column names. */
+  joinConditionSlot?: boolean;
+  /** `JOIN |` slot — tables related (via FKs) to tables already in the
+   *  statement are ranked above the rest. */
+  joinTableSlot?: boolean;
+  /** `USING (…|` slot — suggest bare column names shared between the
+   *  joined tables instead of qualified ones. */
+  usingSlot?: boolean;
+  /** Sub-slot inside a `CREATE TABLE (…)` body. */
+  columnDefSlot?: "type" | "constraint";
   // When set, only these keywords are emitted at high boost; other
   // keywords are either downranked or omitted entirely. Drives the
   // "show only the keywords that make sense at this cursor" behavior.
@@ -54,7 +98,7 @@ interface KeywordContext {
 }
 
 const completeIdentifierPattern = /^[A-Za-z_][A-Za-z0-9_$]*$/;
-const partialIdentifierPattern = /^$|^[A-Za-z_][A-Za-z0-9_$]*$/;
+const bareIdentifierPattern = /^[A-Za-z_][A-Za-z0-9_$]*$/;
 const sqlIdentifierPattern =
   String.raw`(?:[A-Za-z_][A-Za-z0-9_$]*|"(?:""|[^"])+"|` +
   "`[^`]+`" +
@@ -67,43 +111,79 @@ const qualifiedIdentifierPattern = new RegExp(
 // would greedily eat the next clause keyword (e.g. "FROM t JOIN" → alias=JOIN)
 // and we'd lose the second table from the reference set.
 const aliasBlockListSource =
-  String.raw`(?:FROM|JOIN|WHERE|GROUP|ORDER|HAVING|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|ON|USING|INNER|LEFT|RIGHT|FULL|CROSS|OUTER|SET|VALUES|RETURNING|AS|WHEN|CASE)`;
+  String.raw`(?:FROM|JOIN|WHERE|GROUP|ORDER|HAVING|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|ON|USING|INNER|LEFT|RIGHT|FULL|CROSS|OUTER|NATURAL|SEMI|ANTI|ASOF|POSITIONAL|LATERAL|QUALIFY|WINDOW|PIVOT|UNPIVOT|TABLESAMPLE|SET|VALUES|RETURNING|AS|WHEN|CASE|DROP|ADD|RENAME|ALTER|COLUMN|TO|CONSTRAINT|PRIMARY|FOREIGN|UNIQUE|CHECK|REFERENCES|NOT|DEFAULT|COLLATE|GENERATED)`;
 const aliasGroupSource =
   String.raw`(?:\s+(?:AS\s+)?(?!${aliasBlockListSource}\b)([A-Za-z_][A-Za-z0-9_$]*))?`;
+// Optionally schema-qualified table reference: FROM public.orders o.
+// Group 1 = clause keyword, 2 = schema (optional), 3 = table, 4 = alias.
+// `TABLE` is included so ALTER/DROP TABLE targets join the reference set
+// (e.g. `ALTER TABLE t DROP COLUMN |` can complete t's columns).
 const tableReferencePattern = new RegExp(
-  String.raw`\b(?:FROM|JOIN|UPDATE|INTO)\s+(${sqlIdentifierPattern})${aliasGroupSource}`,
+  String.raw`\b(FROM|JOIN|UPDATE|INTO|TABLE)\s+(?:(${sqlIdentifierPattern})\s*\.\s*)?(${sqlIdentifierPattern})${aliasGroupSource}`,
   "gi",
 );
 const commaTableReferencePattern = new RegExp(
-  String.raw`,\s*(${sqlIdentifierPattern})${aliasGroupSource}`,
+  String.raw`,\s*(?:(${sqlIdentifierPattern})\s*\.\s*)?(${sqlIdentifierPattern})${aliasGroupSource}`,
   "g",
 );
 const insertColumnListPattern = new RegExp(
-  String.raw`\bINSERT\s+INTO\s+(${sqlIdentifierPattern})\s*\(([^()]*)$`,
+  String.raw`\bINSERT\s+INTO\s+(?:${sqlIdentifierPattern}\s*\.\s*)?(${sqlIdentifierPattern})\s*\(([^()]*)$`,
   "i",
 );
+// FOREIGN KEY (…) REFERENCES parent(col1, …| — complete the parent's columns.
+const referencesColumnListPattern = new RegExp(
+  String.raw`\bREFERENCES\s+(?:${sqlIdentifierPattern}\s*\.\s*)?(${sqlIdentifierPattern})\s*\(([^()]*)$`,
+  "i",
+);
+// CREATE INDEX idx ON tbl(col1, …| — complete the indexed table's columns.
+const indexColumnListPattern = new RegExp(
+  String.raw`\bON\s+(?:${sqlIdentifierPattern}\s*\.\s*)?(${sqlIdentifierPattern})\s*\(([^()]*)$`,
+  "i",
+);
+const createIndexStatementPattern = /\bCREATE\s+(?:UNIQUE\s+)?INDEX\b/i;
 const usingClausePattern = /\bUSING\s*\(\s*[A-Za-z0-9_$,\s]*$/i;
 const createNewObjectPattern = new RegExp(
-  String.raw`\bCREATE\s+(?:TEMP(?:ORARY)?\s+)?(?:UNIQUE\s+)?(?:TABLE|VIEW|INDEX|TRIGGER)\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:[A-Za-z_][A-Za-z0-9_$]*)?$`,
+  String.raw`\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:TEMP(?:ORARY)?\s+)?(?:UNIQUE\s+)?(?:MATERIALIZED\s+)?(TABLE|VIEW|INDEX|TRIGGER|SCHEMA|SEQUENCE)\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:[A-Za-z_][A-Za-z0-9_$]*)?$`,
   "i",
 );
+// Head of a CREATE TABLE body — everything between this `(` and its
+// matching `)` is column-definition territory with its own slots.
+const createTableBodyPattern = new RegExp(
+  String.raw`\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:TEMP(?:ORARY)?\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:${sqlIdentifierPattern}\s*\.\s*)?${sqlIdentifierPattern}\s*\(`,
+  "gi",
+);
 
-const tableSection = { name: "Tables", rank: 10 };
-const viewSection = { name: "Views", rank: 11 };
-const cteSection = { name: "CTEs", rank: 12 };
-const columnSection = { name: "Columns", rank: 20 };
-const keywordSection = { name: "Keywords", rank: 30 };
+// All sections use `rank: "dynamic"` so the group containing the
+// best-scoring suggestion renders first. With static ranks the section
+// order would *override* every per-option boost — the Tables section
+// would sit above Columns even inside a WHERE clause where columns carry
+// the high boost — which is backwards from how SQL IDEs order results.
+const tableSection = { name: "Tables", rank: "dynamic" } as const;
+const viewSection = { name: "Views", rank: "dynamic" } as const;
+const cteSection = { name: "CTEs", rank: "dynamic" } as const;
+const joinSection = { name: "Join conditions", rank: "dynamic" } as const;
+const columnSection = { name: "Columns", rank: "dynamic" } as const;
+const keywordSection = { name: "Keywords", rank: "dynamic" } as const;
 
 const BOOST = {
   tableInTableContext: 80,
   cteInTableContext: 85,
+  // Tables connected by a foreign key to tables already referenced in the
+  // statement (e.g. after `FROM customers JOIN |`) outrank everything else
+  // in the table list — the DataGrip-style "related tables first" ordering.
+  relatedTableBump: 15,
   keywordInTableContext: 5,
   columnInColumnContext: 90,
   keywordInColumnContext: 20,
   tableInColumnContext: 1,
   qualifiedColumn: 100,
+  starInQualified: 100,
+  joinCondition: 96,
+  usingSharedColumn: 95,
+  usingOtherColumn: 60,
   keywordInKeywordContext: 50,
   tableInKeywordContext: 10,
+  typeInColumnDef: 70,
   functionPenalty: 1,
 } as const;
 
@@ -120,6 +200,7 @@ const CORE_KEYWORDS = [
   "OUTER",
   "FULL",
   "CROSS",
+  "NATURAL",
   "ON",
   "USING",
   "GROUP",
@@ -245,6 +326,12 @@ const SQLITE_FUNCTIONS = [
   "TOTAL",
   "SUBSTR",
   "IFNULL",
+  "IIF",
+  "INSTR",
+  "TRIM",
+  "LTRIM",
+  "RTRIM",
+  "GROUP_CONCAT",
   "DATE",
   "TIME",
   "DATETIME",
@@ -254,6 +341,16 @@ const SQLITE_FUNCTIONS = [
   "RANDOM",
   "HEX",
   "TYPEOF",
+  // SQLite ≥ 3.25 ships window functions; the playground's WASM build is
+  // far newer, so surface the standard set.
+  "ROW_NUMBER",
+  "RANK",
+  "DENSE_RANK",
+  "NTILE",
+  "LAG",
+  "LEAD",
+  "FIRST_VALUE",
+  "LAST_VALUE",
 ] as const;
 
 // Postgres-specific extras (also covers most of what DuckDB's PG-compatible
@@ -354,6 +451,17 @@ const POSTGRES_FUNCTIONS = [
   "NTILE",
   "FIRST_VALUE",
   "LAST_VALUE",
+  "CEIL",
+  "FLOOR",
+  "POWER",
+  "SQRT",
+  "MOD",
+  "INITCAP",
+  "CHAR_LENGTH",
+  "UNNEST",
+  "STRING_TO_ARRAY",
+  "ARRAY_LENGTH",
+  "CARDINALITY",
 ] as const;
 
 // DuckDB sits on top of the Postgres dialect but adds its own syntax
@@ -388,6 +496,7 @@ const DUCKDB_KEYWORDS = [
 const DUCKDB_FUNCTIONS = [
   "LIST",
   "LIST_AGG",
+  "LIST_VALUE",
   "ARRAY_AGG",
   "STRING_AGG",
   "STRING_SPLIT",
@@ -418,7 +527,86 @@ const DUCKDB_FUNCTIONS = [
   "MODE",
   "ARG_MAX",
   "ARG_MIN",
+  "UNNEST",
+  "LEN",
+  "CONTAINS",
+  "STARTS_WITH",
+  "READ_CSV",
+  "READ_CSV_AUTO",
+  "READ_PARQUET",
+  "READ_JSON_AUTO",
 ] as const;
+
+// Data types offered inside CREATE TABLE column definitions, most common
+// first. Detection (is the previous token a type?) uses the shared
+// ALL_TYPE_NAMES set so cross-dialect spellings still classify correctly.
+const DIALECT_TYPES: Record<SqlDialect, readonly string[]> = {
+  sqlite: ["INTEGER", "TEXT", "REAL", "NUMERIC", "BLOB"],
+  postgres: [
+    "INTEGER",
+    "TEXT",
+    "SERIAL",
+    "BIGSERIAL",
+    "BIGINT",
+    "SMALLINT",
+    "VARCHAR",
+    "BOOLEAN",
+    "NUMERIC",
+    "DECIMAL",
+    "REAL",
+    "DOUBLE PRECISION",
+    "DATE",
+    "TIME",
+    "TIMESTAMP",
+    "TIMESTAMPTZ",
+    "INTERVAL",
+    "UUID",
+    "JSON",
+    "JSONB",
+    "BYTEA",
+  ],
+  duckdb: [
+    "INTEGER",
+    "VARCHAR",
+    "BIGINT",
+    "SMALLINT",
+    "TINYINT",
+    "HUGEINT",
+    "DOUBLE",
+    "FLOAT",
+    "DECIMAL",
+    "BOOLEAN",
+    "DATE",
+    "TIME",
+    "TIMESTAMP",
+    "TIMESTAMPTZ",
+    "INTERVAL",
+    "UUID",
+    "BLOB",
+    "JSON",
+  ],
+};
+
+const ALL_TYPE_NAMES = new Set<string>([
+  ...DIALECT_TYPES.sqlite,
+  ...DIALECT_TYPES.postgres,
+  ...DIALECT_TYPES.duckdb,
+  "INT",
+  "CHAR",
+  "CHARACTER",
+  "FLOAT",
+  "DOUBLE",
+  "PRECISION",
+  "VARYING",
+]);
+
+// Schema (namespace) qualifiers recognized when the host doesn't supply
+// an explicit list — `main.` in SQLite/DuckDB, `public.` in Postgres.
+const DEFAULT_SCHEMA_NAMES: Record<SqlDialect, readonly string[]> = {
+  sqlite: ["main", "temp"],
+  postgres: ["public"],
+  duckdb: ["main", "memory"],
+};
 
 interface DialectProfile {
   keywords: string[];
@@ -492,6 +680,8 @@ const tableTargetKeywords = new Set([
   "VIEW",
   "INDEX",
   "TRIGGER",
+  // FK targets: `REFERENCES |` always names an existing table.
+  "REFERENCES",
 ]);
 
 const columnTargetKeywords = new Set([
@@ -507,6 +697,11 @@ const columnTargetKeywords = new Set([
   // DuckDB: `QUALIFY <expr>` filters on window functions — same shape as
   // HAVING, so completion-wise it wants column names + boolean operators.
   "QUALIFY",
+  // CASE expressions: WHEN/THEN/ELSE all introduce sub-expressions that
+  // want column references.
+  "WHEN",
+  "THEN",
+  "ELSE",
 ]);
 
 // Tokens that indicate the user is mid-expression and probably wants a column
@@ -530,6 +725,16 @@ const expressionContinuationTokens = new Set([
   "BETWEEN",
   "(",
 ]);
+
+function columnName(column: SqlCompletionColumn): string {
+  return typeof column === "string" ? column : column.name;
+}
+
+function columnType(column: SqlCompletionColumn): string | undefined {
+  if (typeof column === "string") return undefined;
+  const type = column.type?.trim();
+  return type ? type : undefined;
+}
 
 function normalizeIdentifier(identifier: string | undefined): string {
   if (!identifier) return "";
@@ -600,7 +805,11 @@ function maskCommentsAndStrings(sql: string): string {
     }
     if (ch === "'") {
       const nextIndex = findSingleQuotedStringEnd(sql, i);
-      masked += maskRangePreservingNewlines(sql, i, nextIndex);
+      // Leave a `0` operand marker (length-preserving) so the tokenizer
+      // still sees a value here. Without it, `WHERE name = 'x' |` looks
+      // like a dangling `=` and the keyword context resolver would offer
+      // expression *starters* instead of AND/OR connectors.
+      masked += "0" + maskRangePreservingNewlines(sql, i + 1, nextIndex);
       i = nextIndex;
       continue;
     }
@@ -610,19 +819,30 @@ function maskCommentsAndStrings(sql: string): string {
   return masked;
 }
 
-function currentStatementBeforeCursor(sql: string, pos: number): string {
-  const before = sql.slice(0, pos);
-  const masked = maskCommentsAndStrings(before);
-  const start = masked.lastIndexOf(";") + 1;
-  return before.slice(start);
+/** The statement that contains `pos`, split at the cursor. `before` is
+ *  what precedes the cursor (drives slot detection); `full` also covers
+ *  the text after the cursor up to the next `;` so tables referenced
+ *  *later* in the statement still feed column/alias scope — the
+ *  "SELECT | FROM customers" case every SQL IDE handles. */
+function statementAround(
+  sql: string,
+  pos: number,
+): { before: string; full: string } {
+  const masked = maskCommentsAndStrings(sql);
+  const start = pos === 0 ? 0 : masked.lastIndexOf(";", pos - 1) + 1;
+  const endIndex = masked.indexOf(";", pos);
+  const end = endIndex === -1 ? sql.length : endIndex;
+  return { before: sql.slice(start, pos), full: sql.slice(start, end) };
 }
 
 function tokenize(sql: string): string[] {
   // Operators and punctuation are kept as clause boundaries so nearby SQL
   // expressions don't get folded into identifier/keyword context detection.
+  // Numeric literals tokenize as single units so `1.5` doesn't leak a `.`
+  // token that would be mistaken for a qualified-identifier dot.
   return (
     maskCommentsAndStrings(sql).match(
-      /[A-Za-z_][A-Za-z0-9_$]*|[,().;=*<>+\-/]/g,
+      /[A-Za-z_][A-Za-z0-9_$]*|\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|[,().;=*<>+\-/]/g,
     ) ?? []
   );
 }
@@ -711,9 +931,31 @@ function isIdentifierToken(token: string | undefined): boolean {
   return !clauseBoundaryKeywords.has(token);
 }
 
+/** True when `token` reads as a *complete operand*: an identifier, a
+ *  numeric literal (incl. the `0` marker masked strings leave behind), a
+ *  closing paren, or END finishing a CASE. After an operand the user
+ *  wants connectors (AND/OR), clause keywords, or an alias — not the
+ *  start of a fresh expression. */
+function isOperandToken(token: string | undefined): boolean {
+  if (!token) return false;
+  if (token === ")" || token === "END") return true;
+  if (/^\d/.test(token)) return true;
+  return isIdentifierToken(token);
+}
+
 function isExpressionOperator(token: string | undefined): boolean {
   if (!token) return false;
   return expressionContinuationTokens.has(token);
+}
+
+/** Inside an unfinished CASE expression (more CASEs than ENDs so far)? */
+function inOpenCaseExpression(tokens: string[]): boolean {
+  let open = 0;
+  for (const token of tokens) {
+    if (token === "CASE") open += 1;
+    else if (token === "END" && open > 0) open -= 1;
+  }
+  return open > 0;
 }
 
 // Resolve which keywords to surface at the cursor. Returns `null` when no
@@ -725,6 +967,39 @@ function resolveKeywordContext(
   dialect: SqlDialect,
 ): KeywordContext | null {
   if (tokens.length === 0) return statementStartersFor(dialect);
+
+  // Numeric literal: the slot after `LIMIT 10` / `OFFSET 5` is special;
+  // any other trailing number behaves like a completed operand and falls
+  // through to the clause-relative rules below.
+  if (lastToken && /^\d/.test(lastToken)) {
+    const prev = tokens.at(-2);
+    if (prev === "LIMIT")
+      return { primary: ["OFFSET"], secondary: ["UNION"], restrict: true };
+    if (prev === "OFFSET")
+      return { primary: [], secondary: ["UNION"], restrict: true };
+  }
+
+  // `SELECT * |` — the select list is complete, FROM is next. Without this
+  // the `*` would be read as a dangling multiplication operator.
+  if (
+    lastToken === "*" &&
+    ["SELECT", "DISTINCT", "ALL"].includes(tokens.at(-2) ?? "")
+  ) {
+    return { primary: ["FROM"] };
+  }
+
+  // `OVER (|` — window definition slot.
+  if (lastToken === "(" && tokens.at(-2) === "OVER") {
+    return {
+      primary: ["PARTITION", "ORDER"],
+      secondary: ["ROWS", "RANGE", "GROUPS"],
+    };
+  }
+
+  // `WITH name AS (|` / `CREATE VIEW v AS (|` — a subquery body starts.
+  if (lastToken === "(" && tokens.at(-2) === "AS") {
+    return { primary: ["SELECT"], secondary: ["WITH", "VALUES"] };
+  }
 
   // ── Direct follow-ups: the previous *token* dictates a tightly-scoped slot.
   switch (lastToken) {
@@ -838,14 +1113,58 @@ function resolveKeywordContext(
       return { primary: ["TO", "COLUMN"], restrict: true };
     case "ADD":
       return { primary: ["COLUMN", "CONSTRAINT"], restrict: true };
+    case "TO":
+      return { primary: [], restrict: true };
+    case "PRIMARY":
+    case "FOREIGN":
+      return { primary: ["KEY"], restrict: true };
+    case "PARTITION":
+      return { primary: ["BY"], restrict: true };
+    // Join modifiers always lead to JOIN.
+    case "LEFT":
+    case "RIGHT":
+    case "FULL":
+      return { primary: ["JOIN", "OUTER"], restrict: true };
+    case "INNER":
+    case "CROSS":
+    case "OUTER":
+      return { primary: ["JOIN"], restrict: true };
+    case "NATURAL":
+      return {
+        primary: ["JOIN"],
+        secondary: ["LEFT", "RIGHT", "INNER", "FULL"],
+        restrict: true,
+      };
+    case "SEMI":
+    case "ANTI":
+    case "ASOF":
+    case "POSITIONAL":
+      if (dialect === "duckdb") return { primary: ["JOIN"], restrict: true };
+      break;
+    case "CASE":
+      return { primary: ["WHEN"] };
+    case "WHEN":
+      return { primary: ["NOT", "EXISTS"], secondary: ["NULL", "CASE"] };
+    case "THEN":
+    case "ELSE":
+      return { primary: [], secondary: ["NULL", "NOT", "CASE"] };
     default:
       break;
+  }
+
+  // Open CASE expression: after a complete operand the next step is
+  // THEN (in the WHEN branch) or WHEN/ELSE/END — ahead of clause keywords.
+  if (inOpenCaseExpression(tokens) && isOperandToken(lastToken)) {
+    return {
+      primary: ["THEN", "WHEN", "ELSE", "END", "AND", "OR"],
+      secondary: ["IS", "NOT", "LIKE", "IN", "BETWEEN"],
+    };
   }
 
   // ── Clause-relative defaults: where in the larger statement are we?
   switch (lastClauseKeyword) {
     case "SELECT":
-      if (isIdentifierToken(lastToken)) {
+      if (isOperandToken(lastToken)) {
         return {
           primary: ["AS", "FROM"],
           secondary: [
@@ -889,6 +1208,7 @@ function resolveKeywordContext(
             "OUTER",
             "FULL",
             "CROSS",
+            "NATURAL",
             "HAVING",
             "OFFSET",
             "UNION",
@@ -917,6 +1237,7 @@ function resolveKeywordContext(
             "OUTER",
             "FULL",
             "CROSS",
+            "NATURAL",
             "GROUP",
             "ORDER",
             "HAVING",
@@ -933,10 +1254,16 @@ function resolveKeywordContext(
       if (isExpressionOperator(lastToken)) {
         return {
           primary: ["NOT", "NULL", "EXISTS", "CASE"],
-          secondary: ["CAST", "TRUE", "FALSE"],
+          // An opening paren may start a scalar subquery / IN-list.
+          secondary: [
+            "CAST",
+            "TRUE",
+            "FALSE",
+            ...(lastToken === "(" ? ["SELECT"] : []),
+          ],
         };
       }
-      if (isIdentifierToken(lastToken)) {
+      if (isOperandToken(lastToken)) {
         // The mid-expression operator menu after `WHERE col `. SQLite's
         // tail (GLOB/REGEXP/MATCH) differs from Postgres/DuckDB (ILIKE,
         // SIMILAR); we splice in the right one so users don't see
@@ -967,21 +1294,25 @@ function resolveKeywordContext(
       };
     }
     case "GROUP":
-    case "ORDER":
+    case "ORDER": {
+      // Once BY has been typed, the slot wants sort modifiers and the
+      // next clause — re-suggesting BY would be noise.
+      const clauseIndex = Math.max(
+        tokens.lastIndexOf("GROUP"),
+        tokens.lastIndexOf("ORDER"),
+      );
+      const byTyped = tokens.lastIndexOf("BY") > clauseIndex;
       return {
-        primary: ["BY"],
+        primary: byTyped ? ["ASC", "DESC"] : ["BY"],
         // QUALIFY is DuckDB-specific; keep it out of the SQLite/Postgres
         // secondary list so it doesn't pollute their suggestions.
         secondary: [
-          "ASC",
-          "DESC",
-          "HAVING",
-          "LIMIT",
-          "OFFSET",
-          "UNION",
+          ...(byTyped ? ["HAVING", "LIMIT", "OFFSET", "UNION", "NULLS"]
+            : ["ASC", "DESC", "HAVING", "LIMIT", "OFFSET", "UNION"]),
           ...(dialect === "duckdb" ? ["QUALIFY"] : []),
         ],
       };
+    }
     case "INSERT":
       return {
         primary: ["INTO", "VALUES", "SELECT"],
@@ -1012,6 +1343,29 @@ function resolveKeywordContext(
         ],
       };
     case "CREATE":
+      // Once the object kind *and* its name have been typed, the slot
+      // wants the kind-specific continuation: `CREATE INDEX i ON …`,
+      // `CREATE VIEW v AS …`, `CREATE TABLE t (… | AS …)`.
+      if (isIdentifierToken(lastToken)) {
+        if (tokens.includes("INDEX"))
+          return {
+            primary: ["ON"],
+            secondary: ["IF", "NOT", "EXISTS"],
+            restrict: true,
+          };
+        if (tokens.includes("VIEW"))
+          return {
+            primary: ["AS"],
+            secondary: ["IF", "NOT", "EXISTS"],
+            restrict: true,
+          };
+        if (tokens.includes("TABLE"))
+          return {
+            primary: ["AS"],
+            secondary: ["IF", "NOT", "EXISTS"],
+            restrict: true,
+          };
+      }
       return dialect === "sqlite"
         ? {
             primary: ["TABLE", "VIEW", "INDEX", "TRIGGER"],
@@ -1048,6 +1402,14 @@ function resolveKeywordContext(
     case "SET":
       return { primary: ["WHERE"], secondary: ["AND", "OR", "RETURNING"] };
     case "VALUES":
+      // After the closing paren of a VALUES tuple the row is complete;
+      // what follows is RETURNING / ON CONFLICT (PG, DuckDB), not more
+      // value keywords.
+      if (lastToken === ")") {
+        return dialect === "sqlite"
+          ? { primary: ["RETURNING"] }
+          : { primary: ["ON", "RETURNING"], secondary: ["CONFLICT"] };
+      }
       return { primary: ["DEFAULT", "NULL"], secondary: ["RETURNING"] };
     case "USING":
       return { primary: [], restrict: true };
@@ -1073,14 +1435,137 @@ function isInsideUnclosedParen(prefix: string): boolean {
   return depth > 0;
 }
 
+/** Signed paren balance — unlike `isInsideUnclosedParen` this may go
+ *  negative, which is how we know a `CREATE TABLE (…)` body has already
+ *  been closed before the cursor. */
+function signedParenBalance(masked: string): number {
+  let depth = 0;
+  for (let i = 0; i < masked.length; i += 1) {
+    const ch = masked[i];
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth -= 1;
+  }
+  return depth;
+}
+
+/** Column-definition slots inside a `CREATE TABLE name ( … |`. Returns
+ *  null when the cursor isn't inside such a body. */
+function resolveCreateTableBody(
+  prefixWithoutWord: string,
+  dialect: SqlDialect,
+  explicit: boolean,
+): SqlCompletionContextInfo | null {
+  const masked = maskCommentsAndStrings(prefixWithoutWord);
+  let bodyStart = -1;
+  createTableBodyPattern.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = createTableBodyPattern.exec(masked))) {
+    bodyStart = match.index + match[0].length;
+  }
+  if (bodyStart === -1) return null;
+  const body = masked.slice(bodyStart);
+  const depth = 1 + signedParenBalance(body);
+  if (depth <= 0) return null; // body already closed
+  if (depth > 1) {
+    // Nested paren — CHECK(...), DECIMAL(10,…), etc. Suggestions here are
+    // more likely to mislead than help (the columns being defined aren't
+    // in the schema yet), so stay quiet.
+    return {
+      mode: "naming",
+      from: 0,
+      keywordContext: { primary: [], restrict: true },
+    };
+  }
+
+  const bodyTokens = tokenize(body).map((token) => token.toUpperCase());
+  const last = bodyTokens.at(-1);
+  const prev = bodyTokens.at(-2);
+
+  // Fresh column-name slot — the user is inventing a name, so stay quiet
+  // unless they explicitly ask, in which case offer the table-constraint
+  // starters that are also legal here.
+  if (last === undefined || last === "(" || last === ",") {
+    return {
+      mode: "naming",
+      from: 0,
+      keywordContext: explicit
+        ? {
+            primary: [],
+            secondary: ["PRIMARY", "FOREIGN", "UNIQUE", "CHECK", "CONSTRAINT"],
+            restrict: true,
+          }
+        : { primary: [], restrict: true },
+    };
+  }
+
+  if (last === "REFERENCES") return null; // handled as a table target
+
+  if (last === "PRIMARY" || last === "FOREIGN") {
+    return {
+      mode: "naming",
+      from: 0,
+      keywordContext: { primary: ["KEY"], restrict: true },
+    };
+  }
+  if (last === "NOT") {
+    return {
+      mode: "naming",
+      from: 0,
+      keywordContext: { primary: ["NULL"], restrict: true },
+    };
+  }
+  if (last === "DEFAULT") {
+    return {
+      mode: "naming",
+      from: 0,
+      keywordContext: {
+        primary: ["NULL", "TRUE", "FALSE"],
+        secondary: ["CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"],
+        restrict: true,
+      },
+    };
+  }
+
+  const constraintContext: KeywordContext = {
+    primary: ["NOT", "NULL", "PRIMARY", "KEY", "UNIQUE", "DEFAULT", "REFERENCES", "CHECK"],
+    secondary: [
+      "COLLATE",
+      "GENERATED",
+      "CONSTRAINT",
+      ...(dialect === "sqlite" ? ["AUTOINCREMENT"] : []),
+    ],
+    restrict: true,
+  };
+
+  // `name |` straight after `(`/`,` → the type slot (suggest data types);
+  // anything later (after a type, `)`, KEY, NULL, …) → constraint slot.
+  const inTypeSlot =
+    !ALL_TYPE_NAMES.has(last) &&
+    last !== ")" &&
+    !["KEY", "NULL", "UNIQUE", "AUTOINCREMENT"].includes(last) &&
+    isIdentifierToken(last) &&
+    (prev === undefined || prev === "(" || prev === ",");
+
+  return {
+    mode: "column-def",
+    from: 0,
+    columnDefSlot: inTypeSlot ? "type" : "constraint",
+    keywordContext: inTypeSlot
+      ? {
+          primary: [],
+          secondary: constraintContext.primary,
+          restrict: true,
+        }
+      : constraintContext,
+  };
+}
+
 function inferCompletionContext(
   context: CompletionContext,
+  statementBefore: string,
   dialect: SqlDialect,
 ): SqlCompletionContextInfo | null {
-  const statement = currentStatementBeforeCursor(
-    context.state.doc.toString(),
-    context.pos,
-  );
+  const statement = statementBefore;
   const word = context.matchBefore(/[A-Za-z_][A-Za-z0-9_$]*/);
   const qualified = statement.match(qualifiedIdentifierPattern);
 
@@ -1088,6 +1573,7 @@ function inferCompletionContext(
     return {
       mode: "qualified-columns",
       qualifier: normalizeIdentifier(qualified[1]),
+      viaDot: true,
       from: context.pos - (qualified[2]?.length ?? 0),
     };
   }
@@ -1111,24 +1597,60 @@ function inferCompletionContext(
     };
   }
 
-  // JOIN ... USING (col1, |) — suggest columns from joined tables.
+  // … REFERENCES parent (col1, |) — suggest the parent table's columns.
+  const referencesMatch = referencesColumnListPattern.exec(prefixWithoutWord);
+  if (referencesMatch) {
+    return {
+      mode: "qualified-columns",
+      qualifier: normalizeIdentifier(referencesMatch[1]),
+      from,
+    };
+  }
+
+  // CREATE INDEX … ON <table> (col1, |) — suggest the table's columns.
+  if (createIndexStatementPattern.test(prefixWithoutWord)) {
+    const indexMatch = indexColumnListPattern.exec(prefixWithoutWord);
+    if (indexMatch) {
+      return {
+        mode: "qualified-columns",
+        qualifier: normalizeIdentifier(indexMatch[1]),
+        from,
+      };
+    }
+  }
+
+  // JOIN ... USING (col1, |) — suggest columns shared by the joined tables.
   if (
     usingClausePattern.test(prefixWithoutWord) &&
     isInsideUnclosedParen(prefixWithoutWord)
   ) {
-    return { mode: "columns", from };
+    return { mode: "columns", from, usingSlot: true };
   }
 
   // CREATE [TEMP] [UNIQUE] TABLE|VIEW|INDEX|TRIGGER [IF NOT EXISTS] <newName>
   // — user is naming a new object, so suppress existing-table suggestions
   // and only surface the few keywords that legally appear in this slot.
-  if (createNewObjectPattern.test(prefixWithoutWord)) {
-    return {
-      mode: "naming",
-      from,
-      keywordContext: KW_NAME_TAIL,
-    };
+  const namingMatch = createNewObjectPattern.exec(prefixWithoutWord);
+  if (namingMatch) {
+    const objectKind = namingMatch[1]?.toUpperCase();
+    // After the new name, INDEX continues with ON and VIEW with AS;
+    // IF NOT EXISTS is legal before the name for all of them.
+    const tail: KeywordContext =
+      objectKind === "INDEX"
+        ? { primary: ["ON", "IF", "NOT", "EXISTS"], restrict: true }
+        : objectKind === "VIEW"
+          ? { primary: ["AS", "IF", "NOT", "EXISTS"], restrict: true }
+          : KW_NAME_TAIL;
+    return { mode: "naming", from, keywordContext: tail };
   }
+
+  // Inside a CREATE TABLE ( … ) body: column-definition slots.
+  const bodyInfo = resolveCreateTableBody(
+    prefixWithoutWord,
+    dialect,
+    context.explicit,
+  );
+  if (bodyInfo) return { ...bodyInfo, from };
 
   const tokens = tokenize(prefixWithoutWord).map((token) => token.toUpperCase());
   const lastToken = tokens.at(-1);
@@ -1139,12 +1661,44 @@ function inferCompletionContext(
     resolveKeywordContext(tokens, lastToken, lastClauseKeyword, dialect) ??
     undefined;
 
-  // Right after a clause keyword that introduces tables / columns.
-  if (lastToken && tableTargetKeywords.has(lastToken)) {
+  // CREATE INDEX idx ON | — ON names a table here, not a join condition.
+  if (
+    lastToken === "ON" &&
+    tokens.includes("CREATE") &&
+    tokens.includes("INDEX")
+  ) {
     return { mode: "tables", from, keywordContext };
   }
-  if (lastToken && columnTargetKeywords.has(lastToken)) {
+
+  // ALTER TABLE t DROP/RENAME COLUMN | — complete t's existing columns.
+  // (ADD COLUMN names a new column, so that slot stays quiet.)
+  if (lastToken === "COLUMN" && tokens.includes("ALTER")) {
+    if (tokens.at(-2) === "ADD") {
+      return {
+        mode: "naming",
+        from,
+        keywordContext: { primary: [], restrict: true },
+      };
+    }
     return { mode: "columns", from, keywordContext };
+  }
+
+  // Right after a clause keyword that introduces tables / columns.
+  if (lastToken && tableTargetKeywords.has(lastToken)) {
+    return {
+      mode: "tables",
+      from,
+      keywordContext,
+      joinTableSlot: lastToken === "JOIN",
+    };
+  }
+  if (lastToken && columnTargetKeywords.has(lastToken)) {
+    return {
+      mode: "columns",
+      from,
+      keywordContext,
+      joinConditionSlot: lastToken === "ON",
+    };
   }
 
   // After a comma or open-paren, stay in the surrounding clause's mode.
@@ -1171,22 +1725,45 @@ function inferCompletionContext(
   return { mode: "keywords", from, keywordContext };
 }
 
-function extractTableReferences(sql: string): Map<string, string> {
-  const references = new Map<string, string>();
+interface TableReference {
+  table: string;
+  alias?: string;
+  /** Clause keyword that introduced the reference, lowercased. */
+  via: "from" | "join" | "update" | "into" | "table" | "comma";
+}
+
+/** Ordered table references in the statement (FROM/JOIN/UPDATE/INTO/
+ *  ALTER-TABLE targets plus comma-separated FROM lists), with aliases and
+ *  optional schema qualifiers stripped. */
+function extractTableRefList(sql: string): TableReference[] {
+  const refs: Array<TableReference & { at: number }> = [];
   const masked = maskCommentsAndStrings(sql);
-  const addReference = (tableToken: string, aliasToken?: string) => {
-    const tableName = normalizeIdentifier(tableToken);
-    if (!tableName) return;
-    references.set(tableName.toLowerCase(), tableName);
+  const push = (
+    tableToken: string,
+    aliasToken: string | undefined,
+    via: TableReference["via"],
+    at: number,
+  ) => {
+    const table = normalizeIdentifier(tableToken);
+    if (!table) return;
     const alias = normalizeIdentifier(aliasToken);
-    if (alias && !isClauseBoundaryKeyword(alias))
-      references.set(alias.toLowerCase(), tableName);
+    refs.push({
+      table,
+      alias: alias && !isClauseBoundaryKeyword(alias) ? alias : undefined,
+      via,
+      at,
+    });
   };
 
   let match: RegExpExecArray | null;
   tableReferencePattern.lastIndex = 0;
   while ((match = tableReferencePattern.exec(masked))) {
-    addReference(match[1], match[2]);
+    push(
+      match[3],
+      match[4],
+      match[1].toLowerCase() as TableReference["via"],
+      match.index,
+    );
   }
 
   commaTableReferencePattern.lastIndex = 0;
@@ -1203,10 +1780,25 @@ function extractTableReferences(sql: string): Map<string, string> {
       lastBoundary >= 0 &&
       /\b(FROM|JOIN)\b/.test(beforeComma.slice(lastBoundary))
     ) {
-      addReference(match[1], match[2]);
+      push(match[2], match[3], "comma", match.index);
     }
   }
 
+  // The two scans above each emit in their own document order; merge them
+  // so positional logic ("which table was joined last?") sees the true
+  // statement order.
+  return refs
+    .sort((a, b) => a.at - b.at)
+    .map(({ table, alias, via }) => ({ table, alias, via }));
+}
+
+/** alias/table-name (lowercased) → canonical table name. */
+function referenceMap(refs: TableReference[]): Map<string, string> {
+  const references = new Map<string, string>();
+  for (const ref of refs) {
+    references.set(ref.table.toLowerCase(), ref.table);
+    if (ref.alias) references.set(ref.alias.toLowerCase(), ref.table);
+  }
   return references;
 }
 
@@ -1287,7 +1879,17 @@ function effectiveSchema(
     ...base.entities,
     ...ctes.filter((cte) => !knownNames.has(cte.name.toLowerCase())),
   ];
-  return { entities: merged };
+  return { ...base, entities: merged };
+}
+
+function findEntity(
+  schema: SqlCompletionSchema,
+  name: string,
+): SqlCompletionEntity | undefined {
+  const lower = name.toLowerCase();
+  return schema.entities.find(
+    (entity) => entity.name.toLowerCase() === lower,
+  );
 }
 
 function entitySection(
@@ -1304,19 +1906,62 @@ function entityType(entity: SqlCompletionEntity): string {
   return "type";
 }
 
+/** Quick-doc shown next to a highlighted table suggestion: its column
+ *  list with types, like the structure preview desktop SQL IDEs render. */
+function entityInfo(entity: SqlCompletionEntity): string | undefined {
+  if (entity.columns.length === 0) return undefined;
+  const shown = entity.columns.slice(0, 12).map((column) => {
+    const type = columnType(column);
+    return type ? `${columnName(column)} ${type}` : columnName(column);
+  });
+  const suffix = entity.columns.length > 12 ? ", …" : "";
+  return `${entity.kind} ${entity.name} (${shown.join(", ")}${suffix})`;
+}
+
+/** Table names (lowercased) reachable via a foreign key from/to any of
+ *  the already-referenced tables — used to float likely JOIN partners. */
+function fkRelatedTables(
+  schema: SqlCompletionSchema,
+  refs: TableReference[],
+): Set<string> {
+  const referenced = new Set(refs.map((ref) => ref.table.toLowerCase()));
+  const related = new Set<string>();
+  for (const entity of schema.entities) {
+    const entityLower = entity.name.toLowerCase();
+    for (const fk of entity.foreignKeys ?? []) {
+      const target = fk.refEntity.toLowerCase();
+      // Outgoing edge from an already-referenced table…
+      if (referenced.has(entityLower) && !referenced.has(target)) {
+        related.add(target);
+      }
+      // …or incoming edge pointing at one.
+      if (referenced.has(target) && !referenced.has(entityLower)) {
+        related.add(entityLower);
+      }
+    }
+  }
+  return related;
+}
+
 function tableOptions(
   schema: SqlCompletionSchema,
   defaultBoost: number,
+  related?: Set<string>,
 ): Completion[] {
-  return schema.entities.map((entity) => ({
-    label: entity.name,
-    apply: quoteIdentifier(entity.name),
-    detail: entity.kind,
-    type: entityType(entity),
-    section: entitySection(entity),
-    boost:
-      entity.kind === "cte" ? BOOST.cteInTableContext : defaultBoost,
-  }));
+  return schema.entities.map((entity) => {
+    const base =
+      entity.kind === "cte" ? BOOST.cteInTableContext : defaultBoost;
+    const isRelated = related?.has(entity.name.toLowerCase()) ?? false;
+    return {
+      label: entity.name,
+      apply: quoteIdentifier(entity.name),
+      detail: entity.kind,
+      type: entityType(entity),
+      section: entitySection(entity),
+      info: entityInfo(entity),
+      boost: isRelated ? base + BOOST.relatedTableBump : base,
+    };
+  });
 }
 
 // Boost adjustments applied when the cursor's syntactic position predicts a
@@ -1327,13 +1972,23 @@ const KEYWORD_PRIMARY_BUMP = 30;
 const KEYWORD_SECONDARY_BUMP = 5;
 const KEYWORD_OFF_CONTEXT_PENALTY = 25;
 
+/** Keyword/function casing follows what the user is typing — a
+ *  lowercase prefix completes to `select`, anything else to `SELECT` —
+ *  the "match typed case" insertion mode of desktop SQL IDEs. Labels
+ *  always render uppercase; only the inserted text changes. */
+type KeywordCasing = "upper" | "lower";
+
+function casingOf(typed: string): KeywordCasing {
+  return /^[a-z]/.test(typed) ? "lower" : "upper";
+}
+
 function keywordOptions(
   dialect: SqlDialect,
   boost: number,
   keywordContext?: KeywordContext,
-  options: { includeFunctions?: boolean } = {},
+  options: { includeFunctions?: boolean; casing?: KeywordCasing } = {},
 ): Completion[] {
-  const { includeFunctions = true } = options;
+  const { includeFunctions = true, casing = "upper" } = options;
   const profile = DIALECT_PROFILES[dialect];
   const dialectKeywordSet = new Set(profile.keywords);
   const primary = keywordContext ? new Set(keywordContext.primary) : null;
@@ -1342,6 +1997,8 @@ function keywordOptions(
     : null;
   const restrict = keywordContext?.restrict ?? false;
   const hasContext = primary !== null;
+  const emitFunctions = includeFunctions && !restrict;
+  const functionLabels = emitFunctions ? new Set(profile.functions) : null;
 
   // Primary/secondary entries from the context may reference keywords
   // outside the active dialect (e.g. PRAGMA in Postgres). We keep them in
@@ -1369,6 +2026,10 @@ function keywordOptions(
     // active dialect doesn't recognize *and* isn't pinned by context.
     if (!restrict && !isPrimary && !isSecondary && !dialectKeywordSet.has(keyword))
       continue;
+    // A handful of DuckDB identifiers (LIST, MAP, STRUCT, RANGE) exist as
+    // both keyword and function. Showing both is duplicate noise — keep
+    // the callable form unless the context explicitly pinned the keyword.
+    if (functionLabels?.has(keyword) && !isPrimary && !isSecondary) continue;
     let kwBoost = boost;
     if (hasContext) {
       if (isPrimary) kwBoost = boost + KEYWORD_PRIMARY_BUMP;
@@ -1377,15 +2038,17 @@ function keywordOptions(
     }
     out.push({
       label: keyword,
+      apply: casing === "lower" ? keyword.toLowerCase() : undefined,
       type: "keyword",
       section: keywordSection,
       boost: kwBoost,
     });
   }
-  if (includeFunctions && !restrict) {
+  if (emitFunctions) {
     for (const fn of profile.functions) {
+      const insert = casing === "lower" ? fn.toLowerCase() : fn;
       out.push(
-        snippetCompletion(`${fn}(#{})`, {
+        snippetCompletion(`${insert}(#{})`, {
           label: fn,
           detail: "function",
           type: "function",
@@ -1398,12 +2061,39 @@ function keywordOptions(
   return out;
 }
 
+function typeOptions(
+  dialect: SqlDialect,
+  casing: KeywordCasing,
+): Completion[] {
+  return DIALECT_TYPES[dialect].map((typeName) => ({
+    label: typeName,
+    apply: casing === "lower" ? typeName.toLowerCase() : typeName,
+    detail: "type",
+    type: "type",
+    section: keywordSection,
+    boost: BOOST.typeInColumnDef,
+  }));
+}
+
+function formatColumnDetail(
+  entity: SqlCompletionEntity,
+  column: SqlCompletionColumn,
+  multipleEntities: boolean,
+): string {
+  const type = columnType(column);
+  if (!type) return entity.name;
+  const shortType = type.length > 24 ? `${type.slice(0, 23)}…` : type;
+  // With several tables in scope the owning table is the more valuable
+  // hint; single-table contexts show the type alone.
+  return multipleEntities ? `${entity.name} · ${shortType}` : shortType;
+}
+
 function columnOptions(
   schema: SqlCompletionSchema,
   statement: string,
   boost: number,
 ): Completion[] {
-  const references = extractTableReferences(statement);
+  const references = referenceMap(extractTableRefList(statement));
   const referencedTables = new Set(
     [...references.values()].map((name) => name.toLowerCase()),
   );
@@ -1418,26 +2108,28 @@ function columnOptions(
   const columnOwners = new Map<string, SqlCompletionEntity[]>();
   for (const entity of entities) {
     for (const column of entity.columns) {
-      const key = column.toLowerCase();
+      const key = columnName(column).toLowerCase();
       columnOwners.set(key, [...(columnOwners.get(key) ?? []), entity]);
     }
   }
 
+  const multipleEntities = entities.length > 1;
   const options: Completion[] = [];
   const seen = new Set<string>();
   for (const entity of entities) {
     for (const column of entity.columns) {
-      const owners = columnOwners.get(column.toLowerCase()) ?? [];
+      const name = columnName(column);
+      const owners = columnOwners.get(name.toLowerCase()) ?? [];
       const ambiguous = owners.length > 1;
-      const label = ambiguous ? `${entity.name}.${column}` : column;
+      const label = ambiguous ? `${entity.name}.${name}` : name;
       if (seen.has(label)) continue;
       seen.add(label);
       options.push({
         label,
         apply: ambiguous
-          ? `${quoteIdentifier(entity.name)}.${quoteIdentifier(column)}`
-          : quoteIdentifier(column),
-        detail: entity.name,
+          ? `${quoteIdentifier(entity.name)}.${quoteIdentifier(name)}`
+          : quoteIdentifier(name),
+        detail: formatColumnDetail(entity, column, multipleEntities),
         type: "property",
         section: columnSection,
         boost,
@@ -1447,28 +2139,201 @@ function columnOptions(
   return options;
 }
 
+/** Bare column names for a `USING (…)` list. Columns shared by two or
+ *  more of the joined tables float to the top (those are the only ones
+ *  USING accepts); the rest trail at low rank as a fallback. */
+function usingColumnOptions(
+  schema: SqlCompletionSchema,
+  statement: string,
+): Completion[] {
+  const references = referenceMap(extractTableRefList(statement));
+  const referencedTables = new Set(
+    [...references.values()].map((name) => name.toLowerCase()),
+  );
+  const entities = schema.entities.filter((entity) =>
+    referencedTables.has(entity.name.toLowerCase()),
+  );
+  if (entities.length === 0) return [];
+
+  const owners = new Map<string, { display: string; entities: string[] }>();
+  for (const entity of entities) {
+    for (const column of entity.columns) {
+      const name = columnName(column);
+      const key = name.toLowerCase();
+      const entry = owners.get(key) ?? { display: name, entities: [] };
+      entry.entities.push(entity.name);
+      owners.set(key, entry);
+    }
+  }
+
+  return [...owners.values()].map(({ display, entities: ownerNames }) => ({
+    label: display,
+    apply: quoteIdentifier(display),
+    detail: ownerNames.join(", "),
+    type: "property",
+    section: columnSection,
+    boost:
+      ownerNames.length > 1
+        ? BOOST.usingSharedColumn
+        : BOOST.usingOtherColumn,
+  }));
+}
+
 function qualifiedColumnOptions(
   schema: SqlCompletionSchema,
   statement: string,
   qualifier: string | undefined,
   boost: number,
+  includeStar: boolean,
 ): Completion[] {
   if (!qualifier) return [];
-  const references = extractTableReferences(statement);
-  const tableName =
-    references.get(qualifier.toLowerCase()) ?? qualifier;
-  const entity = schema.entities.find(
-    (item) => item.name.toLowerCase() === tableName.toLowerCase(),
-  );
+  const references = referenceMap(extractTableRefList(statement));
+  const tableName = references.get(qualifier.toLowerCase()) ?? qualifier;
+  const entity = findEntity(schema, tableName);
   if (!entity) return [];
-  return entity.columns.map((column) => ({
-    label: column,
-    apply: quoteIdentifier(column),
-    detail: entity.name,
+  const options: Completion[] = entity.columns.map((column) => ({
+    label: columnName(column),
+    apply: quoteIdentifier(columnName(column)),
+    detail: formatColumnDetail(entity, column, false),
     type: "property",
     section: columnSection,
     boost,
   }));
+  if (includeStar) {
+    options.unshift({
+      label: "*",
+      apply: "*",
+      detail: "all columns",
+      type: "constant",
+      section: columnSection,
+      boost: BOOST.starInQualified,
+    });
+  }
+  return options;
+}
+
+/** Display name for a table reference inside a join condition — the
+ *  alias when one was declared, the table name otherwise. */
+function refDisplay(ref: TableReference): string {
+  return ref.alias ?? ref.table;
+}
+
+function joinConditionCompletion(
+  left: TableReference,
+  leftColumn: string,
+  right: TableReference,
+  rightColumn: string,
+): Completion {
+  const label = `${refDisplay(left)}.${leftColumn} = ${refDisplay(right)}.${rightColumn}`;
+  const apply = `${quoteIdentifier(refDisplay(left))}.${quoteIdentifier(leftColumn)} = ${quoteIdentifier(refDisplay(right))}.${quoteIdentifier(rightColumn)}`;
+  return {
+    label,
+    apply,
+    type: "text",
+    section: joinSection,
+    boost: BOOST.joinCondition,
+  };
+}
+
+/** Ready-made `a.col = b.col` conditions for the `JOIN … ON |` slot.
+ *  Foreign-key metadata drives the suggestions when available (the
+ *  DataGrip behavior); otherwise we fall back to name-matching
+ *  heuristics (`x.customer_id = customers.id`, shared column names). */
+function joinConditionOptions(
+  schema: SqlCompletionSchema,
+  statementBefore: string,
+): Completion[] {
+  const refs = extractTableRefList(statementBefore);
+  if (refs.length < 2) return [];
+  const target = refs[refs.length - 1];
+  if (target.via !== "join") return [];
+  const others = refs.slice(0, -1);
+  const targetEntity = findEntity(schema, target.table);
+
+  const out: Completion[] = [];
+  const seen = new Set<string>();
+  const add = (completion: Completion) => {
+    if (seen.has(completion.label)) return;
+    seen.add(completion.label);
+    out.push(completion);
+  };
+
+  // 1. Foreign keys on the freshly-joined table pointing back at tables
+  //    already in the statement…
+  for (const fk of targetEntity?.foreignKeys ?? []) {
+    const other = others.find(
+      (ref) => ref.table.toLowerCase() === fk.refEntity.toLowerCase(),
+    );
+    if (other) {
+      add(joinConditionCompletion(target, fk.column, other, fk.refColumn));
+    }
+  }
+  // 2. …and foreign keys on already-referenced tables pointing at it.
+  for (const other of others) {
+    const otherEntity = findEntity(schema, other.table);
+    for (const fk of otherEntity?.foreignKeys ?? []) {
+      if (fk.refEntity.toLowerCase() === target.table.toLowerCase()) {
+        add(joinConditionCompletion(target, fk.refColumn, other, fk.column));
+      }
+    }
+  }
+
+  // 3. Heuristics when no FK metadata produced anything (e.g. imported
+  //    CSVs): shared column names, and `<entity>_id` ↔ `id` pairs.
+  if (out.length === 0 && targetEntity) {
+    const targetColumns = targetEntity.columns.map(columnName);
+    for (const other of others) {
+      const otherEntity = findEntity(schema, other.table);
+      if (!otherEntity) continue;
+      const otherColumns = new Set(
+        otherEntity.columns.map((column) => columnName(column).toLowerCase()),
+      );
+      for (const column of targetColumns) {
+        const lower = column.toLowerCase();
+        // A column named exactly the same on both sides is the classic
+        // join key — except bare `id`, which is both tables' own pk.
+        if (lower !== "id" && otherColumns.has(lower)) {
+          add(joinConditionCompletion(target, column, other, column));
+        }
+        // orders.customer_id ↔ customers.id
+        if (lower.endsWith("_id") && otherColumns.has("id")) {
+          const base = lower.slice(0, -3);
+          if (base && other.table.toLowerCase().startsWith(base)) {
+            add(joinConditionCompletion(target, column, other, "id"));
+          }
+        }
+      }
+      // customers JOIN … where the *other* side holds the FK-style column.
+      for (const column of otherEntity.columns.map(columnName)) {
+        const lower = column.toLowerCase();
+        if (lower.endsWith("_id")) {
+          const base = lower.slice(0, -3);
+          if (
+            base &&
+            target.table.toLowerCase().startsWith(base) &&
+            targetColumns.some((c) => c.toLowerCase() === "id")
+          ) {
+            add(joinConditionCompletion(target, "id", other, column));
+          }
+        }
+      }
+    }
+  }
+
+  return out.slice(0, 6);
+}
+
+function schemaNamesFor(
+  schema: SqlCompletionSchema,
+  dialect: SqlDialect,
+): Set<string> {
+  const names = new Set(
+    DEFAULT_SCHEMA_NAMES[dialect].map((name) => name.toLowerCase()),
+  );
+  for (const name of schema.schemas ?? []) {
+    names.add(name.toLowerCase());
+  }
+  return names;
 }
 
 function dedupeOptions(options: Completion[]): Completion[] {
@@ -1489,60 +2354,98 @@ export function createSqlCompletionSource(
 ): CompletionSource {
   const dialect: SqlDialect = options.dialect ?? "sqlite";
   return (context) => {
-    const info = inferCompletionContext(context, dialect);
+    const doc = context.state.doc.toString();
+    const { before, full } = statementAround(doc, context.pos);
+    const info = inferCompletionContext(context, before, dialect);
     if (!info) return null;
 
-    const statement = currentStatementBeforeCursor(
-      context.state.doc.toString(),
-      context.pos,
-    );
-    const localSchema = effectiveSchema(schema, statement);
+    const typed = doc.slice(info.from, context.pos);
+    const casing = casingOf(typed);
+    const localSchema = effectiveSchema(schema, full);
 
     const kw = info.keywordContext;
     const completions = (() => {
       switch (info.mode) {
-        case "tables":
+        case "tables": {
+          const related = info.joinTableSlot
+            ? fkRelatedTables(localSchema, extractTableRefList(before))
+            : undefined;
           return [
-            ...tableOptions(localSchema, BOOST.tableInTableContext),
-            ...keywordOptions(dialect, BOOST.keywordInTableContext, kw),
+            ...tableOptions(localSchema, BOOST.tableInTableContext, related),
+            ...keywordOptions(dialect, BOOST.keywordInTableContext, kw, {
+              casing,
+            }),
           ];
+        }
         case "columns": {
-          const cols = columnOptions(
-            localSchema,
-            statement,
-            BOOST.columnInColumnContext,
-          );
-          if (cols.length === 0) {
+          const cols = info.usingSlot
+            ? usingColumnOptions(localSchema, full)
+            : columnOptions(localSchema, full, BOOST.columnInColumnContext);
+          const joins = info.joinConditionSlot
+            ? joinConditionOptions(localSchema, before)
+            : [];
+          if (cols.length === 0 && joins.length === 0) {
             // No FROM/JOIN/UPDATE/INTO target in scope yet — column suggestions
             // would be misleading, so offer keywords + tables instead.
             return [
-              ...keywordOptions(dialect, BOOST.keywordInColumnContext, kw),
+              ...keywordOptions(dialect, BOOST.keywordInColumnContext, kw, {
+                casing,
+              }),
               ...tableOptions(localSchema, BOOST.tableInColumnContext),
             ];
           }
           return [
+            ...joins,
             ...cols,
-            ...keywordOptions(dialect, BOOST.keywordInColumnContext, kw),
+            ...keywordOptions(dialect, BOOST.keywordInColumnContext, kw, {
+              casing,
+            }),
             ...tableOptions(localSchema, BOOST.tableInColumnContext),
           ];
         }
-        case "qualified-columns":
-          return qualifiedColumnOptions(
+        case "qualified-columns": {
+          const qualified = qualifiedColumnOptions(
             localSchema,
-            statement,
+            full,
             info.qualifier,
             BOOST.qualifiedColumn,
+            info.viaDot ?? false,
           );
+          if (qualified.length > 0) return qualified;
+          // `public.|` / `main.|` — a schema qualifier completes to its
+          // tables rather than columns.
+          if (
+            info.qualifier &&
+            schemaNamesFor(schema, dialect).has(info.qualifier.toLowerCase())
+          ) {
+            return tableOptions(localSchema, BOOST.qualifiedColumn);
+          }
+          return [];
+        }
         case "naming":
           // New-object name slot: only legal trailing keywords like
           // `IF NOT EXISTS`. Tables and free functions would mislead the user
           // here, so we suppress them entirely.
           return keywordOptions(dialect, BOOST.keywordInKeywordContext, kw, {
             includeFunctions: false,
+            casing,
           });
+        case "column-def":
+          // CREATE TABLE column definitions: data types (in the type
+          // slot) plus the legal constraint keywords. No tables, no
+          // free functions.
+          return [
+            ...(info.columnDefSlot === "type" ? typeOptions(dialect, casing) : []),
+            ...keywordOptions(dialect, BOOST.keywordInKeywordContext, kw, {
+              includeFunctions: false,
+              casing,
+            }),
+          ];
         case "keywords":
           return [
-            ...keywordOptions(dialect, BOOST.keywordInKeywordContext, kw),
+            ...keywordOptions(dialect, BOOST.keywordInKeywordContext, kw, {
+              casing,
+            }),
             ...tableOptions(localSchema, BOOST.tableInKeywordContext),
           ];
       }
@@ -1553,7 +2456,12 @@ export function createSqlCompletionSource(
     return {
       from: info.from,
       options: uniqueOptions,
-      validFor: partialIdentifierPattern,
+      // Keep the result alive while the user extends the identifier, but
+      // force a re-query when the casing style flips so keyword inserts
+      // track what's actually being typed.
+      validFor: (text: string) =>
+        (text === "" || bareIdentifierPattern.test(text)) &&
+        casingOf(text) === casing,
     } satisfies CompletionResult;
   };
 }


### PR DESCRIPTION
Reviews and upgrades the shared autocomplete engine used by the SQLite, Postgres, and DuckDB playgrounds to match the behavior of desktop SQL IDEs (DataGrip/DBeaver).

## What was wrong

- **Prefix-only analysis** — completion only saw text *before* the cursor, so the most common editing pattern (`SELECT | FROM customers`) suggested no columns and `c.|` couldn't resolve aliases declared later in the statement.
- **Section ranks silently overrode all boosts** — `@codemirror/autocomplete` orders static-ranked sections *before* per-option scores, so the Tables group always rendered above Columns/Keywords, defeating the existing context-boost design (invisible to the old tests, which sorted by boost manually).
- **Enter hijacked newlines** — `editorSetup.ts` filtered Enter out of the completion keymap with a comment saying "Enter always inserts a newline", but `autocompletion()` injects its own highest-precedence keymap (including Enter→accept), shadowing the filtered copy entirely. Caught by a live-app probe.
- **No types, FKs, schema qualifiers, or DDL contexts**, and the tokenizer choked on numeric/string literals (`WHERE x > 1.5 |` offered expression starters instead of `AND`/`OR`).

## What's new

| Behavior | Example |
|---|---|
| Full-statement scope | `SELECT \| FROM customers` → customer columns |
| FK join conditions | `JOIN cards c ON \|` → `c.user_id = u.user_id` (top suggestion) |
| Related-table ranking | `FROM vendors JOIN \|` → `transactions` first |
| Column types in details | `annual_income  INTEGER`, `total  users · REAL` |
| Schema qualifiers | `public.\|` / `main.\|` → tables; `FROM public.t` resolves columns |
| Qualified star | `u.\|` → `*`, then columns |
| DDL contexts | types after `CREATE TABLE t (id \|`, constraints after a type, `REFERENCES \|` → tables, `REFERENCES t(\|` / `CREATE INDEX … ON t(\|` / `ALTER TABLE … DROP COLUMN \|` → columns |
| Case-following keywords | `sel` + Tab → `select`; `SEL` + Tab → `SELECT` |
| Literal-aware tokenizer | `= 'x' \|`, `> 1.5 \|` → `AND`/`OR`; `LIMIT 10 \|` → `OFFSET` |
| Relevance-ordered groups | sections use `rank: "dynamic"` so the best-matching group leads |
| Catalog upgrades | SQLite window fns/`GROUP_CONCAT`/`TRIM`, PG math/string/array fns, DuckDB `read_csv`/`unnest`, keyword↔function dedupe, `NATURAL`, CASE/OVER slots |

Playgrounds now feed column types, foreign keys, and schema names into the completion schema (Postgres/DuckDB from their cached schema tree; SQLite via `listColumns`/`listForeignKeys`).

## Verification

- 80 unit tests for the completion source (including a simulation of CodeMirror's real section+boost render order) — full suite: 506 passing, `tsc` clean, no new lint warnings.
- Playwright drove all three live playgrounds: tables after `FROM`, typed column details after `WHERE`, FK join condition first after `ON`, alias-dot, mid-statement completion, lowercase insertion, CREATE TABLE types, Enter-inserts-newline, ArrowDown/Tab navigation, Escape close, `public.` on Postgres, DuckDB dialect keywords.

https://claude.ai/code/session_01622fiPGWZ99Mn6cWqr8EVG

---
_Generated by [Claude Code](https://claude.ai/code/session_01622fiPGWZ99Mn6cWqr8EVG)_