### PR TITLE
Fix intermittent /learn page-top cutoff (segment-CSS reorder race)

### DIFF
--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -66,6 +66,40 @@
   }
 }
 
+/* ── Segment-CSS reorder hardening, part 2: layout-chrome visibility ─────────
+   Same root cause as the border-color block above (the App Router doesn't order
+   the /learn segment's CSS chunks deterministically on a client-side navigation),
+   but a different casualty — and one layer up.
+
+   Fumadocs's mobile navbar (`#nd-subnav`) carries both a base `display:flex`
+   utility and a `md:hidden` (`display:none` at ≥48rem) utility. Both live in
+   `@layer utilities`, so which one wins on desktop is decided purely by their
+   source order within that layer. On a normal load Tailwind emits the responsive
+   `md:hidden` after the base `flex`, so the navbar is hidden on desktop. When the
+   reorder flips them, `flex` wins and the mobile navbar paints on desktop — as a
+   sticky bar whose height is `--fd-header-height` (0px on desktop), so its logo +
+   search + sidebar-toggle overflow a zero-height box and the top of the page
+   looks sliced off (the "negative top margin" / cut-off-header symptom), until a
+   hard refresh restores the server cascade.
+
+   The border fix could move one layer up (components > base) because its rival
+   sits in `@layer base`. This rival sits in `@layer utilities` — the top layer —
+   so the only thing that always beats it regardless of chunk order is an
+   *unlayered* rule (unlayered styles outrank every `@layer`). Re-assert the
+   desktop-hidden invariant here, scoped to ≥48rem so the navbar still shows on
+   mobile where it's the only nav. `#id` specificity is incidental — being
+   unlayered is what makes this win the cascade no matter how the chunks land.
+
+   The companion, root-cause mitigation is `experimental.cssChunking: 'strict'`
+   in next.config.ts, which makes the segment-CSS order deterministic in the
+   first place; this rule is the belt-and-suspenders that holds even if a chunk
+   ever slips through in the wrong order. */
+@media (min-width: 48rem) {
+  #nd-subnav {
+    display: none;
+  }
+}
+
 /* Override Fumadocs's default sans stack inside the /learn route with
    Inter and apply slightly tight letter-spacing for a more polished
    editorial feel. We scope to `body` (which is shared, but layout-CSS

--- a/e2e/learn-layout-cutoff.spec.ts
+++ b/e2e/learn-layout-cutoff.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression test for the "top of the page is cut off" glitch on the /learn
+ * (and /interview) routes — the same intermittent, refresh-fixed family as the
+ * black-border bug in `learn-border-color.spec.ts`, one cascade layer up.
+ *
+ * Background
+ * ----------
+ * Fumadocs's mobile navbar (`#nd-subnav`) carries two competing display
+ * utilities: a base `flex` (`display:flex`) and a responsive `md:hidden`
+ * (`display:none` at ≥48rem). Both are emitted into `@layer utilities`, so on
+ * desktop the winner is decided purely by their source order within that layer.
+ * On a normal load Tailwind orders the responsive `md:hidden` after the base
+ * `flex`, so the navbar is hidden on desktop.
+ *
+ * The /learn route loads its Tailwind + Fumadocs CSS as a separate segment
+ * chunk (`app/learn/learn.css`, imported from the layout). The Next.js App
+ * Router does not order segment CSS deterministically on a client-side
+ * navigation into /learn; when the chunk lands such that base `flex` ends up
+ * after `md:hidden`, `flex` wins and the mobile navbar paints on desktop. Its
+ * height is `--fd-header-height`, which is 0px on desktop, so the logo + search +
+ * sidebar-toggle overflow a zero-height sticky bar and the top of the page looks
+ * sliced off — the "negative top margin" symptom — until a hard refresh restores
+ * the server cascade.
+ *
+ * The fix (`app/learn/learn.css`) re-asserts the desktop-hidden invariant in an
+ * *unlayered* rule (`@media (min-width: 48rem) { #nd-subnav { display: none } }`).
+ * Unlayered styles outrank every `@layer`, so this beats the base-`flex` utility
+ * regardless of how the App Router orders the chunks — while leaving the navbar
+ * visible below 48rem, where it is the only navigation. (The companion
+ * root-cause mitigation is `experimental.cssChunking: 'strict'` in next.config.)
+ *
+ * What this test does
+ * -------------------
+ * Reproducing the non-deterministic chunk-order race by timing alone would be
+ * flaky. Instead we reproduce the *cascade state* it produces, deterministically:
+ * we append the base `flex` utility back into `@layer utilities` after the page
+ * has loaded — the exact thing the reorder does — and assert the navbar stays
+ * hidden on desktop. Without the fix the appended rule wins and the navbar shows
+ * (cutting off the top); with it, the unlayered rule holds.
+ */
+
+const UTILITIES_FLEX_REORDER =
+  "@layer utilities { .flex { display: flex } }";
+
+test("learn route: the mobile navbar is hidden on desktop on a normal load", async ({
+  page,
+}) => {
+  await page.goto("/learn");
+  await expect(page.locator("#nd-page")).toBeVisible();
+
+  // Desktop Chrome viewport (≥48rem): the mobile navbar must not be rendered.
+  await expect(page.locator("#nd-subnav")).toBeHidden();
+});
+
+test("learn route: the mobile navbar stays hidden on desktop when the utilities layer is reordered (App Router soft-nav race)", async ({
+  page,
+}) => {
+  await page.goto("/learn");
+  await expect(page.locator("#nd-page")).toBeVisible();
+
+  // Reproduce the soft-navigation cascade: re-apply the base `flex` utility into
+  // @layer utilities *after* the page's CSS. Without the fix this flips the
+  // navbar's desktop display from `none` back to `flex` (the cut-off-top bug);
+  // with the fix (desktop-hidden pinned in an unlayered rule) it cannot.
+  await page.evaluate((css) => {
+    const s = document.createElement("style");
+    s.textContent = css;
+    document.head.appendChild(s);
+  }, UTILITIES_FLEX_REORDER);
+
+  const display = await page
+    .locator("#nd-subnav")
+    .evaluate((el) => getComputedStyle(el).display);
+
+  expect(
+    display,
+    "after the utilities-layer reorder, the mobile navbar must NOT become visible on desktop",
+  ).toBe("none");
+});
+
+test("learn route: the mobile navbar is still shown below 48rem (fix does not over-reach)", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 420, height: 860 });
+  await page.goto("/learn");
+  await expect(page.locator("#nd-page")).toBeVisible();
+
+  // On mobile the navbar is the only navigation — the desktop-hide rule is
+  // scoped to ≥48rem, so it must remain visible here, even under the reorder.
+  await page.evaluate((css) => {
+    const s = document.createElement("style");
+    s.textContent = css;
+    document.head.appendChild(s);
+  }, UTILITIES_FLEX_REORDER);
+
+  await expect(page.locator("#nd-subnav")).toBeVisible();
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,18 @@ const nextConfig: NextConfig = {
   // graphs into every page's chunk.
   experimental: {
     optimizePackageImports: ["lucide-react", "react-icons"],
+    // Load each route's CSS in the exact order it was imported, and keep that
+    // order stable across client-side navigations. The /learn (and /interview)
+    // segment layers Tailwind's preflight, Fumadocs UI, and the app's overrides
+    // into shared cascade layers (`base`, `utilities`); their default 'loose'
+    // chunking lets the App Router merge/reorder those chunks on a soft nav,
+    // which flips same-layer source-order winners and produces intermittent,
+    // refresh-fixed glitches (black borders — see #528 — and the mobile navbar
+    // leaking onto desktop, slicing the top of the page). 'strict' preserves
+    // import order so the cascade is deterministic, fixing the whole class at
+    // the source. It can yield more, smaller CSS chunks, which is fine here.
+    // The scoped re-assertions in app/learn/learn.css remain as defense in depth.
+    cssChunking: "strict",
     // Keep prefetched/visited route payloads reusable in the client router
     // cache so re-hovers and back/forward navigations don't re-hit the edge
     // (every edge-cache miss is a billed ISR Read on Vercel). Lessons are


### PR DESCRIPTION
## Summary

On a client-side navigation into `/learn`, the top of the page was sometimes sliced off — looking like a negative top margin — until a hard refresh. The culprit is Fumadocs's **mobile navbar (`#nd-subnav`) leaking onto desktop**: it renders as a sticky bar whose height is `--fd-header-height` (`0px` on desktop), so its logo + search + sidebar-toggle overflow a zero-height box and clip the top of the content.

Reproduced pixel-for-pixel against the reported screenshot:

| Broken (mobile navbar leaks onto desktop) | Fixed |
|---|---|
| clipped "Dataslope" bar above the H1 | clean H1 at top |

## Root cause

This is the **same non-deterministic segment-CSS ordering** behind the black-border bug (#528), one cascade layer up:

- `#nd-subnav` carries both a base `flex` (`display:flex`) and a `md:hidden` (`display:none` at ≥48rem) utility. Both live in `@layer utilities`, so the desktop winner is decided purely by **source order** within that layer.
- On a normal load Tailwind emits `md:hidden` after `flex`, so the navbar is hidden on desktop.
- The Next.js App Router doesn't order the `/learn` segment's CSS chunks deterministically on a soft navigation. When the order flips, `flex` wins over `md:hidden` and the mobile navbar paints on desktop.

Confirmed by deterministically reproducing the reordered cascade (appending `@layer utilities { .flex { display: flex } }` after load): the navbar flips to `display:flex` with `height: ~0`, clipping the logo at the top.

## The fix — addresses the whole class, not just this one style

- **`next.config.ts`** — `experimental.cssChunking: 'strict'`: makes segment-CSS ordering deterministic across navigations, fixing the **root cause** for every order-dependent rule (borders, navbar, and any future Fumadocs chrome) at the source. Correctness-safe; at worst yields more, smaller CSS chunks.
- **`app/learn/learn.css`** — re-assert the desktop-hidden invariant in an **unlayered**, `≥48rem`-scoped rule. Unlayered styles outrank every `@layer`, so this holds regardless of chunk order, while keeping the navbar visible on mobile (where it's the only nav). This is the defense-in-depth counterpart to the existing `@layer components` border pin. Covers both `/learn` and `/interview` (both import `learn.css`).
- **`e2e/learn-layout-cutoff.spec.ts`** — regression test mirroring `learn-border-color.spec.ts`: reproduces the reordered cascade deterministically and asserts the navbar stays hidden on desktop and visible below 48rem.

## Verification

- Browser repro before/after at the reported viewport (1750px): broken bar gone, mobile navbar intact.
- New e2e (3 tests) + existing `learn-border-color` e2e (2 tests): **5/5 pass**.
- `tsc --noEmit` and ESLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnEpfYxynyorinjAnYgdLM)_