### PR TITLE
Declutter playground headers and simplify output panes

### DIFF
--- a/app/_components/ChallengeCard.module.css
+++ b/app/_components/ChallengeCard.module.css
@@ -1398,16 +1398,19 @@
 .outputHeader {
   display: flex;
   align-items: center;
-  padding: 16px 14px 8px 14px;
+  padding: 10px 14px 6px 14px;
   border-top: 1px solid var(--ch-border-light);
 }
 
+/* Slim accent marker next to the OUTPUT label. Deliberately small (3×11)
+   so the output panel reads as a flat block rather than a heavily framed
+   card; error state flips it red via `[data-error]`. */
 .accentBar {
-  width: 4px;
-  height: 20px;
+  width: 3px;
+  height: 11px;
   background: var(--ds-blue-500);
   border-radius: 2px;
-  margin-right: 10px;
+  margin-right: 8px;
   flex-shrink: 0;
 }
 
@@ -1442,7 +1445,7 @@
 }
 
 .outputBody {
-  padding: 10px 14px 14px 18px;
+  padding: 4px 14px 14px 14px;
   font-family: var(--ch-font-mono);
   font-size: 13.5px;
   line-height: 1.8;
@@ -1451,7 +1454,7 @@
   word-break: break-word;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   max-height: 360px;
   overflow-y: auto;
   scrollbar-width: thin;

--- a/app/_components/CodeBlock.module.css
+++ b/app/_components/CodeBlock.module.css
@@ -93,7 +93,7 @@
    itself (loader, staged copy, progress bar) is the self-contained
    <RuntimeBootNotice> component; this wrapper only supplies the inset. */
 .bootNoticeWrap {
-  padding: 14px 14px 14px 18px;
+  padding: 14px 14px 14px 14px;
 }
 
 /* The running state now shows a centered brand spinner instead of a

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -84,6 +84,8 @@ import {
   Terminal,
   FolderTree,
   ChevronDown,
+  ChevronRight,
+  MoreHorizontal,
   X,
 } from "lucide-react";
 import { FaInfo } from "react-icons/fa";
@@ -142,7 +144,7 @@ import {
   markWorkspaceDirty,
   saveDraftWorkspace,
 } from "./opfs/activeWorkspace";
-import { acquireWorkspaceLock } from "./opfs/workspace";
+import { acquireWorkspaceLock, renameWorkspace } from "./opfs/workspace";
 import { WorkspaceBadge } from "./workspace/WorkspaceBadge";
 import { ShareControls } from "./cloud/ShareControls";
 import { applyEntryFocus } from "./playgroundEntryFocus";
@@ -842,6 +844,19 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       }
     },
     [adapter.id, setWorkspace],
+  );
+
+  // Inline rename from the header badge. Update the visible name right away
+  // (store), then persist to the registry — `renameWorkspace` no-ops on an
+  // unsaved draft, whose name still lives in the store until it's saved.
+  const handleRenameWorkspace = useCallback(
+    async (name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed || !workspaceId) return;
+      setWorkspace(workspaceId, trimmed);
+      await renameWorkspace(workspaceId, trimmed);
+    },
+    [workspaceId, setWorkspace],
   );
 
   // ─── Cloud saves + sharing ──────────────────────────────────────────────
@@ -3811,74 +3826,16 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
               onManagerOpenChange={setWorkspaceManagerOpen}
               unsaved={!workspaceSaved && workspaceDirty}
               onSave={handleSaveWorkspace}
+              onRename={handleRenameWorkspace}
               buildBundle={buildCloudBundle}
             />
           )}
 
           {/* Desktop action group, hidden on narrow viewports in favour
-              of the consolidated mobile menu below. */}
+              of the consolidated mobile menu below. Share stays a
+              first-class button; everything secondary folds into one ⋯
+              menu (Examples, Packages, Export, Runtime info, Settings). */}
           <div className="header-actions desktop-only">
-            <Menu.Root>
-              <Menu.Trigger
-                className="header-btn"
-                title="Examples"
-                aria-label="Examples"
-              >
-                <Library size={14} aria-hidden="true" />
-                <span className="btn-label">Examples</span>
-              </Menu.Trigger>
-              <Menu.Portal>
-                <Menu.Positioner sideOffset={6} align="start" className="playground-header-positioner">
-                  <Menu.Popup className="bui-popup examples-dropdown">
-                    {adapter.examples.map((ex) => (
-                      <Menu.Item
-                        key={ex.key}
-                        className="example-item"
-                        onClick={() => requestExample(ex)}
-                      >
-                        <div className="ex-title">{ex.title}</div>
-                        <div className="ex-desc">{ex.desc}</div>
-                      </Menu.Item>
-                    ))}
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>
-
-            <Menu.Root>
-              <Menu.Trigger
-                className="header-btn"
-                title="Export code"
-                aria-label="Export code"
-              >
-                <ArrowDownToLine size={14} aria-hidden="true" />
-                <span className="btn-label">Export</span>
-              </Menu.Trigger>
-              <Menu.Portal>
-                <Menu.Positioner sideOffset={6} align="start" className="playground-header-positioner">
-                  <Menu.Popup className="bui-popup examples-dropdown export-dropdown">
-                    {adapter.exportFormats.map((fmt) => (
-                      <Menu.Item
-                        key={fmt.extension}
-                        className="example-item export-item"
-                        onClick={() => exportCode(fmt)}
-                      >
-                        <div className="export-item-text">
-                          <div className="ex-title">
-                            {fmt.label}
-                            <span className="ext-badge">.{fmt.extension}</span>
-                          </div>
-                          <div className="ex-desc">
-                            Download as .{fmt.extension}
-                          </div>
-                        </div>
-                      </Menu.Item>
-                    ))}
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>
-
             <ShareControls
               workspaceName={workspaceName}
               buildBundle={buildCloudBundle}
@@ -3886,47 +3843,128 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
               onShareOpenChange={setShareDialogOpen}
             />
 
-            {adapter.packages.length > 0 && (
-              <button
-                type="button"
-                className="header-btn"
-                onClick={() => setPackagesOpen(true)}
-                title="Available packages"
-                aria-label="Available packages"
-              >
-                <Package size={14} aria-hidden="true" />
-                <span className="btn-label">Packages</span>
-              </button>
-            )}
-
-            <Popover.Root>
-              <Popover.Trigger
+            <Menu.Root>
+              <Menu.Trigger
                 className="header-btn icon-only"
-                title="Runtime info"
-                aria-label="Runtime info"
+                title="More"
+                aria-label="More"
               >
-                <FaInfo size={13} aria-hidden="true" />
-              </Popover.Trigger>
-              <Popover.Portal>
-                <Popover.Positioner sideOffset={6} align="end" className="playground-header-positioner">
-                  <Popover.Popup className="bui-popup info-popover">
-                    <RuntimeInfoContent info={adapter.runtimeInfo} />
-                  </Popover.Popup>
-                </Popover.Positioner>
-              </Popover.Portal>
-            </Popover.Root>
+                <MoreHorizontal size={16} aria-hidden="true" />
+              </Menu.Trigger>
+              <Menu.Portal>
+                <Menu.Positioner sideOffset={6} align="end" className="playground-header-positioner">
+                  <Menu.Popup className="bui-popup more-menu">
+                    <Menu.Group className="more-menu-group">
+                      <Menu.GroupLabel className="more-menu-label">
+                        Resources
+                      </Menu.GroupLabel>
+                      <Menu.SubmenuRoot>
+                        <Menu.SubmenuTrigger className="more-menu-item">
+                          <Library size={14} className="more-menu-icon" aria-hidden="true" />
+                          <span className="more-menu-text">Examples</span>
+                          <span className="more-menu-hint">
+                            {adapter.examples.length}
+                          </span>
+                          <ChevronRight size={13} className="more-menu-chev" aria-hidden="true" />
+                        </Menu.SubmenuTrigger>
+                        <Menu.Portal>
+                          <Menu.Positioner side="left" sideOffset={4} align="start" className="playground-header-positioner">
+                            <Menu.Popup className="bui-popup examples-dropdown">
+                              {adapter.examples.map((ex) => (
+                                <Menu.Item
+                                  key={ex.key}
+                                  className="example-item"
+                                  onClick={() => requestExample(ex)}
+                                >
+                                  <div className="ex-title">{ex.title}</div>
+                                  <div className="ex-desc">{ex.desc}</div>
+                                </Menu.Item>
+                              ))}
+                            </Menu.Popup>
+                          </Menu.Positioner>
+                        </Menu.Portal>
+                      </Menu.SubmenuRoot>
 
-            {/* Settings entry co-located with the other global controls in
-                the top-right cluster. */}
-            <button
-              type="button"
-              className="header-btn icon-only"
-              onClick={openSettingsTab}
-              title="Settings"
-              aria-label="Settings"
-            >
-              <Settings size={14} aria-hidden="true" />
-            </button>
+                      {adapter.packages.length > 0 && (
+                        <Menu.Item
+                          className="more-menu-item"
+                          onClick={() => setPackagesOpen(true)}
+                        >
+                          <Package size={14} className="more-menu-icon" aria-hidden="true" />
+                          <span className="more-menu-text">Packages</span>
+                          <span className="more-menu-hint">
+                            {adapter.packages.length}
+                          </span>
+                        </Menu.Item>
+                      )}
+                    </Menu.Group>
+
+                    <Menu.Group className="more-menu-group">
+                      <Menu.GroupLabel className="more-menu-label">
+                        Actions
+                      </Menu.GroupLabel>
+                      <Menu.SubmenuRoot>
+                        <Menu.SubmenuTrigger className="more-menu-item">
+                          <ArrowDownToLine size={14} className="more-menu-icon" aria-hidden="true" />
+                          <span className="more-menu-text">Export code</span>
+                          <ChevronRight size={13} className="more-menu-chev" aria-hidden="true" />
+                        </Menu.SubmenuTrigger>
+                        <Menu.Portal>
+                          <Menu.Positioner side="left" sideOffset={4} align="start" className="playground-header-positioner">
+                            <Menu.Popup className="bui-popup examples-dropdown export-dropdown">
+                              {adapter.exportFormats.map((fmt) => (
+                                <Menu.Item
+                                  key={fmt.extension}
+                                  className="example-item export-item"
+                                  onClick={() => exportCode(fmt)}
+                                >
+                                  <div className="export-item-text">
+                                    <div className="ex-title">
+                                      {fmt.label}
+                                      <span className="ext-badge">.{fmt.extension}</span>
+                                    </div>
+                                    <div className="ex-desc">
+                                      Download as .{fmt.extension}
+                                    </div>
+                                  </div>
+                                </Menu.Item>
+                              ))}
+                            </Menu.Popup>
+                          </Menu.Positioner>
+                        </Menu.Portal>
+                      </Menu.SubmenuRoot>
+                    </Menu.Group>
+
+                    <Menu.Group className="more-menu-group">
+                      <Menu.GroupLabel className="more-menu-label">
+                        Playground
+                      </Menu.GroupLabel>
+                      <Menu.SubmenuRoot>
+                        <Menu.SubmenuTrigger className="more-menu-item">
+                          <FaInfo size={13} className="more-menu-icon" aria-hidden="true" />
+                          <span className="more-menu-text">Runtime info</span>
+                          <ChevronRight size={13} className="more-menu-chev" aria-hidden="true" />
+                        </Menu.SubmenuTrigger>
+                        <Menu.Portal>
+                          <Menu.Positioner side="left" sideOffset={4} align="start" className="playground-header-positioner">
+                            <Menu.Popup className="bui-popup info-popover more-menu-info">
+                              <RuntimeInfoContent info={adapter.runtimeInfo} />
+                            </Menu.Popup>
+                          </Menu.Positioner>
+                        </Menu.Portal>
+                      </Menu.SubmenuRoot>
+                      <Menu.Item
+                        className="more-menu-item"
+                        onClick={openSettingsTab}
+                      >
+                        <Settings size={14} className="more-menu-icon" aria-hidden="true" />
+                        <span className="more-menu-text">Settings</span>
+                      </Menu.Item>
+                    </Menu.Group>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
           </div>
 
           {/* Mobile-only consolidated menu, replaces the header buttons
@@ -5013,6 +5051,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                       className={`out-cell ${onlyStderr ? "stderr" : "stdout"}`}
                     >
                       <div className="out-cell-header">
+                        <span className="out-cell-accent" aria-hidden="true" />
                         <span className="cell-type">
                           {onlyStderr ? "ERROR" : "OUTPUT"}
                         </span>

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1277,10 +1277,10 @@ body.playground-active {
   /* Modest bottom padding, the auto-scroll places the most recent output
      near the top of the viewport, so users no longer need huge slack
      below the last cell. */
-  padding: 16px 16px 32px 16px;
+  padding: 12px 12px 28px 12px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 .out-cell {
   flex-shrink: 0;
@@ -1363,15 +1363,34 @@ body.playground-active {
 .out-cell-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  background: var(--bg2);
+  gap: 7px;
+  padding: 4px 8px 2px 10px;
+  background: transparent;
   font-size: 11px;
   font-family: var(--font-mono);
   color: var(--text-dim);
 }
+/* Small accent marker that replaces the old full-height colored left
+   border: green marks OUTPUT, red marks ERROR (see `.out-cell.stderr`
+   below). Sits inline in the header next to the label. */
+.out-cell-accent {
+  width: 3px;
+  height: 11px;
+  border-radius: 2px;
+  background: var(--green);
+  flex-shrink: 0;
+}
+.out-cell.stderr .out-cell-accent {
+  background: var(--red);
+}
 .out-cell-header .cell-type {
   font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--green);
+}
+.out-cell.stderr .cell-type {
+  color: var(--red);
 }
 .out-cell-header .cell-time {
   margin-left: auto;
@@ -1384,18 +1403,13 @@ body.playground-active {
   flex-shrink: 0;
 }
 
-/* One frame per run: stderr-only runs read as ERROR (red edge); runs with
-   any other output read as OUTPUT (green edge) and render stderr text red
-   inline via .out-seg-stderr. */
-.out-cell.stdout {
-  border-left: 3px solid var(--green);
-}
-.out-cell.stderr {
-  border-left: 3px solid var(--red);
-}
-
+/* One frame per run: stderr-only runs read as ERROR (red accent); runs
+   with any other output read as OUTPUT (green accent) via the small
+   `.out-cell-accent` marker in the header, and render stderr text red
+   inline via .out-seg-stderr. No colored left border or header fill, so
+   cells read as flat blocks separated by the output-body gap. */
 .out-cell-body {
-  padding: 12px;
+  padding: 4px 12px 12px;
 }
 
 .out-cell.stdout .out-cell-body {
@@ -2768,8 +2782,10 @@ input[type="range"].fs-slider:disabled {
   }
 
   /* The workspace badge + save menu move into the hamburger menu on mobile
-     so the header keeps just the logo, language switcher, and menu button. */
-  .workspace-badge,
+     so the header keeps just the logo, language switcher, and menu button.
+     Hiding the whole badge group also takes the inline-rename pencil with
+     it (rename stays available via the manager drawer on mobile). */
+  .workspace-badge-group,
   .workspace-save-btn {
     display: none;
   }
@@ -2895,6 +2911,69 @@ input[type="range"].fs-slider:disabled {
   background: var(--menu-item-hover);
   color: var(--text);
   outline: none;
+}
+
+/* ─── ⋯ More menu ───
+   Consolidates the header's secondary actions into one dropdown so the
+   top bar stays calm: Examples, Packages, Export, Runtime info, Settings
+   on the code playgrounds; Import, Export database, Query history, ER
+   diagram, Runtime info, Settings on SQL. Built on the same Base UI Menu
+   primitive as the other header dropdowns; list-style entries (Examples,
+   Export, Import, Runtime info) open as submenus reusing the
+   examples-dropdown / info-popover popups. */
+.bui-popup.more-menu {
+  width: 256px;
+  padding: 4px;
+}
+.more-menu-group + .more-menu-group {
+  margin-top: 2px;
+}
+.more-menu-label {
+  padding: 8px 10px 3px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.more-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 7px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  outline: none;
+}
+.more-menu-item[data-highlighted],
+.more-menu-item[data-popup-open],
+.more-menu-item:hover {
+  background: var(--menu-item-hover);
+  color: var(--text);
+}
+.more-menu-icon {
+  color: var(--text-dim);
+  flex-shrink: 0;
+  display: inline-flex;
+}
+.more-menu-text {
+  flex: 1;
+  min-width: 0;
+}
+.more-menu-hint {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.more-menu-chev {
+  color: var(--text-dim);
+  flex-shrink: 0;
 }
 
 /* ─── Mobile consolidated menu (bottom-sheet drawer) ───
@@ -3996,6 +4075,59 @@ html[data-playground-theme="dark"] .welcome h3 {
 /* ───────────────────────────────────────────────────────────────────────
    Workspace badge + popover + manager drawer (Phase 6).
    ─────────────────────────────────────────────────────────────────────── */
+
+/* Groups the workspace badge pill with its inline-rename pencil so they
+   read as one control; while editing, the pill is swapped for a text
+   input in place. */
+.workspace-badge-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+/* Pencil next to the name that enters inline-rename mode. */
+.workspace-rename-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  flex: none;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+}
+.workspace-rename-btn:hover {
+  color: var(--text);
+  background: var(--menu-item-hover);
+}
+.workspace-rename-btn:focus-visible {
+  outline: none;
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px var(--primary);
+}
+
+/* Text input shown in place of the badge while renaming. */
+.workspace-rename-input {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--primary);
+  border-radius: 6px;
+  padding: 3px 8px;
+  width: 180px;
+  max-width: 220px;
+  outline: none;
+}
 
 .workspace-badge {
   display: inline-flex;

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -52,6 +52,8 @@ import {
   FileText,
   FileJson,
   History,
+  MoreHorizontal,
+  ChevronRight,
   Network,
   Pencil,
   RotateCcw,
@@ -99,7 +101,11 @@ import {
   saveDraftWorkspace,
   switchActiveWorkspace,
 } from "../opfs/activeWorkspace";
-import { acquireWorkspaceLock, createWorkspace } from "../opfs/workspace";
+import {
+  acquireWorkspaceLock,
+  createWorkspace,
+  renameWorkspace,
+} from "../opfs/workspace";
 import { WorkspaceBadge } from "../workspace/WorkspaceBadge";
 import { ShareControls } from "../cloud/ShareControls";
 import { applyEntryFocus } from "../playgroundEntryFocus";
@@ -729,8 +735,6 @@ function SqlPlaygroundInner() {
   const setRenameDbBaseName = useDialogStore((s) => s.setRenameDbBaseName);
   const renameDbExt = useDialogStore((s) => s.renameDbExt);
   const setRenameDbExt = useDialogStore((s) => s.setRenameDbExt);
-  const exportNoTabsHover = useDialogStore((s) => s.exportNoTabsHover);
-  const setExportNoTabsHover = useDialogStore((s) => s.setExportNoTabsHover);
   // Full workspace-manager drawer, opened from the mobile hamburger menu
   // (the header badge that normally opens it is hidden on mobile).
   const [workspaceManagerOpen, setWorkspaceManagerOpen] = useState(false);
@@ -764,6 +768,19 @@ function SqlPlaygroundInner() {
       setActiveWorkspace({ id: saved.id, name: saved.name });
     }
   }, []);
+
+  // Inline rename from the header badge. Reflect the new name immediately in
+  // local state, then persist to the registry (a no-op for an unsaved draft,
+  // whose name is only local until it is saved).
+  const handleRenameWorkspace = useCallback(
+    async (name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed || !activeWorkspace) return;
+      setActiveWorkspace({ id: activeWorkspace.id, name: trimmed });
+      await renameWorkspace(activeWorkspace.id, trimmed);
+    },
+    [activeWorkspace],
+  );
 
   // ─── Derived values ──────────────────────────────────────────────────
   const isSettingsTabActive = activeTabId === SETTINGS_TAB_ID;
@@ -2047,6 +2064,7 @@ function SqlPlaygroundInner() {
                 tabs.some((t) => !t.kind && t.code !== t.pristineCode)
               }
               onSave={handleSaveWorkspace}
+              onRename={handleRenameWorkspace}
               buildBundle={buildCloudBundle}
             />
           )}
@@ -2059,277 +2077,215 @@ function SqlPlaygroundInner() {
             />
             <Menu.Root>
               <Menu.Trigger
-                className="header-btn"
-                title="Import data"
-                aria-label="Import"
-                disabled={!loaded}
+                className="header-btn icon-only"
+                title="More"
+                aria-label="More"
               >
-                <ArrowUpFromLine size={14} aria-hidden="true" />
-                <span className="btn-label">Import</span>
+                <MoreHorizontal size={16} aria-hidden="true" />
               </Menu.Trigger>
               <Menu.Portal>
-                <Menu.Positioner sideOffset={6} align="start">
-                  <Menu.Popup className="bui-popup examples-dropdown export-dropdown">
-                    <div className="import-section-label">Database</div>
-                    <Menu.Item
-                      className="example-item export-item"
-                      onClick={() => setImportSqliteOpen(true)}
-                    >
-                      <div className="export-item-text">
-                        <div className="ex-title">
-                          <span className="ex-title-text">from file</span>
-                          <span className="ext-badge-group">
-                            <span className="ext-badge">.sql</span>
-                            <span className="ext-badge">.db</span>
-                            <span className="ext-badge">.sqlite</span>
-                            <span className="ext-badge">.sqlite3</span>
-                          </span>
-                        </div>
-                        <div className="ex-desc">
-                          Replace database from a SQLite or SQL dump file
-                        </div>
-                      </div>
-                    </Menu.Item>
-                    <div className="import-section-label">Tables</div>
-                    <Menu.Item
-                      className="example-item export-item"
-                      onClick={() => {
-                        setImportCsvState(null);
-                        setImportCsvOpen(true);
-                      }}
-                    >
-                      <div className="export-item-text">
-                        <div className="ex-title">
-                          from CSV
-                          <span className="ext-badge">.csv</span>
-                        </div>
-                        <div className="ex-desc">Add table from CSV file</div>
-                      </div>
-                    </Menu.Item>
-                    <Menu.Item
-                      className="example-item export-item"
-                      onClick={() => {
-                        setImportJsonState(null);
-                        setImportJsonOpen(true);
-                      }}
-                    >
-                      <div className="export-item-text">
-                        <div className="ex-title">
-                          from JSON
-                          <span className="ext-badge">.json</span>
-                        </div>
-                        <div className="ex-desc">Add table from JSON array</div>
-                      </div>
-                    </Menu.Item>
-                    <Menu.Item
-                      className="example-item export-item"
-                      onClick={() => {
-                        setImportParquetOpen(true);
-                        setImportParquetDragging(false);
-                      }}
-                    >
-                      <div className="export-item-text">
-                        <div className="ex-title">
-                          from Parquet
-                          <span className="ext-badge">.parquet</span>
-                        </div>
-                        <div className="ex-desc">
-                          Add table from Parquet file
-                        </div>
-                      </div>
-                    </Menu.Item>
+                <Menu.Positioner sideOffset={6} align="end" className="playground-header-positioner">
+                  <Menu.Popup className="bui-popup more-menu">
+                    <Menu.Group className="more-menu-group">
+                      <Menu.GroupLabel className="more-menu-label">
+                        Data
+                      </Menu.GroupLabel>
+                      <Menu.SubmenuRoot>
+                        <Menu.SubmenuTrigger
+                          className="more-menu-item"
+                          disabled={!loaded}
+                        >
+                          <ArrowUpFromLine size={14} className="more-menu-icon" aria-hidden="true" />
+                          <span className="more-menu-text">Import…</span>
+                          <ChevronRight size={13} className="more-menu-chev" aria-hidden="true" />
+                        </Menu.SubmenuTrigger>
+                        <Menu.Portal>
+                          <Menu.Positioner side="left" sideOffset={4} align="start" className="playground-header-positioner">
+                            <Menu.Popup className="bui-popup examples-dropdown export-dropdown">
+                              <div className="import-section-label">Database</div>
+                              <Menu.Item
+                                className="example-item export-item"
+                                onClick={() => setImportSqliteOpen(true)}
+                              >
+                                <div className="export-item-text">
+                                  <div className="ex-title">
+                                    <span className="ex-title-text">from file</span>
+                                    <span className="ext-badge-group">
+                                      <span className="ext-badge">.sql</span>
+                                      <span className="ext-badge">.db</span>
+                                      <span className="ext-badge">.sqlite</span>
+                                      <span className="ext-badge">.sqlite3</span>
+                                    </span>
+                                  </div>
+                                  <div className="ex-desc">
+                                    Replace database from a SQLite or SQL dump file
+                                  </div>
+                                </div>
+                              </Menu.Item>
+                              <div className="import-section-label">Tables</div>
+                              <Menu.Item
+                                className="example-item export-item"
+                                onClick={() => {
+                                  setImportCsvState(null);
+                                  setImportCsvOpen(true);
+                                }}
+                              >
+                                <div className="export-item-text">
+                                  <div className="ex-title">
+                                    from CSV
+                                    <span className="ext-badge">.csv</span>
+                                  </div>
+                                  <div className="ex-desc">Add table from CSV file</div>
+                                </div>
+                              </Menu.Item>
+                              <Menu.Item
+                                className="example-item export-item"
+                                onClick={() => {
+                                  setImportJsonState(null);
+                                  setImportJsonOpen(true);
+                                }}
+                              >
+                                <div className="export-item-text">
+                                  <div className="ex-title">
+                                    from JSON
+                                    <span className="ext-badge">.json</span>
+                                  </div>
+                                  <div className="ex-desc">Add table from JSON array</div>
+                                </div>
+                              </Menu.Item>
+                              <Menu.Item
+                                className="example-item export-item"
+                                onClick={() => {
+                                  setImportParquetOpen(true);
+                                  setImportParquetDragging(false);
+                                }}
+                              >
+                                <div className="export-item-text">
+                                  <div className="ex-title">
+                                    from Parquet
+                                    <span className="ext-badge">.parquet</span>
+                                  </div>
+                                  <div className="ex-desc">
+                                    Add table from Parquet file
+                                  </div>
+                                </div>
+                              </Menu.Item>
+                            </Menu.Popup>
+                          </Menu.Positioner>
+                        </Menu.Portal>
+                      </Menu.SubmenuRoot>
+                      <Menu.SubmenuRoot>
+                        <Menu.SubmenuTrigger
+                          className="more-menu-item"
+                          disabled={!loaded || tables.length === 0}
+                          title={
+                            tables.length === 0
+                              ? "Create a table to export the database"
+                              : undefined
+                          }
+                        >
+                          <ArrowDownToLine size={14} className="more-menu-icon" aria-hidden="true" />
+                          <span className="more-menu-text">Export database</span>
+                          <ChevronRight size={13} className="more-menu-chev" aria-hidden="true" />
+                        </Menu.SubmenuTrigger>
+                        <Menu.Portal>
+                          <Menu.Positioner side="left" sideOffset={4} align="start" className="playground-header-positioner">
+                            <Menu.Popup className="bui-popup examples-dropdown export-dropdown">
+                              <div className="sql-result-export-group-label">
+                                SQLite Database
+                              </div>
+                              <Menu.Item
+                                className="example-item export-item"
+                                onClick={exportDatabase}
+                              >
+                                <div className="export-item-text">
+                                  <div className="ex-title">
+                                    SQLite File
+                                    <span className="ext-badge">.sqlite</span>
+                                  </div>
+                                  <div className="ex-desc">Download as .sqlite</div>
+                                </div>
+                              </Menu.Item>
+                              <Menu.Item
+                                className="example-item export-item"
+                                onClick={exportDatabaseAsSqlDump}
+                              >
+                                <div className="export-item-text">
+                                  <div className="ex-title">
+                                    SQL Dump
+                                    <span className="ext-badge">.sql</span>
+                                  </div>
+                                  <div className="ex-desc">DDL + INSERT statements</div>
+                                </div>
+                              </Menu.Item>
+                              <Menu.Item
+                                className="example-item export-item"
+                                onClick={exportDatabaseToXlsx}
+                              >
+                                <div className="export-item-text">
+                                  <div className="ex-title">
+                                    Excel Workbook
+                                    <span className="ext-badge">.xlsx</span>
+                                  </div>
+                                  <div className="ex-desc">One sheet per table</div>
+                                </div>
+                              </Menu.Item>
+                            </Menu.Popup>
+                          </Menu.Positioner>
+                        </Menu.Portal>
+                      </Menu.SubmenuRoot>
+                    </Menu.Group>
+
+                    <Menu.Group className="more-menu-group">
+                      <Menu.GroupLabel className="more-menu-label">
+                        Tools
+                      </Menu.GroupLabel>
+                      <Menu.Item
+                        className="more-menu-item"
+                        onClick={openQueryHistoryTab}
+                      >
+                        <History size={14} className="more-menu-icon" aria-hidden="true" />
+                        <span className="more-menu-text">Query history</span>
+                      </Menu.Item>
+                      <Menu.Item
+                        className="more-menu-item"
+                        onClick={openErDiagramTab}
+                      >
+                        <Network size={14} className="more-menu-icon" aria-hidden="true" />
+                        <span className="more-menu-text">ER diagram</span>
+                      </Menu.Item>
+                    </Menu.Group>
+
+                    <Menu.Group className="more-menu-group">
+                      <Menu.GroupLabel className="more-menu-label">
+                        Playground
+                      </Menu.GroupLabel>
+                      <Menu.SubmenuRoot>
+                        <Menu.SubmenuTrigger className="more-menu-item">
+                          <FaInfo size={13} className="more-menu-icon" aria-hidden="true" />
+                          <span className="more-menu-text">Runtime info</span>
+                          <ChevronRight size={13} className="more-menu-chev" aria-hidden="true" />
+                        </Menu.SubmenuTrigger>
+                        <Menu.Portal>
+                          <Menu.Positioner side="left" sideOffset={4} align="start" className="playground-header-positioner">
+                            <Menu.Popup className="bui-popup info-popover more-menu-info">
+                              <RuntimeInfoContent info={RUNTIME_INFO} />
+                            </Menu.Popup>
+                          </Menu.Positioner>
+                        </Menu.Portal>
+                      </Menu.SubmenuRoot>
+                      <Menu.Item
+                        className="more-menu-item"
+                        onClick={openSettingsTab}
+                      >
+                        <SettingsIcon size={14} className="more-menu-icon" aria-hidden="true" />
+                        <span className="more-menu-text">Settings</span>
+                      </Menu.Item>
+                    </Menu.Group>
                   </Menu.Popup>
                 </Menu.Positioner>
               </Menu.Portal>
             </Menu.Root>
-            {tables.length === 0 && loaded ? (
-              <Popover.Root
-                open={exportNoTabsHover}
-                onOpenChange={setExportNoTabsHover}
-              >
-                <div
-                  style={{ cursor: "not-allowed" }}
-                  onMouseEnter={() => setExportNoTabsHover(true)}
-                  onMouseLeave={() => setExportNoTabsHover(false)}
-                  onFocus={() => setExportNoTabsHover(true)}
-                  onBlur={() => setExportNoTabsHover(false)}
-                  tabIndex={0}
-                  role="button"
-                  aria-disabled="true"
-                  aria-label="Export (create a table to enable)"
-                >
-                  <Popover.Trigger
-                    className="header-btn"
-                    disabled
-                    style={{ pointerEvents: "none" }}
-                    title="Export database"
-                    aria-label="Export"
-                  >
-                    <ArrowDownToLine size={14} aria-hidden="true" />
-                    <span className="btn-label">Export DB</span>
-                  </Popover.Trigger>
-                </div>
-                <Popover.Portal>
-                  <Popover.Positioner
-                    sideOffset={6}
-                    align="start"
-                    className="sql-export-disabled-positioner"
-                  >
-                    <Popover.Popup className="bui-popup sql-export-disabled-popup">
-                      Create a table to export the database
-                    </Popover.Popup>
-                  </Popover.Positioner>
-                </Popover.Portal>
-              </Popover.Root>
-            ) : (
-              <Menu.Root>
-                <Menu.Trigger
-                  className="header-btn"
-                  title="Export database"
-                  aria-label="Export"
-                  disabled={!loaded}
-                >
-                  <ArrowDownToLine size={14} aria-hidden="true" />
-                  <span className="btn-label">Export DB</span>
-                </Menu.Trigger>
-                <Menu.Portal>
-                  <Menu.Positioner sideOffset={6} align="start">
-                    <Menu.Popup className="bui-popup examples-dropdown export-dropdown">
-                      <div className="sql-result-export-group-label">
-                        SQLite Database
-                      </div>
-                      <Menu.Item
-                        className="example-item export-item"
-                        onClick={exportDatabase}
-                      >
-                        <div className="export-item-text">
-                          <div className="ex-title">
-                            SQLite File
-                            <span className="ext-badge">.sqlite</span>
-                          </div>
-                          <div className="ex-desc">Download as .sqlite</div>
-                        </div>
-                      </Menu.Item>
-                      <Menu.Item
-                        className="example-item export-item"
-                        onClick={exportDatabaseAsSqlDump}
-                      >
-                        <div className="export-item-text">
-                          <div className="ex-title">
-                            SQL Dump
-                            <span className="ext-badge">.sql</span>
-                          </div>
-                          <div className="ex-desc">DDL + INSERT statements</div>
-                        </div>
-                      </Menu.Item>
-                      <Menu.Item
-                        className="example-item export-item"
-                        onClick={exportDatabaseToXlsx}
-                      >
-                        <div className="export-item-text">
-                          <div className="ex-title">
-                            Excel Workbook
-                            <span className="ext-badge">.xlsx</span>
-                          </div>
-                          <div className="ex-desc">One sheet per table</div>
-                        </div>
-                      </Menu.Item>
-                    </Menu.Popup>
-                  </Menu.Positioner>
-                </Menu.Portal>
-              </Menu.Root>
-            )}
-            <Popover.Root>
-              <Popover.Trigger
-                openOnHover
-                delay={150}
-                closeDelay={400}
-                render={(triggerProps) => (
-                  <button
-                    {...triggerProps}
-                    type="button"
-                    className="header-btn icon-only"
-                    aria-label="Query history"
-                    onClick={openQueryHistoryTab}
-                  >
-                    <History size={14} aria-hidden="true" />
-                  </button>
-                )}
-              />
-              <Popover.Portal>
-                <Popover.Positioner sideOffset={6} align="end">
-                  <Popover.Popup className="bui-popup pane-btn-popover">
-                    History
-                  </Popover.Popup>
-                </Popover.Positioner>
-              </Popover.Portal>
-            </Popover.Root>
-            <Popover.Root>
-              <Popover.Trigger
-                openOnHover
-                delay={150}
-                closeDelay={400}
-                render={(triggerProps) => (
-                  <button
-                    {...triggerProps}
-                    type="button"
-                    className="header-btn icon-only"
-                    aria-label="ER diagram"
-                    onClick={openErDiagramTab}
-                  >
-                    <Network size={14} aria-hidden="true" />
-                  </button>
-                )}
-              />
-              <Popover.Portal>
-                <Popover.Positioner sideOffset={6} align="end">
-                  <Popover.Popup className="bui-popup pane-btn-popover">
-                    ER Diagram
-                  </Popover.Popup>
-                </Popover.Positioner>
-              </Popover.Portal>
-            </Popover.Root>
-            <Popover.Root>
-              <Popover.Trigger
-                className="header-btn icon-only"
-                title="Runtime info"
-                aria-label="Runtime info"
-              >
-                <FaInfo size={13} aria-hidden="true" />
-              </Popover.Trigger>
-              <Popover.Portal>
-                <Popover.Positioner sideOffset={6} align="end">
-                  <Popover.Popup className="bui-popup info-popover">
-                    <RuntimeInfoContent info={RUNTIME_INFO} />
-                  </Popover.Popup>
-                </Popover.Positioner>
-              </Popover.Portal>
-            </Popover.Root>
-            <Popover.Root>
-              <Popover.Trigger
-                openOnHover
-                delay={150}
-                closeDelay={400}
-                render={(triggerProps) => (
-                  <button
-                    {...triggerProps}
-                    type="button"
-                    className="header-btn icon-only"
-                    aria-label="Settings"
-                    onClick={openSettingsTab}
-                  >
-                    <SettingsIcon size={14} aria-hidden="true" />
-                  </button>
-                )}
-              />
-              <Popover.Portal>
-                <Popover.Positioner sideOffset={6} align="end">
-                  <Popover.Popup className="bui-popup pane-btn-popover">
-                    Settings
-                  </Popover.Popup>
-                </Popover.Positioner>
-              </Popover.Portal>
-            </Popover.Root>
           </div>
         </>
       }

--- a/app/_components/workspace/WorkspaceBadge.tsx
+++ b/app/_components/workspace/WorkspaceBadge.tsx
@@ -107,6 +107,12 @@ export interface WorkspaceBadgeProps {
    *  The host promotes the draft to a saved workspace (see
    *  `saveDraftWorkspace`). */
   onSave?: (name: string) => void | Promise<void>;
+  /** Invoked with the new name when the user renames the active workspace
+   *  inline via the pencil next to the badge. The host is responsible for
+   *  updating the displayed name live (its own store/state) and, for saved
+   *  workspaces, persisting the change (`renameWorkspace`). When omitted,
+   *  the rename pencil is hidden. */
+  onRename?: (name: string) => void | Promise<void>;
   /** Serializes the CURRENT playground state into a bundle, the same
    *  builder the Share dialog uses. Powers "Back up" for the active
    *  workspace; when omitted, the backup action is hidden (cloud rows and
@@ -197,9 +203,27 @@ export function WorkspaceBadge({
   onManagerOpenChange,
   unsaved = false,
   onSave,
+  onRename,
   buildBundle,
 }: WorkspaceBadgeProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
+  // Inline rename: the pencil next to the name swaps the badge for a text
+  // input. Commit persists via `onRename` (the host owns the live name).
+  const [editing, setEditing] = useState(false);
+  const [draftName, setDraftName] = useState("");
+  const startRename = useCallback(() => {
+    setDraftName(activeWorkspaceName || "");
+    setPopoverOpen(false);
+    setEditing(true);
+  }, [activeWorkspaceName]);
+  const cancelRename = useCallback(() => setEditing(false), []);
+  const commitRename = useCallback(() => {
+    setEditing(false);
+    const trimmed = draftName.trim();
+    if (trimmed && trimmed !== activeWorkspaceName) {
+      void onRename?.(trimmed);
+    }
+  }, [draftName, activeWorkspaceName, onRename]);
   // The Save menu's dialog: "local" names the draft; "both" also backs the
   // freshly-saved workspace up to the account afterwards.
   const [saveDialogMode, setSaveDialogMode] = useState<
@@ -384,6 +408,31 @@ export function WorkspaceBadge({
 
   return (
     <>
+      <span
+        className="workspace-badge-group"
+        data-editing={editing || undefined}
+      >
+      {editing ? (
+        <input
+          className="workspace-rename-input"
+          value={draftName}
+          autoFocus
+          maxLength={80}
+          aria-label="Rename workspace"
+          onChange={(e) => setDraftName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              e.currentTarget.blur();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancelRename();
+            }
+          }}
+          onBlur={commitRename}
+        />
+      ) : (
+        <>
       <Popover.Root open={popoverOpen} onOpenChange={setPopoverOpen}>
         <Popover.Trigger
           className="workspace-badge"
@@ -589,6 +638,20 @@ export function WorkspaceBadge({
           </Popover.Positioner>
         </Popover.Portal>
       </Popover.Root>
+          {onRename && (
+            <button
+              type="button"
+              className="workspace-rename-btn"
+              title="Rename workspace"
+              aria-label="Rename workspace"
+              onClick={startRename}
+            >
+              <Pencil size={12} aria-hidden="true" />
+            </button>
+          )}
+        </>
+      )}
+      </span>
 
       {onSave && (
         <Menu.Root>


### PR DESCRIPTION
## Summary

Implements the **Playground Header Redesign** handoff. De-clutters the top bar of both the code and SQL playgrounds by folding most secondary menu items into a single **⋯ More** dropdown, and redesigns the output sections of the playgrounds, code blocks, and challenge cards to drop the heavy colored left border and margins.

Scope was confirmed with the requester: consolidate the action menu into a ⋯ dropdown + add inline rename to the header workspace control (keeping workspace switching reachable via the existing badge popover — no `/playground` index migration), and keep the output accent's green/red semantics.

## Header (code + SQL playgrounds)

- Keep the logo/switcher, workspace name, **Save**, and **Share** visible; move everything else into one Base UI `Menu` (⋯) with grouped sections. List-style entries (Examples, Export, Import, Runtime info) open as submenu flyouts; the rest are direct items.
  - **Code:** Resources (Examples, Packages) · Actions (Export code) · Playground (Runtime info, Settings)
  - **SQL:** Data (Import…, Export database) · Tools (Query history, ER diagram) · Playground (Runtime info, Settings). Import/Export stay disabled until the engine loads.
- Add an **inline pencil** next to the workspace name that renames the active workspace in place (`Enter` commits, `Escape` cancels). A new `onRename` prop lets each playground update its displayed name live and persist via `renameWorkspace`; unsaved drafts just update the local name until saved.
- The desktop cluster stays `desktop-only`; the mobile hamburger sheet is unchanged (it was already consolidated). The badge group (name + pencil) is hidden on mobile alongside the pill, so rename stays available via the manager drawer there.

## Output panes

- **Main playground (`.out-cell`):** remove the full-height green/red `border-left` and the `--bg2` header fill; add a small **3×11 accent marker** beside the OUTPUT/ERROR label — **green** for stdout, **red** for errors — and tighten the padding so cells read as flat blocks.
- **Challenge card / code block (shared `ChallengeCard.module.css`):** shrink the oversized 4×20 accent bar to **3×11** and make the output-body padding symmetric (drop the 18px left inset); the boot-notice inset is realigned to match.

## Verification

- `tsc --noEmit` ✅ · `eslint` on changed files ✅ · `vitest run` (896 tests) ✅
- Drove both playgrounds in a headless browser: the ⋯ menu opens with the correct groups/items, Examples/Import submenu flyouts render, the inline rename pencil swaps in a text input and updates the badge name live, and the redesigned output cells render with no left border and a green/red accent marker (verified via computed styles: `border-left: 0px`, accent `3px × 11px`, `#20C621` / `#FF4F59`).

Notes: the old SQL "create a table to export" hover tooltip is replaced by a disabled Export-database submenu entry with a native title; its now-unused `.sql-export-disabled-*` CSS and `exportNoTabsHover` store field are left in place and can be removed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zZgKd68gsKxjtmG8EwEKF

---
_Generated by [Claude Code](https://claude.ai/code/session_012zZgKd68gsKxjtmG8EwEKF)_