### PR TITLE
Load Chinook/Northwind sample databases from GitHub via raw.githubusercontent

### DIFF
--- a/__tests__/remoteDatasets.test.ts
+++ b/__tests__/remoteDatasets.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Remote-dataset loading tests.
+ *
+ * Covers the URL building / caching helpers in runtime/remoteDatasets.ts
+ * and the PGlite script preparation in runtime/postgres.ts. The fetch
+ * tests stub the global fetch — no network access required.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DATASLOPE_DATASETS_SOURCE,
+  datasetFileName,
+  fetchDatasetBytes,
+  fetchDatasetText,
+  rawGitHubUrl,
+  resolveDatasetUrl,
+} from "../app/_components/runtime/remoteDatasets";
+import { preparePostgresScriptForPglite } from "../app/_components/runtime/postgres";
+
+describe("rawGitHubUrl", () => {
+  it("builds a raw.githubusercontent.com URL for the default datasets repo", () => {
+    expect(rawGitHubUrl("sqlite/chinook_sqlite.sql")).toBe(
+      "https://raw.githubusercontent.com/dataslope/datasets/main/sqlite/chinook_sqlite.sql",
+    );
+  });
+
+  it("strips leading slashes from the path", () => {
+    expect(rawGitHubUrl("/postgres/northwind_postgres.sql")).toBe(
+      "https://raw.githubusercontent.com/dataslope/datasets/main/postgres/northwind_postgres.sql",
+    );
+  });
+
+  it("supports other repositories and refs", () => {
+    expect(
+      rawGitHubUrl("data/trips.parquet", {
+        owner: "someone",
+        repo: "their-datasets",
+        ref: "v1.2.0",
+      }),
+    ).toBe(
+      "https://raw.githubusercontent.com/someone/their-datasets/v1.2.0/data/trips.parquet",
+    );
+  });
+
+  it("defaults to the dataslope/datasets repo on main", () => {
+    expect(DATASLOPE_DATASETS_SOURCE).toEqual({
+      owner: "dataslope",
+      repo: "datasets",
+      ref: "main",
+    });
+  });
+});
+
+describe("resolveDatasetUrl", () => {
+  it("treats repo-relative paths as paths in the default repo", () => {
+    expect(resolveDatasetUrl("sqlite/northwind_sqlite.sql")).toBe(
+      "https://raw.githubusercontent.com/dataslope/datasets/main/sqlite/northwind_sqlite.sql",
+    );
+  });
+
+  it("passes full URLs through untouched", () => {
+    const url = "https://raw.githubusercontent.com/other/repo/main/x.sql";
+    expect(resolveDatasetUrl(url)).toBe(url);
+  });
+});
+
+describe("datasetFileName", () => {
+  it("returns the basename of a repo path", () => {
+    expect(datasetFileName("duckdb/trips.parquet")).toBe("trips.parquet");
+  });
+
+  it("returns the basename of a full URL, ignoring query/hash", () => {
+    expect(
+      datasetFileName("https://example.com/data/sales.csv?token=abc#frag"),
+    ).toBe("sales.csv");
+  });
+
+  it("returns bare filenames as-is", () => {
+    expect(datasetFileName("chinook.sqlite")).toBe("chinook.sqlite");
+  });
+});
+
+describe("fetchDatasetText / fetchDatasetBytes", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches text and memoises by URL", async () => {
+    const fetchMock = vi.fn(async () => new Response("SELECT 1;"));
+    vi.stubGlobal("fetch", fetchMock);
+    const first = await fetchDatasetText("memo/one.sql");
+    const second = await fetchDatasetText("memo/one.sql");
+    expect(first).toBe("SELECT 1;");
+    expect(second).toBe("SELECT 1;");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://raw.githubusercontent.com/dataslope/datasets/main/memo/one.sql",
+    );
+  });
+
+  it("fetches binary files as Uint8Array", async () => {
+    const payload = new Uint8Array([0x50, 0x41, 0x52, 0x31]); // "PAR1"
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(payload.slice())));
+    const bytes = await fetchDatasetBytes("memo/two.parquet");
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(Array.from(bytes)).toEqual([0x50, 0x41, 0x52, 0x31]);
+  });
+
+  it("reports HTTP failures with the URL and does not memoise them", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("nope", { status: 404 }))
+      .mockResolvedValueOnce(new Response("SELECT 2;"));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchDatasetText("memo/three.sql")).rejects.toThrow(
+      /HTTP 404/,
+    );
+    // The failure must be evicted so the next attempt retries.
+    await expect(fetchDatasetText("memo/three.sql")).resolves.toBe(
+      "SELECT 2;",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("wraps network errors in a descriptive message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("Failed to fetch");
+      }),
+    );
+    await expect(fetchDatasetText("memo/four.sql")).rejects.toThrow(
+      /Could not download the sample dataset .*memo\/four\.sql.*Failed to fetch/,
+    );
+  });
+});
+
+describe("preparePostgresScriptForPglite", () => {
+  it("strips psql meta-commands and CREATE/DROP DATABASE lines", () => {
+    const script = [
+      "DROP DATABASE IF EXISTS chinook_auto_increment;",
+      "CREATE DATABASE chinook_auto_increment;",
+      "\\c chinook_auto_increment;",
+      "CREATE TABLE album (album_id INT);",
+      "INSERT INTO album VALUES (1);",
+    ].join("\n");
+    expect(preparePostgresScriptForPglite(script)).toBe(
+      ["CREATE TABLE album (album_id INT);", "INSERT INTO album VALUES (1);"].join(
+        "\n",
+      ),
+    );
+  });
+
+  it("keeps statements that merely mention databases", () => {
+    const script = [
+      "SELECT 'CREATE DATABASE literal';",
+      "CREATE TABLE create_database_log (id INT);",
+    ].join("\n");
+    const prepared = preparePostgresScriptForPglite(script);
+    expect(prepared).toContain("SELECT 'CREATE DATABASE literal';");
+    expect(prepared).toContain("CREATE TABLE create_database_log (id INT);");
+  });
+
+  it("handles indented meta-commands and mixed case", () => {
+    const script = ["  \\connect foo", "  create database foo;", "SELECT 1;"].join(
+      "\n",
+    );
+    expect(preparePostgresScriptForPglite(script)).toBe("SELECT 1;");
+  });
+});

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -158,6 +158,14 @@ export interface SqlChallengeCardProps {
    *  tables, populates seed data, etc. Replaces DataCamp's
    *  `pre-exercise-code` block. */
   initSql?: string;
+  /** Remote dataset to load before `initSql`: a path inside the
+   *  dataslope/datasets GitHub repo (e.g. `sqlite/chinook_sqlite.sql`)
+   *  or a full URL. The script is downloaded from
+   *  raw.githubusercontent.com and executed against the card's engine,
+   *  so a card can clone a complete sample database (Chinook,
+   *  Northwind, …) without embedding it. `initSql` still runs after it
+   *  for any card-specific extras. */
+  remoteInitSql?: string;
   /** Starter SQL shown in the editor. */
   starterCode: string;
   /** Canonical reference solution. When provided, a "Show Solution"
@@ -260,6 +268,26 @@ export function createEngineForDialect(dialect: SqlDialect): Promise<SqlEngineLi
     case "postgres":
       return createPostgresChallengeEngine();
   }
+}
+
+/** Download a remote dataset script (a path inside the
+ *  dataslope/datasets GitHub repo, or a full URL) and prepare it for
+ *  the given dialect's embedded engine. Used by the `remoteInitSql`
+ *  prop of `<SqlChallengeCard>` and `<SqlCodeBlock>`. */
+export async function fetchRemoteInitSql(
+  dialect: SqlDialect,
+  pathOrUrl: string,
+): Promise<string> {
+  const { fetchDatasetText } = await import("./runtime/remoteDatasets");
+  const script = await fetchDatasetText(pathOrUrl);
+  if (dialect === "postgres") {
+    // Scripts authored for a full Postgres server may open with psql
+    // meta-commands / CREATE DATABASE lines that can never run in
+    // PGlite — strip them before execution.
+    const { preparePostgresScriptForPglite } = await import("./runtime/postgres");
+    return preparePostgresScriptForPglite(script);
+  }
+  return script;
 }
 
 /** Default schema where a dialect's user tables live unless qualified
@@ -818,6 +846,7 @@ export default function SqlChallengeCard({
   badge = "SQL Challenge",
   instructions,
   initSql,
+  remoteInitSql,
   starterCode,
   solutionSql,
   tables,
@@ -1089,8 +1118,19 @@ export default function SqlChallengeCard({
   const ensureEngine = useCallback(async (): Promise<SqlEngineLike> => {
     if (!enginePromiseRef.current) {
       enginePromiseRef.current = (async () => {
+        // Start the dataset download while the engine boots — the two
+        // are independent and the WASM fetch usually dominates. The
+        // no-op catch keeps an engine-boot failure from leaving this
+        // promise's rejection unhandled; awaiting it below still throws.
+        const remoteSqlPromise = remoteInitSql
+          ? fetchRemoteInitSql(dialect, remoteInitSql)
+          : null;
+        remoteSqlPromise?.catch(() => {});
         const engine = await createEngineForDialect(dialect);
         setEngineLabel(`${engine.label} ${engine.version}`.trim());
+        if (remoteSqlPromise) {
+          await engine.exec(await remoteSqlPromise);
+        }
         if (initSql && initSql.trim()) {
           await engine.exec(initSql);
         }
@@ -1103,7 +1143,7 @@ export default function SqlChallengeCard({
       });
     }
     return enginePromiseRef.current;
-  }, [dialect, initSql]);
+  }, [dialect, initSql, remoteInitSql]);
 
   // ─── Table viewer ───────────────────────────────────────────────────
   // All table-list / paging / loading state lives in the shared hook so

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -59,6 +59,7 @@ import styles from "./ChallengeCard.module.css";
 import {
   createEngineForDialect,
   DialectGlyph,
+  fetchRemoteInitSql,
   sqlFormatterLanguage,
   TableViewer,
   useSqlTableViewer,
@@ -80,6 +81,14 @@ export interface SqlCodeBlockProps {
   /** Setup SQL run once before the first execution — creates tables,
    *  seeds data, etc. */
   initSql?: string;
+  /** Remote dataset to load before `initSql`: a path inside the
+   *  dataslope/datasets GitHub repo (e.g. `sqlite/chinook_sqlite.sql`)
+   *  or a full URL. The script is downloaded from
+   *  raw.githubusercontent.com and executed against the block's engine,
+   *  so a block can clone a complete sample database (Chinook,
+   *  Northwind, …) without embedding it. `initSql` still runs after it
+   *  for any block-specific extras. */
+  remoteInitSql?: string;
   /** Starter SQL shown in the editor. */
   starterCode: string;
   /** Hand-picked tables (and optional schemas) to display in the table
@@ -109,6 +118,7 @@ export default function SqlCodeBlock({
   title,
   badge = "SQL",
   initSql,
+  remoteInitSql,
   starterCode,
   tables,
   tableRowLimit = 50,
@@ -284,8 +294,19 @@ export default function SqlCodeBlock({
   const ensureEngine = useCallback(async (): Promise<SqlEngineLike> => {
     if (!enginePromiseRef.current) {
       enginePromiseRef.current = (async () => {
+        // Start the dataset download while the engine boots — the two
+        // are independent and the WASM fetch usually dominates. The
+        // no-op catch keeps an engine-boot failure from leaving this
+        // promise's rejection unhandled; awaiting it below still throws.
+        const remoteSqlPromise = remoteInitSql
+          ? fetchRemoteInitSql(dialect, remoteInitSql)
+          : null;
+        remoteSqlPromise?.catch(() => {});
         const engine = await createEngineForDialect(dialect);
         setEngineLabel(`${engine.label} ${engine.version}`.trim());
+        if (remoteSqlPromise) {
+          await engine.exec(await remoteSqlPromise);
+        }
         if (initSql && initSql.trim()) {
           await engine.exec(initSql);
         }
@@ -298,7 +319,7 @@ export default function SqlCodeBlock({
       });
     }
     return enginePromiseRef.current;
-  }, [dialect, initSql]);
+  }, [dialect, initSql, remoteInitSql]);
 
   // ─── Table viewer ───────────────────────────────────────────────────
   // Shared with `<SqlChallengeCard>` so both stay consistent.

--- a/app/_components/runtime/duckdb.ts
+++ b/app/_components/runtime/duckdb.ts
@@ -23,6 +23,7 @@ import {
   DUCKDB_BLANK_DATABASE,
   type DuckDbSampleDatabase,
 } from "./duckdbSamples";
+import { datasetFileName, fetchDatasetBytes, fetchDatasetText } from "./remoteDatasets";
 import {
   toDateOnlyString,
   unscaledDecimalToString,
@@ -796,14 +797,38 @@ async function bootstrapDatabase(
   db: AsyncDuckDB,
 ): Promise<DuckDbConnection> {
   const run = async (): Promise<DuckDbConnection> => {
+    // Resolve remote payloads first — the seed script and any data
+    // files (parquet/CSV/…) the sample registers. Downloading before
+    // the cleanup step means a failed download leaves the current
+    // catalog intact.
+    const seedSql = sample.remoteSql
+      ? await fetchDatasetText(sample.remoteSql)
+      : sample.sql;
+    const remoteFiles = await Promise.all(
+      (sample.remoteFiles ?? []).map(async (file) => ({
+        name: file.registerAs ?? datasetFileName(file.path),
+        bytes: await fetchDatasetBytes(file.path),
+      })),
+    );
     const conn = await db.connect();
     // Force consistent timestamp formatting for reproducible output.
     await conn.query("SET TimeZone='UTC'");
     // Clear any previously loaded sample so that revisiting the page or
     // switching samples never hits "Table with name … already exists!" errors.
     await cleanDuckDbSchema(conn);
-    if (sample.sql && sample.sql.trim()) {
-      const stmts = splitDuckDbStatements(sample.sql);
+    for (const { name, bytes } of remoteFiles) {
+      // Drop any same-named file from a previous bootstrap (re-register
+      // throws), and hand DuckDB a copy — the buffer is transferred to
+      // its worker, which would detach the module-level bytes cache.
+      try {
+        await db.dropFile?.(name);
+      } catch {
+        /* not registered yet */
+      }
+      await db.registerFileBuffer(name, bytes.slice());
+    }
+    if (seedSql && seedSql.trim()) {
+      const stmts = splitDuckDbStatements(seedSql);
       for (const stmt of stmts) {
         await conn.query(stmt);
       }

--- a/app/_components/runtime/duckdbSamples.ts
+++ b/app/_components/runtime/duckdbSamples.ts
@@ -6,8 +6,32 @@ import {
   type SqlSampleDatabaseBase,
 } from "./sqlSamples";
 
+/** A remote data file registered with duckdb-wasm's virtual filesystem
+ *  before a sample's seed SQL runs. */
+export interface DuckDbRemoteFile {
+  /** Path inside the dataslope/datasets GitHub repo, or a full URL. */
+  path: string;
+  /** Filename to register in the virtual filesystem — what the seed SQL
+   *  refers to, e.g. `read_parquet('trips.parquet')`. Defaults to the
+   *  basename of `path`. */
+  registerAs?: string;
+}
+
 export interface DuckDbSampleDatabase extends SqlSampleDatabaseBase {
-  sql: string;
+  /** Inline DDL + seed SQL. Ignored when `remoteSql` is set. */
+  sql?: string;
+  /** Path (inside the dataslope/datasets GitHub repo) or full URL of a
+   *  SQL script that creates *and* populates the database, fetched from
+   *  raw.githubusercontent.com when the sample is loaded — see
+   *  remoteDatasets.ts. The script itself can also read remote data
+   *  directly (e.g. `... FROM read_parquet('https://raw.githubusercontent.com/…')`),
+   *  since duckdb-wasm can query CORS-enabled https URLs natively. */
+  remoteSql?: string;
+  /** Remote data files (`.parquet`, `.csv`, `.json`, …) fetched from
+   *  the datasets repo and registered with duckdb-wasm's virtual
+   *  filesystem before the seed SQL runs, so `sql`/`remoteSql` can
+   *  query them by name: `SELECT * FROM read_parquet('trips.parquet')`. */
+  remoteFiles?: readonly DuckDbRemoteFile[];
   defaultTabs: QueryTabSeed[];
 }
 

--- a/app/_components/runtime/postgres.ts
+++ b/app/_components/runtime/postgres.ts
@@ -21,6 +21,7 @@ import {
   type PostgresSampleDatabase,
 } from "./postgresSamples";
 import { PGLITE_WORKER_CDN } from "./cdn";
+import { fetchDatasetText } from "./remoteDatasets";
 import { toDateOnlyString } from "./valueFormat";
 
 let _pgliteWorkerModulePromise: Promise<{ PGliteWorker: typeof PGliteWorkerType }> | null = null;
@@ -301,6 +302,35 @@ async function createFreshWorker(opts: { dataDir?: string } = {}): Promise<PGlit
   ) as unknown as PGlite;
 }
 
