### PR TITLE
Polish home, nav, footer, and auth UI

### DIFF
--- a/app/_components/auth/AuthMenu.tsx
+++ b/app/_components/auth/AuthMenu.tsx
@@ -7,9 +7,10 @@
  * The session is read client-side via `useSession()` so the header can sit on
  * statically prerendered pages without making them dynamic — the server ships
  * the same anonymous HTML to everyone and this swaps in after hydration. While
- * the first session fetch is in flight we render the signed-out control, so the
- * markup is stable on first paint (no hydration mismatch) and only upgrades to
- * the avatar once a session is confirmed.
+ * the first session fetch is in flight we render a neutral skeleton (not the
+ * "Sign in" button), so the markup is stable on first paint (no hydration
+ * mismatch) and a signed-in visitor doing a full-page load never sees "Sign in"
+ * flash before the avatar resolves.
  */
 import { useState } from "react";
 import { Menu } from "@base-ui-components/react/menu";
@@ -20,6 +21,11 @@ import { signOut, useSession } from "@/lib/auth/client";
 
 const TRIGGER_CLASS =
   "inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-[#121212] transition-colors hover:text-[var(--ds-blue-700)] dark:text-white dark:hover:text-[var(--ds-blue-400)]";
+
+/** Solid, subtly filled "Sign in" button (light: --ds-gray-100 / #F3F4F6).
+ *  Shared with the mobile drawer's sign-in row so the two match. */
+export const SIGN_IN_BUTTON_CLASS =
+  "inline-flex items-center rounded-lg bg-[var(--ds-gray-100)] px-3 py-1.5 text-sm font-medium text-[#121212] transition-colors hover:bg-[var(--ds-gray-200)] dark:bg-white/10 dark:text-white dark:hover:bg-white/15";
 
 /** Circular avatar: the provider image when present, otherwise an initial. */
 function Avatar({ image, name }: { image?: string | null; name?: string | null }) {
@@ -51,12 +57,25 @@ export function AuthMenu() {
   const router = useRouter();
   const [signingOut, setSigningOut] = useState(false);
 
-  // Signed out (or still loading the first session): a plain link to /sign-in.
-  if (isPending || !session) {
+  // Still loading the first session: render a size-matched skeleton rather than
+  // the "Sign in" button, so a signed-in visitor doing a full-page load doesn't
+  // see "Sign in" flash before the avatar swaps in. The server always prerenders
+  // this (isPending) state, so the placeholder is hydration-stable.
+  if (isPending) {
+    return (
+      <span
+        aria-hidden="true"
+        className="inline-block h-8 w-[4.5rem] animate-pulse rounded-lg bg-[var(--ds-gray-100)] dark:bg-white/10"
+      />
+    );
+  }
+
+  // Signed out: a solid, subtly filled button linking to /sign-in.
+  if (!session) {
     return (
       <Link
         href="/sign-in"
-        className="inline-flex items-center rounded-lg border border-[var(--ds-gray-200)] px-3 py-1.5 text-sm font-medium text-[#121212] transition-colors hover:bg-[var(--ds-gray-100)] dark:border-white/15 dark:text-white dark:hover:bg-white/10"
+        className={SIGN_IN_BUTTON_CLASS}
       >
         Sign in
       </Link>

--- a/app/_components/auth/authCard.module.css
+++ b/app/_components/auth/authCard.module.css
@@ -306,6 +306,39 @@
   opacity: 0.6;
 }
 
+/* ── Loading spinner (submit + social buttons) ───────────────────────────── */
+/* Inline layout for a button in its busy state: spinner + label, centered. */
+.btnBusy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+/* Rotating ring in currentColor, so it reads white on the primary button and
+ * the text colour on the social buttons. */
+.spinner {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  animation: authSpin 0.6s linear infinite;
+}
+
+@keyframes authSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 1.4s;
+  }
+}
+
 /* ── Social section ──────────────────────────────────────────────────────── */
 .social {
   display: flex;

--- a/app/_components/home/CoursesSection.tsx
+++ b/app/_components/home/CoursesSection.tsx
@@ -75,7 +75,7 @@ export function CoursesSection({ courses }: { courses: CatalogCourse[] }) {
     <section id="courses" className="mx-auto w-full max-w-5xl px-4 sm:px-6">
       <div className="mb-8 text-center">
         <h2 className="text-4xl font-semibold tracking-tight text-[var(--ds-gray-900)] sm:text-5xl dark:text-white">
-          Courses
+          Free Courses
         </h2>
         <p className="mt-8 text-base text-[var(--ds-gray-900)] sm:text-lg dark:text-white">
           Hands-on, browser-based tracks across data and engineering.

--- a/app/_components/home/EmbeddedPlayground.tsx
+++ b/app/_components/home/EmbeddedPlayground.tsx
@@ -101,15 +101,15 @@ function PlaygroundFacade({
         >
           {lineWidths.map((w, i) => (
             <div key={i} className="flex items-center gap-4">
-              <span className="w-5 text-right text-xs tabular-nums text-[var(--ds-gray-300)] dark:text-white/20">
+              <span className="w-5 text-right text-xs tabular-nums text-[var(--ds-gray-300)] transition-colors group-hover:text-[var(--ds-green-600)] dark:text-white/20 dark:group-hover:text-[var(--ds-green-500)]">
                 {i + 1}
               </span>
               <span
-                className="h-3 animate-pulse rounded bg-[var(--ds-gray-200)] motion-reduce:animate-none dark:bg-white/10"
+                className="h-3 animate-pulse rounded bg-[var(--ds-gray-200)] transition-colors group-hover:bg-[var(--ds-green-200)] motion-reduce:animate-none dark:bg-white/10 dark:group-hover:bg-[var(--ds-green-500)]/25"
                 style={{ width: `${w}%`, animationDelay: `${i * 180}ms` }}
               />
               {i === lineWidths.length - 1 && (
-                <span className="animate-blink-cursor -ml-2.5 h-3 w-1.5 rounded-sm bg-[var(--ds-gray-400)] dark:bg-white/40" />
+                <span className="animate-blink-cursor -ml-2.5 h-3 w-1.5 rounded-sm bg-[var(--ds-gray-400)] transition-colors group-hover:bg-[var(--ds-green-500)] dark:bg-white/40 dark:group-hover:bg-[var(--ds-green-400)]" />
               )}
             </div>
           ))}
@@ -129,7 +129,7 @@ function PlaygroundFacade({
             <Play size={16} aria-hidden="true" />
             Launch the {label} playground
           </ShimmerButton>
-          <span className="text-center text-xs text-[var(--ds-gray-500)] dark:text-[var(--ds-gray-400)]">
+          <span className="text-center text-xs text-[var(--ds-gray-500)] transition-colors group-hover:text-[var(--ds-green-700)] dark:text-[var(--ds-gray-400)] dark:group-hover:text-[var(--ds-green-400)]">
             {suspended
               ? "Paused to free memory — relaunch to pick up where you left off."
               : "Runs entirely in your browser — nothing downloads until you launch it."}

--- a/app/_components/home/HomeClient.tsx
+++ b/app/_components/home/HomeClient.tsx
@@ -66,6 +66,20 @@ export function HomeClient({
               <BlurFade delay={0.05}>
                 <HeroMarquee />
               </BlurFade>
+              {/* One-line "what is this" statement so a first-time visitor
+                  immediately understands the product before the interactive
+                  demo below. */}
+              <BlurFade delay={0.12}>
+                <p className="mx-auto mt-8 max-w-2xl text-center text-lg text-[var(--ds-gray-600)] [text-wrap:pretty] sm:text-xl dark:text-[var(--ds-gray-300)]">
+                  Dataslope is a{" "}
+                  <span className="font-semibold text-[var(--ds-gray-900)] dark:text-white">
+                    100% free
+                  </span>{" "}
+                  platform to learn programming and prep for coding interviews —
+                  interactive courses and language playgrounds that run entirely
+                  in your browser, no sign-up required.
+                </p>
+              </BlurFade>
               <BlurFade delay={0.18}>
                 <div className="mt-12">
                   <HeroInteractive />

--- a/app/_components/home/HomeFooter.tsx
+++ b/app/_components/home/HomeFooter.tsx
@@ -33,7 +33,7 @@ const RESOURCE_LINKS = [
 ];
 
 const linkClass =
-  "text-sm text-[var(--ds-gray-600)] transition-colors hover:text-[var(--ds-blue-700)] dark:text-[var(--ds-gray-400)] dark:hover:text-[var(--ds-blue-400)]";
+  "text-sm text-[#121212] transition-colors hover:text-[var(--ds-blue-700)] dark:text-white dark:hover:text-[var(--ds-blue-400)]";
 
 function FooterLink({
   href,
@@ -66,7 +66,7 @@ function FooterLink({
 export function HomeFooter() {
   return (
     <footer className="mt-24">
-      <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6">
+      <div className="mx-auto max-w-6xl px-4 pt-12 pb-20 sm:px-6 sm:pb-28">
         <div className="ds-footer-grid">
           {/* Column 1 — logo (no wordmark) + GitHub at the bottom. */}
           <div className="flex flex-col justify-between gap-8">
@@ -90,7 +90,7 @@ export function HomeFooter() {
               rel="noopener noreferrer"
               aria-label="View source on GitHub"
               title="GitHub"
-              className="inline-flex size-10 items-center justify-center rounded-lg text-[var(--ds-gray-600)] transition-colors hover:bg-[var(--ds-gray-100)] hover:text-[var(--ds-gray-900)] dark:text-[var(--ds-gray-300)] dark:hover:bg-white/10 dark:hover:text-white"
+              className="inline-flex size-10 items-center justify-center rounded-lg text-[#121212] transition-colors hover:bg-[var(--ds-gray-100)] dark:text-white dark:hover:bg-white/10"
             >
               <GitHubIcon size={26} />
             </a>

--- a/app/_components/home/HomeNav.tsx
+++ b/app/_components/home/HomeNav.tsx
@@ -16,7 +16,7 @@ import {
 import { signOut, useSession } from "@/lib/auth/client";
 import type { IconType } from "react-icons";
 import Link from "../Link";
-import { AuthMenu } from "../auth/AuthMenu";
+import { AuthMenu, SIGN_IN_BUTTON_CLASS } from "../auth/AuthMenu";
 import { GitHubIcon } from "./icons";
 import { PLAYGROUNDS } from "../playgrounds";
 import {
@@ -169,22 +169,32 @@ function BrandLogo() {
   );
 }
 
-/** Auth block for the mobile drawer: a "Sign in" link when signed out, or the
- *  account name + Account/Sign-out actions when signed in. Full-width rows
- *  rather than the desktop avatar dropdown, to match the drawer's nav items. */
+/** Auth block for the top of the mobile drawer: a solid "Sign in" button (styled
+ *  like the desktop control) when signed out, or the account name +
+ *  Account/Sign-out actions when signed in. While the first session read is in
+ *  flight a size-matched skeleton renders instead of "Sign in", so a signed-in
+ *  visitor doing a full-page load doesn't see it flash before the account rows. */
 function MobileAuthSection() {
   const { data: session, isPending } = useSession();
   const router = useRouter();
   const rowClass =
     "flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm font-medium text-[var(--ds-gray-800)] transition-colors hover:bg-[var(--ds-gray-100)] hover:text-[var(--ds-gray-900)] dark:text-[var(--ds-gray-100)] dark:hover:bg-white/10";
 
-  if (isPending || !session) {
+  if (isPending) {
+    return (
+      <span
+        aria-hidden="true"
+        className="block h-9 w-full animate-pulse rounded-lg bg-[var(--ds-gray-100)] dark:bg-white/10"
+      />
+    );
+  }
+
+  if (!session) {
     return (
       <Dialog.Close
         render={<Link href="/sign-in" prefetch={false} />}
-        className={rowClass}
+        className={`${SIGN_IN_BUTTON_CLASS} w-full justify-center`}
       >
-        <UserIcon size={16} />
         Sign in
       </Dialog.Close>
     );
@@ -219,10 +229,44 @@ function MobileAuthSection() {
   );
 }
 
+/** Pill toggle switch (sun ↔ moon) for the drawer footer. The knob position and
+ *  glyph are driven purely by the `.dark` class on <html> (set pre-hydration),
+ *  so they never mismatch on hydration. */
+function ThemeSwitch() {
+  const { theme, toggle } = useTheme();
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      role="switch"
+      aria-checked={theme === "dark"}
+      aria-label="Toggle color theme"
+      title="Toggle color theme"
+      className="relative inline-flex h-7 w-[3.25rem] shrink-0 items-center rounded-full bg-[var(--ds-gray-100)] px-1 transition-colors dark:bg-white/10"
+    >
+      {/* Faint end markers so the control reads as sun ↔ moon. */}
+      <Sun
+        size={13}
+        className="pointer-events-none absolute left-1.5 text-[var(--ds-gray-400)]"
+        aria-hidden="true"
+      />
+      <Moon
+        size={13}
+        className="pointer-events-none absolute right-1.5 text-[var(--ds-gray-400)]"
+        aria-hidden="true"
+      />
+      {/* Knob: sits left in light mode, slides right in dark mode. */}
+      <span className="z-10 inline-flex size-5 items-center justify-center rounded-full bg-white text-[var(--ds-gray-700)] shadow-sm transition-transform duration-200 dark:translate-x-[1.5rem] dark:bg-[#2a2a2a] dark:text-white">
+        <Sun size={12} className="block dark:hidden" aria-hidden="true" />
+        <Moon size={12} className="hidden dark:block" aria-hidden="true" />
+      </span>
+    </button>
+  );
+}
+
 /** Mobile slide-in drawer (a Base UI Dialog presented as a right-edge
  *  drawer) holding the same navigation the desktop bar exposes inline. */
 function MobileDrawer() {
-  const { toggle } = useTheme();
   return (
     <Dialog.Root>
       <Dialog.Trigger
@@ -235,16 +279,17 @@ function MobileDrawer() {
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
         <Dialog.Popup className="fixed inset-y-0 right-0 z-50 flex h-dvh w-[min(82vw,320px)] flex-col border-l border-[var(--ds-gray-200)] bg-white p-4 shadow-2xl transition-transform duration-200 data-[ending-style]:translate-x-full data-[starting-style]:translate-x-full dark:border-white/10 dark:bg-[#1a1a1a]">
-          <div className="mb-2 flex items-center justify-between">
-            <span className="text-sm font-semibold uppercase tracking-wide text-[var(--ds-gray-500)]">
-              Menu
-            </span>
+          {/* Top: close button, then the auth control (Sign in / account). */}
+          <div className="mb-2 flex items-center justify-end">
             <Dialog.Close
               aria-label="Close menu"
               className="inline-flex size-8 items-center justify-center rounded-lg text-[var(--ds-gray-500)] transition-colors hover:bg-[var(--ds-gray-100)] hover:text-[var(--ds-gray-900)] dark:hover:bg-white/10 dark:hover:text-white"
             >
               <X size={18} />
             </Dialog.Close>
+          </div>
+          <div className="mb-2 flex flex-col gap-1 border-b border-[var(--ds-gray-200)] pb-3 dark:border-white/10">
+            <MobileAuthSection />
           </div>
 
           {/* One unified scroll for all nav items (rather than a nested
@@ -288,22 +333,10 @@ function MobileDrawer() {
                 {p.label}
               </Dialog.Close>
             ))}
-
-            <div className="mt-2 border-t border-[var(--ds-gray-200)] pt-2 dark:border-white/10">
-              <MobileAuthSection />
-            </div>
           </div>
 
           <div className="mt-3 flex items-center justify-between border-t border-[var(--ds-gray-200)] pt-3 dark:border-white/10">
-            <button
-              type="button"
-              onClick={toggle}
-              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-[var(--ds-gray-700)] transition-colors hover:bg-[var(--ds-gray-100)] dark:text-[var(--ds-gray-200)] dark:hover:bg-white/10"
-            >
-              <Sun size={16} className="hidden dark:block" />
-              <Moon size={16} className="block dark:hidden" />
-              Theme
-            </button>
+            <ThemeSwitch />
             <a
               href={GITHUB_URL}
               target="_blank"
@@ -324,9 +357,22 @@ export function HomeNav() {
   // Shrink-on-scroll: the header is taller at the top of the page and
   // compacts to its sticky height once scrolled. The background stays a
   // solid white/#121212 (no backdrop blur, shadow, or opacity).
+  //
+  // Two thresholds (hysteresis) with a gap wider than the header's shrink
+  // delta (≤16px). A single threshold caused an infinite bounce near the top:
+  // toggling the header height changes the in-flow document height, and the
+  // browser's scroll-anchoring nudges scrollY to compensate — which flips the
+  // threshold back, resizing the header again, ad infinitum. The gap keeps that
+  // compensation from ever crossing the opposite threshold.
   const [scrolled, setScrolled] = useState(false);
   useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 8);
+    const onScroll = () =>
+      setScrolled((prev) => {
+        const y = window.scrollY;
+        if (!prev && y > 48) return true;
+        if (prev && y < 12) return false;
+        return prev;
+      });
     window.addEventListener("scroll", onScroll, { passive: true });
     // Defer the initial read out of the effect body (handles back-nav into a
     // scrolled position without a synchronous setState).
@@ -362,8 +408,12 @@ export function HomeNav() {
 
         {/* Right: theme + GitHub + (mobile) hamburger */}
         <div className="flex items-center justify-end gap-1">
-          <ThemeToggle />
-          <GitHubLink />
+          {/* Theme + GitHub are desktop-only; on mobile the drawer carries a
+              theme switch and a GitHub link instead. */}
+          <span className="ds-nav-icons items-center gap-1">
+            <ThemeToggle />
+            <GitHubLink />
+          </span>
           {/* Desktop-only: the mobile drawer carries its own auth control so
               this one isn't crammed next to the hamburger on small screens. */}
           <span className="ds-nav-auth">

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -56,7 +56,7 @@ export default async function CoursesPage() {
           {/* Centered heading, matching the /pricing page's title block. */}
           <div className="mx-auto max-w-2xl text-center">
             <h1 className="text-4xl font-semibold tracking-tight text-[var(--ds-gray-900)] sm:text-5xl dark:text-white">
-              Courses
+              Free Courses
             </h1>
             <p className="mt-6 text-base text-[var(--ds-gray-900)] [text-wrap:pretty] sm:text-lg dark:text-white">
               Hands-on, browser-based tracks across data and engineering. Every

--- a/app/home.css
+++ b/app/home.css
@@ -85,6 +85,18 @@ html.dark .ds-home {
   }
 }
 
+/* Header theme + GitHub icon buttons: desktop-only, mirroring the nav menu.
+ * On mobile the drawer exposes a theme switch and a GitHub link instead, so
+ * these hide to keep the compact header to brand + hamburger. */
+.ds-home .ds-nav-icons {
+  display: none;
+}
+@media (min-width: 768px) {
+  .ds-home .ds-nav-icons {
+    display: inline-flex;
+  }
+}
+
 /* Decorative CSS animations pause while their section is offscreen — see
  * AnimationPauseGate.tsx, which toggles the data attribute from an
  * IntersectionObserver. Scoped under .ds-home so the rule can't leak into

--- a/app/sign-in/SignInClient.tsx
+++ b/app/sign-in/SignInClient.tsx
@@ -399,7 +399,14 @@ export function SignInClient() {
         )}
 
         <button type="submit" disabled={busy} className={styles.primary}>
-          {submitting ? cta[1] : cta[0]}
+          {submitting ? (
+            <span className={styles.btnBusy}>
+              <span className={styles.spinner} aria-hidden="true" />
+              {cta[1]}
+            </span>
+          ) : (
+            cta[0]
+          )}
         </button>
       </form>
 
@@ -413,8 +420,17 @@ export function SignInClient() {
               disabled={busy}
               className={styles.socialBtn}
             >
-              <GoogleGlyph />
-              {socialPending === "google" ? "Redirecting…" : "Google"}
+              {socialPending === "google" ? (
+                <>
+                  <span className={styles.spinner} aria-hidden="true" />
+                  Redirecting…
+                </>
+              ) : (
+                <>
+                  <GoogleGlyph />
+                  Google
+                </>
+              )}
             </button>
             <button
               type="button"
@@ -422,8 +438,17 @@ export function SignInClient() {
               disabled={busy}
               className={styles.socialBtn}
             >
-              <GitHubIcon size={16} />
-              {socialPending === "github" ? "Redirecting…" : "GitHub"}
+              {socialPending === "github" ? (
+                <>
+                  <span className={styles.spinner} aria-hidden="true" />
+                  Redirecting…
+                </>
+              ) : (
+                <>
+                  <GitHubIcon size={16} />
+                  GitHub
+                </>
+              )}
             </button>
           </div>
         </div>


### PR DESCRIPTION
A batch of UI polish across the home page, header/nav, footer, and the auth flow. All changes were verified in a running dev server (desktop + mobile) with Playwright screenshots.

## Home page / playground preview
- **Green facade hover (A1):** In the embedded playground preview, hovering the un-launched "Launch the {lang} playground" surface now shifts the line numbers, skeleton bars, blinking caret, and the "Runs entirely in your browser…" caption to green shades (previously gray).
- **What-is-Dataslope statement (A7):** Added a concise one-line description in the hero, placed between the marquee and the interactive demo, so first-time visitors immediately understand the product ("Dataslope is a 100% free platform to learn programming and prep for coding interviews — …, no sign-up required.").
- **"Free Courses" heading (A5, A10):** Renamed the home page's "Courses" `<h2>` and the `/courses` page's "Courses" `<h1>` to "Free Courses".

## Header / navigation
- **Solid Sign-in button (A2):** The desktop "Sign in" control is now a solid button with a subtle `#F3F4F6` (`--ds-gray-100`) fill instead of an outline. The style is shared with the mobile drawer's sign-in button.
- **Fixed the scroll bounce (A6):** Near the top of the page the shrink-on-scroll header could bounce up and down indefinitely — the single scroll threshold fed back through the browser's scroll-anchoring each time the header resized. Replaced it with two thresholds (hysteresis) whose gap is wider than the header's height delta, breaking the loop.
- **No "Sign in" flash on hard load (A4):** While the first client-side session read is in flight, the header (and mobile drawer) now render a size-matched skeleton instead of the "Sign in" button, so a signed-in visitor doing a full-page navigation no longer sees "Sign in" flash before the avatar resolves. The placeholder is the server-prerendered state, so it stays hydration-stable.
- **Mobile header/drawer rework (A8):**
  - Hide the light/dark and GitHub icon buttons in the compact mobile header.
  - In the drawer: removed the "Menu" label, moved the auth control (a desktop-styled "Sign in" button) to the top, and replaced the "Theme" text button at the bottom with a sun/moon toggle switch.

## Sign-in page
- **Loading animation (A3):** The submit button and the Google/GitHub social buttons now show a spinner (with "Signing in…" / "Redirecting…") while a request is in flight.

## Footer
- **Regular text colors + padding (A9):** Recolored the GitHub icon and the resource/dev links to the regular text color (`#121212` in light mode, white in dark mode) and added more bottom padding.

## Verification
Ran the dev server and captured Playwright screenshots confirming each change on desktop and mobile (light + dark), including the green facade hover, both spinner states, the mobile drawer layout, and the theme toggle switch flipping the `dark` class. `tsc --noEmit` and `eslint` pass clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbZjxLdgePHHs8CeKVoNCx)_