### PR TITLE
Cap Python runtime output per run to prevent unbounded memory growth

### DIFF
--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -174,16 +174,59 @@ from pyodide.code import find_imports as _pg_find_imports
 
 _display_outputs = []
 
+# Per-run cap on captured stdout/stderr text. Without it, a runaway program
+# (e.g. \`while True: print(x)\`) grows _display_outputs without bound — the
+# captured string balloons the worker's memory into the gigabytes while the
+# loop pegs a CPU core. Once a run crosses the cap we keep the output already
+# captured (trimmed to the limit), append a one-time notice, and raise to
+# abort the run, which also stops the spinning loop. _pg_output_truncated
+# then drops any further writes so memory stays bounded even if user code
+# swallows the exception.
+_PG_MAX_OUTPUT_CHARS = 2_000_000  # ~2 MB of text per run
+_pg_output_chars = 0
+_pg_output_truncated = False
+
+class _PgOutputLimitError(Exception):
+    """Raised when a run's captured output exceeds _PG_MAX_OUTPUT_CHARS."""
+
+def _pg_reset_output():
+    """Reset the per-run output counter. Called before each run (these names
+    survive _pg_reset_user_globals via the protected-names snapshot, so they
+    must be reset explicitly rather than recreated)."""
+    global _pg_output_chars, _pg_output_truncated
+    _pg_output_chars = 0
+    _pg_output_truncated = False
+
 def _pg_emit_text(kind, s):
     """Append stream text to the ordered output list, merging consecutive
     writes of the same stream into one segment (print() emits the text and
-    its newline as separate writes)."""
+    its newline as separate writes). Enforces a per-run size cap so a
+    runaway/infinite-output program can't grow memory without bound."""
+    global _pg_output_chars, _pg_output_truncated
     if not s:
         return
-    if _display_outputs and _display_outputs[-1].get("type") == kind:
-        _display_outputs[-1]["text"] += s
-    else:
-        _display_outputs.append({"type": kind, "text": s})
+    if _pg_output_truncated:
+        # Cap already hit this run — drop further text so memory stays
+        # bounded even if the abort below was swallowed by user code.
+        return
+    remaining = _PG_MAX_OUTPUT_CHARS - _pg_output_chars
+    if len(s) >= remaining:
+        s = s[:remaining] if remaining > 0 else ""
+        _pg_output_truncated = True
+    if s:
+        _pg_output_chars += len(s)
+        if _display_outputs and _display_outputs[-1].get("type") == kind:
+            _display_outputs[-1]["text"] += s
+        else:
+            _display_outputs.append({"type": kind, "text": s})
+    if _pg_output_truncated:
+        _display_outputs.append({
+            "type": "stderr",
+            "text": "\\n[Output truncated: exceeded %d characters. Stopping the run — check for an unbounded loop.]\\n" % _PG_MAX_OUTPUT_CHARS,
+        })
+        raise _PgOutputLimitError(
+            "Output exceeded the %d-character limit" % _PG_MAX_OUTPUT_CHARS
+        )
 
 # Tee installed over sys.stdout/sys.stderr while user code runs, so prints
 # land in _display_outputs *in order* with display() tables, figures and