+/** Prepare a SQL script authored for a full Postgres server so it can
+ *  run inside PGlite. Dumps and distribution scripts (e.g. the Chinook
+ *  release scripts) open with psql meta-commands and CREATE/DROP
+ *  DATABASE statements; PGlite is a single-database embedded build, so
+ *  those lines can never succeed and are dropped. Works line-by-line —
+ *  both constructs are single-line statements in practice. */
+export function preparePostgresScriptForPglite(sql: string): string {
+  return sql
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith("\\")) return false; // psql meta-command (\c, \connect, …)
+      if (/^(CREATE|DROP)\s+DATABASE\b/i.test(trimmed)) return false;
+      return true;
+    })
+    .join("\n");
+}
+
+/** Resolve the SQL that seeds `sample`: its inline `sql`, or — for
+ *  remote samples — the script fetched from the datasets repo, prepared
+ *  for PGlite. Resolve *before* tearing anything down so a failed
+ *  download leaves the current database intact. */
+async function resolveSampleSql(sample: PostgresSampleDatabase): Promise<string> {
+  if (sample.remoteSql) {
+    return preparePostgresScriptForPglite(await fetchDatasetText(sample.remoteSql));
+  }
+  return sample.sql ?? "";
+}
+
 /** True when the connected PGlite cluster already has at least one
  *  user table in the `public` schema — i.e. it is an existing OPFS
  *  workspace we should *not* re-seed. */
@@ -337,7 +367,8 @@ async function createFreshDatabase(
   if (opts.dataDir && !opts.forceSeed && (await pgHasUserTables(db))) {
     return db;
   }
-  if (sample.sql) await db.exec(sample.sql);
+  const sql = await resolveSampleSql(sample);
+  if (sql) await db.exec(sql);
   return db;
 }
 
