### PR TITLE
Fix R2 cache cleanup crash when no PRs are open

### DIFF
--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -147,7 +147,11 @@ jobs:
             [[ -z "$sha" ]] && continue
             pr_branch["$sha"]="$branch (PR #$num)"
           done < <(printf '%s' "$pr_json" | jq -r '.[] | [.headRefOid, .headRefName, (.number|tostring)] | @tsv')
-          echo "Open PRs (active branches): ${#pr_branch[@]}"
+          # `${#assoc[@]}` on an EMPTY associative array trips `set -u`
+          # ("unbound variable") — bash treats a zero-element associative array
+          # as unset. Expanding its keys is safe when empty, so count those.
+          pr_shas=("${!pr_branch[@]}")
+          echo "Open PRs (active branches): ${#pr_shas[@]}"
 
           # 3) Enumerate the build folders in the bucket.
           mapfile -t folders < <(


### PR DESCRIPTION
## Problem

The **R2 incremental-cache cleanup** workflow failed in run #19 with:

```
Run set -euo pipefail
Live production build: cf028e8b78761b69d99d582f80a95c5ae7f78dc7
/home/runner/work/_temp/….sh: line 48: pr_branch: unbound variable
Error: Process completed with exit code 1.
```

## Root cause

The cleanup step runs under `set -euo pipefail`. It builds an associative array mapping each open PR's head commit to its branch:

```bash
declare -A pr_branch
while IFS=$'\t' read -r sha branch num; do
  [[ -z "$sha" ]] && continue
  pr_branch["$sha"]="$branch (PR #$num)"
done < <(printf '%s' "$pr_json" | jq -r '…')
echo "Open PRs (active branches): ${#pr_branch[@]}"   # line 48 of the step
```

When the repo has **zero open pull requests**, the loop never assigns a key, so `pr_branch` stays empty. Bash treats a zero-element *associative* array as **unset** (unlike indexed arrays), so `${#pr_branch[@]}` trips `-u` and aborts the job. I reproduced this on bash 5.2 — it is not version-specific.

That matches run #19: the log shows it read the production build ID and the `gh pr list` call succeeded, then died at the count line because no PRs were open. The safety design means the job aborted *before* deleting anything, so no cache was lost — but the workflow reports a red failure on every run with no open PRs.

## Fix

Count the array's keys via `"${!pr_branch[@]}"`, which expands safely to nothing when the array is empty, instead of `${#pr_branch[@]}`:

```bash
pr_shas=("${!pr_branch[@]}")
echo "Open PRs (active branches): ${#pr_shas[@]}"
```

The later `${pr_branch[$sha]+set}` lookups already use the alternate-value form and tolerate `set -u`, and the bare `${pr_branch[$sha]}` reads only run inside the branch where the key is known to exist — so no other line needed changing.

## Verification

- Reproduced the original `pr_branch: unbound variable` crash under `set -euo pipefail` with an empty associative array.
- Simulated the PR-mapping + count block with the fix applied for both **no open PRs** (exit 0, prints `Open PRs (active branches): 0`) and **multiple open PRs** (exit 0, correct count and lookups).
- Confirmed the workflow YAML still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEtEGajLJYANwkyb4cMQTK)_