### PR TITLE
Clarify Cloudflare preview URL labels in PR comments

### DIFF
--- a/.github/workflows/cloudflare-build-pr-comments.yml
+++ b/.github/workflows/cloudflare-build-pr-comments.yml
@@ -94,8 +94,8 @@ jobs:
               const conclusion = cr.conclusion;
               if (conclusion === 'success') {
                 const lines = [`✅ **Cloudflare build succeeded** for ${commitLink}`, ''];
-                if (urls.alias) lines.push(`**Preview:** ${urls.alias}`);
-                if (urls.preview) lines.push(`Version preview: ${urls.preview}`);
+                if (urls.alias) lines.push(`**Pull Request/Branch Preview URL:** ${urls.alias}`);
+                if (urls.preview) lines.push(`Commit Preview URL: ${urls.preview}`);
                 lines.push('', `[Build details ↗](${buildUrl})`);
                 body = lines.join('\n');
               } else if (conclusion === 'skipped' || conclusion === 'neutral') {


### PR DESCRIPTION
## What & why

The Cloudflare build PR comments currently show two preview links labeled `Preview` and `Version preview`, which don't make it obvious what each link points to. This renames them so their purpose is clear:

- `Preview` → **Pull Request/Branch Preview URL** (the alias URL that tracks the PR/branch)
- `Version preview` → **Commit Preview URL** (the version-specific URL for that exact commit)

### Before
```
✅ Cloudflare build succeeded for 967ab84

Preview: https://…-dataslope.subwaymatch.workers.dev
Version preview: https://ed3671c2-dataslope.subwaymatch.workers.dev

Build details ↗
```

### After
```
✅ Cloudflare build succeeded for 967ab84

Pull Request/Branch Preview URL: https://…-dataslope.subwaymatch.workers.dev
Commit Preview URL: https://ed3671c2-dataslope.subwaymatch.workers.dev

Build details ↗
```

Only the display labels changed in `.github/workflows/cloudflare-build-pr-comments.yml`; the URL parsing and workflow logic are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JciAbX33PMkk8mMEycfw7Q)_