### PR TITLE
Add neo-brutalist hard shadow to learn cards; make them theme-portable

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -92,9 +92,10 @@
   isolation: isolate; /* contain the z-index:-1 stripe layer to this subtree */
   margin: 1rem 0;
   --ch-shadow-offset: 6px;
-  --ch-shadow-color: color-mix(in srgb, var(--ds-black) 8%, transparent);
-  --ch-shadow-stripe: 2px; /* painted band width */
-  --ch-shadow-period: 6px; /* band + gap */
+  --ch-shadow-color: color-mix(in srgb, var(--ds-black) 6%, transparent);
+  --ch-shadow-stripe: 1px; /* painted band width */
+  --ch-shadow-period: 4px; /* band + gap */
+  --ch-shadow-border-color: var(--ds-gray-200); /* matches --ch-border */
 }
 .cardShell::after {
   content: "";
@@ -102,9 +103,10 @@
   z-index: -1;
   inset: var(--ch-shadow-offset) calc(-1 * var(--ch-shadow-offset))
     calc(-1 * var(--ch-shadow-offset)) var(--ch-shadow-offset);
+  border: 1px solid var(--ch-shadow-border-color);
   border-radius: 8px; /* matches --ch-radius */
   background: repeating-linear-gradient(
-    45deg,
+    90deg,
     var(--ch-shadow-color) 0,
     var(--ch-shadow-color) var(--ch-shadow-stripe),
     transparent var(--ch-shadow-stripe),
@@ -2261,6 +2263,7 @@
    would vanish). Set on the shell, which owns the striped elevation. */
 :global(html:is(.dark, [data-theme="dark"])) .cardShell {
   --ch-shadow-color: color-mix(in srgb, var(--ds-white) 10%, transparent);
+  --ch-shadow-border-color: #2e2e2e; /* matches dark --ch-border */
 }
 
 /* Match CodeMirror editor background to page background in dark mode —

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -106,7 +106,7 @@
   border: 1px solid var(--ch-shadow-border-color);
   border-radius: 8px; /* matches --ch-radius */
   background: repeating-linear-gradient(
-    90deg,
+    135deg,
     var(--ch-shadow-color) 0,
     var(--ch-shadow-color) var(--ch-shadow-stripe),
     transparent var(--ch-shadow-stripe),

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -62,27 +62,55 @@
   --ch-font-mono:
     "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   --ch-radius: 8px;
-  /* Neo-brutalist card lift: one hard, blur-less offset (no spread) instead
-     of a soft ambient shadow. Offset and colour are split into their own
-     tokens so the offset can thin on mobile (media query below) and the
-     colour can flip to a faint light tint in dark mode — the cards sit on a
-     near-black surface there, where a black offset would be invisible. */
-  --ch-shadow-offset: 6px;
-  --ch-shadow-color: color-mix(in srgb, var(--ds-black) 8%, transparent);
-  --ch-shadow:
-    var(--ch-shadow-offset) var(--ch-shadow-offset) 0 0 var(--ch-shadow-color);
 
   background: var(--ch-bg);
   border: 1px solid var(--ch-border);
   border-radius: var(--ch-radius);
-  box-shadow: var(--ch-shadow);
+  /* Elevation is painted by the striped `.cardShell::after` (below), not a
+     box-shadow, so the two never stack. `overflow: hidden` clips the card's
+     own rounded-corner content (header/editor/banner backgrounds) — which is
+     exactly why the offset stripe layer has to live on the shell instead, so
+     it can escape this clip. */
   overflow: hidden;
   font-family: var(--ch-font-ui);
   color: var(--ch-text);
   font-size: 14px;
   line-height: 1.5;
-  margin: 1rem 0;
   position: relative;
+}
+
+/* ── Striped hard-offset elevation ──────────────────────────────────────
+   Replaces the solid drop shadow with a diagonal-stripe texture painted in
+   the down-right offset gap — a "designed" elevation rather than a plain
+   shadow, while keeping the same hard-offset lift. The opaque `.card` sits
+   on top of this shell (negative z-index layer) and covers everything but
+   the offset sliver. Offset + colour reuse the prior shadow tokens so the
+   dark-mode tint and mobile thinning still apply; stripe width/period are
+   their own tokens for easy tuning. */
+.cardShell {
+  position: relative;
+  isolation: isolate; /* contain the z-index:-1 stripe layer to this subtree */
+  margin: 1rem 0;
+  --ch-shadow-offset: 6px;
+  --ch-shadow-color: color-mix(in srgb, var(--ds-black) 8%, transparent);
+  --ch-shadow-stripe: 2px; /* painted band width */
+  --ch-shadow-period: 6px; /* band + gap */
+}
+.cardShell::after {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  inset: var(--ch-shadow-offset) calc(-1 * var(--ch-shadow-offset))
+    calc(-1 * var(--ch-shadow-offset)) var(--ch-shadow-offset);
+  border-radius: 8px; /* matches --ch-radius */
+  background: repeating-linear-gradient(
+    45deg,
+    var(--ch-shadow-color) 0,
+    var(--ch-shadow-color) var(--ch-shadow-stripe),
+    transparent var(--ch-shadow-stripe),
+    transparent var(--ch-shadow-period)
+  );
+  pointer-events: none;
 }
 
 /* ─── Header ──────────────────────────────────────────────────────── */
@@ -1312,9 +1340,9 @@
   .btnKbd {
     display: none;
   }
-  /* Slightly thinner hard shadow so the offset doesn't dominate the layout
-     on narrow screens. */
-  .card {
+  /* Slightly thinner offset so the striped elevation doesn't dominate on
+     narrow screens. */
+  .cardShell {
     --ch-shadow-offset: 5px;
   }
 }
@@ -2227,8 +2255,11 @@
   /* Badge inherits the dark-mode accent (the var() declared above
      auto-tracks --ch-accent), but bg/border need explicit dark tints. */
   --ch-overlay: color-mix(in srgb, var(--ds-black) 65%, transparent);
-  /* Flip the hard offset to a faint light tint so it stays visible against
-     the near-black card surface (a black offset would vanish here). */
+}
+
+/* Dark-mode stripe tint: light on the near-black surface (a black offset
+   would vanish). Set on the shell, which owns the striped elevation. */
+:global(html:is(.dark, [data-theme="dark"])) .cardShell {
   --ch-shadow-color: color-mix(in srgb, var(--ds-white) 10%, transparent);
 }
 

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -106,7 +106,7 @@
   border: 1px solid var(--ch-shadow-border-color);
   border-radius: 8px; /* matches --ch-radius */
   background: repeating-linear-gradient(
-    135deg,
+    45deg,
     var(--ch-shadow-color) 0,
     var(--ch-shadow-color) var(--ch-shadow-stripe),
     transparent var(--ch-shadow-stripe),

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -62,9 +62,15 @@
   --ch-font-mono:
     "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   --ch-radius: 8px;
+  /* Neo-brutalist card lift: one hard, blur-less offset (no spread) instead
+     of a soft ambient shadow. Offset and colour are split into their own
+     tokens so the offset can thin on mobile (media query below) and the
+     colour can flip to a faint light tint in dark mode — the cards sit on a
+     near-black surface there, where a black offset would be invisible. */
+  --ch-shadow-offset: 6px;
+  --ch-shadow-color: color-mix(in srgb, var(--ds-black) 8%, transparent);
   --ch-shadow:
-    0 1px 3px color-mix(in srgb, var(--ds-black) 8%, transparent),
-    0 1px 2px color-mix(in srgb, var(--ds-black) 5%, transparent);
+    var(--ch-shadow-offset) var(--ch-shadow-offset) 0 0 var(--ch-shadow-color);
 
   background: var(--ch-bg);
   border: 1px solid var(--ch-border);
@@ -198,6 +204,12 @@
   margin: 0;
   display: flex;
   flex-direction: column;
+  /* A floating dialog keeps a soft, elevated drop shadow rather than the
+     inline cards' hard neo-brutalist offset (it sits over a dimmed backdrop,
+     not the page surface). */
+  box-shadow:
+    0 10px 30px color-mix(in srgb, var(--ds-black) 22%, transparent),
+    0 2px 8px color-mix(in srgb, var(--ds-black) 12%, transparent);
 }
 
 .modalHeader {
@@ -1002,7 +1014,7 @@
 }
 
 /* Light mode: match the dark-gray Submit button */
