### PR TITLE
Expand interview-prep explanations + fix horizontal mermaid diagrams project-wide

### DIFF
--- a/content/interview/analytics-engineer/dbt.mdx
+++ b/content/interview/analytics-engineer/dbt.mdx
@@ -380,7 +380,7 @@ The DAG (Directed Acyclic Graph) is constructed automatically by parsing every `
 A typical slice of that graph — raw sources flowing through staging models into marts — looks like this:
 
 ```mermaid
-flowchart LR
+flowchart TD
   s1["source: raw.orders"] --> stg1["stg_orders"]
   s2["source: raw.customers"] --> stg2["stg_customers"]
   stg1 --> fct["fct_orders"]

--- a/content/interview/analytics-engineer/dbt.mdx
+++ b/content/interview/analytics-engineer/dbt.mdx
@@ -3,8 +3,8 @@ title: dbt
 description: Analytics Engineer interview questions on dbt models, ref/source, materializations, tests, and incremental builds.
 ---
 
-dbt is the tool AE interviews assume. Review the Q&A, then the concept
-checks.
+dbt is the tool Analytics Engineer interviews assume. Review the Q&A,
+then the concept checks.
 
 > **Note:** dbt compiles these models to your warehouse's SQL dialect, so the SQL below is illustrative. Dataslope's runnable SQL playground uses **DuckDB**.
 
@@ -12,20 +12,24 @@ checks.
 
 ### What is dbt, and what does it actually do?
 
