### PR TITLE
Cut Vercel ISR reads / edge requests: Phase 1 fixes + zero-ISR svg-gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ script-runner-src/__pycache__/
 # `scripts/build-almostnode-workers.mjs` on postinstall + build + dev).
 /public/_workers/
 
+# Static data behind /svg-gallery (rebuilt by
+# `scripts/build-svg-gallery-data.mjs` on build + dev).
+/public/svg-gallery/
+
 # Output of scripts/check-mermaid-errors.mjs (regenerated on demand).
 /mermaid-check-results.json
 

--- a/agent-outputs/20260612-1620-vercel-isr-edge-usage-and-hosting-report.md
+++ b/agent-outputs/20260612-1620-vercel-isr-edge-usage-and-hosting-report.md
@@ -18,7 +18,7 @@
    - **Cache static output harder at the edge** so the CDN absorbs reads instead of falling through to durable storage. *(low risk)*
    - **Structural fix:** this site is *static enough* that a host which serves prerendered pages as free CDN assets (Cloudflare, Netlify) — or a full `output: 'export'` — **removes the ISR-Read meter entirely.** That's the durable answer if usage keeps climbing.
 
-4. **Cloudflare is a viable and cheaper home** for this workload (flat pricing, unlimited bandwidth, no per-read ISR meter), but the migration is *not* zero-cost: Next.js on Cloudflare runs via the **OpenNext adapter**, which has real caveats (Worker size limits, no edge runtime, you wire up your own KV/R2/D1 for caching). Details and alternatives below.
+4. **Cloudflare is a viable and cheaper home** for this workload (flat pricing, unlimited bandwidth, no per-read ISR meter), but the migration is *not* zero-cost: Next.js on Cloudflare runs via the **OpenNext adapter**, which has real caveats (Worker size limits, no edge runtime, you wire up your own KV/R2/D1 for caching). Details and alternatives below. **Self-hosting on a VPS (e.g. a DigitalOcean droplet managed by Coolify) is the other no-meters path** — flat $6–24/mo, native Next.js with zero adapter caveats, deploy-on-push + PR previews via Coolify, at the cost of owning the server; see §6.1.
 
 5. **Once you add the planned backend** (user accounts, workspace DB, "Ask AI"), a *pure* static export can't host those features — but a **hybrid** keeps the 758 lessons free-static and runs only the new `/api/*` routes as server compute. On Cloudflare that means **Workers + OpenNext** (Pages is no longer the steered path for full-stack Next.js), with D1/R2 + Claude via the Anthropic SDK behind AI Gateway. Staying on Vercel supports all of this first-class too. See §5.
 
@@ -220,32 +220,54 @@ Adding server features **tips the recommendation toward Cloudflare Workers + Ope
 
 ---
 
-## 6. Other hosting alternatives (excluding self-hosting / VPS)
+## 6. Other hosting alternatives (including self-hosting / VPS)
 
 | Host | Best for | ISR-Read-style meter? | Bandwidth | Pricing shape | Fit for DataSlope |
 | --- | --- | --- | --- | --- | --- |
 | **Stay on Vercel + tune** | Keeping zero-config DX, easiest path to add auth/DB/AI | Yes (the thing biting you) | Metered (FOT on miss) | Free → $20/dev Pro | **Do this first.** Tuning likely keeps you free; first-class support for the planned backend features. |
 | **Cloudflare (OpenNext on Workers)** | Full Next features + auth/DB/AI, cheap, unlimited bandwidth | **No ISR-Read meter** | **Unlimited** | Flat $0/$20 (not per-user) | **Strong** once you add server features — D1/R2/Workers-AI/AI-Gateway under one flat bill. Adapter caveats. |
 | **Cloudflare Pages/Workers Static** | Static export of *today's* read-only site | None | **Unlimited** | Free at this scale | Removes the meter, but **can't host the planned auth/DB/AI** — you'd need a separate backend. Superseded by the Workers path above once features land. |
+| **VPS + Coolify (DigitalOcean / Hetzner)** | Full control, flat bill, zero per-request meters, 100% Next.js feature support (plain Node) | **None — no meters of any kind** | Included quota (DO: 500 GB–11 TB; overage $0.01/GiB), pair with a free CDN | Flat **$6–24/mo** droplet (+$0–5/mo Coolify) | **Strong if you accept ops ownership.** No adapter, no meters, easy Postgres for the future backend. Single-region origin → put Cloudflare's free CDN in front. See §6.1. |
 | **Netlify** | Content/docs sites, nice DX | Limited free tier; SSR via functions | Metered (100 GB free) | $0 → **$20/seat** Pro | Good DX, but **per-seat** billing and metered bandwidth — less cost-advantaged than Cloudflare for a public free site. |
 | **AWS Amplify Hosting** | Teams already in AWS | Pay-per-use (build/host/transfer) | Metered (AWS egress) | Usage-based | Powerful, but AWS egress + complexity; overkill unless you're already on AWS. |
 | **SST (OpenNext on your AWS)** | Max control, IaC | You configure (S3/CloudFront/Lambda) | AWS egress | AWS usage | Most control, most ops burden. Same OpenNext engine as Cloudflare path, different cloud. |
 | **Render** | Flat-rate PaaS, predictable bills | N/A (container) | Generous, predictable | Flat monthly | Simple and predictable, but you'd run Next as a Node server (less CDN-native for a static docs site). |
 
-| Host | Best for | ISR-Read-style meter? | Bandwidth | Pricing shape | Fit for DataSlope |
-| --- | --- | --- | --- | --- | --- |
-| **Stay on Vercel + tune** | Keeping zero-config DX | Yes (the thing biting you) | Metered (FOT on miss) | Free → $20/dev Pro | **Do this first.** Tuning likely keeps you free. |
-| **Cloudflare (OpenNext)** | Full Next features, cheap, unlimited bandwidth | **No ISR-Read meter** | **Unlimited** | Flat $0/$20 (not per-user) | **Strong** if you want server features + low cost. Adapter caveats. |
-| **Cloudflare Pages/Workers Static** | Static export of this site | None | **Unlimited** | Free at this scale | **Best long-term** if you convert search to static. |
-| **Netlify** | Content/docs sites, nice DX | Limited free tier; SSR via functions | Metered (100 GB free) | $0 → **$20/seat** Pro | Good DX, but **per-seat** billing and metered bandwidth — less cost-advantaged than Cloudflare for a public free site. |
-| **AWS Amplify Hosting** | Teams already in AWS | Pay-per-use (build/host/transfer) | Metered (AWS egress) | Usage-based | Powerful, but AWS egress + complexity; overkill unless you're already on AWS. |
-| **SST (OpenNext on your AWS)** | Max control, IaC | You configure (S3/CloudFront/Lambda) | AWS egress | AWS usage | Most control, most ops burden. Same OpenNext engine as Cloudflare path, different cloud. |
-| **Render** | Flat-rate PaaS, predictable bills | N/A (container) | Generous, predictable | Flat monthly | Simple and predictable, but you'd run Next as a Node server (less CDN-native for a static docs site). |
+### 6.1 — Self-hosting on a VPS with Coolify (e.g. a DigitalOcean droplet)
+
+You asked about running DataSlope on your own VPS — for example a DigitalOcean droplet managed through **Coolify**. This is a legitimate fourth path, and in some ways the most *complete* fix: there are **no per-request meters at all** (no ISR Reads, no Edge Requests, no Fast Origin Transfer, no function invocations, no build minutes). You pay one flat monthly price for a box and everything on it is yours.
+
+**What Coolify is.** An open-source (Apache 2.0), self-hostable PaaS that recreates the Vercel workflow on your own server: connect the GitHub repo via a GitHub App, get **deploy-on-push**, **per-PR preview deployment URLs**, automatic HTTPS (Let's Encrypt via Traefik/Caddy), logs/monitoring, rollbacks, and **280+ one-click services** (including Postgres — relevant for the planned workspace DB). It deploys Next.js either via Nixpacks auto-detection or a Dockerfile; for this repo you'd use Next's `output: "standalone"` mode so the runtime image stays small. The software is **free self-hosted** (you run the Coolify panel on the droplet itself or a $4–6 side box); **Coolify Cloud** — where they host just the control panel for you — is **~$5/mo for up to 2 servers** (+$3/server beyond that), and your apps still run on your own droplet.
+
+**How the economics compare for DataSlope:**
+
+| Cost line | Vercel today | DO droplet + Coolify |
+| --- | --- | --- |
+| ISR Reads / Edge Requests / FOT | Metered (the problem) | **Don't exist** |
+| Bandwidth | Metered (FDT) | DO includes 500 GB–11 TB by droplet size; **$0.01/GiB** overage — and ~free if Cloudflare CDN fronts it |
+| Builds / previews | Build-minute meter (§7) | **Your hardware** — unlimited builds; each PR preview is just another container on the box |
+| Backend (auth/DB/AI later) | First-class, metered | One-click Postgres next to the app; `/api/ask-ai` is just a Node route on the same box |
+| Monthly bill | $0 → unpredictable | **Flat $6–24/mo** (droplet size-dependent) + optional $5 Coolify Cloud |
+
+**Droplet sizing — the build is the constraint, not serving.** Serving 758 static pages from a Node `next start` is light (1 GB RAM is plenty). But *building* this repo (fumadocs-mdx over 758 lessons → esbuild workers → `next build` with the WASM-heavy dependency tree) wants **4 GB+ RAM**; on a $6/mo 1 GB droplet, on-box builds will OOM or crawl, and a build will starve the live site while it runs. Three sane configurations:
+1. **$12/mo (2 GB) droplet + swap**, builds tolerated as slow — minimum viable, previews will hurt.
+2. **$24/mo (4 GB) droplet** — comfortable for app + builds + a few PR preview containers. *(Recommended starting point.)*
+3. **Build elsewhere:** run `next build` in GitHub Actions (free for public repos) and have Coolify deploy the artifact/image, or attach a second cheap box as a dedicated Coolify **build server**. Keeps the serving droplet tiny.
+   - Hetzner equivalent for the same money is roughly 2× the hardware (CPX-class ~€8/mo ≈ $9.50 for 3 vCPU/4 GB; EU regions include 20 TB egress, US regions 1 TB) — same Coolify experience, better $/perf, slightly less polished ecosystem than DO.
+
+**The two things you give up vs. a managed edge platform:**
+1. **A global CDN by default.** A droplet is one origin in one region; Vercel/Cloudflare serve your static lessons from dozens of PoPs. Mitigation is standard and free: put **Cloudflare's free tier in front** (DNS + proxy + cache). Static assets and prerendered HTML then serve from Cloudflare's edge worldwide, origin egress drops to near nothing, and you keep zero meters. (The Phase 1 prefetch/caching fixes carry over here too — they reduce origin hits exactly the same way; see §8.)
+2. **Ops ownership.** You patch the OS, watch disk space, configure backups (DO droplet backups are +20% of droplet price, or snapshot to Spaces), and you are the on-call. Coolify automates the deploy workflow, not the sysadmin work. Budget a few hours up front and ~an hour a month steady-state. Coolify is also still a v4 *beta* line (very widely used — ~56k GitHub stars — but expect occasional rough edges; the announced v5 rewrite has no public timeline yet).
+
+**Migration shape for this repo:** `output: "standalone"` Dockerfile (or Nixpacks) → Coolify app from the GitHub repo → keep the existing `npm run build` chain (fumadocs-mdx + workers + svg-gallery data are all plain Node steps and run fine in a container build) → Cloudflare DNS/proxy in front → done. The jsDelivr WASM offload (§2.5) stays exactly as-is. ISR/`revalidate` semantics work natively (it's just Next on Node — the *only* host class with zero adapter caveats), though for this fully-static site there's nothing to revalidate anyway.
+
+**Verdict:** the strongest fit if you value a *fixed* bill and full control, and the planned backend makes it more attractive (Postgres on the same box, no per-invocation pricing for "Ask AI" calls — you pay only Anthropic). The honest counterweight: for a solo-maintained free site, Cloudflare Workers + OpenNext buys ~the same "no meters that matter" outcome with zero server administration. Pick VPS+Coolify if the ops ownership reads as a feature to you, not a chore.
 
 **Shortlist for your situation (free, public, static-heavy, content site):**
 1. **Tune Vercel** (today) — cheapest change, probably solves it.
-2. **Cloudflare** — if you want to stop watching meters: Path B (static) if you can convert search, else Path A (OpenNext).
-3. **Netlify** — viable, but the per-seat Pro pricing and metered bandwidth make it less attractive than Cloudflare for an ad-free public learning site.
+2. **Cloudflare** — if you want to stop watching meters with zero server ops: Path B (static) if you can convert search, else Path A (OpenNext).
+3. **VPS + Coolify (DO/Hetzner)** — if you want a flat bill, no meters anywhere, native Next.js, and you're happy owning a server (§6.1).
+4. **Netlify** — viable, but the per-seat Pro pricing and metered bandwidth make it less attractive than Cloudflare for an ad-free public learning site.
 
 ---
 
@@ -309,7 +331,7 @@ You already have the most important lever in place — lean into it:
 
 **Phase 2 — If usage still trends toward the cap, or once you start the backend (auth / workspace DB / Ask AI):**
 8. For a *read-only* site staying lean: decide static-export feasibility (convert Orama to Fumadocs **static search**) → any static host removes the meter permanently.
-9. **Once you add server features (the likelier path):** go **Cloudflare Workers + OpenNext** (not Pages — see §5.2). Lessons stay free static; auth/DB/AI run as Worker routes via D1/R2/AI-Gateway (§5.3). Validate Worker size and all 11 playgrounds + search in a preview before DNS cutover. Staying on Vercel is also fine — it supports all three features first-class; the tradeoff is the metered model.
+9. **Once you add server features (the likelier path):** go **Cloudflare Workers + OpenNext** (not Pages — see §5.2). Lessons stay free static; auth/DB/AI run as Worker routes via D1/R2/AI-Gateway (§5.3). Validate Worker size and all 11 playgrounds + search in a preview before DNS cutover. Staying on Vercel is also fine — it supports all three features first-class; the tradeoff is the metered model. If you'd rather own the box than watch any dashboard, the **VPS + Coolify** path (§6.1) hosts the same hybrid — static lessons + Node API routes + one-click Postgres — for a flat monthly price, with Cloudflare's free CDN in front for global edge caching.
 
 ---
 
@@ -338,5 +360,13 @@ You already have the most important lever in place — lean into it:
 - [Vercel — Managing builds](https://vercel.com/docs/builds/managing-builds)
 - [Vercel — Pricing docs](https://vercel.com/docs/pricing)
 - [Cloudflare Workers CI — builds limits & pricing](https://developers.cloudflare.com/workers/ci-cd/builds/limits-and-pricing/)
+- [Coolify — official site](https://coolify.io/) / [Coolify pricing (self-hosted free, Cloud $5/mo)](https://coolify.io/pricing)
+- [Coolify on GitHub (Apache 2.0, ~56k stars)](https://github.com/coollabsio/coolify)
+- [Coolify docs — deploying Next.js](https://coolify.io/docs/applications/nextjs)
+- [Coolify — GitHub PR preview deployments guide](https://lumadock.com/tutorials/coolify-github-pr-previews)
+- [Coolify pricing breakdown 2026 (self-hosted vs Cloud)](https://temps.sh/blog/coolify-pricing-explained-2026)
+- [DigitalOcean pricing in 2026 — plans and real costs](https://kuberns.com/blogs/digitalocean-pricing/)
+- [DigitalOcean vs Hetzner 2026 (pricing, bandwidth, regions)](https://betterstack.com/community/guides/web-servers/digitalocean-vs-hetzner/)
+- [Vercel vs Coolify in 2026](https://uibakery.io/blog/vercel-vs-coolify)
 
 *Prepared from the live repository state (Next.js 16.2.4, Fumadocs, 758 static lessons, WASM runtimes offloaded to jsDelivr) and the attached Vercel ISR observability screenshots showing Writes = 0 across all routes.*

--- a/app/_components/Link.tsx
+++ b/app/_components/Link.tsx
@@ -1,0 +1,27 @@
+/**
+ * Project-wide `next/link` wrapper that defaults `prefetch` to `false`.
+ *
+ * Next.js eagerly prefetches every `<Link>` that enters the viewport, so
+ * link-dense pages (the homepage course grid, the playground index, the
+ * playground headers) fan out dozens of background requests per view. On
+ * Vercel each prefetch that misses the edge cache is billed as an ISR Read
+ * + Edge Request + Fast Origin Transfer — see
+ * agent-outputs/20260612-1620-vercel-isr-edge-usage-and-hosting-report.md.
+ *
+ * In the App Router `prefetch={false}` disables both viewport and hover
+ * prefetching; navigation simply fetches on click, which is fine for this
+ * fully static site. Opt back in per-link (`<Link href="/learn" prefetch>`)
+ * only for primary navigation that should feel instant.
+ *
+ * Note: Fumadocs sidebar/TOC links don't go through this wrapper — their
+ * prefetching is tamed via `sidebar={{ prefetch: false }}` on `DocsLayout`
+ * in `app/learn/layout.tsx`.
+ */
+import NextLink from "next/link";
+import type { ComponentProps } from "react";
+
+export type LinkProps = ComponentProps<typeof NextLink>;
+
+export default function Link({ prefetch = false, ...props }: LinkProps) {
+  return <NextLink prefetch={prefetch} {...props} />;
+}

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -57,7 +57,7 @@ import type {
 } from "./types";
 import { PLAYGROUNDS } from "./playgrounds";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
+import Link from "./Link";
 // Base UI primitives — used for menus, popovers, dialogs, and toasts so
 // that the playground gets consistent positioning, focus management,
 // and natural enter/exit animations out of the box.

--- a/app/_components/sql/components/SqlPlaygroundSwitcher.tsx
+++ b/app/_components/sql/components/SqlPlaygroundSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Link from "../../Link";
 import { useRouter } from "next/navigation";
 import { Select } from "@base-ui-components/react/select";
 import { ChevronDown } from "lucide-react";

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -7,10 +7,24 @@
  * Route Handler.
  *
  * The site is English-only, so the Orama English stemmer is used.
+ *
+ * Responses are cached hard at the CDN edge: the index only changes on
+ * deploy (and Vercel purges its edge cache on deploy), so a repeat of the
+ * same query within a day is served as a free CDN hit instead of another
+ * function invocation + origin transfer.
  */
 import { source } from "@/lib/source";
 import { createFromSource } from "fumadocs-core/search/server";
 
-export const { GET } = createFromSource(source, {
+const search = createFromSource(source, {
   language: "english",
 });
+
+export async function GET(request: Request) {
+  const response = await search.GET(request);
+  response.headers.set(
+    "Cache-Control",
+    "public, s-maxage=86400, stale-while-revalidate=604800",
+  );
+  return response;
+}

--- a/app/learn/layout.tsx
+++ b/app/learn/layout.tsx
@@ -31,6 +31,12 @@ export default function LearnLayout({ children }: { children: ReactNode }) {
       <DocsLayout
         tree={source.pageTree}
         tabs={false}
+        // Don't prefetch sidebar links. The sidebar renders hundreds of
+        // lesson links per page; with Next.js's default viewport prefetch
+        // every visible link fans out segment requests, and on Vercel each
+        // edge-cache miss is a billed ISR Read. Navigation falls back to
+        // fetching on click, which is fast for these fully static pages.
+        sidebar={{ prefetch: false }}
         nav={{
           title: (
             <span

--- a/app/llms/learn/[[...slug]]/route.ts
+++ b/app/llms/learn/[[...slug]]/route.ts
@@ -22,6 +22,7 @@ import path from "node:path";
 import { source } from "@/lib/source";
 
 export const revalidate = false;
+export const dynamic = "force-static";
 
 export async function GET(
   _req: Request,
@@ -39,7 +40,13 @@ export async function GET(
   const content = await readFile(filePath, "utf8");
 
   return new Response(content, {
-    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      // The raw Markdown only changes on deploy (which purges the edge
+      // cache), so let the CDN hold it as long as it likes — every CDN hit
+      // is a free read instead of a metered ISR Read.
+      "Cache-Control": "public, s-maxage=31536000, stale-while-revalidate",
+    },
   });
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
-import Link from "next/link";
+import Link from "./_components/Link";
 import styles from "./root.module.css";
 
 export const metadata = {
@@ -62,7 +62,8 @@ export default async function Home() {
           A growing collection of browser-based developer tools.
         </p>
         <div className={styles.ctas}>
-          <Link href="/learn" className={styles.cta}>
+          {/* Primary CTA — the one link worth prefetching eagerly. */}
+          <Link href="/learn" prefetch className={styles.cta}>
             Browse Learn
             <span aria-hidden="true" className={styles.arrow}>
               →

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "../_components/Link";
 import {
   LANGUAGE_ICONS,
   LANGUAGE_ICON_COLORS,

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,34 @@
+/**
+ * robots.txt — keep crawlers on the content and off everything else.
+ *
+ * Bots requesting cold non-content routes (playground shells, dev/demo
+ * pages, API endpoints, the raw-Markdown mirrors) are pure cost on Vercel:
+ * each edge-cache miss bills an ISR Read / Edge Request / Fast Origin
+ * Transfer with no user benefit. `/learn` and the homepage stay fully
+ * crawlable — they are the indexable content.
+ *
+ * The `*.md` patterns cover the raw-Markdown mirrors exposed by the
+ * `/learn/:path*.md` rewrite (see next.config.ts); `/llms/` covers the
+ * route handler those rewrites point at.
+ */
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/api/",
+          "/llms/",
+          "/playground",
+          "/color-test",
+          "/svg-gallery",
+          "/learn.md",
+          "/learn/*.md$",
+        ],
+      },
+    ],
+  };
+}

--- a/app/svg-gallery/SvgGalleryClient.tsx
+++ b/app/svg-gallery/SvgGalleryClient.tsx
@@ -2,11 +2,14 @@
 
 /**
  * Interactive shell for the SVG graphics gallery. The graphic data is collected
- * at build time (see `lib/svgGallery.ts`) and handed in as a prop; everything
- * here — the light/dark theme toggle, course pagination, and per-graphic copy
- * buttons — is client-side.
+ * at build time (see `lib/svgGallery.ts` and `scripts/build-svg-gallery-data.mjs`)
+ * into the static asset `/svg-gallery/data.json`, which
+ * `SvgGalleryFromStaticData` fetches on mount — keeping the prerendered page a
+ * tiny shell with zero ISR-store involvement. Everything here — the light/dark
+ * theme toggle, course pagination, and per-graphic copy buttons — is
+ * client-side.
  */
-import { useCallback, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { Check, Copy, Moon, Sun } from "lucide-react";
 import type { GalleryCourse } from "@/lib/svgGallery";
 import styles from "./svg-gallery.module.css";
@@ -44,6 +47,48 @@ function useTheme(): [Theme, () => void] {
     themeListeners.forEach((l) => l());
   }, [theme]);
   return [theme, toggle];
+}
+
+/**
+ * Fetches the build-time gallery data from its static-asset home and renders
+ * the gallery once it arrives. The JSON is a few hundred kB, so there's a
+ * brief loading state — acceptable for a dev-only review page, and the
+ * trade that keeps the route off Vercel's ISR-read meter entirely.
+ */
+export function SvgGalleryFromStaticData() {
+  const [courses, setCourses] = useState<GalleryCourse[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/svg-gallery/data.json")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data: GalleryCourse[]) => {
+        if (!cancelled) setCourses(data);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (courses) return <SvgGalleryClient courses={courses} />;
+  return (
+    <div className={styles.page}>
+      <div className={styles.inner}>
+        <p className={styles.empty}>
+          {failed
+            ? "Couldn't load /svg-gallery/data.json — run `npm run build:svg-gallery` and reload."
+            : "Loading gallery data…"}
+        </p>
+      </div>
+    </div>
+  );
 }
 
 export function SvgGalleryClient({ courses }: { courses: GalleryCourse[] }) {

--- a/app/svg-gallery/page.tsx
+++ b/app/svg-gallery/page.tsx
@@ -8,15 +8,15 @@
  * link to the lesson — so the whole set can be skimmed in one place to spot
  * graphics that need replacing or removing.
  *
- * Generated entirely at build time: `force-static` pre-renders the route, and
- * `getSvgGallery()` reads the MDX content from disk during that render. The
- * interactive shell (theme toggle, pagination, copy buttons) lives in the
- * client component below. The page is intended for development but is harmless
- * if publicly reachable.
+ * Cost note: this page is deliberately just a tiny prerendered shell. The
+ * heavy payload (every SVG in every course) is generated at build time by
+ * `scripts/build-svg-gallery-data.mjs` into `public/svg-gallery/data.json`
+ * and fetched client-side — a plain static asset served from the CDN that
+ * never touches Vercel's metered ISR store. Loading is slower than inlining
+ * the data, which is fine for a development-only review tool.
  */
 import type { Metadata } from "next";
-import { getSvgGallery } from "@/lib/svgGallery";
-import { SvgGalleryClient } from "./SvgGalleryClient";
+import { SvgGalleryFromStaticData } from "./SvgGalleryClient";
 
 export const dynamic = "force-static";
 
@@ -27,5 +27,5 @@ export const metadata: Metadata = {
 };
 
 export default function SvgGalleryPage() {
-  return <SvgGalleryClient courses={getSvgGallery()} />;
+  return <SvgGalleryFromStaticData />;
 }

--- a/lib/svgGallery.ts
+++ b/lib/svgGallery.ts
@@ -10,12 +10,18 @@
  * Mermaid charts are excluded — they're authored as ```mermaid fences, never
  * `<svg>` elements, so the `<svg>`-only collection skips them by construction.
  *
- * This module reads the filesystem and is server-only; it runs once at build
- * time when the static `/svg-gallery` route is pre-rendered.
+ * Deliberately free of any Fumadocs `source` dependency: lesson URLs are
+ * derived from file paths (the same `/learn/<path-without-extension>` mapping
+ * the loader uses, with `index` collapsing to the folder) and course titles
+ * come from each course's `meta.json` (same as the homepage course list),
+ * falling back to the index page's frontmatter title, then the slug. That
+ * keeps the module importable from `scripts/build-svg-gallery-data.mjs`,
+ * which runs it ahead of `next build`/`next dev` to emit the gallery data as
+ * a plain static asset (`public/svg-gallery/data.json`) — served straight
+ * from the CDN with no ISR involvement.
  */
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { source } from "./source";
 import { extractSvgGraphics } from "./extractSvgGraphics";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "learn");
@@ -34,9 +40,56 @@ export interface GalleryGraphic {
 export interface GalleryCourse {
   /** Course folder slug (first path segment under content/learn/). */
   slug: string;
-  /** Human-readable course title (from the course index page, if any). */
+  /** Human-readable course title (from the course's meta.json, if any). */
   title: string;
   graphics: GalleryGraphic[];
+}
+
+/** Recursively collect lesson files, as /-separated paths relative to `dir`. */
+function walkLessonFiles(dir: string, prefix = ""): string[] {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      out.push(...walkLessonFiles(path.join(dir, entry.name), rel));
+    } else if (/\.mdx?$/i.test(entry.name)) {
+      out.push(rel);
+    }
+  }
+  return out.sort();
+}
+
+/** `course/lesson.mdx` → `/learn/course/lesson`; `index` collapses away. */
+function lessonUrl(rel: string): string {
+  const stem = rel.replace(/\.mdx?$/i, "").replace(/(^|\/)index$/i, "");
+  return stem ? `/learn/${stem}` : "/learn";
+}
+
+/** Pull `title:` out of a leading YAML frontmatter block, if present. */
+function frontmatterTitle(raw: string): string | undefined {
+  const block = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw);
+  if (!block) return undefined;
+  const line = /^title:[ \t]*(.+?)[ \t]*$/m.exec(block[1]);
+  if (!line) return undefined;
+  const title = line[1].replace(/^(["'])(.*)\1$/, "$2").trim();
+  return title || undefined;
+}
+
+/** Course title from `content/learn/<slug>/meta.json`, if present. */
+function metaTitle(slug: string): string | undefined {
+  try {
+    const raw = readFileSync(path.join(CONTENT_DIR, slug, "meta.json"), "utf8");
+    const meta = JSON.parse(raw) as { title?: unknown };
+    return typeof meta.title === "string" && meta.title ? meta.title : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 let cache: GalleryCourse[] | null = null;
@@ -50,23 +103,29 @@ export function getSvgGallery(): GalleryCourse[] {
   if (cache) return cache;
 
   const courses = new Map<string, GalleryCourse>();
-  // Course titles come from each course's index page (url === /learn/<slug>).
-  const courseTitle = new Map<string, string>();
+  const titles = new Map<string, string>();
 
-  for (const page of source.getPages()) {
-    const rel = page.path; // e.g. "intro-sql-postgres/filtering-rows.mdx"
-    const slug = rel.split("/")[0];
-    if (rel === `${slug}/index.mdx` || rel === `${slug}/index.md`) {
-      const t = page.data.title;
-      if (typeof t === "string" && t) courseTitle.set(slug, t);
-    }
-
+  for (const rel of walkLessonFiles(CONTENT_DIR)) {
     const abs = path.join(CONTENT_DIR, rel);
     let raw: string;
     try {
       raw = readFileSync(abs, "utf8");
     } catch {
       continue;
+    }
+
+    // Nested lessons group under their course folder; loose demo pages
+    // directly under content/learn/ group under their own file stem.
+    const nested = rel.includes("/");
+    const slug = nested ? rel.split("/")[0] : rel.replace(/\.mdx?$/i, "");
+
+    if (!titles.has(slug)) {
+      const title = nested
+        ? (metaTitle(slug) ??
+          frontmatterTitle(readCourseIndex(slug) ?? "") ??
+          slug)
+        : (frontmatterTitle(raw) ?? slug);
+      titles.set(slug, title);
     }
 
     const graphics = extractSvgGraphics(raw, abs);
@@ -77,17 +136,25 @@ export function getSvgGallery(): GalleryCourse[] {
       bucket = { slug, title: slug, graphics: [] };
       courses.set(slug, bucket);
     }
+    const url = lessonUrl(rel);
     for (const g of graphics) {
-      bucket.graphics.push({
-        ...g,
-        route: page.url,
-        href: `${page.url}#${g.id}`,
-      });
+      bucket.graphics.push({ ...g, route: url, href: `${url}#${g.id}` });
     }
   }
 
   cache = [...courses.values()]
-    .map((c) => ({ ...c, title: courseTitle.get(c.slug) ?? c.slug }))
+    .map((c) => ({ ...c, title: titles.get(c.slug) ?? c.slug }))
     .sort((a, b) => a.title.localeCompare(b.title));
   return cache;
+}
+
+function readCourseIndex(slug: string): string | undefined {
+  for (const name of ["index.mdx", "index.md"]) {
+    try {
+      return readFileSync(path.join(CONTENT_DIR, slug, name), "utf8");
+    } catch {
+      // try the next candidate
+    }
+  }
+  return undefined;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,16 @@ const nextConfig: NextConfig = {
   // graphs into every page's chunk.
   experimental: {
     optimizePackageImports: ["lucide-react", "react-icons"],
+    // Keep prefetched/visited route payloads reusable in the client router
+    // cache so re-hovers and back/forward navigations don't re-hit the edge
+    // (every edge-cache miss is a billed ISR Read on Vercel). Lessons are
+    // fully static and only change on deploy, so long client-side staleness
+    // is safe. `dynamic` applies to links without an explicit `prefetch`
+    // prop, `static` to `prefetch={true}` links.
+    staleTimes: {
+      dynamic: 300,
+      static: 1800,
+    },
   },
   redirects: async () => [
     {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "fumadocs-mdx && node scripts/build-almostnode-workers.mjs && next dev",
-    "build": "fumadocs-mdx && node scripts/build-almostnode-workers.mjs && next build",
+    "dev": "fumadocs-mdx && node scripts/build-almostnode-workers.mjs && node scripts/build-svg-gallery-data.mjs && next dev",
+    "build": "fumadocs-mdx && node scripts/build-almostnode-workers.mjs && node scripts/build-svg-gallery-data.mjs && next build",
     "build:workers": "node scripts/build-almostnode-workers.mjs",
+    "build:svg-gallery": "node scripts/build-svg-gallery-data.mjs",
     "postinstall": "fumadocs-mdx && node scripts/patch-almostnode.mjs && node scripts/build-almostnode-workers.mjs",
     "start": "next start",
     "lint": "eslint .",

--- a/scripts/build-svg-gallery-data.mjs
+++ b/scripts/build-svg-gallery-data.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Generate the static data file behind the `/svg-gallery` dev page.
+ *
+ * Why this exists:
+ *
+ * The gallery embeds every hand-authored inline `<svg>` across ~800 lessons.
+ * Rendered server-side into the prerendered page, that multi-hundred-kB
+ * payload lives in Vercel's durable ISR store, and every edge-cache miss
+ * (each region, each eviction, each prefetch) re-reads it as billed ISR
+ * Reads — the gallery was the single largest ISR reader on the project.
+ *
+ * Instead, the page is now a tiny static shell and the heavy payload ships
+ * as `public/svg-gallery/data.json`, a plain static asset that the client
+ * fetches on mount. Files under `public/` are served straight from the CDN
+ * and never touch the ISR store, so opening the gallery costs zero ISR
+ * Reads. A slower first paint is fine — the page is a development review
+ * tool.
+ *
+ * The collector (`lib/svgGallery.ts`) is TypeScript that shares its
+ * unit-tested extraction helpers with the `remarkSvgLabels` build plugin, so
+ * this script bundles it with esbuild into node_modules/.cache and imports
+ * the bundle — the same esbuild-at-build-time approach as
+ * `build-almostnode-workers.mjs`.
+ *
+ * Idempotent. Runs from the `dev` and `build` scripts; the JSON reflects the
+ * content at the time the dev server started, so restart `next dev` (or run
+ * `npm run build:svg-gallery`) to pick up newly authored graphics.
+ */
+
+import { build } from "esbuild";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const BUNDLE = join(ROOT, "node_modules", ".cache", "svg-gallery", "svgGallery.mjs");
+const OUT_DIR = join(ROOT, "public", "svg-gallery");
+const OUT_FILE = join(OUT_DIR, "data.json");
+
+await mkdir(dirname(BUNDLE), { recursive: true });
+await build({
+  entryPoints: [join(ROOT, "lib", "svgGallery.ts")],
+  outfile: BUNDLE,
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  // Bundle only the repo's own TS modules; npm packages (remark etc.) stay
+  // external and resolve from node_modules when the bundle is imported.
+  packages: "external",
+});
+
+const { getSvgGallery } = await import(pathToFileURL(BUNDLE).href);
+const courses = getSvgGallery();
+const total = courses.reduce((n, c) => n + c.graphics.length, 0);
+
+await rm(OUT_DIR, { recursive: true, force: true });
+await mkdir(OUT_DIR, { recursive: true });
+const json = JSON.stringify(courses);
+await writeFile(OUT_FILE, json);
+
+console.log(
+  `[svg-gallery] wrote public/svg-gallery/data.json — ${total} graphics in ` +
+    `${courses.length} courses (${Math.round(json.length / 1024)} kB)`,
+);

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Vercel "Ignored Build Step" — skip deployments that only touch agent-outputs/.
+# Vercel "Ignored Build Step" — skip deployments for pushes that can't change
+# the deployed site.
 #
 # Wired up via the repo's vercel.json:
 #   { "ignoreCommand": "bash scripts/vercel-ignore-build.sh" }
@@ -11,14 +12,42 @@
 #   exit 1 → continue the build / create a deployment
 #   exit 0 → cancel the build (no deployment)
 #
-# Rule: build whenever anything OUTSIDE agent-outputs/ changed in this push;
-# otherwise skip. If the commit range can't be determined we err on the side
-# of building so a real change is never silently dropped.
+# Two rules:
+#   1. Branches prefixed `wip/` never deploy — push throwaway work there
+#      without paying for a preview build.
+#   2. Otherwise, build only when something OUTSIDE the non-shipping paths
+#      below changed in this push. Reports, tests, CI config, and top-level
+#      docs don't affect the deployed output, so a push touching only those
+#      skips the build.
+#
+# If the commit range can't be determined we err on the side of building so
+# a real change is never silently dropped.
 
 set -uo pipefail
 
-# Path(s) that should not, on their own, trigger a deployment.
-EXCLUDE_PATHSPEC=':(exclude)agent-outputs/'
+# Never deploy work-in-progress branches.
+ref="${VERCEL_GIT_COMMIT_REF:-}"
+case "$ref" in
+  wip/*)
+    echo "vercel-ignore-build: branch '$ref' is wip/-prefixed — skipping build."
+    exit 0
+    ;;
+esac
+
+# Paths that should not, on their own, trigger a deployment. Everything here
+# must be provably absent from the production bundle. Note: content/ lessons
+# are .mdx (and pageExtensions includes .md), so markdown is excluded only as
+# the specific top-level doc files, never as a blanket *.md pattern.
+EXCLUDE_PATHSPECS=(
+  ':(exclude)agent-outputs/'
+  ':(exclude)__tests__/'
+  ':(exclude)e2e/'
+  ':(exclude).github/'
+  ':(exclude)cloudflare-cors-proxy/'
+  ':(exclude)README.md'
+  ':(exclude)AGENTS.md'
+  ':(exclude)script-runner-src/README.md'
+)
 
 head_sha="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 base_sha="${VERCEL_GIT_PREVIOUS_SHA:-}"
@@ -34,10 +63,10 @@ if [ -z "$base_sha" ] || ! git rev-parse --verify --quiet "${base_sha}^{commit}"
   fi
 fi
 
-if git diff --quiet "$base_sha" "$head_sha" -- . "$EXCLUDE_PATHSPEC"; then
-  echo "vercel-ignore-build: only agent-outputs/ changed (${base_sha}..${head_sha}) — skipping build."
+if git diff --quiet "$base_sha" "$head_sha" -- . "${EXCLUDE_PATHSPECS[@]}"; then
+  echo "vercel-ignore-build: only non-shipping paths changed (${base_sha}..${head_sha}) — skipping build."
   exit 0
 fi
 
-echo "vercel-ignore-build: changes outside agent-outputs/ detected — proceeding with the build."
+echo "vercel-ignore-build: changes outside non-shipping paths detected — proceeding with the build."
 exit 1


### PR DESCRIPTION
Implements **Phase 1** of the [Vercel ISR/edge usage report](../blob/main/agent-outputs/20260612-1620-vercel-isr-edge-usage-and-hosting-report.md) (§9), reworks `/svg-gallery` to stay off the ISR-read meter entirely, and extends the report with a VPS/Coolify hosting section.

## Phase 1 fixes (report §9, items 1–6)

1. **Link prefetch discipline** — new `app/_components/Link.tsx` wraps `next/link` with `prefetch={false}` by default (in the App Router this disables both viewport and hover prefetch). All app call sites switched (homepage, playground index, playground headers, SQL switcher); only the homepage **Browse Learn** CTA opts back in.
2. **Fumadocs sidebar** — `sidebar={{ prefetch: false }}` on `DocsLayout`. fumadocs-ui 16.9 passes this through `SidebarProvider` to every sidebar item link, so the hundreds of visible lesson links stop fanning out segment prefetches on every page view. This is the biggest lever from the report.
3. **`experimental.staleTimes`** — `dynamic: 300`, `static: 1800`. Slightly stronger than the report's sample (`dynamic: 60, static: 300`) because Next's *default* `static` is already 300 (a no-op) and this site has no dynamic data — content only changes on deploy, so long client-side staleness is safe.
4. **Edge cache headers** — `/api/search` responses get `s-maxage=86400, stale-while-revalidate` (the Orama index only changes on deploy, and deploys purge Vercel's edge cache); the raw-Markdown mirror route gets `force-static` + a year-long `s-maxage` (verified present in the prerender `.meta`).
5. **`app/robots.ts`** — disallows `/api/`, `/llms/`, `/playground`, `/color-test`, `/svg-gallery`, and the `*.md` mirrors. ⚠️ Note: this also de-indexes the 12 playground pages per the report's recommendation — if you'd rather keep "online Python playground"-type SEO, delete the `/playground` line.
6. **Build spend** — `scripts/vercel-ignore-build.sh` now also skips `wip/*` branches and pushes that only touch `__tests__/`, `e2e/`, `.github/`, `cloudflare-cors-proxy/`, or top-level docs (deliberately **not** a blanket `*.md` exclusion, since `pageExtensions` includes `.md`).

## `/svg-gallery`: zero ISR reads

The report's #1 reader (641 units) — explained: the page inlined every `<svg>` from all 758 lessons (**887 graphics, ~2 MB**) into its prerendered payload, *and* the homepage eagerly prefetched it. Now:

- The page is a **~13 kB static shell**; the data ships as `public/svg-gallery/data.json`, a plain CDN static asset that never touches the ISR store, fetched client-side with a loading state (slower first paint accepted — it's a dev review tool).
- Generated by `scripts/build-svg-gallery-data.mjs` (chained into `dev`/`build`, plus a standalone `npm run build:svg-gallery`), which esbuild-bundles the TS collector — same pattern as `build-almostnode-workers.mjs`.
- `lib/svgGallery.ts` no longer depends on the Fumadocs loader (URLs derive from file paths) and course titles now come from each course's `meta.json` — fixing the gallery showing **"Welcome"** as every course heading.

## Report update

- New **§6.1: Self-hosting on a VPS with Coolify** (DigitalOcean droplet, Hetzner alternative): pricing vs Vercel, droplet sizing (the build wants 4 GB+ RAM — options listed), PR-preview support, Cloudflare-free-CDN-in-front guidance, what you give up, and a verdict vs the Cloudflare Workers path. Comparison table gains a VPS row (and the accidentally duplicated §6 table is de-duplicated).

## Verification

- `npm run lint` — 0 errors (48 pre-existing warnings, none in changed files)
- `vitest run` — 29 files, **541 tests pass** (svg ID parity tests unchanged and green)
- `npm run build` — full production build passes; 1,536 static pages; `/svg-gallery` shell contains no embedded SVG data; `robots.txt` and cache headers verified in build output

Expected effect per the report: roughly halved ISR Reads / Edge Requests within a few days, with the svg-gallery line dropping to ~zero. Worth re-checking the Vercel usage dashboard in 3–5 days.

https://claude.ai/code/session_01MDZmA5jzzV9MZ54bby7jSQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDZmA5jzzV9MZ54bby7jSQ)_