### PR TITLE
Playground UI: merged SQLite import, Settings tab polish, settings button relocation, brand welcome mark

### DIFF
--- a/__tests__/importSniff.test.ts
+++ b/__tests__/importSniff.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isSqliteBinary } from "../app/_components/sql/utils/importUtils";
+
+/** The 16-byte magic header every SQLite database file starts with. */
+const MAGIC = new Uint8Array([
+  ...Array.from("SQLite format 3", (c) => c.charCodeAt(0)),
+  0,
+]);
+
+describe("isSqliteBinary", () => {
+  it("accepts a buffer starting with the SQLite magic header", () => {
+    expect(isSqliteBinary(MAGIC)).toBe(true);
+    // Real files have a full header page after the magic.
+    const withPage = new Uint8Array(4096);
+    withPage.set(MAGIC, 0);
+    expect(isSqliteBinary(withPage)).toBe(true);
+  });
+
+  it("rejects SQL dump text, even when it mentions SQLite", () => {
+    const dump = new TextEncoder().encode(
+      "-- SQLite format 3 dump\nCREATE TABLE t (id INTEGER);\n",
+    );
+    expect(isSqliteBinary(dump)).toBe(false);
+  });
+
+  it("requires the trailing NUL of the magic header", () => {
+    const noNul = new TextEncoder().encode("SQLite format 3 ");
+    expect(isSqliteBinary(noNul)).toBe(false);
+  });
+
+  it("rejects buffers shorter than the magic header", () => {
+    expect(isSqliteBinary(new Uint8Array(0))).toBe(false);
+    expect(isSqliteBinary(MAGIC.slice(0, 15))).toBe(false);
+  });
+});

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -102,6 +102,7 @@ import {
   SettingsPanelContent,
   detectIsMac,
 } from "./playgroundShared";
+import { DiamondMark } from "./mdx/loadingAnimations";
 import { TabBar } from "./tabs/TabBar";
 import type { TabContextMenuItem, TabDescriptor } from "./tabs/tabTypes";
 import {
@@ -3071,9 +3072,8 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
               </Popover.Portal>
             </Popover.Root>
 
-            {/* Settings entry co-located with the other global controls so
-                it's reachable from the top-right cluster (it's also still
-                pinned at the bottom of the left icon rail). */}
+            {/* Settings entry co-located with the other global controls in
+                the top-right cluster. */}
             <button
               type="button"
               className="header-btn icon-only"
@@ -3571,36 +3571,6 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                 </Popover.Portal>
               </Popover.Root>
             </div>
-            <div className="playground-icon-sidebar-bottom">
-              <Popover.Root>
-                <Popover.Trigger
-                  openOnHover
-                  delay={150}
-                  closeDelay={100}
-                  render={(triggerProps) => (
-                    <button
-                      {...triggerProps}
-                      type="button"
-                      className="playground-icon-sidebar-btn"
-                      aria-label="Settings"
-                      onClick={openSettingsTab}
-                    >
-                      <svg className="stroke-icon" viewBox="0 0 24 24" width={15} height={15} fill="none" stroke="currentColor" strokeWidth="1.8">
-                        <circle cx="12" cy="12" r="3" />
-                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                      </svg>
-                    </button>
-                  )}
-                />
-                <Popover.Portal>
-                  <Popover.Positioner sideOffset={6} side="right">
-                    <Popover.Popup className="bui-popup pane-btn-popover">
-                      Settings
-                    </Popover.Popup>
-                  </Popover.Positioner>
-                </Popover.Portal>
-              </Popover.Root>
-            </div>
           </nav>
           {filesPaneOpen && (
             <div className="playground-files-sidebar">
@@ -3873,7 +3843,9 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
             <div className="output-body" ref={outputBodyRef}>
               {outputs.length === 0 && statusState !== "running" ? (
                 <div className="welcome">
-                  <div className="welcome-icon">⌬</div>
+                  <div className="welcome-icon">
+                    <DiamondMark size={40} />
+                  </div>
                   <h3>Run your code to see output</h3>
                   {capabilitiesBlurb && <p>{capabilitiesBlurb}</p>}
                 </div>
@@ -3991,6 +3963,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                 onRestoreDefaults={() => setConfirmRestoreOpen(true)}
                 onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
                 onClearAllLocalData={() => setConfirmClearAllDataOpen(true)}
+                onClose={closeSettingsTab}
               />
             </div>
           )}

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -1301,6 +1301,16 @@ function DuckDbPlaygroundInner() {
       setActiveTabId(SETTINGS_TAB_ID);
     }
   }, [setSettingsOpen, setActiveTabId]);
+  /** Close the Settings tab (✕ in its tab strip entry or in the settings
+   *  tab bar) and return focus to the most-recent query tab. */
+  const closeSettingsTab = useCallback(() => {
+    setSettingsOpen(false);
+    const fallback = tabsRef.current[0]?.id;
+    if (fallback && activeTabIdRef.current === SETTINGS_TAB_ID) {
+      activeTabIdRef.current = fallback;
+      setActiveTabId(fallback);
+    }
+  }, [setSettingsOpen, setActiveTabId]);
   const result = activeTab ? (resultsByTab[activeTab.id] ?? null) : null;
   const activeSample = findDuckDbSampleDatabase(activeDbId);
   // customDbFilename applies only for the blank/imported database slot.
@@ -4116,6 +4126,31 @@ function DuckDbPlaygroundInner() {
                 </Popover.Positioner>
               </Popover.Portal>
             </Popover.Root>
+            <Popover.Root>
+              <Popover.Trigger
+                openOnHover
+                delay={150}
+                closeDelay={400}
+                render={(triggerProps) => (
+                  <button
+                    {...triggerProps}
+                    type="button"
+                    className="header-btn icon-only"
+                    aria-label="Settings"
+                    onClick={openSettingsTab}
+                  >
+                    <SettingsIcon size={14} aria-hidden="true" />
+                  </button>
+                )}
+              />
+              <Popover.Portal>
+                <Popover.Positioner sideOffset={6} align="end">
+                  <Popover.Popup className="bui-popup pane-btn-popover">
+                    Settings
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
           </div>
         </>
       }
@@ -4900,18 +4935,6 @@ function DuckDbPlaygroundInner() {
                     isActive: sidebarView === "files",
                   },
                 ]}
-                bottomButtons={[
-                  {
-                    icon: (
-                      <svg className="stroke-icon" viewBox="0 0 24 24" width={15} height={15} fill="none" stroke="currentColor" strokeWidth="1.8">
-                        <circle cx="12" cy="12" r="3" />
-                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                      </svg>
-                    ),
-                    label: "Settings",
-                    onClick: openSettingsTab,
-                  },
-                ]}
               />
               <div className="sql-sidebar-content">
             {sidebarView === "schema" && (
@@ -5186,13 +5209,7 @@ function DuckDbPlaygroundInner() {
                   : undefined
               }
               onExtraTabClose={(tabId) => {
-                if (tabId === SETTINGS_TAB_ID) {
-                  setSettingsOpen(false);
-                  const fallback = tabs[0]?.id;
-                  if (fallback && activeTabIdRef.current === SETTINGS_TAB_ID) {
-                    setActiveTabId(fallback);
-                  }
-                }
+                if (tabId === SETTINGS_TAB_ID) closeSettingsTab();
               }}
               onTabActivate={(tabId) => {
                 const prevId = activeTabIdRef.current;
@@ -5420,6 +5437,7 @@ function DuckDbPlaygroundInner() {
                   onRestoreDefaults={() => setConfirmRestoreOpen(true)}
                   onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
                   onClearAllLocalData={() => setConfirmClearAllDataOpen(true)}
+                  onClose={closeSettingsTab}
                   resetTabsLabel={`Reset query tabs for ${activeSample.label}`}
                   onResetTabs={resetTabsForCurrentDb}
                   extraTabs={[

--- a/app/_components/mdx/loadingAnimations.tsx
+++ b/app/_components/mdx/loadingAnimations.tsx
@@ -28,6 +28,7 @@
  * `prefers-reduced-motion` by swapping motion for an opacity pulse.
  *
  * Exported pieces:
+ *  - <DiamondMark /> — the hollow diamond as a static (non-animated) mark
  *  - <DiamondSpinner />, <DiamondTurnSpinner />, <DiamondAssembleLoader />,
  *    <DiamondAssembleTurnLoader />, <DiamondRippleLoader />, <LogoHopLoader />
  *  - <LogoWave />
@@ -150,6 +151,38 @@ function GradientDiamond({ idPrefix }: { idPrefix: string }) {
 function useSafeId(prefix: string): string {
   const uid = useId().replace(/[^a-zA-Z0-9_-]/g, "");
   return `${prefix}-${uid}`;
+}
+
+// ─── Static mark ───────────────────────────────────────────────────────
+
+/** The hollow-diamond brand shape as a plain, static SVG — the same
+ *  4-point star the spinners rotate, without any animation. Renders
+ *  with `currentColor`, so the parent's CSS `color` sets the tint
+ *  (e.g. the playgrounds' welcome empty-states tint it brand blue via
+ *  `.welcome-icon`). Decorative by default; pass `label` to expose it
+ *  to assistive tech instead. */
+export function DiamondMark({
+  size = 44,
+  label,
+}: {
+  /** Rendered width in px (the diamond is ~square). */
+  size?: number;
+  /** Accessible label; omitted = decorative (aria-hidden). */
+  label?: string;
+}) {
+  const gradId = useSafeId("ds-mark");
+  return (
+    <svg
+      viewBox={`0 0 ${LOGO_W} ${DIAMOND_H}`}
+      width={size}
+      height={size}
+      role={label ? "img" : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
+    >
+      <GradientDiamond idPrefix={gradId} />
+    </svg>
+  );
 }
 
 // ─── Spinners ──────────────────────────────────────────────────────────

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -475,21 +475,13 @@ body.playground-active {
   z-index: 5;
 }
 
-/* Top group: regular panel buttons. Bottom group is pinned to the bottom. */
+/* Top group: regular panel buttons. */
 .playground-icon-sidebar-top {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2px;
   flex: 1;
-}
-
-.playground-icon-sidebar-bottom {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-  padding-top: 4px;
 }
 
 .playground-icon-sidebar-btn {
@@ -805,10 +797,26 @@ body.playground-active {
 .panes {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  /* Pin the single grid row to the container height. Without this the
+     implicit `auto` row tracks its tallest item's content — so a tall
+     Settings pane (e.g. the Themes grid) silently stretched the editor
+     past the viewport, and a short one didn't fill it. */
+  grid-template-rows: minmax(0, 1fr);
   flex: 1;
   min-height: 0;
   overflow: hidden;
   position: relative;
+}
+
+/* While the Settings tab is active, pin the output pane to the cell the
+   settings panel overlays (row 1, column 2). Without this, the settings
+   pane's explicit placement claims that cell first and grid
+   auto-placement spills the output pane into an implicit second row —
+   which both shrank row 1 (the editor) and let the settings panel's
+   content height drive the editor's height. */
+.panes[data-settings-active] .output-pane {
+  grid-row: 1;
+  grid-column: 2;
 }
 
 /* On desktop the settings tab sits in the output column only (so the
@@ -817,6 +825,13 @@ body.playground-active {
    mobile the settings panel covers the whole pane area, so hide the bar
    underneath it there. */
 @media (max-width: 768px) {
+  /* The mobile panes area is a single tab-switched column and the
+     settings panel covers it absolutely, so undo the desktop pinning —
+     an explicit column 2 would otherwise open an implicit track. */
+  .panes[data-settings-active] .output-pane {
+    grid-row: auto;
+    grid-column: auto;
+  }
   .panes[data-settings-active] .pane-bar {
     display: none;
   }
@@ -1317,8 +1332,13 @@ body.playground-active {
   padding: 32px;
 }
 .welcome-icon {
+  /* Tints the static DiamondMark brand SVG (it draws with currentColor). */
   color: var(--primary);
-  font-size: 32px;
+  line-height: 0;
+  margin-bottom: 4px;
+}
+.welcome-icon svg {
+  display: block;
 }
 .welcome h3 {
   /* "Run a query to see results" is an <h3>. A bare `h3` selector (e.g. the
@@ -1687,9 +1707,8 @@ body.playground-active {
 .settings-tabs-list {
   display: flex;
   flex-direction: row;
-  /* Extra right padding so the floating close button doesn't overlap
-     the rightmost tab. */
-  padding: 0 44px 0 10px;
+  align-items: center;
+  padding: 0 10px;
   flex-shrink: 0;
   background: var(--bg2);
 }
@@ -1732,6 +1751,34 @@ body.playground-active {
   flex-shrink: 0;
 }
 
+/* ✕ button pinned to the far right of the settings tab bar — closes the
+   Settings tab and returns to the previously-active surface. */
+.settings-tabs-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  margin-left: auto;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+}
+.settings-tabs-close:hover {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--text);
+}
+.settings-tabs-close:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--text-muted);
+}
+
 .settings-panel-pane {
   flex: 1;
   min-height: 0;
@@ -1768,64 +1815,91 @@ body.playground-active {
 
 /* Restore-defaults / clear-localStorage actions. Sit at the bottom of
    the General tab, separated from the rest by a divider so they don't
-   read as just-another-toggle. The buttons are styled as a vertical
-   grouped control — shared borders, corner-radius only on the outermost
-   buttons — so they read as one cohesive section. */
+   read as just-another-toggle. The buttons are grouped into rounded
+   cards — neutral maintenance actions in one, destructive actions in a
+   red-tinted "danger" one — with each row carrying a soft tinted icon
+   chip, so the section reads as deliberate UI rather than a raw button
+   stack. */
 .settings-actions {
   display: flex;
   flex-direction: column;
-  gap: 0;
-  padding-top: 14px;
+  gap: 12px;
+  padding-top: 16px;
   border-top: 1px solid var(--border);
 }
-.settings-action-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 13px 16px;
-  background: transparent;
+.settings-actions-group {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg2);
   border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.settings-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
   color: var(--text);
   font-family: var(--font-ui);
   font-size: 13px;
   font-weight: 500;
-  border-radius: 0;
+  text-align: left;
   cursor: pointer;
-  position: relative;
   transition:
     background-color 0.15s,
     color 0.15s;
 }
-/* Collapse adjacent borders so each shared edge is 1 px, not 2. */
-.settings-action-btn:not(:first-child) {
-  margin-top: -1px;
+/* Hairline divider between stacked rows inside a group. */
+.settings-action-btn + .settings-action-btn {
+  border-top: 1px solid var(--border);
 }
-/* Hover needs z-index so its border renders on top of siblings. */
 .settings-action-btn:hover {
-  z-index: 1;
-  border-color: color-mix(in srgb, var(--text) 40%, var(--border) 60%);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
 }
-/* Corner radius: top on first, bottom on last, all four on an only-child. */
-.settings-action-btn:first-child {
-  border-radius: var(--radius) var(--radius) 0 0;
+.settings-action-btn:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--primary);
 }
-.settings-action-btn:last-child {
-  border-radius: 0 0 var(--radius) var(--radius);
-}
-.settings-action-btn:only-child {
-  border-radius: var(--radius);
-}
-.settings-action-btn svg {
+/* Soft tinted chip behind each row's icon — brand blue for neutral
+   actions, red for destructive ones. */
+.settings-action-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
   flex-shrink: 0;
-  color: currentColor;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--primary) 14%, transparent);
+  color: var(--primary);
+}
+.settings-action-icon svg {
+  flex-shrink: 0;
+}
+.settings-action-label {
+  min-width: 0;
+}
+/* Destructive rows: red text + red-tinted chip, with the group border
+   warmed toward red so the danger card reads at a glance. */
+.settings-actions-group-danger {
+  border-color: color-mix(in srgb, var(--red) 35%, var(--border));
+}
+.settings-actions-group-danger .settings-action-btn + .settings-action-btn {
+  border-top-color: color-mix(in srgb, var(--red) 20%, var(--border));
 }
 .settings-action-danger {
   color: var(--red);
-  border-color: var(--red);
+}
+.settings-action-danger .settings-action-icon {
+  background: color-mix(in srgb, var(--red) 14%, transparent);
+  color: var(--red);
 }
 .settings-action-danger:hover {
+  background: color-mix(in srgb, var(--red) 9%, transparent);
   color: var(--red);
-  border-color: oklch(from var(--red) calc(l - 0.3) c h);
 }
 
 /* Editor-themes tab — grid of preview cards. */
@@ -1902,23 +1976,18 @@ body.playground-active {
 }
 
 /* On narrow viewports the settings panel takes (almost) the full screen
-   and the tabs switch to a left-side icon-only rail so the body has
-   more vertical room. The labels are visually hidden but kept in the
-   DOM for screen readers. */
+   and the tabs collapse to a horizontal row of icon-only pills across
+   the top, so the body keeps its vertical room. The labels are visually
+   hidden but kept in the DOM for screen readers. */
 @media (max-width: 768px) {
-  .settings-tabs {
-    flex-direction: row;
-  }
   .settings-tabs-list {
-    flex-direction: column;
     gap: 6px;
-    padding: 10px 6px;
-    border-bottom: none;
-    border-right: 1px solid var(--border);
-    flex-shrink: 0;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border);
   }
   .settings-tab {
-    padding: 10px;
+    flex: 1;
+    padding: 9px 10px;
     margin-bottom: 0;
     border: 1px solid transparent;
     border-radius: 8px;
@@ -1944,6 +2013,10 @@ body.playground-active {
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+  }
+  /* The ✕ keeps its intrinsic size at the end of the pill row. */
+  .settings-tabs-close {
+    margin-left: 4px;
   }
   .theme-grid {
     grid-template-columns: 1fr;
@@ -2628,6 +2701,21 @@ input[type="range"].fs-slider:disabled {
 .import-section-label:first-child {
   margin-top: 8px;
   padding-top: 4px;
+}
+
+/* Group of several extension badges beside one item title (the unified
+   database-import entry). The title text keeps to one line; the badges
+   right-align and wrap to extra rows instead of squeezing it. */
+.ex-title-text {
+  white-space: nowrap;
+}
+.ext-badge-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 3px;
+  min-width: 0;
+  margin-left: 8px;
 }
 
 /* File-extension badge — compact inline badge rendered beside the item title. */

--- a/app/_components/playgroundShared.tsx
+++ b/app/_components/playgroundShared.tsx
@@ -18,6 +18,7 @@ import {
   Sliders,
   Trash2,
   WrapText,
+  X,
 } from "lucide-react";
 import {
   ALL_THEMES,
@@ -342,6 +343,9 @@ export interface SettingsPanelProps {
     trigger: ReactNode;
     panel: ReactNode;
   }>;
+  /** Close the Settings tab. When provided, a ✕ button is rendered at
+   *  the far right of the settings tab bar (after the last tab). */
+  onClose?: () => void;
 }
 
 /** Tabbed settings UI body (General + Editor Themes + extra tabs)
@@ -372,6 +376,7 @@ export function SettingsPanelContent({
   extraGeneralRows,
   extraActionRows,
   extraTabs,
+  onClose,
 }: SettingsPanelProps) {
   const [tab, setTab] = useState<string>(() => {
     try {
@@ -414,6 +419,17 @@ export function SettingsPanelContent({
             {t.trigger}
           </Tabs.Tab>
         ))}
+        {onClose && (
+          <button
+            type="button"
+            className="settings-tabs-close"
+            aria-label="Close settings"
+            title="Close settings"
+            onClick={onClose}
+          >
+            <X size={15} aria-hidden="true" />
+          </button>
+        )}
       </Tabs.List>
 
       <Tabs.Panel value="general" className="settings-panel-pane">
@@ -513,33 +529,49 @@ export function SettingsPanelContent({
           {extraGeneralRows}
 
           <div className="settings-actions">
-            {extraActionRows}
-            <button
-              type="button"
-              className="settings-action-btn"
-              onClick={onRestoreDefaults}
-            >
-              <RotateCcw size={14} aria-hidden="true" />
-              <span>Restore default settings</span>
-            </button>
-            <button
-              type="button"
-              className="settings-action-btn settings-action-danger"
-              onClick={onClearLocalStorage}
-            >
-              <Trash2 size={14} aria-hidden="true" />
-              <span>Clear all localStorage data</span>
-            </button>
-            {onClearAllLocalData && (
+            <div className="settings-actions-group">
+              {extraActionRows}
+              <button
+                type="button"
+                className="settings-action-btn"
+                onClick={onRestoreDefaults}
+              >
+                <span className="settings-action-icon" aria-hidden="true">
+                  <RotateCcw size={14} />
+                </span>
+                <span className="settings-action-label">
+                  Restore default settings
+                </span>
+              </button>
+            </div>
+            <div className="settings-actions-group settings-actions-group-danger">
               <button
                 type="button"
                 className="settings-action-btn settings-action-danger"
-                onClick={onClearAllLocalData}
+                onClick={onClearLocalStorage}
               >
-                <Trash2 size={14} aria-hidden="true" />
-                <span>Clear all local data (storage + OPFS)</span>
+                <span className="settings-action-icon" aria-hidden="true">
+                  <Trash2 size={14} />
+                </span>
+                <span className="settings-action-label">
+                  Clear all localStorage data
+                </span>
               </button>
-            )}
+              {onClearAllLocalData && (
+                <button
+                  type="button"
+                  className="settings-action-btn settings-action-danger"
+                  onClick={onClearAllLocalData}
+                >
+                  <span className="settings-action-icon" aria-hidden="true">
+                    <Trash2 size={14} />
+                  </span>
+                  <span className="settings-action-label">
+                    Clear all local data (storage + OPFS)
+                  </span>
+                </button>
+              )}
+            </div>
           </div>
         </div>
       </Tabs.Panel>

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -1258,6 +1258,16 @@ function PostgresPlaygroundInner() {
       setActiveTabId(SETTINGS_TAB_ID);
     }
   }, [setSettingsOpen, setActiveTabId]);
+  /** Close the Settings tab (✕ in its tab strip entry or in the settings
+   *  tab bar) and return focus to the most-recent query tab. */
+  const closeSettingsTab = useCallback(() => {
+    setSettingsOpen(false);
+    const fallback = tabsRef.current[0]?.id;
+    if (fallback && activeTabIdRef.current === SETTINGS_TAB_ID) {
+      activeTabIdRef.current = fallback;
+      setActiveTabId(fallback);
+    }
+  }, [setSettingsOpen, setActiveTabId]);
   const result = activeTab ? (resultsByTab[activeTab.id] ?? null) : null;
   const activeSample = findPostgresSampleDatabase(activeDbId);
   // customDbFilename applies only for the blank/imported database slot.
@@ -3676,6 +3686,31 @@ function PostgresPlaygroundInner() {
                 </Popover.Positioner>
               </Popover.Portal>
             </Popover.Root>
+            <Popover.Root>
+              <Popover.Trigger
+                openOnHover
+                delay={150}
+                closeDelay={400}
+                render={(triggerProps) => (
+                  <button
+                    {...triggerProps}
+                    type="button"
+                    className="header-btn icon-only"
+                    aria-label="Settings"
+                    onClick={openSettingsTab}
+                  >
+                    <SettingsIcon size={14} aria-hidden="true" />
+                  </button>
+                )}
+              />
+              <Popover.Portal>
+                <Popover.Positioner sideOffset={6} align="end">
+                  <Popover.Popup className="bui-popup pane-btn-popover">
+                    Settings
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
           </div>
         </>
       }
@@ -4403,18 +4438,6 @@ function PostgresPlaygroundInner() {
                     isActive: true,
                   },
                 ]}
-                bottomButtons={[
-                  {
-                    icon: (
-                      <svg className="stroke-icon" viewBox="0 0 24 24" width={15} height={15} fill="none" stroke="currentColor" strokeWidth="1.8">
-                        <circle cx="12" cy="12" r="3" />
-                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                      </svg>
-                    ),
-                    label: "Settings",
-                    onClick: openSettingsTab,
-                  },
-                ]}
               />
               <div className="sql-sidebar-content">
             <div className="sql-schema-selector-wrap">
@@ -4775,13 +4798,7 @@ function PostgresPlaygroundInner() {
                   : undefined
               }
               onExtraTabClose={(tabId) => {
-                if (tabId === SETTINGS_TAB_ID) {
-                  setSettingsOpen(false);
-                  const fallback = tabs[0]?.id;
-                  if (fallback && activeTabIdRef.current === SETTINGS_TAB_ID) {
-                    setActiveTabId(fallback);
-                  }
-                }
+                if (tabId === SETTINGS_TAB_ID) closeSettingsTab();
               }}
               onTabActivate={(tabId) => {
                 const prevId = activeTabIdRef.current;
@@ -5009,6 +5026,7 @@ function PostgresPlaygroundInner() {
                   onRestoreDefaults={() => setConfirmRestoreOpen(true)}
                   onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
                   onClearAllLocalData={() => setConfirmClearAllDataOpen(true)}
+                  onClose={closeSettingsTab}
                   resetTabsLabel={`Reset query tabs for ${activeSample.label}`}
                   onResetTabs={resetTabsForCurrentDb}
                   extraTabs={[

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -86,7 +86,6 @@ import { SqlSettingsConfirmDialogs } from "./components/SqlSettingsConfirmDialog
 import { DdlViewerDialog } from "./components/DdlViewerDialog";
 import { SwitchDatabaseDialog } from "./components/SwitchDatabaseDialog";
 import { ImportBinaryFileDialog } from "./components/ImportBinaryFileDialog";
-import { ImportSqlDumpDialog } from "./components/ImportSqlDumpDialog";
 import { RenameDatabaseDialog } from "./components/RenameDatabaseDialog";
 import { SqlEditorToolbar } from "./components/SqlEditorToolbar";
 import { findSampleDatabase } from "../runtime/sqliteSamples";
@@ -172,16 +171,10 @@ const SQLITE_DB_ACTIONS: readonly DatabaseSelectorAction[] = [
     description: "Create a blank database",
   },
   {
-    id: "__import_sqlite__",
+    id: "__import_database__",
     icon: <Upload size={14} />,
-    label: "Import SQLite File",
-    description: "Open a .sqlite or .db file",
-  },
-  {
-    id: "__import_sql_dump__",
-    icon: <FileCode2 size={14} />,
-    label: "Import SQL Dump",
-    description: "Load database from a .sql file",
+    label: "Import Database",
+    description: "Open a SQLite file or SQL dump",
   },
   {
     id: "__export_sql_dump__",
@@ -676,12 +669,6 @@ function SqlPlaygroundInner() {
   const setImportSqliteDragging = useDialogStore(
     (s) => s.setImportSqliteDragging,
   );
-  const importSqlDumpOpen = useDialogStore((s) => s.importSqlDumpOpen);
-  const setImportSqlDumpOpen = useDialogStore((s) => s.setImportSqlDumpOpen);
-  const importSqlDumpDragging = useDialogStore((s) => s.importSqlDumpDragging);
-  const setImportSqlDumpDragging = useDialogStore(
-    (s) => s.setImportSqlDumpDragging,
-  );
   const importCsvOpen = useDialogStore((s) => s.importCsvOpen);
   const setImportCsvOpen = useDialogStore((s) => s.setImportCsvOpen);
   const importCsvDragging = useDialogStore((s) => s.importCsvDragging);
@@ -784,6 +771,17 @@ function SqlPlaygroundInner() {
       setSettingsOpen(true);
       activeTabIdRef.current = SETTINGS_TAB_ID;
       setActiveTabId(SETTINGS_TAB_ID);
+    }
+  }, [setSettingsOpen, setActiveTabId]);
+
+  /** Close the Settings tab (✕ in its tab strip entry or in the settings
+   *  tab bar) and return focus to the most-recent query tab. */
+  const closeSettingsTab = useCallback(() => {
+    setSettingsOpen(false);
+    const fallback = tabsRef.current[0]?.id;
+    if (fallback && activeTabIdRef.current === SETTINGS_TAB_ID) {
+      activeTabIdRef.current = fallback;
+      setActiveTabId(fallback);
     }
   }, [setSettingsOpen, setActiveTabId]);
 
@@ -945,8 +943,7 @@ function SqlPlaygroundInner() {
 
   const {
     performDbSwitch,
-    performImportSqlite,
-    performImportSqlDump,
+    performImportDatabaseFile,
     requestDbSwitch,
     exportDatabase,
     exportDatabaseToXlsx,
@@ -1873,25 +1870,16 @@ function SqlPlaygroundInner() {
                     >
                       <div className="export-item-text">
                         <div className="ex-title">
-                          from SQLite
-                          <span className="ext-badge">.sqlite</span>
+                          <span className="ex-title-text">from file</span>
+                          <span className="ext-badge-group">
+                            <span className="ext-badge">.sql</span>
+                            <span className="ext-badge">.db</span>
+                            <span className="ext-badge">.sqlite</span>
+                            <span className="ext-badge">.sqlite3</span>
+                          </span>
                         </div>
                         <div className="ex-desc">
-                          Replace database from .sqlite file
-                        </div>
-                      </div>
-                    </Menu.Item>
-                    <Menu.Item
-                      className="example-item export-item"
-                      onClick={() => setImportSqlDumpOpen(true)}
-                    >
-                      <div className="export-item-text">
-                        <div className="ex-title">
-                          from SQL dump
-                          <span className="ext-badge">.sql</span>
-                        </div>
-                        <div className="ex-desc">
-                          Load database from a SQL dump file
+                          Replace database from a SQLite or SQL dump file
                         </div>
                       </div>
                     </Menu.Item>
@@ -2110,6 +2098,31 @@ function SqlPlaygroundInner() {
                 </Popover.Positioner>
               </Popover.Portal>
             </Popover.Root>
+            <Popover.Root>
+              <Popover.Trigger
+                openOnHover
+                delay={150}
+                closeDelay={400}
+                render={(triggerProps) => (
+                  <button
+                    {...triggerProps}
+                    type="button"
+                    className="header-btn icon-only"
+                    aria-label="Settings"
+                    onClick={openSettingsTab}
+                  >
+                    <SettingsIcon size={14} aria-hidden="true" />
+                  </button>
+                )}
+              />
+              <Popover.Portal>
+                <Popover.Positioner sideOffset={6} align="end">
+                  <Popover.Popup className="bui-popup pane-btn-popover">
+                    Settings
+                  </Popover.Popup>
+                </Popover.Positioner>
+              </Popover.Portal>
+            </Popover.Root>
           </div>
         </>
       }
@@ -2262,33 +2275,28 @@ function SqlPlaygroundInner() {
           dragging={importSqliteDragging}
           onClose={() => setImportSqliteOpen(false)}
           onDraggingChange={setImportSqliteDragging}
-          onImport={(data, filename) => performImportSqlite(data, filename)}
-          title="Import SQLite File"
+          onImport={(data, filename) =>
+            performImportDatabaseFile(data, filename)
+          }
+          title="Import Database"
           description={
             <>
-              Open a local <code>.sqlite</code> or <code>.db</code> file as a
-              new in-memory database.
+              Open a local SQLite file (<code>.db</code>,{" "}
+              <code>.sqlite</code>, <code>.sqlite3</code>) or SQL dump (
+              <code>.sql</code>) as a new in-memory database. The file&rsquo;s
+              content decides how it is imported, so any extension works.
             </>
           }
           warningText={
             <>
-              This is a playground environment. Your file will{" "}
+              This will replace the current database. Your file will{" "}
               <strong>not</strong> be uploaded or persisted — it is only loaded
               into browser memory and will be gone on reload.
             </>
           }
-          dropText="Drop a SQLite file here"
-          browseHint="or click to browse — .sqlite, .db"
-          accept=".sqlite,.db,.sqlite3"
-          inputAriaLabel="Choose SQLite file"
-        />
-
-        <ImportSqlDumpDialog
-          open={importSqlDumpOpen}
-          dragging={importSqlDumpDragging}
-          onClose={() => setImportSqlDumpOpen(false)}
-          onDraggingChange={setImportSqlDumpDragging}
-          onImport={(sql, filename) => performImportSqlDump(sql, filename)}
+          dropText="Drop a database file here"
+          browseHint="or click to browse — .sql, .db, .sqlite, .sqlite3"
+          inputAriaLabel="Choose database file"
         />
 
         <RenameDatabaseDialog
@@ -3374,12 +3382,8 @@ function SqlPlaygroundInner() {
                       requestDbSwitch("__blank__");
                       return;
                     }
-                    if (value === "__import_sqlite__") {
+                    if (value === "__import_database__") {
                       setImportSqliteOpen(true);
-                      return;
-                    }
-                    if (value === "__import_sql_dump__") {
-                      setImportSqlDumpOpen(true);
                       return;
                     }
                     if (value === "__export_sql_dump__") {
@@ -3423,18 +3427,6 @@ function SqlPlaygroundInner() {
                     label: "Tables",
                     onClick: () => {},
                     isActive: true,
-                  },
-                ]}
-                bottomButtons={[
-                  {
-                    icon: (
-                      <svg className="stroke-icon" viewBox="0 0 24 24" width={15} height={15} fill="none" stroke="currentColor" strokeWidth="1.8">
-                        <circle cx="12" cy="12" r="3" />
-                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                      </svg>
-                    ),
-                    label: "Settings",
-                    onClick: openSettingsTab,
                   },
                 ]}
               />
@@ -3596,15 +3588,7 @@ function SqlPlaygroundInner() {
                   : undefined
               }
               onExtraTabClose={(tabId) => {
-                if (tabId === SETTINGS_TAB_ID) {
-                  setSettingsOpen(false);
-                  // Return focus to the most-recent non-settings tab.
-                  const fallback = tabs[0]?.id;
-                  if (fallback && activeTabIdRef.current === SETTINGS_TAB_ID) {
-                    activeTabIdRef.current = fallback;
-                    setActiveTabId(fallback);
-                  }
-                }
+                if (tabId === SETTINGS_TAB_ID) closeSettingsTab();
               }}
               onTabActivate={(tabId) => {
                 const prevId = activeTabIdRef.current;
@@ -3868,6 +3852,7 @@ function SqlPlaygroundInner() {
                   onRestoreDefaults={() => setConfirmRestoreOpen(true)}
                   onClearLocalStorage={() => setConfirmClearStorageOpen(true)}
                   onClearAllLocalData={() => setConfirmClearAllDataOpen(true)}
+                  onClose={closeSettingsTab}
                   resetTabsLabel={`Reset query tabs for ${activeSample.label}`}
                   onResetTabs={resetTabsForCurrentDb}
                   extraTabs={[

--- a/app/_components/sql/components/ImportBinaryFileDialog.tsx
+++ b/app/_components/sql/components/ImportBinaryFileDialog.tsx
@@ -20,8 +20,10 @@ export interface ImportBinaryFileDialogProps {
   dropText: string;
   /** Secondary hint inside the drop zone ("or click to browse — .sqlite, .db"). */
   browseHint: string;
-  /** `accept` attribute on the hidden file input. */
-  accept: string;
+  /** `accept` attribute on the hidden file input. Omit to accept any
+   *  file — useful when the import sniffs the content rather than
+   *  trusting the extension. */
+  accept?: string;
   /** `aria-label` for the hidden file input. */
   inputAriaLabel: string;
 }

--- a/app/_components/sql/components/ResultView.tsx
+++ b/app/_components/sql/components/ResultView.tsx
@@ -98,6 +98,7 @@ import {
   type ColumnStats,
 } from "../utils/columnStats";
 import { orderEditedStatementByPk } from "../utils/sqlAnalysis";
+import { DiamondMark } from "../../mdx/loadingAnimations";
 
 // ────────────────────────────────────────────────────────────────────────
 // Local helpers
@@ -1500,7 +1501,9 @@ function ResultViewImpl({
   if (loading) {
     return (
       <div className="welcome" data-result-empty="loading">
-        <div className="welcome-icon">⌬</div>
+        <div className="welcome-icon">
+          <DiamondMark size={40} />
+        </div>
         <h3>Loading {engineLabel} engine…</h3>
       </div>
     );
@@ -1508,7 +1511,9 @@ function ResultViewImpl({
   if (!result) {
     return (
       <div className="welcome" data-result-empty="idle">
-        <div className="welcome-icon">⌬</div>
+        <div className="welcome-icon">
+          <DiamondMark size={40} />
+        </div>
         <h3>Run a query to see results</h3>
         <p>
           Press <kbd className="kbd">Run</kbd> or use the keyboard shortcut to

--- a/app/_components/sql/components/SqlIconSidebar.tsx
+++ b/app/_components/sql/components/SqlIconSidebar.tsx
@@ -12,8 +12,6 @@ export interface SqlIconSidebarButton {
 
 interface SqlIconSidebarProps {
   buttons: SqlIconSidebarButton[];
-  /** Buttons pinned to the bottom of the sidebar (e.g. Settings). */
-  bottomButtons?: SqlIconSidebarButton[];
 }
 
 /**
@@ -24,10 +22,8 @@ interface SqlIconSidebarProps {
  * Reuses the `.playground-icon-sidebar` / `.playground-icon-sidebar-btn` CSS from
  * `playground.css` so the visual treatment stays consistent with the
  * language playground (Python, R, etc.) activity bars.
- *
- * `buttons` appear at the top; `bottomButtons` are pinned to the bottom.
  */
-export function SqlIconSidebar({ buttons, bottomButtons }: SqlIconSidebarProps) {
+export function SqlIconSidebar({ buttons }: SqlIconSidebarProps) {
   return (
     <nav className="playground-icon-sidebar" aria-label="Panel navigation">
       <div className="playground-icon-sidebar-top">
@@ -37,15 +33,6 @@ export function SqlIconSidebar({ buttons, bottomButtons }: SqlIconSidebarProps) 
           </React.Fragment>
         ))}
       </div>
-      {bottomButtons && bottomButtons.length > 0 && (
-        <div className="playground-icon-sidebar-bottom">
-          {bottomButtons.map((btn) => (
-            <React.Fragment key={btn.label}>
-              <IconSidebarButton btn={btn} />
-            </React.Fragment>
-          ))}
-        </div>
-      )}
     </nav>
   );
 }

--- a/app/_components/sql/components/SqlSettingsPanel.tsx
+++ b/app/_components/sql/components/SqlSettingsPanel.tsx
@@ -33,6 +33,9 @@ export interface SqlSettingsPanelProps {
   /** Dialect-specific extra tabs (e.g. Pragmas for SQLite, Database for
    *  Postgres/DuckDB). Forwarded verbatim to SettingsPanelContent. */
   extraTabs?: SettingsPanelProps["extraTabs"];
+  /** Close the Settings tab — forwarded to SettingsPanelContent, which
+   *  renders the ✕ button at the right end of the settings tab bar. */
+  onClose?: () => void;
 }
 
 /** Body-only SQL settings panel — same controls shared by SQLite,
@@ -59,6 +62,7 @@ export function SqlSettingsPanelContent(props: SqlSettingsPanelProps) {
     resetTabsLabel,
     onResetTabs,
     extraTabs,
+    onClose,
   } = props;
   const extraActionRows: ReactNode = (
     <button
@@ -66,8 +70,10 @@ export function SqlSettingsPanelContent(props: SqlSettingsPanelProps) {
       className="settings-action-btn"
       onClick={onResetTabs}
     >
-      <RotateCcw size={14} aria-hidden="true" />
-      <span>{resetTabsLabel}</span>
+      <span className="settings-action-icon" aria-hidden="true">
+        <RotateCcw size={14} />
+      </span>
+      <span className="settings-action-label">{resetTabsLabel}</span>
     </button>
   );
   return (
@@ -94,6 +100,7 @@ export function SqlSettingsPanelContent(props: SqlSettingsPanelProps) {
       extraGeneralRows={null}
       extraActionRows={extraActionRows}
       extraTabs={extraTabs}
+      onClose={onClose}
     />
   );
 }

--- a/app/_components/sql/hooks/useDatabaseActions.ts
+++ b/app/_components/sql/hooks/useDatabaseActions.ts
@@ -18,6 +18,7 @@ import {
   parseCsv,
   tableNameFromFilename,
   readParquetFile,
+  isSqliteBinary,
 } from "../utils/importUtils";
 import {
   applyPragmasToEngine,
@@ -86,7 +87,6 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
   const setResultsByTab = useTabStore((s) => s.setResultsByTab);
 
   const setImportSqliteOpen = useDialogStore((s) => s.setImportSqliteOpen);
-  const setImportSqlDumpOpen = useDialogStore((s) => s.setImportSqlDumpOpen);
   const setImportCsvOpen = useDialogStore((s) => s.setImportCsvOpen);
   const setImportCsvState = useDialogStore((s) => s.setImportCsvState);
   const setImportJsonOpen = useDialogStore((s) => s.setImportJsonOpen);
@@ -226,7 +226,7 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
           });
           await engine.execAll(sqlText);
           await applyDbLoad(sample);
-          setImportSqlDumpOpen(false);
+          setImportSqliteOpen(false);
           showToast(`Imported "${filename}".`);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -234,7 +234,22 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
         }
       })();
     },
-    [applyDbLoad, showToast, engineRef, setCustomFilenames, setImportSqlDumpOpen],
+    [applyDbLoad, showToast, engineRef, setCustomFilenames, setImportSqliteOpen],
+  );
+
+  /** Unified entry point for the single "import a database file" dialog.
+   *  Sniffs the file's magic header to decide between the binary SQLite
+   *  path and the SQL-dump path, so any extension (.sql, .db, .sqlite,
+   *  .sqlite3, .db3, …) imports correctly. */
+  const performImportDatabaseFile = useCallback(
+    (bytes: Uint8Array, filename: string) => {
+      if (isSqliteBinary(bytes)) {
+        performImportSqlite(bytes, filename);
+      } else {
+        performImportSqlDump(new TextDecoder().decode(bytes), filename);
+      }
+    },
+    [performImportSqlite, performImportSqlDump],
   );
 
   const exportDatabaseAsSqlDump = useCallback(() => {
@@ -721,8 +736,7 @@ export function useDatabaseActions(refs: DatabaseActionsRefs) {
   return {
     applyDbLoad,
     performDbSwitch,
-    performImportSqlite,
-    performImportSqlDump,
+    performImportDatabaseFile,
     requestDbSwitch,
     exportDatabase,
     exportDatabaseToXlsx,

--- a/app/_components/sql/stores/useDialogStore.ts
+++ b/app/_components/sql/stores/useDialogStore.ts
@@ -26,8 +26,6 @@ interface DialogState {
   } | null;
   importSqliteOpen: boolean;
   importSqliteDragging: boolean;
-  importSqlDumpOpen: boolean;
-  importSqlDumpDragging: boolean;
   importCsvOpen: boolean;
   importCsvState: CsvImportState | null;
   importCsvDragging: boolean;
@@ -76,8 +74,6 @@ interface DialogState {
   ) => void;
   setImportSqliteOpen: (open: boolean) => void;
   setImportSqliteDragging: (dragging: boolean) => void;
-  setImportSqlDumpOpen: (open: boolean) => void;
-  setImportSqlDumpDragging: (dragging: boolean) => void;
   setImportCsvOpen: (open: boolean) => void;
   setImportCsvState: (
     state:
@@ -127,8 +123,6 @@ export const useDialogStore = create<DialogState>((set) => ({
   pendingDropEntity: null,
   importSqliteOpen: false,
   importSqliteDragging: false,
-  importSqlDumpOpen: false,
-  importSqlDumpDragging: false,
   importCsvOpen: false,
   importCsvState: null,
   importCsvDragging: false,
@@ -183,9 +177,6 @@ export const useDialogStore = create<DialogState>((set) => ({
   setImportSqliteOpen: (importSqliteOpen) => set({ importSqliteOpen }),
   setImportSqliteDragging: (importSqliteDragging) =>
     set({ importSqliteDragging }),
-  setImportSqlDumpOpen: (importSqlDumpOpen) => set({ importSqlDumpOpen }),
-  setImportSqlDumpDragging: (importSqlDumpDragging) =>
-    set({ importSqlDumpDragging }),
   setImportCsvOpen: (importCsvOpen) => set({ importCsvOpen }),
   setImportCsvState: (updater) =>
     set((state) => ({

--- a/app/_components/sql/utils/importUtils.ts
+++ b/app/_components/sql/utils/importUtils.ts
@@ -52,6 +52,21 @@ export function parseCsv(text: string): {
   return { headers, rows };
 }
 
+/** Every SQLite database file starts with the 16-byte magic header
+ *  "SQLite format 3\0". The unified database-import flow sniffs this to
+ *  decide whether the picked file is a binary SQLite database or a SQL
+ *  text dump — the filename extension is deliberately ignored so any
+ *  extension (.db3, .bak, …) imports correctly. */
+const SQLITE_MAGIC = "SQLite format 3\0";
+
+export function isSqliteBinary(bytes: Uint8Array): boolean {
+  if (bytes.length < SQLITE_MAGIC.length) return false;
+  for (let i = 0; i < SQLITE_MAGIC.length; i++) {
+    if (bytes[i] !== SQLITE_MAGIC.charCodeAt(i)) return false;
+  }
+  return true;
+}
+
 /** Derive a SQL-safe table name from a filename, stripping the
  *  extension and collapsing non-identifier runs to underscores. */
 export function tableNameFromFilename(filename: string): string {


### PR DESCRIPTION
Five playground UI updates:

## 1. SQLite playground — unified database import
The separate **from SQLite** / **from SQL dump** entries in the Import menu (and the matching database-selector actions) are merged into a single **from file** entry listing `.sql` / `.db` / `.sqlite` / `.sqlite3` badges. The unified **Import Database** dialog accepts any extension (no `accept` filter): the import sniffs the 16-byte `SQLite format 3\0` magic header and routes to the binary path or the SQL-dump path based on content, so files like `.db3` or arbitrary extensions import correctly. Covered by a new unit test (`__tests__/importSniff.test.ts`) and verified in the running app with both a real SQLite binary and a `.weirdext` SQL dump.

## 2. Settings tab — design & layout fixes (all playgrounds)
- **Close button** at the far right of the settings tab bar (after General/Themes/Pragmas/Database), wired to the same close-and-return-to-previous-tab logic as the tab strip ✕.
- **Full-height settings pane on desktop.** Root cause: the settings pane's explicit `grid-row: 1 / column: 2` placement made grid auto-placement spill the output pane into an implicit second row, so row 1 — and with it the editor — tracked the settings content height. The output pane is now pinned to the cell the settings panel overlays and `.panes` gets an explicit `minmax(0, 1fr)` row, so the settings pane fills the viewport and the editor height no longer changes with the active settings tab.
- **Mobile: icon tabs side-by-side.** The vertical left rail of icon-only tabs is now a horizontal row of equal-width pills across the top, with the close button at the row's end.
- **Action buttons restyled.** "Reset query tabs" / "Restore default settings" sit in one rounded card and the two destructive clear-data actions in a red-tinted danger card, each row with a soft brand-tinted icon chip.

## 3. Non-SQL playgrounds — sidebar settings icon removed
The gear pinned to the bottom of the left icon rail is gone; the existing top-right header button (and the mobile menu entry) remain the entry points.

## 4. SQL playgrounds — settings moved to the header
SQLite/PostgreSQL/DuckDB now surface Settings as a top-right header icon button (hover tooltip, same pattern as History / ER Diagram), replacing the sidebar-bottom gear. The now-unused `bottomButtons` prop and its CSS were removed.

## 5. Welcome empty states — static brand mark
The `⌬` glyph is replaced by `DiamondMark`, a new static (non-animated) SVG export in `loadingAnimations.tsx` of the hollow-diamond shape used by the Dataslope loading animations. It renders with `currentColor`, so the existing `.welcome-icon` rule tints it brand blue in the output pane ("Run your code to see output") and SQL results pane ("Run a query to see results" / engine-loading states).

## Verification
Driven in the running dev app with Playwright at desktop (1440×900) and mobile (390×844) viewports: merged import menu + dialog (binary and dump imports through the real file input), settings full-height/close/themes behavior on Python and SQLite, sidebar/header gear placement, mobile pill row, and the diamond welcome mark. `tsc --noEmit` clean, ESLint introduces no new warnings, 535 unit tests pass.

https://claude.ai/code/session_01GTdU9QWM3chPYFAR9v4QAm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTdU9QWM3chPYFAR9v4QAm)_