### PR TITLE
Fix schema-tree tooltip truncation and column-type recognition

### DIFF
--- a/__tests__/columnTypeSelector.test.ts
+++ b/__tests__/columnTypeSelector.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeVisibleTypeGroups,
+  withCurrentTypeOption,
+} from "../app/_components/sql/utils/columnTypeSelector";
+
+// Representative subsets of the real Postgres / DuckDB type groups.
+const PG_GROUPS = [
+  { label: "Numbers", types: ["smallint", "integer", "bigint", "numeric"] },
+  { label: "Text", types: ["text", "varchar", "varchar(255)", "char"] },
+  { label: "Date / time", types: ["date", "timestamp"] },
+] as const;
+const PG_OPTIONS = PG_GROUPS.flatMap((g) => g.types);
+
+const DUCKDB_GROUPS = [
+  { label: "Numbers", types: ["INTEGER", "BIGINT", "DECIMAL(18,3)"] },
+  { label: "Text", types: ["VARCHAR", "VARCHAR(255)", "TEXT"] },
+] as const;
+const DUCKDB_OPTIONS = DUCKDB_GROUPS.flatMap((g) => g.types);
+
+describe("computeVisibleTypeGroups", () => {
+  it("shows every group when the input is empty", () => {
+    const groups = computeVisibleTypeGroups(PG_GROUPS, PG_OPTIONS, "", "text");
+    expect(groups.map((g) => g.label)).toEqual([
+      "Numbers",
+      "Text",
+      "Date / time",
+    ]);
+    expect(groups.flatMap((g) => g.types)).toEqual(PG_OPTIONS);
+  });
+
+  it("shows every group for a committed Postgres type absent from the list (character varying)", () => {
+    // Regression: opening the picker for `categories.category_name` used to
+    // show "No matching built-in types" instead of the full list.
+    const groups = computeVisibleTypeGroups(
+      PG_GROUPS,
+      PG_OPTIONS,
+      "character varying(15)",
+      "character varying(15)",
+    );
+    expect(groups.flatMap((g) => g.types)).toEqual(PG_OPTIONS);
+  });
+
+  it("shows every group for a parameterized committed type (varchar(15))", () => {
+    const groups = computeVisibleTypeGroups(
+      PG_GROUPS,
+      PG_OPTIONS,
+      "varchar(15)",
+      "varchar(15)",
+    );
+    expect(groups.flatMap((g) => g.types)).toEqual(PG_OPTIONS);
+  });
+
+  it("shows every group for a committed DuckDB type absent from the list (DECIMAL(10,2))", () => {
+    const groups = computeVisibleTypeGroups(
+      DUCKDB_GROUPS,
+      DUCKDB_OPTIONS,
+      "DECIMAL(10,2)",
+      "DECIMAL(10,2)",
+    );
+    expect(groups.flatMap((g) => g.types)).toEqual(DUCKDB_OPTIONS);
+  });
+
+  it("normalizes case and whitespace when comparing to the committed value", () => {
+    const groups = computeVisibleTypeGroups(
+      PG_GROUPS,
+      PG_OPTIONS,
+      "  Character Varying(15) ",
+      "character varying(15)",
+    );
+    expect(groups.flatMap((g) => g.types)).toEqual(PG_OPTIONS);
+  });
+
+  it("filters to matching types once the user types a new search fragment", () => {
+    const groups = computeVisibleTypeGroups(PG_GROUPS, PG_OPTIONS, "var", "text");
+    expect(groups).toEqual([{ label: "Text", types: ["varchar", "varchar(255)"] }]);
+  });
+
+  it("returns no groups when the fragment matches nothing (genuine no-match)", () => {
+    expect(computeVisibleTypeGroups(PG_GROUPS, PG_OPTIONS, "zzz", "text")).toEqual(
+      [],
+    );
+  });
+
+  it("still shows every group when a complete known type is typed", () => {
+    const groups = computeVisibleTypeGroups(
+      PG_GROUPS,
+      PG_OPTIONS,
+      "integer",
+      "text",
+    );
+    expect(groups.flatMap((g) => g.types)).toEqual(PG_OPTIONS);
+  });
+});
+
+describe("withCurrentTypeOption", () => {
+  const SQLITE_TYPES = [
+    "INTEGER",
+    "REAL",
+    "TEXT",
+    "BLOB",
+    "NUMERIC",
+    "BOOLEAN",
+    "DATETIME",
+  ];
+
+  it("leaves the list unchanged for a built-in type", () => {
+    expect(withCurrentTypeOption(SQLITE_TYPES, "INTEGER")).toEqual(SQLITE_TYPES);
+  });
+
+  it("ignores surrounding whitespace when matching a built-in type", () => {
+    expect(withCurrentTypeOption(SQLITE_TYPES, "  TEXT  ")).toEqual(SQLITE_TYPES);
+  });
+
+  it("prepends a custom declared type so it stays selectable", () => {
+    expect(withCurrentTypeOption(SQLITE_TYPES, "VARCHAR(15)")).toEqual([
+      "VARCHAR(15)",
+      ...SQLITE_TYPES,
+    ]);
+  });
+
+  it("prepends a case-mismatched type (native select needs an exact match)", () => {
+    expect(withCurrentTypeOption(SQLITE_TYPES, "integer")).toEqual([
+      "integer",
+      ...SQLITE_TYPES,
+    ]);
+  });
+
+  it("leaves the list unchanged for an empty type", () => {
+    expect(withCurrentTypeOption(SQLITE_TYPES, "")).toEqual(SQLITE_TYPES);
+  });
+});

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -211,6 +211,7 @@ import {
   isDuckDbReadableFile,
 } from "./duckdbImport";
 import { FK_ACTIONS } from "../sql/constants";
