### PR TITLE
Use project fonts and fix text contrast in course SVG graphics

### DIFF
--- a/content/learn/beginners-javascript/arrays.mdx
+++ b/content/learn/beginners-javascript/arrays.mdx
@@ -34,7 +34,7 @@ collection is the **array**.
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <circle cx="406" cy="80" r="24" />
   </g>
-  <g fill="currentColor" opacity="0.55" fontFamily="ui-monospace, monospace" fontSize="17" textAnchor="middle">
+  <g fill="currentColor" opacity="0.55" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" textAnchor="middle">
     <text x="130" y="148">0</text>
     <text x="222" y="148">1</text>
     <text x="314" y="148">2</text>

--- a/content/learn/beginners-javascript/booleans-and-logic.mdx
+++ b/content/learn/beginners-javascript/booleans-and-logic.mdx
@@ -30,7 +30,7 @@ program ever makes* is, at the bottom, a boolean.
     <circle cx="288" cy="68" r="21" />
     <circle cx="480" cy="68" r="21" />
   </g>
-  <text x="480" y="150" fontFamily="ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.55">?</text>
+  <text x="480" y="150" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.55">?</text>
 </svg>
 
 ## Where booleans come from

--- a/content/learn/beginners-javascript/functions-basics.mdx
+++ b/content/learn/beginners-javascript/functions-basics.mdx
@@ -33,7 +33,7 @@ is built on top of functions. They are the atom of programming.
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="200" y="56" width="160" height="88" rx="20" />
   </g>
-  <text x="280" y="116" fontFamily="Georgia, serif" fontStyle="italic" fontSize="44" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>ƒ</text>
+  <text x="280" y="116" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="44" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>ƒ</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="450" y="84" width="32" height="32" rx="8" />
     <rect x="496" y="90" width="22" height="22" rx="6" fillOpacity="0.5" />

--- a/content/learn/beginners-javascript/numbers-and-arithmetic.mdx
+++ b/content/learn/beginners-javascript/numbers-and-arithmetic.mdx
@@ -27,8 +27,8 @@ advance.
     <circle cx="458" cy="152" r="3" opacity="0.25" />
     <circle cx="504" cy="152" r="3" opacity="0.25" />
     <circle cx="550" cy="152" r="3" opacity="0.25" />
-    <text x="232" y="90" fontFamily="ui-monospace, monospace" fontSize="30" fontWeight="700" textAnchor="middle" opacity="0.5">+</text>
-    <text x="361" y="90" fontFamily="ui-monospace, monospace" fontSize="30" fontWeight="700" textAnchor="middle" opacity="0.5">=</text>
+    <text x="232" y="90" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="30" fontWeight="700" textAnchor="middle" opacity="0.5">+</text>
+    <text x="361" y="90" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="30" fontWeight="700" textAnchor="middle" opacity="0.5">=</text>
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <circle cx="170" cy="80" r="40" />

--- a/content/learn/beginners-javascript/problem-solving.mdx
+++ b/content/learn/beginners-javascript/problem-solving.mdx
@@ -40,13 +40,13 @@ the answer in one shot. There is a better way.
     <circle cx="200" cy="100" r="18" />
     <circle cx="560" cy="110" r="18" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <circle cx="320" cy="140" r="18" />
   </g>
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <circle cx="440" cy="80" r="18" />
   </g>
-  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-white)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700" textAnchor="middle">
     <text x="80" y="156">1</text>
     <text x="200" y="106">2</text>
     <text x="320" y="146">3</text>

--- a/content/learn/beginners-javascript/problem-solving.mdx
+++ b/content/learn/beginners-javascript/problem-solving.mdx
@@ -46,7 +46,7 @@ the answer in one shot. There is a better way.
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <circle cx="440" cy="80" r="18" />
   </g>
-  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700" textAnchor="middle">
     <text x="80" y="156">1</text>
     <text x="200" y="106">2</text>
     <text x="320" y="146">3</text>

--- a/content/learn/c-programming-for-beginners/computational-thinking.mdx
+++ b/content/learn/c-programming-for-beginners/computational-thinking.mdx
@@ -48,7 +48,7 @@ becomes easier.
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="250" y="130" width="140" height="52" rx="26" fillOpacity="0.12" />
   </g>
-  <text x="425" y="164" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700" fill="currentColor" opacity="0.5">×4</text>
+  <text x="425" y="164" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fontWeight="700" fill="currentColor" opacity="0.5">×4</text>
 </svg>
 
 ## The four habits of computational thinking

--- a/content/learn/c-programming-for-beginners/strings.mdx
+++ b/content/learn/c-programming-for-beginners/strings.mdx
@@ -32,7 +32,7 @@ character" `\0`.
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <rect x="446" y="76" width="24" height="24" rx="6" />
   </g>
-  <text x="458" y="150" fontFamily="ui-monospace, monospace" fontSize="15" textAnchor="middle" fill="currentColor" opacity="0.55">{"\\0"}</text>
+  <text x="458" y="150" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" textAnchor="middle" fill="currentColor" opacity="0.55">{"\\0"}</text>
 </svg>
 
 This page is about how to think about that, and how not to shoot

--- a/content/learn/csharp-linq-functional/modern-csharp-functional.mdx
+++ b/content/learn/csharp-linq-functional/modern-csharp-functional.mdx
@@ -41,7 +41,7 @@ the syntax — every page after this will use them freely.
     <circle cx="292" cy="120" r="3" />
     <circle cx="318" cy="120" r="3" />
   </g>
-  <text x="430" y="132" fontFamily="ui-monospace, monospace" fontSize="34" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>{"=>"}</text>
+  <text x="430" y="132" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="34" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>{"=>"}</text>
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <circle cx="560" cy="64" r="8" />
   </g>

--- a/content/learn/data-analysis-python-pandas/aggregation-basics.mdx
+++ b/content/learn/data-analysis-python-pandas/aggregation-basics.mdx
@@ -47,7 +47,7 @@ introduces `groupby`, which is aggregations *per group*.
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="430" cy="103" r="30" />
   </g>
-  <text x="430" y="114" fontFamily="var(--font-sans), Georgia, serif" fontSize="30" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>Σ</text>
+  <text x="430" y="114" fontFamily="var(--font-sans), Georgia, serif" fontSize="30" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>Σ</text>
 </svg>
 
 ## The reduction methods

--- a/content/learn/data-analysis-python-pandas/aggregation-basics.mdx
+++ b/content/learn/data-analysis-python-pandas/aggregation-basics.mdx
@@ -47,7 +47,7 @@ introduces `groupby`, which is aggregations *per group*.
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="430" cy="103" r="30" />
   </g>
-  <text x="430" y="114" fontFamily="Georgia, serif" fontSize="30" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>Σ</text>
+  <text x="430" y="114" fontFamily="var(--font-sans), Georgia, serif" fontSize="30" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>Σ</text>
 </svg>
 
 ## The reduction methods

--- a/content/learn/data-analysis-python-pandas/choosing-the-right-chart.mdx
+++ b/content/learn/data-analysis-python-pandas/choosing-the-right-chart.mdx
@@ -16,7 +16,7 @@ charts and their failure modes.
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <polygon points="320,30 368,73 320,116 272,73" />
   </g>
-  <text x="320" y="82" fontFamily="Georgia, serif" fontSize="26" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
+  <text x="320" y="82" fontFamily="var(--font-sans), Georgia, serif" fontSize="26" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
   <g fill="currentColor" opacity="0.3">
     <circle cx="248" cy="130" r="3" />
     <circle cx="180" cy="146" r="3" />

--- a/content/learn/data-analysis-python-pandas/choosing-the-right-chart.mdx
+++ b/content/learn/data-analysis-python-pandas/choosing-the-right-chart.mdx
@@ -10,13 +10,13 @@ charts and their failure modes.
 <svg
   viewBox="0 0 640 240"
   role="img"
-  aria-label="A yellow decision diamond with a question mark fans out along dotted paths to four small chart thumbnails — bars, a line, a scatter, and a histogram — pick the chart that answers the question"
+  aria-label="A teal decision diamond with a question mark fans out along dotted paths to four small chart thumbnails — bars, a line, a scatter, and a histogram — pick the chart that answers the question"
   style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
 >
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <polygon points="320,30 368,73 320,116 272,73" />
   </g>
-  <text x="320" y="82" fontFamily="var(--font-sans), Georgia, serif" fontSize="26" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
+  <text x="320" y="82" fontFamily="var(--font-sans), Georgia, serif" fontSize="26" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>?</text>
   <g fill="currentColor" opacity="0.3">
     <circle cx="248" cy="130" r="3" />
     <circle cx="180" cy="146" r="3" />

--- a/content/learn/data-analysis-python-pandas/creating-new-columns.mdx
+++ b/content/learn/data-analysis-python-pandas/creating-new-columns.mdx
@@ -19,14 +19,14 @@ fits a different situation.
     <rect x="150" y="112" width="52" height="26" rx="5" fillOpacity="0.7" />
     <rect x="150" y="148" width="52" height="26" rx="5" fillOpacity="0.7" />
   </g>
-  <text x="231" y="115" fontFamily="ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.55">÷</text>
+  <text x="231" y="115" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.55">÷</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="260" y="40" width="52" height="26" rx="5" fillOpacity="0.7" />
     <rect x="260" y="76" width="52" height="26" rx="5" fillOpacity="0.7" />
     <rect x="260" y="112" width="52" height="26" rx="5" fillOpacity="0.7" />
     <rect x="260" y="148" width="52" height="26" rx="5" fillOpacity="0.7" />
   </g>
-  <text x="348" y="115" fontFamily="ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.55">=</text>
+  <text x="348" y="115" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.55">=</text>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="384" y="40" width="52" height="26" rx="5" fillOpacity="0.95" />
     <rect x="384" y="76" width="52" height="26" rx="5" fillOpacity="0.95" />

--- a/content/learn/data-analysis-python-pandas/duplicates-and-inconsistencies.mdx
+++ b/content/learn/data-analysis-python-pandas/duplicates-and-inconsistencies.mdx
@@ -38,7 +38,7 @@ labels.
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <circle cx="306" cy="111" r="9" />
   </g>
-  <text x="306" y="116" fontFamily="ui-monospace, monospace" fontSize="13" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>x</text>
+  <text x="306" y="116" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>x</text>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="90" y="131" width="160" height="24" rx="12" fillOpacity="0.5" />
   </g>
@@ -49,7 +49,7 @@ labels.
     <rect x="420" y="60" width="110" height="26" rx="13" fillOpacity="0.85" />
     <rect x="420" y="134" width="110" height="26" rx="13" fillOpacity="0.3" />
   </g>
-  <text x="475" y="119" fontFamily="Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.5">≈</text>
+  <text x="475" y="119" fontFamily="var(--font-sans), Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.5">≈</text>
 </svg>
 
 ## What counts as a duplicate?

--- a/content/learn/data-analysis-python-pandas/how-computers-see-data.mdx
+++ b/content/learn/data-analysis-python-pandas/how-computers-see-data.mdx
@@ -17,7 +17,7 @@ like magic.
   style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
 >
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
-    <text x="160" y="64" fontFamily="ui-monospace, monospace" fontSize="42" fontWeight="700" textAnchor="middle">A</text>
+    <text x="160" y="64" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="42" fontWeight="700" textAnchor="middle">A</text>
     <circle cx="118" cy="130" r="6" fillOpacity="0.15" />
     <circle cx="132" cy="130" r="6" />
     <circle cx="146" cy="130" r="6" fillOpacity="0.15" />
@@ -27,7 +27,7 @@ like magic.
     <circle cx="202" cy="130" r="6" />
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
-    <text x="320" y="64" fontFamily="ui-monospace, monospace" fontSize="42" fontWeight="700" textAnchor="middle">7</text>
+    <text x="320" y="64" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="42" fontWeight="700" textAnchor="middle">7</text>
     <circle cx="278" cy="130" r="6" fillOpacity="0.15" />
     <circle cx="292" cy="130" r="6" fillOpacity="0.15" />
     <circle cx="306" cy="130" r="6" />

--- a/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
+++ b/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
@@ -20,7 +20,7 @@ the subject of a dedicated statistics course.)
 <svg
   viewBox="0 0 640 220"
   role="img"
-  aria-label="Two overlapping clouds of blue and green dots whose vertical mean lines sit close together beneath a yellow question mark — is the gap between groups real signal or just noise?"
+  aria-label="Two overlapping clouds of blue and green dots whose vertical mean lines sit close together beneath a teal question mark — is the gap between groups real signal or just noise?"
   style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
 >
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
@@ -49,10 +49,10 @@ the subject of a dedicated statistics course.)
     <circle cx="432" cy="170" r="4" fillOpacity="0.55" />
     <rect x="386" y="42" width="6" height="148" rx="3" fillOpacity="0.95" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <circle cx="329" cy="30" r="14" />
   </g>
-  <text x="329" y="36" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
+  <text x="329" y="36" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>?</text>
 </svg>
 
 ## The core question: noise vs signal

--- a/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
+++ b/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
@@ -52,7 +52,7 @@ the subject of a dedicated statistics course.)
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="329" cy="30" r="14" />
   </g>
-  <text x="329" y="36" fontFamily="Georgia, serif" fontSize="17" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
+  <text x="329" y="36" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
 </svg>
 
 ## The core question: noise vs signal

--- a/content/learn/data-analysis-python-pandas/loc-vs-iloc.mdx
+++ b/content/learn/data-analysis-python-pandas/loc-vs-iloc.mdx
@@ -35,12 +35,12 @@ their split, much of Pandas's apparent quirkiness goes away.
     <rect x="138" y="106" width="50" height="26" rx="5" fillOpacity="0.8" />
   </g>
   <g fill="currentColor" opacity="0.55">
-    <text x="395" y="58" fontFamily="ui-monospace, monospace" fontSize="15" textAnchor="middle">0</text>
-    <text x="453" y="58" fontFamily="ui-monospace, monospace" fontSize="15" textAnchor="middle">1</text>
-    <text x="511" y="58" fontFamily="ui-monospace, monospace" fontSize="15" textAnchor="middle">2</text>
-    <text x="354" y="89" fontFamily="ui-monospace, monospace" fontSize="15" textAnchor="middle">0</text>
-    <text x="354" y="125" fontFamily="ui-monospace, monospace" fontSize="15" textAnchor="middle">1</text>
-    <text x="354" y="161" fontFamily="ui-monospace, monospace" fontSize="15" textAnchor="middle">2</text>
+    <text x="395" y="58" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" textAnchor="middle">0</text>
+    <text x="453" y="58" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" textAnchor="middle">1</text>
+    <text x="511" y="58" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" textAnchor="middle">2</text>
+    <text x="354" y="89" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" textAnchor="middle">0</text>
+    <text x="354" y="125" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" textAnchor="middle">1</text>
+    <text x="354" y="161" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" textAnchor="middle">2</text>
   </g>
   <g fill="currentColor" opacity="0.12">
     <rect x="370" y="70" width="50" height="26" rx="5" />

