### PR TITLE
Load highlight.js from CDN + keep quiz cards off SSR to shrink the Worker bundle

### DIFF
--- a/app/_components/multipleChoice/MdxMultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MdxMultipleChoiceQuestion.tsx
@@ -26,9 +26,23 @@
  * ```
  */
 
-import MultipleChoiceQuestion, {
-  type MultipleChoiceQuestionProps,
-} from "./MultipleChoiceQuestion";
+import dynamic from "next/dynamic";
+import type { MultipleChoiceQuestionProps } from "./MultipleChoiceQuestion";
+
+// Load the quiz card client-side only. It renders entirely in the browser —
+// react-markdown + remark/rehype (KaTeX) plus the jsDelivr-loaded highlight.js
+// — and none of that needs to run during SSR, so `ssr: false` keeps the whole
+// markdown stack out of the OpenNext Worker bundle's render path. (The home
+// page hero loads the same component the same way; see HeroInteractive.) The
+// placeholder reserves vertical space to limit layout shift while the chunk and
+// its CDN dependencies load.
+const MultipleChoiceQuestion = dynamic(
+  () => import("./MultipleChoiceQuestion"),
+  {
+    ssr: false,
+    loading: () => <div aria-hidden style={{ minHeight: 180 }} />,
+  },
+);
 
 export default function MdxMultipleChoiceQuestion(
   props: MultipleChoiceQuestionProps,

--- a/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
+++ b/app/_components/multipleChoice/MultipleChoiceQuestion.tsx
@@ -15,20 +15,41 @@
  *     attempts" UX of the existing `<ChallengeCard>` Check-Answer flow).
  *   - All learner-visible Markdown — body, choice labels, per-choice
  *     explanations, overall explanation — is rendered through
- *     react-markdown with GFM + KaTeX + rehype-highlight so authors
- *     can mix prose, lists, code (with syntax colouring), tables, and
- *     math equations.
+ *     react-markdown with GFM + KaTeX so authors can mix prose, lists,
+ *     code, tables, and math equations. Code blocks are syntax-highlighted
+ *     after render with highlight.js, which is loaded from jsDelivr on
+ *     demand (see HLJS_CDN) rather than bundled — keeping it out of the
+ *     client chunks and the OpenNext Worker bundle, like Plotly/Mermaid.
  */
 
-import { useId, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
-import rehypeHighlight from "rehype-highlight";
 import { Check, X, RotateCcw, MousePointerClick, ScrollText } from "lucide-react";
 import { parseQuestion, type ParsedChoice } from "./parseQuestion";
+import { HLJS_CDN } from "../runtime/cdn";
 import styles from "./MultipleChoiceQuestion.module.css";
+
+// highlight.js is fetched from jsDelivr on demand (see HLJS_CDN in runtime/cdn)
+// and applied to the card's rendered code blocks, keeping it out of both the
+// client bundle and the OpenNext Worker bundle — the same offload used for
+// Plotly and Mermaid. The import is cached at module scope so every quiz card
+// on a page shares a single fetch. `webpackIgnore`/`turbopackIgnore` stop the
+// bundlers from trying to resolve the CDN URL at build time.
+interface Hljs {
+  highlightElement: (el: HTMLElement) => void;
+}
+let hljsPromise: Promise<Hljs> | null = null;
+function loadHljs(): Promise<Hljs> {
+  if (!hljsPromise) {
+    hljsPromise = import(
+      /* webpackIgnore: true */ /* turbopackIgnore: true */ HLJS_CDN
+    ).then((m) => (m.default ?? m) as Hljs);
+  }
+  return hljsPromise;
+}
 
 /** Choice verdict assigned after the learner picks an answer. Drives the
  *  per-choice colour ring + glyph and is read off `data-verdict` in the
@@ -59,7 +80,7 @@ function MarkdownInline({ source }: { source: string }) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeKatex, rehypeHighlight]}
+      rehypePlugins={[rehypeKatex]}
     >
       {source}
     </ReactMarkdown>
@@ -113,8 +134,35 @@ export default function MultipleChoiceQuestion({
     : null;
   const groupName = useId();
 
+  // Syntax-highlight the card's code blocks with highlight.js pulled from
+  // jsDelivr. Runs after mount and after any state change that can reveal new
+  // code (submitting an answer surfaces the per-choice and overall
+  // explanations). highlight.js stamps each block it processes with
+  // `data-highlighted`, so re-runs only touch the newly revealed blocks — the
+  // `:not([data-highlighted])` filter also sidesteps its "already highlighted"
+  // console warning.
+  const cardRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const root = cardRef.current;
+    if (!root) return;
+    const blocks = root.querySelectorAll<HTMLElement>(
+      "pre code:not([data-highlighted])",
+    );
+    if (blocks.length === 0) return;
+    let cancelled = false;
+    void loadHljs().then((hljs) => {
+      if (cancelled) return;
+      blocks.forEach((el) => {
+        if (!el.dataset.highlighted) hljs.highlightElement(el);
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [parsed, submitted, selectedId]);
+
   return (
-    <div className={styles.cardShell}>
+    <div className={styles.cardShell} ref={cardRef}>
     <section className={styles.card} aria-label="Multiple choice question">
       <header className={styles.header}>
         <span className={styles.badge}>

--- a/app/_components/runtime/cdn.ts
+++ b/app/_components/runtime/cdn.ts
@@ -57,3 +57,14 @@ export const PLOTLY_CDN = `https://cdn.jsdelivr.net/npm/plotly.js-dist-min@${PLO
 // CDN base at runtime. Keep MERMAID_VERSION in sync with package.json.
 export const MERMAID_VERSION = "11.15.0";
 export const MERMAID_CDN = `https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_VERSION}/+esm`;
+
+// highlight.js (syntax highlighting for the code blocks inside Multiple-Choice
+// quiz cards) is loaded from jsDelivr in the browser rather than bundled. The
+// quiz card renders client-side only (see MdxMultipleChoiceQuestion's
+// `ssr: false`) and colors its <code> blocks on demand after render, so
+// highlight.js never lands in the client chunks or the OpenNext Worker bundle.
+// Lessons' normal code fences are highlighted at build time by Fumadocs's Shiki
+// pipeline instead, so the quiz card is the only highlight.js consumer. Keep
+// HLJS_VERSION in sync with the highlight.js version in package.json.
+export const HLJS_VERSION = "11.11.1";
+export const HLJS_CDN = `https://cdn.jsdelivr.net/npm/highlight.js@${HLJS_VERSION}/+esm`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "react-dom": "^19.2.5",
         "react-icons": "^5.6.0",
         "react-markdown": "^10.1.0",
-        "rehype-highlight": "^7.0.2",
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
@@ -14612,21 +14611,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lowlight": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
-      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.0.0",
-        "highlight.js": "~11.11.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -17580,23 +17564,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/rehype-highlight": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
-      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-to-text": "^4.0.0",
-        "lowlight": "^3.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-katex": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "react-dom": "^19.2.5",
     "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
-    "rehype-highlight": "^7.0.2",
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",


### PR DESCRIPTION
## What & why

The Cloudflare/OpenNext migration moved heavy **browser-only** libraries (Plotly, Mermaid, PGlite, the WASM runtimes) to jsDelivr so they stay out of the client chunks **and** the Worker bundle. This PR extends that pattern to the last clean candidate: **highlight.js**.

Context: the OpenNext Worker uploads at **~8.7 MiB gzip**, against Cloudflare's **10 MiB** paid limit — so freeing headroom is worthwhile.

### Mechanism note (why only some libs qualify)
A Cloudflare Worker can't import remote code at runtime, so the CDN trick only helps for libraries that are in the Worker bundle **but only ever execute in the browser**. `highlight.js` qualifies: it reached the Worker *solely* because `MultipleChoiceQuestion` (a `"use client"` component) is server-rendered. Lessons' own code fences use Fumadocs's **Shiki**, not highlight.js — so the quiz card was its only consumer.

## Changes

1. **`runtime/cdn.ts`** — add `HLJS_CDN` (jsDelivr `highlight.js@11.11.1/+esm`), alongside the existing Plotly/Mermaid entries.
2. **`MultipleChoiceQuestion.tsx`** — drop `rehype-highlight` from the react-markdown pipeline; highlight `<pre><code>` blocks after render with the CDN-loaded `hljs.highlightElement`. The loader is cached at module scope (one fetch per page) and the effect re-highlights only newly revealed blocks (e.g. explanations shown after answering).
3. **`MdxMultipleChoiceQuestion.tsx`** — load the card via `next/dynamic(…, { ssr: false })`, mirroring what `HeroInteractive` already does on the home page, so the quiz markdown stack stays out of the Worker's SSR render path (and highlight.js can't re-enter via SSR).
4. **`package.json`** — remove the now-unused `rehype-highlight` dependency. `highlight.js` stays as the version source-of-truth for the CDN URL (same convention as `plotly.js-dist-min` / `mermaid`).

## Measured impact

Real OpenNext build + `wrangler deploy --dry-run` (the actual upload size), `main` vs this branch:

| Worker upload | gzip | raw |
| --- | --- | --- |
| baseline (`main`) | 8927.76 KiB | 39583.83 KiB |
| this PR | **8787.36 KiB** | 38977.56 KiB |
| **Δ** | **−140.40 KiB** | −606.27 KiB |

Headroom under the 10 MiB paid limit: **1312 KiB → 1453 KiB (+10.7%)**.

**Proof highlight.js left the bundle** (symbol counts in the wrangler-bundled `worker.js`): `highlightElement` 8 → **0**, `registerLanguage` 6 → **0**, `hljs-keyword` 0. `katex` references 30 → 20 (the MCQ SSR path is gone; the remaining 20 are the lesson MDX-compile path, which is server-side and stays). The lone surviving `lowlight` string is a COBOL **Shiki** grammar keyword, not highlight.js.

> The ~140 KiB win is essentially all highlight.js (removing `rehype-highlight`). The `ssr: false` change contributes little in raw bytes — `react-markdown`/`katex` are shared with other server-reachable components — but it takes the quiz's whole markdown render off the Worker's SSR path and aligns the lesson path with the home page.

## Tradeoff
Quiz cards now render **after hydration** on `/learn` lessons (a brief placeholder, then the card), rather than appearing in the prerendered HTML — the same behavior the home-page hero already uses for this exact component. The `.md` LLM mirror is unaffected (it reads raw markdown).

## Visual parity
highlight.js produces the same `.hljs-*` token classes that `rehype-highlight` did, and the GitHub-theme CSS in `learn.css` already targets those classes; the `<pre>` owns the block background, so there's no flash of wrong styling.

## Validation
`tsc --noEmit` ✓ · `eslint` ✓ · `vitest` ✓ (584 unit tests; the MCQ parser test passes — the only vitest "failures" are Playwright specs the build copied into `.open-next/`, unrelated to this change) · OpenNext build ✓ · `wrangler` dry-run ✓. Not yet smoke-tested live in a browser — happy to run `cf:preview` and click through a code-bearing quiz if you'd like.

## Not in scope (server-side — can't be CDN-loaded)
The Worker's biggest remaining content weights — the Fumadocs `dynamic`-mode MDX compiler (Shiki + KaTeX + unified) and the Orama search index — execute server-side, so they can't use the browser CDN trick (levers there are *trimming*, not CDN). `react-markdown` still enters via `ChallengeCard` — a separate, smaller lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)