### PR TITLE
Replace Source Serif with Inter (tightened tracking)

### DIFF
--- a/app/_components/ChallengeCard.tsx
+++ b/app/_components/ChallengeCard.tsx
@@ -2397,7 +2397,7 @@ function OutputCellView({ cell }: { cell: OutputCell }) {
   if (cell.type === "html") {
     return (
       <div
-        // `not-prose` keeps the docs' prose typography (serif font,
+        // `not-prose` keeps the docs' prose typography (enlarged Inter,
         // table margins) from restyling the dataframe markup when the
         // card sits inside MDX content.
         className={`${styles.outCellHtml} not-prose`}

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -376,9 +376,9 @@
 
 .toastTitle {
   /* `Toast.Title` renders an <h2>, and the toast is portaled to <body> —
-     outside the /learn docs container that maps `--font-serif` to Source
-     Serif. There the docs' `h1–h6 { font-family: var(--font-serif) }` rule
-     resolves to Tailwind's `ui-serif` default and wins over the Inter set on
+     outside the /learn docs container. There the docs' bare
+     `h1–h6 { font-family: var(--font-sans) }` rule applies its tightened
+     heading tracking to this <h2> and wins over the value set on
      `.toastRoot` (a directly-matched element rule beats an inherited value).
      Pin Inter on the title itself so the toast text stays in the UI font. */
   font-family:

--- a/app/_components/CodeBlock.tsx
+++ b/app/_components/CodeBlock.tsx
@@ -1550,7 +1550,7 @@ function OutputSegment({ cell }: { cell: OutputCell }) {
     // Same trust assumption as the main playground: HTML cells are
     // produced by the embedded runtime executing code the user
     // themselves typed in this very widget. `not-prose` keeps the
-    // docs' prose typography (serif, table margins) from restyling
+    // docs' prose typography (enlarged Inter, table margins) from restyling
     // the dataframe markup when the block sits inside MDX content.
     return (
       <div

--- a/app/_components/mdx/timeline.module.css
+++ b/app/_components/mdx/timeline.module.css
@@ -3,7 +3,8 @@
      the article column width, not the viewport. */
   container-type: inline-size;
   margin: 1.75rem 0;
-  font-family: "Source Serif 4", Georgia, "Times New Roman", serif;
+  font-family: var(--font-sans, "Inter", system-ui, -apple-system, sans-serif);
+  letter-spacing: -0.011em;
 }
 
 .title {

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1329,8 +1329,8 @@ body.playground-active {
   color: var(--text);
   /* Pin the empty-state text to Inter. Without this the heading/body simply
      inherit the document font, which is fine on the standalone playground but
-     lets a serif stack leak in wherever the playground is mounted inside a
-     serif-scoped context (the heading especially — see `.welcome h3`). */
+     lets a host's typography leak in wherever the playground is mounted inside
+     another styled context (the heading especially — see `.welcome h3`). */
   font-family: var(--font-ui);
   text-align: center;
   padding: 32px;
@@ -2291,9 +2291,9 @@ input[type="range"].fs-slider:disabled {
   flex-shrink: 0;
 }
 .pkg-drawer-title {
-  /* Same serif-leak guard as .mobile-menu-drawer-title — this Drawer.Title
+  /* Same heading-leak guard as .mobile-menu-drawer-title — this Drawer.Title
      heading is portalled to body and would otherwise pick up the /learn
-     docs' serif `h1–h6` rule. */
+     docs' `h1–h6` rule (Inter with tightened display tracking). */
   font-family: var(--font-ui);
   font-size: 13px;
   font-weight: 600;
@@ -3550,7 +3550,7 @@ input[type="range"].fs-slider:disabled {
   opacity: 0;
 }
 .confirm-popup {
-  /* Anchor the whole dialog to the UI font so a serif-scoped host (the
+  /* Anchor the whole dialog to the UI font so a styled host (the
      /learn docs, where these playgrounds embed) can't leak in via the
      portal. The title still needs its own rule below to beat `h1–h6`. */
   font-family: var(--font-ui);
@@ -3841,8 +3841,8 @@ html[data-playground-theme="light"] .toast {
 
 .toast-title {
   /* `Toast.Title` renders an <h2>. Pin Inter directly (rather than relying on
-     the `.toast` parent's font-family) so a bare `h1–h6` rule from a
-     serif-scoped host context can't override the inherited value. */
+     the `.toast` parent's font-family) so a bare `h1–h6` rule from a styled
+     host context can't override the inherited value. */
   font-family: var(--font-ui);
   font-weight: 600;
   font-size: 12.5px;

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1346,7 +1346,7 @@ body.playground-active {
 }
 .welcome h3 {
   /* "Run a query to see results" is an <h3>. A bare `h3` selector (e.g. the
-     /learn docs' `h1–h6 { font-family: var(--font-serif) }`) would otherwise
+     /learn docs' `h1–h6 { font-family: var(--font-sans) }`) would otherwise
      win over the inherited value above, so pin Inter directly here — the
      `.welcome h3` selector outranks a lone element selector. */
   font-family: var(--font-ui);
@@ -3212,9 +3212,9 @@ input[type="range"].fs-slider:disabled {
 }
 .mobile-menu-drawer-title {
   /* Drawer.Title renders as a heading; pin the UI font so the docs'
-     `h1–h6 { font-family: var(--font-serif) }` rule (active when the
-     playground is embedded in /learn) can't leak serif into the
-     portalled bottom sheet. */
+     `h1–h6 { font-family: var(--font-sans) }` rule (active when the
+     playground is embedded in /learn) can't override the portalled bottom
+     sheet's title with the docs' heading tracking. */
   font-family: var(--font-ui);
   font-size: 13px;
   font-weight: 600;
@@ -3581,8 +3581,8 @@ input[type="range"].fs-slider:disabled {
 .confirm-title {
   /* Base UI renders Dialog.Title as an <h2>. This dialog is portalled to
      document.body, so when a playground is embedded in /learn the docs'
-     `h1–h6 { font-family: var(--font-serif) }` rule lands on it; pin the
-     UI font so the title never falls into serif. */
+     `h1–h6 { font-family: var(--font-sans) }` rule lands on it; pin the
+     UI font so the title keeps its intended weight and tracking. */
   font-family: var(--font-ui);
   font-size: 15px;
   font-weight: 600;

--- a/app/home.css
+++ b/app/home.css
@@ -2,12 +2,13 @@
  * home.css — hardening for the home route ("/").
  * ----------------------------------------------------------------------------
  * The /learn route's stylesheet (app/learn/learn.css) defines GLOBAL element
- * typography — `body { font-family: Inter }` and `h1..h6 { font-family: serif }`
- * — and imports Tailwind's preflight, whose `.hidden` utility competes with our
- * responsive `md:*` display utilities. Next.js can leave that stylesheet
- * applied after a *client-side* back-navigation from /learn, so its rules bleed
- * onto this page: headings turn serif, and the nav menu (`hidden md:flex`) gets
- * stuck collapsed because the leaked `.hidden` outranks `md:flex`.
+ * typography — `body { font-family: Inter }` and `h1..h6 { font-family: Inter }`
+ * with tightened display tracking — and imports Tailwind's preflight, whose
+ * `.hidden` utility competes with our responsive `md:*` display utilities.
+ * Next.js can leave that stylesheet applied after a *client-side*
+ * back-navigation from /learn, so its rules bleed onto this page: headings pick
+ * up the docs' tightened heading tracking, and the nav menu (`hidden md:flex`)
+ * gets stuck collapsed because the leaked `.hidden` outranks `md:flex`.
  *
  * Scoping these rules under `.ds-home` gives them higher specificity than
  * learn.css's element/single-class selectors, so they win regardless of which
@@ -15,8 +16,8 @@
  * they never affect /learn itself.
  * ========================================================================== */
 
-/* Keep the whole page — and every heading in it — on Inter, immune to
- * learn.css's global serif `h1..h6` rule. */
+/* Keep the whole page — and every heading in it — on the home page's own
+ * Inter styling, immune to learn.css's global `h1..h6` heading rule. */
 .ds-home,
 .ds-home h1,
 .ds-home h2,

--- a/app/interview/layout.tsx
+++ b/app/interview/layout.tsx
@@ -12,18 +12,9 @@
  */
 import "../learn/learn.css";
 import type { ReactNode } from "react";
-import { Source_Serif_4 } from "next/font/google";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { interviewSource } from "@/lib/source";
-
-const sourceSerif4 = Source_Serif_4({
-  subsets: ["latin"],
-  axes: ["opsz"],
-  style: ["normal", "italic"],
-  variable: "--font-serif",
-  display: "swap",
-});
 
 export default function InterviewLayout({ children }: { children: ReactNode }) {
   return (
@@ -58,7 +49,6 @@ export default function InterviewLayout({ children }: { children: ReactNode }) {
           url: "/",
         }}
         githubUrl="https://github.com/dataslope/dataslope/"
-        containerProps={{ className: sourceSerif4.variable }}
       >
         {children}
       </DocsLayout>

--- a/app/learn/layout.tsx
+++ b/app/learn/layout.tsx
@@ -12,18 +12,9 @@
  */
 import "./learn.css";
 import type { ReactNode } from "react";
-import { Source_Serif_4 } from "next/font/google";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { source } from "@/lib/source";
-
-const sourceSerif4 = Source_Serif_4({
-  subsets: ["latin"],
-  axes: ["opsz"],
-  style: ["normal", "italic"],
-  variable: "--font-serif",
-  display: "swap",
-});
 
 export default function LearnLayout({ children }: { children: ReactNode }) {
   return (
@@ -61,7 +52,6 @@ export default function LearnLayout({ children }: { children: ReactNode }) {
           url: "/",
         }}
         githubUrl="https://github.com/dataslope/dataslope/"
-        containerProps={{ className: sourceSerif4.variable }}
       >
         {children}
       </DocsLayout>

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -238,19 +238,18 @@ body {
   letter-spacing: -0.011em;
 }
 
-/* Source Serif 4 for headings — the opsz axis is bumped to 20 so the
-   typeface self-optimises at display sizes (wider apertures, adjusted
-   contrast). Letter-spacing resets to 0 to undo the tight Inter value
-   set on `body` above. */
+/* Inter for headings, with tightened tracking for a polished display
+   feel. The bundled Inter is a static (non-variable) webfont, so
+   font-variation-settings is cleared rather than driving an opsz axis. */
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
-  font-variation-settings: "opsz" 20;
-  letter-spacing: 0;
+  font-family: var(--font-sans);
+  font-variation-settings: normal;
+  letter-spacing: -0.02em;
 }
 
 /* ── Syntax highlighting (highlight.js, GitHub theme) ────────────────
@@ -442,7 +441,7 @@ code.hljs {
   background: transparent;
 }
 
-/* ── Source Serif 4 for prose content ───────────────────────────────────
+/* ── Inter for prose content ────────────────────────────────────────────
    Applied to paragraphs, list items, and table cells inside Fumadocs
    prose regions. Explicitly excluded:
    - [data-flavor]                    SQL/non-SQL challenge cards & code blocks
@@ -457,11 +456,9 @@ code.hljs {
                                       overrides Mermaid's own font-size and the
                                       text overflows its measured node boxes
    - h1–h6                            headings (handled separately)
-   Optical size axis (opsz) is enabled via font-variation-settings so the
-   typeface self-optimises at body text sizes. Letter-spacing is pulled in
-   slightly (−0.006em) for a tighter, more polished editorial colour — a
-   gentler value than the −0.011em Inter tracking on `body`, since Source
-   Serif sets a touch looser than Inter at the same measure.
+   The bundled Inter is a static webfont, so font-variation-settings is
+   cleared. Letter-spacing is pulled in to −0.011em, matching the tight
+   Inter tracking set on `body`, for a polished editorial colour.
    ─────────────────────────────────────────────────────────────────────── */
 .prose :where(p, li, td, th):not(
   :where([class~="not-prose"], [class~="not-prose"] *),
@@ -473,16 +470,16 @@ code.hljs {
   :where([data-callout] *, .callout *),
   :where(svg *)
 ) {
-  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+  font-family: var(--font-sans);
   font-size: 1.125rem;
   line-height: 1.75;
-  font-variation-settings: "opsz" 16;
-  letter-spacing: -0.006em;
+  font-variation-settings: normal;
+  letter-spacing: -0.011em;
 }
 
 /* ── Table and callout font-size override ────────────────────────────────
    Tables and callouts are compact, information-dense contexts — scale
-   their Source Serif text back to 1rem (16px) with tighter leading.
+   their prose text back to 1rem (16px) with tighter leading.
 
    Fumadocs v16 callouts don't use [data-callout] or .callout — the
    CalloutContainer renders a plain <div> with an inline CSS custom
@@ -506,7 +503,7 @@ code.hljs {
 
 /* ── Steps component (Fumadocs docs styling) ─────────────────────────────
    Match the Fumadocs docs look for <Steps>/<Step>: compact Inter (sans)
-   with tight tracking instead of the large Source Serif that the `.prose`
+   with tight tracking instead of the larger prose Inter that the `.prose`
    paragraph rule applies. Each step is authored as a bold title paragraph
    (`<p><strong>…</strong></p>`) followed by one description paragraph.
    These selectors outrank the `.prose :where(p, …)` serif rule on
@@ -546,14 +543,14 @@ code.hljs {
 /* ── TOC navigation ──────────────────────────────────────────────────────
    Each TOC item is an <a> inside #nd-toc (desktop) or inside the mobile
    popover ([data-toc-popover-content]). The panel title is an <h3>.
-   opsz 14 is appropriate for the small (~13–14 px) text used here.
+   Inter with the standard tightened body tracking for these small links.
    ─────────────────────────────────────────────────────────────────────── */
 #nd-toc a,
 #nd-toc h3,
 [data-toc-popover-content] a {
-  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
-  font-variation-settings: "opsz" 14;
-  letter-spacing: 0;
+  font-family: var(--font-sans);
+  font-variation-settings: normal;
+  letter-spacing: -0.011em;
 }
 
 /* ── Page-footer navigation (prev / next) ────────────────────────────────
@@ -563,9 +560,9 @@ code.hljs {
    avoids touching breadcrumb links (which use <span>, not <p>).
    ─────────────────────────────────────────────────────────────────────── */
 #nd-page > div a p {
-  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
-  font-variation-settings: "opsz" 14;
-  letter-spacing: 0;
+  font-family: var(--font-sans);
+  font-variation-settings: normal;
+  letter-spacing: -0.011em;
 }
 
 /* ── Inter for MCQ and challenge card body text ─────────────────────────
@@ -590,8 +587,8 @@ code.hljs {
 /* Restore sans-serif on <td> and <th> inside challenge/quiz cards.
    These cover SQL result tables (.sqlResultTable) and markdown tables in
    instructions. The CSS module sets font-family: mono on .sqlResultTable
-   itself (inherited by td/th), so forcing sans-serif here avoids the
-   Source Serif rule overriding that inherited mono value. */
+   itself (inherited by td/th), so forcing sans-serif here keeps the
+   prose Inter rule from overriding that inherited mono value. */
 [data-flavor] td,
 [data-flavor] th,
 [data-testid="challenge-card"] td,

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -506,7 +506,7 @@ code.hljs {
    with tight tracking instead of the larger prose Inter that the `.prose`
    paragraph rule applies. Each step is authored as a bold title paragraph
    (`<p><strong>…</strong></p>`) followed by one description paragraph.
-   These selectors outrank the `.prose :where(p, …)` serif rule on
+   These selectors outrank the `.prose :where(p, …)` prose rule on
    specificity, so they win without !important.
    ─────────────────────────────────────────────────────────────────────── */
 .prose .fd-step > p {


### PR DESCRIPTION
## Summary

Replaces every Source Serif 4 usage with **Inter** and tightened letter-spacing, so the `/learn` and `/interview` docs use the same UI typeface as the rest of the app.

Source Serif had been driving the docs headings, prose body text, table-of-contents links, prev/next footer nav, and the MDX `<Timeline>` component. All of those now render in Inter (the app's existing `--font-sans`).

## Changes

- **`app/learn/layout.tsx` / `app/interview/layout.tsx`** — drop the `Source_Serif_4` `next/font/google` loader, its `--font-serif` variable, and the `containerProps` className that injected it.
- **`app/learn/learn.css`** — point every `var(--font-serif)` rule (headings, prose, TOC, footer nav) at `var(--font-sans)`, clear the `opsz` `font-variation-settings` (the bundled Inter is a static webfont, not variable), and apply tightened tracking.
- **`app/_components/mdx/timeline.module.css`** — switch the timeline from `"Source Serif 4"` to the Inter stack.
- **`app/_components/playground.css` / `app/_components/CodeBlock.module.css`** — update defensive comments that referenced the old serif heading rule.

## Letter-spacing

Following the existing convention (`body` already uses Inter at `-0.011em`):

- Display headings (`h1`–`h6`): **`-0.02em`** (a touch tighter for large display text)
- Prose body, TOC, footer nav, timeline: **`-0.011em`** (matches the body Inter tracking)

## Notes

No remaining references to `Source Serif`, `Source_Serif_4`, or `--font-serif` anywhere in the repo. Changes are CSS + a removed font import only; no behavioral logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbKiJJZkojiRFoVFHktAfK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbKiJJZkojiRFoVFHktAfK)_