### PR TITLE
Add global corner loading badge for slow client-side navigations

### DIFF
--- a/app/_components/NavigationLoadingIndicator.module.css
+++ b/app/_components/NavigationLoadingIndicator.module.css
@@ -1,0 +1,53 @@
+/* Global navigation loading badge — a small fixed card in the BOTTOM-LEFT
+   corner (bottom-right belongs to the AskAi launcher, z-index 60) that hosts
+   the brand "diamond assemble + quarter-turn" loader while an App Router
+   navigation is in flight. Explicit light/dark values (following the site's
+   html.dark class) rather than surface tokens, so it renders identically on
+   the Tailwind-based /courses pages and the plain-CSS /playground pages. The
+   opaque card + border + drop shadow keep the loader legible over any page
+   content scrolling beneath it. */
+
+@keyframes badgeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.badge {
+  position: fixed;
+  left: 20px;
+  bottom: 20px;
+  z-index: 70;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: #ffffff;
+  border: 1px solid #e2e5e9;
+  box-shadow:
+    0 6px 20px rgba(0, 0, 0, 0.16),
+    0 1px 4px rgba(0, 0, 0, 0.08);
+  pointer-events: none;
+  animation: badgeIn 0.18s ease-out;
+}
+
+:global(html.dark) .badge {
+  background: #1a1a1a;
+  border-color: #2c2c2c;
+  box-shadow:
+    0 6px 20px rgba(0, 0, 0, 0.55),
+    0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .badge {
+    animation: none;
+  }
+}

