### PR TITLE
Fix "Invalid origin" on www sign-up + enable social login on Cloudflare previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Key files:
 
    `BETTER_AUTH_URL` is set as a non-secret `var` in `wrangler.jsonc` (defaults to `https://dataslope.com`); change it if the deployed origin differs. A provider whose `*_CLIENT_ID`/`*_CLIENT_SECRET` pair is missing is simply not offered, so you can ship with just one provider configured.
 
+   You only ever register the **production** callback URL above — no per-preview URLs. `lib/auth/server.ts` handles the two hosts that aren't the pinned apex:
+   - **`www.dataslope.com`** (production also serves `www` with no redirect) is trusted for the CSRF origin check alongside the apex and any subdomain, so email/password sign-up/sign-in works there (previously it failed with "Invalid origin").
+   - **`*.workers.dev` preview deployments** trust their own origin for email/password, and Google/GitHub sign-in completes via Better Auth's `oAuthProxy` plugin: the provider still returns to the registered production callback, then the authenticated session is relayed back to the preview. The relay encrypts its payload with a secret shared across deployments — `BETTER_AUTH_SECRET` by default, or set a dedicated `OAUTH_PROXY_SECRET` (`npx wrangler secret put OAUTH_PROXY_SECRET`, identical value everywhere) to narrow the blast radius. The proxy is a no-op on production and `www`.
+
 ### Local development
 
 `npm run dev` reads bindings/vars from `wrangler.jsonc` via OpenNext's `initOpenNextCloudflareForDev()`. Put local secrets and any overrides in a `.dev.vars` file (gitignored), e.g.:

