### PR TITLE
Add "result is above" arrow hint to SQL blocks

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -2595,6 +2595,87 @@
   100% { opacity: 0; }
 }
 
+/* ─── "Result is above the editor" arrow hint ─────────────────────────
+   Shown only while the Result tab is active. SQL blocks surface run
+   output as a tab in the table view ABOVE the editor (unlike the non-SQL
+   code blocks, whose output sits below it), which a learner new to the UI
+   can miss. This curved arrow sweeps from the editor's top-right up to the
+   result table's bottom-right to point that out.
+
+   `.editorArrowAnchor` is the positioning context: it wraps the CodeMirror
+   host so the arrow can be anchored to the editor's top edge without being
+   a child of CodeMirror's scroller — hence scrolling the query never moves
+   it. The arrow extends upward past the editor's top edge (negative `top`)
+   to overlap the result panel; the card's own `overflow: hidden` keeps it
+   within the card. Decorative + click-through so it never blocks editing
+   or the result table's scrollbar. */
+.editorArrowAnchor {
+  position: relative;
+}
+
+.resultLocationArrow {
+  position: absolute;
+  top: -56px;
+  right: 14px;
+  width: 54px;
+  height: 108px;
+  /* Sit above the result panel (static) and the editor (sibling) below. */
+  z-index: 3;
+  color: var(--ch-accent);
+  pointer-events: none;
+  animation: ch-result-arrow-in 0.32s ease-out both;
+}
+
+.resultLocationArrowSvg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  /* Gentle bob to draw the eye upward toward the result; the fade-in on
+     the container runs first, then this loops. */
+  animation: ch-result-arrow-bob 1.9s ease-in-out 0.32s infinite;
+  filter: drop-shadow(
+    0 1px 1.5px color-mix(in srgb, var(--ds-black) 22%, transparent)
+  );
+}
+
+.resultLocationArrowShaft,
+.resultLocationArrowHead {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 4.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+@keyframes ch-result-arrow-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ch-result-arrow-bob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resultLocationArrow,
+  .resultLocationArrowSvg {
+    animation: none;
+  }
+}
+
 .tableViewerEmpty {
   margin: 0 14px 12px;
   padding: 10px 12px;

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -1110,6 +1110,9 @@ export default function SqlChallengeCard({
   const [bannerState, setBannerState] = useState<"pass" | "fail" | null>(null);
   const [isFormatting, setIsFormatting] = useState(false);
   const [resultRunSeq, setResultRunSeq] = useState(0);
+  // True while the Result tab is the active view, driving the arrow hint
+  // that points from the editor up to the result panel above it.
+  const [showResultArrow, setShowResultArrow] = useState(false);
   const toasts = useChallengeToasts();
 
   const isMac = useSyncExternalStore(
@@ -1919,15 +1922,22 @@ export default function SqlChallengeCard({
           onLoadMore={loadMoreActiveTable}
           resultTabData={resultTabDataProp}
           bootState={bootState}
+          onResultActiveChange={setShowResultArrow}
         />
       )}
 
       {/* ── Editor ── */}
-      <div
-        className={styles.editor}
-        ref={editorHostRef}
-        aria-label="SQL solution editor"
-      />
+      {/* Anchor wraps the CodeMirror host so the result-location arrow can
+          be positioned against the editor's top-right without being a child
+          of the host element CodeMirror mounts into. */}
+      <div className={styles.editorArrowAnchor}>
+        <div
+          className={styles.editor}
+          ref={editorHostRef}
+          aria-label="SQL solution editor"
+        />
+        {showResultArrow && <ResultLocationArrow />}
+      </div>
 
       {/* ── Action bar ── */}
       <div className={styles.actionBar} role="toolbar" aria-label="Challenge controls">
@@ -2615,6 +2625,46 @@ export function TableViewerSkeleton() {
   );
 }
 
+/**
+ * Curved "look up here" arrow shown only while the Result tab is active.
+ *
+ * SQL blocks render the run output as a *tab in the table view above* the
+ * editor — unlike the non-SQL code blocks, whose output sits below the
+ * editor. A learner new to the UI can miss that, so this hint sweeps from
+ * the editor's top-right up to the result table's bottom-right.
+ *
+ * It's purely decorative (`aria-hidden`, `pointer-events: none`) and is
+ * positioned absolutely against the editor wrapper — never inside
+ * CodeMirror's own scroller — so scrolling the query doesn't move it.
+ */
+export function ResultLocationArrow() {
+  return (
+    <span
+      className={styles.resultLocationArrow}
+      data-testid="result-location-arrow"
+      aria-hidden="true"
+    >
+      <svg
+        viewBox="0 0 64 128"
+        className={styles.resultLocationArrowSvg}
+        fill="none"
+      >
+        {/* Shaft: sweeps up from the editor (bottom) with a gentle leftward
+            belly, ending at the arrowhead tip pointing up toward the result. */}
+        <path
+          className={styles.resultLocationArrowShaft}
+          d="M46 118 C20 96, 24 40, 48 10"
+        />
+        {/* Arrowhead at the tip (48,10), barbs trailing down toward the editor. */}
+        <path
+          className={styles.resultLocationArrowHead}
+          d="M34 16 L48 10 L45 25"
+        />
+      </svg>
+    </span>
+  );
+}
+
 /** The always-visible "Tables" panel shared by `<SqlChallengeCard>` and
  *  `<SqlCodeBlock>`. Shows a loading skeleton until the first table
  *  list is fetched, then a tab bar (styled to match the non-SQL code
@@ -2629,6 +2679,7 @@ export function TableViewer({
   onLoadMore,
   resultTabData,
   bootState,
+  onResultActiveChange,
 }: {
   dialect: SqlDialect;
   entries: TableViewerEntry[];
@@ -2642,6 +2693,12 @@ export function TableViewer({
    *  in the result area for table-less blocks) so SQL matches the other
    *  runtimes' first-run loading affordance. */
   bootState?: SqlEngineBootState | null;
+  /** Notified whenever the Result tab becomes the active, visible view
+   *  (vs. one of the table tabs, or dismissed). Lets the parent render
+   *  the "result is above the editor" arrow hint only while the Result
+   *  tab is showing — the parent owns the editor element the arrow is
+   *  anchored to, which lives outside this component. */
+  onResultActiveChange?: (active: boolean) => void;
 }) {
   const [resultTabDismissed, setResultTabDismissed] = useState(false);
   const [resultIsActive, setResultIsActive] = useState(false);
@@ -2664,6 +2721,19 @@ export function TableViewer({
   }, [resultTabData]);
 
   const resultTabVisible = resultTabData != null && !resultTabDismissed;
+  // Whether the Result tab is the currently-shown view. Surfaced to the
+  // parent so it can render the arrow hint pointing from the editor up to
+  // this result panel — and only while that panel is actually visible.
+  const resultArrowActive = resultIsActive && resultTabVisible;
+  useEffect(() => {
+    onResultActiveChange?.(resultArrowActive);
+  }, [resultArrowActive, onResultActiveChange]);
+  // Reset the hint on unmount so a parent that keeps the flag in state
+  // doesn't leave a stale arrow behind when the viewer goes away.
+  useEffect(
+    () => () => onResultActiveChange?.(false),
+    [onResultActiveChange],
+  );
   // While the engine cold-boots there are no tables (and any result tab
   // is only showing "Running…"), so the boot loader takes the panel —
   // mirroring how the non-SQL blocks show the notice before first output.

--- a/app/_components/SqlCodeBlock.tsx
+++ b/app/_components/SqlCodeBlock.tsx
@@ -57,6 +57,7 @@ import {
 import styles from "./ChallengeCard.module.css";
 import {
   DialectGlyph,
+  ResultLocationArrow,
   sqlFormatterLanguage,
   TableViewer,
   useSqlEngineBoot,
@@ -151,6 +152,9 @@ export default function SqlCodeBlock({
   const [elapsed, setElapsed] = useState<string>("");
   const [isFormatting, setIsFormatting] = useState(false);
   const [resultRunSeq, setResultRunSeq] = useState(0);
+  // True while the Result tab is the active view, driving the arrow hint
+  // that points from the editor up to the result panel above it.
+  const [showResultArrow, setShowResultArrow] = useState(false);
   const toasts = useChallengeToasts();
 
   const isMac = useSyncExternalStore(
@@ -531,15 +535,22 @@ export default function SqlCodeBlock({
           onLoadMore={loadMoreActiveTable}
           resultTabData={resultTabDataProp}
           bootState={bootState}
+          onResultActiveChange={setShowResultArrow}
         />
       )}
 
       {/* ── Editor ── */}
-      <div
-        className={styles.editor}
-        ref={editorHostRef}
-        aria-label="SQL editor"
-      />
+      {/* Anchor wraps the CodeMirror host so the result-location arrow can
+          be positioned against the editor's top-right without being a child
+          of the host element CodeMirror mounts into. */}
+      <div className={styles.editorArrowAnchor}>
+        <div
+          className={styles.editor}
+          ref={editorHostRef}
+          aria-label="SQL editor"
+        />
+        {showResultArrow && <ResultLocationArrow />}
+      </div>
 
       {/* ── Action bar ── */}
       <div className={styles.actionBar} role="toolbar" aria-label="SQL controls">

--- a/e2e/sql-result-arrow.spec.ts
+++ b/e2e/sql-result-arrow.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+
+// The "result is above the editor" arrow hint. SQL blocks render run
+// output as a tab in the table view ABOVE the editor (unlike the non-SQL
+// code blocks, whose output sits below), so a curved arrow points the
+// learner upward — but only while the Result tab is the active view.
+//
+// Each <SqlCodeBlock> exposes:
+//   - root:  [data-testid="sql-code-block"] with [data-run-status]
+//   - run:   [data-testid="sql-codeblock-run"]
+//   - arrow: [data-testid="result-location-arrow"] (only while Result active)
+
+const DEMO_PAGES: { path: string; label: string }[] = [
+  { path: "sql-code-blocks-sqlite", label: "SQLite" },
+  { path: "sql-code-blocks-duckdb", label: "DuckDB" },
+  { path: "sql-code-blocks-postgres", label: "PostgreSQL" },
+];
+
+test.describe("SQL result-location arrow", () => {
+  for (const { path: pagePath, label } of DEMO_PAGES) {
+    test(`${label} — arrow appears with the Result tab and hides otherwise`, async ({
+      page,
+    }) => {
+      await page.goto(`/learn/${pagePath}`);
+
+      const block = page.getByTestId("sql-code-block").first();
+      await expect(block).toBeVisible({ timeout: 60_000 });
+      await block.scrollIntoViewIfNeeded();
+
+      const arrow = block.getByTestId("result-location-arrow");
+      const runBtn = block.getByTestId("sql-codeblock-run");
+
+      // No Result tab yet → no arrow.
+      await expect(arrow).toHaveCount(0);
+
+      // Run the block; the Result tab activates and the arrow appears.
+      await expect(runBtn).toBeEnabled({ timeout: 120_000 });
+      await runBtn.click();
+      await expect
+        .poll(async () => block.getAttribute("data-run-status"), {
+          timeout: 120_000,
+        })
+        .not.toMatch(/running|loading/);
+      expect(await block.getAttribute("data-run-status")).not.toBe("error");
+
+      await expect(arrow).toBeVisible({ timeout: 30_000 });
+
+      // The arrow is anchored above the editor's top edge — its bottom
+      // should sit near the top of the editor, pointing up into the result.
+      const editor = block.locator(".cm-editor").first();
+      const arrowBox = await arrow.boundingBox();
+      const editorBox = await editor.boundingBox();
+      expect(arrowBox).not.toBeNull();
+      expect(editorBox).not.toBeNull();
+      if (arrowBox && editorBox) {
+        // Top of the arrow is above the editor (reaching into the result).
+        expect(arrowBox.y).toBeLessThan(editorBox.y);
+        // Arrow lives on the right-hand side of the card.
+        const blockBox = await block.boundingBox();
+        if (blockBox) {
+          expect(arrowBox.x).toBeGreaterThan(blockBox.x + blockBox.width / 2);
+        }
+      }
+
+      // Switching to a table tab (if any) hides the arrow; otherwise
+      // dismissing the Result tab does. Prefer a real table tab so we
+      // exercise the active-tab path.
+      const tableTab = block
+        .locator('[role="tab"]')
+        .filter({ hasNotText: "Result" })
+        .first();
+      if (await tableTab.count()) {
+        await tableTab.click();
+        await expect(arrow).toHaveCount(0);
+
+        // Back to the Result tab → arrow returns.
+        await block.locator('[role="tab"]').filter({ hasText: "Result" }).first().click();
+        await expect(arrow).toBeVisible();
+      }
+
+      // Closing the Result tab removes the arrow.
+      await block.getByRole("button", { name: "Close result tab" }).click();
+      await expect(arrow).toHaveCount(0);
+    });
+  }
+});


### PR DESCRIPTION
## What & why

SQL code blocks and SQL challenge cards (SQLite, Postgres, DuckDB) render run output as a **"Result" tab in the table view _above_ the editor** — unlike the non‑SQL code blocks, whose output appears _below_ the editor. A learner unfamiliar with the UI can easily miss that the result showed up above.

This adds a blue, slightly‑curved SVG arrow that sweeps from the **top‑right of the query editor** up to the **bottom‑right of the Result table view**, pointing the learner upward to where the result is.

## Behavior

- **Only while the Result tab is active.** The arrow is hidden when a table tab is selected and disappears when the Result tab is dismissed/closed.
- **Scroll‑stable.** It's absolutely positioned against a thin wrapper around the CodeMirror host — never inside CodeMirror's own scroller — so scrolling the query text doesn't move it.
- **Non‑intrusive.** `aria-hidden` + `pointer-events: none`, so it never blocks editing or the result table's scrollbar. Subtle fade‑in and a gentle bob draw the eye, both disabled under `prefers-reduced-motion`.
- Uses the existing `--ch-accent` brand blue, so it reads well in both light and dark mode.

## Implementation

- New `ResultLocationArrow` component (in `SqlChallengeCard.tsx`, reused by `SqlCodeBlock.tsx`).
- `TableViewer` gains an `onResultActiveChange` callback so each card can render the arrow against **its own** editor element (which lives outside `TableViewer`).
- The editor host is wrapped in a `position: relative` anchor (`.editorArrowAnchor`) so the arrow can be positioned to the editor's top‑right without being a child of the element CodeMirror mounts into.
- Styles + keyframes added to `ChallengeCard.module.css`.

## Tests

- New `e2e/sql-result-arrow.spec.ts` covers all three dialects: asserts the arrow is absent before running, appears with the Result tab, sits above the editor on the right‑hand side, toggles correctly when switching between table/Result tabs, and is removed when the Result tab is closed.
- `tsc` and `eslint` pass; verified visually in `SqlCodeBlock` and `SqlChallengeCard`, light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SE7aFHRUF4eHDkLXTxtUAS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SE7aFHRUF4eHDkLXTxtUAS)_