--- a/app/_components/NavigationLoadingIndicator.tsx
+++ b/app/_components/NavigationLoadingIndicator.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+/**
+ * Global navigation loading indicator.
+ *
+ * App Router navigations to heavy routes (playgrounds, course pages) can
+ * take a few seconds before the new page commits, during which the old page
+ * just sits there and the site feels unresponsive. This component — mounted
+ * once in the root layout — shows the brand "diamond assemble + quarter-turn"
+ * loader in a small corner badge while a navigation is in flight.
+ *
+ * There is no global "navigation started" event in the App Router, so start
+ * is detected the way the top-loader libraries do it: a capture-phase click
+ * listener on `document` that recognises left-clicks on same-origin,
+ * same-tab, non-download links whose path/query differ from the current URL
+ * (capture phase, because next/link calls preventDefault before the bubble
+ * phase — `defaultPrevented` can't distinguish an SPA navigation from an
+ * app-handled click). Back/forward is covered by `popstate`. Programmatic
+ * `router.push` calls are not detected — link clicks are how users reach
+ * playgrounds and courses.
+ *
+ * "Navigation finished" is the router state actually changing:
+ * usePathname/useSearchParams only update when the new route commits, so an
+ * effect keyed on them hides the badge. Two timers keep it honest: the badge
+ * only appears after SHOW_DELAY_MS (fast navigations never flash it), and a
+ * safety timeout clears it if a detected "navigation" never commits (the
+ * click was intercepted by app code, or the fetch failed).
+ */
+
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { DiamondAssembleTurnLoader } from "@/app/_components/mdx/loadingAnimations";
+import styles from "./NavigationLoadingIndicator.module.css";
+
+/** Only show the badge once a navigation has been pending this long, so
+ *  fast (prefetched / cached) navigations never flash it. */
+const SHOW_DELAY_MS = 250;
+
+/** Failsafe: hide the badge if no route change commits — the click never
+ *  actually navigated (app code intercepted it) or the navigation failed. */
+const SAFETY_TIMEOUT_MS = 12_000;
+
+function isModifiedClick(e: MouseEvent): boolean {
+  return e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey;
+}
+
+/** True when the anchor click will trigger a client-side navigation to a
+ *  DIFFERENT page: same-origin, same-tab, not a download, and not a
+ *  same-path navigation (hash-only jumps never change the router state,
+ *  which is what hides the badge again). */
+function isPageNavigation(anchor: HTMLAnchorElement): boolean {
+  const target = anchor.getAttribute("target");
+  if (target && target !== "_self") return false;
+  if (anchor.hasAttribute("download")) return false;
+
+  let url: URL;
+  try {
+    url = new URL(anchor.href, window.location.href);
+  } catch {
+    return false;
+  }
+  if (url.origin !== window.location.origin) return false;
+
+  const { pathname, search } = window.location;
+  return url.pathname !== pathname || url.search !== search;
+}
+
+function IndicatorImpl() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [visible, setVisible] = useState(false);
+
+  const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const safetyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Stable across renders (timers are refs, setVisible is stable) so the
+  // start/stop closures in the listener effect below never go stale.
+  const stop = useCallback(() => {
+    if (showTimer.current) clearTimeout(showTimer.current);
+    if (safetyTimer.current) clearTimeout(safetyTimer.current);
+    showTimer.current = null;
+    safetyTimer.current = null;
+    setVisible(false);
+  }, []);
+
+  const start = useCallback(() => {
+    stop();
+    showTimer.current = setTimeout(() => setVisible(true), SHOW_DELAY_MS);
+    safetyTimer.current = setTimeout(stop, SAFETY_TIMEOUT_MS);
+  }, [stop]);
+
+  /** The last committed path + query, for the popstate handler to tell a
+   *  real back/forward navigation from a hash-only jump. Normalised through
+   *  URLSearchParams so it compares equal to location.search regardless of
+   *  percent-encoding differences. */
+  const committedUrl = useRef("");
+
+  // The route committed — the navigation is done.
+  useEffect(() => {
+    committedUrl.current = `${pathname}?${searchParams.toString()}`;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- the route commit IS the "navigation finished" signal; hiding the badge here is the point
+    stop();
+  }, [pathname, searchParams, stop]);
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (e.defaultPrevented || isModifiedClick(e)) return;
+      const anchor = (e.target as Element | null)?.closest?.("a[href]");
+      if (!(anchor instanceof HTMLAnchorElement)) return;
+      if (!isPageNavigation(anchor)) return;
+      start();
+    };
+
+    // Back/forward can also be slow when the target isn't in the router
+    // cache. By the time popstate fires, location already reflects the
+    // destination, so a hash-only jump (same path + query as the router's
+    // current state) is skipped the same way link clicks are.
+    const onPopState = () => {
+      const location = window.location;
+      const destination = `${location.pathname}?${new URLSearchParams(
+        location.search,
+      ).toString()}`;
+      if (destination === committedUrl.current) return;
+      start();
+    };
+
+    document.addEventListener("click", onClick, true);
+    window.addEventListener("popstate", onPopState);
+    return () => {
+      document.removeEventListener("click", onClick, true);
+      window.removeEventListener("popstate", onPopState);
+      stop();
+    };
+  }, [start, stop]);
+
+  if (!visible) return null;
+
+  return (
+    <div className={styles.badge}>
+      <DiamondAssembleTurnLoader size={36} label="Loading page…" />
+    </div>
+  );
+}
+
+/** Suspense wrapper: useSearchParams requires a boundary so the root
+ *  layout's static shell doesn't bail out to client rendering. */
+export default function NavigationLoadingIndicator() {
+  return (
+    <Suspense fallback={null}>
+      <IndicatorImpl />
+    </Suspense>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./brand.css";
 import "./globals.css";
 import { OG_IMAGE, SITE_URL } from "@/lib/site";
 import AskAi from "@/app/_components/ai/AskAi";
+import NavigationLoadingIndicator from "@/app/_components/NavigationLoadingIndicator";
 
 // The app's two typefaces, self-hosted by next/font and published as CSS
 // variables on <html> so every route (and every portal — portals stay inside
@@ -127,6 +128,9 @@ export default function RootLayout({
             /playground (pathname-gated inside), and its heavy deps are
             dynamically imported so other pages don't pay for them. */}
         <AskAi />
+        {/* Corner badge with the brand diamond loader, shown while a slow
+            client-side navigation (playgrounds, course pages) is pending. */}
+        <NavigationLoadingIndicator />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

Navigating to a playground or a course page can take a few seconds before the new route commits, during which nothing on screen indicates progress and the site feels unresponsive. This adds a **global navigation loading indicator**: while a client-side navigation is pending, the brand **"diamond assemble + quarter-turn"** loader (`DiamondAssembleTurnLoader`) appears in a small corner badge, and disappears the moment the new page renders.

## What it looks like

- Fixed badge in the **bottom-left** corner (bottom-right belongs to the AskAi launcher, z-index 60; the badge uses z-index 70 with `pointer-events: none`).
- The loader sits on an **opaque light/dark-aware card with a border and drop shadow**, so it never blends into page content scrolling beneath it. Dark mode follows the site's `html.dark` class, matching the AskAi widget's approach so it renders identically on the Tailwind-based course pages and the plain-CSS playground pages.

## How it works

`NavigationLoadingIndicator` is mounted once in the root layout (inside a `Suspense` boundary, since it reads `useSearchParams`):

- **Navigation start** — there's no global "navigation started" event in the App Router, so it's detected the way the top-loader libraries do it: a capture-phase `document` click listener that recognises left-clicks (no modifier keys) on same-origin, same-tab, non-download links whose path or query differ from the current URL. Capture phase is required because `next/link` calls `preventDefault` before the bubble phase. `popstate` covers back/forward, with a committed-URL comparison that skips hash-only jumps.
- **Navigation end** — `usePathname`/`useSearchParams` only update when the new route actually commits, so an effect keyed on them hides the badge.
- **250 ms show delay** — fast (prefetched/cached) navigations never flash the badge.
- **12 s safety timeout** — clears the badge if a detected click never turns into a route change (app code intercepted it, or the fetch failed).
- **Reduced motion** — the loader's existing `prefers-reduced-motion` handling applies (opacity pulse instead of motion), and the badge's own fade-in is disabled too.

## Verification

Drove the dev server with Playwright under CDP network throttling (400 ms latency):

- Badge hidden at rest; appears **~230 ms** after clicking a course link.
- URL change, new-page content render, and badge hide all coincide (same 40 ms poll tick) — the badge tracks exactly the pending window.
- Ctrl/Cmd-click (new tab), hash-only links, and back/forward to a cached page show no badge.
- Verified light + dark rendering; SPA navigation confirmed (window state preserved).
- `eslint` and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWNDSQXqSavJPYVZa4tJVe