### PR TITLE
Add dedicated /pricing page with footnotes; add unlimited AI autocomplete to Pro

### DIFF
--- a/app/_components/home/HomeNav.tsx
+++ b/app/_components/home/HomeNav.tsx
@@ -174,6 +174,13 @@ function MobileDrawer() {
               Interview Prep
             </Dialog.Close>
 
+            <Dialog.Close
+              render={<Link href="/pricing" prefetch={false} />}
+              className="rounded-lg px-3 py-2.5 text-sm font-medium text-[var(--ds-gray-800)] transition-colors hover:bg-[var(--ds-gray-100)] hover:text-[var(--ds-gray-900)] dark:text-[var(--ds-gray-100)] dark:hover:bg-white/10"
+            >
+              Pricing
+            </Dialog.Close>
+
             <div className="mt-2 px-3 text-xs font-semibold uppercase tracking-wide text-[var(--ds-gray-400)]">
               Playground
             </div>
@@ -265,6 +272,13 @@ export function HomeNav() {
             Interview Prep
           </Link>
           <PlaygroundMenu />
+          <Link
+            href="/pricing"
+            prefetch={false}
+            className="rounded-lg px-3 py-2 text-sm font-medium text-[#121212] transition-colors hover:text-[var(--ds-blue-700)] dark:text-white dark:hover:text-[var(--ds-blue-400)]"
+          >
+            Pricing
+          </Link>
         </div>
 
         {/* Right: theme + GitHub + (mobile) hamburger */}

--- a/app/_components/home/PricingSection.tsx
+++ b/app/_components/home/PricingSection.tsx
@@ -12,6 +12,7 @@ import {
   Share2,
   Sparkles,
   SquareTerminal,
+  WandSparkles,
   X,
   type LucideIcon,
 } from "lucide-react";
@@ -48,7 +49,7 @@ interface Plan {
   badge?: string;
 }
 
-const FEATURE_COUNT = 8;
+const FEATURE_COUNT = 9;
 
 const PLANS: Plan[] = [
   {
@@ -75,6 +76,7 @@ const PLANS: Plan[] = [
         text: "3 “Ask AI” messages every 24 hours",
         note: "Across playgrounds, challenges, code blocks & lessons",
       },
+      { text: "No AI-suggested autocomplete", included: false },
     ],
     cta: "Get started",
     href: "/learn",
@@ -111,6 +113,7 @@ const PLANS: Plan[] = [
         text: "Up to 10 “Ask AI” messages every 24 hours",
         note: "Across playgrounds, challenges, code blocks & lessons",
       },
+      { text: "No AI-suggested autocomplete", included: false },
     ],
     cta: "Sign up for free",
     href: "/learn",
@@ -146,6 +149,11 @@ const PLANS: Plan[] = [
         icon: Sparkles,
         text: "Unlimited “Ask AI” messages",
         note: "Fair use policy applies",
+      },
+      {
+        icon: WandSparkles,
+        text: "Unlimited AI-suggested autocomplete",
+        note: "Inline, context-aware code completions in every playground",
       },
     ],
     cta: "Go Pro",
@@ -204,7 +212,7 @@ function PlanColumn({
     // shared row tracks); top/bottom breathing room is added to the header and
     // last feature instead.
     <div
-      className={`flex flex-col gap-3 px-6 py-6 lg:row-span-11 lg:row-start-1 lg:grid lg:grid-rows-subgrid lg:px-8 lg:py-0 ${colClass}`}
+      className={`flex flex-col gap-3 px-6 py-6 lg:row-span-12 lg:row-start-1 lg:grid lg:grid-rows-subgrid lg:px-8 lg:py-0 ${colClass}`}
     >
       <div className="lg:pt-8">
         <div className="flex items-center gap-2.5">
@@ -254,22 +262,31 @@ function PlanColumn({
   );
 }
 
-export function PricingSection() {
+export function PricingSection({
+  /** Render the section's own "Pricing" title + blurb. The dedicated /pricing
+   *  page supplies its own page-level heading and turns this off to avoid a
+   *  duplicate; the home page leaves it on. */
+  showHeading = true,
+}: {
+  showHeading?: boolean;
+} = {}) {
   const [billing, setBilling] = useState<"monthly" | "annual">("monthly");
   const annual = billing === "annual";
 
   return (
     <section id="pricing" className="mx-auto w-full max-w-6xl px-4 sm:px-6">
-      <div className="mx-auto mb-10 max-w-2xl text-center">
-        <h2 className="text-4xl font-semibold tracking-tight text-[var(--ds-gray-900)] sm:text-5xl dark:text-white">
-          Pricing
-        </h2>
-        <p className="mt-8 text-base text-[var(--ds-gray-900)] sm:text-lg dark:text-white">
-          Every course, interview track, and playground is free to use. Create a
-          free account for cloud saves and sharing, or go Pro for storage that
-          never expires.
-        </p>
-      </div>
+      {showHeading && (
+        <div className="mx-auto mb-10 max-w-2xl text-center">
+          <h2 className="text-4xl font-semibold tracking-tight text-[var(--ds-gray-900)] sm:text-5xl dark:text-white">
+            Pricing
+          </h2>
+          <p className="mt-8 text-base text-[var(--ds-gray-900)] sm:text-lg dark:text-white">
+            Every course, interview track, and playground is free to use. Create
+            a free account for cloud saves and sharing, or go Pro for storage
+            that never expires.
+          </p>
+        </div>
+      )}
 
       {/* Monthly / annual billing toggle — only the paid tier's price reacts. */}
       <div className="mb-10 flex items-center justify-center">
@@ -309,7 +326,7 @@ export function PricingSection() {
       {/* Comparison: bordered (no fill), no gaps between plans, thin dividers
           between them, and feature rows aligned via subgrid. */}
       <div className="rounded-2xl border border-[var(--ds-gray-200)] dark:border-white/10">
-        <div className="grid grid-cols-1 divide-y divide-[var(--ds-gray-200)] lg:grid-cols-3 lg:grid-rows-[repeat(11,auto)] lg:gap-y-3 lg:divide-x lg:divide-y-0 dark:divide-white/10">
+        <div className="grid grid-cols-1 divide-y divide-[var(--ds-gray-200)] lg:grid-cols-3 lg:grid-rows-[repeat(12,auto)] lg:gap-y-3 lg:divide-x lg:divide-y-0 dark:divide-white/10">
           {PLANS.map((plan, i) => (
             <PlanColumn
               key={plan.name}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,245 @@
+// Opt the pricing route into the same Tailwind + Magic UI bundle the home page
+// uses, and pull in the home-route hardening so the reused HomeNav / HomeFooter
+// (which rely on `.ds-home`-scoped rules in home.css) lay out correctly.
+import "@/app/magicui.css";
+import "@/app/home.css";
+import type { Metadata } from "next";
+import Link from "../_components/Link";
+import { HomeNav } from "../_components/home/HomeNav";
+import { PricingSection } from "../_components/home/PricingSection";
+import { HomeFooter } from "../_components/home/HomeFooter";
+import { OG_IMAGE, SITE_URL } from "@/lib/site";
+
+const PAGE_TITLE = "Pricing — Dataslope";
+const PAGE_DESCRIPTION =
+  "Dataslope pricing in detail. Every course, interview track, and playground is free. Compare the Guest, Free Member, and Pro plans, with footnotes covering cloud storage, sharing, AI usage, and billing.";
+
+export const metadata: Metadata = {
+  // A bare string here lets the root layout's "%s · DataSlope" template render
+  // the tab title as "Pricing · DataSlope".
+  title: "Pricing",
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: "/pricing" },
+  openGraph: {
+    type: "website",
+    url: `${SITE_URL}/pricing`,
+    siteName: "DataSlope",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [OG_IMAGE],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [OG_IMAGE],
+  },
+};
+
+// Applies the persisted light/dark choice before first paint (same contract as
+// the home page) so a returning dark-mode visitor never sees a light flash.
+const THEME_BOOTSTRAP = `(function(){try{var d=localStorage.getItem('theme')==='dark';var r=document.documentElement;r.classList.toggle('dark',d);r.classList.toggle('light',!d);}catch(e){}})();`;
+
+/** One numbered note. `lead` names the exact table row (or topic) it clarifies
+ *  so the footnote reads as an annotation of the pricing table above it. */
+function Footnote({
+  n,
+  lead,
+  children,
+}: {
+  n: number;
+  lead: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <li id={`note-${n}`} className="flex scroll-mt-20 gap-4">
+      <span
+        className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-[var(--ds-gray-100)] text-sm font-semibold text-[var(--ds-gray-700)] dark:bg-white/10 dark:text-[var(--ds-gray-200)]"
+        aria-hidden="true"
+      >
+        {n}
+      </span>
+      <p className="text-[15px] leading-relaxed text-[var(--ds-gray-700)] dark:text-[var(--ds-gray-300)]">
+        <span className="font-semibold text-[var(--ds-gray-900)] dark:text-white">
+          {lead}
+        </span>{" "}
+        {children}
+      </p>
+    </li>
+  );
+}
+
+export default function PricingPage() {
+  return (
+    <>
+      <script dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP }} />
+      <div
+        style={{ fontFamily: "var(--font-sans, Inter, system-ui, sans-serif)" }}
+        className="ds-home min-h-screen bg-white text-[var(--ds-gray-800)] dark:bg-[#121212] dark:text-[var(--ds-gray-100)]"
+      >
+        <HomeNav />
+
+        <main className="overflow-x-clip">
+          {/* ── Page heading ── */}
+          <section className="px-4 pb-4 pt-12 sm:px-6 sm:pt-16">
+            <div className="mx-auto max-w-2xl text-center">
+              <h1 className="text-4xl font-semibold tracking-tight text-[var(--ds-gray-900)] sm:text-5xl dark:text-white">
+                Pricing
+              </h1>
+              <p className="mt-6 text-base text-[var(--ds-gray-900)] sm:text-lg dark:text-white">
+                Every course, interview track, and playground is free to use —
+                no account required. Create a free account for cloud saves and
+                sharing, or go Pro for storage that never expires. The detailed
+                notes below the table explain exactly what each row means.
+              </p>
+            </div>
+          </section>
+
+          {/* ── Pricing table (reused from the home page) ── */}
+          <section className="py-10">
+            <PricingSection showHeading={false} />
+          </section>
+
+          {/* ── Footnotes & extended explanations ── */}
+          <section className="px-4 py-12 sm:px-6">
+            <div className="mx-auto max-w-3xl">
+              <h2 className="text-2xl font-semibold tracking-tight text-[var(--ds-gray-900)] sm:text-3xl dark:text-white">
+                Plan details &amp; fine print
+              </h2>
+              <p className="mt-3 text-[15px] leading-relaxed text-[var(--ds-gray-600)] dark:text-[var(--ds-gray-400)]">
+                The footnotes below expand on the rows in the table above so
+                there are no surprises about what&apos;s included at each tier.
+              </p>
+
+              <ol className="mt-8 space-y-6">
+                <Footnote n={1} lead="Free to learn, always.">
+                  Courses, interview prep, and the playgrounds — including
+                  unlimited code executions across all 11 languages — are
+                  completely free on every tier, including as a guest with no
+                  sign-in. A paid plan only adds cloud storage, sharing, and
+                  more AI chat; it never puts learning content behind a paywall.
+                </Footnote>
+
+                <Footnote n={2} lead="“Save workspaces locally.”">
+                  Local saves live in your browser&apos;s own storage on the
+                  device you&apos;re using. They&apos;re private to that browser,
+                  never uploaded, and persist until you clear your site data.
+                  Because they aren&apos;t synced, they won&apos;t follow you to
+                  another device or browser — that&apos;s what cloud saves are
+                  for.
+                </Footnote>
+
+                <Footnote n={3} lead="“Save workspaces locally and in the cloud.”">
+                  Cloud saves sync your workspaces to your account so you can
+                  pick them up on any device you sign in to. Free Members get
+                  cloud saves with a retention limit (see note 4); Pro keeps them
+                  for as long as your membership is active.
+                </Footnote>
+
+                <Footnote
+                  n={4}
+                  lead="“Cloud saves auto-deleted after a month of inactivity” (Free Member)."
+                >
+                  A cloud workspace counts as inactive once it hasn&apos;t been
+                  opened or edited for about 30 days. After that it may be
+                  removed from the cloud to free up space — your local copy, if
+                  you have one, is untouched. Opening or editing a workspace
+                  resets its clock. Upgrading to Pro removes this limit entirely:
+                  Pro cloud saves are kept for as long as you&apos;re subscribed.
+                </Footnote>
+
+                <Footnote n={5} lead="“100 MB / 10 GB of cloud storage.”">
+                  Your quota is the combined size of everything you keep in the
+                  cloud — saved workspaces, databases, and any files you upload —
+                  totaled across all playgrounds, not measured per playground. If
+                  you reach the limit you can still open and export existing
+                  work; you&apos;ll just need to free up space (or upgrade)
+                  before saving more.
+                </Footnote>
+
+                <Footnote n={6} lead="“Share playgrounds.”">
+                  Sharing creates a link others can open to view and run a copy
+                  of your playground. On the Free Member plan, shared playgrounds
+                  follow the same one-month inactivity cleanup as your other
+                  cloud saves (see note 4); on Pro, shared links stay live for as
+                  long as you&apos;re subscribed. Guests can&apos;t create share
+                  links — that needs a free account.
+                </Footnote>
+
+                <Footnote n={7} lead="“Ask AI” messages.">
+                  “Ask AI” is the in-app assistant available inside playgrounds,
+                  challenges, code blocks, and lessons. Your limit is counted
+                  across all of those surfaces on a rolling 24-hour window —
+                  Guests get 3, Free Members up to 10, and Pro is unlimited. A
+                  rolling window means each message frees up again 24 hours after
+                  you send it, rather than all resetting at a fixed time of day.
+                </Footnote>
+
+                <Footnote
+                  n={8}
+                  lead="“Unlimited ‘Ask AI’ — fair use policy applies” (Pro)."
+                >
+                  Unlimited covers normal interactive use. To keep the assistant
+                  fast and available for everyone, we may rate-limit usage that
+                  looks automated or abusive (for example, scripted bulk
+                  requests). Ordinary day-to-day use is never throttled.
+                </Footnote>
+
+                <Footnote
+                  n={9}
+                  lead="“Unlimited AI-suggested autocomplete” (Pro)."
+                >
+                  As you type in any playground, Pro offers inline,
+                  context-aware code completions you can accept with a keystroke
+                  — like an AI pair programmer suggesting the next line. It&apos;s
+                  unlimited under the same fair-use policy as Ask AI (see note 8),
+                  and it&apos;s a Pro-only feature: the Guest and Free Member
+                  tiers don&apos;t include autocomplete suggestions.
+                </Footnote>
+
+                <Footnote n={10} lead="Monthly vs. annual billing.">
+                  The toggle above the table switches the Pro price between
+                  monthly ($4.99/mo) and annual ($40/yr — about $3.33/mo, a 33%
+                  saving). Annual is a single up-front payment covering twelve
+                  months. Prices are in US dollars and may be subject to tax
+                  depending on where you are.
+                </Footnote>
+
+                <Footnote n={11} lead="Changing or cancelling your plan.">
+                  You can cancel Pro at any time and keep Pro features until the
+                  end of the period you&apos;ve already paid for. After that your
+                  account returns to the Free Member tier and your cloud data
+                  becomes subject to the Free limits again — the 100 MB quota and
+                  the one-month inactivity cleanup — so export anything you want
+                  to keep beyond those limits before you downgrade.
+                </Footnote>
+              </ol>
+
+              <p className="mt-10 border-t border-[var(--ds-gray-200)] pt-6 text-[15px] leading-relaxed text-[var(--ds-gray-600)] dark:border-white/10 dark:text-[var(--ds-gray-400)]">
+                Still have questions? Browse the{" "}
+                <Link
+                  href="/#faq"
+                  className="font-medium text-[var(--ds-blue-700)] hover:underline dark:text-[var(--ds-blue-400)]"
+                >
+                  FAQ
+                </Link>{" "}
+                or reach out on our{" "}
+                <a
+                  href="https://github.com/dataslope/dataslope/discussions"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-[var(--ds-blue-700)] hover:underline dark:text-[var(--ds-blue-400)]"
+                >
+                  GitHub discussions
+                </a>
+                .
+              </p>
+            </div>
+          </section>
+        </main>
+
+        <HomeFooter />
+      </div>
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -32,6 +32,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 1,
   });
 
+  // Standalone pricing page (static; reuses the home page's pricing table).
+  entries.set(abs("/pricing"), {
+    url: abs("/pricing"),
+    changeFrequency: "monthly",
+    priority: 0.8,
+  });
+
   for (const page of source.getPages()) {
     const url = abs(page.url);
     const isIndex = page.url === "/learn";


### PR DESCRIPTION
## Summary

Adds a standalone `/pricing` page that reuses the home page's pricing table and expands it with footnotes and explanations, and (per a follow-up request) adds **Unlimited AI-suggested autocomplete** as a Pro feature.

### What's included

- **New `/pricing` route** (`app/pricing/page.tsx`) that **reuses the existing `PricingSection` component** from the home page — the same pricing table, billing toggle, and plans — wrapped in the same `HomeNav` / `HomeFooter` chrome and `.ds-home` styling as the home page.
- **A "Plan details & fine print" section** of numbered footnotes beneath the table, each annotating a specific row: free-to-learn scope, local vs. cloud saves, the one-month inactivity cleanup, cloud storage quotas, sharing, Ask AI limits (rolling 24h window), the Pro fair-use policy, AI autocomplete, monthly vs. annual billing, and what happens when you cancel.
- **`PricingSection` gains an optional `showHeading` prop** (default `true`) so the dedicated page supplies its own page-level `<h1>` without duplicating the section's built-in "Pricing" heading. The home page renders identically (default keeps the heading).
- **Header "Pricing" link** added to both the desktop nav and the mobile drawer in `HomeNav`.
- **Unlimited AI-suggested autocomplete** added as a new Pro feature row. Because the table uses a subgrid that requires every plan to share the same rows in the same order, the Guest and Free Member tiers show it as not-included so the comparison stays aligned (`FEATURE_COUNT` 8 → 9, subgrid rows 11 → 12). A matching footnote was added to the pricing page.
- **Sitemap**: `/pricing` listed as a static, indexable page.

### Testing

- `npx tsc --noEmit` — passes
- `npx eslint` on all changed files — passes
- Smoke test via `next dev`: `/pricing` and `/` both return 200 and render the expected content (table, autocomplete rows, footnotes, nav link) with no error overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLDFqEw5inW5BtW1aJXK5p)_