### PR TITLE
Remove "hidden test" wording from courses; defer playground editor focus past boot screen

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -1552,8 +1552,16 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     // switch, new-file, duplicate, or close-all action. The Settings
     // tab is handled above (early return), so we never steal focus
     // from the settings form here.
+    //
+    // Hold off while the boot overlay still covers the screen: on mobile,
+    // focusing CodeMirror pops the on-screen keyboard, which would slide up
+    // over the loading screen for no use. `showLoadingOverlay` is in the
+    // deps so that once the overlay unmounts this effect re-runs and the
+    // editor takes focus — the keyboard appears only after the loading
+    // screen is gone.
+    if (showLoadingOverlay) return;
     view.focus();
-  }, [activeFileId, activeTabId, workspaceReady]);
+  }, [activeFileId, activeTabId, workspaceReady, showLoadingOverlay]);
 
   // Push word-wrap changes into CodeMirror after init.
   useEffect(() => {

--- a/content/learn/c-programming-for-beginners/index.mdx
+++ b/content/learn/c-programming-for-beginners/index.mdx
@@ -129,7 +129,7 @@ You will see three kinds of widgets:
 
 1. **Code blocks.** Read them. Then click *Run*. Then **change a
    number** and run again. Curiosity is the engine of learning here.
-2. **Challenge cards.** Small puzzles with hidden tests. Try, fail,
+2. **Challenge cards.** Small puzzles with tests. Try, fail,
    try again. The point is the trying.
 3. **Multiple-choice questions.** Quick checks at the end of most
    sections. Read every explanation — wrong answers are where the

--- a/content/learn/data-analysis-python-pandas/index.mdx
+++ b/content/learn/data-analysis-python-pandas/index.mdx
@@ -118,7 +118,7 @@ You will encounter three kinds of widgets:
 
 1. **Executable code blocks.** Edit the code, click *Run*, and the
    output (printed text, tables, plots) appears right below.
-2. **Challenge cards.** Small problems with hidden test cases —
+2. **Challenge cards.** Small problems with test cases —
    write a solution, click *Run tests*, and see which ones pass.
    Larger challenges may use multiple files so you can practice
    organizing analysis code.

--- a/content/learn/from-zero-to-cpp/index.mdx
+++ b/content/learn/from-zero-to-cpp/index.mdx
@@ -123,7 +123,7 @@ You will see three kinds of interactive widgets on most pages:
    `clang++` *in your browser* and runs as a tiny WebAssembly binary
    under WASI. There is nothing to install. Edit any block and click
    *Run*.
-2. **Challenge cards.** Hidden-test exercises that ask you to fill in
+2. **Challenge cards.** Test-backed exercises that ask you to fill in
    a function, fix a bug, or build a small program. Some span
    multiple files so you can practice the header / implementation
    split used in real C++ projects.

--- a/content/learn/machine-learning-scikit-learn/common-pitfalls-and-misconceptions.mdx
+++ b/content/learn/machine-learning-scikit-learn/common-pitfalls-and-misconceptions.mdx
@@ -493,7 +493,7 @@ the right way.
    \`cross_val_score(...).mean()\`).
 
 By scaling **inside** the pipeline, each fold is scaled using only its own
-training portion — no leakage. The hidden tests check that \`pipe\` is a
+training portion — no leakage. The tests check that \`pipe\` is a
 proper two-step pipeline (so scaling happens inside cross-validation) and
 that \`correct_cv\` is a believable accuracy.`}
   files={[
@@ -569,7 +569,7 @@ predictions are in \`pred\`.
 
 You should find a high \`acc\` next to a \`rare_recall\` of 0.0 — the model
 looks great on accuracy yet catches none of the cases that matter. The
-hidden tests check that \`acc\` is high (above 0.9) while \`rare_recall\`
+tests check that \`acc\` is high (above 0.9) while \`rare_recall\`
 is exactly 0.0, demonstrating the trap.`}
   files={[
     {

--- a/content/learn/machine-learning-scikit-learn/data-preprocessing.mdx
+++ b/content/learn/machine-learning-scikit-learn/data-preprocessing.mdx
@@ -481,7 +481,7 @@ scales. Scale them **without leaking the test set**.
    scaler to both — do not fit it again on the test set.
 4. Store the mean of \`X_train_scaled\` in \`train_mean\`.
 
-The hidden tests check that the scaler was fit on the training set (so the
+The tests check that the scaler was fit on the training set (so the
 training mean is ~0), that the test set was transformed with the *same*
 scaler (so its mean is close to but not exactly 0), and that the shapes are
 unchanged.`}

--- a/content/learn/machine-learning-scikit-learn/decision-trees.mdx
+++ b/content/learn/machine-learning-scikit-learn/decision-trees.mdx
@@ -505,7 +505,7 @@ target (malignant vs. benign).
    (\`max_depth=None\`, \`random_state=0\`) and store its training accuracy in
    \`deep_train_acc\`.
 
-The hidden tests check the depth-limited tree's configuration, that it
+The tests check the depth-limited tree's configuration, that it
 generalizes reasonably (test accuracy above 0.88), and that the unlimited
 tree reaches a perfect training score — the memorization you should be wary
 of.`}

--- a/content/learn/machine-learning-scikit-learn/encoding-categorical-features.mdx
+++ b/content/learn/machine-learning-scikit-learn/encoding-categorical-features.mdx
@@ -486,7 +486,7 @@ not assert relationships the world does not contain.
 3. Store the encoder's output column names (from
    \`get_feature_names_out()\`) in \`columns\` (as a list).
 
-The hidden tests check that \`encoded\` has one row per original row, that
+The tests check that \`encoded\` has one row per original row, that
 the total number of one-hot columns equals the number of distinct categories
 across both features, that the encoded values are only 0s and 1s, and that
 each row sums to exactly 2 (one '1' for fruit, one '1' for country).`}

--- a/content/learn/machine-learning-scikit-learn/ensembles-and-random-forests.mdx
+++ b/content/learn/machine-learning-scikit-learn/ensembles-and-random-forests.mdx
@@ -438,7 +438,7 @@ beats one overfit tree on held-out data.
    training set. Name it \`forest\` and store its **test** accuracy in
    \`forest_acc\`.
 
-The hidden tests check that \`forest\` is a 200-tree
+The tests check that \`forest\` is a 200-tree
 \`RandomForestClassifier\`, that the forest is accurate (test accuracy above
 0.95), and — the key point of the page — that the forest's test accuracy is
 **at least as high as** the single tree's (\`forest_acc >= tree_acc\`).`}

--- a/content/learn/machine-learning-scikit-learn/feature-engineering.mdx
+++ b/content/learn/machine-learning-scikit-learn/feature-engineering.mdx
@@ -436,7 +436,7 @@ room**, which is not any single raw column.
 3. For comparison, store the correlation between raw \`total_sqft\` and
    \`price\` in \`corr_raw\` (use \`df["total_sqft"].corr(df["price"])\`).
 
-The hidden tests check that \`sqft_per_room\` was computed correctly for
+The tests check that \`sqft_per_room\` was computed correctly for
 every row, that it is a new column in \`df\`, and that the engineered feature
 correlates with price more strongly than raw \`total_sqft\` does (showing the
 ratio exposes the signal better).`}

--- a/content/learn/machine-learning-scikit-learn/features-and-targets.mdx
+++ b/content/learn/machine-learning-scikit-learn/features-and-targets.mdx
@@ -470,7 +470,7 @@ patient. We want to predict whether each patient has the condition — the
    except \`has_condition\`). Hint: \`patients.drop(columns=[...])\`.
 3. Store the number of feature columns in \`n_features\` (use \`X.shape\`).
 
-The hidden tests check that \`y\` is the right column, that \`X\` excludes the
+The tests check that \`y\` is the right column, that \`X\` excludes the
 target, that the rows of \`X\` and \`y\` stay aligned, and that \`n_features\`
 is correct.`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/hierarchical-clustering.mdx
+++ b/content/learn/machine-learning-scikit-learn/hierarchical-clustering.mdx
@@ -531,7 +531,7 @@ labels.
    \`largest_cluster\`. Hint: \`np.bincount(labels)\` gives the count per
    label; take its \`max()\`.
 
-The hidden tests check that you standardized the data, found exactly 3
+The tests check that you standardized the data, found exactly 3
 clusters, labeled all 150 points, and that the largest cluster size is
 consistent with the data.`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/hyperparameter-tuning.mdx
+++ b/content/learn/machine-learning-scikit-learn/hyperparameter-tuning.mdx
@@ -559,7 +559,7 @@ the wine dataset, honestly.
 5. Evaluate \`search.best_estimator_\` on the test set with \`.score(...)\`
    and store that in \`test_score\`.
 
-The hidden tests check that the grid was the right size, that
+The tests check that the grid was the right size, that
 \`best_params\` chose a depth from your grid, that \`best_cv_score\` is a
 sensible accuracy, and that you produced a \`test_score\`.`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/index.mdx
+++ b/content/learn/machine-learning-scikit-learn/index.mdx
@@ -159,7 +159,7 @@ You will meet three kinds of widget:
 
 1. **Executable code blocks** — like the one above. Edit and re-run them as
    much as you like; experimentation is the point.
-2. **Challenge cards** — small problems with hidden tests. You write the
+2. **Challenge cards** — small problems with tests. You write the
    solution and press **Check Answer** to see which tests pass.
 3. **Multiple-choice questions** — quick conceptual checks with an
    explanation for *every* option, right or wrong.

--- a/content/learn/machine-learning-scikit-learn/k-means-clustering.mdx
+++ b/content/learn/machine-learning-scikit-learn/k-means-clustering.mdx
@@ -588,7 +588,7 @@ plausible, and only then trusts the result or switches methods.
    array \`cluster_sizes\`, sorted ascending. Hint:
    \`np.unique(labels, return_counts=True)\` then sort the counts.
 
-The hidden tests check that you scaled the data, found exactly 3 clusters,
+The tests check that you scaled the data, found exactly 3 clusters,
 assigned all 300 points, and that the cluster sizes sum to 300.`}
   files={[
     {

--- a/content/learn/machine-learning-scikit-learn/k-nearest-neighbors.mdx
+++ b/content/learn/machine-learning-scikit-learn/k-nearest-neighbors.mdx
@@ -472,7 +472,7 @@ so unscaled KNN does poorly — and scaling fixes it. Show both.
    KNeighborsClassifier(n_neighbors=5))\`, fit it on the training data, and
    store its test accuracy in \`scaled_acc\`. Name the pipeline \`pipe\`.
 
-The hidden tests check that \`pipe\` really contains a \`StandardScaler\`,
+The tests check that \`pipe\` really contains a \`StandardScaler\`,
 that the scaled accuracy is high (above 0.92), and — the key lesson — that
 scaling improved the test accuracy (\`scaled_acc > raw_acc\`).`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/linear-regression.mdx
+++ b/content/learn/machine-learning-scikit-learn/linear-regression.mdx
@@ -497,7 +497,7 @@ learned.
 4. Use the model to predict the target at \`x = 1.5\` and store the number
    in \`pred_at_1_5\`. Remember predict needs a 2D input: \`[[1.5]]\`.
 
-The hidden tests check that \`model\` is fitted, that \`slope\` is the
+The tests check that \`model\` is fitted, that \`slope\` is the
 expected strong positive value, and that \`pred_at_1_5\` matches the line's
 own formula \`intercept + slope * 1.5\`.`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/logistic-regression.mdx
+++ b/content/learn/machine-learning-scikit-learn/logistic-regression.mdx
@@ -540,7 +540,7 @@ out both a class prediction and a probability.
    it is **benign** (class 1) in \`p_benign\`. Hint: it is column 1 of
    \`model.predict_proba(X_test[:1])\`.
 
-The hidden tests check the split size, that \`model\` is fitted, that
+The tests check the split size, that \`model\` is fitted, that
 \`accuracy\` is sensibly high, and that \`p_benign\` is a valid probability
 between 0 and 1.`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/model-interpretation-and-importance.mdx
+++ b/content/learn/machine-learning-scikit-learn/model-interpretation-and-importance.mdx
@@ -470,7 +470,7 @@ out its most important features.
 5. Build a list \`top3\` of the names of the **three** most important
    features, ordered from most to least important.
 
-The hidden tests check that the forest is fitted, that \`importances\` has
+The tests check that the forest is fitted, that \`importances\` has
 one value per feature and sums to about 1, that \`top_feature\` is the
 correct name, and that \`top3\` has the right three names in order.`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/next-steps.mdx
+++ b/content/learn/machine-learning-scikit-learn/next-steps.mdx
@@ -266,7 +266,7 @@ loaded as \`X\`, \`y\`.
    it **once** on the test set with \`.score(...)\`, storing the result in
    \`test_score\`.
 
-The hidden tests check the split sizes, that \`pipe\` is the right two-step
+The tests check the split sizes, that \`pipe\` is the right two-step
 pipeline, that \`cv_mean\` is a strong cross-validated accuracy, and that
 \`test_score\` is a valid accuracy from the held-out set.`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/pipelines-and-columntransformer.mdx
+++ b/content/learn/machine-learning-scikit-learn/pipelines-and-columntransformer.mdx
@@ -568,7 +568,7 @@ target column \`passed\`. The features are already separated for you into
 3. Fit \`pipe\` on \`X_train\`, \`y_train\` (the split is done for you).
 4. Store the pipeline's test accuracy (via \`.score\`) in \`test_acc\`.
 
-The hidden tests check that \`pipe\` is a fitted \`Pipeline\` whose final step
+The tests check that \`pipe\` is a fitted \`Pipeline\` whose final step
 is a \`LogisticRegression\`, that its preprocessing step is a
 \`ColumnTransformer\`, that the transformer outputs the right number of columns
 (2 scaled numeric + one column per distinct subject), and that \`test_acc\` is

--- a/content/learn/machine-learning-scikit-learn/regression-classification-clustering.mdx
+++ b/content/learn/machine-learning-scikit-learn/regression-classification-clustering.mdx
@@ -446,7 +446,7 @@ the strings \`"regression"\`, \`"classification"\`, or \`"clustering"\`:
 6. \`"group_songs_by_audio"\` — organize an unlabeled music library into groups
    of similar-sounding songs.
 
-The hidden tests check each individual answer.`}
+The tests check each individual answer.`}
   files={[
     {
       filename: "main.py",

--- a/content/learn/machine-learning-scikit-learn/supervised-vs-unsupervised.mdx
+++ b/content/learn/machine-learning-scikit-learn/supervised-vs-unsupervised.mdx
@@ -469,7 +469,7 @@ string \`"supervised"\` or the string \`"unsupervised"\`:
 5. \`"diagnose_from_labeled_scans"\` — predict a diagnosis from medical images
    that experts have already labeled with the correct diagnosis.
 
-The hidden tests check each individual answer.`}
+The tests check each individual answer.`}
   files={[
     {
       filename: "main.py",

--- a/content/learn/machine-learning-scikit-learn/the-practical-ml-workflow.mdx
+++ b/content/learn/machine-learning-scikit-learn/the-practical-ml-workflow.mdx
@@ -523,7 +523,7 @@ and metrics change; the disciplined order does not.
 4. Fit \`pipe\` on the full training data, then evaluate it **once** on the
    test set with \`.score(...)\`, storing the result in \`test_score\`.
 
-The hidden tests check the split sizes, that \`pipe\` is a two-step
+The tests check the split sizes, that \`pipe\` is a two-step
 pipeline with the right step names, that \`cv_mean\` is a believable CV
 accuracy, and that \`test_score\` is a valid accuracy.`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/the-scikit-learn-api.mdx
