### PR TITLE
Result-table UX: consistent layouts, stable resizable columns, compact dataframes

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1331,7 +1331,7 @@
 .accentBar {
   width: 4px;
   height: 20px;
-  background: var(--ch-green-dot);
+  background: var(--ds-blue-500);
   border-radius: 2px;
   margin-right: 10px;
   flex-shrink: 0;
@@ -1346,12 +1346,12 @@
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ch-text-muted);
+  color: var(--ds-blue-500);
 }
 
 .outputTime {
   margin-left: auto;
-  font-size: 12.5px;
+  font-size: 11.5px;
   color: var(--ch-text-muted);
   font-family: var(--ch-font-mono);
   display: inline-flex;
@@ -1642,9 +1642,11 @@
 
 /* ─── Test panel ──────────────────────────────────────────────────── */
 
+/* Transparent in both themes — the section sits directly on the card
+   surface to keep the design clean. */
 .testPanel {
   border-top: 1px solid var(--ch-border-light);
-  background: var(--ch-bg-muted);
+  background: transparent;
 }
 
 .testPanelHeader {
@@ -1671,6 +1673,16 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--ch-text-muted);
+}
+
+/* The label takes the verdict colour (brand 500 shades) once results
+   are in. */
+.testLabel[data-state="pass"] {
+  color: var(--ds-green-500);
+}
+
+.testLabel[data-state="fail"] {
+  color: var(--ds-red-500);
 }
 
 .testSummary {
@@ -1759,6 +1771,11 @@
   flex-shrink: 0;
   /* Centers the circle on the row's text line. */
   margin-top: 2px;
+  /* Passing/pending circles carry the 1-based test number. */
+  font-family: var(--ch-font-ui);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1;
 }
 
 .testRailNode[data-state="pass"] {
@@ -1772,6 +1789,7 @@
 .testRailNode[data-state="pending"] {
   background: transparent;
   border: 2px solid var(--ch-border);
+  color: var(--ch-text-muted);
 }
 
 .testRailSeg {
@@ -1817,6 +1835,11 @@
   margin-bottom: 0;
 }
 
+.testRailName {
+  color: var(--ch-text-secondary);
+  font-weight: 500;
+}
+
 .testRailItemBtn:hover .testRailName,
 .testRailItemBtn:focus-visible .testRailName {
   text-decoration: underline;
@@ -1859,6 +1882,7 @@
   --ch-text-secondary: var(--ds-gray-500);
   --ch-text-muted: var(--ds-gray-400);
   --ch-red: var(--ds-red-600);
+  --ch-green: var(--ds-green-600);
   --ch-font-ui: "Inter", system-ui, -apple-system, sans-serif;
   --ch-font-mono: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
 
@@ -1879,6 +1903,7 @@
   --ch-text-secondary: #b0b0b0;
   --ch-text-muted: #808080;
   --ch-red: var(--ds-red-400);
+  --ch-green: var(--ds-green-400);
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.5);
 }
 
@@ -1921,8 +1946,14 @@
   flex-shrink: 0;
 }
 
+/* Verdict word takes the state colour (theme-aware via the token block
+   on .testPopover above); pending stays muted. */
+.testPopoverState[data-state="pass"] {
+  color: var(--ch-green);
+}
+
 .testPopoverState[data-state="fail"] {
-  color: var(--ds-red-500);
+  color: var(--ch-red);
 }
 
 .testPopoverDesc {
@@ -1963,45 +1994,30 @@
 
 /* ─── Status banner ───────────────────────────────────────────────── */
 
-/* Solid colour band, white text, no top border — green-500 / red-500 in
-   light mode, the 600 shades in dark mode (see the html.dark overrides
-   near the end of this file). */
+/* Quiet, centered verdict line on a transparent background — a bare
+   icon + short text in the verdict colour, no band or icon well. */
 .banner {
   display: flex;
   align-items: center;
-  gap: 12px;
+  justify-content: center;
+  gap: 8px;
   padding: 12px 20px;
   border-top: none;
   font-size: 14px;
   font-weight: 500;
-  color: #fff;
+  background: transparent;
 }
 
 .banner[data-state="pass"] {
-  background: var(--ds-green-500);
+  color: var(--ds-green-500);
 }
 
 .banner[data-state="fail"] {
-  background: var(--ds-red-500);
+  color: var(--ds-red-500);
 }
 
-.bannerIcon {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+.banner svg {
   flex-shrink: 0;
-  /* Lightened well of the band colour so the white check / ✕ reads. */
-  background: rgba(255, 255, 255, 0.22);
-}
-
-.bannerSub {
-  font-size: 13px;
-  font-weight: 400;
-  opacity: 0.8;
-  margin-left: 2px;
 }
 
 /* ─── SQL result table ────────────────────────────────────────────────
@@ -2266,23 +2282,16 @@
   background: #222222;
 }
 
-/* The test pill, status banner, and test rail use solid green/red fills
-   with white text in both themes — light uses the 500 shades; dark steps
-   down to the 600 shades below so the bands sit more comfortably on dark
-   surfaces. */
+/* The test pill and test rail use solid green/red fills with white
+   text/numerals in both themes — light uses the 500 shades; dark steps
+   down to the 600 shades below so the fills sit more comfortably on
+   dark surfaces. (The status banner is transparent with verdict-coloured
+   text, so it adapts via the --ch-* tokens and needs nothing here.) */
 :global(html.dark) .testPill[data-state="pass"] {
   background: var(--ds-green-600);
 }
 
 :global(html.dark) .testPill[data-state="fail"] {
-  background: var(--ds-red-600);
-}
-
-:global(html.dark) .banner[data-state="pass"] {
-  background: var(--ds-green-600);
-}
-
-:global(html.dark) .banner[data-state="fail"] {
   background: var(--ds-red-600);
 }
 

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1833,12 +1833,31 @@
   opacity: 1;
 }
 
-/* ── Details popover (description, code/checks, exact error) ── */
+/* ── Details popover (description, code/checks, exact error) ──
+   Matches `.runMenuPositioner`'s portaled-overlay z-index so the popup
+   clears the card chrome (the modal/menu in this file sit at 1000/1100). */
 .testPopoverPositioner {
-  z-index: 220;
+  z-index: 1100;
 }
 
+/* The popup is portaled outside `.card`, so the --ch-* tokens defined on
+   `.card` (and re-pointed for dark mode under `html.dark .card`) don't
+   reach it — `var(--ch-bg)` would resolve to nothing, leaving the popup
+   with a transparent background that the page shows through. Re-declare
+   the token subset this popup uses, mapped to the global --ds-* palette
+   (available at :root) so it stays theme-aware; the `html.dark` block
+   below supplies the dark values, mirroring `.card`. */
 .testPopover {
+  --ch-bg: var(--ds-white);
+  --ch-bg-subtle: var(--ds-gray-50);
+  --ch-border-light: var(--ds-gray-100);
+  --ch-text: var(--ds-gray-900);
+  --ch-text-secondary: var(--ds-gray-500);
+  --ch-text-muted: var(--ds-gray-400);
+  --ch-red: var(--ds-red-600);
+  --ch-font-ui: "Inter", system-ui, -apple-system, sans-serif;
+  --ch-font-mono: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+
   width: min(460px, 92vw);
   background: var(--ch-bg);
   border: 1px solid var(--ch-border-light);
@@ -1846,6 +1865,17 @@
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.14);
   padding: 12px 14px;
   font-family: var(--ch-font-ui);
+}
+
+:global(html.dark) .testPopover {
+  --ch-bg: var(--color-fd-background, #121212);
+  --ch-bg-subtle: color-mix(in srgb, var(--color-fd-background, #121212) 85%, #000000);
+  --ch-border-light: #232323;
+  --ch-text: #e0e0e0;
+  --ch-text-secondary: #b0b0b0;
+  --ch-text-muted: #808080;
+  --ch-red: var(--ds-red-400);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.5);
 }
 
 .testPopoverHead {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1408,38 +1408,95 @@
   white-space: normal;
 }
 
+.outCellHtml {
+  /* Wide frames scroll sideways instead of blowing out the card. */
+  overflow-x: auto;
+}
+
 .outCellHtml :global(img),
 .outCellHtml :global(svg) {
   max-width: 100%;
 }
 
+/* DataFrame tables — kept in lockstep with `.dataframeWrap` in
+   CodeBlock.module.css: slightly tightened Inter (--font-sans) at a
+   compact size with minimal vertical padding, content-width like a
+   Jupyter table. Semantic --ch-* tokens rebind in dark mode, so no
+   separate dark overrides are needed. Selectors use `table th` /
+   `table td` (specificity 0,1,2) so they outrank the learn.css
+   prose-typography rules regardless of stylesheet order. */
 .outCellHtml :global(table) {
   border-collapse: collapse;
-  font-family: var(--ch-font-mono);
-  font-size: 13px;
-}
-
-.outCellHtml :global(th) {
-  background: var(--ch-slate-50);
-  border: 1px solid var(--ch-slate-200);
-  padding: 5px 12px;
-  text-align: right;
+  font-family: var(--font-sans, Inter, system-ui, sans-serif);
+  letter-spacing: -0.011em;
   font-size: 12.5px;
-  color: var(--ch-text-muted);
+  line-height: 1.45;
+  color: var(--ch-text);
+  width: auto;
+  margin: 0;
+  border: 1px solid var(--ch-border-light);
+}
+
+.outCellHtml :global(table th) {
+  padding: 3px 10px;
+  background: var(--ch-bg-hover);
+  border-bottom: 1px solid var(--ch-border-light);
+  border-right: 1px solid var(--ch-border-light);
+  text-align: left;
   font-weight: 600;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--ch-accent);
   white-space: nowrap;
 }
 
-.outCellHtml :global(td) {
-  border: 1px solid var(--ch-slate-100);
-  padding: 4px 12px;
-  text-align: right;
+.outCellHtml :global(table td) {
+  padding: 2px 10px;
+  border-bottom: 1px solid var(--ch-border-light);
+  border-right: 1px solid var(--ch-border-light);
   white-space: nowrap;
-  color: var(--ch-text);
+  color: var(--ch-text-secondary);
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.outCellHtml :global(table th:last-child),
+.outCellHtml :global(table td:last-child) {
+  border-right: none;
 }
 
 .outCellHtml :global(tr:hover td) {
-  background: var(--ch-slate-50);
+  background: var(--ch-bg-hover);
+}
+
+.outCellHtml :global(tr:last-child td) {
+  border-bottom: none;
+}
+
+/* Middle-truncation marker cells/columns (R runtime) — pandas renders
+   its own "..." cells which inherit the same muted colour. */
+.outCellHtml :global(tr.dataframe-ellipsis-row td),
+.outCellHtml :global(.dataframe-ellipsis-col) {
+  text-align: center;
+  color: var(--ch-text-muted);
+}
+
+/* Footer row stating the full row/column count of a truncated frame. */
+.outCellHtml :global(td.dataframe-rows-footer) {
+  padding: 3px 10px;
+  font-size: 11.5px;
+  color: var(--ch-text-muted);
+  font-style: italic;
+  text-align: right;
+  border-top: 1px solid var(--ch-border-light);
+}
+
+/* Dimensions line pandas appends below a truncated frame. */
+.outCellHtml :global(p) {
+  margin: 6px 0 0;
+  font-size: 11.5px;
+  color: var(--ch-text-muted);
 }
 
 /* ─── Running overlay (sine-wave animation) ──────────────────────────
@@ -1779,21 +1836,6 @@
   gap: 8px;
 }
 
-.sqlResultLabel {
-  font-size: 11.5px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--ch-text-muted);
-}
-
-.sqlResultCount {
-  margin-left: auto;
-  font-size: 12.5px;
-  color: var(--ch-text-muted);
-  font-family: var(--ch-font-mono);
-}
-
 /* Full-bleed: no horizontal margin so the table spans the whole card
    width (up to the container). Top/bottom borders only — the card's own
    border supplies the left/right edges, so a boxed border + radius here
@@ -1860,6 +1902,16 @@
 
 .sqlResultTable tr:hover td {
   background: var(--ch-bg-subtle);
+}
+
+/* Trailing filler column: zero content, takes all leftover width so the
+   data columns keep their natural (content) width instead of stretching
+   across the card. The filler header still paints the header band to the
+   card's right edge; filler body cells keep the row hover full-width. */
+.sqlResultTable th.sqlResultFiller,
+.sqlResultTable td.sqlResultFiller {
+  width: 100%;
+  padding: 0;
 }
 
 .sqlNullValue {
@@ -2063,21 +2115,6 @@
   background: color-mix(in srgb, var(--ds-red-500) 22%, transparent);
 }
 
-:global(html.dark) .outCellHtml :global(th) {
-  background: #1a1a1a;
-  border-color: #252525;
-  color: #909090;
-}
-
-:global(html.dark) .outCellHtml :global(td) {
-  border-color: #2a2a2a;
-  color: var(--ch-text);
-}
-
-:global(html.dark) .outCellHtml :global(tr:hover td) {
-  background: #1a1a1a;
-}
-
 /* ─── Table viewer (SQL) ────────────────────────────────────────────── */
 
 .tableViewer {
@@ -2264,16 +2301,6 @@
 .resultPane {
   position: relative;
   overflow: hidden;
-}
-
-.resultPaneInfo {
-  display: flex;
-  align-items: center;
-  padding: 5px 14px;
-  gap: 8px;
-  background: var(--ch-bg-subtle);
-  border-bottom: 1px solid var(--ch-border-light);
-  min-height: 28px;
 }
 
 .resultFlashOverlay {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1690,9 +1690,9 @@
   gap: 4px;
 }
 
-/* Solid, borderless chips with white text. green-500 / red-500 read on
-   both light and dark card surfaces, so no dark-mode overrides are
-   needed (the former translucent variants are gone). */
+/* Solid, borderless chips with white text — green-500 / red-500 in
+   light mode, stepped down to the 600 shades in dark mode (see the
+   html.dark overrides near the end of this file). */
 .testPill[data-state="pass"] {
   background: var(--ds-green-500);
   color: #fff;
@@ -1722,11 +1722,12 @@
 
 /* ─── Test results rail ───
    Minimal pass/fail readout: a vertical rail down the left with one
-   circle per test — green-500 with a white check for a pass, red-500
-   with a white ✕ for a fail — and the rail segment below each circle
-   painted in that test's colour. Rows carry no boxes or borders; the
-   description, test code/checks, and the exact error message live in a
-   click popover. */
+   circle per test — green with a white check for a pass, red with a
+   white ✕ for a fail (500 shades in light mode, 600 in dark — see the
+   html.dark overrides near the end of this file) — and the rail segment
+   below each circle painted in that test's colour. Rows carry no boxes
+   or borders; the description, test code/checks, and the exact error
+   message live in a click popover. */
 .testRail {
   padding: 6px 14px 14px 16px;
   display: flex;
@@ -1962,8 +1963,9 @@
 
 /* ─── Status banner ───────────────────────────────────────────────── */
 
-/* Solid colour band, white text, no top border. green-500 / red-500
-   read on both themes, so no dark-mode overrides are needed. */
+/* Solid colour band, white text, no top border — green-500 / red-500 in
+   light mode, the 600 shades in dark mode (see the html.dark overrides
+   near the end of this file). */
 .banner {
   display: flex;
   align-items: center;
@@ -2264,8 +2266,37 @@
   background: #222222;
 }
 
-/* The test pill and status banner use solid green-500 / red-500 with
-   white text in both themes, so they need no dark-mode overrides. */
+/* The test pill, status banner, and test rail use solid green/red fills
+   with white text in both themes — light uses the 500 shades; dark steps
+   down to the 600 shades below so the bands sit more comfortably on dark
+   surfaces. */
+:global(html.dark) .testPill[data-state="pass"] {
+  background: var(--ds-green-600);
+}
+
+:global(html.dark) .testPill[data-state="fail"] {
+  background: var(--ds-red-600);
+}
+
+:global(html.dark) .banner[data-state="pass"] {
+  background: var(--ds-green-600);
+}
+
+:global(html.dark) .banner[data-state="fail"] {
+  background: var(--ds-red-600);
+}
+
+:global(html.dark) .testRailNode[data-state="pass"],
+:global(html.dark) .testRailSeg[data-state="pass"],
+:global(html.dark) .testPopoverStateDot[data-state="pass"] {
+  background: var(--ds-green-600);
+}
+
+:global(html.dark) .testRailNode[data-state="fail"],
+:global(html.dark) .testRailSeg[data-state="fail"],
+:global(html.dark) .testPopoverStateDot[data-state="fail"] {
+  background: var(--ds-red-600);
+}
 
 /* ─── Table viewer (SQL) ────────────────────────────────────────────── */
 

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1409,8 +1409,9 @@
 }
 
 .outCellHtml {
-  /* Wide frames scroll sideways instead of blowing out the card. */
-  overflow-x: auto;
+  /* Big frames scroll inside the cell instead of blowing out the card. */
+  overflow: auto;
+  max-height: 480px;
 }
 
 .outCellHtml :global(img),
@@ -1419,14 +1420,16 @@
 }
 
 /* DataFrame tables — kept in lockstep with `.dataframeWrap` in
-   CodeBlock.module.css: slightly tightened Inter (--font-sans) at a
-   compact size with minimal vertical padding, content-width like a
-   Jupyter table. Semantic --ch-* tokens rebind in dark mode, so no
+   CodeBlock.module.css: the Jupyter-notebook default look (600-weight
+   header row and index column, very subtle row striping, right-aligned
+   cells, no cell borders) in slightly tightened Inter (--font-sans) at
+   a compact size. Semantic --ch-* tokens rebind in dark mode, so no
    separate dark overrides are needed. Selectors use `table th` /
    `table td` (specificity 0,1,2) so they outrank the learn.css
    prose-typography rules regardless of stylesheet order. */
 .outCellHtml :global(table) {
   border-collapse: collapse;
+  border: none;
   font-family: var(--font-sans, Inter, system-ui, sans-serif);
   letter-spacing: -0.011em;
   font-size: 12.5px;
@@ -1434,44 +1437,45 @@
   color: var(--ch-text);
   width: auto;
   margin: 0;
-  border: 1px solid var(--ch-border-light);
 }
 
 .outCellHtml :global(table th) {
   padding: 3px 10px;
-  background: var(--ch-bg-hover);
-  border-bottom: 1px solid var(--ch-border-light);
-  border-right: 1px solid var(--ch-border-light);
-  text-align: left;
+  background: transparent;
+  border: none;
+  text-align: right;
   font-weight: 600;
   font-size: 12px;
   line-height: 1.45;
-  color: var(--ch-accent);
+  color: var(--ch-text);
   white-space: nowrap;
+  vertical-align: bottom;
+}
+
+.outCellHtml :global(table thead th) {
+  border-bottom: 1px solid var(--ch-border-light);
 }
 
 .outCellHtml :global(table td) {
-  padding: 2px 10px;
-  border-bottom: 1px solid var(--ch-border-light);
-  border-right: 1px solid var(--ch-border-light);
+  padding: 3px 10px;
+  border: none;
+  text-align: right;
   white-space: nowrap;
-  color: var(--ch-text-secondary);
   max-width: 320px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.outCellHtml :global(table th:last-child),
-.outCellHtml :global(table td:last-child) {
-  border-right: none;
+/* Very subtle striping on alternate body rows, like Jupyter. The index
+   <th> cells stripe with their row. */
+.outCellHtml :global(tbody tr:nth-child(even) td),
+.outCellHtml :global(tbody tr:nth-child(even) th) {
+  background: color-mix(in srgb, var(--ch-text) 4%, transparent);
 }
 
-.outCellHtml :global(tr:hover td) {
-  background: var(--ch-bg-hover);
-}
-
-.outCellHtml :global(tr:last-child td) {
-  border-bottom: none;
+.outCellHtml :global(tbody tr:hover td),
+.outCellHtml :global(tbody tr:hover th) {
+  background: color-mix(in srgb, var(--ch-text) 8%, transparent);
 }
 
 /* Middle-truncation marker cells/columns (R runtime) — pandas renders

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1690,22 +1690,25 @@
   gap: 4px;
 }
 
+/* Solid, borderless chips with white text. green-500 / red-500 read on
+   both light and dark card surfaces, so no dark-mode overrides are
+   needed (the former translucent variants are gone). */
 .testPill[data-state="pass"] {
-  background: var(--ch-green-bg);
-  color: var(--ch-green);
-  border: 1px solid var(--ds-green-200);
+  background: var(--ds-green-500);
+  color: #fff;
+  border: none;
 }
 
 .testPill[data-state="fail"] {
-  background: var(--ch-red-bg);
-  color: var(--ch-red);
-  border: 1px solid var(--ds-red-200);
+  background: var(--ds-red-500);
+  color: #fff;
+  border: none;
 }
 
 .testPill[data-state="pending"] {
-  background: var(--ds-gray-100);
-  color: var(--ch-text-muted);
-  border: 1px solid var(--ds-gray-200);
+  background: var(--ds-gray-500);
+  color: #fff;
+  border: none;
 }
 
 .testChevron {
@@ -1959,26 +1962,25 @@
 
 /* ─── Status banner ───────────────────────────────────────────────── */
 
+/* Solid colour band, white text, no top border. green-500 / red-500
+   read on both themes, so no dark-mode overrides are needed. */
 .banner {
   display: flex;
   align-items: center;
   gap: 12px;
   padding: 12px 20px;
-  border-top: 1px solid var(--ch-border-light);
+  border-top: none;
   font-size: 14px;
   font-weight: 500;
+  color: #fff;
 }
 
 .banner[data-state="pass"] {
-  background: var(--ch-green-bg);
-  color: var(--ch-green);
-  border-top-color: var(--ds-green-200);
+  background: var(--ds-green-500);
 }
 
 .banner[data-state="fail"] {
-  background: var(--ch-red-bg);
-  color: var(--ch-red);
-  border-top-color: var(--ds-red-200);
+  background: var(--ds-red-500);
 }
 
 .bannerIcon {
@@ -1989,14 +1991,8 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-}
-
-.banner[data-state="pass"] .bannerIcon {
-  background: var(--ds-green-100);
-}
-
-.banner[data-state="fail"] .bannerIcon {
-  background: var(--ds-red-100);
+  /* Lightened well of the band colour so the white check / ✕ reads. */
+  background: rgba(255, 255, 255, 0.22);
 }
 
 .bannerSub {
@@ -2268,36 +2264,8 @@
   background: #222222;
 }
 
-:global(html.dark) .testPill[data-state="pass"] {
-  background: color-mix(in srgb, var(--ds-green-500) 12%, transparent);
-  border-color: color-mix(in srgb, var(--ds-green-500) 28%, transparent);
-}
-
-:global(html.dark) .testPill[data-state="fail"] {
-  background: color-mix(in srgb, var(--ds-red-500) 12%, transparent);
-  border-color: color-mix(in srgb, var(--ds-red-500) 28%, transparent);
-}
-
-:global(html.dark) .testPill[data-state="pending"] {
-  background: #252525;
-  border-color: #333333;
-}
-
-:global(html.dark) .banner[data-state="pass"] {
-  border-top-color: color-mix(in srgb, var(--ds-green-500) 28%, transparent);
-}
-
-:global(html.dark) .banner[data-state="fail"] {
-  border-top-color: color-mix(in srgb, var(--ds-red-500) 28%, transparent);
-}
-
-:global(html.dark) .banner[data-state="pass"] .bannerIcon {
-  background: color-mix(in srgb, var(--ds-green-500) 22%, transparent);
-}
-
-:global(html.dark) .banner[data-state="fail"] .bannerIcon {
-  background: color-mix(in srgb, var(--ds-red-500) 22%, transparent);
-}
+/* The test pill and status banner use solid green-500 / red-500 with
+   white text in both themes, so they need no dark-mode overrides. */
 
 /* ─── Table viewer (SQL) ────────────────────────────────────────────── */
 

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1354,10 +1354,17 @@
   font-size: 12.5px;
   color: var(--ch-text-muted);
   font-family: var(--ch-font-mono);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.outputTime svg {
+  flex-shrink: 0;
 }
 
 .outputBody {
-  padding: 10px 14px 14px 27px;
+  padding: 10px 14px 14px 18px;
   font-family: var(--ch-font-mono);
   font-size: 13.5px;
   line-height: 1.8;
@@ -1366,7 +1373,7 @@
   word-break: break-word;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 16px;
   max-height: 360px;
   overflow-y: auto;
   scrollbar-width: thin;
@@ -1432,7 +1439,7 @@
   border: none;
   font-family: var(--font-sans, Inter, system-ui, sans-serif);
   letter-spacing: -0.011em;
-  font-size: 12.5px;
+  font-size: 13px;
   line-height: 1.45;
   color: var(--ch-text);
   width: auto;
@@ -1445,7 +1452,6 @@
   border: none;
   text-align: right;
   font-weight: 600;
-  font-size: 12px;
   line-height: 1.45;
   color: var(--ch-text);
   white-space: nowrap;
@@ -1488,10 +1494,11 @@
 
 /* Footer row stating the full row/column count of a truncated frame. */
 .outCellHtml :global(td.dataframe-rows-footer) {
-  padding: 3px 10px;
-  font-size: 11.5px;
+  padding: 4px 10px;
+  font-family: var(--font-inter, var(--font-sans, Inter, system-ui, sans-serif));
+  font-size: 14px;
   color: var(--ch-text-muted);
-  font-style: italic;
+  font-style: normal;
   text-align: right;
   border-top: 1px solid var(--ch-border-light);
 }
@@ -1499,8 +1506,20 @@
 /* Dimensions line pandas appends below a truncated frame. */
 .outCellHtml :global(p) {
   margin: 6px 0 0;
-  font-size: 11.5px;
+  font-family: var(--font-inter, var(--font-sans, Inter, system-ui, sans-serif));
+  font-size: 14px;
   color: var(--ch-text-muted);
+}
+
+/* Plotly chart segment (emitted by code blocks sharing this panel). */
+.outCellPlot {
+  white-space: normal;
+  max-height: 600px;
+  overflow: auto;
+}
+
+.outCellPlot :global(.js-plotly-plot) {
+  width: 100%;
 }
 
 /* ─── Running overlay (sine-wave animation) ──────────────────────────
@@ -1698,78 +1717,214 @@
   transform: rotate(180deg);
 }
 
-.testList {
-  padding: 0 14px 12px;
+/* ─── Test results rail ───
+   Minimal pass/fail readout: a vertical rail down the left with one
+   circle per test — green-500 with a white check for a pass, red-500
+   with a white ✕ for a fail — and the rail segment below each circle
+   painted in that test's colour. Rows carry no boxes or borders; the
+   description, test code/checks, and the exact error message live in a
+   click popover. */
+.testRail {
+  padding: 6px 14px 14px 16px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
 }
 
-.testItem {
+.testRailRow {
   display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 8px 10px;
-  border-radius: 6px;
-  background: var(--ds-white);
-  border: 1px solid var(--ch-border-light);
+  align-items: stretch;
+  gap: 10px;
 }
 
-.testIcon {
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
+.testRailTrack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 18px;
   flex-shrink: 0;
+}
+
+.testRailNode {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-top: 1px;
-}
-
-.testIcon[data-state="pass"] {
-  background: var(--ch-green-bg);
-  color: var(--ch-green);
-}
-
-.testIcon[data-state="fail"] {
-  background: var(--ch-red-bg);
-  color: var(--ch-red);
-}
-
-.testIcon[data-state="pending"] {
-  background: var(--ds-gray-100);
-  color: var(--ch-text-muted);
-}
-
-.testItemBody {
-  flex: 1;
-  min-width: 0;
-}
-
-.testItemName {
-  font-family: var(--ch-font-mono);
-  font-size: 12.5px;
-  color: var(--ch-text);
-  font-weight: 500;
-  line-height: 1.4;
-}
-
-.testItemDesc {
-  font-size: 12.5px;
-  color: var(--ch-text-muted);
+  color: #fff;
+  flex-shrink: 0;
+  /* Centers the circle on the row's text line. */
   margin-top: 2px;
 }
 
-.testItemDetail {
-  margin-top: 4px;
-  font-size: 12.5px;
+.testRailNode[data-state="pass"] {
+  background: var(--ds-green-500);
+}
+
+.testRailNode[data-state="fail"] {
+  background: var(--ds-red-500);
+}
+
+.testRailNode[data-state="pending"] {
+  background: transparent;
+  border: 2px solid var(--ch-border);
+}
+
+.testRailSeg {
+  flex: 1;
+  width: 2px;
+  min-height: 10px;
+  border-radius: 1px;
+}
+
+.testRailSeg[data-state="pass"] {
+  background: var(--ds-green-500);
+}
+
+.testRailSeg[data-state="fail"] {
+  background: var(--ds-red-500);
+}
+
+.testRailSeg[data-state="pending"] {
+  background: var(--ch-border);
+}
+
+/* The whole row is the popover trigger; only text + a hover-revealed
+   info glyph, no chrome. */
+.testRailItemBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin-bottom: 18px;
+  min-height: 22px;
+  cursor: pointer;
+  font-family: var(--ch-font-ui);
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--ch-text);
+  text-align: left;
+}
+
+.testRailRow:last-child .testRailItemBtn {
+  margin-bottom: 0;
+}
+
+.testRailItemBtn:hover .testRailName,
+.testRailItemBtn:focus-visible .testRailName {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--ch-text-muted);
+}
+
+.testRailInfoIcon {
+  color: var(--ch-text-muted);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+  flex-shrink: 0;
+}
+
+.testRailItemBtn:hover .testRailInfoIcon,
+.testRailItemBtn:focus-visible .testRailInfoIcon,
+.testRailItemBtn[data-popup-open] .testRailInfoIcon {
+  opacity: 1;
+}
+
+/* ── Details popover (description, code/checks, exact error) ── */
+.testPopoverPositioner {
+  z-index: 220;
+}
+
+.testPopover {
+  width: min(460px, 92vw);
+  background: var(--ch-bg);
+  border: 1px solid var(--ch-border-light);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.14);
+  padding: 12px 14px;
+  font-family: var(--ch-font-ui);
+}
+
+.testPopoverHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.testPopoverStateDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.testPopoverStateDot[data-state="pass"] {
+  background: var(--ds-green-500);
+}
+
+.testPopoverStateDot[data-state="fail"] {
+  background: var(--ds-red-500);
+}
+
+.testPopoverStateDot[data-state="pending"] {
+  background: var(--ch-border);
+}
+
+.testPopoverName {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--ch-text);
+  min-width: 0;
+}
+
+.testPopoverState {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--ch-text-muted);
+  flex-shrink: 0;
+}
+
+.testPopoverState[data-state="fail"] {
+  color: var(--ds-red-500);
+}
+
+.testPopoverDesc {
+  margin: 8px 0 0;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--ch-text-secondary);
+}
+
+.testPopoverSectionLabel {
+  margin-top: 12px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--ch-text-muted);
+}
+
+.testPopoverCode,
+.testPopoverError {
+  margin: 4px 0 0;
+  padding: 8px 10px;
+  background: var(--ch-bg-subtle);
+  border-radius: 6px;
   font-family: var(--ch-font-mono);
-  color: var(--ch-red);
-  background: var(--ch-red-bg);
-  border-radius: 4px;
-  padding: 3px 8px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--ch-text);
   white-space: pre-wrap;
   word-break: break-word;
+  max-height: 220px;
+  overflow: auto;
+}
+
+.testPopoverError {
+  color: var(--ch-red);
 }
 
 /* ─── Status banner ───────────────────────────────────────────────── */
@@ -2078,11 +2233,6 @@
   background: var(--ds-blue-300);
 }
 
-
-:global(html.dark) .testItem {
-  background: #0d0d0d;
-  border-color: #2a2a2a;
-}
 
 :global(html.dark) .testPanelHeader:hover {
   background: #222222;

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -30,7 +30,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, ChevronUp, Eye, File, FileInput, Info, Play, Terminal, Timer } from "lucide-react";
+import { RotateCcw, Check, CheckCheck, ListChecks, ListX, X, ChevronDown, ChevronUp, Eye, File, FileInput, Info, Play, Terminal, Timer } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   CopyIcon,
@@ -1903,18 +1903,20 @@ export default function ChallengeCard({
             onClick={() => setTestListOpen((v) => !v)}
             aria-expanded={testListOpen}
           >
-            <span className={styles.testLabel}>Test Results</span>
+            <span className={styles.testLabel} data-state={summaryState}>
+              Test Results
+            </span>
             <div className={styles.testSummary}>
               <span className={styles.testPill} data-state={summaryState}>
                 {summaryState === "pending" ? (
                   "Running…"
                 ) : summaryState === "pass" ? (
                   <>
-                    <Check size={10} strokeWidth={3} aria-hidden /> {passedCount}/{totalTests} passed
+                    <ListChecks size={11} strokeWidth={2.5} aria-hidden /> {passedCount}/{totalTests} passed
                   </>
                 ) : (
                   <>
-                    <X size={10} strokeWidth={3} aria-hidden /> {passedCount}/{totalTests} passed
+                    <ListX size={11} strokeWidth={2.5} aria-hidden /> {passedCount}/{totalTests} passed
                   </>
                 )}
               </span>
@@ -1945,28 +1947,19 @@ export default function ChallengeCard({
           data-state={bannerState}
           data-testid="challenge-banner"
         >
-          <div className={styles.bannerIcon}>
-            {bannerState === "pass" ? (
-              <Check size={14} strokeWidth={2.5} aria-hidden />
-            ) : (
-              <X size={14} strokeWidth={2.5} aria-hidden />
-            )}
-          </div>
           {bannerState === "pass" ? (
-            <span>
-              All tests passed!{" "}
-              <span className={styles.bannerSub}>
-                Great work — your solution is correct.
-              </span>
-            </span>
+            <>
+              <CheckCheck size={16} strokeWidth={2.5} aria-hidden />
+              <span>All tests passed!</span>
+            </>
           ) : (
-            <span>
-              {totalTests - passedCount} test
-              {totalTests - passedCount === 1 ? "" : "s"} failed{" "}
-              <span className={styles.bannerSub}>
-                — review the details and try again.
+            <>
+              <X size={16} strokeWidth={2.5} aria-hidden />
+              <span>
+                {totalTests - passedCount} test
+                {totalTests - passedCount === 1 ? "" : "s"} failed
               </span>
-            </span>
+            </>
           )}
         </div>
       )}

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -30,7 +30,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, ChevronUp, Eye, File, FileInput, Info, Play, Terminal } from "lucide-react";
+import { RotateCcw, Check, X, ChevronDown, ChevronUp, Eye, File, FileInput, Info, Play, Terminal, Timer } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   CopyIcon,
@@ -41,6 +41,7 @@ import {
   ChallengeToastViewport,
   useIsDark,
   cmThemeNameFor,
+  TestResultsRail,
 } from "./challengeShared";
 import { EditorState, Compartment } from "@codemirror/state";
 import {
@@ -83,6 +84,7 @@ import {
   isNativeTest,
   isStdoutTest,
   parseHarnessOutput,
+  stdoutExpectSummary,
   type ChallengeTest,
   type ParsedTestResult,
 } from "./challengeHarness";
@@ -1398,6 +1400,17 @@ export default function ChallengeCard({
   }, [adapter, toasts]);
 
   const isBusy = status === "loading" || status === "running";
+
+  // Code (or a readable summary of a declarative stdout expectation) per
+  // test id, surfaced by the test-details popover in the results rail.
+  const testCodeById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const t of tests) {
+      if (isNativeTest(t)) m.set(t.id, t.code);
+      else if (isStdoutTest(t)) m.set(t.id, stdoutExpectSummary(t.expect));
+    }
+    return m;
+  }, [tests]);
   const passedCount = testResults.filter((t) => t.state === "pass").length;
   const totalTests = testResults.length;
   const allPassed = totalTests > 0 && passedCount === totalTests;
