### PR TITLE
Stabilize header-band compositing (marquee ghost) + fix Highlighter underline jumping on mobile

### DIFF
--- a/app/_components/home/HeroMarquee.tsx
+++ b/app/_components/home/HeroMarquee.tsx
@@ -74,8 +74,13 @@ export function HeroMarquee() {
   // compositor level (a plain overflow clip hasn't stopped Chromium from
   // ghosting stale slices of the composited rows over other parts of the
   // page during unrelated repaints, e.g. hovering the sticky header).
+  // `will-change-transform` keeps this container permanently promoted so the
+  // rows' compositing subtree (and its clip) never restructures — without it,
+  // the BlurFade entrance around this component promotes the wrapper while
+  // its transform/filter animate and drops it when they settle, a hand-off
+  // during which Chromium has left stale row raster behind.
   return (
-    <div className="relative mx-auto w-full max-w-3xl select-none overflow-hidden py-2 [contain:paint]">
+    <div className="relative mx-auto w-full max-w-3xl select-none overflow-hidden py-2 will-change-transform [contain:paint]">
       {/* Both lines share one font-size scale so they read as a matched pair. */}
       {/* Line 1, the language roster, scrolling left. */}
       <Marquee className="py-1 text-5xl font-bold tracking-tight [--duration:42s] [--gap:0px] sm:text-6xl lg:text-7xl">

--- a/app/_components/home/HomeNav.tsx
+++ b/app/_components/home/HomeNav.tsx
@@ -100,14 +100,20 @@ function BrandLogo() {
         window.scrollTo({ top: 0, behavior: reduce ? "auto" : "smooth" });
       }}
     >
+      {/* Both hover transforms carry `will-change-transform` so these two
+          elements keep permanent (tiny) compositor layers. Without it, each
+          hover starts an accelerated transform transition that promotes and
+          then drops a layer inside the sticky header — layer churn that has
+          coincided with stale marquee raster ghosting through the band under
+          the header (the original "hover a nav control" repro). */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src="/dataslope-logo-blue.svg"
         alt=""
-        className="relative top-px h-[13px] w-auto transition-transform duration-200 group-hover:rotate-[8deg]"
+        className="relative top-px h-[13px] w-auto transition-transform duration-200 will-change-transform group-hover:rotate-[8deg]"
         aria-hidden="true"
       />
-      <span className="text-lg font-semibold tracking-tight text-[#121212] transition-transform duration-200 group-hover:translate-x-0.5 dark:text-white">
+      <span className="text-lg font-semibold tracking-tight text-[#121212] transition-transform duration-200 will-change-transform group-hover:translate-x-0.5 dark:text-white">
         Dataslope
       </span>
     </Link>
@@ -238,16 +244,22 @@ function MobileDrawer() {
 }
 
 export function HomeNav() {
-  // Shrink-on-scroll: the header is taller at the top of the page and
-  // compacts to its sticky height once scrolled. The background stays a
-  // solid white/#121212 (no backdrop blur, shadow, or opacity).
+  // Shrink-on-scroll: the nav bar is taller at the top of the page and
+  // compacts once scrolled. The background stays a solid white/#121212 (no
+  // backdrop blur, shadow, or opacity).
   //
-  // Two thresholds (hysteresis) with a gap wider than the header's shrink
-  // delta (≤16px). A single threshold caused an infinite bounce near the top:
-  // toggling the header height changes the in-flow document height, and the
-  // browser's scroll-anchoring nudges scrollY to compensate, which flips the
-  // threshold back, resizing the header again, ad infinitum. The gap keeps that
-  // compensation from ever crossing the opposite threshold.
+  // Only the inner <nav> changes height; the <header> box itself is a fixed
+  // h-14/16. That keeps the shrink out of document flow (crossing a threshold
+  // no longer reflows the page, the cause of an earlier scroll-anchoring
+  // bounce) and, just as deliberately, keeps the header's composited layer a
+  // constant size: this header sits over the hero marquee's continuously
+  // animating composited rows, and resizing the sticky layer mid-scroll has
+  // produced stale "ghost" slices of marquee raster in the strip it vacates
+  // (GPU-only; not reproducible under software rasterization). Don't move the
+  // height transition back onto the <header> box.
+  //
+  // Two thresholds (hysteresis) so small scroll jitter around a single
+  // threshold can't flap the shrink transition back and forth.
   const [scrolled, setScrolled] = useState(false);
   useEffect(() => {
     const onScroll = () =>
@@ -270,11 +282,10 @@ export function HomeNav() {
     // `transform-gpu` (translateZ(0)) keeps the sticky header on its own
     // compositing layer, so hover repaints inside it (nav-link colour
     // transitions, the logo's group-hover transform) stay isolated from the
-    // continuously-animating hero marquee below. Defense-in-depth: the
-    // marquee-ghosting-through-the-header bug this originally targeted was
-    // actually caused by BlurFade's residual `filter: blur(0px)` around the
-    // marquee (fixed in components/ui/blur-fade.tsx).
-    <header className="sticky top-0 z-40 transform-gpu bg-white dark:bg-[#121212]">
+    // continuously-animating hero marquee below. Combined with the fixed
+    // h-14/16 box (see above), it makes the header a constant-size opaque
+    // occluder over the marquee.
+    <header className="sticky top-0 z-40 h-14 transform-gpu bg-white md:h-16 dark:bg-[#121212]">
       <nav
         className={`mx-auto grid max-w-6xl grid-cols-[1fr_auto] items-center gap-3 px-4 transition-[height] duration-200 sm:px-6 md:grid-cols-[1fr_auto_1fr] ${
           scrolled ? "h-11 md:h-12" : "h-14 md:h-16"
@@ -315,10 +326,14 @@ export function HomeNav() {
       {/* Short fade below the compacted header so its solid background melts
           into the page instead of slicing through content scrolling under it
           (most visible against the hero marquee). Hidden while the page is at
-          the top, where the header sits in normal flow above the content. */}
+          the top, where the header sits in normal flow above the content.
+          `will-change-[opacity]` keeps this strip permanently on its own
+          compositor layer: without it, the opacity transition creates and
+          destroys a layer on every scroll-threshold crossing, right at the
+          band under the header where stale marquee raster has ghosted. */}
       <div
         aria-hidden="true"
-        className={`pointer-events-none absolute inset-x-0 top-full h-3 bg-gradient-to-b from-white to-transparent transition-opacity duration-200 dark:from-[#121212] ${
+        className={`pointer-events-none absolute inset-x-0 top-full h-3 bg-gradient-to-b from-white to-transparent transition-opacity duration-200 will-change-[opacity] dark:from-[#121212] ${
           scrolled ? "opacity-100" : "opacity-0"
         }`}
       />

--- a/components/ui/highlighter.tsx
+++ b/components/ui/highlighter.tsx
@@ -137,9 +137,22 @@ export function Highlighter({
     multiline,
   ]);
 
+  // The annotated element is the INNER span; rough-notation inserts its
+  // absolutely-positioned <svg> overlay as a sibling of the annotated element
+  // (with top:0/left:0), so the sibling lands inside the OUTER span, whose
+  // `relative` makes it the svg's containing block. That anchors the drawing
+  // to the text itself. Annotating the outer span instead (as this component
+  // originally did) puts the svg outside it, anchored to whatever ancestor
+  // happens to be a containing block — and that ancestor can change out from
+  // under the finished drawing: while a BlurFade entrance animates, the
+  // motion wrapper's inline transform/filter make it the containing block,
+  // and when motion clears them on settle the svg re-anchors to the document
+  // origin, snapping the drawing hundreds of pixels away from the text (seen
+  // on mobile as the hero tagline's underline jumping up into the marquee).
+  // The geometry watcher above can't catch that: the text never moves.
   return (
-    <span ref={elementRef} className="relative inline-block bg-transparent">
-      {children}
+    <span className="relative inline-block bg-transparent">
+      <span ref={elementRef}>{children}</span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Two rendering fixes around the home hero:

1. **Marquee ghost under the sticky header** (3rd attempt, follows #599) — stabilize the header band's compositing structure.
2. **Hero tagline's green underline snapping up into the marquee on mobile** — anchor rough-notation's SVG overlay to the text instead of a mutable ancestor.

---

## 1) Marquee ghost under the header

Attacked from a different angle than #599, based on two new pieces of evidence:

1. **The ghost is frozen** — it doesn't move with the live marquee animation. So it is not a live layer bleeding through the header (what both #599 fixes targeted); it's **stale rasterization Chromium never invalidates**, drawn at whatever animation offset the row had when it was last painted there.
2. **Production already serves both #599 fixes** (verified the live HTML carries the `[contain:paint]` marker), so the header's `transform-gpu` and BlurFade's residual filter were not the cause.

### Diagnosis

The compositing structure of the header band **mutates constantly**, directly above eight giant, mostly-occluded, infinitely-animating composited marquee row textures. Every mutation is an invalidation seam where stale marquee raster can be revealed — and each one fires exactly where/when the ghost shows up:

- The sticky header's composited layer **resized continuously** during the `transition-[height]` shrink (which runs precisely while the marquee passes underneath), forcing per-frame reveal of the strip it vacates.
- The gradient fade strip below the header **gained and dropped a compositor layer** (opacity transition) on every scroll-threshold crossing — at exactly the band where the ghost appears.
- The brand logo's hover transforms **promoted and dropped layers** inside the header on every hover — matching the original "hover a header control" repro.
- The marquee's compositing subtree **restructured once the BlurFade entrance settled** (transient transform/filter effect nodes dropped).

### Fix — make the structure static

- **`HomeNav`**: the `<header>` box is now a fixed `h-14 md:h-16`; only the inner `<nav>` animates height, so the header's composited layer never resizes. Side benefit: the shrink no longer reflows the document — the original cause of the scroll-anchoring bounce the hysteresis was built around. Only visual change: while scrolled, passing content is occluded ~16px earlier, hidden by the same gradient fade.
- **`HomeNav`**: `will-change-[opacity]` on the fade strip and `will-change-transform` on the logo img/span, so their transitions mutate permanent layers instead of creating/destroying them.
- **`HeroMarquee`**: `will-change-transform` on the `[contain:paint]` container, so the rows' clip lives on a permanently promoted surface across the BlurFade settle.

### Verification

- CDP `LayerTree`: header layer, fade strip, logo layers, and marquee container are now **constant-size and present across top / scrolled / logo-hover / return states** (before: the header layer resized and the others appeared/disappeared per transition).
- Honest limitation, same as both prior attempts: the artifact is GPU-only and doesn't reproduce under headless SwiftShader, so it can't be regression-tested here. **On-device check**: load `/`, scroll past the hero, scroll back near the top, hover the logo/nav — the band under the header should stay clean.

---

## 2) Highlighter underline jumping on mobile (pre-existing, not a regression)

On mobile, the tagline's green underline drew in the right place, then **snapped ~300px up into the marquee** when the highlight animation finished.

### Diagnosis (reproduced end-to-end on a mobile-viewport dev server)

rough-notation inserts its `<svg>` overlay as a **sibling** of the annotated element with `position:absolute; top:0; left:0` and bakes `element − svg` offsets into the paths at draw time — so the drawing is only stable while the SVG's absolute **containing block** stays put. The Highlighter span was itself the annotated element, so the SVG landed *outside* it, anchored to the nearest positioned ancestor:

- While the tagline's BlurFade entrance animates, the motion wrapper's inline `transform`/`filter` make it the containing block → underline draws correctly.
- When the entrance settles, motion clears those styles (`transform:none; filter:none`), the wrapper stops being a containing block, and the SVG **re-anchors to the document origin** — teleporting the finished drawing up by the wrapper's page offset.

The component's reposition machinery watches only the annotated element's geometry — which never moves — so nothing redraws. Whether you saw the bug was a race between the annotation drawing and the entrance settling: fast devices (mobile/production) hit it; slow dev loads drew after settle and looked fine.

### Fix

Annotate an **inner** span so the sibling SVG lands *inside* the outer `position:relative` span, which then is its containing block. The drawing is anchored to the text itself, immune to ancestor containing-block changes.

Verified via CDP: the SVG anchor now sits at the text box, and applying/clearing a transform on the BlurFade wrapper (the exact trigger) no longer moves the stroke at all (previously it jumped between y=388 and y=108). Hero + beam-section underlines visually correct on a 412×915 viewport.

---

`tsc --noEmit` and `eslint` clean for all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5641wMuxyqaQjEaMEdSjT