+++ b/content/learn/machine-learning-scikit-learn/the-scikit-learn-api.mdx
@@ -420,7 +420,7 @@ are already provided. Drive the model through the standard scikit-learn API.
 3. Use \`.predict_proba(...)\` on \`X_test\` and store the result in \`probs\`.
 4. Use \`.score(...)\` on the **test** set and store the number in \`accuracy\`.
 
-The hidden tests check that the model is fitted, that \`predictions\` has one
+The tests check that the model is fitted, that \`predictions\` has one
 label per test row, that each row of \`probs\` sums to 1, and that
 \`accuracy\` matches scoring on the test set.`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/train-test-split.mdx
+++ b/content/learn/machine-learning-scikit-learn/train-test-split.mdx
@@ -300,7 +300,7 @@ lives.
 4. Store its training accuracy in \`train_acc\` and its test accuracy in
    \`test_acc\` (both via \`.score(...)\`).
 
-The hidden tests check that the split is the right size, that it is
+The tests check that the split is the right size, that it is
 stratified, and that \`train_acc\` is higher than \`test_acc\` (the
 overfitting gap).`}
   files={[

--- a/content/learn/machine-learning-scikit-learn/what-is-machine-learning.mdx
+++ b/content/learn/machine-learning-scikit-learn/what-is-machine-learning.mdx
@@ -434,7 +434,7 @@ you saw above.
 4. Measure accuracy on the **test** set with \`model.score(...)\` and store
    the number in \`accuracy\`.
 
-The hidden tests check the split sizes, that \`model\` is fitted, and that
+The tests check the split sizes, that \`model\` is fitted, and that
 \`accuracy\` is a sensible held-out score.`}
   files={[
     {

--- a/content/learn/machine-learning-scikit-learn/why-machine-learning-exists.mdx
+++ b/content/learn/machine-learning-scikit-learn/why-machine-learning-exists.mdx
@@ -500,7 +500,7 @@ string \`"rule"\` or the string \`"model"\`:
 5. \`"recommend_next_video"\` — recommend the next video from a user's complex
    viewing history.
 
-The hidden tests check each individual answer.`}
+The tests check each individual answer.`}
   files={[
     {
       filename: "main.py",

--- a/content/learn/machine-learning-scikit-learn/your-first-model.mdx
+++ b/content/learn/machine-learning-scikit-learn/your-first-model.mdx
@@ -595,7 +595,7 @@ the final accuracy so the tests can check it.
    flower \`[[6.0, 2.7, 5.1, 1.6]]\` and store the integer result in
    \`new_pred\`.
 
-The hidden tests check the split sizes, that \`model\` is fitted, that
+The tests check the split sizes, that \`model\` is fitted, that
 \`accuracy\` is a sensible high number, and that \`new_pred\` is a valid
 species code (0, 1, or 2).`}
   files={[

--- a/content/learn/natural-language-processing-python/index.mdx
+++ b/content/learn/natural-language-processing-python/index.mdx
@@ -220,7 +220,7 @@ You will meet three kinds of widget:
 
 1. **Executable code blocks** — like the one above. Edit and re-run them as
    much as you like; experimentation is the entire point.
-2. **Challenge cards** — small problems with hidden tests. You write the
+2. **Challenge cards** — small problems with tests. You write the
    solution and press **Check Answer** to see which tests pass.
 3. **Multiple-choice questions** — quick conceptual checks with an
    explanation for *every* option, right or wrong.

--- a/content/learn/natural-language-processing-python/the-nlp-pipeline.mdx
+++ b/content/learn/natural-language-processing-python/the-nlp-pipeline.mdx
@@ -367,7 +367,7 @@ results look off. Reasoning carefully about order is a real part of the craft.
 
 Time to build the cleaning half yourself. The challenge below asks you to
 write a `preprocess` function that runs the standard cleaning steps in the
-right order. The hidden tests check the output on a couple of sentences,
+right order. The tests check the output on a couple of sentences,
 including one where a stopword changes everything.
 
 <ChallengeCard

--- a/content/learn/practical-r-for-beginners/index.mdx
+++ b/content/learn/practical-r-for-beginners/index.mdx
@@ -112,7 +112,7 @@ You will see four kinds of interactive content:
 2. **Multi-file code blocks.** Some examples span two or three R
    files — the entry script `source()`s the others. This is how real
    analyses are organized.
-3. **Challenge cards.** Small problems with hidden tests. Edit the
+3. **Challenge cards.** Small problems with tests. Edit the
    code, click *Run*, and see whether your solution passes. Peek at
    the solution if you get stuck — peeking is learning.
 4. **Multiple-choice questions.** Quick comprehension checks. Wrong

--- a/content/learn/python-basics/index.mdx
+++ b/content/learn/python-basics/index.mdx
@@ -50,7 +50,7 @@ explanation with three kinds of interactive widgets:
 
 1. **Executable code blocks.** Every snippet runs in your browser — no
    setup required. Edit any block and click *Run* to see the result.
-2. **Challenge cards.** Small coding problems with hidden test cases.
+2. **Challenge cards.** Small coding problems with test cases.
    Some are single-file; a few use multiple files so you can practice
    importing across modules.
 3. **Multiple choice questions.** Quick checks at the end of most

--- a/content/learn/python-basics/python-history.mdx
+++ b/content/learn/python-basics/python-history.mdx
@@ -230,7 +230,7 @@ behavior.
 <ChallengeCard
   adapter="python"
   title="Verify Python 3 division"
-  instructions={`Compute \`5 / 2\` and assign the result to a variable named \`result\`. The hidden test will check that \`result\` is \`2.5\` (a float).`}
+  instructions={`Compute \`5 / 2\` and assign the result to a variable named \`result\`. The test will check that \`result\` is \`2.5\` (a float).`}
   files={[
     {
       filename: "main.py",

--- a/content/learn/python-basics/syntax-and-indentation.mdx
+++ b/content/learn/python-basics/syntax-and-indentation.mdx
@@ -298,7 +298,7 @@ avoid the complexity. Python goes all-in.
 - It has no semicolons.
 - It returns the arithmetic mean of \`numbers\`, or \`0\` if the list is empty.
 
-The hidden tests will call \`average\` with several inputs.`}
+The tests will call \`average\` with several inputs.`}
   files={[
     {
       filename: "main.py",

--- a/content/learn/scientific-computing-python/index.mdx
+++ b/content/learn/scientific-computing-python/index.mdx
@@ -116,7 +116,7 @@ You will see three kinds of widgets:
 1. **Executable code blocks.** Edit any snippet and click *Run*. The
    output area shows `stdout`, plots, and DataFrame tables.
 2. **Multi-file challenge cards.** Small computational problems with
-   hidden test cases. Many use multiple files so you can practice
+   test cases. Many use multiple files so you can practice
    organizing a numerical project the way a real scientist would.
 3. **Multiple choice questions.** Quick conceptual checks at the end
    of most pages, with per-choice feedback.

--- a/content/learn/seaborn-foundations/index.mdx
+++ b/content/learn/seaborn-foundations/index.mdx
@@ -125,7 +125,7 @@ You will meet three kinds of widgets:
 1. **Executable code blocks.** Change a parameter — `hue`, `bins`,
    `kind` — and watch the chart respond.
 2. **Challenge cards.** Small, checked tasks where *you* write the code.
-   Hidden tests tell you the moment you have it right.
+   Tests tell you the moment you have it right.
 3. **Multiple-choice questions.** Quick concept checks. The more
    foundational a page is, the more of these you will find — getting the
    mental model right early saves hours later.

--- a/content/learn/sql-analytics-duckdb/index.mdx
+++ b/content/learn/sql-analytics-duckdb/index.mdx
@@ -154,7 +154,7 @@ You will meet three kinds of interactive elements:
 1. **Runnable SQL blocks.** A live DuckDB editor. Some blocks pre-load
    sample data for you; edit the query, click *Run*, and inspect the
    result table.
-2. **Challenge cards.** Small problems with hidden tests — write a query,
+2. **Challenge cards.** Small problems with tests — write a query,
    run the tests, and see which ones pass.
 3. **Multiple-choice questions.** Quick conceptual checks, with an
    explanation for every choice, so you can confirm an idea has landed

--- a/content/learn/statistics-for-data-science-python/index.mdx
+++ b/content/learn/statistics-for-data-science-python/index.mdx
@@ -192,7 +192,7 @@ be second nature.
 You'll meet three kinds of interactive elements:
 
 1. **Code blocks** — editable, runnable Python. Change anything, re-run, experiment.
-2. **Challenge cards** — small problems with hidden tests. Write a solution, click **Submit**, and see which tests pass. These are where the learning sticks, so do them.
+2. **Challenge cards** — small problems with tests. Write a solution, click **Submit**, and see which tests pass. These are where the learning sticks, so do them.
 3. **Multiple-choice questions** — quick conceptual checks with an explanation for every option.
 
 <Callout type="info" title="Each code block runs on its own">

--- a/content/learn/systems-programming-c/index.mdx
+++ b/content/learn/systems-programming-c/index.mdx
@@ -132,7 +132,7 @@ Each page mixes prose with three kinds of interactive widgets:
    WebAssembly with `clang` in your browser and runs as a tiny WASI
    binary. No installation, no toolchain setup. Edit any block and
    click *Run*.
-2. **Challenge cards.** Hidden-test coding problems. Some are
+2. **Challenge cards.** Test-backed coding problems. Some are
    single-file, some span multiple translation units so you can
    practice header/implementation splitting just like a real project.
 3. **Multiple choice questions.** Quick checks at the end of most

--- a/content/learn/time-series-analysis-python/index.mdx
+++ b/content/learn/time-series-analysis-python/index.mdx
@@ -246,7 +246,7 @@ You'll meet three kinds of interactive elements:
 
 1. **Code blocks** — editable, runnable Python. Change a window size, a
    differencing order, an ARIMA parameter, and re-run to see the effect.
-2. **Challenge cards** — small problems with hidden tests. Write a
+2. **Challenge cards** — small problems with tests. Write a
    solution, click **Submit**, and see which tests pass. These are where
    the learning sticks, so do them.
 3. **Multiple-choice questions** — quick conceptual checks with an


### PR DESCRIPTION
## Summary

Two unrelated fixes from user feedback (with mobile screenshots):

### 1. Courses no longer call tests "hidden"
All test cases are now visible in challenge cards, so the "hidden tests" framing is misleading. Reworded every course description and challenge prompt that referred to **hidden tests** / **hidden test cases** / **Hidden-test exercises** to plainly say *tests* / *test cases*. This spans 40 `.mdx` files across the `content/learn/*` courses, covering both:
- the "How this course is structured" intro lists (e.g. _"Small problems with hidden tests"_ → _"Small problems with tests"_), and
- per-challenge instruction prose (e.g. _"The hidden tests check that…"_ → _"The tests check that…"_).

The two hyphenated variants spotted in the screenshots (_"Hidden-test exercises"_, _"Hidden-test coding problems"_) became _"Test-backed exercises / coding problems"_.

### 2. Mobile keyboard no longer pops up over the loading screen
In `<Playground>`, the editor's auto-focus effect fired as soon as the workspace became ready — which happens *during* the boot/loading overlay. On mobile, focusing CodeMirror raises the on-screen keyboard, so it slid up and covered half the loading screen for no use (see screenshot of the R runtime booting).

The fix gates that `view.focus()` on the boot overlay being gone (`showLoadingOverlay`), and adds it to the effect deps so focus is taken the moment the overlay unmounts. The keyboard now appears only **after** the loading screen, as requested. Tab-switch / new-file / example-load focus behavior is unchanged.

## Testing
- Reworded content verified to read naturally in context; no remaining `hidden test` / `Hidden-test` matches across the repo.
- Focus change is a one-line guard using an already-in-scope value; no behavioral change on desktop beyond deferring the very first focus until the loading screen clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMmSDVtgxkURADuv7kQfKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMmSDVtgxkURADuv7kQfKC)_