### PR TITLE
Add "Create Table" file action to DuckDB playground

### DIFF
--- a/__tests__/duckdbReadableFile.test.ts
+++ b/__tests__/duckdbReadableFile.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  isDuckDbReadableFile,
+  DUCKDB_READABLE_EXTENSIONS,
+} from "../app/_components/sql/utils/importUtils";
+
+describe("isDuckDbReadableFile", () => {
+  it("accepts every documented base extension", () => {
+    for (const ext of DUCKDB_READABLE_EXTENSIONS) {
+      expect(isDuckDbReadableFile(`data.${ext}`)).toBe(true);
+    }
+  });
+
+  it("matches the example file from the playground", () => {
+    expect(isDuckDbReadableFile("lending-club-loan-results.parquet")).toBe(true);
+  });
+
+  it("looks through a single .gz/.zst compression suffix", () => {
+    expect(isDuckDbReadableFile("data.csv.gz")).toBe(true);
+    expect(isDuckDbReadableFile("data.json.zst")).toBe(true);
+    expect(isDuckDbReadableFile("events.ndjson.gz")).toBe(true);
+  });
+
+  it("is case-insensitive on the extension", () => {
+    expect(isDuckDbReadableFile("DATA.CSV")).toBe(true);
+    expect(isDuckDbReadableFile("Report.Parquet")).toBe(true);
+    expect(isDuckDbReadableFile("data.CSV.GZ")).toBe(true);
+  });
+
+  it("resolves the extension from the final path segment", () => {
+    expect(isDuckDbReadableFile("nested/folder/sales.csv")).toBe(true);
+    // A dot in a parent folder must not be mistaken for the file extension.
+    expect(isDuckDbReadableFile("v1.0/notes")).toBe(false);
+  });
+
+  it("rejects extensions DuckDB can't replacement-scan", () => {
+    expect(isDuckDbReadableFile("notes.txt")).toBe(false);
+    expect(isDuckDbReadableFile("book.xlsx")).toBe(false);
+    expect(isDuckDbReadableFile("backup.duckdb")).toBe(false);
+    expect(isDuckDbReadableFile("image.png")).toBe(false);
+  });
+
+  it("rejects files with no usable extension", () => {
+    expect(isDuckDbReadableFile("README")).toBe(false);
+    expect(isDuckDbReadableFile("archive.gz")).toBe(false); // format unknown
+    expect(isDuckDbReadableFile("dump.tar.gz")).toBe(false); // tar isn't readable
+  });
+});

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -202,6 +202,7 @@ import {
   parseCsv,
   readParquetFile,
   tableNameFromFilename,
+  isDuckDbReadableFile,
 } from "./duckdbImport";
 import { FK_ACTIONS } from "../sql/constants";
 
@@ -2681,6 +2682,35 @@ function DuckDbPlaygroundInner() {
     [persistTabs, runSqlForTab],
   );
 
