### PR TITLE
Tighten /learn serif tracking; add build-time SVG graphics gallery

### DIFF
--- a/__tests__/svgGallery.test.ts
+++ b/__tests__/svgGallery.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { remark } from "remark";
+import remarkMdx from "remark-mdx";
+import { remarkMdxMermaid } from "fumadocs-core/mdx-plugins";
+import { VFile } from "vfile";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { remarkSvgLabels } from "../lib/remarkSvgLabels";
+import { extractSvgGraphics } from "../lib/extractSvgGraphics";
+import { jsxSvgToHtml } from "../lib/jsxSvgToHtml";
+
+// The gallery is only useful if its IDs match the labels rendered on the live
+// lesson pages. These tests pin that parity: extractSvgGraphics() must yield the
+// same IDs (for <svg> graphics) that the remarkSvgLabels plugin stamps onto the
+// page — and never a Mermaid label.
+
+const labeller = remark().use(remarkMdx).use(remarkMdxMermaid).use(remarkSvgLabels);
+
+// figIds the plugin stamps; `svgOnly` keeps just those whose immediately
+// preceding sibling is an <svg> node (the plugin inserts each label right after
+// its graphic) — i.e. excluding Mermaid labels.
+function onPageIds(raw: string, p: string, svgOnly: boolean): string[] {
+  const vf = new VFile({ value: raw, path: p });
+  const tree = labeller.runSync(labeller.parse(vf), vf) as unknown as {
+    children: Array<Record<string, unknown>>;
+  };
+  const ids: string[] = [];
+  const walk = (n: Record<string, unknown>) => {
+    const kids = n.children as Array<Record<string, unknown>> | undefined;
+    if (!Array.isArray(kids)) return;
+    for (let i = 0; i < kids.length; i++) {
+      const c = kids[i];
+      if (c.type === "mdxJsxFlowElement" && c.name === "SvgLabel") {
+        const prev = kids[i - 1];
+        if (!svgOnly || (prev && prev.name === "svg")) {
+          const attrs = c.attributes as Array<{ name?: string; value?: unknown }>;
+          const v = attrs.find((a) => a.name === "figId")?.value;
+          if (typeof v === "string") ids.push(v);
+        }
+      }
+      walk(c);
+    }
+  };
+  walk(tree);
+  return ids;
+}
+
+const REPO = process.cwd();
+const abs = (rel: string) => path.join(REPO, rel);
+const read = (rel: string) => readFileSync(abs(rel), "utf8");
+
+// Lessons that mix <svg> graphics with Mermaid diagrams, with clean frontmatter
+// so the labeller can parse them for a direct on-page-vs-gallery comparison.
+const samples = [
+  "content/learn/intro-sql-postgres/filtering-rows.mdx",
+  "content/learn/intro-sql-postgres/what-is-a-database.mdx",
+];
+
+describe("extractSvgGraphics", () => {
+  it("computes IDs identical to the on-page <svg> labels, excluding Mermaid", () => {
+    for (const rel of samples) {
+      const raw = read(rel);
+      const gallery = extractSvgGraphics(raw, abs(rel)).map((g) => g.id);
+      // Reproduces exactly the svg labels, in document order…
+      expect(gallery).toEqual(onPageIds(raw, abs(rel), true));
+      // …and never a Mermaid label, even on pages that mix both.
+      const svgIds = new Set(onPageIds(raw, abs(rel), true));
+      const mermaidIds = onPageIds(raw, abs(rel), false).filter(
+        (id) => !svgIds.has(id),
+      );
+      expect(mermaidIds.length).toBeGreaterThan(0); // sample really does mix
+      for (const id of gallery) expect(mermaidIds).not.toContain(id);
+    }
+  });
+
+  it("matches the example ID format from the task", () => {
+    const rel = "content/learn/intro-sql-postgres/filtering-rows.mdx";
+    const ids = extractSvgGraphics(read(rel), abs(rel)).map((g) => g.id);
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) {
+      expect(id).toMatch(/^svg-intro-sql-postgres-filtering-rows-[0-9a-f]{6}$/);
+    }
+  });
+
+  it("parses lessons whose frontmatter contains JSX-like text", () => {
+    // error-handling-with-types.mdx carries TSX generics (`<T,>`) in its
+    // frontmatter — a frontmatter-unaware MDX parse would throw. Blanking the
+    // frontmatter lets it through and still yields its two graphics.
+    const rel = "content/learn/typescript-from-scratch/error-handling-with-types.mdx";
+    const graphics = extractSvgGraphics(read(rel), abs(rel));
+    expect(graphics.length).toBe(2);
+    for (const g of graphics) {
+      expect(g.id).toMatch(
+        /^svg-typescript-from-scratch-error-handling-with-types-[0-9a-f]{6}$/,
+      );
+      expect(g.html.startsWith("<svg")).toBe(true);
+    }
+  });
+
+  it("returns [] for unreadable/SVG-less content without throwing", () => {
+    expect(extractSvgGraphics("# Just prose\n\nNo graphics here.", abs("x/y.mdx"))).toEqual([]);
+  });
+});
+
+describe("jsxSvgToHtml", () => {
+  it("converts style objects and camelCase attributes to valid SVG", () => {
+    const src =
+      '<svg viewBox="0 0 10 10" style={{ display: "block", maxWidth: "640px" }}>' +
+      '<rect x="1" y="1" width="8" height="8" fillOpacity="0.75" />' +
+      "</svg>";
+    const html = jsxSvgToHtml(src);
+    expect(html).toContain('viewBox="0 0 10 10"'); // casing preserved
+    expect(html).toContain('style="display: block; max-width: 640px"');
+    expect(html).toContain('fill-opacity="0.75"');
+    expect(html).not.toContain("{{");
+    expect(html).not.toContain("fillOpacity");
+  });
+
+  it("preserves real authored graphics structurally", () => {
+    const rel = "content/learn/intro-sql-postgres/filtering-rows.mdx";
+    const html = extractSvgGraphics(read(rel), abs(rel))[0].html;
+    expect(html.startsWith("<svg")).toBe(true);
+    expect(html.trimEnd().endsWith("</svg>")).toBe(true);
+    expect(html).not.toContain("={{");
+    expect(html).not.toContain("fillOpacity");
+    expect(html).toContain("fill-opacity=");
+  });
+});

