### PR TITLE
Fix first Google sign-in failing with "expired or already used" (state_mismatch)

### DIFF
--- a/__tests__/authStateCookie.test.ts
+++ b/__tests__/authStateCookie.test.ts
@@ -1,0 +1,149 @@
+/**
+ * OAuth `state` cookie scoping (lib/auth/server.ts) — the fix for the "first
+ * Google sign-in fails with ?error=state_mismatch, clicking again works" loop.
+ *
+ * The one-time `state` cookie set by the sign-in POST must come back on the
+ * OAuth callback, which Google always sends to the BETTER_AUTH_URL host (the
+ * registered redirect_uri). Host-only cookies made every flow started on
+ * www.dataslope.com fail: the cookie stayed on www while the callback landed
+ * on the apex. The fix scopes the cookie to the registrable domain and aligns
+ * its lifetime with the server-side state's 10-minute window.
+ *
+ * Two layers of coverage, both with a mocked D1 (statement echo — no network,
+ * same posture as adminPromotion.test.ts / polarBilling.test.ts):
+ *   - `oauthStateCookieDomain`: the derivation rules, including the hosts
+ *     where a Domain attribute must NOT be emitted (browsers reject a Domain
+ *     they can't tail-match, which would drop the cookie and break sign-in).
+ *   - the full `sign-in/social` endpoint: the Set-Cookie the browser actually
+ *     receives carries Domain + Max-Age=600, and redirect_uri stays pinned.
+ */
+import { describe, it, expect } from "vitest";
+import type { D1Database } from "@cloudflare/workers-types";
+import { createAuth, oauthStateCookieDomain } from "../lib/auth/server";
+
+describe("oauthStateCookieDomain", () => {
+  it("derives the hostname from the production base URL", () => {
+    expect(oauthStateCookieDomain("https://dataslope.com")).toBe(
+      "dataslope.com",
+    );
+  });
+
+  it("keeps a subdomain base URL scoped to that subdomain", () => {
+    // Domain=www.dataslope.com covers www and *.www — never the apex. That is
+    // the correct (narrowest) scope when the callback host is the subdomain.
+    expect(oauthStateCookieDomain("https://www.dataslope.com")).toBe(
+      "www.dataslope.com",
+    );
+  });
+
+  it("returns undefined when BETTER_AUTH_URL is unset", () => {
+    expect(oauthStateCookieDomain(undefined)).toBeUndefined();
+    expect(oauthStateCookieDomain("")).toBeUndefined();
+  });
+
+  it("returns undefined for localhost (dotless host)", () => {
+    expect(oauthStateCookieDomain("http://localhost:3000")).toBeUndefined();
+  });
+
+  it("returns undefined for IP literals", () => {
+    expect(oauthStateCookieDomain("http://127.0.0.1:8787")).toBeUndefined();
+    expect(oauthStateCookieDomain("http://[::1]:8787")).toBeUndefined();
+  });
+
+  it("returns undefined for an unparseable URL", () => {
+    expect(oauthStateCookieDomain("not a url")).toBeUndefined();
+  });
+});
+
+/**
+ * Minimal D1 that satisfies Better Auth's kysely adapter for this flow: the
+ * only statement `sign-in/social` runs is `INSERT INTO "verification" (...)
+ * VALUES (...) RETURNING *`, so echo the inserted row back by zipping the
+ * column list out of the SQL with the bound values.
+ */
+function echoDb(): D1Database {
+  function stmt(sql: string, binds: unknown[] = []) {
+    return {
+      bind: (...b: unknown[]) => stmt(sql, b),
+      async all() {
+        const cols = /\(([^)]*)\)\s*values/i
+          .exec(sql)?.[1]
+          ?.split(",")
+          .map((c) => c.trim().replace(/^"|"$/g, ""));
+        const row = cols
+          ? Object.fromEntries(cols.map((c, i) => [c, binds[i]]))
+          : undefined;
+        return { results: row ? [row] : [], success: true, meta: {} };
+      },
+      async run() {
+        return { results: [], success: true, meta: {} };
+      },
+      async first() {
+        return null;
+      },
+      raw: async () => [],
+    };
+  }
+  return { prepare: (sql: string) => stmt(sql) } as unknown as D1Database;
+}
+
+function makeEnv(overrides: Partial<CloudflareEnv> = {}): CloudflareEnv {
+  return {
+    DB: echoDb(),
+    BETTER_AUTH_SECRET: "test-secret-test-secret-test-secret",
+    BETTER_AUTH_URL: "https://dataslope.com",
+    GOOGLE_CLIENT_ID: "test-google-id",
+    GOOGLE_CLIENT_SECRET: "test-google-secret",
+    ...overrides,
+  } as CloudflareEnv;
+}
+
+async function startGoogleSignIn(env: CloudflareEnv, origin: string) {
+  const auth = await createAuth(env);
+  return auth.handler(
+    new Request(`${origin}/api/auth/sign-in/social`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin },
+      body: JSON.stringify({ provider: "google", callbackURL: "/account" }),
+    }),
+  );
+}
+
+describe("sign-in/social state cookie", () => {
+  it("sets a domain-scoped state cookie with the 10-minute lifetime", async () => {
+    const res = await startGoogleSignIn(makeEnv(), "https://dataslope.com");
+    expect(res.status).toBe(200);
+
+    const cookie = res.headers.get("set-cookie") ?? "";
+    expect(cookie).toContain("__Secure-better-auth.state=");
+    // The fix: valid on the apex AND every subdomain, so a flow started on
+    // www survives Google redirecting back to the apex callback…
+    expect(cookie).toMatch(/domain=dataslope\.com/i);
+    // …and it lives as long as the server-side state (10 min), not 5.
+    expect(cookie).toMatch(/max-age=600/i);
+    // Lax is what lets the cookie ride the top-level redirect from Google.
+    expect(cookie).toMatch(/samesite=lax/i);
+
+    // redirect_uri stays pinned to BETTER_AUTH_URL regardless of the
+    // request's own host — that pinning is why the domain scope is needed.
+    const { url } = (await res.json()) as { url: string };
+    expect(new URL(url).searchParams.get("redirect_uri")).toBe(
+      "https://dataslope.com/api/auth/callback/google",
+    );
+  });
+
+  it("keeps the cookie host-only when BETTER_AUTH_URL is unset (local dev)", async () => {
+    const res = await startGoogleSignIn(
+      makeEnv({ BETTER_AUTH_URL: undefined }),
+      "https://dataslope.com",
+    );
+    expect(res.status).toBe(200);
+
+    const cookie = res.headers.get("set-cookie") ?? "";
+    // No baseURL → the __Secure- prefix follows NODE_ENV instead, so match
+    // the unprefixed name (a substring of the prefixed one, either way).
+    expect(cookie).toContain("better-auth.state=");
+    expect(cookie).not.toMatch(/domain=/i);
+    expect(cookie).toMatch(/max-age=600/i);
+  });
+});

