### PR TITLE
Fix R2 cache cleanup crash on build folders with >1000 objects

### DIFF
--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -103,9 +103,16 @@ jobs:
             fi
 
             # Newest object in the folder (all written together at deploy time).
+            # The CLI auto-paginates above 1000 objects and applies --query to
+            # each page separately, so a large build folder returns one max
+            # timestamp PER PAGE (multiple lines). Collapse to the overall max —
+            # R2 reports LastModified in a uniform UTC ISO-8601 layout, so a
+            # lexical sort orders them chronologically — and drop the "None" a
+            # genuinely empty page emits, leaving `date` a single value to parse.
             newest="$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$folder" \
-              --query 'sort_by(Contents, &LastModified)[-1].LastModified' --output text 2>/dev/null || true)"
-            if [[ -z "$newest" || "$newest" == "None" ]]; then
+              --query 'sort_by(Contents, &LastModified)[-1].LastModified' --output text 2>/dev/null \
+              | grep -vxF 'None' | sort | tail -n1 || true)"
+            if [[ -z "$newest" ]]; then
               echo "skip  $folder (empty)"; continue
             fi
             ts=$(date -u -d "$newest" +%s)


### PR DESCRIPTION
## Problem

The **R2 incremental-cache cleanup** workflow failed in the "Prune stale build folders" step:

```
date: invalid date '2026-06-22T12:42:14.206000+00:00\n2026-06-22T12:42:14.034000+00:00'
Error: Process completed with exit code 1.
```

## Root cause

The per-folder "newest object" lookup runs:

```bash
newest="$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$folder" \
  --query 'sort_by(Contents, &LastModified)[-1].LastModified' --output text ...)"
```

The AWS CLI **auto-paginates above 1000 objects** and applies the client-side `--query` to **each page independently**. So a build folder larger than one page returns one max timestamp *per page*, and `--output text` joins them with newlines. That multi-line value was passed straight to `date -d`, which rejects it and aborts the job.

An OpenNext build that caches `/learn/*` and many routes easily exceeds 1000 cache objects, which is why this surfaced now.

## Fix

Collapse the per-page maxima to a single overall max before calling `date`:

```bash
  ... --output text 2>/dev/null \
  | grep -vxF 'None' | sort | tail -n1 || true
```

- R2 reports `LastModified` in a uniform UTC ISO-8601 layout, so a lexical `sort` orders the candidates chronologically and `tail -n1` takes the newest.
- `grep -vxF 'None'` drops the placeholder an empty page emits, so the existing emptiness check still skips truly empty folders (the `== "None"` branch is now redundant and was removed).
- The common single-page case is unchanged: `sort | tail -n1` on one line is a no-op.

## Verification

Reproduced the exact CI failure locally and confirmed the fix:
- Multi-page input → collapses to the single newest timestamp; `date` parses it.
- Single-page input → unchanged.
- Empty folder (`None`) → collapses to empty string → folder skipped.

Only the `[-1]` positional query is affected by the pagination gotcha; the folder-enumeration query (`CommonPrefixes[].Prefix`) accumulates all elements and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmTou2rnKrmjNGjBc97E2b)_