--- a/content/learn/data-analysis-python-pandas/missing-values.mdx
+++ b/content/learn/data-analysis-python-pandas/missing-values.mdx
@@ -9,7 +9,7 @@ datasets. This chapter is the playbook for handling it.
 <svg
   viewBox="0 0 640 230"
   role="img"
-  aria-label="A row of cells with one ghostly gap marked by a yellow question badge, and two remedies fanning out below — dropping leaves a shorter row, filling drops a green value into the hole"
+  aria-label="A row of cells with one ghostly gap marked by a teal question badge, and two remedies fanning out below — dropping leaves a shorter row, filling drops a green value into the hole"
   style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
 >
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
@@ -19,10 +19,10 @@ datasets. This chapter is the playbook for handling it.
     <rect x="433" y="50" width="62" height="30" rx="6" fillOpacity="0.5" />
   </g>
   <rect x="289" y="50" width="62" height="30" rx="6" fill="currentColor" opacity="0.05" />
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <circle cx="320" cy="65" r="11" />
   </g>
-  <text x="320" y="71" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
+  <text x="320" y="71" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>?</text>
   <g fill="currentColor" opacity="0.3">
     <circle cx="272" cy="100" r="3" />
     <circle cx="240" cy="116" r="3" />

--- a/content/learn/data-analysis-python-pandas/missing-values.mdx
+++ b/content/learn/data-analysis-python-pandas/missing-values.mdx
@@ -22,7 +22,7 @@ datasets. This chapter is the playbook for handling it.
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="320" cy="65" r="11" />
   </g>
-  <text x="320" y="71" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
+  <text x="320" y="71" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
   <g fill="currentColor" opacity="0.3">
     <circle cx="272" cy="100" r="3" />
     <circle cx="240" cy="116" r="3" />

--- a/content/learn/data-analysis-python-pandas/what-is-data-analysis.mdx
+++ b/content/learn/data-analysis-python-pandas/what-is-data-analysis.mdx
@@ -10,7 +10,7 @@ get ten subtly different answers. Let us pin it down.
 <svg
   viewBox="0 0 640 240"
   role="img"
-  aria-label="Four stations arranged in a circle of dotted steps — a yellow question leads to blue data, data to a green insight, and the insight to a decision diamond that raises new questions"
+  aria-label="Four stations arranged in a circle of dotted steps — a teal question leads to blue data, data to a green insight, and the insight to a decision diamond that raises new questions"
   style={{ display: "block", width: "100%", maxWidth: "560px", height: "auto", margin: "2.5rem auto" }}
 >
   <g fill="currentColor" opacity="0.3">
@@ -27,10 +27,10 @@ get ten subtly different answers. Let us pin it down.
     <circle cx="267" cy="67" r="3" />
     <circle cx="291" cy="51" r="3.5" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <circle cx="320" cy="45" r="22" />
   </g>
-  <text x="320" y="53" fontFamily="var(--font-sans), Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
+  <text x="320" y="53" fontFamily="var(--font-sans), Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>?</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <circle cx="395" cy="120" r="22" />
   </g>
@@ -43,7 +43,7 @@ get ten subtly different answers. Let us pin it down.
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="320" cy="195" r="22" />
   </g>
-  <text x="320" y="204" fontFamily="var(--font-sans), Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>!</text>
+  <text x="320" y="204" fontFamily="var(--font-sans), Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>!</text>
   <polygon points="245,98 267,120 245,142 223,120" fill="currentColor" opacity="0.4" />
 </svg>
 

--- a/content/learn/data-analysis-python-pandas/what-is-data-analysis.mdx
+++ b/content/learn/data-analysis-python-pandas/what-is-data-analysis.mdx
@@ -30,7 +30,7 @@ get ten subtly different answers. Let us pin it down.
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="320" cy="45" r="22" />
   </g>
-  <text x="320" y="53" fontFamily="Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
+  <text x="320" y="53" fontFamily="var(--font-sans), Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>?</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <circle cx="395" cy="120" r="22" />
   </g>
@@ -43,7 +43,7 @@ get ten subtly different answers. Let us pin it down.
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="320" cy="195" r="22" />
   </g>
-  <text x="320" y="204" fontFamily="Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>!</text>
+  <text x="320" y="204" fontFamily="var(--font-sans), Georgia, serif" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>!</text>
   <polygon points="245,98 267,120 245,142 223,120" fill="currentColor" opacity="0.4" />
 </svg>
 

--- a/content/learn/database-design-postgresql/natural-vs-surrogate-keys.mdx
+++ b/content/learn/database-design-postgresql/natural-vs-surrogate-keys.mdx
@@ -41,11 +41,11 @@ keys**.
     <rect x="128" y="86" width="28" height="5" rx="2.5" fillOpacity="0.9" />
     <rect x="128" y="98" width="20" height="5" rx="2.5" fillOpacity="0.7" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <circle cx="474" cy="94" r="19" />
     <circle cx="474" cy="94" r="14" fillOpacity="0.5" />
   </g>
-  <g style={{ color: "var(--ds-gray-900)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-white)" }} fill="currentColor">
     <text x="474" y="100" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="bold">7</text>
   </g>
 </svg>

--- a/content/learn/database-design-postgresql/natural-vs-surrogate-keys.mdx
+++ b/content/learn/database-design-postgresql/natural-vs-surrogate-keys.mdx
@@ -46,7 +46,7 @@ keys**.
     <circle cx="474" cy="94" r="14" fillOpacity="0.5" />
   </g>
   <g style={{ color: "var(--ds-gray-900)" }} fill="currentColor">
-    <text x="474" y="100" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="bold">7</text>
+    <text x="474" y="100" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="bold">7</text>
   </g>
 </svg>
 

--- a/content/learn/database-design-postgresql/primary-keys.mdx
+++ b/content/learn/database-design-postgresql/primary-keys.mdx
@@ -14,7 +14,7 @@ one*.
 <svg
   viewBox="0 0 640 200"
   role="img"
-  aria-label="Two rows with identical contents are told apart only by the numbered yellow key tab on each — a primary key gives look-alike rows distinct identity"
+  aria-label="Two rows with identical contents are told apart only by the numbered teal key tab on each — a primary key gives look-alike rows distinct identity"
   style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
 >
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
@@ -29,11 +29,11 @@ one*.
     <circle cx="246" cy="140" r="8" />
     <circle cx="506" cy="140" r="8" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <rect x="128" y="64" width="44" height="26" rx="13" />
     <rect x="388" y="64" width="44" height="26" rx="13" />
   </g>
-  <g style={{ color: "var(--ds-gray-900)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-white)" }} fill="currentColor">
     <text x="150" y="82" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="bold">1</text>
     <text x="410" y="82" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="bold">2</text>
   </g>

--- a/content/learn/database-design-postgresql/primary-keys.mdx
+++ b/content/learn/database-design-postgresql/primary-keys.mdx
@@ -34,8 +34,8 @@ one*.
     <rect x="388" y="64" width="44" height="26" rx="13" />
   </g>
   <g style={{ color: "var(--ds-gray-900)" }} fill="currentColor">
-    <text x="150" y="82" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="bold">1</text>
-    <text x="410" y="82" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="bold">2</text>
+    <text x="150" y="82" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="bold">1</text>
+    <text x="410" y="82" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="bold">2</text>
   </g>
   <g fill="currentColor" opacity="0.25">
     <circle cx="320" cy="40" r="3" />

--- a/content/learn/database-design-postgresql/what-is-database-design.mdx
+++ b/content/learn/database-design-postgresql/what-is-database-design.mdx
@@ -60,7 +60,7 @@ those tables relate, and what rules protect the data.
     <circle cx="460" cy="152" r="3" />
     <circle cx="500" cy="152" r="3" />
     <circle cx="540" cy="152" r="3" />
-    <text x="460" y="122" textAnchor="middle" fontFamily="Georgia, serif" fontSize="42" fontWeight="bold" fillOpacity="0.85">?</text>
+    <text x="460" y="122" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontSize="42" fontWeight="bold" fillOpacity="0.85">?</text>
   </g>
 </svg>
 

--- a/content/learn/from-zero-to-cpp/computational-thinking.mdx
+++ b/content/learn/from-zero-to-cpp/computational-thinking.mdx
@@ -65,7 +65,7 @@ code blocks for illustration. The goal is to install a habit.
     <circle cx="480" cy="182" r="13" />
     <circle cx="540" cy="182" r="13" />
   </g>
-  <g style={{ fill: "var(--ds-blue-50)" }} fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-blue-50)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700" textAnchor="middle">
     <text x="420" y="187">1</text>
     <text x="480" y="187">2</text>
     <text x="540" y="187">3</text>

--- a/content/learn/from-zero-to-cpp/functions-and-modularity.mdx
+++ b/content/learn/from-zero-to-cpp/functions-and-modularity.mdx
@@ -43,7 +43,7 @@ write our own.
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="260" y="75" width="120" height="70" rx="18" />
   </g>
-  <text x="320" y="124" fontFamily="Georgia, serif" fontStyle="italic" fontSize="42" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>ƒ</text>
+  <text x="320" y="124" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="42" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>ƒ</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="400" cy="86" r="3.5" fillOpacity="0.5" />
     <circle cx="445" cy="70" r="3.5" fillOpacity="0.5" />

--- a/content/learn/from-zero-to-cpp/smart-pointers.mdx
+++ b/content/learn/from-zero-to-cpp/smart-pointers.mdx
@@ -53,10 +53,10 @@ There are three to know:
     <circle cx="533" cy="100" r="2.5" />
     <circle cx="533" cy="122" r="2.5" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <circle cx="354" cy="132" r="11" />
   </g>
-  <text x="354" y="137" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>3</text>
+  <text x="354" y="137" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>3</text>
 </svg>
 
 ## `std::unique_ptr`: one owner, no overhead

--- a/content/learn/from-zero-to-cpp/smart-pointers.mdx
+++ b/content/learn/from-zero-to-cpp/smart-pointers.mdx
@@ -56,7 +56,7 @@ There are three to know:
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="354" cy="132" r="11" />
   </g>
-  <text x="354" y="137" fontFamily="ui-monospace, monospace" fontSize="14" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>3</text>
+  <text x="354" y="137" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>3</text>
 </svg>
 
 ## `std::unique_ptr`: one owner, no overhead

--- a/content/learn/from-zero-to-cpp/variables-and-memory.mdx
+++ b/content/learn/from-zero-to-cpp/variables-and-memory.mdx
@@ -48,7 +48,7 @@ memory for as long as the variable is alive.
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="196" y="96" width="290" height="38" rx="8" fillOpacity="0.9" />
   </g>
-  <text x="250" y="122" fontFamily="ui-monospace, monospace" fontSize="19" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>42</text>
+  <text x="250" y="122" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="19" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>42</text>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="462" cy="115" r="7" />
   </g>

--- a/content/learn/from-zero-to-cpp/your-first-program.mdx
+++ b/content/learn/from-zero-to-cpp/your-first-program.mdx
@@ -41,19 +41,19 @@ int main() {
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="84" y="38" width="46" height="46" rx="11" />
   </g>
-  <text x="107" y="70" fontFamily="ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>#</text>
+  <text x="107" y="70" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>#</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="496" y="38" width="64" height="46" rx="11" />
   </g>
-  <text x="528" y="69" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>{"<<"}</text>
+  <text x="528" y="69" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-blue-50)" }}>{"<<"}</text>
   <g fill="currentColor" opacity="0.15">
     <rect x="88" y="140" width="60" height="46" rx="11" />
   </g>
-  <text x="118" y="171" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.6">{"{ }"}</text>
+  <text x="118" y="171" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fontWeight="700" textAnchor="middle" fill="currentColor" opacity="0.6">{"{ }"}</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="502" y="140" width="46" height="46" rx="11" />
   </g>
-  <text x="525" y="172" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>0</text>
+  <text x="525" y="172" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>0</text>
   <g fill="currentColor" opacity="0.3">
     <circle cx="152" cy="74" r="3" />
     <circle cx="184" cy="84" r="3" />

--- a/content/learn/from-zero-to-cpp/your-first-program.mdx
+++ b/content/learn/from-zero-to-cpp/your-first-program.mdx
@@ -38,10 +38,10 @@ int main() {
     <rect x="266" y="108" width="100" height="9" rx="4.5" />
     <rect x="266" y="124" width="58" height="9" rx="4.5" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <rect x="84" y="38" width="46" height="46" rx="11" />
   </g>
-  <text x="107" y="70" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>#</text>
+  <text x="107" y="70" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="26" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>#</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="496" y="38" width="64" height="46" rx="11" />
   </g>
@@ -53,7 +53,7 @@ int main() {
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="502" y="140" width="46" height="46" rx="11" />
   </g>
-  <text x="525" y="172" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>0</text>
+  <text x="525" y="172" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>0</text>
   <g fill="currentColor" opacity="0.3">
     <circle cx="152" cy="74" r="3" />
     <circle cx="184" cy="84" r="3" />

--- a/content/learn/functional-programming-typescript/higher-order-functions.mdx
+++ b/content/learn/functional-programming-typescript/higher-order-functions.mdx
@@ -23,17 +23,17 @@ replace whole categories of boilerplate with one-line calls.
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="150" y="30" width="48" height="34" rx="8" />
   </g>
-  <text x="174" y="54" fontFamily="var(--font-sans), Georgia, serif" fontSize="22" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>λ</text>
+  <text x="174" y="54" fontFamily="var(--font-sans), Georgia, serif" fontSize="22" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>λ</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="446" y="30" width="48" height="34" rx="8" fillOpacity="0.3" />
     <text x="470" y="54" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" textAnchor="middle">+</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
-    <rect x="296" y="56" width="48" height="34" rx="8" />
+    <rect x="296" y="56" width="48" height="34" rx="8" style={{ fill: "var(--ds-teal-500)" }} />
     <circle cx="320" cy="102" r="3.5" fillOpacity="0.5" />
     <circle cx="320" cy="114" r="3.5" fillOpacity="0.5" />
   </g>
-  <text x="320" y="81" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="21" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>ƒ</text>
+  <text x="320" y="81" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="21" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>ƒ</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="200" y="124" width="240" height="76" rx="16" />
     <circle cx="140" cy="162" r="8" />

--- a/content/learn/functional-programming-typescript/higher-order-functions.mdx
+++ b/content/learn/functional-programming-typescript/higher-order-functions.mdx
@@ -23,17 +23,17 @@ replace whole categories of boilerplate with one-line calls.
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="150" y="30" width="48" height="34" rx="8" />
   </g>
-  <text x="174" y="54" fontFamily="Georgia, serif" fontSize="22" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>λ</text>
+  <text x="174" y="54" fontFamily="var(--font-sans), Georgia, serif" fontSize="22" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>λ</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="446" y="30" width="48" height="34" rx="8" fillOpacity="0.3" />
-    <text x="470" y="54" fontFamily="ui-monospace, monospace" fontSize="20" textAnchor="middle">+</text>
+    <text x="470" y="54" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" textAnchor="middle">+</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="296" y="56" width="48" height="34" rx="8" />
     <circle cx="320" cy="102" r="3.5" fillOpacity="0.5" />
     <circle cx="320" cy="114" r="3.5" fillOpacity="0.5" />
   </g>
-  <text x="320" y="81" fontFamily="Georgia, serif" fontStyle="italic" fontSize="21" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>ƒ</text>
+  <text x="320" y="81" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="21" textAnchor="middle" style={{ fill: "var(--ds-gray-900)" }}>ƒ</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="200" y="124" width="240" height="76" rx="16" />
     <circle cx="140" cy="162" r="8" />

--- a/content/learn/functional-programming-typescript/pattern-matching.mdx
+++ b/content/learn/functional-programming-typescript/pattern-matching.mdx
@@ -35,7 +35,7 @@ matching: *the compiler refuses to build code that forgets a case*.
   <g fill="currentColor" opacity="0.18">
     <polygon points="340,75 372,103 340,131 308,103" />
   </g>
-  <text x="340" y="112" fontFamily="ui-monospace, monospace" fontSize="24" textAnchor="middle" fill="currentColor" opacity="0.7">?</text>
+  <text x="340" y="112" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" textAnchor="middle" fill="currentColor" opacity="0.7">?</text>
   <g fill="currentColor" opacity="0.3">
     <circle cx="296" cy="136" r="3" />
     <circle cx="254" cy="150" r="3" />

--- a/content/learn/functional-programming-typescript/pure-functions.mdx
+++ b/content/learn/functional-programming-typescript/pure-functions.mdx
@@ -22,7 +22,7 @@ caching — they all get easier when the building blocks are pure.
     <circle cx="140" cy="110" r="10" />
     <polygon points="216,103 230,110 216,117" fillOpacity="0.6" />
   </g>
-  <text x="320" y="123" fontFamily="Georgia, serif" fontStyle="italic" fontSize="34" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>ƒ</text>
+  <text x="320" y="123" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="34" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>ƒ</text>
   <g fill="currentColor" opacity="0.3">
     <circle cx="172" cy="110" r="3.5" />
     <circle cx="196" cy="110" r="3.5" />

--- a/content/learn/functional-programming-typescript/referential-transparency.mdx
+++ b/content/learn/functional-programming-typescript/referential-transparency.mdx
@@ -35,11 +35,11 @@ Impure functions don't.
     <rect x="120" y="128" width="120" height="14" rx="7" />
     <rect x="400" y="128" width="120" height="14" rx="7" />
   </g>
-  <text x="320" y="52" fontFamily="ui-monospace, monospace" fontSize="28" textAnchor="middle" fill="currentColor" opacity="0.55">=</text>
+  <text x="320" y="52" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="28" textAnchor="middle" fill="currentColor" opacity="0.55">=</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="142" y="92" width="76" height="36" rx="18" />
   </g>
-  <text x="172" y="117" fontFamily="Georgia, serif" fontStyle="italic" fontSize="22" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>ƒ</text>
+  <text x="172" y="117" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="22" textAnchor="middle" style={{ fill: "var(--ds-white)" }}>ƒ</text>
   <circle cx="198" cy="110" r="6" style={{ fill: "var(--ds-white)" }} fillOpacity="0.9" />
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="460" cy="110" r="18" />

--- a/content/learn/functional-programming-typescript/roots-of-functional-thinking.mdx
+++ b/content/learn/functional-programming-typescript/roots-of-functional-thinking.mdx
@@ -21,7 +21,7 @@ This chapter is the cliff-notes version of that history.
 >
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <circle cx="90" cy="105" r="30" fillOpacity="0.15" />
-    <text x="90" y="118" fontFamily="Georgia, serif" fontSize="38" textAnchor="middle">λ</text>
+    <text x="90" y="118" fontFamily="var(--font-sans), Georgia, serif" fontSize="38" textAnchor="middle">λ</text>
     <circle cx="240" cy="60" r="12" fillOpacity="0.85" />
     <circle cx="240" cy="150" r="12" fillOpacity="0.6" />
     <circle cx="400" cy="40" r="10" fillOpacity="0.9" />

--- a/content/learn/intro-data-viz-plotly/dashboard-intuition.mdx
+++ b/content/learn/intro-data-viz-plotly/dashboard-intuition.mdx
@@ -48,7 +48,7 @@ it fail.
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="163" y="136" width="6" height="38" rx="3" transform="rotate(48 166 172)" />
   </g>
-  <g fill="currentColor" opacity="0.65" fontFamily="ui-monospace, monospace" fontSize="40" textAnchor="middle">
+  <g fill="currentColor" opacity="0.65" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="40" textAnchor="middle">
     <text x="322" y="155">42</text>
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor" fillOpacity="0.8">

--- a/content/learn/intro-data-viz-plotly/graphical-encodings.mdx
+++ b/content/learn/intro-data-viz-plotly/graphical-encodings.mdx
@@ -25,7 +25,7 @@ call.
     <rect x="70" y="95" width="46" height="30" rx="15" />
     <rect x="70" y="150" width="46" height="30" rx="15" />
   </g>
-  <g fill="currentColor" opacity="0.6" fontFamily="ui-monospace, monospace" fontSize="15" textAnchor="middle">
+  <g fill="currentColor" opacity="0.6" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" textAnchor="middle">
     <text x="93" y="61">A</text>
     <text x="93" y="116">B</text>
     <text x="93" y="171">C</text>

--- a/content/learn/intro-data-viz-plotly/pie-charts-controversy.mdx
+++ b/content/learn/intro-data-viz-plotly/pie-charts-controversy.mdx
@@ -28,7 +28,7 @@ isn't — the right tool.
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <path d="M315.5 114.6 L238.7 101 A78 78 0 0 1 315.5 36.6 Z" fillOpacity="0.55" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor" fontFamily="Georgia, serif" fontSize="30" textAnchor="middle">
+  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor" fontFamily="var(--font-sans), Georgia, serif" fontSize="30" textAnchor="middle">
     <text x="316" y="242">?</text>
   </g>
 </svg>

--- a/content/learn/intro-data-viz-plotly/what-is-data-visualization.mdx
+++ b/content/learn/intro-data-viz-plotly/what-is-data-visualization.mdx
@@ -24,7 +24,7 @@ were actually building.
     <rect x="100" y="104" width="44" height="44" rx="10" />
     <rect x="100" y="158" width="44" height="44" rx="10" />
   </g>
-  <g fill="currentColor" opacity="0.55" fontFamily="ui-monospace, monospace" fontSize="20" textAnchor="middle">
+  <g fill="currentColor" opacity="0.55" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" textAnchor="middle">
     <text x="122" y="79">3</text>
     <text x="122" y="133">8</text>
     <text x="122" y="187">5</text>

--- a/content/learn/intro-modern-csharp/anders-and-birth-of-csharp.mdx
+++ b/content/learn/intro-modern-csharp/anders-and-birth-of-csharp.mdx
@@ -38,7 +38,7 @@ the way it does, it helps to know the story of its chief designer:
     <circle cx="250" cy="110" r="30" />
   </g>
   <g style={{ color: "var(--ds-blue-50)" }} fill="currentColor">
-    <text x="250" y="121" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="30" fontWeight="700">#</text>
+    <text x="250" y="121" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="30" fontWeight="700">#</text>
   </g>
   <polygon points="296,108 314,105 304,92" fill="currentColor" opacity="0.4" />
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">

--- a/content/learn/intro-sql-postgres/aggregate-functions.mdx
+++ b/content/learn/intro-sql-postgres/aggregate-functions.mdx
@@ -45,11 +45,11 @@ are aggregate questions, and they are the heart of reporting.
     <circle cx="331" cy="140" r="5" />
     <circle cx="318" cy="156" r="4" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <circle cx="452" cy="124" r="14" />
   </g>
   <g style={{ color: "var(--ds-gray-900)" }} fill="currentColor">
-    <text x="452" y="131" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700" fontStyle="italic">ƒ</text>
+    <text x="452" y="131" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700" fontStyle="italic" style={{ fill: "var(--ds-white)" }}>ƒ</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="320" cy="198" r="16" />

--- a/content/learn/intro-sql-postgres/aggregate-functions.mdx
+++ b/content/learn/intro-sql-postgres/aggregate-functions.mdx
@@ -49,7 +49,7 @@ are aggregate questions, and they are the heart of reporting.
     <circle cx="452" cy="124" r="14" />
   </g>
   <g style={{ color: "var(--ds-gray-900)" }} fill="currentColor">
-    <text x="452" y="131" textAnchor="middle" fontFamily="Georgia, serif" fontSize="17" fontWeight="700" fontStyle="italic">ƒ</text>
+    <text x="452" y="131" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700" fontStyle="italic">ƒ</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="320" cy="198" r="16" />

--- a/content/learn/intro-sql-postgres/expressions-and-aliases.mdx
+++ b/content/learn/intro-sql-postgres/expressions-and-aliases.mdx
@@ -33,7 +33,7 @@ name.
     <rect x="230" y="65" width="140" height="90" rx="16" fillOpacity="0.15" />
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
-    <text x="300" y="122" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="32" fontWeight="700">+</text>
+    <text x="300" y="122" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="32" fontWeight="700">+</text>
     <circle cx="450" cy="110" r="13" />
   </g>
   <g fill="currentColor" opacity="0.3">

--- a/content/learn/intro-sql-postgres/first-queries.mdx
+++ b/content/learn/intro-sql-postgres/first-queries.mdx
@@ -29,13 +29,13 @@ shape of the language.
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <polygon points="142,74 154,82 142,90" fillOpacity="0.8" />
     <rect x="166" y="77" width="64" height="10" rx="5" />
-    <text x="252" y="88" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">{"1+1"}</text>
+    <text x="252" y="88" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" fontWeight="700">{"1+1"}</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="166" y="108" width="44" height="28" rx="9" fillOpacity="0.9" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="188" y="128" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">2</text>
+    <text x="188" y="128" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" fontWeight="700">2</text>
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="166" y="152" width="12" height="18" rx="3" fillOpacity="0.5" />

--- a/content/learn/intro-sql-postgres/grouping-data.mdx
+++ b/content/learn/intro-sql-postgres/grouping-data.mdx
@@ -79,9 +79,9 @@ in SQL. Take your time — there are extra checks at the end.
     <circle cx="432" cy="174" r="10" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="432" y="71" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13" fontWeight="700">3</text>
-    <text x="432" y="132" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="12" fontWeight="700">2</text>
-    <text x="432" y="179" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="11" fontWeight="700">1</text>
+    <text x="432" y="71" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13" fontWeight="700">3</text>
+    <text x="432" y="132" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700">2</text>
+    <text x="432" y="179" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="11" fontWeight="700">1</text>
   </g>
 </svg>
 

--- a/content/learn/intro-sql-postgres/primary-keys.mdx
+++ b/content/learn/intro-sql-postgres/primary-keys.mdx
@@ -38,12 +38,12 @@ foundational ideas in relational databases.
     <circle cx="140" cy="168" r="16" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="140" y="58" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">1</text>
-    <text x="140" y="116" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">2</text>
-    <text x="140" y="174" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">3</text>
+    <text x="140" y="58" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">1</text>
+    <text x="140" y="116" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">2</text>
+    <text x="140" y="174" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">3</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
-    <text x="540" y="148" textAnchor="middle" fontFamily="Georgia, serif" fontSize="28" fontWeight="700" fontStyle="italic">?</text>
+    <text x="540" y="148" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontSize="28" fontWeight="700" fontStyle="italic">?</text>
   </g>
 </svg>
 

--- a/content/learn/intro-sql-postgres/query-execution-order.mdx
+++ b/content/learn/intro-sql-postgres/query-execution-order.mdx
@@ -42,11 +42,11 @@ This is one of the most clarifying ideas in all of SQL.
     <circle cx="392" cy="186" r="10" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="392" y="47" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="12" fontWeight="700">1</text>
-    <text x="392" y="83" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="12" fontWeight="700">2</text>
-    <text x="392" y="119" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="12" fontWeight="700">3</text>
-    <text x="392" y="155" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="12" fontWeight="700">4</text>
-    <text x="392" y="191" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="12" fontWeight="700">5</text>
+    <text x="392" y="47" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700">1</text>
+    <text x="392" y="83" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700">2</text>
+    <text x="392" y="119" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700">3</text>
+    <text x="392" y="155" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700">4</text>
+    <text x="392" y="191" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700">5</text>
   </g>
 </svg>
 

--- a/content/learn/intro-sql-postgres/working-with-null.mdx
+++ b/content/learn/intro-sql-postgres/working-with-null.mdx
@@ -20,9 +20,9 @@ which is why this page has extra checks at the end.
     <circle cx="180" cy="110" r="10" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="240" y="58" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700">=</text>
-    <text x="240" y="118" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700">=</text>
-    <text x="240" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700">=</text>
+    <text x="240" y="58" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fontWeight="700">=</text>
+    <text x="240" y="118" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fontWeight="700">=</text>
+    <text x="240" y="178" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fontWeight="700">=</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="300" cy="110" r="14" fillOpacity="0.15" />
@@ -55,8 +55,8 @@ which is why this page has extra checks at the end.
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="440" cy="110" r="12" fillOpacity="0.25" />
     <circle cx="440" cy="170" r="12" fillOpacity="0.25" />
-    <text x="440" y="117" textAnchor="middle" fontFamily="Georgia, serif" fontSize="17" fontWeight="700">?</text>
-    <text x="440" y="177" textAnchor="middle" fontFamily="Georgia, serif" fontSize="17" fontWeight="700">?</text>
+    <text x="440" y="117" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700">?</text>
+    <text x="440" y="177" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700">?</text>
   </g>
 </svg>
 

--- a/content/learn/java-collections-and-generics-deep-dive/birth-of-containers.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/birth-of-containers.mdx
@@ -53,7 +53,7 @@ specifically to fix what these classes got wrong.
     <circle cx="135" cy="98" r="3" />
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
-    <text x="160" y="54" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="700" textAnchor="middle">{"?"}</text>
+    <text x="160" y="54" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700" textAnchor="middle">{"?"}</text>
   </g>
 </svg>
 

--- a/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
@@ -51,7 +51,7 @@ PECS — falls out naturally.
     <circle cx="470" cy="108" r="3" />
   </g>
   <g fill="currentColor" opacity="0.45">
-    <text x="470" y="180" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700" textAnchor="middle">{"?"}</text>
+    <text x="470" y="180" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fontWeight="700" textAnchor="middle">{"?"}</text>
   </g>
 </svg>
 

--- a/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/equality-and-hashing.mdx
@@ -32,8 +32,8 @@ once and for all.
     <path d="M113 70 a22 22 0 1 0 44 0 a22 22 0 1 0 -44 0 Z M118 70 a17 17 0 1 1 34 0 a17 17 0 1 1 -34 0 Z" fillRule="evenodd" />
     <path d="M213 70 a22 22 0 1 0 44 0 a22 22 0 1 0 -44 0 Z M218 70 a17 17 0 1 1 34 0 a17 17 0 1 1 -34 0 Z" fillRule="evenodd" />
     <path d="M383 70 a22 22 0 1 0 44 0 a22 22 0 1 0 -44 0 Z M388 70 a17 17 0 1 1 34 0 a17 17 0 1 1 -34 0 Z" fillRule="evenodd" />
-    <text x="185" y="78" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700" textAnchor="middle">{"="}</text>
-    <text x="455" y="78" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700" textAnchor="middle">{"="}</text>
+    <text x="185" y="78" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fontWeight="700" textAnchor="middle">{"="}</text>
+    <text x="455" y="78" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fontWeight="700" textAnchor="middle">{"="}</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <path d="M483 70 a22 22 0 1 0 44 0 a22 22 0 1 0 -44 0 Z M488 70 a17 17 0 1 1 34 0 a17 17 0 1 1 -34 0 Z" fillRule="evenodd" />

--- a/content/learn/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
@@ -37,7 +37,7 @@ edit.
     <rect x="538" y="96" width="12" height="8" rx="2" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="410" y="65" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="700" textAnchor="middle">{"T"}</text>
+    <text x="410" y="65" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="700" textAnchor="middle">{"T"}</text>
   </g>
   <g fill="currentColor" opacity="0.3">
     <circle cx="150" cy="110" r="3" />

--- a/content/learn/java-collections-and-generics-deep-dive/iterables-and-iterators.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/iterables-and-iterators.mdx
@@ -44,7 +44,7 @@ tiny interfaces: `Iterable<E>` and `Iterator<E>`.
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="353" cy="48" r="9" />
-    <text x="419" y="54" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" textAnchor="middle">{"?"}</text>
+    <text x="419" y="54" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" textAnchor="middle">{"?"}</text>
   </g>
 </svg>
 

--- a/content/learn/java-collections-and-generics-deep-dive/type-erasure.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/type-erasure.mdx
@@ -32,7 +32,7 @@ crash.
     <circle cx="225" cy="70" r="15" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="225" y="76" fontFamily="ui-monospace, monospace" fontSize="14" fontWeight="700" textAnchor="middle">{"T"}</text>
+    <text x="225" y="76" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fontWeight="700" textAnchor="middle">{"T"}</text>
   </g>
   <rect x="308" y="30" width="18" height="150" rx="9" fill="currentColor" opacity="0.22" />
   <g fill="currentColor" opacity="0.3">
@@ -43,7 +43,7 @@ crash.
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="555" cy="70" r="15" fillOpacity="0.12" />
-    <text x="555" y="76" fontFamily="ui-monospace, monospace" fontSize="14" fontWeight="700" textAnchor="middle" fillOpacity="0.3">{"T"}</text>
+    <text x="555" y="76" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fontWeight="700" textAnchor="middle" fillOpacity="0.3">{"T"}</text>
     <circle cx="560" cy="44" r="3.5" fillOpacity="0.3" />
     <circle cx="572" cy="30" r="3" fillOpacity="0.2" />
     <circle cx="584" cy="18" r="2.5" fillOpacity="0.12" />

--- a/content/learn/java-programming-for-beginners/maps-and-sets.mdx
+++ b/content/learn/java-programming-for-beginners/maps-and-sets.mdx
@@ -42,9 +42,9 @@ Once you have these two in your toolbox, a huge fraction of
     <circle cx="530" cy="196" r="12" fillOpacity="0.9" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="370" y="201" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13" fontWeight="700">1</text>
-    <text x="450" y="201" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13" fontWeight="700">2</text>
-    <text x="530" y="201" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13" fontWeight="700">3</text>
+    <text x="370" y="201" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13" fontWeight="700">1</text>
+    <text x="450" y="201" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13" fontWeight="700">2</text>
+    <text x="530" y="201" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13" fontWeight="700">3</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="450" cy="174" r="3" />

--- a/content/learn/machine-learning-scikit-learn/encoding-categorical-features.mdx
+++ b/content/learn/machine-learning-scikit-learn/encoding-categorical-features.mdx
@@ -49,9 +49,9 @@ shortcut backfires, and how `OneHotEncoder` does it right.
     <rect x="364" y="152" width="68" height="26" rx="7" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="314" y="60" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700">1</text>
-    <text x="398" y="115" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700">1</text>
-    <text x="482" y="170" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700">1</text>
+    <text x="314" y="60" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700">1</text>
+    <text x="398" y="115" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700">1</text>
+    <text x="482" y="170" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700">1</text>
   </g>
 </svg>
 

--- a/content/learn/machine-learning-scikit-learn/encoding-categorical-features.mdx
+++ b/content/learn/machine-learning-scikit-learn/encoding-categorical-features.mdx
@@ -30,6 +30,8 @@ shortcut backfires, and how `OneHotEncoder` does it right.
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="120" y="154" width="64" height="22" rx="11" />
+  </g>
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <rect x="448" y="152" width="68" height="26" rx="7" />
   </g>
   <g fill="currentColor" opacity="0.3">

--- a/content/learn/machine-learning-scikit-learn/features-and-targets.mdx
+++ b/content/learn/machine-learning-scikit-learn/features-and-targets.mdx
@@ -20,8 +20,8 @@ That framing is the skill this page builds.
   aria-label="A grid of translucent blue feature cells beside a single green target column, with one sample row highlighted — every supervised dataset splits into a feature matrix X and a target y"
   style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
 >
-  <text x="243" y="32" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="700" fill="currentColor" opacity="0.55">X</text>
-  <text x="447" y="32" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="700" fill="currentColor" opacity="0.55">y</text>
+  <text x="243" y="32" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="700" fill="currentColor" opacity="0.55">X</text>
+  <text x="447" y="32" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="700" fill="currentColor" opacity="0.55">y</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="120" y="46" width="54" height="26" rx="6" fillOpacity="0.18" />
     <rect x="184" y="46" width="54" height="26" rx="6" fillOpacity="0.18" />

--- a/content/learn/machine-learning-scikit-learn/supervised-vs-unsupervised.mdx
+++ b/content/learn/machine-learning-scikit-learn/supervised-vs-unsupervised.mdx
@@ -48,7 +48,7 @@ to settle on any project, so this page makes the line crisp.
     <circle cx="470" cy="192" r="9" />
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
-    <text x="565" y="130" textAnchor="middle" fontFamily="Georgia, serif" fontSize="48" fontWeight="700" fontStyle="italic">?</text>
+    <text x="565" y="130" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontSize="48" fontWeight="700" fontStyle="italic">?</text>
   </g>
 </svg>
 

--- a/content/learn/mastering-dsa-cpp/complexity-analysis.mdx
+++ b/content/learn/mastering-dsa-cpp/complexity-analysis.mdx
@@ -15,7 +15,7 @@ Algorithms are not judged only by whether they work. They are judged by how thei
     <rect x="80" y="28" width="4" height="160" rx="2" />
     <rect x="80" y="186" width="480" height="4" rx="2" />
   </g>
-  <text x="572" y="208" fontFamily="ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.45">n</text>
+  <text x="572" y="208" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.45">n</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="110" cy="170" r="3.5" fillOpacity="0.55" />
     <circle cx="145" cy="170" r="3.5" fillOpacity="0.55" />

--- a/content/learn/mastering-dsa-cpp/cpp-essentials.mdx
+++ b/content/learn/mastering-dsa-cpp/cpp-essentials.mdx
@@ -29,19 +29,19 @@ You do not need all of C++ to start solving DSA problems. You need a reliable sl
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="150" y="84" width="40" height="44" rx="11" />
-    <text x="170" y="113" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-gray-900)" }}>T</text>
+    <text x="170" y="113" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-gray-900)" }}>T</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="230" y="84" width="40" height="44" rx="11" />
-    <text x="250" y="113" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-gray-900)" }}>λ</text>
+    <text x="250" y="113" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-gray-900)" }}>λ</text>
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="370" y="84" width="40" height="44" rx="11" />
-    <text x="390" y="113" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-blue-50)" }}>{"&"}</text>
+    <text x="390" y="113" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-blue-50)" }}>{"&"}</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="450" y="84" width="40" height="44" rx="11" fillOpacity="0.85" />
-    <text x="470" y="112" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="700" style={{ fill: "var(--ds-gray-900)" }}>{"[]"}</text>
+    <text x="470" y="112" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="700" style={{ fill: "var(--ds-gray-900)" }}>{"[]"}</text>
   </g>
 </svg>
 

--- a/content/learn/mastering-dsa-cpp/cpp-essentials.mdx
+++ b/content/learn/mastering-dsa-cpp/cpp-essentials.mdx
@@ -29,11 +29,11 @@ You do not need all of C++ to start solving DSA problems. You need a reliable sl
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="150" y="84" width="40" height="44" rx="11" />
-    <text x="170" y="113" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-gray-900)" }}>T</text>
+    <text x="170" y="113" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-white)" }}>T</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
-    <rect x="230" y="84" width="40" height="44" rx="11" />
-    <text x="250" y="113" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-gray-900)" }}>λ</text>
+    <rect x="230" y="84" width="40" height="44" rx="11" style={{ fill: "var(--ds-teal-500)" }} />
+    <text x="250" y="113" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-white)" }}>λ</text>
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="370" y="84" width="40" height="44" rx="11" />
@@ -41,7 +41,7 @@ You do not need all of C++ to start solving DSA problems. You need a reliable sl
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="450" y="84" width="40" height="44" rx="11" fillOpacity="0.85" />
-    <text x="470" y="112" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="700" style={{ fill: "var(--ds-gray-900)" }}>{"[]"}</text>
+    <text x="470" y="112" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="700" style={{ fill: "var(--ds-white)" }}>{"[]"}</text>
   </g>
 </svg>
 

--- a/content/learn/mastering-dsa-cpp/graph-traversal.mdx
+++ b/content/learn/mastering-dsa-cpp/graph-traversal.mdx
@@ -54,7 +54,7 @@ Graph traversal means systematically visiting vertices reachable from a starting
     <circle cx="400" cy="122" r="2" />
     <circle cx="409" cy="107" r="2" />
   </g>
-  <g fill="currentColor" opacity="0.45" fontFamily="ui-monospace, monospace" fontSize="12" textAnchor="middle">
+  <g fill="currentColor" opacity="0.45" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" textAnchor="middle">
     <text x="170" y="212">BFS</text>
     <text x="470" y="212">DFS</text>
   </g>

--- a/content/learn/mastering-dsa-cpp/graphs.mdx
+++ b/content/learn/mastering-dsa-cpp/graphs.mdx
@@ -37,7 +37,7 @@ A **graph** is a collection of **vertices** `V` and **edges** `E`. Vertices are 
     <circle cx="420" cy="55" r="9" />
     <circle cx="325" cy="163" r="9" />
   </g>
-  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="ui-monospace, monospace" fontSize="11" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="11" fontWeight="700" textAnchor="middle">
     <text x="220" y="54">2</text>
     <text x="420" y="59">7</text>
     <text x="325" y="167">5</text>

--- a/content/learn/mastering-dsa-cpp/graphs.mdx
+++ b/content/learn/mastering-dsa-cpp/graphs.mdx
@@ -32,12 +32,12 @@ A **graph** is a collection of **vertices** `V` and **edges** `E`. Vertices are 
     <circle cx="220" cy="160" r="9" />
     <circle cx="430" cy="165" r="9" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <circle cx="220" cy="50" r="9" />
     <circle cx="420" cy="55" r="9" />
     <circle cx="325" cy="163" r="9" />
   </g>
-  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="11" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-white)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="11" fontWeight="700" textAnchor="middle">
     <text x="220" y="54">2</text>
     <text x="420" y="59">7</text>
     <text x="325" y="167">5</text>

--- a/content/learn/mastering-dsa-cpp/hash-tables.mdx
+++ b/content/learn/mastering-dsa-cpp/hash-tables.mdx
@@ -28,7 +28,7 @@ A hash table stores key-value data in an array of buckets. A hash function conve
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="290" y="76" width="60" height="42" rx="12" />
-    <text x="320" y="105" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-blue-50)" }}>#</text>
+    <text x="320" y="105" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" style={{ fill: "var(--ds-blue-50)" }}>#</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="288" cy="130" r="2.5" fillOpacity="0.55" />
@@ -50,7 +50,7 @@ A hash table stores key-value data in an array of buckets. A hash function conve
     <rect x="388" y="160" width="56" height="46" rx="8" />
     <rect x="452" y="160" width="56" height="46" rx="8" />
   </g>
-  <g fill="currentColor" opacity="0.45" fontFamily="ui-monospace, monospace" fontSize="11" textAnchor="middle">
+  <g fill="currentColor" opacity="0.45" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="11" textAnchor="middle">
     <text x="160" y="224">0</text>
     <text x="224" y="224">1</text>
     <text x="288" y="224">2</text>

--- a/content/learn/mastering-dsa-cpp/linked-lists.mdx
+++ b/content/learn/mastering-dsa-cpp/linked-lists.mdx
@@ -20,7 +20,7 @@ A singly linked list stores values in separate nodes connected by `next` pointer
     <circle cx="210" cy="154" r="14" />
     <circle cx="450" cy="114" r="14" />
   </g>
-  <g style={{ fill: "var(--ds-blue-50)" }} fontFamily="ui-monospace, monospace" fontSize="13" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-blue-50)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13" fontWeight="700" textAnchor="middle">
     <text x="110" y="89">1</text>
     <text x="300" y="61">2</text>
     <text x="210" y="159">3</text>

--- a/content/learn/mastering-dsa-cpp/shortest-paths.mdx
+++ b/content/learn/mastering-dsa-cpp/shortest-paths.mdx
@@ -47,7 +47,7 @@ The shortest path problem asks for the minimum total edge weight needed to trave
     <circle cx="320" cy="170" r="8" fillOpacity="0.9" />
     <circle cx="462" cy="140" r="8" fillOpacity="0.9" />
   </g>
-  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="ui-monospace, monospace" fontSize="11" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="11" fontWeight="700" textAnchor="middle">
     <text x="320" y="48">9</text>
     <text x="178" y="144">2</text>
     <text x="320" y="174">1</text>

--- a/content/learn/mastering-dsa-cpp/shortest-paths.mdx
+++ b/content/learn/mastering-dsa-cpp/shortest-paths.mdx
@@ -47,7 +47,7 @@ The shortest path problem asks for the minimum total edge weight needed to trave
     <circle cx="320" cy="170" r="8" fillOpacity="0.9" />
     <circle cx="462" cy="140" r="8" fillOpacity="0.9" />
   </g>