+import { computeVisibleTypeGroups } from "../sql/utils/columnTypeSelector";
 
 const PLAYGROUND_ID = duckdbAdapter.playgroundId;
 const STORAGE_PREFIX = duckdbAdapter.storagePrefix;
@@ -506,22 +507,21 @@ function DuckDbTypeSelector({
     }
   }, [value]);
 
-  const query = inputVal.trim().toLowerCase();
-  // When the field is empty or already holds a committed type (i.e. the user
-  // opened the list via the chevron rather than typing a search fragment),
-  // show every group so all types stay discoverable. Only filter once they
-  // type a partial that is not itself a known type.
-  const visibleGroups = useMemo(() => {
-    const showAll =
-      query === "" ||
-      DUCKDB_TYPE_OPTIONS.some((type) => type.toLowerCase() === query);
-    return DUCKDB_TYPE_GROUPS.map((group) => ({
-      ...group,
-      types: showAll
-        ? [...group.types]
-        : group.types.filter((type) => type.toLowerCase().includes(query)),
-    })).filter((group) => group.types.length > 0);
-  }, [query]);
+  // When the field is empty or still holds the column's committed type (i.e.
+  // the user opened the list via the chevron rather than typing a search
+  // fragment), show every group so all types stay discoverable — including
+  // committed types absent from the built-in list such as `DECIMAL(10,2)`.
+  // Only filter once they type a partial that is not itself a known type.
+  const visibleGroups = useMemo(
+    () =>
+      computeVisibleTypeGroups(
+        DUCKDB_TYPE_GROUPS,
+        DUCKDB_TYPE_OPTIONS,
+        inputVal,
+        value,
+      ),
+    [inputVal, value],
+  );
 
   return (
     <Combobox.Root

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -202,6 +202,7 @@ import {
   tableNameFromFilename,
 } from "./postgresImport";
 import { FK_ACTIONS } from "../sql/constants";
+import { computeVisibleTypeGroups } from "../sql/utils/columnTypeSelector";
 
 const PLAYGROUND_ID = postgresAdapter.playgroundId;
 const STORAGE_PREFIX = postgresAdapter.storagePrefix;
@@ -476,22 +477,17 @@ function PgTypeSelector({
     }
   }, [value]);
 
-  const query = inputVal.trim().toLowerCase();
-  // When the field is empty or already holds a committed type (i.e. the user
-  // opened the list via the chevron rather than typing a search fragment),
-  // show every group so all types stay discoverable. Only filter once they
-  // type a partial that is not itself a known type.
-  const visibleGroups = useMemo(() => {
-    const showAll =
-      query === "" ||
-      PG_TYPE_OPTIONS.some((type) => type.toLowerCase() === query);
-    return PG_TYPE_GROUPS.map((group) => ({
-      ...group,
-      types: showAll
-        ? [...group.types]
-        : group.types.filter((type) => type.toLowerCase().includes(query)),
-    })).filter((group) => group.types.length > 0);
-  }, [query]);
+  // When the field is empty or still holds the column's committed type (i.e.
+  // the user opened the list via the chevron rather than typing a search
+  // fragment), show every group so all types stay discoverable — including
+  // committed types absent from the built-in list such as
+  // `character varying(15)`. Only filter once they type a partial that is
+  // not itself a known type.
+  const visibleGroups = useMemo(
+    () =>
+      computeVisibleTypeGroups(PG_TYPE_GROUPS, PG_TYPE_OPTIONS, inputVal, value),
+    [inputVal, value],
+  );
 
   return (
     <Combobox.Root

--- a/app/_components/sql/components/ModifyStructureForm.tsx
+++ b/app/_components/sql/components/ModifyStructureForm.tsx
@@ -32,6 +32,7 @@ import {
 import type { ModifyColumnDraft } from "../types";
 import type { TableColumnInfo, SqliteEngine } from "../../runtime/sqlite";
 import { COLUMN_TYPES, FK_ACTIONS } from "../constants";
+import { withCurrentTypeOption } from "../utils/columnTypeSelector";
 import { DdlViewer } from "./DdlViewer";
 import { GenExprEditor } from "./GenExprEditor";
 import { ColumnHeaderPopover } from "./PragmaSettingsTab";
@@ -170,7 +171,10 @@ export function ModifyColumnRow({
             onChange={(e) => onChange({ type: e.target.value })}
             aria-label="Column type"
           >
-            {COLUMN_TYPES.map((t) => (
+            {/* SQLite columns can declare any type (e.g. `VARCHAR(15)` from an
+                imported schema); surface the current value so the native
+                select doesn't render blank and silently lose it. */}
+            {withCurrentTypeOption(COLUMN_TYPES, col.type).map((t) => (
               <option key={t} value={t}>
                 {t}
               </option>

--- a/app/_components/sql/components/SchemaItem.tsx
+++ b/app/_components/sql/components/SchemaItem.tsx
@@ -186,6 +186,21 @@ function SchemaItemImpl({
       }
     };
   }, []);
+  // Detect when the entity name is visually clipped (CSS ellipsis on
+  // `.sql-tree-item-name`) so the hover tooltip can lead with the full name.
+  // A ResizeObserver catches both window resizes and sidebar drag-resizes
+  // that change the width available to the name.
+  const nameRef = useRef<HTMLSpanElement>(null);
+  const [nameTruncated, setNameTruncated] = useState(false);
+  useEffect(() => {
+    const el = nameRef.current;
+    if (!el) return;
+    const measure = () => setNameTruncated(el.scrollWidth > el.clientWidth);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [name]);
   const handleSingleClick = useCallback(() => {
     if (clickTimerRef.current !== null) {
       window.clearTimeout(clickTimerRef.current);
@@ -202,7 +217,10 @@ function SchemaItemImpl({
     }
     onPreview(name, kind);
   }, [name, kind, onPreview]);
-  const itemHint = `Double-click to preview, click to ${expanded ? "collapse" : "expand"}`;
+  const baseHint = `Double-click to preview, click to ${expanded ? "collapse" : "expand"}`;
+  // When the name is clipped, surface the full name first so it's readable
+  // on hover even though the row only shows a truncated label.
+  const itemHint = nameTruncated ? `${name} — ${baseHint}` : baseHint;
   return (
     <div className="sql-tree-entity">
       <ContextMenu.Root>
@@ -226,7 +244,9 @@ function SchemaItemImpl({
                     )}
                   </span>
                   <EntityIcon size={12} aria-hidden="true" />
-                  <span className="sql-tree-item-name">{name}</span>
+                  <span ref={nameRef} className="sql-tree-item-name">
+                    {name}
+                  </span>
                 </button>
                 <Popover.Root>
                   <Popover.Trigger

--- a/app/_components/sql/utils/columnTypeSelector.ts
+++ b/app/_components/sql/utils/columnTypeSelector.ts
@@ -1,0 +1,65 @@
+/** Helpers shared by the column-type pickers in the Modify Structure
+ *  drawers across SQL dialects. They keep the picker honest about the
+ *  column's *current* type even when that type isn't one of the built-in
+ *  presets — e.g. a Postgres `character varying(15)`, a `varchar(15)`, or a
+ *  DuckDB `DECIMAL(10,2)` introspected from an existing table. */
+
+/** A labelled group of built-in type strings, as rendered by the Postgres
+ *  and DuckDB type comboboxes. */
+export interface ColumnTypeGroup {
+  readonly label: string;
+  readonly types: readonly string[];
+}
+
+/** Decide which built-in type groups to show in a column-type combobox.
+ *
+ *  The combobox doubles as a search box: once the user types a fragment
+ *  that isn't itself a known type, the built-in list is filtered to the
+ *  types that contain that fragment. But when the field still holds the
+ *  column's committed type, opening the list (via the chevron or focus)
+ *  should reveal every group so all types stay browsable.
+ *
+ *  A value counts as the "committed type" — not a search fragment —
+ *  whenever the input still equals it, *including* custom or parameterized
+ *  types that are absent from the built-in list (`character varying(15)`,
+ *  `varchar(15)`, `DECIMAL(10,2)`, …). Previously only exact matches in the
+ *  built-in list were recognised, so opening the picker for a column that
+ *  used any such type wrongly showed "No matching built-in types." */
+export function computeVisibleTypeGroups(
+  groups: readonly ColumnTypeGroup[],
+  options: readonly string[],
+  inputValue: string,
+  committedValue: string,
+): { label: string; types: string[] }[] {
+  const query = inputValue.trim().toLowerCase();
+  const showAll =
+    query === "" ||
+    query === committedValue.trim().toLowerCase() ||
+    options.some((type) => type.toLowerCase() === query);
+  return groups
+    .map((group) => ({
+      label: group.label,
+      types: showAll
+        ? [...group.types]
+        : group.types.filter((type) => type.toLowerCase().includes(query)),
+    }))
+    .filter((group) => group.types.length > 0);
+}
+
+/** A native `<select>` can only display a value that exactly matches one of
+ *  its `<option>`s. SQLite is dynamically typed, so a column's declared type
+ *  may be anything (`VARCHAR(15)`, `character varying(15)`, a lowercase
+ *  `integer`, …) and need not appear in the built-in affinity list. Prepend
+ *  the current type as an extra option whenever it isn't already an exact
+ *  match so it stays visible and is preserved when the user edits other
+ *  fields, instead of the select silently rendering blank. */
+export function withCurrentTypeOption(
+  knownTypes: readonly string[],
+  currentType: string,
+): string[] {
+  const trimmed = currentType.trim();
+  if (!trimmed || knownTypes.includes(trimmed)) {
+    return [...knownTypes];
+  }
+  return [trimmed, ...knownTypes];
+}

--- a/e2e/sql-schema-name-tooltip.spec.ts
+++ b/e2e/sql-schema-name-tooltip.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ─────────────────────────────────────────────────────────────────────
+// Update 1: In the Schema pane, when a table/view name is clipped with a
+// CSS ellipsis, the row's hover tooltip (the native `title`) leads with the
+// FULL name so it's readable on hover — e.g.
+//   "very_long_name — Double-click to preview, click to expand".
+// Names that already fit keep the plain hint. The schema row (`SchemaItem`)
+// is shared by all three engines, so SQLite — which uses a local sample and
+// needs no CDN — exercises the same code path.
+// ─────────────────────────────────────────────────────────────────────
+
+async function runSql(page: Page, sql: string) {
+  const editor = page.locator(".cm-content");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Delete");
+  await page.keyboard.insertText(sql);
+  await page
+    .locator("button.run-btn-split-main, button.run-btn")
+    .first()
+    .click();
+}
+
+const HINT = /^Double-click to preview, click to (expand|collapse)$/;
+
+test("schema tree — clipped table names lead the tooltip with the full name", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  await page.goto("/playground/sqlite");
+
+  const treeRow = (name: RegExp | string) =>
+    page
+      .locator(".sql-tree-item")
+      .filter({ has: page.locator(".sql-tree-item-name", { hasText: name }) })
+      .first();
+
+  // Default sample loaded.
+  await treeRow(/^users$/).waitFor({ state: "visible", timeout: 150_000 });
+
+  // A short name fits → the tooltip is just the hint, with no name prefix.
+  await expect(treeRow(/^users$/)).toHaveAttribute("title", HINT);
+
+  // A name far too long for the sidebar width is clipped → the tooltip leads
+  // with the full name (the DOM text stays complete; only CSS clips it).
+  const longName =
+    "this_is_an_extremely_long_table_name_that_gets_clipped_with_an_ellipsis";
+  await runSql(page, `CREATE TABLE ${longName} (id INTEGER);`);
+  await expect(page.locator(".run-btn-spinner")).toHaveCount(0, {
+    timeout: 60_000,
+  });
+
+  const longRow = treeRow(longName);
+  await longRow.waitFor({ state: "visible", timeout: 40_000 });
+  await expect(longRow).toHaveAttribute(
+    "title",
+    new RegExp(
+      `^${longName} — Double-click to preview, click to (expand|collapse)$`,
+    ),
+  );
+});

--- a/e2e/sql-structure-type-selector.spec.ts
+++ b/e2e/sql-structure-type-selector.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ─────────────────────────────────────────────────────────────────────
+// Update 2: A column whose committed type isn't one of the built-in presets
+// — e.g. Postgres `character varying(15)` (how PGlite reports `varchar(15)`),
+// or any parameterized type — must NOT make the View/Edit Structure type
+// picker show "No matching built-in types." Opening the list should reveal
+// the full set of built-in types while preserving the column's real type.
+// The PgTypeSelector / DuckDb equivalents share `computeVisibleTypeGroups`
+// (unit-tested separately); this exercises the live Postgres wiring against
+// the reported northwind `categories.category_name` scenario.
+// ─────────────────────────────────────────────────────────────────────
+
+async function runSql(page: Page, sql: string) {
+  const editor = page.locator(".cm-content");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Delete");
+  await page.keyboard.insertText(sql);
+  await page
+    .locator("button.run-btn-split-main, button.run-btn")
+    .first()
+    .click();
+}
+
+test("postgres structure editor — a `character varying(n)` column lists all built-in types", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  await page.goto("/playground/postgres");
+  await page
+    .locator("button.run-btn-split-main, button.run-btn")
+    .first()
+    .waitFor({ state: "visible", timeout: 150_000 });
+
+  // Recreate the reported shape: a varchar(n) column, which PGlite introspects
+  // back as `character varying(15)`.
+  await runSql(
+    page,
+    "CREATE TABLE cat_demo (id smallint, cname character varying(15));",
+  );
+  await expect(page.locator(".run-btn-spinner")).toHaveCount(0, {
+    timeout: 60_000,
+  });
+
+  // Open View/Edit Structure from the schema-tree context menu.
+  const treeRow = page
+    .locator(".sql-tree-item")
+    .filter({
+      has: page.locator(".sql-tree-item-name", { hasText: /^cat_demo$/ }),
+    })
+    .first();
+  await treeRow.waitFor({ state: "visible", timeout: 40_000 });
+  await treeRow.click({ button: "right" });
+  await page
+    .locator(".example-item", { hasText: "View/Edit Structure" })
+    .click();
+
+  const drawer = page.locator(".sql-modify-drawer");
+  await expect(drawer).toBeVisible();
+
+  // The second column (cname) keeps its introspected type verbatim.
+  const cnameGroup = drawer.locator(".playground-type-input-group").nth(1);
+  await expect(cnameGroup.locator("input.playground-type-input")).toHaveValue(
+    "character varying(15)",
+  );
+
+  // Opening its type list shows the built-in types — NOT "No matching
+  // built-in types" (the bug).
+  await cnameGroup.locator('[aria-label="Open type list"]').click();
+  const popup = page.locator(".playground-type-popup");
+  await expect(popup).toBeVisible();
+  await expect(popup.locator(".playground-type-empty")).toHaveCount(0);
+  await expect(
+    popup.locator(".bui-select-item", { hasText: /^varchar$/ }),
+  ).toBeVisible();
+  await expect(
+    popup.locator(".bui-select-item", { hasText: /^text$/ }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Two fixes for the SQL playgrounds.

### Update 1 — Schema pane: full table name in the hover tooltip when clipped

When a table/view name in the **Schema** sidebar is cut off with an ellipsis, the row's hover tooltip now leads with the **full name** before the existing hint:

> `customer_customer_demo — Double-click to preview, click to expand`

A `ResizeObserver` on the name span detects clipping (`scrollWidth > clientWidth`) and re-measures on both window resizes and sidebar drag-resizes. Names that already fit keep the plain hint (no redundant prefix). The schema row (`SchemaItem`) is shared, so this applies to SQLite, Postgres, and DuckDB.

### Update 2 — View/Edit Structure: recognize committed / custom column types

In the Postgres northwind `categories` table, editing `category_name` (`character varying(15)`) showed **"No matching built-in types. You can keep the typed value."** when the type list was opened. The picker was treating the column's committed type as a search query that matched nothing.

This was **not** specific to `character varying` — it affected **any** committed type absent from the preset list (parameterized types like `numeric(10,2)` / `varchar(15)`, canonical names, etc.) and existed in **both** the Postgres and DuckDB pickers (identical combobox code; e.g. DuckDB `DECIMAL(10,2)`).

The fix: the picker now shows the full type list whenever the field still holds the committed value (i.e. the user opened it via the chevron rather than typing a search fragment), while preserving the column's real type. Shared logic lives in `computeVisibleTypeGroups`, used by both comboboxes.

**SQLite** uses a native `<select>`, so it can't show a "No matching" message — but it has the analogous problem: a declared type outside the seven affinities (or a different case, e.g. `VARCHAR(15)`) renders **blank** and isn't selectable. `withCurrentTypeOption` surfaces the column's real type as an option so it stays visible and is preserved when other fields are edited.

## Changes
- `app/_components/sql/utils/columnTypeSelector.ts` *(new)* — `computeVisibleTypeGroups` + `withCurrentTypeOption`
- `app/_components/sql/components/SchemaItem.tsx` — truncation detection + conditional tooltip
- `app/_components/postgres/PostgresPlayground.tsx`, `app/_components/duckdb/DuckDbPlayground.tsx` — use shared helper
- `app/_components/sql/components/ModifyStructureForm.tsx` — preserve custom SQLite types in the `<select>`

## Tests
- **Unit** (`__tests__/columnTypeSelector.test.ts`, 13 cases): `character varying(15)`, `varchar(15)`, DuckDB `DECIMAL(10,2)`, case/whitespace normalization, real-search filtering, genuine no-match, and the SQLite custom/case-mismatched type cases.
- **E2E** (`e2e/`): truncated table name → full name in tooltip (short name → plain hint); Postgres `character varying(n)` column lists all built-in types instead of "No matching built-in types."

Verified: `tsc --noEmit` clean, ESLint clean on changed files, full unit suite (584) green, and both new e2e specs pass in a real browser.

https://claude.ai/code/session_01GyHk9dCFY7iH73xkiNVU7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyHk9dCFY7iH73xkiNVU7v)_