### PR TITLE
Make playground Appearance toggle a sun/moon switch

### DIFF
--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -2206,6 +2206,33 @@ input[type="range"].fs-slider:disabled {
   cursor: not-allowed;
 }
 
+/* ─── Appearance (light/dark) toggle ─── */
+/* The Appearance row carries its sun/moon glyphs beside the toggle rather
+   than a single leading icon. Pad the label so it still lines up with the
+   icon'd rows above it (14px icon + 6px gap). */
+.setting-switch-label.is-iconless {
+  padding-left: 20px;
+}
+/* Sun + switch + moon, sitting together on the right of the row. The icon
+   for the active scheme is highlighted; the other is dimmed. */
+.theme-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.theme-switch-icon {
+  color: var(--text-dim);
+  opacity: 0.4;
+  flex-shrink: 0;
+  transition:
+    color 0.15s,
+    opacity 0.15s;
+}
+.theme-switch-icon.is-active {
+  color: var(--text);
+  opacity: 1;
+}
+
 /* ─── Packages drawer ─── */
 .pkg-overlay {
   position: fixed;

--- a/app/_components/playgroundShared.tsx
+++ b/app/_components/playgroundShared.tsx
@@ -16,6 +16,7 @@ import {
   Moon,
   RotateCcw,
   Sliders,
+  Sun,
   Trash2,
   WrapText,
   X,
@@ -294,6 +295,8 @@ export function SettingsPanelContent({
     }
   }, []);
 
+  const isDark = editorTheme === "github-dark";
+
   return (
     <Tabs.Root
       value={tab}
@@ -422,19 +425,30 @@ export function SettingsPanelContent({
 
           <div className="setting-row">
             <label className="setting-switch-row">
-              <span className="setting-switch-label">
-                <Moon size={14} aria-hidden="true" />
-                <span>Dark Theme</span>
+              <span className="setting-switch-label is-iconless">
+                <span>Appearance</span>
               </span>
-              <Switch.Root
-                checked={editorTheme === "github-dark"}
-                onCheckedChange={(checked) =>
-                  setSiteTheme(checked ? "dark" : "light")
-                }
-                className="bui-switch"
-              >
-                <Switch.Thumb className="bui-switch-thumb" />
-              </Switch.Root>
+              <span className="theme-switch">
+                <Sun
+                  size={14}
+                  aria-hidden="true"
+                  className={`theme-switch-icon${isDark ? "" : " is-active"}`}
+                />
+                <Switch.Root
+                  checked={isDark}
+                  onCheckedChange={(checked) =>
+                    setSiteTheme(checked ? "dark" : "light")
+                  }
+                  className="bui-switch"
+                >
+                  <Switch.Thumb className="bui-switch-thumb" />
+                </Switch.Root>
+                <Moon
+                  size={14}
+                  aria-hidden="true"
+                  className={`theme-switch-icon${isDark ? " is-active" : ""}`}
+                />
+              </span>
             </label>
           </div>
 


### PR DESCRIPTION
## Summary

Updates the **"Dark Theme"** row in the playground settings tab:

- **Renamed** the label from "Dark Theme" → **"Appearance"** (it's a light/dark switch now, so the neutral label fits both directions).
- **Added sun + moon icons flanking the toggle** (☀ on the left, ☾ on the right). The icon for the currently active scheme is highlighted; the other is dimmed.
- Kept the existing `Switch.Root` toggle and its `setSiteTheme` wiring — behavior is unchanged, only the presentation.

The row has no leading icon (its sun/moon glyphs sit beside the toggle instead), so its label is padded to stay aligned with the icon'd rows above it.

This lives in the shared `SettingsPanelContent` (`app/_components/playgroundShared.tsx`), which every playground uses — Python directly, and SQL/Postgres/DuckDB via `SqlSettingsPanelContent` — so all playgrounds get the change.

## Changes

- `app/_components/playgroundShared.tsx` — rewrite the theme row: label → "Appearance", `Sun`/`Moon` flanking the toggle with an `is-active` class on the active-scheme icon.
- `app/_components/playground.css` — add `.theme-switch`, `.theme-switch-icon[.is-active]`, and `.setting-switch-label.is-iconless` (label alignment).

## Verification

`node_modules` isn't installed in this environment, so `tsc`/`eslint` only report environment-wide missing-module noise (nothing specific to the edits). I verified the visual result by rendering the row markup with the exact CSS rules in a standalone page and screenshotting it in both light and dark states (brand blue approximated):

- Light (toggle off): ☀ highlighted, toggle grey, ☾ dimmed.
- Dark (toggle on): ☀ dimmed, toggle blue, ☾ highlighted.
- "Appearance" aligns with the neighboring "Word Wrap" / "Clear Output" labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MMUFHqAsLUmjLz9dJsX14

---
_Generated by [Claude Code](https://claude.ai/code/session_013MMUFHqAsLUmjLz9dJsX14)_