-  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="11" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-white)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="11" fontWeight="700" textAnchor="middle">
     <text x="320" y="48">9</text>
     <text x="178" y="144">2</text>
     <text x="320" y="174">1</text>

--- a/content/learn/mastering-dsa-cpp/trees.mdx
+++ b/content/learn/mastering-dsa-cpp/trees.mdx
@@ -16,7 +16,7 @@ A tree is a connected acyclic graph. In a rooted tree, one node is the root, eve
     <rect x="120" y="92" width="400" height="36" rx="10" opacity="0.09" />
     <rect x="120" y="148" width="400" height="36" rx="10" opacity="0.05" />
   </g>
-  <g fill="currentColor" opacity="0.45" fontFamily="ui-monospace, monospace" fontSize="12" textAnchor="middle">
+  <g fill="currentColor" opacity="0.45" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" textAnchor="middle">
     <text x="98" y="60">0</text>
     <text x="98" y="116">1</text>
     <text x="98" y="172">2</text>

--- a/content/learn/mastering-dsa-cpp/tries.mdx
+++ b/content/learn/mastering-dsa-cpp/tries.mdx
@@ -39,7 +39,7 @@ A trie, or prefix tree, stores strings by sharing common prefixes. Each node rep
     <circle cx="250" cy="108" r="12" />
     <circle cx="400" cy="108" r="12" />
   </g>
-  <g style={{ fill: "var(--ds-blue-50)" }} fontFamily="ui-monospace, monospace" fontSize="12" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-blue-50)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700" textAnchor="middle">
     <text x="250" y="72">c</text>
     <text x="400" y="72">d</text>
     <text x="250" y="112">a</text>
@@ -51,7 +51,7 @@ A trie, or prefix tree, stores strings by sharing common prefixes. Each node rep
     <circle cx="310" cy="188" r="12" />
     <circle cx="400" cy="148" r="12" />
   </g>
-  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="ui-monospace, monospace" fontSize="12" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700" textAnchor="middle">
     <text x="190" y="152">t</text>
     <text x="310" y="152">r</text>
     <text x="310" y="192">t</text>

--- a/content/learn/mastering-dsa-cpp/tries.mdx
+++ b/content/learn/mastering-dsa-cpp/tries.mdx
@@ -51,7 +51,7 @@ A trie, or prefix tree, stores strings by sharing common prefixes. Each node rep
     <circle cx="310" cy="188" r="12" />
     <circle cx="400" cy="148" r="12" />
   </g>
-  <g style={{ fill: "var(--ds-gray-900)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700" textAnchor="middle">
+  <g style={{ fill: "var(--ds-white)" }} fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="12" fontWeight="700" textAnchor="middle">
     <text x="190" y="152">t</text>
     <text x="310" y="152">r</text>
     <text x="310" y="192">t</text>

--- a/content/learn/mastering-ggplot2/a-complete-workflow.mdx
+++ b/content/learn/mastering-ggplot2/a-complete-workflow.mdx
@@ -18,7 +18,7 @@ decision.
     <circle cx="105" cy="100" r="38" opacity="0.07" />
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
-    <text x="105" y="112" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="34" fontWeight="bold">{"?"}</text>
+    <text x="105" y="112" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="34" fontWeight="bold">{"?"}</text>
   </g>
   <g fill="currentColor" opacity="0.3">
     <circle cx="162" cy="100" r="3" />

--- a/content/learn/mastering-ggplot2/layering-multiple-geoms.mdx
+++ b/content/learn/mastering-ggplot2/layering-multiple-geoms.mdx
@@ -26,8 +26,8 @@ uses.
     <circle cx="160" cy="75" r="5.5" />
   </g>
   <g fill="currentColor" opacity="0.55">
-    <text x="215" y="103" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="26" fontWeight="bold">{"+"}</text>
-    <text x="403" y="103" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="26" fontWeight="bold">{"="}</text>
+    <text x="215" y="103" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="26" fontWeight="bold">{"+"}</text>
+    <text x="403" y="103" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="26" fontWeight="bold">{"="}</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="265" cy="130" r="3.5" />

--- a/content/learn/mastering-ggplot2/plotting-systems-that-dont-scale.mdx
+++ b/content/learn/mastering-ggplot2/plotting-systems-that-dont-scale.mdx
@@ -58,7 +58,7 @@ maybe without naming it.
   </g>
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <rect x="492" y="70" width="100" height="70" rx="10" fillOpacity="0.12" />
-    <text x="542" y="118" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="36" fontWeight="bold">{"?"}</text>
+    <text x="542" y="118" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="36" fontWeight="bold">{"?"}</text>
   </g>
 </svg>
 

--- a/content/learn/mastering-ggplot2/the-seven-components.mdx
+++ b/content/learn/mastering-ggplot2/the-seven-components.mdx
@@ -32,7 +32,7 @@ using the built-in `mpg` data set (fuel-economy records for 234 cars).
     <polygon points="168,93 180,67 192,93" />
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
-    <text x="245" y="89" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="28">{"ƒ"}</text>
+    <text x="245" y="89" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="28">{"ƒ"}</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="296" y="74" width="48" height="12" rx="5" fillOpacity="0.35" />

--- a/content/learn/mastering-ggplot2/themes-and-styling.mdx
+++ b/content/learn/mastering-ggplot2/themes-and-styling.mdx
@@ -26,7 +26,7 @@ separation is itself a grammar idea.
     <rect x="230" y="102" width="28" height="70" rx="3" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="320" y="118" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="bold">{"="}</text>
+    <text x="320" y="118" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="bold">{"="}</text>
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="368" y="48" width="204" height="124" rx="8" fillOpacity="0.05" />

--- a/content/learn/mastering-ggplot2/thinking-in-layers.mdx
+++ b/content/learn/mastering-ggplot2/thinking-in-layers.mdx
@@ -19,7 +19,7 @@ people who *copy* ggplot code from people who *write* it.
     <circle cx="185" cy="75" r="5" />
     <circle cx="210" cy="100" r="5" />
     <circle cx="190" cy="130" r="5" />
-    <text x="172" y="64" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="bold">{"1"}</text>
+    <text x="172" y="64" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="bold">{"1"}</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="230" y="55" width="200" height="130" rx="14" fillOpacity="0.3" />
@@ -27,12 +27,12 @@ people who *copy* ggplot code from people who *write* it.
     <circle cx="330" cy="160" r="3.5" />
     <circle cx="360" cy="150" r="3.5" />
     <circle cx="390" cy="142" r="3.5" />
-    <text x="252" y="89" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="bold">{"2"}</text>
+    <text x="252" y="89" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="bold">{"2"}</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="310" y="80" width="200" height="130" rx="14" fillOpacity="0.3" />
     <rect x="430" y="180" width="60" height="10" rx="5" fillOpacity="0.9" />
-    <text x="332" y="114" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="bold">{"3"}</text>
+    <text x="332" y="114" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="bold">{"3"}</text>
   </g>
   <g fill="currentColor" opacity="0.35">
     <circle cx="560" cy="150" r="3" />

--- a/content/learn/natural-language-processing-python/rule-based-sentiment.mdx
+++ b/content/learn/natural-language-processing-python/rule-based-sentiment.mdx
@@ -44,7 +44,7 @@ off at once — especially the warning about negation and stopwords.
     <rect x="420" y="128" width="46" height="20" rx="10" fillOpacity="0.9" />
     <rect x="472" y="128" width="36" height="20" rx="10" fillOpacity="0.7" />
   </g>
-  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" textAnchor="middle">
+  <g style={{ color: "var(--ds-green-500)" }} fill="currentColor" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" textAnchor="middle">
     <text x="560" y="65">+</text>
   </g>
 </svg>

--- a/content/learn/natural-language-processing-python/what-is-nlp.mdx
+++ b/content/learn/natural-language-processing-python/what-is-nlp.mdx
@@ -18,7 +18,7 @@ which marks matter, or what any of it *means*. Natural Language Processing
 <svg
   viewBox="0 0 640 190"
   role="img"
-  aria-label="A long flat string bar with confident green cut marks where words clearly end, and two yellow question-mark badges hovering where the right cut is ambiguous"
+  aria-label="A long flat string bar with confident green cut marks where words clearly end, and two teal question-mark badges hovering where the right cut is ambiguous"
   style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
 >
   <g fill="currentColor" opacity="0.14">
@@ -32,12 +32,14 @@ which marks matter, or what any of it *means*. Natural Language Processing
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="228" y="104" width="5" height="50" rx="2.5" fillOpacity="0.55" />
     <rect x="408" y="104" width="5" height="50" rx="2.5" fillOpacity="0.55" />
+  </g>
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <circle cx="230.5" cy="62" r="14" />
     <circle cx="410.5" cy="62" r="14" />
   </g>
-  <g style={{ color: "var(--ds-gray-900)" }} fill="currentColor" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700" textAnchor="middle">
-    <text x="230.5" y="68">?</text>
-    <text x="410.5" y="68">?</text>
+  <g fill="currentColor" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700" textAnchor="middle">
+    <text x="230.5" y="68" style={{ fill: "var(--ds-white)" }}>?</text>
+    <text x="410.5" y="68" style={{ fill: "var(--ds-white)" }}>?</text>
   </g>
   <g fill="currentColor" opacity="0.3">
     <circle cx="230.5" cy="88" r="3" />

--- a/content/learn/natural-language-processing-python/what-is-nlp.mdx
+++ b/content/learn/natural-language-processing-python/what-is-nlp.mdx
@@ -35,7 +35,7 @@ which marks matter, or what any of it *means*. Natural Language Processing
     <circle cx="230.5" cy="62" r="14" />
     <circle cx="410.5" cy="62" r="14" />
   </g>
-  <g style={{ color: "var(--ds-gray-900)" }} fill="currentColor" fontFamily="Georgia, serif" fontSize="17" fontWeight="700" textAnchor="middle">
+  <g style={{ color: "var(--ds-gray-900)" }} fill="currentColor" fontFamily="var(--font-sans), Georgia, serif" fontSize="17" fontWeight="700" textAnchor="middle">
     <text x="230.5" y="68">?</text>
     <text x="410.5" y="68">?</text>
   </g>

--- a/content/learn/practical-r-for-beginners/dplyr-verbs.mdx
+++ b/content/learn/practical-r-for-beginners/dplyr-verbs.mdx
@@ -63,9 +63,9 @@ thing.
     <circle cx="284" cy="100" r="2.5" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="186" y="152" fontFamily="ui-monospace, monospace" fontSize="14">{"|>"}</text>
-    <text x="326" y="152" fontFamily="ui-monospace, monospace" fontSize="14">{"|>"}</text>
-    <text x="466" y="152" fontFamily="ui-monospace, monospace" fontSize="14">{"|>"}</text>
+    <text x="186" y="152" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">{"|>"}</text>
+    <text x="326" y="152" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">{"|>"}</text>
+    <text x="466" y="152" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">{"|>"}</text>
   </g>
 </svg>
 

--- a/content/learn/practical-r-for-beginners/ggplot-grammar.mdx
+++ b/content/learn/practical-r-for-beginners/ggplot-grammar.mdx
@@ -52,8 +52,8 @@ Each part is added with `+`.
     <rect x="266" y="148" width="186" height="8" rx="4" transform="rotate(-14 359 152)" fillOpacity="0.85" />
   </g>
   <g fill="currentColor" opacity="0.6">
-    <text x="524" y="100" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="700">+</text>
-    <text x="548" y="140" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="700">+</text>
+    <text x="524" y="100" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700">+</text>
+    <text x="548" y="140" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700">+</text>
   </g>
 </svg>
 

--- a/content/learn/practical-r-for-beginners/grouped-analysis.mdx
+++ b/content/learn/practical-r-for-beginners/grouped-analysis.mdx
@@ -68,9 +68,9 @@ In dplyr, you do it in two lines: `group_by()` + `summarise()`.
     <circle cx="420" cy="178" r="22" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="222" y="179" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">5</text>
-    <text x="322" y="182" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">4</text>
-    <text x="420" y="184" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700">3</text>
+    <text x="222" y="179" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" fontWeight="700">5</text>
+    <text x="322" y="182" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">4</text>
+    <text x="420" y="184" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700">3</text>
   </g>
   <rect x="160" y="206" width="320" height="5" rx="2.5" fill="currentColor" opacity="0.12" />
 </svg>

--- a/content/learn/practical-r-for-beginners/logical-and-character-vectors.mdx
+++ b/content/learn/practical-r-for-beginners/logical-and-character-vectors.mdx
@@ -27,11 +27,11 @@ This page is about both.
     <rect x="344" y="36" width="32" height="32" rx="8" fillOpacity="0.85" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="100" y="58" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">2</text>
-    <text x="165" y="58" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">7</text>
-    <text x="230" y="58" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">4</text>
-    <text x="295" y="58" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">9</text>
-    <text x="360" y="58" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">1</text>
+    <text x="100" y="58" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">2</text>
+    <text x="165" y="58" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">7</text>
+    <text x="230" y="58" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">4</text>
+    <text x="295" y="58" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">9</text>
+    <text x="360" y="58" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">1</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="75" y="98" width="310" height="10" rx="5" fillOpacity="0.8" />

--- a/content/learn/practical-r-for-beginners/missing-values.mdx
+++ b/content/learn/practical-r-for-beginners/missing-values.mdx
@@ -27,7 +27,7 @@ string. It is R's way of saying: *we don't have a value here.*
     <circle cx="249" cy="105" r="20" fillOpacity="0.12" />
     <circle cx="249" cy="105" r="14" fillOpacity="0.2" />
     <circle cx="249" cy="105" r="8" fillOpacity="0.4" />
-    <text x="249" y="68" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">?</text>
+    <text x="249" y="68" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" fontWeight="700">?</text>
     <circle cx="319" cy="105" r="17" fillOpacity="0.07" />
     <circle cx="389" cy="105" r="19" fillOpacity="0.06" />
     <circle cx="459" cy="105" r="21" fillOpacity="0.05" />

--- a/content/learn/practical-r-for-beginners/principles-of-visualization.mdx
+++ b/content/learn/practical-r-for-beginners/principles-of-visualization.mdx
@@ -21,10 +21,10 @@ what you learn here.
 >
   <rect x="80" y="40" width="70" height="160" rx="12" fill="currentColor" opacity="0.06" />
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
-    <text x="115" y="78" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700">2</text>
-    <text x="115" y="118" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700">5</text>
-    <text x="115" y="158" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700">8</text>
-    <text x="115" y="198" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700">3</text>
+    <text x="115" y="78" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700">2</text>
+    <text x="115" y="118" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700">5</text>
+    <text x="115" y="158" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700">8</text>
+    <text x="115" y="198" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700">3</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="200" y="64" width="28" height="14" rx="7" fillOpacity="0.85" />

--- a/content/learn/practical-r-for-beginners/vectorized-computation.mdx
+++ b/content/learn/practical-r-for-beginners/vectorized-computation.mdx
@@ -70,7 +70,7 @@ often *much* faster.
     <polygon points="401,166 415,166 408,178" fillOpacity="0.8" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="276" y="142" fontFamily="ui-monospace, monospace" fontSize="13" fontWeight="700">+1</text>
+    <text x="276" y="142" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13" fontWeight="700">+1</text>
   </g>
   <g fill="currentColor" opacity="0.08">
     <rect x="150" y="182" width="36" height="36" rx="8" />

--- a/content/learn/practical-r-for-beginners/vectors-everywhere.mdx
+++ b/content/learn/practical-r-for-beginners/vectors-everywhere.mdx
@@ -20,7 +20,7 @@ around that operation from day one.
   style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
 >
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
-    <text x="132" y="82" fontFamily="ui-monospace, monospace" fontSize="32" fontWeight="700">5</text>
+    <text x="132" y="82" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="32" fontWeight="700">5</text>
     <rect x="222" y="44" width="48" height="48" rx="16" fillOpacity="0.12" />
     <circle cx="246" cy="68" r="9" />
   </g>

--- a/content/learn/practical-r-for-beginners/writing-your-own-functions.mdx
+++ b/content/learn/practical-r-for-beginners/writing-your-own-functions.mdx
@@ -26,7 +26,7 @@ of a kitchen ("chop, chop, chop, stir, stir, chop, stir, …").
     <rect x="206" y="54" width="120" height="20" rx="10" fillOpacity="0.55" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="218" y="69" fontFamily="Georgia, serif" fontSize="15" fontStyle="italic" fontWeight="700">ƒ</text>
+    <text x="218" y="69" fontFamily="var(--font-sans), Georgia, serif" fontSize="15" fontStyle="italic" fontWeight="700">ƒ</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="390" cy="20" r="7" fillOpacity="0.5" />

--- a/content/learn/practical-r-for-beginners/your-first-r-program.mdx
+++ b/content/learn/practical-r-for-beginners/your-first-r-program.mdx
@@ -54,7 +54,7 @@ mysterious.
     <rect x="172" y="170" width="150" height="12" rx="6" fillOpacity="0.85" />
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
-    <text x="146" y="97" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="700">{">"}</text>
+    <text x="146" y="97" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="700">{">"}</text>
     <rect x="172" y="85" width="148" height="12" rx="6" fillOpacity="0.55" />
     <circle cx="456" cy="140" r="8" />
   </g>

--- a/content/learn/python-basics/booleans.mdx
+++ b/content/learn/python-basics/booleans.mdx
@@ -24,7 +24,7 @@ Every snippet on this page runs in your browser—no setup required.
     <circle cx="400" cy="52" r="10" />
     <rect x="510" y="38" width="46" height="28" rx="8" />
   </g>
-  <text x="470" y="61" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fill="currentColor" opacity="0.45">0</text>
+  <text x="470" y="61" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fill="currentColor" opacity="0.45">0</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <circle cx="175" cy="84" r="3" fillOpacity="0.45" />
     <circle cx="188" cy="112" r="3" fillOpacity="0.45" />

--- a/content/learn/python-basics/decorators.mdx
+++ b/content/learn/python-basics/decorators.mdx
@@ -15,7 +15,7 @@ A **decorator** is just a function that takes another function and returns a new
     <rect x="90" y="70" width="80" height="80" rx="16" fillOpacity="0.9" />
   </g>
   <g style={{ color: "var(--ds-blue-50)" }} fill="currentColor">
-    <text x="130" y="124" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="30">ƒ</text>
+    <text x="130" y="124" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="30">ƒ</text>
   </g>
   <g fill="currentColor" opacity="0.35">
     <circle cx="192" cy="110" r="3" />
@@ -37,7 +37,7 @@ A **decorator** is just a function that takes another function and returns a new
     <rect x="451" y="77" width="68" height="68" rx="14" fillOpacity="0.85" />
   </g>
   <g style={{ color: "var(--ds-blue-50)" }} fill="currentColor">
-    <text x="485" y="121" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="26">ƒ</text>
+    <text x="485" y="121" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="26">ƒ</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="477" y="46" width="16" height="130" fillOpacity="0.45" />

--- a/content/learn/python-basics/functions.mdx
+++ b/content/learn/python-basics/functions.mdx
@@ -17,7 +17,7 @@ Functions package code so it can be reused, named, and tested. Every program is 
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <circle cx="110" cy="150" r="14" />
     <rect x="470" y="90" width="110" height="70" rx="16" fillOpacity="0.2" />
-    <text x="525" y="137" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="36">ƒ</text>
+    <text x="525" y="137" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="36">ƒ</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="150" cy="118" r="3" fillOpacity="0.5" />

--- a/content/learn/python-basics/hello-world.mdx
+++ b/content/learn/python-basics/hello-world.mdx
@@ -41,7 +41,7 @@ files, no compilation step. Just one line.
     <rect x="128" y="98" width="72" height="9" rx="4.5" fillOpacity="0.9" />
     <rect x="380" y="84" width="170" height="20" rx="10" />
   </g>
-  <text x="330" y="104" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="30" fill="currentColor" opacity="0.4">=</text>
+  <text x="330" y="104" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="30" fill="currentColor" opacity="0.4">=</text>
   <g fill="currentColor" opacity="0.28">
     <circle cx="570" cy="76" r="2.5" />
     <circle cx="562" cy="112" r="2" />

--- a/content/learn/python-basics/strings.mdx
+++ b/content/learn/python-basics/strings.mdx
@@ -42,8 +42,8 @@ Every snippet on this page runs in your browser—no setup required.
     <circle cx="344" cy="112" r="2.5" />
     <circle cx="344" cy="99" r="2.5" />
   </g>
-  <text x="190" y="196" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fill="currentColor" opacity="0.5">2</text>
-  <text x="366" y="196" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fill="currentColor" opacity="0.5">6</text>
+  <text x="190" y="196" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fill="currentColor" opacity="0.5">2</text>
+  <text x="366" y="196" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fill="currentColor" opacity="0.5">6</text>
 </svg>
 
 ## Real-world context: Text is everywhere

--- a/content/learn/scientific-computing-python/arrays-and-tensors.mdx
+++ b/content/learn/scientific-computing-python/arrays-and-tensors.mdx
@@ -53,8 +53,8 @@ course.
     <rect x="430" y="158" width="84" height="26" rx="13" fillOpacity="0.25" />
   </g>
   <g fill="currentColor" opacity="0.7">
-    <text x="458" y="177" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15">3</text>
-    <text x="486" y="177" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15">4</text>
+    <text x="458" y="177" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15">3</text>
+    <text x="486" y="177" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15">4</text>
   </g>
 </svg>
 

--- a/content/learn/scientific-computing-python/fortran-and-matlab.mdx
+++ b/content/learn/scientific-computing-python/fortran-and-matlab.mdx
@@ -26,7 +26,7 @@ production scientific code still is.
     <rect x="80" y="75" width="170" height="50" rx="25" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="165" y="112" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="34">ƒ</text>
+    <text x="165" y="112" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="34">ƒ</text>
   </g>
   <g fill="currentColor" opacity="0.3">
     <circle cx="280" cy="100" r="3.5" />

--- a/content/learn/scientific-computing-python/signal-processing.mdx
+++ b/content/learn/scientific-computing-python/signal-processing.mdx
@@ -38,7 +38,7 @@ but as a function of *frequency*.
     <rect x="280" y="60" width="90" height="80" rx="14" fillOpacity="0.2" />
   </g>
   <g fill="currentColor" opacity="0.7">
-    <text x="325" y="112" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="32">ƒ</text>
+    <text x="325" y="112" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="32">ƒ</text>
   </g>
   <g fill="currentColor" opacity="0.3">
     <circle cx="390" cy="100" r="3" />

--- a/content/learn/seaborn-foundations/why-visualize-statistical-data.mdx
+++ b/content/learn/seaborn-foundations/why-visualize-statistical-data.mdx
@@ -51,7 +51,7 @@ rest of this course exists.
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <circle cx="538" cy="52" r="5.5" />
   </g>
-  <text x="320" y="208" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" fill="currentColor" opacity="0.55">=</text>
+  <text x="320" y="208" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" fill="currentColor" opacity="0.55">=</text>
 </svg>
 
 ## The eye is a pattern detector

--- a/content/learn/sql-analytics-duckdb/conditional-logic.mdx
+++ b/content/learn/sql-analytics-duckdb/conditional-logic.mdx
@@ -273,11 +273,11 @@ Two small but constant companions of conditional logic:
     <rect x="70" y="104" width="68" height="16" rx="8" fillOpacity="0.8" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="178" y="56" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle">÷</text>
-    <text x="178" y="120" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle">÷</text>
+    <text x="178" y="56" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" textAnchor="middle">÷</text>
+    <text x="178" y="120" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" textAnchor="middle">÷</text>
   </g>
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
-    <text x="232" y="57" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle" fontWeight="700">0</text>
+    <text x="232" y="57" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" textAnchor="middle" fontWeight="700">0</text>
   </g>
   <g fill="currentColor" opacity="0.35">
     <path d="M 232 104 m -9 0 a 9 9 0 1 0 18 0 a 9 9 0 1 0 -18 0 M 232 104 m -5 0 a 5 5 0 1 1 10 0 a 5 5 0 1 1 -10 0" fillRule="evenodd" />

--- a/content/learn/sql-analytics-duckdb/loading-and-generating-data.mdx
+++ b/content/learn/sql-analytics-duckdb/loading-and-generating-data.mdx
@@ -146,9 +146,9 @@ common `range()` mistake.
     <circle cx="556" cy="68" r="9" fillOpacity="0.3" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="80" y="118" fontFamily="ui-monospace, monospace" fontSize="14" textAnchor="middle">1</text>
-    <text x="484" y="118" fontFamily="ui-monospace, monospace" fontSize="14" textAnchor="middle">12</text>
-    <text x="556" y="118" fontFamily="ui-monospace, monospace" fontSize="14" textAnchor="middle">13</text>
+    <text x="80" y="118" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" textAnchor="middle">1</text>
+    <text x="484" y="118" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" textAnchor="middle">12</text>
+    <text x="556" y="118" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" textAnchor="middle">13</text>
   </g>
 </svg>
 

--- a/content/learn/sql-analytics-duckdb/pivoting-and-reshaping.mdx
+++ b/content/learn/sql-analytics-duckdb/pivoting-and-reshaping.mdx
@@ -230,7 +230,7 @@ A good rule: **compute in long, present in wide.**
     <rect x="104" y="118" width="40" height="24" rx="6" fillOpacity="0.45" />
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
-    <text x="200" y="98" fontFamily="Georgia, serif" fontSize="52" fontStyle="italic" textAnchor="middle">ƒ</text>
+    <text x="200" y="98" fontFamily="var(--font-sans), Georgia, serif" fontSize="52" fontStyle="italic" textAnchor="middle">ƒ</text>
   </g>
   <g fill="currentColor" opacity="0.15">
     <rect x="276" y="80" width="4" height="10" rx="2" />

--- a/content/learn/sql-analytics-duckdb/ranking-and-row-number.mdx
+++ b/content/learn/sql-analytics-duckdb/ranking-and-row-number.mdx
@@ -38,11 +38,11 @@ the end.
     <circle cx="438" cy="132" r="10" />
   </g>
   <g fill="currentColor" opacity="0.45">
-    <text x="322" y="156" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle">1</text>
-    <text x="438" y="186" fontFamily="ui-monospace, monospace" fontSize="18" textAnchor="middle">3</text>
+    <text x="322" y="156" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" textAnchor="middle">1</text>
+    <text x="438" y="186" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" textAnchor="middle">3</text>
   </g>
   <g fill="currentColor" opacity="0.18">
-    <text x="206" y="172" fontFamily="ui-monospace, monospace" fontSize="20" textAnchor="middle">2</text>
+    <text x="206" y="172" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" textAnchor="middle">2</text>
   </g>
   <g fill="currentColor" opacity="0.2">
     <rect x="120" y="210" width="400" height="5" rx="2.5" />

--- a/content/learn/sql-analytics-duckdb/reproducible-analytical-workflows.mdx
+++ b/content/learn/sql-analytics-duckdb/reproducible-analytical-workflows.mdx
@@ -44,7 +44,7 @@ the habits that turn a one-off query into analysis others can rely on.
     <circle cx="396" cy="110" r="2.5" />
   </g>
   <g fill="currentColor" opacity="0.4">
-    <text x="424" y="118" fontFamily="ui-monospace, monospace" fontSize="22" textAnchor="middle">=</text>
+    <text x="424" y="118" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" textAnchor="middle">=</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="452" y="62" width="116" height="20" rx="10" fillOpacity="0.85" />

--- a/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
+++ b/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
@@ -252,7 +252,7 @@ analytical `SELECT` lists are for.
     <rect x="70" y="92" width="84" height="20" rx="10" fillOpacity="0.85" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="248" y="89" fontFamily="ui-monospace, monospace" fontSize="30" textAnchor="middle">÷</text>
+    <text x="248" y="89" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="30" textAnchor="middle">÷</text>
   </g>
   <g fill="currentColor" opacity="0.25">
     <circle cx="296" cy="79" r="3" />

--- a/content/learn/sqlite-for-beginners/aggregate-functions.mdx
+++ b/content/learn/sqlite-for-beginners/aggregate-functions.mdx
@@ -49,7 +49,7 @@ But many everyday questions are not detail questions. They are summary questions
     <rect x="308" y="42" width="88" height="74" rx="12" fillOpacity="0.9" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="352" y="90" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="30" fontWeight="700">Σ</text>
+    <text x="352" y="90" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="30" fontWeight="700">Σ</text>
   </g>
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <path d="M 352 132 Q 340 152 352 162 Q 364 152 352 132 Z" fillOpacity="0.85" />

--- a/content/learn/sqlite-for-beginners/data-types.mdx
+++ b/content/learn/sqlite-for-beginners/data-types.mdx
@@ -231,7 +231,7 @@ This does **not** mean types do not matter in SQLite. They still matter because 
     <circle cx="463" cy="74" r="3" />
   </g>
   <g fill="currentColor" opacity="0.4">
-    <text x="478" y="92" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="600">?</text>
+    <text x="478" y="92" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="600">?</text>
   </g>
 </svg>
 

--- a/content/learn/sqlite-for-beginners/expressions-and-aliases.mdx
+++ b/content/learn/sqlite-for-beginners/expressions-and-aliases.mdx
@@ -23,7 +23,7 @@ make text uppercase. An **alias** gives the computed result a clear name.
     <circle cx="262" cy="28" r="13" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="217" y="44" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="22" fontWeight="700">*</text>
+    <text x="217" y="44" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fontWeight="700">*</text>
   </g>
   <g fill="currentColor" opacity="0.25">
     <circle cx="180" cy="60" r="2.5" />
@@ -199,7 +199,7 @@ text together.
     <rect x="96" y="34" width="120" height="18" rx="9" fillOpacity="0.85" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="248" y="50" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fontWeight="700">||</text>
+    <text x="248" y="50" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fontWeight="700">||</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="282" y="34" width="96" height="18" rx="9" fillOpacity="0.85" />

--- a/content/learn/sqlite-for-beginners/first-queries.mdx
+++ b/content/learn/sqlite-for-beginners/first-queries.mdx
@@ -38,14 +38,14 @@ One important habit: each block is **independent**. If one block creates a table
     <path d="M 60 22 Q 60 12 70 12 L 196 12 Q 206 12 206 22 L 206 56 Q 206 66 196 66 L 120 66 L 100 84 L 106 66 L 70 66 Q 60 66 60 56 Z" />
   </g>
   <g fill="currentColor" opacity="0.55">
-    <text x="133" y="48" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="600">2+2</text>
+    <text x="133" y="48" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="600">2+2</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <rect x="452" y="14" width="64" height="58" rx="9" fillOpacity="0.3" />
     <rect x="452" y="14" width="64" height="18" rx="9" fillOpacity="0.8" />
   </g>
   <g fill="currentColor" opacity="0.6">
-    <text x="484" y="60" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="700">4</text>
+    <text x="484" y="60" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700">4</text>
   </g>
   <g fill="currentColor" opacity="0.2">
     <path d="M 500 80 L 516 72 L 510 88 Z" />

--- a/content/learn/sqlite-for-beginners/foreign-keys.mdx
+++ b/content/learn/sqlite-for-beginners/foreign-keys.mdx
@@ -80,9 +80,9 @@ This keeps data tidy:
     <rect x="508" y="166" width="76" height="44" rx="7" transform="rotate(-7 546 188)" fillOpacity="0.4" />
   </g>
   <g fill="currentColor" opacity="0.6">
-    <text x="176" y="207" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" transform="rotate(-5 176 200)">1</text>
-    <text x="424" y="207" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" transform="rotate(4 424 200)">3</text>
-    <text x="546" y="195" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20" fontWeight="700" transform="rotate(-7 546 188)">7</text>
+    <text x="176" y="207" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" transform="rotate(-5 176 200)">1</text>
+    <text x="424" y="207" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" transform="rotate(4 424 200)">3</text>
+    <text x="546" y="195" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fontWeight="700" transform="rotate(-7 546 188)">7</text>
   </g>
   <g fill="currentColor" opacity="0.14">
     <circle cx="588" cy="80" r="8" />

--- a/content/learn/sqlite-for-beginners/grouping-data.mdx
+++ b/content/learn/sqlite-for-beginners/grouping-data.mdx
@@ -65,9 +65,9 @@ Aggregate functions can summarize a whole table into one answer. That is useful,
     <rect x="534" y="124" width="26" height="22" rx="6" fillOpacity="0.35" />
   </g>
   <g fill="currentColor" opacity="0.55">
-    <text x="219" y="141" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">3</text>
-    <text x="383" y="141" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">2</text>
-    <text x="547" y="141" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="700">1</text>
+    <text x="219" y="141" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">3</text>
+    <text x="383" y="141" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">2</text>
+    <text x="547" y="141" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="700">1</text>
   </g>
 </svg>
 

--- a/content/learn/sqlite-for-beginners/primary-keys.mdx
+++ b/content/learn/sqlite-for-beginners/primary-keys.mdx
@@ -58,8 +58,8 @@ That is the job of a **primary key**: it gives each row a reliable identity.
     <circle cx="357" cy="190" r="13" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="177" y="196" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700">1</text>
-    <text x="357" y="196" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15" fontWeight="700">2</text>
+    <text x="177" y="196" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700">1</text>
+    <text x="357" y="196" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" fontWeight="700">2</text>
   </g>
 </svg>
 

--- a/content/learn/sqlite-for-beginners/query-execution-order.mdx
+++ b/content/learn/sqlite-for-beginners/query-execution-order.mdx
@@ -34,11 +34,11 @@ This is one of the most clarifying ideas in all of SQL.
     <rect x="536" y="40" width="30" height="30" rx="8" fillOpacity="0.75" />
   </g>
   <g style={{ color: "var(--ds-white)" }} fill="currentColor">
-    <text x="111" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">1</text>
-    <text x="221" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">2</text>
-    <text x="331" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">3</text>
-    <text x="441" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">4</text>
-    <text x="551" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17" fontWeight="700">5</text>
+    <text x="111" y="62" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" fontWeight="700">1</text>
+    <text x="221" y="62" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" fontWeight="700">2</text>
+    <text x="331" y="62" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" fontWeight="700">3</text>
+    <text x="441" y="62" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" fontWeight="700">4</text>
+    <text x="551" y="62" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17" fontWeight="700">5</text>
   </g>
   <g fill="currentColor" opacity="0.2">
     <rect x="108" y="70" width="6" height="80" rx="3" />

--- a/content/learn/sqlite-for-beginners/why-databases-exist.mdx
+++ b/content/learn/sqlite-for-beginners/why-databases-exist.mdx
@@ -330,11 +330,11 @@ The question is not "files or databases forever?"
     <path d="M 110 116 L 134 84 L 152 104 L 168 88 L 184 112 L 184 124 L 110 124 Z" transform="rotate(-4 145 100)" fillOpacity="0.55" />
     <circle cx="126" cy="70" r="8" transform="rotate(-4 145 100)" fillOpacity="0.8" />
   </g>
-  <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
+  <g style={{ color: "var(--ds-teal-500)" }} fill="currentColor">
     <rect x="296" y="76" width="48" height="48" rx="9" transform="rotate(45 320 100)" fillOpacity="0.85" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="320" y="108" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700">?</text>
+    <text x="320" y="108" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700" style={{ fill: "var(--ds-white)", opacity: 1 }}>?</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="430" y="48" width="44" height="30" rx="5" fillOpacity="0.75" />

--- a/content/learn/sqlite-for-beginners/why-databases-exist.mdx
+++ b/content/learn/sqlite-for-beginners/why-databases-exist.mdx
@@ -334,7 +334,7 @@ The question is not "files or databases forever?"
     <rect x="296" y="76" width="48" height="48" rx="9" transform="rotate(45 320 100)" fillOpacity="0.85" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="320" y="108" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fontWeight="700">?</text>
+    <text x="320" y="108" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fontWeight="700">?</text>
   </g>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="430" y="48" width="44" height="30" rx="5" fillOpacity="0.75" />

--- a/content/learn/sqlite-for-beginners/working-with-null.mdx
+++ b/content/learn/sqlite-for-beginners/working-with-null.mdx
@@ -312,8 +312,8 @@ values.
     <circle cx="460" cy="104" r="9" fillOpacity="0.4" />
   </g>
   <g fill="currentColor" opacity="0.45">
-    <text x="122" y="112" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="600">?</text>
-    <text x="238" y="112" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fontWeight="600">?</text>
+    <text x="122" y="112" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="600">?</text>
+    <text x="238" y="112" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fontWeight="600">?</text>
   </g>
 </svg>
 

--- a/content/learn/statistics-for-data-science-python/central-limit-theorem.mdx
+++ b/content/learn/statistics-for-data-science-python/central-limit-theorem.mdx
@@ -45,10 +45,10 @@ the **mean**, things converge to the same familiar bell curve.
     <circle cx="488" cy="94" r="2.5" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="106" y="158" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">1</text>
-    <text x="258" y="158" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">5</text>
-    <text x="408" y="158" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">30</text>
-    <text x="548" y="158" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">100</text>
+    <text x="106" y="158" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">1</text>
+    <text x="258" y="158" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">5</text>
+    <text x="408" y="158" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">30</text>
+    <text x="548" y="158" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">100</text>
   </g>
 </svg>
 

--- a/content/learn/statistics-for-data-science-python/confidence-intervals.mdx
+++ b/content/learn/statistics-for-data-science-python/confidence-intervals.mdx
@@ -373,7 +373,7 @@ responds to exactly three levers:
     <rect x="68" y="88" width="130" height="8" rx="4" fillOpacity="0.3" />
     <rect x="103" y="126" width="60" height="8" rx="4" fillOpacity="0.75" />
   </g>
-  <text x="319" y="62" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fill="currentColor" opacity="0.5">%</text>
+  <text x="319" y="62" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fill="currentColor" opacity="0.5">%</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="289" y="88" width="60" height="8" rx="4" fillOpacity="0.75" />
     <rect x="254" y="126" width="130" height="8" rx="4" fillOpacity="0.3" />

--- a/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
@@ -36,7 +36,7 @@ into place.
   </g>
   <g style={{ color: "var(--ds-red-500)" }} fill="currentColor">
     <rect x="129" y="96" width="2.5" height="64" fillOpacity="0.9" />
-    <text x="130" y="86" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">0</text>
+    <text x="130" y="86" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">0</text>
   </g>
 </svg>
 
@@ -304,7 +304,7 @@ print(f"90th percentile score  = {scores.ppf(0.9):.1f}")
     <circle cx="429.5" cy="166" r="6" />
     <circle cx="478" cy="48" r="17" fillOpacity="0.2" />
   </g>
-  <text x="478" y="54" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="16" fill="currentColor" opacity="0.6">%</text>
+  <text x="478" y="54" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="16" fill="currentColor" opacity="0.6">%</text>
   <g fill="currentColor" opacity="0.35">
     <circle cx="466" cy="74" r="2.5" />
     <circle cx="454" cy="92" r="2.5" />

--- a/content/learn/statistics-for-data-science-python/correlation-and-nonparametric.mdx
+++ b/content/learn/statistics-for-data-science-python/correlation-and-nonparametric.mdx
@@ -354,11 +354,11 @@ is the rank-based cousin of the **independent** two-sample t-test, and
     <circle cx="500" cy="146" r="8" />
   </g>
   <g fill="currentColor" opacity="0.55">
-    <text x="120" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">1</text>
-    <text x="215" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">2</text>
-    <text x="310" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">3</text>
-    <text x="405" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">4</text>
-    <text x="500" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">5</text>
+    <text x="120" y="178" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13">1</text>
+    <text x="215" y="178" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13">2</text>
+    <text x="310" y="178" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13">3</text>
+    <text x="405" y="178" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13">4</text>
+    <text x="500" y="178" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13">5</text>
   </g>
 </svg>
 

--- a/content/learn/statistics-for-data-science-python/discrete-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/discrete-distributions.mdx
@@ -374,9 +374,9 @@ more** — a spike worth staffing for?
     <rect x="500" y="84" width="5" height="24" rx="2.5" />
   </g>
   <g fill="currentColor" opacity="0.55">
-    <text x="146" y="68" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17">2</text>
-    <text x="320" y="68" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17">5</text>
-    <text x="494" y="68" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="17">1</text>
+    <text x="146" y="68" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17">2</text>
+    <text x="320" y="68" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17">5</text>
+    <text x="494" y="68" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="17">1</text>
   </g>
 </svg>
 

--- a/content/learn/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
+++ b/content/learn/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
@@ -51,7 +51,7 @@ statistics is to keep those two activities on opposite sides of a wall.
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <circle cx="244" cy="120" r="11" fillOpacity="0.25" />
   </g>
-  <text x="244" y="126" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.6">?</text>
+  <text x="244" y="126" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.6">?</text>
   <g fill="currentColor" opacity="0.4">
     <circle cx="262" cy="88" r="2.5" />
     <circle cx="286" cy="56" r="2.5" />

--- a/content/learn/statistics-for-data-science-python/probability-basics.mdx
+++ b/content/learn/statistics-for-data-science-python/probability-basics.mdx
@@ -34,9 +34,9 @@ the vocabulary and the handful of rules everything else rests on.
     <path d="M 200 110 L 132.5 71 A 78 78 0 0 1 200 32 Z" />
   </g>
   <g fill="currentColor" opacity="0.7">
-    <text x="246" y="116" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15">2</text>
-    <text x="172" y="162" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15">4</text>
-    <text x="172" y="72" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="15">6</text>
+    <text x="246" y="116" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15">2</text>
+    <text x="172" y="162" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15">4</text>
+    <text x="172" y="72" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15">6</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <path d="M 190 12 L 210 12 L 200 32 Z" />

--- a/content/learn/statistics-for-data-science-python/probability-basics.mdx
+++ b/content/learn/statistics-for-data-science-python/probability-basics.mdx
@@ -33,10 +33,10 @@ the vocabulary and the handful of rules everything else rests on.
     <path d="M 200 110 L 200 188 A 78 78 0 0 1 132.5 149 Z" />
     <path d="M 200 110 L 132.5 71 A 78 78 0 0 1 200 32 Z" />
   </g>
-  <g fill="currentColor" opacity="0.7">
-    <text x="246" y="116" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15">2</text>
-    <text x="172" y="162" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15">4</text>
-    <text x="172" y="72" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15">6</text>
+  <g opacity="0.7">
+    <text x="246" y="116" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" style={{ fill: "var(--ds-white)" }}>2</text>
+    <text x="172" y="162" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" style={{ fill: "var(--ds-white)" }}>4</text>
+    <text x="172" y="72" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="15" style={{ fill: "var(--ds-white)" }}>6</text>
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <path d="M 190 12 L 210 12 L 200 32 Z" />

--- a/content/learn/statistics-for-data-science-python/random-variables.mdx
+++ b/content/learn/statistics-for-data-science-python/random-variables.mdx
@@ -49,7 +49,7 @@ real-world decisions.
   </g>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="266" y="80" width="72" height="72" rx="14" fillOpacity="0.18" />
-    <text x="302" y="128" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="34">ƒ</text>
+    <text x="302" y="128" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="34">ƒ</text>
   </g>
   <g fill="currentColor" opacity="0.3">
     <circle cx="358" cy="120" r="2.5" />
@@ -63,9 +63,9 @@ real-world decisions.
     <circle cx="572" cy="138" r="6" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="436" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">0</text>
-    <text x="504" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">1</text>
-    <text x="572" y="178" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14">2</text>
+    <text x="436" y="178" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">0</text>
+    <text x="504" y="178" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">1</text>
+    <text x="572" y="178" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14">2</text>
   </g>
 </svg>
 

--- a/content/learn/statistics-for-data-science-python/shape-and-outliers.mdx
+++ b/content/learn/statistics-for-data-science-python/shape-and-outliers.mdx
@@ -276,7 +276,7 @@ for opposite responses:
     <path d="M396 80 a34 34 0 1 0 68 0 a34 34 0 1 0 -68 0 M404 80 a26 26 0 1 0 52 0 a26 26 0 1 0 -52 0" fillRule="evenodd" />
     <rect x="448" y="98" width="14" height="56" rx="7" transform="rotate(-45 455 105)" />
   </g>
-  <text x="430" y="66" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="18" fill="currentColor" opacity="0.55">?</text>
+  <text x="430" y="66" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="18" fill="currentColor" opacity="0.55">?</text>
 </svg>
 
 <Callout type="danger" title="Misconception: outliers are errors you should delete">

--- a/content/learn/statistics-for-data-science-python/standard-error.mdx
+++ b/content/learn/statistics-for-data-science-python/standard-error.mdx
@@ -235,9 +235,9 @@ The curve drops steeply at first, then flattens into a long, slow crawl.
     <rect x="256" y="146" width="330" height="24" rx="5" fillOpacity="0.55" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="72" y="192" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">25</text>
-    <text x="170" y="192" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">100</text>
-    <text x="421" y="192" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="13">400</text>
+    <text x="72" y="192" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13">25</text>
+    <text x="170" y="192" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13">100</text>
+    <text x="421" y="192" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="13">400</text>
   </g>
 </svg>
 

--- a/content/learn/statistics-for-data-science-python/the-normal-distribution.mdx
+++ b/content/learn/statistics-for-data-science-python/the-normal-distribution.mdx
@@ -302,8 +302,8 @@ print("\\nSame answer: standardizing and using norm.cdf are equivalent.")
     <rect x="450" y="148" width="4" height="12" rx="2" />
     <rect x="516" y="148" width="4" height="12" rx="2" />
   </g>
-  <text x="320" y="182" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.5">0</text>
-  <text x="452" y="182" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.5">+2</text>
+  <text x="320" y="182" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.5">0</text>
+  <text x="452" y="182" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fill="currentColor" opacity="0.5">+2</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <circle cx="446" cy="132" r="6.5" />
   </g>

--- a/content/learn/statistics-for-data-science-python/visualizing-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/visualizing-distributions.mdx
@@ -44,8 +44,8 @@ every chart runs as-is.
     <rect x="470" y="166" width="60" height="7" rx="3.5" />
   </g>
   <g fill="currentColor" opacity="0.5">
-    <text x="230" y="166" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20">=</text>
-    <text x="410" y="166" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="20">=</text>
+    <text x="230" y="166" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20">=</text>
+    <text x="410" y="166" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20">=</text>
   </g>
 </svg>
 

--- a/content/learn/systems-programming-c/arrays-and-pointers.mdx
+++ b/content/learn/systems-programming-c/arrays-and-pointers.mdx
@@ -10,7 +10,7 @@ not quite a pointer, but it *becomes* one almost any time you use it.
 <svg
   viewBox="0 0 640 200"
   role="img"
-  aria-label="A six-car array train with a yellow length badge rolls under a function arch and emerges as ghost cars led by a single blue pointer flag — the badge drops off at the gate, because arrays decay to a bare pointer when passed in"
+  aria-label="A six-car array train with a teal length badge rolls under a function arch and emerges as ghost cars led by a single blue pointer flag — the badge drops off at the gate, because arrays decay to a bare pointer when passed in"
   style={{ display: "block", width: "100%", maxWidth: "640px", height: "auto", margin: "2.5rem auto" }}
 >
   <rect x="40" y="158" width="560" height="5" rx="2.5" fill="currentColor" opacity="0.2" />
@@ -34,10 +34,10 @@ not quite a pointer, but it *becomes* one almost any time you use it.
     <circle cx="263" cy="135" r="4" />
   </g>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
-    <circle cx="73" cy="96" r="13" />
+    <circle cx="73" cy="96" r="13" style={{ fill: "var(--ds-teal-500)" }} />
     <circle cx="388" cy="140" r="10" fillOpacity="0.85" />
   </g>
-  <text x="73" y="101" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fontWeight="700" fill="currentColor" opacity="0.75">6</text>
+  <text x="73" y="101" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fontWeight="700" style={{ fill: "var(--ds-white)" }}>6</text>
   <g fill="currentColor" opacity="0.22">
     <rect x="330" y="58" width="14" height="100" rx="4" />
     <rect x="396" y="58" width="14" height="100" rx="4" />

--- a/content/learn/systems-programming-c/arrays-and-pointers.mdx
+++ b/content/learn/systems-programming-c/arrays-and-pointers.mdx
@@ -37,13 +37,13 @@ not quite a pointer, but it *becomes* one almost any time you use it.
     <circle cx="73" cy="96" r="13" />
     <circle cx="388" cy="140" r="10" fillOpacity="0.85" />
   </g>
-  <text x="73" y="101" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="14" fontWeight="700" fill="currentColor" opacity="0.75">6</text>
+  <text x="73" y="101" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="14" fontWeight="700" fill="currentColor" opacity="0.75">6</text>
   <g fill="currentColor" opacity="0.22">
     <rect x="330" y="58" width="14" height="100" rx="4" />
     <rect x="396" y="58" width="14" height="100" rx="4" />
     <rect x="322" y="44" width="96" height="16" rx="8" />
   </g>
-  <text x="370" y="58" textAnchor="middle" fontFamily="Georgia, serif" fontStyle="italic" fontSize="15" fill="currentColor" opacity="0.55">ƒ</text>
+  <text x="370" y="58" textAnchor="middle" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="15" fill="currentColor" opacity="0.55">ƒ</text>
   <g fill="currentColor" opacity="0.25">
     <rect x="385" y="112" width="4" height="8" rx="2" />
     <rect x="392" y="122" width="4" height="8" rx="2" />

--- a/content/learn/systems-programming-c/c-toolchain.mdx
+++ b/content/learn/systems-programming-c/c-toolchain.mdx
@@ -255,7 +255,7 @@ linker.
     <circle cx="205" cy="100" r="7" fillOpacity="0.55" />
   </g>
   <path d="M242 100 h110 v52 h-110 Z M248 106 h98 v40 h-98 Z" fillRule="evenodd" fill="currentColor" opacity="0.18" />
-  <text x="297" y="134" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="22" fill="currentColor" opacity="0.4">?</text>
+  <text x="297" y="134" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fill="currentColor" opacity="0.4">?</text>
   <g fill="currentColor" opacity="0.3">
     <circle cx="470" cy="116" r="2.5" />
     <circle cx="440" cy="128" r="2.5" />

--- a/content/learn/systems-programming-c/memory-bugs.mdx
+++ b/content/learn/systems-programming-c/memory-bugs.mdx
@@ -95,7 +95,7 @@ patterns is half the battle.
     <circle cx="249" cy="198" r="2.5" />
     <circle cx="266" cy="196" r="2.5" />
   </g>
-  <text x="249" y="186" textAnchor="middle" fontFamily="ui-monospace, monospace" fontSize="24" fill="currentColor" opacity="0.45">?</text>
+  <text x="249" y="186" textAnchor="middle" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="24" fill="currentColor" opacity="0.45">?</text>
   <circle cx="386" cy="150" r="13" fill="currentColor" opacity="0.1" />
   <path d="M384 204 Q378 190 384 176 Q390 165 386 152 L389 151 Q394 165 388 177 Q382 190 388 204 Z" fill="currentColor" opacity="0.4" />
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">

--- a/content/learn/time-series-analysis-python/decomposition-trend-seasonality.mdx
+++ b/content/learn/time-series-analysis-python/decomposition-trend-seasonality.mdx
@@ -38,15 +38,15 @@ and known noise, then ask `seasonal_decompose` to hand the pieces back.
     <circle cx="340" cy="44" r="4" />
     <circle cx="440" cy="34" r="4" />
   </g>
-  <text x="60" y="124" fontFamily="ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">=</text>
+  <text x="60" y="124" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">=</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <path d="M 90 130 L 550 96 L 550 104 L 90 138 Z" fillOpacity="0.55" />
   </g>
-  <text x="60" y="182" fontFamily="ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">+</text>
+  <text x="60" y="182" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">+</text>
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <path d="M 90 176 C 113 158 136 158 159 176 C 182 194 205 194 228 176 C 251 158 274 158 297 176 C 320 194 343 194 366 176 C 389 158 412 158 435 176 C 458 194 481 194 504 176 C 527 158 538 158 550 166 L 550 176 C 538 168 527 168 504 186 C 481 204 458 204 435 186 C 412 168 389 168 366 186 C 343 204 320 204 297 186 C 274 168 251 168 228 186 C 205 204 182 204 159 186 C 136 168 113 168 90 186 Z" fillOpacity="0.55" />
   </g>
-  <text x="60" y="232" fontFamily="ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">+</text>
+  <text x="60" y="232" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">+</text>
   <g fill="currentColor" opacity="0.45">
     <circle cx="104" cy="228" r="3" />
     <circle cx="140" cy="220" r="3" />
@@ -253,7 +253,7 @@ ones until they're the same size — exactly what an additive model wants.
   <g style={{ color: "var(--ds-yellow-500)" }} fill="currentColor">
     <path d="M 286 100 a 34 34 0 1 0 68 0 a 34 34 0 1 0 -68 0 Z M 294 100 a 26 26 0 1 0 52 0 a 26 26 0 1 0 -52 0 Z" fillRule="evenodd" />
   </g>
-  <text x="320" y="107" fontFamily="Georgia, serif" fontStyle="italic" fontSize="20" fill="currentColor" opacity="0.55" textAnchor="middle">ln</text>
+  <text x="320" y="107" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="20" fill="currentColor" opacity="0.55" textAnchor="middle">ln</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <path d="M 370 100 C 380 88 390 84 400 84 C 415 84 430 116 445 116 C 460 116 475 84 490 84 C 505 84 520 116 535 116 C 550 116 562 96 580 92 L 580 101 C 562 105 550 125 535 125 C 520 125 505 93 490 93 C 475 93 460 125 445 125 C 430 125 415 93 400 93 C 390 93 380 97 370 109 Z" fillOpacity="0.6" />
   </g>

--- a/content/learn/time-series-analysis-python/differencing.mdx
+++ b/content/learn/time-series-analysis-python/differencing.mdx
@@ -29,7 +29,7 @@ too far.
     <circle cx="360" cy="128" r="3.5" />
     <circle cx="376" cy="128" r="3.5" />
   </g>
-  <text x="497" y="140" fontFamily="ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">Δ</text>
+  <text x="497" y="140" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="20" fill="currentColor" opacity="0.45" textAnchor="middle">Δ</text>
   <g style={{ color: "var(--ds-green-500)" }} fill="currentColor">
     <rect x="396" y="164" width="34" height="20" rx="5" fillOpacity="0.85" />
     <rect x="438" y="164" width="34" height="20" rx="5" fillOpacity="0.85" />

--- a/content/learn/time-series-analysis-python/resampling-and-aggregation.mdx
+++ b/content/learn/time-series-analysis-python/resampling-and-aggregation.mdx
@@ -180,7 +180,7 @@ This is the choice beginners get wrong most often. The rule:
     <rect x="158" y="116" width="44" height="16" rx="4" fillOpacity="0.7" />
     <rect x="158" y="98" width="44" height="16" rx="4" fillOpacity="0.55" />
   </g>
-  <text x="116" y="128" fontFamily="ui-monospace, monospace" fontSize="22" fill="currentColor" opacity="0.45">Σ</text>
+  <text x="116" y="128" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="22" fill="currentColor" opacity="0.45">Σ</text>
   <g style={{ color: "var(--ds-blue-500)" }} fill="currentColor">
     <rect x="368" y="124" width="184" height="9" rx="4.5" fillOpacity="0.35" />
     <circle cx="380" cy="112" r="5" />

--- a/content/learn/time-series-analysis-python/rolling-and-expanding-windows.mdx
+++ b/content/learn/time-series-analysis-python/rolling-and-expanding-windows.mdx
@@ -313,7 +313,7 @@ stops. People see a smooth upward moving-average curve and imagine it
     <path d="M 502 62 a 6 6 0 1 0 12 0 a 6 6 0 1 0 -12 0 Z M 505 62 a 3 3 0 1 0 6 0 a 3 3 0 1 0 -6 0 Z" fillRule="evenodd" />
     <path d="M 538 56 a 6 6 0 1 0 12 0 a 6 6 0 1 0 -12 0 Z M 541 56 a 3 3 0 1 0 6 0 a 3 3 0 1 0 -6 0 Z" fillRule="evenodd" />
   </g>
-  <text x="500" y="124" fontFamily="ui-monospace, monospace" fontSize="30" fill="currentColor" opacity="0.45" textAnchor="middle">?</text>
+  <text x="500" y="124" fontFamily="var(--font-mono), ui-monospace, monospace" fontSize="30" fill="currentColor" opacity="0.45" textAnchor="middle">?</text>
 </svg>
 
 <CodeBlock

--- a/content/learn/typescript-from-scratch/generics-basics.mdx
+++ b/content/learn/typescript-from-scratch/generics-basics.mdx
@@ -363,7 +363,7 @@ This is the power of generics: you write one function, and the compiler figures 
   <g fill="currentColor" opacity="0.08">
     <rect x="120" y="76" width="440" height="28" rx="14" />
   </g>
-  <text x="96" y="99" fontFamily="Georgia, serif" fontStyle="italic" fontSize="22" fill="currentColor" fillOpacity="0.45" textAnchor="middle">ƒ</text>
+  <text x="96" y="99" fontFamily="var(--font-sans), Georgia, serif" fontStyle="italic" fontSize="22" fill="currentColor" fillOpacity="0.45" textAnchor="middle">ƒ</text>
   <g fill="currentColor" opacity="0.25">
     <circle cx="160" cy="90" r="2.5" />
     <circle cx="250" cy="90" r="2.5" />


### PR DESCRIPTION
## What & why

Custom inline SVG graphics across the `/learn` courses were using non-project fonts (the browser default `ui-monospace` instead of JetBrains Mono, and `Georgia` serif), and several had poor text/background contrast — most notably dark/gray glyphs on solid colored fills and gray text on solid yellow backgrounds.

This PR makes the custom SVGs (not Mermaid charts) consistent with the project's design system.

## Changes

**Fonts (mechanical, all custom SVGs)**
- `fontFamily="ui-monospace, monospace"` → `var(--font-mono), ui-monospace, monospace` (JetBrains Mono) — 193 occurrences
- `fontFamily="Georgia, serif"` → `var(--font-sans), Georgia, serif` (Inter) — 33 occurrences

**Contrast (per-SVG review of the 124 files containing `<text>`)**
- Text that sits on a **solid green / red / blue** fill is now **white** where it previously inherited a dark/gray color.
- **Solid yellow backgrounds that carried gray text** are recolored to **teal-500** with **white text**, for consistent, legible contrast. Affected `aria-label`s that named the color ("yellow …") were updated to "teal".

**Deliberately left unchanged**
- Decorative yellow shapes with no text on them (tags, dots, accent bars, chart marks).
- Dark text sitting over faint translucent tints (low-opacity backgrounds), where dark text is the correct, readable choice.
- Mermaid code blocks, `CodeBlock`, `ChallengeCard`, prose, and SVG geometry.

21 files received contrast edits; 124 SVG-bearing files were reviewed individually to determine which text actually overlaps which filled shape.

https://claude.ai/code/session_01JzmpghXRPrB8Z2ZRZSacm7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzmpghXRPrB8Z2ZRZSacm7)_