### PR TITLE
Fix hero marquee ghosting through the sticky home header on hover

### DIFF
--- a/app/_components/home/HeroMarquee.tsx
+++ b/app/_components/home/HeroMarquee.tsx
@@ -70,8 +70,12 @@ function RosterSegment() {
 }
 
 export function HeroMarquee() {
+  // [contain:paint] hard-clips the infinitely-animating marquee rows at the
+  // compositor level (a plain overflow clip hasn't stopped Chromium from
+  // ghosting stale slices of the composited rows over other parts of the
+  // page during unrelated repaints, e.g. hovering the sticky header).
   return (
-    <div className="relative mx-auto w-full max-w-3xl select-none overflow-hidden py-2">
+    <div className="relative mx-auto w-full max-w-3xl select-none overflow-hidden py-2 [contain:paint]">
       {/* Both lines share one font-size scale so they read as a matched pair. */}
       {/* Line 1, the language roster, scrolling left. */}
       <Marquee className="py-1 text-5xl font-bold tracking-tight [--duration:42s] [--gap:0px] sm:text-6xl lg:text-7xl">

--- a/app/_components/home/HomeNav.tsx
+++ b/app/_components/home/HomeNav.tsx
@@ -267,7 +267,16 @@ export function HomeNav() {
     };
   }, []);
   return (
-    <header className="sticky top-0 z-40 bg-white dark:bg-[#121212]">
+    // `transform-gpu` (translateZ(0)) promotes the sticky header to its own
+    // compositing layer. The hero marquee below runs a continuous transform
+    // animation, so the browser composites it onto its own GPU layer; without
+    // a layer of its own the header paints on the root layer, and a
+    // hover-triggered partial repaint (a nav link's colour transition, the
+    // logo's group-hover transform) re-exposes the marquee scrolling under the
+    // header in just the invalidated band, bleeding a slice of marquee text
+    // through the opaque background. Its own layer makes the header composite
+    // as a whole over the marquee, eliminating the bleed-through.
+    <header className="sticky top-0 z-40 transform-gpu bg-white dark:bg-[#121212]">
       <nav
         className={`mx-auto grid max-w-6xl grid-cols-[1fr_auto] items-center gap-3 px-4 transition-[height] duration-200 sm:px-6 md:grid-cols-[1fr_auto_1fr] ${
           scrolled ? "h-11 md:h-12" : "h-14 md:h-16"

--- a/app/_components/home/HomeNav.tsx
+++ b/app/_components/home/HomeNav.tsx
@@ -267,15 +267,13 @@ export function HomeNav() {
     };
   }, []);
   return (
-    // `transform-gpu` (translateZ(0)) promotes the sticky header to its own
-    // compositing layer. The hero marquee below runs a continuous transform
-    // animation, so the browser composites it onto its own GPU layer; without
-    // a layer of its own the header paints on the root layer, and a
-    // hover-triggered partial repaint (a nav link's colour transition, the
-    // logo's group-hover transform) re-exposes the marquee scrolling under the
-    // header in just the invalidated band, bleeding a slice of marquee text
-    // through the opaque background. Its own layer makes the header composite
-    // as a whole over the marquee, eliminating the bleed-through.
+    // `transform-gpu` (translateZ(0)) keeps the sticky header on its own
+    // compositing layer, so hover repaints inside it (nav-link colour
+    // transitions, the logo's group-hover transform) stay isolated from the
+    // continuously-animating hero marquee below. Defense-in-depth: the
+    // marquee-ghosting-through-the-header bug this originally targeted was
+    // actually caused by BlurFade's residual `filter: blur(0px)` around the
+    // marquee (fixed in components/ui/blur-fade.tsx).
     <header className="sticky top-0 z-40 transform-gpu bg-white dark:bg-[#121212]">
       <nav
         className={`mx-auto grid max-w-6xl grid-cols-[1fr_auto] items-center gap-3 px-4 transition-[height] duration-200 sm:px-6 md:grid-cols-[1fr_auto_1fr] ${

--- a/components/ui/blur-fade.tsx
+++ b/components/ui/blur-fade.tsx
@@ -58,6 +58,15 @@ export function BlurFade({
       [direction === "left" || direction === "right" ? "x" : "y"]: 0,
       opacity: 1,
       filter: `blur(0px)`,
+      // Once the entrance settles, drop the filter entirely. Motion keeps the
+      // last keyframe as an inline style, so without this the wrapper carries
+      // `filter: blur(0px)` forever — and any filter, even an identity blur,
+      // routes the subtree through a compositor effect node backed by a cached
+      // texture. With an infinite composited animation inside (the hero
+      // marquee), Chromium can redraw that texture stale and misplaced during
+      // unrelated partial repaints (e.g. hovering the sticky header),
+      // ghosting a slice of marquee text elsewhere on the page.
+      transitionEnd: { filter: "none" },
     },
   }
   const combinedVariants = variant ?? defaultVariants

--- a/components/ui/blur-fade.tsx
+++ b/components/ui/blur-fade.tsx
@@ -47,15 +47,24 @@ export function BlurFade({
   const ref = useRef(null)
   const inViewResult = useInView(ref, { once: true, margin: inViewMargin })
   const isInView = !inView || inViewResult
+  // Axis props are built as plain objects (not a computed `[x|y]:` key inside
+  // the variant literal): a computed key collapses the variant's type to a
+  // string index signature, which can't hold the nested `transitionEnd`
+  // object below.
+  const offsetAxis =
+    direction === "left" || direction === "right"
+      ? { x: direction === "right" ? -offset : offset }
+      : { y: direction === "down" ? -offset : offset }
+  const restAxis =
+    direction === "left" || direction === "right" ? { x: 0 } : { y: 0 }
   const defaultVariants: Variants = {
     hidden: {
-      [direction === "left" || direction === "right" ? "x" : "y"]:
-        direction === "right" || direction === "down" ? -offset : offset,
+      ...offsetAxis,
       opacity: 0,
       filter: `blur(${blur})`,
     },
     visible: {
-      [direction === "left" || direction === "right" ? "x" : "y"]: 0,
+      ...restAxis,
       opacity: 1,
       filter: `blur(0px)`,
       // Once the entrance settles, drop the filter entirely. Motion keeps the


### PR DESCRIPTION
## What & why

On the home page, hovering certain areas of the header made a slice of the hero marquee text paint over/under the header (dark and light mode, Chrome).

**Root cause — BlurFade's residual `filter`:**

- `BlurFade` (Magic UI) animates `filter: blur(6px) → blur(0px)` for its entrance, and motion keeps the final keyframe as an inline style — so the wrapper around the hero marquee carries **`filter: blur(0px)` permanently**.
- Any non-`none` filter, even an identity blur, routes its subtree through a compositor effect node backed by a cached texture.
- The marquee rows inside it run an **infinite composited transform animation** (`animate-marquee`). During unrelated partial repaints (hovering the header's nav links), Chromium can composite that cached texture **stale and misplaced**, painting a slice of an old marquee frame elsewhere on the page. This matches the reported artifact exactly: the ghost slice shows a *different animation offset* of the row than the live marquee below it.

An earlier commit on this branch promoted the sticky header to its own compositing layer (`transform-gpu`). That deployed but did **not** fix the artifact (confirmed on the preview build — the class and its CSS rule were live), proving the header was never the root cause; it is kept as defense-in-depth with an updated comment.

## The fix

- **`components/ui/blur-fade.tsx`** — add `transitionEnd: { filter: "none" }` to the visible variant, so the filter is removed entirely once the entrance settles. The blur entrance is visually unchanged; the permanent compositor effect node disappears. This also removes a pointless effect node from every other BlurFade-wrapped section (small compositing win site-wide). The variants' axis props are built as conditional objects and spread in (instead of a computed `[x|y]:` key) so the variant literals keep precise object types that accept the nested `transitionEnd` — with the computed key, the literal collapsed to a string index signature and failed to type-check against motion's `Variants`.
- **`app/_components/home/HeroMarquee.tsx`** — add `[contain:paint]` to the marquee container as defense-in-depth, hard-clipping the animated rows at the compositor level so any residual misdraw stays inside the marquee's own box.
- **`app/_components/home/HomeNav.tsx`** — comment-only: reword the `transform-gpu` rationale to defense-in-depth.

## Testing

- Type-checked `blur-fade.tsx` against `typescript@5.7.3` with the repo's strict compiler settings; the same harness reproduces the Workers-build type error on the intermediate revision, and passes on the final one.
- Bundled the actual `blur-fade.tsx` with `motion@12` and drove it in headless Chromium: computed `filter` on the wrapper is `blur(3.6px)` mid-entrance (effect intact), then settles to **`none`** (previously a permanent `blur(0px)`).
- The GPU ghosting artifact itself is hardware/driver-dependent and not reproducible headless (SwiftShader), so the definitive check is re-testing the preview deployment on the affected machine.
- `node_modules` isn't provisioned in this environment (heavy postinstall chain), so the full repo build/lint were not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012D21RrCzvzJ2nQPaqKarps