### PR TITLE
Place new risograph figures; let figures fill width with a height cap

### DIFF
--- a/app/_components/mdx/Figure.module.css
+++ b/app/_components/mdx/Figure.module.css
@@ -13,6 +13,13 @@
   width: 100%;
   height: auto;
   max-width: 100%;
+  /* Fill the full content width (the figure carries no width cap of its own),
+     but keep tall/square art from dominating the page: cap the rendered
+     height and let object-fit letterbox against the page background so the
+     image stays centered and its aspect ratio is preserved. Wide art
+     (shorter than the cap at full width) is unaffected. */
+  max-height: 32rem;
+  object-fit: contain;
   margin: 0 auto;
 }
 

--- a/app/_components/mdx/Figure.tsx
+++ b/app/_components/mdx/Figure.tsx
@@ -45,7 +45,11 @@ interface FigureProps {
   alt: string;
   /** Optional caption shown under the image. */
   caption?: string;
-  /** Max display width in px (default 640, matching the inline-SVG heroes). */
+  /**
+   * Optional cap on display width in px. Omitted by default so the figure
+   * fills the full content width; pass a value only to deliberately hold a
+   * single figure narrower than the column.
+   */
   maxWidth?: number;
   /** Eager-load + high fetch priority for an above-the-fold hero. */
   priority?: boolean;
@@ -55,7 +59,7 @@ export function Figure({
   slug,
   alt,
   caption,
-  maxWidth = 640,
+  maxWidth,
   priority = false,
 }: FigureProps) {
   const entry = imageManifest[slug];
@@ -85,7 +89,10 @@ export function Figure({
   const sources = entry.formats.slice(0, -1);
 
   return (
-    <figure className={styles.figure} style={{ maxWidth: `${maxWidth}px` }}>
+    <figure
+      className={styles.figure}
+      style={maxWidth ? { maxWidth: `${maxWidth}px` } : undefined}
+    >
       <picture>
         {sources.map((ext) => (
           <source

--- a/assets/images/README.md
+++ b/assets/images/README.md
@@ -64,6 +64,18 @@ call to match.
 | `line-chart`         | Minimal line chart                      | `courses/time-series-analysis-python` |
 | `data-visualization` | Assortment of charts                    | `courses/mastering-ggplot2` · `interview-prep/data-scientist` |
 | `bi-dashboard`       | Business-intelligence dashboard         | `courses/sql-analytics-duckdb` · `interview-prep/analytics-engineer` |
+| `a-risograph-of-a-blueprint`                  | Architectural blueprint (class as a plan) | `courses/oop-blueprint-java` |
+| `a-risograph-of-a-gardener-stemming`          | Gardener pruning stems                     | `courses/natural-language-processing-python` (`stemming-and-lemmatization`) |
+| `a-risograph-of-a-linked-list-data-structure` | Linked list                                | `courses/mastering-dsa-cpp` (`linked-lists`) |
+| `a-risograph-of-a-pipeline`                   | Data pipeline                              | `interview-prep/data-engineer` (`pipelines`) |
+| `a-risograph-of-a-queue-data-structure`       | Queue (FIFO)                               | `courses/mastering-dsa-cpp` (`queues`) |
+| `a-risograph-of-a-string-data-structure`      | String of characters                       | `courses/python-basics` (`strings`) |
+| `a-risograph-of-a-warehouse`                  | Warehouse (data warehouse)                 | `interview-prep/analytics-engineer` (`dimensional-modeling`) |
+| `a-risograph-of-beautiful-sea`                | Calm sea                                    | `courses/seaborn-foundations` (`visual-storytelling`) |
+| `a-risograph-of-inside-a-data-center`         | Inside a data center                       | `courses/intro-sql-postgres` (`what-is-a-database`) |
+| `a-risograph-of-sorting`                      | Sorting into order                         | `courses/mastering-dsa-cpp` (`sorting-basic`) |
+| `a-risograph-of-the-boolean-data-type`        | Boolean (true / false)                     | `courses/python-basics` (`booleans`) |
+| `a-risograph-of-the-dictionary-data-type`     | Dictionary (key → value)                   | `courses/python-basics` (`dictionaries`) |
 
 To add more, drop `<slug>.<ext>` here and place a `<Figure slug="<slug>" alt="…" />`
 wherever it fits.

--- a/content/courses/intro-sql-postgres/what-is-a-database.mdx
+++ b/content/courses/intro-sql-postgres/what-is-a-database.mdx
@@ -295,6 +295,11 @@ important image in this course — almost everything we do from here
 is *reading* such a grid, *changing* it, or *combining* two of
 them. The next section makes each part of it precise.
 
+<Figure
+  slug="a-risograph-of-inside-a-data-center"
+  alt="A risograph of the inside of a data center, where the servers running a database live"
+/>
+
 ## Where the database hides in an app
 
 One last piece of the picture. When you use an app — a store, a

--- a/content/courses/intro-sql-postgres/what-is-a-database.mdx
+++ b/content/courses/intro-sql-postgres/what-is-a-database.mdx
@@ -11,6 +11,11 @@ every one of them leaned on a database. They are the most invisible
 successful technology in the world, and this page makes them
 visible.
 
+<Figure
+  slug="a-risograph-of-inside-a-data-center"
+  alt="A risograph of the inside of a data center, where the servers running a database live"
+/>
+
 <svg
   viewBox="0 0 640 220"
   role="img"
@@ -294,11 +299,6 @@ The `*` means "every column." That labeled grid is the single most
 important image in this course — almost everything we do from here
 is *reading* such a grid, *changing* it, or *combining* two of
 them. The next section makes each part of it precise.
-
-<Figure
-  slug="a-risograph-of-inside-a-data-center"
-  alt="A risograph of the inside of a data center, where the servers running a database live"
-/>
 
 ## Where the database hides in an app
 

--- a/content/courses/mastering-dsa-cpp/linked-lists.mdx
+++ b/content/courses/mastering-dsa-cpp/linked-lists.mdx
@@ -9,6 +9,11 @@ That is the linked list: values in separate nodes, stitched together by `next` p
 
 The price of this flexibility is the loss of the array's address formula. Nodes are not contiguous, so there is no O(1) random access: to reach the ith node you must walk i links. Linked lists trade arithmetic for navigation.
 
+<Figure
+  slug="a-risograph-of-a-linked-list-data-structure"
+  alt="A risograph of a linked list, its nodes chained one to the next"
+/>
+
 <svg
   viewBox="0 0 640 210"
   role="img"
@@ -296,11 +301,6 @@ int main() {
 <Callout type="warn" title="Pointers are links, not values">
 When you reverse or delete nodes, you are rewiring addresses. Draw the links before changing them; losing the only pointer to a node causes a memory leak.
 </Callout>
-
-<Figure
-  slug="a-risograph-of-a-linked-list-data-structure"
-  alt="A risograph of a linked list, its nodes chained one to the next"
-/>
 
 ## Practice: reverse a linked list
 

--- a/content/courses/mastering-dsa-cpp/linked-lists.mdx
+++ b/content/courses/mastering-dsa-cpp/linked-lists.mdx
@@ -297,6 +297,11 @@ int main() {
 When you reverse or delete nodes, you are rewiring addresses. Draw the links before changing them; losing the only pointer to a node causes a memory leak.
 </Callout>
 
+<Figure
+  slug="a-risograph-of-a-linked-list-data-structure"
+  alt="A risograph of a linked list, its nodes chained one to the next"
+/>
+
 ## Practice: reverse a linked list
 
 Reversing a singly linked list in place is *the* classic pointer exercise — simple to state, unforgiving of sloppy thinking. The standard solution walks the list once with three pointers: `previous` (the already-reversed part), `current` (the node being flipped), and `next` (a bookmark so the rest of the list isn't lost when `current->next` is overwritten). Trace it by hand on `1->2->3->4` before you code: after one step, `previous` is `1`, `current` is `2`, and `1->next` is null.

--- a/content/courses/mastering-dsa-cpp/queues.mdx
+++ b/content/courses/mastering-dsa-cpp/queues.mdx
@@ -209,6 +209,11 @@ int main() {
   ]}
 />
 
+<Figure
+  slug="a-risograph-of-a-queue-data-structure"
+  alt="A risograph of a queue, items lined up and served first-in, first-out"
+/>
+
 ## Breadth-first flavor
 
 Here is a preview of the queue's biggest job, three chapters early. Breadth-first search explores a graph in waves: visit a node, enqueue its neighbors, and keep serving the queue in arrival order — so everything one hop away is processed before anything two hops away. The miniature below traverses a four-node graph (it is tree-shaped, so no visited-tracking is needed yet; real graphs with cycles will demand one, as the graph chapter explains).

--- a/content/courses/mastering-dsa-cpp/queues.mdx
+++ b/content/courses/mastering-dsa-cpp/queues.mdx
@@ -7,6 +7,11 @@ Flip the stack's rule and you get its mirror twin. A queue is **first in, first 
 
 Queues were studied mathematically before computers existed to hold them: in 1909 the Danish engineer A. K. Erlang, working for the Copenhagen Telephone Company, founded queueing theory to answer how many circuits a telephone exchange needs before callers start hearing busy signals. The unit of telecom traffic load is still called the *erlang*. Software queues inherit the same questions — how fast must the consumer drain the line to keep the producer from backing up? — which is why the producer-consumer pattern below appears in every messaging system ever built.
 
+<Figure
+  slug="a-risograph-of-a-queue-data-structure"
+  alt="A risograph of a queue, items lined up and served first-in, first-out"
+/>
+
 <svg
   viewBox="0 0 640 190"
   role="img"
@@ -207,11 +212,6 @@ int main() {
 `,
     },
   ]}
-/>
-
-<Figure
-  slug="a-risograph-of-a-queue-data-structure"
-  alt="A risograph of a queue, items lined up and served first-in, first-out"
 />
 
 ## Breadth-first flavor

--- a/content/courses/mastering-dsa-cpp/sorting-basic.mdx
+++ b/content/courses/mastering-dsa-cpp/sorting-basic.mdx
@@ -6,6 +6,11 @@ Sorting is the gateway drug of algorithm design. Binary search demands sorted in
 
 This page covers the three classic "slow" sorts: bubble, selection, and insertion. None is the right tool for a million elements — all are O(n²) in the worst case — so why learn them? Three honest reasons. They are small enough to *fully* understand, which makes them ideal for learning loop invariants, the reasoning tool behind every correct algorithm. One of them (insertion sort) is genuinely the fastest known method for tiny or nearly-sorted inputs, and lives on inside the hybrid sorts of every standard library. And they give the efficient sorts of the next page something to be measured against.
 
+<Figure
+  slug="a-risograph-of-sorting"
+  alt="A risograph of items being arranged into sorted order"
+/>
+
 <svg
   viewBox="0 0 640 200"
   role="img"
@@ -163,11 +168,6 @@ Insertion sort is O(n²) in the worst case (input sorted backward — every elem
 <Callout type="success" title="Stability">
 A stable sort keeps equal elements in their original relative order. Why care? Suppose you sort emails by date, then by sender: with a stable sort, each sender's messages stay date-ordered — the second sort preserves the first one's work on ties. Insertion sort is stable because it shifts only values *strictly greater* than the key. Selection sort is not stable in its typical swap-based form: the long-range swap can leapfrog one equal element over another.
 </Callout>
-
-<Figure
-  slug="a-risograph-of-sorting"
-  alt="A risograph of items being arranged into sorted order"
-/>
 
 ## Comparing basic sorts
 

--- a/content/courses/mastering-dsa-cpp/sorting-basic.mdx
+++ b/content/courses/mastering-dsa-cpp/sorting-basic.mdx
@@ -164,6 +164,11 @@ Insertion sort is O(n²) in the worst case (input sorted backward — every elem
 A stable sort keeps equal elements in their original relative order. Why care? Suppose you sort emails by date, then by sender: with a stable sort, each sender's messages stay date-ordered — the second sort preserves the first one's work on ties. Insertion sort is stable because it shifts only values *strictly greater* than the key. Selection sort is not stable in its typical swap-based form: the long-range swap can leapfrog one equal element over another.
 </Callout>
 
+<Figure
+  slug="a-risograph-of-sorting"
+  alt="A risograph of items being arranged into sorted order"
+/>
+
 ## Comparing basic sorts
 
 | Algorithm | Best | Average | Worst | Extra space | Stable? |

--- a/content/courses/natural-language-processing-python/stemming-and-lemmatization.mdx
+++ b/content/courses/natural-language-processing-python/stemming-and-lemmatization.mdx
@@ -293,6 +293,11 @@ unchanged, while \`lemmatize("running", pos="v")\` returns "run"?
 The default-noun behavior trips up nearly everyone the first time; the fix is to pass the correct POS.`}
 />
 
+<Figure
+  slug="a-risograph-of-a-gardener-stemming"
+  alt="A risograph of a gardener pruning stems, echoing how stemming trims words down to their root"
+/>
+
 ## When to use which
 
 ```mermaid

--- a/content/courses/natural-language-processing-python/stemming-and-lemmatization.mdx
+++ b/content/courses/natural-language-processing-python/stemming-and-lemmatization.mdx
@@ -14,6 +14,11 @@ There are two classic techniques for that collapse, and the difference
 between them — in mechanism, in output, and in when to use them — is one of
 the most clarifying things you can learn in NLP.
 
+<Figure
+  slug="a-risograph-of-a-gardener-stemming"
+  alt="A risograph of a gardener pruning stems, echoing how stemming trims words down to their root"
+/>
+
 <svg
   viewBox="0 0 640 210"
   role="img"
@@ -291,11 +296,6 @@ unchanged, while \`lemmatize("running", pos="v")\` returns "run"?
   > "Running" and "run" are different grammatical forms of the same verb; the lemmatizer correctly links them once told the word is a verb by passing \`pos="v"\`.
 
 The default-noun behavior trips up nearly everyone the first time; the fix is to pass the correct POS.`}
-/>
-
-<Figure
-  slug="a-risograph-of-a-gardener-stemming"
-  alt="A risograph of a gardener pruning stems, echoing how stemming trims words down to their root"
 />
 
 ## When to use which

--- a/content/courses/oop-blueprint-java/index.mdx
+++ b/content/courses/oop-blueprint-java/index.mdx
@@ -17,6 +17,12 @@ real-world problem — a library, a hospital ward, a vending machine, a
 ride-share system — and **decompose it into a small society of
 collaborating objects**.
 
+<Figure
+  slug="a-risograph-of-a-blueprint"
+  alt="A risograph-style architectural blueprint — a class is the plan you build objects from"
+  priority
+/>
+
 ## Try it right now
 
 This whole course runs in your browser — every page has live,

--- a/content/courses/python-basics/booleans.mdx
+++ b/content/courses/python-basics/booleans.mdx
@@ -199,6 +199,11 @@ print(x is None)  # the idiomatic check
 
 For singletons like `None`, `True`, `False`, always use `is`.
 
+<Figure
+  slug="a-risograph-of-the-boolean-data-type"
+  alt="A risograph of the boolean data type, evoking a simple true-or-false switch"
+/>
+
 ## Truthiness
 
 Any object can be tested in a boolean context (e.g., `if`, `while`, `and`, `or`). Python's rules:

--- a/content/courses/python-basics/booleans.mdx
+++ b/content/courses/python-basics/booleans.mdx
@@ -7,6 +7,11 @@ description: True and False, truthiness, comparison, and the and / or / not oper
 
 Every snippet on this page runs in your browser—no setup required.
 
+<Figure
+  slug="a-risograph-of-the-boolean-data-type"
+  alt="A risograph of the boolean data type, evoking a simple true-or-false switch"
+/>
+
 <svg
   viewBox="0 0 640 210"
   role="img"
@@ -198,11 +203,6 @@ print(x is None)  # the idiomatic check
 />
 
 For singletons like `None`, `True`, `False`, always use `is`.
-
-<Figure
-  slug="a-risograph-of-the-boolean-data-type"
-  alt="A risograph of the boolean data type, evoking a simple true-or-false switch"
-/>
 
 ## Truthiness
 

--- a/content/courses/python-basics/dictionaries.mdx
+++ b/content/courses/python-basics/dictionaries.mdx
@@ -273,6 +273,11 @@ print("person:", person)
   ]}
 />
 
+<Figure
+  slug="a-risograph-of-the-dictionary-data-type"
+  alt="A risograph of the dictionary data type, mapping keys to their values"
+/>
+
 ## Iterating
 
 By default, iteration yields keys.

--- a/content/courses/python-basics/dictionaries.mdx
+++ b/content/courses/python-basics/dictionaries.mdx
@@ -7,6 +7,11 @@ A `dict` maps **keys** to **values**. Lookups, insertions, and deletions are all
 
 Every snippet on this page runs in your browser — no setup required.
 
+<Figure
+  slug="a-risograph-of-the-dictionary-data-type"
+  alt="A risograph of the dictionary data type, mapping keys to their values"
+/>
+
 <svg
   viewBox="0 0 640 230"
   role="img"
@@ -271,11 +276,6 @@ print("person:", person)
 `,
     },
   ]}
-/>
-
-<Figure
-  slug="a-risograph-of-the-dictionary-data-type"
-  alt="A risograph of the dictionary data type, mapping keys to their values"
 />
 
 ## Iterating

--- a/content/courses/python-basics/strings.mdx
+++ b/content/courses/python-basics/strings.mdx
@@ -7,6 +7,11 @@ A `str` in Python 3 is an immutable sequence of Unicode code points. Strings are
 
 Every snippet on this page runs in your browser—no setup required.
 
+<Figure
+  slug="a-risograph-of-a-string-data-structure"
+  alt="A risograph of a string as a sequence of characters threaded in order"
+/>
+
 <svg
   viewBox="0 0 640 210"
   role="img"
@@ -289,11 +294,6 @@ result = "".join(parts)
 
 `str.join()` is the idiomatic way to build a string from many pieces.
 </Callout>
-
-<Figure
-  slug="a-risograph-of-a-string-data-structure"
-  alt="A risograph of a string as a sequence of characters threaded in order"
-/>
 
 ## Common methods
 

--- a/content/courses/python-basics/strings.mdx
+++ b/content/courses/python-basics/strings.mdx
@@ -290,6 +290,11 @@ result = "".join(parts)
 `str.join()` is the idiomatic way to build a string from many pieces.
 </Callout>
 
+<Figure
+  slug="a-risograph-of-a-string-data-structure"
+  alt="A risograph of a string as a sequence of characters threaded in order"
+/>
+
 ## Common methods
 
 A selection of methods you'll use constantly:

--- a/content/courses/seaborn-foundations/visual-storytelling.mdx
+++ b/content/courses/seaborn-foundations/visual-storytelling.mdx
@@ -276,6 +276,11 @@ An explanatory title states the *message*; if it could sit on any dataset's
 chart, it is only naming axes.`}
 />
 
+<Figure
+  slug="a-risograph-of-beautiful-sea"
+  alt="A risograph of a calm, beautiful sea — a reminder that a good explanatory chart should feel effortless to read"
+/>
+
 ## A worked example: one clean explanatory figure
 
 Let's build a single explanatory figure end to end. The message: **heavier

--- a/content/courses/seaborn-foundations/visual-storytelling.mdx
+++ b/content/courses/seaborn-foundations/visual-storytelling.mdx
@@ -16,6 +16,11 @@ should take away,"* and you draw them for an audience that will give you a
 few seconds of attention. The data work is the same; the *editing* is
 different.
 
+<Figure
+  slug="a-risograph-of-beautiful-sea"
+  alt="A risograph of a calm, beautiful sea — a reminder that a good explanatory chart should feel effortless to read"
+/>
+
 <svg
   viewBox="0 0 640 230"
   role="img"
@@ -274,11 +279,6 @@ single takeaway to an audience?
 
 An explanatory title states the *message*; if it could sit on any dataset's
 chart, it is only naming axes.`}
-/>
-
-<Figure
-  slug="a-risograph-of-beautiful-sea"
-  alt="A risograph of a calm, beautiful sea — a reminder that a good explanatory chart should feel effortless to read"
 />
 
 ## A worked example: one clean explanatory figure

--- a/content/interview/analytics-engineer/dimensional-modeling.mdx
+++ b/content/interview/analytics-engineer/dimensional-modeling.mdx
@@ -8,6 +8,11 @@ well-grained dimensional models. Review the Q&A, then build a mart.
 
 > **SQL dialect:** the runnable challenge on this page executes in your browser on **DuckDB**, so the SQL below targets DuckDB. It is standard SQL except where noted.
 
+<Figure
+  slug="a-risograph-of-a-warehouse"
+  alt="A risograph of a warehouse — a nod to the data warehouse a dimensional model feeds"
+/>
+
 ## Q&A
 
 ### What are fact and dimension tables?

--- a/content/interview/data-engineer/pipelines.mdx
+++ b/content/interview/data-engineer/pipelines.mdx
@@ -7,6 +7,11 @@ The systems half of a Data Engineer interview: moving data reliably and
 cheaply at scale. These are the recurring "how would you build it?"
 themes.
 
+<Figure
+  slug="a-risograph-of-a-pipeline"
+  alt="A risograph of a data pipeline carrying data from source to destination"
+/>
+
 ## Q&A
 
 ### Batch vs streaming — how do you choose?


### PR DESCRIPTION
## What & why

Three related changes to the raster-image (`<Figure>`) pipeline.

### A1 — Place the twelve new `a-risograph-of-*` images

Each new source is wired into the page whose content it illustrates. Where a lesson already carries a bespoke inline-SVG diagram of the same concept, the raster figure is placed **directly above that SVG** so the two render side by side — either can be kept and the other removed later. On pages with no existing visual, the figure simply leads the page.

| Image | Page | Placement |
| --- | --- | --- |
| `a-risograph-of-a-blueprint` | `courses/oop-blueprint-java` | index lead (a class is a blueprint) |
| `a-risograph-of-a-gardener-stemming` | `courses/natural-language-processing-python` | `stemming-and-lemmatization` — beside the stemming SVG |
| `a-risograph-of-a-linked-list-data-structure` | `courses/mastering-dsa-cpp` | `linked-lists` — beside the linked-list SVG |
| `a-risograph-of-a-pipeline` | `interview-prep/data-engineer` | `pipelines` (lead) |
| `a-risograph-of-a-queue-data-structure` | `courses/mastering-dsa-cpp` | `queues` — beside the queue SVG |
| `a-risograph-of-a-string-data-structure` | `courses/python-basics` | `strings` — beside the string-slicing SVG |
| `a-risograph-of-a-warehouse` | `interview-prep/analytics-engineer` | `dimensional-modeling` (lead) |
| `a-risograph-of-beautiful-sea` | `courses/seaborn-foundations` | `visual-storytelling` — beside the storytelling SVG |
| `a-risograph-of-inside-a-data-center` | `courses/intro-sql-postgres` | `what-is-a-database` — beside the top SVG |
| `a-risograph-of-sorting` | `courses/mastering-dsa-cpp` | `sorting-basic` — beside the sorting SVG |
| `a-risograph-of-the-boolean-data-type` | `courses/python-basics` | `booleans` — beside the boolean SVG |
| `a-risograph-of-the-dictionary-data-type` | `courses/python-basics` | `dictionaries` — beside the dictionary SVG |

The nine concept images sit adjacent to their matching topic SVG; the three on SVG-less pages (blueprint, pipeline, warehouse) lead their pages. The optimized outputs and manifest for these slugs were already committed, so this PR only adds the `<Figure>` placements and documents them in `assets/images/README.md`. Every image in `assets/images` is now placed.

### A3 — Figures fill the full horizontal space

Dropped the default `640px` max-width the `<figure>` carried, so figures now span the full content column. `maxWidth` remains as an **optional** per-figure override for anyone who deliberately wants a narrower figure.

### A2 — Cap figure height

Now that figures span the full width, tall/square art would otherwise become very tall. Added `max-height: 32rem` + `object-fit: contain` on the image, so tall art is height-capped and centered with its aspect ratio preserved, while wide art (shorter than the cap at full width) fills the width untouched.

## Verification

- `__tests__/figureSlugs.test.ts` — passes (every placement references a known slug and has alt text).
- `tsc --noEmit` and `eslint` — clean.
- `fumadocs-mdx` compiles all edited MDX without error.
- `build:images` is a no-op (`28 cached, 0 encoded`) — no manifest drift.
- Rendered the exact `.figure`/`.img` CSS against real images in Chromium and measured the boxes: a 3:1 image fills the full 740px column (247px tall, uncapped); 1:1 and 0.7 images are height-capped at 512px, centered, undistorted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUC8MmXw8PAAqQvpwdVS8g