--- a/__tests__/authOriginPreview.test.ts
+++ b/__tests__/authOriginPreview.test.ts
@@ -1,0 +1,255 @@
+/**
+ * CSRF origin allow-list + Cloudflare-preview auth (lib/auth/server.ts).
+ *
+ * Two things are covered:
+ *   1. The "Invalid origin" fix for email/password on www.dataslope.com. Better
+ *      Auth pins its trusted set to BETTER_AUTH_URL (the apex), but production
+ *      also serves www with no canonical redirect, so a sign-up POST from www
+ *      was rejected. `isSameSiteHost`/`extraTrustedOrigins` now trust the apex
+ *      and its subdomains (and *.workers.dev previews).
+ *   2. Google/GitHub sign-in completing on a *.workers.dev preview via the
+ *      oAuthProxy plugin, which must engage ONLY on previews — apex and www
+ *      keep their exact production flow.
+ *
+ * Better Auth disables the origin check when NODE_ENV=test (skipOriginCheck),
+ * so the end-to-end origin tests build an instance with
+ * `advanced.disableOriginCheck: false` to force it on — using the SAME
+ * `extraTrustedOrigins` that createAuth wires in.
+ */
+import { describe, it, expect } from "vitest";
+import type { D1Database } from "@cloudflare/workers-types";
+import { betterAuth } from "better-auth";
+import { D1Dialect } from "kysely-d1";
+import {
+  createAuth,
+  deploymentOrigin,
+  extraTrustedOrigins,
+  isSameSiteHost,
+} from "../lib/auth/server";
+
+const APEX = "https://dataslope.com";
+const WWW = "https://www.dataslope.com";
+const PREVIEW = "https://x-dataslope.subwaymatch.workers.dev";
+
+/** Minimal D1 that echoes back INSERT ... RETURNING * rows (enough for the
+ *  sign-up / social-verification writes) and, optionally, records the `value`
+ *  column of the last `verification` insert so a test can inspect it. */
+function echoDb(sink?: { value?: string }): D1Database {
+  function stmt(sql: string, binds: unknown[] = []) {
+    const cols = /\(([^)]*)\)\s*values/i
+      .exec(sql)?.[1]
+      ?.split(",")
+      .map((c) => c.trim().replace(/^"|"$/g, ""));
+    return {
+      bind: (...b: unknown[]) => stmt(sql, b),
+      async all() {
+        if (sink && cols && /insert into "verification"/i.test(sql)) {
+          const idx = cols.indexOf("value");
+          if (idx >= 0) sink.value = binds[idx] as string;
+        }
+        const row = cols
+          ? Object.fromEntries(cols.map((c, i) => [c, binds[i]]))
+          : undefined;
+        return { results: row ? [row] : [], success: true, meta: {} };
+      },
+      async run() {
+        return { results: [], success: true, meta: {} };
+      },
+      async first() {
+        return null;
+      },
+      raw: async () => [],
+    };
+  }
+  return { prepare: (sql: string) => stmt(sql) } as unknown as D1Database;
+}
+
+function makeEnv(overrides: Partial<CloudflareEnv> = {}): CloudflareEnv {
+  return {
+    DB: echoDb(),
+    BETTER_AUTH_SECRET: "test-secret-test-secret-test-secret",
+    BETTER_AUTH_URL: APEX,
+    GOOGLE_CLIENT_ID: "test-google-id",
+    GOOGLE_CLIENT_SECRET: "test-google-secret",
+    ...overrides,
+  } as CloudflareEnv;
+}
+
+describe("isSameSiteHost", () => {
+  it("trusts the apex and its subdomains", () => {
+    expect(isSameSiteHost(APEX, "dataslope.com")).toBe(true);
+    expect(isSameSiteHost(APEX, "www.dataslope.com")).toBe(true);
+    expect(isSameSiteHost(APEX, "app.dataslope.com")).toBe(true);
+    expect(isSameSiteHost(APEX, "DATASLOPE.COM")).toBe(true); // case-insensitive
+  });
+
+  it("rejects look-alike and unrelated hosts", () => {
+    expect(isSameSiteHost(APEX, "dataslope.com.evil.com")).toBe(false);
+    expect(isSameSiteHost(APEX, "notdataslope.com")).toBe(false);
+    expect(isSameSiteHost(APEX, "evil.example")).toBe(false);
+    // A leading-dot anchor is required: bare "com" must not match.
+    expect(isSameSiteHost(APEX, "com")).toBe(false);
+  });
+
+  it("returns false for missing or unparseable inputs", () => {
+    expect(isSameSiteHost(undefined, "www.dataslope.com")).toBe(false);
+    expect(isSameSiteHost(APEX, undefined)).toBe(false);
+    expect(isSameSiteHost("not a url", "www.dataslope.com")).toBe(false);
+  });
+});
+
+describe("deploymentOrigin", () => {
+  const req = (origin: string) =>
+    new Request(`${origin}/api/auth/sign-in/social`, { method: "POST" });
+
+  it("floats to the request origin only on *.workers.dev", () => {
+    expect(deploymentOrigin(APEX, req(PREVIEW))).toBe(PREVIEW);
+  });
+
+  it("keeps the pinned apex on apex and www requests", () => {
+    expect(deploymentOrigin(APEX, req(APEX))).toBe(APEX);
+    expect(deploymentOrigin(APEX, req(WWW))).toBe(APEX);
+  });
+
+  it("returns the pinned value for request-less calls", () => {
+    expect(deploymentOrigin(APEX)).toBe(APEX);
+    expect(deploymentOrigin(undefined)).toBeUndefined();
+  });
+});
+
+describe("extraTrustedOrigins", () => {
+  const req = (origin: string) =>
+    new Request(`${origin}/api/auth/sign-up/email`, { method: "POST" });
+
+  it("adds www (and apex) so www.dataslope.com is trusted", () => {
+    expect(extraTrustedOrigins(makeEnv(), req(WWW))).toContain(WWW);
+    expect(extraTrustedOrigins(makeEnv(), req(APEX))).toContain(APEX);
+  });
+
+  it("adds the *.workers.dev preview origin", () => {
+    expect(extraTrustedOrigins(makeEnv(), req(PREVIEW))).toContain(PREVIEW);
+  });
+
+  it("never adds an unrelated origin", () => {
+    expect(extraTrustedOrigins(makeEnv(), req("https://evil.example"))).not.toContain(
+      "https://evil.example",
+    );
+  });
+
+  it("passes through the configured TRUSTED_ORIGINS", () => {
+    const env = makeEnv({ TRUSTED_ORIGINS: "https://staging.example, https://qa.example" });
+    const origins = extraTrustedOrigins(env, req(APEX));
+    expect(origins).toContain("https://staging.example");
+    expect(origins).toContain("https://qa.example");
+  });
+});
+
+/**
+ * End-to-end origin enforcement. Built with disableOriginCheck:false (Better
+ * Auth otherwise skips the check under NODE_ENV=test) and the real
+ * extraTrustedOrigins, so this exercises the exact list createAuth produces.
+ */
+function enforcingAuth(env: CloudflareEnv) {
+  return betterAuth({
+    database: { dialect: new D1Dialect({ database: env.DB }), type: "sqlite" },
+    secret: env.BETTER_AUTH_SECRET,
+    baseURL: env.BETTER_AUTH_URL,
+    emailAndPassword: { enabled: true },
+    trustedOrigins: (req) => extraTrustedOrigins(env, req),
+    advanced: { disableOriginCheck: false },
+  });
+}
+
+async function signUp(reqHost: string, origin: string) {
+  const auth = enforcingAuth(makeEnv());
+  const res = await auth.handler(
+    new Request(`https://${reqHost}/api/auth/sign-up/email`, {
+      method: "POST",
+      // A cookie is what makes Better Auth run the origin check on this request.
+      headers: { "content-type": "application/json", origin, cookie: "sid=1" },
+      body: JSON.stringify({
+        email: "user@example.com",
+        password: "supersecret123",
+        name: "User",
+      }),
+    }),
+  );
+  return { status: res.status, body: await res.text() };
+}
+
+describe("origin enforcement (email sign-up)", () => {
+  it("accepts a same-site request from www.dataslope.com (the bug fix)", async () => {
+    const { status, body } = await signUp("www.dataslope.com", WWW);
+    expect(status).not.toBe(403);
+    expect(body).not.toMatch(/invalid origin/i);
+  });
+
+  it("accepts a request from a *.workers.dev preview", async () => {
+    const host = "x-dataslope.subwaymatch.workers.dev";
+    const { status, body } = await signUp(host, `https://${host}`);
+    expect(status).not.toBe(403);
+    expect(body).not.toMatch(/invalid origin/i);
+  });
+
+  it("still rejects a genuine cross-site Origin (CSRF intact)", async () => {
+    // Request arrives at the trusted apex host but claims an evil Origin.
+    const { status, body } = await signUp("dataslope.com", "https://evil.example");
+    expect(status).toBe(403);
+    expect(body).toMatch(/invalid origin/i);
+  });
+});
+
+/**
+ * oAuthProxy engagement. The stored `verification.value.callbackURL` tells us
+ * whether the proxy rewrote the flow: on a preview it routes through the
+ * preview's /oauth-proxy-callback; on apex/www it stays the raw app path.
+ */
+async function socialCallbackURL(origin: string) {
+  const sink: { value?: string } = {};
+  const env = makeEnv({ DB: echoDb(sink) });
+  const auth = await createAuth(
+    env,
+    new Request(`${origin}/api/auth/sign-in/social`, { method: "POST" }),
+  );
+  const res = await auth.handler(
+    new Request(`${origin}/api/auth/sign-in/social`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin },
+      body: JSON.stringify({ provider: "google", callbackURL: "/account" }),
+    }),
+  );
+  const { url } = (await res.json()) as { url: string };
+  const stored = sink.value ? (JSON.parse(sink.value) as { callbackURL: string }) : undefined;
+  return {
+    redirectUri: new URL(url).searchParams.get("redirect_uri"),
+    stateCookieDomain:
+      /domain=([^;]+)/i.exec(res.headers.get("set-cookie") ?? "")?.[1] ?? null,
+    storedCallbackURL: stored?.callbackURL,
+  };
+}
+
+describe("oAuthProxy on Cloudflare previews", () => {
+  it("engages on a *.workers.dev preview: relays via the preview and pins redirect_uri to production", async () => {
+    const r = await socialCallbackURL(PREVIEW);
+    // The provider is still sent to the REGISTERED production callback…
+    expect(r.redirectUri).toBe(`${APEX}/api/auth/callback/google`);
+    // …but the post-auth hop routes back through the preview's proxy endpoint.
+    expect(r.storedCallbackURL).toContain(`${PREVIEW}/api/auth/oauth-proxy-callback`);
+    // And the state cookie is scoped to the preview host, not dataslope.com.
+    expect(r.stateCookieDomain).toBe("x-dataslope.subwaymatch.workers.dev");
+  });
+
+  it("is a no-op on the apex (production flow unchanged)", async () => {
+    const r = await socialCallbackURL(APEX);
+    expect(r.redirectUri).toBe(`${APEX}/api/auth/callback/google`);
+    expect(r.storedCallbackURL).toBe("/account");
+    expect(r.stateCookieDomain).toBe("dataslope.com");
+  });
+
+  it("is a no-op on www (keeps the domain-scoped state cookie, no proxy)", async () => {
+    const r = await socialCallbackURL(WWW);
+    expect(r.redirectUri).toBe(`${APEX}/api/auth/callback/google`);
+    expect(r.storedCallbackURL).toBe("/account");
+    expect(r.stateCookieDomain).toBe("dataslope.com");
+  });
+});

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -35,9 +35,10 @@ declare global {
     BETTER_AUTH_URL: string;
     // From address for transactional email (must be on a Resend-verified domain).
     EMAIL_FROM?: string;
-    // Extra CSRF-trusted origins (comma-separated), on top of BETTER_AUTH_URL
-    // and the auto-trusted *.workers.dev preview origins. For custom preview or
-    // staging domains. See `trustedOrigins` in lib/auth/server.ts.
+    // Extra CSRF-trusted origins (comma-separated), on top of BETTER_AUTH_URL,
+    // the apex + its subdomains (so www.dataslope.com is trusted), and the
+    // auto-trusted *.workers.dev preview origins. For custom preview or staging
+    // domains. See `trustedOrigins` in lib/auth/server.ts.
     TRUSTED_ORIGINS?: string;
 
     // --- "Ask AI" model config (vars; see lib/ai/models.ts) ---
@@ -76,6 +77,13 @@ declare global {
     // (lib/auth/server.ts) hard-fails when it's unset rather than falling back
     // to Better Auth's built-in key.
     BETTER_AUTH_SECRET: string;
+    // Optional dedicated key for the oAuthProxy plugin (Google/GitHub sign-in
+    // on *.workers.dev preview deployments; see `oAuthProxy` in
+    // lib/auth/server.ts). It encrypts the profile relayed from the production
+    // callback back to the preview, so it must be identical across all
+    // deployments. Defaults to BETTER_AUTH_SECRET (already Worker-wide) when
+    // unset; set a distinct value to narrow the blast radius.
+    OAUTH_PROXY_SECRET?: string;
     GOOGLE_CLIENT_ID?: string;
     GOOGLE_CLIENT_SECRET?: string;
     GITHUB_CLIENT_ID?: string;

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -22,7 +22,7 @@
  */
 import { betterAuth } from "better-auth";
 import { createAuthMiddleware } from "better-auth/api";
-import { admin } from "better-auth/plugins";
+import { admin, oAuthProxy } from "better-auth/plugins";
 import { D1Dialect } from "kysely-d1";
 import { promoteConfiguredAdmins } from "@/lib/auth/adminBootstrap";
 import { resetPasswordEmail, sendEmail, verifyEmail } from "@/lib/auth/email";
@@ -74,6 +74,115 @@ export function oauthStateCookieDomain(
   if (!hostname.includes(".") || hostname.startsWith("[")) return undefined;
   if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) return undefined;
   return hostname;
+}
+
+/**
+ * Is `requestHost` the same site as the host of `baseURL` — that exact host or
+ * a subdomain of it? Used to widen the CSRF origin allow-list.
+ *
+ * Production serves this app on BOTH dataslope.com and www.dataslope.com with
+ * no canonical redirect (the very reason oauthStateCookieDomain exists). Better
+ * Auth trusts only `baseURL` (pinned to the apex, https://dataslope.com) plus
+ * whatever `trustedOrigins` adds, so an email/password sign-up POST issued from
+ * www.dataslope.com carried `Origin: https://www.dataslope.com`, which matched
+ * neither the apex baseURL nor a workers.dev preview, and Better Auth rejected
+ * it with "Invalid origin". Trusting the apex and its subdomains closes that
+ * gap without a per-host TRUSTED_ORIGINS entry.
+ *
+ * The subdomain test is anchored on a leading dot, so `dataslope.com` trusts
+ * `www.dataslope.com` but never a look-alike whose registrable domain differs:
+ * `dataslope.com.evil.com` ends with `.evil.com`, not `.dataslope.com`, and
+ * `notdataslope.com` isn't a suffix match either. This only ever adds the
+ * request's *own* host to the allow-list; Better Auth still compares the actual
+ * `Origin` header against it, so a cross-site POST (Origin: evil.com) arriving
+ * at www is still rejected — CSRF protection is intact.
+ */
+export function isSameSiteHost(
+  baseURL: string | undefined,
+  requestHost: string | undefined,
+): boolean {
+  if (!baseURL || !requestHost) return false;
+  let baseHost: string;
+  try {
+    baseHost = new URL(baseURL).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  const req = requestHost.toLowerCase();
+  return req === baseHost || req.endsWith(`.${baseHost}`);
+}
+
+/**
+ * The origin THIS deployment is actually served from: the request's own origin
+ * on a *.workers.dev preview, otherwise the pinned production URL (and the
+ * pinned value — possibly undefined — for request-less calls or local dev).
+ *
+ * It drives the two places that must distinguish "this is a throwaway preview"
+ * from "this is production":
+ *
+ *   - the OAuth `state` cookie's Domain (oauthStateCookieDomain): a preview
+ *     gets a host-valid Domain instead of Domain=dataslope.com, which the
+ *     browser would reject on a workers.dev host and drop the cookie.
+ *   - oAuthProxy's `currentURL`: the proxy engages only when currentURL differs
+ *     from productionURL, so pinning previews to their own origin and every
+ *     other host (apex, www) to the production URL confines the whole OAuth
+ *     relay to previews — apex and www keep their exact current flows.
+ *
+ * Only workers.dev floats; www.dataslope.com resolves to the pinned apex, so it
+ * is treated as production (its social login keeps completing via the
+ * domain-scoped state cookie, and email/password via the origin allow-list).
+ */
+export function deploymentOrigin(
+  pinned: string | undefined,
+  request?: Request,
+): string | undefined {
+  if (!request) return pinned;
+  try {
+    const { origin, hostname } = new URL(request.url);
+    if (hostname.endsWith(".workers.dev")) return origin;
+  } catch {
+    // Unparseable request URL → fall back to the pinned value.
+  }
+  return pinned;
+}
+
+/**
+ * The extra CSRF-trusted origins to merge on top of Better Auth's defaults
+ * (which already trust `baseURL`). Passed as the `trustedOrigins` callback, so
+ * Better Auth still compares the real `Origin`/`Referer` header against the
+ * merged list — this only ever contributes the request's OWN origin, plus the
+ * configured TRUSTED_ORIGINS. A cross-site POST (Origin: evil.example arriving
+ * at our host) is still rejected, and session cookies stay SameSite=Lax.
+ *
+ * Two dynamic additions, both scoped to the request's own host:
+ *   - the production site and its subdomains (isSameSiteHost), so
+ *     www.dataslope.com is trusted even though BETTER_AUTH_URL pins the apex —
+ *     this is the fix for "Invalid origin" on email sign-up from www.
+ *   - *.workers.dev preview deployments, so auth works on a preview URL.
+ *
+ * Note the origin check only runs in production: Better Auth skips it when
+ * NODE_ENV=test (see skipOriginCheck), which is why the endpoint tests force it
+ * back on with `advanced.disableOriginCheck: false`.
+ */
+export function extraTrustedOrigins(
+  env: CloudflareEnv,
+  request?: Request,
+): string[] {
+  const origins = parseList(env.TRUSTED_ORIGINS);
+  try {
+    if (request) {
+      const { origin, hostname } = new URL(request.url);
+      if (
+        hostname.endsWith(".workers.dev") ||
+        isSameSiteHost(env.BETTER_AUTH_URL, hostname)
+      ) {
+        origins.push(origin);
+      }
+    }
+  } catch {
+    // A request without a parseable URL contributes no extra origin.
+  }
+  return origins;
 }
 
 /**
@@ -175,7 +284,27 @@ export async function createAuth(env: CloudflareEnv, request?: Request) {
 
   const adminUserIdsResolved = await resolveAdminUserIds(env, request);
 
-  const stateCookieDomain = oauthStateCookieDomain(env.BETTER_AUTH_URL);
+  // Where THIS deployment is served from: its own origin on a *.workers.dev
+  // preview, else the pinned apex (production/www). Drives the state-cookie
+  // Domain and oAuthProxy's currentURL. See deploymentOrigin.
+  const thisOrigin = deploymentOrigin(env.BETTER_AUTH_URL, request);
+
+  // Scope the OAuth `state` cookie off THIS deployment's origin so a preview
+  // sets a host-valid Domain (its own workers.dev host) instead of
+  // Domain=dataslope.com, which the browser would reject on a workers.dev host
+  // and drop the cookie. On production/www this is the apex, so it's unchanged
+  // (Domain=dataslope.com, covering the apex + the www→apex callback).
+  const stateCookieDomain = oauthStateCookieDomain(thisOrigin);
+
+  // Turn on the OAuth-proxy relay only when there's a pinned production origin
+  // to proxy through AND at least one social provider to proxy. It's a no-op on
+  // the production origin itself (productionURL === currentURL), and on a
+  // preview it rewrites the provider redirect_uri to the production callback and
+  // relays the authenticated session back to the preview. Requires the same
+  // secret across deployments; BETTER_AUTH_SECRET already is (same Worker), so
+  // it's the default, with OAUTH_PROXY_SECRET as an optional dedicated key.
+  const oauthProxyEnabled =
+    Boolean(env.BETTER_AUTH_URL) && Object.keys(socialProviders).length > 0;
 
   return betterAuth({
     // D1 via the Kysely SQLite dialect, the most Cloudflare-native path, with
@@ -188,33 +317,31 @@ export async function createAuth(env: CloudflareEnv, request?: Request) {
     secret: env.BETTER_AUTH_SECRET,
     // Canonical origin for OAuth callback URLs. Unset → inferred from the
     // request; set BETTER_AUTH_URL (wrangler `vars`, or `.dev.vars` locally)
-    // when the deployed origin must be pinned.
+    // when the deployed origin must be pinned. Stays pinned on every host,
+    // including previews: oAuthProxy (below) does the preview relay via its own
+    // `currentURL`, so the base URL never has to float.
     baseURL: env.BETTER_AUTH_URL,
-    // CSRF origin allow-list. Better Auth always trusts `baseURL` (pinned to
-    // https://dataslope.com so OAuth callbacks resolve). Preview deployments,
-    // though, are served from the account's *.workers.dev subdomain, which is
-    // therefore NOT trusted, so email/password sign-in and sign-up on a preview
-    // fail the origin check with "Invalid origin". Trust the request's own
-    // origin when it's a workers.dev host, so previews work without per-URL
-    // config, plus any explicit TRUSTED_ORIGINS extras (custom preview/staging
-    // domains). This function's result is merged with the defaults, so baseURL
-    // stays trusted. It's not a production CSRF hole: production runs on the
-    // custom domain (never the workers.dev branch), and session cookies are
-    // SameSite=Lax. NOTE: social login still can't *complete* on a preview,
-    // its OAuth redirect_uri is pinned to baseURL, so Google/GitHub return to
-    // production; use email/password to exercise auth on a preview URL.
-    trustedOrigins: (req) => {
-      const origins = parseList(env.TRUSTED_ORIGINS);
-      try {
-        if (req) {
-          const { origin, hostname } = new URL(req.url);
-          if (hostname.endsWith(".workers.dev")) origins.push(origin);
-        }
-      } catch {
-        // A request without a parseable URL contributes no extra origin.
-      }
-      return origins;
-    },
+    // CSRF origin allow-list. Better Auth always trusts `baseURL`. Two extra
+    // classes of origin get the request's own origin added:
+    //
+    //   - The production site itself: BETTER_AUTH_URL is pinned to the apex
+    //     (https://dataslope.com), but the app is ALSO served on
+    //     www.dataslope.com with no canonical redirect. An email/password
+    //     sign-up POST from www therefore carried Origin: https://www.dataslope.com,
+    //     which matched neither the apex baseURL nor a preview host, and Better
+    //     Auth rejected it with "Invalid origin". Trust the apex and any
+    //     subdomain of it (isSameSiteHost) so www — and any future *.dataslope.com
+    //     host — is accepted.
+    //   - Preview deployments on the account's *.workers.dev subdomain, which
+    //     are otherwise untrusted, so auth on a preview also failed the origin
+    //     check. (Social login additionally needs the oAuthProxy plugin below to
+    //     *complete* on a preview; email/password works from the origin trust
+    //     alone.)
+    //
+    // Plus any explicit TRUSTED_ORIGINS extras (custom preview/staging domains).
+    // See extraTrustedOrigins: the result is merged with the defaults (so
+    // baseURL stays trusted) and only ever adds the request's OWN host.
+    trustedOrigins: (req) => extraTrustedOrigins(env, req),
     // Where failed OAuth callbacks land. Without this, Better Auth bounces
     // them through its built-in /api/auth/error page, which in production
     // redirects to `/?error=<code>`, stranding codes like `state_mismatch`
@@ -360,12 +487,42 @@ export async function createAuth(env: CloudflareEnv, request?: Request) {
     // endpoints when configured, see lib/billing/polar.ts. Like every other
     // integration here it's fail-safe: with no POLAR_* config the plugin
     // simply isn't registered and auth runs exactly as before.
+    //
+    // oAuthProxy makes Google/GitHub sign-in *complete* on a *.workers.dev
+    // preview. Google requires an exact, pre-registered redirect_uri, so only
+    // the production callback (https://dataslope.com/api/auth/callback/*) is
+    // registered and previews can't be. The proxy rewrites the redirect_uri to
+    // that production callback, lets production exchange the code, then relays
+    // the authenticated session back to the preview's own origin (the session
+    // is created on the preview, not production). It no-ops on production
+    // itself, where `productionURL` equals `currentURL`, so the apex/www flow
+    // is unchanged. It needs one secret shared across deployments to encrypt the
+    // relayed profile; the Worker's BETTER_AUTH_SECRET already is, so it's the
+    // default (override with a dedicated OAUTH_PROXY_SECRET if desired).
     plugins: (() => {
       const adminPlugin = admin({
         adminUserIds: adminUserIdsResolved,
       });
       const billing = polarPlugin(env);
-      return billing ? [adminPlugin, billing] : [adminPlugin];
+      const proxy = oauthProxyEnabled
+        ? oAuthProxy({
+            productionURL: env.BETTER_AUTH_URL,
+            // Pin the proxy's notion of "current URL" to THIS deployment's
+            // origin. The plugin skips proxying when currentURL === productionURL
+            // and otherwise relays back to currentURL, so this confines the
+            // relay to workers.dev previews: apex and www both resolve to the
+            // apex here (=== productionURL) and are never proxied, while a
+            // preview resolves to its own origin and is. Without it the plugin
+            // falls back to the raw request host and would proxy www too.
+            currentURL: thisOrigin,
+            secret: env.OAUTH_PROXY_SECRET ?? env.BETTER_AUTH_SECRET,
+          })
+        : null;
+      return [
+        adminPlugin,
+        ...(billing ? [billing] : []),
+        ...(proxy ? [proxy] : []),
+      ];
     })(),
     session: {
       // Cache the session in a short-lived signed cookie so the common


### PR DESCRIPTION
## Problem

Creating an account with email/password on **www.dataslope.com** failed with **"Invalid origin"** (see the reported screenshot).

Production serves the app on both `dataslope.com` and `www.dataslope.com` with no canonical redirect, but Better Auth only trusts `BETTER_AUTH_URL` (pinned to the apex) for its CSRF origin check. A form POST from `www` carries `Origin: https://www.dataslope.com`, which matched neither the apex `baseURL` nor a `*.workers.dev` preview — so Better Auth rejected it. (The check only fires in production; `NODE_ENV=test` disables it, which is why it wasn't caught by tests.)

A follow-up ask was also addressed: **make password auth and Google/GitHub sign-in work on Cloudflare preview branches.** Password auth already worked on previews (workers.dev was trusted); social login did **not** — the OAuth `redirect_uri` is pinned to the registered production callback, so Google/GitHub returned to production and stranded the user there.

## Changes

**`lib/auth/server.ts`**
- **Trust the apex + its subdomains** (`isSameSiteHost`) in the CSRF allow-list, so `www.dataslope.com` (and any future `*.dataslope.com` host) is accepted. It only ever adds the request's *own* host; the real `Origin` header is still checked, so cross-site POSTs stay rejected and session cookies stay `SameSite=Lax`.
- Extracted the trusted-origins builder into **`extraTrustedOrigins()`** for direct testing.
- **Enable Better Auth's `oAuthProxy` plugin** so Google/GitHub sign-in completes on `*.workers.dev` previews: the provider still returns to the registered production callback, then the authenticated session is relayed back to the preview (session created on the preview, not production). Only the production callback needs to be registered with the providers.
- The proxy is **scoped to previews only** via `currentURL = deploymentOrigin(...)`: apex and `www` resolve to the production URL (`currentURL === productionURL`), so the proxy is a no-op there and their flows are byte-for-byte unchanged. The relay secret defaults to `BETTER_AUTH_SECRET` (already shared across the Worker's deployments); `OAUTH_PROXY_SECRET` can override it.
- **Scope the OAuth `state` cookie's `Domain` per deployment** (`deploymentOrigin`) so a preview gets a host-valid `Domain` instead of `Domain=dataslope.com`, which the browser would reject on a `workers.dev` host and drop.

**`cloudflare-env.d.ts`** — added optional `OAUTH_PROXY_SECRET`; updated the `TRUSTED_ORIGINS` note.

**`README.md`** — documented the www / preview behavior and the optional `OAUTH_PROXY_SECRET`.

## Behavior matrix

| Host | Email/password origin check | Google/GitHub | State cookie `Domain` |
|------|------|------|------|
| `dataslope.com` (apex) | trusted (unchanged) | direct (proxy no-op) | `dataslope.com` |
| `www.dataslope.com` | **now trusted** | via domain-scoped state cookie (proxy no-op) | `dataslope.com` |
| `*.workers.dev` preview | trusted | **now completes via oAuthProxy relay** | preview host |
| cross-site `Origin` | **rejected** ✓ | rejected ✓ | — |

## Testing

New `__tests__/authOriginPreview.test.ts` (16 tests):
- Unit tests for `isSameSiteHost`, `deploymentOrigin`, `extraTrustedOrigins` (incl. look-alike rejection: `dataslope.com.evil.com`, `notdataslope.com`).
- **End-to-end origin enforcement** (forces the check on with `advanced.disableOriginCheck: false`): www and preview accepted, cross-site `Origin` rejected with "Invalid origin".
- **oAuthProxy engagement**: preview relays through `/oauth-proxy-callback` with `redirect_uri` pinned to the production callback and a preview-scoped state cookie; apex/www are no-ops.

Full suite: **912 passing** (60 files). `tsc --noEmit` and `eslint` clean.

> ⚠️ OAuth can't be exercised end-to-end in unit tests (no live provider). The proxy mechanism is verified at the request/DB-write level; please smoke-test one real Google/GitHub sign-in on a preview URL after deploy. Requirements: keep only the production callback registered with the providers, and ensure the relay secret (`BETTER_AUTH_SECRET`, or `OAUTH_PROXY_SECRET` if set) is identical across production and preview deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEPTuKLCP46vJmqr7xsXjc)_