--- a/app/sign-in/SignInClient.tsx
+++ b/app/sign-in/SignInClient.tsx
@@ -18,11 +18,18 @@ const CALLBACK_URL = "/account";
 /**
  * Friendly copy for the `?error=<code>` a failed OAuth callback forwards here
  * (see `onAPIError` in lib/auth/server.ts). The dominant code,
- * `state_mismatch`, is usually a *duplicate* callback request whose one-time
- * state was already consumed by the request that signed the user in — in that
- * case a session exists and the signed-in redirect below whisks the visitor to
- * /account before any copy renders. When one of these does render, the sign-in
- * genuinely failed and retrying is the fix.
+ * `state_mismatch`, has two known shapes:
+ *
+ *   - The one-time `state` cookie didn't make it back to the callback host.
+ *     This used to fail *every* sign-in started on www.dataslope.com (the
+ *     host-only cookie stayed on www while Google returned to the apex);
+ *     fixed by domain-scoping the cookie — see `oauthStateCookieDomain` in
+ *     lib/auth/server.ts. It still happens on hosts no cookie can bridge,
+ *     e.g. a workers.dev preview, where retrying (now from the apex this
+ *     error page landed on) is genuinely the fix.
+ *   - A *duplicate* callback request whose state was already consumed by the
+ *     request that signed the user in — a session exists, and the signed-in
+ *     redirect below whisks the visitor to /account before any copy renders.
  */
 const STALE_ATTEMPT_COPY =
   "That sign-in attempt expired or was already used. Please try again.";

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -39,6 +39,44 @@ export function parseList(raw: string | undefined): string[] {
 }
 
 /**
+ * Domain attribute for the OAuth `state` cookie, derived from BETTER_AUTH_URL.
+ *
+ * Why it exists: a social sign-in spans two requests — the sign-in POST sets a
+ * signed one-time `state` cookie, then the provider redirects back to the
+ * callback, which requires that cookie (Better Auth's login-CSRF check). By
+ * default the cookie is host-only, while the callback always lands on the
+ * BETTER_AUTH_URL host because the OAuth redirect_uri is pinned to it. Both
+ * dataslope.com and www.dataslope.com serve this app with no canonical
+ * redirect, so a sign-in started on www set its cookie on www, Google returned
+ * to the apex where the cookie doesn't exist, and the callback failed with
+ * `?error=state_mismatch` — reproducibly, on every first attempt from www. The
+ * failure redirect lands on the apex /sign-in, which is why *retrying* always
+ * worked. Scoping the state cookie to the registrable domain (`Domain=
+ * dataslope.com` covers the apex and every subdomain) lets a flow started on
+ * any *.dataslope.com host complete on the apex callback. Session cookies are
+ * deliberately left host-only — this widens only the short-lived random nonce.
+ *
+ * Returns undefined (host-only cookie, today's behavior) when BETTER_AUTH_URL
+ * is unset or its host is not a dotted DNS name: browsers reject a Domain
+ * attribute they can't tail-match against the request host (localhost, IP
+ * literals), which would drop the cookie entirely and break sign-in outright.
+ */
+export function oauthStateCookieDomain(
+  baseURL: string | undefined,
+): string | undefined {
+  if (!baseURL) return undefined;
+  let hostname: string;
+  try {
+    hostname = new URL(baseURL).hostname;
+  } catch {
+    return undefined;
+  }
+  if (!hostname.includes(".") || hostname.startsWith("[")) return undefined;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) return undefined;
+  return hostname;
+}
+
+/**
  * Resolve who is an admin for this request. Two config sources, which merge —
  * both grant admin regardless of the `role` column, which solves the bootstrap
  * problem (there's no admin to promote the first one yet):
@@ -137,6 +175,8 @@ export async function createAuth(env: CloudflareEnv, request?: Request) {
 
   const adminUserIdsResolved = await resolveAdminUserIds(env, request);
 
+  const stateCookieDomain = oauthStateCookieDomain(env.BETTER_AUTH_URL);
+
   return betterAuth({
     // D1 via the Kysely SQLite dialect — the most Cloudflare-native path, with
     // full ownership of the tables (schema in /migrations). One dialect per
@@ -216,6 +256,31 @@ export async function createAuth(env: CloudflareEnv, request?: Request) {
         }
       : undefined,
     socialProviders,
+    // Fix for the "first Google sign-in fails with ?error=state_mismatch,
+    // clicking again works" loop. Two hardenings of the one-time OAuth `state`
+    // cookie, which the callback demands back (see oauthStateCookieDomain):
+    //
+    //   - `domain`: scope it to the registrable domain instead of host-only,
+    //     so a flow started on www.dataslope.com survives Google returning to
+    //     the pinned apex callback. (workers.dev previews still can't complete
+    //     social login — Google only redirects to the registered production
+    //     URI, and no cookie scope spans workers.dev → dataslope.com.)
+    //   - `maxAge`: Better Auth sets the cookie to 5 minutes but honours the
+    //     server-side state for 10 — someone who sits on Google's account
+    //     chooser for 6 minutes would fail the cookie check with the same
+    //     stale-attempt error. Align the cookie with the 10-minute window.
+    //
+    // Only the `state` cookie is touched; session cookies keep their defaults.
+    advanced: {
+      cookies: {
+        state: {
+          attributes: {
+            ...(stateCookieDomain ? { domain: stateCookieDomain } : {}),
+            maxAge: 600,
+          },
+        },
+      },
+    },
     // Membership tier, surfaced on the session so the "Ask AI" endpoint can
     // pick the model by plan (free → cheaper OpenRouter model; pro → OpenAI).
     // Backed by the `plan` column added in migrations/0003. `input: false` means

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    // Mirror tsconfig's `@/*` → repo root, so tests can import modules that
+    // themselves use the alias (e.g. lib/auth/server.ts).
+    alias: { "@": path.resolve(import.meta.dirname) },
+  },
   test: {
     // Tests that use browser APIs (WebAssembly, WebWorker, SharedArrayBuffer)
     // are tagged as "browser" and skipped in the Node environment.


### PR DESCRIPTION
## Problem

Signing in with Google reproducibly failed on the **first** attempt with *"That sign-in attempt expired or was already used. Please try again."* — and clicking the Google button once more worked.

## Root cause (reproduced against production)

Both `www.dataslope.com` and `dataslope.com` serve the app (www does not redirect to the apex), but the two halves of a social sign-in disagree about hosts:

1. The sign-in POST sets Better Auth's one-time `__Secure-better-auth.state` cookie **host-only** — on whichever host the user is browsing (e.g. `www.dataslope.com`).
2. The Google `redirect_uri` is pinned to the apex via `BETTER_AUTH_URL`, so the callback always lands on `dataslope.com` — where the www-scoped cookie is never sent.
3. Better Auth 1.6's callback requires that cookie back (login-CSRF check) in addition to the DB verification row → `state_security_mismatch`, surfaced as `?error=state_mismatch`.
4. The error redirect (`onAPIError.errorURL = "/sign-in"`) resolves relative to the callback, parking the user on the **apex** `/sign-in` — which is exactly why the retry always succeeded.

Verified live with curl:
- `POST https://www.dataslope.com/api/auth/sign-in/social` → sets the state cookie on www, returns a Google URL with `redirect_uri=https://dataslope.com/...`
- `GET https://dataslope.com/api/auth/callback/google?state=…` **without** the cookie → `302 /sign-in?error=state_mismatch` (the reported bug)
- the same callback **with** the cookie → passes the state check (fails later at `invalid_code`, as expected with a fake code)

## Fix

Scoped to the short-lived random state nonce only — session cookies stay host-only:

- **`Domain=dataslope.com`** (derived from `BETTER_AUTH_URL`'s hostname) on the state cookie, so a flow started on any `*.dataslope.com` host survives the callback landing on the apex. Skipped when the host is `localhost` or an IP literal, where browsers reject the attribute and would drop the cookie outright (breaking local dev sign-in).
- **`Max-Age: 600`** instead of Better Auth's 5-minute default, matching the server-side state's 10-minute window — previously, sitting on Google's account chooser for 5–10 minutes hit the same stale-attempt error even on the right host.

Also updates the `SignInClient` comment that attributed `state_mismatch` mainly to duplicate callbacks, so the next person debugging this finds the real dominant cause documented.

## Tests

- `__tests__/authStateCookie.test.ts`: unit tests for the domain derivation (apex, subdomain, unset, localhost, IPs, garbage), plus a mocked-D1 behavioral test of `sign-in/social` asserting the actual `Set-Cookie` (`Domain=dataslope.com`, `Max-Age=600`, `SameSite=Lax`) and the pinned `redirect_uri` — and that the cookie stays host-only with `BETTER_AUTH_URL` unset.
- `vitest.config.ts` now resolves the tsconfig `@/*` alias so tests can import modules that use it (`lib/auth/server.ts`).
- Full suite: 761 tests pass; eslint and `tsc --noEmit` clean.

## Notes / follow-ups (infrastructure, not in this diff)

- Consider a Cloudflare redirect rule `www.dataslope.com/* → https://dataslope.com/$1` (301). It would canonicalize sessions too — today someone signed in on the apex still looks signed out if they browse www, since session cookies are (deliberately) host-only. The app itself can't do this: prerendered pages are served from static assets before the Worker runs.
- workers.dev preview URLs still can't complete social login (Google only redirects to the registered production URI, and no cookie scope spans `workers.dev` → `dataslope.com`) — unchanged, and already documented in `lib/auth/server.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHgA7kS64uGX4CJmQ2DkV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJHgA7kS64uGX4CJmQ2DkV)_