### PR TITLE
Make R2 cache cleanup resilient to transient DeleteObject errors

### DIFF
--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -88,6 +88,13 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
       AWS_EC2_METADATA_DISABLED: "true"
+      # R2 intermittently returns a transient 500 InternalError on DeleteObject.
+      # The CLI's default (legacy) retry gives up after ~2 tries; switch to the
+      # standard retry mode and raise the attempt count so a burst of transient
+      # errors is absorbed inside a single `aws s3 rm` before the per-folder
+      # retry loop (see delete_folder) even has to intervene.
+      AWS_RETRY_MODE: standard
+      AWS_MAX_ATTEMPTS: "10"
       ENDPOINT: https://${{ secrets.CF_ACCOUNT_ID }}.r2.cloudflarestorage.com
     steps:
       - name: Prune stale build folders
@@ -95,6 +102,24 @@ jobs:
         run: |
           set -euo pipefail
           aws() { command aws --endpoint-url "$ENDPOINT" "$@"; }
+
+          # Delete a folder, tolerating R2's intermittent 500 InternalError on
+          # DeleteObject. `aws s3 rm --recursive` re-lists the folder on every
+          # invocation and only deletes what is still present, so repeated
+          # attempts converge on an empty folder. Returns non-zero only if the
+          # folder still has objects after every attempt (a persistent, not
+          # transient, failure) — so one flaky delete no longer aborts the run.
+          delete_folder() {
+            local folder="$1" attempt
+            for attempt in 1 2 3 4 5; do
+              if aws s3 rm "s3://${BUCKET}/${folder}" --recursive --only-show-errors; then
+                return 0
+              fi
+              echo "  delete attempt ${attempt}/5 for $folder hit transient R2 errors; retrying in $((attempt * 5))s"
+              sleep $((attempt * 5))
+            done
+            return 1
+          }
 
           # 1) Ask the live production Worker which build it is serving from.
           prod_id="$(curl -fsS --max-time 30 "$BUILD_ID_URL" || true)"
@@ -171,7 +196,7 @@ jobs:
           done
 
           echo "KEEP  $prod_folder (live production)"
-          kept=1; deleted=0; branches=0
+          kept=1; deleted=0; failed=0; branches=0
           while IFS=$'\t' read -r ts newest folder; do
             [[ -z "$folder" ]] && continue
             # Folder name is the commit SHA: strip the prefix and trailing slash.
@@ -192,10 +217,17 @@ jobs:
               echo "DELETE $folder (last written $newest, not the head of any open PR — merged, closed, or superseded)"
             fi
 
-            if [[ "$DRY_RUN" != "true" ]]; then
-              aws s3 rm "s3://${BUCKET}/${folder}" --recursive --only-show-errors
+            if [[ "$DRY_RUN" == "true" ]]; then
+              deleted=$((deleted+1))
+            elif delete_folder "$folder"; then
+              deleted=$((deleted+1))
+            else
+              # Persistent (non-transient) failure: log it, keep sweeping the
+              # rest, and fail the job at the end so it's surfaced. The next
+              # scheduled run retries this folder from scratch.
+              echo "::error::Could not fully delete $folder after 5 attempts (persistent R2 errors)."
+              failed=$((failed+1))
             fi
-            deleted=$((deleted+1))
           done < <(printf '%s\n' ${entries[@]+"${entries[@]}"} | sort -rn)
 
           echo "---"
@@ -205,5 +237,12 @@ jobs:
           if [[ "$DRY_RUN" == "true" ]]; then
             echo "Folders kept: $kept | folders would be deleted: $deleted"
           else
-            echo "Folders kept: $kept | folders deleted: $deleted"
+            echo "Folders kept: $kept | folders deleted: $deleted | folders failed: $failed"
+          fi
+
+          # Surface persistent delete failures loudly, but only after every
+          # folder has been attempted — a later run will retry the stragglers.
+          if (( failed > 0 )); then
+            echo "::error::${failed} folder(s) could not be fully deleted after retries; the next scheduled run will retry them."
+            exit 1
           fi


### PR DESCRIPTION
## Problem

The **R2 incremental-cache cleanup** workflow fails intermittently with:

```
delete failed: s3://dataslope-inc-cache/incremental-cache/<sha>/<hash>.cache
  An error occurred (InternalError) when calling the DeleteObject operation
  (reached max retries: 2): We encountered an internal error. Please try again.
Error: Process completed with exit code 1.
```

R2 occasionally returns a transient **500 `InternalError`** on `DeleteObject`. The AWS CLI's default (legacy) retry gives up after ~2 attempts, so `aws s3 rm` exits non-zero. Because the step runs under `set -euo pipefail`, that single flaky delete aborted the **entire** cleanup job — even though the error is transient and a retry would have succeeded. Stale build folders then pile up in the bucket until a run happens to get lucky.

## Fix

Two layers of resilience, both scoped to `.github/workflows/r2-cache-cleanup.yml`:

1. **Harder in-CLI retries** — set `AWS_RETRY_MODE=standard` and `AWS_MAX_ATTEMPTS=10` so a burst of transient errors is absorbed inside a single `aws s3 rm` invocation before anything else has to intervene.

2. **Per-folder retry loop** — a new `delete_folder` helper retries a folder's deletion up to 5 times with linear backoff. Since `aws s3 rm --recursive` re-lists the folder on every invocation and only removes what's still present, repeated attempts converge on an empty folder. A folder that *still* fails after all attempts is treated as a persistent (not transient) error: it's logged, the sweep **continues to the remaining folders**, and the job exits non-zero at the end so the failure is surfaced. The next scheduled run retries it from scratch.

The summary line now also reports `folders failed: N` on real runs.

## Behavior preserved

- Dry-run accounting, the keep/delete policy, and all existing safety aborts (unreadable production build ID, missing production folder, PR-list API failure) are unchanged.
- The job still fails loudly on a genuinely stuck folder — it just no longer lets one transient hiccup abort cleanup of everything else.

## Testing

- `python3` YAML parse of the workflow + `bash -n` on the extracted `run` script — both pass.
- Simulated `delete_folder` against a mock `aws` that fails N times then succeeds: transient failures converge after retries; a persistently-failing folder increments the failure counter, the loop continues, and the job exits 1 at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRMmwgJb46saT1rqAzdLUW

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRMmwgJb46saT1rqAzdLUW)_