### PR TITLE
Fix spurious "workspace open in another tab" on back/forward navigation

### DIFF
--- a/__tests__/opfs.workspace.test.ts
+++ b/__tests__/opfs.workspace.test.ts
@@ -259,6 +259,53 @@ describe("deleteWorkspace", () => {
 // acquireWorkspaceLock
 // ---------------------------------------------------------------------------
 
+/**
+ * Minimal in-memory Web Locks stub modelling exclusive, *queued* requests.
+ * A request for a free name is granted immediately; a request for a held name
+ * waits until the holder releases (its callback's promise settles) — or
+ * rejects if the request's `AbortSignal` fires first, which is how the real
+ * API surfaces both our grace-window timeout and caller-unmount cancellation.
+ */
+function makeLocksStub() {
+  const held = new Set<string>();
+  const waiters = new Map<string, Array<() => void>>();
+
+  function request(
+    name: string,
+    opts: { signal?: AbortSignal },
+    cb: (lock: unknown) => Promise<unknown> | unknown,
+  ): Promise<unknown> {
+    const grant = (): Promise<unknown> => {
+      held.add(name);
+      return Promise.resolve(cb({})).finally(() => {
+        held.delete(name);
+        waiters.get(name)?.shift()?.();
+      });
+    };
+    if (!held.has(name)) return grant();
+    // Held: queue until release, or reject if this request aborts first.
+    return new Promise((resolve, reject) => {
+      const onGrant = () => {
+        opts.signal?.removeEventListener("abort", onAbort);
+        resolve(grant());
+      };
+      const onAbort = () => {
+        const queue = waiters.get(name);
+        const i = queue?.indexOf(onGrant) ?? -1;
+        if (queue && i >= 0) queue.splice(i, 1);
+        reject(new Error("AbortError"));
+      };
+      if (opts.signal?.aborted) return onAbort();
+      opts.signal?.addEventListener("abort", onAbort);
+      const queue = waiters.get(name) ?? [];
+      queue.push(onGrant);
+      waiters.set(name, queue);
+    });
+  }
+
+  return { request };
+}
+
 describe("acquireWorkspaceLock", () => {
   it("returns true when Web Locks API is unavailable", async () => {
     vi.stubGlobal("navigator", {
@@ -271,19 +318,10 @@ describe("acquireWorkspaceLock", () => {
     expect(await acquireWorkspaceLock("ws_test")).toBe(true);
   });
 
-  it("returns true when lock is granted", async () => {
+  it("returns true when the lock is free", async () => {
     vi.stubGlobal("navigator", {
       storage: { getDirectory: () => Promise.resolve(makeOpfsRoot()) },
-      locks: {
-        request: (
-          _name: string,
-          _opts: object,
-          cb: (lock: object) => Promise<void>,
-        ) => {
-          // Simulate granting the lock (lock object is truthy)
-          void cb({});
-        },
-      },
+      locks: makeLocksStub(),
     });
     const { acquireWorkspaceLock } = await import(
       "../app/_components/opfs/workspace"
@@ -291,23 +329,49 @@ describe("acquireWorkspaceLock", () => {
     expect(await acquireWorkspaceLock("ws_test")).toBe(true);
   });
 
-  it("returns false when lock is already held by another tab", async () => {
+  it("returns false when another live tab holds the lock past the grace window", async () => {
+    const locks = makeLocksStub();
+    // Another tab holds the lock indefinitely (its callback never settles).
+    void locks.request(
+      "playground_workspace_ws_test",
+      {},
+      () => new Promise<void>(() => {}),
+    );
     vi.stubGlobal("navigator", {
       storage: { getDirectory: () => Promise.resolve(makeOpfsRoot()) },
-      locks: {
-        request: (
-          _name: string,
-          _opts: object,
-          cb: (lock: null) => Promise<void>,
-        ) => {
-          // Simulate lock being unavailable (lock is null)
-          void cb(null);
-        },
-      },
+      locks,
     });
     const { acquireWorkspaceLock } = await import(
       "../app/_components/opfs/workspace"
     );
-    expect(await acquireWorkspaceLock("ws_test")).toBe(false);
+    expect(await acquireWorkspaceLock("ws_test", { graceMs: 25 })).toBe(false);
+  });
+
+  it("releases the lock when the caller aborts, so a remount can re-acquire", async () => {
+    // Regression test for the back/forward false-conflict: the first mount must
+    // hand the lock off to the next mount instead of holding it for the life of
+    // the document.
+    vi.stubGlobal("navigator", {
+      storage: { getDirectory: () => Promise.resolve(makeOpfsRoot()) },
+      locks: makeLocksStub(),
+    });
+    const { acquireWorkspaceLock } = await import(
+      "../app/_components/opfs/workspace"
+    );
+
+    // First mount acquires and holds the lock.
+    const first = new AbortController();
+    expect(
+      await acquireWorkspaceLock("ws_test", { signal: first.signal }),
+    ).toBe(true);
+
+    // Second mount queues behind it; releasing the first (unmount) grants it.
+    const second = new AbortController();
+    const secondResult = acquireWorkspaceLock("ws_test", {
+      signal: second.signal,
+      graceMs: 1000,
+    });
+    first.abort();
+    expect(await secondResult).toBe(true);
   });
 });

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -980,6 +980,12 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   useEffect(() => {
     if (typeof window === "undefined") return;
     let cancelled = false;
+    // Releases the workspace lock when this effect tears down (unmount /
+    // client-side navigation away) so a later remount — e.g. a browser
+    // back-then-forward return to the playground — can re-acquire it instead
+    // of colliding with this document's own stale lock and showing a spurious
+    // "already open in another tab" warning.
+    const lockController = new AbortController();
     (async () => {
       try {
         const ws = await ensureActiveWorkspace(adapter.id);
@@ -1045,7 +1051,9 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
         const noticeKey = `playground_ws_warned_${ws.id}`;
         try {
           if (window.sessionStorage.getItem(noticeKey) !== "1") {
-            const hasLock = await acquireWorkspaceLock(ws.id);
+            const hasLock = await acquireWorkspaceLock(ws.id, {
+              signal: lockController.signal,
+            });
             if (!cancelled && !hasLock) {
               window.sessionStorage.setItem(noticeKey, "1");
               showToast(
@@ -1080,6 +1088,8 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     })();
     return () => {
       cancelled = true;
+      // Release the workspace lock so the next mount can re-acquire it.
+      lockController.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [adapter.id]);

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -1866,6 +1866,11 @@ function DuckDbPlaygroundInner() {
   // ─── Editor + engine init ────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false;
+    // Releases the workspace lock when this effect tears down (unmount /
+    // client-side navigation away) so a later remount — e.g. a browser
+    // back-then-forward return to the playground — can re-acquire it instead
+    // of colliding with this document's own stale lock.
+    const lockController = new AbortController();
     if (editorHostRef.current && !editorRef.current) {
       const compartments = makeSqlEditorCompartments();
       const initialTheme =
@@ -1919,7 +1924,9 @@ function DuckDbPlaygroundInner() {
           const noticeKey = `playground_ws_warned_${workspace.id}`;
           try {
             if (window.sessionStorage.getItem(noticeKey) !== "1") {
-              const hasLock = await acquireWorkspaceLock(workspace.id);
+              const hasLock = await acquireWorkspaceLock(workspace.id, {
+                signal: lockController.signal,
+              });
               if (!cancelled && !hasLock) {
                 window.sessionStorage.setItem(noticeKey, "1");
                 showToast(
@@ -2000,6 +2007,8 @@ function DuckDbPlaygroundInner() {
     })();
     return () => {
       cancelled = true;
+      // Release the workspace lock so the next mount can re-acquire it.
+      lockController.abort();
       editorRef.current?.destroy();
       editorRef.current = null;
       langCompRef.current = null;

--- a/app/_components/opfs/workspace.ts
+++ b/app/_components/opfs/workspace.ts
@@ -368,43 +368,97 @@ async function copyDirectoryHandle(
 interface LockManager {
   request: (
     name: string,
-    options: { ifAvailable: boolean },
-    callback: (lock: unknown) => Promise<void>,
-  ) => void;
+    options: { mode?: "exclusive" | "shared"; signal?: AbortSignal },
+    callback: (lock: unknown) => Promise<unknown> | unknown,
+  ) => Promise<unknown>;
+}
+
+/** Options for {@link acquireWorkspaceLock}. */
+export interface WorkspaceLockOptions {
+  /**
+   * Aborting this signal releases the held lock. Pass the signal from the
+   * acquiring effect's cleanup so the lock is released when the playground
+   * unmounts (e.g. a client-side navigation away).
+   *
+   * Without it the lock leaks for the whole lifetime of the document, and a
+   * later remount in the *same* document — most visibly a browser
+   * back-then-forward return to the playground — re-runs this acquisition and
+   * collides with the document's own stale lock, reporting a spurious
+   * "workspace is open in another tab" conflict.
+   */
+  signal?: AbortSignal;
+  /**
+   * How long to wait for the lock before declaring a conflict, in ms
+   * (default 1500). The wait lets a just-unmounted predecessor in this
+   * document — or another tab/page still tearing down — release the lock and
+   * hand it over, instead of racing to a false conflict. A genuinely
+   * concurrent live tab holds the lock for its whole lifetime, so the wait
+   * elapses and a real conflict is still reported.
+   */
+  graceMs?: number;
 }
 
 /**
  * Attempts to acquire an exclusive lock for `workspaceId` using the Web Locks
- * API. The lock is held for the lifetime of the browser tab (automatically
- * released when the tab is closed or crashes).
+ * API, holding it until `opts.signal` aborts (caller unmount) or the tab is
+ * closed.
  *
  * Returns `true` if the lock was acquired (this tab may use the workspace).
- * Returns `false` if another tab already holds the lock.
+ * Returns `false` if another live tab still holds the lock after the grace
+ * window.
  * Returns `true` unconditionally when the Web Locks API is unavailable (no
  * enforcement possible — callers should proceed with a warning).
  */
 export async function acquireWorkspaceLock(
   workspaceId: string,
+  opts: WorkspaceLockOptions = {},
 ): Promise<boolean> {
   if (!hasWebLocks()) return true;
+  const { signal: releaseSignal, graceMs = 1500 } = opts;
+  if (releaseSignal?.aborted) return false;
+
+  const locks = (navigator as unknown as { locks: LockManager }).locks;
+  const lockName = `playground_workspace_${workspaceId}`;
 
   return new Promise<boolean>((resolve) => {
-    const locks = (navigator as unknown as { locks: LockManager }).locks;
+    // The *wait* is aborted when the grace window elapses or the caller
+    // unmounts before the lock is ever granted. (Once granted, the lock is
+    // instead held until `releaseSignal` aborts — see the callback below.) A
+    // queued request — rather than `ifAvailable`, which fails instantly — lets
+    // a predecessor that is mid-release hand the lock over within the window.
+    const waitController = new AbortController();
+    const timer = setTimeout(() => waitController.abort(), graceMs);
+    const onCallerAbort = () => waitController.abort();
+    releaseSignal?.addEventListener("abort", onCallerAbort, { once: true });
+    const endWait = () => {
+      clearTimeout(timer);
+      releaseSignal?.removeEventListener("abort", onCallerAbort);
+    };
 
-    locks.request(
-      `playground_workspace_${workspaceId}`,
-      { ifAvailable: true },
-      (lock: unknown) => {
-        if (!lock) {
-          resolve(false);
-          // Return a never-settling promise so the lock request is also
-          // never settled (keeping the "busy" signal alive).
-          return new Promise<void>(() => {});
-        }
+    let granted = false;
+    locks
+      .request(lockName, { signal: waitController.signal }, () => {
+        granted = true;
+        endWait();
         resolve(true);
-        // Hold the lock indefinitely until the tab is closed.
-        return new Promise<void>(() => {});
-      },
-    );
+        // Hold the lock until the caller releases it (effect cleanup) or the
+        // tab is destroyed, then settle so the browser frees it for the next
+        // waiter — e.g. this same document's next mount after a back/forward.
+        return new Promise<void>((release) => {
+          if (!releaseSignal) return; // hold until the tab is closed
+          if (releaseSignal.aborted) release();
+          else
+            releaseSignal.addEventListener("abort", () => release(), {
+              once: true,
+            });
+        });
+      })
+      .catch(() => {
+        // The wait aborted before the lock was granted: the grace window
+        // elapsed (another live tab genuinely holds it) or the caller
+        // unmounted mid-wait. Either way this tab did not acquire the lock.
+        endWait();
+        if (!granted) resolve(false);
+      });
   });
 }

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -1796,6 +1796,11 @@ function PostgresPlaygroundInner() {
   // ─── Editor + engine init ────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false;
+    // Releases the workspace lock when this effect tears down (unmount /
+    // client-side navigation away) so a later remount — e.g. a browser
+    // back-then-forward return to the playground — can re-acquire it instead
+    // of colliding with this document's own stale lock.
+    const lockController = new AbortController();
     if (editorHostRef.current && !editorRef.current) {
       const compartments = makeSqlEditorCompartments();
       const initialTheme =
@@ -1847,7 +1852,9 @@ function PostgresPlaygroundInner() {
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
           setWorkspaceSaved(workspace.saved);
           try {
-            const hasLock = await acquireWorkspaceLock(workspace.id);
+            const hasLock = await acquireWorkspaceLock(workspace.id, {
+              signal: lockController.signal,
+            });
             if (!cancelled && !hasLock) {
               // The same OPFS-backed workspace can't be opened in two tabs:
               // PGlite's exclusive OPFS access handle would deadlock the
@@ -1890,6 +1897,8 @@ function PostgresPlaygroundInner() {
     })();
     return () => {
       cancelled = true;
+      // Release the workspace lock so the next mount can re-acquire it.
+      lockController.abort();
       editorRef.current?.destroy();
       editorRef.current = null;
       langCompRef.current = null;

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -1236,6 +1236,11 @@ function SqlPlaygroundInner() {
   // ─── Boot the engine and CodeMirror ──────────────────────────────────
   useEffect(() => {
     let cancelled = false;
+    // Releases the workspace lock when this effect tears down (unmount /
+    // client-side navigation away) so a later remount — e.g. a browser
+    // back-then-forward return to the playground — can re-acquire it instead
+    // of colliding with this document's own stale lock.
+    const lockController = new AbortController();
 
     if (editorHostRef.current && !editorRef.current) {
       const initialTheme =
@@ -1296,7 +1301,9 @@ function SqlPlaygroundInner() {
           setActiveWorkspace({ id: workspace.id, name: workspace.name });
           setWorkspaceSaved(workspace.saved);
           try {
-            const hasLock = await acquireWorkspaceLock(workspace.id);
+            const hasLock = await acquireWorkspaceLock(workspace.id, {
+              signal: lockController.signal,
+            });
             if (!cancelled && !hasLock) {
               // The same OPFS-backed workspace can't be opened in two tabs:
               // SQLite's exclusive OPFS access handle would deadlock the
@@ -1364,6 +1371,8 @@ function SqlPlaygroundInner() {
     })();
     return () => {
       cancelled = true;
+      // Release the workspace lock so the next mount can re-acquire it.
+      lockController.abort();
       // Terminate the engine worker so its OPFS access handles are
       // released — a zombie worker would otherwise keep the workspace's
       // opfs-sahpool locked across StrictMode remounts and client-side


### PR DESCRIPTION
## Problem

Returning to a playground via the browser's **back-then-forward** navigation reliably triggered a false single-tab conflict — the full-screen overlay ("This workspace is open in another tab") on SQLite/Postgres, and the toast ("This workspace is already open in another tab…") on DuckDB and the Python/JS playground — even when only one tab was open.

## Root cause

`acquireWorkspaceLock()` held the Web Lock through a promise that **never settled and was never released on unmount**. The Web Locks API is scoped to the **document**, not the React component, so:

1. First mount acquires + holds the lock (forever).
2. Navigating away unmounts the playground, but the cleanup never releases the lock — the never-settling promise keeps it held in the still-alive document.
3. Navigating forward back to the playground remounts it and re-runs the acquisition, which collides with **the document's own stale lock** → spurious conflict.

This is deterministic and document-scoped, which is why it reproduced every time and across every playground.

## Fix

- **Release on unmount.** `acquireWorkspaceLock` now accepts an `AbortSignal`; aborting it releases the held lock. Each playground's boot effect creates an `AbortController` and aborts it in cleanup, so a later mount can re-acquire.
- **Queue with a grace window instead of an instant probe.** Switched from `ifAvailable` (which fails immediately) to a queued request with a default 1.5s window. A predecessor that's mid-teardown (StrictMode remount, a bfcache-evicted page, the unmount→remount race) hands the lock over within the window instead of racing to a false conflict. A genuinely concurrent live tab holds the lock for its whole lifetime, so the window elapses and a **real** conflict is still reported (just ~1.5s later, during which the boot overlay is shown — no functional regression).

The happy path (no contention) is unaffected: a free lock is granted instantly with no added latency.

## Files

- `app/_components/opfs/workspace.ts` — releasable, queued lock acquisition (`WorkspaceLockOptions` with `signal` / `graceMs`).
- `app/_components/sql/SqlPlayground.tsx`, `postgres/PostgresPlayground.tsx`, `duckdb/DuckDbPlayground.tsx`, `Playground.tsx` — pass an abort signal from each boot effect's cleanup.
- `__tests__/opfs.workspace.test.ts` — model the queued/abortable Web Locks API; add a regression test asserting the lock is handed off on release.

## Verification

- `vitest run` — 571 tests pass (32 files), including the new lock hand-off regression test.
- `tsc --noEmit` — clean.
- `eslint` — clean (only pre-existing unrelated warnings).

https://claude.ai/code/session_01WVPTCZ2MXkACxPWb2M1CFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVPTCZ2MXkACxPWb2M1CFh)_