--- a/app/_components/mdx/SvgLabel.tsx
+++ b/app/_components/mdx/SvgLabel.tsx
@@ -1,6 +1,9 @@
 export function SvgLabel({ figId }: { figId: string }) {
   return (
+    // `id={figId}` makes each graphic a deep-link target, so the build-time
+    // SVG gallery (/svg-gallery) can link straight to a graphic on its lesson.
     <div
+      id={figId}
       data-svg-id={figId}
       style={{
         fontFamily: "var(--font-sans)",

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -427,8 +427,10 @@ code.hljs {
                                       text overflows its measured node boxes
    - h1–h6                            headings (handled separately)
    Optical size axis (opsz) is enabled via font-variation-settings so the
-   typeface self-optimises at body text sizes. Letter-spacing resets to 0
-   to avoid the tight value set on `body` above bleeding into serif text.
+   typeface self-optimises at body text sizes. Letter-spacing is pulled in
+   slightly (−0.006em) for a tighter, more polished editorial colour — a
+   gentler value than the −0.011em Inter tracking on `body`, since Source
+   Serif sets a touch looser than Inter at the same measure.
    ─────────────────────────────────────────────────────────────────────── */
 .prose :where(p, li, td, th):not(
   :where([class~="not-prose"], [class~="not-prose"] *),
@@ -444,7 +446,7 @@ code.hljs {
   font-size: 1.125rem;
   line-height: 1.75;
   font-variation-settings: "opsz" 16;
-  letter-spacing: 0;
+  letter-spacing: -0.006em;
 }
 
 /* ── Table and callout font-size override ────────────────────────────────

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,6 +74,9 @@ export default async function Home() {
           <Link href="/color-test" className={styles.ctaSecondary}>
             Color Theme Test
           </Link>
+          <Link href="/svg-gallery" className={styles.ctaSecondary}>
+            SVG Gallery
+          </Link>
           <a
             href="https://github.com/dataslope/dataslope/"
             target="_blank"

--- a/app/svg-gallery/SvgGalleryClient.tsx
+++ b/app/svg-gallery/SvgGalleryClient.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * Interactive shell for the SVG graphics gallery. The graphic data is collected
+ * at build time (see `lib/svgGallery.ts`) and handed in as a prop; everything
+ * here — the light/dark theme toggle, course pagination, and per-graphic copy
+ * buttons — is client-side.
+ */
+import { useCallback, useState, useSyncExternalStore } from "react";
+import { Check, Copy, Moon, Sun } from "lucide-react";
+import type { GalleryCourse } from "@/lib/svgGallery";
+import styles from "./svg-gallery.module.css";
+
+const COURSES_PER_PAGE = 4;
+const THEME_KEY = "svg_gallery_theme";
+type Theme = "light" | "dark";
+
+// Theme is sourced from localStorage (falling back to the OS preference) via an
+// external store, so reading it needs no effect and the server snapshot stays a
+// stable "light" — avoiding both the set-state-in-effect lint and any hydration
+// mismatch. A module-level listener set lets the toggle notify subscribers
+// (the `storage` event doesn't fire in the same document).
+const themeListeners = new Set<() => void>();
+
+function readTheme(): Theme {
+  const saved = localStorage.getItem(THEME_KEY);
+  if (saved === "light" || saved === "dark") return saved;
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function useTheme(): [Theme, () => void] {
+  const theme = useSyncExternalStore<Theme>(
+    (cb) => {
+      themeListeners.add(cb);
+      return () => themeListeners.delete(cb);
+    },
+    readTheme,
+    () => "light",
+  );
+  const toggle = useCallback(() => {
+    localStorage.setItem(THEME_KEY, theme === "light" ? "dark" : "light");
+    themeListeners.forEach((l) => l());
+  }, [theme]);
+  return [theme, toggle];
+}
+
+export function SvgGalleryClient({ courses }: { courses: GalleryCourse[] }) {
+  const total = courses.reduce((n, c) => n + c.graphics.length, 0);
+  const pageCount = Math.max(1, Math.ceil(courses.length / COURSES_PER_PAGE));
+
+  const [theme, toggleTheme] = useTheme();
+  const [page, setPage] = useState(0);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const goTo = useCallback((p: number) => {
+    setPage(p);
+    window.scrollTo({ top: 0 });
+  }, []);
+
+  const copyMeta = useCallback(async (id: string, route: string) => {
+    const text = `SVG ID: ${id}   Route: ${route}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(id);
+      window.setTimeout(() => setCopied((c) => (c === id ? null : c)), 1500);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — ignore.
+    }
+  }, []);
+
+  const start = page * COURSES_PER_PAGE;
+  const visible = courses.slice(start, start + COURSES_PER_PAGE);
+
+  const pager =
+    pageCount > 1 ? (
+      <nav className={styles.pager} aria-label="Gallery pages">
+        <button
+          type="button"
+          className={styles.pagerBtn}
+          onClick={() => goTo(page - 1)}
+          disabled={page === 0}
+        >
+          ← Prev
+        </button>
+        <div className={styles.pagerNums}>
+          {Array.from({ length: pageCount }, (_, i) => (
+            <button
+              type="button"
+              key={i}
+              className={`${styles.pagerNum} ${i === page ? styles.pagerNumActive : ""}`}
+              onClick={() => goTo(i)}
+              aria-current={i === page ? "page" : undefined}
+            >
+              {i + 1}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className={styles.pagerBtn}
+          onClick={() => goTo(page + 1)}
+          disabled={page === pageCount - 1}
+        >
+          Next →
+        </button>
+      </nav>
+    ) : null;
+
+  return (
+    <div className={`${styles.page} ${theme === "dark" ? styles.dark : ""}`}>
+      <div className={styles.inner}>
+        <header className={styles.header}>
+          <div className={styles.headerRow}>
+            <h1 className={styles.title}>SVG graphics gallery</h1>
+            <button
+              type="button"
+              className={styles.themeToggle}
+              onClick={toggleTheme}
+              aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+              title={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+            >
+              {theme === "light" ? <Moon size={16} /> : <Sun size={16} />}
+              <span>{theme === "light" ? "Dark" : "Light"}</span>
+            </button>
+          </div>
+          <p className={styles.subtitle}>
+            Every custom inline <code>&lt;svg&gt;</code> graphic across the{" "}
+            <code>/learn</code> courses — <span className={styles.count}>{total}</span>{" "}
+            graphic{total === 1 ? "" : "s"} in {courses.length} course
+            {courses.length === 1 ? "" : "s"}. Mermaid diagrams are excluded.
+          </p>
+        </header>
+
+        {pager}
+
+        {total === 0 ? (
+          <p className={styles.empty}>No custom SVG graphics found.</p>
+        ) : (
+          visible.map((course) => (
+            <section key={course.slug} className={styles.course}>
+              <h2 className={styles.courseHeading}>
+                {course.title}
+                <span className={styles.courseSlug}>{course.slug}</span>
+                <span className={styles.courseCount}>
+                  {course.graphics.length} graphic
+                  {course.graphics.length === 1 ? "" : "s"}
+                </span>
+              </h2>
+              <div className={styles.list}>
+                {course.graphics.map((g) => (
+                  <figure key={g.id} className={styles.card}>
+                    <div
+                      className={styles.figure}
+                      // Authored SVG source, rewritten to valid markup by
+                      // jsxSvgToHtml in lib/jsxSvgToHtml.ts. Content is repo-owned.
+                      dangerouslySetInnerHTML={{ __html: g.html }}
+                    />
+                    <figcaption className={styles.meta}>
+                      <div className={styles.metaText}>
+                        <p className={styles.id}>{g.id}</p>
+                        <p className={styles.route}>{g.route}</p>
+                        <a className={styles.link} href={g.href}>
+                          View on lesson page →
+                        </a>
+                      </div>
+                      <button
+                        type="button"
+                        className={styles.copyBtn}
+                        onClick={() => copyMeta(g.id, g.route)}
+                        aria-label="Copy SVG ID and route"
+                        title="Copy SVG ID and route"
+                      >
+                        {copied === g.id ? (
+                          <Check size={15} />
+                        ) : (
+                          <Copy size={15} />
+                        )}
+                      </button>
+                    </figcaption>
+                  </figure>
+                ))}
+              </div>
+            </section>
+          ))
+        )}
+
+        {pager}
+      </div>
+    </div>
+  );
+}

--- a/app/svg-gallery/page.tsx
+++ b/app/svg-gallery/page.tsx
@@ -1,0 +1,76 @@
+/**
+ * `/svg-gallery` — a build-time review page for every custom inline `<svg>`
+ * graphic used across the `/learn` courses (Mermaid diagrams excluded).
+ *
+ * Each graphic is rendered alongside its globally-unique ID (the same label
+ * shown under the graphic on its lesson page, e.g.
+ * `svg-intro-sql-postgres-filtering-rows-f4f4db`) and a deep link to the
+ * lesson, so the whole set can be skimmed in one place to spot graphics that
+ * need replacing or removing.
+ *
+ * Generated entirely at build time: `force-static` pre-renders the route, and
+ * `getSvgGallery()` reads the MDX content from disk during that render. The
+ * page is intended for development but is harmless if publicly reachable.
+ */
+import type { Metadata } from "next";
+import { getSvgGallery } from "@/lib/svgGallery";
+import styles from "./svg-gallery.module.css";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = {
+  title: "SVG graphics gallery",
+  description: "Every custom SVG graphic used across the Dataslope courses.",
+  robots: { index: false, follow: false },
+};
+
+export default function SvgGalleryPage() {
+  const courses = getSvgGallery();
+  const total = courses.reduce((n, c) => n + c.graphics.length, 0);
+
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>SVG graphics gallery</h1>
+        <p className={styles.subtitle}>
+          Every custom inline <code>&lt;svg&gt;</code> graphic across the{" "}
+          <code>/learn</code> courses — <span className={styles.count}>{total}</span>{" "}
+          graphic{total === 1 ? "" : "s"} in {courses.length} course
+          {courses.length === 1 ? "" : "s"}. Mermaid diagrams are excluded. Each
+          graphic shows its ID and links to the lesson that contains it.
+        </p>
+      </header>
+
+      {total === 0 ? (
+        <p className={styles.empty}>No custom SVG graphics found.</p>
+      ) : (
+        courses.map((course) => (
+          <section key={course.slug} className={styles.course}>
+            <h2 className={styles.courseHeading}>
+              {course.title}
+              <span className={styles.courseSlug}>{course.slug}</span>
+            </h2>
+            <div className={styles.grid}>
+              {course.graphics.map((g) => (
+                <figure key={g.id} className={styles.card}>
+                  <div
+                    className={styles.figure}
+                    // Authored SVG source, rewritten to valid markup by
+                    // jsxSvgToHtml in lib/svgGallery.ts. Content is repo-owned.
+                    dangerouslySetInnerHTML={{ __html: g.html }}
+                  />
+                  <figcaption className={styles.meta}>
+                    <p className={styles.id}>{g.id}</p>
+                    <a className={styles.link} href={g.href}>
+                      View on lesson page →
+                    </a>
+                  </figcaption>
+                </figure>
+              ))}
+            </div>
+          </section>
+        ))
+      )}
+    </main>
+  );
+}

--- a/app/svg-gallery/page.tsx
+++ b/app/svg-gallery/page.tsx
@@ -4,17 +4,19 @@
  *
  * Each graphic is rendered alongside its globally-unique ID (the same label
  * shown under the graphic on its lesson page, e.g.
- * `svg-intro-sql-postgres-filtering-rows-f4f4db`) and a deep link to the
- * lesson, so the whole set can be skimmed in one place to spot graphics that
- * need replacing or removing.
+ * `svg-intro-sql-postgres-filtering-rows-f4f4db`), the lesson route, and a deep
+ * link to the lesson — so the whole set can be skimmed in one place to spot
+ * graphics that need replacing or removing.
  *
  * Generated entirely at build time: `force-static` pre-renders the route, and
  * `getSvgGallery()` reads the MDX content from disk during that render. The
- * page is intended for development but is harmless if publicly reachable.
+ * interactive shell (theme toggle, pagination, copy buttons) lives in the
+ * client component below. The page is intended for development but is harmless
+ * if publicly reachable.
  */
 import type { Metadata } from "next";
 import { getSvgGallery } from "@/lib/svgGallery";
-import styles from "./svg-gallery.module.css";
+import { SvgGalleryClient } from "./SvgGalleryClient";
 
 export const dynamic = "force-static";
 
@@ -25,52 +27,5 @@ export const metadata: Metadata = {
 };
 
 export default function SvgGalleryPage() {
-  const courses = getSvgGallery();
-  const total = courses.reduce((n, c) => n + c.graphics.length, 0);
-
-  return (
-    <main className={styles.page}>
-      <header className={styles.header}>
-        <h1 className={styles.title}>SVG graphics gallery</h1>
-        <p className={styles.subtitle}>
-          Every custom inline <code>&lt;svg&gt;</code> graphic across the{" "}
-          <code>/learn</code> courses — <span className={styles.count}>{total}</span>{" "}
-          graphic{total === 1 ? "" : "s"} in {courses.length} course
-          {courses.length === 1 ? "" : "s"}. Mermaid diagrams are excluded. Each
-          graphic shows its ID and links to the lesson that contains it.
-        </p>
-      </header>
-
-      {total === 0 ? (
-        <p className={styles.empty}>No custom SVG graphics found.</p>
-      ) : (
-        courses.map((course) => (
-          <section key={course.slug} className={styles.course}>
-            <h2 className={styles.courseHeading}>
-              {course.title}
-              <span className={styles.courseSlug}>{course.slug}</span>
-            </h2>
-            <div className={styles.grid}>
-              {course.graphics.map((g) => (
-                <figure key={g.id} className={styles.card}>
-                  <div
-                    className={styles.figure}
-                    // Authored SVG source, rewritten to valid markup by
-                    // jsxSvgToHtml in lib/svgGallery.ts. Content is repo-owned.
-                    dangerouslySetInnerHTML={{ __html: g.html }}
-                  />
-                  <figcaption className={styles.meta}>
-                    <p className={styles.id}>{g.id}</p>
-                    <a className={styles.link} href={g.href}>
-                      View on lesson page →
-                    </a>
-                  </figcaption>
-                </figure>
-              ))}
-            </div>
-          </section>
-        ))
-      )}
-    </main>
-  );
+  return <SvgGalleryClient courses={getSvgGallery()} />;
 }

--- a/app/svg-gallery/svg-gallery.module.css
+++ b/app/svg-gallery/svg-gallery.module.css
@@ -1,0 +1,132 @@
+.page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 6rem;
+  max-width: 1280px;
+  background: #ffffff;
+  color: var(--ds-gray-900, #111827);
+  font-family: var(--font-sans, system-ui, sans-serif);
+}
+
+.header {
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--ds-gray-200, #e5e7eb);
+}
+
+.title {
+  margin: 0 0 0.5rem;
+  font-size: 1.875rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  margin: 0;
+  max-width: 60ch;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--ds-gray-600, #4b5563);
+}
+
+.count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--ds-gray-900, #111827);
+}
+
+.course {
+  margin-top: 3.5rem;
+}
+
+.courseHeading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.625rem;
+  margin: 0 0 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--ds-gray-100, #f3f4f6);
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.courseSlug {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--ds-gray-400, #9ca3af);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--ds-gray-200, #e5e7eb);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.figure {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  min-height: 180px;
+  /* Subtle checkerboard so fully-transparent / white-on-white graphics are
+     still visible against the card. */
+  background-color: #fbfbfc;
+  background-image:
+    linear-gradient(45deg, #f0f1f3 25%, transparent 25%),
+    linear-gradient(-45deg, #f0f1f3 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #f0f1f3 75%),
+    linear-gradient(-45deg, transparent 75%, #f0f1f3 75%);
+  background-size: 16px 16px;
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+}
+
+.figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem 1rem;
+  border-top: 1px solid var(--ds-gray-200, #e5e7eb);
+}
+
+.id {
+  margin: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--ds-gray-700, #374151);
+  word-break: break-all;
+  user-select: all;
+}
+
+.link {
+  font-size: 0.82rem;
+  color: var(--ds-blue-ink, #1d4ed8);
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.empty {
+  margin-top: 2rem;
+  color: var(--ds-gray-500, #6b7280);
+}

--- a/app/svg-gallery/svg-gallery.module.css
+++ b/app/svg-gallery/svg-gallery.module.css
@@ -1,93 +1,220 @@
+/* Theme tokens. Light is the default; `.dark` (toggled on the root) swaps in
+   the dark palette. The page background is pure white in light mode and
+   #121212 in dark mode, matching the /learn content surfaces. */
 .page {
+  --bg: #ffffff;
+  --fg: #111827;
+  --muted: #4b5563;
+  --faint: #9ca3af;
+  --border: #e5e7eb;
+  --border-soft: #f3f4f6;
+  --card: #ffffff;
+  --figure-bg: #fbfbfc;
+  --checker: #f0f1f3;
+  --link: var(--ds-blue-ink, #1d4ed8);
+  --btn-bg: #ffffff;
+  --btn-hover: #f3f4f6;
+
   box-sizing: border-box;
   min-height: 100vh;
-  margin: 0 auto;
-  padding: 3rem 1.5rem 6rem;
-  max-width: 1280px;
-  background: #ffffff;
-  color: var(--ds-gray-900, #111827);
+  background: var(--bg);
+  color: var(--fg);
   font-family: var(--font-sans, system-ui, sans-serif);
 }
 
+.page.dark {
+  --bg: #121212;
+  --fg: #e6e6e6;
+  --muted: #a3a3a3;
+  --faint: #6b6b6b;
+  --border: #2a2a2a;
+  --border-soft: #1f1f1f;
+  --card: #181818;
+  --figure-bg: #1a1a1a;
+  --checker: #242424;
+  --link: var(--ds-blue-400, #5ba7ff);
+  --btn-bg: #1c1c1c;
+  --btn-hover: #262626;
+}
+
+/* Single-column reading column, sized to roughly match the /learn content. */
+.inner {
+  box-sizing: border-box;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 5rem;
+  max-width: 860px;
+}
+
 .header {
-  margin-bottom: 2.5rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 1px solid var(--ds-gray-200, #e5e7eb);
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.headerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
 .title {
-  margin: 0 0 0.5rem;
-  font-size: 1.875rem;
+  margin: 0;
+  font-size: 1.75rem;
   font-weight: 700;
   letter-spacing: -0.02em;
 }
 
 .subtitle {
-  margin: 0;
-  max-width: 60ch;
+  margin: 0.75rem 0 0;
+  max-width: 62ch;
   font-size: 0.95rem;
   line-height: 1.6;
-  color: var(--ds-gray-600, #4b5563);
+  color: var(--muted);
+}
+
+.subtitle code {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.85em;
 }
 
 .count {
   font-variant-numeric: tabular-nums;
   font-weight: 600;
-  color: var(--ds-gray-900, #111827);
+  color: var(--fg);
 }
 
+.themeToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--btn-bg);
+  color: var(--fg);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.themeToggle:hover {
+  background: var(--btn-hover);
+}
+
+/* ── Pagination ─────────────────────────────────────────────────────────── */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 1.75rem 0;
+}
+
+.pagerNums {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.pagerBtn,
+.pagerNum {
+  min-width: 2.25rem;
+  padding: 0.4rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--btn-bg);
+  color: var(--fg);
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+
+.pagerBtn:hover:not(:disabled),
+.pagerNum:hover {
+  background: var(--btn-hover);
+}
+
+.pagerBtn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.pagerNumActive,
+.pagerNumActive:hover {
+  background: var(--link);
+  border-color: var(--link);
+  color: #ffffff;
+  font-weight: 600;
+}
+
+/* ── Courses & cards ────────────────────────────────────────────────────── */
 .course {
-  margin-top: 3.5rem;
+  margin-top: 3rem;
+}
+
+.course:first-of-type {
+  margin-top: 1rem;
 }
 
 .courseHeading {
   display: flex;
   align-items: baseline;
+  flex-wrap: wrap;
   gap: 0.625rem;
-  margin: 0 0 1.5rem;
+  margin: 0 0 1.25rem;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--ds-gray-100, #f3f4f6);
-  font-size: 1.25rem;
+  border-bottom: 1px solid var(--border-soft);
+  font-size: 1.2rem;
   font-weight: 600;
   letter-spacing: -0.01em;
 }
 
 .courseSlug {
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   font-weight: 400;
-  color: var(--ds-gray-400, #9ca3af);
+  color: var(--faint);
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+.courseCount {
+  margin-left: auto;
+  font-size: 0.78rem;
+  font-weight: 400;
+  color: var(--faint);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
 }
 
 .card {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--ds-gray-200, #e5e7eb);
+  margin: 0;
+  border: 1px solid var(--border);
   border-radius: 0.75rem;
   overflow: hidden;
-  background: #ffffff;
+  background: var(--card);
 }
 
 .figure {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.25rem;
-  min-height: 180px;
+  padding: 1.5rem;
   /* Subtle checkerboard so fully-transparent / white-on-white graphics are
      still visible against the card. */
-  background-color: #fbfbfc;
+  background-color: var(--figure-bg);
   background-image:
-    linear-gradient(45deg, #f0f1f3 25%, transparent 25%),
-    linear-gradient(-45deg, #f0f1f3 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, #f0f1f3 75%),
-    linear-gradient(-45deg, transparent 75%, #f0f1f3 75%);
+    linear-gradient(45deg, var(--checker) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--checker) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--checker) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--checker) 75%);
   background-size: 16px 16px;
   background-position: 0 0, 0 8px, 8px -8px, -8px 0;
 }
@@ -100,25 +227,46 @@
 
 .meta {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0;
   padding: 0.875rem 1rem 1rem;
-  border-top: 1px solid var(--ds-gray-200, #e5e7eb);
+  border-top: 1px solid var(--border);
+}
+
+.metaText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
 }
 
 .id {
   margin: 0;
   font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--fg);
+  word-break: break-all;
+  user-select: all;
+}
+
+.route {
+  margin: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 0.78rem;
   line-height: 1.4;
-  color: var(--ds-gray-700, #374151);
+  color: var(--muted);
   word-break: break-all;
   user-select: all;
 }
 
 .link {
+  width: fit-content;
+  margin-top: 0.15rem;
   font-size: 0.82rem;
-  color: var(--ds-blue-ink, #1d4ed8);
+  color: var(--link);
   text-decoration: none;
 }
 
@@ -126,7 +274,26 @@
   text-decoration: underline;
 }
 
+.copyBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--btn-bg);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.copyBtn:hover {
+  background: var(--btn-hover);
+  color: var(--fg);
+}
+
 .empty {
   margin-top: 2rem;
-  color: var(--ds-gray-500, #6b7280);
+  color: var(--muted);
 }

--- a/lib/extractSvgGraphics.ts
+++ b/lib/extractSvgGraphics.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure extraction of custom inline `<svg>` graphics from a single lesson's MDX
+ * source — the parsing core behind the build-time SVG gallery (lib/svgGallery.ts).
+ *
+ * Kept free of any Fumadocs `source` / filesystem dependency so it can be unit
+ * tested directly (lib/svgGallery.ts layers the page-URL/course grouping on top).
+ *
+ * Parsing pipeline: the leading YAML frontmatter is blanked out (a handful of
+ * lessons carry JSX-like text — `<Animal>`, `<T,>` — in their title/description,
+ * which a frontmatter-unaware MDX parser would choke on), then the body is parsed
+ * with the same micromark extensions the real build relies on — GFM, math, MDX,
+ * and Mermaid — so every lesson parses and `<svg>` source offsets line up.
+ *
+ * IDs are computed with the very helpers `remarkSvgLabels` uses, so each ID here
+ * is byte-for-byte the label the plugin stamps under the graphic on its page
+ * (e.g. `svg-intro-sql-postgres-filtering-rows-f4f4db`). The hash is a pure
+ * function of the graphic's own `<svg>` source, so blanking the frontmatter
+ * (which never moves an svg's bytes) leaves it unchanged.
+ *
+ * Mermaid diagrams are authored as ```mermaid fences, never `<svg>` elements, so
+ * collecting only `name === "svg"` nodes excludes them by construction.
+ */
+import { remark } from "remark";
+import remarkMdx from "remark-mdx";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import { remarkMdxMermaid } from "fumadocs-core/mdx-plugins";
+import { VFile } from "vfile";
+import {
+  hash6,
+  graphicSignature,
+  pageSlugFromPath,
+  type AnyNode,
+} from "./remarkSvgLabels";
+import { jsxSvgToHtml } from "./jsxSvgToHtml";
+
+export interface ExtractedSvg {
+  /** Globally-unique, content-hashed ID — identical to the on-page label. */
+  id: string;
+  /** Render-ready SVG markup (JSX-isms rewritten to valid HTML). */
+  html: string;
+}
+
+const processor = remark()
+  .use(remarkGfm)
+  .use(remarkMath)
+  .use(remarkMdx)
+  .use(remarkMdxMermaid);
+
+// Replace a leading `---\n…\n---` YAML frontmatter block with whitespace of the
+// exact same length (newlines preserved), so the body parses without a
+// frontmatter extension while every byte offset stays aligned with the source.
+export function blankFrontmatter(raw: string): string {
+  const m = /^---\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/.exec(raw);
+  if (!m) return raw;
+  return m[0].replace(/[^\r\n]/g, " ") + raw.slice(m[0].length);
+}
+
+function collectSvgNodes(node: AnyNode, out: AnyNode[]): void {
+  const children = node.children;
+  if (!Array.isArray(children)) return;
+  for (const child of children) {
+    if (child.type === "mdxJsxFlowElement" && child.name === "svg") {
+      // Don't recurse into a graphic's own subtree — nested shapes aren't
+      // separately referenceable figures.
+      out.push(child);
+    } else {
+      collectSvgNodes(child, out);
+    }
+  }
+}
+
+/**
+ * Extract every custom inline `<svg>` graphic from one lesson's MDX source.
+ * `absPath` is the lesson's absolute path; it drives the page slug embedded in
+ * each ID. Returns `[]` (and warns) if the source can't be parsed, so one bad
+ * lesson never fails the whole gallery build.
+ */
+export function extractSvgGraphics(
+  rawSource: string,
+  absPath: string,
+): ExtractedSvg[] {
+  // Cheap early-out: most lessons have no inline SVG at all.
+  if (!rawSource.includes("<svg")) return [];
+
+  const src = blankFrontmatter(rawSource);
+  const file = new VFile({ value: src, path: absPath });
+
+  let tree: AnyNode;
+  try {
+    tree = processor.runSync(processor.parse(file), file) as unknown as AnyNode;
+  } catch (err) {
+    console.warn(
+      `[svg-gallery] skipping ${absPath}: failed to parse (${
+        (err as Error)?.message ?? err
+      })`,
+    );
+    return [];
+  }
+
+  const nodes: AnyNode[] = [];
+  collectSvgNodes(tree, nodes);
+  if (nodes.length === 0) return [];
+
+  const slug = pageSlugFromPath(absPath);
+  const out: ExtractedSvg[] = [];
+  for (const node of nodes) {
+    const start = node.position?.start?.offset;
+    const end = node.position?.end?.offset;
+    if (typeof start !== "number" || typeof end !== "number") continue;
+    out.push({
+      id: `svg-${slug}-${hash6(graphicSignature(node, src))}`,
+      html: jsxSvgToHtml(src.slice(start, end)),
+    });
+  }
+  return out;
+}

--- a/lib/jsxSvgToHtml.ts
+++ b/lib/jsxSvgToHtml.ts
@@ -1,0 +1,138 @@
+/**
+ * Rewrite a hand-authored JSX `<svg>…</svg>` source slice into valid SVG
+ * markup that a browser can render directly (via `dangerouslySetInnerHTML`).
+ *
+ * The lesson SVGs are written as JSX, which differs from raw SVG in two ways
+ * this module reverses:
+ *   1. `style={{ … }}` object literals  → `style="…"` declaration strings
+ *   2. camelCase presentation attributes → hyphenated names (fillOpacity →
+ *      fill-opacity, fontSize → font-size, …)
+ * Attributes whose casing is significant in SVG (viewBox, preserveAspectRatio)
+ * are left untouched.
+ *
+ * Kept dependency-free and separate from `lib/svgGallery.ts` (which reaches
+ * into the Fumadocs `source`) so the conversion can be unit-tested in
+ * isolation.
+ */
+
+// camelCase (JSX) → hyphenated (SVG) presentation-attribute names. Names absent
+// here (viewBox, preserveAspectRatio, gradientUnits, …) pass through unchanged.
+const ATTR_MAP: Record<string, string> = {
+  fillOpacity: "fill-opacity",
+  fillRule: "fill-rule",
+  strokeWidth: "stroke-width",
+  strokeLinecap: "stroke-linecap",
+  strokeLinejoin: "stroke-linejoin",
+  strokeOpacity: "stroke-opacity",
+  strokeDasharray: "stroke-dasharray",
+  strokeDashoffset: "stroke-dashoffset",
+  strokeMiterlimit: "stroke-miterlimit",
+  clipRule: "clip-rule",
+  clipPath: "clip-path",
+  fontSize: "font-size",
+  fontFamily: "font-family",
+  fontWeight: "font-weight",
+  fontStyle: "font-style",
+  textAnchor: "text-anchor",
+  letterSpacing: "letter-spacing",
+  dominantBaseline: "dominant-baseline",
+  stopColor: "stop-color",
+  stopOpacity: "stop-opacity",
+  vectorEffect: "vector-effect",
+  paintOrder: "paint-order",
+  markerEnd: "marker-end",
+  markerStart: "marker-start",
+  markerMid: "marker-mid",
+};
+
+function camelToKebab(s: string): string {
+  return s.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}
+
+// Convert the body of a JSX `style={{ … }}` object literal into a CSS
+// declaration string. Values are string literals in these SVGs (e.g. "block",
+// "100%", "var(--ds-blue-500)"); a quote- and bracket-aware split keeps any
+// value that contains a comma (e.g. a font stack) intact.
+function styleObjectToCss(inner: string): string {
+  const parts: string[] = [];
+  let cur = "";
+  let depth = 0;
+  let quote = "";
+  for (const c of inner) {
+    if (quote) {
+      cur += c;
+      if (c === quote) quote = "";
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      cur += c;
+      continue;
+    }
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") depth--;
+    else if (c === "," && depth === 0) {
+      parts.push(cur);
+      cur = "";
+      continue;
+    }
+    cur += c;
+  }
+  if (cur.trim()) parts.push(cur);
+
+  const decls: string[] = [];
+  for (const part of parts) {
+    const idx = part.indexOf(":");
+    if (idx < 0) continue;
+    const key = part.slice(0, idx).trim().replace(/^['"`]|['"`]$/g, "");
+    let val = part.slice(idx + 1).trim();
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'")) ||
+      (val.startsWith("`") && val.endsWith("`"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    if (!key || !val) continue;
+    decls.push(`${camelToKebab(key)}: ${val}`);
+  }
+  return decls.join("; ");
+}
+
+// Rewrite every `style={{ … }}` attribute to `style="…"`. The inner object
+// never nests a `}}` (these graphics contain no expressions), so the first
+// `}}` after each `style={{` reliably closes it.
+function inlineStyleObjects(src: string): string {
+  const OPEN = "style={{";
+  let out = "";
+  let i = 0;
+  for (;;) {
+    const at = src.indexOf(OPEN, i);
+    if (at < 0) {
+      out += src.slice(i);
+      break;
+    }
+    out += src.slice(i, at);
+    const innerStart = at + OPEN.length;
+    const close = src.indexOf("}}", innerStart);
+    if (close < 0) {
+      out += src.slice(at);
+      break;
+    }
+    out += `style="${styleObjectToCss(src.slice(innerStart, close))}"`;
+    i = close + 2;
+  }
+  return out;
+}
+
+/** Rewrite an authored JSX `<svg>…</svg>` source slice into valid SVG markup. */
+export function jsxSvgToHtml(src: string): string {
+  let out = inlineStyleObjects(src);
+  // Rename camelCase presentation attributes (fillOpacity → fill-opacity, …).
+  // Matches a bare `name=` token; these JSX-only spellings don't occur inside
+  // the quoted prose of aria-labels, so quoted text is left untouched.
+  out = out.replace(/\b([A-Za-z][A-Za-z0-9]*)=/g, (m, name: string) =>
+    ATTR_MAP[name] ? `${ATTR_MAP[name]}=` : m,
+  );
+  return out.replace(/\bclassName=/g, "class=");
+}

--- a/lib/remarkSvgLabels.ts
+++ b/lib/remarkSvgLabels.ts
@@ -39,7 +39,7 @@ interface JsxAttribute {
   value?: unknown;
 }
 
-type AnyNode = Record<string, unknown> & {
+export type AnyNode = Record<string, unknown> & {
   type?: string;
   name?: string;
   children?: AnyNode[];
@@ -50,7 +50,7 @@ type AnyNode = Record<string, unknown> & {
 // FNV-1a 32-bit hash → 6 lowercase hex chars (the low 24 bits). Deterministic
 // and dependency-free; 24 bits is ample to distinguish the handful of graphics
 // on a page while staying short and opaque.
-function hash6(input: string): string {
+export function hash6(input: string): string {
   let h = 0x811c9dc5;
   for (let i = 0; i < input.length; i++) {
     h ^= input.charCodeAt(i);
@@ -59,11 +59,12 @@ function hash6(input: string): string {
   return ((h >>> 0) & 0xffffff).toString(16).padStart(6, "0");
 }
 
-// Derive a page slug from the lesson's absolute .mdx path: drop everything up
+// Derive a page slug from a lesson's absolute .mdx path: drop everything up
 // to and including `content/learn/`, strip the extension and a trailing
-// `/index`, then flatten to a dash-delimited lowercase slug.
-function pageSlug(file: VFile | undefined): string {
-  const raw = file?.path ?? file?.history?.[file.history.length - 1] ?? "";
+// `/index`, then flatten to a dash-delimited lowercase slug. Exported so the
+// build-time SVG gallery (lib/svgGallery.ts) can reproduce the exact same IDs
+// this plugin stamps onto the rendered pages.
+export function pageSlugFromPath(raw: string): string {
   const marker = "content/learn/";
   const at = raw.indexOf(marker);
   const rel = at >= 0 ? raw.slice(at + marker.length) : raw;
@@ -74,6 +75,11 @@ function pageSlug(file: VFile | undefined): string {
     .replace(/^-+|-+$/g, "")
     .toLowerCase();
   return slug || `x-${hash6(raw)}`;
+}
+
+function pageSlug(file: VFile | undefined): string {
+  const raw = file?.path ?? file?.history?.[file.history.length - 1] ?? "";
+  return pageSlugFromPath(raw);
 }
 
 function isGraphic(node: AnyNode): boolean {
@@ -90,7 +96,7 @@ function isGraphic(node: AnyNode): boolean {
 // representation — falling back to a structural serialization if positions are
 // missing. Whitespace is collapsed so reindenting a graphic doesn't change its
 // ID.
-function graphicSignature(node: AnyNode, source: string): string {
+export function graphicSignature(node: AnyNode, source: string): string {
   let raw: string | undefined;
 
   if (node.name === "Mermaid") {

--- a/lib/svgGallery.ts
+++ b/lib/svgGallery.ts
@@ -1,0 +1,87 @@
+/**
+ * Build-time collector for the custom SVG graphics gallery (`/svg-gallery`).
+ *
+ * Walks every lesson under `content/learn/`, extracts each hand-authored inline
+ * `<svg>` graphic (via `extractSvgGraphics`), and groups them by course, tagging
+ * each with the same globally-unique ID that `remarkSvgLabels` stamps onto the
+ * rendered page (e.g. `svg-intro-sql-postgres-filtering-rows-f4f4db`) plus a
+ * deep link back to the lesson that contains it.
+ *
+ * Mermaid charts are excluded — they're authored as ```mermaid fences, never
+ * `<svg>` elements, so the `<svg>`-only collection skips them by construction.
+ *
+ * This module reads the filesystem and is server-only; it runs once at build
+ * time when the static `/svg-gallery` route is pre-rendered.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { source } from "./source";
+import { extractSvgGraphics } from "./extractSvgGraphics";
+
+const CONTENT_DIR = path.join(process.cwd(), "content", "learn");
+
+export interface GalleryGraphic {
+  /** Globally-unique, content-hashed ID — identical to the on-page label. */
+  id: string;
+  /** Render-ready SVG markup (JSX-isms rewritten to valid HTML). */
+  html: string;
+  /** URL of the lesson that contains this graphic, anchored to its label. */
+  href: string;
+}
+
+export interface GalleryCourse {
+  /** Course folder slug (first path segment under content/learn/). */
+  slug: string;
+  /** Human-readable course title (from the course index page, if any). */
+  title: string;
+  graphics: GalleryGraphic[];
+}
+
+let cache: GalleryCourse[] | null = null;
+
+/**
+ * Collect every custom inline `<svg>` graphic across all `/learn` lessons,
+ * grouped by course and tagged with its on-page ID and a link to its lesson.
+ * Memoised so the work runs once per build.
+ */
+export function getSvgGallery(): GalleryCourse[] {
+  if (cache) return cache;
+
+  const courses = new Map<string, GalleryCourse>();
+  // Course titles come from each course's index page (url === /learn/<slug>).
+  const courseTitle = new Map<string, string>();
+
+  for (const page of source.getPages()) {
+    const rel = page.path; // e.g. "intro-sql-postgres/filtering-rows.mdx"
+    const slug = rel.split("/")[0];
+    if (rel === `${slug}/index.mdx` || rel === `${slug}/index.md`) {
+      const t = page.data.title;
+      if (typeof t === "string" && t) courseTitle.set(slug, t);
+    }
+
+    const abs = path.join(CONTENT_DIR, rel);
+    let raw: string;
+    try {
+      raw = readFileSync(abs, "utf8");
+    } catch {
+      continue;
+    }
+
+    const graphics = extractSvgGraphics(raw, abs);
+    if (graphics.length === 0) continue;
+
+    let bucket = courses.get(slug);
+    if (!bucket) {
+      bucket = { slug, title: slug, graphics: [] };
+      courses.set(slug, bucket);
+    }
+    for (const g of graphics) {
+      bucket.graphics.push({ ...g, href: `${page.url}#${g.id}` });
+    }
+  }
+
+  cache = [...courses.values()]
+    .map((c) => ({ ...c, title: courseTitle.get(c.slug) ?? c.slug }))
+    .sort((a, b) => a.title.localeCompare(b.title));
+  return cache;
+}

--- a/lib/svgGallery.ts
+++ b/lib/svgGallery.ts
@@ -25,7 +25,9 @@ export interface GalleryGraphic {
   id: string;
   /** Render-ready SVG markup (JSX-isms rewritten to valid HTML). */
   html: string;
-  /** URL of the lesson that contains this graphic, anchored to its label. */
+  /** URL of the lesson that contains this graphic (e.g. /learn/foo/bar). */
+  route: string;
+  /** Same lesson URL, anchored to this graphic's label. */
   href: string;
 }
 
@@ -76,7 +78,11 @@ export function getSvgGallery(): GalleryCourse[] {
       courses.set(slug, bucket);
     }
     for (const g of graphics) {
-      bucket.graphics.push({ ...g, href: `${page.url}#${g.id}` });
+      bucket.graphics.push({
+        ...g,
+        route: page.url,
+        href: `${page.url}#${g.id}`,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Two changes:

### Update 1 — Tighter Source Serif tracking in `/learn` content
The reading body on `/learn` (Source Serif paragraphs, list items, table cells) was set to `letter-spacing: 0`. Pulled it in slightly to `-0.006em` for a tighter, more polished editorial colour — a gentler value than the `-0.011em` Inter tracking on `body`, since Source Serif sets a touch looser at the same measure. Headings, sidebar, and TOC are unchanged.

### Update 2 — `/svg-gallery`, a build-time review page for all custom SVGs
A new static page that surfaces **every custom inline `<svg>` graphic** across the courses so they can be reviewed in one place to spot ones that need replacing/removing. Under each graphic it shows:
- its globally-unique id (the same label `remarkSvgLabels` stamps on the lesson, e.g. `svg-intro-sql-postgres-filtering-rows-f4f4db`), and
- a deep link to the graphic on its lesson page.

**Mermaid charts are excluded** — they're authored as fenced ` ```mermaid ` blocks, never `<svg>` elements, so collecting only `<svg>` nodes skips them by construction.

The page is **generated at build time** (`force-static`, prerendered as static content). It's intended for development but is harmless if publicly reachable (and marked `noindex`).

## Implementation
- **`lib/jsxSvgToHtml.ts`** — rewrites authored JSX `<svg>` source (`style={{…}}` objects, camelCase presentation attributes like `fillOpacity`) into render-ready SVG markup. Pure/dependency-free and unit-tested.
- **`lib/extractSvgGraphics.ts`** — parses a lesson with the same micromark extensions the real build relies on (GFM / math / MDX / Mermaid), blanking the YAML frontmatter first (a few lessons carry JSX-like text such as `<T,>` in their title/description that a frontmatter-unaware parse chokes on, with byte offsets preserved). Collects `<svg>` nodes and computes ids using the exact helpers `remarkSvgLabels` uses, so gallery ids equal on-page ids.
- **`lib/svgGallery.ts`** — groups graphics by course and links each to its lesson.
- **`app/svg-gallery/`** — the static review page + styles.
- **`lib/remarkSvgLabels.ts`** — exports `hash6` / `graphicSignature` / `pageSlugFromPath` (extracted `pageSlugFromPath` from the existing `pageSlug`); behaviour unchanged.
- **`SvgLabel`** — adds `id={figId}` so the gallery's deep links land on the graphic.

## Verification
- New tests in `__tests__/svgGallery.test.ts` pin id parity with the on-page `SvgLabel` labels (excluding Mermaid), the JSX→HTML conversion, and the frontmatter-JSX edge case. Existing `remarkSvgLabels` tests still pass.
- Full production build succeeds: `/svg-gallery` prerenders statically with **887 graphics / 887 unique ids**, and a spot-checked id (`…filtering-rows-f4f4db`) matches the `SvgLabel` anchor on its lesson page, so the deep link resolves.

https://claude.ai/code/session_01B2D3GWV9LLL8ABMqRHKciX

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2D3GWV9LLL8ABMqRHKciX)_