### PR TITLE
Add brand-coloured border beam around the SQL result table

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -2595,6 +2595,83 @@
   100% { opacity: 0; }
 }
 
+/* ─── Result table border beam ──────────────────────────────────────────
+   An animated beam of light that travels around the result table's border
+   so it reads as distinct from the seeded database tables next to it.
+   Reproduces the Magic UI "Border Beam" effect — a gradient ray riding an
+   `offset-path` rectangle, revealed only over a transparent border via an
+   intersect mask — in plain CSS so it works on the Tailwind-free `/learn`
+   route. Brand coloured (blue ⇄ teal) so the highlight stays on palette.
+   `.resultPane` is `position: relative; overflow: hidden`, which contains
+   and clips the beam. */
+.resultBeam {
+  --beam-width: 1.5px;
+  --beam-size: 120px;
+  --beam-duration: 7s;
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  border-radius: inherit;
+  border: var(--beam-width) solid transparent;
+  /* Paint only the (transparent) border ring: a fully transparent
+     padding-box mask layer intersected with an opaque border-box layer
+     leaves just the border band of this element — and its rays — visible. */
+  -webkit-mask-image: linear-gradient(transparent, transparent),
+    linear-gradient(#000, #000);
+  -webkit-mask-clip: padding-box, border-box;
+  -webkit-mask-composite: source-in;
+  mask-image: linear-gradient(transparent, transparent),
+    linear-gradient(#000, #000);
+  mask-clip: padding-box, border-box;
+  mask-composite: intersect;
+}
+
+.resultBeamRay {
+  position: absolute;
+  aspect-ratio: 1 / 1;
+  width: var(--beam-size);
+  /* Comet tail: solid brand colour at the head, fading to transparent. */
+  background: linear-gradient(
+    to left,
+    var(--ds-blue),
+    var(--ds-teal),
+    transparent
+  );
+  offset-path: rect(0 auto auto 0 round var(--beam-size));
+  animation: result-beam-travel var(--beam-duration) linear infinite;
+}
+
+/* A second ray of the opposite hue, offset half a lap, so the border keeps
+   a highlight somewhere along its run rather than going dark between passes. */
+.resultBeamRayAlt {
+  background: linear-gradient(
+    to left,
+    var(--ds-teal),
+    var(--ds-blue),
+    transparent
+  );
+  animation-delay: calc(var(--beam-duration) / -2);
+}
+
+@keyframes result-beam-travel {
+  from {
+    offset-distance: 0%;
+  }
+  to {
+    offset-distance: 100%;
+  }
+}
+
+/* Respect reduced-motion: drop the travelling rays entirely (a frozen comet
+   parked in one corner would just read as a stray blob). The Result tab is
+   still labelled, so nothing is lost. */
+@media (prefers-reduced-motion: reduce) {
+  .resultBeamRay {
+    display: none;
+  }
+}
+
 .tableViewerEmpty {
   margin: 0 14px 12px;
   padding: 10px 12px;

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -2758,6 +2758,14 @@ export function TableViewer({
               className={`${styles.resultPane}${resultTabData.loading ? ` ${styles.resultPaneBusy}` : ""}`}
               style={{ position: "relative" }}
             >
+              {/* Brand-coloured border beam — distinguishes the result
+                  table from the seeded database tables. See `.resultBeam`. */}
+              <div className={styles.resultBeam} aria-hidden="true">
+                <span className={styles.resultBeamRay} />
+                <span
+                  className={`${styles.resultBeamRay} ${styles.resultBeamRayAlt}`}
+                />
+              </div>
               {flashKey > 0 && (
                 <div key={flashKey} className={styles.resultFlashOverlay} aria-hidden />
               )}


### PR DESCRIPTION
## What & why

In the SQL code blocks and challenge cards, the **Result** tab and the seeded **database-table** tabs share the exact same grid chrome, so a freshly-run result set reads as "just another table." This adds an animated [Magic UI Border Beam](https://magicui.design/docs/components/border-beam)–style highlight around the result table, in brand colours, so it's clearly differentiated from the database tables next to it: a gradient ray of light travels around the result pane's border.

## How

- **Effect**: faithfully reproduces the Magic UI Border Beam technique — a gradient ray riding an `offset-path` rectangle, revealed only over a transparent border via an intersect mask. Two rays (offset half a lap) keep the border lit continuously.
- **Brand colours**: the rays sweep through `--ds-blue` ⇄ `--ds-teal` from the brand palette (`app/brand.css`), so the highlight stays on-palette in both light and dark mode.
- **Scope**: the beam lives only on the result pane (`.resultPane`), never on the table-viewer panes — that's what creates the result-vs-database distinction. Because both `<SqlChallengeCard>` and `<SqlCodeBlock>` render through the shared `<TableViewer>`, both get it for free.
- **Accessibility**: the decoration is `aria-hidden`, and `prefers-reduced-motion` drops the travelling rays entirely.

### Why CSS instead of the stock Magic UI component

The stock `BorderBeam` is built from Tailwind v4 utilities (`bg-linear-to-l`, `mask-intersect`, …). The `/learn` route — where these cards render — loads Tailwind only for Fumadocs and its `@source` globs do **not** cover `components/ui`, so those utility classes would never be generated there (`components/ui` is currently used only by `/magicui-demo`). The `ChallengeCard` is also styled entirely with CSS modules. Implementing the same effect in `ChallengeCard.module.css` keeps it self-contained, certain to render on `/learn`, and consistent with the surrounding code.

## Testing

Visual/CSS-only change plus two presentational `<div>`/`<span>` nodes with no new imports. Local `tsc`/`eslint` couldn't run (dev dependencies aren't installed in this environment), but the change adds no new type or lint surface. Worth a quick visual check of a SQL card's Result tab in light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)