### PR TITLE
Clear test results when running challenge code without submitting

### DIFF
--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -979,6 +979,10 @@ export default function ChallengeCard({
   const run = useCallback(async () => {
     const mySeq = ++runSeqRef.current;
     setActiveAction("run");
+    // Running without submitting isn't a graded attempt, so clear any prior
+    // test results and pass/fail banner instead of leaving stale state behind.
+    setTestResults([]);
+    setBannerState(null);
     const snapshot = snapshotAllFiles();
     const entryCode = snapshot.get(resolvedEntryFilename) ?? "";
     const combined = effectiveSourceFor(resolvedEntryFilename, entryCode);


### PR DESCRIPTION
## Summary

When a user runs challenge code via **Run without Submitting**, the previous submission's test results and pass/fail banner stayed on screen. Since a plain run isn't a graded attempt, showing stale results (e.g. "0/1 passed", "1 test failed") is misleading.

This clears `testResults` and `bannerState` at the start of `run()` in `ChallengeCard.tsx`, so a non-graded run no longer displays results from an earlier submit.

## Notes

- The SQL challenge card (`SqlChallengeCard.tsx`) already does exactly this; this change brings the standard `ChallengeCard` in line.
- Submitting still populates and displays test results as before.

https://claude.ai/code/session_013HrrLrm6i9gCdjeXyMksfa

---
_Generated by [Claude Code](https://claude.ai/code/session_013HrrLrm6i9gCdjeXyMksfa)_