### PR TITLE
Fix home-page challenge UI: modal backdrop, switcher, SQL table styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,20 @@ OpenNext serves the prerendered home page and `/learn/*` lessons from an R2-back
 npx wrangler r2 bucket create dataslope-inc-cache
 ```
 
-The bucket is bound as `NEXT_INC_CACHE_R2_BUCKET` in `wrangler.jsonc`. It is **populated at deploy time**, so the deploy command must run `opennextjs-cloudflare deploy` (which `npm run cf:deploy` does) — a bare `wrangler deploy` skips the populate step and leaves the cache empty. If you deploy via Cloudflare Workers Builds, set its deploy command to `npx opennextjs-cloudflare deploy`.
+The bucket is bound as `NEXT_INC_CACHE_R2_BUCKET` in `wrangler.jsonc`. It is **populated at deploy time**, so the deploy command must run `opennextjs-cloudflare deploy` (which `npm run cf:deploy` does) — a bare `wrangler deploy` skips the populate step and leaves the cache empty. If you deploy via Cloudflare Workers Builds (the CI path that builds production and per-branch previews), configure its build settings as shown below.
+
+### Cloudflare Workers Builds configuration
+
+Production and preview deploys run through Cloudflare Workers Builds rather than the local `npm run cf:*` scripts, so its build settings (Workers → the `dataslope` worker → Settings → Build) must populate the R2 cache on **both** paths. The non-production (preview) command is the easy one to get wrong: a bare `npx wrangler versions upload` builds the Worker but skips the cache populate step, leaving previews with an empty cache that 500s the home page and `/learn/*`.
+
+| Field | Value |
+| --- | --- |
+| Build command | `npx opennextjs-cloudflare build` |
+| Deploy command | `npx opennextjs-cloudflare deploy` |
+| Non-production branch deploy command | `npx opennextjs-cloudflare upload` |
+| Path | `/` |
+
+Both `deploy` (production) and `upload` (preview versions) populate the R2 cache before shipping — `upload` wraps `wrangler versions upload`, so previews get the same populated cache production does. `Path` is `/` because this Worker lives at the repo root; the CORS proxy under `cloudflare-cors-proxy/` is a separate Worker with its own config.
 
 ### Incremental cache cleanup
 

--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -219,12 +219,23 @@
 .modalBackdrop {
   position: fixed;
   inset: 0;
+  /* The dialog is portaled to <body> (see ChallengeCard / SqlChallengeCard) so
+     a transformed ancestor — e.g. the home hero's BlurFade, whose lingering
+     `filter` turns it into the containing block — can't trap this fixed layer
+     and shrink the backdrop to the card. Portaling drops it outside any `.card`,
+     so the overlay tint is re-declared here (it can no longer inherit
+     --ch-overlay / the --ch-slate-900 it derives from). */
+  --ch-overlay: color-mix(in srgb, #0f172a 55%, transparent);
   background: var(--ch-overlay);
   z-index: 1000;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 24px;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .modalBackdrop {
+  --ch-overlay: color-mix(in srgb, var(--ds-black) 65%, transparent);
 }
 
 .modalCard {
@@ -2233,7 +2244,11 @@
      card surface matches the surrounding learn-page chrome exactly.
      The `var(--color-fd-background, …)` fallback keeps the component
      usable when Fumadocs is not present (e.g. Storybook / unit tests). */
-  --ch-bg: var(--color-fd-background, var(--ch-slate-900));
+  /* Neutral near-black fallback (matches the home route's #121212) for the
+     no-token case — Storybook/tests, and the solution dialog once it's portaled
+     to <body>, outside the .ds-home scope that supplies --color-fd-background.
+     Avoids the blue-slate --ch-slate-900 tint the surrounding chrome dropped. */
+  --ch-bg: var(--color-fd-background, #121212);
   --ch-bg-muted: color-mix(in srgb, var(--color-fd-background, #111827) 70%, #000000);
   --ch-bg-subtle: color-mix(in srgb, var(--color-fd-background, #111827) 85%, #000000);
   --ch-bg-hover: #222222;
@@ -2378,8 +2393,15 @@
 /* ─── Table viewer (SQL) ────────────────────────────────────────────── */
 
 .tableViewer {
-  background: var(--ch-bg-muted);
+  /* White (the card surface) in light mode so the result/table preview reads as
+     a clean white table rather than a muted gray panel. Dark mode keeps the
+     subtly-darker --ch-bg-muted tint for panel separation (see below). */
+  background: var(--ch-bg);
   border-bottom: 1px solid var(--ch-border-light);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .tableViewer {
+  background: var(--ch-bg-muted);
 }
 
 /* Static label row — the panel is no longer collapsible, so this is a
@@ -2596,7 +2618,9 @@
 }
 
 .tableViewerEmpty {
-  margin: 0 14px 12px;
+  /* Symmetric top/bottom margin so the message sits evenly inside the panel
+     rather than flush against the tab bar above it. */
+  margin: 12px 14px;
   padding: 10px 12px;
   background: var(--ch-bg);
   border: 1px solid var(--ch-border-light);

--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -30,6 +30,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { createPortal } from "react-dom";
 import { RotateCcw, Check, CheckCheck, ListChecks, ListX, X, ChevronDown, ChevronUp, Eye, File, FileInput, Info, Play, Terminal, Timer } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
@@ -2241,7 +2242,7 @@ function SolutionModal({
     }
   }, [activeRaw]);
 
-  return (
+  const modal = (
     <div
       role="dialog"
       aria-modal="true"
@@ -2377,6 +2378,14 @@ function SolutionModal({
       </div>
     </div>
   );
+
+  // Portal to <body> so the backdrop's `position: fixed` is sized to the
+  // viewport. Left inline, an ancestor with a transform/filter (e.g. the home
+  // hero's BlurFade) becomes the containing block and the backdrop shrinks to
+  // that ancestor — see app/_components/ChallengeCard.module.css (.modalBackdrop).
+  return typeof document === "undefined"
+    ? modal
+    : createPortal(modal, document.body);
 }
 
 /** Minimal output cell renderer — text cells use mono-spaced pre-wrap,

--- a/app/_components/SqlChallengeCard.tsx
+++ b/app/_components/SqlChallengeCard.tsx
@@ -35,6 +35,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { createPortal } from "react-dom";
 import { RotateCcw, Check, CheckCheck, ListChecks, ListX, X, ChevronDown, Eye, Play, Database, Table, List, FileInput } from "lucide-react";
 import { Menu } from "@base-ui-components/react/menu";
 import {
@@ -2296,7 +2297,7 @@ function SolutionModal({
     }
   }, [source]);
 
-  return (
+  const modal = (
     <div
       role="dialog"
       aria-modal="true"
@@ -2374,6 +2375,14 @@ function SolutionModal({
       </div>
     </div>
   );
+
+  // Portal to <body> so the backdrop's `position: fixed` is sized to the
+  // viewport. Left inline, an ancestor with a transform/filter (e.g. the home
+  // hero's BlurFade) becomes the containing block and the backdrop shrinks to
+  // that ancestor — see app/_components/ChallengeCard.module.css (.modalBackdrop).
+  return typeof document === "undefined"
+    ? modal
+    : createPortal(modal, document.body);
 }
 
 /** Human-readable form of a cell value, used both for the visible text

--- a/app/_components/home/HeroInteractive.tsx
+++ b/app/_components/home/HeroInteractive.tsx
@@ -83,18 +83,21 @@ function PickerSelect({
           if (next != null) onValueChange(next);
         }}
       >
-        {/* Magic UI ShimmerButton as the select trigger. --ds-gray-900 is a
-            fixed near-black in both themes, so white text + the blue shimmer
-            read well in light and dark mode alike. */}
+        {/* Magic UI ShimmerButton as the select trigger. The background tracks
+            the page surface (--color-fd-background: white in light, #121212 in
+            dark — see app/home.css) so the trigger reads as part of the page
+            rather than a floating dark pill; text/border/chevron flip per theme
+            so they stay legible on either surface, with the blue shimmer as the
+            accent edge. */}
         <Select.Trigger
           render={(triggerProps) => (
             <ShimmerButton
               {...triggerProps}
-              background="var(--ds-gray-900)"
+              background="var(--color-fd-background)"
               shimmerColor="#148CFF"
               shimmerSize="0.15em"
               borderRadius="0.625rem"
-              className="min-w-40 justify-between gap-2 px-3.5 py-1.5 text-sm font-medium focus-visible:outline-none"
+              className="min-w-40 justify-between gap-2 border-[color:var(--ds-gray-200)] px-3.5 py-1.5 text-sm font-medium text-[color:var(--ds-gray-900)] focus-visible:outline-none dark:border-white/10 dark:text-white"
             >
               {active && <OptionIcon id={active.iconId} />}
               {/* Render the label explicitly — a bare <Select.Value/> shows the
@@ -102,7 +105,7 @@ function PickerSelect({
               <Select.Value className="flex-1 truncate text-left">
                 {active?.label ?? value}
               </Select.Value>
-              <Select.Icon className="text-white/70">
+              <Select.Icon className="text-[var(--ds-gray-500)] dark:text-white/70">
                 <ChevronDown size={14} />
               </Select.Icon>
             </ShimmerButton>

--- a/components/ui/shimmer-button.tsx
+++ b/components/ui/shimmer-button.tsx
@@ -69,7 +69,7 @@ export const ShimmerButton = React.forwardRef<
           className={cn(
             "absolute inset-0 size-full",
 
-            "rounded-2xl px-4 py-1.5 text-sm font-medium shadow-[inset_0_-8px_10px_#ffffff1f]",
+            "[border-radius:var(--radius)] px-4 py-1.5 text-sm font-medium shadow-[inset_0_-8px_10px_#ffffff1f]",
 
             // transition
             "transform-gpu transition-all duration-300 ease-in-out",
@@ -82,10 +82,13 @@ export const ShimmerButton = React.forwardRef<
           )}
         />
 
-        {/* backdrop */}
+        {/* backdrop — inset by --cut on every side, so its corner radius has to
+            shrink by the same amount to stay concentric with the outer border.
+            Reusing the full --radius here left the inner fill looking rounder
+            than the edge (a mismatched, uneven shimmer ring at the corners). */}
         <div
           className={cn(
-            "absolute inset-(--cut) -z-20 [border-radius:var(--radius)] [background:var(--bg)]"
+            "absolute inset-(--cut) -z-20 [border-radius:calc(var(--radius)_-_var(--cut))] [background:var(--bg)]"
           )}
         />
       </button>


### PR DESCRIPTION
Four UI fixes, mostly on the home page's embedded challenge previews. Each was verified by running the app and inspecting both screenshots and computed styles in light + dark mode.

### 1. Solution modal backdrop now covers the full viewport
The "Reference solution" dialog's `position: fixed` backdrop was being trapped by a transformed ancestor — the home hero wraps the interactive cards in a `BlurFade` (`motion.div`) whose lingering `filter` becomes the containing block, so the dim/clickable backdrop shrank to the card instead of the page.

The dialog is now **portaled to `<body>`** (in both `ChallengeCard` and `SqlChallengeCard`), so the backdrop is sized to the viewport. Because it no longer lives inside a `.card`, `.modalBackdrop` re-declares `--ch-overlay`, and `.card`'s dark-mode `--ch-bg` fallback is now a neutral `#121212` (was the blue-slate `--ch-slate-900`) so the portaled dialog stays neutral in dark mode.

### 2. Language switcher background + border radius
- The trigger background now tracks the page surface (`--color-fd-background`: white in light, `#121212` in dark) instead of a fixed near-black, so it reads as part of the page rather than a floating dark pill. Text, border, and chevron flip per theme to stay legible.
- The `ShimmerButton`'s inner fill is inset by `--cut` on every side but reused the full `--radius`, leaving its corners rounder than the outer edge (an uneven shimmer ring). The inner radius is now `calc(var(--radius) - var(--cut))` so it stays concentric.

### 3. Empty-table message spacing
`.tableViewerEmpty` had no top margin (`0 14px 12px`), sitting flush against the tab bar. It now uses `12px 14px` so the top margin matches the bottom.

### 4. SQL result/table preview background
The result/table preview used a muted gray panel (`--ch-bg-muted`). In light mode it now uses the white card surface (`--ch-bg`) to match the rest of the card; dark mode keeps its subtle tint for panel separation.

### Verification
Ran the app and confirmed, in light and dark:
- Modal backdrop rect equals the full viewport `(0,0,1280,900)` and is parented to `<body>`; dark dialog card is `rgb(18,18,18)`.
- Switcher background `rgb(255,255,255)` / `rgb(18,18,18)` with legible per-theme text; inner radius `7.9px` vs outer `10px` (concentric).
- `.tableViewerEmpty` compiles to `margin: 12px 14px`.
- `.tableViewer` resolves to white in light mode.

`tsc --noEmit` and `eslint` both pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G31bkD555F2biXBaU7SwvN

---
_Generated by [Claude Code](https://claude.ai/code/session_01G31bkD555F2biXBaU7SwvN)_