### PR TITLE
Warm up Java at boot; apply the runtime boot loader to SQL runtimes

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1321,6 +1321,14 @@
   position: relative;
 }
 
+/* While a run is in flight the output body can be empty (no "Running…"
+   placeholder anymore), so reserve height for the blue wave overlay —
+   mirrors `<CodeBlock>`'s `.outputRunning`. */
+.outputRunning {
+  min-height: 84px;
+  padding-bottom: 48px;
+}
+
 .outputHeader {
   display: flex;
   align-items: center;
@@ -2508,6 +2516,12 @@
 .resultPane {
   position: relative;
   overflow: hidden;
+}
+
+/* While a query is in flight the pane can be empty (no "Running…" text),
+   so reserve height for the blue wave overlay on a first run. */
+.resultPaneBusy {
+  min-height: 96px;
 }
 
 .resultFlashOverlay {

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -2432,6 +2432,17 @@
   overflow: hidden;
 }
 
+/* Hosts the shared <RuntimeBootNotice> while a dialect's WASM engine
+   downloads / seeds. Centred in a skeleton-sized box so the panel keeps
+   a stable height across the boot → skeleton → tables transition. */
+.tableViewerBoot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 132px;
+  padding: 18px 16px;
+}
+
 .skeletonRow {
   display: flex;
   gap: 10px;

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -2023,7 +2023,10 @@ export default function ChallengeCard({
 
       {/* ── Output panel ── */}
       {(outputs.length > 0 || isBusy) && (
-        <div className={styles.outputPanel} aria-live="polite">
+        <div
+          className={`${styles.outputPanel}${isBusy ? ` ${styles.outputRunning}` : ""}`}
+          aria-live="polite"
+        >
           {/* The "Output" header is hidden while the boot notice (loading
               animation) is showing — there's no output yet, just setup.
               It returns the moment user code actually runs. */}
@@ -2062,22 +2065,21 @@ export default function ChallengeCard({
                 downloadMB={
                   status === "loading" ? adapter.coldDownloadMB : undefined
                 }
+                compiled={adapter.compiled}
                 fraction={status === "loading" ? bootDisplayFraction : null}
                 testId="challenge-boot"
               />
             </div>
           )}
-          {outputs.length === 0 ? (
-            !showBootNotice && (
-              <div className={styles.outputEmpty}>Running…</div>
-            )
-          ) : (
+          {outputs.length > 0 && (
             <div className={styles.outputBody}>
               {outputs.map((cell) => (
                 <OutputCellView key={cell.id} cell={cell} />
               ))}
             </div>
           )}
+          {/* No "Running…" placeholder while output is empty — the blue
+              wave overlay already signals the run is in progress. */}
           <RunOverlay active={isBusy} />
         </div>
       )}

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -1493,23 +1493,21 @@ function CodeBlockInner({
                 downloadMB={
                   status === "loading" ? adapter.coldDownloadMB : undefined
                 }
+                compiled={adapter.compiled}
                 fraction={status === "loading" ? bootDisplayFraction : null}
                 testId="codeblock-boot"
               />
             </div>
           )}
-          {outputs.length > 0 ? (
+          {outputs.length > 0 && (
             <div className={challengeStyles.outputBody}>
               {outputs.map((cell) => (
                 <OutputSegment key={cell.id} cell={cell} />
               ))}
             </div>
-          ) : (
-            status === "running" &&
-            !midRunPreparing && (
-              <div className={challengeStyles.outputEmpty}>Running…</div>
-            )
           )}
+          {/* No "Running…" placeholder while output is empty — the blue
+              wave overlay already signals the run is in progress. */}
           <RunOverlay active={isBusy} />
         </div>
       )}

--- a/app/_components/RuntimeBootNotice.tsx
+++ b/app/_components/RuntimeBootNotice.tsx
@@ -39,6 +39,10 @@ export interface RuntimeBootNoticeProps {
   cold?: boolean;
   /** Approximate cold download size in MB (adapter.coldDownloadMB). */
   downloadMB?: number;
+  /** True for compiled languages (Java, C, C++, C#): the cold hint then
+   *  promises "later runs are much faster" instead of "instant", since
+   *  they still compile on every run once the runtime is warm. */
+  compiled?: boolean;
   /** Smoothed boot fraction in 0..1, or null for an indeterminate boot
    *  (loader + copy only, no bar). */
   fraction?: number | null;
@@ -51,6 +55,7 @@ export function RuntimeBootNotice({
   statusMessage,
   cold = false,
   downloadMB,
+  compiled = false,
   fraction = null,
   testId,
 }: RuntimeBootNoticeProps) {
@@ -73,8 +78,8 @@ export function RuntimeBootNotice({
         {cold && (
           <span className={styles.hint}>
             Downloading the {language} runtime
-            {downloadMB ? ` (~${downloadMB} MB)` : ""} — this happens once;
-            later runs are instant.
+            {downloadMB ? ` (~${downloadMB} MB)` : ""} — this happens once;{" "}
+            {compiled ? "later runs are much faster" : "later runs are instant"}.
           </span>
         )}
         {pct != null && (
@@ -147,6 +152,7 @@ export function CodeBlockLoadingPreview({
   statusMessage,
   cold = false,
   downloadMB,
+  compiled = false,
   fraction = null,
 }: CodeBlockLoadingPreviewProps) {
   const lines = code.replace(/\n$/, "").split("\n");
@@ -249,6 +255,7 @@ export function CodeBlockLoadingPreview({
             statusMessage={statusMessage}
             cold={cold}
             downloadMB={downloadMB}
+            compiled={compiled}
             fraction={fraction}
           />
         </div>
@@ -448,14 +455,15 @@ function noticeItems(): ShowcaseItem[] {
       ),
     },
     {
-      title: "Cold start — finishing",
+      title: "Cold start — finishing (compiled language)",
       blurb:
-        "Near the end (the bar never hits 100% — the notice unmounts the moment the runtime is ready).",
+        "Near the end (the bar never hits 100% — the notice unmounts the moment the runtime is ready). Compiled languages (C#, Java, C, C++) promise faster — not instant — later runs, since they still compile on every run.",
       jsx: `<RuntimeBootNotice
   language="C#"
   statusMessage="Loading Roslyn (C# scripting engine)…"
   cold
   downloadMB={35}
+  compiled
   fraction={0.9}
 />`,
       node: (
@@ -464,6 +472,7 @@ function noticeItems(): ShowcaseItem[] {
           statusMessage="Loading Roslyn (C# scripting engine)…"
           cold
           downloadMB={35}
+          compiled
           fraction={0.9}
         />
       ),

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -2752,7 +2752,10 @@ export function TableViewer({
             )}
           </div>
           {resultIsActive && resultTabVisible && resultTabData ? (
-            <div className={styles.resultPane} style={{ position: "relative" }}>
+            <div
+              className={`${styles.resultPane}${resultTabData.loading ? ` ${styles.resultPaneBusy}` : ""}`}
+              style={{ position: "relative" }}
+            >
               {flashKey > 0 && (
                 <div key={flashKey} className={styles.resultFlashOverlay} aria-hidden />
               )}
@@ -2792,9 +2795,8 @@ export function TableViewer({
                   {resultTabData.message}
                   {resultTabData.elapsed ? ` · ${resultTabData.elapsed}` : ""}
                 </div>
-              ) : (
-                <div className={styles.sqlMessage}>Running…</div>
-              )}
+              ) : null /* No "Running…" text — the blue wave overlay below
+                          signals the run; .resultPaneBusy reserves height. */}
               <RunOverlay active={resultTabData.loading} />
             </div>
           ) : (

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -84,6 +84,7 @@ import {
   persistKey,
   savePersistedCode,
 } from "./codePersistence";
+import { RuntimeBootNotice } from "./RuntimeBootNotice";
 import styles from "./ChallengeCard.module.css";
 
 // ─── Types ────────────────────────────────────────────────────────────
@@ -298,6 +299,181 @@ export function createEngineForDialect(dialect: SqlDialect): Promise<SqlEngineLi
     case "postgres":
       return createPostgresChallengeEngine();
   }
+}
+
+/** Human-readable engine name for a dialect — used in the boot loader
+ *  copy ("Setting up the DuckDB runtime…"). */
+export function sqlDialectDisplayName(dialect: SqlDialect): string {
+  return dialect === "sqlite"
+    ? "SQLite"
+    : dialect === "duckdb"
+      ? "DuckDB"
+      : "PostgreSQL";
+}
+
+/** Approximate cold-download size (MB) of each dialect's in-browser
+ *  WASM engine — feeds the boot notice's "downloads once (~N MB)" hint.
+ *  Ballpark figures (SQLite ~1 MB, PGlite ~3 MB, DuckDB ~5–10 MB), in
+ *  the same spirit as `LanguageAdapter.coldDownloadMB` for the other
+ *  runtimes. */
+export function sqlDialectColdMB(dialect: SqlDialect): number {
+  return dialect === "sqlite" ? 1 : dialect === "duckdb" ? 6 : 3;
+}
+
+/** Engine label shown before the live runtime reports its exact version. */
+function defaultSqlEngineLabel(dialect: SqlDialect): string {
+  return dialect === "sqlite"
+    ? "SQLite 3.53"
+    : dialect === "duckdb"
+      ? `DuckDB ${DUCKDB_VERSION}`
+      : "PostgreSQL 17";
+}
+
+// Dialects whose engine has booted at least once this page session.
+// Mirrors runtimeRegistry's `ready` set for the non-SQL adapters: it
+// lets the boot notice show its "downloads once (~N MB)" cold copy only
+// on the first block of each dialect, not on every later block (whose
+// WASM is already served from the HTTP cache).
+const bootedSqlDialects = new Set<SqlDialect>();
+
+/** Boot-progress snapshot consumed by `<TableViewer>` to render the
+ *  shared `<RuntimeBootNotice>` while a dialect's WASM engine downloads
+ *  and seeds. `null` once the engine is ready (or if the boot failed —
+ *  the error surfaces in the result pane instead). */
+export interface SqlEngineBootState {
+  cold: boolean;
+  message: string;
+  dialect: SqlDialect;
+  downloadMB: number;
+}
+
+export interface UseSqlEngineBootOptions {
+  dialect: SqlDialect;
+  initSql?: string;
+  remoteInitSql?: string;
+}
+
+/** Shared engine-boot lifecycle for `<SqlChallengeCard>` and
+ *  `<SqlCodeBlock>`. Owns the per-block engine promise (boot + seed
+ *  folded into one cached promise so every caller awaits the same
+ *  fully-seeded engine — see the race note below), the live engine
+ *  label, and the boot-progress state that drives the branded boot
+ *  loader. Keeping it here lets both card components surface the same
+ *  loading affordance the non-SQL blocks already show. */
+export function useSqlEngineBoot({
+  dialect,
+  initSql,
+  remoteInitSql,
+}: UseSqlEngineBootOptions) {
+  // The promise (not the resolved engine) is cached so two near-
+  // simultaneous callers — e.g. the mount-time table-viewer boot and a
+  // Run click — share one boot. Seeding (`initSql`) is folded INTO the
+  // promise so every caller awaits the same fully-seeded engine; an
+  // earlier design flipped a "seeded" flag before `await
+  // engine.exec(initSql)` resolved, letting a second caller query a
+  // table that didn't exist yet — invisible on in-process SQLite but
+  // reliably racy on DuckDB, whose multi-second WASM download widens the
+  // window.
+  const enginePromiseRef = useRef<Promise<SqlEngineLike> | null>(null);
+  const [engineLabel, setEngineLabel] = useState<string>(() =>
+    defaultSqlEngineLabel(dialect),
+  );
+  const [booting, setBooting] = useState(false);
+  const [bootFailed, setBootFailed] = useState(false);
+  const [bootCold, setBootCold] = useState<boolean>(
+    () => !bootedSqlDialects.has(dialect),
+  );
+  const [bootMessage, setBootMessage] = useState<string>(
+    () => `Starting the ${sqlDialectDisplayName(dialect)} engine…`,
+  );
+
+  const ensureEngine = useCallback(async (): Promise<SqlEngineLike> => {
+    if (!enginePromiseRef.current) {
+      setBooting(true);
+      setBootFailed(false);
+      setBootCold(!bootedSqlDialects.has(dialect));
+      setBootMessage(`Starting the ${sqlDialectDisplayName(dialect)} engine…`);
+      enginePromiseRef.current = (async () => {
+        // Start the dataset download while the engine boots — the two
+        // are independent and the WASM fetch usually dominates. The
+        // no-op catch keeps an engine-boot failure from leaving this
+        // promise's rejection unhandled; awaiting it below still throws.
+        const remoteSqlPromise = remoteInitSql
+          ? fetchRemoteInitSql(dialect, remoteInitSql)
+          : null;
+        remoteSqlPromise?.catch(() => {});
+        const engine = await createEngineForDialect(dialect);
+        setEngineLabel(`${engine.label} ${engine.version}`.trim());
+        bootedSqlDialects.add(dialect);
+        if (remoteSqlPromise || (initSql && initSql.trim())) {
+          setBootMessage("Loading sample data…");
+        }
+        if (remoteSqlPromise) {
+          await engine.exec(await remoteSqlPromise);
+        }
+        if (initSql && initSql.trim()) {
+          await engine.exec(initSql);
+        }
+        return engine;
+      })().then(
+        (engine) => {
+          setBooting(false);
+          return engine;
+        },
+        (err) => {
+          // Don't poison the cache with a failed init — let the next
+          // attempt try again.
+          enginePromiseRef.current = null;
+          setBooting(false);
+          setBootFailed(true);
+          throw err;
+        },
+      );
+    }
+    return enginePromiseRef.current;
+  }, [dialect, initSql, remoteInitSql]);
+
+  /** Destroy the current engine (if any) — used on unmount so the
+   *  underlying WASM workers don't leak. */
+  const destroyEngine = useCallback(() => {
+    const p = enginePromiseRef.current;
+    if (p) {
+      void p.then((e) => e.destroy?.()).catch(() => {
+        /* engine never finished initialising; nothing to clean up */
+      });
+    }
+  }, []);
+
+  /** Destroy the current engine and re-arm boot state so the next
+   *  `ensureEngine()` boots + re-seeds a fresh instance — used by Reset. */
+  const resetEngine = useCallback(() => {
+    const old = enginePromiseRef.current;
+    enginePromiseRef.current = null;
+    setBooting(false);
+    setBootFailed(false);
+    if (old) {
+      void old.then((e) => e.destroy?.()).catch(() => {});
+    }
+  }, []);
+
+  const bootState: SqlEngineBootState | null =
+    booting && !bootFailed
+      ? {
+          cold: bootCold,
+          message: bootMessage,
+          dialect,
+          downloadMB: sqlDialectColdMB(dialect),
+        }
+      : null;
+
+  return {
+    ensureEngine,
+    engineLabel,
+    setEngineLabel,
+    bootState,
+    destroyEngine,
+    resetEngine,
+  };
 }
 
 /** Download a remote dataset script (a path inside the
@@ -904,11 +1080,12 @@ export default function SqlChallengeCard({
     [dialect, title, starterCode],
   );
 
-  // Each card owns its own engine instance — sharing across cards
-  // would let one challenge's CREATE TABLE leak into another's
-  // checks. The promise (not the resolved engine) is cached so two
-  // near-simultaneous clicks share a single boot.
-  const enginePromiseRef = useRef<Promise<SqlEngineLike> | null>(null);
+  // Each card owns its own engine instance — sharing across cards would
+  // let one challenge's CREATE TABLE leak into another's checks. The
+  // shared hook owns the cached boot+seed promise, the live engine
+  // label, and the boot-progress state that drives the boot loader.
+  const { ensureEngine, engineLabel, bootState, destroyEngine, resetEngine } =
+    useSqlEngineBoot({ dialect, initSql, remoteInitSql });
   const runSeqRef = useRef(0);
   const runRef = useRef<() => void>(() => {});
   // Default action of the split button (Submit when canCheck,
@@ -934,13 +1111,6 @@ export default function SqlChallengeCard({
   const [isFormatting, setIsFormatting] = useState(false);
   const [resultRunSeq, setResultRunSeq] = useState(0);
   const toasts = useChallengeToasts();
-  const [engineLabel, setEngineLabel] = useState<string>(
-    dialect === "sqlite"
-      ? "SQLite 3.53"
-      : dialect === "duckdb"
-        ? `DuckDB ${DUCKDB_VERSION}`
-        : "PostgreSQL 17",
-  );
 
   const isMac = useSyncExternalStore(
     () => () => {},
@@ -1119,62 +1289,15 @@ export default function SqlChallengeCard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [solutionOpen]);
 
-  // Clean up the engine on unmount so workers don't leak. The ref is
-  // a counter we mutate (not a DOM node we read), so the standard
-  // exhaustive-deps caveat about stale ref values doesn't apply.
+  // Clean up the engine on unmount so workers don't leak. (Bumping the
+  // run sequence makes any in-flight run bail out of its post-await
+  // state updates.)
   useEffect(() => {
     return () => {
       runSeqRef.current = runSeqRef.current + 1;
-      const p = enginePromiseRef.current;
-      if (p) {
-        void p
-          .then((e) => e.destroy?.())
-          .catch(() => {
-            /* engine never finished initialising; nothing to clean up */
-          });
-      }
+      destroyEngine();
     };
-  }, []);
-
-  // ─── Engine bootstrap ───────────────────────────────────────────────
-  // Seeding (running `initSql`) is folded INTO the cached promise so
-  // every caller awaits the same fully-seeded engine. A previous design
-  // flipped a separate "seeded" flag *before* `await engine.exec(initSql)`
-  // resolved, which let a second caller — e.g. the user clicking Submit
-  // while the mount-time table-viewer boot was still seeding — get the
-  // engine back and query a table that didn't exist yet. That race is
-  // invisible for in-process SQLite but fired reliably on DuckDB (whose
-  // multi-second WASM download widens the window), especially for
-  // multi-statement `initSql` that seeds several tables.
-  const ensureEngine = useCallback(async (): Promise<SqlEngineLike> => {
-    if (!enginePromiseRef.current) {
-      enginePromiseRef.current = (async () => {
-        // Start the dataset download while the engine boots — the two
-        // are independent and the WASM fetch usually dominates. The
-        // no-op catch keeps an engine-boot failure from leaving this
-        // promise's rejection unhandled; awaiting it below still throws.
-        const remoteSqlPromise = remoteInitSql
-          ? fetchRemoteInitSql(dialect, remoteInitSql)
-          : null;
-        remoteSqlPromise?.catch(() => {});
-        const engine = await createEngineForDialect(dialect);
-        setEngineLabel(`${engine.label} ${engine.version}`.trim());
-        if (remoteSqlPromise) {
-          await engine.exec(await remoteSqlPromise);
-        }
-        if (initSql && initSql.trim()) {
-          await engine.exec(initSql);
-        }
-        return engine;
-      })().catch((err) => {
-        // Don't poison the cache with a failed init — let the next
-        // attempt try again.
-        enginePromiseRef.current = null;
-        throw err;
-      });
-    }
-    return enginePromiseRef.current;
-  }, [dialect, initSql, remoteInitSql]);
+  }, [destroyEngine]);
 
   // ─── Table viewer ───────────────────────────────────────────────────
   // All table-list / paging / loading state lives in the shared hook so
@@ -1596,11 +1719,9 @@ export default function SqlChallengeCard({
       persistSaveTimerRef.current = null;
     }
     clearPersistedCode(persistedKey);
-    const oldEngine = enginePromiseRef.current;
-    enginePromiseRef.current = null;
-    if (oldEngine) {
-      void oldEngine.then((e) => e.destroy?.()).catch(() => {});
-    }
+    // Destroy the engine and re-arm boot state so the next ensureEngine()
+    // boots + re-seeds a fresh instance (the boot loader shows again).
+    resetEngine();
     setResultSet(null);
     setResultError("");
     setResultMessage("");
@@ -1621,7 +1742,7 @@ export default function SqlChallengeCard({
         });
     }
     toasts.show("Reset to starter SQL.");
-  }, [starterCode, persistedKey, ensureEngine, refreshTableViewer, clearTableViewer, tableViewerEnabled, toasts]);
+  }, [starterCode, persistedKey, resetEngine, ensureEngine, refreshTableViewer, clearTableViewer, tableViewerEnabled, toasts]);
 
   // ─── Apply solution ─────────────────────────────────────────────────
   // Load the reference SQL into the learner's editor (the "Load Solution
@@ -1796,6 +1917,7 @@ export default function SqlChallengeCard({
           initializing={tablesInitializing}
           onLoadMore={loadMoreActiveTable}
           resultTabData={resultTabDataProp}
+          bootState={bootState}
         />
       )}
 
@@ -2504,6 +2626,7 @@ export function TableViewer({
   initializing,
   onLoadMore,
   resultTabData,
+  bootState,
 }: {
   dialect: SqlDialect;
   entries: TableViewerEntry[];
@@ -2512,6 +2635,11 @@ export function TableViewer({
   initializing: boolean;
   onLoadMore: () => void;
   resultTabData?: ResultTabData | null;
+  /** When set, the dialect's WASM engine is still downloading / seeding;
+   *  show the shared branded boot loader in place of the skeleton (and
+   *  in the result area for table-less blocks) so SQL matches the other
+   *  runtimes' first-run loading affordance. */
+  bootState?: SqlEngineBootState | null;
 }) {
   const [resultTabDismissed, setResultTabDismissed] = useState(false);
   const [resultIsActive, setResultIsActive] = useState(false);
@@ -2534,13 +2662,35 @@ export function TableViewer({
   }, [resultTabData]);
 
   const resultTabVisible = resultTabData != null && !resultTabDismissed;
-  const showSkeleton = initializing && entries.length === 0 && !resultTabVisible;
-  // Nothing to show: not initializing and no tables were found.
-  if (!showSkeleton && entries.length === 0 && !resultTabVisible) return null;
+  // While the engine cold-boots there are no tables (and any result tab
+  // is only showing "Running…"), so the boot loader takes the panel —
+  // mirroring how the non-SQL blocks show the notice before first output.
+  const showBootNotice = bootState != null && entries.length === 0;
+  const showSkeleton =
+    !showBootNotice && initializing && entries.length === 0 && !resultTabVisible;
+  // Nothing to show: engine ready, no tables found, no result yet.
+  if (
+    !showBootNotice &&
+    !showSkeleton &&
+    entries.length === 0 &&
+    !resultTabVisible
+  )
+    return null;
   const active = entries[activeIdx];
   return (
     <div className={styles.tableViewer}>
-      {showSkeleton ? (
+      {showBootNotice ? (
+        <div className={styles.tableViewerBoot}>
+          <RuntimeBootNotice
+            language={sqlDialectDisplayName(bootState.dialect)}
+            statusMessage={bootState.message}
+            cold={bootState.cold}
+            downloadMB={bootState.cold ? bootState.downloadMB : undefined}
+            fraction={null}
+            testId="sql-boot"
+          />
+        </div>
+      ) : showSkeleton ? (
         <TableViewerSkeleton />
       ) : (
         <>

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -48,7 +48,6 @@ import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirro
 import { bracketMatching, indentOnInput, indentUnit } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
 import { themeFor, noActiveLine, redoKeymap } from "./cmExtensions";
-import { DUCKDB_VERSION } from "./runtime/duckdb";
 import {
   clearPersistedCode,
   loadPersistedCode,
@@ -57,15 +56,13 @@ import {
 } from "./codePersistence";
 import styles from "./ChallengeCard.module.css";
 import {
-  createEngineForDialect,
   DialectGlyph,
-  fetchRemoteInitSql,
   sqlFormatterLanguage,
   TableViewer,
+  useSqlEngineBoot,
   useSqlTableViewer,
   type ResultTabData,
   type SqlDialect,
-  type SqlEngineLike,
   type SqlResult,
   type SqlTableViewerSpec,
 } from "./SqlChallengeCard";
@@ -139,9 +136,10 @@ export default function SqlCodeBlock({
 
   // Each block owns its own engine instance — sharing across blocks
   // would let one block's CREATE TABLE leak into another's results. The
-  // promise (not the resolved engine) is cached so two near-simultaneous
-  // clicks share a single boot.
-  const enginePromiseRef = useRef<Promise<SqlEngineLike> | null>(null);
+  // shared hook owns the cached boot+seed promise, the live engine
+  // label, and the boot-progress state that drives the boot loader.
+  const { ensureEngine, engineLabel, bootState, destroyEngine, resetEngine } =
+    useSqlEngineBoot({ dialect, initSql, remoteInitSql });
   const runSeqRef = useRef(0);
   const runRef = useRef<() => void>(() => {});
 
@@ -154,13 +152,6 @@ export default function SqlCodeBlock({
   const [isFormatting, setIsFormatting] = useState(false);
   const [resultRunSeq, setResultRunSeq] = useState(0);
   const toasts = useChallengeToasts();
-  const [engineLabel, setEngineLabel] = useState<string>(
-    dialect === "sqlite"
-      ? "SQLite 3.53"
-      : dialect === "duckdb"
-        ? `DuckDB ${DUCKDB_VERSION}`
-        : "PostgreSQL 17",
-  );
 
   const isMac = useSyncExternalStore(
     () => () => {},
@@ -268,59 +259,15 @@ export default function SqlCodeBlock({
     }
   }, [cmThemeName]);
 
-  // Clean up the engine on unmount so workers don't leak.
+  // Clean up the engine on unmount so workers don't leak. (Bumping the
+  // run sequence makes any in-flight run bail out of its post-await
+  // state updates.)
   useEffect(() => {
     return () => {
       runSeqRef.current = runSeqRef.current + 1;
-      const p = enginePromiseRef.current;
-      if (p) {
-        void p
-          .then((e) => e.destroy?.())
-          .catch(() => {
-            /* engine never finished initialising; nothing to clean up */
-          });
-      }
+      destroyEngine();
     };
-  }, []);
-
-  // ─── Engine bootstrap ───────────────────────────────────────────────
-  // Seeding (running `initSql`) is folded INTO the cached promise so
-  // every caller awaits the same fully-seeded engine. A previous design
-  // flipped a separate "seeded" flag *before* `await engine.exec(initSql)`
-  // resolved, which let a second caller — e.g. the user clicking Run
-  // while the mount-time table-viewer boot was still seeding — get the
-  // engine back and query a table that didn't exist yet. That race is
-  // invisible for in-process SQLite but fired reliably on DuckDB, whose
-  // multi-second WASM download widens the window.
-  const ensureEngine = useCallback(async (): Promise<SqlEngineLike> => {
-    if (!enginePromiseRef.current) {
-      enginePromiseRef.current = (async () => {
-        // Start the dataset download while the engine boots — the two
-        // are independent and the WASM fetch usually dominates. The
-        // no-op catch keeps an engine-boot failure from leaving this
-        // promise's rejection unhandled; awaiting it below still throws.
-        const remoteSqlPromise = remoteInitSql
-          ? fetchRemoteInitSql(dialect, remoteInitSql)
-          : null;
-        remoteSqlPromise?.catch(() => {});
-        const engine = await createEngineForDialect(dialect);
-        setEngineLabel(`${engine.label} ${engine.version}`.trim());
-        if (remoteSqlPromise) {
-          await engine.exec(await remoteSqlPromise);
-        }
-        if (initSql && initSql.trim()) {
-          await engine.exec(initSql);
-        }
-        return engine;
-      })().catch((err) => {
-        // Don't poison the cache with a failed init — let the next
-        // attempt try again.
-        enginePromiseRef.current = null;
-        throw err;
-      });
-    }
-    return enginePromiseRef.current;
-  }, [dialect, initSql, remoteInitSql]);
+  }, [destroyEngine]);
 
   // ─── Table viewer ───────────────────────────────────────────────────
   // Shared with `<SqlChallengeCard>` so both stay consistent.
@@ -465,11 +412,9 @@ export default function SqlCodeBlock({
       persistSaveTimerRef.current = null;
     }
     clearPersistedCode(persistedKey);
-    const oldEngine = enginePromiseRef.current;
-    enginePromiseRef.current = null;
-    if (oldEngine) {
-      void oldEngine.then((e) => e.destroy?.()).catch(() => {});
-    }
+    // Destroy the engine and re-arm boot state so the next ensureEngine()
+    // boots + re-seeds a fresh instance (the boot loader shows again).
+    resetEngine();
     setResultSet(null);
     setResultError("");
     setResultMessage("");
@@ -485,7 +430,7 @@ export default function SqlCodeBlock({
         });
     }
     toasts.show("Reset to starter SQL.");
-  }, [starterCode, persistedKey, ensureEngine, refreshTableViewer, clearTableViewer, markTablesInitDone, tableViewerEnabled, toasts]);
+  }, [starterCode, persistedKey, resetEngine, ensureEngine, refreshTableViewer, clearTableViewer, markTablesInitDone, tableViewerEnabled, toasts]);
 
   const copyCode = useCallback(async () => {
     const code = editorRef.current?.state.doc.toString() ?? "";
@@ -584,6 +529,7 @@ export default function SqlCodeBlock({
           initializing={tablesInitializing}
           onLoadMore={loadMoreActiveTable}
           resultTabData={resultTabDataProp}
+          bootState={bootState}
         />
       )}
 

--- a/app/_components/runtime/c.tsx
+++ b/app/_components/runtime/c.tsx
@@ -544,6 +544,8 @@ export const cAdapter: LanguageAdapter = {
   codeMirrorMode: "text/x-csrc",
   // clang + lld WASM and the sysroot from jsDelivr, compressed transfer.
   coldDownloadMB: 35,
+  // Compiles (clang) on every run, so later runs are faster, not instant.
+  compiled: true,
   // clang-format LLVM style (see formatCode) — keep in sync.
   indentWidth: 2,
   examples: EXAMPLES,

--- a/app/_components/runtime/cpp.tsx
+++ b/app/_components/runtime/cpp.tsx
@@ -613,6 +613,8 @@ export const cppAdapter: LanguageAdapter = {
   // clang + lld WASM, the sysroot, and the C++ precompiled header
   // from jsDelivr, compressed transfer.
   coldDownloadMB: 45,
+  // Compiles (clang) on every run, so later runs are faster, not instant.
+  compiled: true,
   // clang-format LLVM style (see formatCode) — keep in sync.
   indentWidth: 2,
   examples: EXAMPLES,

--- a/app/_components/runtime/csharp.tsx
+++ b/app/_components/runtime/csharp.tsx
@@ -493,6 +493,8 @@ export const csharpAdapter: LanguageAdapter = {
   codeMirrorMode: "text/x-csharp",
   // .NET runtime + Roslyn assembly bundle from jsDelivr — see cdn.ts.
   coldDownloadMB: 35,
+  // Compiles (Roslyn) on every run, so later runs are faster, not instant.
+  compiled: true,
   // clang-format Microsoft style (see formatCode) — keep in sync.
   indentWidth: 4,
   examples: EXAMPLES,

--- a/app/_components/runtime/java.tsx
+++ b/app/_components/runtime/java.tsx
@@ -725,6 +725,8 @@ export const javaAdapter: LanguageAdapter = {
   // CheerpJ runtime from cjrtnc.leaningtech.com plus the bundled
   // tools.jar (~18 MB) that provides javac.
   coldDownloadMB: 30,
+  // Compiles (javac) on every run, so later runs are faster, not instant.
+  compiled: true,
   // clang-format LLVM style (see formatCode) — keep in sync.
   indentWidth: 2,
   examples: EXAMPLES,

--- a/app/_components/runtime/java.tsx
+++ b/app/_components/runtime/java.tsx
@@ -515,8 +515,90 @@ class JavaRuntime implements LanguageRuntime {
   // staged by prepareFileSystem. The active file (from run()) is
   // always added to this set so javac sees all workspace files.
   private stagedJavaPaths: string[] = [];
+  // Set once the JVM has compiled + run a throwaway program (see
+  // `warmUp`) so the warm-up only runs on the first init per instance.
+  private warmedUp = false;
 
   constructor(private api: CheerpJApi) {}
+
+  // Capture javac's diagnostics + a program's output by intercepting
+  // console.log / console.error for the duration of one cheerpjRunMain
+  // invocation. CheerpJ writes Java's System.out/System.err to those
+  // globals (verified in cj3.js — there's no other println sink to
+  // hook); it forwards each underlying `write` as one console.log call
+  // and includes the chunk's own newline bytes (so `println("x")`
+  // arrives as "x\n"). We therefore concatenate the args verbatim —
+  // adding our own "\n" per call would produce a blank line between
+  // every chunk. The wrap+restore is in a try/finally so a thrown error
+  // during `await` can't leave the page's console permanently patched.
+  private async runWithCapture(
+    fn: () => Promise<number>,
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const origLog = console.log;
+    const origErr = console.error;
+    let stdout = "";
+    let stderr = "";
+    console.log = (...args: unknown[]) => {
+      stdout += args.map(String).join(" ");
+    };
+    console.error = (...args: unknown[]) => {
+      stderr += args.map(String).join(" ");
+    };
+    try {
+      const exitCode = await fn();
+      return { exitCode, stdout, stderr };
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
+  }
+
+  /** Compile and run a tiny throwaway program so the expensive
+   *  first-use costs happen now, behind the boot animation, instead of
+   *  on the learner's first Run.
+   *
+   *  `cheerpjInit` (in `loadCheerpJ`) only bootstraps the CheerpJ
+   *  runtime — it does NOT load `tools.jar`, `javac`, or the core
+   *  OpenJDK classes. Those are pulled in (and JIT-compiled) lazily on
+   *  the *first* `cheerpjRunMain` call, which without this warm-up is
+   *  the user's first Run: that one execution paid the whole
+   *  tools.jar + javac + runtime class-load + JIT bill while later runs
+   *  were instant. Running a no-op `main` here moves that cost into
+   *  `init()` (covered by the loading notice). Best-effort: any failure
+   *  is swallowed so a warm-up hiccup never blocks running real code. */
+  async warmUp(
+    report?: (message: string, fraction?: number) => void,
+  ): Promise<void> {
+    if (this.warmedUp) return;
+    this.warmedUp = true;
+    try {
+      const warmupClass = "__DataslopeWarmup";
+      const source = `public class ${warmupClass} { public static void main(String[] args) { System.out.print(""); } }`;
+      const sourcePath = `${SOURCE_DIR}${warmupClass}.java`;
+      this.api.cheerpjAddStringFile(
+        sourcePath,
+        new TextEncoder().encode(source),
+      );
+      report?.("Warming up the Java compiler…", 0.55);
+      const compiled = await this.runWithCapture(() =>
+        this.api.cheerpjRunMain(
+          "com.sun.tools.javac.Main",
+          CLASSPATH,
+          sourcePath,
+          "-d",
+          OUTPUT_DIR,
+        ),
+      );
+      if (compiled.exitCode === 0) {
+        report?.("Warming up the Java runtime…", 0.85);
+        await this.runWithCapture(() =>
+          this.api.cheerpjRunMain(warmupClass, CLASSPATH),
+        );
+      }
+    } catch {
+      // Warm-up is best-effort — never let it block real runs.
+    }
+  }
 
   async prepareFileSystem(files: Map<string, Uint8Array>): Promise<void> {
     this.stagedJavaPaths = [];
@@ -573,48 +655,17 @@ class JavaRuntime implements LanguageRuntime {
       filesToCompile.push(sourcePath);
     }
 
-    // 3) Capture javac's diagnostics + the program's output by
-    //    intercepting console.log / console.error for the duration of
-    //    each invocation. CheerpJ writes Java's System.out/System.err
-    //    to those globals (verified in cj3.js — there's no other
-    //    println sink to hook). We wrap+restore in a try/finally so a
-    //    thrown error during `await` can't leave the page's console
-    //    permanently patched.
-    //
-    //    CheerpJ forwards each underlying `write` call as one
-    //    `console.log` invocation and includes the chunk's own newline
-    //    bytes in the string (so `println("x")` arrives as "x\n").
-    //    `printf("%a %b%n", …)` triggers several writes per logical
-    //    line. We therefore concatenate the args verbatim — adding our
-    //    own "\n" per call would produce a blank line between every
-    //    chunk (the bug fixed here).
-    const runWithCapture = async (
-      fn: () => Promise<number>,
-    ): Promise<{ exitCode: number; stdout: string; stderr: string }> => {
-      const origLog = console.log;
-      const origErr = console.error;
-      let stdout = "";
-      let stderr = "";
-      console.log = (...args: unknown[]) => {
-        stdout += args.map(String).join(" ");
-      };
-      console.error = (...args: unknown[]) => {
-        stderr += args.map(String).join(" ");
-      };
-      try {
-        const exitCode = await fn();
-        return { exitCode, stdout, stderr };
-      } finally {
-        console.log = origLog;
-        console.error = origErr;
-      }
-    };
+    // 3) Capture javac's diagnostics + the program's output via the
+    //    shared `runWithCapture` helper (which intercepts console.log /
+    //    console.error — CheerpJ's only println sink). `printf("%a
+    //    %b%n", …)` triggers several writes per logical line, so the
+    //    helper concatenates chunks verbatim rather than adding newlines.
 
     // 4) Compile all staged .java files together. Passing every source
     //    file in a single javac invocation lets the compiler resolve
     //    cross-file references (e.g. Main.java using Dog from Dog.java)
     //    in one pass. `-Xlint` matches JavaFiddle's defaults.
-    const javacResult = await runWithCapture(() =>
+    const javacResult = await this.runWithCapture(() =>
       this.api.cheerpjRunMain(
         "com.sun.tools.javac.Main",
         CLASSPATH,
@@ -637,7 +688,7 @@ class JavaRuntime implements LanguageRuntime {
     }
 
     // 5) Run the user's main() with /files/ on the classpath.
-    const runResult = await runWithCapture(() =>
+    const runResult = await this.runWithCapture(() =>
       this.api.cheerpjRunMain(className, CLASSPATH),
     );
 
@@ -727,6 +778,13 @@ export const javaAdapter: LanguageAdapter = {
       0.08,
     );
     const api = await loadCheerpJ();
-    return new JavaRuntime(api);
+    const runtime = new JavaRuntime(api);
+    // Compile + run a throwaway program now so the first user Run
+    // doesn't pay the one-time tools.jar + javac + runtime class-load +
+    // JIT cost (see `JavaRuntime.warmUp`). Done before resolving init so
+    // the boot notice stays up — and `isRuntimeReady` only reports ready
+    // — once the JVM can actually run code without a multi-second stall.
+    await runtime.warmUp(setLoadingMessage);
+    return runtime;
   },
 };

--- a/app/_components/types.ts
+++ b/app/_components/types.ts
@@ -211,6 +211,11 @@ export interface LanguageAdapter {
    *  version pins the adapter maintains; omit for runtimes that boot
    *  from local/bundled assets in well under a second. */
   coldDownloadMB?: number;
+  /** True for languages that compile on every run (Java, C, C++, C#), so
+   *  the first-run boot copy doesn't promise that "later runs are
+   *  instant" — they still pay a per-run compile step even once the
+   *  runtime is warm. Omit (falsy) for interpreted runtimes. */
+  compiled?: boolean;
   /** Render-only: footer note shown at the bottom of the packages drawer. */
   packagesFooter: React.ReactNode;
   /** Build the snippet inserted at the top of the editor when the user


### PR DESCRIPTION
Follow-ups to #491 (faster-feeling first-run runtime loading).

## Q1 — Java's first execution was slow *even after* the boot animation

**Root cause.** `javaAdapter.init()` only ran `cheerpjInit()` — the CheerpJ bootstrap, which is all the boot notice covered. But the expensive one-time work — mounting the bundled `tools.jar` (~18 MB), loading + JIT-compiling `javac` (`com.sun.tools.javac.Main`), and loading the core OpenJDK runtime classes — is all done **lazily on the first `cheerpjRunMain` call**, i.e. the learner's first Run, *after* the animation was already gone. That single run paid the whole bill; every later run was instant. This matches the report exactly: "the first execution takes unusually long, even after the boot loading animation… subsequent executions are faster."

**Fix.** `JavaRuntime.warmUp()` compiles + runs a tiny throwaway program at the end of `init()`, moving that cost **behind the loading notice** (new staged messages: *"Warming up the Java compiler…"* → *"Warming up the Java runtime…"*). `init` doesn't resolve — and `isRuntimeReady` doesn't report ready — until the JVM can actually run code without a stall, so the first real Run is now as fast as later ones. The warm-up is best-effort (failures swallowed so they can never block running real code), and the console-capture helper is extracted to a private method shared by `run()` and `warmUp()`.

## Q2 — the boot loader wasn't applied to the SQL runtimes

The branded `RuntimeBootNotice` from #491 was only wired into the non-SQL `CodeBlock` / `ChallengeCard`. The `/learn` SQL blocks (SQLite, Postgres, DuckDB) showed only a status dot + a table-viewer skeleton while their WASM engine downloaded — most noticeable on DuckDB's multi-MB boot. (The full SQL *playgrounds* already have their own branded loaders.)

**Fix.** A shared `useSqlEngineBoot` hook — extracted from the two near-identical `ensureEngine` implementations — now owns the cached boot+seed promise, the live engine label, and boot-progress state. `<TableViewer>` renders the **same `<RuntimeBootNotice>`** the other runtimes use while the engine cold-boots, with per-dialect copy and a "downloads once (~N MB)" hint (SQLite ~1 MB, PGlite ~3 MB, DuckDB ~6 MB). A module-level booted-dialects set drives the cold hint so it only shows on the first block of each dialect. On boot failure the notice gives way to the error in the result pane instead of spinning forever.

## Follow-up tweaks (review feedback)

- **Honest boot copy for compiled languages.** The cold hint promised "later runs are instant", which is wrong for languages that compile on every run — Java/C/C++/C# still pay a `javac`/`clang`/Roslyn step once warm. Added a `compiled` flag to `LanguageAdapter` (set on those four adapters), threaded to `RuntimeBootNotice`; the hint now reads **"later runs are much faster"** for them, while interpreted runtimes keep **"later runs are instant"**.
- **Dropped the redundant "Running…" text.** While a run is in flight the blue wave overlay already signals it, so the separate "Running…" placeholder under the OUTPUT header (CodeBlock + ChallengeCard) and in the SQL result pane was doubling up. Removed it; the panel height the text used to provide is reserved via an `.outputRunning` min-height (challenge card) and a `.resultPaneBusy` min-height (SQL pane) so the wave keeps its space on an empty first run.

## Verification
- `tsc --noEmit`, `eslint`, **563 unit tests**, and `next build` all clean.
- In a real browser: the SQL boot loader confirmed for all three dialects (correct copy/sizes), transitioning to the live result table (and to the error pane on a failed boot); the Java warm-up stages render behind the animation with **first-run ≈ second-run timing**; the Java notice now reads "later runs are much faster" while Python still reads "later runs are instant"; and the running state shows only the wave (no "Running…" placeholder).

https://claude.ai/code/session_017kGqmcmDrHhsG3F8KjoVKX