### PR TITLE
Fix "falsedeleted" in R2 cache cleanup summary line

### DIFF
--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -130,4 +130,11 @@ jobs:
           done
 
           echo "---"
-          echo "Folders kept: $kept | folders ${DRY_RUN/true/would be }deleted: $deleted"
+          # DRY_RUN is always exactly "true" or "false"; choose the verb to match.
+          # (A ${DRY_RUN/true/would be } substitution used to leak a literal
+          # "false" into the summary on real runs — "folders falsedeleted".)
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Folders kept: $kept | folders would be deleted: $deleted"
+          else
+            echo "Folders kept: $kept | folders deleted: $deleted"
+          fi


### PR DESCRIPTION
## What

The final summary line of the **R2 incremental-cache cleanup** workflow prints `folders falsedeleted: N` on real (non-dry-run) executions, e.g.:

```
Folders kept: 12 | folders falsedeleted: 8
```

## Why

The line used a bash pattern-substitution trick:

```bash
echo "Folders kept: $kept | folders ${DRY_RUN/true/would be }deleted: $deleted"
```

`${DRY_RUN/true/would be }` replaces the substring `true` with `would be ` inside the value of `$DRY_RUN`. The intent was:

- **Dry run** (`DRY_RUN=true`) → `true` → `would be ` → `folders would be deleted: N` ✅
- **Real run** (`DRY_RUN=false`) → expected an empty string → `folders deleted: N`

But the substitution only matches the `true` case. When `DRY_RUN=false` there is no `true` substring to replace, so the expansion returns the **unchanged** value `false`, yielding `folders falsedeleted: N`.

This is **cosmetic only** — the delete logic itself was already correct, and the 8 folders reported really were deleted.

## Fix

Replace the trick with an explicit conditional that picks the verb per run mode:

- Dry run: `Folders kept: 12 | folders would be deleted: 8`
- Real run: `Folders kept: 12 | folders deleted: 8`

Verified both branches produce the correct text and the workflow YAML still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQHxKnAVJudo4cnf34ggRJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQHxKnAVJudo4cnf34ggRJ)_