-dbt is the **T** in ELT: you write transformations as `SELECT` statements
-("models"), and dbt handles building them **in order** in your warehouse,
-managing dependencies, materializations, tests, and docs. It brings
-software practices — version control, modularity, testing, CI — to SQL
-analytics. It transforms data already in the warehouse; it doesn't move
-data (that's EL tools).
+dbt is the **T** in extract, load, transform (ELT): you write
+transformations as `SELECT` statements ("models"), and dbt handles
+building them **in order** in your warehouse, managing dependencies,
+materializations, tests, and docs. It brings software practices —
+version control, modularity, testing, continuous integration (CI) — to
+SQL analytics. It transforms data already in the warehouse; it doesn't
+move data (that's EL tools).
 
 ### What do `ref()` and `source()` do?
 
 `ref('stg_orders')` references another **model**; `source('raw', 'orders')`
 references a declared raw **source** table. Both let dbt build the
-**dependency graph (DAG)** — so it knows build order and can swap
-schemas between dev and prod. Hardcoding table names breaks lineage and
-environment handling.
+dependency graph — a **Directed Acyclic Graph (DAG)** — so it knows
+build order and can swap schemas between dev and prod. Hardcoding table
+names breaks lineage and environment handling.
+
+Here `fct_orders` builds from two upstream models via `ref()`, so dbt
+adds edges from `stg_orders` and `stg_customers` and runs them first:
 
 ```sql
 -- models/marts/fct_orders.sql
@@ -36,6 +40,9 @@ SELECT
 FROM {{ ref('stg_orders') }}    AS o   -- references another model
 JOIN {{ ref('stg_customers') }} AS c   ON c.customer_id = o.customer_id;
 ```
+
+By contrast, `source('raw', 'orders')` points at a declared raw table
+(the `raw` source, `orders` table) rather than a dbt-built model:
 
 ```sql
 -- Referencing a raw source table
@@ -69,6 +76,10 @@ refresh** to repair drift.
 
 The `is_incremental()` macro returns `true` only when the model already exists in the warehouse and the run is not a full refresh. You use it in a `WHERE` clause to limit rows to those newer than the max value already loaded.
 
+Below, the `config()` marks the model `incremental`, and the
+`is_incremental()` guard keeps only `events` rows whose `event_at`
+exceeds the max already loaded:
+
 ```sql
 -- models/fct_events.sql
 {{
@@ -87,7 +98,11 @@ FROM {{ source('raw', 'events') }}
 
 ### What is `dbt snapshot`, and what SCD type does it implement?
 
-`dbt snapshot` implements **SCD Type 2**: it checks a source table for changed rows on each run and inserts new history rows with `dbt_valid_from` and `dbt_valid_to` timestamps rather than overwriting. You configure it with a `strategy` — `timestamp` (compares an `updated_at` column) or `check` (compares a list of columns). Snapshots are defined in `.sql` files under the `snapshots/` directory.
+`dbt snapshot` implements **Slowly Changing Dimension (SCD) Type 2**: it checks a source table for changed rows on each run and inserts new history rows with `dbt_valid_from` and `dbt_valid_to` timestamps rather than overwriting. You configure it with a `strategy` — `timestamp` (compares an `updated_at` column) or `check` (compares a list of columns). Snapshots are defined in `.sql` files under the `snapshots/` directory.
+
+This `snap_customers` snapshot uses the `timestamp` strategy on the
+`updated_at` column, keyed by `customer_id`, to record history of the
+raw `customers` source:
 
 ```sql
 {% snapshot snap_customers %}
@@ -117,6 +132,10 @@ Seeds are **CSV files** checked into the repository and loaded into the warehous
 
 **Generic tests** (`unique`, `not_null`, `accepted_values`, `relationships`) are configured in YAML and applied to columns across many models. **Singular tests** are standalone `.sql` files that return rows when the test fails. Use singular tests for complex, business-specific assertions that don't fit a generic pattern.
 
+This YAML attaches generic tests to `fct_orders`: `unique` and
+`not_null` on `order_id`, an `accepted_values` allowlist on `status`,
+and a `relationships` check tying `customer_id` back to `dim_customer`:
+
 ```yaml
 # models/schema.yml — generic tests on fct_orders
 models:
@@ -137,6 +156,9 @@ models:
               field: customer_id
 ```
 
+The singular test below is just a query: any `fct_orders` row with a
+negative `amount` is returned, so a non-empty result fails the run:
+
 ```sql
 -- tests/assert_no_negative_amounts.sql — singular test (returns rows on failure)
 SELECT order_id, amount
@@ -146,7 +168,11 @@ WHERE amount < 0
 
 ### How do macros work in dbt?
 
-Macros are **reusable Jinja functions** defined in `.sql` files under the `macros/` directory. They generate SQL dynamically, accept arguments, and can be called from models, other macros, or schema tests. They enable DRY SQL — for example, a macro that generates a `CASE WHEN` block for currency conversion.
+Macros are **reusable Jinja functions** defined in `.sql` files under the `macros/` directory. They generate SQL dynamically, accept arguments, and can be called from models, other macros, or schema tests. They enable don't repeat yourself (DRY) SQL — for example, a macro that generates a `CASE WHEN` block for currency conversion.
+
+The `cents_to_dollars` macro takes a `column_name` argument and emits
+the division expression, so models call it instead of repeating the
+`/ 100.0` arithmetic:
 
 ```sql
 -- macros/cents_to_dollars.sql
@@ -162,6 +188,9 @@ Macros are **reusable Jinja functions** defined in `.sql` files under the `macro
 
 Packages are **shared dbt projects** (macros, models, tests) installed from the dbt Hub or a Git repo. You declare them in `packages.yml` and run `dbt deps` to install. The most common package is `dbt_utils`, which provides macros like `surrogate_key`, `pivot`, and `date_spine`.
 
+This `packages.yml` pins `dbt-labs/dbt_utils` to version `1.1.1`; `dbt
+deps` then fetches that exact release into the project:
+
 ```yaml
 # packages.yml
 packages:
@@ -172,6 +201,9 @@ packages:
 ### What is source freshness, and how do you configure it?
 
 Source freshness checks whether a raw source table has been updated recently enough. You declare a `loaded_at_field` (timestamp column) and `freshness` thresholds (`warn_after`, `error_after`) in `sources.yml`, then run `dbt source freshness`. It alerts you when upstream data pipelines are late before bad data propagates through your models.
+
+Here the `orders` source measures lag from its `_loaded_at` column,
+warning after 6 hours and erroring after 12:
 
 ```yaml
 sources:
@@ -186,7 +218,11 @@ sources:
 
 ### What are exposures in dbt?
 
-Exposures declare **downstream consumers** of your dbt models — dashboards, ML models, reverse ETL pipelines — in YAML. They appear in the lineage DAG so you can see which models feed which business artifacts, assess the impact of changes, and communicate dependencies to stakeholders.
+Exposures declare **downstream consumers** of your dbt models — dashboards, machine learning (ML) models, reverse extract, transform, load (ETL) pipelines — in YAML. They appear in the lineage DAG so you can see which models feed which business artifacts, assess the impact of changes, and communicate dependencies to stakeholders.
+
+This exposure registers a `weekly_revenue_dashboard` that `depends_on`
+`fct_orders` and `dim_customer`, so those models show an edge to the
+dashboard in lineage:
 
 ```yaml
 exposures:
@@ -201,7 +237,7 @@ exposures:
 
 ### How does dbt manage documentation and lineage?
 
-dbt generates a **documentation site** (`dbt docs generate` + `dbt docs serve`) from YAML descriptions on models and columns, plus markdown doc blocks. The site includes an **interactive DAG** showing all model dependencies derived from `ref()` and `source()` calls — giving you lineage from raw source to BI exposure automatically.
+dbt generates a **documentation site** (`dbt docs generate` + `dbt docs serve`) from YAML descriptions on models and columns, plus markdown doc blocks. The site includes an **interactive DAG** showing all model dependencies derived from `ref()` and `source()` calls — giving you lineage from raw source to business intelligence (BI) exposure automatically.
 
 ### What are environments and targets in dbt?
 
@@ -214,6 +250,10 @@ A **target** is a named warehouse connection configuration (database, schema, cr
 ### How do you run only a subset of models in dbt?
 
 Use **node selection syntax** with `dbt run --select`. You can select by model name, directory, tag, or graph operators. The `+` operator selects upstream or downstream nodes.
+
+These three invocations show the common selectors: the `+fct_orders`
+graph operator, the `marts` directory path, and the `tag:nightly`
+tag selector:
 
 ```bash
 # Run one model and all its upstream dependencies
@@ -229,6 +269,10 @@ dbt run --select tag:nightly
 ### What is the `unique_key` config on an incremental model, and what does it control?
 
 `unique_key` tells dbt how to **handle duplicate rows** when merging new data into an incremental model. If a new row's key already exists in the target table, dbt will `MERGE`/`UPDATE` (upsert) rather than inserting a duplicate. Without `unique_key`, dbt only appends; with it, dbt uses a MERGE strategy (or DELETE+INSERT on warehouses that lack MERGE).
+
+Setting `unique_key='event_id'` in the `config()` below means a
+re-loaded `event_id` upserts in place instead of appending a duplicate
+to `fct_events`:
 
 ```sql
 -- models/fct_events.sql — incremental with upsert on event_id
@@ -250,6 +294,9 @@ FROM {{ source('raw', 'events') }}
 ### What is a dbt model contract?
 
 A **model contract** enforces that a model's output schema (column names, data types, and constraints) matches a declared specification. If the model's SQL produces a different shape, the run fails. Contracts are defined in YAML with `contract: {enforced: true}` and column-level `data_type` declarations. They are useful for models with downstream consumers who depend on a stable interface.
+
+With `enforced: true`, dbt fails the run unless `fct_orders` emits
+`order_id` as `bigint` (and `not_null`) and `amount_usd` as `numeric`:
 
 ```yaml
 models:
@@ -278,6 +325,10 @@ On a pull request, CI runs `dbt build --select state:modified+` — building and
 
 An ephemeral model is **not materialized** — it is compiled as a CTE and injected into any model that references it. Use ephemeral models for intermediate logic that is referenced only once or twice and does not need to be queryable directly. Avoid them when the same logic is referenced by many downstream models (the CTE is duplicated each time) or when you need to test the intermediate result directly.
 
+The `materialized='ephemeral'` config means `int_orders_cleaned` is
+never built as its own object; this cleanup SELECT is inlined as a CTE
+wherever a downstream model `ref()`s it:
+
 ```sql
 -- models/intermediate/int_orders_cleaned.sql
 {{ config(materialized='ephemeral') }}
@@ -294,10 +345,16 @@ WHERE amount_cents > 0
 
 Use `var()` in Jinja to reference variables defined in `dbt_project.yml` under `vars:` or passed on the CLI with `--vars`. This enables environment-aware logic without code changes.
 
+In the model, `var("start_date")` injects the variable's value into the
+`WHERE` filter at compile time:
+
 ```sql
 -- In a model
 WHERE order_date >= '{{ var("start_date") }}'
 ```
+
+At run time, `--vars` supplies that `start_date` value as JSON,
+overriding any default set in `dbt_project.yml`:
 
 ```bash
 # Override on the CLI
@@ -319,6 +376,17 @@ dbt supports **model versioning** natively (v1.5+): you declare multiple version
 ### What is the dbt lineage DAG, and how is it built?
 
 The DAG (Directed Acyclic Graph) is constructed automatically by parsing every `ref()` and `source()` call across all model files. Each call creates a directed edge from the referenced model to the current model. dbt uses the DAG to determine execution order, parallelize independent branches, and power the documentation lineage view.
+
+A typical slice of that graph — raw sources flowing through staging models into marts — looks like this:
+
+```mermaid
+flowchart LR
+  s1["source: raw.orders"] --> stg1["stg_orders"]
+  s2["source: raw.customers"] --> stg2["stg_customers"]
+  stg1 --> fct["fct_orders"]
+  stg2 --> dim["dim_customer"]
+  dim --> fct
+```
 
 ### How do you handle environment-specific schemas in dbt?
 

--- a/content/interview/analytics-engineer/dimensional-modeling.mdx
+++ b/content/interview/analytics-engineer/dimensional-modeling.mdx
@@ -3,8 +3,8 @@ title: Dimensional Modeling
 description: Analytics Engineer interview questions on facts, dimensions, grain, and star schemas — with answers, a concept check, and a runnable mart challenge.
 ---
 
-The AE craft is turning raw tables into clean, well-grained dimensional
-models. Review the Q&A, then build a mart.
+The Analytics Engineer's craft is turning raw tables into clean,
+well-grained dimensional models. Review the Q&A, then build a mart.
 
 > **SQL dialect:** the runnable challenge on this page executes in your browser on **DuckDB**, so the SQL below targets DuckDB. It is standard SQL except where noted.
 
@@ -25,12 +25,35 @@ order line item") up front keeps measures additive and prevents
 double-counting. Every column then either describes that grain or is a
 measure at that grain.
 
+<Callout type="tip" title="Interview tip">
+State the grain in a single sentence ("one row per order line item")
+before you talk about measures or keys. Interviewers read a clearly
+declared grain as the signal that you can model dimensionally.
+</Callout>
+
 ### Star vs snowflake?
 
 **Star** keeps dimensions denormalized (one table each) for simple, fast
-joins — the BI default. **Snowflake** normalizes dimensions into
-sub-tables, reducing redundancy at the cost of more joins. Prefer star
-unless a dimension is huge or genuinely shared.
+joins — the Business Intelligence (BI) default. **Snowflake** normalizes
+dimensions into sub-tables, reducing redundancy at the cost of more joins.
+Prefer star unless a dimension is huge or genuinely shared.
+
+A star schema is exactly that shape — one central fact table surrounded by
+single-table dimensions:
+
+```mermaid
+flowchart TB
+  d["dim_date"] --> f["fact_orders"]
+  p["dim_product"] --> f
+  c["dim_customer"] --> f
+```
+
+The query below is a textbook star-schema read: the central `fact_orders`
+table joins directly to two single-table dimensions (`dim_date` and
+`dim_product`) on their surrogate keys, then sums revenue grouped by the
+descriptive attributes those dimensions provide. Because each dimension is
+one flat table, there are no extra hops — exactly the simplicity that makes
+the star the default shape.
 
 <SqlCodeBlock
   dialect="duckdb"
@@ -69,9 +92,14 @@ ORDER BY d.full_date, p.category;`}
 
 A **surrogate key** is a synthetic, meaningless identifier (an integer or
 hash) for a dimension row, independent of the source's **natural key**.
-It's stable across source changes, enables SCD Type 2 (each version gets
-its own surrogate), and keeps fact joins fast and decoupled from business
-identifiers.
+It's stable across source changes, enables Slowly Changing Dimension (SCD)
+Type 2 (each version gets its own surrogate), and keeps fact joins fast and
+decoupled from business identifiers.
+
+The query below derives a surrogate key by hashing the natural key
+(`customer_id`) and carries the natural key alongside it, so downstream
+facts can join on the stable `customer_sk` while you can still trace back
+to the source identifier:
 
 ```sql
 -- Hash-based surrogate key (DuckDB: md5 returns a hex string)
@@ -109,6 +137,16 @@ SCD Type 1 **overwrites** the old attribute value with the new one, preserving n
 
 SCD Type 2 adds a **new row** for each attribute change, preserving the full history. Each row gets its own surrogate key plus `valid_from`, `valid_to`, and `is_current` columns. Fact rows joined to their surrogate key automatically reflect the attribute values that were true at event time.
 
+The runnable example below makes this tangible. The `initSql` setup seeds a
+`dim_customer` in which customer 42 has **two** versions — an `East` row
+valid through 2023-06-14 and a `West` row valid afterward — and the comment
+header above it shows that row layout at a glance. The query then joins
+each order to the version that was current on its `order_date`, using the
+predicate `f.order_date BETWEEN c.valid_from AND c.valid_to`. The output
+attributes the 2022 order to `East` and the 2024 order to `West`: that
+`BETWEEN` against the validity window is exactly the mechanism that makes
+Type 2 history queryable point-in-time.
+
 <SqlCodeBlock
   dialect="duckdb"
   initSql={`-- SCD Type 2 row layout: customer moved from East to West
@@ -138,8 +176,13 @@ JOIN dim_customer c
 ORDER BY f.order_id;`}
 />
 
+When you instead want only the **current** state of each customer — not the
+full history — you filter on the `is_current` flag, which is `TRUE` for
+exactly one row per entity. That turns the versioned dimension back into a
+simple "latest value" lookup:
+
 ```sql
--- Example dim_customer with SCD2 columns
+-- Read only the present state of each customer (one row per entity)
 SELECT
     customer_sk,      -- surrogate key
     customer_id,      -- natural key
@@ -168,6 +211,8 @@ A conformed dimension is shared across **multiple fact tables or subject areas**
 
 A degenerate dimension is a dimensional attribute stored directly in the fact table rather than in a separate dimension table, because it has no descriptive attributes of its own. An order number or invoice number is the canonical example — it provides grouping ability but carries no extra columns worth their own table.
 
+The query below groups by `order_number` straight off the fact table — there is no `dim_order` to join — showing how a degenerate dimension still supports grouping even though it lives on the fact:
+
 ```sql
 -- order_number lives in the fact table (degenerate dimension)
 -- No separate dim_order table exists
@@ -181,6 +226,8 @@ GROUP BY order_number;
 ### What is a role-playing dimension?
 
 A role-playing dimension is a single physical dimension table used **multiple times** in the same fact table under different aliases. A `dim_date` table might be joined three times to `fact_orders` as `order_date`, `ship_date`, and `delivery_date`, each a "role."
+
+In the query below, `dim_date` is joined to `fact_orders` three separate times under three aliases (`od`, `sd`, `dd`), each turning a different date key into a readable date. One physical table plays three roles in a single result:
 
 <SqlCodeBlock
   dialect="duckdb"
@@ -219,6 +266,8 @@ A junk dimension bundles **miscellaneous low-cardinality flags and indicators** 
 
 A factless fact table records **events or coverage** with no numeric measure — just foreign keys. Examples: student course enrollments (the fact is attendance, not a count), or a coverage fact listing which products are on promotion in which stores on which days. You derive counts by querying "how many rows match this criteria."
 
+Because there is no measure to sum, you answer questions by **counting rows**. The query below counts how many distinct products were on promotion in one store over a week — the kind of coverage question a factless fact exists to answer:
+
 ```sql
 -- Factless fact: which products were on promotion per store per day
 -- fact_promotion_coverage(date_sk, store_sk, product_sk) — no measures
@@ -234,6 +283,8 @@ WHERE pc.store_sk = 5
 ### What is a bridge table, and when do you need one?
 
 A bridge table resolves **many-to-many relationships** between a fact and a dimension. For example, an order can have multiple promotions, and a promotion can apply to multiple orders. The bridge table contains (order_sk, promotion_sk) pairs with an optional weighting factor. It avoids row multiplication in the fact while still allowing drill-down to all related dimension members.
+
+The query below joins `fact_orders` to `dim_promotion` *through* the `bridge_order_promotion` table and multiplies each order's amount by the bridge's `weight_factor`. That weighting splits one order's value across its promotions (0.6 / 0.4 for order 201) instead of double-counting the full amount once per promotion:
 
 <SqlCodeBlock
   dialect="duckdb"
@@ -276,7 +327,7 @@ Third Normal Form (3NF) eliminates all non-key dependencies and redundancy to op
 
 ### What is a wide (one-big-table) approach, and when is it appropriate?
 
-A wide table (OBT) pre-joins dimensions into the fact, producing a single flat table with all attributes. It maximizes query speed and simplifies BI tooling, but loses the flexibility of separate dimension tables and makes maintenance harder. It is appropriate for highly performance-sensitive use cases or for serving tools that struggle with joins.
+A wide table (one big table) pre-joins dimensions into the fact, producing a single flat table with all attributes. It maximizes query speed and simplifies BI tooling, but loses the flexibility of separate dimension tables and makes maintenance harder. It is appropriate for highly performance-sensitive use cases or for serving tools that struggle with joins.
 
 ### How do you handle late-arriving dimension records?
 
@@ -313,6 +364,8 @@ Measures in fact tables are generally fixed at event time and should not change.
 ### What are the trade-offs of using a hash surrogate key vs. a sequence integer?
 
 **Hash surrogates** (e.g., `MD5(natural_key)`) are deterministic — you can compute the same key in any environment without a central sequence, which helps distributed/incremental builds. **Integer sequences** are more compact, faster for joins, and easier to debug, but require a coordination mechanism. Hashes can collide (rare but possible) and are larger in storage. Most modern data warehouses use either approach; hashes are common in dbt pipelines.
+
+The two queries below contrast the approaches: the first hashes the natural key (computable anywhere, no central counter), while the second assigns a sequential integer with `row_number()` (compact and human-readable, but dependent on a single ordering pass):
 
 ```sql
 -- Hash surrogate (DuckDB): deterministic, no sequence needed

--- a/content/interview/backend-engineer/algorithms.mdx
+++ b/content/interview/backend-engineer/algorithms.mdx
@@ -12,32 +12,33 @@ browser.
 ### What is Big-O notation, and why do interviewers care?
 
 Big-O describes how an algorithm's time or space grows with input size
-**n**, ignoring constants — O(1), O(log n), O(n), O(n log n), O(n²), …
-Interviewers care because it predicts whether a solution scales: an O(n²)
-double loop that's fine for 100 items melts at 1,000,000. The usual game
-is "make this brute-force O(n²) into O(n) with the right data structure."
+**n**, ignoring constants — $O(1)$, $O(\log n)$, $O(n)$, $O(n \log n)$,
+$O(n^2)$, … Interviewers care because it predicts whether a solution
+scales: an $O(n^2)$ double loop that's fine for 100 items melts at
+1,000,000. The usual game is "make this brute-force $O(n^2)$ into $O(n)$
+with the right data structure."
 
 ### When do you reach for a hash map?
 
-When you need **O(1) average lookup/insert by key** — membership tests,
+When you need **$O(1)$ average lookup/insert by key** — membership tests,
 counting frequencies, grouping, or "have I seen this before?" It's what
-turns many O(n²) "compare all pairs" problems into a single O(n) pass
+turns many $O(n^2)$ "compare all pairs" problems into a single $O(n)$ pass
 (see Two Sum below).
 
 ### Array vs linked list — trade-offs?
 
-**Arrays**: O(1) random access by index, cache-friendly, but O(n) insert
-/delete in the middle. **Linked lists**: O(1) insert/delete given the
-node, but O(n) access and poor cache locality. Most day-to-day code
+**Arrays**: $O(1)$ random access by index, cache-friendly, but $O(n)$
+insert/delete in the middle. **Linked lists**: $O(1)$ insert/delete given
+the node, but $O(n)$ access and poor cache locality. Most day-to-day code
 favors dynamic arrays; linked lists shine for frequent splice operations
-or as building blocks (queues, LRU caches).
+or as building blocks (queues, least-recently-used (LRU) caches).
 
 ### When is a stack the right structure?
 
 When the problem is about the **most recently seen** item — matching/
-nesting (parentheses), undo, backtracking, or DFS. Its LIFO order encodes
-"close the thing you opened last," which a counter can't (see Valid
-Parentheses).
+nesting (parentheses), undo, backtracking, or depth-first search (DFS).
+Its last-in-first-out (LIFO) order encodes "close the thing you opened
+last," which a counter can't (see Valid Parentheses).
 
 ### Recursion vs iteration?
 
@@ -51,18 +52,20 @@ factor. Convert recursion to iteration when depth can be large.
 
 Amortized analysis spreads the cost of occasional expensive operations
 across many cheap ones. A dynamic array (Python `list`) appends in
-amortized O(1): most appends are O(1), but every doubling resize is O(n).
-Because doublings become exponentially rare, the average per-operation
-cost stays O(1). Similarly, a hash table rehash is amortized O(1) per
-insert.
+amortized $O(1)$: most appends are $O(1)$, but every doubling resize is
+$O(n)$. Because doublings become exponentially rare, the average
+per-operation cost stays $O(1)$. Similarly, a hash table rehash is
+amortized $O(1)$ per insert.
 
 ### What are the time complexities of heap operations?
 
-A binary heap supports `insert` in `O(log n)` (bubble up), `extract-min`
-or `extract-max` in `O(log n)` (sift down), and `peek` in O(1). Building
-a heap from n elements is O(n) via heapify — not `O(n log n)` — because
-most nodes are near the leaves and travel very little. Python's `heapq`
-module is a min-heap.
+A binary heap supports `insert` in $O(\log n)$ (bubble up), `extract-min`
+or `extract-max` in $O(\log n)$ (sift down), and `peek` in $O(1)$.
+Building a heap from n elements is $O(n)$ via heapify — not
+$O(n \log n)$ — because most nodes are near the leaves and travel very
+little. Python's `heapq` module is a min-heap. The snippet below uses
+`heapify` to build the heap in place, then `heappush` and `heappop` to
+add and remove the smallest element.
 
 <CodeBlock
   adapter="python"
@@ -80,27 +83,42 @@ print(heapq.heappop(h))  # 1  — O(log n)`,
 
 ### How does a priority queue differ from a regular queue?
 
-A queue is FIFO — elements leave in insertion order. A priority queue
-always removes the element with the highest (or lowest) priority, regardless
-of insertion order. It is commonly implemented with a heap, giving
-`O(log n)` push and pop. Use it for Dijkstra's algorithm, task schedulers,
-and merge-k-sorted-lists.
+A queue is first-in-first-out (FIFO) — elements leave in insertion order.
+A priority queue always removes the element with the highest (or lowest)
+priority, regardless of insertion order. It is commonly implemented with a
+heap, giving $O(\log n)$ push and pop. Use it for Dijkstra's algorithm,
+task schedulers, and merge-k-sorted-lists.
 
 ### What is a deque, and when should you prefer it over a list?
 
-A deque (double-ended queue) supports O(1) append and pop from **both**
+A deque (double-ended queue) supports $O(1)$ append and pop from **both**
 ends. Python's `collections.deque` is implemented as a doubly-linked list
-of fixed-size blocks. Use it when you need a sliding-window buffer, a BFS
-queue, or any "add to one end, remove from other end" pattern. `list.pop(0)`
-is O(n) and should be replaced with `deque.popleft()`.
+of fixed-size blocks. Use it when you need a sliding-window buffer, a
+breadth-first search (BFS) queue, or any "add to one end, remove from
+other end" pattern. `list.pop(0)` is $O(n)$ and should be replaced with
+`deque.popleft()`.
 
 ### Walk me through BFS vs DFS — when do you choose each?
 
-BFS (breadth-first search) uses a queue and explores level by level,
-guaranteeing the **shortest path** in an unweighted graph. DFS uses a
-stack (or recursion) and dives deep first — natural for cycle detection,
-topological sort, connected components, and backtracking. BFS memory usage
-can be O(n) at the widest level; DFS memory is proportional to depth.
+BFS uses a queue and explores level by level, guaranteeing the
+**shortest path** in an unweighted graph. DFS uses a stack (or recursion)
+and dives deep first — natural for cycle detection, topological sort,
+connected components, and backtracking. BFS memory usage can be $O(n)$ at
+the widest level; DFS memory is proportional to depth.
+
+The example graph below has `A` branching to `B` and `C`, which both lead
+to `D`; breadth-first search visits it level by level as `A, B, C, D`:
+
+```mermaid
+flowchart TD
+  A --> B
+  A --> C
+  B --> D
+  C --> D
+```
+
+The `bfs` function below uses a `deque` as the queue and a `visited` set so
+each node is enqueued at most once.
 
 <CodeBlock
   adapter="python"
@@ -166,11 +184,13 @@ print(has_cycle(cyclic))   # True`,
 
 ### What is topological sort, and when is it applicable?
 
-Topological sort orders the nodes of a **directed acyclic graph** (DAG)
+Topological sort orders the nodes of a **directed acyclic graph (DAG)**
 so every edge goes from earlier to later. It's used for build-dependency
 resolution, course prerequisites, and task scheduling. Kahn's algorithm
 (iteratively remove nodes with in-degree 0) or DFS post-order both work
-in `O(V + E)`.
+in $O(V + E)$. The `topo_sort` function below implements the Kahn variant:
+it builds an `in_degree` map, seeds a queue with the zero-in-degree nodes,
+then peels them off one layer at a time.
 
 <CodeBlock
   adapter="python"
@@ -207,9 +227,12 @@ print(topo_sort(graph))  # e.g. ['A', 'B', 'C', 'D']`,
 
 Dijkstra finds the shortest path from a source to all other nodes in a
 graph with **non-negative** edge weights. It uses a min-heap of
-`(distance, node)` pairs. Each node is processed once; each edge relaxation
-costs `O(log V)` for the heap update. Total: `O((V + E) log V)`. It
-fails with negative weights — use Bellman-Ford there.
+`(distance, node)` pairs. Each node is processed once; each edge
+relaxation costs $O(\log V)$ for the heap update. Total:
+$O((V + E)\log V)$. It fails with negative weights — use Bellman-Ford
+there. In the `dijkstra` function below, the `dist` dict holds the best
+known distance and the stale-entry check (`if d > dist.get(u, ...)`) skips
+heap entries that have already been improved.
 
 <CodeBlock
   adapter="python"
@@ -246,11 +269,14 @@ print(dijkstra(graph, "A"))  # {'A': 0, 'B': 1, 'C': 3, 'D': 4}`,
 
 ### What is a BST and what are its operation complexities?
 
-A binary search tree stores keys so that every left subtree node is
+A binary search tree (BST) stores keys so that every left subtree node is
 smaller and every right subtree node is larger. Search, insert, and delete
-are all `O(h)` where h is the tree height. For a balanced tree h = `O(log n)`;
-a degenerate (sorted-input) tree has h = O(n). Balanced BST variants like
-AVL trees and red-black trees guarantee `O(log n)`.
+are all $O(h)$ where h is the tree height. For a balanced tree
+h = $O(\log n)$; a degenerate (sorted-input) tree has h = $O(n)$. Balanced
+BST variants like AVL trees and red-black trees guarantee $O(\log n)$. The
+`bst_insert` function below walks left or right by comparison until it
+finds an empty slot, and `bst_search` follows the same path to locate a
+key.
 
 <CodeBlock
   adapter="python"
@@ -291,7 +317,9 @@ print(bst_search(root, 9))            # None`,
 In-order (left → root → right) visits BST nodes in **sorted** order.
 Pre-order (root → left → right) is useful for serializing a tree.
 Post-order (left → right → root) is useful for deletion or evaluating
-expression trees. All three are `O(n)`.
+expression trees. All three are $O(n)$. The `inorder` function below
+recurses left, prints the current node, then recurses right — yielding the
+keys in ascending order.
 
 <CodeBlock
   adapter="python"
@@ -329,7 +357,7 @@ inorder(root)  # prints 1 3 4 5 7 in sorted order`,
 ### What is a trie, and what problems is it suited for?
 
 A trie (prefix tree) stores strings character by character in a tree.
-Lookup, insert, and prefix search are all `O(L)` where L is the key
+Lookup, insert, and prefix search are all $O(L)$ where L is the key
 length — independent of how many keys are stored. It excels at
 autocomplete, spell-check, and IP routing tables. The trade-off is higher
 memory than a hash map for sparse key sets.
@@ -340,7 +368,9 @@ Binary search requires a **sorted, random-access** collection. The classic
 mistake is the off-by-one error in the loop bounds (`lo < hi` vs `lo <= hi`)
 and the midpoint overflow: use `mid = lo + (hi - lo) // 2` rather than
 `(lo + hi) // 2` (matters in languages with fixed-width integers). Variants
-find the leftmost or rightmost insertion point.
+find the leftmost or rightmost insertion point. The `binary_search`
+function below uses the `lo <= hi` convention and halves the search range
+each iteration, returning the index or `-1`.
 
 <CodeBlock
   adapter="python"
@@ -371,8 +401,10 @@ print(binary_search(arr, 6))   # -1`,
 Two pointers start at opposite ends (or both at the start) and converge
 to avoid a nested loop. For "find pair summing to target in a sorted
 array," one pointer at the left and one at the right narrows the window
-in O(n) instead of `O(n^2)`. The same idea works for removing duplicates,
-palindrome checks, and merging sorted arrays.
+in $O(n)$ instead of $O(n^2)$. The same idea works for removing
+duplicates, palindrome checks, and merging sorted arrays. The
+`two_sum_sorted` function below moves `lo` up when the sum is too small
+and `hi` down when it is too large.
 
 <CodeBlock
   adapter="python"
@@ -401,9 +433,11 @@ print(two_sum_sorted([1, 2, 3, 4, 6], 10))  # None`,
 
 A sliding window maintains a contiguous subarray (or substring) of
 variable or fixed size, expanding and shrinking it rather than recomputing
-from scratch. It reduces many `O(n^2)` substring problems to O(n). For
+from scratch. It reduces many $O(n^2)$ substring problems to $O(n)$. For
 example, "longest substring without repeating characters" expands the
-right pointer and shrinks the left when a duplicate enters the window.
+right pointer and shrinks the left when a duplicate enters the window —
+exactly what `length_of_longest_substring` does below using the `seen`
+map of last-seen indices.
 
 <CodeBlock
   adapter="python"
@@ -430,10 +464,12 @@ print(length_of_longest_substring("pwwkew"))    # 3 ("wke")`,
 ### Explain merge sort and its complexity.
 
 Merge sort divides the array in half, recursively sorts each half, then
-merges the two sorted halves in O(n). The recurrence `T(n) = 2T(n/2) + O(n)`
-solves to `O(n log n)` by the Master Theorem. It is **stable** and
-performs well on linked lists, but requires O(n) extra space for the merge
-step. It is the basis for Python's Timsort.
+merges the two sorted halves in $O(n)$. The recurrence
+$T(n) = 2\,T(n/2) + O(n)$ solves to $O(n \log n)$ by the Master Theorem.
+It is **stable** and performs well on linked lists, but requires $O(n)$
+extra space for the merge step. It is the basis for Python's Timsort. The
+`merge_sort` function below recurses on `arr[:mid]` and `arr[mid:]`, then
+the while-loop interleaves the two sorted halves into `result`.
 
 <CodeBlock
   adapter="python"
@@ -462,11 +498,13 @@ print(merge_sort([38, 27, 43, 3, 9, 82, 10]))  # [3, 9, 10, 27, 38, 43, 82]`,
 ### How does quicksort work, and what is its worst-case?
 
 Quicksort picks a pivot, partitions elements into smaller and larger
-groups, and recurses. Average case is `O(n log n)`, but worst case is
-`O(n^2)` when the pivot is always the smallest or largest element (e.g.,
+groups, and recurses. Average case is $O(n \log n)$, but worst case is
+$O(n^2)$ when the pivot is always the smallest or largest element (e.g.,
 sorted input with a naive "pick last" pivot). Randomized pivot selection
 makes worst case extremely unlikely in practice. Quicksort is in-place
-(O(log n) stack space) unlike merge sort.
+($O(\log n)$ stack space) unlike merge sort. The `quicksort` function
+below chooses a random `pivot` and recurses on the `lo` and `hi`
+partitions around it.
 
 <CodeBlock
   adapter="python"
@@ -492,11 +530,11 @@ print(quicksort([3, 6, 8, 10, 1, 2, 1]))  # [1, 1, 2, 3, 6, 8, 10]`,
 
 ### When is heapsort preferable?
 
-Heapsort is `O(n log n)` worst-case and O(1) extra space — no recursion,
-no merge buffer. It is less cache-friendly than quicksort in practice, so
-real libraries rarely use it alone. Its main advantage is the guaranteed
-`O(n log n)` with constant space, useful for embedded or memory-constrained
-systems.
+Heapsort is $O(n \log n)$ worst-case and $O(1)$ extra space — no
+recursion, no merge buffer. It is less cache-friendly than quicksort in
+practice, so real libraries rarely use it alone. Its main advantage is the
+guaranteed $O(n \log n)$ with constant space, useful for embedded or
+memory-constrained systems.
 
 ### What makes a sort "stable," and why does it matter?
 
@@ -508,12 +546,14 @@ preserves the last-name ordering among ties. Python's built-in sort
 
 ### Explain memoization vs tabulation in dynamic programming.
 
-**Memoization** is top-down DP: recursively solve sub-problems and cache
-results so each is computed once. **Tabulation** is bottom-up: fill a
-table iteratively in dependency order. Memoization is often easier to
-write (matches the recursive definition) but has call-stack overhead.
-Tabulation avoids that and can be optimized to use O(1) space when only
-the last row is needed.
+**Memoization** is top-down dynamic programming (DP): recursively solve
+sub-problems and cache results so each is computed once. **Tabulation** is
+bottom-up: fill a table iteratively in dependency order. Memoization is
+often easier to write (matches the recursive definition) but has
+call-stack overhead. Tabulation avoids that and can be optimized to use
+$O(1)$ space when only the last row is needed. Below, `fib` uses
+`@lru_cache` to memoize, while `fib_tab` rolls two variables `a, b`
+bottom-up with no recursion.
 
 <CodeBlock
   adapter="python"
@@ -564,7 +604,9 @@ Backtracking is systematic trial-and-error: build candidates incrementally
 and abandon ("prune") a branch as soon as it cannot lead to a valid
 solution. It is used for N-Queens, Sudoku solver, permutations,
 combinations, and subset generation. The worst-case time is exponential,
-but pruning makes practical performance far better.
+but pruning makes practical performance far better. The `permutations`
+function below grows `path` one element at a time and calls `path.pop()`
+to undo each choice before trying the next.
 
 <CodeBlock
   adapter="python"
@@ -602,9 +644,11 @@ search are divide and conquer; Fibonacci and Knapsack are DP.
 
 Bit ops (AND, OR, XOR, shifts) are single CPU instructions. Useful tricks:
 `n & (n - 1)` clears the lowest set bit (test if power of two: `n & (n-1) == 0`),
-`x ^ x == 0` cancels pairs (find the single non-duplicate in O(n) time and
-O(1) space), and left-shifting by k multiplies by `2^k`. Bit sets can
-represent subsets in O(1) space per subset.
+`x ^ x == 0` cancels pairs (find the single non-duplicate in $O(n)$ time
+and $O(1)$ space), and left-shifting by k multiplies by $2^k$. Bit sets
+can represent subsets in $O(1)$ space per subset. The `single_number`
+function below XORs every element together so the duplicates cancel and
+the lone value remains.
 
 <CodeBlock
   adapter="python"
@@ -626,15 +670,15 @@ print(single_number([2, 2, 1]))         # 1`,
 
 ### What is the time and space complexity of a hash set?
 
-Average-case: O(1) insert, delete, and lookup; O(n) space. Worst-case
-(all keys collide) degrades to O(n) per operation. Python's `set` uses
+Average-case: $O(1)$ insert, delete, and lookup; $O(n)$ space. Worst-case
+(all keys collide) degrades to $O(n)$ per operation. Python's `set` uses
 open addressing with pseudo-random probing and resizes when the load
-factor exceeds ~2/3, maintaining near-O(1) average performance.
+factor exceeds ~2/3, maintaining near-$O(1)$ average performance.
 
 ### How does a balanced BST differ from a heap?
 
 Both are tree-based, but a balanced BST (AVL, red-black) maintains a
-sorted order across the entire tree, giving O(log n) for predecessor,
+sorted order across the entire tree, giving $O(\log n)$ for predecessor,
 successor, and range queries. A heap only guarantees the parent-child
 relationship (min or max at root), so it cannot answer "all elements
 between a and b" efficiently. Use a heap when you only need the min/max;
@@ -642,34 +686,45 @@ use a balanced BST for ordered iteration or range queries.
 
 ### What is the Master Theorem?
 
-The Master Theorem solves recurrences of the form `T(n) = aT(n/b) + O(n^d)`.
-If `d > log_b(a)`: `O(n^d)`. If `d == log_b(a)`: `O(n^d log n)`.
-If `d < log_b(a)`: `O(n^(log_b a))`. For merge sort `a=2, b=2, d=1`:
-`d == log_2(2) = 1`, so `O(n log n)`.
+The Master Theorem solves recurrences of the form
+
+$$T(n) = a\,T(n/b) + O(n^d)$$
+
+by comparing $d$ against $\log_b a$ across three cases:
+
+- $d > \log_b a \Rightarrow O(n^d)$
+- $d = \log_b a \Rightarrow O(n^d \log n)$
+- $d < \log_b a \Rightarrow O(n^{\log_b a})$
+
+For merge sort $a = 2$, $b = 2$, $d = 1$: since $d = \log_2 2 = 1$, we are
+in the middle case, so $O(n \log n)$.
 
 ### Explain the difference between in-place and out-of-place algorithms.
 
-An in-place algorithm uses only O(1) (or O(log n) for call stack) extra
-memory beyond the input. Out-of-place algorithms allocate auxiliary
+An in-place algorithm uses only $O(1)$ (or $O(\log n)$ for call stack)
+extra memory beyond the input. Out-of-place algorithms allocate auxiliary
 structures proportional to input size. Quicksort is in-place; merge sort
 is out-of-place. The trade-off is memory overhead vs simplicity and
 sometimes performance (cache effects).
 
 ### What graph representation should you use — adjacency list vs matrix?
 
-An adjacency **list** uses `O(V + E)` space and is efficient for sparse
-graphs; iterating over neighbors is O(degree). An adjacency **matrix**
-uses `O(V²)` space but gives O(1) edge-existence checks. For most
-interview problems (sparse graphs), an adjacency list (dict of lists) is
-preferred.
+An adjacency **list** uses $O(V + E)$ space and is efficient for sparse
+graphs; iterating over neighbors is $O(\text{degree})$. An adjacency
+**matrix** uses $O(V^2)$ space but gives $O(1)$ edge-existence checks. For
+most interview problems (sparse graphs), an adjacency list (dict of lists)
+is preferred.
 
 ### What is Kahn's algorithm and what does it detect?
 
 Kahn's algorithm iteratively removes nodes with in-degree 0 from a DAG,
-appending them to the topological order. It runs in `O(V + E)`. If the
+appending them to the topological order. It runs in $O(V + E)$. If the
 final order contains fewer than V nodes, at least one cycle exists and a
 full topological sort is impossible. It is an alternative to DFS-based
-topological sort and naturally detects cycles.
+topological sort and naturally detects cycles. The `kahns` function below
+takes an edge list, computes each node's `in_deg`, and drains the
+zero-in-degree queue — comparing `len(order)` against `num_nodes` to
+report a cycle.
 
 <CodeBlock
   adapter="python"

--- a/content/interview/backend-engineer/python.mdx
+++ b/content/interview/backend-engineer/python.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python Fundamentals
-description: Backend interview questions on Python's mutability, identity vs equality, generators, *args/**kwargs, and the GIL.
+description: Backend interview questions on Python's mutability, identity vs equality, generators, *args/**kwargs, and the Global Interpreter Lock (GIL).
 ---
 
 Language-fundamentals questions check that you know Python's sharp edges,
@@ -67,7 +67,9 @@ print(add(2))   # [2]  <- fresh list each call`,
 A list builds and holds **all** items in memory; a generator (`yield`, or
 a generator expression) produces items **lazily**, one at a time. Use a
 generator for large or streaming sequences to keep memory flat — `sum(x*x
-for x in range(10_000_000))` never materializes the squares.
+for x in range(10_000_000))` never materializes the squares. The
+`fibonacci` generator below uses `yield` in an infinite loop, which is
+safe precisely because `next` pulls only as many values as you ask for.
 
 <CodeBlock
   adapter="python"
@@ -91,7 +93,9 @@ print([next(gen) for _ in range(8)])  # [0, 1, 1, 2, 3, 5, 8, 13]`,
 `*args` captures extra **positional** arguments as a tuple; `**kwargs`
 captures extra **keyword** arguments as a dict. They let a function
 accept a variable number of arguments and forward them:
-`wrapper(*args, **kwargs) → fn(*args, **kwargs)`.
+`wrapper(*args, **kwargs) → fn(*args, **kwargs)`. Below, `log` collects
+its message parts in `args` and reads options from `kwargs`, while
+`passthrough` forwards both straight through to `fn`.
 
 <CodeBlock
   adapter="python"
@@ -114,8 +118,9 @@ print(passthrough(sorted, [3, 1, 2], reverse=True))   # [3, 2, 1]`,
 
 ### What is the GIL, and when does it bite?
 
-CPython's **Global Interpreter Lock** lets only one thread execute Python
-bytecode at a time. So threads don't speed up **CPU-bound** work — use
+CPython's **Global Interpreter Lock (GIL)** lets only one thread execute
+Python bytecode at a time. So threads don't speed up **CPU-bound** work —
+use
 `multiprocessing` (separate processes) for that. Threads still help
 **I/O-bound** work (network, disk), where they wait, not compute; `async`
 is another I/O-bound option.
@@ -127,7 +132,9 @@ Python calls implicitly. `__init__` constructs an object, `__repr__`
 provides a developer-readable string, `__str__` the user-facing string,
 `__len__` makes `len(obj)` work, `__eq__` powers `==`, and `__lt__` /
 `__le__` enable sorting. Implementing `__enter__` and `__exit__` makes a
-class a context manager.
+class a context manager. The `Vector` class below defines `__add__` so the
+`+` operator returns a new `Vector`, and `__repr__` so printing shows
+readable coordinates.
 
 <CodeBlock
   adapter="python"
@@ -163,7 +170,9 @@ Python syntax and built-ins, without inheritance from a special base class.
 A decorator is a callable that wraps another function, adding behavior
 before and/or after the call. It is syntactic sugar for
 `fn = decorator(fn)`. A correct decorator preserves the wrapped
-function's metadata using `functools.wraps`.
+function's metadata using `functools.wraps`. The `timer` decorator below
+wraps `fn`, records the elapsed time around the call, and returns the
+original result unchanged.
 
 <CodeBlock
   adapter="python"
@@ -197,7 +206,9 @@ Python resolves names in four scopes in order: **L**ocal (inside the
 current function), **E**nclosing (outer function for nested functions),
 **G**lobal (module level), **B**uilt-in. A closure is a nested function
 that captures variables from its enclosing scope — those variables survive
-even after the outer function returns.
+even after the outer function returns. Below, `increment` closes over
+`count` from `make_counter` and uses `nonlocal` to keep updating that same
+captured variable across calls.
 
 <CodeBlock
   adapter="python"
@@ -242,6 +253,8 @@ option: single-threaded cooperative concurrency for I/O-bound async code.
 an I/O operation, the event loop runs another coroutine instead of
 blocking. Use it for high-concurrency network servers (web APIs, websockets)
 where most time is spent waiting on I/O. Avoid it for CPU-bound code.
+Below, `asyncio.gather` runs both `fetch` coroutines concurrently and
+`asyncio.run` drives the `main` coroutine on the event loop.
 
 <CodeBlock
   adapter="python"
@@ -269,7 +282,9 @@ asyncio.run(main())`,
 A context manager implements `__enter__` (run on entry) and `__exit__`
 (run on exit, even if an exception occurs). The `with` statement calls
 these automatically, ensuring cleanup. The `contextlib.contextmanager`
-decorator lets you write one as a generator with a single `yield`.
+decorator lets you write one as a generator with a single `yield`. In
+`managed_resource` below, code before the `yield` is the setup and the
+`finally` block is the guaranteed teardown.
 
 <CodeBlock
   adapter="python"
@@ -355,7 +370,9 @@ By default, Python stores instance attributes in a per-instance `__dict__`,
 which is flexible but memory-heavy. Declaring `__slots__` replaces that
 dict with a fixed-size array, reducing memory per instance by 30–50% and
 slightly speeding up attribute access. Use slots for classes that create
-millions of instances.
+millions of instances. The `Point` class below declares
+`__slots__ = ("x", "y")`, so each instance stores only those two
+attributes and has no `__dict__`.
 
 <CodeBlock
   adapter="python"
@@ -418,7 +435,9 @@ The `finally` block of a `try`/`except`/`finally` statement runs
 **always** — whether an exception is raised, caught, or not raised at all,
 and even if there is a `return` statement in `try` or `except`. It is
 used for cleanup (closing files, releasing locks) that must happen
-regardless of outcome. It does not suppress exceptions.
+regardless of outcome. It does not suppress exceptions. In `read_file`
+below, the `return f.read()` still hands back the contents, yet `f.close()`
+in the `finally` block runs first on the way out.
 
 ```python
 def read_file(path):
@@ -455,7 +474,9 @@ An **iterable** implements `__iter__()`, which returns an **iterator**.
 An iterator implements both `__iter__()` (returns itself) and `__next__()`,
 which returns the next value or raises `StopIteration`. The `for` loop
 calls `iter(obj)` once, then repeatedly calls `next()` until
-`StopIteration`. Generators implement this protocol automatically.
+`StopIteration`. Generators implement this protocol automatically. The
+`Range3` class below implements both methods directly, counting up in
+`__next__` and raising `StopIteration` once it reaches 3.
 
 <CodeBlock
   adapter="python"
@@ -492,7 +513,10 @@ Python.
 A `@staticmethod` receives no implicit first argument; it is essentially
 a regular function namespaced inside the class. A `@classmethod` receives
 the class itself as `cls` as its first argument, enabling factory methods
-and subclass-aware behavior. Neither receives the instance.
+and subclass-aware behavior. Neither receives the instance. Below,
+`Date.from_string` is a `@classmethod` factory that parses a string and
+calls `cls(...)`, while `Date.is_leap` is a `@staticmethod` helper that
+needs neither the class nor an instance.
 
 <CodeBlock
   adapter="python"
@@ -534,7 +558,9 @@ All exceptions inherit from `BaseException`. User-defined exceptions
 should inherit from `Exception`. `KeyboardInterrupt` and `SystemExit`
 inherit from `BaseException` directly so a bare `except Exception` doesn't
 catch them. The `raise` statement re-raises the current exception; `raise
-ExceptionType from original` chains exceptions, preserving context.
+ExceptionType from original` chains exceptions, preserving context. The
+example below defines a custom `AppError`, catches `ZeroDivisionError`, and
+re-raises it as `AppError` with `from e` so the original cause is kept.
 
 ```python
 class AppError(Exception):
@@ -559,7 +585,8 @@ finally:
 add validation or computed behavior without changing the public API.
 A matching `@name.setter` handles assignment. This follows the principle
 that you can start with a plain attribute and upgrade to a property later
-without breaking callers.
+without breaking callers. The `Circle` class below exposes `radius` as a
+property, and its setter rejects negative values with a `ValueError`.
 
 <CodeBlock
   adapter="python"

--- a/content/interview/data-analyst/pandas.mdx
+++ b/content/interview/data-analyst/pandas.mdx
@@ -3,8 +3,8 @@ title: Pandas
 description: Data Analyst pandas interview questions — selection, groupby, merging, and missing data — with answers, a concept check, and a runnable challenge.
 ---
 
-When the analyst screen isn't SQL, it's usually **pandas**. Review the
-Q&A, then run the challenge in your browser.
+When the Data Analyst screen isn't SQL, it's usually **pandas**. Review
+the Q&A, then run the challenge in your browser.
 
 ## Q&A
 
@@ -323,6 +323,10 @@ print(result)`,
     },
   ]}
 />
+
+Here the chain filters with `query`, adds a `tax` column via `assign`,
+aggregates it per `region` with `groupby(...).sum()`, then flattens and
+renames the result with `reset_index` and `rename`.
 
 ### What is the difference between a view and a copy in pandas?
 

--- a/content/interview/data-analyst/sql.mdx
+++ b/content/interview/data-analyst/sql.mdx
@@ -51,8 +51,8 @@ ordered*" is the classic tell for a `LEFT JOIN`.
 
 Joining to a table with **multiple matching rows** duplicates the left
 row once per match — so summing a left-side column double-counts it. Fix
-it by aggregating the one-to-many side **first** (in a subquery/CTE) to
-the right grain, then joining:
+it by aggregating the one-to-many side **first** (in a subquery or Common
+Table Expression, CTE) to the right grain, then joining:
 
 ```sql
 WITH order_totals AS (
@@ -92,6 +92,9 @@ SELECT e.name AS employee, m.name AS manager
 FROM employees e
 LEFT JOIN employees m ON e.manager_id = m.id;
 ```
+
+Aliasing `employees` as both `e` and `m` lets one row reference another;
+the `LEFT JOIN` keeps top-level employees whose `manager_id` is `NULL`.
 
 ### How do you find rows in one table that have no match in another (anti-join)?
 
@@ -362,8 +365,8 @@ A **clustered index** determines the physical order of rows on disk; a
 table can have only one. A **non-clustered index** is a separate structure
 pointing back to the data rows; a table can have many. Clustered indexes
 speed up range scans on the key column; non-clustered indexes accelerate
-lookups and joins on non-key columns. As an analyst you mainly need to
-know: filtering or joining on un-indexed columns causes full table scans,
+lookups and joins on non-key columns. As a Data Analyst you mainly need
+to know: filtering or joining on un-indexed columns causes full table scans,
 which are slow on large tables.
 
 ### When does adding an index slow things down?

--- a/content/interview/data-analyst/statistics-and-communication.mdx
+++ b/content/interview/data-analyst/statistics-and-communication.mdx
@@ -50,12 +50,17 @@ recommended action. Save methodology for an appendix or backup slide.
 
 ### What are variance and standard deviation, and what do they measure?
 
-**Variance** is the average squared deviation from the mean. **Standard
-deviation** is its square root, returned to the original units. Both
-measure the **spread** of a distribution: a higher value means data
-points are more dispersed around the mean. Standard deviation is easier
-to interpret because it shares units with the data (e.g., dollars, not
-dollars-squared).
+**Variance** is the average squared deviation from the mean,
+$\sigma^2 = \frac{1}{n}\sum_{i=1}^{n}(x_i - \bar{x})^2$. **Standard
+deviation** is its square root, $\sigma = \sqrt{\sigma^2}$, returned to
+the original units. Both measure the **spread** of a distribution: a
+higher value means data points are more dispersed around the mean.
+Standard deviation is easier to interpret because it shares units with
+the data (e.g., dollars, not dollars-squared).
+
+The snippet below builds a `pd.Series` and calls `.var()` and `.std()`,
+which return the **sample** variance and standard deviation (`ddof=1`)
+that divide by $n - 1$ rather than $n$.
 
 <CodeBlock
   adapter="python"
@@ -98,9 +103,13 @@ population parameters, subject to sampling error.
 
 A **percentile** is the value below which a given percentage of
 observations fall: the 90th percentile means 90% of values are below
-that point. **Quartiles** divide data into four equal parts: Q1 (25th),
-Q2 (50th = median), Q3 (75th). The interquartile range (IQR = Q3 - Q1)
-is a robust measure of spread.
+that point. **Quartiles** divide data into four equal parts: $Q_1$
+(25th), $Q_2$ (50th = median), $Q_3$ (75th). The interquartile range
+($\text{IQR} = Q_3 - Q_1$) is a robust measure of spread.
+
+The snippet below uses `Series.quantile` to pull $Q_1$ and $Q_3$,
+derives the IQR as their difference, and also reads off the 90th
+percentile.
 
 <CodeBlock
   adapter="python"
@@ -121,12 +130,16 @@ print(f"Q1={q1}, Q3={q3}, IQR={iqr}, 90th pct={p90}")`,
 ### How do you identify outliers?
 
 Common methods:
-- **IQR rule**: values below `Q1 - 1.5 * IQR` or above `Q3 + 1.5 * IQR` are flagged as outliers.
-- **Z-score**: values more than 2-3 standard deviations from the mean.
+- **IQR rule**: values below $Q_1 - 1.5\times\text{IQR}$ or above $Q_3 + 1.5\times\text{IQR}$ are flagged as outliers.
+- **Z-score**: values whose $z = \frac{x - \bar{x}}{s}$ exceeds 2-3 in absolute value, i.e. more than 2-3 standard deviations from the mean.
 - **Visual**: box plots or scatter plots reveal extreme points quickly.
 
 Always investigate outliers before removing them — they may be data
 errors or genuinely important observations.
+
+The snippet below applies both rules to the `amount` column: it builds
+the IQR fences to flag `outliers_iqr`, then computes a z-score per row
+and flags `outliers_z` where the absolute z-score exceeds 2.
 
 <CodeBlock
   adapter="python"
@@ -184,20 +197,32 @@ effect size alongside p-values.
   is actually false — missing a real effect. Controlled by statistical
   power (typically 80%).
 
+|                          | $H_0$ is true                                | $H_0$ is false                              |
+| ------------------------ | -------------------------------------------- | ------------------------------------------- |
+| **Reject $H_0$**         | Type I error (false positive) — rate $\alpha$ | Correct decision — power $= 1 - \beta$       |
+| **Fail to reject $H_0$** | Correct decision — rate $1 - \alpha$          | Type II error (false negative) — rate $\beta$ |
+
 ### What is statistical power?
 
 Power is the probability of correctly detecting a real effect (rejecting
-the null when it is false). Power increases with larger sample sizes,
-larger effect sizes, and higher significance levels. A common target is
-80% power. Low-powered tests risk missing real improvements.
+the null when it is false), defined as $1 - \beta$ where $\beta$ is the
+Type II error rate. Power increases with larger sample sizes, larger
+effect sizes, and higher significance levels. A common target is 80%
+power. Low-powered tests risk missing real improvements.
 
 ### How do you choose the right sample size for an A/B test?
 
 Use a power calculation based on: the minimum detectable effect (the
 smallest change worth caring about), the baseline metric value, the
 desired power (commonly 80%), and the significance level (commonly 5%).
-Online calculators and Python's `statsmodels` can compute this before
-running the test.
+Larger samples shrink the standard error of the estimate,
+$SE = \frac{\sigma}{\sqrt{n}}$, which is what makes a given effect easier
+to detect. Online calculators and Python's `statsmodels` can compute the
+required size before running the test.
+
+The snippet below uses `statsmodels`' `NormalIndPower` and its
+`solve_power` method to back out the required sample size per group for a
+0.1 effect size at 80% power and a 5% significance level.
 
 <CodeBlock
   adapter="python"
@@ -216,10 +241,15 @@ print(f"Required n per group: {n:.0f}")`,
 ### What is the difference between correlation and the correlation coefficient?
 
 **Correlation** is a general term for the linear association between two
-variables. The **Pearson correlation coefficient** (r) quantifies it from
--1 (perfect negative) to +1 (perfect positive), with 0 meaning no linear
-relationship. Spearman rank correlation is used when the relationship is
-monotonic but not linear, or when data is ordinal.
+variables. The **Pearson correlation coefficient** ($r$) quantifies it on
+the range $-1 \le r \le 1$ — from $-1$ (perfect negative) to $+1$
+(perfect positive), with 0 meaning no linear relationship. Spearman rank
+correlation is used when the relationship is monotonic but not linear, or
+when data is ordinal.
+
+The snippet below calls `Series.corr` to get the Pearson $r$ between
+`price` and `sales`, builds a full `corr()` matrix over three columns,
+and then switches to `method="spearman"` for the rank-based coefficient.
 
 <CodeBlock
   adapter="python"
@@ -277,7 +307,8 @@ and stakeholder communication.
 
 ### What makes a dashboard effective?
 
-Keep it to the key metrics decision-makers act on. Group related KPIs.
+Keep it to the key metrics decision-makers act on. Group related key
+performance indicators (KPIs).
 Use consistent scales and color conventions. Add clear titles and data
 freshness labels. Avoid clutter: every element should earn its place.
 Design for the audience — an executive view differs from an ops team view.

--- a/content/interview/data-engineer/data-modeling.mdx
+++ b/content/interview/data-engineer/data-modeling.mdx
@@ -16,6 +16,10 @@ tables (each fact stored once) — great for OLTP write integrity.
 where reads dominate. The trade-off: denormalizing buys read speed at the
 cost of storage and the risk of copies disagreeing (update anomalies).
 
+The block below contrasts a normalized `customers`/`orders` design with a
+denormalized `orders_wide`, then shows the `JOIN` the normalized layout
+requires to recover the customer `name` and `city`.
+
 ```sql
 -- Normalized (3NF): customer stored once, referenced by foreign key
 -- customers(customer_id, name, city)
@@ -38,7 +42,18 @@ A **star** schema has a central fact table joined directly to
 **denormalized** dimension tables — simple, fast, fewer joins. A
 **snowflake** further **normalizes** dimensions into sub-tables (e.g.
 product → category → department) — less redundancy but more joins. Stars
-are the default for BI; snowflake when dimensions are large or shared.
+are the default for **Business Intelligence (BI)**; snowflake when
+dimensions are large or shared.
+
+A star keeps each dimension in one table (the solid edge); a snowflake
+splits that dimension further into a normalized chain (the dotted edges):
+
+```mermaid
+flowchart LR
+  f["fact"] --> p["dim_product"]
+  p -. normalize .-> c["dim_category"]
+  c -. normalize .-> d["dim_department"]
+```
 
 ### What are fact and dimension tables?
 
@@ -56,13 +71,18 @@ grain.
 
 ### How do you preserve history when a dimension attribute changes (SCD)?
 
-Use a **slowly-changing dimension**:
+Use a **Slowly Changing Dimension (SCD)**:
 
 - **Type 1** — overwrite (no history).
 - **Type 2** — add a new row with effective-date ranges + a "current" flag (full history; facts join to the version that was current at the time).
 - **Type 3** — keep a "previous value" column (limited history).
 
 Type 2 is the standard when point-in-time accuracy matters.
+
+The example below builds a Type 2 `dim_customer` (with `valid_from`,
+`valid_to`, and `is_current`) and joins `fact_orders` to it on the date
+range, so each order resolves to the `city` that was current when it was
+placed.
 
 <SqlCodeBlock
   dialect="duckdb"
@@ -112,6 +132,10 @@ ORDER BY f.order_id;`}
 
 A **surrogate key** is a system-generated identifier (auto-increment integer or UUID) with no business meaning. It is preferred because natural keys (customer email, product code) can change, be reused, or be long strings that make joins expensive. Surrogate keys are stable, compact, and immune to upstream business logic changes, which is especially important for SCD Type 2 where multiple rows represent the same entity.
 
+The query below joins `fact_orders` to `dim_product` on the surrogate
+`product_key` rather than the natural `product_code`, illustrating why the
+integer key keeps the join stable even when the business code changes.
+
 ```sql
 -- Surrogate key join: fact holds a compact integer key pointing to the
 -- exact dimension version that was current at the time of the event.
@@ -144,6 +168,10 @@ A dimension shared — with identical structure and values — across multiple f
 
 When an attribute changes, you close the existing row by setting its `valid_to` date (or `is_current = false`) and insert a new row with the updated value and a new `valid_from` date. Facts that occurred before the change still join to the old dimension row via the surrogate key, preserving point-in-time accuracy. Queries for the current state filter `WHERE is_current = true`.
 
+The two statements below implement that change for `customer_id = 42`: an
+`UPDATE` closes the current row by setting `valid_to` and `is_current =
+false`, then an `INSERT` adds the new `Austin` version as the current row.
+
 ```sql
 -- Step 1: close the existing row
 UPDATE dim_customer
@@ -174,6 +202,10 @@ A single physical dimension table used multiple times in the same schema under d
 
 A **bridge table** (also called an association table) resolves **many-to-many** relationships between a fact table and a dimension — for example, an order that belongs to multiple promotions simultaneously. The bridge table has a surrogate key, the fact foreign key, and the dimension foreign key. Without it you would either fan out fact rows (inflating counts) or store comma-separated lists (violating 1NF).
 
+The query below joins `fact_orders` through `order_promotion_bridge` to
+`dim_promotion`, showing how an order tied to multiple promotions fans out
+into one row per promotion.
+
 ```sql
 -- Bridge table: one row per (order, promotion) pair
 -- order_promotion_bridge(order_key, promo_key)
@@ -197,6 +229,11 @@ A **data vault** separates hubs (business keys), links (relationships), and sate
 ### What does "grain mismatch" mean, and how do you fix it?
 
 A grain mismatch occurs when you join two fact tables at different grains — for example, a daily budget table joined to a transaction-level sales table — causing double-counting or incorrect aggregations. Fix it by aggregating the finer-grain table to match the coarser grain before joining, or by storing both at a common grain in a separate bridging step.
+
+The example below has transaction-grain `fact_sales` and daily-grain
+`fact_budget`; the query rolls `fact_sales` up to one row per
+`sale_date`/`region` in a Common Table Expression first, so the join to
+`fact_budget` compares like grains instead of double-counting budget rows.
 
 <SqlCodeBlock
   dialect="duckdb"
@@ -263,6 +300,10 @@ A **bus matrix** (or enterprise bus matrix) is a planning artifact that maps bus
 
 A `dim_date` table pre-computes every calendar attribute — fiscal week, quarter, holiday flag, day-of-week name — so analysts can filter and group by any combination without writing date-arithmetic functions inline. It also lets the business encode custom fiscal calendars, retail weeks, or regional holidays once and share them universally, rather than scattering business-specific date logic across every query.
 
+The query below joins `fact_orders` to `dim_date` and groups by the
+pre-computed `fiscal_quarter` while filtering out holidays with
+`is_holiday = false` — no inline date arithmetic required.
+
 <SqlCodeBlock
   dialect="duckdb"
   initSql={`CREATE TABLE dim_date (
@@ -309,6 +350,10 @@ An **auto-increment integer** surrogate key is compact, fast to join, and natura
 ### How do you model a many-to-many relationship between facts and dimensions?
 
 Use a **bridge table**: a separate table with one row per (fact, dimension) combination. For example, if an order can be associated with multiple promotions, the bridge table `order_promotion_bridge` holds `(order_key, promo_key)` pairs. The fact table joins to the bridge, which joins to the promotion dimension. A **weighting factor** column on the bridge can distribute additive measures proportionally across the associated dimension members.
+
+The query below multiplies `f.amount` by the bridge's `weight` before
+summing, so each promotion in `dim_promotion` receives only its
+proportional share of revenue rather than the full order amount.
 
 ```sql
 -- Bridge table with optional weighting factor (sums to 1.0 per order)

--- a/content/interview/data-engineer/data-modeling.mdx
+++ b/content/interview/data-engineer/data-modeling.mdx
@@ -49,7 +49,7 @@ A star keeps each dimension in one table (the solid edge); a snowflake
 splits that dimension further into a normalized chain (the dotted edges):
 
 ```mermaid
-flowchart LR
+flowchart TD
   f["fact"] --> p["dim_product"]
   p -. normalize .-> c["dim_category"]
   c -. normalize .-> d["dim_department"]

--- a/content/interview/data-engineer/pipelines.mdx
+++ b/content/interview/data-engineer/pipelines.mdx
@@ -3,8 +3,9 @@ title: Pipelines & Systems
 description: Data Engineer interview questions on batch vs streaming, idempotency, partitioning, orchestration, and file formats.
 ---
 
-The systems half of a DE interview: moving data reliably and cheaply at
-scale. These are the recurring "how would you build it?" themes.
+The systems half of a Data Engineer interview: moving data reliably and
+cheaply at scale. These are the recurring "how would you build it?"
+themes.
 
 ## Q&A
 
@@ -24,6 +25,10 @@ This makes retries and backfills safe after partial failures. Achieve it
 by **overwriting** a target partition or **upserting** by key
 (`MERGE`/delete-then-insert) instead of blind `INSERT` (which would
 duplicate rows on a re-run).
+
+The block below shows both patterns: an `ON CONFLICT (order_id)` upsert
+into `orders`, and a delete-then-insert that replaces a single
+`event_date` partition of `events` from `events_stage`.
 
 ```sql
 -- Idempotent upsert: re-running with the same source data is safe.
@@ -47,6 +52,10 @@ match a query — cutting scan cost dramatically. A good key is one queries
 **filter on** (usually a date like `event_date`) with even, not-too-small
 partitions. Too-granular partitioning creates many tiny files (the
 "small files problem") and hurts performance.
+
+The query below filters `events` on `event_date = '2024-06-01'` so only
+that day's rows are scanned, and the trailing comment shows how wrapping
+`event_date` in `YEAR(...)` would defeat pruning.
 
 <SqlCodeBlock
   dialect="duckdb"
@@ -75,10 +84,14 @@ ORDER BY user_id, event_type;
 
 ### What does an orchestrator (Airflow/Dagster) give you over cron?
 
-A **DAG** of tasks with explicit dependencies, so steps run in the right
-order and only after upstreams succeed; plus retries, backfills,
-scheduling, monitoring, and lineage. Cron just fires a command at a time
-with no dependency awareness or recovery.
+A **Directed Acyclic Graph (DAG)** of tasks with explicit dependencies,
+so steps run in the right order and only after upstreams succeed; plus
+retries, backfills, scheduling, monitoring, and lineage. Cron just fires
+a command at a time with no dependency awareness or recovery.
+
+The Airflow example below declares `extract`, `transform`, and `load`
+tasks and wires them with `load(transform(extract()))`, so the scheduler
+derives the dependency order from that call rather than from cron timing.
 
 ```python
 from airflow.decorators import dag, task
@@ -119,6 +132,10 @@ Writing many tiny files (e.g., one Parquet file per minute instead of one per da
 
 CDC tracks row-level changes (inserts, updates, deletes) in a source database — typically by reading the database's write-ahead log (WAL) — and propagates them downstream in near real time. Use it when you need low-latency replication of transactional data to a warehouse or lake without polling the source table, and when you must capture deletes (which a simple `WHERE updated_at > last_run` query misses).
 
+The config below sets up a Debezium Postgres connector that reads the WAL
+(`plugin.name: pgoutput`) for the `public.orders` table and publishes
+change events to Kafka topics under the `cdc` prefix.
+
 ```yaml
 # Debezium connector config (Kafka Connect) — streams Postgres WAL events
 # to a Kafka topic as JSON change events with op: "c" / "u" / "d"
@@ -144,6 +161,10 @@ Common strategies: (1) set a generous **allowed lateness window** so the engine 
 
 A **backfill** reprocesses historical data through a pipeline, usually to populate a new table, fix a bug, or apply a schema change. Design for it by making pipelines **parameterized by date range** and **idempotent** (safe to run multiple times). In Airflow, set `catchup=True` and choose a sensible `start_date`; in Dagster, use partitioned assets. Backfills of years of data may require throttling to avoid overwhelming source systems.
 
+The `process_partition` task below takes the run's logical date `ds` and
+deletes-then-reinserts only that `event_date` slice of `events_clean`, so
+re-running any single day is safe (idempotent).
+
 ```python
 # Parameterize the pipeline by logical date so each run is independent
 # and the same date can be re-run safely (idempotent).
@@ -162,7 +183,7 @@ def process_partition(ds: str):  # ds = "2024-06-01" injected by Airflow
 
 ### What is a lakehouse and how does it differ from a data warehouse?
 
-A **data warehouse** stores structured, processed data in a proprietary format optimized for SQL queries (e.g., Snowflake, BigQuery, Redshift). A **data lake** stores raw data in open formats (Parquet, ORC, Avro) on cheap object storage. A **lakehouse** adds a transactional metadata layer (Delta Lake, Apache Iceberg, Apache Hudi) on top of lake storage, giving you ACID transactions, schema enforcement, time travel, and efficient updates — warehouse-like reliability on lake-like open storage at lower cost.
+A **data warehouse** stores structured, processed data in a proprietary format optimized for SQL queries (e.g., Snowflake, BigQuery, Redshift). A **data lake** stores raw data in open formats (Parquet, Optimized Row Columnar (ORC), Avro) on cheap object storage. A **lakehouse** adds a transactional metadata layer (Delta Lake, Apache Iceberg, Apache Hudi) on top of lake storage, giving you ACID transactions, schema enforcement, time travel, and efficient updates — warehouse-like reliability on lake-like open storage at lower cost.
 
 ### What is Apache Avro and when is it preferred over Parquet?
 
@@ -170,7 +191,7 @@ Avro is a **row-based**, schema-embedded binary format. It excels at **streaming
 
 ### What is ORC and how does it compare to Parquet?
 
-ORC (Optimized Row Columnar) is another columnar format — like Parquet it supports compression and predicate pushdown, and it originated in the Hive/Hadoop ecosystem. ORC has historically had slightly better compression for string-heavy data and stronger native support in Hive/Presto; Parquet has broader ecosystem support (Spark, Pandas, BigQuery, Snowflake). In practice, Parquet is the more portable choice for modern stacks.
+ORC is another columnar format — like Parquet it supports compression and predicate pushdown, and it originated in the Hive/Hadoop ecosystem. ORC has historically had slightly better compression for string-heavy data and stronger native support in Hive/Presto; Parquet has broader ecosystem support (Spark, Pandas, BigQuery, Snowflake). In practice, Parquet is the more portable choice for modern stacks.
 
 ### What is schema evolution, and how do Parquet and Avro handle it?
 
@@ -178,7 +199,11 @@ Schema evolution is the ability to change a schema (add, rename, remove, or chan
 
 ### What is a DAG in Airflow, and what are common anti-patterns?
 
-A **DAG (Directed Acyclic Graph)** defines the set of tasks and their dependencies for a workflow. Common anti-patterns: (1) **dynamic DAGs generated at parse time** with expensive API calls — they slow the scheduler; (2) **tasks that do too much** — large monolithic tasks make retries expensive; (3) **no idempotency** — tasks that fail partway through corrupt state; (4) **passing large data through XComs** — XComs are for small metadata, not DataFrames; use external storage.
+A **DAG** defines the set of tasks and their dependencies for a workflow. Common anti-patterns: (1) **dynamic DAGs generated at parse time** with expensive API calls — they slow the scheduler; (2) **tasks that do too much** — large monolithic tasks make retries expensive; (3) **no idempotency** — tasks that fail partway through corrupt state; (4) **passing large data through XComs** — XComs are for small metadata, not DataFrames; use external storage.
+
+The two `extract` versions below contrast returning a million rows
+directly into the XCom database against writing them to S3 and returning
+only the `path` string — keeping the XCom payload tiny.
 
 ```python
 # Anti-pattern: XCom used to pass a large result set
@@ -197,6 +222,10 @@ def extract():
 ### What is a task vs a sensor in Airflow?
 
 A **task** performs an action (run SQL, call an API, submit a Spark job). A **sensor** is a special task that polls a condition (does this S3 file exist? has the upstream DAG succeeded?) and blocks until it is true or times out. Sensors hold a worker slot while polling; for long-waiting sensors, use `mode='reschedule'` so the slot is freed between polls.
+
+The `S3KeySensor` below blocks until the daily `orders.parquet` export
+lands in the `data-lake` bucket, polling every 5 minutes in
+`reschedule` mode and failing after a 2-hour `timeout`.
 
 ```python
 from airflow.sensors.s3_key_sensor import S3KeySensor
@@ -223,6 +252,10 @@ Data quality tests validate that data meets expectations before it flows downstr
 
 **dbt (data build tool)** is a transformation framework that runs SQL `SELECT` statements against a warehouse and materializes the results as tables or views. It handles dependency ordering (via `ref()` calls), incremental models, testing, documentation, and lineage. It occupies the "T" in ELT — after raw data is loaded into the warehouse, dbt transforms it into clean, modeled tables for analytics.
 
+The model below builds `fct_orders` by joining `stg_orders` to the
+`dim_customer` and `dim_date` models through `ref()` calls, which is how
+dbt infers the build order across these models.
+
 ```sql
 -- models/marts/fct_orders.sql
 -- dbt materializes this SELECT as a table; ref() wires the dependency graph.
@@ -244,7 +277,14 @@ A layered data lake or lakehouse design:
 - **Silver** — cleaned, deduplicated, conformed data; joins applied; a reliable "single source of truth."
 - **Gold** — business-level aggregates and denormalized tables optimized for specific BI or ML use cases.
 
-Each layer is idempotent — gold can always be rebuilt from silver, silver from bronze.
+Each layer is idempotent — gold can always be rebuilt from silver, silver from bronze:
+
+```mermaid
+flowchart LR
+  src["source systems"] --> bronze["Bronze: raw, as-is"]
+  bronze --> silver["Silver: cleaned, conformed"]
+  silver --> gold["Gold: business aggregates"]
+```
 
 ### What is a Lambda vs Kappa architecture?
 

--- a/content/interview/data-engineer/pipelines.mdx
+++ b/content/interview/data-engineer/pipelines.mdx
@@ -280,7 +280,7 @@ A layered data lake or lakehouse design:
 Each layer is idempotent — gold can always be rebuilt from silver, silver from bronze:
 
 ```mermaid
-flowchart LR
+flowchart TD
   src["source systems"] --> bronze["Bronze: raw, as-is"]
   bronze --> silver["Silver: cleaned, conformed"]
   silver --> gold["Gold: business aggregates"]

--- a/content/interview/data-engineer/sql.mdx
+++ b/content/interview/data-engineer/sql.mdx
@@ -19,6 +19,10 @@ All number rows within a partition; they differ on **ties**:
 - **`RANK`** — ties share a rank, then it **skips** (1, 2, 2, 4).
 - **`DENSE_RANK`** — ties share a rank, **no skip** (1, 2, 2, 3).
 
+The query below runs all three over the same `players` table ordered by
+`score` so you can compare `rn`, `rnk`, and `dr` side by side on the
+tied 80-point scores.
+
 <SqlCodeBlock
   dialect="duckdb"
   initSql={`CREATE TABLE players (name VARCHAR, score INTEGER);
@@ -61,11 +65,15 @@ filter `WHERE rn = 1`.
 
 ### What's the difference between a CTE and a subquery? When is a CTE worth it?
 
-Both produce an intermediate result. A **CTE** (`WITH … AS`) is named and
-can be referenced multiple times and read top-to-bottom, which makes
-multi-step transformations far more readable. A correlated **subquery**
+Both produce an intermediate result. A **Common Table Expression (CTE)**
+(`WITH … AS`) is named and can be referenced multiple times and read
+top-to-bottom, which makes multi-step transformations far more readable. A correlated **subquery**
 runs per outer row and can be a performance trap. CTEs shine for staging
 steps and recursive queries.
+
+The block below computes the same per-`user_id` `SUM(amount)` two ways —
+once as a nested subquery and once as a named `user_totals` CTE — to
+contrast readability for the same `total > 1000` filter.
 
 ```sql
 -- Subquery: nested and harder to read; calculated inline each time
@@ -95,6 +103,10 @@ expensive sort/hash); `UNION ALL` keeps everything, including duplicates.
 Prefer `UNION ALL` unless you specifically need dedup — it skips the
 distinct step.
 
+The block below combines `user_id` from `app_users` and `legacy_users`
+both ways, showing where `UNION ALL` keeps duplicate ids and `UNION`
+collapses them.
+
 ```sql
 -- UNION ALL: fast, keeps every row including duplicates
 SELECT user_id FROM app_users
@@ -110,6 +122,9 @@ SELECT user_id FROM legacy_users;
 ### How do LAG and LEAD work?
 
 `LAG(col, n)` returns the value of `col` from `n` rows **before** the current row within the partition; `LEAD(col, n)` looks `n` rows **ahead**. Both accept an optional default for when the offset falls outside the partition. They are commonly used to compute period-over-period differences without a self-join.
+
+The query below pulls the prior day's `revenue` from `daily_revenue` with
+`LAG(revenue, 1, 0)` and subtracts it to produce a `delta` column.
 
 ```sql
 SELECT
@@ -169,6 +184,10 @@ FROM daily_metrics;
 
 `QUALIFY` is a clause that filters on **window function results** after they are computed, similar to how `HAVING` filters aggregate results. It avoids the need for a wrapping subquery. It is natively supported in BigQuery, Snowflake, DuckDB, and Databricks SQL; Postgres and MySQL require a subquery workaround.
 
+The query below uses `QUALIFY` to keep only the top two `products` per
+`category` by `revenue`, filtering on the `RANK()` result without a
+wrapping subquery.
+
 ```sql
 -- Keep top-2 products per category
 SELECT product_id, category, revenue
@@ -179,6 +198,10 @@ QUALIFY RANK() OVER (PARTITION BY category ORDER BY revenue DESC) <= 2;
 ### How do you write a recursive CTE?
 
 A recursive CTE has an **anchor** member (the base case) and a **recursive** member that references the CTE itself, joined with `UNION ALL`. The engine iterates until the recursive member returns no rows.
+
+The `org_tree` example below walks an `employees` self-reference: the
+anchor selects top-level managers, and the recursive member joins each
+employee to rows already in `org_tree` to compute a `depth` level.
 
 ```sql
 WITH RECURSIVE org_tree AS (
@@ -287,6 +310,10 @@ This is why you cannot reference a `SELECT` alias in `WHERE` (alias does not exi
 
 `WHERE` filters **individual rows before** grouping; `HAVING` filters **groups after** aggregation. Use `WHERE` to reduce the row count early (more efficient); use `HAVING` only when the filter condition references an aggregate.
 
+The query below filters individual rows with `WHERE status = 'active'`
+before grouping by `department`, then drops whole groups with `HAVING
+AVG(salary) > 80000`.
+
 ```sql
 SELECT department, AVG(salary) AS avg_sal
 FROM employees
@@ -310,7 +337,7 @@ To retrieve the full duplicate rows, join back to the original table or use `ROW
 
 ### What is an index, and when does it help (or hurt)?
 
-An index is a data structure (B-tree by default in most RDBMS) that lets the engine find rows matching a predicate without scanning the full table. Indexes help when queries are **selective** (returning a small fraction of rows) on the indexed columns. They hurt for bulk writes (each insert/update must also update the index) and for low-cardinality columns where a full scan beats index + random I/O.
+An index is a data structure (B-tree by default in most relational database management systems (RDBMS)) that lets the engine find rows matching a predicate without scanning the full table. Indexes help when queries are **selective** (returning a small fraction of rows) on the indexed columns. They hurt for bulk writes (each insert/update must also update the index) and for low-cardinality columns where a full scan beats index + random I/O.
 
 ### What is a covering index?
 
@@ -362,6 +389,10 @@ Look at (1) **node types** — sequential scan vs index scan vs hash join vs sor
 
 A **correlated subquery** references a column from the outer query. The engine re-executes the subquery for each outer row, making it O(N * M). Rewrite as a `JOIN` or a window function when performance matters.
 
+The block below computes each employee's `dept_avg` salary first as a
+correlated subquery (re-run per row) and then as a `dept_avgs` CTE joined
+once — the same result with far less repeated work.
+
 ```sql
 -- Slow correlated subquery
 SELECT e.name,
@@ -409,7 +440,7 @@ FROM user_revenue;
 
 ### What is the difference between PERCENT_RANK and CUME_DIST?
 
-Both express a row's relative position in a window as a value between 0 and 1. `PERCENT_RANK` = (rank - 1) / (total rows - 1) — the fraction of rows **ranked below** the current row. `CUME_DIST` = rank / total rows — the fraction of rows with a value **less than or equal to** the current row. `CUME_DIST` is always >= `PERCENT_RANK` and the last row always has `CUME_DIST = 1`.
+Both express a row's relative position in a window as a value between 0 and 1. `PERCENT_RANK` is $\text{PERCENT\_RANK} = \dfrac{\text{rank} - 1}{N - 1}$ — the fraction of rows **ranked below** the current row. `CUME_DIST` is $\text{CUME\_DIST} = \dfrac{\text{rank}}{N}$ — the fraction of rows with a value **less than or equal to** the current row, where $N$ is the total number of rows. `CUME_DIST` is always $\geq$ `PERCENT_RANK` and the last row always has $\text{CUME\_DIST} = 1$.
 
 ### What is a materialized view, and when would you use one?
 

--- a/content/interview/data-scientist/experimentation.mdx
+++ b/content/interview/data-scientist/experimentation.mdx
@@ -3,8 +3,8 @@ title: Experimentation
 description: Data Scientist interview questions on A/B test design, statistical power, sample size, and common experimentation pitfalls.
 ---
 
-"Design an experiment to test X" is a staple DS round. These cover the
-design choices and traps interviewers look for.
+"Design an experiment to test X" is a staple Data Scientist round. These
+cover the design choices and traps interviewers look for.
 
 ## Q&A
 
@@ -19,11 +19,15 @@ cycles, then test for a significant difference and check guardrails.
 
 ### What is statistical power, and what drives it?
 
-Power = probability of detecting a real effect (1 − β). It rises with
-**larger sample size**, **larger true effect**, **lower variance**, and a
-**higher α**. Underpowered tests waste traffic and miss real effects, so
-you size the experiment to hit a target power for the smallest effect
-worth detecting.
+Power = probability of detecting a real effect ($1 - \beta$). It rises
+with **larger sample size**, **larger true effect**, **lower variance**,
+and a **higher α**. Underpowered tests waste traffic and miss real
+effects, so you size the experiment to hit a target power for the smallest
+effect worth detecting.
+
+The code uses `NormalIndPower.solve_power` to back out the per-variant
+sample size needed for a given `effect_size`, `alpha`, and `power`,
+demonstrating how the three inputs determine n.
 
 <CodeBlock
   adapter="python"
@@ -47,6 +51,13 @@ Repeatedly checking and stopping as soon as p < 0.05 (**peeking**)
 massively inflates the false-positive rate — you'll eventually cross the
 threshold by chance. Either fix n up front, or use methods designed for
 continuous monitoring (sequential testing / always-valid p-values).
+
+<Callout type="warning" title="Peeking inflates false positives">
+Every extra look at a running test is another chance to cross
+$p < 0.05$ by luck. At a fixed $\alpha = 0.05$, continuously peeking and
+stopping on the first significant result can push the real false-positive
+rate well above 30%. Commit to the sample size before you start.
+</Callout>
 
 ### What are common A/B testing pitfalls?
 
@@ -73,7 +84,11 @@ The analysis unit must match or be nested within the randomization unit to keep 
 
 You need four inputs: baseline conversion rate, minimum detectable effect (MDE), `alpha` (commonly 0.05), and desired power (commonly 0.8).
 The formula for a two-proportion z-test is derived from the pooled standard error; most practitioners use a sample size calculator.
-Sample size scales inversely with the square of the MDE: halving the MDE you want to detect quadruples the required sample.
+Sample size scales inversely with the square of the MDE, $n \propto \dfrac{1}{\text{MDE}^2}$: halving the MDE you want to detect quadruples the required sample.
+
+The code implements that formula in `sample_size_per_variant`, combining
+`z_alpha`, `z_beta`, and the pooled variance to return the rounded-up n for
+a 10% baseline and a 2-point MDE.
 
 <CodeBlock
   adapter="python"
@@ -104,6 +119,10 @@ print(f"Sample size per variant: {n}")
 A **sample ratio mismatch (SRM)** occurs when the observed split between control and treatment differs significantly from the intended ratio (e.g., you expected 50/50 but got 48/52).
 Causes: bot traffic filtering differently across variants, logging bugs, caching that prevents re-assignment, and redirect latency biasing which users complete page load.
 An SRM invalidates the experiment; the data cannot be trusted until the root cause is found and fixed.
+
+The code runs a `chisquare` goodness-of-fit test of the observed
+per-variant counts against the intended 50/50 split, where a small p-value
+flags an SRM.
 
 <CodeBlock
   adapter="python"
@@ -143,8 +162,12 @@ Best practice: define one primary metric before the test and treat secondary met
 ### What is CUPED and how does it reduce variance?
 
 **CUPED** (Controlled-experiment Using Pre-Experiment Data) reduces variance in the outcome metric by regressing out a pre-experiment covariate that is correlated with the outcome (e.g., the user's metric value in the week before the experiment).
-The adjusted metric `Y_adj = Y - theta * (X - E[X])` has lower variance, giving the same statistical power with fewer users or detecting smaller effects.
+The adjusted metric $Y_{\text{adj}} = Y - \theta\,(X - \mathbb{E}[X])$ has lower variance, giving the same statistical power with fewer users or detecting smaller effects.
 It does not change the expectation of the estimator, only its variance.
+
+The code estimates `theta` from the covariance of `Y` and `X`, forms
+`Y_adj`, and prints the original versus CUPED variance to show the
+reduction firsthand.
 
 <CodeBlock
   adapter="python"
@@ -214,6 +237,10 @@ An **A/A test** assigns users to two groups that receive identical experiences.
 Because there is no real effect, significant results indicate a problem with the testing infrastructure (randomization bugs, logging errors, pre-existing imbalance).
 A/A tests should produce about `alpha` false-positive rate across many runs; running them regularly validates your experimentation platform.
 
+The code simulates 1,000 A/A tests with `ttest_ind` on two samples drawn
+from the same distribution and reports the share with p < 0.05, which
+should land near 0.05 on a healthy platform.
+
 <CodeBlock
   adapter="python"
   files={[
@@ -259,6 +286,10 @@ Instead of a p-value, you report the **probability that treatment is better than
 It allows intuitive probability statements and can incorporate prior knowledge, but conclusions depend on the prior choice.
 Frequentist tests offer guaranteed error-rate control; Bayesian tests are more flexible but require careful prior specification.
 
+The code draws posterior samples from `Beta(1,1)` priors updated with each
+variant's conversions, then estimates `P(treatment > control)` as the
+fraction of draws where treatment's rate exceeds control's.
+
 <CodeBlock
   adapter="python"
   files={[
@@ -283,7 +314,7 @@ print(f"P(treatment > control) = {p_treatment_wins:.3f}")
 ### What is the difference between a Type I and Type II error in experiment design?
 
 A **Type I error** (false positive) declares a winner when the treatment has no real effect; controlled by `alpha`.
-A **Type II error** (false negative) fails to detect a real effect; its rate is `beta` and power is `1 - beta`.
+A **Type II error** (false negative) fails to detect a real effect; its rate is $\beta$ and power is $1 - \beta$.
 In product experimentation, false positives ship ineffective features; false negatives cause you to abandon good ones.
 Size experiments to control both: typical targets are `alpha = 0.05` and power of 0.8.
 

--- a/content/interview/data-scientist/machine-learning.mdx
+++ b/content/interview/data-scientist/machine-learning.mdx
@@ -1,6 +1,6 @@
 ---
 title: Machine Learning
-description: Data Scientist ML interview questions — bias–variance, regularization, cross-validation, metrics — with answers, concept checks, and a runnable metrics challenge.
+description: Data Scientist Machine Learning interview questions — bias–variance, regularization, cross-validation, metrics — with answers, concept checks, and a runnable metrics challenge.
 ---
 
 Modeling questions probe whether you understand generalization, not just
@@ -31,6 +31,10 @@ drive coefficients to **exactly zero**, performing feature selection
 (sparse models). **L2 (ridge)** shrinks them toward zero but rarely to
 zero. Elastic net combines both.
 
+The code fits both penalties on the same data and prints `ridge.coef_`
+versus `lasso.coef_`, so you can see lasso zero out a coefficient while
+ridge only shrinks it.
+
 <CodeBlock
   adapter="python"
   files={[
@@ -58,6 +62,10 @@ estimate of generalization that also uses all data for both training and
 validation across folds. For time series, use a **forward-chaining**
 split (never validate on the past).
 
+Here `cross_val_score` runs a `LogisticRegression` across 5 folds on the
+iris data and reports the mean accuracy with its standard deviation, so
+the spread tells you how stable the estimate is.
+
 <CodeBlock
   adapter="python"
   files={[
@@ -83,6 +91,19 @@ are costly (disease screening, fraud); favor **precision** when false
 alarms are costly (spam filters flagging real mail). **F1** balances the
 two.
 
+| | Predicted positive | Predicted negative |
+| --- | --- | --- |
+| **Actually positive** | True Positive (TP) | False Negative (FN) |
+| **Actually negative** | False Positive (FP) | True Negative (TN) |
+
+$$\text{Precision} = \frac{TP}{TP + FP} \qquad \text{Recall} = \frac{TP}{TP + FN}$$
+
+$$F_1 = 2 \cdot \frac{\text{Precision} \times \text{Recall}}{\text{Precision} + \text{Recall}}$$
+
+The code computes `precision_score`, `recall_score`, and `f1_score` on the
+same `y_true`/`y_pred` pair so you can map each number back to the table
+above.
+
 <CodeBlock
   adapter="python"
   files={[
@@ -102,10 +123,14 @@ print(f"F1:        {f1_score(y_true, y_pred):.2f}")
 
 ### What is ROC-AUC and when is PR-AUC preferred?
 
-**ROC-AUC** is the area under the Receiver Operating Characteristic curve (TPR vs FPR across thresholds).
-An AUC of 0.5 is random; 1.0 is perfect.
+**ROC-AUC** is the area under the Receiver Operating Characteristic curve (true positive rate, TPR, vs false positive rate, FPR, across thresholds).
+An AUC of $0.5$ is random; $1.0$ is perfect.
 On highly imbalanced datasets, ROC-AUC can be optimistic because it includes many true negatives in the FPR denominator.
 **PR-AUC** (precision-recall AUC) focuses only on the positive class and better reflects performance when positives are rare.
+
+The code scores the same predictions with `roc_auc_score` and
+`average_precision_score`, letting you compare ROC-AUC against PR-AUC on
+one set of probabilities.
 
 <CodeBlock
   adapter="python"
@@ -127,7 +152,7 @@ print(f"PR-AUC:  {average_precision_score(y_true, y_score):.3f}")
 
 **Gradient descent** minimizes a loss function by iteratively stepping in the direction of the negative gradient.
 **Learning rate** controls step size: too large and it overshoots or diverges; too small and training is slow.
-**SGD** uses one example per step (noisy but fast per iteration); **mini-batch SGD** uses small batches; **Adam** adapts the learning rate per parameter using momentum and RMS scaling.
+**Stochastic gradient descent (SGD)** uses one example per step (noisy but fast per iteration); **mini-batch SGD** uses small batches; **Adam** adapts the learning rate per parameter using momentum and root-mean-square scaling.
 
 ### What is the difference between bagging and boosting?
 
@@ -138,9 +163,13 @@ Bagging is more robust to noise; boosting often achieves higher accuracy but is 
 ### How does a Random Forest work?
 
 Random Forest builds many decision trees on bootstrap samples of the training data.
-At each split it considers only a random subset of features (`sqrt(p)` for classification, `p/3` for regression by default), which decorrelates the trees.
+At each split it considers only a random subset of features ($\sqrt{p}$ for classification, $p/3$ for regression by default), which decorrelates the trees.
 Final predictions are made by majority vote (classification) or averaging (regression).
 The combination of row sampling and feature sampling reduces variance without greatly increasing bias.
+
+The code trains a `RandomForestClassifier` on a synthetic dataset and
+reports test `roc_auc_score` from `predict_proba`, showing the ensemble in
+end-to-end use.
 
 <CodeBlock
   adapter="python"
@@ -165,7 +194,13 @@ print(f"ROC-AUC: {roc_auc_score(y_test, rf.predict_proba(X_test)[:, 1]):.3f}")
 
 **RMSE** (Root Mean Squared Error) penalizes large errors quadratically; sensitive to outliers. Use when large errors are especially costly.
 **MAE** (Mean Absolute Error) is more robust to outliers and interpretable in the same units as the target.
-**R-squared** measures the fraction of variance in the target explained by the model (1 is perfect; 0 means no better than the mean). It is scale-free, making it useful for comparing across datasets.
+**R-squared** ($R^2$) measures the fraction of variance in the target explained by the model (1 is perfect; 0 means no better than the mean). It is scale-free, making it useful for comparing across datasets.
+
+The root mean squared error is $\text{RMSE} = \sqrt{\frac{1}{n}\sum (y_i - \hat{y}_i)^2}$.
+
+The code evaluates the same `y_true`/`y_pred` arrays with
+`mean_squared_error` (wrapped in `np.sqrt` for RMSE), `mean_absolute_error`,
+and `r2_score` so you can contrast all three on identical predictions.
 
 <CodeBlock
   adapter="python"
@@ -188,8 +223,12 @@ print(f"R²:   {r2_score(y_true, y_pred):.3f}")
 ### What is feature scaling and when is it necessary?
 
 Feature scaling (standardization or min-max normalization) puts features on a comparable scale.
-It is **necessary** for distance-based models (kNN, SVM, k-means) and gradient descent-based models (logistic/linear regression, neural nets) because unscaled features bias distances and gradient steps.
+It is **necessary** for distance-based models — k-Nearest Neighbors (kNN), support vector machines (SVM), k-means — and gradient descent-based models (logistic/linear regression, neural nets) because unscaled features bias distances and gradient steps.
 Tree-based models (decision trees, random forests, GBMs) are **invariant** to monotonic feature transforms and do not require scaling.
+
+The code applies `StandardScaler` to a matrix whose two columns live on
+very different scales, and prints the result with mean near 0 and standard
+deviation near 1.
 
 <CodeBlock
   adapter="python"
@@ -224,6 +263,10 @@ Common strategies:
 **Target encoding** replaces a category with the mean target value within that category; powerful but risks leakage without careful cross-validation.
 High-cardinality categoricals can also be handled with embeddings in neural nets or frequency encoding.
 
+The code runs `OneHotEncoder` on a single `color` column and prints
+`get_feature_names_out()` alongside the encoded matrix, one binary column
+per category.
+
 <CodeBlock
   adapter="python"
   files={[
@@ -248,6 +291,10 @@ print(encoded)
 It reduces dimensionality while preserving as much variance as possible, useful for visualization, noise reduction, and removing multicollinearity.
 PCA requires centered (and usually scaled) data and assumes linear structure.
 
+The code scales the iris features, fits `PCA(n_components=2)`, and prints
+`explained_variance_ratio_` so you can see how much variance the first two
+components retain.
+
 <CodeBlock
   adapter="python"
   files={[
@@ -270,14 +317,18 @@ print("Explained variance ratio:", pca.explained_variance_ratio_.round(3))
 ### What is the curse of dimensionality?
 
 As dimensionality grows, data becomes increasingly sparse: the volume of the space grows exponentially and the nearest neighbor becomes almost as far as the farthest neighbor.
-This hurts distance-based methods (kNN, SVM with RBF kernel, k-means) and increases the sample size needed to learn accurate models.
+This hurts distance-based methods — kNN, SVM with a radial basis function (RBF) kernel, k-means — and increases the sample size needed to learn accurate models.
 Remedies include dimensionality reduction (PCA, autoencoders), feature selection, and regularization.
 
 ### What is logistic regression and how does it output probabilities?
 
-Logistic regression models the log-odds of the positive class as a linear combination of features, then passes it through the **sigmoid** function `sigma(z) = 1 / (1 + exp(-z))` to produce a probability between 0 and 1.
+Logistic regression models the log-odds of the positive class as a linear combination of features, then passes it through the **sigmoid** function $\sigma(z) = \frac{1}{1 + e^{-z}}$ to produce a probability between 0 and 1.
 It is trained by maximizing log-likelihood (equivalent to minimizing binary cross-entropy).
 Despite its name it is a classification model; it is interpretable, fast, and often a strong baseline.
+
+The code fits `LogisticRegression` and calls `predict_proba` on the first
+three test rows, printing per-class probabilities to show the sigmoid
+output in action.
 
 <CodeBlock
   adapter="python"
@@ -303,7 +354,7 @@ print(f"Test accuracy: {accuracy_score(y_test, model.predict(X_test)):.3f}")
 ### What is the difference between a generative and a discriminative model?
 
 A **discriminative model** learns `P(y|x)` directly — the conditional probability of the label given input (logistic regression, SVM, neural nets).
-A **generative model** learns the joint `P(x, y)` or the data distribution per class (Naive Bayes, GMM), then applies Bayes' theorem to classify.
+A **generative model** learns the joint `P(x, y)` or the data distribution per class — Naive Bayes, Gaussian mixture model (GMM) — then applies Bayes' theorem to classify.
 Generative models can generate new data and work better with limited labeled data; discriminative models typically achieve higher classification accuracy with enough labeled data.
 
 ### How does a decision tree split?
@@ -326,6 +377,10 @@ It minimizes within-cluster sum of squared distances.
 Limitations: requires specifying k, sensitive to initialization (use k-means++ to mitigate), assumes spherical clusters, and is sensitive to outliers.
 Use the elbow method or silhouette score to choose k.
 
+The code fits `KMeans` on three blobs and prints both `inertia_`
+(within-cluster sum of squares) and `silhouette_score`, the two numbers you
+would compare across candidate values of k.
+
 <CodeBlock
   adapter="python"
   files={[
@@ -346,7 +401,7 @@ print("Silhouette:", round(silhouette_score(X, km.labels_), 3))
 
 ### What is elastic net regularization?
 
-**Elastic net** combines L1 (lasso) and L2 (ridge) penalties: `alpha * L1 + (1 - alpha) * L2`.
+**Elastic net** combines L1 (lasso) and L2 (ridge) penalties: $\alpha \cdot \text{L1} + (1-\alpha)\cdot \text{L2}$.
 It inherits lasso's sparsity (feature selection) and ridge's stability when features are highly correlated.
 It is useful when you have many correlated features and want a sparse but stable solution.
 
@@ -356,6 +411,10 @@ Feature selection reduces the number of input features to decrease overfitting, 
 **Filter methods** score features independently of the model (correlation, mutual information, chi-square).
 **Wrapper methods** train a model on feature subsets (recursive feature elimination, RFE).
 **Embedded methods** perform selection during training (L1 regularization, tree feature importances).
+
+The code wraps `LogisticRegression` in `RFE` to keep the five strongest
+features of the breast-cancer dataset and prints their indices via
+`get_support`.
 
 <CodeBlock
   adapter="python"
@@ -377,7 +436,7 @@ print("Selected feature indices:", selector.get_support(indices=True))
 
 ### How does cross-entropy loss differ from MSE for classification?
 
-For binary classification, **cross-entropy** loss is `-(y * log(p) + (1-y) * log(1-p))`.
+For binary classification, **cross-entropy** loss is $-\bigl(y\log p + (1-y)\log(1-p)\bigr)$.
 It penalizes confident wrong predictions very heavily (log goes to infinity near 0), which drives the model to produce well-calibrated probabilities.
 MSE on probabilities has a flatter gradient near saturation, causing slow learning; cross-entropy is the correct choice for classification with sigmoid/softmax outputs.
 
@@ -397,7 +456,7 @@ Simpler models that perform comparably should be preferred.
 
 ### What is the difference between linear and logistic regression for a binary target?
 
-**Linear regression** predicts a continuous output and is unbounded; it can produce predictions outside `[0, 1]` and its residuals are heteroscedastic for binary targets, violating OLS assumptions.
+**Linear regression** predicts a continuous output and is unbounded; it can produce predictions outside `[0, 1]` and its residuals are heteroscedastic for binary targets, violating ordinary least squares (OLS) assumptions.
 **Logistic regression** maps a linear combination of features through the sigmoid to a probability in `[0, 1]` and is trained with maximum likelihood / cross-entropy, which is appropriate for binary outcomes.
 
 ### What is gradient boosting and how does it differ from AdaBoost?

--- a/content/interview/data-scientist/statistics.mdx
+++ b/content/interview/data-scientist/statistics.mdx
@@ -256,7 +256,7 @@ sufficient evidence against a null hypothesis. The four steps are:
 4. Reject $H_0$ if $p < \alpha$ and interpret the result in context.
 
 ```mermaid
-flowchart LR
+flowchart TD
   a["State H0 and H1"] --> b["Choose alpha and size the sample"]
   b --> c["Collect data; compute test statistic and p-value"]
   c --> d["Reject H0 when p is below alpha"]

--- a/content/interview/data-scientist/statistics.mdx
+++ b/content/interview/data-scientist/statistics.mdx
@@ -3,51 +3,228 @@ title: Statistics
 description: Data Scientist interview questions on p-values, hypothesis testing, Type I/II errors, confidence intervals, and the Central Limit Theorem.
 ---
 
-Statistics is the part of a DS interview most candidates are rustiest on.
-Review the Q&A, then the concept checks.
+Statistics is the part of a Data Scientist interview most candidates are
+rustiest on. The questions below build up in a deliberate order — sampling
+and distributions first, then estimation, then the hypothesis-testing
+machinery (which is where the p-value finally appears). Review the Q&A,
+then the concept checks.
 
 ## Q&A
 
-### What exactly is a p-value?
+### What's the difference between a parameter and a statistic?
 
-The probability of observing data **at least as extreme** as yours
-**assuming the null hypothesis is true**. It is *not* the probability the
-null is true, nor the probability your result is a fluke. Small p → the
-data would be surprising under the null, so you reject it at your chosen
-α.
+A **parameter** describes the population (the true mean $\mu$) and is
+usually unknown; a **statistic** is computed from a sample (the sample
+mean $\bar{x}$) and estimates the parameter. Inference is the bridge from
+statistic to parameter, with quantified uncertainty — everything below is
+about crossing that bridge responsibly.
+
+### What is the standard error, and how does it differ from standard deviation?
+
+**Standard deviation** measures the variability of individual
+observations around the mean. **Standard error** measures the variability
+of a *sample statistic* (such as the mean) around the true parameter:
+
+$$SE = \frac{\sigma}{\sqrt{n}}$$
+
+The standard error shrinks as the sample size $n$ grows (you can estimate
+the mean more precisely with more data); the standard deviation does not,
+because it estimates a fixed population property that does not depend on
+$n$.
+
+### What is a sampling distribution?
+
+A **sampling distribution** is the probability distribution of a statistic
+(like the sample mean) over all possible samples of the same size from a
+population. Its standard deviation is the standard error,
+$SE = \sigma / \sqrt{n}$, and the Central Limit Theorem says its shape
+approaches a normal curve as $n$ grows.
+
+The code below makes this concrete: it draws 2,000 samples of size 50 from
+a deliberately skewed (exponential) population and compares the spread of
+those sample means against the formula. The two numbers come out nearly
+equal, demonstrating that $SE = \sigma/\sqrt{n}$ holds even when the raw
+data is not normal.
 
 <CodeBlock
   adapter="python"
   files={[
     {
       filename: "main.py",
-      starterCode: `from scipy import stats
+      starterCode: `import numpy as np
 
-# Two-sample t-test: compute t-statistic and p-value
-group_a = [12, 15, 14, 10, 13]
-group_b = [18, 20, 17, 22, 19]
-t_stat, p_value = stats.ttest_ind(group_a, group_b)
-print(f"t={t_stat:.3f}, p={p_value:.4f}")
-# p < 0.05 → reject the null that the means are equal
+rng = np.random.default_rng(42)
+population = rng.exponential(scale=5, size=100_000)  # skewed population
+sample_means = [rng.choice(population, 50).mean() for _ in range(2000)]
+print(f"SE (formula): {population.std() / 50**0.5:.3f}")
+print(f"SE (simulated): {np.std(sample_means):.3f}")
+# Both should be close — CLT at work
 `,
     },
   ]}
 />
 
-### Type I vs Type II error?
+### Why does the Central Limit Theorem matter?
 
-- **Type I (false positive)** — rejecting a true null (claiming an effect that isn't real); its rate is **α**.
-- **Type II (false negative)** — failing to detect a real effect; its rate is **β**, and **power = 1 − β**.
+For a large enough sample, the distribution of the **sample mean** is
+approximately normal **regardless of the population's shape**. That's
+what justifies normal-based confidence intervals and z/t-tests for means
+even when the underlying data is skewed. A common rule of thumb is that
+$n \geq 30$ is "large enough" for moderately skewed data; heavier skew
+needs more.
 
-Lowering α (stricter) reduces false positives but raises false negatives,
-all else equal.
+### What is the Law of Large Numbers?
+
+The Law of Large Numbers states that as the sample size grows, the sample
+mean converges in probability to the population mean. This is what
+justifies using large samples to estimate population parameters and why
+more data improves estimates. The **weak** law gives convergence in
+probability; the **strong** law gives almost-sure convergence.
+
+Note the distinction from the Central Limit Theorem: the Law of Large
+Numbers says *where* the sample mean ends up (at $\mu$); the Central Limit
+Theorem says *what shape* its uncertainty takes (normal) along the way.
+
+### What is conditional probability?
+
+$P(A \mid B)$ is the probability of event $A$ given that $B$ has already
+occurred:
+
+$$P(A \mid B) = \frac{P(A \cap B)}{P(B)}$$
+
+Events $A$ and $B$ are independent if $P(A \mid B) = P(A)$ — knowing $B$
+tells you nothing about $A$.
+
+### What does it mean for two events to be mutually exclusive vs. independent?
+
+**Mutually exclusive** events cannot both occur, so $P(A \cap B) = 0$.
+**Independent** events have no influence on each other, so
+$P(A \cap B) = P(A)\,P(B)$. The two ideas are often confused but are
+nearly opposites: mutually exclusive events with non-zero probability are
+*never* independent, because knowing one occurred rules the other out.
+
+### What is Bayes' theorem?
+
+Bayes' theorem updates a prior belief given new evidence:
+
+$$P(A \mid B) = \frac{P(B \mid A)\,P(A)}{P(B)}$$
+
+In data science it powers spam filters, medical diagnosis, and Bayesian
+inference, where you update a prior distribution over parameters into a
+posterior after observing data.
+
+The code below works the classic medical-test example: even with a 99%
+accurate test, a rare disease (1% prevalence) means a positive result
+still implies a fairly low probability of actually being sick — because
+the many false positives from the healthy majority swamp the few true
+positives. It is the canonical demonstration of why base rates matter.
+
+<CodeBlock
+  adapter="python"
+  files={[
+    {
+      filename: "main.py",
+      starterCode: `# Medical test example: P(disease | positive test)
+p_disease = 0.01          # prior prevalence
+p_pos_given_disease = 0.99  # sensitivity
+p_pos_given_no_disease = 0.05  # 1 - specificity
+
+p_pos = p_pos_given_disease * p_disease + p_pos_given_no_disease * (1 - p_disease)
+p_disease_given_pos = p_pos_given_disease * p_disease / p_pos
+print(f"P(disease | positive) = {p_disease_given_pos:.3f}")
+`,
+    },
+  ]}
+/>
+
+### Describe the normal distribution and its key properties.
+
+The normal (Gaussian) distribution is symmetric and bell-shaped,
+parameterized by mean $\mu$ and variance $\sigma^2$. By the **empirical
+rule**, about 68%, 95%, and 99.7% of the data fall within 1, 2, and 3
+standard deviations of the mean:
+
+$$P(\mu - k\sigma \leq X \leq \mu + k\sigma) \approx 68\%,\ 95\%,\ 99.7\% \quad \text{for } k = 1, 2, 3$$
+
+It arises naturally via the Central Limit Theorem and is the foundation
+for many statistical tests.
+
+### What is a Poisson distribution?
+
+The Poisson distribution models the number of events in a fixed interval
+when events occur independently at a constant average rate $\lambda$:
+
+$$P(X = k) = \frac{\lambda^k e^{-\lambda}}{k!}$$
+
+Its mean and variance are **both** $\lambda$. Common uses: customer
+arrivals per hour, defects per unit, or server requests per second.
+
+### What is a binomial distribution?
+
+The binomial distribution counts the number of successes in $n$
+independent Bernoulli trials, each with success probability $p$:
+
+$$P(X = k) = \binom{n}{k} p^k (1 - p)^{n-k}$$
+
+Its mean is $np$ and its variance is $np(1 - p)$. It is used for click
+rates, conversion rates, and quality control.
+
+### What is Maximum Likelihood Estimation?
+
+Maximum Likelihood Estimation finds the parameter values that maximize the
+probability (the *likelihood*) of observing the data under a given model.
+For a normal distribution the maximum-likelihood estimate of the mean is
+just the sample mean; for logistic regression it maximizes the
+log-likelihood of the observed labels. The method is consistent and
+asymptotically efficient but can overfit small samples.
+
+### What are the properties of an unbiased estimator?
+
+An estimator is **unbiased** if its expected value equals the true
+parameter. The sample mean is an unbiased estimator of the population
+mean. The sample variance with denominator $n - 1$ (Bessel's correction)
+is unbiased; dividing by $n$ gives a biased (but lower-variance)
+estimator. Bias and variance combine into mean squared error:
+
+$$\text{MSE} = \text{Bias}^2 + \text{Variance}$$
+
+The code below computes both variance estimators on the same data so you
+can see the gap: `ddof=1` applies Bessel's correction (unbiased), while
+`ddof=0` is the biased maximum-likelihood version that divides by $n$.
+
+<CodeBlock
+  adapter="python"
+  files={[
+    {
+      filename: "main.py",
+      starterCode: `import numpy as np
+
+data = np.array([4.0, 7.0, 13.0, 2.0, 1.0])
+# ddof=1 → Bessel's correction (unbiased); ddof=0 → biased MLE
+unbiased_var = np.var(data, ddof=1)
+biased_var   = np.var(data, ddof=0)
+print(f"Unbiased variance (n-1): {unbiased_var:.2f}")
+print(f"Biased variance (n):     {biased_var:.2f}")
+`,
+    },
+  ]}
+/>
 
 ### What does a 95% confidence interval actually mean?
 
 It's a procedure: if you repeated the experiment many times and built an
-interval each time, ~95% of those intervals would contain the true
-parameter. It is **not** "95% probability the parameter is in *this*
-interval" (the parameter is fixed; the interval is random).
+interval each time, about 95% of those intervals would contain the true
+parameter. It is **not** "a 95% probability the parameter is in *this*
+interval" — the parameter is fixed; the interval is what's random. For a
+mean, the interval is
+
+$$\bar{x} \pm t^{*}_{n-1} \cdot \frac{s}{\sqrt{n}}$$
+
+where $t^{*}_{n-1}$ is the critical value from the t-distribution.
+
+The code below builds exactly that interval: `stats.sem` computes the
+standard error $s/\sqrt{n}$, and `stats.t.interval` multiplies it by the
+critical value and centers it on the sample mean.
 
 <CodeBlock
   adapter="python"
@@ -68,54 +245,48 @@ print(f"95% CI: ({ci_low:.2f}, {ci_high:.2f})")
   ]}
 />
 
-### Why does the Central Limit Theorem matter?
+### What is hypothesis testing, and what are its four key steps?
 
-For a large enough sample, the distribution of the **sample mean** is
-approximately normal **regardless of the population's shape**. That's
-what justifies normal-based confidence intervals and z/t-tests for means
-even when the underlying data is skewed.
+Hypothesis testing is a formal procedure for deciding whether data provide
+sufficient evidence against a null hypothesis. The four steps are:
 
-### What's the difference between a parameter and a statistic?
+1. State the null hypothesis $H_0$ and the alternative hypothesis $H_1$.
+2. Choose the significance level $\alpha$ and compute the required sample size.
+3. Collect data and compute the test statistic and its p-value.
+4. Reject $H_0$ if $p < \alpha$ and interpret the result in context.
 
-A **parameter** describes the population (true mean μ) and is usually
-unknown; a **statistic** is computed from a sample (sample mean x̄) and
-estimates the parameter. Inference is the bridge from statistic to
-parameter, with quantified uncertainty.
+```mermaid
+flowchart LR
+  a["State H0 and H1"] --> b["Choose alpha and size the sample"]
+  b --> c["Collect data; compute test statistic and p-value"]
+  c --> d["Reject H0 when p is below alpha"]
+```
+
+Always state the hypotheses and fix $\alpha$ **before** collecting data,
+to avoid bias. The remaining questions in this section unpack each piece
+of this procedure.
 
 ### State the null and alternative hypotheses for an A/B test on click-through rate.
 
-The **null hypothesis** `H0` is that the two CTRs are equal (no effect).
-The **alternative hypothesis** `H1` is that the treatment CTR differs from control (two-sided) or is greater/less (one-sided).
-You choose the alternative before seeing data. A two-sided test is safer because it catches effects in either direction without inflating one-sided power.
-
-### What is statistical power?
-
-Power is `1 - beta`, where `beta` is the probability of a Type II error (false negative).
-It is the probability of correctly rejecting the null when the alternative is true.
-A power of 0.8 means you have an 80% chance of detecting the true effect if one exists.
-Power rises with larger sample size, larger effect size, lower variance, and a higher `alpha`.
-
-<CodeBlock
-  adapter="python"
-  files={[
-    {
-      filename: "main.py",
-      starterCode: `from statsmodels.stats.power import TTestIndPower
-
-analysis = TTestIndPower()
-# Compute power given effect size (Cohen's d), sample size, and alpha
-power = analysis.solve_power(effect_size=0.5, nobs1=50, alpha=0.05)
-print(f"Power: {power:.3f}")
-`,
-    },
-  ]}
-/>
+The **null hypothesis** $H_0$ is that the two click-through rates are
+equal (no effect). The **alternative hypothesis** $H_1$ is that the
+treatment click-through rate differs from the control (two-sided) or is
+specifically greater/less (one-sided). You choose the alternative before
+seeing data. A two-sided test is safer because it catches effects in
+either direction without inflating power in one direction.
 
 ### When do you use a z-test vs a t-test?
 
-Use a **z-test** when the population variance is known or the sample is large enough (roughly `n >= 30`) that the sample standard deviation is a reliable estimate.
-Use a **t-test** for small samples where you must estimate the variance; the t-distribution has heavier tails to account for that extra uncertainty.
-In practice, software always uses t, which converges to z as n grows.
+Use a **z-test** when the population variance is known or the sample is
+large enough (roughly $n \geq 30$) that the sample standard deviation is a
+reliable estimate. Use a **t-test** for small samples where you must
+estimate the variance; the t-distribution has heavier tails to account for
+that extra uncertainty. In practice, software always uses the t-test,
+which converges to the z-test as $n$ grows.
+
+The code below runs a one-sample t-test asking whether a small sample's
+mean differs from a hypothesized value of 10. It returns the test
+statistic and the p-value you would compare against $\alpha$.
 
 <CodeBlock
   adapter="python"
@@ -135,9 +306,19 @@ print(f"t={t_stat:.3f}, p={p_value:.4f}")
 
 ### What is the chi-square test used for?
 
-The chi-square test checks whether observed counts in categories differ from expected counts (goodness-of-fit), or whether two categorical variables are independent (test of independence).
-The test statistic sums `(observed - expected)^2 / expected` over all cells; large values indicate the null is implausible.
-It requires expected cell counts of at least 5 in most cells.
+The chi-square test checks whether observed counts in categories differ
+from expected counts (goodness-of-fit), or whether two categorical
+variables are independent (test of independence). The test statistic sums
+the squared, normalized gaps between observed and expected counts:
+
+$$\chi^2 = \sum_i \frac{(O_i - E_i)^2}{E_i}$$
+
+Large values indicate the null is implausible. The test requires expected
+cell counts of at least 5 in most cells.
+
+The code below applies it to an A/B conversion table: `chi2_contingency`
+computes the $\chi^2$ statistic above, its p-value, and the degrees of
+freedom for a 2×2 table of variant vs. converted/not-converted.
 
 <CodeBlock
   adapter="python"
@@ -156,12 +337,18 @@ print(f"chi2={chi2:.3f}, p={p:.4f}, dof={dof}")
   ]}
 />
 
-### What is ANOVA and when do you use it?
+### What is ANOVA, and when do you use it?
 
-**ANOVA** (Analysis of Variance) tests whether the means of three or more groups are equal.
-It compares within-group variance to between-group variance via an F-statistic.
-A significant F only tells you at least one group differs; post-hoc tests (Tukey, Bonferroni) identify which pairs differ.
-Use it instead of running multiple t-tests, which would inflate the Type I error rate.
+ANOVA (Analysis of Variance) tests whether the means of three or more
+groups are equal. It compares within-group variance to between-group
+variance via an F-statistic. A significant F only tells you that at least
+one group differs; post-hoc tests (Tukey, Bonferroni) identify which pairs
+differ. Use it instead of running many pairwise t-tests, which would
+inflate the Type I error rate.
+
+The code below runs a one-way ANOVA across three groups; `f_oneway`
+returns the F-statistic and the p-value for the null that all three means
+are equal.
 
 <CodeBlock
   adapter="python"
@@ -180,121 +367,124 @@ print(f"F={f_stat:.3f}, p={p_value:.4f}")
   ]}
 />
 
-### What is the difference between correlation and causation?
+### What exactly is a p-value?
 
-Correlation measures the linear association between two variables (Pearson's r ranges from -1 to 1).
-Causation means one variable directly produces a change in another.
-Correlation does not imply causation: a lurking third variable (confounder) can drive both, or the relationship may be coincidental.
-Establishing causation requires controlled experiments or causal inference methods.
+Now that the tests above each emit one, here is what the number means: a
+p-value is the probability of observing data **at least as extreme** as
+yours **assuming the null hypothesis is true**. It is *not* the
+probability that the null is true, nor the probability your result is a
+fluke. A small p-value means the data would be surprising under the null,
+so you reject it at your chosen significance level $\alpha$:
 
-### What is Bayes' theorem?
+$$\text{reject } H_0 \quad \text{when} \quad p < \alpha$$
 
-Bayes' theorem updates a prior belief given new evidence: `P(A|B) = P(B|A) * P(A) / P(B)`.
-In data science it is used in spam filters, medical diagnosis, and Bayesian inference where you update a prior distribution over parameters to a posterior after observing data.
+<Callout type="warning" title="Common misconception">
+A p-value is **not** the probability that the null hypothesis is true, and
+**not** the probability your result is a fluke — it is computed *assuming*
+the null holds. Conflating the two is the single most common statistics
+interview slip.
+</Callout>
 
-<CodeBlock
-  adapter="python"
-  files={[
-    {
-      filename: "main.py",
-      starterCode: `# Medical test example: P(disease | positive test)
-p_disease = 0.01          # prior prevalence
-p_pos_given_disease = 0.99  # sensitivity
-p_pos_given_no_disease = 0.05  # 1 - specificity
-
-p_pos = p_pos_given_disease * p_disease + p_pos_given_no_disease * (1 - p_disease)
-p_disease_given_pos = p_pos_given_disease * p_disease / p_pos
-print(f"P(disease | positive) = {p_disease_given_pos:.3f}")
-`,
-    },
-  ]}
-/>
-
-### What is conditional probability?
-
-`P(A|B)` is the probability of event A given that B has already occurred.
-It equals `P(A and B) / P(B)`.
-A and B are independent if `P(A|B) = P(A)`, meaning knowing B tells you nothing about A.
-
-### What is Maximum Likelihood Estimation?
-
-**MLE** finds the parameter values that maximize the probability (likelihood) of observing the data under a given model.
-For a normal distribution, the MLE of the mean is the sample mean; for logistic regression it maximizes the log-likelihood of the observed labels.
-MLE is consistent and asymptotically efficient but can overfit small samples.
-
-### What are properties of an unbiased estimator?
-
-An estimator is **unbiased** if its expected value equals the true parameter.
-The sample mean is an unbiased estimator of the population mean.
-The sample variance with denominator `n - 1` (Bessel's correction) is unbiased; dividing by `n` gives a biased (but lower-variance) estimator.
-Bias and variance together determine MSE: `MSE = bias^2 + variance`.
+The code below runs a two-sample t-test (the two-group analogue of the
+one-sample test above) and prints the t-statistic and p-value; here
+$p < 0.05$ would lead you to reject the null that the two group means are
+equal.
 
 <CodeBlock
   adapter="python"
   files={[
     {
       filename: "main.py",
-      starterCode: `import numpy as np
+      starterCode: `from scipy import stats
 
-data = np.array([4.0, 7.0, 13.0, 2.0, 1.0])
-# ddof=1 → Bessel's correction (unbiased); ddof=0 → biased MLE
-unbiased_var = np.var(data, ddof=1)
-biased_var   = np.var(data, ddof=0)
-print(f"Unbiased variance (n-1): {unbiased_var:.2f}")
-print(f"Biased variance (n):     {biased_var:.2f}")
+# Two-sample t-test: compute t-statistic and p-value
+group_a = [12, 15, 14, 10, 13]
+group_b = [18, 20, 17, 22, 19]
+t_stat, p_value = stats.ttest_ind(group_a, group_b)
+print(f"t={t_stat:.3f}, p={p_value:.4f}")
+# p < 0.05 → reject the null that the means are equal
 `,
     },
   ]}
 />
 
-### What is the Law of Large Numbers?
+### What is the difference between a Type I and a Type II error?
 
-The LLN states that as sample size grows, the sample mean converges in probability to the population mean.
-This justifies using large samples to estimate population parameters and is why more data improves estimates.
-The **weak** LLN gives convergence in probability; the **strong** LLN gives almost-sure convergence.
+A **Type I error** is a false positive (rejecting a true null); its rate
+is $\alpha$. A **Type II error** is a false negative (failing to detect a
+real effect); its rate is $\beta$, and **power** $= 1 - \beta$. The four
+possible outcomes of a test form a decision matrix:
 
-### Describe the normal distribution and its key properties.
+|                          | $H_0$ is true                                | $H_0$ is false                              |
+| ------------------------ | -------------------------------------------- | ------------------------------------------- |
+| **Reject $H_0$**         | Type I error (false positive) — rate $\alpha$ | Correct decision — power $= 1 - \beta$       |
+| **Fail to reject $H_0$** | Correct decision — rate $1 - \alpha$          | Type II error (false negative) — rate $\beta$ |
 
-The normal (Gaussian) distribution is symmetric and bell-shaped, parameterized by mean `mu` and variance `sigma^2`.
-About 68%, 95%, and 99.7% of the data falls within 1, 2, and 3 standard deviations of the mean (the empirical rule).
-It arises naturally via the CLT and is the foundation for many statistical tests.
+Lowering $\alpha$ (a stricter test) reduces false positives but raises
+false negatives, all else equal — the two error rates trade off against
+each other.
 
-### What is a Poisson distribution?
+### What is statistical power?
 
-The Poisson distribution models the number of events in a fixed interval when events occur independently at a constant average rate `lambda`.
-Its mean and variance are both `lambda`.
-Common uses: number of customer arrivals per hour, defects per unit, or server requests per second.
+Power is the probability of correctly rejecting the null when the
+alternative is true:
 
-### What is a binomial distribution?
+$$\text{power} = 1 - \beta$$
 
-The binomial distribution counts the number of successes in `n` independent Bernoulli trials, each with success probability `p`.
-Its mean is `n * p` and variance is `n * p * (1 - p)`.
-It is used for click rates, conversion rates, and quality control.
+where $\beta$ is the Type II error rate. A power of 0.8 means an 80% chance
+of detecting a true effect if one exists. Power rises with larger sample
+size, larger effect size, lower variance, and a higher $\alpha$.
 
-### What is p-hacking and why is it dangerous?
+The code below solves for power given an effect size (Cohen's d), a
+per-group sample size, and $\alpha$ — the standard pre-experiment check
+that a planned test is sensitive enough to find the effect you care about.
 
-P-hacking is the practice of trying many analyses, subgroups, or metrics until a significant result appears, then reporting only that result.
-It exploits the fact that with enough comparisons, some will be significant by chance (Type I error inflation).
-It leads to irreproducible findings and is a major driver of the replication crisis.
-Remedies: pre-registration, Bonferroni or FDR correction, and separating exploratory from confirmatory analysis.
+<CodeBlock
+  adapter="python"
+  files={[
+    {
+      filename: "main.py",
+      starterCode: `from statsmodels.stats.power import TTestIndPower
+
+analysis = TTestIndPower()
+# Compute power given effect size (Cohen's d), sample size, and alpha
+power = analysis.solve_power(effect_size=0.5, nobs1=50, alpha=0.05)
+print(f"Power: {power:.3f}")
+`,
+    },
+  ]}
+/>
 
 ### What is the difference between one-tailed and two-tailed tests?
 
-A **two-tailed test** detects effects in either direction (greater or less than the null value) and splits `alpha` between both tails.
-A **one-tailed test** focuses on one direction, giving more power there but missing effects in the other direction.
-Use two-tailed tests by default unless you have a strong directional hypothesis stated before seeing data.
+A **two-tailed test** detects effects in either direction (greater or less
+than the null value) and splits $\alpha$ between both tails. A
+**one-tailed test** focuses on one direction, giving more power there but
+missing effects in the other direction. Use two-tailed tests by default
+unless you have a strong directional hypothesis stated before seeing data.
 
-### What is effect size and why does it matter alongside p-values?
+### What is effect size, and why does it matter alongside p-values?
 
-**Effect size** quantifies the magnitude of a difference (e.g., Cohen's d for means, odds ratio, r for correlations).
-A result can be statistically significant but practically negligible (large n, tiny effect), or practically large but not significant (small n).
-Always report effect sizes and confidence intervals alongside p-values.
+**Effect size** quantifies the *magnitude* of a difference (Cohen's d for
+means, the odds ratio for proportions, Pearson's r for correlations). A
+result can be statistically significant but practically negligible (large
+$n$, tiny effect), or practically large but not significant (small $n$).
+Always report effect sizes and confidence intervals alongside p-values, so
+the reader sees both "is it real?" and "is it big enough to matter?"
 
 ### How do you correct for multiple comparisons?
 
-The **Bonferroni correction** divides `alpha` by the number of tests, making each individual test stricter.
-The **Benjamini-Hochberg procedure** controls the false discovery rate (FDR) rather than the family-wise error rate, giving more power when many tests are run.
-Choose the correction based on whether you can tolerate any false positives (use Bonferroni) or a controlled proportion of them (use FDR).
+The **Bonferroni correction** divides $\alpha$ by the number of tests $m$
+(testing each at $\alpha / m$), controlling the family-wise error rate.
+The **Benjamini-Hochberg procedure** controls the false discovery rate
+instead, giving more power when many tests are run. Choose Bonferroni when
+you cannot tolerate *any* false positive, and Benjamini-Hochberg when you
+can accept a controlled proportion of them.
+
+The code below applies the Benjamini-Hochberg procedure to five raw
+p-values: it returns which hypotheses to reject and the adjusted p-values,
+which are larger than the originals because the correction makes each test
+stricter.
 
 <CodeBlock
   adapter="python"
@@ -313,66 +503,52 @@ print("Corrected p-values:", [f"{p:.3f}" for p in p_corrected])
   ]}
 />
 
+### What is p-hacking, and why is it dangerous?
+
+P-hacking is trying many analyses, subgroups, or metrics until a
+significant result appears, then reporting only that one. It exploits the
+fact that with enough comparisons some will be significant by chance
+(Type I error inflation), and it leads to irreproducible findings — a major
+driver of the replication crisis. Remedies: pre-registration, Bonferroni
+or false-discovery-rate correction, and separating exploratory from
+confirmatory analysis.
+
 ### What is the difference between frequentist and Bayesian statistics?
 
-**Frequentist** statistics treats probability as long-run frequency: parameters are fixed (unknown) constants and you draw conclusions from data alone via p-values and CIs.
-**Bayesian** statistics treats parameters as random variables with a prior distribution that is updated by data to form a posterior.
-Bayesian inference allows direct probability statements about parameters and naturally incorporates prior knowledge, but requires specifying priors.
-
-### What is a sampling distribution?
-
-A **sampling distribution** is the probability distribution of a statistic (like the sample mean) over all possible samples of the same size from a population.
-The standard deviation of the sampling distribution of the mean is the **standard error**: `SE = sigma / sqrt(n)`.
-The CLT tells us this distribution approaches normal for large n.
-
-<CodeBlock
-  adapter="python"
-  files={[
-    {
-      filename: "main.py",
-      starterCode: `import numpy as np
-
-rng = np.random.default_rng(42)
-population = rng.exponential(scale=5, size=100_000)  # skewed population
-sample_means = [rng.choice(population, 50).mean() for _ in range(2000)]
-print(f"SE (formula): {population.std() / 50**0.5:.3f}")
-print(f"SE (simulated): {np.std(sample_means):.3f}")
-# Both should be close — CLT at work
-`,
-    },
-  ]}
-/>
-
-### What does it mean for two events to be mutually exclusive vs independent?
-
-**Mutually exclusive** events cannot both occur: `P(A and B) = 0`.
-**Independent** events have no influence on each other: `P(A and B) = P(A) * P(B)`.
-Mutually exclusive events with non-zero probability are never independent (knowing one occurred rules out the other).
-
-### What is the standard error and how does it differ from standard deviation?
-
-**Standard deviation** measures variability of individual observations around the mean.
-**Standard error** measures variability of a sample statistic (like the mean) around the true parameter; `SE = SD / sqrt(n)`.
-SE shrinks with larger samples; SD does not (it estimates a population property that doesn't depend on n).
+**Frequentist** statistics treats probability as long-run frequency:
+parameters are fixed (unknown) constants, and you draw conclusions from
+data alone via p-values and confidence intervals. **Bayesian** statistics
+treats parameters as random variables with a prior distribution that is
+updated by data into a posterior. Bayesian inference allows direct
+probability statements about parameters and naturally incorporates prior
+knowledge, but requires specifying priors.
 
 ### What is the difference between parametric and non-parametric tests?
 
-**Parametric tests** assume data follows a specific distribution (usually normal) and test parameters of that distribution.
-**Non-parametric tests** make fewer distributional assumptions and work on ranks (Wilcoxon, Mann-Whitney, Kruskal-Wallis).
-Non-parametric tests are preferred for small samples, ordinal data, or when normality is clearly violated.
+**Parametric tests** assume the data follow a specific distribution
+(usually normal) and test parameters of that distribution. **Non-parametric
+tests** make fewer distributional assumptions and work on ranks (Wilcoxon,
+Mann-Whitney, Kruskal-Wallis). Non-parametric tests are preferred for
+small samples, ordinal data, or when normality is clearly violated.
+
+### What is the difference between correlation and causation?
+
+Correlation measures the linear association between two variables
+(Pearson's r ranges from $-1$ to $1$). Causation means one variable
+directly produces a change in another. Correlation does not imply
+causation: a lurking third variable (a confounder) can drive both, or the
+relationship may be coincidental. Establishing causation requires
+controlled experiments or causal-inference methods.
 
 ### What is Simpson's paradox?
 
-Simpson's paradox occurs when a trend that appears in several groups reverses (or disappears) when the groups are combined.
-It arises because a lurking confounding variable drives the aggregated result.
-The classic example: a treatment looks worse overall but is better within every patient subgroup because sicker patients were routed to treatment.
-Resolution requires analyzing data at the right stratification level and understanding causal structure.
-
-### What is hypothesis testing and what are its four key steps?
-
-**Hypothesis testing** is a formal procedure for deciding whether data provide sufficient evidence against a null hypothesis.
-The four steps are: (1) state `H0` and `H1`; (2) choose `alpha` and compute the required sample size; (3) collect data and compute the test statistic and p-value; (4) reject `H0` if `p < alpha` and interpret in context.
-Always state the hypothesis and fix `alpha` before collecting data to avoid bias.
+Simpson's paradox occurs when a trend that appears in several groups
+reverses (or disappears) when the groups are combined, because a lurking
+confounding variable drives the aggregated result. The classic example: a
+treatment looks worse overall but is better within every patient subgroup,
+because sicker patients were disproportionately routed to it. Resolving it
+requires analyzing data at the right stratification level and
+understanding the causal structure.
 
 ## Concept checks
 
@@ -418,3 +594,4 @@ Always state the hypothesis and fix `alpha` before collecting data to avoid bias
 ## Go deeper
 
 - [Statistics for Data Science with Python](/learn/statistics-for-data-science-python)
+

--- a/content/interview/machine-learning-engineer/ml-fundamentals.mdx
+++ b/content/interview/machine-learning-engineer/ml-fundamentals.mdx
@@ -1,10 +1,11 @@
 ---
 title: ML Fundamentals
-description: ML Engineer interview questions on supervised vs unsupervised learning, bias–variance, regularization, and data splits — with a runnable metric challenge.
+description: Machine Learning Engineer interview questions on supervised vs unsupervised learning, bias–variance, regularization, and data splits — with a runnable metric challenge.
 ---
 
-ML Engineer screens pair coding with ML theory. Review the Q&A, take the
-concept checks, then implement the metric.
+Machine Learning Engineer screens pair coding with machine learning
+theory. Review the Q&A, take the concept checks, then implement the
+metric.
 
 ## Q&A
 
@@ -49,6 +50,10 @@ print(f"Train: {len(X_train)}  Val: {len(X_val)}  Test: {len(X_test)}")
   ]}
 />
 
+This calls `train_test_split` twice — first carving off a 20% `X_test`
+hold-out, then splitting the remainder so `X_val` is another 20% of the
+original — yielding a 60/20/20 train/validation/test partition.
+
 ### L1 vs L2 regularization?
 
 Both penalize large weights to reduce overfitting. **L1 (lasso)** can
@@ -78,6 +83,10 @@ print("Lasso coef sample:", lasso.coef_[:10].round(2))
     },
   ]}
 />
+
+Counting non-zero entries in `ridge.coef_` versus `lasso.coef_` makes the
+contrast concrete: `Ridge` keeps every coefficient non-zero, while `Lasso`
+zeroes out the uninformative features, leaving a sparse model.
 
 ### What is data leakage, and how do you prevent it?
 
@@ -114,13 +123,17 @@ print(f"CV accuracy: {scores.mean():.3f} ± {scores.std():.3f}")  # mean ± std 
   ]}
 />
 
+Here `KFold` defines the 5 rotating splits and `cross_val_score` trains
+and scores `LogisticRegression` on each; reporting `scores.mean()` with
+`scores.std()` captures both the typical accuracy and its variability.
+
 ### What is dropout and how does it regularize a neural network?
 
-During training, each neuron is independently zeroed with probability p
+During training, each neuron is independently zeroed with probability $p$
 (commonly 0.2–0.5). This prevents co-adaptation: no single unit can rely
 on specific others, so the network learns more redundant, robust
 representations. At inference, dropout is disabled and weights are scaled
-by `(1 - p)` (or equivalently, inverted dropout scales during training).
+by $(1-p)$ (or equivalently, inverted dropout scales during training).
 
 ### Explain early stopping.
 
@@ -148,8 +161,14 @@ strength, and engineering better features.
 Gradient descent minimizes a loss function by iteratively updating
 parameters in the direction opposite to the gradient of the loss with
 respect to those parameters. The step size is controlled by the
-**learning rate**. Batch GD uses all training examples per update; SGD
-uses one; mini-batch GD uses a small subset (the typical default).
+**learning rate**. Batch GD uses all training examples per update;
+stochastic gradient descent (SGD) uses one; mini-batch GD uses a small
+subset (the typical default).
+
+The `gradient_descent` function below implements the batch variant: each
+epoch computes the full mean-squared-error gradient `grad` over all rows
+and nudges `theta` against it by `lr`, so the learned `theta_hat`
+converges toward the `true_theta` that generated the data.
 
 <CodeBlock
   adapter="python"
@@ -198,11 +217,21 @@ tests (plotting loss vs. log LR) help find a good starting value.
 
 ### What are precision, recall, and F1-score?
 
-**Precision** = TP / (TP + FP): of all predicted positives, how many are
-correct. **Recall** = TP / (TP + FN): of all actual positives, how many
-did we catch. **F1** is the harmonic mean of precision and recall —
-useful when you want a single metric that balances both. Choose precision
-when false positives are costly; choose recall when false negatives are.
+**Precision** asks, of all predicted positives, how many are correct.
+**Recall** asks, of all actual positives, how many did we catch. **F1** is
+the harmonic mean of precision and recall — useful when you want a single
+metric that balances both. Choose precision when false positives are
+costly; choose recall when false negatives are. The four outcomes come
+from the confusion matrix:
+
+| | Predicted positive | Predicted negative |
+| --- | --- | --- |
+| **Actually positive** | True Positive (TP) | False Negative (FN) |
+| **Actually negative** | False Positive (FP) | True Negative (TN) |
+
+$$\text{Precision} = \frac{TP}{TP + FP} \qquad \text{Recall} = \frac{TP}{TP + FN}$$
+
+$$F_1 = 2 \cdot \frac{\text{Precision} \times \text{Recall}}{\text{Precision} + \text{Recall}}$$
 
 <CodeBlock
   adapter="python"
@@ -222,14 +251,20 @@ print(f"Precision: {p:.3f}  Recall: {r:.3f}  F1: {f1:.3f}")
   ]}
 />
 
+This applies the formulas above directly: `precision_score`,
+`recall_score`, and `f1_score` count the TP/FP/FN entries from `y_true`
+and `y_pred` so you can read off all three metrics at once.
+
 ### What is ROC-AUC and when does PR-AUC matter more?
 
-The ROC curve plots TPR vs. FPR at every threshold; AUC summarizes it as
-the probability that the model ranks a random positive above a random
-negative. ROC-AUC can be misleadingly optimistic on **class-imbalanced**
-datasets because FPR stays low even with many false positives. The
-Precision-Recall curve focuses only on positives, so **PR-AUC** is the
-preferred metric when the positive class is rare (fraud, rare disease).
+The receiver operating characteristic (ROC) curve plots true positive
+rate (TPR) vs. false positive rate (FPR) at every threshold; the area
+under the curve (AUC) summarizes it as the probability that the model
+ranks a random positive above a random negative. ROC-AUC can be
+misleadingly optimistic on **class-imbalanced** datasets because FPR
+stays low even with many false positives. The Precision-Recall curve
+focuses only on positives, so **PR-AUC** is the preferred metric when the
+positive class is rare (fraud, rare disease).
 
 <CodeBlock
   adapter="python"
@@ -248,13 +283,17 @@ print(f"ROC-AUC: {roc_auc:.3f}  PR-AUC: {pr_auc:.3f}")
   ]}
 />
 
+Both metrics take the continuous `y_scores` rather than hard labels:
+`roc_auc_score` computes ROC-AUC and `average_precision_score` computes
+PR-AUC, letting you compare a ranking on the same predictions.
+
 ### What is the difference between RMSE, MAE, and R²?
 
 **RMSE** (root mean squared error) penalizes large errors heavily —
 sensitive to outliers. **MAE** (mean absolute error) treats all errors
-equally — more robust to outliers. **R²** (coefficient of determination)
-measures the fraction of variance explained by the model; 1.0 is perfect,
-0.0 means the model is no better than predicting the mean.
+equally — more robust to outliers. **$R^2$** (coefficient of
+determination) measures the fraction of variance explained by the model;
+1.0 is perfect, 0.0 means the model is no better than predicting the mean.
 
 ### What is class imbalance and how do you handle it?
 
@@ -268,9 +307,10 @@ the loss function; or use anomaly detection framing for extreme imbalance.
 
 Feature scaling (standardization or min-max normalization) brings
 features onto comparable scales. It is critical for distance-based models
-(kNN, SVM, k-means), regularized models (ridge, lasso), and gradient-based
-optimizers (which converge faster with similar feature magnitudes).
-Tree-based models are scale-invariant and do not require it.
+(k-nearest neighbours (kNN), support vector machine (SVM), k-means),
+regularized models (ridge, lasso), and gradient-based optimizers (which
+converge faster with similar feature magnitudes). Tree-based models are
+scale-invariant and do not require it.
 
 <CodeBlock
   adapter="python"
@@ -295,6 +335,11 @@ print(f"After  scaling — mean: {X_train_scaled[:, 0].mean():.3f}  std: {X_trai
     },
   ]}
 />
+
+Note that `scaler.fit_transform` learns the mean and standard deviation
+from `X_train` only, then `scaler.transform` reuses those statistics on
+`X_val` and `X_test` — the discipline that prevents leakage from the
+hold-out sets back into training.
 
 ### What is one-hot encoding?
 
@@ -321,6 +366,11 @@ print("Encoded:\\n", encoded)
     },
   ]}
 />
+
+Fitting `OneHotEncoder` on the three colour values in `X_cat` turns each
+row into a binary indicator vector; `handle_unknown="ignore"` makes the
+encoder emit all-zeros for any category unseen at fit time rather than
+erroring at serving.
 
 ### What is feature engineering?
 
@@ -359,10 +409,11 @@ and efficient histogram-based splitting for speed and regularization.
 ### How does logistic regression work?
 
 Logistic regression models the log-odds of the positive class as a linear
-combination of features, then applies the sigmoid function to produce a
-probability in `(0, 1)`. It is trained by minimizing binary cross-entropy
-(log loss). Despite its name it is a **classification** model. It is
-interpretable, fast, and a strong baseline.
+combination of features, then applies the sigmoid function
+$\sigma(z) = \frac{1}{1 + e^{-z}}$ to produce a probability in $(0, 1)$.
+It is trained by minimizing binary cross-entropy (log loss),
+$-[y \log \hat{y} + (1 - y) \log(1 - \hat{y})]$. Despite its name it is a
+**classification** model. It is interpretable, fast, and a strong baseline.
 
 <CodeBlock
   adapter="python"
@@ -391,6 +442,10 @@ print(f"First 5 probabilities: {y_prob[:5].round(3)}")
   ]}
 />
 
+`clf.predict` returns the hard 0/1 labels for `accuracy_score`, while
+`clf.predict_proba(...)[:, 1]` exposes the underlying sigmoid
+probabilities for the positive class — the raw output before thresholding.
+
 ### What is the difference between a parametric and a non-parametric model?
 
 **Parametric** models (linear regression, logistic regression, neural
@@ -417,11 +472,12 @@ spherical, equally-sized clusters.
 
 ### What is PCA and what does it do?
 
-Principal Component Analysis finds the directions (principal components)
-of maximum variance in the data and projects it onto a lower-dimensional
-subspace. It is used for dimensionality reduction, visualization (2D/3D),
-and decorrelating features before feeding them to a downstream model. The
-components are orthogonal and are ordered by explained variance.
+Principal component analysis (PCA) finds the directions (principal
+components) of maximum variance in the data and projects it onto a
+lower-dimensional subspace. It is used for dimensionality reduction,
+visualization (2D/3D), and decorrelating features before feeding them to a
+downstream model. The components are orthogonal and are ordered by
+explained variance.
 
 <CodeBlock
   adapter="python"
@@ -446,6 +502,11 @@ print(f"Reduced shape: {X_train_scaled.shape} → {X_2d.shape}")
     },
   ]}
 />
+
+Projecting the scaled features down to two components with
+`PCA(n_components=2)` collapses the 10-feature input to `X_2d`, and
+`explained_variance_ratio_` reports how much of the original variance
+those two components retain.
 
 ### Name common activation functions and their trade-offs.
 
@@ -495,9 +556,9 @@ when the model is wrong and confident, leading to faster convergence.
 An SVM finds the hyperplane that maximizes the margin between classes.
 Support vectors are the training points closest to the boundary. The
 **kernel trick** implicitly maps inputs to a higher-dimensional space
-(RBF, polynomial), enabling non-linear decision boundaries without
-explicit feature expansion. SVMs are effective in high dimensions but
-slow on large datasets.
+(radial basis function (RBF) kernel, polynomial), enabling non-linear
+decision boundaries without explicit feature expansion. SVMs are
+effective in high dimensions but slow on large datasets.
 
 ## Concept checks
 

--- a/content/interview/machine-learning-engineer/ml-system-design.mdx
+++ b/content/interview/machine-learning-engineer/ml-system-design.mdx
@@ -255,7 +255,7 @@ The funnel narrows the candidate set at each stage so the expensive model
 only scores a few hundred items, not millions:
 
 ```mermaid
-flowchart LR
+flowchart TD
   c["millions of items"] --> r["Retrieval: nearest-neighbour search"]
   r --> k["hundreds of candidates"]
   k --> g["Ranking: gradient boosting / neural net"]

--- a/content/interview/machine-learning-engineer/ml-system-design.mdx
+++ b/content/interview/machine-learning-engineer/ml-system-design.mdx
@@ -1,11 +1,11 @@
 ---
 title: ML System Design
-description: ML Engineer interview questions on batch vs online inference, feature stores, training–serving skew, and model/data drift.
+description: Machine Learning Engineer interview questions on batch vs online inference, feature stores, training–serving skew, and model/data drift.
 ---
 
-The round that most distinguishes an ML *Engineer* is getting models
-into production and keeping them healthy. Review the Q&A, then the
-concept checks.
+The round that most distinguishes a Machine Learning *Engineer* is
+getting models into production and keeping them healthy. Review the Q&A,
+then the concept checks.
 
 ## Q&A
 
@@ -103,9 +103,10 @@ the pipeline into both stores to keep them consistent.
 ### How do you ensure reproducibility of ML experiments?
 
 Pin library versions (requirements.txt or lock files), version training
-data (DVC, Delta Lake snapshots), log all hyperparameters and random seeds
-(MLflow, W&B), and version model code in git with a tag linked to the
-experiment run. Container images (Docker) capture the full environment.
+data (Data Version Control (DVC), Delta Lake snapshots), log all
+hyperparameters and random seeds (MLflow, W&B), and version model code in
+git with a tag linked to the experiment run. Container images (Docker)
+capture the full environment.
 A reproducible run should regenerate the same model artifact from the same
 code, data, and config.
 
@@ -166,13 +167,14 @@ models in production while retaining accuracy close to a large teacher.
 
 ### How do you design a CI/CD pipeline for ML?
 
-An ML CI/CD pipeline typically includes: (1) **data validation** on new
-data; (2) **unit and integration tests** for feature transforms and
-preprocessing code; (3) **training run** on a versioned dataset; (4)
-**evaluation gate** — the new model must beat the incumbent on a holdout
-set; (5) **model registry promotion**; (6) **staged rollout** (canary,
-then full). Infrastructure-as-code (Terraform, CDK) provisions training
-and serving environments reproducibly.
+An ML continuous integration and continuous delivery (CI/CD) pipeline
+typically includes: (1) **data validation** on new data; (2) **unit and
+integration tests** for feature transforms and preprocessing code; (3)
+**training run** on a versioned dataset; (4) **evaluation gate** — the new
+model must beat the incumbent on a holdout set; (5) **model registry
+promotion**; (6) **staged rollout** (canary, then full).
+Infrastructure-as-code (Terraform, CDK) provisions training and serving
+environments reproducibly.
 
 ### What is throughput vs latency in model serving?
 
@@ -249,6 +251,18 @@ rules (diversity, freshness, promotions); (4) **feature store** for
 real-time user and item features; (5) A/B testing on ranking model
 variants tied to business metrics (revenue, engagement).
 
+The funnel narrows the candidate set at each stage so the expensive model
+only scores a few hundred items, not millions:
+
+```mermaid
+flowchart LR
+  c["millions of items"] --> r["Retrieval: nearest-neighbour search"]
+  r --> k["hundreds of candidates"]
+  k --> g["Ranking: gradient boosting / neural net"]
+  g --> rr["Re-ranking: diversity, freshness, rules"]
+  rr --> out["final ranked list"]
+```
+
 ### What is the difference between online and offline feature computation?
 
 **Offline** features are computed in batch jobs over historical data
@@ -262,10 +276,11 @@ training features and online serving features is the core challenge.
 
 Monitor the relationship between model inputs and outputs over time.
 Proxy signals (when true labels are delayed): prediction distribution
-shift, input feature distribution shift (PSI, KL divergence, Kolmogorov-
-Smirnov tests). When true labels become available: track live accuracy,
-precision, recall. Responses range from alerting to automated retraining
-to feature redesign if the drift is structural.
+shift, input feature distribution shift (population stability index (PSI),
+Kullback–Leibler (KL) divergence, Kolmogorov–Smirnov test). When true
+labels become available: track live accuracy, precision, recall.
+Responses range from alerting to automated retraining to feature redesign
+if the drift is structural.
 
 ### What is population stability index (PSI)?
 
@@ -274,7 +289,15 @@ a current distribution (production) for a single feature. Buckets are
 defined on the reference; the fraction of examples per bucket is compared
 between reference and current using a symmetric KL-divergence-like formula.
 PSI below 0.1 is stable; 0.1–0.2 warrants monitoring; above 0.2 signals
-significant shift requiring action.
+significant shift requiring action. Formally, summing over the buckets:
+
+$$\text{PSI} = \sum_i (\text{cur}_i - \text{ref}_i)\,\ln\frac{\text{cur}_i}{\text{ref}_i}$$
+
+The `compute_psi` function below implements exactly this: it bins the
+reference (training) distribution into deciles via `np.percentile`,
+compares the fraction of examples per bucket between `reference` and
+`current`, and returns the summed PSI value — the demo prints a `stable`
+case under 0.1 and a `drifted` case above 0.2.
 
 <CodeBlock
   adapter="python"

--- a/content/learn/beginners-javascript/functional-intuition.mdx
+++ b/content/learn/beginners-javascript/functional-intuition.mdx
@@ -117,7 +117,7 @@ The functional advice is not "never have side effects" — it's
 logic pure.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Input from outside] --> B[Pure core: transformations]
     B --> C[Output to outside]
     style B fill:#dff,stroke:#066

--- a/content/learn/beginners-javascript/functions-basics.mdx
+++ b/content/learn/beginners-javascript/functions-basics.mdx
@@ -47,7 +47,7 @@ A **function** is a named, reusable piece of code that takes some
 You define it once. You call it many times.
 
 ```mermaid
-flowchart LR
+flowchart TD
     I1((inputs)) --> F[Function: do something with the inputs]
     F --> O((output))
 ```

--- a/content/learn/beginners-javascript/how-computers-execute-programs.mdx
+++ b/content/learn/beginners-javascript/how-computers-execute-programs.mdx
@@ -237,7 +237,7 @@ that array itself lives "on the heap", with `list` holding a kind
 of address pointing to it.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Stack["Stack (per running function)"]
         S1["<code>x = 5</code>"]
         S2["list = (pointer)"]

--- a/content/learn/beginners-javascript/modular-organization.mdx
+++ b/content/learn/beginners-javascript/modular-organization.mdx
@@ -264,7 +264,7 @@ Modules should form a **directed acyclic graph** — A may depend
 on B, B may depend on C, but C must not depend on A.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>index.js</code>"] --> B["<code>users.js</code>"]
     A --> C["<code>orders.js</code>"]
     C --> D["shared/<code>http.js</code>"]

--- a/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/learn/c-programming-for-beginners/compilation-and-execution.mdx
@@ -261,7 +261,7 @@ The compiler is happy with just declarations. The linker demands at
 least one definition per used symbol — no more, no less.
 
 ```mermaid
-flowchart LR
+flowchart TD
     H["greetings.h<br/>void <code>say_hello(...)</code>"] -->|included by| M["<code>main.c</code>"]
     H -->|included by| G["<code>greetings.c</code>"]
     G -->|defines| BODY["body of<br/><code>say_hello</code>"]

--- a/content/learn/c-programming-for-beginners/data-types.mdx
+++ b/content/learn/c-programming-for-beginners/data-types.mdx
@@ -108,7 +108,7 @@ A 32-bit signed `int` ranges from roughly −2.1 × 10⁹ to +2.1 × 10⁹.
 A 32-bit unsigned `int` ranges from 0 to about 4.3 × 10⁹.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph "signed int (32 bits)"
       direction LR
       A1["-2,147,483,648"] --- A2["0"] --- A3["+2,147,483,647"]

--- a/content/learn/c-programming-for-beginners/how-computers-execute-programs.mdx
+++ b/content/learn/c-programming-for-beginners/how-computers-execute-programs.mdx
@@ -52,7 +52,7 @@ This chapter builds that picture.
 For our purposes, every computer is made of two cooperating parts:
 
 ```mermaid
-flowchart LR
+flowchart TD
     CPU[CPU<br/>follows instructions]
     MEM[Memory<br/>holds data and instructions]
     CPU <-->|reads / writes| MEM
@@ -101,7 +101,7 @@ addresses.
 The CPU works in a tight loop, billions of times per second:
 
 ```mermaid
-flowchart LR
+flowchart TD
     F[Fetch:<br/>read the next<br/>instruction from<br/>memory] --> D[Decode:<br/>figure out<br/>what it means]
     D --> E[Execute:<br/>do it]
     E --> F

--- a/content/learn/c-programming-for-beginners/linked-lists.mdx
+++ b/content/learn/c-programming-for-beginners/linked-lists.mdx
@@ -215,7 +215,7 @@ prev->next = n;
 ```
 
 ```mermaid
-flowchart LR
+flowchart TD
     P["prev"] -- "before" --> A["[ A | * ]"] --> B["[ B | * ]"]
     P2["prev"] -- "after" --> A2["[ A | * ]"] --> N["[ N | * ]"] --> B2["[ B | * ]"]
 ```

--- a/content/learn/c-programming-for-beginners/pointers.mdx
+++ b/content/learn/c-programming-for-beginners/pointers.mdx
@@ -53,7 +53,7 @@ int  *p = &n;     // a pointer that holds the address of n
 ```
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph memory
       N["address <code>0x100</code><br/><code>n = 42</code>"]
       P["address <code>0x200</code><br/><code>p = 0x100</code>"]

--- a/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
+++ b/content/learn/c-programming-for-beginners/scope-and-modularity.mdx
@@ -205,7 +205,7 @@ the file offers*: function signatures, struct definitions, important
 constants. It says nothing about *how* those things are implemented.
 
 ```mermaid
-flowchart LR
+flowchart TD
     M["<code>main.c</code><br/>#include <code>parser.h</code><br/>#include <code>evaluator.h</code>"] -.uses.-> PH["<code>parser.h</code>"]
     M -.uses.-> EH["<code>evaluator.h</code>"]
     PH --- P["<code>parser.c</code>"]

--- a/content/learn/c-programming-for-beginners/strings.mdx
+++ b/content/learn/c-programming-for-beginners/strings.mdx
@@ -241,7 +241,7 @@ We'll see why that pattern is so common in the pointers chapter.
 ## Picture: a `char` array versus a `char *`
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph stack
       A["<code>buf[6]<br/>'h','e','l','l','o','\\0'</code>"]
     end

--- a/content/learn/csharp-linq-functional/birth-of-linq.mdx
+++ b/content/learn/csharp-linq-functional/birth-of-linq.mdx
@@ -282,7 +282,7 @@ into an XML config file, build a SQL string by hand for the
 database, and call a SOAP service that returned yet another shape.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Your C# code] -->|"for/foreach"| B[Objects]
     A -->|XPath strings| C[XML]
     A -->|"SQL strings"| D[Database]

--- a/content/learn/csharp-linq-functional/composing-pipelines.mdx
+++ b/content/learn/csharp-linq-functional/composing-pipelines.mdx
@@ -107,7 +107,7 @@ You're not limited to combining existing operators. `yield return`
 lets you implement entirely new ones, and they remain lazy.
 
 ```mermaid
-flowchart LR
+flowchart TD
     S[Source] --> O["Custom operator<br/>yield return"] --> N[Next stage]
     note["Each yield = one element, on demand"]
 ```
@@ -160,7 +160,7 @@ costs no extra memory.
 A well-composed pipeline tends to have four phases:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Source] --> B[Filter] --> C[Shape] --> D[Aggregate / Materialize]
 ```
 

--- a/content/learn/csharp-linq-functional/deferred-execution.mdx
+++ b/content/learn/csharp-linq-functional/deferred-execution.mdx
@@ -123,7 +123,7 @@ A pipeline can describe a transformation over a million-element
 sequence without ever holding all million elements in memory.
 
 ```mermaid
-flowchart LR
+flowchart TD
     F[1 million-row file] --> W[Where] --> S[Select] --> T[Take 10]
     T --> R[10 results]
 ```
@@ -291,7 +291,7 @@ recipe. It is the *promise* of a result. The first time a consumer
 walks it (or asks for `.Count()`, etc.), the recipe is executed.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q[Pipeline = recipe] -.Built lazily.-> Q
     Q -->|"ToList / Count / foreach"| E[Execution]
     E --> R[Result]

--- a/content/learn/csharp-linq-functional/filtering-and-projection.mdx
+++ b/content/learn/csharp-linq-functional/filtering-and-projection.mdx
@@ -49,7 +49,7 @@ Picture a sequence as data flowing through a pipe. Each operator is
 a stage in the pipe.
 
 ```mermaid
-flowchart LR
+flowchart TD
     S[Source: 1,2,3,4,5,6] --> W[Where: keep evens] --> P[Select: square it] --> O[Result: 4,16,36]
 ```
 

--- a/content/learn/csharp-linq-functional/generic-abstractions.mdx
+++ b/content/learn/csharp-linq-functional/generic-abstractions.mdx
@@ -50,7 +50,7 @@ That's it. No indexing, no length, no mutation. The minimum
 necessary to *walk* a sequence.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>IEnumerable&lt;T&gt;</code>"] -->|"<code>GetEnumerator</code>"| B["<code>IEnumerator&lt;T&gt;</code>"]
     B -->|"<code>MoveNext</code>"| C{has next?}
     C -- yes --> D[Current] --> B

--- a/content/learn/csharp-linq-functional/immutability.mdx
+++ b/content/learn/csharp-linq-functional/immutability.mdx
@@ -79,7 +79,7 @@ same mutable object, and one of them quietly changes what the other
 is reading.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Caller] -->|"passes List&lt;decimal&gt;"| F[Total]
     F -->|"mutates the same list"| A
 ```

--- a/content/learn/csharp-linq-functional/lambdas-and-delegates.mdx
+++ b/content/learn/csharp-linq-functional/lambdas-and-delegates.mdx
@@ -267,7 +267,7 @@ your lambda; they walk its tree and *translate* it into another
 language (SQL, BSON, an HTTP query).
 
 ```mermaid
-flowchart LR
+flowchart TD
     L["<code>x =&gt; x.Age &gt; 30</code>"] -->|"compiled as Func"| D[Delegate: callable in C#]
     L -->|"compiled as Expression"| T[Tree of nodes: translatable]
     T --> S["<code>SELECT * FROM ... WHERE Age &gt; 30</code>"]

--- a/content/learn/csharp-linq-functional/next-steps.mdx
+++ b/content/learn/csharp-linq-functional/next-steps.mdx
@@ -132,7 +132,7 @@ operators for `IAsyncEnumerable<T>`. Async iterators (`async` methods
 that `yield return`) make defining sources delightful.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>IAsyncEnumerable&lt;T&gt;</code>"] --> W["<code>WhereAwait / WhereAsync</code>"]
       --> S["<code>SelectAwait / SelectAsync</code>"]
       --> AF["await foreach"]

--- a/content/learn/csharp-linq-functional/pure-functions.mdx
+++ b/content/learn/csharp-linq-functional/pure-functions.mdx
@@ -247,7 +247,7 @@ This is sometimes called the *functional core, imperative shell*
 pattern.
 
 ```mermaid
-flowchart LR
+flowchart TD
     I[Input: file, HTTP, user] --> C{Core: pure functions}
     C --> O[Output: print, write, respond]
     style C fill:#e6f7e6

--- a/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
+++ b/content/learn/csharp-linq-functional/query-vs-method-syntax.mdx
@@ -86,7 +86,7 @@ as **syntactic sugar**: it mechanically rewrites it into method
 calls.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q["<code>from p in xs<br/>where p.A &gt; 0<br/>select p.B</code>"]
       -->|compiler rewrite| M["<code>xs.Where(p =&gt; p.A &gt; 0)</code><br/><code>.Select(p =&gt; p.B)</code>"]
     M --> IL[Same IL bytecode]

--- a/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
+++ b/content/learn/csharp-linq-functional/selectmany-and-flattening.mdx
@@ -128,7 +128,7 @@ them all into a single sequence.
 ## Visual mental model
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Departments: [Eng, Sales, Finance]"] --> S["<code>Select(d ⇒ d.Employees)</code>"]
     S --> N["[[Ada, Bilal], [Chiara, Dmitri, Esther], [Farah]]"]
     A --> M["<code>SelectMany(d ⇒ d.Employees)</code>"]

--- a/content/learn/csharp-linq-functional/set-operations.mdx
+++ b/content/learn/csharp-linq-functional/set-operations.mdx
@@ -113,7 +113,7 @@ Console.WriteLine($"Except b-a: [{string.Join(",", b.Except(a))}]");
 />
 
 ```mermaid
-flowchart LR
+flowchart TD
     A((a: 1,2,3,4,5)) --- I((4,5)) --- B((b: 4,5,6,7,8))
     A -. "Except a-b → 1,2,3" .- B
     A -. "Union → 1..8" .- B

--- a/content/learn/csharp-linq-functional/side-effect-management.mdx
+++ b/content/learn/csharp-linq-functional/side-effect-management.mdx
@@ -43,7 +43,7 @@ imperative shell**.
 ## The two halves of a program
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph "Imperative shell (IO)"
       I[Read inputs] --> X[Pure core] --> O[Write outputs]
     end

--- a/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
+++ b/content/learn/data-analysis-python-pandas/hypothesis-intuition.mdx
@@ -62,7 +62,7 @@ day — they're 95, 110, 102, 88, 130. So when one group looks
 "different" from another, you have to ask:
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Observed difference<br/>between two groups"] --> B{"Is it bigger<br/>than random wiggle?"}
   B -- "Yes" --> C["Signal — worth investigating"]
   B -- "No"  --> D["Noise — don't over-interpret"]

--- a/content/learn/data-analysis-python-pandas/pivot-tables.mdx
+++ b/content/learn/data-analysis-python-pandas/pivot-tables.mdx
@@ -83,7 +83,7 @@ rows, product to columns, sum of sales to values — Pandas's
 ## The shape of a pivot
 
 ```mermaid
-flowchart LR
+flowchart TD
   L["Long DataFrame<br/>region, product, sales"] -->|"<code>pivot_table</code>"| W["Wide grid<br/>rows=region<br/>cols=product<br/>cells=<code>sum(sales)</code>"]
 ```
 

--- a/content/learn/data-analysis-python-pandas/project-organization.mdx
+++ b/content/learn/data-analysis-python-pandas/project-organization.mdx
@@ -112,7 +112,7 @@ new step easy — `02.5-fix-encoding.ipynb` if you must.
 ## When to graduate to scripts
 
 ```mermaid
-flowchart LR
+flowchart TD
   N["Exploratory notebook<br/>(one-off, narrative)"] --> P{"Is it<br/>re-run regularly?"}
   P -- "No" --> N
   P -- "Yes" --> S["Promote to .py script<br/>or import shared logic from src/"]

--- a/content/learn/data-analysis-python-pandas/python-and-pandas-story.mdx
+++ b/content/learn/data-analysis-python-pandas/python-and-pandas-story.mdx
@@ -65,7 +65,7 @@ plus a notebook of side scripts to track which columns meant
 what. Spreadsheets had labels. Python did not.
 
 ```mermaid
-flowchart LR
+flowchart TD
     N[NumPy<br/>fast arrays] --> SP[SciPy<br/>algorithms]
     SP --> MPL[Matplotlib<br/>plots]
     N --> MPL

--- a/content/learn/data-analysis-python-pandas/the-analyst-mindset.mdx
+++ b/content/learn/data-analysis-python-pandas/the-analyst-mindset.mdx
@@ -78,7 +78,7 @@ number, ask:
   "tap" mid-year?
 
 ```mermaid
-flowchart LR
+flowchart TD
     R[Reality] -->|imperfect<br/>measurement| C[Collected<br/>data]
     C -->|pipelines,<br/>filters,<br/>bugs| D[Data you<br/>actually see]
     D -.->|easy to forget<br/>these arrows| R

--- a/content/learn/data-analysis-python-pandas/visualization-basics.mdx
+++ b/content/learn/data-analysis-python-pandas/visualization-basics.mdx
@@ -253,7 +253,7 @@ a clearer bar chart.
 ## Visualization vs summary statistics
 
 ```mermaid
-flowchart LR
+flowchart TD
   D["Same dataset"] --> S["Summary stats<br/>(mean, median, std)"]
   D --> V["Visualization<br/>(histogram, scatter)"]
   S --> M["Quick numbers<br/>Hide shape"]

--- a/content/learn/data-analysis-python-pandas/wide-vs-long.mdx
+++ b/content/learn/data-analysis-python-pandas/wide-vs-long.mdx
@@ -112,7 +112,7 @@ variable (year) — but they are sitting in column names. That's
 the tell-tale sign of "untidy" data.
 
 ```mermaid
-flowchart LR
+flowchart TD
   W["WIDE<br/>Columns = years"] -->|melt| L["LONG<br/>One row per person-year"]
   L -->|pivot| W
 ```

--- a/content/learn/database-design-postgresql/attributes-and-domains.mdx
+++ b/content/learn/database-design-postgresql/attributes-and-domains.mdx
@@ -213,7 +213,7 @@ if orders ship to saved addresses, or if addresses need their own
 validation and history.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Customer["Customer"] --> Simple["email<br/>single value"]
     Customer --> Complex["addresses<br/>many saved places"]
     Complex --> AddressEntity["Address entity"]

--- a/content/learn/database-design-postgresql/case-study-blog.mdx
+++ b/content/learn/database-design-postgresql/case-study-blog.mdx
@@ -87,7 +87,7 @@ The many-to-many relationship between posts and tags needs a fifth
 table: `post_tags`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Users["<code>users</code>"] --> Posts["<code>posts</code>"]
     Users --> Comments["<code>comments</code>"]
     Posts --> Comments
@@ -293,7 +293,7 @@ The design choices come from the rules:
   attached to the same post twice.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Rule["One tag per post only once"] --> Key["PRIMARY KEY on <code>post_id</code> and <code>tag_id</code>"]
     Key --> Reject["Duplicate pair is rejected"]
 ```

--- a/content/learn/database-design-postgresql/case-study-ecommerce.mdx
+++ b/content/learn/database-design-postgresql/case-study-ecommerce.mdx
@@ -180,7 +180,7 @@ It repeats a fact on purpose because order history must not change
 when a product's current price changes.
 
 ```mermaid
-flowchart LR
+flowchart TD
     ProductPrice["Product current price changes"] --> Catalog["Catalog updates"]
     ProductPrice -->|must not change| PastOrder["Past order total"]
     PastOrder --> LinePrice["Stored <code>unit_price</code>"]

--- a/content/learn/database-design-postgresql/check-constraints.mdx
+++ b/content/learn/database-design-postgresql/check-constraints.mdx
@@ -52,7 +52,7 @@ A CHECK constraint is a boolean expression that must be true for every
 row. If the expression is false, PostgreSQL rejects the write.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Row["Incoming row"] --> Check{"CHECK expression<br/>is true?"}
     Check -->|yes| Store["Store row"]
     Check -->|no| Reject["Reject row"]
@@ -136,7 +136,7 @@ CHECK constraints can compare columns in the same row. For an event,
 `end_date` should come after `start_date`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Start["<code>start_date</code>"] --> Rule{"<code>end_date &gt; start_date</code>"}
     End["end_date"] --> Rule
     Rule -->|true| Valid["Valid event"]
@@ -217,7 +217,7 @@ NULL expression may be unknown rather than false. If the column must be
 present, say that directly with `NOT NULL`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Required["Required domain value"] --> NN["NOT NULL"]
     Required --> CH["CHECK rule"]
     NN --> Safe["Present and valid"]

--- a/content/learn/database-design-postgresql/choosing-data-types.mdx
+++ b/content/learn/database-design-postgresql/choosing-data-types.mdx
@@ -52,7 +52,7 @@ A **domain** is the set of values a column is allowed to hold. Choosing a
 type chooses the broad domain before any other constraint narrows it.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Type["Column type"] --> Domain["Allowed domain<br/>what values can exist"]
     Domain --> Integrity["Fewer impossible<br/>rows"]
 ```
@@ -245,7 +245,7 @@ flowchart TB
 Types are broad constraints. Other constraints narrow the rule.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Broad["NUMERIC<br/>any exact number"] --> Narrow["CHECK (<code>price &gt;= 0</code>)<br/>valid price"]
     Narrow --> Required["NOT NULL<br/>required valid price"]
 ```

--- a/content/learn/database-design-postgresql/denormalization.mdx
+++ b/content/learn/database-design-postgresql/denormalization.mdx
@@ -76,7 +76,7 @@ These are not random copies. They are **derived facts** stored because a
 particular read path benefits from having them ready.
 
 ```mermaid
-flowchart LR
+flowchart TD
     N["Normalized tables<br/>customers, orders,<br/><code>order_items</code>, products"] --> R["Derived read table<br/><code>daily_sales_summary</code>"]
     N --> C["Cached value<br/><code>comment_count</code>"]
     R --> Benefit["Simpler reads"]
@@ -91,7 +91,7 @@ be easier to read, but now duplicated or derived data must be kept in
 sync.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Normal["Normalized<br/>one source of truth"] -->|"add derived copies"| Denormal["Denormalized<br/>faster or simpler reads"]
     Denormal -->|"sync carefully"| Normal
     Normal --> Correct["Correctness is easier"]

--- a/content/learn/database-design-postgresql/design-and-data-quality.mdx
+++ b/content/learn/database-design-postgresql/design-and-data-quality.mdx
@@ -165,7 +165,7 @@ Normalization keeps each fact in the right place. That prevents one
 fact from disagreeing with itself.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Duplicate["Customer email repeated in orders"] --> Disagree["Rows can disagree"]
     Disagree --> Normalize["Store customer once"]
     Normalize --> Reference["Orders reference customer"]

--- a/content/learn/database-design-postgresql/design-and-scale.mdx
+++ b/content/learn/database-design-postgresql/design-and-scale.mdx
@@ -158,7 +158,7 @@ unit price. Unbounded duplication is different. It repeats the same
 fact across many rows for no good reason.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Repeat["Product name copied into every order item"] --> ManyCopies["many copies"]
     ManyCopies --> ExpensiveChange["hard to change safely"]
     Normalize["<code>order_items</code> references products"] --> OneCopy["product name stored once"]

--- a/content/learn/database-design-postgresql/entity-relationship-diagrams.mdx
+++ b/content/learn/database-design-postgresql/entity-relationship-diagrams.mdx
@@ -68,7 +68,7 @@ it. ER diagrams let you discuss questions like:
 - Is the relationship one-to-many, many-to-many, or something else?
 
 ```mermaid
-flowchart LR
+flowchart TD
     Idea["Real system"] --> Diagram["ER diagram"]
     Diagram --> Review["Discuss meaning<br/>and rules"]
     Review --> Tables["PostgreSQL tables"]
@@ -115,7 +115,7 @@ Crow's-foot puts symbols at both ends of the relationship line, and
 the symbols tell you how many rows may connect on each side.
 
 ```mermaid
-flowchart LR
+flowchart TD
     One["||<br/>exactly one"] --> Line["relationship line"]
     Many["o{<br/>zero or many"] --> Line
     Line --> Sentence["One customer<br/>places many orders"]

--- a/content/learn/database-design-postgresql/evolving-schemas-safely.mdx
+++ b/content/learn/database-design-postgresql/evolving-schemas-safely.mdx
@@ -61,7 +61,7 @@ Good migrations are:
 - tested against existing data
 
 ```mermaid
-flowchart LR
+flowchart TD
     Design["Design decision"] --> Migration["Migration steps"]
     Migration --> Schema["New schema shape"]
     Schema --> Data["Data still makes sense"]
@@ -174,7 +174,7 @@ A **backfill** fills new structure using existing data or a chosen
 default. The design question is: what value should old rows mean?
 
 ```mermaid
-flowchart LR
+flowchart TD
     OldRows["Existing rows"] --> Rule["Backfill rule"]
     Rule --> NewValues["New column values"]
     NewValues --> Constraint["Constraint can be tightened"]
@@ -208,7 +208,7 @@ you move data and code toward the new shape. Finally, after the old
 shape is no longer needed, you contract by removing it.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Old["Old schema"] --> Expand["Expand: add new structure"]
     Expand --> Parallel["Both shapes work"]
     Parallel --> Move["Move reads and writes"]

--- a/content/learn/database-design-postgresql/first-normal-form.mdx
+++ b/content/learn/database-design-postgresql/first-normal-form.mdx
@@ -57,7 +57,7 @@ Common warning signs:
 - a cell that must be split apart before you can query it
 
 ```mermaid
-flowchart LR
+flowchart TD
     B["Before<br/><code>order_id</code>: 10<br/>items: Book, Pen"] --> A["After<br/><code>order_id</code>: 10 item: Book<br/><code>order_id</code>: 10 item: Pen"]
 ```
 
@@ -204,7 +204,7 @@ products, but that does not mean the order row should contain a product
 list.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Bad["orders<br/>id | customer | items<br/>10 | Ada | Book, Pen"] --> Good["<code>order_items</code><br/><code>order_id</code> | product<br/>10 | Book<br/>10 | Pen"]
 ```
 
@@ -218,7 +218,7 @@ Reaching 1NF does not mean the design is fully normalized. It only means
 the table no longer has repeating groups or multi-value cells.
 
 ```mermaid
-flowchart LR
+flowchart TD
     UNF["UNF<br/>lists and repeating groups"] --> NF1["1NF<br/>atomic cells"]
     NF1 --> NF2["2NF<br/>whole composite key"]
     NF2 --> NF3["3NF<br/>nothing but the key"]

--- a/content/learn/database-design-postgresql/foreign-keys.mdx
+++ b/content/learn/database-design-postgresql/foreign-keys.mdx
@@ -64,7 +64,7 @@ The `orders.customer_id` column points at `customers.customer_id`. One
 customer can have many orders, and each order belongs to one customer.
 
 ```mermaid
-flowchart LR
+flowchart TD
     O["orders.<code>customer_id</code> = 7"] -->|"FK -> PK"| C["customers.<code>customer_id</code> = 7<br/>Mina Patel"]
 ```
 
@@ -167,7 +167,7 @@ The rejected insert prevents an **orphan row**: a child row whose parent
 row does not exist.
 
 ```mermaid
-flowchart LR
+flowchart TD
     O["Order 102<br/><code>customer_id</code> = 99"] --> M["Missing customer 99"]:::bad
     M --> R["Rejected by FK constraint"]:::good
     classDef bad fill:#fee2e2,stroke:#b91c1c

--- a/content/learn/database-design-postgresql/from-ingres-to-postgresql.mdx
+++ b/content/learn/database-design-postgresql/from-ingres-to-postgresql.mdx
@@ -41,7 +41,7 @@ it did not speak SQL. It used its own language, POSTQUEL. By the
 1990s, that was a problem — SQL had won.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Ingres<br/>Berkeley, 1970s<br/>QUEL"] --> B["POSTGRES<br/>Berkeley, 1986<br/>POSTQUEL"]
     B --> C["Postgres95<br/>1994 to 95<br/>SQL added"]
     C --> D["PostgreSQL<br/>1996 onward<br/>open-source community"]

--- a/content/learn/database-design-postgresql/junction-tables.mdx
+++ b/content/learn/database-design-postgresql/junction-tables.mdx
@@ -59,7 +59,7 @@ relationship itself has many instances. A junction table gives each
 instance its own row.
 
 ```mermaid
-flowchart LR
+flowchart TD
     MN["Many-to-many<br/>students and courses"] --> J["enrollments<br/>one row per pairing"]
     J --> A["One student<br/>many enrollments"]
     J --> B["One course<br/>many enrollments"]
@@ -140,7 +140,7 @@ For an enrollment:
 - `role` might distinguish learner, assistant, or auditor.
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["Student: Ada"] --> E["Enrollment:<br/><code>enrolled_on</code> = 2025-01-15<br/>grade = A"]
     C["Course: Math"] --> E
     E --> Meaning["Facts about this pairing"]

--- a/content/learn/database-design-postgresql/many-to-many.mdx
+++ b/content/learn/database-design-postgresql/many-to-many.mdx
@@ -162,7 +162,7 @@ one student has many enrollment rows, and one course has many
 enrollment rows.
 
 ```mermaid
-flowchart LR
+flowchart TD
     MN["Conceptual M:N<br/>students to courses"] --> J["Add enrollments<br/>one row per pairing"]
     J --> L["students 1:N enrollments"]
     J --> R["courses 1:N enrollments"]

--- a/content/learn/database-design-postgresql/next-steps.mdx
+++ b/content/learn/database-design-postgresql/next-steps.mdx
@@ -77,7 +77,7 @@ Start with sentences. Circle the nouns and verbs. Draw an ER diagram.
 Then write the tables.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Familiar["System you know"] --> Sentences["Requirement sentences"]
     Sentences --> Diagram["ER diagram"]
     Diagram --> Tables["PostgreSQL tables"]
@@ -117,7 +117,7 @@ It covers the SQL skills you will use to explore the schemas you
 design.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Design["Design tables"] --> Query["Query relationships"]
     Query --> Notice["Notice design issues"]
     Notice --> Improve["Improve the schema"]

--- a/content/learn/database-design-postgresql/not-null-and-defaults.mdx
+++ b/content/learn/database-design-postgresql/not-null-and-defaults.mdx
@@ -80,7 +80,7 @@ column. PostgreSQL rejects any insert or update that would leave the
 column empty.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Fact["Column fact"] --> Q{"Must every row<br/>know this?"}
     Q -->|yes| Req["Use NOT NULL"]
     Q -->|no| Opt["Allow NULL"]
@@ -258,7 +258,7 @@ whether some orders have no date. If every product has `name NOT NULL`,
 interfaces can show product names without inventing placeholders.
 
 ```mermaid
-flowchart LR
+flowchart TD
     NN["NOT NULL"] --> Promise["Every row has<br/>the value"]
     Promise --> Trust["Queries and apps<br/>can rely on it"]
 ```

--- a/content/learn/database-design-postgresql/one-to-many.mdx
+++ b/content/learn/database-design-postgresql/one-to-many.mdx
@@ -95,7 +95,7 @@ related row. In a one-to-many relationship, that foreign key belongs on
 the **many** side.
 
 ```mermaid
-flowchart LR
+flowchart TD
     C["<code>customers.id = 1</code><br/>Ada"] --> O1["<code>orders.id = 101<br/>customer_id = 1</code>"]
     C --> O2["<code>orders.id = 102<br/>customer_id = 1</code>"]
     C --> O3["<code>orders.id = 103<br/>customer_id = 1</code>"]
@@ -187,7 +187,7 @@ Designers often call the one side the **parent** and the many side the
 **child**. The child depends on the parent for meaning.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Parent["Parent row<br/><code>customers.id = 1</code>"] --> ChildA["Child row<br/>order 101"]
     Parent --> ChildB["Child row<br/>order 102"]
     Parent --> ChildC["Child row<br/>order 103"]

--- a/content/learn/database-design-postgresql/primary-keys.mdx
+++ b/content/learn/database-design-postgresql/primary-keys.mdx
@@ -88,7 +88,7 @@ Those two rules are a design promise: every row can be pointed at, and
 no pointer has to mean "maybe this row, maybe that one."
 
 ```mermaid
-flowchart LR
+flowchart TD
     PK["Primary key"] --> U["Unique<br/>no duplicates"]
     PK --> N["Not null<br/>never missing"]
     U --> I["Stable row identity"]

--- a/content/learn/database-design-postgresql/referential-integrity.mdx
+++ b/content/learn/database-design-postgresql/referential-integrity.mdx
@@ -61,7 +61,7 @@ An **orphan row** is a child row that points to a parent row that does
 not exist.
 
 ```mermaid
-flowchart LR
+flowchart TD
     O["orders<br/><code>order_id</code> = 101<br/><code>customer_id</code> = 7"] --> C["customers<br/><code>customer_id</code> = 7"]
     X["orders<br/><code>order_id</code> = 102<br/><code>customer_id</code> = 99"] --> M["missing customer 99"]:::bad
     M --> P["Orphan row"]:::bad
@@ -136,7 +136,7 @@ Examples: orders that must keep their customer, invoice lines that must
 keep their invoice, payments that must keep their account.
 
 ```mermaid
-flowchart LR
+flowchart TD
     C["Customer"] --> O["Orders exist"]
     O --> R["Delete is blocked"]:::warn
     classDef warn fill:#fef3c7,stroke:#b45309
@@ -152,7 +152,7 @@ Examples: comments on a deleted draft, line items in a temporary cart,
 settings owned by a removed profile.
 
 ```mermaid
-flowchart LR
+flowchart TD
     P["Delete project"] --> T["Delete project tasks"] --> D["No leftovers"]:::good
     classDef good fill:#dcfce7,stroke:#15803d
 ```
@@ -166,7 +166,7 @@ Examples: a support ticket whose assigned employee left, or a blog post
 whose optional editor was removed.
 
 ```mermaid
-flowchart LR
+flowchart TD
     E["Delete employee"] --> T["ticket.<code>assigned_employee_id</code> = NULL"]
     T --> K["Ticket stays open"]
 ```

--- a/content/learn/database-design-postgresql/second-normal-form.mdx
+++ b/content/learn/database-design-postgresql/second-normal-form.mdx
@@ -259,7 +259,7 @@ is determined by the whole composite key or only part of it.
 ## 2NF in the normal-forms path
 
 ```mermaid
-flowchart LR
+flowchart TD
     NF1["1NF<br/>atomic values"] --> NF2["2NF<br/>no partial dependencies"]
     NF2 --> NF3["3NF<br/>no transitive dependencies"]
 ```

--- a/content/learn/database-design-postgresql/self-referencing-relationships.mdx
+++ b/content/learn/database-design-postgresql/self-referencing-relationships.mdx
@@ -78,7 +78,7 @@ A self-reference is still just a foreign key. The referenced table
 happens to be the same table.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Child["employees.<code>manager_id</code> = 2<br/>Mina's row"] -->|"FK -> PK"| Parent["<code>employees.id = 2</code><br/>Grace's row"]
 ```
 
@@ -201,7 +201,7 @@ as A parent of B, B parent of C, and C parent of A. It also does not
 stop a row from pointing to itself unless you add a check.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Good["Foreign key guarantees:<br/>parent row exists"] --> Not["Does not automatically guarantee:<br/>no cycles"]
     Not --> Extra["Extra rules may be needed<br/>for strict trees"]
 ```

--- a/content/learn/database-design-postgresql/the-design-process.mdx
+++ b/content/learn/database-design-postgresql/the-design-process.mdx
@@ -135,7 +135,7 @@ In those sentences, **nouns** hint at things and **verbs** hint at
 relationships.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Sentences["Requirement sentences"] --> Nouns["Nouns: organizer, event, venue, attendee"]
     Sentences --> Verbs["Verbs: creates, hosts, registers"]
     Nouns --> Candidates["Candidate entities"]
@@ -283,7 +283,7 @@ Common constraints include:
 - `REFERENCES` for valid relationships
 
 ```mermaid
-flowchart LR
+flowchart TD
     Rule["Design rule"] --> Constraint["Database constraint"]
     Constraint --> Reject["Rejects invalid rows"]
     Reject --> Trust["More trustworthy data"]
@@ -364,7 +364,7 @@ Review the design by walking through real scenarios:
 - Delete or archive old data.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Example["Real example"] --> TryInsert["Try the rows"]
     TryInsert --> FindRule["Find missing rule"]
     FindRule --> Adjust["Adjust schema"]

--- a/content/learn/database-design-postgresql/thinking-in-entities.mdx
+++ b/content/learn/database-design-postgresql/thinking-in-entities.mdx
@@ -61,7 +61,7 @@ One entity type usually becomes **one table**. One real thing of that
 type becomes **one row**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     E["Entity type<br/><code>customer</code>"] --> T["Table<br/><code>customers</code>"]
     R["One real customer<br/>Ada Lovelace"] --> Row["One row<br/><code>id = 1</code>"]
     T --> Row
@@ -192,7 +192,7 @@ A helpful question is: *can I imagine many rows of this kind?* If yes,
 you may have an entity type.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q{"Can there be many of these?"} -->|"yes"| T["Likely table"]
     Q -->|"no"| A["Maybe an attribute<br/>or setting"]
     T --> R["One real thing<br/>per row"]

--- a/content/learn/database-design-postgresql/third-normal-form.mdx
+++ b/content/learn/database-design-postgresql/third-normal-form.mdx
@@ -67,7 +67,7 @@ the order. But `customer_name` and `customer_city` are not facts about
 the order itself. They are facts about the customer.
 
 ```mermaid
-flowchart LR
+flowchart TD
     K["<code>order_id</code><br/>primary key"] --> C["<code>customer_id</code><br/>non-key column"]
     C --> City["<code>customer_city</code><br/>non-key column"]
     C --> Name["<code>customer_name</code><br/>non-key column"]
@@ -255,7 +255,7 @@ For the bad orders table:
 mistakes.
 
 ```mermaid
-flowchart LR
+flowchart TD
     NF1["1NF<br/>atomic cells"] --> NF2["2NF<br/>no partial dependency<br/>on part of a composite key"]
     NF2 --> NF3["3NF<br/>no transitive dependency<br/>through a non-key column"]
 ```

--- a/content/learn/database-design-postgresql/what-are-constraints.mdx
+++ b/content/learn/database-design-postgresql/what-are-constraints.mdx
@@ -49,7 +49,7 @@ That rejection is not a failure of the database. It is the database
 protecting the meaning of your data.
 
 ```mermaid
-flowchart LR
+flowchart TD
     W["Write request<br/>INSERT or UPDATE"] --> C{"Constraint<br/>check"}
     C -->|passes| A["Accept row<br/>store data"]
     C -->|fails| R["Reject write<br/>return error"]
@@ -167,7 +167,7 @@ Suppose your application has orders. The schema can express facts like
 these:
 
 ```mermaid
-flowchart LR
+flowchart TD
     Rule["Business rule"] --> Constraint["Schema constraint"]
     Constraint --> Data["Trustworthy data"]
 ```

--- a/content/learn/database-design-postgresql/what-are-relationships.mdx
+++ b/content/learn/database-design-postgresql/what-are-relationships.mdx
@@ -47,7 +47,7 @@ verbs: a customer **places** an order, a book **belongs to** an author,
 a student **enrolls in** a course.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Customer["<code>Customer</code>"] -->|places| Order["<code>Order</code>"]
     Order -->|contains| Product["<code>Product</code>"]
 ```
@@ -77,7 +77,7 @@ has a **primary key**. Another table stores a **foreign key** that
 points to it.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Real["Real world:<br/>Ada placed order 101"] --> Model["Model:<br/>customer relates to order"]
     Model --> Schema["Schema:<br/>orders.<code>customer_id</code> points to customers.id"]
 ```

--- a/content/learn/database-design-postgresql/what-is-database-design.mdx
+++ b/content/learn/database-design-postgresql/what-is-database-design.mdx
@@ -263,7 +263,7 @@ runs that schema: indexes, storage settings, partitioning. Those
 topics matter in production, but they are not our focus here.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Conceptual design<br/>customers place orders"] --> B["Logical design<br/>tables, keys, constraints"]
     B --> C["Physical design<br/>indexes, storage choices"]
 ```

--- a/content/learn/database-design-postgresql/why-normalization.mdx
+++ b/content/learn/database-design-postgresql/why-normalization.mdx
@@ -215,7 +215,7 @@ tracking?* In this example, there are customers, products, and orders.
 Those are different kinds of facts, so they deserve different homes.
 
 ```mermaid
-flowchart LR
+flowchart TD
     F["Flat order rows<br/>customers and products repeated"] --> C["customers<br/>one row per customer"]
     F --> P["products<br/>one row per product"]
     F --> O["orders<br/>one row per order"]
@@ -259,7 +259,7 @@ The normal forms are a step-by-step path away from messy, duplicated
 storage and toward single-source-of-truth tables.
 
 ```mermaid
-flowchart LR
+flowchart TD
     UNF["UNF<br/>repeating groups<br/>and mixed facts"] --> NF1["1NF<br/>one value per cell"]
     NF1 --> NF2["2NF<br/>whole composite key"]
     NF2 --> NF3["3NF<br/>nothing but the key"]

--- a/content/learn/database-design-postgresql/why-schemas-change.mdx
+++ b/content/learn/database-design-postgresql/why-schemas-change.mdx
@@ -56,7 +56,7 @@ history. Each new requirement asks the schema to represent a new fact
 or rule.
 
 ```mermaid
-flowchart LR
+flowchart TD
     V1["v1: tasks only"] --> V2["v2: add <code>due_date</code>"]
     V2 --> V3["v3: add projects"]
     V3 --> V4["v4: add labels"]
@@ -121,7 +121,7 @@ single owner might become a team of assignees. That turns a one-to-many
 relationship into many-to-many.
 
 ```mermaid
-flowchart LR
+flowchart TD
     One["tasks.<code>owner_id</code>"] --> Many["<code>task_assignees</code>"]
     Many --> Team["many users per task"]
 ```
@@ -133,7 +133,7 @@ move from `customers` into `billing_profiles` when they gain their own
 rules.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Wide["customers with billing columns"] --> Split["customers plus <code>billing_profiles</code>"]
     Split --> Clear["separate rules and lifetimes"]
 ```
@@ -147,7 +147,7 @@ Early in a product, a column may allow nulls because old data is
 messy. Later, the team may learn that the fact is always required.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Loose["status nullable"] --> Clean["fill missing statuses"]
     Clean --> Tight["status NOT NULL"]
 ```

--- a/content/learn/from-zero-to-cpp/a-brief-history.mdx
+++ b/content/learn/from-zero-to-cpp/a-brief-history.mdx
@@ -261,7 +261,7 @@ call `malloc` or `free` directly — you use `std::vector`,
 under the hood, but you rarely touch them.
 
 ```mermaid
-flowchart LR
+flowchart TD
     C[C: small + raw] --> CXX[C++: large + abstract]
     CXX --> M[Modern C++<br/>RAII, smart pointers,<br/>algorithms, ranges]
 ```

--- a/content/learn/from-zero-to-cpp/arrays-and-strings.mdx
+++ b/content/learn/from-zero-to-cpp/arrays-and-strings.mdx
@@ -61,7 +61,7 @@ This puts five `int`s in **contiguous** memory. The size is part of
 the type (`int[5]`) and is fixed at compile time.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph "scores[5]"
         S0[90] --- S1[85] --- S2[72] --- S3[95] --- S4[88]
     end
@@ -162,7 +162,7 @@ int main() {
 Under the hood:
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Stack
         V["v: <code>std::vector&lt;int&gt;</code><br/>size=3, capacity=4<br/>data: 0x6020a0"]
     end

--- a/content/learn/from-zero-to-cpp/building-maintainable-software.mdx
+++ b/content/learn/from-zero-to-cpp/building-maintainable-software.mdx
@@ -96,7 +96,7 @@ C++ code is typically split across two kinds of file:
 - **Source files (`.cpp`)** define the implementations.
 
 ```mermaid
-flowchart LR
+flowchart TD
     H1["<code>geometry.h</code><br/>declarations"]
     C1["<code>geometry.cpp</code><br/>definitions"]
     M["<code>main.cpp</code>"]

--- a/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
+++ b/content/learn/from-zero-to-cpp/compilation-pipeline.mdx
@@ -113,7 +113,7 @@ handles every line that starts with `#`:
   blocks based on whether a name is defined.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>your.cpp</code><br/>#include &lt;iostream&gt;"] --> P[Preprocessor]
     B[iostream<br/>thousands of lines] --> P
     P --> X["<code>your.cpp.i</code><br/>tens of thousands of<br/>lines, all C++ text"]
@@ -188,7 +188,7 @@ The **assembler** translates assembly text into actual binary
 This step is essentially a one-to-one translation table.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>file.s</code><br/>'mov eax, 42'"] --> AS[Assembler]
     AS --> B["<code>file.o</code><br/>binary bytes:<br/>B8 2A 00 00 00 ..."]
 ```

--- a/content/learn/from-zero-to-cpp/dynamic-memory.mdx
+++ b/content/learn/from-zero-to-cpp/dynamic-memory.mdx
@@ -94,7 +94,7 @@ int main() {
 A picture of what happened:
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Stack
         P["p: int*<br/><code>0x6020a0</code>"]
     end
@@ -160,7 +160,7 @@ void leaker() {
 ```
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[new] -->|allocates| H[Heap block]
     H -.->|never reached again| L[(LEAKED)]
 ```

--- a/content/learn/from-zero-to-cpp/encapsulation-and-abstraction.mdx
+++ b/content/learn/from-zero-to-cpp/encapsulation-and-abstraction.mdx
@@ -71,7 +71,7 @@ to it. Making it `private` and offering controlled methods is how
 you defend the invariant.
 
 ```mermaid
-flowchart LR
+flowchart TD
     O[Outside code] -->|deposit / withdraw| API[Public methods]
     API -->|enforce rules| F[Private fields]
     O -.cannot reach.-x F

--- a/content/learn/from-zero-to-cpp/functions-and-modularity.mdx
+++ b/content/learn/from-zero-to-cpp/functions-and-modularity.mdx
@@ -10,7 +10,7 @@ have for managing complexity: they let you replace a tangle of
 inline code with a one-line *call* whose name documents intent.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[caller] -->|arguments| F[function body]
     F -->|return value| A
 ```

--- a/content/learn/from-zero-to-cpp/how-computers-execute.mdx
+++ b/content/learn/from-zero-to-cpp/how-computers-execute.mdx
@@ -131,7 +131,7 @@ The CPU does *exactly one thing*, over and over, billions of times
 per second. It is called the **fetch–decode–execute loop**:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Fetch:<br/>read the next<br/>instruction from<br/>memory"] --> B["Decode:<br/>figure out what<br/>this instruction<br/>means"]
     B --> C["Execute:<br/>do it, read or<br/>write memory,<br/>do math, jump"]
     C --> A
@@ -150,7 +150,7 @@ numbers means: copy them into registers, add the registers, copy
 the result back to memory.
 
 ```mermaid
-flowchart LR
+flowchart TD
     M[("Main memory<br/>billions of bytes<br/>slow-ish")] -->|load| R["CPU registers<br/>~32 slots<br/>blazing fast"]
     R -->|store| M
     R --> ALU["Arithmetic/Logic Unit:<br/>add, sub, and, or, ..."]

--- a/content/learn/from-zero-to-cpp/memory-model.mdx
+++ b/content/learn/from-zero-to-cpp/memory-model.mdx
@@ -152,7 +152,7 @@ When you allocate on the heap, the *pointer* (typically 8 bytes on
 64-bit systems) lives on the stack. The *object* lives on the heap.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Stack
         P[p : int*<br/>holds heap address]
     end
@@ -230,7 +230,7 @@ We'll meet `std::unique_ptr` and friends in a couple chapters.
 does its data live?
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Stack
         V["v : <code>std::vector</code>&lt;int&gt;<br/>holds a pointer, a size,<br/>and a capacity"]
     end

--- a/content/learn/from-zero-to-cpp/move-semantics-intuition.mdx
+++ b/content/learn/from-zero-to-cpp/move-semantics-intuition.mdx
@@ -72,7 +72,7 @@ flowchart LR
 A **move** just steals the pointer:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A2["a: vector<br/>data ptr = nullptr<br/><code>size = 0</code>"]
     B2["b: vector<br/>data ptr -> buffer A"] --> BA2["buffer A<br/>1,000,000 ints"]
 ```

--- a/content/learn/from-zero-to-cpp/pointers-and-references.mdx
+++ b/content/learn/from-zero-to-cpp/pointers-and-references.mdx
@@ -63,7 +63,7 @@ After the second line, two variables exist:
   `n`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Stack
         N["n: int<br/>value 42<br/>at <code>0x7fff_4cf0</code>"]
         P["p: int*<br/>value <code>0x7fff_4cf0</code><br/>at <code>0x7fff_4cf8</code>"]
@@ -167,7 +167,7 @@ std::cout << n;  // prints 100
 ```
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Stack
         N["n: int<br/>value 100"]
         R["r: int& <br/>alias for n"]
@@ -232,7 +232,7 @@ Arrays in C++ live in *contiguous* memory. You can do arithmetic on
 pointers to step through them.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph "int a[5] in memory"
         A0[10] --- A1[20] --- A2[30] --- A3[40] --- A4[50]
     end

--- a/content/learn/from-zero-to-cpp/smart-pointers.mdx
+++ b/content/learn/from-zero-to-cpp/smart-pointers.mdx
@@ -106,7 +106,7 @@ std::unique_ptr<Widget> c = std::move(a);   // OK: ownership transferred
 ```
 
 ```mermaid
-flowchart LR
+flowchart TD
     Before["<code>a -&gt; Widget</code><br/><code>b = nullptr</code>"]
     After["<code>a = nullptr</code><br/><code>c -&gt; Widget</code>"]
     Before -- std::move --> After
@@ -167,7 +167,7 @@ to the other. Neither's count ever hits zero, so neither is
 destroyed — a **cycle leak**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["A<br/><code>shared_ptr</code> to B"] --> B["B<br/><code>shared_ptr</code> to A"]
     B --> A
 ```

--- a/content/learn/from-zero-to-cpp/types-and-values.mdx
+++ b/content/learn/from-zero-to-cpp/types-and-values.mdx
@@ -55,7 +55,7 @@ A *static* type system answers all three at *compile time*. Bugs
 caught by the compiler are bugs your users never see.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[You write code] --> B[Compiler checks<br/>types]
     B -->|consistent| C[Program builds]
     B -->|inconsistent| D[Error message<br/>BEFORE the program ever runs]

--- a/content/learn/from-zero-to-cpp/your-first-program.mdx
+++ b/content/learn/from-zero-to-cpp/your-first-program.mdx
@@ -91,7 +91,7 @@ by convention, `0` means success and any other value means a
 particular kind of failure.
 
 ```mermaid
-flowchart LR
+flowchart TD
     OS[Operating system] -->|calls| M[main]
     M -->|returns int| OS
     OS -->|exit code| S[Shell / parent process]

--- a/content/learn/functional-programming-typescript/algebraic-data-types.mdx
+++ b/content/learn/functional-programming-typescript/algebraic-data-types.mdx
@@ -51,7 +51,7 @@ anything you need.
 ## Two operations: *and* (products) and *or* (sums)
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Product
       direction LR
       A1["A"] -.AND.- B1["B"]

--- a/content/learn/functional-programming-typescript/category-theory-intuitions.mdx
+++ b/content/learn/functional-programming-typescript/category-theory-intuitions.mdx
@@ -120,7 +120,7 @@ or fail in surprising ways. If you've ever felt that
 identity law.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>F&lt;A&gt;</code>"] -- "map(f)" --> B["<code>F&lt;B&gt;</code>"]
     B -- "map(g)" --> C["<code>F&lt;C&gt;</code>"]
     A -- "map(g ∘ f)" --> C

--- a/content/learn/functional-programming-typescript/effect-management.mdx
+++ b/content/learn/functional-programming-typescript/effect-management.mdx
@@ -288,7 +288,7 @@ That separation is the heart of functional effect management.
 ## A diagram of the boundary
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Pure core<br/>builds IO/Task/Effect values] --> B[Edge<br/>interpreter / runtime]
     B --> C[(World)]
     C --> B

--- a/content/learn/functional-programming-typescript/function-composition.mdx
+++ b/content/learn/functional-programming-typescript/function-composition.mdx
@@ -52,7 +52,7 @@ is the function `A → C` defined by `(g ∘ f)(x) = g(f(x))`. You apply
 `f` first, then feed the result into `g`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A((A)) -- f --> B((B)) -- g --> C((C))
     A2((A)) == "g ∘ f" ==> C2((C))
 ```

--- a/content/learn/functional-programming-typescript/functional-state-management.mdx
+++ b/content/learn/functional-programming-typescript/functional-state-management.mdx
@@ -332,7 +332,7 @@ Treating state as a value gives you:
   threads, workers, requests, components without locking.
 
 ```mermaid
-flowchart LR
+flowchart TD
     S0["State <code>t=0</code>"] -- "reducer(s, a0)" --> S1["State <code>t=1</code>"]
     S1 -- "reducer(s, a1)" --> S2["State <code>t=2</code>"]
     S2 -- "reducer(s, a2)" --> S3["State <code>t=3</code>"]

--- a/content/learn/functional-programming-typescript/option-and-result.mdx
+++ b/content/learn/functional-programming-typescript/option-and-result.mdx
@@ -329,7 +329,7 @@ computation". Every later chapter will use it for some `M<A>`:
 `Option<A>`, `Result<E, A>`, `Task<A>`, `Promise<A>`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>M&lt;A&gt;</code>"] -- "flatMap(f)" --> B["<code>M&lt;B&gt;</code>"]
     A -.->|"if 'none'/'err' or empty"| B
     A -->|"if 'some'/'ok' value a"| C["f(a) = <code>M&lt;B&gt;</code>"] --> B

--- a/content/learn/functional-programming-typescript/pure-functions.mdx
+++ b/content/learn/functional-programming-typescript/pure-functions.mdx
@@ -235,7 +235,7 @@ This is sometimes called the *functional core, imperative shell*
 pattern.
 
 ```mermaid
-flowchart LR
+flowchart TD
     I[Input: HTTP, file, user] --> C{Core: pure functions}
     C --> O[Output: write, print, respond]
     style C fill:#e6f7e6

--- a/content/learn/functional-programming-typescript/referential-transparency.mdx
+++ b/content/learn/functional-programming-typescript/referential-transparency.mdx
@@ -123,7 +123,7 @@ are also exactly the *refactorings* a human wants to do. Pure code
 makes both safe.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["expr"] -->|"equivalent"| B["value"]
     B -->|"replace freely"| C["anywhere expr appears"]
     style A fill:#e6f7e6

--- a/content/learn/intro-modern-csharp/debugging-and-reasoning.mdx
+++ b/content/learn/intro-modern-csharp/debugging-and-reasoning.mdx
@@ -58,7 +58,7 @@ of figuring out which step in your mental story doesn't match
 reality — and then fixing one or the other.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["story #1<br/>what I expect"]
     B["story #2<br/>what actually happens"]
     A --> X{"compare"}

--- a/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
+++ b/content/learn/intro-modern-csharp/encapsulation-and-abstraction.mdx
@@ -157,7 +157,7 @@ owns its rules.
 ## Encapsulation as a picture
 
 ```mermaid
-flowchart LR
+flowchart TD
     Out["outside code"] -->|"Deposit(50)"| API["public methods<br/>(Deposit / Withdraw)"]
     API --> State["private state<br/>(Balance)"]
     Out -. "cannot reach" .-> State

--- a/content/learn/intro-modern-csharp/how-programs-execute.mdx
+++ b/content/learn/intro-modern-csharp/how-programs-execute.mdx
@@ -134,7 +134,7 @@ lower-level language called **CIL** (Common Intermediate Language,
 sometimes "IL" for short).
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["<code>Program.cs</code>"] --> R["Roslyn compiler"]
     R --> D["<code>Program.dll</code><br/>(contains CIL)"]
 ```

--- a/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
+++ b/content/learn/intro-modern-csharp/java-and-managed-runtimes.mdx
@@ -139,7 +139,7 @@ For most software, this trade — slight runtime overhead for
 ## The "Write Once, Run Anywhere" promise
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["<code>MyApp.java</code>"] --> C["javac"] --> B["<code>MyApp.class</code><br/>(bytecode)"]
     B --> JVMW["JVM on Windows"]
     B --> JVML["JVM on Linux"]
@@ -172,7 +172,7 @@ multi-year lawsuit. Microsoft eventually settled, and effectively
 withdrew from the Java world.
 
 ```mermaid
-flowchart LR
+flowchart TD
     J["Sun owns Java<br/>(neutral, cross-platform)"] -->|threatens| W["Windows dominance"]
     L["Lawsuit blocks<br/>Microsoft from<br/>shaping Java"] --> N["Microsoft must build<br/>its own answer"]
     N --> NET[".NET + C#"]

--- a/content/learn/intro-modern-csharp/the-road-to-csharp.mdx
+++ b/content/learn/intro-modern-csharp/the-road-to-csharp.mdx
@@ -69,7 +69,7 @@ those numbers human-readable names: instead of `B8 04`, you wrote
 back.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Assembly source<br/>MOV EAX, 4<br/>MOV EBX, 2<br/>ADD EAX, EBX"]
       --> B[Assembler]
     B --> C["Machine code<br/>B8 04 00 00 00<br/>BB 02 00 00 00<br/>01 D8"]

--- a/content/learn/intro-sql-postgres/aggregate-functions.mdx
+++ b/content/learn/intro-sql-postgres/aggregate-functions.mdx
@@ -59,7 +59,7 @@ are aggregate questions, and they are the heart of reporting.
 ## From many rows to one number
 
 ```mermaid
-flowchart LR
+flowchart TD
     R["Many rows<br/>(5 salaries)"] --> A["An aggregate<br/>function"]
     A --> One["One summary value<br/>(e.g. the average)"]
 ```
@@ -175,7 +175,7 @@ WHERE
 />
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[("<code>employees</code>")] --> W["WHERE<br/><code>dept = 'Engineering'</code>"]
     W --> A["AVG(salary)"]
     A --> R["one number"]

--- a/content/learn/intro-sql-postgres/common-table-expressions.mdx
+++ b/content/learn/intro-sql-postgres/common-table-expressions.mdx
@@ -170,7 +170,7 @@ the next — much clearer than nesting these as two subqueries.
 ## When to reach for a CTE
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q["A question with<br/>several stages"] --> C["Name each stage<br/>with a CTE"]
     C --> R["A readable,<br/>step-by-step query"]
 ```

--- a/content/learn/intro-sql-postgres/data-types.mdx
+++ b/content/learn/intro-sql-postgres/data-types.mdx
@@ -52,7 +52,7 @@ number, and the database will refuse the text `"banana"`. Declare it
 as a date, and `"someday"` is rejected.
 
 ```mermaid
-flowchart LR
+flowchart TD
     V["A value you<br/>try to store"] --> T{"Does it match<br/>the column's type?"}
     T -->|"yes"| OK["Stored"]
     T -->|"no"| NO["Rejected — caught early"]

--- a/content/learn/intro-sql-postgres/expressions-and-aliases.mdx
+++ b/content/learn/intro-sql-postgres/expressions-and-aliases.mdx
@@ -89,7 +89,7 @@ self-explanatory and let later parts of bigger queries refer to the
 value by name.
 
 ```mermaid
-flowchart LR
+flowchart TD
     E["price * qty"] -->|"AS <code>line_total</code>"| C["a clearly<br/>named column"]
 ```
 

--- a/content/learn/intro-sql-postgres/filtering-groups.mdx
+++ b/content/learn/intro-sql-postgres/filtering-groups.mdx
@@ -55,7 +55,7 @@ therefore their `COUNT`s and `SUM`s — **do not exist yet.** Asking
 has been added up.
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[("rows")] --> W["<code>WHERE</code><br/>(per-row filter)<br/>no totals exist yet"]
     W --> G["<code>GROUP BY</code><br/>totals computed here"]
     G --> H["<code>HAVING</code><br/>(per-group filter)<br/>can see the totals"]

--- a/content/learn/intro-sql-postgres/filtering-rows.mdx
+++ b/content/learn/intro-sql-postgres/filtering-rows.mdx
@@ -56,7 +56,7 @@ database checks it against every row and keeps only the rows where
 the test comes out **true**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["All rows"] --> T{"<code>WHERE</code><br/>condition true?"}
     T -->|"true"| K["Kept in result"]
     T -->|"false"| D["Dropped"]
@@ -195,7 +195,7 @@ which rows pass `WHERE`, *then* picks the `SELECT` columns from those
 surviving rows.
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[("table")] --> W["<code>WHERE</code><br/>keep matching rows"]
     W --> S["<code>SELECT</code><br/>pick columns"]
     S --> R["Result"]

--- a/content/learn/intro-sql-postgres/first-queries.mdx
+++ b/content/learn/intro-sql-postgres/first-queries.mdx
@@ -86,7 +86,7 @@ Here is the basic shape you will type thousands of times, with the
 parts named:
 
 ```mermaid
-flowchart LR
+flowchart TD
     K["<code>SELECT</code>"] --> C["which columns<br/>or values you want"]
     C --> F["<code>FROM</code>"]
     F --> T["which table<br/>to read from"]
@@ -114,7 +114,7 @@ it becomes essential when you run several statements together — so we
 will always include it as a good habit.
 
 ```mermaid
-flowchart LR
+flowchart TD
     S1["<code>SELECT 1;</code>"] --> S2["<code>SELECT 2;</code>"] --> S3["<code>SELECT 3;</code>"]
 ```
 

--- a/content/learn/intro-sql-postgres/foreign-keys.mdx
+++ b/content/learn/intro-sql-postgres/foreign-keys.mdx
@@ -76,7 +76,7 @@ the `id` of some customer. Order 101 storing `customer_id = 1` means
 "this order belongs to customer 1 (Ada)."
 
 ```mermaid
-flowchart LR
+flowchart TD
     O["orders.<code>customer_id</code> = 1"] -->|"refers to"| C["<code>customers.id = 1</code><br/>(Ada)"]
 ```
 

--- a/content/learn/intro-sql-postgres/grouping-data.mdx
+++ b/content/learn/intro-sql-postgres/grouping-data.mdx
@@ -223,7 +223,7 @@ ORDER BY
 />
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[("rows")] --> W["<code>WHERE</code><br/>drop interns"] --> G["<code>GROUP BY dept</code><br/>form groups"] --> A["AVG per group"]
 ```
 

--- a/content/learn/intro-sql-postgres/how-applications-use-databases.mdx
+++ b/content/learn/intro-sql-postgres/how-applications-use-databases.mdx
@@ -85,7 +85,7 @@ really **two separate things** working together:
    everything.
 
 ```mermaid
-flowchart LR
+flowchart TD
     User["You<br/>(tap, type, click)"] --> App["Application<br/>(screens & logic)"]
     App -->|"a query: please give me X"| DB[("Database")]
     DB -->|"the rows that match"| App

--- a/content/learn/intro-sql-postgres/normalization.mdx
+++ b/content/learn/intro-sql-postgres/normalization.mdx
@@ -179,7 +179,7 @@ forms**. You do not need the formal definitions yet — the intuition
 is what counts:
 
 ```mermaid
-flowchart LR
+flowchart TD
     UNF["Unnormalized<br/>one big table"] --> NF1["1NF:<br/>one value per cell,<br/>no repeating groups"]
     NF1 --> NF2["2NF:<br/>non-key columns depend<br/>on the whole key"]
     NF2 --> NF3["3NF:<br/>non-key columns depend<br/>on nothing but the key"]

--- a/content/learn/intro-sql-postgres/outer-joins.mdx
+++ b/content/learn/intro-sql-postgres/outer-joins.mdx
@@ -145,7 +145,7 @@ Once `LEFT JOIN` makes sense, its siblings are easy:
   `NULL`s on whichever side lacks a match.
 
 ```mermaid
-flowchart LR
+flowchart TD
     I["INNER<br/>only matches"] --- LJ["LEFT<br/>all left + matches"]
     LJ --- RJ["RIGHT<br/>all right + matches"]
     RJ --- FJ["FULL<br/>everything,<br/>NULLs where unmatched"]

--- a/content/learn/intro-sql-postgres/query-execution-order.mdx
+++ b/content/learn/intro-sql-postgres/query-execution-order.mdx
@@ -166,7 +166,7 @@ rows*. `HAVING` (step 4) runs **after** grouping, so it filters
 *whole groups*:
 
 ```mermaid
-flowchart LR
+flowchart TD
     R["rows"] --> W["<code>WHERE</code><br/>filter rows<br/>(before grouping)"]
     W --> G["<code>GROUP BY</code><br/>form groups"]
     G --> H["<code>HAVING</code><br/>filter groups<br/>(after grouping)"]

--- a/content/learn/intro-sql-postgres/select-basics.mdx
+++ b/content/learn/intro-sql-postgres/select-basics.mdx
@@ -126,7 +126,7 @@ little table — and hands that back to you. The stored data sits
 untouched, ready for the next question.
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[("employees<br/>(stored table)")] -->|"<code>SELECT name, salary</code>"| R["Result set<br/>name + salary<br/>(a new table)"]
     T -.->|"unchanged"| T
 ```

--- a/content/learn/intro-sql-postgres/sorting-and-limiting.mdx
+++ b/content/learn/intro-sql-postgres/sorting-and-limiting.mdx
@@ -103,7 +103,7 @@ department, sorted by salary high to low. The order of the columns
 in `ORDER BY` is the order of priority.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Sort by<br/>dept (A→Z)"] --> B["Ties broken by<br/>salary (high→low)"]
 ```
 
@@ -178,7 +178,7 @@ the web.
 So far you have met four clauses. They must appear in this order:
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["<code>SELECT</code><br/>columns"] --> F["<code>FROM<br/>table</code>"]
     F --> W["<code>WHERE</code><br/>filter rows"]
     W --> O["<code>ORDER BY</code><br/>sort"]

--- a/content/learn/intro-sql-postgres/subqueries.mdx
+++ b/content/learn/intro-sql-postgres/subqueries.mdx
@@ -137,7 +137,7 @@ A subquery can appear in several parts of a statement, depending on
 the shape of its result:
 
 ```mermaid
-flowchart LR
+flowchart TD
     W["In WHERE<br/>compare against a value or list"]
     F["In FROM<br/>treat a result as a temporary table"]
     S["In SELECT<br/>compute one extra value per row"]

--- a/content/learn/intro-sql-postgres/tables-rows-columns.mdx
+++ b/content/learn/intro-sql-postgres/tables-rows-columns.mdx
@@ -126,7 +126,7 @@ in the picture is not a property of the data — it is just how we
 happened to print it.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q["A table is an<br/>unordered bag of rows"] --> S["Want a specific order?<br/>Ask for it with ORDER BY"]
 ```
 

--- a/content/learn/intro-sql-postgres/understanding-joins.mdx
+++ b/content/learn/intro-sql-postgres/understanding-joins.mdx
@@ -46,7 +46,7 @@ name is in `customers`; the amount is in `orders`. A join stitches
 them together:
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph C["<code>customers</code>"]
         C1["1 · Ada"]
         C2["2 · Grace"]

--- a/content/learn/intro-sql-postgres/what-is-a-database.mdx
+++ b/content/learn/intro-sql-postgres/what-is-a-database.mdx
@@ -72,7 +72,7 @@ Read that again slowly. There are four verbs hiding in it, and they
 are the whole reason databases exist:
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["Store<br/>(keep data safely)"] --> F["Find<br/>(answer questions)"]
     F --> C["Change<br/>(add, edit, delete)"]
     C --> P["Protect<br/>(stay correct and safe)"]
@@ -307,7 +307,7 @@ sends the database a request written in SQL. That request is called
 a **query**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     User["You<br/>(tap, type, click)"] --> App["Application<br/>(screens & logic)"]
     App -->|"a query: please give me X"| DB[("Database")]
     DB -->|"the rows that match"| App
@@ -330,7 +330,7 @@ For the rest of this course, hold this picture in your head: a
 database is a **trustworthy librarian** for your data.
 
 ```mermaid
-flowchart LR
+flowchart TD
     U["You / an app"] -->|"a request"| L["Database<br/>(the librarian)"]
     L -->|"exactly the right data"| U
     L --- D[("Stored data")]

--- a/content/learn/intro-sql-postgres/working-with-null.mdx
+++ b/content/learn/intro-sql-postgres/working-with-null.mdx
@@ -201,7 +201,7 @@ behavior is the price of that honesty — and `IS NULL` plus
 `COALESCE` make it manageable.
 
 ```mermaid
-flowchart LR
+flowchart TD
     M["Missing real data"] --> N["Store NULL<br/>(honest 'unknown')"]
     N --> T1["Test with IS NULL"]
     N --> T2["Display with COALESCE"]

--- a/content/learn/java-collections-and-generics-deep-dive/lists.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/lists.mdx
@@ -110,7 +110,7 @@ public class Main {
 (typically 1.5× the current capacity) and copies.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Heap
       direction LR
       A["<code>ArrayList<br/>size=4<br/>capacity=8</code>"]

--- a/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
@@ -68,7 +68,7 @@ Bloch, the architect of the Collections Framework: *"Does anyone
 actually use LinkedList? I wrote it, and I never use it."*
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph AL[ArrayList - contiguous]
       direction LR
       A0[a0] --- A1[a1] --- A2[a2] --- A3[a3] --- A4[a4]

--- a/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/queues-and-deques.mdx
@@ -86,7 +86,7 @@ buffer of `Object` — contiguous memory, no node allocation per
 element, very fast.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Buffer["circular buffer (<code>capacity = 8</code>)"]
       direction LR
       S0["[_]"] --- S1["[_]"] --- S2["[a]"] --- S3["[b]"] --- S4["[c]"] --- S5["[d]"] --- S6["[_]"] --- S7["[_]"]

--- a/content/learn/java-collections-and-generics-deep-dive/sets.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/sets.mdx
@@ -141,7 +141,7 @@ foundations chapter if you need to put your own classes in a set.
 through the entries to remember **insertion order**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     HT[Hash table] --- E1["[a | next | prev]"]
     HT --- E2["[b | next | prev]"]
     HT --- E3["[c | next | prev]"]

--- a/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
+++ b/content/learn/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
@@ -343,7 +343,7 @@ reuse in type safety.**
 ## The arc, in one picture
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[1996<br/>Vector, Hashtable<br/>Object-only<br/>casts everywhere]
       --> B[1998<br/>JCF<br/>shape is right<br/>but still untyped]
     B --> C[2004<br/>Java 5 generics<br/>shape AND type<br/>are right]

--- a/content/learn/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
+++ b/content/learn/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
@@ -242,7 +242,7 @@ You enqueue items at the back; you dequeue from the front. Like a
 line at a coffee shop.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Front["front (dequeue here)"] -.-> Q1[1] --- Q2[2] --- Q3[3] -.-> Back["back (enqueue here)"]
 ```
 

--- a/content/learn/java-programming-for-beginners/jvm-conceptually.mdx
+++ b/content/learn/java-programming-for-beginners/jvm-conceptually.mdx
@@ -87,7 +87,7 @@ services to your program:
    `java.util`, `java.io`, etc. that ship with every JVM.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph J[Java Virtual Machine]
       CL[Class Loader]
       MM[Memory Manager + GC]
@@ -171,7 +171,7 @@ references?" Anything not reachable is dead, and its memory is
 reclaimed.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Roots
         L[Local variable account]
     end

--- a/content/learn/java-programming-for-beginners/software-organization.mdx
+++ b/content/learn/java-programming-for-beginners/software-organization.mdx
@@ -126,7 +126,7 @@ We met this idea in the interfaces chapter; here we see why it
 matters at the system level.
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["Service: OrderProcessor"] --> I[OrderRepository<br/>interface]
     I -.->|implemented by| H1[InMemoryRepo<br/>for tests]
     I -.->|implemented by| H2[PostgresRepo<br/>for production]

--- a/content/learn/java-programming-for-beginners/stack-and-heap.mdx
+++ b/content/learn/java-programming-for-beginners/stack-and-heap.mdx
@@ -61,7 +61,7 @@ the **stack** and the **heap** turns confusion into clarity.
 ## The two regions, side by side
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Stack[Stack — one per thread]
         direction TB
         F1[main frame]

--- a/content/learn/java-programming-for-beginners/variables-and-memory.mdx
+++ b/content/learn/java-programming-for-beginners/variables-and-memory.mdx
@@ -61,7 +61,7 @@ hold a small amount of data. Each box has an **address** (a number),
 and each box has **contents** (the data).
 
 ```mermaid
-flowchart LR
+flowchart TD
     M0["<code>0x1000</code><br/>?"] --- M1["<code>0x1004</code><br/>?"] --- M2["<code>0x1008</code><br/>?"] --- M3["<code>0x100C</code><br/>?"] --- M4["<code>0x1010</code><br/>?"]
 ```
 
@@ -72,7 +72,7 @@ When you write `int x = 5;`, three things happen:
 3. Java writes the value `5` into the box.
 
 ```mermaid
-flowchart LR
+flowchart TD
     M0["<code>0x1000</code><br/>?"] --- M1["<code>0x1004</code><br/>5<br/>(x)"] --- M2["<code>0x1008</code><br/>?"] --- M3["<code>0x100C</code><br/>?"] --- M4["<code>0x1010</code><br/>?"]
     style M1 fill:#efe
 ```

--- a/content/learn/java-programming-for-beginners/what-is-a-program.mdx
+++ b/content/learn/java-programming-for-beginners/what-is-a-program.mdx
@@ -68,7 +68,7 @@ just a way of writing those instructions more clearly.
 Almost every program, at the largest scale, looks like this:
 
 ```mermaid
-flowchart LR
+flowchart TD
     In[Input] --> P[Processing] --> Out[Output]
 ```
 

--- a/content/learn/machine-learning-scikit-learn/cross-validation.mdx
+++ b/content/learn/machine-learning-scikit-learn/cross-validation.mdx
@@ -235,7 +235,7 @@ contest with some luck in it. A final, untouched test set gives you one
 clean number after all the choosing is done.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["All data"] --> B["Hold out a final test set"]
     B --> C["Cross-validate on the rest<br/>to choose model and settings"]
     C --> D["Refit the chosen model<br/>on all non-test data"]

--- a/content/learn/machine-learning-scikit-learn/evaluating-clusters.mdx
+++ b/content/learn/machine-learning-scikit-learn/evaluating-clusters.mdx
@@ -77,7 +77,7 @@ well-clustered if it is **close to its own cluster** and **far from the
 nearest other cluster**. For each point `i`:
 
 ```mermaid
-flowchart LR
+flowchart TD
     P["A point i in cluster C"] --> A["a(i) = mean distance to the<br/>other points in C (cohesion)"]
     P --> B["b(i) = mean distance to points in the<br/>nearest other cluster (separation)"]
     A --> S["silhouette s(i) = (b - a) / <code>max(a, b)</code>"]

--- a/content/learn/machine-learning-scikit-learn/feature-engineering.mdx
+++ b/content/learn/machine-learning-scikit-learn/feature-engineering.mdx
@@ -63,7 +63,7 @@ reconstruct the ratio from two separate columns and you have made its job
 harder for no reason.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["raw columns<br/>rooms, people, date, ..."] --> B["feature engineering<br/>ratios, bins, date parts, interactions"]
     B --> C["engineered features<br/>signal made visible"]
     C --> D["model<br/>learns the pattern easily"]

--- a/content/learn/machine-learning-scikit-learn/generalization-and-overfitting.mdx
+++ b/content/learn/machine-learning-scikit-learn/generalization-and-overfitting.mdx
@@ -74,7 +74,7 @@ captured the underlying pattern. A model that fails to generalize has
 latched onto quirks of the sample that will not repeat.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Underfitting<br/>(model too simple)"] --> B["Good generalization<br/>(captures the pattern)"]
     B --> C["Overfitting<br/>(model too flexible)"]
     A -. "high bias" .-> A

--- a/content/learn/machine-learning-scikit-learn/hierarchical-clustering.mdx
+++ b/content/learn/machine-learning-scikit-learn/hierarchical-clustering.mdx
@@ -426,7 +426,7 @@ These two methods are the classic pairing in introductory clustering, and
 knowing when to pick which is a practical skill.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q["You have unlabeled<br/>numeric data to cluster"] --> A{"Do you know<br/>how many<br/>clusters?"}
     A -->|"yes, and groups<br/>look round"| KM["K-means<br/>(fast, scales big)"]
     A -->|"not sure, or want<br/>to see structure"| HC["Hierarchical<br/>(one tree, any cut)"]

--- a/content/learn/machine-learning-scikit-learn/hyperparameter-tuning.mdx
+++ b/content/learn/machine-learning-scikit-learn/hyperparameter-tuning.mdx
@@ -476,7 +476,7 @@ genuinely new data stalls or even drops. You have **overfit the
 validation set**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Try many, many settings"] --> B["Validation score keeps rising"]
     B --> C["But you are now fitting<br/>validation-set noise"]
     C --> D["True new-data performance<br/>flattens or falls"]

--- a/content/learn/machine-learning-scikit-learn/linear-regression.mdx
+++ b/content/learn/machine-learning-scikit-learn/linear-regression.mdx
@@ -110,7 +110,7 @@ smallest possible total. That criterion has a name — **least squares** — and
 it is what `LinearRegression` solves for you.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Cloud of points<br/>(feature x, target y)"] --> B["Try a straight line<br/>y = intercept + slope * x"]
     B --> C["Measure residuals<br/>(vertical gaps to the line)"]
     C --> D["Square them and add up<br/>(total squared error)"]

--- a/content/learn/machine-learning-scikit-learn/model-interpretation-and-importance.mdx
+++ b/content/learn/machine-learning-scikit-learn/model-interpretation-and-importance.mdx
@@ -229,7 +229,7 @@ collapses, that feature was important; if the score barely moves, the model
 was not really relying on it. Repeat for every feature.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Trained model"] --> B["Score on clean data"]
     A --> C["Shuffle feature j,<br/>re-score"]
     B --> D["Drop in score =<br/>importance of feature j"]

--- a/content/learn/machine-learning-scikit-learn/pipelines-and-columntransformer.mdx
+++ b/content/learn/machine-learning-scikit-learn/pipelines-and-columntransformer.mdx
@@ -99,7 +99,7 @@ is enforced by construction — you cannot accidentally fit a step on the test
 set, because you never touch the steps individually.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Training ["Training: pipeline.fit(X_train, y_train)"]
         A["<code>X_train</code>"] --> B["StandardScaler<br/>fit + transform"]
         B --> C["LogisticRegression<br/>fit"]
@@ -108,7 +108,7 @@ flowchart LR
 ```
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Prediction ["Prediction: pipeline.predict(X_new)"]
         E["<code>X_new</code>"] --> F["StandardScaler<br/>transform only"]
         F --> G["LogisticRegression<br/>predict"]

--- a/content/learn/machine-learning-scikit-learn/regression-metrics.mdx
+++ b/content/learn/machine-learning-scikit-learn/regression-metrics.mdx
@@ -48,7 +48,7 @@ Every regression metric is built from **residuals** — the differences
 between actual and predicted values, one per example.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Actual y"] --> R["Residual = actual - predicted"]
     P["Predicted y-hat"] --> R
     R --> M["Summarize all residuals<br/>into one number (the metric)"]

--- a/content/learn/machine-learning-scikit-learn/roc-curves-and-auc.mdx
+++ b/content/learn/machine-learning-scikit-learn/roc-curves-and-auc.mdx
@@ -83,7 +83,7 @@ threshold sweeps from very strict to very lenient. Each threshold is one
 point on the curve.
 
 ```mermaid
-flowchart LR
+flowchart TD
     P["Predicted probabilities"] --> S["Sweep the threshold<br/>from 1.0 down to 0.0"]
     S --> M["At each threshold,<br/>compute TPR and FPR"]
     M --> C["Plot TPR vs FPR<br/>= the ROC curve"]

--- a/content/learn/machine-learning-scikit-learn/the-scikit-learn-api.mdx
+++ b/content/learn/machine-learning-scikit-learn/the-scikit-learn-api.mdx
@@ -83,7 +83,7 @@ The rhythm is almost always the same two beats: **fit, then use.** You `fit`
 on training data, then `predict` (or `transform`, or `score`) on new data.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Raw training data<br/>(<code>X_train</code>, <code>y_train</code>)"] -->|"<code>fit(X_train, y_train)</code>"| B["Fitted estimator<br/>(holds what it learned)"]
     C["New data<br/>(<code>X_new</code>)"] -->|"<code>predict(X_new)</code>"| B
     B --> D["Predictions<br/>(numbers, labels, or groups)"]

--- a/content/learn/machine-learning-scikit-learn/what-is-machine-learning.mdx
+++ b/content/learn/machine-learning-scikit-learn/what-is-machine-learning.mdx
@@ -76,7 +76,7 @@ In that world, a program takes **rules** (the code you wrote) and **data**
 (the input) and produces **answers** (the output).
 
 ```mermaid
-flowchart LR
+flowchart TD
     R1["Rules<br/>(the code you write)"] --> P1["Program"]
     D1["Data<br/>(the input)"] --> P1
     P1 --> A1["Answers<br/>(the output)"]
@@ -105,7 +105,7 @@ Instead you provide **data** *paired with* the **answers** you want, and the
 algorithm produces the **rules** — a thing we call a **model**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     D2["Data<br/>(example inputs)"] --> M["Learning<br/>algorithm"]
     A2["Answers<br/>(the labels)"] --> M
     M --> R2["Model<br/>(the learned rules)"]
@@ -168,7 +168,7 @@ inputs to get answers. In scikit-learn this is `model.predict(X_new)`. The
 model never sees the true answers here — producing them is its job.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Training data<br/>(X and y)"] -->|"fit"| B["Trained model"]
     C["New data<br/>(X only)"] -->|"predict"| B
     B --> D["Predictions"]

--- a/content/learn/mastering-dsa-cpp/arrays.mdx
+++ b/content/learn/mastering-dsa-cpp/arrays.mdx
@@ -137,7 +137,7 @@ Use `operator[]` when you know the index is valid. Use `.at()` when you want bou
 A vector keeps values next to each other in memory, and modern hardware rewards that handsomely. When the CPU needs one value from main memory, it does not fetch four bytes — it fetches a whole *cache line*, typically 64 bytes, on the bet that you will want the neighbors next. With a vector of `int`s, that bet pays off sixteen to one: one slow memory trip delivers the next fifteen elements for free. A linked structure scattered across the heap loses the bet on almost every step.
 
 ```mermaid
-flowchart LR
+flowchart TD
     I0["index 0"] --> I1["index 1"] --> I2["index 2"] --> I3["index 3"]
     V0["10"] --> V1["20"] --> V2["30"] --> V3["40"]
     I0 -. points to .-> V0

--- a/content/learn/mastering-dsa-cpp/binary-search-trees.mdx
+++ b/content/learn/mastering-dsa-cpp/binary-search-trees.mdx
@@ -105,7 +105,7 @@ int main() {
 Insertion follows the same path as search, then attaches the new node at the first empty child position.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["compare with root"] --> B{"smaller?"}
     B -- "yes" --> C["go left"]
     B -- "no" --> D["go right"]

--- a/content/learn/mastering-dsa-cpp/doubly-linked-lists.mdx
+++ b/content/learn/mastering-dsa-cpp/doubly-linked-lists.mdx
@@ -65,7 +65,7 @@ That one capability — *unlink this exact node, right now, cheaply* — is the 
 ## The shape of a doubly linked list
 
 ```mermaid
-flowchart LR
+flowchart TD
     H["head"] <--> N1["n1 | 10"]
     N1 <--> N2["n2 | 20"]
     N2 <--> N3["n3 | 30"]

--- a/content/learn/mastering-dsa-cpp/dynamic-programming.mdx
+++ b/content/learn/mastering-dsa-cpp/dynamic-programming.mdx
@@ -201,7 +201,7 @@ int main() {
 Now the same mathematics in a costume. You climb a staircase of n steps, taking 1 or 2 steps at a time — how many distinct ways up? The DP habit is to interrogate the *last move*: every route to step n arrived either from step n−1 (final hop of 1) or from step n−2 (final hop of 2), and those two groups overlap nowhere. So `f(n) = f(n-1) + f(n-2)` — Fibonacci wearing a tracksuit. Spotting a known recurrence under an unfamiliar story is half the DP skill.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["step n-2"] --> C["+2"] --> N["step n"]
     B["step n-1"] --> D["+1"] --> N
 ```

--- a/content/learn/mastering-dsa-cpp/graphs.mdx
+++ b/content/learn/mastering-dsa-cpp/graphs.mdx
@@ -66,7 +66,7 @@ graph TD
 This is a small undirected graph. Edge `0-1` also means `1-0`.
 
 ```mermaid
-graph LR
+graph TD
     A((0)) -- "5" --> B((1))
     A -- "2" --> C((2))
     C -- "1" --> B

--- a/content/learn/mastering-dsa-cpp/greedy.mdx
+++ b/content/learn/mastering-dsa-cpp/greedy.mdx
@@ -53,7 +53,7 @@ So this page teaches two skills, and the second matters more: how to write greed
 </svg>
 
 ```mermaid
-flowchart LR
+flowchart TD
     S[State] --> C[Choose best local move]
     C --> N[New state]
     N --> C

--- a/content/learn/mastering-dsa-cpp/heaps.mdx
+++ b/content/learn/mastering-dsa-cpp/heaps.mdx
@@ -71,7 +71,7 @@ flowchart TD
 ```
 
 ```mermaid
-flowchart LR
+flowchart TD
     I0["0:50"] --> I1["1:30"] --> I2["2:40"] --> I3["3:10"] --> I4["4:20"] --> I5["5:35"]
 ```
 
@@ -105,7 +105,7 @@ int main() {
 Both heap operations follow the same playbook: *restore completeness first, then repair the one broken promise.* To push, append the new value at the end of the array — the only spot that keeps the tree complete. The shape is now right, but the newcomer may outrank its parent, so it bubbles upward, swapping with its parent until the heap property holds. The path from any node to the root is at most log n long, so a push is O(log n).
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["append new value"] --> B{"larger than parent?"}
     B -- "yes" --> C["swap with parent"] --> B
     B -- "no" --> D["done"]

--- a/content/learn/mastering-dsa-cpp/shortest-paths.mdx
+++ b/content/learn/mastering-dsa-cpp/shortest-paths.mdx
@@ -62,7 +62,7 @@ The algorithm at the heart of it has the best origin story in computer science. 
 BFS minimizes the number of edges. In a weighted graph, fewer edges may cost more.
 
 ```mermaid
-graph LR
+graph TD
     A((0)) -- "100" --> B((1))
     A -- "1" --> C((2))
     C -- "1" --> B

--- a/content/learn/mastering-dsa-cpp/strings.mdx
+++ b/content/learn/mastering-dsa-cpp/strings.mdx
@@ -230,7 +230,7 @@ int main() {
 />
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>std::string</code> owns characters"] --> B["dynamic storage"]
     C["<code>std::string_view</code>"] --> D["pointer + length"]
     D --> E["does not own data"]

--- a/content/learn/mastering-dsa-cpp/tries.mdx
+++ b/content/learn/mastering-dsa-cpp/tries.mdx
@@ -80,7 +80,7 @@ flowchart TD
 ```
 
 ```mermaid
-flowchart LR
+flowchart TD
     Root["root prefix: empty"] --> Ca["c"] --> Cat["ca"] --> Cat2["cat word"]
     Cat --> Car["car word"] --> Cart["cart word"]
 ```

--- a/content/learn/mastering-dsa-cpp/union-find.mdx
+++ b/content/learn/mastering-dsa-cpp/union-find.mdx
@@ -125,7 +125,7 @@ int main() {
 The first fix is gloriously lazy. Since `find(x)` has to walk all the way to the root anyway, why not make every node it passes point *directly* to the root on the way back? That is **path compression**: one recursive line, and every future `find` through those nodes is a single hop. The tree flattens itself as a side effect of being used.
 
 ```mermaid
-graph LR
+graph TD
     A["before: 4 -> 3 -> 2 -> 1 -> 0"] --> B["<code>find(4)</code>"] --> C["after: 4,3,2,1 all point to 0"]
 ```
 
@@ -360,7 +360,7 @@ Kruskal(edges, n):
 ```
 
 ```mermaid
-graph LR
+graph TD
     S["sort edges"] --> C["consider cheapest edge"]
     C --> U{"endpoints already connected?"}
     U -- "yes" --> X["skip to avoid cycle"]

--- a/content/learn/mastering-ggplot2/flipping-and-polar-coordinates.mdx
+++ b/content/learn/mastering-ggplot2/flipping-and-polar-coordinates.mdx
@@ -153,7 +153,7 @@ You just made a pie chart — and you did it without a `geom_pie()`
 stacked bar, re-expressed in polar coordinates.
 
 ```mermaid
-flowchart LR
+flowchart TD
     SB["Stacked bar<br/>height = count"] -->|"<code>coord_polar(theta = y)</code>"| PIE["Pie chart<br/>angle = count"]
 ```
 

--- a/content/learn/mastering-ggplot2/what-scales-do.mdx
+++ b/content/learn/mastering-ggplot2/what-scales-do.mdx
@@ -52,7 +52,7 @@ This pairing mirrors the stat/geom split from earlier. One component
 describes intent; the other carries it out:
 
 ```mermaid
-flowchart LR
+flowchart TD
     COL["Data column<br/><code>displ = 1.6</code> ... 7.0"] --> MAP["Mapping<br/><code>aes(x = displ)</code>"]
     MAP --> SCALE["Scale<br/><code>scale_x_continuous</code>"]
     SCALE --> PIX["Visual value<br/>pixel x-position"]

--- a/content/learn/mermaid-test.mdx
+++ b/content/learn/mermaid-test.mdx
@@ -68,7 +68,7 @@ Add a fenced code block with ` ```mermaid ` as the opening fence anywhere in you
 
 ````md
 ```mermaid
-graph LR;
+graph TD;
   A --> B --> C;
 ```
 ````

--- a/content/learn/natural-language-processing-python/choosing-your-pipeline.mdx
+++ b/content/learn/natural-language-processing-python/choosing-your-pipeline.mdx
@@ -229,7 +229,7 @@ your task.** This is called an **ablation**: hold everything else fixed, toggle
 one step, and compare results on a metric you care about.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Pick a metric<br/>tied to your task"] --> B["Run WITH the step"]
     A --> C["Run WITHOUT the step"]
     B --> D{"Which scores better<br/>on your data?"}

--- a/content/learn/natural-language-processing-python/frequency-distributions.mdx
+++ b/content/learn/natural-language-processing-python/frequency-distributions.mdx
@@ -57,7 +57,7 @@ what is happening under the hood. NLTK wraps it in a `FreqDist` ("frequency
 distribution") that adds text-specific conveniences.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Clean tokens:<br/>fox, dog, fox, run, fox, dog"] --> B["FreqDist<br/>(tally each word)"]
     B --> C["Counts:<br/><code>fox=3</code>, <code>dog=2</code>, <code>run=1</code>"]
     C --> D["<code>most_common(2)</code>:<br/>[('fox', 3), ('dog', 2)]"]

--- a/content/learn/natural-language-processing-python/stopwords.mdx
+++ b/content/learn/natural-language-processing-python/stopwords.mdx
@@ -98,7 +98,7 @@ and it concentrates attention on **content words** (nouns, verbs, adjectives)
 that actually signal the topic.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Tokens:<br/>the, movie, was, great"] --> F{"In stopword list?"}
     F -->|"yes"| D["Dropped:<br/>the, was"]
     F -->|"no"| K["Kept (content words):<br/>movie, great"]

--- a/content/learn/natural-language-processing-python/what-is-nlp.mdx
+++ b/content/learn/natural-language-processing-python/what-is-nlp.mdx
@@ -59,7 +59,7 @@ rather than labeled. Before a program can do anything useful with text, that
 implicit structure has to be made explicit.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Raw text<br/>(a flat string of characters)"] --> B["NLP pipeline<br/>(tokenize, normalize, tag, count)"]
     B --> C["Structure a program can use<br/>(words, sentences, tags, counts)"]
 ```
@@ -242,7 +242,7 @@ adds structure in **layers**, each layer building on the last. A typical
 analysis pipeline looks like this:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Characters"] --> B["Tokens<br/>(words)"]
     B --> C["Normalized tokens<br/>(lowercased, cleaned)"]
     C --> D["Tagged tokens<br/>(part of speech)"]

--- a/content/learn/oop-blueprint-java/aggregation-and-dependency.mdx
+++ b/content/learn/oop-blueprint-java/aggregation-and-dependency.mdx
@@ -47,7 +47,7 @@ happens when one object goes away*.
 ## A spectrum of relationships
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Dependency<br/>(uses-a)<br/>method-scope"] --> B["Aggregation<br/>(weak has-a)<br/>references something<br/>that lives independently"]
     B --> C["Composition<br/>(strong has-a)<br/>owns lifetime"]
     style A fill:#eef

--- a/content/learn/oop-blueprint-java/birth-of-oop.mdx
+++ b/content/learn/oop-blueprint-java/birth-of-oop.mdx
@@ -78,7 +78,7 @@ Nobel Prize — for inventing the concepts on which this entire course
 is built.
 
 ```mermaid
-flowchart LR
+flowchart TD
     R["Real world<br/>(ships, customers,<br/>traffic lights)"] --> M["Model in code<br/>(class Ship,<br/>class Customer)"]
     M --> S["Simulation runs by<br/>objects interacting"]
 ```

--- a/content/learn/oop-blueprint-java/composition.mdx
+++ b/content/learn/oop-blueprint-java/composition.mdx
@@ -152,7 +152,7 @@ ones. Each small one is well-encapsulated, easy to reason about, and
 easy to test. The big one just orchestrates.
 
 ```mermaid
-flowchart LR
+flowchart TD
     L[Library] -->|has many| B[Book]
     L -->|has many| M[Member]
     L -->|has| C[Catalog]

--- a/content/learn/oop-blueprint-java/constructors-and-state.mdx
+++ b/content/learn/oop-blueprint-java/constructors-and-state.mdx
@@ -195,7 +195,7 @@ shorter one that fills in defaults by calling the real one with
 `this(...)`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["new Point()"] -->|delegates| C["new Point(0,0)"]
     B["new Point(5)"] -->|delegates| C
     C --> S["sets <code>this.x</code> and <code>this.y</code>"]

--- a/content/learn/oop-blueprint-java/methods-and-messages.mdx
+++ b/content/learn/oop-blueprint-java/methods-and-messages.mdx
@@ -182,7 +182,7 @@ A small, classic distinction that helps you design methods:
   state. Example: `lamp.brightness()`, `account.balance()`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     M["A method"] --> Q{Changes<br/>state?}
     Q -->|Yes| C["Command<br/>(usually void)"]
     Q -->|No| Y["Query<br/>(returns a value)"]

--- a/content/learn/oop-blueprint-java/objects-in-memory.mdx
+++ b/content/learn/oop-blueprint-java/objects-in-memory.mdx
@@ -66,7 +66,7 @@ write `Dog d = new Dog(...)`, two things happen:
    address) pointing to that heap object.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph S["Stack (current method)"]
         V1["d : Dog ref ──┐"]
     end
@@ -181,7 +181,7 @@ Java gives it the special value `null`. A reference variable is
 either an arrow into the heap, or it is `null`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Stack
         N["d : Dog <code>ref = null</code>"]
     end
@@ -347,7 +347,7 @@ and a list of `LineItem`s. The whole point of OOP is that the heap
 ends up looking like a small map of your problem domain.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Heap
       P["Person<br/><code>name='Ada'</code>"]
       A["Address<br/><code>city='Oslo'</code>"]

--- a/content/learn/oop-blueprint-java/polymorphism.mdx
+++ b/content/learn/oop-blueprint-java/polymorphism.mdx
@@ -339,7 +339,7 @@ tension that sounds paradoxical at first — how can code be extendable
 *and* untouchable at the same time? Polymorphism is the answer.
 
 ```mermaid
-flowchart LR
+flowchart TD
     R["Existing code<br/>(Renderer, Cashier,<br/>OrderProcessor...)"]
     N["New behavior<br/>(new Shape subclass,<br/>new PaymentProcessor,<br/>new Notification kind)"]
     N -->|plug in| R

--- a/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
+++ b/content/learn/oop-blueprint-java/responsibility-driven-design.mdx
@@ -388,7 +388,7 @@ A classic shorthand:
 > you can do something with the data yourself.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Bad["<code>account.getBalance()</code> > 100<br/>→ ... do stuff externally"]
     Good["<code>account.tryWithdraw(100)</code>"]
     Bad -. refactor .-> Good

--- a/content/learn/practical-r-for-beginners/logical-and-character-vectors.mdx
+++ b/content/learn/practical-r-for-beginners/logical-and-character-vectors.mdx
@@ -221,7 +221,7 @@ frames — but understanding it on vectors first is what makes the
 whole library click.
 
 ```mermaid
-flowchart LR
+flowchart TD
   v["values: [82, 91, 76, 100, 65, 88, 79, 93, 71, 85]"]
   cond["condition: <code>scores &gt;= 90</code>"]
   mask["[F, T, F, T, F, F, F, T, F, F]"]

--- a/content/learn/practical-r-for-beginners/relationships-between-variables.mdx
+++ b/content/learn/practical-r-for-beginners/relationships-between-variables.mdx
@@ -143,7 +143,7 @@ A few rules to remember about correlation:
 ## A glance at the four "famous" patterns
 
 ```mermaid
-flowchart LR
+flowchart TD
   pos["positive linear (r ≈ +1)"]
   neg["negative linear (r ≈ -1)"]
   zero["no relationship (r ≈ 0)"]

--- a/content/learn/practical-r-for-beginners/reshaping-data.mdx
+++ b/content/learn/practical-r-for-beginners/reshaping-data.mdx
@@ -73,7 +73,7 @@ and your tools want it long.
 ## Wide vs. long, visually
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph wide["Wide form (humans love this)"]
     direction TB
     w["country | y2020 | y2021 | y2022"]

--- a/content/learn/practical-r-for-beginners/subsetting-and-filtering.mdx
+++ b/content/learn/practical-r-for-beginners/subsetting-and-filtering.mdx
@@ -72,7 +72,7 @@ The bracket on a data frame takes two arguments separated by a
 comma: which rows, which columns. An empty slot means *all*.
 
 ```mermaid
-flowchart LR
+flowchart TD
   df["data frame"] -->|"[rows, cols]"| sub["subset"]
   rows["rows: numeric, logical, or character"] --> df
   cols["cols: numeric, logical, character, or empty"] --> df

--- a/content/learn/practical-r-for-beginners/thinking-in-data.mdx
+++ b/content/learn/practical-r-for-beginners/thinking-in-data.mdx
@@ -65,7 +65,7 @@ time* — is the entire essence of **computational thinking** for
 data analysis.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Hand["By hand: one number at a time"]
     A1["5 × 4 = 20"] --> A2["7 × 3 = 21"] --> A3["2 × 8 = 16"] --> A4["..."]
   end

--- a/content/learn/practical-r-for-beginners/vectorized-computation.mdx
+++ b/content/learn/practical-r-for-beginners/vectorized-computation.mdx
@@ -144,7 +144,7 @@ This is the heart of how data analysts think: you have
 *parallel columns*, and you operate on them as wholes.
 
 ```mermaid
-flowchart LR
+flowchart TD
   q["quantities: [2, 1, 3, 4]"] --> mul
   p["<code>unit_prices: [9.99, 14.50, 24.00, 5.75]</code>"] --> mul
   mul["element-wise * "] --> r["totals: [19.98, 14.50, 72.00, 23.00]"]

--- a/content/learn/python-basics/functions.mdx
+++ b/content/learn/python-basics/functions.mdx
@@ -80,7 +80,7 @@ When you hear "functional programming," it means **prefer pure functions**: no s
 ## Anatomy of a function call
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["caller: <code>greet('Ada')</code>"] --> B["function body executes"]
     B --> C["return value: 'Hello, Ada!'"]
     C --> A

--- a/content/learn/scientific-computing-python/approximation-and-error.mdx
+++ b/content/learn/scientific-computing-python/approximation-and-error.mdx
@@ -62,7 +62,7 @@ You cannot escape both at once. The minimum total error is the
 **sweet spot**, and finding it is a recurring design problem.
 
 ```mermaid
-flowchart LR
+flowchart TD
     L[Large h] -->|truncation dominates| M[Optimal h]
     S[Small h] -->|round-off dominates| M
     M --> A[Minimum total error]

--- a/content/learn/scientific-computing-python/arrays-and-tensors.mdx
+++ b/content/learn/scientific-computing-python/arrays-and-tensors.mdx
@@ -63,7 +63,7 @@ course.
 A NumPy array has three pieces:
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph "ndarray"
         H[Header<br/>dtype, shape,<br/>strides, offset]
         B[Contiguous<br/>byte buffer]

--- a/content/learn/scientific-computing-python/math-meets-computation.mdx
+++ b/content/learn/scientific-computing-python/math-meets-computation.mdx
@@ -60,7 +60,7 @@ wrongness controllable.
 ## Continuous mathematics, discrete machines
 
 ```mermaid
-flowchart LR
+flowchart TD
     M[Continuous<br/>mathematics]
     D[Discretization]
     F[Floating-point<br/>arithmetic]

--- a/content/learn/scientific-computing-python/rise-of-computational-science.mdx
+++ b/content/learn/scientific-computing-python/rise-of-computational-science.mdx
@@ -180,7 +180,7 @@ every PDE solver in existence.
 ## A new scientific method
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[Theory] <--> S[Simulation]
     S <--> E[Experiment]
     E <--> T

--- a/content/learn/scientific-computing-python/signal-processing.mdx
+++ b/content/learn/scientific-computing-python/signal-processing.mdx
@@ -65,7 +65,7 @@ of peaks. Once you can see a signal in frequency space, filtering
 and analysis become almost trivial.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Time["signal x(t)"] -- FFT --> Freq["spectrum X(f)"]
     Freq -- "filter / analyze" --> Freq2["modified X̃(f)"]
     Freq2 -- IFFT --> Time2["modified x̃(t)"]

--- a/content/learn/seaborn-foundations/the-eda-workflow.mdx
+++ b/content/learn/seaborn-foundations/the-eda-workflow.mdx
@@ -246,7 +246,7 @@ straight line from raw data to a finished answer. We went around a **loop**,
 and each lap left us knowing more than the last.
 
 ```mermaid
-flowchart LR
+flowchart TD
     P["Plot<br/>a quick, honest chart"] --> N["Notice<br/>a peak, cluster, outlier, or gap"]
     N --> Q["Ask a<br/>sharper question"]
     Q -->|"add hue / col, or change kind"| P

--- a/content/learn/seaborn-foundations/tidy-data-for-seaborn.mdx
+++ b/content/learn/seaborn-foundations/tidy-data-for-seaborn.mdx
@@ -95,7 +95,7 @@ Here is the move you will make over and over: reshape a **wide** table into
 a **long/tidy** one so Seaborn can map its columns to visual roles.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["WIDE table<br/>one column per group<br/>(easy to read)"] -->|"melt to long"| B["TIDY / LONG table<br/>one row per observation<br/>(easy to plot)"]
     B --> C["Map columns to roles<br/>x, y, hue, col, ..."]
     C --> D["Seaborn groups, aggregates,<br/>and colors automatically"]

--- a/content/learn/sql-analytics-duckdb/aggregate-functions.mdx
+++ b/content/learn/sql-analytics-duckdb/aggregate-functions.mdx
@@ -72,7 +72,7 @@ the bridge between **data too big to read** and **knowledge small enough
 to act on**.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Many[("Many rows<br/>(5 salaries)")] --> Agg["Aggregate<br/>function"]
     Agg --> One["One summary value<br/>(e.g. the average)"]
 ```
@@ -261,7 +261,7 @@ WHERE
 />
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[("orders")] --> W["<code>WHERE amount &gt; 50</code>"]
     W --> A["AVG(amount),<br/>COUNT(*)"]
     A --> R["summary of the<br/>filtered slice"]

--- a/content/learn/sql-analytics-duckdb/building-business-metrics.mdx
+++ b/content/learn/sql-analytics-duckdb/building-business-metrics.mdx
@@ -69,7 +69,7 @@ from which step to which, counted by users or by sessions? Most metric
 disputes are definition disputes, not SQL bugs.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q["Vague question:<br/>how is conversion?"] --> D["Precise definition:<br/>distinct users who purchased<br/>/ distinct users who visited"]
     D --> SQL["SQL that<br/>implements the definition"]
     SQL --> M["A metric you<br/>can defend"]
@@ -322,7 +322,7 @@ A few habits that separate trustworthy metrics from misleading ones:
   data can hide the zeros (recall the date-spine fix).
 
 ```mermaid
-flowchart LR
+flowchart TD
     Raw[("Raw rows")] --> Def["Clear definition"]
     Def --> Unit["Right unit<br/>(users vs events)"]
     Unit --> Guard["Guard NULLs<br/>and gaps"]

--- a/content/learn/sql-analytics-duckdb/common-table-expressions.mdx
+++ b/content/learn/sql-analytics-duckdb/common-table-expressions.mdx
@@ -138,7 +138,7 @@ says what it is. This is how analysts write queries they can revisit a
 month later and still understand.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["WITH paid<br/>(filter)"] --> B["<code>per_region</code><br/>(aggregate)"]
     B --> C["final SELECT<br/>(filter + sort)"]
 ```

--- a/content/learn/sql-analytics-duckdb/conditional-logic.mdx
+++ b/content/learn/sql-analytics-duckdb/conditional-logic.mdx
@@ -195,7 +195,7 @@ category into columns. The last column uses DuckDB's cleaner **`FILTER`**
 clause, which does the same thing more readably.
 
 ```mermaid
-flowchart LR
+flowchart TD
     R[("rows with<br/>status: paid / refunded")] --> C1["SUM(CASE WHEN paid)"]
     R --> C2["SUM(CASE WHEN refunded)"]
     C1 --> Out["one row:<br/><code>paid_revenue</code> | <code>refunded_revenue</code>"]

--- a/content/learn/sql-analytics-duckdb/filtering-and-slicing.mdx
+++ b/content/learn/sql-analytics-duckdb/filtering-and-slicing.mdx
@@ -53,7 +53,7 @@ Every business question hides a filter. "How are sales in the West?" means
 Learning to *hear* the filter inside a question is half of analytical SQL.
 
 ```mermaid
-flowchart LR
+flowchart TD
     All[("Whole dataset")] --> F["<code>WHERE</code><br/>(the slice)"]
     F --> Sub[("Just the rows<br/>the question is about")]
     Sub --> A["Summarize / inspect"]
@@ -252,7 +252,7 @@ Filtering early is both a performance habit and a clarity habit:
   easier to think about.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Big[("10M rows")] --> W["WHERE early"]
     W --> Small[("10K relevant rows")]
     Small --> Cheap["Cheap, clear<br/>analysis"]

--- a/content/learn/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
+++ b/content/learn/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
@@ -98,7 +98,7 @@ but the intent is clearer and the query is harder to get wrong. This is
 one of the small ergonomics that make DuckDB pleasant for fast analysis.
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["<code>SELECT region, product,<br/>channel, SUM(amount)</code>"] --> A["<code>GROUP BY ALL</code>"]
     A --> G["Groups by the three<br/>non-aggregated columns"]
 ```

--- a/content/learn/sql-analytics-duckdb/grouping-data.mdx
+++ b/content/learn/sql-analytics-duckdb/grouping-data.mdx
@@ -126,7 +126,7 @@ refuses. The column must either *define* the group (`region`) or be
 *summarized* across it (`SUM(amount)`).
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q["<code>SELECT region, id, SUM(amount)</code>"] --> X["id is neither grouped<br/>nor aggregated"]
     X --> Err["Ambiguous:<br/>which row's id?"]
 ```
@@ -251,7 +251,7 @@ It helps to picture the order of operations: filter, then group, then
 aggregate, then sort.
 
 ```mermaid
-flowchart LR
+flowchart TD
     F["FROM rows"] --> W["<code>WHERE</code><br/>(filter rows)"]
     W --> G["<code>GROUP BY</code><br/>(form bins)"]
     G --> A["aggregate<br/>(one value per bin)"]

--- a/content/learn/sql-analytics-duckdb/profiling-a-dataset.mdx
+++ b/content/learn/sql-analytics-duckdb/profiling-a-dataset.mdx
@@ -226,7 +226,7 @@ analysts type when they meet a new table — it answers size, range,
 distinctness, and nulls for *every* column simultaneously.
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["SUMMARIZE table"] --> R["Per-column report:<br/>count, distinct,<br/>null %, min, max,<br/>avg, quantiles"]
 ```
 

--- a/content/learn/sql-analytics-duckdb/reproducible-analytical-workflows.mdx
+++ b/content/learn/sql-analytics-duckdb/reproducible-analytical-workflows.mdx
@@ -70,7 +70,7 @@ later. Reproducible work means:
   *what*.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q["A question"] --> SQL["A saved,<br/>readable query"]
     SQL --> Same["Same answer<br/>every run"]
     SQL --> Explain["Logic anyone<br/>can audit"]

--- a/content/learn/sql-analytics-duckdb/sorting-and-top-n.mdx
+++ b/content/learn/sql-analytics-duckdb/sorting-and-top-n.mdx
@@ -177,7 +177,7 @@ Two subtleties that quietly trip up analysts:
   which matters for analysis you intend to repeat.
 
 ```mermaid
-flowchart LR
+flowchart TD
     R[("Rows")] --> O["<code>ORDER BY amount DESC,<br/>id ASC (tiebreaker)</code>"]
     O --> S["Stable, reproducible<br/>ordering"]
     S --> L["<code>LIMIT N</code>"]

--- a/content/learn/sql-analytics-duckdb/thinking-in-datasets.mdx
+++ b/content/learn/sql-analytics-duckdb/thinking-in-datasets.mdx
@@ -89,7 +89,7 @@ Each answer is a single number or a short list. Stacked together, they
 form a **mental picture** of a dataset you will never see row-by-row.
 
 ```mermaid
-flowchart LR
+flowchart TD
     D[("Millions of rows<br/>(too big to see)")] --> Q["Summarizing<br/>questions"]
     Q --> P["A handful of numbers<br/>you can hold in your head"]
     P --> U["A mental model<br/>of the data"]
@@ -105,7 +105,7 @@ Analysis is rarely a straight line from question to answer. It is a
 and the result almost always suggests a sharper question.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Ask a<br/>question"] --> B["Write a<br/>query"]
     B --> C["Look at the<br/>result"]
     C --> D["Notice something<br/>surprising"]

--- a/content/learn/sql-analytics-duckdb/why-duckdb.mdx
+++ b/content/learn/sql-analytics-duckdb/why-duckdb.mdx
@@ -82,7 +82,7 @@ For a single analyst poking at a few gigabytes on a laptop, both are
 overkill. DuckDB fills exactly that gap.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Transactional DB<br/>(row store, needs a server)"] -- "too slow for<br/>big scans" --> Gap["The analyst's gap"]
     B["Cloud warehouse<br/>(heavy, needs setup and cost)"] -- "too much overhead<br/>for quick analysis" --> Gap
     Gap --> D["DuckDB<br/>(fast, in-process,<br/>zero setup)"]
@@ -140,7 +140,7 @@ DuckDB rarely replaces the cloud warehouse or the app's database. It sits
   transformation steps.
 
 ```mermaid
-flowchart LR
+flowchart TD
     W[("Warehouse /<br/>app database")] -- "export sample" --> F["CSV / Parquet<br/>file"]
     F --> Duck["DuckDB<br/>(local exploration)"]
     Duck --> Insight["Charts, reports,<br/>decisions"]

--- a/content/learn/sql-analytics-duckdb/why-window-functions.mdx
+++ b/content/learn/sql-analytics-duckdb/why-window-functions.mdx
@@ -199,7 +199,7 @@ ORDER BY
 />
 
 ```mermaid
-flowchart LR
+flowchart TD
     All[("All orders")] --> P["PARTITION BY region"]
     P --> W["West window"]
     P --> E["East window"]

--- a/content/learn/sql-analytics-duckdb/working-with-dates.mdx
+++ b/content/learn/sql-analytics-duckdb/working-with-dates.mdx
@@ -95,7 +95,7 @@ ORDER BY
 />
 
 ```mermaid
-flowchart LR
+flowchart TD
     D1["2024-03-04"] --> M["<code>date_trunc('month')</code>"]
     D2["2024-03-18"] --> M
     D3["2024-03-29"] --> M
@@ -248,7 +248,7 @@ correct, gap-free series ready to chart. Skipping this step is one of the
 most common ways an analyst's trend chart misleads.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Spine["Generated date spine<br/>(every day)"] --> J["<code>LEFT JOIN orders</code>"]
     J --> S["Days with no orders<br/>become 0, not missing"]
 ```

--- a/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
+++ b/content/learn/sql-analytics-duckdb/your-first-analytical-query.mdx
@@ -152,7 +152,7 @@ to the top. "Longest trips", "biggest spenders", "slowest pages": every
 one is an `ORDER BY` followed by a glance at the head of the result.
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[("All rows")] --> W["<code>WHERE</code><br/>(choose a slice)"]
     W --> O["<code>ORDER BY</code><br/>(surface extremes)"]
     O --> L["<code>LIMIT</code><br/>(look at the top)"]

--- a/content/learn/sqlite-for-beginners/aggregate-functions.mdx
+++ b/content/learn/sqlite-for-beginners/aggregate-functions.mdx
@@ -67,7 +67,7 @@ But many everyday questions are not detail questions. They are summary questions
 Think of an aggregate as a tiny summarizing machine. Many rows go in. One value comes out.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Rows["Many rows<br/>five order amounts"] --> Agg["Aggregate function<br/>SUM, AVG, COUNT"]
     Agg --> One["One summary value<br/>total, average, or count"]
 ```
@@ -298,7 +298,7 @@ WHERE
 Read this as: "Keep only Ada's rows, then add their amounts."
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[("orders table")] --> W["WHERE <code>customer = 'Ada'</code>"]
     W --> S["SUM(amount)"]
     S --> R["one total"]

--- a/content/learn/sqlite-for-beginners/creating-tables.mdx
+++ b/content/learn/sqlite-for-beginners/creating-tables.mdx
@@ -75,7 +75,7 @@ flowchart TB
 The table definition becomes an empty grid. The columns are ready; rows come later with `INSERT`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>CREATE TABLE books<br/>id, title, author, year</code>"] --> B["books grid"]
     B --> C["columns exist<br/>rows are empty"]
 ```
@@ -165,7 +165,7 @@ ORDER BY
 Notice that the `INSERT` statement did not provide `id` values. SQLite filled them in because `id` is an `INTEGER PRIMARY KEY`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     I["<code>INSERT</code> title and author"] --> S["SQLite assigns id"]
     S --> R["stored row<br/>id, title, author"]
 ```

--- a/content/learn/sqlite-for-beginners/data-exploration.mdx
+++ b/content/learn/sqlite-for-beginners/data-exploration.mdx
@@ -71,7 +71,7 @@ shape, peek at rows, then ask sharper questions as the data tells you
 what to ask next.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["What tables<br/>exist?"] --> B["What columns<br/>does each have?"]
     B --> C["What do a few<br/>rows look like?"]
     C --> D["How big? What<br/>ranges and values?"]

--- a/content/learn/sqlite-for-beginners/data-organization.mdx
+++ b/content/learn/sqlite-for-beginners/data-organization.mdx
@@ -186,7 +186,7 @@ The formal theory has stages called **normal forms**, but you do not
 need the definitions yet. One memorable rule captures most of it:
 
 ```mermaid
-flowchart LR
+flowchart TD
     UNF["One big table<br/>with duplication"] --> STEP["Give every fact<br/>a single home"]
     STEP --> GOAL["Each column describes<br/>'the key, the whole key,<br/>and nothing but the key'"]
 ```

--- a/content/learn/sqlite-for-beginners/data-types.mdx
+++ b/content/learn/sqlite-for-beginners/data-types.mdx
@@ -87,7 +87,7 @@ the declared type. For this course, we work with ordinary flexible
 tables, because understanding them is understanding SQLite.
 
 ```mermaid
-flowchart LR
+flowchart TD
     V["Value to store"] --> C["Column affinity<br/>preferred kind"]
     C --> T{"Can SQLite convert it<br/>without losing the idea?"}
     T -->|"yes"| CONVERT["Store converted value"]

--- a/content/learn/sqlite-for-beginners/expressions-and-aliases.mdx
+++ b/content/learn/sqlite-for-beginners/expressions-and-aliases.mdx
@@ -66,7 +66,7 @@ Anywhere you can select a column, you can also write a calculation.
 SQLite evaluates that calculation for each row in the result.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["one row<br/>price 12.99<br/>quantity 2"] --> B["expression<br/>price * quantity"]
     B --> C["new result column<br/><code>line_total</code> 25.98"]
 ```
@@ -179,7 +179,7 @@ The two computed values are the same. The aliased one is easier to read.
 This course uses `AS` because it makes your intent obvious.
 
 ```mermaid
-flowchart LR
+flowchart TD
     E["price * quantity"] --> N["AS <code>line_total</code>"]
     N --> R["clear result heading"]
 ```

--- a/content/learn/sqlite-for-beginners/filtering-groups.mdx
+++ b/content/learn/sqlite-for-beginners/filtering-groups.mdx
@@ -70,7 +70,7 @@ These are not row-by-row conditions. They are conditions about **groups after ag
 `WHERE` runs before grouping. At that moment, there are only individual rows. There are no group totals yet, so `WHERE COUNT(*) > 2` does not make sense.
 
 ```mermaid
-flowchart LR
+flowchart TD
     From["<code>FROM</code><br/>read rows"] --> Where["<code>WHERE</code><br/>filter individual rows"]
     Where --> Group["<code>GROUP BY</code><br/>form groups"]
     Group --> Having["<code>HAVING</code><br/>filter groups"]

--- a/content/learn/sqlite-for-beginners/filtering-rows.mdx
+++ b/content/learn/sqlite-for-beginners/filtering-rows.mdx
@@ -58,7 +58,7 @@ is true, the row stays in the result. If the test is false, the row is
 left out.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["all rows<br/>in books"] --> W{"WHERE condition<br/>is true?"}
     W -->|"true"| K["keep row<br/>in result"]
     W -->|"false"| D["drop row<br/>from result"]

--- a/content/learn/sqlite-for-beginners/first-queries.mdx
+++ b/content/learn/sqlite-for-beginners/first-queries.mdx
@@ -66,7 +66,7 @@ The keyword `SELECT` means: *compute something and show me the result.* You can 
 The result is a tiny table: one row and one column. The value is text, so it is wrapped in single quotes.
 
 ```mermaid
-flowchart LR
+flowchart TD
     E["Editor<br/>your SQL"] -->|"send statement"| S["SQLite engine"]
     S -->|"returns"| R["Result table"]
 ```
@@ -155,7 +155,7 @@ FROM
 Read the final query like a sentence: *select the `name` and `species` columns from the `pets` table.*
 
 ```mermaid
-flowchart LR
+flowchart TD
     Q["<code>SELECT name, species<br/>FROM pets;</code>"] --> T["pets table"]
     T --> R["name column<br/>species column"]
 ```

--- a/content/learn/sqlite-for-beginners/foreign-keys.mdx
+++ b/content/learn/sqlite-for-beginners/foreign-keys.mdx
@@ -26,7 +26,7 @@ erDiagram
 In this picture, order `101` does not copy Ada's whole customer record. It stores `customer_id = 1`, which points to `customers.id = 1`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     O["orders row<br/>id = 101<br/><code>customer_id</code> = 1"] -->|"points to"| C["customers row<br/><code>id = 1</code><br/>name = Ada"]
 ```
 

--- a/content/learn/sqlite-for-beginners/grouping-data.mdx
+++ b/content/learn/sqlite-for-beginners/grouping-data.mdx
@@ -126,7 +126,7 @@ Read the query out loud like this:
 The `dept` column appears in the result because it labels each group. Without it, you would see numbers but not know which department they describe.
 
 ```mermaid
-flowchart LR
+flowchart TD
     F["<code>FROM employees</code>"] --> G["<code>GROUP BY dept</code>"]
     G --> S["<code>SELECT dept,<br/>COUNT(*), AVG(salary)</code>"]
     S --> O["<code>ORDER BY dept</code>"]
@@ -352,7 +352,7 @@ ORDER BY
 The intern row is removed first. Then SQLite groups the remaining rows by department.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Raw["Raw employee rows"] --> Where["WHERE <code>is_intern</code> = 0<br/>keep full-time rows"]
     Where --> Group["<code>GROUP BY dept</code><br/>make department groups"]
     Group --> Avg["AVG(salary)<br/>inside each group"]

--- a/content/learn/sqlite-for-beginners/how-applications-store-information.mdx
+++ b/content/learn/sqlite-for-beginners/how-applications-store-information.mdx
@@ -107,7 +107,7 @@ due_date: 2026-04-15
 SQLite stores those facts as a row in a table.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["To-do app"] --> B["Save task"]
     B --> C["tasks table"]
     C --> D[("SQLite database file")]
@@ -204,7 +204,7 @@ The application owns the buttons, forms, pages, images, and interactions.
 The database owns the stored facts.
 
 ```mermaid
-flowchart LR
+flowchart TD
     U["User"] --> A["Application screen"]
     A --> S["SQLite"]
     S --> D[("Database file")]
@@ -258,7 +258,7 @@ Examples:
 - "Find products under $50."
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[("Many saved rows")] --> B["SQL question"]
     B --> C["Small useful answer"]
 ```

--- a/content/learn/sqlite-for-beginners/inner-joins.mdx
+++ b/content/learn/sqlite-for-beginners/inner-joins.mdx
@@ -239,7 +239,7 @@ ORDER BY
 You can chain inner joins. Each `JOIN ... ON ...` adds another table and another matching rule.
 
 ```mermaid
-flowchart LR
+flowchart TD
     C["<code>customers</code>"] -->|"c.id = o.<code>customer_id</code>"| O["<code>orders</code>"]
     O -->|"o.<code>product_id</code> = p.id"| P["<code>products</code>"]
     P --> R["customer + product result"]

--- a/content/learn/sqlite-for-beginners/inserting-data.mdx
+++ b/content/learn/sqlite-for-beginners/inserting-data.mdx
@@ -65,7 +65,7 @@ The SQL statement for adding rows is `INSERT INTO`.
 An `INSERT` statement names the table, names the columns you are filling, and supplies matching values.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>INSERT INTO</code>"] --> B["which table"]
     B --> C["which columns"]
     C --> D["<code>VALUES</code>"]
@@ -127,7 +127,7 @@ ORDER BY
 The insert only gave `title`. SQLite supplied `id`, and `DEFAULT 0` supplied `done`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     V["<code>VALUES<br/>'Water plants'</code>"] --> T["tasks table"]
     T --> R["id assigned<br/>done defaults to 0"]
 ```

--- a/content/learn/sqlite-for-beginners/many-to-many.mdx
+++ b/content/learn/sqlite-for-beginners/many-to-many.mdx
@@ -193,7 +193,7 @@ ORDER BY
 The primary key is the pair `(student_id, course_id)`. That means the same student cannot be enrolled in the same course twice.
 
 ```mermaid
-flowchart LR
+flowchart TD
     S["<code>students</code>"] -->|"<code>student_id</code>"| E["enrollments<br/>one row per link"]
     E -->|"<code>course_id</code>"| C["<code>courses</code>"]
 ```

--- a/content/learn/sqlite-for-beginners/outer-joins.mdx
+++ b/content/learn/sqlite-for-beginners/outer-joins.mdx
@@ -125,7 +125,7 @@ A left join preserves the left side even when the right side has no match.`}
 When SQLite cannot find a matching right-side row, it cannot show a real `orders.id` or `orders.amount`. So it shows `NULL`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     C["customer<br/>Linus"] -->|"no matching order"| N["<code>order_id</code> = NULL<br/>amount = NULL"]
 ```
 
@@ -245,7 +245,7 @@ Linus gets `0` because there are no non-NULL order ids to count.
 For beginners, `LEFT JOIN` is the most important outer join. Recent SQLite versions also support `RIGHT JOIN` and `FULL OUTER JOIN`, but you can usually make your query clearer by arranging the table you want to preserve on the left and using `LEFT JOIN`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     I["<code>INNER JOIN</code><br/>only matches"] --- L["<code>LEFT JOIN</code><br/>all left rows"]
     L --- R["<code>RIGHT JOIN</code><br/>all right rows"]
     R --- F["<code>FULL OUTER JOIN</code><br/>all rows from both sides"]

--- a/content/learn/sqlite-for-beginners/query-execution-order.mdx
+++ b/content/learn/sqlite-for-beginners/query-execution-order.mdx
@@ -206,7 +206,7 @@ rows*. `HAVING` (step 4) runs **after** grouping, so it filters
 *whole groups*:
 
 ```mermaid
-flowchart LR
+flowchart TD
     R["rows"] --> W["<code>WHERE</code><br/>filter rows<br/>(before grouping)"]
     W --> G["<code>GROUP BY</code><br/>form groups"]
     G --> H["<code>HAVING</code><br/>filter groups<br/>(after grouping)"]

--- a/content/learn/sqlite-for-beginners/relationships-intro.mdx
+++ b/content/learn/sqlite-for-beginners/relationships-intro.mdx
@@ -73,7 +73,7 @@ Ada's phone number is copied in multiple rows. If it changes, you must find and 
 The relational solution is to store each fact once.
 
 ```mermaid
-flowchart LR
+flowchart TD
     BAD["Repeated customer details<br/>inside order rows"] --> GOOD["Separate tables"]
     GOOD --> C["customers<br/>customer details once"]
     GOOD --> O["orders<br/>order facts only"]
@@ -85,7 +85,7 @@ flowchart LR
 The customer table has a primary key: `customers.id`. The orders table stores a matching value: `orders.customer_id`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     C["<code>customers.id</code><br/>primary key"]:::pk --> O["orders.<code>customer_id</code><br/>points to customer"]:::fk
     classDef pk fill:#fde68a,stroke:#b45309
     classDef fk fill:#dcfce7,stroke:#15803d
@@ -163,7 +163,7 @@ erDiagram
 ```
 
 ```mermaid
-flowchart LR
+flowchart TD
     P["Person row<br/>Maya"] --> PASS["Passport row<br/>Maya's passport"]
 ```
 

--- a/content/learn/sqlite-for-beginners/select-basics.mdx
+++ b/content/learn/sqlite-for-beginners/select-basics.mdx
@@ -75,7 +75,7 @@ going across. `SELECT` names the columns you want to see, and `FROM`
 names the table that holds them.
 
 ```mermaid
-flowchart LR
+flowchart TD
     T[("books table<br/>stored data")] --> C["<code>SELECT title, author</code><br/>choose columns"]
     C --> R["result table<br/>title + author"]
     T -.-> T

--- a/content/learn/sqlite-for-beginners/sorting-and-limiting.mdx
+++ b/content/learn/sqlite-for-beginners/sorting-and-limiting.mdx
@@ -119,7 +119,7 @@ ORDER BY
 />
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["unsorted result rows"] --> B["<code>ORDER BY price DESC</code><br/>sort high to low"]
     B --> C["ordered result rows"]
 ```
@@ -241,7 +241,7 @@ cheapest three, newest three, or first three alphabetically, sort first.
 with `LIMIT`, it is how websites make pages of results.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["all matching rows"] --> S["<code>ORDER BY</code><br/>sort rows"]
     S --> O["<code>OFFSET 2</code><br/>skip two"]
     O --> L["<code>LIMIT 2</code><br/>take two"]
@@ -286,7 +286,7 @@ next two.
 When these clauses appear together, write them in this order:
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["<code>SELECT</code><br/>columns"] --> B["<code>FROM<br/>table</code>"]
     B --> C["<code>WHERE</code><br/>filter rows"]
     C --> D["<code>ORDER BY</code><br/>sort rows"]

--- a/content/learn/sqlite-for-beginners/spreadsheets-vs-databases.mdx
+++ b/content/learn/sqlite-for-beginners/spreadsheets-vs-databases.mdx
@@ -127,7 +127,7 @@ This structure helps applications trust the data.
 If a column is meant to store a price, the database can treat it as a value to compare, sort, sum, and validate.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Same shape rows"] --> B["Reliable queries"]
     B --> C["Trusted app behavior"]
 ```
@@ -189,7 +189,7 @@ Is "Maya Chen" the same customer in both rows? What if her name changes? How man
 A relational database can separate those ideas:
 
 ```mermaid
-flowchart LR
+flowchart TD
     C["<code>customers</code>"] --> O["<code>orders</code>"]
     O --> I["<code>order_items</code>"]
     I --> P["<code>products</code>"]

--- a/content/learn/sqlite-for-beginners/tables-rows-columns.mdx
+++ b/content/learn/sqlite-for-beginners/tables-rows-columns.mdx
@@ -244,7 +244,7 @@ A table is not a numbered list. SQLite may return rows in any
 order unless you ask for an order.
 
 ```mermaid
-flowchart LR
+flowchart TD
     TABLE["Table rows<br/>stored without a promised order"] --> QUERY["Need a sorted result?"]
     QUERY --> ORDER["Use ORDER BY"]
 ```

--- a/content/learn/sqlite-for-beginners/understanding-joins.mdx
+++ b/content/learn/sqlite-for-beginners/understanding-joins.mdx
@@ -8,7 +8,7 @@ A **join** combines rows from two tables into one result. You use it when one ta
 For example, `orders` knows the amount. `customers` knows the name. A join lets you ask: "show each order with the customer's name."
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph C["<code>customers</code>"]
         C1["id 1<br/>Ada"]
         C2["id 2<br/>Grace"]

--- a/content/learn/sqlite-for-beginners/what-is-a-database.mdx
+++ b/content/learn/sqlite-for-beginners/what-is-a-database.mdx
@@ -298,7 +298,7 @@ word "database" for two related things:
   surviving crashes.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Your app"] -->|"sends SQL"| C["SQLite<br/>the DBMS"]
     C -->|"manages"| B[("Database file<br/>the data")]
 ```

--- a/content/learn/sqlite-for-beginners/working-with-null.mdx
+++ b/content/learn/sqlite-for-beginners/working-with-null.mdx
@@ -215,7 +215,7 @@ silently. That is the bug, and that is why SQL provides `IS NULL`
 as a separate test that genuinely answers true or false.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["comparison<br/><code>phone = NULL</code>"] --> U["unknown<br/>not true"]
     U --> W["WHERE keeps only true rows"]
     W --> D["row is not kept"]
@@ -418,7 +418,7 @@ For beginners, `COALESCE` is a great default because it is standard SQL
 and can handle more than two choices.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["possibly NULL value"] --> B{"is it NULL?"}
     B -->|"no"| C["use original value"]
     B -->|"yes"| D["use fallback value"]

--- a/content/learn/statistics-for-data-science-python/anova-and-chi-square.mdx
+++ b/content/learn/statistics-for-data-science-python/anova-and-chi-square.mdx
@@ -241,7 +241,7 @@ expected are close, no association; if they diverge a lot, the variables
 are linked.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Two categorical columns<br/>(e.g. device, churned)"] --> B["pandas crosstab<br/>(contingency table of COUNTS)"]
   B --> C["<code>chi2_contingency</code><br/>compares observed vs expected"]
   C --> D{"<code>p &lt;= alpha</code>?"}

--- a/content/learn/statistics-for-data-science-python/central-limit-theorem.mdx
+++ b/content/learn/statistics-for-data-science-python/central-limit-theorem.mdx
@@ -77,7 +77,7 @@ Read that again, because three different claims are packed in:
    essentially normal.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["ANY population shape<br/>(skewed, uniform, bimodal...)<br/>finite variance"] --> B["Take many samples of size n<br/>compute x-bar each time"]
     B --> C["Sampling distribution of x-bar<br/>becomes approx NORMAL as n grows"]
 ```

--- a/content/learn/statistics-for-data-science-python/conditional-probability.mdx
+++ b/content/learn/statistics-for-data-science-python/conditional-probability.mdx
@@ -129,7 +129,7 @@ is information you can exploit.
   shifts your beliefs about the other.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Does knowing B change<br/>P of A?"] --> B{"P(A given B) = P(A)?"}
   B -->|"yes, unchanged"| C["INDEPENDENT<br/>(B is uninformative about A)"]
   B -->|"no, it shifts"| D["DEPENDENT<br/>(B carries information about A)"]

--- a/content/learn/statistics-for-data-science-python/confidence-intervals.mdx
+++ b/content/learn/statistics-for-data-science-python/confidence-intervals.mdx
@@ -61,7 +61,7 @@ error*, a typical sample-to-sample wobble. The point estimate throws
 that information away. The confidence interval keeps it.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Point estimate<br/>(x-bar)"] --> C["CI: x-bar +/- margin"]
   B["Margin of error<br/>(critical value x standard error)"] --> C
   C --> D["A range of plausible<br/>values for mu"]

--- a/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/continuous-distributions.mdx
@@ -254,7 +254,7 @@ reverse: *probability → value*. "What wait time are 90% of waits below?"
 percentile. It's the tool for setting thresholds, SLAs, and cutoffs.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["a value x"] -->|"cdf: P(X <= x)"| B["a probability"]
   B -->|"ppf: inverse"| A
   C["<code>ppf(0.9)</code> = the value below<br/>which 90% of outcomes fall"]

--- a/content/learn/statistics-for-data-science-python/effect-sizes.mdx
+++ b/content/learn/statistics-for-data-science-python/effect-sizes.mdx
@@ -59,7 +59,7 @@ certain sample size, is almost guaranteed — so it stops carrying
 information about whether you should care.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Effect exists?"] -->|"p-value answers this"| B["Yes / can't tell"]
   C["How big is it?"] -->|"effect size answers this"| D["<code>d = 0.05</code>? <code>r = 0.6</code>?<br/>+8% revenue?"]
   B --> E{"Ship decision<br/>needs BOTH"}
@@ -245,7 +245,7 @@ data:
   makes it *more precise*, not bigger or smaller.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Collect more data"] --> B["p-value shrinks<br/>toward 0"]
   A --> C["Effect size estimate<br/>gets more precise<br/>(not larger)"]
   B --> D["Significance becomes<br/>almost guaranteed"]

--- a/content/learn/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
+++ b/content/learn/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
@@ -86,7 +86,7 @@ conflating them is how analyses go wrong.
   confidence interval.*
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph EXP["Exploratory (generate)"]
     A["Look broadly:<br/>distributions, relationships,<br/>missingness, outliers"] --> B["Form candidate<br/>hypotheses"]
   end
@@ -516,7 +516,7 @@ ANOVA, or a chi-square from the *Hypothesis Testing* section — run
 leads, full stop.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["EDA surfaced:<br/>'big parties tip less %'"] --> B{"How to confirm<br/>honestly?"}
   B -->|"new data"| C["Collect more receipts,<br/>test there"]
   B -->|"held-out split"| D["Test on the locked-away<br/>30% slice"]

--- a/content/learn/statistics-for-data-science-python/measures-of-spread.mdx
+++ b/content/learn/statistics-for-data-science-python/measures-of-spread.mdx
@@ -301,7 +301,7 @@ outlier-prone data, and it's the engine behind box plots and the
 `1.5×IQR` outlier rule we'll meet in *Shape and Outliers*.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Q1<br/>25th percentile"] --- B["median<br/>50th percentile"]
   B --- C["Q3<br/>75th percentile"]
   A -. "IQR = Q3 - Q1<br/>(middle 50%)" .-> C

--- a/content/learn/statistics-for-data-science-python/populations-and-samples.mdx
+++ b/content/learn/statistics-for-data-science-python/populations-and-samples.mdx
@@ -120,7 +120,7 @@ generate, every wafer the machine could ever produce. The **sample** is
 the subset you managed to observe and put in a DataFrame.
 
 ```mermaid
-flowchart LR
+flowchart TD
     P["Population<br/>(everyone/everything you care about)"] -->|"draw a subset"| S["Sample<br/>(what you observed)"]
     S -->|"compute a summary"| ST["Statistic<br/>(x-bar, s, p-hat)"]
     ST -. "estimate / infer" .-> PA["Parameter<br/>(mu, sigma, p)"]

--- a/content/learn/statistics-for-data-science-python/probability-basics.mdx
+++ b/content/learn/statistics-for-data-science-python/probability-basics.mdx
@@ -134,7 +134,7 @@ This is why a run of outcomes gets unlikely fast: two fair-coin heads is
 0.5 × 0.5 = 0.25; ten in a row is 0.5¹⁰ ≈ 0.001.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Question: do you want<br/>'or' or 'and'?"] --> B{"'OR' / either one"}
   A --> C{"'AND' / both together"}
   B -->|"mutually exclusive"| D["ADD the probabilities"]

--- a/content/learn/statistics-for-data-science-python/sampling-and-bias.mdx
+++ b/content/learn/statistics-for-data-science-python/sampling-and-bias.mdx
@@ -100,7 +100,7 @@ contract that connects the sample you have to the population you care
 about.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Target population<br/>(who you want to describe)"] --> B{"How is the<br/>sample chosen?"}
     B -->|"random mechanism"| C["Representative sample<br/>(inference is licensed)"]
     B -->|"convenience / self-selection"| D["Biased sample<br/>(systematically off)"]
@@ -488,7 +488,7 @@ planes hit in the engines and cockpit weren't in the dataset — they
 when hit, were fatal.
 
 ```mermaid
-flowchart LR
+flowchart TD
     ALL["All planes sent out"] --> RET["Planes that RETURNED<br/>(the data you see)"]
     ALL --> LOST["Planes that were LOST<br/>(missing from the data)"]
     RET -->|"holes here = survivable"| WRONG["Armor the holes?<br/>(wrong)"]

--- a/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
+++ b/content/learn/statistics-for-data-science-python/statistical-fallacies.mdx
@@ -121,7 +121,7 @@ purely because women concentrated in the hard-to-enter department. Same
 numbers, opposite story.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph WITHIN["Within each group"]
     W1["<code>Women &gt; Men</code><br/>in Dept Easy"]
     W2["<code>Women &gt; Men</code><br/>in Dept Hard"]
@@ -350,7 +350,7 @@ back — so the holes you *see* mark the survivable hits. The data was
 literally the survivors.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["All planes hit"] --> B{"Survived?"}
   B -->|"yes"| C["In your data<br/>(holes on wings/tail)"]
   B -->|"no"| D["NOT in your data<br/>(holes on engine)"]
@@ -451,7 +451,7 @@ run a "coaching program" on the bottom 10%, you'd wrongly credit it for
 the rebound.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Extreme reading<br/>(skill + lucky noise)"] --> B["Noise won't repeat"]
   B --> C["Next reading drifts<br/>back toward the mean"]
   C --> D["Looks like an effect,<br/>but it's automatic"]

--- a/content/learn/statistics-for-data-science-python/statistical-thinking.mdx
+++ b/content/learn/statistics-for-data-science-python/statistical-thinking.mdx
@@ -312,7 +312,7 @@ peer through the noise and estimate the signal — while being honest
 that you can never fully separate them from a single sample.
 
 ```mermaid
-flowchart LR
+flowchart TD
     DGP["Data-generating process<br/>(the real mechanism)"] -->|"emits noisy output"| S["Your sample<br/>(what you actually have)"]
     S -->|"compute a summary"| T["A statistic<br/>(mean, rate, gap)"]
     T -->|"reason backward"| I["Inference about<br/>the process"]

--- a/content/learn/statistics-for-data-science-python/t-tests.mdx
+++ b/content/learn/statistics-for-data-science-python/t-tests.mdx
@@ -79,7 +79,7 @@ error in *Standard Error*). So:
 - **Small |t|** → the gap is the size of ordinary noise → nothing to see.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Observed difference<br/>(signal)"] --> C["t = signal / noise"]
   B["Standard error<br/>(noise)"] --> C
   C --> D{"|t| large?"}

--- a/content/learn/statistics-for-data-science-python/the-bootstrap.mdx
+++ b/content/learn/statistics-for-data-science-python/the-bootstrap.mdx
@@ -143,7 +143,7 @@ That's it. The same five steps work for any statistic — you only change
 the function in step 3.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Observed sample"] --> B["Loop B times:<br/>resample n with replacement"]
   B --> C["Compute statistic<br/>on each resample"]
   C --> D["Collect B values =<br/>bootstrap distribution"]

--- a/content/learn/statistics-for-data-science-python/the-normal-distribution.mdx
+++ b/content/learn/statistics-for-data-science-python/the-normal-distribution.mdx
@@ -57,7 +57,7 @@ roughly independent contributions, its distribution drifts toward a bell
 curve — *regardless* of what the individual pieces look like.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Many small,<br/>independent effects"] --> B["They add up"]
   B --> C["The sum looks<br/>bell-shaped"]
   C --> D["Normal distribution<br/>(emerges naturally)"]
@@ -236,7 +236,7 @@ a temperature on equal footing. The distribution of z-scores is the
 arguments.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["raw value x<br/>(score, height, ...)"] -->|"z = (x − mu) / sigma"| B["z-score<br/>(SDs from the mean)"]
   B -->|"<code>norm.cdf(z)</code>"| C["percentile<br/>(fraction below)"]
   C -->|"<code>norm.ppf(p)</code>"| B

--- a/content/learn/statistics-for-data-science-python/types-of-data.mdx
+++ b/content/learn/statistics-for-data-science-python/types-of-data.mdx
@@ -136,7 +136,7 @@ it and adds one. The two boundaries that trip people up:
   long" or "half the price" are valid.
 
 ```mermaid
-flowchart LR
+flowchart TD
     N["Nominal<br/>(= and not-equal only)"] --> O["Ordinal<br/>(adds order: < >)"]
     O --> I["Interval<br/>(adds equal gaps: + and -)"]
     I --> R["Ratio<br/>(adds true zero: * and /)"]

--- a/content/learn/statistics-for-data-science-python/visualizing-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/visualizing-distributions.mdx
@@ -93,7 +93,7 @@ bimodality, outliers, and skew that change the whole conclusion.
 </Callout>
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Raw distribution<br/>(all the detail)"] --> B["mean + std<br/>(2 numbers)"]
   B --> C["loses skew, modality,<br/>tails, outliers"]
   A --> D["a plot<br/>(keeps the shape)"]

--- a/content/learn/statistics-for-data-science-python/why-statistics-matters.mdx
+++ b/content/learn/statistics-for-data-science-python/why-statistics-matters.mdx
@@ -76,7 +76,7 @@ questions about the *world the data came from*. Those are different
 things, and the gap between them is where careers are made or wrecked.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["The world<br/>(what you care about)"] -->|"you only observe a slice"| B["Your dataset<br/>(what you actually have)"]
     B -->|"describe it"| C["Facts about the dataset"]
     C -->|"statistics"| D["Justified claims<br/>about the world"]

--- a/content/learn/statistics-for-data-science-python/working-with-distributions.mdx
+++ b/content/learn/statistics-for-data-science-python/working-with-distributions.mdx
@@ -66,7 +66,7 @@ authoritative, *wrong* answers.
 </svg>
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Real data"] --> B["Fit a distribution<br/>(.fit -> parameters)"]
   B --> C["Sanity-check the fit<br/>(histogram overlay, Q-Q plot)"]
   C -->|"looks good"| D["Use the model:<br/>probabilities, thresholds, sims"]
@@ -287,7 +287,7 @@ A **Q–Q (quantile–quantile) plot** is the sharper check. The idea:
   means the model misses the data's shape there.
 
 ```mermaid
-flowchart LR
+flowchart TD
   A["Sample quantiles<br/>(sorted data)"] --> C["Scatter:<br/>sample vs theoretical"]
   B["Theoretical quantiles<br/>(from fitted model)"] --> C
   C --> D{"Points on a<br/>straight line?"}

--- a/content/learn/systems-programming-c/arrays-and-pointers.mdx
+++ b/content/learn/systems-programming-c/arrays-and-pointers.mdx
@@ -97,7 +97,7 @@ WASI). That is what we mean by "contiguous": no gaps, no indirection,
 no per-element header.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph Mem["Memory"]
         A0["<code>nums[0]<br/>10</code>"] --> A1["<code>nums[1]<br/>20</code>"] --> A2["<code>nums[2]<br/>30</code>"] --> A3["<code>nums[3]<br/>40</code>"] --> A4["<code>nums[4]<br/>50</code>"]
     end

--- a/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/learn/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -106,7 +106,7 @@ malloc" as a suggested project; after this page you will know enough
 to try.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Program] -->|"<code>malloc(n)</code>"| B[Allocator]
     B -->|"void *"| A
     A -->|"writes / reads"| C["Heap block<br/>(n bytes)"]

--- a/content/learn/systems-programming-c/pointers.mdx
+++ b/content/learn/systems-programming-c/pointers.mdx
@@ -138,7 +138,7 @@ Two operators move between values and addresses:
 | `*p` | "value at `p`" | the thing it points to (dereference) |
 
 ```mermaid
-flowchart LR
+flowchart TD
     P["pointer p<br/>(its value is<br/><code>0x7ffc1234</code>)"] -->|*p reads /<br/>writes there| V["int value 42<br/>at <code>0x7ffc1234</code>"]
     V -->|&x gives| P
 ```

--- a/content/learn/systems-programming-c/strings.mdx
+++ b/content/learn/systems-programming-c/strings.mdx
@@ -27,7 +27,7 @@ function in `<string.h>` becomes a loaded gun.
 ## Null-terminated character arrays
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["'H'"] --> B["'e'"] --> C["'l'"] --> D["'l'"] --> E["'o'"] --> F["'\\0'"]
 ```
 

--- a/content/learn/systems-programming-c/structs-and-unions.mdx
+++ b/content/learn/systems-programming-c/structs-and-unions.mdx
@@ -126,7 +126,7 @@ is also padded to a multiple of its strictest member's alignment, so
 that arrays of the struct stay aligned.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph bad["struct Bad <code>{ char c; int i; char d; }</code>"]
         b0["c<br/>1 B"] --> b1["pad<br/>3 B"] --> b2["i<br/>4 B"] --> b3["d<br/>1 B"] --> b4["pad<br/>3 B"]
     end

--- a/content/learn/time-series-analysis-python/differencing.mdx
+++ b/content/learn/time-series-analysis-python/differencing.mdx
@@ -202,7 +202,7 @@ season earlier: `y(t) - y(t-m)`. For monthly data with a yearly cycle that's
 pattern cancels against its own copy.
 
 ```mermaid
-flowchart LR
+flowchart TD
     L["Level series y(t)<br/>trend + yearly season"] -->|"first difference: y(t) - y(t-1)"| D1["Changes series<br/>(trend removed, season remains)"]
     D1 -->|"seasonal difference: y(t) - y(t-12)"| D2["Stationary-looking<br/>(trend AND season removed)"]
 ```

--- a/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
+++ b/content/learn/time-series-analysis-python/the-pandas-timeline.mdx
@@ -480,7 +480,7 @@ April-to-April — even if they're in different orders or have different
 lengths. Where a label is missing on one side, the result is `NaN`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A["Series A<br/>Jan-01, Jan-02, Jan-03"] --> U["Align on the union<br/>of the two indices"]
     B["Series B<br/>Jan-02, Jan-03, Jan-04"] --> U
     U --> R["Jan-01 = NaN<br/>Jan-02 = A+B<br/>Jan-03 = A+B<br/>Jan-04 = NaN"]

--- a/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
+++ b/content/learn/typescript-from-scratch/api-modeling-and-contracts.mdx
@@ -163,7 +163,7 @@ export type User = {
 Both `service.ts` and `client.ts` import from `types.ts`. If you add a field to `User`, both sides see it immediately. If the service forgets to include it, the compiler complains.
 
 ```mermaid
-graph LR
+graph TD
     A["<code>types.ts</code><br/>Shared Contract"] --> B["<code>service.ts</code><br/>Producer"]
     A --> C["<code>client.ts</code><br/>Consumer"]
     B --> D[Runtime]

--- a/content/learn/typescript-from-scratch/structural-typing.mdx
+++ b/content/learn/typescript-from-scratch/structural-typing.mdx
@@ -99,7 +99,7 @@ printPoint(v); // ❌ Compile error: incompatible types
 Even though `Point` and `Vector` have identical fields, Java rejects the call because the *names* differ. TypeScript doesn't care about names — only structure.
 
 ```mermaid
-graph LR
+graph TD
     A["Type A: <code>{ x: number; y: number }</code>"]
     B["Type B: <code>{ x: number; y: number }</code>"]
     C["Type C: <code>{ x: number; y: number; z: number }</code>"]


### PR DESCRIPTION
This PR has two parts.

## 1. Expand explanations in the interview prep section (`content/interview/`)

The `/interview` Q&A pages dropped in runnable code, formulas, and concept
checks but often left the code blocks under-explained and used bare
acronyms. This pass makes every page more self-explanatory.

- **Code-block explanations** — every `<CodeBlock>` / `<SqlCodeBlock>` and
  fenced block now has a lead-in or follow-up that says what the code does
  and how it ties to the question, naming the concrete identifiers used.
  Includes the **SCD Type 2** example called out on the dimensional-modeling
  page.
- **Acronyms spelled out** — full role names everywhere (Analytics
  Engineer, Data Scientist, Data Engineer, Machine Learning Engineer,
  Business Intelligence) and technical terms expanded on first use
  (CTE, DAG, CDC, SCD, ELT, SGD, PSI, RDBMS, …).
- **Formulas in KaTeX** — standard error, power, Bayes' theorem,
  chi-square, precision/recall/F1, the sigmoid, cross-entropy, Big-O and
  the Master Theorem, `PERCENT_RANK`/`CUME_DIST`, PSI, and more.
- **Tables** — a True/False Positive/Negative **confusion matrix** on the
  machine-learning pages, and a **Type I / Type II error decision matrix**
  on the statistics pages.
- **Logical ordering** — the Data Scientist statistics Q&A is reordered so
  the **p-value is introduced after the hypothesis tests that produce it**.
- **Callouts & mermaid diagrams** where they aid understanding — star
  schema, dbt lineage, Medallion layers, two-stage ranking, hypothesis-test
  flow, BFS example graph; warning/tip callouts for the p-value
  misconception, the "peeking" trap, and declaring grain.

## 2. Convert long horizontal mermaid diagrams to vertical (project-wide)

Horizontal `flowchart LR` / `graph LR` diagrams overflow and clip on narrow
screens (the hypothesis-test flow was a visible example on mobile). I
scanned **all 1,179 mermaid diagrams** across `content/` and flipped the
direction to top-down (`TD`) for the **332** where that reduces width.

Targeting is structural, not blanket: for each diagram I compute the
longest-path **depth** (LR's horizontal extent) versus the widest level's
**breadth** (TD's horizontal extent), and rotate only when `breadth < depth`.
So chains and deep pipelines become vertical, while fan-in / fan-out
diagrams — where LR is already the narrower orientation — are left as-is.
The change is a mechanical direction-token edit only (+332/−332, no diagram
content altered).

## Verification

These pages compile MDX on demand (Fumadocs `dynamic` mode). Validated
statically: balanced code fences, every component self-closed, balanced
`<Callout>` tags and `$…$` math delimiters, no stray JSX-breaking
characters, and all math/table/mermaid/callout patterns match those already
shipping in `content/learn/` (same remark/rehype + KaTeX pipeline). The
mermaid diff was confirmed to be direction-header lines only. No component
prop contents or `<MultipleChoice>` blocks were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxWqztNwNmezf7U6P3i9x8