### PR TITLE
Land OAuth failures on /sign-in, promote config admins to role + Pro, fix auth-review findings

### DIFF
--- a/__tests__/adminPromotion.test.ts
+++ b/__tests__/adminPromotion.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Config-admin role promotion (lib/auth/adminBootstrap.ts): the conditional
+ * D1 UPDATE that completes the ADMIN_EMAILS / ADMIN_USER_IDS bootstrap on
+ * sign-in requests. D1 is mocked with a statement recorder, so assertions
+ * cover the decision logic (when a statement runs at all) and the SQL/bind
+ * shape — same no-network posture as polarBilling.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import type { D1Database } from "@cloudflare/workers-types";
+import { promoteConfiguredAdmins } from "../lib/auth/adminBootstrap";
+
+interface RecordedStatement {
+  sql: string;
+  binds: unknown[];
+}
+
+function mockDb() {
+  const statements: RecordedStatement[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...binds: unknown[]) {
+          return {
+            async run() {
+              statements.push({ sql, binds });
+              return { success: true };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+  return { db, statements };
+}
+
+describe("promoteConfiguredAdmins", () => {
+  it("does nothing when no admins are configured", async () => {
+    const { db, statements } = mockDb();
+    await promoteConfiguredAdmins(db, { adminUserIds: [], adminEmails: [] });
+    expect(statements).toHaveLength(0);
+  });
+
+  it("promotes by email, matching case-insensitively", async () => {
+    const { db, statements } = mockDb();
+    await promoteConfiguredAdmins(db, {
+      adminUserIds: [],
+      adminEmails: ["Admin@Example.com"],
+    });
+    expect(statements).toHaveLength(1);
+    const [stmt] = statements;
+    expect(stmt.sql).toContain("SET role = 'admin'");
+    expect(stmt.sql).toContain("lower(email) IN (?)");
+    expect(stmt.binds).toEqual(["admin@example.com"]);
+  });
+
+  it("promotes by user id", async () => {
+    const { db, statements } = mockDb();
+    await promoteConfiguredAdmins(db, {
+      adminUserIds: ["user-1", "user-2"],
+      adminEmails: [],
+    });
+    expect(statements).toHaveLength(1);
+    const [stmt] = statements;
+    expect(stmt.sql).toContain("id IN (?, ?)");
+    expect(stmt.binds).toEqual(["user-1", "user-2"]);
+  });
+
+  it("merges both config sources into one statement", async () => {
+    const { db, statements } = mockDb();
+    await promoteConfiguredAdmins(db, {
+      adminUserIds: ["user-1"],
+      adminEmails: ["a@example.com", "b@example.com"],
+    });
+    expect(statements).toHaveLength(1);
+    const [stmt] = statements;
+    expect(stmt.sql).toContain("id IN (?)");
+    expect(stmt.sql).toContain("lower(email) IN (?, ?)");
+    // Ids bind first, then emails, matching the matcher order in the SQL.
+    expect(stmt.binds).toEqual(["user-1", "a@example.com", "b@example.com"]);
+  });
+
+  it("only targets rows that don't already hold the admin role", async () => {
+    const { db, statements } = mockDb();
+    await promoteConfiguredAdmins(db, {
+      adminUserIds: [],
+      adminEmails: ["a@example.com"],
+    });
+    const [stmt] = statements;
+    // The role guard makes re-promotion a zero-row write, and nothing outside
+    // the config lists can ever match.
+    expect(stmt.sql).toMatch(/WHERE role <> 'admin' AND \(/);
+  });
+});

--- a/__tests__/aiModels.test.ts
+++ b/__tests__/aiModels.test.ts
@@ -94,26 +94,16 @@ describe("resolveModel", () => {
     );
   });
 
-  it("degrades free to the pro provider when only pro is fully configured, keeping free budgets", () => {
+  it("never upgrades free to the pro provider (cost fail-closed)", () => {
+    // Only the expensive pro provider is configured: free-tier requests must
+    // get "not configured" (503 at the route), not the pricey model.
     const e = env({
       AI_PRO_API_KEY: "oai-key",
       AI_PRO_BASE_URL: "https://api.openai.com/v1",
       AI_PRO_MODEL: "gpt-4o",
     });
-    const free = resolveModel("free", e)!;
-    expect(free.apiKey).toBe("oai-key");
-    expect(free.baseUrl).toBe("https://api.openai.com/v1");
-    expect(free.tier).toBe("free");
-    expect(free.dailyRequestBudget).toBe(
-      resolveModel(
-        "free",
-        env({
-          AI_FREE_API_KEY: "x",
-          AI_FREE_BASE_URL: "https://openrouter.ai/api/v1",
-          AI_FREE_MODEL: "some/model",
-        }),
-      )!.dailyRequestBudget,
-    );
+    expect(resolveModel("free", e)).toBeNull();
+    expect(resolveModel("pro", e)).not.toBeNull();
   });
 
   it("treats a tier as unconfigured if base URL or model is missing, even with a key set", () => {

--- a/app/_components/auth/AuthMenu.tsx
+++ b/app/_components/auth/AuthMenu.tsx
@@ -64,9 +64,10 @@ export function AuthMenu() {
   }
 
   const { user } = session;
-  // Role-based admins see a shortcut to /admin. `adminUserIds` admins (pinned
-  // by config, role still "user") won't see the link but can navigate directly;
-  // either way the dashboard's actions are server-enforced.
+  // Admins see a shortcut to /admin. Config-listed admins (ADMIN_EMAILS /
+  // ADMIN_USER_IDS) have their `role` column promoted to "admin" at sign-in
+  // (sign-in hooks in lib/auth/server.ts), so this role check covers them
+  // too; either way the dashboard's actions are server-enforced.
   const isAdmin = user.role === "admin";
 
   async function handleSignOut() {

--- a/app/_components/auth/AuthMenu.tsx
+++ b/app/_components/auth/AuthMenu.tsx
@@ -72,9 +72,13 @@ export function AuthMenu() {
 
   async function handleSignOut() {
     setSigningOut(true);
-    await signOut();
-    // Re-render anything reading the session; the menu collapses to "Sign in".
-    router.refresh();
+    try {
+      await signOut();
+      // Re-render anything reading the session; the menu collapses to "Sign in".
+      router.refresh();
+    } catch {
+      // Network failure — leave the session as-is; the item re-enables.
+    }
     setSigningOut(false);
   }
 

--- a/app/_components/billing/proCheckout.ts
+++ b/app/_components/billing/proCheckout.ts
@@ -99,6 +99,35 @@ export async function openBillingPortal(): Promise<string | null> {
   }
 }
 
+/** sessionStorage key remembering the billing period a signed-out visitor
+ *  picked on the pricing page before being detoured through /sign-in. */
+const PENDING_PERIOD_KEY = "pending-checkout-period";
+
+export type CheckoutPeriod = "monthly" | "annual";
+
+/** Remember the chosen billing period across the sign-in detour. Same-tab
+ *  only (sessionStorage), so a stashed choice can't leak into another
+ *  visitor's session on a shared machine. */
+export function stashCheckoutPeriod(period: CheckoutPeriod): void {
+  try {
+    sessionStorage.setItem(PENDING_PERIOD_KEY, period);
+  } catch {
+    // Storage unavailable — the buyer just defaults to monthly on /account.
+  }
+}
+
+/** Read-and-clear the stashed billing period (single-use by design: it
+ *  should only influence the immediately-following upgrade offer). */
+export function takeCheckoutPeriod(): CheckoutPeriod | null {
+  try {
+    const value = sessionStorage.getItem(PENDING_PERIOD_KEY);
+    sessionStorage.removeItem(PENDING_PERIOD_KEY);
+    return value === "annual" || value === "monthly" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * After returning from checkout, the webhook that flips `plan` to 'pro' can
  * land a moment after the redirect — and the session cookie cache can lag up

--- a/app/_components/home/PricingSection.tsx
+++ b/app/_components/home/PricingSection.tsx
@@ -209,7 +209,7 @@ function FeatureRow({ feature, last }: { feature: Feature; last: boolean }) {
  * (or the annual product isn't), the button says so instead of dead-ending.
  */
 function ProCheckoutCta({ plan, annual }: { plan: Plan; annual: boolean }) {
-  const { data: session } = useSession();
+  const { data: session, isPending } = useSession();
   const router = useRouter();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -225,6 +225,10 @@ function ProCheckoutCta({ plan, annual }: { plan: Plan; annual: boolean }) {
 
   async function handleClick() {
     setError(null);
+    // While the first session fetch is in flight a signed-in user would be
+    // misrouted to /sign-in (which bounces to /account, never checkout) —
+    // ignore clicks until the session state is known.
+    if (isPending) return;
     if (!session) {
       router.push("/sign-in");
       return;

--- a/app/_components/home/PricingSection.tsx
+++ b/app/_components/home/PricingSection.tsx
@@ -20,7 +20,10 @@ import {
 import Link from "../Link";
 import { useRouter } from "next/navigation";
 import { useSession } from "@/lib/auth/client";
-import { startProCheckout } from "../billing/proCheckout";
+import {
+  stashCheckoutPeriod,
+  startProCheckout,
+} from "../billing/proCheckout";
 
 /** A single capability line: an icon that maps to the feature, the text, and an
  *  optional clarifying sub-note. Set `included: false` to render it as a
@@ -230,6 +233,10 @@ function ProCheckoutCta({ plan, annual }: { plan: Plan; annual: boolean }) {
     // ignore clicks until the session state is known.
     if (isPending) return;
     if (!session) {
+      // Remember the chosen billing period across the sign-in detour — the
+      // buyer lands on /account afterwards, whose Upgrade button honors it
+      // (otherwise an annual purchase silently becomes monthly).
+      stashCheckoutPeriod(annual ? "annual" : "monthly");
       router.push("/sign-in");
       return;
     }

--- a/app/_components/home/PricingSection.tsx
+++ b/app/_components/home/PricingSection.tsx
@@ -213,9 +213,15 @@ function ProCheckoutCta({ plan, annual }: { plan: Plan; annual: boolean }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const sessionUser = session?.user as
+    | { plan?: string; role?: string }
+    | undefined;
+  // Admins are treated as Pro everywhere (lib/ai/tier.ts) — route them to
+  // their account page rather than into a checkout for a plan they already
+  // effectively have, mirroring app/account/AccountClient.tsx.
   const isPro =
-    ((session?.user as { plan?: string } | undefined)?.plan ?? "")
-      .toLowerCase() === "pro";
+    (sessionUser?.plan ?? "").toLowerCase() === "pro" ||
+    sessionUser?.role === "admin";
 
   async function handleClick() {
     setError(null);

--- a/app/account/AccountClient.tsx
+++ b/app/account/AccountClient.tsx
@@ -35,8 +35,11 @@ export function AccountClient() {
 
   // Detect the checkout return via window.location (not useSearchParams, so
   // the page keeps prerendering statically without a Suspense boundary).
+  // Require the exact value Polar sends (lib/billing/polar.ts) — a stale or
+  // hand-typed `?checkout=` must not flash a "payment received" notice.
   useEffect(() => {
-    if (!new URLSearchParams(window.location.search).has("checkout")) return;
+    const value = new URLSearchParams(window.location.search).get("checkout");
+    if (value !== "success") return;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- driven by the URL, which only exists client-side
     setActivation("waiting");
     let cancelled = false;
@@ -88,8 +91,12 @@ export function AccountClient() {
 
   async function handleSignOut() {
     setSigningOut(true);
-    await signOut();
-    router.refresh();
+    try {
+      await signOut();
+      router.refresh();
+    } catch {
+      // Network failure — leave the session as-is; the button re-enables.
+    }
     setSigningOut(false);
   }
 

--- a/app/account/AccountClient.tsx
+++ b/app/account/AccountClient.tsx
@@ -5,8 +5,10 @@ import { useRouter } from "next/navigation";
 import Link from "../_components/Link";
 import { signOut, useSession } from "@/lib/auth/client";
 import {
+  type CheckoutPeriod,
   openBillingPortal,
   startProCheckout,
+  takeCheckoutPeriod,
   waitForProActivation,
 } from "../_components/billing/proCheckout";
 
@@ -32,6 +34,16 @@ export function AccountClient() {
   const [activation, setActivation] = useState<"idle" | "waiting" | "slow">(
     "idle",
   );
+  // Billing period picked on the pricing page while signed out — the sign-in
+  // detour lands here, and the Upgrade button must honor the original choice
+  // (an annual pick must not silently become a monthly checkout).
+  const [period, setPeriod] = useState<CheckoutPeriod>("monthly");
+
+  useEffect(() => {
+    const stashed = takeCheckoutPeriod();
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sessionStorage only exists client-side
+    if (stashed) setPeriod(stashed);
+  }, []);
 
   // Detect the checkout return via window.location (not useSearchParams, so
   // the page keeps prerendering statically without a Suspense boundary).
@@ -103,7 +115,7 @@ export function AccountClient() {
   async function handleUpgrade() {
     setBillingBusy(true);
     setBillingError(null);
-    const error = await startProCheckout();
+    const error = await startProCheckout(period);
     // On success the browser navigates to Polar; we only get here on failure.
     if (error) setBillingError(error);
     setBillingBusy(false);
@@ -189,7 +201,11 @@ export function AccountClient() {
           disabled={billingBusy}
           className="mt-6 inline-flex w-full items-center justify-center rounded-xl bg-[var(--ds-blue-600)] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--ds-blue-700)] disabled:opacity-60"
         >
-          {billingBusy ? "Opening checkout…" : "Upgrade to Pro — $4.99/month"}
+          {billingBusy
+            ? "Opening checkout…"
+            : period === "annual"
+              ? "Upgrade to Pro — $40/year"
+              : "Upgrade to Pro — $4.99/month"}
         </button>
       )}
 

--- a/app/admin/UsersClient.tsx
+++ b/app/admin/UsersClient.tsx
@@ -293,6 +293,28 @@ export function UsersClient() {
     setBusyId(null);
   }
 
+  async function handleToggleRole(user: AdminUser) {
+    const next = user.role === "admin" ? "user" : "admin";
+    setBusyId(user.id);
+    setError(null);
+    try {
+      const { error: roleError } = await authClient.admin.setRole({
+        userId: user.id,
+        role: next,
+      });
+      if (roleError) {
+        setError(roleError.message ?? "Couldn't change that user's role.");
+      } else {
+        setUsers((prev) =>
+          prev.map((u) => (u.id === user.id ? { ...u, role: next } : u)),
+        );
+      }
+    } catch {
+      setError("Couldn't reach the server. Please try again.");
+    }
+    setBusyId(null);
+  }
+
   async function handleImpersonate(user: AdminUser) {
     setBusyId(user.id);
     setError(null);
@@ -364,6 +386,41 @@ export function UsersClient() {
         <ArrowRightLeft className="size-3.5" />
         <span className="sr-only">Switch plan</span>
       </Button>
+    </div>
+  );
+
+  // Role display + toggle. Demoting is the explicit revocation path — the
+  // ADMIN_EMAILS/ADMIN_USER_IDS allowlists only ever *grant* (a listed user
+  // is re-promoted at their next sign-in), so removal from the env list must
+  // be paired with a demotion here. Self is excluded: locking yourself out
+  // of the dashboard you're standing in is never what you meant.
+  const renderRole = (user: AdminUser, isSelf: boolean, isBusy: boolean) => (
+    <div className="flex items-center gap-1">
+      {user.role === "admin" ? (
+        <Badge className="border-transparent bg-[var(--ds-blue-600)]/10 text-[var(--ds-blue-600)] dark:bg-white/10 dark:text-white">
+          <ShieldCheck />
+          Admin
+        </Badge>
+      ) : (
+        <span className="text-sm text-muted-foreground">User</span>
+      )}
+      {!isSelf && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className={`size-7 ${quietActionClass}`}
+          onClick={() => void handleToggleRole(user)}
+          disabled={isBusy}
+          title={
+            user.role === "admin"
+              ? "Demote to regular user"
+              : "Grant admin access"
+          }
+        >
+          <ArrowRightLeft className="size-3.5" />
+          <span className="sr-only">Toggle role</span>
+        </Button>
+      )}
     </div>
   );
 
@@ -560,16 +617,7 @@ export function UsersClient() {
                             {renderPlan(user, isBusy)}
                           </TableCell>
                           <TableCell className={cellClass}>
-                            {isAdminRow ? (
-                              <Badge className="border-transparent bg-[var(--ds-blue-600)]/10 text-[var(--ds-blue-600)] dark:bg-white/10 dark:text-white">
-                                <ShieldCheck />
-                                Admin
-                              </Badge>
-                            ) : (
-                              <span className="text-sm text-muted-foreground">
-                                User
-                              </span>
-                            )}
+                            {renderRole(user, isSelf, isBusy)}
                           </TableCell>
                           <TableCell className={cellClass}>
                             <StatusBadge banned={user.banned} />
@@ -607,12 +655,7 @@ export function UsersClient() {
                         {renderPlan(user, isBusy)}
                       </div>
                       <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-                        {isAdminRow && (
-                          <Badge className="border-transparent bg-[var(--ds-blue-600)]/10 text-[var(--ds-blue-600)] dark:bg-white/10 dark:text-white">
-                            <ShieldCheck />
-                            Admin
-                          </Badge>
-                        )}
+                        {renderRole(user, isSelf, isBusy)}
                         <StatusBadge banned={user.banned} />
                         <span>Joined {formatJoined(user.createdAt)}</span>
                       </div>
@@ -650,10 +693,14 @@ export function UsersClient() {
             email so the person can sign up again.{" "}
             <strong className="font-medium text-foreground">Ban</strong> blocks
             sign-in but keeps the account.{" "}
-            <strong className="font-medium text-foreground">Plan</strong>{" "}
-            changes (and bans) reach the AI endpoints immediately — they read
-            the session fresh — but the person&apos;s header/account display
-            can lag up to five minutes (the session cookie cache).
+            <strong className="font-medium text-foreground">Plan</strong> and{" "}
+            <strong className="font-medium text-foreground">Role</strong>{" "}
+            changes (and bans) reach the AI and admin endpoints immediately —
+            they read the session fresh — but the person&apos;s
+            header/account display can lag up to five minutes (the session
+            cookie cache). Demoting an admin who is still listed in
+            ADMIN_EMAILS / ADMIN_USER_IDS only lasts until their next sign-in
+            — remove them from the config too.
           </p>
         </PanelBody>
       </Panel>

--- a/app/admin/UsersClient.tsx
+++ b/app/admin/UsersClient.tsx
@@ -22,7 +22,7 @@
  * row (and the email) occupied. "Impersonate" becomes that user in this
  * browser (refused for admins server-side); return to /admin to stop.
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ArrowRightLeft,
   Ban,
@@ -82,13 +82,21 @@ interface AdminUser {
   createdAt: string | Date;
 }
 
-/** How many users to pull in one page (the dashboard filters client-side). */
+/** Page size for the browse list; each search request also caps at this. */
 const LIST_LIMIT = 200;
+
+/** How long to sit on keystrokes before firing the server-side search. */
+const SEARCH_DEBOUNCE_MS = 300;
 
 export function UsersClient() {
   const { data: session, isPending: sessionPending } = useSession();
   const [users, setUsers] = useState<AdminUser[]>([]);
+  // Total matching accounts as reported by the server — the table may hold
+  // more rows than one page, so `users.length` alone under-reports.
+  const [total, setTotal] = useState(0);
+  const [searchTruncated, setSearchTruncated] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [denied, setDenied] = useState(false);
   const [query, setQuery] = useState("");
@@ -98,54 +106,151 @@ export function UsersClient() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [confirmId, setConfirmId] = useState<string | null>(null);
 
-  const loadUsers = useCallback(async () => {
+  // Monotonic sequence for loads: rapid typing fires overlapping requests,
+  // and a slow stale response must not overwrite a newer result.
+  const loadSeq = useRef(0);
+
+  /**
+   * Load the first page (no search) or the search results. Search runs
+   * SERVER-side: filtering the loaded page client-side would silently hide
+   * every account older than the newest LIST_LIMIT — with enough sign-ups an
+   * admin couldn't find (or ban) an old account at all. The endpoint searches
+   * one field per request, so a query fans out to email + name and merges.
+   */
+  const loadUsers = useCallback(async (search: string) => {
+    const seq = ++loadSeq.current;
     setLoading(true);
     setError(null);
     setDenied(false);
-    const { data, error: listError } = await authClient.admin.listUsers({
-      query: { limit: LIST_LIMIT, sortBy: "createdAt", sortDirection: "desc" },
-    });
-    if (listError) {
-      // 401/403 means "signed in but not an admin" — show a distinct notice.
-      if (listError.status === 401 || listError.status === 403) {
-        setDenied(true);
+    try {
+      const q = search.trim();
+      const baseQuery = {
+        limit: LIST_LIMIT,
+        sortBy: "createdAt",
+        sortDirection: "desc" as const,
+      };
+      const responses = q
+        ? await Promise.all(
+            (["email", "name"] as const).map((searchField) =>
+              authClient.admin.listUsers({
+                query: {
+                  ...baseQuery,
+                  searchValue: q,
+                  searchField,
+                  searchOperator: "contains" as const,
+                },
+              }),
+            ),
+          )
+        : [await authClient.admin.listUsers({ query: baseQuery })];
+      if (seq !== loadSeq.current) return; // superseded by a newer load
+
+      const failed = responses.find((r) => r.error)?.error;
+      if (failed) {
+        // 401/403 means "signed in but not an admin" — show a distinct notice.
+        if (failed.status === 401 || failed.status === 403) {
+          setDenied(true);
+        } else {
+          setError(failed.message ?? "Couldn't load users. Please try again.");
+        }
+        setUsers([]);
+        setTotal(0);
+        setSearchTruncated(false);
+      } else if (q) {
+        const seen = new Set<string>();
+        const merged: AdminUser[] = [];
+        for (const r of responses) {
+          for (const u of (r.data?.users ?? []) as AdminUser[]) {
+            if (!seen.has(u.id)) {
+              seen.add(u.id);
+              merged.push(u);
+            }
+          }
+        }
+        merged.sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+        setUsers(merged);
+        setTotal(merged.length);
+        // Either field maxing out its page means matches were left behind.
+        setSearchTruncated(
+          responses.some((r) => (r.data?.users?.length ?? 0) >= LIST_LIMIT),
+        );
       } else {
-        setError(listError.message ?? "Couldn't load users. Please try again.");
+        const { data } = responses[0];
+        setUsers((data?.users ?? []) as AdminUser[]);
+        setTotal(data?.total ?? 0);
+        setSearchTruncated(false);
       }
+    } catch {
+      if (seq !== loadSeq.current) return;
+      setError("Couldn't reach the server. Please try again.");
       setUsers([]);
-    } else {
-      setUsers((data?.users ?? []) as AdminUser[]);
+      setTotal(0);
     }
-    setLoading(false);
+    if (seq === loadSeq.current) setLoading(false);
   }, []);
 
   useEffect(() => {
     // Fetch once a session is confirmed (the admin-gated request is rejected
     // server-side for non-admins). No session → we fall through to the sign-in
-    // prompt below, which doesn't read `loading`.
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial data load on mount; the fetch's setState is intentional
-    if (!sessionPending && session) void loadUsers();
-  }, [sessionPending, session, loadUsers]);
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return users;
-    return users.filter(
-      (u) =>
-        u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
+    // prompt below, which doesn't read `loading`. Search input re-runs this,
+    // debounced; the empty query (initial load, cleared box) fires at once.
+    if (sessionPending || !session) return;
+    const timer = setTimeout(
+      () => void loadUsers(query),
+      query.trim() ? SEARCH_DEBOUNCE_MS : 0,
     );
-  }, [users, query]);
+    return () => clearTimeout(timer);
+  }, [sessionPending, session, loadUsers, query]);
+
+  /** Append the next browse page (search results are single-shot). */
+  async function handleLoadMore() {
+    setLoadingMore(true);
+    setError(null);
+    try {
+      const { data, error: listError } = await authClient.admin.listUsers({
+        query: {
+          limit: LIST_LIMIT,
+          offset: users.length,
+          sortBy: "createdAt",
+          sortDirection: "desc",
+        },
+      });
+      if (listError) {
+        setError(listError.message ?? "Couldn't load more users.");
+      } else {
+        setUsers((prev) => {
+          const seen = new Set(prev.map((u) => u.id));
+          const fresh = ((data?.users ?? []) as AdminUser[]).filter(
+            (u) => !seen.has(u.id),
+          );
+          return [...prev, ...fresh];
+        });
+        setTotal(data?.total ?? 0);
+      }
+    } catch {
+      setError("Couldn't reach the server. Please try again.");
+    }
+    setLoadingMore(false);
+  }
 
   async function handleRemove(userId: string) {
     setBusyId(userId);
     setError(null);
-    const { error: removeError } = await authClient.admin.removeUser({
-      userId,
-    });
-    if (removeError) {
-      setError(removeError.message ?? "Couldn't remove that user.");
-    } else {
-      setUsers((prev) => prev.filter((u) => u.id !== userId));
+    try {
+      const { error: removeError } = await authClient.admin.removeUser({
+        userId,
+      });
+      if (removeError) {
+        setError(removeError.message ?? "Couldn't remove that user.");
+      } else {
+        setUsers((prev) => prev.filter((u) => u.id !== userId));
+        setTotal((t) => Math.max(0, t - 1));
+      }
+    } catch {
+      setError("Couldn't reach the server. Please try again.");
     }
     setBusyId(null);
     setConfirmId(null);
@@ -154,17 +259,21 @@ export function UsersClient() {
   async function handleToggleBan(user: AdminUser) {
     setBusyId(user.id);
     setError(null);
-    const { error: banError } = user.banned
-      ? await authClient.admin.unbanUser({ userId: user.id })
-      : await authClient.admin.banUser({ userId: user.id });
-    if (banError) {
-      setError(banError.message ?? "Couldn't update that user.");
-    } else {
-      setUsers((prev) =>
-        prev.map((u) =>
-          u.id === user.id ? { ...u, banned: !user.banned } : u,
-        ),
-      );
+    try {
+      const { error: banError } = user.banned
+        ? await authClient.admin.unbanUser({ userId: user.id })
+        : await authClient.admin.banUser({ userId: user.id });
+      if (banError) {
+        setError(banError.message ?? "Couldn't update that user.");
+      } else {
+        setUsers((prev) =>
+          prev.map((u) =>
+            u.id === user.id ? { ...u, banned: !user.banned } : u,
+          ),
+        );
+      }
+    } catch {
+      setError("Couldn't reach the server. Please try again.");
     }
     setBusyId(null);
   }
@@ -368,14 +477,22 @@ export function UsersClient() {
           description={
             loading
               ? "Loading users…"
-              : `${users.length} ${users.length === 1 ? "account" : "accounts"}`
+              : query.trim()
+                ? `${users.length} ${users.length === 1 ? "match" : "matches"}${
+                    searchTruncated
+                      ? " (more exist — narrow the search)"
+                      : ""
+                  }`
+                : users.length < total
+                  ? `Showing ${users.length} of ${total} accounts`
+                  : `${total} ${total === 1 ? "account" : "accounts"}`
           }
           action={
             <Button
               variant="ghost"
               size="sm"
               className={quietActionClass}
-              onClick={() => void loadUsers()}
+              onClick={() => void loadUsers(query)}
               disabled={loading}
             >
               <RefreshCw className={loading ? "animate-spin" : undefined} />
@@ -404,11 +521,11 @@ export function UsersClient() {
               <Loader2 className="mr-2 inline size-4 animate-spin" />
               Loading…
             </p>
-          ) : filtered.length === 0 ? (
+          ) : users.length === 0 ? (
             <p className="py-12 text-center text-sm text-muted-foreground">
-              {users.length === 0
-                ? "No users yet."
-                : "No users match your search."}
+              {query.trim()
+                ? "No users match your search."
+                : "No users yet."}
             </p>
           ) : (
             <>
@@ -428,7 +545,7 @@ export function UsersClient() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {filtered.map((user) => {
+                    {users.map((user) => {
                       const isSelf = user.id === session.user.id;
                       const isAdminRow = user.role === "admin";
                       const isBusy = busyId === user.id;
@@ -476,7 +593,7 @@ export function UsersClient() {
 
               {/* Mobile: stacked cards */}
               <ul className="md:hidden">
-                {filtered.map((user) => {
+                {users.map((user) => {
                   const isSelf = user.id === session.user.id;
                   const isAdminRow = user.role === "admin";
                   const isBusy = busyId === user.id;
@@ -506,6 +623,24 @@ export function UsersClient() {
                   );
                 })}
               </ul>
+
+              {/* Browse mode pages through the full table; search is
+                  single-shot (the server already scoped it). */}
+              {!query.trim() && users.length < total && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={`${quietActionClass} self-center`}
+                  onClick={() => void handleLoadMore()}
+                  disabled={loadingMore}
+                >
+                  {loadingMore ? (
+                    <Loader2 className="animate-spin" />
+                  ) : (
+                    `Load ${Math.min(LIST_LIMIT, total - users.length)} more`
+                  )}
+                </Button>
+              )}
             </>
           )}
 
@@ -516,9 +651,9 @@ export function UsersClient() {
             <strong className="font-medium text-foreground">Ban</strong> blocks
             sign-in but keeps the account.{" "}
             <strong className="font-medium text-foreground">Plan</strong>{" "}
-            changes can take up to five minutes to reach an already-signed-in
-            session (the session cookie cache); impersonation and fresh
-            sign-ins see the new plan immediately.
+            changes (and bans) reach the AI endpoints immediately — they read
+            the session fresh — but the person&apos;s header/account display
+            can lag up to five minutes (the session cookie cache).
           </p>
         </PanelBody>
       </Panel>

--- a/app/admin/_components/shared.tsx
+++ b/app/admin/_components/shared.tsx
@@ -275,11 +275,18 @@ export async function setUserPlan(
   userId: string,
   plan: "free" | "pro",
 ): Promise<string | null> {
-  const { error } = await authClient.admin.updateUser({
-    userId,
-    data: { plan },
-  });
-  return error ? (error.message ?? "Couldn't update that user's plan.") : null;
+  // Server-side failures resolve with {error}; a network failure rejects.
+  try {
+    const { error } = await authClient.admin.updateUser({
+      userId,
+      data: { plan },
+    });
+    return error
+      ? (error.message ?? "Couldn't update that user's plan.")
+      : null;
+  } catch {
+    return "Couldn't reach the server. Please try again.";
+  }
 }
 
 /**
@@ -290,8 +297,12 @@ export async function setUserPlan(
  * Returns an error message, or navigates away on success.
  */
 export async function impersonateUser(userId: string): Promise<string | null> {
-  const { error } = await authClient.admin.impersonateUser({ userId });
-  if (error) return error.message ?? "Couldn't impersonate that user.";
+  try {
+    const { error } = await authClient.admin.impersonateUser({ userId });
+    if (error) return error.message ?? "Couldn't impersonate that user.";
+  } catch {
+    return "Couldn't reach the server. Please try again.";
+  }
   window.location.assign("/");
   return null;
 }

--- a/app/admin/ai-usage/AiUsageClient.tsx
+++ b/app/admin/ai-usage/AiUsageClient.tsx
@@ -14,7 +14,7 @@
  * tabular layout on mobile and scroll horizontally (the ui Table wrapper is
  * already overflow-x-auto).
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2, RefreshCw } from "lucide-react";
 import { useSession } from "@/lib/auth/client";
 import { Badge } from "@/components/ui/badge";
@@ -115,13 +115,20 @@ export function AiUsageClient() {
   const [error, setError] = useState<string | null>(null);
   const [denied, setDenied] = useState(false);
 
+  // Monotonic sequence: flipping the day picker quickly fires overlapping
+  // fetches, and a slow stale response must not overwrite the newer report
+  // (or snap the picker back to the stale day).
+  const loadSeq = useRef(0);
+
   const load = useCallback(async (requestedDay?: string) => {
+    const seq = ++loadSeq.current;
     setLoading(true);
     setError(null);
     setDenied(false);
     try {
       const qs = requestedDay ? `?day=${requestedDay}` : "";
       const res = await fetch(`/api/admin/ai-usage${qs}`);
+      if (seq !== loadSeq.current) return; // superseded by a newer load
       if (!res.ok) {
         if (res.status === 401 || res.status === 403) {
           setDenied(true);
@@ -131,14 +138,16 @@ export function AiUsageClient() {
         setReport(null);
       } else {
         const data = (await res.json()) as AiUsageReport;
+        if (seq !== loadSeq.current) return;
         setReport(data);
         setDay(data.day);
       }
     } catch {
+      if (seq !== loadSeq.current) return;
       setError("Couldn't load AI usage. Please try again.");
       setReport(null);
     }
-    setLoading(false);
+    if (seq === loadSeq.current) setLoading(false);
   }, []);
 
   useEffect(() => {
@@ -157,9 +166,12 @@ export function AiUsageClient() {
     );
   }
 
-  const dayTotal = report
-    ? (report.global.find((g) => g.day === report.day)?.totalTok ?? 0)
-    : 0;
+  // The `global` totals only cover the server's recent-days window — a day
+  // older than that has no entry, which must read as "no data", not "0
+  // tokens" (the per-user table below may show real usage for it).
+  const dayEntry = report?.global.find((g) => g.day === report.day);
+  const dayTotal = dayEntry?.totalTok ?? 0;
+  const dayInWindow = dayEntry !== undefined;
   const chatRequests =
     report?.users.reduce((sum, u) => sum + u.requests, 0) ?? 0;
   const completions =
@@ -203,14 +215,18 @@ export function AiUsageClient() {
         <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
           <StatTile
             label="Tokens used"
-            value={loading ? "…" : compact.format(dayTotal)}
+            value={loading ? "…" : dayInWindow ? compact.format(dayTotal) : "—"}
             detail={
               report
-                ? `${Math.round((dayTotal / report.globalCap) * 100)}% of the ${compact.format(report.globalCap)} daily cap`
+                ? dayInWindow
+                  ? `${Math.round((dayTotal / report.globalCap) * 100)}% of the ${compact.format(report.globalCap)} daily cap`
+                  : "Totals are only kept for recent days"
                 : undefined
             }
           >
-            {report && <CapMeter fraction={dayTotal / report.globalCap} />}
+            {report && dayInWindow && (
+              <CapMeter fraction={dayTotal / report.globalCap} />
+            )}
           </StatTile>
           <StatTile
             label="Chat requests"

--- a/app/admin/test-users/TestUsersClient.tsx
+++ b/app/admin/test-users/TestUsersClient.tsx
@@ -84,11 +84,17 @@ interface CreatedAccount {
 
 const LIST_LIMIT = 200;
 const MAX_BATCH = 10;
+/** Backstop on the pagination loop — 50 pages of 200 is far beyond any
+ *  plausible test-account count and keeps a server bug from looping forever. */
+const MAX_LIST_PAGES = 50;
 
+/** Random base-36 slug from the Web Crypto CSPRNG. These slugs become live
+ *  credentials — default passwords and sign-in-able email prefixes on
+ *  pre-verified (often Pro) accounts — so Math.random()'s guessable output
+ *  isn't good enough. */
 function randomSlug(length = 5): string {
-  return Math.random()
-    .toString(36)
-    .slice(2, 2 + length);
+  const bytes = crypto.getRandomValues(new Uint8Array(length));
+  return Array.from(bytes, (b) => (b % 36).toString(36)).join("");
 }
 
 export function TestUsersClient() {
@@ -126,19 +132,46 @@ export function TestUsersClient() {
     setLoading(true);
     setError(null);
     setDenied(false);
-    const { data, error: listError } = await authClient.admin.listUsers({
-      query: { limit: LIST_LIMIT, sortBy: "createdAt", sortDirection: "desc" },
-    });
-    if (listError) {
-      if (listError.status === 401 || listError.status === 403) {
-        setDenied(true);
-      } else {
-        setError(listError.message ?? "Couldn't load users. Please try again.");
+    // Filter server-side (email ends with the reserved domain) and page
+    // through EVERY match. Filtering one newest-first page client-side would
+    // hide any test account older than the newest LIST_LIMIT sign-ups — and
+    // "Remove all" would silently skip it while claiming the cleanup is done.
+    try {
+      const collected: TestUser[] = [];
+      for (let page = 0; page < MAX_LIST_PAGES; page++) {
+        const { data, error: listError } = await authClient.admin.listUsers({
+          query: {
+            limit: LIST_LIMIT,
+            offset: collected.length,
+            sortBy: "createdAt",
+            sortDirection: "desc",
+            searchValue: `@${TEST_EMAIL_DOMAIN}`,
+            searchField: "email",
+            searchOperator: "ends_with",
+          },
+        });
+        if (listError) {
+          if (listError.status === 401 || listError.status === 403) {
+            setDenied(true);
+          } else {
+            setError(
+              listError.message ?? "Couldn't load users. Please try again.",
+            );
+          }
+          setUsers([]);
+          setLoading(false);
+          return;
+        }
+        const batch = (data?.users ?? []) as TestUser[];
+        collected.push(...batch);
+        const totalMatches = data?.total ?? collected.length;
+        if (batch.length === 0 || collected.length >= totalMatches) break;
       }
+      // isTestEmail is the same domain rule — a belt-and-braces re-check.
+      setUsers(collected.filter((u) => isTestEmail(u.email)));
+    } catch {
+      setError("Couldn't reach the server. Please try again.");
       setUsers([]);
-    } else {
-      const all = (data?.users ?? []) as TestUser[];
-      setUsers(all.filter((u) => isTestEmail(u.email)));
     }
     setLoading(false);
   }, []);
@@ -174,20 +207,27 @@ export function TestUsersClient() {
           ? emailPrefix.trim().toLowerCase()
           : `test-${plan}-${slug}`;
       const email = `${prefix}@${TEST_EMAIL_DOMAIN}`;
-      const { error: createErr } = await authClient.admin.createUser({
-        email,
-        password: pw,
-        name: `Test ${label} ${slug}`,
-        role: "user",
-        // `emailVerified: true` skips verification (a @dataslope.test address
-        // can't receive mail); `plan` sets the membership tier directly —
-        // exactly what a billing webhook would do.
-        data: { plan, emailVerified: true },
-      });
-      if (createErr) {
+      try {
+        const { error: createErr } = await authClient.admin.createUser({
+          email,
+          password: pw,
+          name: `Test ${label} ${slug}`,
+          role: "user",
+          // `emailVerified: true` skips verification (a @dataslope.test address
+          // can't receive mail); `plan` sets the membership tier directly —
+          // exactly what a billing webhook would do.
+          data: { plan, emailVerified: true },
+        });
+        if (createErr) {
+          setCreateError(
+            createErr.message ??
+              "Couldn't create a test user. Check the email prefix isn't taken.",
+          );
+          break;
+        }
+      } catch {
         setCreateError(
-          createErr.message ??
-            "Couldn't create a test user. Check the email prefix isn't taken.",
+          "Couldn't reach the server. Please check your connection and try again.",
         );
         break;
       }
@@ -238,14 +278,18 @@ export function TestUsersClient() {
   async function handleRemove(user: TestUser) {
     setBusyId(user.id);
     setError(null);
-    const { error: removeError } = await authClient.admin.removeUser({
-      userId: user.id,
-    });
-    if (removeError) {
-      setError(removeError.message ?? "Couldn't remove that user.");
-    } else {
-      setUsers((prev) => prev.filter((u) => u.id !== user.id));
-      setCreated((prev) => prev.filter((c) => c.email !== user.email));
+    try {
+      const { error: removeError } = await authClient.admin.removeUser({
+        userId: user.id,
+      });
+      if (removeError) {
+        setError(removeError.message ?? "Couldn't remove that user.");
+      } else {
+        setUsers((prev) => prev.filter((u) => u.id !== user.id));
+        setCreated((prev) => prev.filter((c) => c.email !== user.email));
+      }
+    } catch {
+      setError("Couldn't reach the server. Please try again.");
     }
     setBusyId(null);
   }
@@ -253,14 +297,18 @@ export function TestUsersClient() {
   async function handleRemoveAll() {
     setRemoveAll("busy");
     setError(null);
-    for (const user of users) {
-      const { error: removeError } = await authClient.admin.removeUser({
-        userId: user.id,
-      });
-      if (removeError) {
-        setError(removeError.message ?? "Couldn't remove every test user.");
-        break;
+    try {
+      for (const user of users) {
+        const { error: removeError } = await authClient.admin.removeUser({
+          userId: user.id,
+        });
+        if (removeError) {
+          setError(removeError.message ?? "Couldn't remove every test user.");
+          break;
+        }
       }
+    } catch {
+      setError("Couldn't reach the server. Please try again.");
     }
     setCreated([]);
     await loadTestUsers();
@@ -643,9 +691,9 @@ export function TestUsersClient() {
             <p className="text-xs leading-relaxed text-muted-foreground">
               Test users are ordinary accounts identified by the reserved
               @{TEST_EMAIL_DOMAIN} domain — safe to remove at any time. Plan
-              changes can take up to five minutes to reach an already-signed-in
-              session (the session cookie cache); impersonation and fresh
-              sign-ins see the new plan immediately.
+              changes reach the AI endpoints immediately — they read the
+              session fresh — but the account&apos;s header/plan display can
+              lag up to five minutes (the session cookie cache).
             </p>
           </PanelBody>
         </Panel>

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -170,8 +170,11 @@ export async function POST(request: Request): Promise<Response> {
         // it, else a char/4 estimate of what streamed before any interruption).
         const inTok = usageIn || approxInputTokens;
         const outTok = usageOut || estimateTokens(answer);
+        // A failed write undercounts usage against the daily budgets — it
+        // must not fail the (already-streamed) response, but log it so
+        // undercounting is visible in the Worker logs rather than silent.
         const write = recordUsage(env, user.id, day, inTok, outTok).catch(
-          () => {},
+          (err) => console.error("ai/chat: usage write failed", err),
         );
         if (ctx?.waitUntil) ctx.waitUntil(write);
       }

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -37,10 +37,18 @@ export async function POST(request: Request): Promise<Response> {
   const { env, ctx } = getCloudflareContext();
 
   // --- Auth gate: Ask AI is an action, so it requires a session. ---
+  // The cookie cache is bypassed here: this route spends provider tokens per
+  // request, and the cached session outlives bans/plan changes by up to five
+  // minutes (banUser revokes DB sessions, but the signed cookie stays valid
+  // until its maxAge). One extra D1 read is noise next to the model call.
   const auth = await createAuth(env, request);
-  const session = await auth.api.getSession({ headers: request.headers });
+  const session = await auth.api.getSession({
+    headers: request.headers,
+    query: { disableCookieCache: true },
+  });
   if (!session) return json({ error: "Sign in to use Ask AI." }, 401);
   const user = session.user;
+  if (user.banned) return json({ error: "This account is suspended." }, 403);
 
   // --- Parse + validate the request body. ---
   let body: AskAiRequest;

--- a/app/api/ai/complete/route.ts
+++ b/app/api/ai/complete/route.ts
@@ -153,8 +153,11 @@ export async function POST(request: Request): Promise<Response> {
   );
   const inTok = result.inputTokens || approxInput;
   const outTok = result.outputTokens || estimateTokens(result.text);
+  // A failed write undercounts usage against the daily budgets — it must not
+  // fail the response, but log it so undercounting is visible in the Worker
+  // logs rather than silent.
   const write = recordCompletionUsage(env, user.id, day, inTok, outTok).catch(
-    () => {},
+    (err) => console.error("ai/complete: usage write failed", err),
   );
   if (ctx?.waitUntil) ctx.waitUntil(write);
 

--- a/app/api/ai/complete/route.ts
+++ b/app/api/ai/complete/route.ts
@@ -57,12 +57,22 @@ export async function POST(request: Request): Promise<Response> {
   const { env, ctx } = getCloudflareContext();
 
   // --- Auth gate: guests are blocked outright. ---
+  // Cookie cache bypassed: this endpoint spends provider tokens per request,
+  // and the cached session outlives bans/plan changes by up to five minutes.
+  // (The advisory GET probe above stays on the cheap cached path — the POST
+  // re-checks everything anyway.)
   const auth = await createAuth(env, request);
-  const session = await auth.api.getSession({ headers: request.headers });
+  const session = await auth.api.getSession({
+    headers: request.headers,
+    query: { disableCookieCache: true },
+  });
   if (!session) {
     return json({ error: "Sign in to use AI autocomplete." }, 401);
   }
   const user = session.user;
+  if (user.banned) {
+    return json({ error: "This account is suspended." }, 403);
+  }
 
   // --- Tier gate: completions are a pro feature, enforced server-side. ---
   const tier = resolveTier(user, env);

--- a/app/reset-password/ResetPasswordClient.tsx
+++ b/app/reset-password/ResetPasswordClient.tsx
@@ -61,10 +61,20 @@ export function ResetPasswordClient() {
     }
     if (!token) return;
     setSubmitting(true);
-    const { error } = await resetPassword({ newPassword: password, token });
-    if (error) {
+    // Server-side failures resolve with {error}; a network failure rejects —
+    // catch it so the form doesn't stay disabled at "Updating…".
+    try {
+      const { error } = await resetPassword({ newPassword: password, token });
+      if (error) {
+        setError(
+          error.message ?? "Couldn't reset your password. Request a new link.",
+        );
+        setSubmitting(false);
+        return;
+      }
+    } catch {
       setError(
-        error.message ?? "Couldn't reset your password. Request a new link.",
+        "Couldn't reach the server. Please check your connection and try again.",
       );
       setSubmitting(false);
       return;

--- a/app/sign-in/SignInClient.tsx
+++ b/app/sign-in/SignInClient.tsx
@@ -146,6 +146,20 @@ export function SignInClient() {
     setError(AUTH_ERROR_COPY[code] ?? AUTH_ERROR_FALLBACK);
   }, []);
 
+  // A browser Back from the OAuth provider can restore this page from the
+  // bfcache with `socialPending`/`submitting` still set from before the
+  // navigation — which would leave every control disabled with no request in
+  // flight. `pageshow` with `persisted` fires exactly on that restore.
+  useEffect(() => {
+    function onPageShow(e: PageTransitionEvent) {
+      if (!e.persisted) return;
+      setSocialPending(null);
+      setSubmitting(false);
+    }
+    window.addEventListener("pageshow", onPageShow);
+    return () => window.removeEventListener("pageshow", onPageShow);
+  }, []);
+
   if (!isPending && session) {
     return <p className={styles.redirecting}>Redirecting to your account…</p>;
   }
@@ -165,12 +179,32 @@ export function SignInClient() {
     setNotice(null);
   }
 
-  function startSocial(provider: string) {
+  async function startSocial(provider: string) {
     setSocialPending(provider);
-    // Full-page redirect to the provider, returning to CALLBACK_URL.
-    void signIn
-      .social({ provider, callbackURL: CALLBACK_URL })
-      .catch(() => setSocialPending(null));
+    setError(null);
+    // Full-page redirect to the provider, returning to CALLBACK_URL. On
+    // success the client's redirect plugin navigates away, so the button
+    // staying "pending" is right. Server-side failures resolve with {error}
+    // (they do NOT reject) — e.g. the provider isn't configured in this
+    // environment — and must re-enable the card; a rejection is a network
+    // failure and must too.
+    try {
+      const { error } = await signIn.social({
+        provider,
+        callbackURL: CALLBACK_URL,
+      });
+      if (error) {
+        setError(
+          error.message ?? "Couldn't start sign-in with that provider.",
+        );
+        setSocialPending(null);
+      }
+    } catch {
+      setError(
+        "Couldn't reach the server. Please check your connection and try again.",
+      );
+      setSocialPending(null);
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -179,13 +213,31 @@ export function SignInClient() {
     setNotice(null);
 
     if (isForgot) {
-      // Fire-and-forget: show the same neutral message whether or not the email
-      // exists, so the form can't be used to probe which addresses are registered.
       setSubmitting(true);
-      await requestPasswordReset({ email, redirectTo: "/reset-password" });
-      setNotice(
-        "If an account exists for that email, a reset link is on its way.",
-      );
+      try {
+        // The server already answers 200 with a neutral body for unknown
+        // emails, so the form can't probe which addresses are registered.
+        // A returned error is therefore always a genuine failure (sender not
+        // configured, Resend outage) — surfacing it leaks nothing, and
+        // pretending the link was sent would leave the user waiting forever.
+        const { error } = await requestPasswordReset({
+          email,
+          redirectTo: "/reset-password",
+        });
+        if (error) {
+          setError(
+            error.message ?? "Couldn't send the reset link. Please try again.",
+          );
+        } else {
+          setNotice(
+            "If an account exists for that email, a reset link is on its way.",
+          );
+        }
+      } catch {
+        setError(
+          "Couldn't reach the server. Please check your connection and try again.",
+        );
+      }
       setSubmitting(false);
       return;
     }
@@ -196,37 +248,47 @@ export function SignInClient() {
     // derive it from the email rather than prompting for it.
     const derivedName = email.split("@")[0]?.trim() || email;
 
-    const { data, error } = isSignup
-      ? await signUp.email({
-          name: derivedName,
-          email,
-          password,
-          callbackURL: CALLBACK_URL,
-        })
-      : await signIn.email({ email, password, callbackURL: CALLBACK_URL });
+    // Server-side failures resolve with {error}; only a network-level failure
+    // rejects — catch it so the form doesn't stay disabled at "Signing in…".
+    try {
+      const { data, error } = isSignup
+        ? await signUp.email({
+            name: derivedName,
+            email,
+            password,
+            callbackURL: CALLBACK_URL,
+          })
+        : await signIn.email({ email, password, callbackURL: CALLBACK_URL });
 
-    if (error) {
-      // When verification is required, an unverified sign-in is rejected and a
-      // fresh verification email is sent — tell the user to check their inbox.
-      if (error.code === "EMAIL_NOT_VERIFIED") {
-        setNotice(
-          "Please verify your email first. We've sent you a new verification link.",
-        );
-      } else {
-        setError(error.message ?? "Something went wrong. Please try again.");
+      if (error) {
+        // When verification is required, an unverified sign-in is rejected and a
+        // fresh verification email is sent — tell the user to check their inbox.
+        if (error.code === "EMAIL_NOT_VERIFIED") {
+          setNotice(
+            "Please verify your email first. We've sent you a new verification link.",
+          );
+        } else {
+          setError(error.message ?? "Something went wrong. Please try again.");
+        }
+        setSubmitting(false);
+        return;
       }
-      setSubmitting(false);
-      return;
-    }
 
-    // Sign-up with verification required returns no active session — prompt to
-    // verify rather than redirecting into a gated page.
-    if (isSignup && data && !("token" in data && data.token)) {
-      setPassword("");
-      go("signin"); // clears notice…
-      setNotice(
-        "Account created. Check your email for a verification link, then sign in.",
-      ); // …so set it after the switch
+      // Sign-up with verification required returns no active session — prompt to
+      // verify rather than redirecting into a gated page.
+      if (isSignup && data && !("token" in data && data.token)) {
+        setPassword("");
+        go("signin"); // clears notice…
+        setNotice(
+          "Account created. Check your email for a verification link, then sign in.",
+        ); // …so set it after the switch
+        setSubmitting(false);
+        return;
+      }
+    } catch {
+      setError(
+        "Couldn't reach the server. Please check your connection and try again.",
+      );
       setSubmitting(false);
       return;
     }
@@ -347,7 +409,7 @@ export function SignInClient() {
           <div className={styles.socialGrid}>
             <button
               type="button"
-              onClick={() => startSocial("google")}
+              onClick={() => void startSocial("google")}
               disabled={busy}
               className={styles.socialBtn}
             >
@@ -356,7 +418,7 @@ export function SignInClient() {
             </button>
             <button
               type="button"
-              onClick={() => startSocial("github")}
+              onClick={() => void startSocial("github")}
               disabled={busy}
               className={styles.socialBtn}
             >

--- a/app/sign-in/SignInClient.tsx
+++ b/app/sign-in/SignInClient.tsx
@@ -15,6 +15,26 @@ import styles from "../_components/auth/authCard.module.css";
 /** Where to land after a successful sign-in. */
 const CALLBACK_URL = "/account";
 
+/**
+ * Friendly copy for the `?error=<code>` a failed OAuth callback forwards here
+ * (see `onAPIError` in lib/auth/server.ts). The dominant code,
+ * `state_mismatch`, is usually a *duplicate* callback request whose one-time
+ * state was already consumed by the request that signed the user in — in that
+ * case a session exists and the signed-in redirect below whisks the visitor to
+ * /account before any copy renders. When one of these does render, the sign-in
+ * genuinely failed and retrying is the fix.
+ */
+const STALE_ATTEMPT_COPY =
+  "That sign-in attempt expired or was already used. Please try again.";
+const AUTH_ERROR_COPY: Record<string, string> = {
+  state_mismatch: STALE_ATTEMPT_COPY,
+  state_not_found: STALE_ATTEMPT_COPY,
+  state_invalid: STALE_ATTEMPT_COPY,
+  access_denied: "Sign-in was cancelled before it completed. Please try again.",
+};
+const AUTH_ERROR_FALLBACK =
+  "Something went wrong during sign-in. Please try again.";
+
 /** Minimum password length — mirrors Better Auth's default (`minPasswordLength`). */
 const MIN_PASSWORD = 8;
 
@@ -104,6 +124,27 @@ export function SignInClient() {
   useEffect(() => {
     if (!isPending && session) router.replace(CALLBACK_URL);
   }, [isPending, session, router]);
+
+  // Surface a forwarded OAuth-callback failure (`/sign-in?error=<code>`) and
+  // scrub the code from the address bar so it doesn't linger through reloads,
+  // bookmarks, or copied links. Read via window.location (not useSearchParams)
+  // so the page keeps prerendering statically without a Suspense boundary —
+  // same pattern as the checkout return in app/account/AccountClient.tsx.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("error");
+    if (!code) return;
+    params.delete("error");
+    params.delete("error_description");
+    const rest = params.toString();
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${rest ? `?${rest}` : ""}${window.location.hash}`,
+    );
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- driven by the URL, which only exists client-side
+    setError(AUTH_ERROR_COPY[code] ?? AUTH_ERROR_FALLBACK);
+  }, []);
 
   if (!isPending && session) {
     return <p className={styles.redirecting}>Redirecting to your account…</p>;

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -40,8 +40,9 @@ declare global {
     // tier needs its base URL, model id, AND API key (below) all set to be
     // usable. Both providers must speak the OpenAI /chat/completions
     // streaming API. Currently both tiers point at OpenRouter's DeepSeek V4
-    // Flash model (see wrangler.jsonc). Leave a tier's base URL/model/key
-    // unset to have it degrade to the other tier's provider (resolveModel).
+    // Flash model (see wrangler.jsonc). Fallback is asymmetric, by cost
+    // (resolveModel): pro degrades to the free provider when unconfigured,
+    // but free never silently upgrades to the pro provider.
     AI_FREE_BASE_URL?: string;
     AI_FREE_MODEL?: string;
     AI_PRO_BASE_URL?: string;

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -89,7 +89,11 @@ declare global {
     // Admins for /admin, regardless of their `role` column (bootstraps the
     // first admin). Both are comma-separated and merge; specify whichever is
     // handier. ADMIN_EMAILS is resolved to user IDs against D1 (see
-    // resolveAdminUserIds in lib/auth/server.ts).
+    // resolveAdminUserIds in lib/auth/server.ts). Signing in while listed
+    // promotes the user's `role` column to 'admin' (sign-in hooks in
+    // lib/auth/server.ts + lib/auth/adminBootstrap.ts), which surfaces the
+    // /admin shortcut in the avatar menu and the Pro tier (lib/ai/tier.ts)
+    // on their session.
     ADMIN_EMAILS?: string;
     ADMIN_USER_IDS?: string;
   }

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -77,12 +77,17 @@ function tierConfig(tier: MemberTier, env: CloudflareEnv): ResolvedModel | null 
 }
 
 /**
- * Resolve the model to use for `tier`. If that tier's provider isn't fully
- * configured (key, base URL, and model all set), degrade to whichever tier
- * *is* configured (so a half-wired environment still answers) while keeping
- * the requesting tier's budgets and output cap. Returns null only when
- * NEITHER tier is configured → the caller should 503 ("assistant isn't
- * configured yet").
+ * Resolve the model to use for `tier`.
+ *
+ * Fallback is asymmetric, by cost: a pro member whose provider isn't fully
+ * configured (key, base URL, and model all set) degrades to the FREE
+ * provider — cheaper, so a half-wired environment still answers — while
+ * keeping pro budgets and output cap. A free member never silently upgrades
+ * to the pro provider: in an environment with only the expensive AI_PRO_*
+ * vars set, that would route every free-tier request to the priciest model,
+ * a cost fail-open on misconfiguration. Returns null when the requesting
+ * tier can't be served → the caller should 503 ("assistant isn't configured
+ * yet").
  */
 export function resolveModel(
   tier: MemberTier,
@@ -90,14 +95,15 @@ export function resolveModel(
 ): ResolvedModel | null {
   const primary = tierConfig(tier, env);
   if (primary) return primary;
+  if (tier !== "pro") return null;
 
-  const fallback = tierConfig(tier === "pro" ? "free" : "pro", env);
+  const fallback = tierConfig("free", env);
   if (!fallback) return null;
 
-  // Use the available provider, but keep the requesting tier's limits.
+  // Use the free provider, but keep pro's limits.
   return {
     ...fallback,
     tier,
-    ...LIMITS[tier],
+    ...LIMITS.pro,
   };
 }

--- a/lib/auth/admin.ts
+++ b/lib/auth/admin.ts
@@ -36,13 +36,20 @@ export type AdminGate =
   | { ok: false; status: 401 | 403; message: string };
 
 /** Resolve the request's session and require an admin. 401 = no session,
- *  403 = signed in but not an admin. */
+ *  403 = signed in but not an admin. The cookie cache is bypassed so a
+ *  demotion or ban takes effect immediately instead of after the cache's
+ *  five-minute maxAge — matching Better Auth's own admin endpoints, which
+ *  force an authoritative session read. Admin routes are rare, so the extra
+ *  D1 read costs nothing that matters. */
 export async function requireAdmin(
   env: CloudflareEnv,
   request: Request,
 ): Promise<AdminGate> {
   const auth = await createAuth(env, request);
-  const session = await auth.api.getSession({ headers: request.headers });
+  const session = await auth.api.getSession({
+    headers: request.headers,
+    query: { disableCookieCache: true },
+  });
   if (!session) {
     return { ok: false, status: 401, message: "Sign in required." };
   }

--- a/lib/auth/adminBootstrap.ts
+++ b/lib/auth/adminBootstrap.ts
@@ -1,0 +1,67 @@
+/**
+ * Config-admin role promotion — the write half of the ADMIN_EMAILS /
+ * ADMIN_USER_IDS bootstrap.
+ *
+ * The env allowlists let the first admin exist before anyone holds the
+ * `role = 'admin'` column (see resolveAdminUserIds in lib/auth/server.ts).
+ * But the column is what the rest of the product reads: the avatar menu's
+ * /admin shortcut (app/_components/auth/AuthMenu.tsx), the account page's
+ * "Pro (admin)" display, and the Pro tier itself (lib/ai/tier.ts) all key off
+ * the session's `role`. So on sign-in requests the hook in lib/auth/server.ts
+ * calls this to finish the bootstrap: config-listed users get their `role`
+ * column set to 'admin', and from then on the role behaves as if an existing
+ * admin had granted it.
+ *
+ * One conditional UPDATE per sign-in request, nothing on the hot get-session
+ * path, and a no-op (zero rows written) when every listed admin already holds
+ * the role. Deliberately one-way: removing someone from the env lists revokes
+ * their *allowlist* access but does not demote the column — demotion stays an
+ * explicit admin action.
+ *
+ * This module stays off the Better Auth import chain so it can be unit-tested
+ * directly (see __tests__/adminPromotion.test.ts).
+ */
+import type { D1Database } from "@cloudflare/workers-types";
+
+export interface AdminBootstrapConfig {
+  /** Literal Better Auth user ids (parsed ADMIN_USER_IDS). */
+  adminUserIds: string[];
+  /** Admin email addresses (parsed ADMIN_EMAILS); matched case-insensitively. */
+  adminEmails: string[];
+}
+
+/**
+ * Set `role = 'admin'` on every config-listed user who doesn't hold it yet.
+ * `role` is NOT NULL DEFAULT 'user' (migrations/0002), so the
+ * `role <> 'admin'` guard never trips over NULL. The allowlists are a
+ * handful of operators at most, so promoting them all in one statement is
+ * as cheap as targeting one — and it means the promotion can run *before*
+ * a sign-in handler reads the user row, keeping the session response (and
+ * the cookie cache seeded from it) fresh.
+ */
+export async function promoteConfiguredAdmins(
+  db: D1Database,
+  { adminUserIds, adminEmails }: AdminBootstrapConfig,
+): Promise<void> {
+  const emails = adminEmails.map((e) => e.toLowerCase());
+  if (adminUserIds.length === 0 && emails.length === 0) return;
+
+  const matchers: string[] = [];
+  const binds: string[] = [];
+  if (adminUserIds.length > 0) {
+    matchers.push(`id IN (${adminUserIds.map(() => "?").join(", ")})`);
+    binds.push(...adminUserIds);
+  }
+  if (emails.length > 0) {
+    matchers.push(`lower(email) IN (${emails.map(() => "?").join(", ")})`);
+    binds.push(...emails);
+  }
+
+  await db
+    .prepare(
+      `UPDATE user SET role = 'admin'
+       WHERE role <> 'admin' AND (${matchers.join(" OR ")})`,
+    )
+    .bind(...binds)
+    .run();
+}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -21,8 +21,10 @@
  * route handlers / server components instead.
  */
 import { betterAuth } from "better-auth";
+import { createAuthMiddleware } from "better-auth/api";
 import { admin } from "better-auth/plugins";
 import { D1Dialect } from "kysely-d1";
+import { promoteConfiguredAdmins } from "@/lib/auth/adminBootstrap";
 import { resetPasswordEmail, sendEmail, verifyEmail } from "@/lib/auth/email";
 import { polarPlugin } from "@/lib/billing/polar";
 
@@ -46,6 +48,12 @@ export function parseList(raw: string | undefined): string[] {
  *     admin plugin only understands user *ids*, so we resolve emails → ids
  *     against D1 here.
  *   - `ADMIN_USER_IDS` — literal Better Auth user ids (no DB lookup needed).
+ *
+ * Signing in additionally *promotes* a config-listed user's `role` column to
+ * 'admin' (see the sign-in hooks in createAuth), so the session the client
+ * reads — the avatar menu's /admin shortcut, the account page's Pro display,
+ * the Pro tier in lib/ai/tier.ts — reflects admin status without hand-editing
+ * D1. These allowlists then act as the safety net for endpoints in between.
  *
  * The email→id lookup is one indexed D1 read, and `adminUserIds` is only ever
  * consulted inside the admin plugin's own endpoints (`/api/auth/admin/*`). So
@@ -86,7 +94,7 @@ export async function createAuth(env: CloudflareEnv, request?: Request) {
   // requests can land on different Worker isolates or straddle a new deployment.
   // If the secret differs across the round-trip, the signature no longer
   // verifies, Better Auth treats the state cookie as missing, and the sign-in
-  // aborts to `/?error=state_mismatch` (the user silently ends up signed out).
+  // aborts with `error=state_mismatch` (the user silently ends up signed out).
   //
   // Passing `undefined` here does NOT fail — Better Auth falls back to a
   // built-in key whose selection depends on `process.env.NODE_ENV`, which is not
@@ -167,6 +175,18 @@ export async function createAuth(env: CloudflareEnv, request?: Request) {
       }
       return origins;
     },
+    // Where failed OAuth callbacks land. Without this, Better Auth bounces
+    // them through its built-in /api/auth/error page, which in production
+    // redirects to `/?error=<code>` — stranding codes like `state_mismatch`
+    // in the home page URL with no UI that reads them. The most common
+    // occurrence isn't even a real failure: a *duplicate* callback request
+    // (back button, browser re-fetch) whose one-time state was already
+    // consumed by the request that signed the user in, so they're signed in
+    // yet parked on `/?error=state_mismatch`. Land on /sign-in instead:
+    // SignInClient strips the code from the URL and shows friendly copy for
+    // genuine failures, while an already-signed-in visitor (the duplicate-
+    // callback case) is immediately redirected on to /account.
+    onAPIError: { errorURL: "/sign-in" },
     // Email + password sign-in. Passwords are hashed by Better Auth and stored
     // in the `account` table (providerId "credential") — the existing schema
     // already has the `password` column, so no migration change is needed.
@@ -210,6 +230,54 @@ export async function createAuth(env: CloudflareEnv, request?: Request) {
           required: false,
           defaultValue: "free",
           input: false,
+        },
+      },
+    },
+    // Complete the ADMIN_EMAILS / ADMIN_USER_IDS bootstrap: config-listed
+    // admins get their `role` column promoted to 'admin' when they sign in,
+    // so the session the client reads carries admin status — which surfaces
+    // the /admin shortcut in the avatar menu and, since admins are treated
+    // as Pro (lib/ai/tier.ts), the full Pro feature set. See
+    // lib/auth/adminBootstrap.ts for the promotion semantics (one-way,
+    // no-op for everyone not config-listed).
+    //
+    // The promotion runs as a request-level *before* hook on the sign-in and
+    // OAuth-callback endpoints — not a session.create database hook — so the
+    // role is already 'admin' when the handler reads the user row. That
+    // matters because the handler seeds the 5-minute session cookie cache
+    // from that read: a database hook fires after the read, which would leave
+    // a freshly signed-in admin looking like a plain user until the cache
+    // expired. Sign-in requests are rare, so this stays off the hot
+    // get-session path.
+    hooks: {
+      before: createAuthMiddleware(async (ctx) => {
+        if (!ctx.path.startsWith("/sign-in") && !ctx.path.startsWith("/callback")) {
+          return;
+        }
+        try {
+          await promoteConfiguredAdmins(env.DB, {
+            adminUserIds: parseList(env.ADMIN_USER_IDS),
+            adminEmails: parseList(env.ADMIN_EMAILS),
+          });
+        } catch {
+          // Best-effort: a failed promotion must never abort a sign-in.
+        }
+      }),
+    },
+    databaseHooks: {
+      user: {
+        create: {
+          // New sign-ups don't have a row for the hook above to promote —
+          // write role 'admin' into the INSERT itself, so even the first
+          // session's cookie cache carries the admin role.
+          before: async (user) => {
+            const email = (user.email ?? "").toLowerCase();
+            const isConfigAdmin = parseList(env.ADMIN_EMAILS)
+              .map((e) => e.toLowerCase())
+              .includes(email);
+            if (!isConfigAdmin) return;
+            return { data: { ...user, role: "admin" } };
+          },
         },
       },
     },


### PR DESCRIPTION
Three parts: the three originally requested fixes (commit `ca99f74`), fixes for the high/medium findings of a full auth review (commit `4d55971`), and the remaining low-severity review items (commit `c1f296d`).

# Part 1 — requested fixes

## 1. No more `/?error=state_mismatch` in the URL

The root `state_mismatch` cause was fixed in #545, but the *redirect* remained: Better Auth's built-in `/api/auth/error` page 302s to `/?error=<code>` in production, stranding the code in the home page URL with no UI that reads it. The most common occurrence isn't even a real failure — a **duplicate OAuth callback request** (back button, browser re-fetch) whose one-time state was already consumed by the request that signed the user in, so you're signed in yet parked on `/?error=state_mismatch`.

- `onAPIError.errorURL` now points at `/sign-in`, so failed callbacks land there instead of the home page.
- `SignInClient` reads the forwarded `?error=<code>`, shows friendly copy for genuine failures, and scrubs the code from the address bar via `history.replaceState` (no `useSearchParams`, so the page keeps prerendering statically).
- Already-signed-in visitors (the duplicate-callback case) are redirected straight on to `/account` by the existing signed-in redirect — the spurious error is never shown.

## 2. Admin link in the avatar dropdown

The Admin item already existed but was gated on `role === "admin"`, which config-listed admins (`ADMIN_EMAILS` / `ADMIN_USER_IDS`) never had — their role column stayed `user`. The bootstrap now completes itself:

- A request-level sign-in hook (`hooks.before` on `/sign-in*` + `/callback*`) promotes config-listed users' `role` column to `admin` **before** the handler reads the user row, so the sign-in response — and the 5-minute session cookie cache seeded from it — carries the admin role immediately. (A `session.create` database hook was tried first and rejected: it fires after the user row is read, leaving a freshly signed-in admin looking like a plain user until the cache expired.)
- Brand-new sign-ups get the role written into the INSERT via a `user.create` database hook.
- Promotion is one conditional `UPDATE` per sign-in request (a no-op zero-row write once promoted), nothing on the hot `get-session` path, and deliberately one-way — removing someone from the env lists doesn't demote the column (use the new role toggle in Part 3 for that).

**Note:** takes effect on your next sign-in (sign out → sign in once after deploying).

## 3. Full Pro for admins

`lib/ai/tier.ts` already resolves `role === "admin"` to the pro tier, so with the promotion in place admins get every Pro feature (Ask AI pro model, AI autocomplete) via their session. Client surfaces now agree:

- Account page already showed "Pro (admin)" for role-admins — now reachable by config-listed admins too.
- The pricing CTA treats admins as Pro: "Manage your plan" → `/account`, instead of offering a checkout for a plan they effectively have.

# Part 2 — auth-review fixes (high/medium)

Findings from a full review of the auth-related code, each verified against better-auth 1.6.22's actual behavior before fixing:

## Sign-in card could wedge permanently (high)

`signIn.social` resolves server-side failures as `{ error }` — it does **not** reject — but the pending flag was only cleared in `.catch()`. Clicking a provider that isn't configured in the environment (e.g. previews) disabled the entire card at "Redirecting…" until a full page reload; browser Back from the provider page (bfcache) wedged it the same way. Fixed by handling the resolved error path (message + re-enable) and resetting transient state on `pageshow` restores.

## Network failures stranded busy flags everywhere (medium)

Server-side failures resolve with `{error}`, but network-level failures (offline, connection reset) **reject** — and almost no auth call site caught them, leaving forms stuck at "Signing in…" / infinite spinners with no error shown. Every call site now catches: sign-in, sign-up, forgot/reset password, both sign-out buttons, and all admin dashboard actions (`setUserPlan` / `impersonateUser` hardened in `_components/shared.tsx`).

## Forgot-password reported false success (medium)

The `requestPasswordReset` result was discarded, so genuine failures (email sender not configured, Resend outage) still showed "a reset link is on its way." The server already returns a neutral 200 for unknown emails, so surfacing a returned error leaks nothing about which addresses exist — it's now shown.

## Session cookie cache outlived bans/demotions on sensitive routes (medium)

`banUser` revokes DB sessions, but the signed session-data cookie stays valid for its 5-minute maxAge — and `/api/ai/chat`, `/api/ai/complete` (token-spending), and `requireAdmin` (custom `/api/admin/*`) honored it. A just-banned user kept making billable AI calls and a demoted admin kept reading admin reports for up to 5 minutes. These routes now pass `disableCookieCache: true` (matching Better Auth's own admin endpoints, which force an authoritative read) and the AI routes also reject `banned` users explicitly. The advisory `GET /api/ai/complete` probe stays on the cheap cached path — the POST re-checks everything.

## Admin user list silently capped at 200 (medium)

One newest-first page of 200, `total` ignored, search client-side over that page — with 201+ accounts, older users were invisible and unbannable. Now:

- **Users**: server-side search (fans out to email + name `contains`, merges, dedups), real pagination via `offset` with a "Load more" control, true totals in the header ("Showing 200 of 214 accounts"), and a stale-response sequence guard on the debounced search.
- **Test users**: lists by server-side `email ends_with @dataslope.test` and pages through **every** match, so "Remove all" can no longer silently miss test accounts older than the newest 200 sign-ups.

## Smaller fixes (low)

- Test-account default passwords now come from `crypto.getRandomValues` instead of `Math.random()` (they're live credentials on pre-verified, often-Pro accounts).
- `/account` only treats `checkout=success` (the exact value Polar sends) as a checkout return — a stale or hand-typed `?checkout=` no longer flashes "payment received" and hides the Upgrade button.
- AI-usage day picker: out-of-order responses can no longer overwrite a newer report or snap the selection back; days outside the server's recent-days totals window show "—" ("Totals are only kept for recent days") instead of a false 0.
- Pricing CTA ignores clicks until the first session fetch resolves (a signed-in user could be bounced to /sign-in → /account, never reaching checkout).

# Part 3 — remaining review items (low)

- **Admin role control (revocation path).** The Users page gets a promote/demote toggle in the Role column (Better Auth `setRole`), hidden on your own row so an admin can't lock themselves out mid-session. This closes the operational gap where removing someone from `ADMIN_EMAILS` didn't revoke anything: the allowlists only ever *grant* (and re-promote at next sign-in), so the footnote spells out that demotion of an env-listed admin must be paired with a config change.
- **Model fallback fails closed on cost.** `resolveModel` no longer upgrades free-tier requests to the pro provider when only `AI_PRO_*` is configured — that routed every free request to the priciest model on misconfiguration. Pro degrading to the (cheaper) free provider stays. Free with no free provider now 503s like an unconfigured assistant.
- **Failed usage writes are visible.** The deferred `recordUsage` / `recordCompletionUsage` writes logged nothing on failure, silently undercounting daily budgets; they now `console.error` to the Worker logs. (The check-then-record race itself stays as documented — bounded by request concurrency and explicitly deferred to a future per-minute limiter.)
- **Annual purchases survive the sign-in detour.** A signed-out visitor picking Annual on the pricing page was silently sold monthly: the CTA redirected to /sign-in and the /account Upgrade button was hardwired to monthly. The chosen period is now stashed in sessionStorage (same-tab, read-once) and the Upgrade button offers and starts the annual checkout ("Upgrade to Pro — $40/year").

**Known, not addressed:** the daily AI budget remains check-then-deferred-record and can overshoot by roughly the request concurrency; migration 0003 documents this as accepted until a per-minute limiter lands.

# Verification

- `__tests__/adminPromotion.test.ts` (5 new tests) + updated `aiModels` fallback tests; full vitest suite: 44 files / **702 tests green**; `tsc --noEmit` + eslint clean.
- Driven end-to-end against `next dev` + local D1 (migrations applied, `ADMIN_EMAILS` set):
  - `GET /api/auth/error?error=state_mismatch` → 302 `/sign-in?error=state_mismatch`; browser shows the friendly copy and the URL is scrubbed to `/sign-in` ✔
  - Config-listed sign-up → `"role":"admin"` in the response; demoted existing user → promoted at sign-in, fresh in the sign-in response **and** cookie-cached `get-session`; unlisted users untouched ✔
  - Browser with admin session: Admin item in the avatar dropdown; pricing CTA reads "Manage your plan" ✔
  - Clicking an unconfigured social provider: error shown, button re-enabled (previously wedged) ✔
  - `requireAdmin` with a cookie-cached session: 403 → D1 role promotion → **immediate** 200 on the same cookie → demotion → immediate 403 ✔
  - Seeded 214 accounts: header shows "Showing 200 of 214 accounts", Load more completes the table, search finds an account beyond the first page, test-users lists an old test account that the previous code hid ✔
  - Role toggle: promotes a user to Admin and back from the dashboard; no toggle rendered on the admin's own row ✔
  - Annual flow: signed-out "Go Pro" with Annual selected → /sign-in (period stashed) → form sign-in → /account button reads "Upgrade to Pro — $40/year", stash cleared after use ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAaXG4fAwsBvThHqW6MTuz