### PR TITLE
Support Ctrl/Cmd+Shift+Z for redo in all CodeMirror editors

### DIFF
--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -60,7 +60,7 @@ import {
   indentUnit,
 } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
-import { loadLanguage, themeFor, noActiveLine } from "./cmExtensions";
+import { loadLanguage, themeFor, noActiveLine, redoKeymap } from "./cmExtensions";
 import {
   LANGUAGE_ICONS,
   LANGUAGE_ICON_SIZE_FACTOR,
@@ -568,6 +568,7 @@ export default function ChallengeCard({
           ...closeBracketsKeymap,
           ...defaultKeymap,
           ...historyKeymap,
+          ...redoKeymap,
           indentWithTab,
         ]),
         languageComp.of([]),

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -34,7 +34,7 @@ import {
   indentUnit,
 } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
-import { loadLanguage, themeFor, noActiveLine } from "./cmExtensions";
+import { loadLanguage, themeFor, noActiveLine, redoKeymap } from "./cmExtensions";
 
 import type {
   LanguageAdapter,
@@ -521,6 +521,7 @@ function CodeBlockInner({
           ...closeBracketsKeymap,
           ...defaultKeymap,
           ...historyKeymap,
+          ...redoKeymap,
           indentWithTab,
         ]),
         languageComp.of([]),

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -44,7 +44,7 @@ import {
   type CompletionResult,
 } from "@codemirror/autocomplete";
 import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
-import { loadLanguage, themeFor } from "./cmExtensions";
+import { loadLanguage, themeFor, redoKeymap } from "./cmExtensions";
 
 import type {
   ExampleSnippet,
@@ -1362,6 +1362,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
             ...defaultKeymap,
             ...searchKeymap,
             ...historyKeymap,
+            ...redoKeymap,
             ...completionKeymap,
             indentWithTab,
           ]),

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -76,7 +76,7 @@ import {
   indentUnit,
 } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
-import { themeFor, noActiveLine } from "./cmExtensions";
+import { themeFor, noActiveLine, redoKeymap } from "./cmExtensions";
 import { DUCKDB_VERSION } from "./runtime/duckdb";
 import {
   clearPersistedCode,
@@ -1012,6 +1012,7 @@ export default function SqlChallengeCard({
           ...closeBracketsKeymap,
           ...defaultKeymap,
           ...historyKeymap,
+          ...redoKeymap,
           indentWithTab,
         ]),
         languageComp.of([]),

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -47,7 +47,7 @@ import {
 import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import { bracketMatching, indentOnInput, indentUnit } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
-import { themeFor, noActiveLine } from "./cmExtensions";
+import { themeFor, noActiveLine, redoKeymap } from "./cmExtensions";
 import { DUCKDB_VERSION } from "./runtime/duckdb";
 import {
   clearPersistedCode,
@@ -214,6 +214,7 @@ export default function SqlCodeBlock({
           ...closeBracketsKeymap,
           ...defaultKeymap,
           ...historyKeymap,
+          ...redoKeymap,
           indentWithTab,
         ]),
         languageComp.of([]),

--- a/app/_components/cmExtensions.ts
+++ b/app/_components/cmExtensions.ts
@@ -8,7 +8,8 @@
 // extensions / decorations / annotations later is just appending to the
 // extension list at the call site.
 
-import { EditorView } from "@codemirror/view";
+import { EditorView, type KeyBinding } from "@codemirror/view";
+import { redo } from "@codemirror/commands";
 import {
   HighlightStyle,
   StreamLanguage,
@@ -23,6 +24,19 @@ import {
   THEME_PALETTES,
   type ThemePalette,
 } from "./playgroundTheme";
+
+// ─── Redo keybinding ─────────────────────────────────────────────────────
+//
+// `@codemirror/commands`' default `historyKeymap` binds redo to Ctrl-y on
+// Windows/Linux and Cmd-Shift-z on macOS, so the near-universal Ctrl-Shift-z
+// redo chord does nothing on Windows/Linux. `Mod-Shift-z` fills that gap:
+// `Mod` resolves to Ctrl on Windows/Linux and Cmd on macOS, so redo now
+// fires on Ctrl-Shift-z (Win/Linux) and Cmd-Shift-z (macOS), alongside the
+// existing Ctrl-y. Append after `historyKeymap` wherever an editable editor
+// is mounted.
+export const redoKeymap: readonly KeyBinding[] = [
+  { key: "Mod-Shift-z", run: redo, preventDefault: true },
+];
 
 // ─── Language loader ─────────────────────────────────────────────────────
 //

--- a/app/_components/sql/components/GenExprEditor.tsx
+++ b/app/_components/sql/components/GenExprEditor.tsx
@@ -5,7 +5,7 @@ import { Compartment } from "@codemirror/state";
 import { EditorView, keymap, placeholder as cmPlaceholder } from "@codemirror/view";
 import { history, historyKeymap, defaultKeymap } from "@codemirror/commands";
 import { sql as sqlLang, SQLite, PostgreSQL } from "@codemirror/lang-sql";
-import { themeFor } from "../../cmExtensions";
+import { themeFor, redoKeymap } from "../../cmExtensions";
 
 /**
  * A compact, auto-expanding CodeMirror editor for SQL expressions, used in
@@ -51,7 +51,7 @@ export function GenExprEditor({
           upperCaseKeywords: false,
         }),
         themeComp.of(themeFor(theme)),
-        keymap.of([...defaultKeymap, ...historyKeymap]),
+        keymap.of([...defaultKeymap, ...historyKeymap, ...redoKeymap]),
         history(),
         EditorView.lineWrapping,
         EditorView.updateListener.of((update) => {

--- a/app/_components/sql/shared/editorSetup.ts
+++ b/app/_components/sql/shared/editorSetup.ts
@@ -33,7 +33,7 @@ import {
   rectangularSelection,
   tooltips,
 } from "@codemirror/view";
-import { themeFor } from "../../cmExtensions";
+import { themeFor, redoKeymap } from "../../cmExtensions";
 import {
   createSqlCompletionSource,
   type SqlCompletionSchema,
@@ -265,6 +265,7 @@ export function createSqlEditorExtensions(
       ...defaultKeymap,
       ...searchKeymap,
       ...historyKeymap,
+      ...redoKeymap,
       indentWithTab,
     ]),
   ];


### PR DESCRIPTION
## Summary

Adds **Ctrl+Shift+Z** (Windows/Linux) and **Cmd+Shift+Z** (macOS) as a redo shortcut to every CodeMirror editor in the app. Previously only **Ctrl+Y** worked.

### Why

The default `historyKeymap` from `@codemirror/commands` binds redo to `Mod-y` with a `mac: "Mod-Shift-z"` override — so on Windows/Linux only `Ctrl+Y` fires redo and the near-universal `Ctrl+Shift+Z` chord does nothing.

### What changed

- Added a shared `redoKeymap` to `app/_components/cmExtensions.ts` binding `Mod-Shift-z` → `redo`. `Mod` resolves to `Ctrl` on Windows/Linux and `Cmd` on macOS, so a single binding covers both: `Ctrl+Shift+Z` and `Cmd+Shift+Z`. The existing `Ctrl+Y` (and macOS `Cmd+Shift+Z` via the default keymap) keep working.
- Appended `...redoKeymap` after `...historyKeymap` in every editable editor mount:
  - `CodeBlock.tsx`
  - `SqlCodeBlock.tsx`
  - `Playground.tsx`
  - `ChallengeCard.tsx`
  - `SqlChallengeCard.tsx`
  - `sql/components/GenExprEditor.tsx`
  - `sql/shared/editorSetup.ts` (covers the SQLite, Postgres, and DuckDB playgrounds)

Read-only solution editors have no undo/redo `history()` and were intentionally left untouched.

### Verification

- `npx tsc --noEmit` — no type errors in any touched file (the only reported error is the pre-existing `@/.source/dynamic` codegen module, unrelated to this change).
- `npx eslint` on all 8 changed files — clean.

https://claude.ai/code/session_0163XqkBfZTuf2kSr4euqNjG

---
_Generated by [Claude Code](https://claude.ai/code/session_0163XqkBfZTuf2kSr4euqNjG)_