### PR TITLE
Fix intermittent black borders on /learn (Tailwind v4 currentColor default)

### DIFF
--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -33,6 +33,39 @@
 @import "fumadocs-ui/css/preset.css";
 @import "katex/dist/katex.min.css";
 
+/* ── Tailwind v4 border-color default hardening (intermittent black borders) ──
+   Tailwind v4's preflight resets every element to `border: 0 solid`, which
+   leaves the default border *color* at `currentColor` (the near-black text
+   color) — it dropped v3's gray default. Fumadocs restores a sensible gray
+   default in its own `@layer base` (`* { border-color: var(--color-fd-border) }`),
+   and on a normal page load that rule wins because it's imported after Tailwind
+   above.
+
+   But this stylesheet is scoped to the /learn segment, and the Next.js App
+   Router does not order segment CSS deterministically on a *client-side*
+   navigation into /learn. When the preflight's `@layer base` rule ends up
+   applied after Fumadocs's (same layer → later source order wins), the
+   `border: 0 solid` shorthand resets border-color back to `currentColor` and
+   every border relying on the default paints black — until a hard refresh
+   restores the server cascade. That's the "refreshing fixes it" symptom.
+
+   Re-declaring the default in `@layer base` wouldn't help: it shares the same
+   layer and is equally vulnerable to the reorder. Instead we pin the default
+   one layer up, in `@layer components`. Layer precedence (components > base) is
+   independent of stylesheet/chunk order, so this always beats the base-layer
+   preflight no matter how the App Router orders the chunks — while still losing
+   to Tailwind/Fumadocs border-color *utilities* (`@layer utilities`), so
+   intentional colored borders (callouts, focus rings, …) are unaffected. */
+@layer components {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-fd-border, currentColor);
+  }
+}
+
 /* Override Fumadocs's default sans stack inside the /learn route with
    Inter and apply slightly tight letter-spacing for a more polished
    editorial feel. We scope to `body` (which is shared, but layout-CSS

--- a/e2e/learn-border-color.spec.ts
+++ b/e2e/learn-border-color.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression test for the Tailwind v4 `currentColor` border-color default on
+ * the /learn route ("intermittent black borders, fixed by refresh").
+ *
+ * Background
+ * ----------
+ * The /learn route loads Tailwind v4 via `app/learn/learn.css`, imported from
+ * `app/learn/layout.tsx` and therefore scoped to the /learn segment's CSS
+ * chunk. Tailwind v4 dropped v3's gray border default: its preflight emits
+ * `*, ::before, ::after { border: 0 solid }`, leaving the default border *color*
+ * at `currentColor` (the near-black text color). Fumadocs restores a gray
+ * default in its own `@layer base` rule (`* { border-color: var(--color-fd-border) }`),
+ * which wins on a normal load because it is imported after Tailwind.
+ *
+ * Both rules live in `@layer base`, so their winner is decided by source order.
+ * The Next.js App Router does not order segment CSS deterministically on a
+ * client-side navigation into /learn; when the preflight rule ends up applied
+ * after Fumadocs's, its `border: 0 solid` shorthand resets border-color back to
+ * `currentColor` and every border relying on the default paints black — until a
+ * hard refresh restores the server cascade. (Verified empirically: appending a
+ * late `@layer base { * { border: 0 solid } }` to a loaded /learn page flips the
+ * universal border default from gray to the black text color.)
+ *
+ * The fix (`app/learn/learn.css`) pins the gray default one layer up, in
+ * `@layer components`. Layer precedence (components > base) is independent of
+ * stylesheet/chunk order, so it always beats the base-layer preflight regardless
+ * of how the App Router orders the chunks, while still losing to border-color
+ * *utilities* in `@layer utilities` (so intentional colored borders are kept).
+ *
+ * What this test does
+ * -------------------
+ * Reproducing the non-deterministic chunk-order race by timing alone would be
+ * flaky. Instead we reproduce the *cascade state* it produces, deterministically:
+ * we append the preflight's universal `border: 0 solid` rule back into
+ * `@layer base` after the page has loaded — the exact thing the reorder does —
+ * and assert that a width-only border (one that relies on the default color)
+ * still resolves to the Fumadocs gray token rather than the black text color.
+ * Without the fix the appended rule wins and the border goes black; with it, the
+ * components-layer default holds and the border stays gray.
+ */
+
+const PREFLIGHT_BORDER_RESET =
+  "@layer base { *, ::after, ::before, ::backdrop, ::file-selector-button { border: 0 solid } }";
+
+/** Injects a 1px-bordered probe with no explicit border-color, plus a reference
+ *  element using the Fumadocs token, and returns their resolved colors. */
+async function readBorderColors(evaluate: <T>(fn: () => T) => Promise<T>) {
+  return evaluate(() => {
+    const host = document.querySelector("#nd-page") ?? document.body;
+
+    // Probe: border width + style only (never the `border` shorthand, which
+    // would itself set border-color inline). Its color comes purely from the
+    // cascade — the base-layer preflight default or the components-layer fix.
+    const el = document.createElement("div");
+    el.style.borderStyle = "solid";
+    el.style.borderWidth = "1px";
+    host.appendChild(el);
+
+    // Reference: same element with the Fumadocs border token applied explicitly,
+    // to capture its resolved rgb() value in this exact context.
+    const ref = document.createElement("div");
+    ref.style.borderStyle = "solid";
+    ref.style.borderWidth = "1px";
+    ref.style.borderColor = "var(--color-fd-border)";
+    host.appendChild(ref);
+
+    const result = {
+      borderColor: getComputedStyle(el).borderTopColor,
+      textColor: getComputedStyle(el).color, // what `currentColor` resolves to
+      tokenColor: getComputedStyle(ref).borderTopColor, // resolved --color-fd-border
+    };
+    el.remove();
+    ref.remove();
+    return result;
+  });
+}
+
+test("learn route: default border color is the Fumadocs gray token on a normal load", async ({
+  page,
+}) => {
+  await page.goto("/learn");
+  await expect(page.locator("#nd-page")).toBeVisible();
+
+  const c = await readBorderColors((fn) => page.evaluate(fn));
+
+  // Sanity: the token must be a real color distinct from the text color, or the
+  // assertions below would be meaningless.
+  expect(
+    c.tokenColor,
+    "--color-fd-border should resolve to a real color distinct from the text color",
+  ).not.toBe(c.textColor);
+
+  expect(c.borderColor, "default border should be the Fumadocs gray token").toBe(
+    c.tokenColor,
+  );
+  expect(c.borderColor).not.toBe(c.textColor);
+});
+
+test("learn route: default border stays gray when the base-layer preflight is reordered last (App Router soft-nav race)", async ({
+  page,
+}) => {
+  await page.goto("/learn");
+  await expect(page.locator("#nd-page")).toBeVisible();
+
+  // Reproduce the soft-navigation cascade: re-apply the preflight's universal
+  // `border: 0 solid` into @layer base *after* the page's CSS. Without the fix
+  // this resets the default border color to currentColor (black); with the fix
+  // (default pinned in @layer components) it cannot.
+  await page.evaluate((css) => {
+    const s = document.createElement("style");
+    s.textContent = css;
+    document.head.appendChild(s);
+  }, PREFLIGHT_BORDER_RESET);
+
+  const c = await readBorderColors((fn) => page.evaluate(fn));
+
+  expect(
+    c.borderColor,
+    "after the base-layer preflight reorder, the default border must NOT fall back to the black currentColor",
+  ).not.toBe(c.textColor);
+  expect(c.borderColor, "default border should still be the Fumadocs gray token").toBe(
+    c.tokenColor,
+  );
+});


