### PR TITLE
Account page: connected sign-in methods, account deletion, and clearer sign-up collision

### DIFF
--- a/app/_components/home/icons.tsx
+++ b/app/_components/home/icons.tsx
@@ -13,3 +13,28 @@ export function GitHubIcon({ size = 18 }: { size?: number }) {
     </svg>
   );
 }
+
+/** Google "G" mark, inline (its four-colour brand glyph isn't in lucide). Used
+ *  on the sign-in card and the account page's connected-accounts section. */
+export function GoogleIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 18 18" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62Z"
+      />
+      <path
+        fill="#34A853"
+        d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18Z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33Z"
+      />
+      <path
+        fill="#EA4335"
+        d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58Z"
+      />
+    </svg>
+  );
+}

--- a/app/account/AccountClient.tsx
+++ b/app/account/AccountClient.tsx
@@ -13,6 +13,7 @@ import {
 } from "../_components/billing/proCheckout";
 import { CloudStorageSection } from "./CloudStorageSection";
 import { ConnectedAccountsSection } from "./ConnectedAccountsSection";
+import { DeleteAccountSection } from "./DeleteAccountSection";
 
 /**
  * The account area is the canonical example of the report's rule: auth gates
@@ -240,6 +241,11 @@ export function AccountClient() {
     {/* Cloud saves + share links (all playgrounds), the quota is
         account-wide, so this is where users see and free up everything. */}
     <CloudStorageSection />
+
+    {/* Irreversible account deletion, kept last. `plan === "pro"` (not the
+        admin-as-Pro case) is what carries a real Polar subscription to warn
+        about. */}
+    <DeleteAccountSection email={user.email} isPaidPro={plan === "pro"} />
     </>
   );
 }

--- a/app/account/AccountClient.tsx
+++ b/app/account/AccountClient.tsx
@@ -12,6 +12,7 @@ import {
   waitForProActivation,
 } from "../_components/billing/proCheckout";
 import { CloudStorageSection } from "./CloudStorageSection";
+import { ConnectedAccountsSection } from "./ConnectedAccountsSection";
 
 /**
  * The account area is the canonical example of the report's rule: auth gates
@@ -231,6 +232,10 @@ export function AccountClient() {
         {signingOut ? "Signing out…" : "Sign out"}
       </button>
     </div>
+
+    {/* Connected sign-in methods (Google / GitHub), plus the guard against
+        removing a user's only way back in. */}
+    <ConnectedAccountsSection />
 
     {/* Cloud saves + share links (all playgrounds), the quota is
         account-wide, so this is where users see and free up everything. */}