@@ -1861,7 +1874,12 @@ export default function ChallengeCard({
               data-error={outputs.some((c) => c.type === "stderr")}
             />
             <span className={styles.outputLabel}>Output</span>
-            {elapsed && <span className={styles.outputTime}>{elapsed}</span>}
+            {elapsed && (
+              <span className={styles.outputTime}>
+                <Timer size={12} aria-hidden="true" />
+                {elapsed}
+              </span>
+            )}
           </div>
           {outputs.length === 0 ? (
             <div className={styles.outputEmpty}>Running…</div>
@@ -1910,38 +1928,12 @@ export default function ChallengeCard({
             />
           </button>
           {testListOpen && (
-            <div className={styles.testList}>
-              {testResults.map((t) => (
-                <div key={t.id} className={styles.testItem}>
-                  <div className={styles.testIcon} data-state={t.state}>
-                    {t.state === "pass" ? (
-                      <Check size={9} strokeWidth={3} aria-hidden />
-                    ) : t.state === "fail" ? (
-                      <X size={9} strokeWidth={3} aria-hidden />
-                    ) : (
-                      <svg
-                        width="9"
-                        height="9"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2.5"
-                        aria-hidden
-                      >
-                        <circle cx="12" cy="12" r="5" />
-                      </svg>
-                    )}
-                  </div>
-                  <div className={styles.testItemBody}>
-                    <div className={styles.testItemName}>{t.name}</div>
-                    {t.description && <div className={styles.testItemDesc}>{t.description}</div>}
-                    {t.state === "fail" && t.detail && (
-                      <div className={styles.testItemDetail}>{t.detail}</div>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
+            <TestResultsRail
+              tests={testResults.map((t) => ({
+                ...t,
+                code: testCodeById.get(t.id),
+              }))}
+            />
           )}
         </div>
       )}

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -2211,7 +2211,10 @@ function OutputCellView({ cell }: { cell: OutputCell }) {
   if (cell.type === "html") {
     return (
       <div
-        className={styles.outCellHtml}
+        // `not-prose` keeps the docs' prose typography (serif font,
+        // table margins) from restyling the dataframe markup when the
+        // card sits inside MDX content.
+        className={`${styles.outCellHtml} not-prose`}
         // Same trust assumption as the playground / code block: HTML
         // cells originate from code the user typed in this very widget.
         dangerouslySetInnerHTML={{ __html: cell.content }}

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -71,28 +71,29 @@
 
 /* ─── Output ──────────────────────────────────────────────────────── */
 
-/* Cap the overall output column height — without this, a code block
-   that emits many cells (or a single very tall one) can grow far past
-   the viewport and force the surrounding page to scroll just to reach
-   the action bar. Capping at ~60vh keeps the output panel reachable
-   while still letting individual cells render at a reasonable size.
-   The per-cell caps (`.outCellBody` rules below) still apply for
-   visually heavy single cells. */
-.output {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  background: var(--cb-bg);
-  border-top: 1px solid var(--cb-border);
-  max-height: 68vh;
-  overflow-y: auto;
-  position: relative;
-}
-
 .outputRunning {
   min-height: 84px;
   padding-bottom: 48px;
+}
+
+/* Right side of the shared output-panel header: elapsed time + copy.
+   The wrapper carries the margin-left:auto so the copy button stays on
+   the right edge whether or not the time is present. */
+.outputHeaderRight {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.outputCopyBtn {
+  width: 22px;
+  height: 22px;
+}
+
+/* Aligns the boot notice with the output body's text inset. */
+.bootNoticeWrap {
+  padding: 4px 14px 14px 18px;
 }
 
 /* First-run boot affordance — shown while the runtime is downloading /
@@ -139,205 +140,6 @@
   color: var(--cb-text-dim);
   font-size: 11.5px;
   line-height: 1.35;
-}
-
-/* One frame per run. The body is transparent (it sits on the output
-   panel's background) so dataframes, figures, and text read as one
-   continuous output — only the header strip carries a fill. */
-.outCell {
-  border-radius: var(--cb-radius);
-  overflow: hidden;
-  animation: cb-fadeSlide 0.2s ease;
-  flex: 0 0 auto;
-}
-@keyframes cb-fadeSlide {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.outCellStdout {
-  border-left: 3px solid var(--cb-green);
-}
-.outCellStderr {
-  border-left: 3px solid var(--cb-red);
-}
-
-.outCellHeader {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 10px;
-  background: var(--cb-bg2);
-  border-bottom: 1px solid var(--cb-border);
-  font-size: 10px;
-  font-family: var(--cb-font-mono);
-  color: var(--cb-text-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-weight: 600;
-}
-
-.outCellType {
-  font-weight: 600;
-}
-
-.outCellTime {
-  margin-left: auto;
-  font-weight: 500;
-  text-transform: none;
-  letter-spacing: 0;
-  color: var(--cb-text-dim);
-}
-
-/* Anchor the cell-header copy button on the right edge regardless of
-   whether `outCellTime` (which uses `margin-left: auto`) is present. */
-.outCellCopy {
-  margin-left: 4px;
-  width: 22px;
-  height: 22px;
-}
-
-.outCellBody {
-  padding: 10px 12px;
-  font-family: var(--cb-font-mono);
-  font-size: 13px;
-  line-height: 1.6;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: var(--cb-text);
-}
-
-.outCellStderr .outCellBody {
-  color: var(--cb-red);
-}
-
-/* ─── Output segments ───
-   One run renders as a single OUTPUT cell whose body stacks segments in
-   chronological order: text, dataframes, figures, charts. stderr mixed
-   into other output reads red inline (a pure-error run gets the
-   .outCellStderr frame instead). Visually heavy segments are
-   height-capped so a giant figure / wide frame stays in the page flow
-   but remains reachable via its own scrollbar. */
-.outSegStderr {
-  color: var(--cb-red);
-}
-.outSegImage {
-  text-align: center;
-  max-height: 600px;
-  overflow: auto;
-  white-space: normal;
-}
-.outSegImage :global(img),
-.outSegImage :global(svg) {
-  max-width: 100%;
-}
-.outSegPlot {
-  max-height: 600px;
-  overflow: auto;
-  white-space: normal;
-}
-.outSegPlot :global(.js-plotly-plot) {
-  width: 100%;
-}
-
-/* ─── DataFrame tables ─── */
-
-/* Pandas / polars / R data frames arrive as bare <table> markup (the
-   runtimes strip any injected <style> blocks). The look mirrors a
-   Jupyter notebook's default dataframe: 600-weight header row and index
-   column, very subtle row striping, right-aligned cells, no cell
-   borders — in slightly tightened Inter (--font-sans) at a compact size
-   with minimal vertical padding. The table is content-width (like
-   Jupyter), never stretched; the wrapper scrolls both axes for big
-   frames. `not-prose` keeps the docs' prose typography (serif font,
-   table margins, roomy cell padding) from restyling the cells.
-
-   Selectors use `table th` / `table td` (specificity 0,1,2) so they
-   outrank the learn.css prose-typography rules regardless of stylesheet
-   order. */
-.dataframeWrap {
-  overflow: auto;
-  max-height: 480px;
-  padding: 6px 0;
-  /* .outCellBody renders text with pre-wrap; the newlines between the
-     tags of pandas' HTML must not become blank lines above/below the
-     table. */
-  white-space: normal;
-}
-
-.dataframeWrap :global(table) {
-  border-collapse: collapse;
-  border: none;
-  font-family: var(--font-sans, Inter, system-ui, sans-serif);
-  letter-spacing: -0.011em;
-  font-size: 12.5px;
-  line-height: 1.45;
-  color: var(--cb-text);
-  width: auto;
-  margin: 0;
-}
-.dataframeWrap :global(table th) {
-  padding: 3px 10px;
-  background: transparent;
-  border: none;
-  text-align: right;
-  font-weight: 600;
-  font-size: 12px;
-  line-height: 1.45;
-  color: var(--cb-text);
-  white-space: nowrap;
-  vertical-align: bottom;
-}
-.dataframeWrap :global(table thead th) {
-  border-bottom: 1px solid var(--cb-border);
-}
-.dataframeWrap :global(table td) {
-  padding: 3px 10px;
-  border: none;
-  text-align: right;
-  white-space: nowrap;
-  /* One enormous value shouldn't blow out its column — clip with an
-     ellipsis (pandas itself truncates cell text, R values can be long). */
-  max-width: 320px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-/* Very subtle striping on alternate body rows, like Jupyter. The index
-   <th> cells stripe with their row. */
-.dataframeWrap :global(tbody tr:nth-child(even) td),
-.dataframeWrap :global(tbody tr:nth-child(even) th) {
-  background: color-mix(in srgb, var(--cb-text) 4%, transparent);
-}
-.dataframeWrap :global(tbody tr:hover td),
-.dataframeWrap :global(tbody tr:hover th) {
-  background: color-mix(in srgb, var(--cb-text) 8%, transparent);
-}
-/* Middle-truncation marker cells/columns (R runtime) — pandas renders
-   its own "..." cells which inherit the same muted colour. */
-.dataframeWrap :global(tr.dataframe-ellipsis-row td),
-.dataframeWrap :global(.dataframe-ellipsis-col) {
-  text-align: center;
-  color: var(--cb-text-dim);
-}
-/* Footer row stating the full row/column count of a truncated frame. */
-.dataframeWrap :global(td.dataframe-rows-footer) {
-  padding: 3px 10px;
-  font-size: 11.5px;
-  color: var(--cb-text-dim);
-  font-style: italic;
-  text-align: right;
-  border-top: 1px solid var(--cb-border);
-}
-/* Dimensions line pandas appends below a truncated frame
-   ("100 rows × 40 columns"). */
-.dataframeWrap :global(p) {
-  margin: 6px 0 0;
-  font-size: 11.5px;
-  color: var(--cb-text-dim);
 }
 
 /* ─── Running overlay (sine-wave animation) ──────────────────────────

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -141,10 +141,12 @@
   line-height: 1.35;
 }
 
+/* One frame per run. The body is transparent (it sits on the output
+   panel's background) so dataframes, figures, and text read as one
+   continuous output — only the header strip carries a fill. */
 .outCell {
   border-radius: var(--cb-radius);
   overflow: hidden;
-  background: var(--cb-bg2);
   animation: cb-fadeSlide 0.2s ease;
   flex: 0 0 auto;
 }
@@ -162,15 +164,6 @@
 }
 .outCellStderr {
   border-left: 3px solid var(--cb-red);
-}
-.outCellHtml {
-  border-left: 3px solid var(--cb-accent);
-}
-.outCellImage {
-  border-left: 3px solid var(--cb-yellow);
-}
-.outCellPlot {
-  border-left: 3px solid var(--cb-accent);
 }
 
 .outCellHeader {
@@ -222,60 +215,63 @@
   color: var(--cb-red);
 }
 
-/* Cap the body height for visually heavy cells so a giant figure /
-   wide DataFrame / Plotly chart stays inside the page flow but is
-   still fully reachable via a scrollbar. Plain text cells (stdout /
-   stderr) intentionally have no cap so short outputs read inline. */
-.outCellHtml .outCellBody {
-  padding: 0;
-  max-height: 480px;
-  overflow: auto;
+/* ─── Output segments ───
+   One run renders as a single OUTPUT cell whose body stacks segments in
+   chronological order: text, dataframes, figures, charts. stderr mixed
+   into other output reads red inline (a pure-error run gets the
+   .outCellStderr frame instead). Visually heavy segments are
+   height-capped so a giant figure / wide frame stays in the page flow
+   but remains reachable via its own scrollbar. */
+.outSegStderr {
+  color: var(--cb-red);
 }
-.outCellImage .outCellBody {
+.outSegImage {
   text-align: center;
   max-height: 600px;
   overflow: auto;
+  white-space: normal;
 }
-.outCellPlot .outCellBody {
-  padding: 0;
-  max-height: 600px;
-  overflow: auto;
-}
-
-.outCellHtml :global(img),
-.outCellHtml :global(svg) {
+.outSegImage :global(img),
+.outSegImage :global(svg) {
   max-width: 100%;
 }
-
-.outCellPlot :global(.js-plotly-plot) {
+.outSegPlot {
+  max-height: 600px;
+  overflow: auto;
+  white-space: normal;
+}
+.outSegPlot :global(.js-plotly-plot) {
   width: 100%;
 }
 
 /* ─── DataFrame tables ─── */
 
 /* Pandas / polars / R data frames arrive as bare <table> markup (the
-   runtimes strip any injected <style> blocks). Typography: slightly
-   tightened Inter (--font-sans) at a compact size with minimal vertical
-   padding — a Jupyter-style dense table. The table is content-width
-   (like Jupyter), never stretched, and the wrapper scrolls horizontally
-   for wide frames. The wrapper also carries `not-prose` so the docs'
-   prose typography (serif font, table margins, roomy cell padding)
-   can't restyle the cells.
+   runtimes strip any injected <style> blocks). The look mirrors a
+   Jupyter notebook's default dataframe: 600-weight header row and index
+   column, very subtle row striping, right-aligned cells, no cell
+   borders — in slightly tightened Inter (--font-sans) at a compact size
+   with minimal vertical padding. The table is content-width (like
+   Jupyter), never stretched; the wrapper scrolls both axes for big
+   frames. `not-prose` keeps the docs' prose typography (serif font,
+   table margins, roomy cell padding) from restyling the cells.
 
    Selectors use `table th` / `table td` (specificity 0,1,2) so they
    outrank the learn.css prose-typography rules regardless of stylesheet
    order. */
 .dataframeWrap {
-  overflow-x: auto;
-  padding: 10px 12px;
-  /* .outCellBody renders text cells with pre-wrap; the newlines between
-     the tags of pandas' HTML must not become blank lines above/below
-     the table. */
+  overflow: auto;
+  max-height: 480px;
+  padding: 6px 0;
+  /* .outCellBody renders text with pre-wrap; the newlines between the
+     tags of pandas' HTML must not become blank lines above/below the
+     table. */
   white-space: normal;
 }
 
 .dataframeWrap :global(table) {
   border-collapse: collapse;
+  border: none;
   font-family: var(--font-sans, Inter, system-ui, sans-serif);
   letter-spacing: -0.011em;
   font-size: 12.5px;
@@ -283,41 +279,42 @@
   color: var(--cb-text);
   width: auto;
   margin: 0;
-  border: 1px solid var(--cb-border);
 }
 .dataframeWrap :global(table th) {
   padding: 3px 10px;
-  background: var(--cb-bg3);
-  border-bottom: 1px solid var(--cb-border);
-  border-right: 1px solid var(--cb-border);
-  text-align: left;
+  background: transparent;
+  border: none;
+  text-align: right;
   font-weight: 600;
   font-size: 12px;
   line-height: 1.45;
-  color: var(--cb-accent);
+  color: var(--cb-text);
   white-space: nowrap;
+  vertical-align: bottom;
+}
+.dataframeWrap :global(table thead th) {
+  border-bottom: 1px solid var(--cb-border);
 }
 .dataframeWrap :global(table td) {
-  padding: 2px 10px;
-  border-bottom: 1px solid var(--cb-border);
-  border-right: 1px solid var(--cb-border);
+  padding: 3px 10px;
+  border: none;
+  text-align: right;
   white-space: nowrap;
-  color: var(--cb-text-muted);
   /* One enormous value shouldn't blow out its column — clip with an
      ellipsis (pandas itself truncates cell text, R values can be long). */
   max-width: 320px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.dataframeWrap :global(table th:last-child),
-.dataframeWrap :global(table td:last-child) {
-  border-right: none;
+/* Very subtle striping on alternate body rows, like Jupyter. The index
+   <th> cells stripe with their row. */
+.dataframeWrap :global(tbody tr:nth-child(even) td),
+.dataframeWrap :global(tbody tr:nth-child(even) th) {
+  background: color-mix(in srgb, var(--cb-text) 4%, transparent);
 }
-.dataframeWrap :global(tr:hover td) {
-  background: var(--cb-bg3);
-}
-.dataframeWrap :global(tr:last-child td) {
-  border-bottom: none;
+.dataframeWrap :global(tbody tr:hover td),
+.dataframeWrap :global(tbody tr:hover th) {
+  background: color-mix(in srgb, var(--cb-text) 8%, transparent);
 }
 /* Middle-truncation marker cells/columns (R runtime) — pandas renders
    its own "..." cells which inherit the same muted colour. */

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -253,45 +253,94 @@
 
 /* ─── DataFrame tables ─── */
 
-/* Mirrors `.dataframe-wrap` + `.out-cell.html table` in playground.css
-   so a DataFrame rendered inside a learning code block matches the
-   playground's table chrome (accent-coloured headers, hover rows,
-   horizontal scroll for wide frames). */
+/* Pandas / polars / R data frames arrive as bare <table> markup (the
+   runtimes strip any injected <style> blocks). Typography: slightly
+   tightened Inter (--font-sans) at a compact size with minimal vertical
+   padding — a Jupyter-style dense table. The table is content-width
+   (like Jupyter), never stretched, and the wrapper scrolls horizontally
+   for wide frames. The wrapper also carries `not-prose` so the docs'
+   prose typography (serif font, table margins, roomy cell padding)
+   can't restyle the cells.
+
+   Selectors use `table th` / `table td` (specificity 0,1,2) so they
+   outrank the learn.css prose-typography rules regardless of stylesheet
+   order. */
 .dataframeWrap {
   overflow-x: auto;
-  padding: 12px;
+  padding: 10px 12px;
+  /* .outCellBody renders text cells with pre-wrap; the newlines between
+     the tags of pandas' HTML must not become blank lines above/below
+     the table. */
+  white-space: normal;
 }
 
 .dataframeWrap :global(table) {
   border-collapse: collapse;
-  font-family: var(--cb-font-mono);
+  font-family: var(--font-sans, Inter, system-ui, sans-serif);
+  letter-spacing: -0.011em;
   font-size: 12.5px;
+  line-height: 1.45;
   color: var(--cb-text);
-  width: 100%;
-  min-width: max-content;
+  width: auto;
+  margin: 0;
+  border: 1px solid var(--cb-border);
 }
-.dataframeWrap :global(th) {
-  padding: 7px 14px;
+.dataframeWrap :global(table th) {
+  padding: 3px 10px;
   background: var(--cb-bg3);
   border-bottom: 1px solid var(--cb-border);
   border-right: 1px solid var(--cb-border);
   text-align: left;
   font-weight: 600;
+  font-size: 12px;
+  line-height: 1.45;
   color: var(--cb-accent);
   white-space: nowrap;
 }
-.dataframeWrap :global(td) {
-  padding: 6px 14px;
+.dataframeWrap :global(table td) {
+  padding: 2px 10px;
   border-bottom: 1px solid var(--cb-border);
   border-right: 1px solid var(--cb-border);
   white-space: nowrap;
   color: var(--cb-text-muted);
+  /* One enormous value shouldn't blow out its column — clip with an
+     ellipsis (pandas itself truncates cell text, R values can be long). */
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dataframeWrap :global(table th:last-child),
+.dataframeWrap :global(table td:last-child) {
+  border-right: none;
 }
 .dataframeWrap :global(tr:hover td) {
   background: var(--cb-bg3);
 }
 .dataframeWrap :global(tr:last-child td) {
   border-bottom: none;
+}
+/* Middle-truncation marker cells/columns (R runtime) — pandas renders
+   its own "..." cells which inherit the same muted colour. */
+.dataframeWrap :global(tr.dataframe-ellipsis-row td),
+.dataframeWrap :global(.dataframe-ellipsis-col) {
+  text-align: center;
+  color: var(--cb-text-dim);
+}
+/* Footer row stating the full row/column count of a truncated frame. */
+.dataframeWrap :global(td.dataframe-rows-footer) {
+  padding: 3px 10px;
+  font-size: 11.5px;
+  color: var(--cb-text-dim);
+  font-style: italic;
+  text-align: right;
+  border-top: 1px solid var(--cb-border);
+}
+/* Dimensions line pandas appends below a truncated frame
+   ("100 rows × 40 columns"). */
+.dataframeWrap :global(p) {
+  margin: 6px 0 0;
+  font-size: 11.5px;
+  color: var(--cb-text-dim);
 }
 
 /* ─── Running overlay (sine-wave animation) ──────────────────────────

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { ChevronDown, ChevronUp, File, Lock, Play, RotateCcw } from "lucide-react";
+import { ChevronDown, ChevronUp, File, Lock, Play, RotateCcw, Timer } from "lucide-react";
 import { Toast } from "@base-ui/react/toast";
 import {
   LANGUAGE_ICONS,
@@ -994,6 +994,17 @@ function CodeBlockInner({
 
   const isBusy = status === "loading" || status === "running";
 
+  // Header readouts for the merged output panel. Cells stream in during
+  // the run, each stamped with the elapsed time at its arrival — the last
+  // one is the closest to the run's total. Only text is sensibly
+  // copyable: skipping image/plot content avoids dumping a raw base64
+  // PNG / Plotly JSON blob behind a misleading "Copy" affordance.
+  const outputElapsed = outputs[outputs.length - 1]?.elapsed ?? "";
+  const outputCopyText = outputs
+    .filter((c) => c.type === "stdout" || c.type === "stderr")
+    .map((c) => c.content)
+    .join("\n");
+
   // ─── Render ────────────────────────────────────────────────────────────
   return (
     <div
@@ -1288,45 +1299,79 @@ function CodeBlockInner({
       </div>
 
       {(outputs.length > 0 || isBusy) && (
+        // Same output panel as the challenge card (its styles are shared
+        // through ChallengeCard.module.css): an accent-bar header with the
+        // elapsed time, and one clean body that stacks the run's segments
+        // in chronological order, no per-segment chrome.
         <div
-          className={`${styles.output}${isBusy ? ` ${styles.outputRunning}` : ""}`}
+          className={`${challengeStyles.outputPanel}${isBusy ? ` ${styles.outputRunning}` : ""}`}
           aria-live="polite"
         >
-          {status === "loading" && (
-            <div className={styles.bootNotice} data-testid="codeblock-boot">
-
-              <svg
-                viewBox="0 0 24 24"
-                className={styles.bootSpinner}
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                aria-hidden
-              >
-                <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-              </svg>
-              <span className={styles.bootNoticeText}>
-                <span className={styles.bootNoticeTitle}>
-                  {statusMessage ||
-                    `Setting up the ${adapter.runtimeInfo.language} runtime…`}
+          <div className={challengeStyles.outputHeader}>
+            <div
+              className={challengeStyles.accentBar}
+              data-error={outputs.some((c) => c.type === "stderr")}
+            />
+            <span className={challengeStyles.outputLabel}>Output</span>
+            <span className={styles.outputHeaderRight}>
+              {outputElapsed && (
+                <span className={challengeStyles.outputTime}>
+                  <Timer size={12} aria-hidden="true" />
+                  {outputElapsed}
                 </span>
-                {bootCold && (
-                  <span className={styles.bootNoticeHint}>
-                    Downloading the {adapter.runtimeInfo.language} runtime — this
-                    happens once; later runs are instant.
+              )}
+              {outputCopyText.length > 0 && (
+                <button
+                  type="button"
+                  className={`${styles.iconBtn} ${styles.outputCopyBtn}`}
+                  title="Copy output to clipboard"
+                  aria-label="Copy output to clipboard"
+                  onClick={() => void copyToClipboard(outputCopyText)}
+                >
+                  <CopyIcon />
+                </button>
+              )}
+            </span>
+          </div>
+          {status === "loading" && (
+            <div className={styles.bootNoticeWrap}>
+              <div className={styles.bootNotice} data-testid="codeblock-boot">
+                <svg
+                  viewBox="0 0 24 24"
+                  className={styles.bootSpinner}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  aria-hidden
+                >
+                  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                </svg>
+                <span className={styles.bootNoticeText}>
+                  <span className={styles.bootNoticeTitle}>
+                    {statusMessage ||
+                      `Setting up the ${adapter.runtimeInfo.language} runtime…`}
                   </span>
-                )}
-              </span>
+                  {bootCold && (
+                    <span className={styles.bootNoticeHint}>
+                      Downloading the {adapter.runtimeInfo.language} runtime —
+                      this happens once; later runs are instant.
+                    </span>
+                  )}
+                </span>
+              </div>
             </div>
           )}
-          {outputs.length > 0 && (
-            <OutputGroupView
-              cells={outputs}
-              onCopy={(content) => {
-                void copyToClipboard(content);
-              }}
-            />
+          {outputs.length > 0 ? (
+            <div className={challengeStyles.outputBody}>
+              {outputs.map((cell) => (
+                <OutputSegment key={cell.id} cell={cell} />
+              ))}
+            </div>
+          ) : (
+            status === "running" && (
+              <div className={challengeStyles.outputEmpty}>Running…</div>
+            )
           )}
           <RunOverlay active={isBusy} />
         </div>
@@ -1357,63 +1402,11 @@ async function copyToClipboard(text: string): Promise<void> {
   }
 }
 
-/** Renders one run's outputs as a single OUTPUT cell — text, dataframes,
- *  figures, and charts stacked in chronological order inside one frame,
- *  the way a notebook shows a cell's output. The frame reads as ERROR
- *  when the run produced nothing but stderr; stderr mixed into other
- *  output renders red inline. */
-function OutputGroupView({
-  cells,
-  onCopy,
-}: {
-  cells: OutputCell[];
-  onCopy: (content: string) => void;
-}) {
-  const onlyStderr = cells.every((c) => c.type === "stderr");
-  // Only text is sensibly copyable. Skipping image/plot content avoids
-  // dumping a raw base64 PNG / Plotly JSON blob behind a misleading
-  // "Copy" affordance — same rule the playground uses.
-  const copyText = cells
-    .filter((c) => c.type === "stdout" || c.type === "stderr")
-    .map((c) => c.content)
-    .join("\n");
-  // Cells stream in during the run, each stamped with the elapsed time at
-  // its arrival — the last one is the closest to the run's total.
-  const elapsed = cells[cells.length - 1]?.elapsed;
-
-  return (
-    <div
-      className={`${styles.outCell} ${onlyStderr ? styles.outCellStderr : styles.outCellStdout}`}
-    >
-      <div className={styles.outCellHeader}>
-        <span className={styles.outCellType}>
-          {onlyStderr ? "ERROR" : "OUTPUT"}
-        </span>
-        {elapsed && <span className={styles.outCellTime}>{elapsed}</span>}
-        {copyText.length > 0 && (
-          <button
-            type="button"
-            className={`${styles.iconBtn} ${styles.outCellCopy}`}
-            title="Copy output to clipboard"
-            aria-label="Copy output to clipboard"
-            onClick={() => onCopy(copyText)}
-          >
-            <CopyIcon />
-          </button>
-        )}
-      </div>
-      <div className={styles.outCellBody}>
-        {cells.map((cell) => (
-          <OutputSegment key={cell.id} cell={cell} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-/** One chronological piece of a run's output. Keeps the `data-cell-type`
- *  attribute the per-cell rendering used to carry, so tests and tooling
- *  can keep counting stdout/stderr/html/image/plot outputs. */
+/** One chronological piece of a run's output, rendered with the challenge
+ *  card's output-panel styles so both surfaces read identically. Keeps the
+ *  `data-cell-type` attribute the per-cell rendering used to carry, so
+ *  tests and tooling can keep counting stdout/stderr/html/image/plot
+ *  outputs. */
 function OutputSegment({ cell }: { cell: OutputCell }) {
   if (cell.type === "html") {
     // Same trust assumption as the main playground: HTML cells are
@@ -1423,7 +1416,7 @@ function OutputSegment({ cell }: { cell: OutputCell }) {
     // the dataframe markup when the block sits inside MDX content.
     return (
       <div
-        className={`${styles.dataframeWrap} not-prose`}
+        className={`${challengeStyles.outCellHtml} not-prose`}
         data-cell-type="html"
         dangerouslySetInnerHTML={{ __html: cell.content }}
       />
@@ -1431,7 +1424,7 @@ function OutputSegment({ cell }: { cell: OutputCell }) {
   }
   if (cell.type === "image") {
     return (
-      <div className={styles.outSegImage} data-cell-type="image">
+      <div className={challengeStyles.outCellImage} data-cell-type="image">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={`data:image/png;base64,${cell.content}`}
@@ -1443,14 +1436,18 @@ function OutputSegment({ cell }: { cell: OutputCell }) {
   }
   if (cell.type === "plot" && cell.plot) {
     return (
-      <div className={styles.outSegPlot} data-cell-type="plot">
+      <div className={challengeStyles.outCellPlot} data-cell-type="plot">
         <PlotlyChart figure={cell.plot} />
       </div>
     );
   }
   return (
     <div
-      className={cell.type === "stderr" ? styles.outSegStderr : undefined}
+      className={
+        cell.type === "stderr"
+          ? challengeStyles.outCellStderr
+          : challengeStyles.outCellStdout
+      }
       data-cell-type={cell.type}
     >
       {cell.content}

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -1320,15 +1320,14 @@ function CodeBlockInner({
               </span>
             </div>
           )}
-          {outputs.map((cell) => (
-            <OutputCellView
-              key={cell.id}
-              cell={cell}
+          {outputs.length > 0 && (
+            <OutputGroupView
+              cells={outputs}
               onCopy={(content) => {
                 void copyToClipboard(content);
               }}
             />
-          ))}
+          )}
           <RunOverlay active={isBusy} />
         </div>
       )}
@@ -1358,93 +1357,103 @@ async function copyToClipboard(text: string): Promise<void> {
   }
 }
 
-// Cell-type → playground-style header label. Keeping these in sync with
-// `Playground.tsx`'s `typeLabel` map ensures a code block's outputs read
-// identically to the playground's outputs.
-const CELL_TYPE_LABEL: Record<OutputCell["type"], string> = {
-  stdout: "OUTPUT",
-  stderr: "ERROR",
-  html: "DATAFRAME",
-  image: "FIGURE",
-  plot: "CHART",
-};
-
-function OutputCellView({
-  cell,
+/** Renders one run's outputs as a single OUTPUT cell — text, dataframes,
+ *  figures, and charts stacked in chronological order inside one frame,
+ *  the way a notebook shows a cell's output. The frame reads as ERROR
+ *  when the run produced nothing but stderr; stderr mixed into other
+ *  output renders red inline. */
+function OutputGroupView({
+  cells,
   onCopy,
 }: {
-  cell: OutputCell;
+  cells: OutputCell[];
   onCopy: (content: string) => void;
 }) {
-  // Renders text (stdout/stderr), HTML (e.g. dataframes from Python/R),
-  // base64 PNG images (e.g. matplotlib figures), and Plotly figures —
-  // matching what the main playground supports so a code block dropped
-  // into a learning page can show the same dynamic outputs as the
-  // playground itself.
-  const wrapperClass = (() => {
-    switch (cell.type) {
-      case "stderr":
-        return `${styles.outCell} ${styles.outCellStderr}`;
-      case "html":
-        return `${styles.outCell} ${styles.outCellHtml}`;
-      case "image":
-        return `${styles.outCell} ${styles.outCellImage}`;
-      case "plot":
-        return `${styles.outCell} ${styles.outCellPlot}`;
-      default:
-        return `${styles.outCell} ${styles.outCellStdout}`;
-    }
-  })();
-  const headerLabel = CELL_TYPE_LABEL[cell.type];
-  // Only text-ish cells are sensibly copyable. Skipping image/plot
-  // cells avoids exposing the raw base64 PNG / Plotly JSON blob behind
-  // a misleading "Copy" affordance — same rule the playground uses.
-  const isCopyable =
-    cell.type === "stdout" || cell.type === "stderr" || cell.type === "html";
+  const onlyStderr = cells.every((c) => c.type === "stderr");
+  // Only text is sensibly copyable. Skipping image/plot content avoids
+  // dumping a raw base64 PNG / Plotly JSON blob behind a misleading
+  // "Copy" affordance — same rule the playground uses.
+  const copyText = cells
+    .filter((c) => c.type === "stdout" || c.type === "stderr")
+    .map((c) => c.content)
+    .join("\n");
+  // Cells stream in during the run, each stamped with the elapsed time at
+  // its arrival — the last one is the closest to the run's total.
+  const elapsed = cells[cells.length - 1]?.elapsed;
 
   return (
-    <div className={wrapperClass} data-cell-type={cell.type}>
+    <div
+      className={`${styles.outCell} ${onlyStderr ? styles.outCellStderr : styles.outCellStdout}`}
+    >
       <div className={styles.outCellHeader}>
-        <span className={styles.outCellType}>{headerLabel}</span>
-        {cell.elapsed && (
-          <span className={styles.outCellTime}>{cell.elapsed}</span>
-        )}
-        {isCopyable && (
+        <span className={styles.outCellType}>
+          {onlyStderr ? "ERROR" : "OUTPUT"}
+        </span>
+        {elapsed && <span className={styles.outCellTime}>{elapsed}</span>}
+        {copyText.length > 0 && (
           <button
             type="button"
             className={`${styles.iconBtn} ${styles.outCellCopy}`}
             title="Copy output to clipboard"
             aria-label="Copy output to clipboard"
-            onClick={() => onCopy(cell.content)}
+            onClick={() => onCopy(copyText)}
           >
             <CopyIcon />
           </button>
         )}
       </div>
       <div className={styles.outCellBody}>
-        {cell.type === "html" ? (
-          // Same trust assumption as the main playground: HTML cells are
-          // produced by the embedded runtime executing code the user
-          // themselves typed in this very widget. `not-prose` keeps the
-          // docs' prose typography (serif, table margins) from restyling
-          // the dataframe markup when the block sits inside MDX content.
-          <div
-            className={`${styles.dataframeWrap} not-prose`}
-            dangerouslySetInnerHTML={{ __html: cell.content }}
-          />
-        ) : cell.type === "image" ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={`data:image/png;base64,${cell.content}`}
-            alt=""
-            style={{ maxWidth: "100%" }}
-          />
-        ) : cell.type === "plot" && cell.plot ? (
-          <PlotlyChart figure={cell.plot} />
-        ) : (
-          cell.content
-        )}
+        {cells.map((cell) => (
+          <OutputSegment key={cell.id} cell={cell} />
+        ))}
       </div>
+    </div>
+  );
+}
+
+/** One chronological piece of a run's output. Keeps the `data-cell-type`
+ *  attribute the per-cell rendering used to carry, so tests and tooling
+ *  can keep counting stdout/stderr/html/image/plot outputs. */
+function OutputSegment({ cell }: { cell: OutputCell }) {
+  if (cell.type === "html") {
+    // Same trust assumption as the main playground: HTML cells are
+    // produced by the embedded runtime executing code the user
+    // themselves typed in this very widget. `not-prose` keeps the
+    // docs' prose typography (serif, table margins) from restyling
+    // the dataframe markup when the block sits inside MDX content.
+    return (
+      <div
+        className={`${styles.dataframeWrap} not-prose`}
+        data-cell-type="html"
+        dangerouslySetInnerHTML={{ __html: cell.content }}
+      />
+    );
+  }
+  if (cell.type === "image") {
+    return (
+      <div className={styles.outSegImage} data-cell-type="image">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={`data:image/png;base64,${cell.content}`}
+          alt=""
+          style={{ maxWidth: "100%" }}
+        />
+      </div>
+    );
+  }
+  if (cell.type === "plot" && cell.plot) {
+    return (
+      <div className={styles.outSegPlot} data-cell-type="plot">
+        <PlotlyChart figure={cell.plot} />
+      </div>
+    );
+  }
+  return (
+    <div
+      className={cell.type === "stderr" ? styles.outSegStderr : undefined}
+      data-cell-type={cell.type}
+    >
+      {cell.content}
     </div>
   );
 }

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -1425,9 +1425,11 @@ function OutputCellView({
         {cell.type === "html" ? (
           // Same trust assumption as the main playground: HTML cells are
           // produced by the embedded runtime executing code the user
-          // themselves typed in this very widget.
+          // themselves typed in this very widget. `not-prose` keeps the
+          // docs' prose typography (serif, table margins) from restyling
+          // the dataframe markup when the block sits inside MDX content.
           <div
-            className={styles.dataframeWrap}
+            className={`${styles.dataframeWrap} not-prose`}
             dangerouslySetInnerHTML={{ __html: cell.content }}
           />
         ) : cell.type === "image" ? (

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -789,6 +789,9 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   const [isFormatting, setIsFormatting] = useState(false);
   const [formatPopoverOpen, setFormatPopoverOpen] = useState(false);
   const outputCounter = useRef(0);
+  // Monotonic per-run id stamped on every cell a run appends, so the
+  // output pane can render one merged frame per run (see outputGroups).
+  const runCounter = useRef(0);
   const runtimeRef = useRef<LanguageRuntime | null>(null);
 
   // ─── CodeMirror ─────────────────────────────────────────────────────────
@@ -1708,6 +1711,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     const collected: Omit<OutputCell, "id" | "elapsed">[] = [];
     const firstId = outputCounter.current + 1;
     newRunFirstIdRef.current = firstId;
+    const runId = ++runCounter.current;
 
     // Mirror files the runtime created during the run (e.g. an R
     // download.file() destination) into the Files pane and persist them to
@@ -1802,6 +1806,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
           ...c,
           id: ++outputCounter.current,
           elapsed,
+          runId,
         })),
       ]);
       if (collected.length === 0) {
@@ -1825,12 +1830,14 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
           ...c,
           id: ++outputCounter.current,
           elapsed,
+          runId,
         })),
         {
           id: ++outputCounter.current,
           type: "stderr" as const,
           content: msg,
           elapsed,
+          runId,
         },
       ]);
       setStatusState("error");
@@ -2684,20 +2691,25 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   // and Escape themselves, so the legacy click-outside effects for the
   // examples / export / info dropdowns are no longer needed.
 
-  const typeLabel: Record<OutputCell["type"], string> = {
-    stdout: "OUTPUT",
-    stderr: "ERROR",
-    html: "DATAFRAME",
-    image: "FIGURE",
-    plot: "CHART",
-  };
-
-  // The output cell shows a copy button only when its content is plain
-  // text or HTML markup that is meaningful to copy. Skipping image/plot
-  // cells avoids exposing the raw base64 PNG / Plotly JSON blob behind a
-  // misleading "Copy" affordance.
-  const isCopyableCell = (cell: OutputCell) =>
-    cell.type === "stdout" || cell.type === "stderr" || cell.type === "html";
+  // One merged output frame per run: cells produced by the same run stack
+  // inside a single OUTPUT cell in chronological order (text, dataframes,
+  // figures, charts), notebook-style. Cells without a runId (defensive —
+  // shouldn't occur) each get their own group.
+  const outputGroups = useMemo(() => {
+    const groups: OutputCell[][] = [];
+    let current: OutputCell[] | null = null;
+    let currentRun: number | undefined;
+    for (const cell of outputs) {
+      if (current && cell.runId !== undefined && cell.runId === currentRun) {
+        current.push(cell);
+      } else {
+        current = [cell];
+        currentRun = cell.runId;
+        groups.push(current);
+      }
+    }
+    return groups;
+  }, [outputs]);
 
   // Rotate through the witty loading messages while the runtime is
   // still initialising. The cadence is intentionally a touch slower than
@@ -3841,9 +3853,10 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
             <div className="pane-bar">
               <span className="pane-label">
                 <Terminal size={12} aria-hidden="true" />
-                {outputs.length === 0
+                {/* Count merged per-run frames, not raw cells. */}
+                {outputGroups.length === 0
                   ? "Output"
-                  : `${outputs.length} ${outputs.length === 1 ? "Output" : "Outputs"}`}
+                  : `${outputGroups.length} ${outputGroups.length === 1 ? "Output" : "Outputs"}`}
               </span>
               <div className="pane-bar-sep" />
               <button
@@ -3865,58 +3878,96 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                   {capabilitiesBlurb && <p>{capabilitiesBlurb}</p>}
                 </div>
               ) : (
-                outputs.map((cell) => (
-                  <div
-                    key={cell.id}
-                    data-cell-id={cell.id}
-                    className={`out-cell ${cell.type}`}
-                  >
-                    <div className="out-cell-header">
-                      <span className="cell-type">{typeLabel[cell.type]}</span>
-                      <span className="cell-time">
-                        <Timer size={12} aria-hidden="true" />
-                        <span>Done in {cell.elapsed}</span>
-                      </span>
-                      {isCopyableCell(cell) && (
-                        <button
-                          type="button"
-                          className="icon-btn out-cell-copy"
-                          title="Copy output to clipboard"
-                          aria-label="Copy output to clipboard"
-                          onClick={() =>
-                            void copyToClipboard(
-                              cell.content,
-                              cell.type === "stderr" ? "Error" : "Output",
-                            )
-                          }
-                        >
-                          <CopyIcon />
-                        </button>
-                      )}
+                outputGroups.map((group) => {
+                  // One frame per run: stderr-only runs read as ERROR;
+                  // stderr mixed into other output renders red inline.
+                  const onlyStderr = group.every((c) => c.type === "stderr");
+                  const copyText = group
+                    .filter(
+                      (c) => c.type === "stdout" || c.type === "stderr",
+                    )
+                    .map((c) => c.content)
+                    .join("\n");
+                  return (
+                    <div
+                      key={group[0].id}
+                      data-cell-id={group[0].id}
+                      className={`out-cell ${onlyStderr ? "stderr" : "stdout"}`}
+                    >
+                      <div className="out-cell-header">
+                        <span className="cell-type">
+                          {onlyStderr ? "ERROR" : "OUTPUT"}
+                        </span>
+                        <span className="cell-time">
+                          <Timer size={12} aria-hidden="true" />
+                          <span>Done in {group[group.length - 1].elapsed}</span>
+                        </span>
+                        {copyText.length > 0 && (
+                          <button
+                            type="button"
+                            className="icon-btn out-cell-copy"
+                            title="Copy output to clipboard"
+                            aria-label="Copy output to clipboard"
+                            onClick={() =>
+                              void copyToClipboard(
+                                copyText,
+                                onlyStderr ? "Error" : "Output",
+                              )
+                            }
+                          >
+                            <CopyIcon />
+                          </button>
+                        )}
+                      </div>
+                      <div className="out-cell-body">
+                        {group.map((cell) =>
+                          cell.type === "image" ? (
+                            <div
+                              key={cell.id}
+                              className="out-seg out-seg-image"
+                              data-cell-type="image"
+                            >
+                              {/* Base64 PNGs from Pyodide/WebR have unknown
+                                  intrinsic dimensions and are not eligible
+                                  for next/image. */}
+                              {/* eslint-disable-next-line @next/next/no-img-element */}
+                              <img
+                                src={`data:image/png;base64,${cell.content}`}
+                                alt="figure"
+                                onLoad={scrollToLatestOutput}
+                              />
+                            </div>
+                          ) : cell.type === "html" ? (
+                            <div
+                              key={cell.id}
+                              className="dataframe-wrap"
+                              data-cell-type="html"
+                              dangerouslySetInnerHTML={{
+                                __html: cell.content,
+                              }}
+                            />
+                          ) : cell.type === "plot" && cell.plot ? (
+                            <div
+                              key={cell.id}
+                              className="out-seg out-seg-plot"
+                              data-cell-type="plot"
+                            >
+                              <PlotlyChart figure={cell.plot} />
+                            </div>
+                          ) : (
+                            <div
+                              key={cell.id}
+                              className={`out-seg out-seg-${cell.type}`}
+                              data-cell-type={cell.type}
+                            >
+                              {cell.content}
+                            </div>
+                          ),
+                        )}
+                      </div>
                     </div>
-                    <div className="out-cell-body">
-                      {cell.type === "image" ? (
-                        // Base64 PNGs from Pyodide/WebR have unknown intrinsic
-                        // dimensions and are not eligible for next/image.
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={`data:image/png;base64,${cell.content}`}
-                          alt="figure"
-                          onLoad={scrollToLatestOutput}
-                        />
-                      ) : cell.type === "html" ? (
-                        <div
-                          className="dataframe-wrap"
-                          dangerouslySetInnerHTML={{ __html: cell.content }}
-                        />
-                      ) : cell.type === "plot" && cell.plot ? (
-                        <PlotlyChart figure={cell.plot} />
-                      ) : (
-                        <span>{cell.content}</span>
-                      )}
-                    </div>
-                  </div>
-                ))
+                  );
+                })
               )}
             </div>
             <DataslopeRunOverlay running={statusState === "running"} />

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -2325,7 +2325,8 @@ export function VirtualizedResultTable({
       ? rowVirtualizer.getTotalSize() -
         (virtualRows[virtualRows.length - 1]?.end ?? 0)
       : 0;
-  const colSpan = tableColumns.length;
+  // Data columns + the trailing filler column that absorbs leftover width.
+  const colSpan = tableColumns.length + 1;
 
   // Infinite scroll: when the last virtualised row gets within a short
   // distance of the end of what's loaded, ask the owner for the next
@@ -2358,6 +2359,10 @@ export function VirtualizedResultTable({
                     : flexRender(h.column.columnDef.header, h.getContext())}
                 </th>
               ))}
+              {/* Filler column — absorbs the leftover width so the data
+                  columns only take the space their content needs instead
+                  of stretching across the card. */}
+              <th className={styles.sqlResultFiller} aria-hidden />
             </tr>
           ))}
         </thead>
@@ -2380,6 +2385,7 @@ export function VirtualizedResultTable({
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
                 ))}
+                <td className={styles.sqlResultFiller} aria-hidden />
               </tr>
             );
           })}
@@ -2588,36 +2594,42 @@ export function TableViewer({
               {flashKey > 0 && (
                 <div key={flashKey} className={styles.resultFlashOverlay} aria-hidden />
               )}
-              <div className={styles.resultPaneInfo}>
-                {resultTabData.error ? (
-                  <span className={styles.sqlResultLabel} style={{ color: "var(--ch-red)" }}>
-                    Error
-                  </span>
-                ) : resultTabData.resultSet && resultTabData.resultSet.columns.length > 0 ? (
-                  <span className={styles.sqlResultCount}>
-                    {resultTabData.resultSet.values.length} row{resultTabData.resultSet.values.length === 1 ? "" : "s"}
-                    {resultTabData.elapsed ? ` · ${resultTabData.elapsed}` : ""}
-                  </span>
-                ) : resultTabData.elapsed ? (
-                  <span className={styles.sqlResultCount}>{resultTabData.elapsed}</span>
-                ) : null}
-              </div>
+              {/* Mirrors TableViewerPane's layout — table first, then the
+                  row-count footnote — so the Result tab reads exactly like
+                  the table tabs. The execution time rides along in the
+                  footnote instead of a separate info bar above the table. */}
               {resultTabData.error ? (
                 <div className={styles.sqlMessage} style={{ color: "var(--ch-red)" }}>
                   {resultTabData.error}
                 </div>
               ) : resultTabData.resultSet && resultTabData.resultSet.columns.length > 0 ? (
                 resultTabData.resultSet.values.length === 0 ? (
-                  <div className={styles.sqlEmptyResult}>Query returned no rows.</div>
+                  <>
+                    <div className={styles.sqlEmptyResult}>Query returned no rows.</div>
+                    <div className={styles.tableViewerFootnote}>
+                      0 rows
+                      {resultTabData.elapsed ? ` · ${resultTabData.elapsed}` : ""}
+                    </div>
+                  </>
                 ) : (
-                  <VirtualizedResultTable
-                    columns={resultTabData.resultSet.columns}
-                    values={resultTabData.resultSet.values}
-                    maxHeight={TABLE_VIEWER_HEIGHT}
-                  />
+                  <>
+                    <VirtualizedResultTable
+                      columns={resultTabData.resultSet.columns}
+                      values={resultTabData.resultSet.values}
+                      maxHeight={TABLE_VIEWER_HEIGHT}
+                    />
+                    <div className={styles.tableViewerFootnote}>
+                      {resultTabData.resultSet.values.length} row
+                      {resultTabData.resultSet.values.length === 1 ? "" : "s"}
+                      {resultTabData.elapsed ? ` · ${resultTabData.elapsed}` : ""}
+                    </div>
+                  </>
                 )
               ) : resultTabData.message ? (
-                <div className={styles.sqlMessage}>{resultTabData.message}</div>
+                <div className={styles.sqlMessage}>
+                  {resultTabData.message}
+                  {resultTabData.elapsed ? ` · ${resultTabData.elapsed}` : ""}
+                </div>
               ) : (
                 <div className={styles.sqlMessage}>Running…</div>
               )}

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -1775,7 +1775,9 @@ export default function SqlChallengeCard({
                 type="button"
                 className={styles.runBtn}
                 onClick={() => void check()}
-                disabled={isBusy}
+                // Also disabled while the table viewer's first load seeds
+                // the database, so Submit can't race the engine boot.
+                disabled={isBusy || tablesInitializing}
               >
                 {isBusy ? (
                   <svg
@@ -1818,7 +1820,7 @@ export default function SqlChallengeCard({
               <Menu.Root>
                 <Menu.Trigger
                   className={styles.runBtnChevron}
-                  disabled={isBusy}
+                  disabled={isBusy || tablesInitializing}
                   aria-label="More run options"
                   title="More run options"
                 >
@@ -1878,7 +1880,9 @@ export default function SqlChallengeCard({
               type="button"
               className={styles.runBtn}
               onClick={() => void run()}
-              disabled={isBusy}
+              // Also disabled while the table viewer's first load seeds
+              // the database, so Run can't race the engine boot.
+              disabled={isBusy || tablesInitializing}
             >
               {isBusy ? (
                 <svg

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -35,7 +35,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { RotateCcw, Check, X, ChevronDown, Eye, Play, Database, Table, List, FileInput } from "lucide-react";
+import { RotateCcw, Check, CheckCheck, ListChecks, ListX, X, ChevronDown, Eye, Play, Database, Table, List, FileInput } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
   createColumnHelper,
@@ -2044,18 +2044,20 @@ export default function SqlChallengeCard({
             onClick={() => setTestListOpen((v) => !v)}
             aria-expanded={testListOpen}
           >
-            <span className={styles.testLabel}>Test Results</span>
+            <span className={styles.testLabel} data-state={summaryState}>
+              Test Results
+            </span>
             <div className={styles.testSummary}>
               <span className={styles.testPill} data-state={summaryState}>
                 {summaryState === "pending" ? (
                   "Running…"
                 ) : summaryState === "pass" ? (
                   <>
-                    <Check size={10} strokeWidth={3} aria-hidden /> {passedCount}/{totalTests} passed
+                    <ListChecks size={11} strokeWidth={2.5} aria-hidden /> {passedCount}/{totalTests} passed
                   </>
                 ) : (
                   <>
-                    <X size={10} strokeWidth={3} aria-hidden /> {passedCount}/{totalTests} passed
+                    <ListX size={11} strokeWidth={2.5} aria-hidden /> {passedCount}/{totalTests} passed
                   </>
                 )}
               </span>
@@ -2083,28 +2085,19 @@ export default function SqlChallengeCard({
       {/* ── Banner ── */}
       {bannerState && (
         <div className={styles.banner} data-state={bannerState}>
-          <div className={styles.bannerIcon}>
-            {bannerState === "pass" ? (
-              <Check size={14} strokeWidth={2.5} aria-hidden />
-            ) : (
-              <X size={14} strokeWidth={2.5} aria-hidden />
-            )}
-          </div>
           {bannerState === "pass" ? (
-            <span>
-              All tests passed!{" "}
-              <span className={styles.bannerSub}>
-                Great work — your solution is correct.
-              </span>
-            </span>
+            <>
+              <CheckCheck size={16} strokeWidth={2.5} aria-hidden />
+              <span>All tests passed!</span>
+            </>
           ) : (
-            <span>
-              {totalTests - passedCount} test
-              {totalTests - passedCount === 1 ? "" : "s"} failed{" "}
-              <span className={styles.bannerSub}>
-                — review the details and try again.
+            <>
+              <X size={16} strokeWidth={2.5} aria-hidden />
+              <span>
+                {totalTests - passedCount} test
+                {totalTests - passedCount === 1 ? "" : "s"} failed
               </span>
-            </span>
+            </>
           )}
         </div>
       )}

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -57,6 +57,7 @@ import {
   ChallengeToastViewport,
   useIsDark,
   cmThemeNameFor,
+  TestResultsRail,
 } from "./challengeShared";
 import { EditorState, Compartment } from "@codemirror/state";
 import {
@@ -136,6 +137,35 @@ export interface SqlChallengeTest {
   runAfterEquals?: unknown;
   /** Required row count of the `runAfterSql` result. */
   runAfterRowCount?: number;
+}
+
+/** Human-readable, one-check-per-line summary of a SQL test's
+ *  declarative expectations — shown by the test-details popover where a
+ *  code-based test would show its code. */
+export function sqlTestChecksSummary(t: SqlChallengeTest): string {
+  const lines: string[] = [];
+  if (t.expectedRowCount !== undefined)
+    lines.push(`row count = ${t.expectedRowCount}`);
+  if (t.rowCountAtLeast !== undefined)
+    lines.push(`row count >= ${t.rowCountAtLeast}`);
+  if (t.expectedColumns)
+    lines.push(`columns = [${t.expectedColumns.join(", ")}]`);
+  if (t.expectedColumnsInclude)
+    lines.push(`columns include [${t.expectedColumnsInclude.join(", ")}]`);
+  if (t.expectedRows)
+    lines.push(
+      `rows equal the expected values${t.expectedRows.ordered ? " (in order)" : ""}`,
+    );
+  if (t.matchesSolution)
+    lines.push(
+      `result matches the reference solution${t.ordered ? " (in order)" : ""}`,
+    );
+  if (t.runAfterSql) lines.push(`after your SQL, run:\n${t.runAfterSql.trim()}`);
+  if (t.runAfterEquals !== undefined)
+    lines.push(`…its first cell = ${JSON.stringify(t.runAfterEquals)}`);
+  if (t.runAfterRowCount !== undefined)
+    lines.push(`…its row count = ${t.runAfterRowCount}`);
+  return lines.join("\n");
 }
 
 /** Specification for which tables the table viewer should display.
@@ -1662,6 +1692,15 @@ export default function SqlChallengeCard({
   }, [dialect, toasts]);
 
   const isBusy = status === "loading" || status === "running";
+
+  // Readable summary of each test's declarative checks, surfaced by the
+  // test-details popover in the results rail.
+  const testChecksById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const t of tests) m.set(t.id, sqlTestChecksSummary(t));
+    return m;
+  }, [tests]);
+
   const hasResult = isBusy || resultSet !== null || resultError !== "" || resultMessage !== "";
   const resultTabDataProp: ResultTabData | null = hasResult
     ? {
@@ -2030,38 +2069,13 @@ export default function SqlChallengeCard({
             />
           </button>
           {testListOpen && (
-            <div className={styles.testList}>
-              {testResults.map((t) => (
-                <div key={t.id} className={styles.testItem}>
-                  <div className={styles.testIcon} data-state={t.state}>
-                    {t.state === "pass" ? (
-                      <Check size={9} strokeWidth={3} aria-hidden />
-                    ) : t.state === "fail" ? (
-                      <X size={9} strokeWidth={3} aria-hidden />
-                    ) : (
-                      <svg
-                        width="9"
-                        height="9"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2.5"
-                        aria-hidden
-                      >
-                        <circle cx="12" cy="12" r="5" />
-                      </svg>
-                    )}
-                  </div>
-                  <div className={styles.testItemBody}>
-                    <div className={styles.testItemName}>{t.name}</div>
-                    {t.description && <div className={styles.testItemDesc}>{t.description}</div>}
-                    {t.state === "fail" && t.detail && (
-                      <div className={styles.testItemDetail}>{t.detail}</div>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
+            <TestResultsRail
+              tests={testResults.map((t) => ({
+                ...t,
+                code: testChecksById.get(t.id),
+              }))}
+              codeLabel="Checks"
+            />
           )}
         </div>
       )}

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -600,7 +600,9 @@ export default function SqlCodeBlock({
             type="button"
             className={styles.runBtn}
             onClick={() => void run()}
-            disabled={isBusy}
+            // Also disabled while the table viewer's first load seeds the
+            // database, so Run can't race the engine boot.
+            disabled={isBusy || tablesInitializing}
             data-testid="sql-codeblock-run"
           >
             {isBusy ? (

--- a/app/_components/challengeHarness.ts
+++ b/app/_components/challengeHarness.ts
@@ -95,6 +95,33 @@ export function isNativeTest(t: ChallengeTest): t is NativeChallengeTest {
   return "code" in t && typeof (t as NativeChallengeTest).code === "string";
 }
 
+/** Human-readable, one-check-per-line summary of a declarative stdout
+ *  expectation — shown by the test-details popover where a native test
+ *  would show its code. */
+export function stdoutExpectSummary(e: StdoutExpect): string {
+  const lines: string[] = [];
+  const list = (v: string | string[]) =>
+    (Array.isArray(v) ? v : [v]).map((s) => JSON.stringify(s)).join(", ");
+  if (e.stdoutEquals !== undefined)
+    lines.push(`stdout equals ${JSON.stringify(e.stdoutEquals)}`);
+  if (e.stdoutContains !== undefined)
+    lines.push(`stdout contains ${list(e.stdoutContains)}`);
+  if (e.stdoutDoesNotContain !== undefined)
+    lines.push(`stdout does not contain ${list(e.stdoutDoesNotContain)}`);
+  if (e.stdoutMatches !== undefined)
+    lines.push(`stdout matches /${e.stdoutMatches}/${e.stdoutMatchesFlags ?? "s"}`);
+  if (e.stdoutLines !== undefined)
+    lines.push(
+      `stdout lines${e.stdoutLinesExact ? " (exact)" : ""}:\n${e.stdoutLines
+        .map((l) => `  ${l}`)
+        .join("\n")}`,
+    );
+  if (e.noStderr) lines.push("no stderr output");
+  if (e.stderrContains !== undefined)
+    lines.push(`stderr contains ${list(e.stderrContains)}`);
+  return lines.join("\n");
+}
+
 /** Sentinel printed once, before any per-test result, so the component
  *  can locate where the harness output begins inside captured stdout. */
 export const HARNESS_BEGIN = "__DSTEST_BEGIN__";

--- a/app/_components/challengeShared.tsx
+++ b/app/_components/challengeShared.tsx
@@ -227,7 +227,7 @@ export function useShortId(prefix: string): string {
 // just the test name; the description, the test's code/checks, and the
 // exact error message live in a click-popover so the list stays clean.
 
-import { Check, Info } from "lucide-react";
+import { Info } from "lucide-react";
 import { Popover } from "@base-ui-components/react/popover";
 import railStyles from "./ChallengeCard.module.css";
 
@@ -263,11 +263,13 @@ export function TestResultsRail({
         <div key={t.id} className={railStyles.testRailRow}>
           <div className={railStyles.testRailTrack} aria-hidden>
             <span className={railStyles.testRailNode} data-state={t.state}>
-              {t.state === "pass" ? (
-                <Check size={11} strokeWidth={3.2} aria-hidden />
-              ) : t.state === "fail" ? (
+              {/* Failures keep the ✕ for emphasis; passing/pending
+                  circles carry the 1-based test number. */}
+              {t.state === "fail" ? (
                 <X size={11} strokeWidth={3.2} aria-hidden />
-              ) : null}
+              ) : (
+                i + 1
+              )}
             </span>
             {i < tests.length - 1 && (
               <span className={railStyles.testRailSeg} data-state={t.state} />

--- a/app/_components/challengeShared.tsx
+++ b/app/_components/challengeShared.tsx
@@ -217,3 +217,117 @@ export function useShortId(prefix: string): string {
   const suffix = h.toString(16).slice(0, 4).padStart(4, "0");
   return `${prefix}-${suffix}`;
 }
+
+// ─── Test results rail ───────────────────────────────────────────────
+// Shared by `<ChallengeCard>` and `<SqlChallengeCard>`: a minimal
+// pass/fail readout. A vertical rail runs down the left; each test is a
+// circle on the rail — green (--ds-green-500) with a white check for a
+// pass, red (--ds-red-500) with a white ✕ for a fail — and the rail
+// segment below each circle is painted in that test's colour. Rows are
+// just the test name; the description, the test's code/checks, and the
+// exact error message live in a click-popover so the list stays clean.
+
+import { Check, Info } from "lucide-react";
+import { Popover } from "@base-ui-components/react/popover";
+import railStyles from "./ChallengeCard.module.css";
+
+export interface TestRailEntry {
+  id: string;
+  name: string;
+  description?: string | null;
+  state: "pass" | "fail" | "pending";
+  detail?: string | null;
+  /** Code (or a readable summary of declarative checks) shown in the
+   *  details popover under `codeLabel`. */
+  code?: string;
+}
+
+const TEST_STATE_LABEL: Record<TestRailEntry["state"], string> = {
+  pass: "Passed",
+  fail: "Failed",
+  pending: "Pending",
+};
+
+export function TestResultsRail({
+  tests,
+  codeLabel = "Test code",
+}: {
+  tests: TestRailEntry[];
+  /** Heading for the code section of the popover (e.g. "Checks" for
+   *  SQL's declarative expectations). */
+  codeLabel?: string;
+}) {
+  return (
+    <div className={railStyles.testRail}>
+      {tests.map((t, i) => (
+        <div key={t.id} className={railStyles.testRailRow}>
+          <div className={railStyles.testRailTrack} aria-hidden>
+            <span className={railStyles.testRailNode} data-state={t.state}>
+              {t.state === "pass" ? (
+                <Check size={11} strokeWidth={3.2} aria-hidden />
+              ) : t.state === "fail" ? (
+                <X size={11} strokeWidth={3.2} aria-hidden />
+              ) : null}
+            </span>
+            {i < tests.length - 1 && (
+              <span className={railStyles.testRailSeg} data-state={t.state} />
+            )}
+          </div>
+          <Popover.Root>
+            <Popover.Trigger
+              className={railStyles.testRailItemBtn}
+              aria-label={`${t.name} — ${TEST_STATE_LABEL[t.state]}. View details`}
+            >
+              <span className={railStyles.testRailName}>{t.name}</span>
+              <Info size={13} className={railStyles.testRailInfoIcon} aria-hidden />
+            </Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Positioner
+                side="bottom"
+                align="start"
+                sideOffset={6}
+                className={railStyles.testPopoverPositioner}
+              >
+                <Popover.Popup className={railStyles.testPopover}>
+                  <div className={railStyles.testPopoverHead}>
+                    <span
+                      className={railStyles.testPopoverStateDot}
+                      data-state={t.state}
+                      aria-hidden
+                    />
+                    <span className={railStyles.testPopoverName}>{t.name}</span>
+                    <span
+                      className={railStyles.testPopoverState}
+                      data-state={t.state}
+                    >
+                      {TEST_STATE_LABEL[t.state]}
+                    </span>
+                  </div>
+                  {t.description && (
+                    <p className={railStyles.testPopoverDesc}>{t.description}</p>
+                  )}
+                  {t.code && (
+                    <>
+                      <div className={railStyles.testPopoverSectionLabel}>
+                        {codeLabel}
+                      </div>
+                      <pre className={railStyles.testPopoverCode}>{t.code}</pre>
+                    </>
+                  )}
+                  {t.state === "fail" && t.detail && (
+                    <>
+                      <div className={railStyles.testPopoverSectionLabel}>
+                        Error
+                      </div>
+                      <pre className={railStyles.testPopoverError}>{t.detail}</pre>
+                    </>
+                  )}
+                </Popover.Popup>
+              </Popover.Positioner>
+            </Popover.Portal>
+          </Popover.Root>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -437,13 +437,6 @@
   background: rgba(255, 255, 255, 0.22);
 }
 
-.bannerSub {
-  font-size: 13px;
-  font-weight: 400;
-  opacity: 0.85;
-  margin-left: 4px;
-}
-
 /* ─── Overall explanation ─────────────────────────────────────────── */
 
 .overall {

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -404,8 +404,9 @@
 
 /* ─── Status banner ───────────────────────────────────────────────── */
 
-/* Solid colour band, white text (matches the challenge card's banner).
-   green-500 / red-500 read on both themes, so no dark-mode overrides. */
+/* Solid colour band, white text (matches the challenge card's banner) —
+   green-500 / red-500 in light mode, the 600 shades in dark mode (see
+   the html.dark overrides further down). */
 .banner {
   display: flex;
   align-items: center;
@@ -511,8 +512,15 @@
   background: color-mix(in srgb, var(--ds-red) 15%, transparent);
 }
 
-/* The verdict banner uses solid green-500 / red-500 with white text in
-   both themes, so it needs no dark-mode overrides. */
+/* Verdict banner: step the solid fill down to the 600 shades on dark
+   surfaces (matches the challenge card's banner). */
+:global(html.dark) .banner[data-state="pass"] {
+  background: var(--ds-green-600);
+}
+
+:global(html.dark) .banner[data-state="fail"] {
+  background: var(--ds-red-600);
+}
 
 :global(html.dark) .choiceLabel code,
 :global(html.dark) .choiceExplanation code,

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -404,6 +404,8 @@
 
 /* ─── Status banner ───────────────────────────────────────────────── */
 
+/* Solid colour band, white text (matches the challenge card's banner).
+   green-500 / red-500 read on both themes, so no dark-mode overrides. */
 .banner {
   display: flex;
   align-items: center;
@@ -411,16 +413,15 @@
   padding: 12px 20px;
   font-size: 14px;
   font-weight: 500;
+  color: #fff;
 }
 
 .banner[data-state="pass"] {
-  background: var(--ds-green-50);
-  color: var(--ds-green-700);
+  background: var(--ds-green-500);
 }
 
 .banner[data-state="fail"] {
-  background: var(--ds-red-50);
-  color: var(--ds-red-700);
+  background: var(--ds-red-500);
 }
 
 .bannerIcon {
@@ -431,14 +432,8 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-}
-
-.banner[data-state="pass"] .bannerIcon {
-  background: var(--ds-green-100);
-}
-
-.banner[data-state="fail"] .bannerIcon {
-  background: var(--ds-red-100);
+  /* Lightened well of the band colour so the white check / ✕ reads. */
+  background: rgba(255, 255, 255, 0.22);
 }
 
 .bannerSub {
@@ -516,15 +511,8 @@
   background: color-mix(in srgb, var(--ds-red) 15%, transparent);
 }
 
-:global(html.dark) .banner[data-state="pass"] {
-  background: color-mix(in srgb, var(--ds-green) 12%, transparent);
-  color: var(--ds-green-300);
-}
-
-:global(html.dark) .banner[data-state="fail"] {
-  background: color-mix(in srgb, var(--ds-red) 12%, transparent);
-  color: var(--ds-red-300);
-}
+/* The verdict banner uses solid green-500 / red-500 with white text in
+   both themes, so it needs no dark-mode overrides. */
 
 :global(html.dark) .choiceLabel code,
 :global(html.dark) .choiceExplanation code,
@@ -573,15 +561,6 @@
 :global(html.dark) .choice[data-verdict="wrong-selected"] .choiceMark {
   background: color-mix(in srgb, var(--ds-red) 20%, transparent);
   color: var(--ds-red-300);
-}
-
-/* Banner icon circles — light green/red fills need dark-mode tints. */
-:global(html.dark) .banner[data-state="pass"] .bannerIcon {
-  background: color-mix(in srgb, var(--ds-green) 20%, transparent);
-}
-
-:global(html.dark) .banner[data-state="fail"] .bannerIcon {
-  background: color-mix(in srgb, var(--ds-red) 20%, transparent);
 }
 
 /* Retry button uses an explicit white background in light mode. */

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -220,11 +220,6 @@ export default function MultipleChoiceQuestion({
           </span>
           <span>
             {result === "pass" ? "Correct!" : "Not quite — try again"}
-            <span className={styles.bannerSub}>
-              {result === "pass"
-                ? "Great choice."
-                : "Review the explanations and give it another go."}
-            </span>
           </span>
         </div>
       ) : null}

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1462,7 +1462,7 @@ body.playground-active {
   border: none;
   font-family: var(--font-sans, Inter, system-ui, sans-serif);
   letter-spacing: -0.011em;
-  font-size: 12.5px;
+  font-size: 13px;
   line-height: 1.45;
   color: var(--text);
   width: auto;
@@ -1474,7 +1474,6 @@ body.playground-active {
   border: none;
   text-align: right;
   font-weight: 600;
-  font-size: 12px;
   line-height: 1.45;
   color: var(--text);
   white-space: nowrap;
@@ -1512,17 +1511,18 @@ body.playground-active {
 }
 /* Footer row that states the full row/column count for truncated frames. */
 .dataframe-wrap .dataframe-rows-footer {
-  padding: 3px 10px;
-  font-size: 11.5px;
+  padding: 4px 10px;
+  font-family: var(--font-inter, var(--font-sans, Inter, system-ui, sans-serif));
+  font-size: 14px;
   color: var(--text-dim);
-  font-style: italic;
   text-align: right;
   border-top: 1px solid var(--border);
 }
 /* Dimensions line pandas appends below a truncated frame. */
 .dataframe-wrap p {
   margin: 6px 0 0;
-  font-size: 11.5px;
+  font-family: var(--font-inter, var(--font-sans, Inter, system-ui, sans-serif));
+  font-size: 14px;
   color: var(--text-dim);
 }
 

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1418,40 +1418,56 @@ body.playground-active {
   word-break: break-word;
 }
 
-/* DataFrame tables */
+/* DataFrame tables — kept in lockstep with `.dataframeWrap` in
+   CodeBlock.module.css and `.outCellHtml` in ChallengeCard.module.css:
+   slightly tightened Inter (--font-sans) at a compact size with minimal
+   vertical padding, content-width like a Jupyter table. */
 .out-cell.html .out-cell-body {
   overflow-x: auto;
   padding: 0;
 }
 .dataframe-wrap {
   overflow-x: auto;
-  padding: 12px;
+  padding: 10px 12px;
 }
 
 .out-cell.html table {
   border-collapse: collapse;
-  font-family: var(--font-mono);
+  font-family: var(--font-sans, Inter, system-ui, sans-serif);
+  letter-spacing: -0.011em;
   font-size: 12.5px;
+  line-height: 1.45;
   color: var(--text);
-  width: 100%;
-  min-width: max-content;
+  width: auto;
+  margin: 0;
+  border: 1px solid var(--border);
 }
 .out-cell.html th {
-  padding: 7px 14px;
+  padding: 3px 10px;
   background: var(--bg3);
   border-bottom: 1px solid var(--border);
   border-right: 1px solid var(--border);
   text-align: left;
   font-weight: 600;
+  font-size: 12px;
+  line-height: 1.45;
   color: var(--primary);
   white-space: nowrap;
 }
 .out-cell.html td {
-  padding: 6px 14px;
+  padding: 2px 10px;
   border-bottom: 1px solid var(--border);
   border-right: 1px solid var(--border);
   white-space: nowrap;
   color: var(--text-muted);
+  /* One enormous value shouldn't blow out its column. */
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.out-cell.html th:last-child,
+.out-cell.html td:last-child {
+  border-right: none;
 }
 .out-cell.html tr:hover td {
   background: var(--bg3);
@@ -1459,16 +1475,16 @@ body.playground-active {
 .out-cell.html tr:last-child td {
   border-bottom: none;
 }
-/* Ellipsis row shown when a data frame is truncated (R runtime). */
-.out-cell.html .dataframe-ellipsis-row td {
+/* Middle-truncation marker cells/columns (R runtime) — pandas renders
+   its own "..." cells which inherit the same muted colour. */
+.out-cell.html .dataframe-ellipsis-row td,
+.out-cell.html .dataframe-ellipsis-col {
   text-align: center;
   color: var(--text-dim);
-  letter-spacing: 0.15em;
-  background: var(--bg2);
 }
-/* Footer row that states total row count for truncated data frames. */
+/* Footer row that states the full row/column count for truncated frames. */
 .out-cell.html .dataframe-rows-footer {
-  padding: 5px 14px;
+  padding: 3px 10px;
   font-size: 11.5px;
   color: var(--text-dim);
   font-style: italic;
@@ -1480,6 +1496,12 @@ body.playground-active {
    cell keeps its top border. */
 .out-cell.html tfoot tr:last-child td {
   border-bottom: none;
+}
+/* Dimensions line pandas appends below a truncated frame. */
+.out-cell.html .dataframe-wrap p {
+  margin: 6px 0 0;
+  font-size: 11.5px;
+  color: var(--text-dim);
 }
 
 /* Plotly chart */

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1381,20 +1381,14 @@ body.playground-active {
   flex-shrink: 0;
 }
 
+/* One frame per run: stderr-only runs read as ERROR (red edge); runs with
+   any other output read as OUTPUT (green edge) and render stderr text red
+   inline via .out-seg-stderr. */
 .out-cell.stdout {
   border-left: 3px solid var(--green);
 }
 .out-cell.stderr {
   border-left: 3px solid var(--red);
-}
-.out-cell.html {
-  border-left: 3px solid var(--primary);
-}
-.out-cell.plot {
-  border-left: 3px solid var(--yellow);
-}
-.out-cell.image {
-  border-left: 3px solid var(--yellow);
 }
 
 .out-cell-body {
@@ -1418,21 +1412,54 @@ body.playground-active {
   word-break: break-word;
 }
 
-/* DataFrame tables — kept in lockstep with `.dataframeWrap` in
-   CodeBlock.module.css and `.outCellHtml` in ChallengeCard.module.css:
-   slightly tightened Inter (--font-sans) at a compact size with minimal
-   vertical padding, content-width like a Jupyter table. */
-.out-cell.html .out-cell-body {
-  overflow-x: auto;
-  padding: 0;
+/* ─── Output segments ───
+   One run renders as a single OUTPUT cell whose body stacks segments in
+   chronological order: text, dataframes, figures, charts — notebook
+   style. Visually heavy segments are height-capped so a giant figure /
+   frame stays in the page flow but remains reachable via its own
+   scrollbar. */
+.out-seg-stderr {
+  color: var(--red);
 }
-.dataframe-wrap {
-  overflow-x: auto;
-  padding: 10px 12px;
+.out-seg-image {
+  text-align: center;
+  white-space: normal;
+  max-height: 600px;
+  overflow: auto;
+}
+.out-seg-image img {
+  max-width: 100%;
+  border-radius: 4px;
+}
+.out-seg-plot {
+  white-space: normal;
+  max-height: 600px;
+  overflow: auto;
+}
+.plotly-chart {
+  width: 100%;
+  height: 380px;
 }
 
-.out-cell.html table {
+/* DataFrame tables — kept in lockstep with `.dataframeWrap` in
+   CodeBlock.module.css and `.outCellHtml` in ChallengeCard.module.css:
+   the Jupyter-notebook default look (600-weight header row and index
+   column, very subtle row striping, right-aligned cells, no cell
+   borders) in slightly tightened Inter (--font-sans) at a compact size.
+   Content-width like Jupyter, never stretched; the wrapper scrolls both
+   axes for big frames. */
+.dataframe-wrap {
+  overflow: auto;
+  max-height: 480px;
+  padding: 6px 0;
+  /* The merged output body renders text with pre-wrap — the newlines
+     between the tags of pandas' HTML must not become blank lines. */
+  white-space: normal;
+}
+
+.dataframe-wrap table {
   border-collapse: collapse;
+  border: none;
   font-family: var(--font-sans, Inter, system-ui, sans-serif);
   letter-spacing: -0.011em;
   font-size: 12.5px;
@@ -1440,86 +1467,63 @@ body.playground-active {
   color: var(--text);
   width: auto;
   margin: 0;
-  border: 1px solid var(--border);
 }
-.out-cell.html th {
+.dataframe-wrap th {
   padding: 3px 10px;
-  background: var(--bg3);
-  border-bottom: 1px solid var(--border);
-  border-right: 1px solid var(--border);
-  text-align: left;
+  background: transparent;
+  border: none;
+  text-align: right;
   font-weight: 600;
   font-size: 12px;
   line-height: 1.45;
-  color: var(--primary);
+  color: var(--text);
   white-space: nowrap;
+  vertical-align: bottom;
 }
-.out-cell.html td {
-  padding: 2px 10px;
+.dataframe-wrap thead th {
   border-bottom: 1px solid var(--border);
-  border-right: 1px solid var(--border);
+}
+.dataframe-wrap td {
+  padding: 3px 10px;
+  border: none;
+  text-align: right;
   white-space: nowrap;
-  color: var(--text-muted);
   /* One enormous value shouldn't blow out its column. */
   max-width: 320px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.out-cell.html th:last-child,
-.out-cell.html td:last-child {
-  border-right: none;
+/* Very subtle striping on alternate body rows, like Jupyter. The index
+   <th> cells stripe with their row. */
+.dataframe-wrap tbody tr:nth-child(even) td,
+.dataframe-wrap tbody tr:nth-child(even) th {
+  background: color-mix(in srgb, var(--text) 4%, transparent);
 }
-.out-cell.html tr:hover td {
-  background: var(--bg3);
-}
-.out-cell.html tr:last-child td {
-  border-bottom: none;
+.dataframe-wrap tbody tr:hover td,
+.dataframe-wrap tbody tr:hover th {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
 }
 /* Middle-truncation marker cells/columns (R runtime) — pandas renders
    its own "..." cells which inherit the same muted colour. */
-.out-cell.html .dataframe-ellipsis-row td,
-.out-cell.html .dataframe-ellipsis-col {
+.dataframe-wrap .dataframe-ellipsis-row td,
+.dataframe-wrap .dataframe-ellipsis-col {
   text-align: center;
   color: var(--text-dim);
 }
 /* Footer row that states the full row/column count for truncated frames. */
-.out-cell.html .dataframe-rows-footer {
+.dataframe-wrap .dataframe-rows-footer {
   padding: 3px 10px;
   font-size: 11.5px;
   color: var(--text-dim);
   font-style: italic;
   text-align: right;
   border-top: 1px solid var(--border);
-  border-right: none;
-}
-/* tfoot inherits the last-child no-border rule — override so the footer
-   cell keeps its top border. */
-.out-cell.html tfoot tr:last-child td {
-  border-bottom: none;
 }
 /* Dimensions line pandas appends below a truncated frame. */
-.out-cell.html .dataframe-wrap p {
+.dataframe-wrap p {
   margin: 6px 0 0;
   font-size: 11.5px;
   color: var(--text-dim);
-}
-
-/* Plotly chart */
-.out-cell.plot .out-cell-body {
-  padding: 0;
-}
-.plotly-chart {
-  width: 100%;
-  height: 380px;
-}
-
-/* Matplotlib / R image */
-.out-cell.image .out-cell-body {
-  text-align: center;
-}
-.out-cell.image img {
-  max-width: 100%;
-  border-radius: 4px;
 }
 
 /* Clear button — uses a subtle border that blends with the pane bar

--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -119,19 +119,19 @@ async function ensureMicropipPackages(code: string): Promise<void> {
   }
 }
 
-function isStringArray(v: unknown): v is string[] {
-  return Array.isArray(v) && v.every((x) => typeof x === "string");
-}
-
 interface PyDisplayDataframe { type: "dataframe"; html: string }
 interface PyDisplayHtml { type: "html"; html: string }
 interface PyDisplayImage { type: "image"; data: string }
 interface PyDisplayStdout { type: "stdout"; text: string }
+interface PyDisplayStderr { type: "stderr"; text: string }
+interface PyDisplayPlot { type: "plot"; json: string }
 type PyDisplayOutput =
   | PyDisplayDataframe
   | PyDisplayHtml
   | PyDisplayImage
-  | PyDisplayStdout;
+  | PyDisplayStdout
+  | PyDisplayStderr
+  | PyDisplayPlot;
 
 function isPyDisplayOutputs(v: unknown): v is PyDisplayOutput[] {
   return Array.isArray(v);
@@ -184,6 +184,45 @@ import matplotlib.pyplot as plt
 
 _display_outputs = []
 
+def _pg_emit_text(kind, s):
+    """Append stream text to the ordered output list, merging consecutive
+    writes of the same stream into one segment (print() emits the text and
+    its newline as separate writes)."""
+    if not s:
+        return
+    if _display_outputs and _display_outputs[-1].get("type") == kind:
+        _display_outputs[-1]["text"] += s
+    else:
+        _display_outputs.append({"type": kind, "text": s})
+
+# Tee installed over sys.stdout/sys.stderr while user code runs, so prints
+# land in _display_outputs *in order* with display() tables, figures and
+# charts — print → display(df) → print renders exactly in that sequence,
+# like a notebook.
+class _PgTee(io.TextIOBase):
+    def __init__(self, kind):
+        self._kind = kind
+    def writable(self):
+        return True
+    def write(self, s):
+        _pg_emit_text(self._kind, s)
+        return len(s)
+
+def _ensure_pd_notebook_options(pd):
+    """Pin pandas' Jupyter-style display limits once per session.
+
+    Pyodide is not an IPython session, so pandas falls back to its
+    terminal defaults — display.max_columns resolves to 0 (no limit) and
+    a wide frame renders every column. Pin the notebook default (20) so
+    wide frames middle-truncate with "..." columns; a later explicit
+    pd.set_option(...) by the user still wins because this runs once.
+    """
+    if getattr(pd, "_pg_display_defaults_applied", False):
+        return
+    pd._pg_display_defaults_applied = True
+    if not pd.get_option("display.max_columns"):
+        pd.set_option("display.max_columns", 20)
+
 def _strip_html_styles(h):
     """Remove <style> blocks from HTML to prevent them from overriding playground CSS."""
     return _re.sub(r'<style[^>]*>.*?</style>', '', h, flags=_re.DOTALL)
@@ -192,6 +231,7 @@ def display(*objs):
     import pandas as pd
     import matplotlib.axes
     import matplotlib.figure
+    _ensure_pd_notebook_options(pd)
     for obj in objs:
         if obj is None:
             continue
@@ -226,7 +266,7 @@ def display(*objs):
                 h = _strip_html_styles(h)
                 _display_outputs.append({"type": "html", "html": h})
         else:
-            _display_outputs.append({"type": "stdout", "text": repr(obj)})
+            _pg_emit_text("stdout", repr(obj) + "\\n")
 
 import builtins
 builtins.display = display
@@ -410,22 +450,33 @@ import plotly as _plotly
 import plotly.io as _pio
 _pio.templates.default = "${plotlyDefaultTemplate}"
 
-_plotly_json_outputs = []
 _orig_plotly_show = _plotly.io.show
 
+# Plotly figures land in the same ordered output list as prints and
+# display() tables, so fig.show() keeps its place in the run's output.
 def _patched_plotly_show(fig, *args, **kwargs):
-    _plotly_json_outputs.append(fig.to_json())
+    _display_outputs.append({"type": "plot", "json": fig.to_json()})
 
 _plotly.io.show = _patched_plotly_show
 try:
     import plotly.graph_objects as _go
     _orig_go_show = _go.Figure.show
     def _patched_go_show(self, *args, **kwargs):
-        _plotly_json_outputs.append(self.to_json())
+        _display_outputs.append({"type": "plot", "json": self.to_json()})
     _go.Figure.show = _patched_go_show
 except: pass
 
-await _execute_with_last_display(_user_code_str)
+# Route the user code's stdout/stderr into the ordered output list (see
+# _PgTee) so text interleaves chronologically with tables/figures/charts.
+_pg_prev_stdout, _pg_prev_stderr = sys.stdout, sys.stderr
+sys.stdout, sys.stderr = _PgTee("stdout"), _PgTee("stderr")
+try:
+    await _execute_with_last_display(_user_code_str)
+finally:
+    sys.stdout, sys.stderr = _pg_prev_stdout, _pg_prev_stderr
+    _plotly.io.show = _orig_plotly_show
+    try: _go.Figure.show = _orig_go_show
+    except: pass
 
 # Auto-flush any matplotlib figures that the user did not explicitly show.
 # This handles patterns like df.x.plot.density() which create a figure
@@ -436,44 +487,57 @@ for _fig_num in list(plt.get_fignums()):
     _fig.savefig(_buf, format="png", bbox_inches="tight", dpi=130, facecolor=_fig.get_facecolor())
     _display_outputs.append({"type": "image", "data": base64.b64encode(_buf.getvalue()).decode()})
 plt.close("all")
-
-_plotly.io.show = _orig_plotly_show
-try: _go.Figure.show = _orig_go_show
-except: pass
 `;
 
-  await pyodide.runPythonAsync(wrappedCode);
+  // Post the ordered output stream. Runs in a finally so that output
+  // produced *before* an exception (prints, tables, figures) still
+  // renders — the traceback then follows it, like a notebook.
+  const flushOutputs = () => {
+    if (!pyodide) return;
+    let displayOutputsRaw: unknown;
+    try {
+      const displayProxy = pyodide.globals.get("_display_outputs");
+      displayOutputsRaw = displayProxy.toJs({
+        dict_converter: Object.fromEntries,
+      });
+      displayProxy.destroy();
+    } catch {
+      return;
+    }
 
-  const displayProxy = pyodide.globals.get("_display_outputs");
-  const displayOutputsRaw = displayProxy.toJs({
-    dict_converter: Object.fromEntries,
-  });
-  displayProxy.destroy();
+    // Anything the JS-level capture saw (output emitted outside the
+    // per-run tee window) is posted first — in practice this is the
+    // pre-run package-loader failure note added above.
+    if (stdout.trim()) post({ kind: "output", id, cell: { type: "stdout", content: stdout.trim() } });
+    if (stderr.trim()) post({ kind: "output", id, cell: { type: "stderr", content: stderr.trim() } });
 
-  const plotlyProxy = pyodide.globals.get("_plotly_json_outputs");
-  const plotlyOutputsRaw = plotlyProxy.toJs();
-  plotlyProxy.destroy();
-
-  if (stdout.trim()) post({ kind: "output", id, cell: { type: "stdout", content: stdout.trim() } });
-  if (stderr.trim()) post({ kind: "output", id, cell: { type: "stderr", content: stderr.trim() } });
-
-  if (isPyDisplayOutputs(displayOutputsRaw)) {
+    if (!isPyDisplayOutputs(displayOutputsRaw)) return;
     for (const out of displayOutputsRaw) {
       if (out.type === "dataframe" || out.type === "html") {
         post({ kind: "output", id, cell: { type: "html", content: out.html } });
       } else if (out.type === "image") {
         post({ kind: "output", id, cell: { type: "image", content: out.data } });
-      } else if (out.type === "stdout") {
-        post({ kind: "output", id, cell: { type: "stdout", content: out.text } });
+      } else if (out.type === "stdout" || out.type === "stderr") {
+        const text = out.text.trim();
+        if (text) post({ kind: "output", id, cell: { type: out.type, content: text } });
+      } else if (out.type === "plot") {
+        try {
+          const fig = JSON.parse(out.json) as {
+            data: unknown[];
+            layout?: Record<string, unknown>;
+          };
+          post({ kind: "output", id, cell: { type: "plot", content: out.json, plot: fig } });
+        } catch {
+          /* malformed figure JSON — skip the cell */
+        }
       }
     }
-  }
+  };
 
-  if (isStringArray(plotlyOutputsRaw)) {
-    for (const jsonStr of plotlyOutputsRaw) {
-      const fig = JSON.parse(jsonStr) as { data: unknown[]; layout?: Record<string, unknown> };
-      post({ kind: "output", id, cell: { type: "plot", content: jsonStr, plot: fig } });
-    }
+  try {
+    await pyodide.runPythonAsync(wrappedCode);
+  } finally {
+    flushOutputs();
   }
 }
 

--- a/app/_components/runtime/r.tsx
+++ b/app/_components/runtime/r.tsx
@@ -621,11 +621,17 @@ async function imageBitmapToPngBase64(bmp: ImageBitmap): Promise<string> {
 const R_MAX_DISPLAY_ROWS = 20;
 const R_HEAD_ROWS = 10;
 const R_TAIL_ROWS = 5;
+// Column-display limits (Jupyter/pandas-style): a frame wider than MAX
+// columns shows the first HEAD and last TAIL columns with an ellipsis
+// column between, so very wide frames stay scannable.
+const R_MAX_DISPLAY_COLS = 20;
+const R_HEAD_COLS = 10;
+const R_TAIL_COLS = 10;
 
 function dataFrameToHtml(rows: Record<string, unknown>[]): string | null {
   if (rows.length === 0) return null;
-  const cols = Object.keys(rows[0] ?? {});
-  if (cols.length === 0) return null;
+  const allCols = Object.keys(rows[0] ?? {});
+  if (allCols.length === 0) return null;
   const escape = (v: unknown): string => {
     const s = v === null || v === undefined ? "" : String(v);
     return s
@@ -633,14 +639,33 @@ function dataFrameToHtml(rows: Record<string, unknown>[]): string | null {
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;");
   };
-  const head = cols.map((c) => `<th>${escape(c)}</th>`).join("");
 
   const totalRows = rows.length;
-  const truncated = totalRows > R_MAX_DISPLAY_ROWS;
+  const totalCols = allCols.length;
+  const rowsTruncated = totalRows > R_MAX_DISPLAY_ROWS;
+  const colsTruncated = totalCols > R_MAX_DISPLAY_COLS;
 
-  // Build the list of rows to render: real rows or null (= ellipsis row).
+  // Columns to render: real names or null (= the "⋯" marker column).
+  type DisplayCol = string | null;
+  const displayCols: DisplayCol[] = colsTruncated
+    ? [
+        ...allCols.slice(0, R_HEAD_COLS),
+        null,
+        ...allCols.slice(totalCols - R_TAIL_COLS),
+      ]
+    : allCols;
+
+  const head = displayCols
+    .map((c) =>
+      c === null
+        ? '<th class="dataframe-ellipsis-col">&#x22EF;</th>'
+        : `<th>${escape(c)}</th>`,
+    )
+    .join("");
+
+  // Rows to render: real rows or null (= ellipsis row).
   type DisplayRow = Record<string, unknown> | null;
-  const displayRows: DisplayRow[] = truncated
+  const displayRows: DisplayRow[] = rowsTruncated
     ? [
         ...rows.slice(0, R_HEAD_ROWS),
         null,
@@ -651,19 +676,33 @@ function dataFrameToHtml(rows: Record<string, unknown>[]): string | null {
   const body = displayRows
     .map((r) => {
       if (r === null) {
-        return `<tr class="dataframe-ellipsis-row">${cols
+        return `<tr class="dataframe-ellipsis-row">${displayCols
           .map(() => "<td>&#x22EF;</td>")
           .join("")}</tr>`;
       }
-      return `<tr>${cols.map((c) => `<td>${escape(r[c])}</td>`).join("")}</tr>`;
+      return `<tr>${displayCols
+        .map((c) =>
+          c === null
+            ? '<td class="dataframe-ellipsis-col">&#x22EF;</td>'
+            : `<td>${escape(r[c])}</td>`,
+        )
+        .join("")}</tr>`;
     })
     .join("");
 
-  const footer = truncated
-    ? `<tfoot><tr><td colspan="${cols.length}" class="dataframe-rows-footer">` +
-      `Showing ${R_HEAD_ROWS + R_TAIL_ROWS} of ${totalRows} rows` +
-      `</td></tr></tfoot>`
-    : "";
+  const footerParts: string[] = [];
+  if (rowsTruncated) {
+    footerParts.push(`${R_HEAD_ROWS + R_TAIL_ROWS} of ${totalRows} rows`);
+  }
+  if (colsTruncated) {
+    footerParts.push(`${R_HEAD_COLS + R_TAIL_COLS} of ${totalCols} columns`);
+  }
+  const footer =
+    footerParts.length > 0
+      ? `<tfoot><tr><td colspan="${displayCols.length}" class="dataframe-rows-footer">` +
+        `Showing ${footerParts.join(" · ")}` +
+        `</td></tr></tfoot>`
+      : "";
 
   return `<table class="dataframe"><thead><tr>${head}</tr></thead><tbody>${body}</tbody>${footer}</table>`;
 }

--- a/app/_components/sql/components/ResultView.tsx
+++ b/app/_components/sql/components/ResultView.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { memo, useState, useCallback, useEffect, useRef, useMemo } from "react";
+import {
+  memo,
+  useState,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useMemo,
+} from "react";
 import React from "react";
 import {
   flexRender,
@@ -267,6 +275,22 @@ const PAGE_SIZE_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
 
 const VIRTUAL_ROW_HEIGHT_ESTIMATE = 30;
 const LOAD_MORE_THRESHOLD_ROWS = 25;
+// ─── Column sizing ──────────────────────────────────────────────────────
+// Data columns get an explicit pixel width right after the first paint of a
+// result: the grid renders once with the browser's auto table layout,
+// measures each header cell, freezes those widths and switches to
+// `table-layout: fixed` (plus a trailing filler column that absorbs any
+// leftover space, so columns only take the width their content needs).
+// Frozen widths keep the grid predictable — entering/leaving inline cell
+// edit or streaming in more rows can no longer reflow every column — and
+// they're what the drag-to-resize header handles adjust.
+const COL_MIN_WIDTH = 48;
+// Cap for the *measured* width — mirrors the auto-layout `max-width` clamp
+// the CSS applies to cells, so one long value can't take the whole pane.
+// Users can still drag a column wider, up to COL_MAX_WIDTH.
+const COL_MAX_MEASURED_WIDTH = 340;
+const COL_MAX_WIDTH = 1600;
+const SELECT_COL_WIDTH = 28;
 // Stage 1 (DuckDB perf): when a paged result still contains more than
 // this many DOM rows (e.g. the user disabled pagination, or chose a
 // very large page size), switch the rendering path to the same
@@ -2239,6 +2263,96 @@ export function ResultTableBody({
     stats: ColumnStats;
   } | null>(null);
 
+  // ── Column widths ──────────────────────────────────────────────────────
+  // Explicit pixel width per leaf column id, frozen from a one-time
+  // auto-layout measurement and then user-adjustable via the header drag
+  // handles (the model every desktop SQL IDE uses — DBeaver, DataGrip,
+  // TablePlus: size to content once, keep stable, let the user resize).
+  // `null` = not measured yet → the table renders one frame with the
+  // browser's natural auto layout and the layout effect below freezes
+  // what that produced, before paint.
+  const tableElRef = useRef<HTMLTableElement | null>(null);
+  const thElsRef = useRef<Record<string, HTMLTableCellElement | null>>({});
+  const colElsRef = useRef<Record<string, HTMLTableColElement | null>>({});
+  const [colWidths, setColWidths] = useState<Record<string, number> | null>(
+    null,
+  );
+  const colWidthsRef = useRef(colWidths);
+  colWidthsRef.current = colWidths;
+  // Re-measure only when the column set changes (a different query shape).
+  // Re-fetches of the same shape — cell-edit/sort/filter reloads, paging,
+  // infinite-scroll appends — keep the frozen widths so the grid never
+  // reflows under the user.
+  const colSig = `${deletable ? "select" : ""}${set.columns.join("")}`;
+  const [prevColSig, setPrevColSig] = useState(colSig);
+  if (prevColSig !== colSig) {
+    setPrevColSig(colSig);
+    setColWidths(null);
+  }
+
+  // During a drag the <col> element is updated imperatively (a cheap
+  // fixed-layout reflow, no React re-render per pointermove); the final
+  // width is committed to state on release.
+  const resizeRef = useRef<{
+    colId: string;
+    startX: number;
+    startWidth: number;
+    latest: number;
+  } | null>(null);
+
+  const handleResizePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>, colId: string) => {
+      if (e.button !== 0) return;
+      const startWidth = colWidthsRef.current?.[colId];
+      if (startWidth === undefined) return;
+      e.preventDefault();
+      e.stopPropagation();
+      resizeRef.current = {
+        colId,
+        startX: e.clientX,
+        startWidth,
+        latest: startWidth,
+      };
+      e.currentTarget.setPointerCapture(e.pointerId);
+    },
+    [],
+  );
+
+  const handleResizePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      const r = resizeRef.current;
+      if (!r) return;
+      const w = Math.max(
+        COL_MIN_WIDTH,
+        Math.min(
+          COL_MAX_WIDTH,
+          Math.round(r.startWidth + (e.clientX - r.startX)),
+        ),
+      );
+      if (w !== r.latest) {
+        r.latest = w;
+        const colEl = colElsRef.current[r.colId];
+        if (colEl) colEl.style.width = `${w}px`;
+      }
+    },
+    [],
+  );
+
+  const handleResizePointerEnd = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      const r = resizeRef.current;
+      if (!r) return;
+      resizeRef.current = null;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        /* capture already released (e.g. pointercancel) */
+      }
+      setColWidths((prev) => (prev ? { ...prev, [r.colId]: r.latest } : prev));
+    },
+    [],
+  );
+
   // Keep mutable refs so that click handlers inside the columns useMemo
   // always access the latest values without needing them in the dep array.
   const visibleRef = useRef(visible);
@@ -2492,7 +2606,9 @@ export function ResultTableBody({
                                 </Popover.Portal>
                               </Popover.Root>
                             )}
-                            <span>{displayName}</span>
+                            <span className="sql-result-th-name">
+                              {displayName}
+                            </span>
                             {isReadOnly && (
                               <span
                                 className="sql-result-th-readonly"
@@ -3049,7 +3165,80 @@ export function ResultTableBody({
     virtualized,
   ]);
 
-  const colSpan = table.getAllLeafColumns().length;
+  // Freeze the auto-layout column widths before the first paint of a new
+  // result shape. Virtualized grids materialize their rows in the
+  // virtualizer's own layout effect (a second commit in the same frame) —
+  // wait for that commit so widths reflect real cell content, not just the
+  // headers.
+  useLayoutEffect(() => {
+    if (colWidths !== null) return;
+    if (virtualized && tableRows.length > 0 && renderedRows.length === 0) {
+      return;
+    }
+    const next: Record<string, number> = {};
+    for (const col of table.getAllLeafColumns()) {
+      if (col.id === "select") continue;
+      const th = thElsRef.current[col.id];
+      if (!th) continue;
+      // +2 guards against fractional-width rounding re-clipping a value
+      // that just fit during the measure pass.
+      next[col.id] = Math.min(
+        COL_MAX_MEASURED_WIDTH,
+        Math.max(
+          COL_MIN_WIDTH,
+          Math.ceil(th.getBoundingClientRect().width) + 2,
+        ),
+      );
+    }
+    if (Object.keys(next).length > 0) setColWidths(next);
+  }, [colWidths, virtualized, tableRows.length, renderedRows.length, table]);
+
+  // Double-clicking a resize handle auto-fits the column to its rendered
+  // content (same affordance as DBeaver / DataGrip / spreadsheet apps).
+  const handleAutoFitColumn = useCallback(
+    (colId: string) => {
+      const tableEl = tableElRef.current;
+      if (!tableEl) return;
+      const leafIndex = table
+        .getAllLeafColumns()
+        .findIndex((c) => c.id === colId);
+      if (leafIndex < 0) return;
+      let fit = COL_MIN_WIDTH;
+      const rows = tableEl.querySelectorAll<HTMLTableRowElement>(
+        'tbody tr:not([aria-hidden="true"])',
+      );
+      rows.forEach((tr) => {
+        const td = tr.cells[leafIndex];
+        // scrollWidth includes the cell padding; +2 for rounding.
+        if (td) fit = Math.max(fit, td.scrollWidth + 2);
+      });
+      fit = Math.min(COL_MAX_WIDTH, fit);
+      setColWidths((prev) => (prev ? { ...prev, [colId]: fit } : prev));
+    },
+    [table],
+  );
+
+  /** Drag handle for one column boundary. Pointer-only affordance (like
+   *  desktop SQL IDEs); double-click auto-fits the column to its content. */
+  const renderColResizer = (targetId: string) => (
+    <span
+      className="sql-result-col-resizer"
+      aria-hidden="true"
+      onPointerDown={(e) => handleResizePointerDown(e, targetId)}
+      onPointerMove={handleResizePointerMove}
+      onPointerUp={handleResizePointerEnd}
+      onPointerCancel={handleResizePointerEnd}
+      onDoubleClick={() => handleAutoFitColumn(targetId)}
+      onClick={(e) => e.stopPropagation()}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+    />
+  );
+
+  // Leaf columns + the trailing filler column that absorbs leftover width.
+  const colSpan = table.getAllLeafColumns().length + 1;
 
   const renderRow = (row: (typeof tableRows)[number]) => {
     const absoluteRow = row.original.absoluteRow;
@@ -3123,6 +3312,14 @@ export function ResultTableBody({
         }}
       >
         {cells}
+        {/* Filler cell — absorbs the leftover width so data columns keep
+            their natural (content) width instead of stretching. */}
+        <td
+          className="sql-result-td-filler"
+          onContextMenu={() => {
+            rightClickedCellRef.current = null;
+          }}
+        />
       </tr>
     );
   };
@@ -3336,29 +3533,86 @@ export function ResultTableBody({
                 props.onContextMenu?.(e);
               }}
             >
-        <table className="sql-result-table">
+        <table
+          ref={tableElRef}
+          className={`sql-result-table${colWidths ? " sql-result-table-sized" : ""}`}
+        >
+          {/* Explicit per-column widths (once measured) + a width-less
+              filler col. With table-layout:fixed and width:100%, the
+              filler absorbs all leftover space, so the data columns only
+              take the width they need — and resizing one column never
+              reflows its neighbours. */}
+          <colgroup>
+            {table.getAllLeafColumns().map((col) => (
+              <col
+                key={col.id}
+                ref={(el) => {
+                  colElsRef.current[col.id] = el;
+                }}
+                style={{
+                  width:
+                    col.id === "select"
+                      ? SELECT_COL_WIDTH
+                      : colWidths?.[col.id],
+                }}
+              />
+            ))}
+            <col />
+          </colgroup>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <th
-                    key={header.id}
-                    className={
-                      header.column.id === "select"
-                        ? "sql-result-th-select"
-                        : header.column.getIsSorted()
-                          ? "sql-result-th-sorted"
-                          : undefined
-                    }
-                  >
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </th>
-                ))}
+                {headerGroup.headers.map((header, hi) => {
+                  // Drag handle on the *left* edge of each header,
+                  // controlling the previous column's width: rendered in
+                  // the later (higher-painted) sticky cell, it can
+                  // straddle the boundary without the neighbour
+                  // swallowing its hit area.
+                  const prevId =
+                    hi > 0 ? headerGroup.headers[hi - 1].column.id : null;
+                  const resizeTarget =
+                    colWidths && prevId && prevId !== "select"
+                      ? prevId
+                      : null;
+                  return (
+                    <th
+                      key={header.id}
+                      ref={(el) => {
+                        thElsRef.current[header.column.id] = el;
+                      }}
+                      className={
+                        header.column.id === "select"
+                          ? "sql-result-th-select"
+                          : header.column.getIsSorted()
+                            ? "sql-result-th-sorted"
+                            : undefined
+                      }
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                      {resizeTarget && renderColResizer(resizeTarget)}
+                    </th>
+                  );
+                })}
+                {/* Filler header keeps the sticky band painting to the
+                    pane's right edge; its left handle resizes the last
+                    data column. */}
+                <th className="sql-result-th-filler" aria-hidden="true">
+                  {colWidths &&
+                    headerGroup.headers.length > 0 &&
+                    (() => {
+                      const lastId =
+                        headerGroup.headers[headerGroup.headers.length - 1]
+                          .column.id;
+                      return lastId === "select"
+                        ? null
+                        : renderColResizer(lastId);
+                    })()}
+                </th>
               </tr>
             ))}
           </thead>

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -917,11 +917,28 @@
   font-size: 13px;
 }
 
+/* The grid renders in two phases. Measure pass (no explicit widths yet):
+   the browser's auto table layout sizes every column to its content —
+   `width: auto` so columns are NOT stretched across the pane. The
+   component then freezes those widths and adds `.sql-result-table-sized`:
+   fixed layout + explicit <col> widths + a trailing filler column that
+   absorbs the leftover space. Columns only take the width they need, stay
+   put when a cell enters inline edit or more rows stream in, and resize
+   independently via the header drag handles. */
 .sql-result-table {
-  width: 100%;
+  width: auto;
   border-collapse: collapse;
   font-family: var(--font-ui);
   font-size: 13px;
+}
+
+.sql-result-table-sized {
+  /* Fixed layout reads widths from <colgroup>; width:100% guarantees the
+     table never paints narrower than the pane (the filler column soaks up
+     the difference). When the column widths sum to more than the pane the
+     table grows past 100% and the pane scrolls horizontally, as before. */
+  table-layout: fixed;
+  width: 100%;
 }
 
 .sql-result-table thead th {
@@ -944,12 +961,62 @@
   padding: 5px 10px;
   color: var(--text);
   white-space: nowrap;
-  max-width: 320px;
   overflow: hidden;
   text-overflow: ellipsis;
   /* Containing block for the absolutely-positioned inline cell editor
      (.sql-cell-input), so editing never resizes the column/row. */
   position: relative;
+}
+
+/* Cap each column's *measured* contribution during the auto-layout pass
+   so one long value or column name can't take the whole pane. Once sized,
+   the <col> widths govern and the cap must not fight a user resize. */
+.sql-result-table:not(.sql-result-table-sized) tbody td {
+  max-width: 320px;
+}
+
+.sql-result-table:not(.sql-result-table-sized) thead th {
+  max-width: 340px;
+}
+
+/* Trailing filler column: zero content, absorbs the leftover width. The
+   header keeps the sticky band painting to the pane's right edge; body
+   filler cells keep zebra striping / row hover spanning the full row. */
+.sql-result-table th.sql-result-th-filler,
+.sql-result-table td.sql-result-td-filler {
+  padding: 0;
+}
+
+/* ─── Column resize handles ───
+   A slim hit area straddling each column boundary (rendered in the
+   right-hand header cell so the sticky stacking order can't swallow it).
+   The visible 2px bar only appears on hover/drag. */
+.sql-result-col-resizer {
+  position: absolute;
+  top: 0;
+  left: -4px;
+  width: 9px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 3;
+  /* Required for pointer-capture dragging on touch devices. */
+  touch-action: none;
+}
+
+.sql-result-col-resizer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3.5px;
+  width: 2px;
+  background: transparent;
+  transition: background 100ms ease;
+}
+
+.sql-result-col-resizer:hover::after,
+.sql-result-col-resizer:active::after {
+  background: var(--primary);
 }
 
 /* Subtle zebra stripes that read more as a tint than a strong band.
@@ -1651,6 +1718,13 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  /* Let the label shrink (ellipsizing the name) in a narrowed column. */
+  min-width: 0;
+}
+
+.sql-result-th-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .sql-result-th-pk {
@@ -2511,6 +2585,10 @@
   width: 100%;
   text-align: left;
   white-space: nowrap;
+  /* Clip (rather than bleed into the neighbour) when the user resizes a
+     column narrower than its header text. */
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Top row: column name + sort chevron */
@@ -2567,6 +2645,9 @@
   display: inline-flex;
   align-items: center;
   gap: 3px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .sql-result-th-type svg {

--- a/app/_components/types.ts
+++ b/app/_components/types.ts
@@ -11,6 +11,11 @@ export interface OutputCell {
   /** For "plot" cells, the parsed Plotly figure JSON. */
   plot?: PlotlyFigure;
   elapsed: string;
+  /** Identifies the run that produced this cell, so the UI can render
+   *  one merged output frame per run (cells of one run stack inside a
+   *  single OUTPUT cell, notebook-style). Surfaces that clear outputs
+   *  on every run can omit it. */
+  runId?: number;
 }
 
 export interface PlotlyFigure {

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -416,6 +416,7 @@ code.hljs {
    prose regions. Explicitly excluded:
    - [data-flavor]                    SQL/non-SQL challenge cards & code blocks
    - [data-testid="challenge-card"]   non-SQL challenge cards
+   - [data-testid="code-block"]       non-SQL code blocks (dataframe tables!)
    - [aria-label="Multiple choice question"]  quiz components
    - .nd-codeblock, pre, code         code blocks
    - [data-rehype-pretty-code-figure] Fumadocs syntax-highlighted code
@@ -433,6 +434,7 @@ code.hljs {
   :where([class~="not-prose"], [class~="not-prose"] *),
   :where([data-flavor] *),
   :where([data-testid="challenge-card"] *),
+  :where([data-testid="code-block"] *),
   :where([aria-label="Multiple choice question"] *),
   :where(.nd-codeblock *, pre *, [data-rehype-pretty-code-figure] *),
   :where([data-callout] *, .callout *),
@@ -457,6 +459,7 @@ code.hljs {
   :where([class~="not-prose"], [class~="not-prose"] *),
   :where([data-flavor] *),
   :where([data-testid="challenge-card"] *),
+  :where([data-testid="code-block"] *),
   :where([aria-label="Multiple choice question"] *)
 ) {
   font-size: 1rem;

--- a/content/learn/dataframe-stress-test.mdx
+++ b/content/learn/dataframe-stress-test.mdx
@@ -4,10 +4,11 @@ description: Large pandas and R data frames for verifying Jupyter-style middle t
 ---
 
 This page exists to exercise the DataFrame renderer with outputs that are
-much larger than the usual examples. Every frame below should render as a
-compact, sans-serif (Inter) table with minimal vertical padding, truncated
-in the middle — head rows … tail rows, and head columns … tail columns —
-the way Jupyter notebooks display large frames. Wide tables scroll
+much larger than the usual examples. Every frame below should render in a
+single OUTPUT cell, interleaved with prints in execution order, as a
+compact Jupyter-style table (600-weight header row and index column,
+subtle row striping, no cell borders) truncated in the middle — head rows
+… tail rows, and head columns … tail columns. Wide tables scroll
 horizontally inside the output cell instead of stretching the page.
 
 ## Pandas: 1,000 rows × 41 columns
@@ -15,7 +16,8 @@ horizontally inside the output cell instead of stretching the page.
 Pandas applies its own display limits (`display.max_rows`,
 `display.max_columns`), so `display(df)` shows the first and last five
 rows and the first and last ten columns with `...` markers in between,
-plus a dimensions line below the table.
+plus a dimensions line below the table. The prints before and after the
+`display()` call must surround the table in the output.
 
 <CodeBlock
   adapter="python"
@@ -34,6 +36,7 @@ df["category"] = rng.choice(["alpha", "beta", "gamma", "delta"], size=len(df))
 
 print("Shape:", df.shape)
 display(df)
+print("Printed after the display() call")
 `,
     },
   ]}

--- a/content/learn/dataframe-stress-test.mdx
+++ b/content/learn/dataframe-stress-test.mdx
@@ -1,0 +1,166 @@
+---
+title: DataFrame Stress Test
+description: Large pandas and R data frames for verifying Jupyter-style middle truncation, compact typography, and table layout in code blocks and challenge cards.
+---
+
+This page exists to exercise the DataFrame renderer with outputs that are
+much larger than the usual examples. Every frame below should render as a
+compact, sans-serif (Inter) table with minimal vertical padding, truncated
+in the middle — head rows … tail rows, and head columns … tail columns —
+the way Jupyter notebooks display large frames. Wide tables scroll
+horizontally inside the output cell instead of stretching the page.
+
+## Pandas: 1,000 rows × 41 columns
+
+Pandas applies its own display limits (`display.max_rows`,
+`display.max_columns`), so `display(df)` shows the first and last five
+rows and the first and last ten columns with `...` markers in between,
+plus a dimensions line below the table.
+
+<CodeBlock
+  adapter="python"
+  files={[
+    {
+      filename: "main.py",
+      starterCode: `import numpy as np
+import pandas as pd
+
+rng = np.random.default_rng(42)
+df = pd.DataFrame(
+    rng.integers(0, 1_000, size=(1_000, 40)),
+    columns=[f"col_{i:02d}" for i in range(40)],
+)
+df["category"] = rng.choice(["alpha", "beta", "gamma", "delta"], size=len(df))
+
+print("Shape:", df.shape)
+display(df)
+`,
+    },
+  ]}
+/>
+
+## Pandas: long text values
+
+Long strings are truncated by pandas itself (`display.max_colwidth`), and
+the table styles additionally clip any oversized cell with an ellipsis so
+one column can never blow out the layout.
+
+<CodeBlock
+  adapter="python"
+  files={[
+    {
+      filename: "main.py",
+      starterCode: `import pandas as pd
+
+quotes = pd.DataFrame({
+    "id": range(1, 6),
+    "title": ["Very long text example for checking cell clipping behaviour " * 3] * 5,
+    "note": ["short value"] * 5,
+})
+display(quotes)
+`,
+    },
+  ]}
+/>
+
+## Pandas challenge card with a large frame
+
+The same truncation rules must hold inside a challenge card's output
+panel.
+
+<ChallengeCard
+  adapter="python"
+  title="Count the rows of a wide frame"
+  instructions={`The init code created a DataFrame called \`wide\` with 800 rows and 60 columns. Set \`row_total\` to the number of rows in \`wide\`.`}
+  files={[
+    {
+      filename: "main.py",
+      initCode: `import numpy as np
+import pandas as pd
+
+rng = np.random.default_rng(7)
+wide = pd.DataFrame(
+    rng.normal(0, 1, size=(800, 60)).round(3),
+    columns=[f"metric_{i:02d}" for i in range(60)],
+)`,
+      starterCode: `# 'wide' is 800 rows x 60 columns - display() truncates it like Jupyter.
+display(wide)
+
+row_total = None  # TODO: number of rows in wide
+print(row_total)
+`,
+      solutionCode: `display(wide)
+
+row_total = len(wide)
+print(row_total)
+`,
+    },
+  ]}
+  tests={[
+    {
+      id: "row_total",
+      name: "row_total is correct",
+      description: "row_total equals the number of rows in wide (800)",
+      code: `assert row_total == 800, f"expected 800, got {row_total}"`,
+    },
+  ]}
+/>
+
+## R: 500 rows × 41 columns
+
+The R runtime truncates frames itself: ten head rows, an ellipsis row,
+five tail rows — and for wide frames the first and last ten columns with
+an ellipsis column between. The footer states the full dimensions.
+
+<CodeBlock
+  adapter="r"
+  files={[
+    {
+      filename: "main.r",
+      starterCode: `set.seed(42)
+n <- 500
+wide <- as.data.frame(matrix(round(rnorm(n * 40), 2), nrow = n))
+names(wide) <- sprintf("metric_%02d", seq_len(40))
+wide$group <- sample(c("alpha", "beta", "gamma"), n, replace = TRUE)
+
+cat("dim:", dim(wide), "\\n")
+
+# A returned data.frame renders as a truncated table.
+wide
+`,
+    },
+  ]}
+/>
+
+## R challenge card with a large frame
+
+<ChallengeCard
+  adapter="r"
+  title="Count the rows of a wide frame"
+  instructions={`The init code created a data.frame called \`metrics\` with 300 rows and 30 columns. Set \`n_rows\` to the number of rows in \`metrics\`.`}
+  files={[
+    {
+      filename: "main.r",
+      initCode: `set.seed(7)
+metrics <- as.data.frame(matrix(round(rnorm(300 * 30), 2), nrow = 300))
+names(metrics) <- sprintf("metric_%02d", seq_len(30))`,
+      starterCode: `n_rows <- NA  # TODO: number of rows in metrics
+
+# The frame below renders as a truncated table.
+metrics
+`,
+      solutionCode: `n_rows <- nrow(metrics)
+
+metrics
+`,
+    },
+  ]}
+  tests={[
+    {
+      id: "n_rows",
+      name: "n_rows is correct",
+      description: "n_rows equals the number of rows in metrics (300)",
+      code: `if (!isTRUE(all.equal(n_rows, 300L)) && !isTRUE(all.equal(n_rows, 300))) stop(sprintf("expected 300, got %s", n_rows))`,
+    },
+  ]}
+/>

--- a/content/learn/meta.json
+++ b/content/learn/meta.json
@@ -32,6 +32,7 @@
     "sql-challenge-cards-postgres",
     "---",
     "multiple-choice",
-    "mermaid-test"
+    "mermaid-test",
+    "dataframe-stress-test"
   ]
 }

--- a/e2e/sql-array-editor.spec.ts
+++ b/e2e/sql-array-editor.spec.ts
@@ -88,11 +88,12 @@ for (const { id, route, insert } of ENGINES) {
     ).toBeVisible({ timeout: 40_000 });
 
     // The re-fetched array reflects the edit (written as a real array, then
-    // read back as JSON) — and the old elements are gone.
+    // read back as JSON) — and the old elements are gone. The last cell of
+    // each row is the width-absorbing filler, so skip it.
     const numsCell = page
       .locator(".sql-result-table tbody tr")
       .first()
-      .locator("td")
+      .locator("td:not(.sql-result-td-filler)")
       .last();
     await expect(numsCell).toContainText("40", { timeout: 40_000 });
     await expect(numsCell).toContainText("50");


### PR DESCRIPTION
UX audit of the SQL result views (code blocks, challenge cards, playground) and the Python/R dataframe rendering. The column model follows the conventions of desktop SQL IDEs (DBeaver / DataGrip / TablePlus): size columns to content once, keep them stable, let the user resize, and report row count + execution time below the grid.

## SQL code blocks / challenge cards

- **Result tab now matches the table tabs' layout.** The row count reads in the same footnote below the table that the table tabs use, with the execution time appended (`5 rows · 300ms`). The old info bar above the table is gone.
- **Columns take only the width they need.** A trailing filler column absorbs leftover space in the shared `VirtualizedResultTable`, so a 2–3 column result no longer stretches across the whole card while the header band still paints edge-to-edge.
- **Run/Submit are disabled while the database boots.** SQL code blocks and SQL challenge cards now disable their primary action while the table viewer's first load seeds the engine (the playground toolbar already did this via its `loaded` flag).

## Playground result grid (`ResultView`)

- **Predictable column widths.** The grid renders one frame with the browser's auto table layout, measures the headers, then freezes those widths into `<colgroup>` + `table-layout: fixed`. Double-clicking a long cell to edit it inline no longer shrinks the column; paging, sorting, filtering, and infinite-scroll appends keep the widths too. Widths reset only when the result's column set changes.
- **No more stretching.** Same filler-column approach: with one or two columns the data columns hug their content and the filler takes the slack (sticky header band still spans the pane).
- **Resizable columns.** Drag the boundary between headers to resize (blue indicator on hover, pointer-captured drag, 48px minimum with header text ellipsizing). Double-click a handle to auto-fit the column to its rendered content. During a drag the `<col>` is updated imperatively, so there's no per-pointermove React re-render.

## Python / R outputs (code blocks, challenge cards, playground)

- **Chronological output order.** The Pyodide worker tees `sys.stdout`/`sys.stderr` into the same ordered list as `display()` tables, matplotlib figures, and Plotly charts while user code runs, so `print → display(df) → print` renders exactly in that sequence. Output collected before an exception is flushed too, with the traceback following it, like a notebook.
- **One output panel per run, challenge-card style everywhere.** Code blocks (all languages) now render outputs with the challenge card's output panel — accent-bar header, "Output" label, timer icon + elapsed, copy button — and a single clean body stacking text, dataframes, figures, and charts in execution order with no gray per-cell chrome. Segments keep their `data-cell-type` attributes for tests/tooling. The playground groups its accumulated history per run (new `OutputCell.runId`); its pane label counts runs. Panel metrics tuned: body left inset 18px, segment gap 16px.
- **Jupyter-notebook dataframe look.** 600-weight header row and index column, very subtle alternate-row striping, right-aligned values, no cell borders, content-width table — slightly tightened Inter at 13px; the rows × columns count line renders in Inter at 14px. The docs' prose typography no longer leaks serif/margins into output cells (`not-prose` + `.prose` rule exclusions + `pre-wrap` fix).
- **Jupyter-style middle truncation, both axes.** Pandas: `display.max_columns` resolved to 0 under Pyodide (not an IPython session) so wide frames rendered every column — the notebook default (20) is pinned once per session (explicit `pd.set_option` still wins). R: rows were already truncated (10 head … 5 tail); columns now truncate too (first/last 10 with an `⋯` column), footer reporting `Showing 15 of 500 rows · 20 of 41 columns`.

## Test Results rail (SQL and non-SQL challenge cards)

New shared `<TestResultsRail>`: a vertical rail on the left with one circle per test — `green-500` with a white check for a pass, `red-500` with a white ✕ for a fail — and the rail segment below each circle painted in that test's colour (so `[pass, fail, pass, pass]` reads green / red / green down the rail; pending tests are hollow gray). Rows are just the test name — no boxes, borders, or inline error dumps. Clicking a row opens a minimal popover with the description, the test's code (or a readable "Checks" summary for SQL's declarative tests / stdout expectations), and the exact error message for failures.

## Test page

**`/learn/dataframe-stress-test`** (registered in `meta.json`): pandas and R code blocks and challenge cards rendering 300–1000 rows × 30–60 columns, a long-text-values block, and prints before/after `display(df)` to pin the output ordering.

## Verification

- `tsc --noEmit`, `eslint` (0 errors), `vitest` 522/522.
- Playwright e2e: SQL grid suites (edit ergonomics, result filter, edit undo/refetch, multi-result edit, column stats, enum/array editors, create-object, param binding, run-at-cursor) across SQLite/PostgreSQL/DuckDB; SQL code blocks ×3 engines; Python/R/JS/TS code blocks; playgrounds suite; python-stale-module; challenge-solutions (Python, SQLite) — all green.
- Browser-verified: ordering (`stdout → html → stdout` in one panel), pandas 20-column truncation + dims line, R row+column truncation, Jupyter table styling, challenge-panel reuse in code blocks (18px inset, 16px gap, timer icon, 13px table, 14px Inter count line), SQL Run disabled during engine boot, playground per-run grouping, test rail with `[pass, fail, pass, pass]` (green/red/green segments, white icons) and the failing test's popover showing code + "expected 3, got 2", SQL "Checks" popover, light + dark.

https://claude.ai/code/session_01FuCK9QdjrCWyN8khhZHF4q