@@ -366,6 +397,10 @@ export async function createPostgresEngine(
    *  legacy "spin up a brand-new in-memory PGlite per sample" path. */
   async function rebuildForSample(target: PostgresSampleDatabase): Promise<PGlite> {
     if (dataDir) {
+      // Resolve (and, for remote samples, download) the seed SQL before
+      // wiping the cluster, so a failed download can't leave the
+      // workspace empty.
+      const sql = await resolveSampleSql(target);
       // In-place reset of the persistent cluster. PGlite supports
       // `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` to wipe
       // every user object in one statement; we keep extensions intact.
@@ -375,7 +410,7 @@ export async function createPostgresEngine(
         // If the bulk reset fails (e.g. permissions on a system extension),
         // fall through to per-table drops as a best-effort fallback.
       }
-      if (target.sql) await db.exec(target.sql);
+      if (sql) await db.exec(sql);
       return db;
     }
     const next = await createFreshDatabase(target, { dataDir, forceSeed: true });
@@ -385,8 +420,11 @@ export async function createPostgresEngine(
 
   const engine: PostgresEngine = {
     async loadSampleDatabase(id) {
-      sample = findPostgresSampleDatabase(id);
-      db = await rebuildForSample(sample);
+      // Rebuild before adopting the new sample so a failed download /
+      // seed leaves both the database and `activeSample()` unchanged.
+      const target = findPostgresSampleDatabase(id);
+      db = await rebuildForSample(target);
+      sample = target;
       return sample;
     },
 
@@ -958,7 +996,10 @@ export async function createPostgresEngine(
       const next = await createFreshWorker();
       await next.waitReady;
       try {
-        await next.exec(sql);
+        // Dumps taken from a full Postgres server often open with
+        // `\connect` / CREATE DATABASE lines that can never run in
+        // PGlite — strip them instead of failing the whole import.
+        await next.exec(preparePostgresScriptForPglite(sql));
       } catch (err) {
         try {
           await next.close();

--- a/app/_components/runtime/postgresSamples.ts
+++ b/app/_components/runtime/postgresSamples.ts
@@ -7,7 +7,14 @@ import {
 } from "./sqlSamples";
 
 export interface PostgresSampleDatabase extends SqlSampleDatabaseBase {
-  sql: string;
+  /** Inline DDL + seed SQL. Ignored when `remoteSql` is set. */
+  sql?: string;
+  /** Path (inside the dataslope/datasets GitHub repo) or full URL of a
+   *  SQL script that creates *and* populates the database. Fetched from
+   *  raw.githubusercontent.com when the sample is loaded and prepared
+   *  for PGlite (psql meta-commands and CREATE/DROP DATABASE statements
+   *  stripped) — see remoteDatasets.ts and postgres.ts. */
+  remoteSql?: string;
   defaultTabs: QueryTabSeed[];
 }
 
@@ -436,253 +443,36 @@ const CREDIT_CARD_TABS: QueryTabSeed[] = [
   },
 ];
 
-const CHINOOK_SQL = `
-CREATE TABLE artists (artist_id integer PRIMARY KEY, name text NOT NULL);
-CREATE TABLE albums (album_id integer PRIMARY KEY, title text NOT NULL, artist_id integer REFERENCES artists(artist_id));
-CREATE TABLE tracks (
-  track_id integer PRIMARY KEY,
-  name text NOT NULL,
-  album_id integer REFERENCES albums(album_id),
-  genre text,
-  milliseconds integer,
-  unit_price numeric(10,2),
-  duration_seconds numeric(10,1) GENERATED ALWAYS AS (ROUND(milliseconds / 1000.0, 1)) STORED
-);
-CREATE TABLE customers (
-  customer_id integer PRIMARY KEY,
-  first_name text,
-  last_name text,
-  country text,
-  email text,
-  full_name text GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED
-);
-CREATE TABLE invoices (
-  invoice_id integer PRIMARY KEY,
-  customer_id integer REFERENCES customers(customer_id),
-  invoice_date date,
-  billing_country text,
-  total numeric(10,2)
-);
-CREATE TABLE invoice_items (
-  invoice_item_id integer PRIMARY KEY,
-  invoice_id integer REFERENCES invoices(invoice_id),
-  track_id integer REFERENCES tracks(track_id),
-  unit_price numeric(10,2),
-  quantity integer
-);
-CREATE INDEX idx_albums_artist_id ON albums(artist_id);
-CREATE INDEX idx_tracks_album_id ON tracks(album_id);
-CREATE INDEX idx_invoices_customer_id ON invoices(customer_id);
-CREATE INDEX idx_invoice_items_invoice_id ON invoice_items(invoice_id);
-
-INSERT INTO artists VALUES
-  (1,'AC/DC'),(2,'Accept'),(3,'Aerosmith'),(4,'Alanis Morissette'),
-  (5,'Alice In Chains'),(6,'Antônio Carlos Jobim'),(7,'Apocalyptica'),
-  (8,'Audioslave'),(9,'BackBeat'),(10,'Billy Cobham');
-INSERT INTO albums VALUES
-  (1,'For Those About To Rock We Salute You',1),
-  (2,'Balls to the Wall',2),
-  (3,'Restless and Wild',2),
-  (4,'Let There Be Rock',1),
-  (5,'Big Ones',3),
-  (6,'Jagged Little Pill',4),
-  (7,'Facelift',5),
-  (8,'Warner 25 Anos',6),
-  (9,'Plays Metallica By Four Cellos',7),
-  (10,'Audioslave',8);
-INSERT INTO tracks (track_id, name, album_id, genre, milliseconds, unit_price) VALUES
-  (1,'For Those About To Rock (We Salute You)',1,'Rock',343719,0.99),
-  (2,'Put The Finger On You',1,'Rock',205662,0.99),
-  (3,'Let''s Get It Up',1,'Rock',233926,0.99),
-  (4,'Inject The Venom',1,'Rock',210834,0.99),
-  (5,'Snowballed',1,'Rock',203102,0.99),
-  (6,'Balls to the Wall',2,'Rock',342562,0.99),
-  (7,'Fast As a Shark',3,'Rock',230619,0.99),
-  (8,'Restless and Wild',3,'Rock',252051,0.99),
-  (9,'Princess of the Dawn',3,'Rock',375418,0.99),
-  (10,'Go Down',4,'Rock',313398,0.99),
-  (11,'Dream On',5,'Rock',275866,0.99),
-  (12,'Walk This Way',5,'Rock',211098,0.99),
-  (13,'All I Really Want',6,'Rock',284891,0.99),
-  (14,'You Oughta Know',6,'Rock',249234,0.99),
-  (15,'Ironic',6,'Rock',229733,0.99),
-  (16,'Man In The Box',7,'Alternative',286641,0.99),
-  (17,'Them Bones',7,'Alternative',150221,0.99),
-  (18,'Garota De Ipanema',8,'Latin',285673,0.99),
-  (19,'Enter Sandman',9,'Classical',214665,0.99),
-  (20,'Cochise',10,'Alternative',222380,0.99);
-INSERT INTO customers (customer_id, first_name, last_name, country, email) VALUES
-  (1,'Luís','Gonçalves','Brazil','luisg@embraer.com.br'),
-  (2,'Leonie','Köhler','Germany','leonekohler@surfeu.de'),
-  (3,'François','Tremblay','Canada','ftremblay@gmail.com'),
-  (4,'Bjørn','Hansen','Norway','bjorn.hansen@yahoo.no'),
-  (5,'František','Wichterlová','Czech Republic','frantisekw@jetbrains.com'),
-  (6,'Helena','Holý','Czech Republic','hholy@gmail.com'),
-  (7,'Astrid','Gruber','Austria','astrid.gruber@apple.at'),
-  (8,'Daan','Peeters','Belgium','daan_peeters@apple.be'),
-  (9,'Kara','Nielsen','Denmark','kara.nielsen@jubii.dk'),
-  (10,'Eduardo','Martins','Brazil','eduardo@woodstock.com.br');
-INSERT INTO invoices VALUES
-  (1,1,'2023-01-01','Brazil',1.98),
-  (2,2,'2023-01-02','Germany',3.96),
-  (3,3,'2023-01-03','Canada',5.94),
-  (4,4,'2023-01-04','Norway',8.91),
-  (5,5,'2023-01-05','Czech Republic',13.86),
-  (6,6,'2023-02-01','Czech Republic',0.99),
-  (7,7,'2023-02-02','Austria',1.98),
-  (8,8,'2023-02-03','Belgium',3.96),
-  (9,9,'2023-02-04','Denmark',5.94),
-  (10,10,'2023-02-05','Brazil',8.91),
-  (11,1,'2023-03-01','Brazil',13.86),
-  (12,2,'2023-03-02','Germany',0.99),
-  (13,3,'2023-03-03','Canada',1.98),
-  (14,4,'2023-03-04','Norway',7.92),
-  (15,5,'2023-03-05','Czech Republic',1.98);
-INSERT INTO invoice_items VALUES
-  (1,1,1,0.99,1),(2,1,2,0.99,1),
-  (3,2,3,0.99,1),(4,2,4,0.99,1),(5,2,5,0.99,1),(6,2,6,0.99,1),
-  (7,3,7,0.99,1),(8,3,8,0.99,1),(9,3,9,0.99,1),(10,3,10,0.99,1),(11,3,11,0.99,1),(12,3,12,0.99,1),
-  (13,4,13,0.99,1),(14,4,14,0.99,1),(15,4,15,0.99,1),(16,4,16,0.99,1),(17,4,17,0.99,1),(18,4,18,0.99,1),(19,4,19,0.99,1),(20,4,20,0.99,1),(21,4,1,0.99,1),
-  (22,5,2,0.99,1),(23,5,3,0.99,1),(24,5,4,0.99,1),(25,5,5,0.99,1),(26,5,6,0.99,1),(27,5,7,0.99,1),(28,5,8,0.99,1),(29,5,9,0.99,1),(30,5,10,0.99,1),(31,5,11,0.99,1),(32,5,12,0.99,1),(33,5,13,0.99,1),(34,5,14,0.99,1),(35,5,15,0.99,1),
-  (36,6,16,0.99,1),
-  (37,7,17,0.99,1),(38,7,18,0.99,1),
-  (39,8,19,0.99,1),(40,8,20,0.99,1),(41,8,1,0.99,1),(42,8,2,0.99,1),
-  (43,9,3,0.99,1),(44,9,4,0.99,1),(45,9,5,0.99,1),(46,9,6,0.99,1),(47,9,7,0.99,1),(48,9,8,0.99,1),
-  (49,10,9,0.99,1),(50,10,10,0.99,1),(51,10,11,0.99,1),(52,10,12,0.99,1),(53,10,13,0.99,1),(54,10,14,0.99,1),(55,10,15,0.99,1),(56,10,16,0.99,1),(57,10,17,0.99,1),
-  (58,11,18,0.99,1),(59,11,19,0.99,1),(60,11,20,0.99,1),(61,11,1,0.99,1),(62,11,2,0.99,1),(63,11,3,0.99,1),(64,11,4,0.99,1),(65,11,5,0.99,1),(66,11,6,0.99,1),(67,11,7,0.99,1),(68,11,8,0.99,1),(69,11,9,0.99,1),(70,11,10,0.99,1),(71,11,11,0.99,1),
-  (72,12,12,0.99,1),
-  (73,13,13,0.99,1),(74,13,14,0.99,1),
-  (75,14,15,0.99,1),(76,14,16,0.99,1),(77,14,17,0.99,1),(78,14,18,0.99,1),(79,14,19,0.99,1),(80,14,20,0.99,1),(81,14,1,0.99,1),(82,14,2,0.99,1),
-  (83,15,3,0.99,1),(84,15,4,0.99,1);
-
-CREATE VIEW top_genres AS
-  SELECT t.genre, COUNT(*) AS tracks_sold, ROUND(SUM(ii.unit_price * ii.quantity), 2) AS catalog_value
-  FROM tracks t
-  JOIN invoice_items ii ON ii.track_id = t.track_id
-  GROUP BY t.genre;
-CREATE VIEW artist_catalog AS
-  SELECT ar.name AS artist, COUNT(DISTINCT al.album_id) AS album_count,
-         COUNT(t.track_id) AS track_count, ROUND(SUM(t.unit_price), 2) AS catalog_value
-  FROM artists ar
-  LEFT JOIN albums al ON al.artist_id = ar.artist_id
-  LEFT JOIN tracks t ON t.album_id = al.album_id
-  GROUP BY ar.artist_id, ar.name
-  ORDER BY catalog_value DESC;
-`;
+// ────────────────────────────────────────────────────────────────────────
+// Sample 2: chinook.pg — the complete Chinook music store database
+// (v1.4.5, auto-increment PKs variant), fetched from the
+// dataslope/datasets GitHub repo at load time. Table names are
+// snake_case singular: album, artist, track, genre, media_type,
+// playlist, playlist_track, customer, employee, invoice, invoice_line.
+// ────────────────────────────────────────────────────────────────────────
 
 const CHINOOK_TABS: QueryTabSeed[] = [
   {
     title: "Browse tracks",
-    code: `-- Browse the track catalogue\nSELECT t.name, a.title AS album, ar.name AS artist, t.genre\nFROM tracks t\nJOIN albums a ON t.album_id = a.album_id\nJOIN artists ar ON a.artist_id = ar.artist_id\nORDER BY ar.name, a.title\nLIMIT 25;`,
+    code: `-- Browse the track catalogue\nSELECT t.name AS track, a.title AS album, ar.name AS artist, g.name AS genre\nFROM track t\nJOIN album a ON t.album_id = a.album_id\nJOIN artist ar ON a.artist_id = ar.artist_id\nLEFT JOIN genre g ON t.genre_id = g.genre_id\nORDER BY ar.name, a.title\nLIMIT 25;`,
   },
   {
     title: "Top genres",
-    code: `-- Catalogue value by genre\nSELECT *\nFROM top_genres\nORDER BY catalog_value DESC;`,
+    code: `-- Track count and catalogue value by genre\nSELECT g.name AS genre,\n       COUNT(*) AS track_count,\n       ROUND(SUM(t.unit_price), 2) AS catalog_value\nFROM track t\nJOIN genre g ON t.genre_id = g.genre_id\nGROUP BY g.genre_id\nORDER BY catalog_value DESC;`,
   },
   {
     title: "Customer spend",
-    code: `-- Total spend per customer\nSELECT c.first_name || ' ' || c.last_name AS customer,\n       c.country,\n       ROUND(SUM(i.total), 2) AS total_spend\nFROM customers c\nJOIN invoices i ON i.customer_id = c.customer_id\nGROUP BY c.customer_id\nORDER BY total_spend DESC;`,
+    code: `-- Total spend per customer\nSELECT c.first_name || ' ' || c.last_name AS customer,\n       c.country,\n       ROUND(SUM(i.total), 2) AS total_spend\nFROM customer c\nJOIN invoice i ON i.customer_id = c.customer_id\nGROUP BY c.customer_id\nORDER BY total_spend DESC\nLIMIT 20;`,
   },
 ];
 
-const NORTHWIND_SQL = `
-CREATE TABLE customers (customer_id text PRIMARY KEY, company_name text, contact_name text, country text);
-CREATE TABLE employees (employee_id integer PRIMARY KEY, first_name text, last_name text, title text, hire_date date);
-CREATE TABLE products (product_id integer PRIMARY KEY, product_name text, category text, unit_price numeric(10,2), units_in_stock integer, inventory_value numeric(10,2) GENERATED ALWAYS AS (unit_price * units_in_stock) STORED);
-CREATE TABLE orders (
-  order_id integer PRIMARY KEY,
-  customer_id text REFERENCES customers(customer_id),
-  employee_id integer REFERENCES employees(employee_id),
-  order_date date,
-  ship_country text
-);
-CREATE TABLE order_details (
-  order_id integer REFERENCES orders(order_id),
-  product_id integer REFERENCES products(product_id),
-  quantity integer,
-  unit_price numeric(10,2),
-  line_total numeric(10,2) GENERATED ALWAYS AS (quantity * unit_price) STORED,
-  PRIMARY KEY (order_id, product_id)
-);
-CREATE INDEX idx_orders_customer_id ON orders(customer_id);
-CREATE INDEX idx_orders_employee_id ON orders(employee_id);
-CREATE INDEX idx_order_details_product_id ON order_details(product_id);
-
-INSERT INTO customers VALUES
-  ('ALFKI','Alfreds Futterkiste','Maria Anders','Germany'),
-  ('ANATR','Ana Trujillo Emparedados','Ana Trujillo','Mexico'),
-  ('ANTON','Antonio Moreno Taquería','Antonio Moreno','Mexico'),
-  ('AROUT','Around the Horn','Thomas Hardy','UK'),
-  ('BERGS','Berglunds snabbköp','Christina Berglund','Sweden'),
-  ('BLAUS','Blauer See Delikatessen','Hanna Moos','Germany'),
-  ('BLONP','Blondesddsl père et fils','Frédérique Citeaux','France'),
-  ('BOLID','Bólido Comidas preparadas','Martín Sommer','Spain'),
-  ('BONAP','Bon app''','Laurence Lebihan','France'),
-  ('BOTTM','Bottom-Dollar Markets','Elizabeth Lincoln','Canada');
-INSERT INTO employees VALUES
-  (1,'Nancy','Davolio','Sales Representative','1992-05-01'),
-  (2,'Andrew','Fuller','Vice President, Sales','1992-08-14'),
-  (3,'Janet','Leverling','Sales Representative','1992-04-01'),
-  (4,'Margaret','Peacock','Sales Representative','1993-05-03'),
-  (5,'Steven','Buchanan','Sales Manager','1993-10-17');
-INSERT INTO products (product_id, product_name, category, unit_price, units_in_stock) VALUES
-  (1,'Chai','Beverages',18.00,39),
-  (2,'Chang','Beverages',19.00,17),
-  (3,'Aniseed Syrup','Condiments',10.00,13),
-  (4,'Chef Anton''s Cajun Seasoning','Condiments',22.00,53),
-  (5,'Grandma''s Boysenberry Spread','Condiments',25.00,120),
-  (6,'Uncle Bob''s Organic Dried Pears','Produce',30.00,15),
-  (7,'Northwoods Cranberry Sauce','Condiments',40.00,50),
-  (8,'Mishi Kobe Niku','Meat/Poultry',97.00,29),
-  (9,'Ikura','Seafood',31.00,31),
-  (10,'Queso Cabrales','Dairy Products',21.00,30);
-INSERT INTO orders VALUES
-  (10248,'ALFKI',1,'2023-07-04','France'),
-  (10249,'ANATR',2,'2023-07-05','Germany'),
-  (10250,'ANTON',3,'2023-07-08','Brazil'),
-  (10251,'AROUT',4,'2023-07-08','France'),
-  (10252,'BERGS',5,'2023-07-09','Belgium'),
-  (10253,'BLAUS',1,'2023-07-10','Germany'),
-  (10254,'BLONP',2,'2023-07-11','France'),
-  (10255,'BOLID',3,'2023-07-12','Spain'),
-  (10256,'BONAP',4,'2023-07-15','France'),
-  (10257,'BOTTM',5,'2023-07-16','Canada');
-INSERT INTO order_details (order_id, product_id, quantity, unit_price) VALUES
-  (10248,1,12,18.00),
-  (10248,2,10,19.00),
-  (10249,3,5,10.00),
-  (10250,4,9,22.00),
-  (10250,5,35,25.00),
-  (10251,6,6,30.00),
-  (10252,7,40,40.00),
-  (10253,8,20,97.00),
-  (10254,9,15,31.00),
-  (10255,10,25,21.00),
-  (10256,1,5,18.00),
-  (10257,2,4,19.00);
-
-CREATE VIEW order_totals AS
-  SELECT o.order_id, o.order_date, c.company_name, ROUND(SUM(od.quantity * od.unit_price), 2) AS total
-  FROM orders o
-  JOIN customers c ON o.customer_id = c.customer_id
-  JOIN order_details od ON od.order_id = o.order_id
-  GROUP BY o.order_id, o.order_date, c.company_name;
-CREATE VIEW product_revenue AS
-  SELECT p.product_id, p.product_name, p.category, COALESCE(SUM(od.quantity), 0) AS units_sold,
-         ROUND(COALESCE(SUM(od.quantity * od.unit_price), 0), 2) AS revenue
-  FROM products p
-  LEFT JOIN order_details od ON od.product_id = p.product_id
-  GROUP BY p.product_id, p.product_name, p.category;
-CREATE VIEW sales_by_employee AS
-  SELECT e.employee_id, e.first_name || ' ' || e.last_name AS employee, e.title,
-         COUNT(DISTINCT o.order_id) AS order_count,
-         ROUND(SUM(od.quantity * od.unit_price), 2) AS total_sales
-  FROM employees e
-  LEFT JOIN orders o ON o.employee_id = e.employee_id
-  LEFT JOIN order_details od ON od.order_id = o.order_id
-  GROUP BY e.employee_id, e.first_name, e.last_name, e.title
-  ORDER BY total_sales DESC;
-`;
+// ────────────────────────────────────────────────────────────────────────
+// Sample 3: northwind.pg — the classic Northwind database (the
+// pgsql-flavoured port), fetched from the dataslope/datasets GitHub
+// repo at load time. Table names are snake_case plural: categories,
+// customers, employees, order_details, orders, products, region,
+// shippers, suppliers, territories, us_states, …
+// ────────────────────────────────────────────────────────────────────────
 
 const NORTHWIND_TABS: QueryTabSeed[] = [
   {
@@ -691,11 +481,11 @@ const NORTHWIND_TABS: QueryTabSeed[] = [
   },
   {
     title: "Top products",
-    code: `-- Best-selling products by units shipped\nSELECT p.product_name,\n       p.category,\n       SUM(od.quantity) AS units_sold,\n       ROUND(SUM(od.quantity * od.unit_price), 2) AS revenue\nFROM order_details od\nJOIN products p ON od.product_id = p.product_id\nGROUP BY p.product_id, p.product_name, p.category\nORDER BY revenue DESC;`,
+    code: `-- Best-selling products by revenue (after discount)\nSELECT p.product_name,\n       cat.category_name,\n       SUM(od.quantity) AS units_sold,\n       ROUND(SUM(od.unit_price * od.quantity * (1 - od.discount))::numeric, 2) AS revenue\nFROM order_details od\nJOIN products p ON od.product_id = p.product_id\nJOIN categories cat ON p.category_id = cat.category_id\nGROUP BY p.product_id, cat.category_name\nORDER BY revenue DESC\nLIMIT 15;`,
   },
   {
     title: "Order totals",
-    code: `-- Order totals view\nSELECT *\nFROM order_totals\nORDER BY total DESC\nLIMIT 10;`,
+    code: `-- Largest orders by total value\nSELECT o.order_id,\n       o.order_date,\n       c.company_name,\n       ROUND(SUM(od.unit_price * od.quantity * (1 - od.discount))::numeric, 2) AS total\nFROM orders o\nJOIN customers c ON o.customer_id = c.customer_id\nJOIN order_details od ON od.order_id = o.order_id\nGROUP BY o.order_id, c.company_name\nORDER BY total DESC\nLIMIT 10;`,
   },
 ];
 
@@ -712,16 +502,16 @@ export const POSTGRES_SAMPLE_DATABASES: PostgresSampleDatabase[] = [
     id: "chinook",
     label: "Chinook music store",
     filename: "chinook.pg",
-    description: "Artists, albums, tracks, customers, and invoices.",
-    sql: CHINOOK_SQL,
+    description: "The complete Chinook music store: artists, albums, tracks, playlists, customers, and invoices.",
+    remoteSql: "postgres/chinook_postgres_AutoIncrementPKs.sql",
     defaultTabs: CHINOOK_TABS,
   },
   {
     id: "northwind",
     label: "Northwind",
     filename: "northwind.pg",
-    description: "Classic Northwind subset: customers, products, and orders.",
-    sql: NORTHWIND_SQL,
+    description: "The classic Northwind store: customers, products, orders, and suppliers.",
+    remoteSql: "postgres/northwind_postgres.sql",
     defaultTabs: NORTHWIND_TABS,
   },
 ];

--- a/app/_components/runtime/remoteDatasets.ts
+++ b/app/_components/runtime/remoteDatasets.ts
@@ -1,0 +1,121 @@
+// Remote sample datasets, fetched straight from a GitHub repository via
+// raw.githubusercontent.com. The default source is the companion
+// dataslope/datasets repo, which holds the original (untrimmed) sample
+// databases as SQL scripts — and, later, parquet/CSV files for DuckDB.
+//
+// Why raw.githubusercontent.com:
+//   - it serves `access-control-allow-origin: *`, so browsers (main
+//     thread *and* web workers) can fetch the files directly without
+//     the CORS proxy hop other runtimes need, and
+//   - the bytes come from GitHub's CDN, so sample databases stop
+//     counting against Vercel's bandwidth budget.
+//
+// The helpers below are dialect-agnostic: SQLite and Postgres fetch SQL
+// scripts with `fetchDatasetText`, and the DuckDB runtime can reuse
+// `fetchDatasetBytes` for binary datasets (e.g. registering a remote
+// parquet file) or embed `rawGitHubUrl(...)` directly in sample SQL,
+// since duckdb-wasm can read CORS-enabled https URLs natively.
+
+/** A GitHub repository (plus ref) that hosts dataset files. */
+export interface RemoteDatasetSource {
+  owner: string;
+  repo: string;
+  /** Branch name, tag, or commit SHA. */
+  ref: string;
+}
+
+/** The companion repository holding the playgrounds' sample databases:
+ *  https://github.com/dataslope/datasets */
+export const DATASLOPE_DATASETS_SOURCE: RemoteDatasetSource = {
+  owner: "dataslope",
+  repo: "datasets",
+  ref: "main",
+};
+
+/** Build the raw.githubusercontent.com URL for a file in a GitHub repo. */
+export function rawGitHubUrl(
+  path: string,
+  source: RemoteDatasetSource = DATASLOPE_DATASETS_SOURCE,
+): string {
+  const cleanPath = path.replace(/^\/+/, "");
+  return `https://raw.githubusercontent.com/${source.owner}/${source.repo}/${source.ref}/${cleanPath}`;
+}
+
+/** Resolve a dataset reference to an absolute URL. Accepts either a
+ *  path inside the default datasets repo (e.g. `sqlite/chinook_sqlite.sql`)
+ *  or a full `https://` URL, so a sample can clone a database from any
+ *  repository (or any other CORS-enabled host). */
+export function resolveDatasetUrl(pathOrUrl: string): string {
+  return /^https?:\/\//i.test(pathOrUrl) ? pathOrUrl : rawGitHubUrl(pathOrUrl);
+}
+
+// Session-scoped memoisation. raw.githubusercontent.com only allows
+// ~5-minute HTTP caching, so without this a user flipping between two
+// sample databases would re-download a few hundred KB per switch.
+// Failed downloads are evicted so a transient network error doesn't
+// poison the sample for the rest of the session. (Workers get their own
+// module instance and therefore their own cache — that's fine, each
+// context fetches a given file at most once.)
+const textCache = new Map<string, Promise<string>>();
+const bytesCache = new Map<string, Promise<Uint8Array>>();
+
+async function fetchDataset(url: string): Promise<Response> {
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Could not download the sample dataset (${url}): ${reason}. Check your network connection and try again.`,
+    );
+  }
+  if (!res.ok) {
+    throw new Error(
+      `Could not download the sample dataset (${url}): HTTP ${res.status}.`,
+    );
+  }
+  return res;
+}
+
+function memoised<T>(
+  cache: Map<string, Promise<T>>,
+  url: string,
+  load: () => Promise<T>,
+): Promise<T> {
+  let promise = cache.get(url);
+  if (!promise) {
+    promise = load();
+    promise.catch(() => cache.delete(url));
+    cache.set(url, promise);
+  }
+  return promise;
+}
+
+/** Fetch a text dataset (e.g. a `.sql` script) by repo path or URL. */
+export function fetchDatasetText(pathOrUrl: string): Promise<string> {
+  const url = resolveDatasetUrl(pathOrUrl);
+  return memoised(textCache, url, async () => (await fetchDataset(url)).text());
+}
+
+/** Fetch a binary dataset (e.g. a `.parquet`, `.csv`, or `.sqlite`
+ *  file) by repo path or URL. Callers that hand the buffer to an engine
+ *  which takes ownership of it (worker transfer, virtual-FS
+ *  registration) should pass a copy (`bytes.slice()`) so the cached
+ *  array stays usable for the next load. */
+export function fetchDatasetBytes(pathOrUrl: string): Promise<Uint8Array> {
+  const url = resolveDatasetUrl(pathOrUrl);
+  return memoised(
+    bytesCache,
+    url,
+    async () => new Uint8Array(await (await fetchDataset(url)).arrayBuffer()),
+  );
+}
+
+/** Filename component of a dataset path or URL (e.g.
+ *  `duckdb/trips.parquet` → `trips.parquet`). Used as the default name
+ *  when registering a remote file with an engine's virtual filesystem. */
+export function datasetFileName(pathOrUrl: string): string {
+  const path = pathOrUrl.replace(/[?#].*$/, "");
+  const base = path.slice(path.lastIndexOf("/") + 1);
+  return base || path;
+}

--- a/app/_components/runtime/sqlite-core.ts
+++ b/app/_components/runtime/sqlite-core.ts
@@ -26,6 +26,7 @@ import {
   type SqlValue,
 } from "./sqlite-wasm";
 import { findSampleDatabase, type SqliteSampleDatabase, type SqliteSampleMetadata } from "./sqliteSamples";
+import { fetchDatasetBytes, fetchDatasetText } from "./remoteDatasets";
 
 export type { QueryExecResult } from "./sqlite-wasm";
 
@@ -627,16 +628,51 @@ function copyDatabaseContents(src: Database, dst: Database): void {
   }
 }
 
+/** The `SqliteEngine` surface with every promise unwrapped — the
+ *  in-process engine executes synchronously — except for
+ *  `loadSampleDatabase`, which stays async because samples backed by
+ *  `remoteSql` download their seed script before the rebuild. */
+export type InProcessSqliteEngine = Omit<
+  {
+    [K in keyof SqliteEngine]: Awaited<
+      ReturnType<NonNullable<SqliteEngine[K]>>
+    > extends infer R
+      ? (...args: Parameters<NonNullable<SqliteEngine[K]>>) => R
+      : never;
+  },
+  "loadSampleDatabase"
+> & {
+  loadSampleDatabase: (id: string) => Promise<SqliteSampleMetadata>;
+};
+
+/** Execute a multi-statement script that creates *and* populates a
+ *  database (a remote sample download or imported dump). Wrapped in a
+ *  transaction when the script doesn't manage its own, so scripts made
+ *  of thousands of single-row INSERTs commit in one journal write
+ *  instead of one implicit transaction per statement. */
+function execSeedScript(target: Database, script: string): void {
+  if (/^\s*(BEGIN|COMMIT)\b/im.test(script)) {
+    target.exec(script);
+    return;
+  }
+  target.exec("BEGIN");
+  try {
+    target.exec(script);
+    target.exec("COMMIT");
+  } catch (err) {
+    try {
+      target.exec("ROLLBACK");
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}
+
 export async function createSqliteEngineInProcess(
   initialSampleId: string,
   openOptions: SqliteEngineOpenOptions = {},
-): Promise<{
-  [K in keyof SqliteEngine]: Awaited<
-    ReturnType<NonNullable<SqliteEngine[K]>>
-  > extends infer R
-    ? (...args: Parameters<NonNullable<SqliteEngine[K]>>) => R
-    : never;
-}> {
+): Promise<InProcessSqliteEngine> {
   const sqlite3 = await loadSqlite3();
   let db: Database | null = null;
   let active: SqliteSampleDatabase = findSampleDatabase(initialSampleId);
@@ -672,15 +708,75 @@ export async function createSqliteEngineInProcess(
     }
   }
 
-  function build(sample: SqliteSampleDatabase, opts: { skipSeed?: boolean } = {}): void {
-    let firstOpenOfPersistent = false;
+  /** Replace the active database's contents with the database encoded
+   *  in `bytes` (a binary `.sqlite` file). Persistent (OPFS) mode
+   *  copies object-by-object into the on-disk file — we can't
+   *  sqlite3_deserialize into an OPFS-backed DB because the OPFS VFS
+   *  requires the file backing to remain in place. In-memory mode
+   *  deserialises directly. */
+  function adoptDatabaseBytes(bytes: Uint8Array): void {
+    if (persistent && db) {
+      // Open a transient in-memory DB from `bytes` to validate, dump
+      // every CREATE/INSERT into the on-disk DB, then close the
+      // transient one. For most databases this is fine; very large
+      // ones should go through the export/import flow instead.
+      const transient = openDatabase(sqlite3, { bytes });
+      try {
+        transient.exec("PRAGMA foreign_keys = ON;");
+        dropAllUserObjects(db);
+        copyDatabaseContents(transient, db);
+      } finally {
+        transient.close();
+      }
+    } else {
+      const next = openDatabase(sqlite3, { bytes });
+      try {
+        next.exec("PRAGMA foreign_keys = ON;");
+      } catch (err) {
+        try {
+          next.close();
+        } catch {
+          /* ignore */
+        }
+        throw err;
+      }
+      if (db) {
+        try {
+          db.close();
+        } catch {
+          // Ignore close errors.
+        }
+      }
+      db = next;
+    }
+  }
+
+  async function build(
+    sample: SqliteSampleDatabase,
+    opts: { skipSeed?: boolean } = {},
+  ): Promise<void> {
+    const firstOpenOfPersistent = persistent && !db;
+    // Download a remote sample's payload *before* touching the current
+    // database so a failed download leaves the existing contents
+    // intact. Deferred on the first open of a persistent (OPFS) file:
+    // that path usually re-attaches to an existing workspace and never
+    // seeds, and when the file does turn out to be empty the late
+    // fetch below can at worst leave a blank database.
+    let remoteSqlText: string | null = null;
+    let remoteDbBytes: Uint8Array | null = null;
+    if (!opts.skipSeed && !firstOpenOfPersistent) {
+      if (sample.remoteSql) {
+        remoteSqlText = await fetchDatasetText(sample.remoteSql);
+      } else if (sample.remoteDb) {
+        remoteDbBytes = await fetchDatasetBytes(sample.remoteDb);
+      }
+    }
     if (persistent) {
       // Open the persistent file lazily on the first build call, and
       // wipe its current schema on subsequent calls so a sample swap
       // doesn't accumulate stale tables.
       if (!db) {
         db = openFresh();
-        firstOpenOfPersistent = true;
       } else {
         dropAllUserObjects(db);
       }
@@ -707,13 +803,21 @@ export async function createSqliteEngineInProcess(
       opts.skipSeed === true ||
       (firstOpenOfPersistent && hasUserObjects(db));
     if (!shouldSkipSeed) {
-      if (sample.schema) db.exec(sample.schema);
-      sample.seed(db);
+      if (sample.remoteSql) {
+        remoteSqlText ??= await fetchDatasetText(sample.remoteSql);
+        execSeedScript(db, remoteSqlText);
+      } else if (sample.remoteDb) {
+        remoteDbBytes ??= await fetchDatasetBytes(sample.remoteDb);
+        adoptDatabaseBytes(remoteDbBytes);
+      } else {
+        if (sample.schema) db.exec(sample.schema);
+        sample.seed?.(db);
+      }
     }
     active = sample;
   }
 
-  build(active, { skipSeed: openOptions.skipSeed });
+  await build(active, { skipSeed: openOptions.skipSeed });
 
   function require(): Database {
     if (!db) throw new Error("SQLite database is not initialised");
@@ -746,8 +850,8 @@ export async function createSqliteEngineInProcess(
   }
 
   return {
-    loadSampleDatabase(id: string) {
-      build(findSampleDatabase(id));
+    async loadSampleDatabase(id: string) {
+      await build(findSampleDatabase(id));
       const { seed: _seed, ...meta } = active;
       return meta;
     },
@@ -1395,46 +1499,7 @@ export async function createSqliteEngineInProcess(
       return meta;
     },
     loadFromBytes(bytes: Uint8Array, filename: string) {
-      if (persistent && db) {
-        // Persistent mode: open a transient in-memory DB from `bytes`
-        // to validate, dump every CREATE/INSERT into the on-disk DB,
-        // then close the transient one. We can't sqlite3_deserialize
-        // into an OPFS-backed DB because the OPFS VFS requires the
-        // file backing to remain in place.
-        const transient = openDatabase(sqlite3, { bytes });
-        try {
-          transient.exec("PRAGMA foreign_keys = ON;");
-          dropAllUserObjects(db);
-          // Copy every CREATE statement + every row out via a small
-          // backup loop. For most user uploads this is fine; for very
-          // large databases the user should be using the export/import
-          // flow instead.
-          copyDatabaseContents(transient, db);
-        } finally {
-          transient.close();
-        }
-      } else {
-        // In-memory mode: just open a fresh DB from the bytes.
-        const next = openDatabase(sqlite3, { bytes });
-        try {
-          next.exec("PRAGMA foreign_keys = ON;");
-        } catch (err) {
-          try {
-            next.close();
-          } catch {
-            /* ignore */
-          }
-          throw err;
-        }
-        if (db) {
-          try {
-            db.close();
-          } catch {
-            // Ignore close errors.
-          }
-        }
-        db = next;
-      }
+      adoptDatabaseBytes(bytes);
       // Derive a stable-ish id from the filename so the UI can
       // distinguish this from the blank placeholder.
       const basename = filename

--- a/app/_components/runtime/sqliteSamples.ts
+++ b/app/_components/runtime/sqliteSamples.ts
@@ -1,8 +1,9 @@
 // Declarative catalogue of the sample SQLite databases offered by the
-// SQL playground's database-selector. Each entry owns its own schema,
-// seed data, and the editor tabs that should be opened the first time
-// the user lands on that database — so adding a new sample (or, later,
-// loading a binary `.sqlite` file) is a one-entry change.
+// SQL playground's database-selector. Each entry owns its own seed
+// payload — either an embedded schema + seed function, or a `remoteSql`
+// reference into the dataslope/datasets GitHub repo — and the editor
+// tabs that should be opened the first time the user lands on that
+// database, so adding a new sample is a one-entry change.
 
 import type { Database } from "./sqlite-wasm";
 import {
@@ -14,12 +15,23 @@ import {
 export type { QueryTabSeed } from "./sqlSamples";
 
 export interface SqliteSampleDatabase extends SqlSampleDatabaseBase {
-  /** Multi-statement DDL string. Run as one batch via `db.run`. */
-  schema: string;
+  /** Multi-statement DDL string. Run as one batch via `db.run`.
+   *  Ignored when `remoteSql` is set. */
+  schema?: string;
   /** Populates the database tables created by `schema`. Receives a fresh
    *  `Database` so the function can use prepared statements for batch
-   *  inserts without interfering with later samples. */
-  seed: (db: Database) => void;
+   *  inserts without interfering with later samples. Ignored when
+   *  `remoteSql` is set. */
+  seed?: (db: Database) => void;
+  /** Path (inside the dataslope/datasets GitHub repo) or full URL of a
+   *  SQL script that creates *and* populates the database. Fetched from
+   *  raw.githubusercontent.com when the sample is loaded — see
+   *  remoteDatasets.ts. */
+  remoteSql?: string;
+  /** Path (inside the dataslope/datasets GitHub repo) or full URL of a
+   *  binary SQLite database file (`.sqlite` / `.db`) to clone instead
+   *  of running a script. Considered when `remoteSql` is not set. */
+  remoteDb?: string;
   /** Default editor tabs opened on the first visit to this database. */
   defaultTabs: QueryTabSeed[];
 }
@@ -430,414 +442,47 @@ const CC_DEFAULT_TABS: QueryTabSeed[] = [
 ];
 
 // ────────────────────────────────────────────────────────────────────────
-// Sample 2: chinook.db (tiny subset of the classic Chinook music store)
+// Sample 2: chinook.db — the complete Chinook music store database
+// (v1.4.5), fetched from the dataslope/datasets GitHub repo at load
+// time. Table names are PascalCase: Album, Artist, Track, Genre,
+// MediaType, Playlist, PlaylistTrack, Customer, Employee, Invoice,
+// InvoiceLine.
 // ────────────────────────────────────────────────────────────────────────
-
-const CHINOOK_SCHEMA = `
-  CREATE TABLE artists (
-    artist_id INTEGER PRIMARY KEY,
-    name TEXT
-  );
-  CREATE TABLE albums (
-    album_id INTEGER PRIMARY KEY,
-    title TEXT,
-    artist_id INTEGER REFERENCES artists(artist_id)
-  );
-  CREATE TABLE tracks (
-    track_id INTEGER PRIMARY KEY,
-    name TEXT,
-    album_id INTEGER REFERENCES albums(album_id),
-    genre TEXT,
-    milliseconds INTEGER,
-    unit_price REAL,
-    duration_seconds REAL GENERATED ALWAYS AS (ROUND(milliseconds / 1000.0, 1)) STORED
-  );
-  CREATE TABLE customers (
-    customer_id INTEGER PRIMARY KEY,
-    first_name TEXT, last_name TEXT,
-    email TEXT, country TEXT,
-    full_name TEXT GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED
-  );
-  CREATE TABLE invoices (
-    invoice_id INTEGER PRIMARY KEY,
-    customer_id INTEGER REFERENCES customers(customer_id),
-    invoice_date TEXT,
-    total REAL
-  );
-  CREATE INDEX idx_albums_artist_id ON albums(artist_id);
-  CREATE INDEX idx_tracks_album_id ON tracks(album_id);
-  CREATE INDEX idx_tracks_genre ON tracks(genre);
-  CREATE INDEX idx_invoices_customer_id ON invoices(customer_id);
-  CREATE INDEX idx_invoices_date ON invoices(invoice_date);
-  CREATE TRIGGER trg_block_negative_invoice
-    BEFORE INSERT ON invoices
-    WHEN NEW.total < 0
-    BEGIN
-      SELECT RAISE(ABORT, 'Invoice total cannot be negative');
-    END;
-  CREATE TRIGGER trg_block_negative_invoice_update
-    BEFORE UPDATE OF total ON invoices
-    WHEN NEW.total < 0
-    BEGIN
-      SELECT RAISE(ABORT, 'Invoice total cannot be negative');
-    END;
-  CREATE TRIGGER trg_prevent_duplicate_email
-    BEFORE INSERT ON customers
-    WHEN (SELECT COUNT(*) FROM customers WHERE email = NEW.email) > 0
-    BEGIN
-      SELECT RAISE(ABORT, 'A customer with this email already exists');
-    END;
-  CREATE VIEW top_genres AS
-    SELECT
-      genre,
-      COUNT(*) AS track_count,
-      ROUND(AVG(milliseconds) / 1000.0, 1) AS avg_seconds,
-      ROUND(SUM(unit_price), 2) AS catalog_value
-    FROM tracks
-    GROUP BY genre;
-  CREATE VIEW artist_catalog AS
-    SELECT
-      ar.name AS artist,
-      COUNT(DISTINCT al.album_id) AS album_count,
-      COUNT(t.track_id) AS track_count,
-      ROUND(SUM(t.unit_price), 2) AS catalog_value
-    FROM artists ar
-    LEFT JOIN albums al ON al.artist_id = ar.artist_id
-    LEFT JOIN tracks t ON t.album_id = al.album_id
-    GROUP BY ar.artist_id
-    ORDER BY catalog_value DESC;
-  CREATE VIEW customer_invoice_summary AS
-    SELECT
-      c.customer_id,
-      c.first_name || ' ' || c.last_name AS full_name,
-      c.country,
-      COUNT(i.invoice_id) AS invoice_count,
-      ROUND(SUM(i.total), 2) AS total_spent,
-      ROUND(AVG(i.total), 2) AS avg_invoice
-    FROM customers c
-    LEFT JOIN invoices i ON i.customer_id = c.customer_id
-    GROUP BY c.customer_id
-    ORDER BY total_spent DESC;
-  CREATE VIEW genre_revenue AS
-    SELECT
-      t.genre,
-      COUNT(t.track_id) AS track_count,
-      ROUND(SUM(t.unit_price), 2) AS potential_revenue
-    FROM tracks t
-    GROUP BY t.genre
-    ORDER BY potential_revenue DESC;
-`;
-
-function seedChinook(db: Database): void {
-  const artists: Row[] = [
-    [1, "AC/DC"],
-    [2, "Accept"],
-    [3, "Aerosmith"],
-    [4, "Alanis Morissette"],
-    [5, "Alice In Chains"],
-    [6, "Antônio Carlos Jobim"],
-    [7, "Apocalyptica"],
-    [8, "Audioslave"],
-    [9, "BackBeat"],
-    [10, "Billy Cobham"],
-  ];
-  bulkInsert(db, "INSERT INTO artists VALUES (?, ?)", artists);
-
-  const albums: Row[] = [
-    [1, "For Those About To Rock We Salute You", 1],
-    [2, "Balls to the Wall", 2],
-    [3, "Restless and Wild", 2],
-    [4, "Let There Be Rock", 1],
-    [5, "Big Ones", 3],
-    [6, "Jagged Little Pill", 4],
-    [7, "Facelift", 5],
-    [8, "Warner 25 Anos", 6],
-    [9, "Plays Metallica By Four Cellos", 7],
-    [10, "Audioslave", 8],
-  ];
-  bulkInsert(db, "INSERT INTO albums VALUES (?, ?, ?)", albums);
-
-  const tracks: Row[] = [
-    [1, "For Those About To Rock (We Salute You)", 1, "Rock", 343719, 0.99],
-    [2, "Put The Finger On You", 1, "Rock", 205662, 0.99],
-    [3, "Let's Get It Up", 1, "Rock", 233926, 0.99],
-    [4, "Inject The Venom", 1, "Rock", 210834, 0.99],
-    [5, "Snowballed", 1, "Rock", 203102, 0.99],
-    [6, "Balls to the Wall", 2, "Rock", 342562, 0.99],
-    [7, "Fast As a Shark", 3, "Rock", 230619, 0.99],
-    [8, "Restless and Wild", 3, "Rock", 252051, 0.99],
-    [9, "Princess of the Dawn", 3, "Rock", 375418, 0.99],
-    [10, "Go Down", 4, "Rock", 313398, 0.99],
-    [11, "Dream On", 5, "Rock", 275866, 0.99],
-    [12, "Walk This Way", 5, "Rock", 211098, 0.99],
-    [13, "All I Really Want", 6, "Rock", 284891, 0.99],
-    [14, "You Oughta Know", 6, "Rock", 249234, 0.99],
-    [15, "Ironic", 6, "Rock", 229733, 0.99],
-    [16, "Man In The Box", 7, "Alternative", 286641, 0.99],
-    [17, "Them Bones", 7, "Alternative", 150221, 0.99],
-    [18, "Garota De Ipanema", 8, "Latin", 285673, 0.99],
-    [19, "Enter Sandman", 9, "Classical", 214665, 0.99],
-    [20, "Cochise", 10, "Alternative", 222380, 0.99],
-  ];
-  bulkInsert(
-    db,
-    "INSERT INTO tracks (track_id, name, album_id, genre, milliseconds, unit_price) VALUES (?, ?, ?, ?, ?, ?)",
-    tracks,
-  );
-
-  const customers: Row[] = [
-    [1, "Luís", "Gonçalves", "luisg@embraer.com.br", "Brazil"],
-    [2, "Leonie", "Köhler", "leonekohler@surfeu.de", "Germany"],
-    [3, "François", "Tremblay", "ftremblay@gmail.com", "Canada"],
-    [4, "Bjørn", "Hansen", "bjorn.hansen@yahoo.no", "Norway"],
-    [5, "František", "Wichterlová", "frantisekw@jetbrains.com", "Czech Republic"],
-    [6, "Helena", "Holý", "hholy@gmail.com", "Czech Republic"],
-    [7, "Astrid", "Gruber", "astrid.gruber@apple.at", "Austria"],
-    [8, "Daan", "Peeters", "daan_peeters@apple.be", "Belgium"],
-    [9, "Kara", "Nielsen", "kara.nielsen@jubii.dk", "Denmark"],
-    [10, "Eduardo", "Martins", "eduardo@woodstock.com.br", "Brazil"],
-  ];
-  bulkInsert(db, "INSERT INTO customers (customer_id, first_name, last_name, email, country) VALUES (?, ?, ?, ?, ?)", customers);
-
-  const invoices: Row[] = [
-    [1, 1, "2023-01-01", 1.98],
-    [2, 2, "2023-01-02", 3.96],
-    [3, 3, "2023-01-03", 5.94],
-    [4, 4, "2023-01-04", 8.91],
-    [5, 5, "2023-01-05", 13.86],
-    [6, 6, "2023-02-01", 0.99],
-    [7, 7, "2023-02-02", 1.98],
-    [8, 8, "2023-02-03", 3.96],
-    [9, 9, "2023-02-04", 5.94],
-    [10, 10, "2023-02-05", 8.91],
-    [11, 1, "2023-03-01", 13.86],
-    [12, 2, "2023-03-02", 0.99],
-    [13, 3, "2023-03-03", 1.98],
-    [14, 4, "2023-03-04", 7.96],
-    [15, 5, "2023-03-05", 1.98],
-  ];
-  bulkInsert(db, "INSERT INTO invoices VALUES (?, ?, ?, ?)", invoices);
-}
 
 const CHINOOK_TABS: QueryTabSeed[] = [
   {
     title: "Browse tracks",
-    code: `-- Browse the track catalogue\nSELECT t.name, a.title AS album, ar.name AS artist, t.genre\nFROM tracks t\nJOIN albums a ON t.album_id = a.album_id\nJOIN artists ar ON a.artist_id = ar.artist_id\nORDER BY ar.name, a.title\nLIMIT 25;`,
+    code: `-- Browse the track catalogue\nSELECT t.Name AS Track, a.Title AS Album, ar.Name AS Artist, g.Name AS Genre\nFROM Track t\nJOIN Album a ON t.AlbumId = a.AlbumId\nJOIN Artist ar ON a.ArtistId = ar.ArtistId\nLEFT JOIN Genre g ON t.GenreId = g.GenreId\nORDER BY ar.Name, a.Title\nLIMIT 25;`,
   },
   {
     title: "Top genres",
-    code: `-- Catalogue value by genre\nSELECT *\nFROM top_genres\nORDER BY catalog_value DESC;`,
+    code: `-- Track count and catalogue value by genre\nSELECT g.Name AS Genre,\n       COUNT(*) AS TrackCount,\n       ROUND(SUM(t.UnitPrice), 2) AS CatalogValue\nFROM Track t\nJOIN Genre g ON t.GenreId = g.GenreId\nGROUP BY g.GenreId\nORDER BY CatalogValue DESC;`,
   },
   {
     title: "Customer spend",
-    code: `-- Total spend per customer\nSELECT c.first_name || ' ' || c.last_name AS customer,\n       c.country,\n       ROUND(SUM(i.total), 2) AS total_spend\nFROM customers c\nJOIN invoices i ON i.customer_id = c.customer_id\nGROUP BY c.customer_id\nORDER BY total_spend DESC;`,
+    code: `-- Total spend per customer\nSELECT c.FirstName || ' ' || c.LastName AS Customer,\n       c.Country,\n       ROUND(SUM(i.Total), 2) AS TotalSpend\nFROM Customer c\nJOIN Invoice i ON i.CustomerId = c.CustomerId\nGROUP BY c.CustomerId\nORDER BY TotalSpend DESC\nLIMIT 20;`,
   },
 ];
 
 // ────────────────────────────────────────────────────────────────────────
-// Sample 3: northwind.db (tiny subset of the classic Northwind store)
+// Sample 3: northwind.db — the classic Northwind store, fetched from
+// the dataslope/datasets GitHub repo at load time. Table names are
+// PascalCase: Categories, Customers, Employees, OrderDetails, Orders,
+// Products, Shippers, Suppliers.
 // ────────────────────────────────────────────────────────────────────────
-
-const NORTHWIND_SCHEMA = `
-  CREATE TABLE customers (
-    customer_id TEXT PRIMARY KEY,
-    company_name TEXT,
-    contact_name TEXT,
-    country TEXT
-  );
-  CREATE TABLE employees (
-    employee_id INTEGER PRIMARY KEY,
-    first_name TEXT,
-    last_name TEXT,
-    title TEXT,
-    hire_date TEXT
-  );
-  CREATE TABLE products (
-    product_id INTEGER PRIMARY KEY,
-    product_name TEXT,
-    category TEXT,
-    unit_price REAL,
-    units_in_stock INTEGER,
-    inventory_value REAL GENERATED ALWAYS AS (unit_price * units_in_stock) STORED
-  );
-  CREATE TABLE orders (
-    order_id INTEGER PRIMARY KEY,
-    customer_id TEXT REFERENCES customers(customer_id),
-    employee_id INTEGER REFERENCES employees(employee_id),
-    order_date TEXT,
-    ship_country TEXT
-  );
-  CREATE TABLE order_details (
-    order_id INTEGER REFERENCES orders(order_id),
-    product_id INTEGER REFERENCES products(product_id),
-    quantity INTEGER,
-    unit_price REAL,
-    line_total REAL GENERATED ALWAYS AS (quantity * unit_price) STORED,
-    PRIMARY KEY (order_id, product_id)
-  );
-  CREATE INDEX idx_orders_customer_id ON orders(customer_id);
-  CREATE INDEX idx_orders_employee_id ON orders(employee_id);
-  CREATE INDEX idx_orders_date ON orders(order_date);
-  CREATE INDEX idx_order_details_product_id ON order_details(product_id);
-  CREATE INDEX idx_products_category ON products(category);
-  CREATE TRIGGER trg_block_out_of_stock
-    BEFORE INSERT ON order_details
-    WHEN (SELECT units_in_stock FROM products WHERE product_id = NEW.product_id) < NEW.quantity
-    BEGIN
-      SELECT RAISE(ABORT, 'Insufficient stock for this product');
-    END;
-  CREATE TRIGGER trg_reduce_stock
-    AFTER INSERT ON order_details
-    BEGIN
-      UPDATE products
-        SET units_in_stock = units_in_stock - NEW.quantity
-        WHERE product_id = NEW.product_id;
-    END;
-  CREATE TRIGGER trg_restore_stock
-    AFTER DELETE ON order_details
-    BEGIN
-      UPDATE products
-        SET units_in_stock = units_in_stock + OLD.quantity
-        WHERE product_id = OLD.product_id;
-    END;
-  CREATE VIEW order_totals AS
-    SELECT
-      o.order_id,
-      o.order_date,
-      c.company_name,
-      ROUND(SUM(od.quantity * od.unit_price), 2) AS total
-    FROM orders o
-    JOIN customers c ON o.customer_id = c.customer_id
-    JOIN order_details od ON od.order_id = o.order_id
-    GROUP BY o.order_id;
-  CREATE VIEW sales_by_employee AS
-    SELECT
-      e.employee_id,
-      e.first_name || ' ' || e.last_name AS employee,
-      e.title,
-      COUNT(DISTINCT o.order_id) AS order_count,
-      ROUND(SUM(od.quantity * od.unit_price), 2) AS total_sales
-    FROM employees e
-    LEFT JOIN orders o ON o.employee_id = e.employee_id
-    LEFT JOIN order_details od ON od.order_id = o.order_id
-    GROUP BY e.employee_id
-    ORDER BY total_sales DESC;
-  CREATE VIEW product_revenue AS
-    SELECT
-      p.product_id,
-      p.product_name,
-      p.category,
-      p.unit_price AS list_price,
-      p.units_in_stock,
-      COALESCE(SUM(od.quantity), 0) AS units_sold,
-      ROUND(COALESCE(SUM(od.quantity * od.unit_price), 0), 2) AS revenue
-    FROM products p
-    LEFT JOIN order_details od ON od.product_id = p.product_id
-    GROUP BY p.product_id
-    ORDER BY revenue DESC;
-  CREATE VIEW customer_order_stats AS
-    SELECT
-      c.customer_id,
-      c.company_name,
-      c.country,
-      COUNT(DISTINCT o.order_id) AS order_count,
-      ROUND(SUM(od.quantity * od.unit_price), 2) AS total_spent
-    FROM customers c
-    LEFT JOIN orders o ON o.customer_id = c.customer_id
-    LEFT JOIN order_details od ON od.order_id = o.order_id
-    GROUP BY c.customer_id
-    ORDER BY total_spent DESC;
-`;
-
-function seedNorthwind(db: Database): void {
-  const customers: Row[] = [
-    ["ALFKI", "Alfreds Futterkiste", "Maria Anders", "Germany"],
-    ["ANATR", "Ana Trujillo Emparedados", "Ana Trujillo", "Mexico"],
-    ["ANTON", "Antonio Moreno Taquería", "Antonio Moreno", "Mexico"],
-    ["AROUT", "Around the Horn", "Thomas Hardy", "UK"],
-    ["BERGS", "Berglunds snabbköp", "Christina Berglund", "Sweden"],
-    ["BLAUS", "Blauer See Delikatessen", "Hanna Moos", "Germany"],
-    ["BLONP", "Blondesddsl père et fils", "Frédérique Citeaux", "France"],
-    ["BOLID", "Bólido Comidas preparadas", "Martín Sommer", "Spain"],
-    ["BONAP", "Bon app'", "Laurence Lebihan", "France"],
-    ["BOTTM", "Bottom-Dollar Markets", "Elizabeth Lincoln", "Canada"],
-  ];
-  bulkInsert(db, "INSERT INTO customers VALUES (?, ?, ?, ?)", customers);
-
-  const employees: Row[] = [
-    [1, "Nancy", "Davolio", "Sales Representative", "1992-05-01"],
-    [2, "Andrew", "Fuller", "Vice President, Sales", "1992-08-14"],
-    [3, "Janet", "Leverling", "Sales Representative", "1992-04-01"],
-    [4, "Margaret", "Peacock", "Sales Representative", "1993-05-03"],
-    [5, "Steven", "Buchanan", "Sales Manager", "1993-10-17"],
-  ];
-  bulkInsert(db, "INSERT INTO employees VALUES (?, ?, ?, ?, ?)", employees);
-
-  const products: Row[] = [
-    [1, "Chai", "Beverages", 18.0, 39],
-    [2, "Chang", "Beverages", 19.0, 17],
-    [3, "Aniseed Syrup", "Condiments", 10.0, 13],
-    [4, "Chef Anton's Cajun Seasoning", "Condiments", 22.0, 53],
-    [5, "Grandma's Boysenberry Spread", "Condiments", 25.0, 120],
-    [6, "Uncle Bob's Organic Dried Pears", "Produce", 30.0, 15],
-    [7, "Northwoods Cranberry Sauce", "Condiments", 40.0, 50],
-    [8, "Mishi Kobe Niku", "Meat/Poultry", 97.0, 29],
-    [9, "Ikura", "Seafood", 31.0, 31],
-    [10, "Queso Cabrales", "Dairy Products", 21.0, 30],
-  ];
-  bulkInsert(
-    db,
-    "INSERT INTO products (product_id, product_name, category, unit_price, units_in_stock) VALUES (?, ?, ?, ?, ?)",
-    products,
-  );
-
-  const orders: Row[] = [
-    [10248, "ALFKI", 1, "2023-07-04", "France"],
-    [10249, "ANATR", 2, "2023-07-05", "Germany"],
-    [10250, "ANTON", 3, "2023-07-08", "Brazil"],
-    [10251, "AROUT", 4, "2023-07-08", "France"],
-    [10252, "BERGS", 5, "2023-07-09", "Belgium"],
-    [10253, "BLAUS", 1, "2023-07-10", "Germany"],
-    [10254, "BLONP", 2, "2023-07-11", "France"],
-    [10255, "BOLID", 3, "2023-07-12", "Spain"],
-    [10256, "BONAP", 4, "2023-07-15", "France"],
-    [10257, "BOTTM", 5, "2023-07-16", "Canada"],
-  ];
-  bulkInsert(db, "INSERT INTO orders VALUES (?, ?, ?, ?, ?)", orders);
-
-  const orderDetails: Row[] = [
-    [10248, 1, 12, 18.0],
-    [10248, 2, 10, 19.0],
-    [10249, 3, 5, 10.0],
-    [10250, 4, 9, 22.0],
-    [10250, 5, 35, 25.0],
-    [10251, 6, 6, 30.0],
-    [10252, 7, 40, 40.0],
-    [10253, 8, 20, 97.0],
-    [10254, 9, 15, 31.0],
-    [10255, 10, 25, 21.0],
-    [10256, 1, 5, 18.0],
-    [10257, 2, 4, 19.0],
-  ];
-  bulkInsert(
-    db,
-    "INSERT INTO order_details (order_id, product_id, quantity, unit_price) VALUES (?, ?, ?, ?)",
-    orderDetails,
-  );
-}
 
 const NORTHWIND_TABS: QueryTabSeed[] = [
   {
     title: "Recent orders",
-    code: `-- Recent orders with company + ship country\nSELECT o.order_id, o.order_date, c.company_name, o.ship_country\nFROM orders o\nJOIN customers c ON o.customer_id = c.customer_id\nORDER BY o.order_date DESC\nLIMIT 20;`,
+    code: `-- Recent orders with customer and shipper\nSELECT o.OrderID, o.OrderDate, c.CustomerName, s.ShipperName\nFROM Orders o\nJOIN Customers c ON o.CustomerID = c.CustomerID\nJOIN Shippers s ON o.ShipperID = s.ShipperID\nORDER BY o.OrderDate DESC\nLIMIT 20;`,
   },
   {
     title: "Top products",
-    code: `-- Best-selling products by units shipped\nSELECT p.product_name,\n       p.category,\n       SUM(od.quantity) AS units_sold,\n       ROUND(SUM(od.quantity * od.unit_price), 2) AS revenue\nFROM order_details od\nJOIN products p ON od.product_id = p.product_id\nGROUP BY p.product_id\nORDER BY revenue DESC;`,
+    code: `-- Best-selling products by revenue\nSELECT p.ProductName,\n       cat.CategoryName,\n       SUM(od.Quantity) AS UnitsSold,\n       ROUND(SUM(od.Quantity * p.Price), 2) AS Revenue\nFROM OrderDetails od\nJOIN Products p ON od.ProductID = p.ProductID\nJOIN Categories cat ON p.CategoryID = cat.CategoryID\nGROUP BY p.ProductID\nORDER BY Revenue DESC\nLIMIT 15;`,
   },
   {
     title: "Order totals",
-    code: `-- Order totals view\nSELECT *\nFROM order_totals\nORDER BY total DESC\nLIMIT 10;`,
+    code: `-- Largest orders by total value\nSELECT o.OrderID,\n       o.OrderDate,\n       c.CustomerName,\n       ROUND(SUM(od.Quantity * p.Price), 2) AS Total\nFROM Orders o\nJOIN Customers c ON o.CustomerID = c.CustomerID\nJOIN OrderDetails od ON od.OrderID = o.OrderID\nJOIN Products p ON p.ProductID = od.ProductID\nGROUP BY o.OrderID\nORDER BY Total DESC\nLIMIT 10;`,
   },
 ];
 
@@ -859,18 +504,16 @@ export const SQLITE_SAMPLE_DATABASES: SqliteSampleDatabase[] = [
     id: "chinook",
     label: "Chinook music store",
     filename: "chinook.db",
-    description: "Artists, albums, tracks, customers, and invoices.",
-    schema: CHINOOK_SCHEMA,
-    seed: seedChinook,
+    description: "The complete Chinook music store: artists, albums, tracks, playlists, customers, and invoices.",
+    remoteSql: "sqlite/chinook_sqlite.sql",
     defaultTabs: CHINOOK_TABS,
   },
   {
     id: "northwind",
     label: "Northwind",
     filename: "northwind.db",
-    description: "Classic Northwind subset: customers, products, and orders.",
-    schema: NORTHWIND_SCHEMA,
-    seed: seedNorthwind,
+    description: "The classic Northwind store: customers, products, orders, and shippers.",
+    remoteSql: "sqlite/northwind_sqlite.sql",
     defaultTabs: NORTHWIND_TABS,
   },
 ];

--- a/content/learn/sql-challenge-cards-postgres.mdx
+++ b/content/learn/sql-challenge-cards-postgres.mdx
@@ -415,3 +415,101 @@ ORDER BY
   ]}
 />
 ```
+
+## 5. Remote dataset — Northwind from GitHub
+
+`remoteInitSql` clones a complete sample database from the
+[dataslope/datasets](https://github.com/dataslope/datasets) GitHub repo
+before the first run — here the classic **Northwind** store (the
+Postgres port, snake_case names). The script is fetched from
+raw.githubusercontent.com and prepared for PGlite (psql meta-commands
+and `CREATE DATABASE` lines are stripped); `initSql` (when present)
+still runs afterwards for challenge-specific extras.
+
+<SqlChallengeCard
+  dialect="postgres"
+  title="Five most expensive products"
+  instructions={`The classic **Northwind** database has been cloned straight from the dataslope/datasets GitHub repo. Query its \`products\` table for the five most expensive products — columns \`product_name\` and \`unit_price\`, sorted by \`unit_price\` descending.`}
+  remoteInitSql="postgres/northwind_postgres.sql"
+  tables={["products", "categories", "suppliers"]}
+  starterCode={`-- Your query here:
+SELECT
+  *
+FROM
+  products;`}
+  solutionSql={`SELECT
+  product_name,
+  unit_price
+FROM
+  products
+ORDER BY
+  unit_price DESC
+LIMIT
+  5;`}
+  tests={[
+    {
+      id: "row_count",
+      name: "Returns 5 rows",
+      description: "Northwind has 77 products; only the top five should remain",
+      expectedRowCount: 5,
+    },
+    {
+      id: "columns",
+      name: "Has product_name and unit_price columns",
+      description: "In that exact order",
+      expectedColumns: ["product_name", "unit_price"],
+    },
+    {
+      id: "ordering",
+      name: "Most expensive first",
+      description: "Côte de Blaye (263.5) should lead the list",
+      matchesSolution: true,
+      ordered: true,
+    },
+  ]}
+/>
+
+```jsx
+<SqlChallengeCard
+  dialect="postgres"
+  title="Five most expensive products"
+  instructions={`The classic **Northwind** database has been cloned straight from the dataslope/datasets GitHub repo. Query its \`products\` table for the five most expensive products — columns \`product_name\` and \`unit_price\`, sorted by \`unit_price\` descending.`}
+  remoteInitSql="postgres/northwind_postgres.sql"
+  tables={["products", "categories", "suppliers"]}
+  starterCode={`-- Your query here:
+SELECT
+  *
+FROM
+  products;`}
+  solutionSql={`SELECT
+  product_name,
+  unit_price
+FROM
+  products
+ORDER BY
+  unit_price DESC
+LIMIT
+  5;`}
+  tests={[
+    {
+      id: "row_count",
+      name: "Returns 5 rows",
+      description: "Northwind has 77 products; only the top five should remain",
+      expectedRowCount: 5,
+    },
+    {
+      id: "columns",
+      name: "Has product_name and unit_price columns",
+      description: "In that exact order",
+      expectedColumns: ["product_name", "unit_price"],
+    },
+    {
+      id: "ordering",
+      name: "Most expensive first",
+      description: "Côte de Blaye (263.5) should lead the list",
+      matchesSolution: true,
+      ordered: true,
+    },
+  ]}
+/>
+```

--- a/content/learn/sql-challenge-cards-sqlite.mdx
+++ b/content/learn/sql-challenge-cards-sqlite.mdx
@@ -405,3 +405,100 @@ ORDER BY
   ]}
 />
 ```
+
+## 5. Remote dataset — Northwind from GitHub
+
+`remoteInitSql` clones a complete sample database from the
+[dataslope/datasets](https://github.com/dataslope/datasets) GitHub repo
+before the first run — here the classic **Northwind** store. The script
+is fetched from raw.githubusercontent.com, so the card embeds no seed
+SQL at all; `initSql` (when present) still runs afterwards for
+challenge-specific extras.
+
+<SqlChallengeCard
+  dialect="sqlite"
+  title="Five most expensive products"
+  instructions={`The classic **Northwind** database has been cloned straight from the dataslope/datasets GitHub repo. Query its \`Products\` table for the five most expensive products — columns \`ProductName\` and \`Price\`, sorted by \`Price\` descending.`}
+  remoteInitSql="sqlite/northwind_sqlite.sql"
+  tables={["Products", "Categories", "Suppliers"]}
+  starterCode={`-- Your query here:
+SELECT
+  *
+FROM
+  Products;`}
+  solutionSql={`SELECT
+  ProductName,
+  Price
+FROM
+  Products
+ORDER BY
+  Price DESC
+LIMIT
+  5;`}
+  tests={[
+    {
+      id: "row_count",
+      name: "Returns 5 rows",
+      description: "Northwind has 77 products; only the top five should remain",
+      expectedRowCount: 5,
+    },
+    {
+      id: "columns",
+      name: "Has ProductName and Price columns",
+      description: "In that exact order",
+      expectedColumns: ["ProductName", "Price"],
+    },
+    {
+      id: "ordering",
+      name: "Most expensive first",
+      description: "Côte de Blaye (263.5) should lead the list",
+      matchesSolution: true,
+      ordered: true,
+    },
+  ]}
+/>
+
+```jsx
+<SqlChallengeCard
+  dialect="sqlite"
+  title="Five most expensive products"
+  instructions={`The classic **Northwind** database has been cloned straight from the dataslope/datasets GitHub repo. Query its \`Products\` table for the five most expensive products — columns \`ProductName\` and \`Price\`, sorted by \`Price\` descending.`}
+  remoteInitSql="sqlite/northwind_sqlite.sql"
+  tables={["Products", "Categories", "Suppliers"]}
+  starterCode={`-- Your query here:
+SELECT
+  *
+FROM
+  Products;`}
+  solutionSql={`SELECT
+  ProductName,
+  Price
+FROM
+  Products
+ORDER BY
+  Price DESC
+LIMIT
+  5;`}
+  tests={[
+    {
+      id: "row_count",
+      name: "Returns 5 rows",
+      description: "Northwind has 77 products; only the top five should remain",
+      expectedRowCount: 5,
+    },
+    {
+      id: "columns",
+      name: "Has ProductName and Price columns",
+      description: "In that exact order",
+      expectedColumns: ["ProductName", "Price"],
+    },
+    {
+      id: "ordering",
+      name: "Most expensive first",
+      description: "Côte de Blaye (263.5) should lead the list",
+      matchesSolution: true,
+      ordered: true,
+    },
+  ]}
+/>
+```

--- a/content/learn/sql-code-blocks-postgres.mdx
+++ b/content/learn/sql-code-blocks-postgres.mdx
@@ -256,3 +256,55 @@ ORDER BY
   id;`}
 />
 ```
+
+## 6. Remote dataset — Chinook from GitHub
+
+`remoteInitSql` clones a complete sample database from the
+[dataslope/datasets](https://github.com/dataslope/datasets) GitHub repo
+before the block boots — here the full **Chinook** music store (11
+tables, snake_case names). Pass a path inside the repo (or any full URL)
+and the script is fetched from raw.githubusercontent.com, then prepared
+for PGlite (psql meta-commands and `CREATE DATABASE` lines are
+stripped). `tables` keeps the viewer focused on a hand-picked subset.
+
+<SqlCodeBlock
+  dialect="postgres"
+  title="Explore the Chinook music store"
+  remoteInitSql="postgres/chinook_postgres_AutoIncrementPKs.sql"
+  tables={["artist", "album", "track"]}
+  starterCode={`SELECT
+  t.name AS track,
+  ar.name AS artist,
+  t.unit_price
+FROM
+  track t
+  JOIN album a ON a.album_id = t.album_id
+  JOIN artist ar ON ar.artist_id = a.artist_id
+ORDER BY
+  ar.name,
+  t.name
+LIMIT
+  15;`}
+/>
+
+```jsx
+<SqlCodeBlock
+  dialect="postgres"
+  title="Explore the Chinook music store"
+  remoteInitSql="postgres/chinook_postgres_AutoIncrementPKs.sql"
+  tables={["artist", "album", "track"]}
+  starterCode={`SELECT
+  t.name AS track,
+  ar.name AS artist,
+  t.unit_price
+FROM
+  track t
+  JOIN album a ON a.album_id = t.album_id
+  JOIN artist ar ON ar.artist_id = a.artist_id
+ORDER BY
+  ar.name,
+  t.name
+LIMIT
+  15;`}
+/>
+```

--- a/content/learn/sql-code-blocks-sqlite.mdx
+++ b/content/learn/sql-code-blocks-sqlite.mdx
@@ -311,3 +311,54 @@ ORDER BY
   id;`}
 />
 ```
+
+## 6. Remote dataset — Chinook from GitHub
+
+`remoteInitSql` clones a complete sample database from the
+[dataslope/datasets](https://github.com/dataslope/datasets) GitHub repo
+before the block boots — here the full **Chinook** music store (11
+tables). Pass a path inside the repo (or any full URL) and the script is
+fetched from raw.githubusercontent.com; no seed SQL is embedded in the
+page. `tables` keeps the viewer focused on a hand-picked subset.
+
+<SqlCodeBlock
+  dialect="sqlite"
+  title="Explore the Chinook music store"
+  remoteInitSql="sqlite/chinook_sqlite.sql"
+  tables={["Artist", "Album", "Track"]}
+  starterCode={`SELECT
+  t.Name AS Track,
+  ar.Name AS Artist,
+  t.UnitPrice
+FROM
+  Track t
+  JOIN Album a ON a.AlbumId = t.AlbumId
+  JOIN Artist ar ON ar.ArtistId = a.ArtistId
+ORDER BY
+  ar.Name,
+  t.Name
+LIMIT
+  15;`}
+/>
+
+```jsx
+<SqlCodeBlock
+  dialect="sqlite"
+  title="Explore the Chinook music store"
+  remoteInitSql="sqlite/chinook_sqlite.sql"
+  tables={["Artist", "Album", "Track"]}
+  starterCode={`SELECT
+  t.Name AS Track,
+  ar.Name AS Artist,
+  t.UnitPrice
+FROM
+  Track t
+  JOIN Album a ON a.AlbumId = t.AlbumId
+  JOIN Artist ar ON ar.ArtistId = a.ArtistId
+ORDER BY
+  ar.Name,
+  t.Name
+LIMIT
+  15;`}
+/>
+```


### PR DESCRIPTION
## Summary

The SQLite and Postgres playgrounds previously created **trimmed-down** Chinook/Northwind databases from SQL embedded in the bundle. They now load the **original, complete sample databases** from the [dataslope/datasets](https://github.com/dataslope/datasets) repo at load time, via `raw.githubusercontent.com`.

Why raw.githubusercontent.com: it serves `access-control-allow-origin: *`, so browsers (main thread *and* workers) fetch the files directly — no CORS-proxy hop — and the dataset bytes come from GitHub's CDN instead of counting against Vercel bandwidth.

## Runtime changes

- **New `runtime/remoteDatasets.ts`** — dialect-agnostic loader: raw-URL builder for any repo/ref (or full URL, so any GitHub repo can be cloned), session-memoised `fetchDatasetText` / `fetchDatasetBytes` with failure eviction, and `datasetFileName` for virtual-FS registration.
- **SQLite** — samples accept `remoteSql` (script) or `remoteDb` (binary `.sqlite`); chinook/northwind now reference `sqlite/chinook_sqlite.sql` and `sqlite/northwind_sqlite.sql`. Remote payloads download **before** the current DB is touched (a failed fetch leaves it intact), and seed scripts run inside one transaction. `loadFromBytes` shares the new byte-adoption helper.
- **Postgres** — samples accept `remoteSql`; fetched scripts are prepared for PGlite (psql meta-commands like `\c` and `CREATE`/`DROP DATABASE` stripped — the Chinook release script needs this). The same preparation now also benefits `importSqlDump`. Sample switch adopts the new sample only after a successful rebuild.
- **DuckDB** (per the upcoming parquet plans) — samples accept `remoteSql` plus `remoteFiles` (parquet/CSV/JSON fetched and registered in the wasm virtual FS before seeding, with buffer-copy semantics so the cache survives worker transfer). Sample SQL can also `read_parquet('https://raw.githubusercontent.com/…')` directly since duckdb-wasm reads CORS-enabled URLs natively.
- Default editor tabs rewritten for the original schemas (PascalCase `Album`/`Track`/`Orders` on SQLite, snake_case `album`/`track`/`orders` on Postgres).

## /learn changes

- `<SqlCodeBlock>` and `<SqlChallengeCard>` gain a **`remoteInitSql`** prop: a datasets-repo path or full URL cloned into the block's engine before `initSql` (which still runs afterwards for extras). The dataset download races the WASM boot, and Postgres scripts get the PGlite preparation automatically.
- Added live examples — with the raw JSX shown beneath each — to four `/learn` pages: Chinook code blocks on `sql-code-blocks-sqlite` / `sql-code-blocks-postgres`, Northwind challenge cards on `sql-challenge-cards-sqlite` / `sql-challenge-cards-postgres`.

## Validation

- Both SQLite scripts executed under `PRAGMA foreign_keys = ON` in a transaction: 11/8 tables, **zero** `foreign_key_check` violations; all new default-tab queries verified.
- Both Postgres scripts executed in **PGlite 0.4.5 itself** (Node): chinook seeds in ~0.7&nbsp;s (11 tables), northwind in ~0.2&nbsp;s (14 tables); all new tab queries and challenge expectations verified (Côte de Blaye tops both dialects at 263.5).
- `tsc --noEmit` clean, ESLint 0 errors, **522/522** unit tests pass (16 new in `__tests__/remoteDatasets.test.ts`), `next build` succeeds.

https://claude.ai/code/session_01CwmGYgyTrhcrvdEUSWU9PU

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwmGYgyTrhcrvdEUSWU9PU)_