### PR TITLE
Turn OUTPUT label red on errors; move challenge instructions out of code comments

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1349,6 +1349,10 @@
   color: var(--ds-blue-500);
 }
 
+.outputLabel[data-error="true"] {
+  color: var(--ch-red);
+}
+
 .outputTime {
   margin-left: auto;
   font-size: 11.5px;

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -1874,7 +1874,12 @@ export default function ChallengeCard({
               className={styles.accentBar}
               data-error={outputs.some((c) => c.type === "stderr")}
             />
-            <span className={styles.outputLabel}>Output</span>
+            <span
+              className={styles.outputLabel}
+              data-error={outputs.some((c) => c.type === "stderr")}
+            >
+              Output
+            </span>
             {elapsed && (
               <span className={styles.outputTime}>
                 <Timer size={12} aria-hidden="true" />

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -1313,7 +1313,12 @@ function CodeBlockInner({
               className={challengeStyles.accentBar}
               data-error={outputs.some((c) => c.type === "stderr")}
             />
-            <span className={challengeStyles.outputLabel}>Output</span>
+            <span
+              className={challengeStyles.outputLabel}
+              data-error={outputs.some((c) => c.type === "stderr")}
+            >
+              Output
+            </span>
             <span className={styles.outputHeaderRight}>
               {outputElapsed && (
                 <span className={challengeStyles.outputTime}>

--- a/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
+++ b/content/learn/csharp-linq-functional/capstone-data-pipeline.mdx
@@ -102,6 +102,33 @@ record. *Data first, behavior second* — the functional move.
 
 <ChallengeCard
   adapter="csharp"
+  title="Build the full data pipeline"
+  instructions={`Assemble a pure, LINQ-driven batch pipeline across four files. \`Program.cs\` is already wired to call \`Pipeline.BuildReport\` — implement the three classes below.
+
+**\`Parsing.cs\`**
+- \`ParseLine\` — parse one \`"yyyy-MM-dd,product,quantity,unitPrice,status"\` line into a \`Txn\`, returning \`null\` on any failure.
+- \`ParseAll\` — parse every line and drop the nulls.
+
+**\`Summarize.cs\`**
+- \`ByProduct\` — group transactions by product and, for each group, compute:
+  - \`UnitsSold\` = sum of \`Quantity\` over **paid** transactions only,
+  - \`Gross\` = sum of \`Quantity * UnitPrice\` over **paid** transactions only,
+  - \`Net\` = paid total minus refund total (the refund total also uses \`Quantity * UnitPrice\`).
+  - Return the summaries ordered by \`Product\` ascending.
+
+**\`Pipeline.cs\`**
+- \`BuildReport\` — compose the stages and produce the report string in **exactly** this format (amounts formatted as \`0.00\`), with one block per product followed by a \`TOTAL\` block:
+
+\`\`\`
+=== Product {key} ===
+  units sold:   {units}
+  gross:        {gross}
+  net:          {net}
+=== TOTAL ===
+  units sold:   {sumUnits}
+  gross:        {sumGross}
+  net:          {sumNet}
+\`\`\``}
   entryFilename="Program.cs"
   files={[
     {
@@ -157,14 +184,13 @@ using System.Linq;
 
 public static class Parsing
 {
-    // TODO: parse one line into a Txn or null on failure.
-    // Format: "yyyy-MM-dd,product,quantity,unitPrice,status".
+    // TODO: implement
     public static Txn? ParseLine(string line)
     {
         throw new NotImplementedException();
     }
 
-    // TODO: parse all lines, dropping nulls.
+    // TODO: implement
     public static IEnumerable<Txn> ParseAll(IEnumerable<string> lines)
     {
         throw new NotImplementedException();
@@ -211,11 +237,7 @@ using System.Linq;
 
 public static class Summarize
 {
-    // TODO: group txns by product; for each group compute:
-    //   UnitsSold = sum of Quantity for paid txns only,
-    //   Gross     = sum of Quantity * UnitPrice for paid txns only,
-    //   Net       = paid total minus refund total (refund total uses Quantity*UnitPrice).
-    // Return summaries ordered by Product ascending.
+    // TODO: implement
     public static IEnumerable<ProductSummary> ByProduct(IEnumerable<Txn> txns)
     {
         throw new NotImplementedException();
@@ -253,17 +275,7 @@ using System.Text;
 
 public static class Pipeline
 {
-    // TODO: assemble the full pipeline and produce the report string.
-    // Format EXACTLY:
-    //   === Product {key} ===
-    //     units sold:   {units}
-    //     gross:        {gross:0.00}
-    //     net:          {net:0.00}
-    //   ...repeat...
-    //   === TOTAL ===
-    //     units sold:   {sumUnits}
-    //     gross:        {sumGross:0.00}
-    //     net:          {sumNet:0.00}
+    // TODO: implement
     public static string BuildReport(IEnumerable<string> lines)
     {
         throw new NotImplementedException();

--- a/content/learn/csharp-linq-functional/composing-pipelines.mdx
+++ b/content/learn/csharp-linq-functional/composing-pipelines.mdx
@@ -208,6 +208,15 @@ to combine before they ever touch LINQ.
 
 <ChallengeCard
   adapter="csharp"
+  title="Build a log-pipeline vocabulary"
+  instructions={`Implement the four extension methods in \`LogExtensions.cs\` so the composed pipeline in \`Program.cs\` runs:
+
+- \`Recent(window)\` — keep events whose \`At\` falls within the past \`window\` from now.
+- \`OfLevel(level)\` — keep only events whose \`Level\` matches.
+- \`Messages()\` — project each event to its \`Message\` string.
+- \`Join(sep)\` — join the strings with the given separator.
+
+Each method should be a tiny one-liner of LINQ — the goal is a readable vocabulary that names the intent.`}
   entryFilename="Program.cs"
   files={[
     {
@@ -256,18 +265,18 @@ using System.Linq;
 
 public static class LogExtensions
 {
-    // TODO: return events whose At is within the past 'window' from now.
+    // TODO: implement
     public static IEnumerable<LogEvent> Recent(this IEnumerable<LogEvent> src,
                                                TimeSpan window) => throw new NotImplementedException();
 
-    // TODO: return only events whose Level matches.
+    // TODO: implement
     public static IEnumerable<LogEvent> OfLevel(this IEnumerable<LogEvent> src,
                                                 string level) => throw new NotImplementedException();
 
-    // TODO: project to the Message strings.
+    // TODO: implement
     public static IEnumerable<string> Messages(this IEnumerable<LogEvent> src) => throw new NotImplementedException();
 
-    // TODO: join strings with the given separator.
+    // TODO: implement
     public static string Join(this IEnumerable<string> src, string sep) => throw new NotImplementedException();
 }
 `,

--- a/content/learn/csharp-linq-functional/functional-design-patterns.mdx
+++ b/content/learn/csharp-linq-functional/functional-design-patterns.mdx
@@ -255,6 +255,15 @@ combinator** library.
 
 <ChallengeCard
   adapter="csharp"
+  title="Validator combinators"
+  instructions={`A *validator* is a function from a value to a (possibly empty) list of error messages. Implement these rules in \`Validator.cs\`:
+
+- \`NonEmpty(field)\` — yields the error \`"{field} is empty"\` when the value is null or an empty string.
+- \`MaxLen(field, max)\` — yields \`"{field} too long"\` when \`value.Length > max\`.
+- \`NoDigits(field)\` — yields \`"{field} contains digits"\` when the value contains any digit character.
+- \`All(rules)\` — a *combinator* that runs every rule and concatenates their errors in argument order.
+
+A rule that passes returns an **empty** sequence (no error).`}
   entryFilename="Program.cs"
   files={[
     {
@@ -295,16 +304,16 @@ public static class Validator<T>
     // A validator is a function from a value to a (possibly empty) list of error messages.
     public delegate IEnumerable<string> Rule(T value);
 
-    // TODO: NonEmpty<string>: error "{field} is empty" iff value is null or empty string.
+    // TODO: implement
     public static Rule NonEmpty(string field) => throw new NotImplementedException();
 
-    // TODO: MaxLen<string>: error "{field} too long" iff value.Length > max.
+    // TODO: implement
     public static Rule MaxLen(string field, int max) => throw new NotImplementedException();
 
-    // TODO: NoDigits<string>: error "{field} contains digits" iff value has any digit char.
+    // TODO: implement
     public static Rule NoDigits(string field) => throw new NotImplementedException();
 
-    // TODO: All: combine rules; concatenate all their errors in argument order.
+    // TODO: implement
     public static Rule All(params Rule[] rules) => throw new NotImplementedException();
 }
 `,

--- a/content/learn/csharp-linq-functional/generic-abstractions.mdx
+++ b/content/learn/csharp-linq-functional/generic-abstractions.mdx
@@ -230,6 +230,13 @@ key extracted from any sequence.
 
 <ChallengeCard
   adapter="csharp"
+  title="A generic Histogram operator"
+  instructions={`Implement the generic extension method \`Histogram<T, TKey>\` in \`Histogram.cs\`:
+
+1. Count how many elements of \`source\` produce each key (via \`keySelector\`).
+2. Return \`(key, count)\` pairs ordered by key **ascending**.
+
+The \`where TKey : notnull\` constraint lets \`TKey\` be used as a grouping/dictionary key. The *same* operator must work unchanged for both demos in \`Program.cs\` — words grouped by length (\`TKey = int\`) and numbers grouped by parity (\`TKey = string\`).`}
   entryFilename="Program.cs"
   files={[
     {
@@ -279,10 +286,7 @@ using System.Linq;
 
 public static class HistogramOp
 {
-    // TODO: implement Histogram<T, TKey>:
-    //   1) Use a generic constraint so TKey can be compared / used as a dictionary key.
-    //   2) Count how many elements of 'source' produce each key (via keySelector).
-    //   3) Return pairs ordered by key ascending.
+    // TODO: implement
     public static IEnumerable<(TKey key, int count)> Histogram<T, TKey>(this IEnumerable<T> source,
                                                                         Func<T, TKey> keySelector)
         where TKey : notnull

--- a/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
+++ b/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
@@ -233,17 +233,18 @@ ergonomics layer on top.
 
 <ChallengeCard
   adapter="csharp"
+  title="Rewrite both ways"
+  instructions={`Implement **both** \`QueryStyle\` and \`MethodStyle\` so they produce the **same output in the same order**.
+
+Each should return, one per line, the authors whose books total **more than 1500 pages**, **ordered by author name**, formatted as \`"Name: totalPages"\`.
+
+Write \`QueryStyle\` using **query syntax** (the SQL-like \`from … where … select\` form) and \`MethodStyle\` using **method syntax** (the fluent \`.GroupBy().Where()…\` chain). Edit \`QueryStyle.cs\` and \`MethodStyle.cs\` — \`Program.cs\` is already wired up.`}
   entryFilename="Program.cs"
   files={[
     {
       filename: "Program.cs",
       starterCode: `using System;
 using System.Linq;
-
-// TODO: implement both QueryStyle and MethodStyle below.
-// They must produce the same output (in the same order):
-// authors whose books total > 1500 pages, ordered by author name,
-// printed as "Name: totalPages".
 
 var books = new[] {
     new Book("Knuth", "TAOCP V1", 650), new Book("Knuth", "TAOCP V2", 700),

--- a/content/learn/csharp-linq-functional/side-effect-management.mdx
+++ b/content/learn/csharp-linq-functional/side-effect-management.mdx
@@ -239,6 +239,15 @@ The function still returns *data*. The shell decides whether
 
 <ChallengeCard
   adapter="csharp"
+  title="Keep the core pure"
+  instructions={`Implement \`Report.Build\` in \`Report.cs\` as a **pure** function — no \`Console\`, no \`DateTime.UtcNow\`, no file IO. It takes all of its inputs explicitly (\`lines\`, \`today\`, \`windowDays\`) and returns a string:
+
+1. Parse each line as \`"yyyy-MM-dd,status,amount"\` (use \`decimal.Parse\` with \`InvariantCulture\` for the amount). Skip lines that fail to parse.
+2. Keep entries where \`status == "paid"\` **and** \`date >= today.AddDays(-windowDays)\`.
+3. Sum the amounts.
+4. Return the single string \`$"PAID in last {windowDays} days: {total}"\`.
+
+Because time and configuration are arguments rather than ambient state, the output is fully deterministic.`}
   entryFilename="Program.cs"
   files={[
     {
@@ -280,18 +289,11 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
-// Build the report PURELY: no Console, no DateTime.UtcNow, no File IO inside.
-// The whole function takes its inputs explicitly and returns a string.
 public static class Report
 {
     public static string Build(IEnumerable<string> lines, DateTime today, int windowDays)
     {
-        // TODO:
-        // 1) Parse each line as "yyyy-MM-dd,status,amount".
-        //    Skip lines that fail to parse. (decimal.Parse with InvariantCulture for amount.)
-        // 2) Keep entries where status == "paid" AND date >= today.AddDays(-windowDays).
-        // 3) Sum the amounts.
-        // 4) Return a single string: $"PAID in last {windowDays} days: {total}".
+        // TODO: implement
         throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
## Summary

Two independent updates to the interactive learning components.

### Update 1 — OUTPUT label turns red on errors

When a **code block** or **challenge card** produces an error (a `stderr` cell — e.g. a syntax/compile/runtime error), the `OUTPUT` label now turns red, matching the red accent bar that already signals errors. This is distinct from a *failed test case*: when code runs cleanly but a test assertion fails, no `stderr` cell is produced, so the label stays blue — exactly as requested.

- `ChallengeCard.tsx` / `CodeBlock.tsx`: added a `data-error` attribute to the output label `<span>`, driven by the same `outputs.some(c => c.type === "stderr")` signal already used for the accent bar.
- `ChallengeCard.module.css`: added `.outputLabel[data-error="true"] { color: var(--ch-red); }`.

### Update 2 — Exercise instructions live in the card, not in comments

Several `csharp-linq-functional` challenge cards conveyed the task purely through `// TODO:` blocks in the starter code, with no `instructions` prop (the instructions panel rendered empty). Those instructions are now moved into each card's `title` + `instructions` props, leaving only short `// TODO: implement` markers to show *where* to edit.

Fixed cards:
- `query-vs-method-syntax.mdx` (the one called out in the request)
- `composing-pipelines.mdx`
- `functional-design-patterns.mdx`
- `generic-abstractions.mdx`
- `side-effect-management.mdx`
- `capstone-data-pipeline.mdx`

A full scan of **all 607 `<ChallengeCard>` usages across every course** confirms every card now supplies an `instructions` prop; no other course was affected.

## Verification

- All six edited `instructions={`...`}` template literals were validated to parse and close cleanly.
- Re-scanned every MDX file: zero challenge cards remain without an `instructions` prop.

https://claude.ai/code/session_01GNvRpnEKD6VYDBjW6ph5jM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNvRpnEKD6VYDBjW6ph5jM)_