-:global(html:not(.dark)) .runBtnChevron {
+:global(html:not(.dark):not([data-theme="dark"])) .runBtnChevron {
   background: #1a1a1a;
 }
 
@@ -1010,7 +1022,7 @@
   background: var(--ch-accent-hover);
 }
 
-:global(html:not(.dark)) .runBtnChevron:hover:not(:disabled) {
+:global(html:not(.dark):not([data-theme="dark"])) .runBtnChevron:hover:not(:disabled) {
   background: #111111;
 }
 
@@ -1019,7 +1031,7 @@
   cursor: not-allowed;
 }
 
-:global(html:not(.dark)) .runBtnChevron:disabled {
+:global(html:not(.dark):not([data-theme="dark"])) .runBtnChevron:disabled {
   background: #8a8a8a;
 }
 
@@ -1027,7 +1039,7 @@
   background: var(--ch-accent-hover);
 }
 
-:global(html:not(.dark)) .runBtnChevron[data-popup-open] {
+:global(html:not(.dark):not([data-theme="dark"])) .runBtnChevron[data-popup-open] {
   background: #111111;
 }
 
@@ -1299,6 +1311,11 @@
 @media (max-width: 640px) {
   .btnKbd {
     display: none;
+  }
+  /* Slightly thinner hard shadow so the offset doesn't dominate the layout
+     on narrow screens. */
+  .card {
+    --ch-shadow-offset: 5px;
   }
 }
 
@@ -1907,7 +1924,7 @@
   font-family: var(--ch-font-ui);
 }
 
-:global(html.dark) .testPopover {
+:global(html:is(.dark, [data-theme="dark"])) .testPopover {
   --ch-bg: var(--color-fd-background, #121212);
   --ch-bg-subtle: color-mix(in srgb, var(--color-fd-background, #121212) 85%, #000000);
   --ch-border-light: #232323;
@@ -2165,11 +2182,16 @@
 }
 
 /* ─── Dark mode ───────────────────────────────────────────────────────
-   Fumadocs toggles a `.dark` class on `<html>`. We rebind the card's
-   CSS variables so the same selectors keep working — no extra rules
-   per element needed. Background matches `var(--color-fd-background)`
-   so the card surface blends with the surrounding learn-page chrome. */
-:global(html.dark) .card {
+   Two dark hooks are honoured so these cards theme correctly wherever
+   they're embedded, not just on /learn: `html.dark` (Fumadocs / next-themes,
+   the class strategy) and `html[data-theme="dark"]` (the attribute strategy
+   used by /playground — and whatever the home page's planned light/dark
+   toggle settles on). We rebind the card's CSS variables so the same
+   selectors keep working — no extra rules per element needed. Background
+   matches `var(--color-fd-background)` so the card surface blends with the
+   surrounding learn-page chrome (falling back to a neutral dark when those
+   Fumadocs vars aren't present, e.g. on the home page). */
+:global(html:is(.dark, [data-theme="dark"])) .card {
   /* Dark-theme additions to the Tailwind palette (the light tokens
      above are still available). All values come from the Tailwind
      palette so a future colour audit only has to look at these
@@ -2205,61 +2227,61 @@
   /* Badge inherits the dark-mode accent (the var() declared above
      auto-tracks --ch-accent), but bg/border need explicit dark tints. */
   --ch-overlay: color-mix(in srgb, var(--ds-black) 65%, transparent);
-  --ch-shadow:
-    0 1px 2px color-mix(in srgb, var(--ds-black) 50%, transparent),
-    0 1px 3px color-mix(in srgb, var(--ds-black) 40%, transparent);
+  /* Flip the hard offset to a faint light tint so it stays visible against
+     the near-black card surface (a black offset would vanish here). */
+  --ch-shadow-color: color-mix(in srgb, var(--ds-white) 10%, transparent);
 }
 
 /* Match CodeMirror editor background to page background in dark mode —
    the default dark theme sets #0d1117 which doesn't match #121212. */
-:global(html.dark) .editor :global(.cm-editor),
-:global(html.dark) .editor :global(.cm-scroller),
-:global(html.dark) .initEditor :global(.cm-editor),
-:global(html.dark) .initEditor :global(.cm-scroller),
-:global(html.dark) .modalEditor :global(.cm-editor),
-:global(html.dark) .modalEditor :global(.cm-scroller) {
+:global(html:is(.dark, [data-theme="dark"])) .editor :global(.cm-editor),
+:global(html:is(.dark, [data-theme="dark"])) .editor :global(.cm-scroller),
+:global(html:is(.dark, [data-theme="dark"])) .initEditor :global(.cm-editor),
+:global(html:is(.dark, [data-theme="dark"])) .initEditor :global(.cm-scroller),
+:global(html:is(.dark, [data-theme="dark"])) .modalEditor :global(.cm-editor),
+:global(html:is(.dark, [data-theme="dark"])) .modalEditor :global(.cm-scroller) {
   background-color: var(--ch-bg) !important;
 }
 
-:global(html.dark) .headerRuntimeLabel svg {
+:global(html:is(.dark, [data-theme="dark"])) .headerRuntimeLabel svg {
   color: #ffffff;
 }
 
-:global(html.dark) .instructionsBody code {
+:global(html:is(.dark, [data-theme="dark"])) .instructionsBody code {
   background: #252525;
   color: var(--ch-text);
 }
 
-:global(html.dark) .initToggle,
-:global(html.dark) .initHeaderStatic {
+:global(html:is(.dark, [data-theme="dark"])) .initToggle,
+:global(html:is(.dark, [data-theme="dark"])) .initHeaderStatic {
   color: var(--ds-gray-300);
 }
 
-:global(html.dark) .initToggle:hover {
+:global(html:is(.dark, [data-theme="dark"])) .initToggle:hover {
   color: #ffffff;
   background: var(--ch-bg-hover);
 }
 
-:global(html.dark) .initLabel {
+:global(html:is(.dark, [data-theme="dark"])) .initLabel {
   color: var(--ds-gray-300);
 }
 
-:global(html.dark) .initCollapseBtn {
+:global(html:is(.dark, [data-theme="dark"])) .initCollapseBtn {
   color: var(--ds-gray-300);
 }
 
-:global(html.dark) .initCollapseBtn:hover {
+:global(html:is(.dark, [data-theme="dark"])) .initCollapseBtn:hover {
   color: #ffffff;
   background: var(--ch-bg-hover);
 }
 
-:global(html.dark) .utilBtn:hover:not(:disabled),
-:global(html.dark) .copyBtn:hover {
+:global(html:is(.dark, [data-theme="dark"])) .utilBtn:hover:not(:disabled),
+:global(html:is(.dark, [data-theme="dark"])) .copyBtn:hover {
   background: var(--ch-bg-hover);
   color: var(--ch-text);
 }
 
-:global(html.dark) .kbd {
+:global(html:is(.dark, [data-theme="dark"])) .kbd {
   background: #252525;
   color: #b8b8b8;
   box-shadow: 0 1px 0 #0d0d0d;
@@ -2267,7 +2289,7 @@
 
 /* Keep the dropdown menu's kbd chips readable on the blue popup background
    in dark mode. */
-:global(html.dark) .runMenuKbd .kbd {
+:global(html:is(.dark, [data-theme="dark"])) .runMenuKbd .kbd {
   background: color-mix(in srgb, #ffffff 16%, transparent);
   border-color: color-mix(in srgb, #ffffff 28%, transparent);
   color: color-mix(in srgb, #ffffff 88%, transparent);
@@ -2277,20 +2299,20 @@
 /* Restore original blue accent for Run/Submit buttons in dark mode.
    The base style uses #1a1a1a for light-mode contrast; dark mode reverts
    to the standard accent (blue) so the button reads as a primary action. */
-:global(html.dark) .runBtn {
+:global(html:is(.dark, [data-theme="dark"])) .runBtn {
   background: var(--ds-blue-600);
 }
 
-:global(html.dark) .runBtn:hover:not(:disabled) {
+:global(html:is(.dark, [data-theme="dark"])) .runBtn:hover:not(:disabled) {
   background: var(--ds-blue-700);
 }
 
-:global(html.dark) .runBtn:disabled {
+:global(html:is(.dark, [data-theme="dark"])) .runBtn:disabled {
   background: var(--ds-blue-300);
 }
 
 
-:global(html.dark) .testPanelHeader:hover {
+:global(html:is(.dark, [data-theme="dark"])) .testPanelHeader:hover {
   background: #222222;
 }
 
@@ -2299,23 +2321,23 @@
    down to the 600 shades below so the fills sit more comfortably on
    dark surfaces. (The status banner is transparent with verdict-coloured
    text, so it adapts via the --ch-* tokens and needs nothing here.) */
-:global(html.dark) .testPill[data-state="pass"] {
+:global(html:is(.dark, [data-theme="dark"])) .testPill[data-state="pass"] {
   background: var(--ds-green-600);
 }
 
-:global(html.dark) .testPill[data-state="fail"] {
+:global(html:is(.dark, [data-theme="dark"])) .testPill[data-state="fail"] {
   background: var(--ds-red-600);
 }
 
-:global(html.dark) .testRailNode[data-state="pass"],
-:global(html.dark) .testRailSeg[data-state="pass"],
-:global(html.dark) .testPopoverStateDot[data-state="pass"] {
+:global(html:is(.dark, [data-theme="dark"])) .testRailNode[data-state="pass"],
+:global(html:is(.dark, [data-theme="dark"])) .testRailSeg[data-state="pass"],
+:global(html:is(.dark, [data-theme="dark"])) .testPopoverStateDot[data-state="pass"] {
   background: var(--ds-green-600);
 }
 
-:global(html.dark) .testRailNode[data-state="fail"],
-:global(html.dark) .testRailSeg[data-state="fail"],
-:global(html.dark) .testPopoverStateDot[data-state="fail"] {
+:global(html:is(.dark, [data-theme="dark"])) .testRailNode[data-state="fail"],
+:global(html:is(.dark, [data-theme="dark"])) .testRailSeg[data-state="fail"],
+:global(html:is(.dark, [data-theme="dark"])) .testPopoverStateDot[data-state="fail"] {
   background: var(--ds-red-600);
 }
 
@@ -2557,7 +2579,7 @@
   color: var(--ds-gray-900);
 }
 
-:global(html.dark) .tableViewerEmpty code {
+:global(html:is(.dark, [data-theme="dark"])) .tableViewerEmpty code {
   background: #252525;
   color: #e0e0e0;
 }

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -1593,6 +1593,7 @@ export default function ChallengeCard({
   }, [solutionFiles]);
 
   return (
+    <div className={styles.cardShell}>
     <div
       ref={cardRef}
       className={styles.card}
@@ -2168,6 +2169,7 @@ export default function ChallengeCard({
         />
       )}
 
+    </div>
     </div>
   );
 }

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -1148,6 +1148,7 @@ function CodeBlockInner({
 
   // ─── Render ────────────────────────────────────────────────────────────
   return (
+    <div className={challengeStyles.cardShell}>
     <div
       ref={cardRef}
       className={`${challengeStyles.card} ${styles.outputScope}`}
@@ -1511,6 +1512,7 @@ function CodeBlockInner({
           <RunOverlay active={isBusy} />
         </div>
       )}
+    </div>
     </div>
   );
 }

--- a/app/_components/RuntimeBootNotice.tsx
+++ b/app/_components/RuntimeBootNotice.tsx
@@ -160,6 +160,7 @@ export function CodeBlockLoadingPreview({
 }: CodeBlockLoadingPreviewProps) {
   const lines = code.replace(/\n$/, "").split("\n");
   return (
+    <div className={challengeStyles.cardShell}>
     <div
       className={`${challengeStyles.card} ${codeBlockStyles.outputScope}`}
       aria-label={`${language} code block (loading preview)`}
@@ -263,6 +264,7 @@ export function CodeBlockLoadingPreview({
           />
         </div>
       </div>
+    </div>
     </div>
   );
 }

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -1846,6 +1846,7 @@ export default function SqlChallengeCard({
         : "pending";
 
   return (
+    <div className={styles.cardShell}>
     <div
       className={styles.card}
       data-flavor="sql"
@@ -2235,6 +2236,7 @@ export default function SqlChallengeCard({
         />
       )}
 
+    </div>
     </div>
   );
 }

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -491,6 +491,7 @@ export default function SqlCodeBlock({
     : null;
 
   return (
+    <div className={styles.cardShell}>
     <div
       className={styles.card}
       data-flavor="sql"
@@ -639,6 +640,7 @@ export default function SqlCodeBlock({
         />
       </div>
 
+    </div>
     </div>
   );
 }

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -65,7 +65,7 @@
   border: 1px solid var(--mc-shadow-border-color);
   border-radius: 8px; /* matches --mc-radius */
   background: repeating-linear-gradient(
-    135deg,
+    45deg,
     var(--mc-shadow-color) 0,
     var(--mc-shadow-color) var(--mc-shadow-stripe),
     transparent var(--mc-shadow-stripe),

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -30,25 +30,46 @@
   --mc-font-mono:
     "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   --mc-radius: 8px;
-  /* Neo-brutalist card lift — kept in sync with ChallengeCard's `--ch-shadow`
-     (one hard, blur-less offset; offset thins on mobile, colour flips to a
-     light tint in dark mode). */
-  --mc-shadow-offset: 6px;
-  --mc-shadow-color: color-mix(in srgb, var(--ds-black) 8%, transparent);
-  --mc-shadow:
-    var(--mc-shadow-offset) var(--mc-shadow-offset) 0 0 var(--mc-shadow-color);
 
   background: var(--mc-bg);
   border: 1px solid var(--mc-border);
   border-radius: var(--mc-radius);
-  box-shadow: var(--mc-shadow);
+  /* Elevation comes from the striped `.cardShell::after` (below), not a
+     box-shadow. `overflow: hidden` clips the card's rounded-corner content,
+     so the offset stripe layer lives on the shell to escape that clip. */
   overflow: hidden;
   font-family: var(--mc-font-ui);
   color: var(--mc-text);
   font-size: 14px;
   line-height: 1.5;
-  margin: 1rem 0;
   position: relative;
+}
+
+/* ── Striped hard-offset elevation (mirrors ChallengeCard's .cardShell) ── */
+.cardShell {
+  position: relative;
+  isolation: isolate;
+  margin: 1rem 0;
+  --mc-shadow-offset: 6px;
+  --mc-shadow-color: color-mix(in srgb, var(--ds-black) 8%, transparent);
+  --mc-shadow-stripe: 2px;
+  --mc-shadow-period: 6px;
+}
+.cardShell::after {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  inset: var(--mc-shadow-offset) calc(-1 * var(--mc-shadow-offset))
+    calc(-1 * var(--mc-shadow-offset)) var(--mc-shadow-offset);
+  border-radius: 8px; /* matches --mc-radius */
+  background: repeating-linear-gradient(
+    45deg,
+    var(--mc-shadow-color) 0,
+    var(--mc-shadow-color) var(--mc-shadow-stripe),
+    transparent var(--mc-shadow-stripe),
+    transparent var(--mc-shadow-period)
+  );
+  pointer-events: none;
 }
 
 /* ─── Header ──────────────────────────────────────────────────────── */
@@ -499,8 +520,10 @@
   --mc-border-light: #232323;
   --mc-text: #e0e0e0;
   --mc-text-muted: #808080;
-  /* Faint light tint so the hard offset stays visible on the near-black
-     surface (matches ChallengeCard's dark-mode shadow). */
+}
+
+/* Dark-mode stripe tint (set on the shell, which owns the elevation). */
+:global(html:is(.dark, [data-theme="dark"])) .cardShell {
   --mc-shadow-color: color-mix(in srgb, var(--ds-white) 10%, transparent);
 }
 
@@ -626,7 +649,7 @@
 /* Slightly thinner hard shadow so the offset doesn't dominate on narrow
    screens (mirrors ChallengeCard). */
 @media (max-width: 640px) {
-  .card {
+  .cardShell {
     --mc-shadow-offset: 5px;
   }
 }

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -30,9 +30,13 @@
   --mc-font-mono:
     "JetBrains Mono", "Fira Code", ui-monospace, monospace;
   --mc-radius: 8px;
+  /* Neo-brutalist card lift — kept in sync with ChallengeCard's `--ch-shadow`
+     (one hard, blur-less offset; offset thins on mobile, colour flips to a
+     light tint in dark mode). */
+  --mc-shadow-offset: 6px;
+  --mc-shadow-color: color-mix(in srgb, var(--ds-black) 8%, transparent);
   --mc-shadow:
-    0 1px 3px color-mix(in srgb, var(--ds-black) 8%, transparent),
-    0 1px 2px color-mix(in srgb, var(--ds-black) 5%, transparent);
+    var(--mc-shadow-offset) var(--mc-shadow-offset) 0 0 var(--mc-shadow-color);
 
   background: var(--mc-bg);
   border: 1px solid var(--mc-border);
@@ -479,9 +483,10 @@
 /* ─── Dark mode ───────────────────────────────────────────────────── */
 /* Mirror the existing ChallengeCard dark-mode strategy: re-bind the
    semantic --mc-* tokens to darker palette values, leaving the
-   structural rules above untouched. The Fumadocs root toggles
-   `html.dark`, so we scope via :global(html.dark). */
-:global(html.dark) .card {
+   structural rules above untouched. Both dark hooks are honoured —
+   `html.dark` (Fumadocs / next-themes) and `html[data-theme="dark"]`
+   (attribute strategy) — so the card themes outside /learn too. */
+:global(html:is(.dark, [data-theme="dark"])) .card {
   /* Match the Fumadocs page background so the card surface blends with
      the surrounding chrome. Falls back to gray-900 when Fumadocs vars
      are not present (e.g. isolated Storybook / unit-test environments).
@@ -494,91 +499,94 @@
   --mc-border-light: #232323;
   --mc-text: #e0e0e0;
   --mc-text-muted: #808080;
+  /* Faint light tint so the hard offset stays visible on the near-black
+     surface (matches ChallengeCard's dark-mode shadow). */
+  --mc-shadow-color: color-mix(in srgb, var(--ds-white) 10%, transparent);
 }
 
-:global(html.dark) .choice[data-verdict="correct-selected"],
-:global(html.dark) .choice[data-verdict="correct-missed"] {
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="correct-selected"],
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="correct-missed"] {
   background: color-mix(in srgb, var(--ds-green) 15%, transparent);
 }
 
-:global(html.dark) .choice[data-verdict="wrong-selected"] {
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="wrong-selected"] {
   background: color-mix(in srgb, var(--ds-red) 15%, transparent);
 }
 
 /* Verdict banner: step the solid fill down to the 600 shades on dark
    surfaces (matches the challenge card's banner). */
-:global(html.dark) .banner[data-state="pass"] {
+:global(html:is(.dark, [data-theme="dark"])) .banner[data-state="pass"] {
   background: var(--ds-green-600);
 }
 
-:global(html.dark) .banner[data-state="fail"] {
+:global(html:is(.dark, [data-theme="dark"])) .banner[data-state="fail"] {
   background: var(--ds-red-600);
 }
 
-:global(html.dark) .choiceLabel code,
-:global(html.dark) .choiceExplanation code,
-:global(html.dark) .bodyMd code,
-:global(html.dark) .overallBody code {
+:global(html:is(.dark, [data-theme="dark"])) .choiceLabel code,
+:global(html:is(.dark, [data-theme="dark"])) .choiceExplanation code,
+:global(html:is(.dark, [data-theme="dark"])) .bodyMd code,
+:global(html:is(.dark, [data-theme="dark"])) .overallBody code {
   background: #252525;
   color: var(--mc-text);
 }
 
-:global(html.dark) .bodyMd pre,
-:global(html.dark) .choiceLabel pre {
+:global(html:is(.dark, [data-theme="dark"])) .bodyMd pre,
+:global(html:is(.dark, [data-theme="dark"])) .choiceLabel pre {
   background: #1a1a1a;
 }
 
 /* Force code inside pre to be transparent so it doesn't show a lighter
    background (#252525) on top of the pre's #1a1a1a — the higher specificity
    here beats the general dark-mode code background rule. */
-:global(html.dark) .bodyMd pre code,
-:global(html.dark) .choiceLabel pre code {
+:global(html:is(.dark, [data-theme="dark"])) .bodyMd pre code,
+:global(html:is(.dark, [data-theme="dark"])) .choiceLabel pre code {
   background: transparent;
 }
 
 /* Unselected radio: no ring, subtle fill close to the page bg. */
-:global(html.dark) .choiceInput:not(:checked) {
+:global(html:is(.dark, [data-theme="dark"])) .choiceInput:not(:checked) {
   background: rgba(255, 255, 255, 0.05);
 }
 
 /* Choice explanation boxes inside verdict choices use explicit white in
    light mode — override to a translucent tinted dark surface. */
-:global(html.dark) .choice[data-verdict="correct-selected"] .choiceExplanation,
-:global(html.dark) .choice[data-verdict="correct-missed"] .choiceExplanation {
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="correct-selected"] .choiceExplanation,
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="correct-missed"] .choiceExplanation {
   background: color-mix(in srgb, var(--ds-green) 8%, transparent);
 }
 
-:global(html.dark) .choice[data-verdict="wrong-selected"] .choiceExplanation {
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="wrong-selected"] .choiceExplanation {
   background: color-mix(in srgb, var(--ds-red) 8%, transparent);
 }
 
 /* Choice mark icons — replace light green/red fill with translucent dark tints. */
-:global(html.dark) .choice[data-verdict="correct-selected"] .choiceMark,
-:global(html.dark) .choice[data-verdict="correct-missed"] .choiceMark {
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="correct-selected"] .choiceMark,
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="correct-missed"] .choiceMark {
   background: color-mix(in srgb, var(--ds-green) 20%, transparent);
   color: var(--ds-green-300);
 }
 
-:global(html.dark) .choice[data-verdict="wrong-selected"] .choiceMark {
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="wrong-selected"] .choiceMark {
   background: color-mix(in srgb, var(--ds-red) 20%, transparent);
   color: var(--ds-red-300);
 }
 
 /* Retry button uses an explicit white background in light mode. */
-:global(html.dark) .retryBtn {
+:global(html:is(.dark, [data-theme="dark"])) .retryBtn {
   background: var(--mc-bg-subtle);
   border-color: var(--mc-border);
   color: var(--mc-text);
 }
 
-:global(html.dark) .retryBtn:hover {
+:global(html:is(.dark, [data-theme="dark"])) .retryBtn:hover {
   background: var(--mc-bg-hover);
   border-color: #3a3a3a;
 }
 
 /* Choice hover in dark mode — use the dark bg-hover token instead of the
    light gray-50 that the base rule references directly. */
-:global(html.dark) .choice:not([data-locked="true"]):hover {
+:global(html:is(.dark, [data-theme="dark"])) .choice:not([data-locked="true"]):hover {
   background: var(--mc-bg-hover);
 }
 
@@ -587,31 +595,39 @@
    not pick, as well as the tinted green/red verdict backgrounds. Without
    the base (neutral) rule, those distractor explanations kept the
    light-mode gray-700 text and were almost invisible on the dark card. */
-:global(html.dark) .choiceExplanation {
+:global(html:is(.dark, [data-theme="dark"])) .choiceExplanation {
   color: #ffffff;
 }
 
 /* Neutral checked state for the radio input in dark mode. */
-:global(html.dark) .choiceInput:checked {
+:global(html:is(.dark, [data-theme="dark"])) .choiceInput:checked {
   background: radial-gradient(circle, white 30%, #fff6 31%);
   box-shadow: none;
 }
 
 /* Inline code inside verdict choice explanations: use a tinted background
    that blends with the dark green / dark red surface instead of gray. */
-:global(html.dark) .choice[data-verdict="correct-selected"] .choiceExplanation code,
-:global(html.dark) .choice[data-verdict="correct-missed"] .choiceExplanation code {
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="correct-selected"] .choiceExplanation code,
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="correct-missed"] .choiceExplanation code {
   background: color-mix(in srgb, var(--ds-green) 30%, transparent);
   color: var(--ds-green-200);
 }
 
-:global(html.dark) .choice[data-verdict="wrong-selected"] .choiceExplanation code {
+:global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="wrong-selected"] .choiceExplanation code {
   background: color-mix(in srgb, var(--ds-red) 30%, transparent);
   color: var(--ds-red-200);
 }
 
 /* Overall explanation paragraph text is white in dark mode. */
-:global(html.dark) .overallBody {
+:global(html:is(.dark, [data-theme="dark"])) .overallBody {
   color: #ffffff;
+}
+
+/* Slightly thinner hard shadow so the offset doesn't dominate on narrow
+   screens (mirrors ChallengeCard). */
+@media (max-width: 640px) {
+  .card {
+    --mc-shadow-offset: 5px;
+  }
 }
 

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -51,9 +51,10 @@
   isolation: isolate;
   margin: 1rem 0;
   --mc-shadow-offset: 6px;
-  --mc-shadow-color: color-mix(in srgb, var(--ds-black) 8%, transparent);
-  --mc-shadow-stripe: 2px;
-  --mc-shadow-period: 6px;
+  --mc-shadow-color: color-mix(in srgb, var(--ds-black) 6%, transparent);
+  --mc-shadow-stripe: 1px;
+  --mc-shadow-period: 4px;
+  --mc-shadow-border-color: var(--ds-gray-200); /* matches --mc-border */
 }
 .cardShell::after {
   content: "";
@@ -61,9 +62,10 @@
   z-index: -1;
   inset: var(--mc-shadow-offset) calc(-1 * var(--mc-shadow-offset))
     calc(-1 * var(--mc-shadow-offset)) var(--mc-shadow-offset);
+  border: 1px solid var(--mc-shadow-border-color);
   border-radius: 8px; /* matches --mc-radius */
   background: repeating-linear-gradient(
-    45deg,
+    90deg,
     var(--mc-shadow-color) 0,
     var(--mc-shadow-color) var(--mc-shadow-stripe),
     transparent var(--mc-shadow-stripe),
@@ -525,6 +527,7 @@
 /* Dark-mode stripe tint (set on the shell, which owns the elevation). */
 :global(html:is(.dark, [data-theme="dark"])) .cardShell {
   --mc-shadow-color: color-mix(in srgb, var(--ds-white) 10%, transparent);
+  --mc-shadow-border-color: #2e2e2e; /* matches dark --mc-border */
 }
 
 :global(html:is(.dark, [data-theme="dark"])) .choice[data-verdict="correct-selected"],

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.module.css
@@ -65,7 +65,7 @@
   border: 1px solid var(--mc-shadow-border-color);
   border-radius: 8px; /* matches --mc-radius */
   background: repeating-linear-gradient(
-    90deg,
+    135deg,
     var(--mc-shadow-color) 0,
     var(--mc-shadow-color) var(--mc-shadow-stripe),
     transparent var(--mc-shadow-stripe),

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -114,6 +114,7 @@ export default function MultipleChoiceQuestion({
   const groupName = useId();
 
   return (
+    <div className={styles.cardShell}>
     <section className={styles.card} aria-label="Multiple choice question">
       <header className={styles.header}>
         <span className={styles.badge}>
@@ -242,5 +243,6 @@ export default function MultipleChoiceQuestion({
         </div>
       ) : null}
     </section>
+    </div>
   );
 }


### PR DESCRIPTION
Reworks the elevation treatment on the `/learn` embeddable components (code blocks, challenge cards, SQL variants, MCQ) and makes them theme-portable for reuse outside `/learn`.

## Elevation — a bordered, striped offset plate (latest)
The cards no longer use a `box-shadow`. Each card root is wrapped in a thin `.cardShell` whose `::after` paints a striped, **bordered** plate in the down-right offset gap — a "designed" elevation rather than a plain shadow, keeping the same hard-offset lift. It reads as a bordered plate stacked behind the card.

```
stripes: repeating-linear-gradient(45deg, <tint> 0–1px, transparent 1–4px)   (fine diagonal ribs, top-left → bottom-right)
tint:    ds-black 6% (light) · ds-white 10% (dark)
border:  1px solid, matches the card border token (ds-gray-200 light · #2e2e2e dark)
offset:  6px, thinning to 5px on mobile (≤640px)
```

Why a wrapper: `.card` sets `overflow: hidden` to clip its own rounded-corner content, and an element can't paint its opaque background over its own pseudo-element — so the plate can't live on `.card`. The shell hosts it on `::after` (`z-index:-1`, behind the opaque card, contained via `isolation: isolate`); only the offset sliver shows. Offset, stripe geometry, angle, tint, and border colour are all tokens / single values for easy tuning, with dark-mode overrides on the shell.

Applied to ChallengeCard, SqlChallengeCard, CodeBlock, SqlCodeBlock, MultipleChoiceQuestion, and the CodeBlock loading preview. The solution **modal is unchanged** — it keeps a soft, elevated dialog shadow (a hard offset would look wrong floating over the backdrop).

<sub>(History: solid `6px 6px 0 0` hard-offset shadow → 45° diagonal-stripe texture → fine vertical stripes + bordered plate → diagonal stripes at 45° running top-left → bottom-right (current). Token split / dark tint / mobile thinning shared throughout.)</sub>

## Theme-portability (reuse outside /learn)
Dark hooks were broadened from `html.dark` to `html:is(.dark, [data-theme="dark"])` so the cards respond to **both** the class strategy (Fumadocs / next-themes) and the attribute strategy — covering whatever the planned home-page light/dark toggle uses. Specificity is preserved; the light-only chevron rules are narrowed to match. Brand tokens, neutral palette, and fonts were already self-contained, and the Fumadocs background var keeps a neutral-dark fallback off-route.

## Verification
`tsc --noEmit` clean; all five demo pages compile (HTTP 200); computed `::after` confirmed in both themes (border ds-gray-200/#2e2e2e, 45° stripe gradient running top-left → bottom-right, card `box-shadow: none`); corners intact; light / dark / mobile checked in a headless browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aJN4aLqjCv1cpo7NnXU8D