### PR DESCRIPTION
## Symptom

Navigating **into** a `/learn` page sometimes renders elements (the Copy Markdown / Open buttons, code blocks, tables, etc.) with **black borders**. A hard refresh always fixes it.

## Root cause

Tailwind v4's preflight resets every element to `border: 0 solid`, which leaves the default border **color** at `currentColor` (the near-black text color) — it dropped v3's gray default. Fumadocs restores a gray default in its own `@layer base` rule (`* { border-color: var(--color-fd-border) }`), and on a normal load that rule wins because it's imported after Tailwind in `app/learn/learn.css`.

Both rules live in **`@layer base`**, so the winner is decided by source order. `learn.css` is scoped to the `/learn` segment (imported from `app/learn/layout.tsx`), and the Next.js App Router does **not** order segment CSS deterministically on a client-side navigation into `/learn`. When the preflight's base-layer rule ends up applied *after* Fumadocs's, its `border: 0 solid` shorthand resets `border-color` back to `currentColor` and every border relying on the default paints black — until a hard refresh restores the server cascade. That's the "refreshing fixes it" tell.

This was confirmed empirically: appending a late `@layer base { * { border: 0 solid } }` to a fully-loaded `/learn` page flips a width-only border from the gray token `rgba(204, 204, 204, 0.5)` to the black text color `rgb(10, 10, 10)`.

## Fix

Pin the gray default **one layer up**, in `@layer components`. Layer precedence (`components` > `base`) is independent of stylesheet/chunk order, so it always beats the base-layer preflight no matter how the App Router orders the chunks — while still **losing** to border-color *utilities* in `@layer utilities`, so intentional colored borders (callouts, focus rings, …) are unaffected.

A duplicate `@layer base` rule would **not** help — it shares the same layer and is equally vulnerable to the reorder (and is what Fumadocs already ships).

## Verification

Added `e2e/learn-border-color.spec.ts`, which reproduces the cascade deterministically (re-applies the base-layer preflight to a loaded `/learn` page) and asserts the default border stays the gray token:

- ✅ **Normal load** — default border is the Fumadocs gray token.
- ✅ **After the base-layer preflight reorder** — default border stays gray (this is the regression guard).

Both pass with the `@layer components` fix. To prove the test is real, I temporarily weakened the fix to `@layer base` and the race test **failed** (border = `rgb(10, 10, 10)`), then restored `@layer components` and it passed again. Separately verified a `@layer utilities` colored border (`rgb(255, 0, 0)`) still wins, so colored borders are preserved. `eslint` clean.

## Files

- `app/learn/learn.css` — `@layer components` border-color default (+ rationale comment).
- `e2e/learn-border-color.spec.ts` — new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018j8oDYQbWpdjGez4eQjmZn

---
_Generated by [Claude Code](https://claude.ai/code/session_018j8oDYQbWpdjGez4eQjmZn)_