@@ -376,6 +419,10 @@ _PG_PROTECTED_NAMES = set(globals().keys()) | {
     # here makes the intent obvious and guards against future reordering.
     "_PG_PROTECTED_NAMES", "_pg_reset_user_globals",
     "_pg_evict_staged_modules",
+    # Output-cap state/helpers: _pg_reset_output() reassigns the counters
+    # each run, so they must persist across the per-run global reset.
+    "_PG_MAX_OUTPUT_CHARS", "_pg_output_chars", "_pg_output_truncated",
+    "_PgOutputLimitError", "_pg_reset_output", "_pg_emit_text",
 }
 `);
 
@@ -573,7 +620,7 @@ async function runCode(
     post({ kind: "run-status", id, message: "Running…", preparing: false });
   }
 
-  await pyodide.runPythonAsync("_pg_reset_user_globals(); _display_outputs.clear()");
+  await pyodide.runPythonAsync("_pg_reset_user_globals(); _display_outputs.clear(); _pg_reset_output()");
 
   // Pass the user code as a Python string to avoid template-literal escaping
   // issues and to let _execute_with_last_display parse it with the ast module.


### PR DESCRIPTION
## Background

Investigating a report that the Dataslope tab grows to a huge memory footprint (~10 GB, with ~40% CPU in Chrome's task manager), likely while on the home page.

### What I found

The home page's own marketing/animation code is **clean** — every timer, observer, and listener (FlickeringGrid, AnimatedBeam, the typing / test-rail / course-list animations, Highlighter/rough-notation, marquee, nav scroll handler, etc.) is correctly cleaned up and all animation state is bounded.

The large footprint comes from the home page eagerly mounting two heavy WebAssembly runtimes:
- The hero "Code Challenge" panel mounts a Python `<ChallengeCard>` **above the fold**, which warms Pyodide on mount + on scroll-into-view (`ChallengeCard.tsx:1273-1312`). Since it's at the top, Pyodide boots on every home-page load.
- The "Try the playground" section embeds the full Postgres playground (pglite) in an iframe.

These explain the ~1.2 GB baseline seen even on idle Dataslope tabs (heavy but stable, <1% CPU). The distinctive **10 GB + ~40% CPU** tab is a *runaway* — a loop actively allocating without bound.

The concrete code-level cause this PR addresses: the Pyodide worker captured user `stdout`/`stderr` into the `_display_outputs` list with **no size limit** (`pyodide-worker.ts`, `_pg_emit_text`). A runaway or infinite-output program such as `while True: print(x)` grows the captured string without bound — ballooning the worker heap into the gigabytes while the loop pegs a CPU core. (Contrast the C runtime, which already terminates its worker.)

## Change

Add a per-run output cap (~2 MB of text) at the single capture chokepoint (`_pg_emit_text`):

- Track captured chars per run; reset alongside the existing global / `_display_outputs` reset (`_pg_reset_output()`).
- When a run crosses the cap, keep the already-captured output (trimmed to the limit), append a one-time truncation notice, and `raise` to abort the run — which also stops the spinning loop.
- A `_pg_output_truncated` flag drops any further writes, so memory stays bounded even if user code swallows the exception.

The cap only applies to raw stdout/stderr *text* — DataFrame/plot/HTML cells are unaffected (and pandas already truncates frame rendering). 2 MB (~30k+ lines) is far above any normal educational example, so legitimate output is untouched.

## Testing

`node_modules` was not installed in this environment, so the project's lint/test harness could not be run here. The cap logic is Python embedded in a worker string (not validated by TS), so I extracted it and validated it standalone with `python3`:

- Output is hard-capped (never exceeds the limit).
- The run aborts via the raised exception.
- Exactly one truncation notice is emitted.
- Post-truncation writes are dropped (no further growth, no duplicate notice).

All assertions passed.

## Notes / follow-ups (not in this PR)

These were identified during the investigation and have product trade-offs, so they're left for a follow-up decision:
- **Lazy-load home-page runtimes** — avoid eagerly booting Pyodide (and the embedded Postgres playground) on the marketing home page to cut the ~1.2 GB baseline. Changes the "warm up while you read" UX.
- **Postgres playground infinite scroll** — `PostgresPlayground.tsx:2505` does `[...latestSet.values, ...nextSet.values]` on every "load more" (O(n²) copy); large result sets balloon memory.
- **Full execution timeout** — the output cap stops runaway *output*, but a non-printing busy loop (e.g. `while True: pass`) still pegs CPU; a worker-termination timeout would be the complementary fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01356SuNSrEmLLTYULKJXQEm

---
_Generated by [Claude Code](https://claude.ai/code/session_01356SuNSrEmLLTYULKJXQEm)_