### PR TITLE
Drop hardcoded Ask AI defaults, switch to DeepSeek V4 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,22 +173,21 @@ The Cloudflare bindings interface (`CloudflareEnv`, used by `getCloudflareContex
 
 A signed-in, streaming "Ask AI" chat pane on the `/learn` lessons and `/playground/*` pages (`app/api/ai/chat/route.ts` + `app/_components/ai/`). It runs on the Workers runtime and pipes an OpenAI-compatible provider's Server-Sent-Event stream straight through — no Node APIs, no filesystem (lesson context is fetched from the prerendered `${slug}.md` asset, not read from disk).
 
-**Model per membership tier.** Free members use a cheaper model via **OpenRouter**; **Pro** members use an **OpenAI** model (`lib/ai/models.ts`). The base URLs and model ids are non-secret `vars` in `wrangler.jsonc` (`AI_FREE_BASE_URL` / `AI_FREE_MODEL` / `AI_PRO_BASE_URL` / `AI_PRO_MODEL`); the API keys are secrets:
+**Model per membership tier.** Base URL + model id are non-secret `vars` in `wrangler.jsonc` (`AI_FREE_BASE_URL` / `AI_FREE_MODEL` / `AI_PRO_BASE_URL` / `AI_PRO_MODEL`) — there's no hardcoded fallback (`lib/ai/models.ts`), so a tier needs its base URL, model id, and API key all set to be usable. Both tiers currently point at **OpenRouter**'s **DeepSeek V4 Flash** model. The API key is a secret:
 
 ```bash
-npx wrangler secret put AI_FREE_API_KEY   # OpenRouter key (free tier)
-npx wrangler secret put AI_PRO_API_KEY    # OpenAI key (pro tier)
+npx wrangler secret put AI_FREE_API_KEY   # OpenRouter key — covers both tiers today
+npx wrangler secret put AI_PRO_API_KEY    # optional: only needed if pro should use a separate key
 ```
 
-If only one key is set, both tiers use that provider (a half-wired env still answers). With neither set, Ask AI stays inert (503). A user's tier comes from the `plan` column (`migrations/0003`, default `'free'`); admins and any address in `PRO_USER_EMAILS` are treated as Pro as a bootstrap before billing exists (`lib/ai/tier.ts`).
+If a tier is missing its key, base URL, or model, it degrades to whichever tier *is* fully configured (a half-wired env still answers), keeping its own budgets. With neither tier fully configured, Ask AI stays inert (503). A user's tier comes from the `plan` column (`migrations/0003`, default `'free'`); admins and any address in `PRO_USER_EMAILS` are treated as Pro as a bootstrap before billing exists (`lib/ai/tier.ts`).
 
 **Cost / abuse controls.** Signed-in only; per-user daily request + token budgets and a global daily token ceiling (`AI_DAILY_GLOBAL_TOKEN_CAP`, default 5M) bound spend regardless of account/IP rotation (`lib/ai/limits.ts`, backed by the `ai_usage_*` tables in `migrations/0003`). Output is capped per tier. Per-minute limiting (a Durable Object / the Rate Limiting binding) and per-widget context capture are tracked as follow-ups in `agent-outputs/20260701-1107-ask-ai-cloudflare-implementation.md`.
 
 For local dev, add the keys to `.dev.vars`:
 
 ```
-AI_FREE_API_KEY="sk-or-…"   # OpenRouter
-AI_PRO_API_KEY="sk-…"       # OpenAI
+AI_FREE_API_KEY="sk-or-…"   # OpenRouter — covers both tiers today
 PRO_USER_EMAILS="you@example.com"   # optional; grants the pro model without billing
 ```
 

--- a/__tests__/aiModels.test.ts
+++ b/__tests__/aiModels.test.ts
@@ -46,19 +46,25 @@ describe("resolveTier", () => {
 });
 
 describe("resolveModel", () => {
-  const bothKeys = env({
+  const bothTiers = env({
     AI_FREE_API_KEY: "or-key",
+    AI_FREE_BASE_URL: "https://openrouter.ai/api/v1",
+    AI_FREE_MODEL: "deepseek/deepseek-v4-flash",
     AI_PRO_API_KEY: "oai-key",
+    AI_PRO_BASE_URL: "https://api.openai.com/v1",
+    AI_PRO_MODEL: "gpt-4o",
   });
 
-  it("uses OpenRouter for free and OpenAI for pro by default", () => {
-    const free = resolveModel("free", bothKeys)!;
-    expect(free.baseUrl).toContain("openrouter");
+  it("uses each tier's own base URL/model/key when fully configured", () => {
+    const free = resolveModel("free", bothTiers)!;
+    expect(free.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(free.model).toBe("deepseek/deepseek-v4-flash");
     expect(free.apiKey).toBe("or-key");
     expect(free.tier).toBe("free");
 
-    const pro = resolveModel("pro", bothKeys)!;
-    expect(pro.baseUrl).toContain("openai");
+    const pro = resolveModel("pro", bothTiers)!;
+    expect(pro.baseUrl).toBe("https://api.openai.com/v1");
+    expect(pro.model).toBe("gpt-4o");
     expect(pro.apiKey).toBe("oai-key");
     expect(pro.tier).toBe("pro");
     // Pro gets a larger output cap + budget than free.
@@ -66,38 +72,57 @@ describe("resolveModel", () => {
     expect(pro.dailyTokenBudget).toBeGreaterThan(free.dailyTokenBudget);
   });
 
-  it("honours base URL + model overrides", () => {
+  it("degrades pro to the free provider when only free is fully configured, keeping pro budgets", () => {
     const e = env({
-      AI_FREE_API_KEY: "k",
-      AI_FREE_BASE_URL: "https://example.com/v1",
-      AI_FREE_MODEL: "some/model",
+      AI_FREE_API_KEY: "or-key",
+      AI_FREE_BASE_URL: "https://openrouter.ai/api/v1",
+      AI_FREE_MODEL: "deepseek/deepseek-v4-flash",
     });
-    const m = resolveModel("free", e)!;
-    expect(m.baseUrl).toBe("https://example.com/v1");
-    expect(m.model).toBe("some/model");
-  });
-
-  it("degrades pro to the free provider when only the free key is set, keeping pro budgets", () => {
-    const e = env({ AI_FREE_API_KEY: "or-key" });
     const pro = resolveModel("pro", e)!;
     expect(pro.apiKey).toBe("or-key");
-    expect(pro.baseUrl).toContain("openrouter");
+    expect(pro.baseUrl).toBe("https://openrouter.ai/api/v1");
     expect(pro.tier).toBe("pro"); // still reported as pro
-    expect(pro.maxTokens).toBe(resolveModel("pro", env({ AI_PRO_API_KEY: "x" }))!.maxTokens);
-  });
-
-  it("degrades free to the pro provider when only the pro key is set, keeping free budgets", () => {
-    const e = env({ AI_PRO_API_KEY: "oai-key" });
-    const free = resolveModel("free", e)!;
-    expect(free.apiKey).toBe("oai-key");
-    expect(free.baseUrl).toContain("openai");
-    expect(free.tier).toBe("free");
-    expect(free.dailyRequestBudget).toBe(
-      resolveModel("free", env({ AI_FREE_API_KEY: "x" }))!.dailyRequestBudget,
+    expect(pro.maxTokens).toBe(
+      resolveModel(
+        "pro",
+        env({
+          AI_PRO_API_KEY: "x",
+          AI_PRO_BASE_URL: "https://api.openai.com/v1",
+          AI_PRO_MODEL: "gpt-4o",
+        }),
+      )!.maxTokens,
     );
   });
 
-  it("returns null when no provider key is configured", () => {
+  it("degrades free to the pro provider when only pro is fully configured, keeping free budgets", () => {
+    const e = env({
+      AI_PRO_API_KEY: "oai-key",
+      AI_PRO_BASE_URL: "https://api.openai.com/v1",
+      AI_PRO_MODEL: "gpt-4o",
+    });
+    const free = resolveModel("free", e)!;
+    expect(free.apiKey).toBe("oai-key");
+    expect(free.baseUrl).toBe("https://api.openai.com/v1");
+    expect(free.tier).toBe("free");
+    expect(free.dailyRequestBudget).toBe(
+      resolveModel(
+        "free",
+        env({
+          AI_FREE_API_KEY: "x",
+          AI_FREE_BASE_URL: "https://openrouter.ai/api/v1",
+          AI_FREE_MODEL: "some/model",
+        }),
+      )!.dailyRequestBudget,
+    );
+  });
+
+  it("treats a tier as unconfigured if base URL or model is missing, even with a key set", () => {
+    const e = env({ AI_FREE_API_KEY: "or-key" }); // no base URL/model
+    expect(resolveModel("free", e)).toBeNull();
+    expect(resolveModel("pro", e)).toBeNull();
+  });
+
+  it("returns null when no provider is configured at all", () => {
     expect(resolveModel("free", env({}))).toBeNull();
     expect(resolveModel("pro", env({}))).toBeNull();
   });

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -1,10 +1,10 @@
 /**
  * "Ask AI" streaming chat endpoint.
  *
- * Signed-in only. Selects the model by membership tier (free → a cheaper
- * OpenRouter model; pro → an OpenAI model — see lib/ai/models.ts), assembles
- * page/playground context, enforces per-user + global budgets, then streams the
- * provider's answer straight through as Server-Sent Events.
+ * Signed-in only. Selects the model by membership tier (see lib/ai/models.ts
+ * for the per-tier provider/model config), assembles page/playground context,
+ * enforces per-user + global budgets, then streams the provider's answer
+ * straight through as Server-Sent Events.
  *
  * `force-dynamic` keeps it off the incremental cache — it reads the session,
  * calls an external API, and streams, so it must run per request (same posture

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -36,11 +36,12 @@ declare global {
     TRUSTED_ORIGINS?: string;
 
     // --- "Ask AI" model config (vars; see lib/ai/models.ts) ---
-    // Base URL + model id per membership tier. Both providers must speak the
-    // OpenAI /chat/completions streaming API. Defaults: free → OpenRouter
-    // (openai/gpt-4o-mini), pro → OpenAI (gpt-4o). The API keys are secrets
-    // (below). Leave a tier's key unset to have it degrade to the other tier's
-    // provider.
+    // Base URL + model id per membership tier — no hardcoded fallback, so a
+    // tier needs its base URL, model id, AND API key (below) all set to be
+    // usable. Both providers must speak the OpenAI /chat/completions
+    // streaming API. Currently both tiers point at OpenRouter's DeepSeek V4
+    // Flash model (see wrangler.jsonc). Leave a tier's base URL/model/key
+    // unset to have it degrade to the other tier's provider (resolveModel).
     AI_FREE_BASE_URL?: string;
     AI_FREE_MODEL?: string;
     AI_PRO_BASE_URL?: string;

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -1,13 +1,13 @@
 // Per-tier model + provider resolution for "Ask AI".
 //
-// The product decision: FREE members use a cheaper model from an
-// OpenAI-compatible aggregator (OpenRouter by default), and PAID (pro) members
-// use an OpenAI model. Each tier has its own base URL, API key, and model id,
-// plus its own output cap and daily budgets. Everything is overridable by env
-// so the actual provider/model is a config change, never a code change.
+// Base URL, model id, and API key are all required per tier — there are no
+// hardcoded fallbacks, so the actual provider/model lives entirely in env
+// (wrangler.jsonc `vars` for the base URL + model id, `wrangler secret put`
+// for the API key) and can change without touching this file. A tier missing
+// any of the three is treated as unconfigured (see resolveModel below).
 //
-// Both providers speak the OpenAI `/chat/completions` streaming API, so the
-// same adapter (lib/ai/provider.ts) drives either one.
+// Both providers must speak the OpenAI `/chat/completions` streaming API, so
+// the same adapter (lib/ai/provider.ts) drives whichever ones are configured.
 import type { MemberTier } from "./types";
 
 export interface ResolvedModel {
@@ -17,7 +17,7 @@ export interface ResolvedModel {
   baseUrl: string;
   /** Provider API key (a secret). */
   apiKey: string;
-  /** Model id, e.g. "openai/gpt-4o-mini" (OpenRouter) or "gpt-4o" (OpenAI). */
+  /** Model id, e.g. "deepseek/deepseek-v4-flash" (OpenRouter). */
   model: string;
   /** Max output tokens — the single biggest per-request cost lever. */
   maxTokens: number;
@@ -29,22 +29,20 @@ export interface ResolvedModel {
   contextBudget: number;
 }
 
-/** Non-secret defaults per tier. Only the API keys have no default. */
-const DEFAULTS: Record<
-  MemberTier,
-  Omit<ResolvedModel, "tier" | "apiKey">
-> = {
+type TierLimits = Pick<
+  ResolvedModel,
+  "maxTokens" | "dailyTokenBudget" | "dailyRequestBudget" | "contextBudget"
+>;
+
+/** Non-secret per-tier limits. Provider/model have no defaults — see wrangler.jsonc. */
+const LIMITS: Record<MemberTier, TierLimits> = {
   free: {
-    baseUrl: "https://openrouter.ai/api/v1",
-    model: "openai/gpt-4o-mini",
     maxTokens: 800,
     dailyTokenBudget: 60_000,
     dailyRequestBudget: 40,
     contextBudget: 8_000,
   },
   pro: {
-    baseUrl: "https://api.openai.com/v1",
-    model: "gpt-4o",
     maxTokens: 1_200,
     dailyTokenBudget: 400_000,
     dailyRequestBudget: 400,
@@ -52,35 +50,39 @@ const DEFAULTS: Record<
   },
 };
 
-/** Build a tier's provider config from env, or null if its key is unset. */
+/** Build a tier's provider config from env, or null if key/base URL/model isn't all set. */
 function tierConfig(tier: MemberTier, env: CloudflareEnv): ResolvedModel | null {
-  const d = DEFAULTS[tier];
   if (tier === "pro") {
-    if (!env.AI_PRO_API_KEY) return null;
+    if (!env.AI_PRO_API_KEY || !env.AI_PRO_BASE_URL || !env.AI_PRO_MODEL) {
+      return null;
+    }
     return {
-      ...d,
+      ...LIMITS.pro,
       tier,
       apiKey: env.AI_PRO_API_KEY,
-      baseUrl: env.AI_PRO_BASE_URL || d.baseUrl,
-      model: env.AI_PRO_MODEL || d.model,
+      baseUrl: env.AI_PRO_BASE_URL,
+      model: env.AI_PRO_MODEL,
     };
   }
-  if (!env.AI_FREE_API_KEY) return null;
+  if (!env.AI_FREE_API_KEY || !env.AI_FREE_BASE_URL || !env.AI_FREE_MODEL) {
+    return null;
+  }
   return {
-    ...d,
+    ...LIMITS.free,
     tier,
     apiKey: env.AI_FREE_API_KEY,
-    baseUrl: env.AI_FREE_BASE_URL || d.baseUrl,
-    model: env.AI_FREE_MODEL || d.model,
+    baseUrl: env.AI_FREE_BASE_URL,
+    model: env.AI_FREE_MODEL,
   };
 }
 
 /**
- * Resolve the model to use for `tier`. If that tier's provider key isn't
- * configured, degrade to whichever provider *is* configured (so a half-wired
- * environment still answers) while keeping the requesting tier's budgets and
- * output caps. Returns null only when NO provider key is set at all → the
- * caller should 503 ("assistant isn't configured yet").
+ * Resolve the model to use for `tier`. If that tier's provider isn't fully
+ * configured (key, base URL, and model all set), degrade to whichever tier
+ * *is* configured (so a half-wired environment still answers) while keeping
+ * the requesting tier's budgets and output cap. Returns null only when
+ * NEITHER tier is configured → the caller should 503 ("assistant isn't
+ * configured yet").
  */
 export function resolveModel(
   tier: MemberTier,
@@ -93,13 +95,9 @@ export function resolveModel(
   if (!fallback) return null;
 
   // Use the available provider, but keep the requesting tier's limits.
-  const d = DEFAULTS[tier];
   return {
     ...fallback,
     tier,
-    maxTokens: d.maxTokens,
-    dailyTokenBudget: d.dailyTokenBudget,
-    dailyRequestBudget: d.dailyRequestBudget,
-    contextBudget: d.contextBudget,
+    ...LIMITS[tier],
   };
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -60,15 +60,18 @@
     // `npx wrangler secret put RESEND_API_KEY` (see README). Email verification
     // and password reset stay off until that key is set.
     "EMAIL_FROM": "Dataslope <no-reply@dataslope.com>",
-    // "Ask AI" model selection (non-secret). Free members use a cheaper model
-    // via OpenRouter; pro members use an OpenAI model. Override the model ids
-    // here without a code change. The API keys are secrets: set them with
-    // `npx wrangler secret put AI_FREE_API_KEY` and `... AI_PRO_API_KEY`.
-    // Ask AI stays inert (503) until at least one key is set.
+    // "Ask AI" model selection (non-secret). Both tiers currently point at
+    // OpenRouter's DeepSeek V4 Flash model. There's no hardcoded fallback
+    // (see lib/ai/models.ts) — change the model ids here without a code
+    // change. The API key is a secret: set it with
+    // `npx wrangler secret put AI_FREE_API_KEY` (one OpenRouter key covers
+    // both tiers via resolveModel's fallback; add AI_PRO_API_KEY too if pro
+    // should use a separate key later). Ask AI stays inert (503) until a
+    // tier has its key + base URL + model all set.
     "AI_FREE_BASE_URL": "https://openrouter.ai/api/v1",
-    "AI_FREE_MODEL": "openai/gpt-4o-mini",
-    "AI_PRO_BASE_URL": "https://api.openai.com/v1",
-    "AI_PRO_MODEL": "gpt-4o"
+    "AI_FREE_MODEL": "deepseek/deepseek-v4-flash",
+    "AI_PRO_BASE_URL": "https://openrouter.ai/api/v1",
+    "AI_PRO_MODEL": "deepseek/deepseek-v4-flash"
   },
   // Lets the worker invoke itself (used by OpenNext for cache/revalidation
   // plumbing). Must match "name" above.


### PR DESCRIPTION
## Summary
- Remove the hardcoded base URL/model fallbacks from `lib/ai/models.ts` — a tier is now only usable once its base URL, model id, and API key are **all** set via env (no baked-in default provider/model in source).
- Point both the free and pro tiers at OpenRouter's `deepseek/deepseek-v4-flash` (`wrangler.jsonc` vars); per-tier output caps and budgets are unchanged.
- Update `cloudflare-env.d.ts`, the route header comment, and the README's Ask AI section to reflect the new required-fields behavior and current model config.
- Update `__tests__/aiModels.test.ts` to cover the new "missing base URL/model → unconfigured" case and exercise explicit per-tier configs instead of relying on defaults.

## Test plan
- [x] `npx vitest run __tests__/aiModels.test.ts` — 11/11 passing
- [x] `npx vitest run` (full suite) — 610/610 passing
- [x] `npx tsc --noEmit` — no new type errors


---
_Generated by [Claude Code](https://claude.ai/code/session_016zqXVJsLCvGb9KkpqyPwu8)_