### PR TITLE
Fix light/dark mismatch between Fumadocs and non-Fumadocs pages

### DIFF
--- a/app/courses/[...slug]/layout.tsx
+++ b/app/courses/[...slug]/layout.tsx
@@ -28,7 +28,13 @@ export default function CourseLessonLayout({
   children: ReactNode;
 }) {
   return (
-    <RootProvider>
+    // Override next-themes' defaults (defaultTheme "system", enableSystem) to
+    // match the rest of the site: the non-Fumadocs pages' bootstrap scripts
+    // and the shared pill toggle (siteTheme.ts) treat the `theme` key as a
+    // binary "light" | "dark" with a light default, so without this a dark-OS
+    // visitor with no stored choice would get dark docs but light pages
+    // everywhere else.
+    <RootProvider theme={{ defaultTheme: "light", enableSystem: false }}>
       <DocsLayout
         tree={courseSource.pageTree}
         tabs={false}

--- a/app/fumadocs-dev/layout.tsx
+++ b/app/fumadocs-dev/layout.tsx
@@ -25,7 +25,9 @@ export default function FumadocsDevLayout({
   children: ReactNode;
 }) {
   return (
-    <RootProvider>
+    // Match the site-wide binary light/dark contract (light default); see the
+    // note in app/courses/[...slug]/layout.tsx.
+    <RootProvider theme={{ defaultTheme: "light", enableSystem: false }}>
       <DocsLayout
         tree={devSource.pageTree}
         tabs={false}

--- a/app/interview-prep/[...slug]/layout.tsx
+++ b/app/interview-prep/[...slug]/layout.tsx
@@ -25,7 +25,9 @@ import { ThemePillToggleSlot } from "@/app/_components/ThemePillToggle";
 
 export default function InterviewLayout({ children }: { children: ReactNode }) {
   return (
-    <RootProvider>
+    // Match the site-wide binary light/dark contract (light default); see the
+    // note in app/courses/[...slug]/layout.tsx.
+    <RootProvider theme={{ defaultTheme: "light", enableSystem: false }}>
       <DocsLayout
         tree={interviewSource.pageTree}
         tabs={false}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,18 +60,33 @@ export const metadata: Metadata = {
   },
 };
 
-// Runs before React hydrates. On /playground routes it applies the SITE
-// light/dark choice (the shared `theme` localStorage key + `.dark`/`.light`
-// class, the same one /learn and the home page use) to the playground's CSS
-// custom properties + `data-playground-theme`, so the chrome never paints in
-// the wrong palette before the React app (and usePlaygroundThemeSync) takes
-// over. The two GitHub palettes mirror THEME_PALETTES in playgroundTheme.ts.
+// Runs before React hydrates, on EVERY route.
+//
+// First it normalizes the shared `localStorage["theme"]` key to the site's
+// binary contract ("light" | "dark"): any other value (e.g. a legacy
+// "system" written by Fumadocs's default theme switch before it was replaced
+// by the shared pill toggle) is removed, so both the non-Fumadocs bootstrap
+// scripts (which treat non-"dark" as light) and next-themes on the Fumadocs
+// routes (configured with defaultTheme "light", enableSystem false) resolve
+// a missing value to the same light default instead of diverging.
+//
+// Then, on /playground routes only, it applies the site light/dark choice to
+// the playground's CSS custom properties + `data-playground-theme`, so the
+// chrome never paints in the wrong palette before the React app (and
+// usePlaygroundThemeSync) takes over. The two GitHub palettes mirror
+// THEME_PALETTES in playgroundTheme.ts.
 const themeBootstrapScript = `
 (function () {
   try {
-    if (location.pathname.indexOf("/playground") !== 0) return;
     var stored = null;
-    try { stored = localStorage.getItem("theme"); } catch (e) {}
+    try {
+      stored = localStorage.getItem("theme");
+      if (stored !== null && stored !== "dark" && stored !== "light") {
+        localStorage.removeItem("theme");
+        stored = null;
+      }
+    } catch (e) {}
+    if (location.pathname.indexOf("/playground") !== 0) return;
     var dark = stored === "dark" ||
       (stored !== "light" && document.documentElement.classList.contains("dark"));
     var p = dark


### PR DESCRIPTION
## Problem

The dark/light appearance sometimes diverged between the Fumadocs routes (`/courses/...`, `/interview-prep/...`, `/fumadocs-dev`) and every other page.

Root cause: the three Fumadocs layouts rendered `RootProvider` with no `theme` config, so next-themes ran on its defaults — `defaultTheme: "system"`, `enableSystem: true`. The rest of the site (home, pricing, playgrounds, auth, legal, share pages) uses pre-hydration bootstrap scripts and `siteTheme.ts`, which treat the shared `localStorage["theme"]` key as a strict binary with a **light** default (anything other than stored `"dark"` renders light).

So a visitor with a dark OS preference and no stored choice got **dark docs pages but light everything else**. A legacy stored `"system"` value (writable by Fumadocs's default theme switch before it was replaced by the shared pill toggle) caused the same permanent split.

## Fix

- Pass `theme={{ defaultTheme: "light", enableSystem: false }}` to all three `RootProvider` layouts so the Fumadocs routes follow the same binary light-default contract as the rest of the site.
- Extend the root layout's pre-hydration script to run on **every** route and normalize `localStorage["theme"]` first: any value other than `"light"`/`"dark"` (e.g. a legacy `"system"`) is removed before next-themes' inline script reads it, so both worlds resolve a missing value to the same light default. (With `enableSystem: false`, an un-normalized `"system"` would have made next-themes strip the `light`/`dark` classes and apply a useless `system` class.)

## Verification

Drove the dev server with Playwright under an emulated dark OS (`prefers-color-scheme: dark`), comparing `<html>` class / `color-scheme` / storage across `/`, `/pricing`, and a `/courses` lesson:

- **Before:** fresh visitor → course page `class=["dark"]`, home/pricing `class=["light"]` (the reported mismatch).
- **After:** fresh visitor → all three `class=["light"]`; legacy stored `"system"` and garbage values normalize to light everywhere; stored `"dark"` renders dark everywhere; toggling the pill on a course page persists (`stored=dark`) and the home page honors it on the next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2W2cmDahMVLXhtQDgmGkX

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2W2cmDahMVLXhtQDgmGkX)_