### PR TITLE
Editorial pass: Systems Programming in C & TypeScript from Scratch

### DIFF
--- a/content/learn/systems-programming-c/arrays-and-pointers.mdx
+++ b/content/learn/systems-programming-c/arrays-and-pointers.mdx
@@ -134,6 +134,16 @@ Yes, `2[a]` is valid C: by definition `i[a] == *(i + a) == *(a + i)
 == a[i]`. Do not write that in real code — but knowing it explains
 *why* arrays and pointers feel so interchangeable.
 
+It also explains a question every beginner asks: why does indexing
+start at 0 instead of 1? Because the index is not a position — it is
+an **offset**. `a[0]` means "zero elements past the start," which is
+the start itself. Edsger Dijkstra wrote a famously opinionated 1982
+note, *"Why numbering should start at zero"* (EWD831), defending the
+convention on mathematical grounds, but in C the justification is
+mechanical: the index is literally the number the compiler multiplies
+by `sizeof` and adds to the base address. Starting at 1 would mean
+paying for a subtraction on every single array access.
+
 ## Array decay
 
 Almost every time you *use* an array (pass it to a function, assign

--- a/content/learn/systems-programming-c/c-toolchain.mdx
+++ b/content/learn/systems-programming-c/c-toolchain.mdx
@@ -210,6 +210,18 @@ standard libraries (libc for `printf`, libm for `sqrt`, etc.) and
 resolves *undefined symbols* — references that one object file makes
 to functions defined in another.
 
+<Callout type="info" title="Why is the default output called a.out?">
+If you link without `-o`, the executable is named `a.out` — short for
+*assembler output*. The name comes from the assembler on the PDP-7
+that the first version of Unix was built on around 1969, where it was
+the fixed name of the assembler's output file. The file *format*
+called a.out was replaced decades ago (by COFF, then ELF on Linux),
+but the default file *name* has now outlived the machine that coined
+it by more than half a century. When you type `clang hello.c` today,
+you are participating in a tradition older than the C language
+itself.
+</Callout>
+
 If you see:
 
 ```

--- a/content/learn/systems-programming-c/data-types-and-memory.mdx
+++ b/content/learn/systems-programming-c/data-types-and-memory.mdx
@@ -313,6 +313,20 @@ disk or send them over a network; protocols like TCP/IP standardize
 on big-endian ("network byte order") and provide `htonl` / `ntohl` to
 convert.
 
+<Callout type="info" title="Why &quot;endian&quot;? Blame Jonathan Swift">
+The names come from *Gulliver's Travels* (1726), in which the empire
+of Lilliput fights a bitter civil war over which end of a boiled egg
+to crack first — the Big-Endians versus the Little-Endians. In 1980,
+network engineer Danny Cohen borrowed the names for a satirical
+memo, *"On Holy Wars and a Plea for Peace"* (IEN 137, dated April
+1), pointing out that the byte-order argument raging between
+computer architectures was exactly as theological as Swift's egg
+war: both orders work fine, and the only real sin is failing to
+agree. The names stuck; the holy war, as you can see from the table
+above, was never fully resolved — we just learned to convert at the
+border.
+</Callout>
+
 ## Alignment
 
 Most CPUs read memory most efficiently when an `N`-byte type lives at

--- a/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -90,6 +90,21 @@ feature. This page is the long, careful introduction.
 
 They all live in `<stdlib.h>`.
 
+It is worth pausing on what `malloc` actually *is*: not a syscall,
+not magic, just a library function managing a big region of memory
+with ordinary data structures — free lists, size bins, boundary
+tags. Anyone can write one, and one person famously did. In 1987,
+computer science professor Doug Lea began writing a general-purpose
+allocator, **dlmalloc**, and placed it in the public domain. It was
+so well engineered that the GNU C library's allocator (ptmalloc2,
+which Linux programs use to this day) was built directly on it. For
+decades, nearly every `malloc` call on a Linux box has been running
+a descendant of one professor's freely given code — a useful thing
+to remember when the allocator feels like an inscrutable black box.
+Near the end of this course's roadmap you will find "write a toy
+malloc" as a suggested project; after this page you will know enough
+to try.
+
 ```mermaid
 flowchart LR
     A[Program] -->|"<code>malloc(n)</code>"| B[Allocator]
@@ -306,14 +321,19 @@ int main(void) {
 
 ## Building a dynamic array (mini `std::vector`)
 
-A small, complete `vec` type to show how growable arrays really work.
+Everything on this page comes together in one small data structure:
+a growable array. The struct and its boilerplate live in the
+read-only setup; the part worth your attention is `vec_push`, which
+contains the whole growth strategy — when the array is full, double
+the capacity with `realloc` (using the safe temporary pattern from
+above), then append.
 
 <CodeBlock
   adapter="c"
   files={[
     {
       filename: "main.c",
-      starterCode: `#include <stdio.h>
+      initCode: `#include <stdio.h>
 #include <stdlib.h>
 
 typedef struct {
@@ -322,14 +342,14 @@ typedef struct {
   size_t cap;
 } Vec;
 
-static int vec_init(Vec *v) {
-  v->data = NULL;
-  v->len = 0;
-  v->cap = 0;
-  return 0;
-}
+static void vec_init(Vec *v) { v->data = NULL; v->len = v->cap = 0; }
 
-static int vec_push(Vec *v, int x) {
+static void vec_free(Vec *v) {
+  free(v->data);
+  v->data = NULL;
+  v->len = v->cap = 0;
+}`,
+      starterCode: `static int vec_push(Vec *v, int x) {
   if (v->len == v->cap) {
     size_t new_cap = v->cap == 0 ? 4 : v->cap * 2;
     int *tmp = realloc(v->data, new_cap * sizeof *v->data);
@@ -340,12 +360,6 @@ static int vec_push(Vec *v, int x) {
   }
   v->data[v->len++] = x;
   return 0;
-}
-
-static void vec_free(Vec *v) {
-  free(v->data);
-  v->data = NULL;
-  v->len = v->cap = 0;
 }
 
 int main(void) {
@@ -366,6 +380,10 @@ int main(void) {
     },
   ]}
 />
+
+Watch the final line of output: after ten pushes the length is 10
+but the capacity is 16, because the array grew 4 → 8 → 16. Try
+pushing 17 elements and predict the capacity before you run.
 
 Doubling the capacity each time gives amortized O(1) `push`. This is
 exactly how `std::vector<T>` in C++ and `Vec<T>` in Rust grow.

--- a/content/learn/systems-programming-c/index.mdx
+++ b/content/learn/systems-programming-c/index.mdx
@@ -17,6 +17,44 @@ language but a *model of the machine* — a small, honest model in which
 every byte has an address, every variable has a type with a known
 size, and every allocation is yours to manage.
 
+## This course runs in your browser — try it
+
+Before anything else, here is the most important fact about this
+course: **every C snippet on every page is live.** Click *Run* below
+and a real `clang` compiler — running as WebAssembly inside your
+browser tab — will compile this program and execute it. No
+installation, no setup, no account.
+
+<CodeBlock
+  adapter="c"
+  files={[
+    {
+      filename: "main.c",
+      starterCode: `#include <stdio.h>
+
+int main(void) {
+  int height = 5; // try changing this, then press Run again
+
+  for (int row = 1; row <= height; row++) {
+    for (int i = 0; i < row; i++) {
+      putchar('#');
+    }
+    putchar('\\n');
+  }
+  printf("Compiled with clang, in your browser.\\n");
+  return 0;
+}
+`,
+    },
+  ]}
+/>
+
+Change `height` to `8` and run it again. That edit–run–observe loop
+is how the whole course works: the prose explains an idea, a code
+block makes it concrete, and you are expected to poke at it. The
+pages where you break things on purpose — and there will be several —
+are where C actually sinks in.
+
 <svg
   viewBox="0 0 640 280"
   role="img"
@@ -132,9 +170,10 @@ free it twice, or read from it after, or write past its end, the
 program may crash, leak, or silently corrupt unrelated data.
 
 That's why this course pairs *systems programming* (the toolchain,
-process layout, file I/O, syscalls) with *memory management* (stack
-vs heap, pointer arithmetic, allocators, common bugs and how to spot
-them). The two are inseparable.
+the process address space, the contracts between your program and
+the operating system) with *memory management* (stack vs heap,
+pointer arithmetic, allocators, common bugs and how to spot them).
+The two are inseparable.
 
 ```mermaid
 flowchart TD

--- a/content/learn/systems-programming-c/memory-layout.mdx
+++ b/content/learn/systems-programming-c/memory-layout.mdx
@@ -181,6 +181,15 @@ A common surprise: declaring a 10-million-element zero-initialized
 global does **not** make your binary 40 MB larger, because BSS is
 "described by metadata" rather than stored as bytes.
 
+The name, by the way, is one of computing's oldest living fossils.
+"Block Started by Symbol" was an assembler directive on the IBM 704
+in the mid-1950s — a machine programmed with punched cards, a decade
+before C existed. The directive reserved a block of memory without
+storing its contents, which is exactly what the segment still does.
+Like `a.out` from the toolchain chapter, it is a name that outlived
+every machine, operating system, and programmer fashion of its era
+because the *idea* it names never stopped being useful.
+
 <svg
   viewBox="0 0 640 180"
   role="img"

--- a/content/learn/systems-programming-c/pointers.mdx
+++ b/content/learn/systems-programming-c/pointers.mdx
@@ -7,6 +7,16 @@ A pointer is just a variable whose value is the address of another
 piece of memory. That one sentence is the whole concept — and also
 the source of half the things that make C feel hard.
 
+If the sentence feels slippery, try the postal version. Every house
+on a street has an address. A pointer is a slip of paper with an
+address written on it. The slip is not the house: you can copy the
+slip, lose the slip, or write a different address on it, all without
+touching the house. But if you *walk to* the address on the slip —
+that's dereferencing — you arrive at the actual house and can look
+inside or repaint the door. Everything on this page is a precise
+version of that picture: `&` writes a house's address onto a slip,
+`*` walks to whatever address a slip currently holds.
+
 <svg
   viewBox="0 0 640 220"
   role="img"
@@ -161,6 +171,17 @@ int main(void) {
 A pointer that does not point anywhere meaningful should be `NULL`
 (defined in `<stddef.h>`, usually as `((void*)0)`). Dereferencing a
 `NULL` pointer is undefined behavior — usually a crash.
+
+The idea of a special "points at nothing" value is older than C, and
+its inventor regrets it. Tony Hoare added the null reference to the
+ALGOL W language in 1965 — in his words, "simply because it was so
+easy to implement." At a conference in 2009 he formally apologized,
+calling it his **billion-dollar mistake**: his estimate of what null
+dereferences have cost the industry in crashes, vulnerabilities, and
+debugging time over four decades. C inherited the idea wholesale, so
+you will be living with Hoare's mistake for the rest of this course.
+The discipline that keeps it survivable is simple and non-negotiable:
+*check before you dereference.*
 
 <CodeBlock
   adapter="c"

--- a/content/learn/systems-programming-c/real-world-disasters.mdx
+++ b/content/learn/systems-programming-c/real-world-disasters.mdx
@@ -293,10 +293,13 @@ of the page buffer — into whatever happened to be in the next memory
 region.
 
 **Bug class:** *off-by-one*, leading to a buffer over-read.
-**Fallout:** Cloudflare estimated ~3,400 customer sites were
-affected and ~770,000 requests potentially leaked sensitive data.
-The fix was a single character; the cleanup (purging caches
-worldwide) took weeks.
+**Fallout:** during the worst stretch, Cloudflare estimated that
+roughly 1 in every 3.3 million HTTP requests passing through its
+edge leaked memory — a tiny rate multiplied by an enormous volume of
+traffic, over a period of months. The fix was a single character;
+the cleanup — hunting down and purging leaked fragments from search
+engine caches across the entire web — took weeks of coordinated
+work with Google, Bing, and others.
 
 ## 6. Stagefright (2015) — Android, a media file, and one integer overflow
 
@@ -469,15 +472,19 @@ widely studied accident reports in software engineering. The lesson
 different environment"* — applies directly to porting C code across
 architectures.
 
-## 12. PlayStation 3 hypervisor break (2010) — `hvcall_repository_node_lookup`
+## 12. PlayStation 3 hypervisor break (2010) — a glitch and a dangling mapping
 
-George Hotz published a glitch attack against the PS3 hypervisor
-that, combined with carefully chosen hypervisor calls, allowed
-arbitrary read/write of hypervisor memory. The root cause was that
-the hypervisor handled a freed memory region in a way that allowed
-an unprivileged guest to *re-allocate the same physical page* and
-read or modify hypervisor state through it — essentially a
-hypervisor-scope use-after-free.
+In January 2010, George Hotz (geohot) published an attack on the
+PS3's hypervisor — the privileged layer that kept the console's
+"OtherOS" Linux feature safely caged. His technique combined
+software and a literal hardware glitch: he had Linux ask the
+hypervisor to create and then tear down memory mappings while he
+pulsed a wire on the memory bus at precisely the wrong moment, so
+the hypervisor's *deallocation write was lost in transit*. The
+hypervisor believed a mapping was gone; the page tables still
+contained it. Through that dangling, stale mapping he could read
+and write hypervisor-owned memory — in effect, a use-after-free
+where the "free" itself was sabotaged from outside the software.
 
 **Bug class:** use-after-free across a privilege boundary.
 **Fallout:** "OtherOS" Linux support on the PS3 was permanently

--- a/content/learn/systems-programming-c/stack-and-functions.mdx
+++ b/content/learn/systems-programming-c/stack-and-functions.mdx
@@ -172,6 +172,16 @@ When recursion is too deep — or a function declares a huge local
 array — you hit the end of the stack region and the program crashes
 with a stack overflow.
 
+The error is common enough to have a website named after it. When
+Jeff Atwood and Joel Spolsky launched their programming Q&A site in
+2008, they let readers vote on the name, and *Stack Overflow* won —
+a knowing joke that the place you go when your program crashes
+should be named after one of the crashes. The bug earned that fame
+honestly: it is one of the few failures that can happen *before
+your first line of code runs* (a too-large local array can blow the
+stack during function entry) and one of the few that recursion makes
+trivially easy to write.
+
 <svg
   viewBox="0 0 640 230"
   role="img"

--- a/content/learn/systems-programming-c/strings.mdx
+++ b/content/learn/systems-programming-c/strings.mdx
@@ -8,6 +8,22 @@ sequence of `char` ending in a zero byte (`'\0'`). Every function in
 `<string.h>` relies on that single byte to know where the string
 stops.
 
+It did not have to be this way. The other classic design —
+used by Pascal, and by many languages since — stores the *length*
+in front of the characters, so the runtime always knows where a
+string ends without scanning it. Thompson, Ritchie, and Kernighan
+chose the terminator instead, probably because it made strings of
+any length cost exactly one extra byte on the tiny machines Unix
+ran on. In 2011, veteran FreeBSD developer Poul-Henning Kamp wrote
+an ACM Queue essay calling that choice
+*"The Most Expensive One-Byte Mistake"*: four decades of buffer
+overflows, `strlen` scans, and security advisories, all downstream
+of one byte saved per string in 1970. Whether or not you accept his
+accounting, the lesson of this page is that the terminator is a
+**convention enforced by nothing**. The language will not stop you
+from losing it — and the moment a string loses its `'\0'`, every
+function in `<string.h>` becomes a loaded gun.
+
 ## Null-terminated character arrays
 
 ```mermaid

--- a/content/learn/systems-programming-c/structs-and-unions.mdx
+++ b/content/learn/systems-programming-c/structs-and-unions.mdx
@@ -421,7 +421,23 @@ int main(void) {
 />
 
 This *type punning* pattern is common in low-level code (graphics,
-serialization). A "tagged union" — a struct with an enum tag and a
+serialization), and it has one genuinely legendary appearance. When
+id Software released the *Quake III Arena* source code in 2005,
+readers found a function that computes 1/√x — needed constantly for
+normalizing 3D vectors — by reinterpreting a float's bits as an
+integer, shifting them right, and subtracting them from the magic
+constant `0x5f3759df`. The technique exploits exactly what the code
+block above shows: an IEEE 754 float's bit pattern, read as an
+integer, approximates its logarithm. The routine became famous both
+for its near-sorcery and for its bewildered comments (the politest
+of which is "evil floating point bit level hacking"). John Carmack,
+to whom the internet immediately attributed it, said he didn't write
+it; later sleuthing traced its lineage back through earlier graphics
+companies. The lesson for you: understanding *exactly* how your
+bytes are laid out occasionally lets you do things that look like
+magic.
+
+A "tagged union" — a struct with an enum tag and a
 union of payloads — is how C encodes sum types like `Result<Ok, Err>`.
 
 <CodeBlock

--- a/content/learn/systems-programming-c/why-c-for-systems.mdx
+++ b/content/learn/systems-programming-c/why-c-for-systems.mdx
@@ -73,6 +73,29 @@ the language — and what *not* to expect.
   </g>
 </svg>
 
+## A language named after its predecessor
+
+C did not appear from nowhere — it is the third draft of an idea.
+At Bell Labs in the late 1960s, Ken Thompson wrote **B**, a
+stripped-down descendant of the British language BCPL, to program a
+cast-off PDP-7 minicomputer. B had a fatal limitation: it knew only
+one data type, the machine word. That was tolerable on the
+word-addressed PDP-7, but the new PDP-11 the Unix group acquired in
+1970 was *byte*-addressed, and B simply could not express "a byte"
+or "a structure." So Ritchie extended B with types and structs, and
+the extended language needed a name. After B came **C** — the joke
+writes itself, and yes, people immediately began asking whether the
+successor would be called D or P (the next letter in "BCPL").
+
+The payoff came in 1973, when Thompson and Ritchie rewrote the Unix
+kernel itself in C. This was a radical act: operating systems were
+written in assembly, period, because nothing else was believed fast
+enough. A kernel in a high-level language meant the *operating
+system itself* became portable — and when Unix spread to new
+machines in the late 1970s, C went everywhere with it. Twenty years
+later, Ritchie summed up his creation with characteristic dryness:
+*"C is quirky, flawed, and an enormous success."*
+
 ## C runs the world
 
 | Software | Written in |

--- a/content/learn/typescript-from-scratch/any-unknown-never.mdx
+++ b/content/learn/typescript-from-scratch/any-unknown-never.mdx
@@ -423,38 +423,13 @@ console.log("x:", x); // undefined
 `void` is the conventional return type for event handlers, loggers, and
 other side-effect functions.
 
-## `void` vs `undefined`
-
-There's a subtle distinction:
-- **`void`** means "I don't care about the return value."
-- **`undefined`** means "the return value is explicitly `undefined`."
-
-<CodeBlock
-  adapter="typescript"
-  files={[
-    {
-      filename: "main.ts",
-      starterCode: `function returnsVoid(): void {
-  // No return, or 'return;'
-}
-
-function returnsUndefined(): undefined {
-  return undefined;
-}
-
-const a = returnsVoid(); // type: void
-const b = returnsUndefined(); // type: undefined
-
-console.log("a:", a);
-console.log("b:", b);
-`,
-    },
-  ]}
-/>
-
-In practice, `void` is more common. Use `undefined` when the return type
-matters (e.g., a function that might return `T | undefined` to signal
-absence).
+We drew the line between `void` and `undefined` back in
+[Functions and Signatures](./functions-and-signatures), so just the
+one-sentence recap here: `void` says "callers shouldn't use this
+return value at all," while `undefined` makes the absence of a value
+an explicit, inspectable part of the contract. What's new on this
+page is seeing where `void` sits in the lattice — it's a deliberate
+blind spot, not a real point on the `unknown`-to-`never` axis.
 
 ## Type relationships: assignability
 

--- a/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
+++ b/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
@@ -479,7 +479,7 @@ export type ApiResponse<T> =
       id: "out",
       name: "Prints order-1 with total",
       description: "stdout includes 'order-1' and '99.99'",
-      expect: { stdoutIncludes: "order-1" },
+      expect: { stdoutContains: ["order-1", "99.99"] },
     },
   ]}
 />

--- a/content/learn/typescript-from-scratch/arrays-and-tuples.mdx
+++ b/content/learn/typescript-from-scratch/arrays-and-tuples.mdx
@@ -522,10 +522,14 @@ if (result !== 5) throw new Error("Expected 5, got " + result);
 
 TypeScript's array type does *not* track length. If you declare `numbers:
 number[]`, the compiler doesn't know if the array has 0, 1, or 100
-elements. Indexing `numbers[0]` gives `number | undefined` (in strict
-mode), because the array might be empty. Tuples, by contrast, *do* track
+elements. By default it optimistically types `numbers[0]` as plain
+`number` even though the array might be empty — and with the
+`noUncheckedIndexedAccess` compiler option (from the
+[tsconfig chapter](./setup-and-tsconfig)) it honestly reports
+`number | undefined`. Tuples, by contrast, *do* track
 length: if you declare `pair: [number, number]`, the compiler knows
-`pair[0]` and `pair[1]` exist and are `number`s (no `| undefined`).
+`pair[0]` and `pair[1]` exist and are `number`s (no `| undefined`),
+under either setting.
 
 <CodeBlock
   adapter="typescript"

--- a/content/learn/typescript-from-scratch/birth-of-typescript.mdx
+++ b/content/learn/typescript-from-scratch/birth-of-typescript.mdx
@@ -1,17 +1,63 @@
 ---
 title: The Birth of TypeScript
-description: The story of how Microsoft built a static type system on top of JavaScript — and why it succeeded where others failed.
+description: How a language built in ten days conquered the world, hit a maintainability wall, and got a type system bolted on by one of the great compiler designers.
 ---
 
-By 2010, large JavaScript applications were everywhere. They were also incredibly fragile. A single typo — `user.emial` instead of `user.email` — could hide in a codebase for months, lurking until the right (wrong) code path triggered a runtime error. Refactoring a function used in fifty places meant manually hunting down every call site and hoping you didn't miss one. Your IDE's "Find All References" barely worked because JavaScript is so dynamic.
+JavaScript was never designed for what we ask of it. In May 1995,
+Netscape gave a programmer named **Brendan Eich ten days** to build a
+scripting language for the browser — something forgiving and small,
+meant for sprinkling a little interactivity onto web pages. It worked
+far better than anyone planned. The AJAX revolution of 2004–2005
+(Gmail, Google Maps) turned web pages into applications; **Node.js**
+in 2009 carried JavaScript onto servers; and by 2010 the ten-day
+prototype language was running codebases of hundreds of thousands of
+lines, maintained by teams of dozens. (The full, decade-by-decade
+version of that story is great reading, and it lives in this
+course's appendix:
+[The Evolution of JavaScript](./evolution-of-javascript). You don't
+need it to continue — what you need is the problem it created.)
 
-Developers felt the pain acutely:
+The problem was that JavaScript's forgiving nature stops being
+charming at scale. Run this — it executes without a single
+complaint:
 
-- **At 3am**, your pager goes off: `TypeError: Cannot read property 'map' of undefined`. You forgot that `/api/users` sometimes returns `null` instead of an array.
-- **During a refactor**, you rename `calculatePrice(item)` to `calculatePrice(item, taxRate)`. You update 47 of the 50 call sites. The other three silently pass `undefined` for `taxRate`. Your unit tests don't catch it because those code paths only run in production under rare conditions.
-- **While onboarding**, a new developer asks, "What shape does this function expect?" You point them to a 500-line JSDoc comment that's six months out of sync with the code.
+<CodeBlock
+  adapter="typescript"
+  files={[
+    {
+      filename: "main.ts",
+      starterCode: `// Four lines of perfectly legal JavaScript chaos:
+console.log("5" + 3); // "53"  (string concatenation)
+console.log("5" - 3); // 2     (numeric subtraction!)
+console.log(5 + null); // 5    (null quietly becomes 0)
+console.log(5 + undefined); // NaN
 
-The tools didn't help. JavaScript's dynamism — its greatest strength for quick prototyping — made it nearly impossible for editors to provide reliable autocomplete, refactoring, or go-to-definition. The language itself offered no way to declare contracts or constraints.
+// And the classic: a typo that nobody will notice for months.
+const user = { name: "Alice", age: 30, email: "alice@example.com" };
+console.log(user.emial); // undefined — no error, no warning
+`,
+    },
+  ]}
+/>
+
+That last line is the one that ruins weekends. `user.emial` is not an
+error in JavaScript — it is merely a property that doesn't exist, so
+you get `undefined`, which flows silently through your program until
+some distant function calls `.toLowerCase()` on it and pages you at
+3am. In a 1,000-line script you'd spot it. In a 100,000-line
+application split across dozens of modules and maintained by a
+rotating cast of developers, these bugs are a tax on everything:
+refactoring means manually hunting down every call site and hoping;
+onboarding means absorbing tribal knowledge about what shape each
+function secretly expects; "Find All References" barely works
+because the editor can't reason about a language this dynamic.
+
+Teams tried workarounds — JSDoc comments that nothing enforced,
+linters that couldn't reason about types, runtime assertions that
+bloated every function. None of it solved the core problem:
+**JavaScript had no static type system**, so nothing could check,
+before the code ran, whether a variable held a string or a number,
+or whether an object actually had a `save()` method.
 
 <svg
   viewBox="0 0 640 240"
@@ -243,14 +289,14 @@ Looking back, TypeScript's success came from getting the fundamentals right:
 
 ## The modern landscape
 
-In 2024, TypeScript is the default for serious JavaScript development. It powers:
+Today, TypeScript is the default for serious JavaScript development. It powers:
 
 - **Frontend frameworks**: React, Vue, Angular, Svelte, Solid all have first-class TypeScript support
 - **Backend frameworks**: Express, Fastify, NestJS, tRPC, Deno (Deno is TypeScript-first by design)
 - **Tools and libraries**: VS Code, Jest, Storybook, ESLint, Prettier
 - **Platforms**: AWS CDK, Terraform CDK, GitHub Actions
 
-A 2023 Stack Overflow survey found that **over 38%** of professional developers use TypeScript — more than C, C++, or Go. npm reports that **over 60%** of new projects** include TypeScript.
+The 2023 Stack Overflow Developer Survey found that nearly **39%** of professional developers use TypeScript — more than C, C++, or Go — and it has ranked among the survey's most admired languages year after year.
 
 The question is no longer "Should we use TypeScript?" but "How strict should our `tsconfig.json` be?"
 

--- a/content/learn/typescript-from-scratch/birth-of-typescript.mdx
+++ b/content/learn/typescript-from-scratch/birth-of-typescript.mdx
@@ -185,7 +185,7 @@ timeline
     title TypeScript's Journey
     2010 : Microsoft internal team starts project
     2012 Oct : TypeScript 0.8 public announcement
-               Anders Hejlsberg presents at Microsoft's BUILD conference
+               Anders Hejlsberg introduces the language in a launch video
     2013 : TypeScript 0.9 adds generics
     2014 : TypeScript 1.0 released (production-ready)
            Facebook releases Flow (main competitor)
@@ -197,13 +197,13 @@ timeline
     2018 : TypeScript 3.0 (project references for monorepos)
     2019 : TypeScript becomes default for new projects in many surveys
     2020 : TypeScript 4.0 (variadic tuple types, labeled tuple elements)
-    2023 : Over 3 million npm packages use TypeScript
+    2023 : Used by nearly 39 percent of professional developers (Stack Overflow survey)
            TypeScript is the default for serious JavaScript projects
 ```
 
 ## The October 2012 announcement
 
-On October 1, 2012, Microsoft unveiled **TypeScript 0.8** at the BUILD developer conference. Hejlsberg demoed the language live, showing how a simple JavaScript object could gain type safety with a single annotation:
+On October 1, 2012, Microsoft unveiled **TypeScript 0.8** to the public, with Hejlsberg introducing the language on camera and showing how a simple JavaScript object could gain type safety with a single annotation:
 
 <CodeBlock
   adapter="typescript"
@@ -238,7 +238,7 @@ console.log(typedUser.name); // Still works
   ]}
 />
 
-Try uncommenting that last line in the code block above. You'll see the TypeScript compiler catch the typo *before* the code runs. That's the magic: **types as documentation that the compiler enforces.**
+That commented-out last line is the whole pitch. In an editor, `typedUser.emial` gets a red squiggle the instant you type it, and `tsc` refuses to build until it's fixed: *Property 'emial' does not exist on type 'User'. Did you mean 'email'?* — the compiler even guesses the fix. That's the magic Hejlsberg demonstrated: **types as documentation that the compiler enforces.**
 
 The initial reaction was mixed. JavaScript purists worried Microsoft was trying to "embrace, extend, extinguish" their beloved language. Skeptics pointed out that Closure Compiler and other tools had tried annotations before. Why would this succeed?
 

--- a/content/learn/typescript-from-scratch/branded-types.mdx
+++ b/content/learn/typescript-from-scratch/branded-types.mdx
@@ -384,11 +384,11 @@ Brands are *not* necessary for:
 <ChallengeCard
   adapter="typescript"
   title="Branded Temperature Units"
-  instructions={`Create two branded types, \`Celsius\` and \`Fahrenheit\`, both based on \`number\`. Implement smart constructors \`toCelsius\` and \`toFahrenheit\`, and a conversion function \`celsiusToFahrenheit\` that accepts \`Celsius\` and returns \`Fahrenheit\`.
+  instructions={`The read-only setup defines two branded types, \`Celsius\` and \`Fahrenheit\` (both \`number\` underneath), plus their smart constructors. Implement \`celsiusToFahrenheit\` so it accepts a \`Celsius\` value and returns the equivalent \`Fahrenheit\` value.
 
-**Conversion formula**: \`F = C × 9/5 + 32\`
+**Conversion formula**: \`F = C × 9/5 + 32\` — so \`toCelsius(0)\` must convert to \`32\` and \`toCelsius(100)\` to \`212\`.
 
-The compiler should prevent passing \`Fahrenheit\` where \`Celsius\` is expected, and vice versa.`}
+Because the result type is branded, remember to cast your computed number with \`as Fahrenheit\` before returning it.`}
   files={[
     {
       filename: "main.ts",
@@ -404,28 +404,10 @@ function toCelsius(value: number): Celsius {
 
 function toFahrenheit(value: number): Fahrenheit {
   return value as Fahrenheit;
-}
-
+}`,
+      starterCode: `// The branded types and smart constructors are provided above.
 function celsiusToFahrenheit(c: Celsius): Fahrenheit {
-  // Implement conversion
-  return 0 as Fahrenheit;
-}
-`,
-      starterCode: `declare const CelsiusBrand: unique symbol;
-declare const FahrenheitBrand: unique symbol;
-
-type Celsius = number & { readonly [CelsiusBrand]: true };
-type Fahrenheit = number & { readonly [FahrenheitBrand]: true };
-
-function toCelsius(value: number): Celsius {
-  return value as Celsius;
-}
-
-function toFahrenheit(value: number): Fahrenheit {
-  return value as Fahrenheit;
-}
-
-function celsiusToFahrenheit(c: Celsius): Fahrenheit {
+  // Your code here: F = C × 9/5 + 32
   return 0 as Fahrenheit;
 }
 
@@ -433,21 +415,7 @@ const temp = toCelsius(0);
 const converted = celsiusToFahrenheit(temp);
 console.log(converted); // Should be 32
 `,
-      solutionCode: `declare const CelsiusBrand: unique symbol;
-declare const FahrenheitBrand: unique symbol;
-
-type Celsius = number & { readonly [CelsiusBrand]: true };
-type Fahrenheit = number & { readonly [FahrenheitBrand]: true };
-
-function toCelsius(value: number): Celsius {
-  return value as Celsius;
-}
-
-function toFahrenheit(value: number): Fahrenheit {
-  return value as Fahrenheit;
-}
-
-function celsiusToFahrenheit(c: Celsius): Fahrenheit {
+      solutionCode: `function celsiusToFahrenheit(c: Celsius): Fahrenheit {
   return ((c * 9) / 5 + 32) as Fahrenheit;
 }
 
@@ -538,7 +506,7 @@ export function sendEmail(to: Email, message: string): string {
       id: "out",
       name: "Sends valid email",
       description: "Output contains 'Sending'",
-      expect: { stdoutIncludes: "Sending" },
+      expect: { stdoutContains: "Sending" },
     },
   ]}
 />

--- a/content/learn/typescript-from-scratch/discriminated-unions.mdx
+++ b/content/learn/typescript-from-scratch/discriminated-unions.mdx
@@ -205,9 +205,7 @@ console.log(render({ kind: "error", message: "Network failure" }));
   ]}
 />
 
-In the `default` case, we try to assign `status` to a variable of type `never`. If every variant has been handled, `status` is type `never` (the "empty" type), so the assignment succeeds. If we forgot a case, `status` still has a type (the unhandled variant), and assigning it to `never` fails with a compile error.
-
-Try it: comment out one of the cases above and uncomment the code. The `_exhaustive` assignment will error, telling you exactly which variant you missed.
+In the `default` case, we try to assign `status` to a variable of type `never`. If every variant has been handled, `status` is type `never` (the "empty" type), so the assignment succeeds. If we forgot a case, `status` still has a type (the unhandled variant), and assigning it to `never` fails with a compile error — under `tsc`, deleting the `"error"` case from the function above produces *Type '\{ kind: "error"; message: string; \}' is not assignable to type 'never'*, an error message that names the exact variant you forgot.
 
 <Callout type="success" title="Add a variant, get a compile error">
 This is the dream: you add a new variant to the union (e.g., `| { kind: "cancelled" }`), and every `switch` statement that handles `Status` lights up with an error until you add the new case. The compiler becomes your refactoring assistant.

--- a/content/learn/typescript-from-scratch/evolution-of-javascript.mdx
+++ b/content/learn/typescript-from-scratch/evolution-of-javascript.mdx
@@ -1,7 +1,15 @@
 ---
-title: The Evolution of JavaScript
+title: "Appendix: The Evolution of JavaScript"
 description: How a 10-day prototype became the world's most popular programming language — and outgrew its scripting roots.
 ---
+
+<Callout type="info" title="An optional deep dive">
+This appendix is the long version of the history that
+[The Birth of TypeScript](./birth-of-typescript) compresses into a
+paragraph. Nothing later in the course depends on it — it's here for
+readers who want the whole saga of how JavaScript grew from a
+ten-day prototype into the substrate of modern software.
+</Callout>
 
 In 1995, the web was young. Websites were static documents — text, images, and hyperlinks. Netscape Communications, riding high on the success of its Navigator browser, saw an opportunity: what if pages could *respond* to the user? What if forms could validate themselves before submission? What if you could build interactive experiences without waiting for a server round-trip?
 
@@ -219,7 +227,10 @@ By 2012, JavaScript had conquered the world. But the codebases built on it were 
 
 The industry needed a way to make JavaScript **safe** without making it **different**. The solution would have to be *optional*, *gradual*, and *pragmatic*. It would have to compile to readable JavaScript so existing tooling still worked. It would have to integrate with editors so developers got instant feedback.
 
-That solution was **TypeScript**. And its story begins at Microsoft, with a language designer who had spent decades thinking about types.
+That solution, as you know from the rest of this course, was
+**TypeScript** — the story told in
+[The Birth of TypeScript](./birth-of-typescript), back where your
+journey started.
 
 ---
 

--- a/content/learn/typescript-from-scratch/functions-and-signatures.mdx
+++ b/content/learn/typescript-from-scratch/functions-and-signatures.mdx
@@ -292,8 +292,12 @@ properties (e.g., a function with a `.version` property).
   version: string;
 }
 
-const increment: CallableWithVersion = ((x: number) => x + 1) as any;
-increment.version = "1.0.0";
+// Object.assign merges the function with the extra property in one
+// step, so the compiler can verify the combined shape — no casts.
+const increment: CallableWithVersion = Object.assign(
+  (x: number) => x + 1,
+  { version: "1.0.0" },
+);
 
 console.log("increment(5):", increment(5));
 console.log("version:", increment.version);

--- a/content/learn/typescript-from-scratch/generic-constraints.mdx
+++ b/content/learn/typescript-from-scratch/generic-constraints.mdx
@@ -374,6 +374,16 @@ When you have generic types, you might wonder: is `Box<Dog>` assignable to `Box<
 - **Contravariant:** If `A extends B`, then `Handler<B>` extends `Handler<A>`. (Function parameters are contravariant.)
 - **Invariant:** No subtyping relationship. (Mutable containers are often invariant.)
 
+Why does anyone care about these rules? Because getting them wrong is a famous, expensive mistake. Java (1995) made its arrays **covariant**: a `String[]` may be used wherever an `Object[]` is expected. That sounds harmless — every string *is* an object — until someone writes through the wider type:
+
+```java
+// Java — compiles without complaint
+Object[] objects = new String[3];
+objects[0] = Integer.valueOf(42); // runtime ArrayStoreException!
+```
+
+A *mutable* container can't safely be covariant, because the wider alias lets you put a wrong-typed value in. Java's designers knew this and accepted the runtime check as the price of making early APIs like `sort(Object[])` usable before the language had generics; every Java programmer since has met `ArrayStoreException`, the type error that escaped to runtime. The covariance-of-mutable-arrays decision is now a standard cautionary tale in language design. (Full disclosure: TypeScript knowingly makes the same bet — its mutable arrays are covariant too, trading a sliver of soundness for ergonomics, with no runtime check to catch you. Pragmatism is a theme with this language.) Here are the safe rules, which TypeScript otherwise applies for you:
+
 TypeScript infers variance automatically based on how the type parameter is used. You don't usually need to think about it, but it's good to know the terms:
 
 <CodeBlock

--- a/content/learn/typescript-from-scratch/how-typescript-works.mdx
+++ b/content/learn/typescript-from-scratch/how-typescript-works.mdx
@@ -67,31 +67,29 @@ Let's see this in action:
   files={[
     {
       filename: "main.ts",
-      starterCode: `// Plain JavaScript — no type annotations
-let x = 10;
-x = "hello"; // JavaScript allows this
-console.log(x);
-
-// TypeScript will accept the above (x has inferred type 'number',
-// but we reassign to string, which would be an error in strict mode)
-// Let's demonstrate explicit types:
+      starterCode: `let x = 10; // no annotation, but TypeScript infers x: number
+// x = "hello";  // tsc rejects this even without an annotation —
+//                  inference already locked x to 'number'.
 
 let y: number = 10;
-// y = "hello";  // Uncommenting this line causes a compile error:
-// Type 'string' is not assignable to type 'number'.
+// y = "hello";  // and this is the classic compile error:
+//                  Type 'string' is not assignable to type 'number'.
 
+console.log("x is", x);
 console.log("y is", y);
 
-// TypeScript checks the types, then erases them.
-// The compiled JS looks like:
-// let y = 10;
-// console.log("y is", y);
+// After checking, TypeScript erases the types. The JavaScript that
+// actually runs is just:
+//   let x = 10;
+//   let y = 10;
 `,
     },
   ]}
 />
 
-The code above shows the key mechanic: TypeScript checks that `y` is used consistently as a number. If you try to assign a string to `y`, the compiler stops you. But the *runtime* code — the JavaScript that actually executes — has no mention of `: number`. Types exist only at *compile time*.
+The code above shows the key mechanic: TypeScript checks that `x` and `y` are used consistently as numbers — whether the type came from an explicit annotation or from inference. But the *runtime* code — the JavaScript that actually executes — has no mention of `: number` at all. Types exist only at *compile time*.
+
+You can verify the "erased" half of that claim right here: this page's in-browser runner deliberately behaves like the *runtime* side of TypeScript — it strips the types and executes. If you uncomment `y = "hello"` and run, the sandbox will shrug and print `hello`, exactly as the compiled JavaScript would. The *checking* half is the compiler's job, done before the code ships; it's what your editor and `tsc` add on top. Holding both halves in your head — checked before, erased after — is the single most important model in this chapter.
 
 ## Compile time vs. runtime
 

--- a/content/learn/typescript-from-scratch/how-typescript-works.mdx
+++ b/content/learn/typescript-from-scratch/how-typescript-works.mdx
@@ -161,6 +161,8 @@ We'll explore structural typing in depth later. For now, just know: **TypeScript
 
 When you run `tsc` (the TypeScript compiler) or save a file in VS Code, your code flows through a multi-stage pipeline. Each stage transforms or analyzes the code, building up information until the type checker can prove your program is safe (or report errors).
 
+Before we open it up, one detail worth savoring: **the TypeScript compiler is written in TypeScript.** Every stage you're about to read about — scanner, parser, binder, checker, emitter — is itself TypeScript source code, type-checked by an earlier build of itself. This is a classic compiler tradition called *self-hosting* (C's compilers are written in C, for the same reason), and it doubles as the ultimate confidence test: a language good enough to build its own hundred-thousand-line compiler is good enough for your application.
+
 Here's the high-level flow:
 
 ```mermaid

--- a/content/learn/typescript-from-scratch/index.mdx
+++ b/content/learn/typescript-from-scratch/index.mdx
@@ -14,6 +14,40 @@ shape of modules. From there, we build up the *why* and *how* of
 TypeScript layer by layer, all the way to advanced type modeling and
 type-driven architecture.
 
+## This course runs in your browser — try it
+
+One thing before anything else: **every code block in this course is
+live.** The TypeScript compiler itself runs inside your browser tab,
+type-checks what you write, and executes it. Click *Run*:
+
+<CodeBlock
+  adapter="typescript"
+  files={[
+    {
+      filename: "main.ts",
+      starterCode: `type Greeting = "hello" | "ahoy" | "howdy";
+
+function greet(style: Greeting, name: string): string {
+  return \`\${style}, \${name}!\`;
+}
+
+console.log(greet("ahoy", "TypeScript"));
+
+// Now change "ahoy" above to "yo" and press Run again.
+// The compiler rejects it before a single line executes —
+// "yo" is not one of the three allowed greetings.
+// Then add "yo" to the Greeting type and watch it pass.
+`,
+    },
+  ]}
+/>
+
+That little loop — write, get corrected by the compiler, fix, run —
+is the entire experience of TypeScript compressed into ten lines,
+and it is how every page of this course works. You will read a
+little, run a little, and break things on purpose to see exactly
+where the compiler draws its lines.
+
 <svg
   viewBox="0 0 640 250"
   role="img"
@@ -147,9 +181,11 @@ own, but later chapters lean on earlier ideas.
 </svg>
 
 ### 1. The story of TypeScript
-How JavaScript outgrew its scripting roots, the maintainability
-crisis that followed, and why Microsoft built a static type system on
-top of it. We also peek inside the compiler.
+Why a language built in ten days needed a type system bolted on
+thirty years later, how Microsoft pulled it off, and what the
+compiler actually does with your annotations. (The full
+decade-by-decade history of JavaScript lives in an appendix at the
+end of the course, for when you want the whole saga.)
 
 ### 2. The core type system
 Primitives, objects, arrays and tuples, functions, type aliases,

--- a/content/learn/typescript-from-scratch/index.mdx
+++ b/content/learn/typescript-from-scratch/index.mdx
@@ -17,36 +17,49 @@ type-driven architecture.
 ## This course runs in your browser — try it
 
 One thing before anything else: **every code block in this course is
-live.** The TypeScript compiler itself runs inside your browser tab,
-type-checks what you write, and executes it. Click *Run*:
+live.** The TypeScript compiler runs inside your browser tab,
+translates what you write into JavaScript, and executes it on the
+spot. Click *Run*:
 
 <CodeBlock
   adapter="typescript"
   files={[
     {
       filename: "main.ts",
-      starterCode: `type Greeting = "hello" | "ahoy" | "howdy";
+      starterCode: `type Mood = "delighted" | "curious" | "skeptical";
 
-function greet(style: Greeting, name: string): string {
-  return \`\${style}, \${name}!\`;
+function announce(mood: Mood, language: string): string {
+  return \`\${language} makes me \${mood}.\`;
 }
 
-console.log(greet("ahoy", "TypeScript"));
+console.log(announce("curious", "TypeScript"));
+console.log(announce("skeptical", "JavaScript"));
 
-// Now change "ahoy" above to "yo" and press Run again.
-// The compiler rejects it before a single line executes —
-// "yo" is not one of the three allowed greetings.
-// Then add "yo" to the Greeting type and watch it pass.
+// Change "skeptical" to "delighted" and press Run again.
+// That type on the first line is a real contract: in an editor or a
+// real project build, announce("bored", ...) is rejected before the
+// program ever runs, because "bored" is not a Mood.
 `,
     },
   ]}
 />
 
-That little loop — write, get corrected by the compiler, fix, run —
-is the entire experience of TypeScript compressed into ten lines,
-and it is how every page of this course works. You will read a
-little, run a little, and break things on purpose to see exactly
-where the compiler draws its lines.
+That little file already contains the whole idea of the course: a
+`type` that pins down exactly which values are allowed, a function
+whose signature declares its contract, and code you can edit and
+re-run in seconds. Every page works this way — you read a little,
+run a little, and poke at the examples to see where the rules bend.
+
+<Callout type="info" title="Where the red squiggles live">
+The in-page runner favors speed: it checks syntax, strips the types,
+and executes — like the real TypeScript toolchain, where types never
+survive to runtime. The full type-checking experience (squiggles
+under `announce("bored")` before you run anything) lives in
+editors like VS Code and in the `tsc` compiler, which the
+[setup chapter](./setup-and-tsconfig) shows you how to run. The
+course will tell you, for each "broken" line, exactly what the
+compiler would say about it.
+</Callout>
 
 <svg
   viewBox="0 0 640 250"
@@ -103,7 +116,7 @@ Each page mixes narrative, diagrams, runnable code, and short
 challenges. Three interactive widgets appear throughout:
 
 1. **Executable TypeScript code blocks.** Every snippet is
-   type-checked and transpiled in your browser, then executed by
+   compiled to JavaScript in your browser, then executed by
    [almostnode](https://almostnode.dev/) — no setup required. Edit
    any block and click *Run*.
 2. **Multi-file code blocks and challenge cards.** Real software is

--- a/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
+++ b/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
@@ -478,7 +478,8 @@ type Handlers = EventHandlerMap<Events>;
   files={[
     {
       filename: "main.ts",
-      starterCode: `type EventHandlerMap<T> = any; // Replace 'any'
+      starterCode: `// Replace the right-hand side with a key-remapping mapped type
+type EventHandlerMap<T> = T;
 
 type Events = { click: { x: number }; focus: { id: string } };
 type Handlers = EventHandlerMap<Events>;

--- a/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
+++ b/content/learn/typescript-from-scratch/keyof-typeof-template-literals.mdx
@@ -478,9 +478,7 @@ type Handlers = EventHandlerMap<Events>;
   files={[
     {
       filename: "main.ts",
-      initCode: `type EventHandlerMap<T> = any; // Replace 'any'
-`,
-      starterCode: `type EventHandlerMap<T> = any;
+      starterCode: `type EventHandlerMap<T> = any; // Replace 'any'
 
 type Events = { click: { x: number }; focus: { id: string } };
 type Handlers = EventHandlerMap<Events>;

--- a/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
+++ b/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
@@ -534,9 +534,7 @@ Here, the conditional type checks if `T[K]` is a function. If so, it unions with
   files={[
     {
       filename: "main.ts",
-      initCode: `type Mutable<T> = any; // Replace 'any' with your implementation
-`,
-      starterCode: `type Mutable<T> = any;
+      starterCode: `type Mutable<T> = any; // Replace 'any' with your implementation
 
 type ReadonlyUser = { readonly id: number; readonly name: string };
 type MutableUser = Mutable<ReadonlyUser>;

--- a/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
+++ b/content/learn/typescript-from-scratch/mapped-and-conditional-types.mdx
@@ -534,7 +534,8 @@ Here, the conditional type checks if `T[K]` is a function. If so, it unions with
   files={[
     {
       filename: "main.ts",
-      starterCode: `type Mutable<T> = any; // Replace 'any' with your implementation
+      starterCode: `// Replace the right-hand side with a mapped type that strips readonly
+type Mutable<T> = T;
 
 type ReadonlyUser = { readonly id: number; readonly name: string };
 type MutableUser = Mutable<ReadonlyUser>;

--- a/content/learn/typescript-from-scratch/meta.json
+++ b/content/learn/typescript-from-scratch/meta.json
@@ -5,7 +5,6 @@
     "pages": [
         "index",
         "---",
-        "evolution-of-javascript",
         "birth-of-typescript",
         "how-typescript-works",
         "setup-and-tsconfig",
@@ -37,6 +36,9 @@
         "scalable-architecture",
         "---",
         "static-analysis-in-action",
+        "---",
+        "evolution-of-javascript",
+        "---",
         "next-steps"
     ]
 }

--- a/content/learn/typescript-from-scratch/modeling-domains-with-types.mdx
+++ b/content/learn/typescript-from-scratch/modeling-domains-with-types.mdx
@@ -693,22 +693,16 @@ export type Post = {
 ## Multiple choice check
 
 <MultipleChoice
-  markdown={`You're modeling a feature flag that can be:
-- Disabled
-  > This state means the feature is completely off; no percentage applies.
-- Enabled for everyone
-  > This state means the feature is on for all users; no percentage applies.
-- Enabled for a specific percentage of users
-  > This state requires a percentage value; the other two states do not.
+  markdown={`You're modeling a feature flag with three possible states: *disabled*, *enabled for everyone*, or *enabled for a specific percentage of users* (only this last state carries a percentage value).
 
 Which type definition makes illegal states **unrepresentable**?
 
 - \`type Flag = { enabled: boolean; percentage?: number }\`
-  > No. This allows \`enabled: false, percentage: 50\` (disabled but with a percentage?) and \`enabled: true, percentage: undefined\` (enabled for everyone or for a percentage?). The type is ambiguous.
+  > This allows \`enabled: false, percentage: 50\` (disabled but with a percentage?) and \`enabled: true, percentage: undefined\` (enabled for everyone, or for a percentage that wasn't given?). The type is ambiguous.
 - [o] \`type Flag = { kind: "disabled" } | { kind: "enabled-all" } | { kind: "enabled-percentage"; percentage: number }\`
   > Each state is a distinct variant. Disabled has no percentage, enabled-all has no percentage, and enabled-percentage requires a percentage. Illegal states cannot be represented.
 - \`type Flag = { kind: "disabled" | "enabled-all" | "enabled-percentage"; percentage?: number }\`
-  > No. This allows \`kind: "disabled", percentage: 50\` (disabled but with a percentage?). The discriminant and the optional field are independent, so invalid combinations are possible.
+  > This allows \`kind: "disabled", percentage: 50\` (disabled but with a percentage?). The discriminant and the optional field are independent, so invalid combinations are possible.
 
 Discriminated unions eliminate ambiguity by making each state explicit and self-contained. If a field only makes sense in one state, include it in that state's variant — not as a shared optional field.`}
 />

--- a/content/learn/typescript-from-scratch/scalable-architecture.mdx
+++ b/content/learn/typescript-from-scratch/scalable-architecture.mdx
@@ -615,7 +615,7 @@ export class InMemoryTodoRepository implements TodoRepository {
       id: "out",
       name: "Toggles todo",
       description: "done: true appears in output",
-      expect: { stdoutIncludes: "done: true" },
+      expect: { stdoutContains: "done: true" },
     },
   ]}
 />

--- a/content/learn/typescript-from-scratch/setup-and-tsconfig.mdx
+++ b/content/learn/typescript-from-scratch/setup-and-tsconfig.mdx
@@ -298,7 +298,7 @@ if (name !== null) {
 }
 ```
 
-This eliminates the "billion-dollar mistake" — `TypeError: Cannot read property 'x' of null/undefined` — which plagues JavaScript.
+This eliminates the famous "billion-dollar mistake." That phrase is Tony Hoare's own: he invented the null reference for ALGOL W in 1965 ("simply because it was so easy to implement," he said), and in a 2009 conference talk he publicly apologized, estimating that null dereferences had cost the industry a billion dollars in crashes and vulnerabilities over the decades since. JavaScript inherited the mistake *twice over* — it has both `null` and `undefined` — which makes `strictNullChecks` arguably the single highest-value flag in the entire compiler.
 
 <svg
   viewBox="0 0 640 210"

--- a/content/learn/typescript-from-scratch/setup-and-tsconfig.mdx
+++ b/content/learn/typescript-from-scratch/setup-and-tsconfig.mdx
@@ -501,7 +501,7 @@ If you're building a browser app, add `"DOM"` and `"DOM.Iterable"` to `lib`. If 
 
 ## Running TypeScript in the browser (this course)
 
-Every code block on this site is a live TypeScript environment. The TypeScript compiler runs in your browser (via WebAssembly), type-checks your code, transpiles it to JavaScript, and executes it using [almostnode](https://almostnode.dev/) — a browser-based Node.js runtime.
+Every code block on this site is a live TypeScript environment. The TypeScript compiler runs in your browser, transpiles your code to JavaScript, and executes it using [almostnode](https://almostnode.dev/) — a browser-based Node.js runtime. (Like a production build, the in-page runner erases the types before executing; the red-squiggle, refuse-to-build experience described on this page is what `tsc` and your editor add on a real machine.)
 
 Try it:
 
@@ -518,8 +518,8 @@ function greet(name: string): string {
 console.log(greet("Ada"));
 console.log(greet("Grace"));
 
-// Uncomment the next line to see a type error:
-// console.log(greet(42));  // Argument of type 'number' is not assignable to parameter of type 'string'.
+// Under tsc, calling greet(42) is a compile error:
+// "Argument of type 'number' is not assignable to parameter of type 'string'."
 `,
     },
   ]}

--- a/content/learn/typescript-from-scratch/static-analysis-in-action.mdx
+++ b/content/learn/typescript-from-scratch/static-analysis-in-action.mdx
@@ -217,9 +217,9 @@ Suppose you rename `fullName` to `name`. Every place that accesses `.fullName` b
 
 ---
 
-## The Compiler Pipeline
+## The Pipeline, Revisited
 
-The TypeScript compiler is organized into phases:
+Back in [How TypeScript Works](./how-typescript-works), near the very start of the course, we walked through the compiler's stages — scanner, parser, binder, checker, emitter — when most of them were still abstractions. Now you can read the same diagram with different eyes: every guarantee on this page is the **Checker** doing its job, and everything you've learned since (narrowing, discriminated unions, generics, mapped types) is vocabulary the checker reasons in.
 
 ```mermaid
 graph TD
@@ -233,29 +233,7 @@ graph TD
     style G fill:#d4edda
 ```
 
-1. **Scanner**: Breaks source code into tokens (keywords, identifiers, operators).
-2. **Parser**: Builds an Abstract Syntax Tree (AST) from tokens.
-3. **Binder**: Resolves identifiers to their declarations, builds symbol tables.
-4. **Checker**: Performs type checking, control flow analysis, and error reporting.
-5. **Emitter**: Generates JavaScript and type declarations (`.d.ts`).
-6. **Language Service**: Provides editor features (autocomplete, go-to-definition, refactoring).
-
-The **Checker** is the heart of static analysis. It's what proves your types are correct.
-
----
-
-## The Language Service
-
-The language service is a persistent process that runs in your editor (VS Code, IntelliJ, etc.). It provides:
-
-- **Autocomplete**: As you type, it suggests completions based on the type context.
-- **Type hints**: Hover over a variable to see its type.
-- **Go-to-definition**: Jump from a usage to its declaration.
-- **Find references**: Find all places a symbol is used.
-- **Quick fixes**: Suggest fixes for common errors (e.g., "Add missing property").
-- **Rename refactoring**: Rename a symbol across all files safely.
-
-All of these are powered by the same type checker that runs when you compile. The editor is constantly recompiling in the background, giving you instant feedback.
+Notice the arrow this chapter cares about: the checker feeds two consumers. The **emitter** uses it once per build. The **language service** uses it *continuously* — every keystroke in your editor re-runs the same analysis, which is why the red squiggle under `user.emial`, the autocomplete dropdown, "Find All References," and project-wide rename are not separate features bolted onto your editor. They are one type checker, asked different questions. When you rename `fullName` to `name` and twelve files light up with errors, that's static analysis acting as a refactoring engine: the compiler has a complete, always-current map of every place each symbol flows, so nothing can hide.
 
 <Callout type="info" title="The Editor Is Your Compiler">
 With TypeScript, the editor *is* the compiler. Every red squiggle, autocomplete suggestion, and refactor command is driven by the same type analysis that runs at build time. This tight integration is what makes TypeScript so productive.
@@ -396,13 +374,7 @@ Write a function \`processPayment(payment: Payment): string\` that handles all t
   files={[
     {
       filename: "main.ts",
-      initCode: `type Payment = any; // Replace 'any'
-
-function processPayment(payment: Payment): string {
-  return "Not implemented";
-}
-`,
-      starterCode: `type Payment = any;
+      starterCode: `type Payment = any; // Replace 'any' with the discriminated union
 
 function processPayment(payment: Payment): string {
   return "Not implemented";

--- a/content/learn/typescript-from-scratch/structural-typing.mdx
+++ b/content/learn/typescript-from-scratch/structural-typing.mdx
@@ -150,6 +150,8 @@ welcomeUser({ id: "456", name: "Grace" }); // ✅ OK
 
 This is why TypeScript is often described as having **duck typing for compilers**: "If it looks like a duck and quacks like a duck, it's a duck."
 
+The phrase has a real lineage, and it's older than any programming language. The "duck test" — *if it looks like a duck, swims like a duck, and quacks like a duck, it's probably a duck* — was a piece of American folk reasoning long before computing. The Python community adopted it around 2000 to describe their language's habit of caring only about what an object can *do*, never what class it claims to be; Alex Martelli's postings on the comp.lang.python newsgroup are usually credited with cementing the term. TypeScript's contribution was to take this runtime philosophy and make a *compiler* enforce it: you get duck typing's flexibility, but the quack-check happens before the program ever runs.
+
 <Callout type="info" title="Contrast with Go's interfaces">
 Go also uses structural typing for interfaces, but it's stricter: a type must implement *all* methods of an interface to satisfy it. TypeScript is more permissive — extra properties are fine, and even functions can be structurally compatible if their parameter and return types align.
 </Callout>
@@ -370,16 +372,14 @@ TypeScript's structural typing gives you flexibility by default, but you can lay
 
 ## Challenge: Structural compatibility
 
-Let's test your understanding. You'll fix a function so it works with any object that has the required shape.
+Let's test your understanding. The function below is typed against a small `LogEntry` interface, and — thanks to structural typing — the program feeds it objects that were never declared as `LogEntry` but happen to have the right shape (plus extra fields). Your job is just the body.
 
 <ChallengeCard
   adapter="typescript"
-  title="Making a structurally compatible logger"
-  instructions={`The \`logItem\` function currently expects a specific \`LogEntry\` type, but we want it to work with *any* object that has \`level\` and \`message\` properties.
+  title="A structurally typed log formatter"
+  instructions={`Implement the body of \`formatEntry\` so it returns the entry's level in uppercase, wrapped in square brackets, followed by a space and the message — exactly like \`[INFO] App started\`.
 
-**Your task:**
-1. Change the parameter type of \`logItem\` from \`LogEntry\` to a more general shape.
-2. The test will pass various objects with extra properties — all should work as long as they have \`level\` and \`message\`.`}
+Note the two objects passed in \`main.ts\`: neither was declared as a \`LogEntry\`, and both carry extra properties (\`uptimeMs\`, \`stack\`). Structural typing accepts them anyway, because each has at least \`level\` and \`message\`.`}
   files={[
     {
       filename: "main.ts",
@@ -388,52 +388,51 @@ Let's test your understanding. You'll fix a function so it works with any object
   message: string;
 }
 
-// Fix this function's parameter type to accept any compatible shape
-function logItem(entry: LogEntry) {
-  console.log(\`[\${entry.level.toUpperCase()}] \${entry.message}\`);
+function formatEntry(entry: LogEntry): string {
+  // Your code here: return "[LEVEL] message", e.g. "[INFO] App started"
+  return "";
 }
 
-// These should all work:
-logItem({ level: "info", message: "App started" });
-logItem({ level: "error", message: "Crash", stack: "..." });
-logItem({ level: "warn", message: "Low memory", timestamp: Date.now() });
-`,
-      solutionCode: `// Solution: Keep the same interface, but TypeScript's structural typing
-// already allows extra properties on non-literal arguments.
-// The original code works as-is for stored objects!
+// Structural typing in action: not declared as LogEntry, extra
+// properties included — both are accepted because the shape fits.
+const boot = { level: "info", message: "App started", uptimeMs: 12 };
+const crash = { level: "error", message: "Crash", stack: "at main.ts:1" };
 
-interface LogEntry {
+console.log(formatEntry(boot));
+console.log(formatEntry(crash));
+`,
+      solutionCode: `interface LogEntry {
   level: string;
   message: string;
 }
 
-function logItem(entry: LogEntry) {
-  console.log(\`[\${entry.level.toUpperCase()}] \${entry.message}\`);
+function formatEntry(entry: LogEntry): string {
+  return \`[\${entry.level.toUpperCase()}] \${entry.message}\`;
 }
 
-// Store in variables to bypass excess property checking
-const entry1 = { level: "info", message: "App started" };
-const entry2 = { level: "error", message: "Crash", stack: "..." };
-const entry3 = { level: "warn", message: "Low memory", timestamp: Date.now() };
+const boot = { level: "info", message: "App started", uptimeMs: 12 };
+const crash = { level: "error", message: "Crash", stack: "at main.ts:1" };
 
-logItem(entry1);
-logItem(entry2);
-logItem(entry3);
+console.log(formatEntry(boot));
+console.log(formatEntry(crash));
 `,
     },
   ]}
   tests={[
     {
       id: "info",
-      name: "Logs info level",
-      description: "logItem({ level: 'info', message: '...' }) works",
-      code: `const entry = { level: "info", message: "Test" }; logItem(entry);`,
+      name: "Formats a plain entry",
+      description: "formatEntry({level:'info',message:'Test'}) === '[INFO] Test'",
+      code: `const r = formatEntry({ level: "info", message: "Test" });
+if (r !== "[INFO] Test") throw new Error("Expected '[INFO] Test', got: " + r);`,
     },
     {
       id: "extra",
-      name: "Allows extra properties",
-      description: "logItem({ level, message, extra }) works",
-      code: `const entry = { level: "debug", message: "Extra", extra: 123 }; logItem(entry);`,
+      name: "Accepts extra properties",
+      description: "An object with extra fields formats the same way",
+      code: `const e = { level: "warn", message: "Low memory", extra: 123 };
+const r = formatEntry(e);
+if (r !== "[WARN] Low memory") throw new Error("Expected '[WARN] Low memory', got: " + r);`,
     },
   ]}
 />

--- a/content/learn/typescript-from-scratch/type-inference.mdx
+++ b/content/learn/typescript-from-scratch/type-inference.mdx
@@ -272,27 +272,30 @@ console.log(\`points: { x: number; y: number }[] =\`, JSON.stringify(points));
   ]}
 />
 
-If no single type fits all elements, the compiler creates a **union** of the candidates. This is usually what you want, but sometimes it's too loose. You can add an explicit type annotation to narrow it:
+If no single type fits all elements, the compiler creates a **union** of the candidates. This is usually what you want, but sometimes it's too loose — and the inference is locked in at the moment of initialization, so a union you created by accident follows the array around forever:
 
 <CodeBlock
   adapter="typescript"
   files={[
     {
       filename: "main.ts",
-      starterCode: `// Without annotation: inferred as (string | number)[]
-const loose = [42];
-loose.push("hello"); // allowed
-console.log(loose); // [42, "hello"]
+      starterCode: `// One stray string in the initializer...
+const loose = [42, "hello"]; // inferred as (string | number)[]
+loose.push("world"); // ...and now strings are allowed forever
+loose.push(7); // numbers too, of course
+console.log(loose); // [42, "hello", "world", 7]
 
-// With annotation: restricted to number[]
+// An explicit annotation pins the element type down
 const strict: number[] = [42];
-// strict.push("hello"); // ❌ Error: Argument of type 'string' is not assignable to parameter of type 'number'
+// strict.push("hello"); // ❌ Error: 'string' is not assignable to 'number'
 strict.push(100); // ✅ OK
 console.log(strict); // [42, 100]
 `,
     },
   ]}
 />
+
+Note what inference does *not* do: it never widens beyond the evidence. `const nums = [42]` is inferred as `number[]`, so `nums.push("hello")` is already an error with no annotation needed. You only reach for an explicit annotation when the initializer's evidence is wrong about your intent — usually because a value snuck in that shouldn't be there at all.
 
 ## How inference walks expressions
 

--- a/content/learn/typescript-from-scratch/utility-types.mdx
+++ b/content/learn/typescript-from-scratch/utility-types.mdx
@@ -673,7 +673,8 @@ console.log(directory);
   files={[
     {
       filename: "main.ts",
-      starterCode: `type MyPick<T, K extends keyof T> = any; // Replace 'any'
+      starterCode: `// Replace the right-hand side with a mapped type over K
+type MyPick<T, K extends keyof T> = T;
 
 type User = { id: number; name: string; email: string };
 type UserPreview = MyPick<User, "id" | "name">;

--- a/content/learn/typescript-from-scratch/utility-types.mdx
+++ b/content/learn/typescript-from-scratch/utility-types.mdx
@@ -673,9 +673,7 @@ console.log(directory);
   files={[
     {
       filename: "main.ts",
-      initCode: `type MyPick<T, K extends keyof T> = any; // Replace 'any'
-`,
-      starterCode: `type MyPick<T, K extends keyof T> = any;
+      starterCode: `type MyPick<T, K extends keyof T> = any; // Replace 'any'
 
 type User = { id: number; name: string; email: string };
 type UserPreview = MyPick<User, "id" | "name">;
@@ -719,9 +717,7 @@ if (p.id !== 1 || p.name !== "Alice") throw new Error("Pick failed");`,
   files={[
     {
       filename: "main.ts",
-      initCode: `type MyExclude<T, U> = any; // Replace 'any'
-`,
-      starterCode: `type MyExclude<T, U> = any;
+      starterCode: `type MyExclude<T, U> = any; // Replace 'any'
 
 type All = "a" | "b" | "c";
 type Result = MyExclude<All, "a" | "c">;


### PR DESCRIPTION
Full developmental-editing pass over both courses, per the course-editing directives.

## Structural changes

**TypeScript from Scratch**
- Both welcome pages previously had **no runnable code**; each now opens with a live `<CodeBlock>` and an explicit "this runs in your browser" framing.
- The course opened with two pure-history pages before any meaningful interaction. *The Birth of TypeScript* now absorbs the load-bearing JavaScript-crisis narrative (with a runnable "legal chaos" demo), and *The Evolution of JavaScript* moved to a new appendix section at the end of the course (slug unchanged, cross-linked both ways). `meta.json` updated accordingly.

## Bug fixes (widgets that were broken as shipped)

- Five challenges had an `initCode` that duplicated the starter's declarations — since initCode is prepended on every run, the same type was defined twice (`Mutable`, `MyPick`, `MyExclude`, `EventHandlerMap`, `Payment`; the branded-temperature challenge duplicated its entire scaffold). Scaffolding now lives in initCode only where it belongs.
- Three challenges asserted with a nonexistent `stdoutIncludes` matcher (the harness supports `stdoutContains`) — those tests were asserting nothing.
- A type-inference example claimed `const loose = [42]` infers `(string | number)[]` and that `loose.push("hello")` is allowed; it infers `number[]` and errors. Rewritten to demonstrate the real behavior.
- The arrays page claimed plain `strict` mode types indexing as `T | undefined`; that's `noUncheckedIndexedAccess`. Corrected and cross-linked.
- The structural-typing challenge's instructions told learners to widen a parameter type while the solution did something else entirely; rebuilt as a coherent quick win whose starter fails and solution passes.
- A `MultipleChoice` on the domain-modeling page used `-` bullets inside the question body, which the parser reserves for choices — the question rendered with six garbled options. Body list reworked.
- An `as any` cast in a teaching example replaced with the type-safe `Object.assign` pattern.

## Sandbox honesty

The in-page TS runner transpiles with syntax-level diagnostics and erases types before executing (`transpileModule`); it does not run the semantic checker. The most prominent "uncomment this to see the compile error" claims (welcome, birth, how-typescript-works, setup, discriminated-unions) now say what `tsc`/editors do instead of promising in-sandbox rejections — and the *How TypeScript Works* example was turned into an explicit, runnable demonstration of type erasure. Type-level challenge starters use an identity alias instead of `any` so the checker visibly rejects them.

## Reading like a book (true stories added, all verifiable)

- **C:** B→C lineage and Ritchie's "quirky, flawed, and an enormous success"; `a.out` = "assembler output"; *Gulliver's Travels* / Danny Cohen's IEN 137 endianness naming; Hoare's billion-dollar-mistake apology (NULL); Kamp's "Most Expensive One-Byte Mistake" (NUL-terminated strings); the IBM 704 origin of "BSS"; the naming of stackoverflow.com; Doug Lea's dlmalloc → glibc lineage; the Quake III fast inverse square root (type punning).
- **TS:** the duck test's route from folklore through Python (Martelli) into TypeScript; Java's covariant arrays and `ArrayStoreException` as the canonical variance war story (and TypeScript's deliberate repeat of the bet); the self-hosted compiler; Hoare's apology on the `strictNullChecks` page.
- Plus: a postal-address walkthrough for pointers, a zero-based-indexing explainer, redundancy trims (`void` vs `undefined` duplicated across two TS chapters; compiler pipeline restated in *Static Analysis in Action* now reads as a deliberate capstone recap), and verifiability fixes in *Real-World Memory Disasters* (PS3 hypervisor account, Cloudbleed figures) and the TypeScript timeline (announcement venue, adoption stats).

## Verification

- `node scripts/audit/validate-mdx.mjs` clean for all 42 course pages
- `npm run check:mcq` clean
- `npm run build` passes on the rebased tree
- Every modified challenge re-checked by hand: solution satisfies each expect clause / test, unmodified starter fails, instructions state exact expected output

## Flagged but left alone

- Challenge test snippets across the TS course inconsistently use `import` vs `require` in test code (both pre-existing patterns); `npm run test:solutions` (Playwright + WASM toolchains) wasn't run in this environment.
- Course-wide, many remaining "uncomment to see a type error" asides still assume semantic checking the sandbox doesn't do; the prominent early instances are fixed, the long tail is noted for a follow-up (or a runtime upgrade to a real checker, which would fix them all at once).
- *Early experiments* on the birth page lists Flow (2014) before TypeScript's 2012 announcement — chronologically awkward but factually dated, kept as-is.

https://claude.ai/code/session_01SkLRGoTee5HCJnARoziVFo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkLRGoTee5HCJnARoziVFo)_