### PR TITLE
Fix schema-loading overlay scroll position; use DiamondRippleLoader

### DIFF
--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -91,6 +91,7 @@ import {
   RuntimeInfoContent,
   detectIsMac,
 } from "../playgroundShared";
+import { DiamondRippleLoader } from "../mdx/loadingAnimations";
 import { SqlSettingsPanelContent } from "../sql/components/SqlSettingsPanel";
 import { SqlSettingsConfirmDialogs } from "../sql/components/SqlSettingsConfirmDialogs";
 import { DdlViewerDialog } from "../sql/components/DdlViewerDialog";
@@ -5027,15 +5028,19 @@ function DuckDbPlaygroundInner() {
               </div>
             </div>
             )}
-            <div className="sql-tree">
+            <div className="sql-tree-wrap">
               {(schemaLoading || dbLoading) && (
                 <div className="sql-tree-loading-overlay">
+                  <DiamondRippleLoader
+                    size={56}
+                    label={dbLoading ? "Loading database…" : "Loading schema…"}
+                  />
                   <span className="sql-tree-loading-label">
                     {dbLoading ? "Loading database…" : "Loading schema…"}
                   </span>
-                  <DataslopeRunOverlay running />
                 </div>
               )}
+              <div className="sql-tree">
               {sidebarView === "files" && (
                 <FilesPanel
                   files={virtualFiles}
@@ -5176,6 +5181,7 @@ function DuckDbPlaygroundInner() {
               */}
                 </>
               )}
+              </div>
             </div>
               </div>
             </div>

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -90,6 +90,7 @@ import {
   RuntimeInfoContent,
   detectIsMac,
 } from "../playgroundShared";
+import { DiamondRippleLoader } from "../mdx/loadingAnimations";
 import {
   SqlSettingsPanelContent,
 } from "../sql/components/SqlSettingsPanel";
@@ -4623,15 +4624,19 @@ function PostgresPlaygroundInner() {
                 </Popover.Portal>
               </Popover.Root>
             </div>
-            <div className="sql-tree">
+            <div className="sql-tree-wrap">
               {(schemaLoading || dbLoading) && (
                 <div className="sql-tree-loading-overlay">
+                  <DiamondRippleLoader
+                    size={56}
+                    label={dbLoading ? "Loading database…" : "Loading schema…"}
+                  />
                   <span className="sql-tree-loading-label">
                     {dbLoading ? "Loading database…" : "Loading schema…"}
                   </span>
-                  <DataslopeRunOverlay running />
                 </div>
               )}
+              <div className="sql-tree">
               <SchemaSection
                 label="TABLES"
                 count={tables.length}
@@ -4765,6 +4770,7 @@ function PostgresPlaygroundInner() {
                   />
                 ))}
               </SchemaSection>
+              </div>
             </div>
               </div>
             </div>

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -127,6 +127,17 @@
   color: var(--text-dim);
 }
 
+/* Non-scrolling positioning context for the schema tree. The loading
+   overlay lives here (a sibling of the scrollable .sql-tree) so it stays
+   pinned to the viewport and is not dragged along when the tree scrolls. */
+.sql-tree-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .sql-tree {
   flex: 1;
   overflow-y: auto;
@@ -135,16 +146,18 @@
 }
 
 /* ─── Schema-loading overlay (shown while a schema switch is in flight) ───
-   Covers the entire sql-tree with a semi-transparent backdrop and a
-   DataslopeRunOverlay wave at the bottom so the loading state matches the
-   code-execution animation used in the results pane. */
+   Covers the visible schema-tree area with a semi-transparent backdrop and
+   a DiamondRippleLoader above the loading label. Positioned against the
+   non-scrolling .sql-tree-wrap so it stays fixed while the tree scrolls. */
 .sql-tree-loading-overlay {
   position: absolute;
   inset: 0;
   z-index: 10;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 12px;
   background: color-mix(in oklab, var(--bg) 72%, transparent);
   backdrop-filter: blur(2px);
   pointer-events: auto;
@@ -154,9 +167,6 @@
   font-family: var(--font-ui);
   font-size: 12px;
   color: var(--text);
-  /* Keep the label above the wave overlay that sits at the bottom */
-  position: relative;
-  z-index: 5;
 }
 
 .sql-tree-section {


### PR DESCRIPTION
## Summary

In the SQL playgrounds, the schema-loading overlay ("Loading schema…") was positioned incorrectly: it lived **inside** the scrollable `.sql-tree`, so scrolling the schema pane dragged the overlay along with the content. This PR pins the overlay so it stays fixed while the tree scrolls, and replaces the blue-wave animation with the `DiamondRippleLoader`.

## Changes

- **Scroll fix:** Introduced a non-scrolling `.sql-tree-wrap` positioning context that wraps the scrollable `.sql-tree`. The loading overlay is now a sibling of `.sql-tree` (absolutely positioned against the wrap), so it no longer moves when the tree is scrolled.
- **Loader swap:** Replaced `DataslopeRunOverlay` (blue wave) with `DiamondRippleLoader`, rendered **above** the "Loading schema…" / "Loading database…" label. The overlay is now a centered vertical flex stack (loader on top, label below).

## Files touched

- `app/_components/sqlPlayground.css` — added `.sql-tree-wrap`, restyled `.sql-tree-loading-overlay` to a centered column, updated comments.
- `app/_components/postgres/PostgresPlayground.tsx` — markup + import.
- `app/_components/duckdb/DuckDbPlayground.tsx` — markup + import.

The third playground (`sql/SqlPlayground.tsx`) does not render this overlay, so it was left unchanged.

https://claude.ai/code/session_014pNa34EyRFq7QHfcrmQSeW

---
_Generated by [Claude Code](https://claude.ai/code/session_014pNa34EyRFq7QHfcrmQSeW)_