--- a/app/account/ConnectedAccountsSection.tsx
+++ b/app/account/ConnectedAccountsSection.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+/**
+ * Account-page management for connected sign-in methods (social integrations).
+ *
+ * Every login method a user has is one row in the `account` table, keyed by
+ * `providerId` ("google" / "github" for OAuth, "credential" for email +
+ * password). This section reads them back with Better Auth's `listAccounts`
+ * and lets the user attach another provider (`linkSocial`, an OAuth redirect)
+ * or detach one (`unlinkAccount`). All three are Better Auth's own
+ * `/api/auth/*` endpoints, already served by the catch-all handler
+ * (app/api/auth/[...all]/route.ts), so no server code is added here.
+ *
+ * Lockout guard: Better Auth refuses to unlink a user's *only* account (it
+ * would leave them with no way back in). We mirror that in the UI, the Remove
+ * button is disabled with an explanation when a provider is the last remaining
+ * method, rather than firing a call that comes back 400.
+ *
+ * Provider availability: like the sign-in card (app/sign-in/SignInClient.tsx),
+ * both Google and GitHub are always offered. A provider that isn't configured
+ * in this environment simply surfaces an error when Connect is pressed, the
+ * same behavior as that card, kept deliberately consistent.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { GitHubIcon, GoogleIcon } from "@/app/_components/home/icons";
+import { linkSocial, listAccounts, unlinkAccount } from "@/lib/auth/client";
+
+/** The subset of a Better Auth account row this section reads. */
+interface LinkedAccount {
+  providerId: string;
+  accountId?: string;
+  createdAt?: string | Date;
+}
+
+/** The social providers offered here, in display order. `credential` (email +
+ *  password) is intentionally not listed, it's counted toward the lockout
+ *  guard below but managed via the password/reset flow, not connect/disconnect. */
+const PROVIDERS: {
+  id: string;
+  label: string;
+  Icon: ({ size }: { size?: number }) => React.ReactElement;
+}[] = [
+  { id: "google", label: "Google", Icon: GoogleIcon },
+  { id: "github", label: "GitHub", Icon: GitHubIcon },
+];
+
+const actionClass =
+  "rounded-lg border border-[var(--ds-gray-200)] px-2.5 py-1 text-xs font-medium text-[var(--ds-gray-900)] transition-colors hover:bg-[var(--ds-gray-100)] disabled:opacity-50 dark:border-white/15 dark:text-white dark:hover:bg-white/10";
+const dangerActionClass =
+  "rounded-lg border border-red-200 px-2.5 py-1 text-xs font-medium text-red-700 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-500/30 dark:text-red-300 dark:hover:bg-red-500/10";
+
+export function ConnectedAccountsSection() {
+  const [accounts, setAccounts] = useState<LinkedAccount[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const { data, error: apiError } = await listAccounts();
+      if (apiError) {
+        setError(apiError.message ?? "Couldn't load your sign-in methods.");
+        return;
+      }
+      setAccounts((data ?? []) as LinkedAccount[]);
+      setError(null);
+    } catch {
+      setError("Couldn't load your sign-in methods. Please try again.");
+    }
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- state lands asynchronously after the fetch, not in the effect body
+    void refresh();
+  }, [refresh]);
+
+  const handleConnect = useCallback(async (id: string, label: string) => {
+    setBusy(id);
+    setError(null);
+    // Full-page redirect to the provider on success (the browser leaves this
+    // page, so keeping the button "busy" is right), returning to /account where
+    // the mount re-fetches and shows the newly-linked provider. A server-side
+    // failure resolves with {error} (it does NOT reject), e.g. the provider
+    // isn't configured here, or the OAuth email doesn't match the account, and
+    // must re-enable the button; a rejection is a network failure and must too.
+    try {
+      const { error: apiError } = await linkSocial({
+        provider: id,
+        callbackURL: "/account",
+      });
+      if (apiError) {
+        setError(apiError.message ?? `Couldn't connect ${label}.`);
+        setBusy(null);
+      }
+    } catch {
+      setError(
+        "Couldn't reach the server. Please check your connection and try again.",
+      );
+      setBusy(null);
+    }
+  }, []);
+
+  const handleRemove = useCallback(
+    async (id: string, label: string) => {
+      if (
+        !window.confirm(
+          `Disconnect ${label} from your account? You'll no longer be able ` +
+            `to sign in with ${label}. This doesn't delete your account or ` +
+            `your saved work.`,
+        )
+      ) {
+        return;
+      }
+      setBusy(id);
+      setError(null);
+      try {
+        const { error: apiError } = await unlinkAccount({ providerId: id });
+        if (apiError) {
+          setError(apiError.message ?? `Couldn't disconnect ${label}.`);
+        } else {
+          await refresh();
+        }
+      } catch {
+        setError(
+          "Couldn't reach the server. Please check your connection and try again.",
+        );
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refresh],
+  );
+
+  // Total sign-in methods, including email + password ("credential"). Removing
+  // the last one would lock the user out, so Better Auth blocks it and so do we.
+  const methodCount = accounts?.length ?? 0;
+  const hasPassword = accounts?.some((a) => a.providerId === "credential");
+
+  return (
+    <div className="mt-6 rounded-2xl border border-[var(--ds-gray-200)] bg-white p-6 dark:border-white/10 dark:bg-white/5">
+      <h2 className="text-base font-semibold text-[var(--ds-gray-900)] dark:text-white">
+        Sign-in methods
+      </h2>
+      <p className="mt-1 text-sm text-[var(--ds-gray-500)]">
+        Connect Google or GitHub to sign in with one tap. Removing a method
+        doesn&rsquo;t delete your account or your saved work.
+      </p>
+
+      {error && (
+        <p
+          role="alert"
+          className="mt-4 rounded-xl bg-red-500/[0.08] px-4 py-3 text-sm text-red-700 dark:bg-red-500/[0.12] dark:text-red-300"
+        >
+          {error}
+        </p>
+      )}
+
+      {accounts === null ? (
+        <p className="mt-4 text-sm text-[var(--ds-gray-500)]">Loading…</p>
+      ) : (
+        <ul className="mt-3 divide-y divide-[var(--ds-gray-100)] dark:divide-white/5">
+          {PROVIDERS.map(({ id, label, Icon }) => {
+            const linked = accounts.some((a) => a.providerId === id);
+            // Disconnect is blocked when this is the account's only sign-in
+            // method (Better Auth would reject it), guiding the user to add
+            // another method — or a password — before removing this one.
+            const isOnlyMethod = linked && methodCount <= 1;
+            return (
+              <li
+                key={id}
+                className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 py-3"
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-[var(--ds-gray-100)] dark:bg-white/10">
+                    <Icon size={18} />
+                  </span>
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-[var(--ds-gray-900)] dark:text-white">
+                      {label}
+                    </div>
+                    <div className="text-xs text-[var(--ds-gray-500)]">
+                      {linked ? "Connected" : "Not connected"}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  {isOnlyMethod && (
+                    <span className="text-xs text-[var(--ds-gray-500)]">
+                      Only sign-in method
+                    </span>
+                  )}
+                  {linked ? (
+                    <button
+                      type="button"
+                      className={dangerActionClass}
+                      disabled={busy !== null || isOnlyMethod}
+                      title={
+                        isOnlyMethod
+                          ? "Add another sign-in method before removing this one."
+                          : undefined
+                      }
+                      onClick={() => void handleRemove(id, label)}
+                    >
+                      {busy === id ? "Removing…" : "Remove"}
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className={actionClass}
+                      disabled={busy !== null}
+                      onClick={() => void handleConnect(id, label)}
+                    >
+                      {busy === id ? "Redirecting…" : "Connect"}
+                    </button>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {accounts !== null && !hasPassword && (
+        <p className="mt-4 border-t border-[var(--ds-gray-200)] pt-4 text-xs leading-relaxed text-[var(--ds-gray-500)] dark:border-white/10">
+          You sign in with a social provider only. To add an email &amp;
+          password, use{" "}
+          <span className="font-medium">Forgot password?</span> on the sign-in
+          page to set one for your email address.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/account/DeleteAccountSection.tsx
+++ b/app/account/DeleteAccountSection.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+/**
+ * Account-page "danger zone": self-service account deletion.
+ *
+ * Wired to Better Auth's `deleteUser` (lib/auth/server.ts enables it). Two
+ * server behaviours, both handled here:
+ *
+ *   - A mailer is configured → Better Auth emails a confirmation link and does
+ *     NOT delete until it's clicked, so the call returns "Verification email
+ *     sent" and the account stays put. We show a check-your-inbox notice. This
+ *     path works for social-only accounts regardless of how old the session is.
+ *   - No mailer → deletion is immediate, but Better Auth requires a *fresh*
+ *     session (signed in recently); a stale one comes back SESSION_EXPIRED,
+ *     which we translate into a "sign out and back in" prompt.
+ *
+ * Deleting drops the user row, which cascades to sessions, linked accounts,
+ * cloud saves, share links, and custom content; the server's beforeDelete hook
+ * additionally purges the R2 payloads those saves/shares point at.
+ *
+ * A typed-email confirmation guards the button, deletion is irreversible and a
+ * heavier gate than the one-tap window.confirm used elsewhere on this page.
+ */
+
+import { useState } from "react";
+
+import { deleteUser } from "@/lib/auth/client";
+
+export function DeleteAccountSection({
+  email,
+  isPaidPro,
+}: {
+  email: string;
+  /** True only for an actually-billed Pro plan (not admins treated as Pro), so
+   *  the Polar-billing warning shows exactly when there's a subscription to
+   *  cancel. */
+  isPaidPro: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Set once the emailed-confirmation path succeeds; the account isn't gone yet
+  // (the link completes it), so we swap the form for a standing notice.
+  const [emailSent, setEmailSent] = useState(false);
+
+  const confirmed = confirmText.trim().toLowerCase() === email.toLowerCase();
+
+  async function handleDelete() {
+    if (!confirmed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { data, error: apiError } = await deleteUser({ callbackURL: "/" });
+      if (apiError) {
+        if (apiError.code === "SESSION_EXPIRED") {
+          setError(
+            "For your security, deleting your account needs a recent sign-in. " +
+              "Please sign out, sign back in, and try again.",
+          );
+        } else {
+          setError(
+            apiError.message ??
+              "Couldn't delete your account. Please try again.",
+          );
+        }
+        setBusy(false);
+        return;
+      }
+      // A mailer is configured: Better Auth sent a confirmation link and hasn't
+      // deleted anything yet. Anything else means the row is already gone and
+      // the session is invalidated, so leave for home.
+      if (typeof data?.message === "string" && /email/i.test(data.message)) {
+        setEmailSent(true);
+        setBusy(false);
+        return;
+      }
+      window.location.assign("/");
+    } catch {
+      setError(
+        "Couldn't reach the server. Please check your connection and try again.",
+      );
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mt-6 rounded-2xl border border-red-200 bg-white p-6 dark:border-red-500/25 dark:bg-white/5">
+      <h2 className="text-base font-semibold text-red-700 dark:text-red-300">
+        Delete account
+      </h2>
+      <p className="mt-1 text-sm text-[var(--ds-gray-600)] dark:text-[var(--ds-gray-400)]">
+        Permanently delete your account and everything tied to it, your
+        sign-in methods, cloud saves, share links, and custom challenges. This
+        can&rsquo;t be undone.
+      </p>
+
+      {isPaidPro && (
+        <p className="mt-4 rounded-xl bg-amber-500/[0.10] px-4 py-3 text-sm text-amber-800 dark:bg-amber-500/[0.12] dark:text-amber-200">
+          You have an active Pro subscription. Deleting your account here
+          doesn&rsquo;t cancel billing, cancel it first with{" "}
+          <span className="font-medium">Manage subscription</span> above, or you
+          may continue to be charged.
+        </p>
+      )}
+
+      {emailSent ? (
+        <p
+          role="status"
+          className="mt-4 rounded-xl bg-[var(--ds-blue-600)]/10 px-4 py-3 text-sm text-[var(--ds-blue-600)]"
+        >
+          Check your email, we&rsquo;ve sent a confirmation link. Your account
+          stays active until you open it, and the link expires in 24 hours.
+        </p>
+      ) : !open ? (
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(true);
+            setError(null);
+          }}
+          className="mt-5 inline-flex items-center justify-center rounded-xl border border-red-300 px-4 py-2.5 text-sm font-semibold text-red-700 transition-colors hover:bg-red-50 dark:border-red-500/40 dark:text-red-300 dark:hover:bg-red-500/10"
+        >
+          Delete account
+        </button>
+      ) : (
+        <div className="mt-5">
+          <label
+            htmlFor="delete-confirm"
+            className="block text-sm text-[var(--ds-gray-700)] dark:text-[var(--ds-gray-300)]"
+          >
+            Type <span className="font-semibold">{email}</span> to confirm.
+          </label>
+          <input
+            id="delete-confirm"
+            type="email"
+            autoComplete="off"
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            disabled={busy}
+            className="mt-2 w-full rounded-xl border border-[var(--ds-gray-200)] bg-white px-3 py-2 text-sm text-[var(--ds-gray-900)] outline-none focus:border-red-400 focus:ring-2 focus:ring-red-400/30 disabled:opacity-60 dark:border-white/15 dark:bg-white/5 dark:text-white"
+          />
+
+          {error && (
+            <p
+              role="alert"
+              className="mt-3 rounded-xl bg-red-500/[0.08] px-4 py-3 text-sm text-red-700 dark:bg-red-500/[0.12] dark:text-red-300"
+            >
+              {error}
+            </p>
+          )}
+
+          <div className="mt-4 flex gap-2">
+            <button
+              type="button"
+              onClick={() => void handleDelete()}
+              disabled={!confirmed || busy}
+              className="inline-flex items-center justify-center rounded-xl bg-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy ? "Deleting…" : "Permanently delete"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                setConfirmText("");
+                setError(null);
+              }}
+              disabled={busy}
+              className="inline-flex items-center justify-center rounded-xl border border-[var(--ds-gray-200)] px-4 py-2.5 text-sm font-medium text-[var(--ds-gray-900)] transition-colors hover:bg-[var(--ds-gray-100)] disabled:opacity-60 dark:border-white/15 dark:text-white dark:hover:bg-white/10"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/sign-in/SignInClient.tsx
+++ b/app/sign-in/SignInClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, KeyRound, LogIn, Mail, UserPlus } from "lucide-react";
-import { GitHubIcon } from "../_components/home/icons";
+import { GitHubIcon, GoogleIcon } from "../_components/home/icons";
 import {
   requestPasswordReset,
   signIn,
@@ -100,30 +100,6 @@ const DOC_TITLE: Record<Mode, string> = {
   signup: "Create your account",
   forgot: "Reset your password",
 };
-
-function GoogleGlyph() {
-  // Google "G" mark, inline so it needs no extra icon dependency.
-  return (
-    <svg width="16" height="16" viewBox="0 0 18 18" aria-hidden="true">
-      <path
-        fill="#4285F4"
-        d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62Z"
-      />
-      <path
-        fill="#34A853"
-        d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18Z"
-      />
-      <path
-        fill="#FBBC05"
-        d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33Z"
-      />
-      <path
-        fill="#EA4335"
-        d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58Z"
-      />
-    </svg>
-  );
-}
 
 /**
  * Auth card spanning three modes, sign in, create account, and request a
@@ -340,6 +316,21 @@ export function SignInClient({
           setNotice(
             "Please verify your email first. We've sent you a new verification link.",
           );
+        } else if (isSignup && error.code === "USER_ALREADY_EXISTS") {
+          // Sign-up never attaches a password to an existing account, it only
+          // ever creates a new user, so a same-email sign-up is a collision.
+          // The most common cause is someone who first signed in with Google or
+          // GitHub and doesn't realize they already have an account. Point them
+          // at signing in (including socially) or the reset flow to set a
+          // password, rather than the bare "User already exists". (This branch
+          // only runs where Better Auth surfaces the collision as an error;
+          // when email verification is on it instead returns a neutral success
+          // to prevent enumeration, handled below.)
+          setError(
+            "An account already exists for that email. Try signing in below — " +
+              "including with Google or GitHub if that's how you first signed " +
+              "up. You can also use “Forgot password?” to set a password.",
+          );
         } else {
           setError(error.message ?? "Something went wrong. Please try again.");
         }
@@ -348,12 +339,20 @@ export function SignInClient({
       }
 
       // Sign-up with verification required returns no active session, prompt to
-      // verify rather than redirecting into a gated page.
+      // verify rather than redirecting into a gated page. The copy is kept
+      // honest for BOTH outcomes this branch covers without leaking which one
+      // happened: a genuinely new sign-up (a link really is on its way) and a
+      // same-email collision, where Better Auth returns this same neutral
+      // success to prevent user enumeration and no account or password was
+      // created. So it avoids claiming "account created" and nudges an existing
+      // (often social) user to just sign in.
       if (isSignup && data && !("token" in data && data.token)) {
         setPassword("");
         go("signin"); // clears notice…
         setNotice(
-          "Account created. Check your email for a verification link, then sign in.",
+          "Almost there — check your email for a verification link, then sign " +
+            "in. Already have an account (including with Google or GitHub)? " +
+            "Just sign in instead.",
         ); // …so set it after the switch
         setSubmitting(false);
         return;
@@ -519,7 +518,7 @@ export function SignInClient({
                 </>
               ) : (
                 <>
-                  <GoogleGlyph />
+                  <GoogleIcon size={16} />
                   Google
                 </>
               )}

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -27,4 +27,12 @@ export const {
   useSession,
   requestPasswordReset,
   resetPassword,
+  // Connected sign-in methods, surfaced on the account page: list the user's
+  // linked providers, attach another (OAuth redirect), or detach one. These hit
+  // Better Auth's built-in /api/auth/{list-accounts,link-social,unlink-account}
+  // endpoints, already served by the catch-all handler, so no server code is
+  // added. Better Auth refuses to unlink a user's only account (lockout guard).
+  listAccounts,
+  linkSocial,
+  unlinkAccount,
 } = authClient;

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -35,4 +35,9 @@ export const {
   listAccounts,
   linkSocial,
   unlinkAccount,
+  // Self-service account deletion (the account page's danger zone). Hits Better
+  // Auth's /api/auth/delete-user; server-side (lib/auth/server.ts) this cleans
+  // up the user's R2 objects and, when a mailer is configured, requires an
+  // emailed confirmation link before the row is actually removed.
+  deleteUser,
 } = authClient;

--- a/lib/auth/email.ts
+++ b/lib/auth/email.ts
@@ -108,3 +108,19 @@ export function verifyEmail(url: string): Omit<SendArgs, "to"> {
     }),
   };
 }
+
+/** Account-deletion confirmation email content. The link completes an
+ *  irreversible deletion, so the copy is unambiguous and the "ignore if you
+ *  didn't request this" footer (added by `layout`) matters more than usual. */
+export function deleteAccountEmail(url: string): Omit<SendArgs, "to"> {
+  return {
+    subject: "Confirm your Dataslope account deletion",
+    text: `Confirm that you want to permanently delete your Dataslope account, including your cloud saves, share links, and custom content, by opening this link:\n\n${url}\n\nThis cannot be undone. If you didn't request this, ignore this email and your account stays exactly as it is.`,
+    html: layout({
+      heading: "Confirm account deletion",
+      body: "Click below to permanently delete your Dataslope account, including your cloud saves, share links, and custom content. This can&rsquo;t be undone.",
+      cta: "Delete my account",
+      url,
+    }),
+  };
+}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -25,8 +25,14 @@ import { createAuthMiddleware } from "better-auth/api";
 import { admin, oAuthProxy } from "better-auth/plugins";
 import { D1Dialect } from "kysely-d1";
 import { promoteConfiguredAdmins } from "@/lib/auth/adminBootstrap";
-import { resetPasswordEmail, sendEmail, verifyEmail } from "@/lib/auth/email";
+import {
+  deleteAccountEmail,
+  resetPasswordEmail,
+  sendEmail,
+  verifyEmail,
+} from "@/lib/auth/email";
 import { polarPlugin } from "@/lib/billing/polar";
+import { deleteAllUserObjects } from "@/lib/workspaces/store";
 
 /** Split a comma-separated secret into a trimmed, non-empty list. Exported
  *  for the custom admin API routes' authorization check (lib/auth/admin.ts). */
@@ -423,6 +429,47 @@ export async function createAuth(env: CloudflareEnv, request?: Request) {
           defaultValue: "free",
           input: false,
         },
+      },
+      // Let a user delete their own account from /account. The `user` row's
+      // deletion cascades to their `session` + `account` rows and their
+      // cloud_workspaces / playground_shares rows (ON DELETE CASCADE,
+      // migrations/0001 + 0005), but the *R2 payloads* behind those saves and
+      // shares don't cascade, so beforeDelete drops them first. It's
+      // best-effort (never throws) so a storage hiccup can't trap a user in an
+      // account they asked to delete.
+      //
+      // Confirmation model mirrors the rest of the email surface, gated on a
+      // configured sender: with RESEND set, deletion always requires clicking a
+      // link we email (Better Auth sends it and holds off deleting until the
+      // callback), which is safe for social-only users regardless of session
+      // age. With no sender, Better Auth falls back to requiring a *fresh*
+      // session (or the account password); the account page surfaces that.
+      //
+      // NOTE: this does not cancel a Pro user's Polar subscription (billing is
+      // Polar's own record, keyed by customer, not deleted with our user row).
+      // The account page warns paying users to cancel via the billing portal
+      // first; wiring an automatic Polar cancel here is a possible follow-up.
+      deleteUser: {
+        enabled: true,
+        beforeDelete: async (user) => {
+          await deleteAllUserObjects(env, user.id);
+        },
+        ...(emailConfigured
+          ? {
+              sendDeleteAccountVerification: async ({
+                user,
+                url,
+              }: {
+                user: { email: string };
+                url: string;
+              }) => {
+                await sendEmail(env, {
+                  to: user.email,
+                  ...deleteAccountEmail(url),
+                });
+              },
+            }
+          : {}),
       },
     },
     // Complete the ADMIN_EMAILS / ADMIN_USER_IDS bootstrap: config-listed

--- a/lib/workspaces/store.ts
+++ b/lib/workspaces/store.ts
@@ -235,6 +235,41 @@ export async function deleteShares(
   await env.DB.batch(rows.map((r) => stmt.bind(r.id)));
 }
 
+/**
+ * Drop every R2 object a user owns, their cloud saves *and* their share links,
+ * used when the whole account is deleted (Better Auth `deleteUser.beforeDelete`
+ * in lib/auth/server.ts). The `cloud_workspaces` / `playground_shares` rows
+ * themselves cascade from the `user` row's deletion (ON DELETE CASCADE in
+ * migrations/0005), but their R2 payloads do not, so we remove those here
+ * *before* the user row goes.
+ *
+ * Deliberately best-effort, it never throws: orphaned bytes are a storage cost,
+ * not a reason to trap a user in an account they asked to delete. R2's
+ * multi-delete caps at 1000 keys per call, so keys are chunked.
+ */
+export async function deleteAllUserObjects(
+  env: CloudflareEnv,
+  userId: string,
+): Promise<void> {
+  const bucket = env.WORKSPACES_BUCKET;
+  if (!bucket) return;
+  try {
+    const [workspaces, shares] = await Promise.all([
+      listWorkspaceRows(env, userId),
+      listShareRows(env, userId),
+    ]);
+    const keys = [
+      ...workspaces.map((r) => r.r2_key),
+      ...shares.map((r) => r.r2_key),
+    ];
+    for (let i = 0; i < keys.length; i += 1000) {
+      await bucket.delete(keys.slice(i, i + 1000));
+    }
+  } catch {
+    // Best-effort; see doc comment. A cleanup hiccup must not block deletion.
+  }
+}
+
 /** Amortized cleanup of expired *guest* shares (nobody lists them, so nothing
  *  else would ever encounter the rows). Called opportunistically from the
  *  share-creation route via ctx.waitUntil; bounded so a single request never


### PR DESCRIPTION
## What & why

Account/OAuth improvements to the `/account` page:

1. **Show Google/GitHub integration status with a way to remove them.**
2. **Self-service account deletion** (danger zone).
3. **Clear up the confusing email/password sign-up collision** for users who first signed in with Google/GitHub.

## Changes

### New "Sign-in methods" section on `/account`
- `app/account/ConnectedAccountsSection.tsx` lists Google and GitHub with **Connected / Not connected** status and **Connect / Remove** actions, wired to `authClient.listAccounts` / `linkSocial` / `unlinkAccount`. **No server code added** — these are Better Auth's own `/api/auth/*` endpoints, already mounted.
- **Lockout guard:** Remove is disabled with an explanation when a provider is the account's last remaining method (mirrors Better Auth's own refusal to unlink your only account; `credential` counts). A footnote points social-only users at **Forgot password?** to set a password.

### New "Delete account" section (danger zone)
- `app/account/DeleteAccountSection.tsx` — permanently deletes the account behind a **typed-email confirmation**. Enabled via `user.deleteUser` in `lib/auth/server.ts`.
- **Data cleanup:** the `user` row's deletion cascades to sessions, linked accounts, cloud saves, share links, and custom content — but the **R2 payloads** behind saves/shares don't cascade, so a `beforeDelete` hook purges them first via a new best-effort `deleteAllUserObjects` (`lib/workspaces/store.ts`, never throws, chunks R2 deletes at 1000 keys).
- **Confirmation model** (matches the app's email-gated pattern): with `RESEND_API_KEY` set, Better Auth **emails a confirmation link** and holds off deleting until it's clicked — safe for social-only users regardless of session age; the UI shows a check-your-inbox notice. Without a mailer, Better Auth requires a **fresh session**, and the UI translates the resulting `SESSION_EXPIRED` into a "sign out and back in" prompt. New `deleteAccountEmail` template in `lib/auth/email.ts`.
- **Billing:** paid-Pro users get a warning to cancel their Polar subscription first — deletion here doesn't cancel Polar billing (Polar keeps its own customer-keyed record). Automatic Polar cancellation is a deliberate follow-up.

### Sign-up collision clarity (`app/sign-in/SignInClient.tsx`)
Sign-up never attaches a password to an existing account — it only creates a new user — so a same-email sign-up is a collision. Two enumeration-safe copy fixes:
- **Verification-off deployments** (`USER_ALREADY_EXISTS`): replace the bare "User already exists" with guidance to sign in (incl. Google/GitHub) or reset a password.
- **Verification-on deployments** (Better Auth returns a *neutral success* to prevent enumeration): reword the notice so it no longer falsely claims *"Account created"* on the collision path, while revealing nothing about whether the email exists.

### Small refactor
- Extract the shared Google mark into `GoogleIcon` (`app/_components/home/icons.tsx`, next to `GitHubIcon`) and reuse it on both the sign-in card and the account page, removing a duplicated inline SVG.

## Testing
- `tsc --noEmit`: clean.
- `eslint` on all changed files: clean.
- `vitest run`: 923 passing (the one unrelated failure, `brandFallbacks.test.ts`, is a missing generated asset from installing with `--ignore-scripts`, not from this change).
- Behavior of Better Auth's `deleteUser` endpoint (email-vs-fresh-session paths, return shapes, `SESSION_EXPIRED` code, `beforeDelete` on both paths) was verified against the installed `better-auth@1.6.22` source. The live delete flow (D1 cascade + R2 purge + Resend email) needs a deployed environment to exercise end-to-end.

## Notes / decisions for review
- **Last-method removal:** safe default (disable Remove) over enabling `allowUnlinkingAll`.
- **No new DB migration:** `deleteUser` reuses the existing `verification` table for its token; all cascade columns already exist.
- **Polar cancellation on delete** and a dedicated in-account **"Set password"** flow for social-only users are called out as possible follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)