+  // Build a new table from a file via DuckDB's replacement scan
+  // (`CREATE TABLE … AS SELECT * FROM 'file'`). The table name is derived
+  // from the file name, suffixed with a counter if that name is already
+  // taken in the active schema so a repeat invocation doesn't error out.
+  const createTableFromFile = useCallback(
+    (path: string) => {
+      const filename = path.split("/").pop() ?? path;
+      const schema = selectedSchemaRef.current;
+      const base = tableNameFromFilename(filename);
+      const taken = new Set(tablesRef.current);
+      let tableName = base;
+      for (let n = 2; taken.has(tableName); n++) {
+        tableName = `${base}_${n}`;
+      }
+      const sql = `CREATE TABLE ${quoteIdent(schema)}.${quoteIdent(tableName)} AS SELECT * FROM "${path}";`;
+      const tab: QueryTab = {
+        id: newTabId(),
+        title: tableName,
+        code: sql,
+        pristineCode: sql,
+      };
+      tabHistoryRef.current = pushTabHistory(tabHistoryRef.current, activeTabIdRef.current, tab.id);
+      persistTabs([...tabsRef.current, tab]);
+      setActiveTabId(tab.id);
+      void runSqlForTab(tab.id, sql, `File: ${filename}`);
+    },
+    [persistTabs, runSqlForTab, selectedSchemaRef],
+  );
+
   // ─── Settings actions ────────────────────────────────────────────────
   const restoreDefaultSettings = useCallback(() => {
     const D = DEFAULT_PLAYGROUND_SETTINGS;
@@ -5053,6 +5083,8 @@ function DuckDbPlaygroundInner() {
                   onCreateFolder={handleFilesCreateFolder}
                   onMove={handleFilesMove}
                   onOpenQuery={queryFileWithSelect}
+                  onCreateTable={createTableFromFile}
+                  canCreateTable={isDuckDbReadableFile}
                 />
               )}
               {sidebarView === "schema" && (

--- a/app/_components/duckdb/duckdbImport.ts
+++ b/app/_components/duckdb/duckdbImport.ts
@@ -3,7 +3,12 @@
 import { sanitizeImportColName } from "../sql/utils/importUtils";
 import type { DuckDbEngine } from "../runtime/duckdb";
 
-export { parseCsv, tableNameFromFilename, readParquetFile } from "../sql/utils/importUtils";
+export {
+  parseCsv,
+  tableNameFromFilename,
+  readParquetFile,
+  isDuckDbReadableFile,
+} from "../sql/utils/importUtils";
 
 function quoteIdent(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;

--- a/app/_components/files/FilesPanel.tsx
+++ b/app/_components/files/FilesPanel.tsx
@@ -20,6 +20,7 @@ import {
   Info,
   Play,
   Copy,
+  Table,
 } from "lucide-react";
 
 export interface VirtualFile {
@@ -57,6 +58,16 @@ interface FilesPanelProps {
   onOpenQuery?: (path: string) => void;
   /** Label for the open-query menu item (defaults to "Query with SELECT"). */
   openQueryLabel?: string;
+  /** Called when the user chooses to create a table from a file. Only
+   *  rendered when provided — use to surface a runtime-specific "import as
+   *  table" action. */
+  onCreateTable?: (path: string) => void;
+  /** Predicate gating the create-table menu item per file (e.g. only for
+   *  extensions the runtime can read). When omitted, the item shows for
+   *  every file as long as `onCreateTable` is provided. */
+  canCreateTable?: (path: string) => boolean;
+  /** Label for the create-table menu item (defaults to "Create Table"). */
+  createTableLabel?: string;
 }
 
 function buildTree(files: VirtualFile[]): TreeNode {
@@ -147,6 +158,9 @@ interface TreeRowProps {
   onRequestInfo: (node: TreeNode) => void;
   onOpenQuery?: (path: string) => void;
   openQueryLabel?: string;
+  onCreateTable?: (path: string) => void;
+  canCreateTable?: (path: string) => boolean;
+  createTableLabel?: string;
   onCopyFileName: (path: string) => void;
   onCopyPath: (path: string) => void;
   onDragStart: (path: string) => void;
@@ -175,6 +189,9 @@ function TreeRow({
   onRequestInfo,
   onOpenQuery,
   openQueryLabel = "Query with SELECT",
+  onCreateTable,
+  canCreateTable,
+  createTableLabel = "Create Table",
   onCopyFileName,
   onCopyPath,
   onDragStart,
@@ -309,6 +326,17 @@ function TreeRow({
                   <div className="ex-title">{openQueryLabel}</div>
                 </ContextMenu.Item>
               )}
+              {!node.isFolder &&
+                onCreateTable &&
+                (!canCreateTable || canCreateTable(node.fullPath)) && (
+                  <ContextMenu.Item
+                    className="example-item"
+                    onClick={() => onCreateTable(node.fullPath)}
+                  >
+                    <Table size={12} aria-hidden="true" />
+                    <div className="ex-title">{createTableLabel}</div>
+                  </ContextMenu.Item>
+                )}
               {!node.isFolder && (
                 <ContextMenu.Item
                   className="example-item"
@@ -386,6 +414,9 @@ function TreeRow({
             onRequestInfo={onRequestInfo}
             onOpenQuery={onOpenQuery}
             openQueryLabel={openQueryLabel}
+            onCreateTable={onCreateTable}
+            canCreateTable={canCreateTable}
+            createTableLabel={createTableLabel}
             onCopyFileName={onCopyFileName}
             onCopyPath={onCopyPath}
             onDragStart={onDragStart}
@@ -412,6 +443,9 @@ export function FilesPanel({
   onMove,
   onOpenQuery,
   openQueryLabel,
+  onCreateTable,
+  canCreateTable,
+  createTableLabel,
 }: FilesPanelProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -768,6 +802,9 @@ export function FilesPanel({
                     onRequestInfo={handleRequestInfo}
                     onOpenQuery={onOpenQuery}
                     openQueryLabel={openQueryLabel}
+                    onCreateTable={onCreateTable}
+                    canCreateTable={canCreateTable}
+                    createTableLabel={createTableLabel}
                     onCopyFileName={handleCopyFileName}
                     onCopyPath={handleCopyPath}
                     onDragStart={handleInternalDragStart}

--- a/app/_components/sql/utils/importUtils.ts
+++ b/app/_components/sql/utils/importUtils.ts
@@ -78,6 +78,39 @@ export function tableNameFromFilename(filename: string): string {
   return base || "imported_table";
 }
 
+/** File extensions DuckDB can read directly through a replacement scan —
+ *  i.e. `SELECT * FROM 'file.ext'` works without an explicit `read_*`
+ *  wrapper. Used by the Files panel to decide whether to offer a
+ *  "Create Table" action for a given file. */
+export const DUCKDB_READABLE_EXTENSIONS = [
+  "csv",
+  "tsv",
+  "json",
+  "jsonl",
+  "ndjson",
+  "parquet",
+] as const;
+
+/** Transparent compression suffixes DuckDB unwraps for its text formats,
+ *  so `data.csv.gz` reads the same as `data.csv`. */
+const DUCKDB_COMPRESSION_SUFFIXES = ["gz", "zst"];
+
+/** True when DuckDB can build a table straight from this file via a
+ *  replacement scan, judged from its (case-insensitive) extension. A
+ *  single `.gz`/`.zst` compression suffix is looked through to the real
+ *  format extension (e.g. `data.csv.gz`). */
+export function isDuckDbReadableFile(path: string): boolean {
+  const name = (path.split("/").pop() ?? path).toLowerCase();
+  const parts = name.split(".");
+  if (parts.length < 2) return false; // no extension at all
+  let ext = parts[parts.length - 1];
+  if (DUCKDB_COMPRESSION_SUFFIXES.includes(ext)) {
+    if (parts.length < 3) return false; // bare ".gz"/".zst", format unknown
+    ext = parts[parts.length - 2];
+  }
+  return (DUCKDB_READABLE_EXTENSIONS as readonly string[]).includes(ext);
+}
+
 /** Read a Parquet file and materialise it into the same column/row
  *  shape parseCsv returns, so callers can hand the result off to a
  *  shared import preview component. */


### PR DESCRIPTION
## Summary

Adds a **Create Table** option to the Files panel context menu in the DuckDB playground (the menu that already has *Query with SELECT*, *Download*, *Copy Path*, etc.).

Selecting it runs `CREATE TABLE <name> AS SELECT * FROM '<file>'` through DuckDB's replacement scan and opens the statement in a new tab, so the file's data lands as a real table (visible in the schema panel after the refresh that `runSqlForTab` already triggers).

As requested:
- **Only files DuckDB can read directly show the option.** A new `isDuckDbReadableFile` helper gates the item by extension — `csv`, `tsv`, `json`, `jsonl`, `ndjson`, `parquet`, plus transparent `.gz`/`.zst` compression variants (e.g. `data.csv.gz`). Unsupported files (`.txt`, `.xlsx`, `.duckdb`, no extension, bare `.gz`, …) don't get the option.
- **The table name is derived from the file name** via the existing `tableNameFromFilename` (e.g. `lending-club-loan-results.parquet` → `lending_club_loan_results`). On a name clash in the active schema it's suffixed (`_2`, `_3`, …) so re-running on the same file doesn't error with "table already exists".

## Implementation notes
- `FilesPanel` gains generic, optional `onCreateTable` / `canCreateTable` / `createTableLabel` props (mirroring the existing `onOpenQuery` / `openQueryLabel` pattern), so the panel stays runtime-agnostic and the DuckDB-specific extension logic lives in the DuckDB layer.
- `isDuckDbReadableFile` + `DUCKDB_READABLE_EXTENSIONS` live in `importUtils.ts` next to `tableNameFromFilename`, re-exported through `duckdbImport.ts`.
- The new table is created in the currently selected schema (`CREATE TABLE <schema>.<name> …`), consistent with the other entity actions.

## Testing
- New unit tests in `__tests__/duckdbReadableFile.test.ts` covering supported/unsupported extensions, compression suffixes, case-insensitivity, and path handling.
- `npm test` — all 570 tests pass (32 files).
- `tsc --noEmit` — clean.
- `eslint` — no new errors/warnings in the changed files.

https://claude.ai/code/session_014nL36CdEN5jfqHgvzGjer2

---
_Generated by [Claude Code](https://claude.ai/code/session_014nL36CdEN5jfqHgvzGjer2)_