### PR TITLE
Playground loading, multi-tab, save, and SQL styling improvements

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -104,7 +104,10 @@ import {
   detectIsMac,
 } from "./playgroundShared";
 import { DiamondMark } from "./mdx/loadingAnimations";
-import { PlaygroundBootOverlay } from "./PlaygroundBootOverlay";
+import {
+  PlaygroundBootOverlay,
+  useBootOverlayVisibility,
+} from "./PlaygroundBootOverlay";
 import {
   hasRuntimeBootedBefore,
   markRuntimeBooted,
@@ -741,19 +744,13 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   // until one arrives); smoothed below to drive a determinate loading
   // bar instead of the indeterminate sweep.
   const [bootFraction, setBootFraction] = useState<number | null>(null);
-  // Two-phase teardown for the loading overlay: when `loaded` flips
-  // true we keep the overlay mounted briefly so its CSS opacity
-  // transition can play out (avoids the "blink" effect on languages
-  // that initialise quickly), then unmount it once the fade completes.
-  // `loadingFading` is derived from `loaded` and `showLoadingOverlay`
-  // so we don't have to setState() directly inside an effect.
-  const [showLoadingOverlay, setShowLoadingOverlay] = useState(true);
-  const loadingFading = loaded && showLoadingOverlay;
-  useEffect(() => {
-    if (!loaded) return;
-    const id = window.setTimeout(() => setShowLoadingOverlay(false), 400);
-    return () => window.clearTimeout(id);
-  }, [loaded]);
+  // Loading-overlay lifecycle (show → fade → unmount) with a minimum
+  // on-screen time, so a warm revisit — where the shared runtime is
+  // already booted and `loaded` flips almost immediately — shows a
+  // deliberate loading screen instead of a one-frame "blink". Cold boots
+  // exceed the floor, so they fade the instant boot finishes.
+  const { mounted: showLoadingOverlay, fading: loadingFading } =
+    useBootOverlayVisibility(loaded);
   const [statusState, setStatusState] = useState<
     "loading" | "ready" | "running" | "error"
   >("loading");

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -127,7 +127,12 @@ import {
   readFile as opfsReadFile,
   writeFile as opfsWriteFile,
 } from "./opfs/fileStorage";
-import { ensureActiveWorkspace } from "./opfs/activeWorkspace";
+import {
+  ensureActiveWorkspace,
+  isWorkspaceDirty,
+  markWorkspaceDirty,
+  saveDraftWorkspace,
+} from "./opfs/activeWorkspace";
 import { acquireWorkspaceLock } from "./opfs/workspace";
 import { WorkspaceBadge } from "./workspace/WorkspaceBadge";
 import { FileCode2, Settings } from "lucide-react";
@@ -798,6 +803,32 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   const dirtyBuffersRef = useRef(dirtyBuffers);
   const settingsOpenRef = useRef(false);
   const activeTabIdRef = useRef(activeTabId);
+
+  // ─── Explicit-save state ────────────────────────────────────────────────
+  // `workspaceSaved` is false for the auto-created draft (not yet in the saved
+  // list); `workspaceDirty` latches true once the user changes anything. The
+  // Save affordance shows only when the workspace is an unsaved, changed draft.
+  const [workspaceSaved, setWorkspaceSaved] = useState(true);
+  const [workspaceDirty, setWorkspaceDirty] = useState(false);
+  const dirtyMarkedRef = useRef(false);
+  const markDirty = useCallback(() => {
+    if (dirtyMarkedRef.current) return;
+    dirtyMarkedRef.current = true;
+    const wsId = workspaceIdRef.current;
+    if (wsId) markWorkspaceDirty(wsId);
+    setWorkspaceDirty(true);
+  }, []);
+  const handleSaveWorkspace = useCallback(
+    async (name: string) => {
+      const saved = saveDraftWorkspace(adapter.id, name);
+      if (saved) {
+        setWorkspace(saved.id, saved.name);
+        setWorkspaceSaved(true);
+      }
+    },
+    [adapter.id, setWorkspace],
+  );
+
   useEffect(() => {
     settingsOpenRef.current = settingsOpen;
     // Reset tab position when settings is closed so it starts at the end
@@ -956,6 +987,10 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       try {
         const ws = await ensureActiveWorkspace(adapter.id);
         if (cancelled) return;
+        setWorkspaceSaved(ws.saved);
+        const wsDirty = isWorkspaceDirty(ws.id);
+        setWorkspaceDirty(wsDirty);
+        dirtyMarkedRef.current = wsDirty;
 
         const manifest = loadManifest(adapter.id, ws.id);
         let files: PlaygroundFile[];
@@ -1335,6 +1370,8 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
             updateDirtyBuffer(fileId, content);
             if (wsId) opfsWriteFile(wsId, fileId, content);
           }
+          // A genuine user edit makes the workspace eligible to be saved.
+          markDirty();
         }
         for (const tr of update.transactions) {
           if (!tr.isUserEvent("input.type")) continue;
@@ -3001,6 +3038,8 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
               activeWorkspaceName={workspaceName}
               managerOpen={workspaceManagerOpen}
               onManagerOpenChange={setWorkspaceManagerOpen}
+              unsaved={!workspaceSaved && workspaceDirty}
+              onSave={handleSaveWorkspace}
             />
           )}
 

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -105,6 +105,10 @@ import {
 } from "./playgroundShared";
 import { DiamondMark } from "./mdx/loadingAnimations";
 import { PlaygroundBootOverlay } from "./PlaygroundBootOverlay";
+import {
+  hasRuntimeBootedBefore,
+  markRuntimeBooted,
+} from "./runtime/bootHistory";
 import { TabBar } from "./tabs/TabBar";
 import type { TabContextMenuItem, TabDescriptor } from "./tabs/tabTypes";
 import {
@@ -718,6 +722,16 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     "Initializing runtime…",
   );
   const [loaded, setLoaded] = useState(false);
+  // First-ever cold boot vs warm revisit. The WASM payload is served from
+  // the browser's HTTP cache after the first boot, so only a genuine
+  // first-ever boot in this browser shows the "Downloading … this happens
+  // once" reassurance — later visits just show the status line + bar.
+  const [isColdBoot] = useState(
+    () => adapter.coldDownloadMB != null && !hasRuntimeBootedBefore(adapter.id),
+  );
+  useEffect(() => {
+    if (loaded) markRuntimeBooted(adapter.id);
+  }, [loaded, adapter.id]);
   // Latest stage-floor fraction reported by the adapter's boot (null
   // until one arrives); smoothed below to drive a determinate loading
   // bar instead of the indeterminate sweep.
@@ -2893,7 +2907,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
               ? loadingMessage
               : loadingMessage || LOADING_QUIPS[quipIndex]
           }
-          cold={adapter.coldDownloadMB != null}
+          cold={isColdBoot}
           downloadMB={adapter.coldDownloadMB}
           compiled={adapter.compiled}
           fraction={bootDisplayFraction}

--- a/app/_components/PlaygroundBootOverlay.tsx
+++ b/app/_components/PlaygroundBootOverlay.tsx
@@ -34,7 +34,8 @@ function BootTitle({ message }: { message: ReactNode }) {
 }
 
 export interface PlaygroundBootOverlayProps {
-  /** Runtime / language name used in the download hint (e.g. "Python"). */
+  /** Runtime / language name (e.g. "Python"). Retained for call-site
+   *  compatibility — the boot copy no longer names the runtime. */
   title: string;
   /** Current stage line (the playground's loading caption). */
   statusMessage: ReactNode;
@@ -55,7 +56,6 @@ export interface PlaygroundBootOverlayProps {
 }
 
 export function PlaygroundBootOverlay({
-  title,
   statusMessage,
   cold = false,
   downloadMB,
@@ -87,11 +87,15 @@ export function PlaygroundBootOverlay({
             <BootTitle message={statusMessage} />
           </span>
           {!error && cold && (
-            <span className="playground-boot-hint">
-              Downloading the {title} runtime
-              {downloadMB ? ` (~${downloadMB} MB)` : ""} — this happens once;{" "}
-              later runs are much faster.
-            </span>
+            <div className="playground-boot-hints">
+              <span className="playground-boot-hint">
+                This can take a moment on first load
+              </span>
+              <span className="playground-boot-hint playground-boot-hint-sub">
+                {downloadMB ? `Downloading (~${downloadMB} MB) — ` : ""}This
+                happens once. Later runs are much faster.
+              </span>
+            </div>
           )}
           {!error && pct != null && (
             <div className="playground-boot-progress">

--- a/app/_components/PlaygroundBootOverlay.tsx
+++ b/app/_components/PlaygroundBootOverlay.tsx
@@ -8,8 +8,60 @@
 // determinate progress bar — so a multi-second cold start reads the same
 // everywhere. Styling lives in playground.css (`.playground-boot-*`).
 
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { DiamondAssembleTurnLoader } from "./mdx/loadingAnimations";
+
+/** Boot-overlay opacity fade duration in ms; mirrors the CSS
+ *  `transition: opacity 0.4s` on `.pyodide-loading`. The overlay is kept
+ *  mounted for this long after it begins fading so the animation finishes
+ *  before it unmounts. */
+const BOOT_OVERLAY_FADE_MS = 400;
+
+/** Minimum time (ms) the boot overlay stays fully visible, measured from
+ *  mount, before it is allowed to fade out. On a warm revisit the runtime
+ *  is already booted and `loaded` flips within a frame or two; without this
+ *  floor the overlay would appear for a single frame and vanish — a jarring
+ *  "blink". Holding it briefly makes re-entering a playground read as a
+ *  deliberate transition. Cold boots take far longer than this, so the floor
+ *  is a no-op there (the overlay fades the instant boot finishes). */
+export const MIN_BOOT_OVERLAY_MS = 500;
+
+export interface BootOverlayVisibility {
+  /** Render the overlay while true; it unmounts once the fade finishes. */
+  mounted: boolean;
+  /** Apply the `.hidden` fade-out class while true. */
+  fading: boolean;
+}
+
+/** Drives the boot overlay's show → fade → unmount lifecycle from a single
+ *  `loaded` flag, enforcing {@link MIN_BOOT_OVERLAY_MS} of on-screen time so
+ *  a warm revisit doesn't blink. Shared by the language playgrounds
+ *  (`<Playground>`) and the SQL playgrounds (`<SqlPlaygroundShell>`) so every
+ *  loading screen behaves identically. Returns `{ mounted, fading }`: render
+ *  the overlay while `mounted` and pass `fading` through as the `.hidden`
+ *  class. */
+export function useBootOverlayVisibility(
+  loaded: boolean,
+): BootOverlayVisibility {
+  // Captured once on mount ≈ when the overlay first painted.
+  const [mountedAt] = useState(() => Date.now());
+  const [mounted, setMounted] = useState(true);
+  const [fading, setFading] = useState(false);
+  useEffect(() => {
+    if (!loaded) return;
+    const holdFor = Math.max(0, MIN_BOOT_OVERLAY_MS - (Date.now() - mountedAt));
+    const fadeId = window.setTimeout(() => setFading(true), holdFor);
+    const unmountId = window.setTimeout(
+      () => setMounted(false),
+      holdFor + BOOT_OVERLAY_FADE_MS,
+    );
+    return () => {
+      window.clearTimeout(fadeId);
+      window.clearTimeout(unmountId);
+    };
+  }, [loaded, mountedAt]);
+  return { mounted, fading };
+}
 
 /** Renders a status string with its trailing ellipsis ("…" or "...")
  *  replaced by three dots that cycle one → two → three. Non-string

--- a/app/_components/RuntimeBootNotice.tsx
+++ b/app/_components/RuntimeBootNotice.tsx
@@ -75,11 +75,15 @@ export function RuntimeBootNotice({
           {title}
         </span>
         {cold && (
-          <span className={styles.hint}>
-            Downloading the {language} runtime
-            {downloadMB ? ` (~${downloadMB} MB)` : ""} — this happens once;{" "}
-            later runs are much faster.
-          </span>
+          <>
+            <span className={styles.hint}>
+              This can take a moment on first load
+            </span>
+            <span className={styles.hint}>
+              {downloadMB ? `Downloading (~${downloadMB} MB) — ` : ""}This
+              happens once. Later runs are much faster.
+            </span>
+          </>
         )}
         {pct != null && (
           <div className={styles.progress}>
@@ -287,10 +291,10 @@ print(by_species.round(1))`;
  *  components feed the notice during a cold Pyodide boot. */
 function SimulatedCodeBlock() {
   const stages: Array<{ at: number; message: string }> = [
-    { at: 0.04, message: "Starting Python worker…" },
-    { at: 0.2, message: "Loading Pyodide…" },
+    { at: 0.04, message: "Starting Python runtime…" },
+    { at: 0.2, message: "Loading Python runtime…" },
     { at: 0.55, message: "Preparing the Python environment…" },
-    { at: 0.82, message: "Installing the data packages…" },
+    { at: 0.82, message: "Installing data packages…" },
   ];
   const [fraction, setFraction] = useState(0.04);
 
@@ -348,7 +352,7 @@ function codeBlockItems(): ShowcaseItem[] {
   language="Python"
   version="3.13.2"
   code={pandasSnippet}
-  statusMessage="Loading Pyodide…"
+  statusMessage="Loading Python runtime…"
   cold
   downloadMB={6}
   fraction={0.42}
@@ -363,7 +367,7 @@ function codeBlockItems(): ShowcaseItem[] {
   language="Python"
   version="3.13.2"
   code={pandasSnippet}
-  statusMessage="Starting Python worker…"
+  statusMessage="Starting Python runtime…"
   cold
   downloadMB={6}
   fraction={0.06}
@@ -374,7 +378,7 @@ function codeBlockItems(): ShowcaseItem[] {
           version="3.13.2"
           langId="python"
           code={SAMPLE_CODE}
-          statusMessage="Starting Python worker…"
+          statusMessage="Starting Python runtime…"
           cold
           downloadMB={6}
           fraction={0.06}
@@ -389,7 +393,7 @@ function codeBlockItems(): ShowcaseItem[] {
   language="Python"
   version="3.13.2"
   code={pandasSnippet}
-  statusMessage="Installing the Python data packages — first run only…"
+  statusMessage="Installing data packages — first run only…"
   cold
   fraction={0.7}
 />`,
@@ -399,7 +403,7 @@ function codeBlockItems(): ShowcaseItem[] {
           version="3.13.2"
           langId="python"
           code={SAMPLE_CODE}
-          statusMessage="Installing the Python data packages — first run only…"
+          statusMessage="Installing data packages — first run only…"
           cold
           fraction={0.7}
         />
@@ -417,7 +421,7 @@ function noticeItems(): ShowcaseItem[] {
         "The first stage floor: the worker has started and the runtime download is about to stream in.",
       jsx: `<RuntimeBootNotice
   language="Python"
-  statusMessage="Starting Python worker…"
+  statusMessage="Starting Python runtime…"
   cold
   downloadMB={6}
   fraction={0.05}
@@ -425,7 +429,7 @@ function noticeItems(): ShowcaseItem[] {
       node: (
         <RuntimeBootNotice
           language="Python"
-          statusMessage="Starting Python worker…"
+          statusMessage="Starting Python runtime…"
           cold
           downloadMB={6}
           fraction={0.05}
@@ -459,7 +463,7 @@ function noticeItems(): ShowcaseItem[] {
         "Near the end (the bar never hits 100% — the notice unmounts the moment the runtime is ready). The boot copy promises that later runs are much faster for every runtime.",
       jsx: `<RuntimeBootNotice
   language="C#"
-  statusMessage="Loading Roslyn (C# scripting engine)…"
+  statusMessage="Preparing C# compiler…"
   cold
   downloadMB={35}
   compiled
@@ -468,7 +472,7 @@ function noticeItems(): ShowcaseItem[] {
       node: (
         <RuntimeBootNotice
           language="C#"
-          statusMessage="Loading Roslyn (C# scripting engine)…"
+          statusMessage="Preparing C# compiler…"
           cold
           downloadMB={35}
           compiled

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -108,7 +108,11 @@ import { RenameDatabaseDialog } from "../sql/components/RenameDatabaseDialog";
 import { SqlEditorToolbar } from "../sql/components/SqlEditorToolbar";
 import { findDuckDbSampleDatabase } from "../runtime/duckdbSamples";
 import { duckdbAdapter } from "./duckdbAdapter";
-import { ensureActiveWorkspace, switchActiveWorkspace } from "../opfs/activeWorkspace";
+import {
+  ensureActiveWorkspace,
+  saveDraftWorkspace,
+  switchActiveWorkspace,
+} from "../opfs/activeWorkspace";
 import { acquireWorkspaceLock, createWorkspace } from "../opfs/workspace";
 import {
   deleteDataEntry as opfsDeleteDataEntry,
@@ -1023,6 +1027,16 @@ function DuckDbPlaygroundInner() {
     id: string;
     name: string;
   } | null>(null);
+  // False for the auto-created draft workspace (kept out of the saved list
+  // until the user saves it). Drives the Save affordance in the badge.
+  const [workspaceSaved, setWorkspaceSaved] = useState(true);
+  const handleSaveWorkspace = useCallback(async (name: string) => {
+    const saved = saveDraftWorkspace(PLAYGROUND_ID, name);
+    if (saved) {
+      setWorkspaceSaved(true);
+      setActiveWorkspace({ id: saved.id, name: saved.name });
+    }
+  }, []);
   // Mirror activeWorkspace.id in a ref so the file-pane handlers can
   // read the current workspace synchronously without participating in
   // useCallback dep arrays (which would force them to rebuild every
@@ -1901,6 +1915,7 @@ function DuckDbPlaygroundInner() {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
+          setWorkspaceSaved(workspace.saved);
           const noticeKey = `playground_ws_warned_${workspace.id}`;
           try {
             if (window.sessionStorage.getItem(noticeKey) !== "1") {
@@ -3986,6 +4001,11 @@ function DuckDbPlaygroundInner() {
               activeWorkspaceName={activeWorkspace.name}
               managerOpen={workspaceManagerOpen}
               onManagerOpenChange={setWorkspaceManagerOpen}
+              unsaved={
+                !workspaceSaved &&
+                tabs.some((t) => !t.kind && t.code !== t.pristineCode)
+              }
+              onSave={handleSaveWorkspace}
             />
           )}
           <div className="header-actions desktop-only">

--- a/app/_components/mdx/loadingAnimations.tsx
+++ b/app/_components/mdx/loadingAnimations.tsx
@@ -615,8 +615,10 @@ export default function LoadingAnimationsGallery({
               Setting up the Python runtime…
             </span>
             <span className={styles.bootHint}>
-              Downloading the Python runtime — this happens once; later runs
-              are much faster.
+              This can take a moment on first load
+            </span>
+            <span className={styles.bootHint}>
+              This happens once. Later runs are much faster.
             </span>
           </span>
         </div>

--- a/app/_components/opfs/activeWorkspace.ts
+++ b/app/_components/opfs/activeWorkspace.ts
@@ -25,10 +25,21 @@ import {
   createWorkspace,
   getWorkspaceRegistry,
   openWorkspace,
+  registerWorkspace,
   type WorkspaceEntry,
 } from "./workspace";
 
 const SESSION_KEY_PREFIX = "playground_active_ws_";
+// Per-tab store for a *draft* (unsaved) workspace — one that has OPFS backing
+// but is intentionally kept out of the saved-workspaces registry until the
+// user makes a change and clicks Save. Stored as the full entry (not just the
+// id) so a reload in the same tab restores the same draft instead of spawning
+// a new one.
+const DRAFT_KEY_PREFIX = "playground_draft_ws_";
+
+/** An active workspace plus whether it is a saved (registry) workspace or a
+ *  still-unsaved draft. */
+export type ActiveWorkspace = WorkspaceEntry & { saved: boolean };
 
 const DEFAULT_NAMES: Record<string, string> = {
   sqlite: "Default SQLite Workspace",
@@ -38,6 +49,47 @@ const DEFAULT_NAMES: Record<string, string> = {
 
 function sessionKey(playgroundId: string): string {
   return `${SESSION_KEY_PREFIX}${playgroundId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Per-workspace "dirty" latch
+// ---------------------------------------------------------------------------
+// A one-way flag, keyed by workspace id, recording that the user has changed a
+// workspace away from its pristine default. Stored in localStorage so it
+// survives reloads and SPA navigation (the OPFS content does too), which lets
+// the Save affordance reappear for an unsaved draft after a refresh. Once a
+// draft is saved, `saved` gates the button so the flag no longer matters.
+
+const DIRTY_KEY_PREFIX = "playground_ws_dirty_";
+
+/** Marks a workspace as changed from its default (idempotent). */
+export function markWorkspaceDirty(workspaceId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(`${DIRTY_KEY_PREFIX}${workspaceId}`, "1");
+  } catch {
+    /* quota / private mode — ignore */
+  }
+}
+
+/** True if the workspace has been changed from its default. */
+export function isWorkspaceDirty(workspaceId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(`${DIRTY_KEY_PREFIX}${workspaceId}`) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Clears the dirty latch (e.g. after the draft is saved). */
+export function clearWorkspaceDirty(workspaceId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(`${DIRTY_KEY_PREFIX}${workspaceId}`);
+  } catch {
+    /* ignore */
+  }
 }
 
 /** Returns the active workspace ID stored in `sessionStorage` for the
@@ -84,16 +136,53 @@ export function switchActiveWorkspace(
   }
 }
 
+function draftKey(playgroundId: string): string {
+  return `${DRAFT_KEY_PREFIX}${playgroundId}`;
+}
+
+/** Reads the per-tab draft workspace for a playground, or null. */
+function getDraftWorkspace(playgroundId: string): WorkspaceEntry | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(draftKey(playgroundId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as WorkspaceEntry;
+    return parsed && typeof parsed.id === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function setDraftWorkspace(playgroundId: string, entry: WorkspaceEntry): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(draftKey(playgroundId), JSON.stringify(entry));
+  } catch {
+    /* sessionStorage unavailable (private mode); ignore. */
+  }
+}
+
+function clearDraftWorkspace(playgroundId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(draftKey(playgroundId));
+  } catch {
+    /* ignore */
+  }
+}
+
 /**
  * Resolve (or create) the active workspace for a playground.
  *
- * Returns the full `WorkspaceEntry` (id, name, createdAt, etc.) so
- * callers can use the id when wiring engines and the name when
- * rendering the workspace switcher.
+ * Returns the full entry plus a `saved` flag: `true` for a workspace in the
+ * saved registry, `false` for an unsaved draft (the auto-created default, kept
+ * out of the registry until the user saves it). Callers use the id when wiring
+ * engines, the name in the switcher, and `saved` to decide whether to offer a
+ * Save affordance.
  */
 export async function ensureActiveWorkspace(
   playgroundId: string,
-): Promise<WorkspaceEntry> {
+): Promise<ActiveWorkspace> {
   const storedId = getActiveWorkspaceId(playgroundId);
   if (storedId) {
     const registry = getWorkspaceRegistry();
@@ -103,13 +192,43 @@ export async function ensureActiveWorkspace(
     if (entry) {
       // Touch lastUsedAt and reuse.
       const opened = await openWorkspace(storedId);
-      return opened ?? entry;
+      return { ...(opened ?? entry), saved: true };
     }
-    // Stale session pointer — fall through to create a fresh one.
+    // Not registered — restore the draft if it's the one this tab created.
+    const draft = getDraftWorkspace(playgroundId);
+    if (draft && draft.id === storedId) {
+      return { ...draft, saved: false };
+    }
+    // Stale session pointer — fall through to create a fresh draft.
   }
 
   const defaultName = DEFAULT_NAMES[playgroundId] ?? `Default ${playgroundId}`;
-  const created = await createWorkspace(defaultName, playgroundId);
+  // Create the default as a draft: OPFS-backed (so edits persist for the
+  // session) but kept out of the registry until the user saves it.
+  const created = await createWorkspace(defaultName, playgroundId, {
+    register: false,
+  });
   setActiveWorkspaceId(playgroundId, created.id);
-  return created;
+  setDraftWorkspace(playgroundId, created);
+  return { ...created, saved: false };
+}
+
+/**
+ * Promote this tab's draft workspace to a saved one: adds it to the registry
+ * (optionally under a new name) and clears the per-tab draft marker. Returns
+ * the saved entry, or `null` if there is no draft to save. The OPFS data is
+ * already in place (drafts persist as they go), so this only makes the
+ * workspace appear in the saved list.
+ */
+export function saveDraftWorkspace(
+  playgroundId: string,
+  name?: string,
+): WorkspaceEntry | null {
+  const draft = getDraftWorkspace(playgroundId);
+  if (!draft) return null;
+  const saved = registerWorkspace(draft, name);
+  clearDraftWorkspace(playgroundId);
+  clearWorkspaceDirty(saved.id);
+  setActiveWorkspaceId(playgroundId, saved.id);
+  return saved;
 }

--- a/app/_components/opfs/workspace.ts
+++ b/app/_components/opfs/workspace.ts
@@ -144,16 +144,25 @@ async function getWorkspaceDir(
 
 /**
  * Creates a new workspace: allocates a workspace ID, writes `meta.json` to
- * OPFS, creates the `files/` and `db/` sub-directories, and adds an entry to
- * the registry in localStorage.
+ * OPFS, creates the `files/` and `db/` sub-directories, and (by default) adds
+ * an entry to the registry in localStorage.
  *
- * If OPFS is unavailable the workspace entry is still added to the registry
- * (with no OPFS backing) so callers can fall back to localStorage-only mode.
+ * Pass `{ register: false }` to create a "draft" workspace — its OPFS backing
+ * is created so the engine can persist into it, but it is NOT added to the
+ * saved-workspaces registry. This backs the explicit-save model: the
+ * auto-created default workspace stays a draft (it never clutters the
+ * workspace list) until the user makes a change and clicks Save, at which
+ * point it is promoted via `registerWorkspace`.
+ *
+ * If OPFS is unavailable the workspace entry is still returned (with no OPFS
+ * backing) so callers can fall back to localStorage-only mode.
  */
 export async function createWorkspace(
   name: string,
   playground: string,
+  opts: { register?: boolean } = {},
 ): Promise<WorkspaceEntry> {
+  const { register = true } = opts;
   const id = newWorkspaceId();
   const now = Date.now();
   const entry: WorkspaceEntry = {
@@ -180,10 +189,35 @@ export async function createWorkspace(
     }
   }
 
-  const registry = getWorkspaceRegistry();
-  registry.push(entry);
-  updateWorkspaceRegistry(registry);
+  if (register) {
+    const registry = getWorkspaceRegistry();
+    registry.push(entry);
+    updateWorkspaceRegistry(registry);
+  }
   return entry;
+}
+
+/**
+ * Adds a workspace entry to the registry (promoting a draft created with
+ * `{ register: false }` to a saved workspace). Idempotent: if an entry with
+ * the same id already exists it is updated in place. Returns the saved entry,
+ * with `name` overridden when a new name is supplied.
+ */
+export function registerWorkspace(
+  entry: WorkspaceEntry,
+  name?: string,
+): WorkspaceEntry {
+  const saved: WorkspaceEntry = {
+    ...entry,
+    name: name ?? entry.name,
+    lastUsedAt: Date.now(),
+  };
+  const registry = getWorkspaceRegistry();
+  const idx = registry.findIndex((e) => e.id === saved.id);
+  if (idx === -1) registry.push(saved);
+  else registry[idx] = saved;
+  updateWorkspaceRegistry(registry);
+  return saved;
 }
 
 /**

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -2532,7 +2532,7 @@ input[type="range"].fs-slider:disabled {
 .playground-boot-title {
   font-family: var(--font-ui);
   font-size: 30px;
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: -0.02em;
   color: var(--text);
   line-height: 1.25;

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -2572,11 +2572,21 @@ input[type="range"].fs-slider:disabled {
   }
 }
 
+.playground-boot-hints {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
 .playground-boot-hint {
   font-family: var(--font-ui);
   font-size: 15px;
   color: var(--text-muted, #9aa4b2);
   line-height: 1.6;
+}
+.playground-boot-hint-sub {
+  font-size: 13px;
+  opacity: 0.85;
 }
 .playground-boot-progress {
   display: flex;

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -2531,7 +2531,7 @@ input[type="range"].fs-slider:disabled {
 }
 .playground-boot-title {
   font-family: var(--font-ui);
-  font-size: 30px;
+  font-size: 20px;
   font-weight: 600;
   letter-spacing: -0.02em;
   color: var(--text);
@@ -2659,7 +2659,7 @@ input[type="range"].fs-slider:disabled {
 
 @media (max-width: 560px) {
   .playground-boot-title {
-    font-size: 24px;
+    font-size: 16px;
   }
 }
 .pyodide-loading.playground-boot-overlay.has-error .playground-boot-title {

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -4274,6 +4274,32 @@ html[data-playground-theme="dark"] .welcome h3 {
   white-space: nowrap;
 }
 
+/* Save button — shown next to the badge only when the active workspace is an
+   unsaved draft the user has changed. Accent-filled so it reads as the call to
+   action (the draft isn't in the saved list until it's clicked). */
+.workspace-save-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: 6px;
+  padding: 4px 10px;
+  background: var(--primary);
+  border: 1px solid var(--primary);
+  border-radius: 999px;
+  color: #fff;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.workspace-save-btn:hover {
+  background: color-mix(in srgb, var(--primary) 88%, #000);
+}
+
 .workspace-popover {
   min-width: 260px;
   max-width: 320px;

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -2532,7 +2532,7 @@ input[type="range"].fs-slider:disabled {
 .playground-boot-title {
   font-family: var(--font-ui);
   font-size: 20px;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: -0.02em;
   color: var(--text);
   line-height: 1.25;

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -2592,6 +2592,41 @@ input[type="range"].fs-slider:disabled {
   font-size: 13px;
   opacity: 0.85;
 }
+/* Workspace-conflict overlay — reuses the boot-overlay chrome but offers
+   actions instead of a progress bar (shown when the workspace is already
+   open in another browser tab). */
+.playground-conflict-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 8px;
+}
+.playground-conflict-btn {
+  font-family: var(--font-ui);
+  font-size: 14px;
+  font-weight: 500;
+  padding: 9px 16px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg2);
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+.playground-conflict-btn:hover {
+  background: var(--bg3);
+}
+.playground-conflict-btn-primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+.playground-conflict-btn-primary:hover {
+  background: color-mix(in srgb, var(--primary) 88%, #000);
+}
 .playground-boot-progress {
   display: flex;
   align-items: center;

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -44,6 +44,10 @@
   --danger: var(--ds-red);
   --ok-accent: var(--ds-green);
   --err-accent: var(--ds-red);
+  /* Very subtle hover tint shared by dropdown / drawer / dialog menu items
+     across the playgrounds — a faint lift that reads consistently on any
+     surface (--bg, --bg2, popups) rather than the heavier --bg3 step. */
+  --menu-item-hover: color-mix(in srgb, var(--text) 6%, transparent);
   --font-mono:
     "JetBrains Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace;
   --font-ui: "Inter", system-ui, -apple-system, sans-serif;
@@ -295,7 +299,7 @@ body.playground-active {
 }
 .bui-select-item[data-highlighted],
 .bui-select-item:hover {
-  background: var(--bg3);
+  background: var(--menu-item-hover);
 }
 .bui-select-item[data-selected] {
   color: var(--primary);
@@ -440,7 +444,7 @@ body.playground-active {
   border-bottom: none;
 }
 .example-item:hover {
-  background: var(--bg3);
+  background: var(--menu-item-hover);
   color: var(--text);
 }
 .example-item .ex-title {
@@ -1046,7 +1050,7 @@ body.playground-active {
 }
 .run-split-item[data-highlighted],
 .run-split-item:hover {
-  background: var(--bg3);
+  background: var(--menu-item-hover);
 }
 .run-split-item-label {
   flex: 1 1 auto;
@@ -1163,7 +1167,7 @@ body.playground-active {
 }
 .playground-run-multi-item[data-highlighted],
 .playground-run-multi-item:hover {
-  background: var(--bg3);
+  background: var(--menu-item-hover);
 }
 .playground-run-multi-item-label {
   flex: 1 1 auto;
@@ -2365,7 +2369,7 @@ input[type="range"].fs-slider:disabled {
   border-radius: 0;
 }
 .pkg-item:hover {
-  background: var(--bg3);
+  background: var(--menu-item-hover);
 }
 .pkg-item:focus-visible {
   outline: none;
@@ -3057,7 +3061,7 @@ input[type="range"].fs-slider:disabled {
 /* Menu items keep the same example-item / export-item presentation but
    need keyboard-highlight states from Base UI's `data-highlighted`. */
 .example-item[data-highlighted] {
-  background: var(--bg3);
+  background: var(--menu-item-hover);
   color: var(--text);
   outline: none;
 }
@@ -4283,7 +4287,7 @@ html[data-playground-theme="dark"] .welcome h3 {
 }
 
 .workspace-popover-item:hover {
-  background: color-mix(in srgb, var(--primary) 12%, transparent);
+  background: var(--menu-item-hover);
 }
 
 .workspace-popover-item.active {

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -112,6 +112,7 @@ import { postgresAdapter } from "./postgresAdapter";
 import {
   ensureActiveWorkspace,
   setActiveWorkspaceId,
+  switchActiveWorkspace,
 } from "../opfs/activeWorkspace";
 import { acquireWorkspaceLock, createWorkspace } from "../opfs/workspace";
 import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
@@ -979,6 +980,9 @@ function PostgresPlaygroundInner() {
     Record<string, QueryRunResult | null>
   >({});
   const [loaded, setLoaded] = useState(false);
+  // True when this workspace is already open (locked) in another tab, so
+  // the shell shows a conflict overlay instead of deadlocking on boot.
+  const [workspaceConflict, setWorkspaceConflict] = useState(false);
   const [statusState, setStatusState] = useState<
     "loading" | "ready" | "running" | "error"
   >("loading");
@@ -1837,24 +1841,23 @@ function PostgresPlaygroundInner() {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
-          const noticeKey = `playground_ws_warned_${workspace.id}`;
           try {
-            if (window.sessionStorage.getItem(noticeKey) !== "1") {
-              const hasLock = await acquireWorkspaceLock(workspace.id);
-              if (!cancelled && !hasLock) {
-                window.sessionStorage.setItem(noticeKey, "1");
-                showToast(
-                  "This workspace is already open in another tab. Edits here may conflict — switch workspaces via the badge in the header.",
-                  "warn",
-                );
-              }
+            const hasLock = await acquireWorkspaceLock(workspace.id);
+            if (!cancelled && !hasLock) {
+              // The same OPFS-backed workspace can't be opened in two tabs:
+              // PGlite's exclusive OPFS access handle would deadlock the
+              // boot (it hangs at ~90%). Surface a conflict overlay and
+              // skip the boot rather than hang.
+              setWorkspaceConflict(true);
+              return;
             }
           } catch {
-            /* sessionStorage / Locks unavailable — ignore. */
+            /* Web Locks unavailable — proceed without cross-tab exclusivity. */
           }
         } catch {
           /* proceed in-memory */
         }
+        if (cancelled) return;
         const engine = await postgresAdapter.createEngine(
           initialDbId,
           workspaceId,
@@ -2164,6 +2167,22 @@ function PostgresPlaygroundInner() {
     },
     [persistTabs, refreshSchema, refreshSchemas, showToast],
   );
+
+  // From the "open in another tab" conflict overlay: create a fresh
+  // workspace and switch to it. No engine is open in the conflict case
+  // (the boot was skipped), so a reload is the simplest safe path — the
+  // new workspace id isn't locked, so it boots normally.
+  const handleConflictNewWorkspace = useCallback(() => {
+    void (async () => {
+      try {
+        const newWs = await createWorkspace("Postgres Workspace", PLAYGROUND_ID);
+        switchActiveWorkspace(PLAYGROUND_ID, newWs.id);
+      } catch {
+        /* If creation fails, a plain reload at least re-checks the lock. */
+        window.location.reload();
+      }
+    })();
+  }, []);
 
   const requestDbSwitch = useCallback(
     (nextId: string) => {
@@ -3500,6 +3519,8 @@ function PostgresPlaygroundInner() {
       loaded={loaded}
       statusState={statusState}
       loadingCaption={loadingMessage}
+      workspaceConflict={workspaceConflict}
+      onOpenNewWorkspace={handleConflictNewWorkspace}
       headerActions={
         <>
           {activeWorkspace && (

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -111,6 +111,7 @@ import { findPostgresSampleDatabase } from "../runtime/postgresSamples";
 import { postgresAdapter } from "./postgresAdapter";
 import {
   ensureActiveWorkspace,
+  saveDraftWorkspace,
   setActiveWorkspaceId,
   switchActiveWorkspace,
 } from "../opfs/activeWorkspace";
@@ -993,6 +994,9 @@ function PostgresPlaygroundInner() {
     id: string;
     name: string;
   } | null>(null);
+  // False for the auto-created draft workspace (kept out of the saved list
+  // until the user saves it). Drives the Save affordance in the badge.
+  const [workspaceSaved, setWorkspaceSaved] = useState(true);
   const [indexesExpanded, setIndexesExpanded] = useState(true);
   const [viewsExpanded, setViewsExpanded] = useState(true);
   const [tablesExpanded, setTablesExpanded] = useState(true);
@@ -1841,6 +1845,7 @@ function PostgresPlaygroundInner() {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
+          setWorkspaceSaved(workspace.saved);
           try {
             const hasLock = await acquireWorkspaceLock(workspace.id);
             if (!cancelled && !hasLock) {
@@ -2182,6 +2187,15 @@ function PostgresPlaygroundInner() {
         window.location.reload();
       }
     })();
+  }, []);
+
+  // Save (promote) the current draft workspace into the saved list.
+  const handleSaveWorkspace = useCallback(async (name: string) => {
+    const saved = saveDraftWorkspace(PLAYGROUND_ID, name);
+    if (saved) {
+      setWorkspaceSaved(true);
+      setActiveWorkspace({ id: saved.id, name: saved.name });
+    }
   }, []);
 
   const requestDbSwitch = useCallback(
@@ -3530,6 +3544,11 @@ function PostgresPlaygroundInner() {
               activeWorkspaceName={activeWorkspace.name}
               managerOpen={workspaceManagerOpen}
               onManagerOpenChange={setWorkspaceManagerOpen}
+              unsaved={
+                !workspaceSaved &&
+                tabs.some((t) => !t.kind && t.code !== t.pristineCode)
+              }
+              onSave={handleSaveWorkspace}
             />
           )}
           <div className="header-actions desktop-only">

--- a/app/_components/runtime/bootHistory.ts
+++ b/app/_components/runtime/bootHistory.ts
@@ -1,0 +1,39 @@
+// Per-browser record of which runtimes have booted at least once.
+//
+// The heavy WASM payloads (Pyodide, WebR, CheerpJ, PGlite, the DuckDB /
+// SQLite engines, …) are served with immutable, long-lived HTTP cache
+// headers, so after the very first boot in a browser they are read from
+// disk cache rather than re-downloaded. The boot overlay, however, still
+// appears on every playground visit because each playground recreates its
+// engine on mount (engines are torn down on unmount for isolation).
+//
+// Showing "Downloading … this happens once" on *every* visit is therefore
+// misleading: nothing is being downloaded after the first time. This tiny
+// localStorage flag lets the overlay distinguish a genuine first-ever cold
+// start (show the download reassurance) from a warm revisit (just the
+// status line + progress bar, no download copy).
+//
+// It is intentionally best-effort: if localStorage is unavailable (privacy
+// mode, quota) we simply treat every boot as cold, which is harmless.
+
+const KEY_PREFIX = "ds_runtime_booted_";
+
+/** True if `runtimeId` has successfully booted before in this browser. */
+export function hasRuntimeBootedBefore(runtimeId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(KEY_PREFIX + runtimeId) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Record that `runtimeId` has booted, so later visits skip the cold copy. */
+export function markRuntimeBooted(runtimeId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(KEY_PREFIX + runtimeId, "1");
+  } catch {
+    /* ignore quota / privacy-mode write failures */
+  }
+}

--- a/app/_components/runtime/browsercc-worker.ts
+++ b/app/_components/runtime/browsercc-worker.ts
@@ -119,7 +119,7 @@ let initPromise: Promise<void> | null = null;
 async function initRuntime(): Promise<void> {
   post({
     kind: "loading",
-    message: "Loading browsercc clang toolchain (this can take a moment on first load)…",
+    message: "Loading the compiler…",
   });
   const [api, shim] = await Promise.all([
     dynamicImport(BROWSERCC_URL) as Promise<BrowserccApi>,

--- a/app/_components/runtime/c.tsx
+++ b/app/_components/runtime/c.tsx
@@ -588,7 +588,7 @@ export const cAdapter: LanguageAdapter = {
     return format(code, "main.c", "LLVM");
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Loading C worker…", 0.02);
+    setLoadingMessage("Starting C runtime…", 0.02);
     const worker = new Worker(
       new URL("./browsercc-worker.ts", import.meta.url),
     );

--- a/app/_components/runtime/cpp.tsx
+++ b/app/_components/runtime/cpp.tsx
@@ -663,7 +663,7 @@ export const cppAdapter: LanguageAdapter = {
     return format(code, "main.cpp", "LLVM");
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Loading C++ worker…", 0.02);
+    setLoadingMessage("Starting C++ runtime…", 0.02);
     const worker = new Worker(
       new URL("./browsercc-worker.ts", import.meta.url),
     );

--- a/app/_components/runtime/dotnet.ts
+++ b/app/_components/runtime/dotnet.ts
@@ -102,7 +102,7 @@ export function loadDotnet(
       throw new Error(".NET runtime requires a browser environment.");
     }
 
-    setLoadingMessage("Loading .NET runtime (Mono WebAssembly)…", 0.05);
+    setLoadingMessage("Loading C# runtime…", 0.05);
 
     // dotnet.js is an ES module that exports a `dotnet` DotnetHostBuilder.
     // Dynamic import() lets the module's internal relative imports
@@ -120,7 +120,7 @@ export function loadDotnet(
 
     // `create()` is the heavy stage: it streams the ~35 MB assembly
     // bundle from jsDelivr and instantiates the Mono WASM runtime.
-    setLoadingMessage("Initialising .NET runtime…", 0.15);
+    setLoadingMessage("Initialising C# runtime…", 0.15);
     const host = await dotnetBuilder
       .withConfigSrc(BOOT_CONFIG_URL)
       .withResourceLoader((_type, name) => {
@@ -134,7 +134,7 @@ export function loadDotnet(
       getDotnetBundleBaseUrl: () => RUNTIME_BUNDLE_BASE,
     });
 
-    setLoadingMessage("Loading Roslyn (C# scripting engine)…", 0.85);
+    setLoadingMessage("Preparing C# compiler…", 0.85);
     const exports = await host.getAssemblyExports("ScriptRunner");
     const runScriptExport = lookupExport(exports, [
       "ScriptRunner",

--- a/app/_components/runtime/java.tsx
+++ b/app/_components/runtime/java.tsx
@@ -776,7 +776,7 @@ export const javaAdapter: LanguageAdapter = {
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
     setLoadingMessage(
-      "Loading CheerpJ (OpenJDK + javac in WebAssembly — this can take a moment on first load)…",
+      "Loading Java runtime…",
       0.08,
     );
     const api = await loadCheerpJ();

--- a/app/_components/runtime/javascript.tsx
+++ b/app/_components/runtime/javascript.tsx
@@ -359,7 +359,7 @@ export const javascriptAdapter: LanguageAdapter = {
     return format(code, "script.js", WEB_FMT_2SPACE);
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Starting almostnode runtime…");
+    setLoadingMessage("Starting JavaScript runtime…");
     // The worker is pre-bundled by `scripts/build-almostnode-workers
     // .mjs` to `public/_workers/javascript-worker.js`. We point the
     // Worker constructor at the resulting static URL (not at

--- a/app/_components/runtime/php-worker.ts
+++ b/app/_components/runtime/php-worker.ts
@@ -150,7 +150,7 @@ async function initPhp(): Promise<void> {
     /* webpackIgnore: true */ /* turbopackIgnore: true */ PHP_WASM_ENTRY
   )) as { PhpWeb: PhpWebClass };
 
-  post({ kind: "loading", message: "Initialising PHP (WebAssembly)…" });
+  post({ kind: "loading", message: "Initialising PHP runtime…" });
   php = new mod.PhpWeb({
     // Return undefined for paths php-wasm handles internally — most
     // importantly `libxml2.so`, which PhpBase suppresses with a data: URL

--- a/app/_components/runtime/php.tsx
+++ b/app/_components/runtime/php.tsx
@@ -297,7 +297,7 @@ export const phpAdapter: LanguageAdapter = {
     return format(code, "main.php");
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Loading PHP worker…");
+    setLoadingMessage("Starting PHP runtime…");
     const worker = new Worker(new URL("./php-worker.ts", import.meta.url));
     return new Promise<LanguageRuntime>((resolve, reject) => {
       const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {

--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -154,7 +154,7 @@ function isPyDisplayOutputs(v: unknown): v is PyDisplayOutput[] {
 }
 
 async function initPyodide(): Promise<void> {
-  post({ kind: "loading", message: "Loading Pyodide…", fraction: 0.06 });
+  post({ kind: "loading", message: "Loading Python runtime…", fraction: 0.06 });
   pyodide = await self.loadPyodide({ indexURL: PYODIDE_INDEX_URL });
 
   post({
@@ -527,7 +527,7 @@ async function runCode(
     post({
       kind: "run-status",
       id,
-      message: "Installing the Python data packages — first run only…",
+      message: "Installing data packages — first run only…",
       preparing: true,
     });
     await ensurePackages();

--- a/app/_components/runtime/python.tsx
+++ b/app/_components/runtime/python.tsx
@@ -840,7 +840,7 @@ export const pythonAdapter: LanguageAdapter = {
     return format(code, "main.py");
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Starting Python worker…", 0.02);
+    setLoadingMessage("Starting Python runtime…", 0.02);
     // Standard Web Worker construction pattern that Next.js / Turbopack
     // recognises: it bundles the worker as a separate chunk. The worker
     // itself avoids the bundler's dynamic-import handling by loading

--- a/app/_components/runtime/r.tsx
+++ b/app/_components/runtime/r.tsx
@@ -1282,7 +1282,7 @@ export const rAdapter: LanguageAdapter = {
     return formatRWithStyler(code);
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Loading WebR…", 0.03);
+    setLoadingMessage("Loading R runtime…", 0.03);
     // @ts-expect-error -- webr ships without bundled type declarations
     const { WebR } = (await import("webr")) as { WebR: new () => WebRInstance };
 

--- a/app/_components/runtime/typescript.tsx
+++ b/app/_components/runtime/typescript.tsx
@@ -406,7 +406,7 @@ export const typescriptAdapter: LanguageAdapter = {
     return format(code, "script.ts", WEB_FMT_2SPACE);
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
-    setLoadingMessage("Starting TypeScript worker…");
+    setLoadingMessage("Starting TypeScript runtime…");
     // Pre-bundled by `scripts/build-almostnode-workers.mjs`; see
     // javascript.tsx for the rationale (Turbopack's worker bundler
     // chunks almostnode's tree and load-collides on minified

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -93,7 +93,11 @@ import { sqliteAdapter } from "./sqliteAdapter";
 import { DROP_KIND_LABELS, IMPORT_COL_STATUS_LABEL } from "./constants";
 import { computeImportColComparison } from "./utils/importUtils";
 import { splitSqlStatements, statementAtCursor } from "./utils/sqlAnalysis";
-import { ensureActiveWorkspace, switchActiveWorkspace } from "../opfs/activeWorkspace";
+import {
+  ensureActiveWorkspace,
+  saveDraftWorkspace,
+  switchActiveWorkspace,
+} from "../opfs/activeWorkspace";
 import { acquireWorkspaceLock, createWorkspace } from "../opfs/workspace";
 import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
 import { MobileMenuAction, MobileMenuSubSheet } from "../MobileMenuSheet";
@@ -739,6 +743,16 @@ function SqlPlaygroundInner() {
     id: string;
     name: string;
   } | null>(null);
+  // False for the auto-created draft workspace (kept out of the saved list
+  // until the user saves it). Drives the Save affordance in the badge.
+  const [workspaceSaved, setWorkspaceSaved] = useState(true);
+  const handleSaveWorkspace = useCallback(async (name: string) => {
+    const saved = saveDraftWorkspace(PLAYGROUND_ID, name);
+    if (saved) {
+      setWorkspaceSaved(true);
+      setActiveWorkspace({ id: saved.id, name: saved.name });
+    }
+  }, []);
 
   // ─── Derived values ──────────────────────────────────────────────────
   const isSettingsTabActive = activeTabId === SETTINGS_TAB_ID;
@@ -1289,6 +1303,7 @@ function SqlPlaygroundInner() {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
+          setWorkspaceSaved(workspace.saved);
           try {
             const hasLock = await acquireWorkspaceLock(workspace.id);
             if (!cancelled && !hasLock) {
@@ -1910,6 +1925,11 @@ function SqlPlaygroundInner() {
               activeWorkspaceName={activeWorkspace.name}
               managerOpen={workspaceManagerOpen}
               onManagerOpenChange={setWorkspaceManagerOpen}
+              unsaved={
+                !workspaceSaved &&
+                tabs.some((t) => !t.kind && t.code !== t.pristineCode)
+              }
+              onSave={handleSaveWorkspace}
             />
           )}
           <div className="header-actions desktop-only">

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -727,7 +727,6 @@ function SqlPlaygroundInner() {
   const [loadingMessage, setLoadingMessage] = useState(
     "Loading SQLite engine…",
   );
-  const [showLoadingOverlay, setShowLoadingOverlay] = useState(true);
   const [indexesSectionExpanded, setIndexesSectionExpanded] = useState(false);
   const [triggersSectionExpanded, setTriggersSectionExpanded] = useState(false);
   const [hasEditorSelection, setHasEditorSelection] = useState(false);
@@ -762,7 +761,6 @@ function SqlPlaygroundInner() {
     [activeTab?.code],
   );
   const result = activeTabId ? (resultsByTab[activeTabId] ?? null) : null;
-  const loadingFading = loaded && showLoadingOverlay;
 
   // ─── Refs ────────────────────────────────────────────────────────────
   const engineRef = useRef<SqliteEngine | null>(null);
@@ -1132,13 +1130,6 @@ function SqlPlaygroundInner() {
       setIsFormatting(false);
     }
   }, [showToast]);
-
-  // ─── Loading overlay fade-out ────────────────────────────────────────
-  useEffect(() => {
-    if (!loaded) return;
-    const id = window.setTimeout(() => setShowLoadingOverlay(false), 400);
-    return () => window.clearTimeout(id);
-  }, [loaded]);
 
   // When tabs are closed (or replaced wholesale), drop any result
   // entries whose owning tab no longer exists.
@@ -1910,8 +1901,6 @@ function SqlPlaygroundInner() {
       statusState={statusState}
       workspaceConflict={workspaceConflict}
       onOpenNewWorkspace={handleConflictNewWorkspace}
-      keepOverlayMounted={showLoadingOverlay}
-      loadingOverlayClassName={loadingFading ? "hidden" : ""}
       loadingHeroRepeat={4}
       loadingCaption={
         statusState === "error" ? loadingMessage : LOADING_QUIPS[quipIndex]

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -570,6 +570,23 @@ function SqlPlaygroundInner() {
     [setGlobalPageSizeState],
   );
 
+  // True when this workspace is already open (locked) in another tab, so
+  // the shell shows a conflict overlay instead of deadlocking on boot.
+  const [workspaceConflict, setWorkspaceConflict] = useState(false);
+  // From the conflict overlay: create a fresh workspace and switch to it.
+  // No engine is open in the conflict case, so a reload is the simplest
+  // safe path — the new workspace id isn't locked, so it boots normally.
+  const handleConflictNewWorkspace = useCallback(() => {
+    void (async () => {
+      try {
+        const newWs = await createWorkspace("SQLite Workspace", PLAYGROUND_ID);
+        switchActiveWorkspace(PLAYGROUND_ID, newWs.id);
+      } catch {
+        window.location.reload();
+      }
+    })();
+  }, []);
+
   // ─── Engine store ────────────────────────────────────────────────────
   const loaded = useEngineStore((s) => s.loaded);
   const setLoaded = useEngineStore((s) => s.setLoaded);
@@ -1272,27 +1289,23 @@ function SqlPlaygroundInner() {
           const workspace = await ensureActiveWorkspace(PLAYGROUND_ID);
           workspaceId = workspace.id;
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
-          // Tab-isolation notice: warn once per (workspace × session)
-          // when another tab already holds the OPFS lock for this
-          // workspace, so the user knows edits here can conflict.
-          const noticeKey = `playground_ws_warned_${workspace.id}`;
           try {
-            if (window.sessionStorage.getItem(noticeKey) !== "1") {
-              const hasLock = await acquireWorkspaceLock(workspace.id);
-              if (!cancelled && !hasLock) {
-                window.sessionStorage.setItem(noticeKey, "1");
-                showToast(
-                  "This workspace is already open in another tab. Edits here may conflict — switch workspaces via the badge in the header.",
-                  "warn",
-                );
-              }
+            const hasLock = await acquireWorkspaceLock(workspace.id);
+            if (!cancelled && !hasLock) {
+              // The same OPFS-backed workspace can't be opened in two tabs:
+              // SQLite's exclusive OPFS access handle would deadlock the
+              // boot (it hangs at ~90%). Surface a conflict overlay and
+              // skip the boot rather than hang.
+              setWorkspaceConflict(true);
+              return;
             }
           } catch {
-            /* sessionStorage / Locks unavailable — ignore. */
+            /* Web Locks unavailable — proceed without cross-tab exclusivity. */
           }
         } catch {
           // Workspace bootstrap is best-effort — proceed in-memory.
         }
+        if (cancelled) return;
         const engine = await sqliteAdapter.createEngine(
           initialSampleId,
           workspaceId,
@@ -1880,6 +1893,8 @@ function SqlPlaygroundInner() {
       playgroundTitle="SQLite Playground"
       loaded={loaded}
       statusState={statusState}
+      workspaceConflict={workspaceConflict}
+      onOpenNewWorkspace={handleConflictNewWorkspace}
       keepOverlayMounted={showLoadingOverlay}
       loadingOverlayClassName={loadingFading ? "hidden" : ""}
       loadingHeroRepeat={4}

--- a/app/_components/sql/components/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/components/SqlPlaygroundShell.tsx
@@ -8,6 +8,10 @@ import { SqlPlaygroundSwitcher } from "./SqlPlaygroundSwitcher";
 import { paneForActivatedTab, type SqlMobilePane } from "../utils/mobilePane";
 import { MobileMenuSheet } from "../../MobileMenuSheet";
 import { PlaygroundBootOverlay } from "../../PlaygroundBootOverlay";
+import {
+  hasRuntimeBootedBefore,
+  markRuntimeBooted,
+} from "../../runtime/bootHistory";
 
 /**
  * Re-exported from the pure helper module (`../utils/mobilePane`) so existing
@@ -108,6 +112,15 @@ export function SqlPlaygroundShell({
   children,
 }: SqlPlaygroundShellProps) {
   const showLoadingOverlay = keepOverlayMounted || !loaded;
+  // First-ever cold boot vs warm revisit. The engine's WASM payload is
+  // served from the browser's HTTP cache after the first boot, so only a
+  // genuine first boot in this browser shows the "Downloading … this
+  // happens once" copy; later visits just show the status line + bar.
+  // Captured once at mount, before `loaded` flips and we record the boot.
+  const [isColdBoot] = useState(() => !hasRuntimeBootedBefore(playgroundId));
+  useEffect(() => {
+    if (loaded) markRuntimeBooted(playgroundId);
+  }, [loaded, playgroundId]);
   // Mobile hamburger menu open state (the shell owns it; dialects only
   // supply the rows via `mobileMenu`).
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -278,7 +291,7 @@ export function SqlPlaygroundShell({
         <PlaygroundBootOverlay
           title={playgroundTitle.replace(/\s*Playground$/i, "")}
           statusMessage={loadingCaption}
-          cold
+          cold={isColdBoot}
           fraction={overlayFraction}
           error={statusState === "error"}
           className={loadingOverlayClassName}

--- a/app/_components/sql/components/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/components/SqlPlaygroundShell.tsx
@@ -8,6 +8,7 @@ import { SqlPlaygroundSwitcher } from "./SqlPlaygroundSwitcher";
 import { paneForActivatedTab, type SqlMobilePane } from "../utils/mobilePane";
 import { MobileMenuSheet } from "../../MobileMenuSheet";
 import { PlaygroundBootOverlay } from "../../PlaygroundBootOverlay";
+import { DiamondMark } from "../../mdx/loadingAnimations";
 import {
   hasRuntimeBootedBefore,
   markRuntimeBooted,
@@ -77,6 +78,15 @@ export interface SqlPlaygroundShellProps {
    *  progress (DuckDB). Omit for engines that don't — the shell then
    *  creeps a determinate bar over time instead. */
   bootFraction?: number | null;
+  /** True when the active workspace is already open (locked) in another
+   *  browser tab. The shell then shows a conflict overlay instead of the
+   *  boot overlay — opening the same OPFS-backed database in two tabs would
+   *  otherwise deadlock the engine boot (it hangs at ~90%). */
+  workspaceConflict?: boolean;
+  /** Invoked when the user picks "Open a new workspace" from the conflict
+   *  overlay. The host should create a fresh workspace and switch to it
+   *  (a reload is fine — a new workspace id isn't locked elsewhere). */
+  onOpenNewWorkspace?: () => void;
   /** Main body of the page — typically the top toolbar + sidebar +
    *  editor + results pane structure. Rendered directly inside
    *  `<div className="playground-app">` after the header. */
@@ -109,6 +119,8 @@ export function SqlPlaygroundShell({
   headerActions,
   mobileMenu,
   bootFraction,
+  workspaceConflict = false,
+  onOpenNewWorkspace,
   children,
 }: SqlPlaygroundShellProps) {
   const showLoadingOverlay = keepOverlayMounted || !loaded;
@@ -287,15 +299,58 @@ export function SqlPlaygroundShell({
       data-mobile-pane={mobilePane}
       data-settings-active={settingsTabActive || undefined}
     >
-      {showLoadingOverlay && (
-        <PlaygroundBootOverlay
-          title={playgroundTitle.replace(/\s*Playground$/i, "")}
-          statusMessage={loadingCaption}
-          cold={isColdBoot}
-          fraction={overlayFraction}
-          error={statusState === "error"}
-          className={loadingOverlayClassName}
-        />
+      {workspaceConflict ? (
+        <div
+          className="pyodide-loading playground-boot-overlay playground-conflict-overlay"
+          role="alertdialog"
+          aria-modal="true"
+        >
+          <div className="playground-boot-card">
+            <span className="playground-boot-loader" aria-hidden="true">
+              <DiamondMark size={88} />
+            </span>
+            <div className="playground-boot-text">
+              <span className="playground-boot-title">
+                This workspace is open in another tab
+              </span>
+              <div className="playground-boot-hints">
+                <span className="playground-boot-hint">
+                  A workspace can run in only one tab at a time. Keep using it
+                  in the original tab, or open a separate workspace here.
+                </span>
+              </div>
+              <div className="playground-conflict-actions">
+                {onOpenNewWorkspace && (
+                  <button
+                    type="button"
+                    className="playground-conflict-btn playground-conflict-btn-primary"
+                    onClick={onOpenNewWorkspace}
+                  >
+                    Open a new workspace
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="playground-conflict-btn"
+                  onClick={() => window.location.reload()}
+                >
+                  Try again
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        showLoadingOverlay && (
+          <PlaygroundBootOverlay
+            title={playgroundTitle.replace(/\s*Playground$/i, "")}
+            statusMessage={loadingCaption}
+            cold={isColdBoot}
+            fraction={overlayFraction}
+            error={statusState === "error"}
+            className={loadingOverlayClassName}
+          />
+        )
       )}
       <div className="playground-app">
         <header className="playground-header">

--- a/app/_components/sql/components/SqlPlaygroundShell.tsx
+++ b/app/_components/sql/components/SqlPlaygroundShell.tsx
@@ -7,7 +7,10 @@ import "../../sqlPlayground.css";
 import { SqlPlaygroundSwitcher } from "./SqlPlaygroundSwitcher";
 import { paneForActivatedTab, type SqlMobilePane } from "../utils/mobilePane";
 import { MobileMenuSheet } from "../../MobileMenuSheet";
-import { PlaygroundBootOverlay } from "../../PlaygroundBootOverlay";
+import {
+  PlaygroundBootOverlay,
+  useBootOverlayVisibility,
+} from "../../PlaygroundBootOverlay";
 import { DiamondMark } from "../../mdx/loadingAnimations";
 import {
   hasRuntimeBootedBefore,
@@ -50,14 +53,6 @@ export interface SqlPlaygroundShellProps {
   /** Current playground status; used by the overlay to render the
    *  red-tinted error state when something goes wrong during boot. */
   statusState: SqlPlaygroundOverlayStatus;
-  /** Optional className appended to the loading overlay (currently
-   *  used by SQLite for its fade-out animation). */
-  loadingOverlayClassName?: string;
-  /** When `true`, the loading overlay stays mounted even after
-   *  `loaded` becomes true (SQLite uses this with `loadingFading` so
-   *  the overlay can animate out). Defaults to `false` (= unmount the
-   *  instant `loaded` becomes `true`, which matches Postgres/DuckDB). */
-  keepOverlayMounted?: boolean;
   /** Body of the loading overlay's caption. Pass a plain status string
    *  for Postgres/DuckDB, or a rotating quip for SQLite. */
   loadingCaption: ReactNode;
@@ -113,8 +108,6 @@ export function SqlPlaygroundShell({
   playgroundTitle,
   loaded,
   statusState,
-  loadingOverlayClassName = "",
-  keepOverlayMounted = false,
   loadingCaption,
   headerActions,
   mobileMenu,
@@ -123,7 +116,12 @@ export function SqlPlaygroundShell({
   onOpenNewWorkspace,
   children,
 }: SqlPlaygroundShellProps) {
-  const showLoadingOverlay = keepOverlayMounted || !loaded;
+  // Loading-overlay lifecycle (show → fade → unmount) with a minimum
+  // on-screen time, shared by all three SQL dialects. A warm revisit
+  // boots the cached engine almost instantly; the floor keeps the overlay
+  // up long enough to read as a deliberate transition rather than a blink.
+  const { mounted: showLoadingOverlay, fading: loadingFading } =
+    useBootOverlayVisibility(loaded);
   // First-ever cold boot vs warm revisit. The engine's WASM payload is
   // served from the browser's HTTP cache after the first boot, so only a
   // genuine first boot in this browser shows the "Downloading … this
@@ -348,7 +346,7 @@ export function SqlPlaygroundShell({
             cold={isColdBoot}
             fraction={overlayFraction}
             error={statusState === "error"}
-            className={loadingOverlayClassName}
+            className={loadingFading ? "hidden" : ""}
           />
         )
       )}

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -122,6 +122,10 @@
 .sql-db-popup {
   min-width: 260px;
   z-index: 500;
+  /* Both the database and schema selector dropdowns use this popup; pin
+     it to the base surface so it reads a touch darker than the default
+     --bg2 popup chrome. */
+  background: var(--bg);
 }
 
 .sql-db-item {
@@ -1796,7 +1800,7 @@
      whitespace; on narrower screens it shrinks to leave a small
      gap on the left so the underlying UI stays peeking through. */
   width: min(1280px, calc(100vw - 32px));
-  background: var(--bg2);
+  background: var(--bg);
   border-left: 1px solid var(--border);
   box-shadow: -16px 0 48px #000a;
   z-index: 401;
@@ -1821,7 +1825,7 @@
   gap: 12px;
   padding: 16px 20px;
   border-bottom: 1px solid var(--border);
-  background: var(--bg2);
+  background: var(--bg);
 }
 
 .sql-modify-drawer-heading {
@@ -1832,6 +1836,7 @@
 }
 
 .sql-modify-drawer-title {
+  font-family: var(--font-ui);
   font-size: 15px;
   font-weight: 600;
   color: var(--text);
@@ -1877,7 +1882,7 @@
   gap: 8px;
   padding: 14px 20px;
   border-top: 1px solid var(--border);
-  background: var(--bg2);
+  background: var(--bg);
 }
 
 .sql-modify-drawer-drop {

--- a/app/_components/workspace/WorkspaceBadge.tsx
+++ b/app/_components/workspace/WorkspaceBadge.tsx
@@ -34,6 +34,7 @@ import {
   HardDrive,
   Pencil,
   Plus,
+  Save,
   Settings2,
   Trash2,
   Upload,
@@ -68,6 +69,14 @@ export interface WorkspaceBadgeProps {
    *  omitted the badge manages the manager itself. */
   managerOpen?: boolean;
   onManagerOpenChange?: (open: boolean) => void;
+  /** True when the active workspace is an unsaved draft that the user has
+   *  changed — surfaces a "Save" button next to the badge. Drafts (the
+   *  auto-created default) stay out of the saved list until saved. */
+  unsaved?: boolean;
+  /** Invoked with the chosen name when the user saves an unsaved draft.
+   *  The host promotes the draft to a saved workspace (see
+   *  `saveDraftWorkspace`). */
+  onSave?: (name: string) => void | Promise<void>;
 }
 
 function formatBytes(bytes: number): string {
@@ -124,8 +133,11 @@ export function WorkspaceBadge({
   activeWorkspaceName,
   managerOpen: managerOpenProp,
   onManagerOpenChange,
+  unsaved = false,
+  onSave,
 }: WorkspaceBadgeProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [internalManagerOpen, setInternalManagerOpen] = useState(false);
   // Controlled when the host passes `managerOpen`/`onManagerOpenChange`
   // (the mobile hamburger does), otherwise self-managed.
@@ -307,6 +319,29 @@ export function WorkspaceBadge({
         </Popover.Portal>
       </Popover.Root>
 
+      {unsaved && onSave && (
+        <button
+          type="button"
+          className="workspace-save-btn"
+          onClick={() => setSaveDialogOpen(true)}
+          title="Save this workspace so it appears in your list"
+        >
+          <Save size={12} aria-hidden="true" />
+          <span>Save</span>
+        </button>
+      )}
+
+      <SaveWorkspaceDialog
+        open={saveDialogOpen}
+        defaultName={defaultWorkspaceName(registry, playgroundId)}
+        onClose={() => setSaveDialogOpen(false)}
+        onConfirm={async (name) => {
+          setSaveDialogOpen(false);
+          await onSave?.(name);
+          refreshRegistry();
+        }}
+      />
+
       <WorkspaceManagerDrawer
         open={managerOpen}
         onOpenChange={setManagerOpen}
@@ -316,6 +351,61 @@ export function WorkspaceBadge({
         onRegistryChange={refreshRegistry}
       />
     </>
+  );
+}
+
+function SaveWorkspaceDialog({
+  open,
+  defaultName,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  defaultName: string;
+  onClose: () => void;
+  onConfirm: (name: string) => void | Promise<void>;
+}) {
+  const [draft, setDraft] = useState("");
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (open) setDraft(defaultName);
+  }, [open, defaultName]);
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="confirm-backdrop" />
+        <Dialog.Popup className="confirm-popup sql-rename-popup">
+          <Dialog.Title className="confirm-title">Save workspace</Dialog.Title>
+          <Dialog.Description className="confirm-desc">
+            Give this workspace a name to add it to your saved list. Your work
+            stays in this browser.
+          </Dialog.Description>
+          <form
+            className="sql-rename-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              const name = draft.trim() || defaultName;
+              void onConfirm(name);
+            }}
+          >
+            <input
+              className="sql-rename-input"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              autoFocus
+            />
+            <div className="confirm-actions">
+              <Dialog.Close className="confirm-btn confirm-btn-secondary">
+                Cancel
+              </Dialog.Close>
+              <button type="submit" className="confirm-btn confirm-btn-primary">
+                Save
+              </button>
+            </div>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }
 


### PR DESCRIPTION
Addresses the batch of playground UX requests. All seven updates are implemented. Validated with `npm run build`, `npx tsc --noEmit` (0 errors), `eslint` (0 errors), and `vitest run` (570/570 pass).

## Updates

- [x] **Update 3 — Simplify loading messages (all runtimes).** Boot/loading copy across code blocks, challenge cards, and playgrounds no longer names tools/libraries (CheerpJ, Pyodide, Roslyn, WebR, browsercc, .NET/Mono, almostnode) and drops semicolons. Covers Python, R, Java, C#, C, C++, PHP, JavaScript, TypeScript. The shared cold-boot hint now reads as two short lines: "This can take a moment on first load" / "Downloading (~N MB) — This happens once. Later runs are much faster."
- [x] **Update 1 — Runtime caching.** The WASM payloads ARE cached (immutable HTTP cache) — see findings below. Added a `bootHistory` flag so the first-run "Downloading… this happens once" copy only shows on a genuine first boot, not on every revisit (where nothing is actually downloaded).
- [x] **Update 2 — Multi-tab workspaces.** Fixed the boot overlay hanging at ~90% when a workspace is already open in another tab (OPFS access-handle deadlock). Postgres/SQLite now detect the lock conflict before booting and show a conflict overlay ("This workspace is open in another tab") with "Open a new workspace" and "Try again".
- [x] **Update 4 — Explicit save.** The auto-created default workspace is now a draft (OPFS-backed but not in the saved list). A "Save" button appears next to the workspace badge only once the draft has been changed; clicking it names and promotes the workspace. Applies to SQL and non-SQL.
- [x] **Update 5 — `.sql-modify-drawer`** uses `var(--bg)` (body, header, footer) and the drawer title uses Inter.
- [x] **Update 6 — Database & schema selector dropdowns** (shared `.sql-db-popup`) use `var(--bg)`.
- [x] **Update 7 — Subtle hover.** Shared `--menu-item-hover` token (a faint text-tinted lift) applied to dropdown / popover / context-menu items across the playgrounds.

## Findings

### Update 1 — Are the runtime/WASM files cached?
Yes. The heavy runtimes (PGlite/PostgreSQL, SQLite, DuckDB, Pyodide, WebR, CheerpJ, …) are loaded from jsDelivr/unpkg with pinned versions and **immutable, 1-year `Cache-Control`**, so after the first load they come from the browser's HTTP cache — they are not re-downloaded. The loading screen reappears on every visit because each playground **tears down and recreates its engine on unmount** (for isolation), so the (cached) WASM is re-instantiated — that's CPU/instantiation time, not a network download. The misleading part was the "Downloading… this happens once" copy showing every time; this PR makes that copy appear only on a genuine first boot.

### Update 2 — Root cause of the 90% hang + multi-tab options
A workspace's database is opened via an **exclusive OPFS access handle** (PGlite `opfs-ahp`, SQLite `opfs-sahpool`), which is per-origin. Opening the same workspace in a second tab made `createSyncAccessHandle` block forever, so `db.waitReady` never resolved and the creeping progress bar stalled at its 90% ceiling. The app already had a Web Lock check but only used it to show a toast and then booted anyway. Fix: detect the lock conflict *before* creating the engine and show a conflict overlay instead of deadlocking.

Better multi-tab handling options (the overlay is implemented now; the rest are noted for future work):
- **Implemented:** detect the conflict and inform the user via an overlay, with a one-click "Open a new workspace" escape hatch.
- **Future — real-time sync:** a `BroadcastChannel` (or `SharedWorker`) per workspace to mirror schema/data changes between tabs. Significantly more complex (conflict resolution, change log) and not needed to resolve the reported bug.

https://claude.ai/code/session_01UKZuozxHuCYCJtJb1bmYbV