### PR TITLE
Auth-shell + Ask AI polish, single free plan, legal accuracy pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ sparingly, to highlight or differentiate.
 
 Each hue has a full tonal ramp exposed as CSS variables in `app/brand.css`
 (`--ds-<hue>-<step>`) and previewable at `/color-test`. **Prefer the `500`
-shade** (the primary/base color) — the other steps exist for when a lighter or
+shade** (the primary/base color); the other steps exist for when a lighter or
 darker tone is required (backgrounds, borders, hover states, AA-legible text on
 white, and telling chart/diagram series apart). `500` = the brand color; the
 `ink` text anchors that clear WCAG AA body text on white are noted per hue.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,37 @@
+Dataslope is made available under more than one license:
+
+  - Source code:      MIT License (the full text below).
+  - Learning content: the courses, lessons, exercises, and other written
+                      materials in the `content/` directory are licensed under
+                      Creative Commons Attribution 4.0 International
+                      (CC BY 4.0). See LICENSE-CONTENT.
+
+Third-party software and language runtimes that Dataslope depends on or loads
+at runtime are NOT covered by the licenses above and retain their own terms.
+See THIRD-PARTY-NOTICES.md. In particular, the Java runtime (CheerpJ, by
+Leaning Technologies) is distributed under its own, non-MIT license and may
+require a separate commercial license for some uses.
+
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2026 Dataslope
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-CONTENT
+++ b/LICENSE-CONTENT
@@ -1,29 +1,29 @@
 Dataslope Learning Content License
 ==================================
 
-The learning content in this repository — the courses, lessons, exercises,
+The learning content in this repository, i.e. the courses, lessons, exercises,
 quizzes, and other written or illustrative teaching materials in the `content/`
-directory (the "Content") — is licensed under the
+directory (the "Content"), is licensed under the
 
     Creative Commons Attribution 4.0 International License (CC BY 4.0).
 
 (This is separate from Dataslope's source code, which is licensed under the MIT
-License; see LICENSE. It also does not cover third-party material — see
+License; see LICENSE. It also does not cover third-party material; see
 THIRD-PARTY-NOTICES.md.)
 
 You are free to:
 
-  - Share — copy and redistribute the Content in any medium or format.
-  - Adapt — remix, transform, and build upon the Content for any purpose, even
+  - Share: copy and redistribute the Content in any medium or format.
+  - Adapt: remix, transform, and build upon the Content for any purpose, even
     commercially.
 
 Under the following terms:
 
-  - Attribution — You must give appropriate credit to Dataslope
+  - Attribution: You must give appropriate credit to Dataslope
     (https://dataslope.com), provide a link to this license, and indicate if
     changes were made. You may do so in any reasonable manner, but not in any
     way that suggests Dataslope endorses you or your use.
-  - No additional restrictions — You may not apply legal terms or technological
+  - No additional restrictions: You may not apply legal terms or technological
     measures that legally restrict others from doing anything the license
     permits.
 

--- a/LICENSE-CONTENT
+++ b/LICENSE-CONTENT
@@ -1,0 +1,44 @@
+Dataslope Learning Content License
+==================================
+
+The learning content in this repository — the courses, lessons, exercises,
+quizzes, and other written or illustrative teaching materials in the `content/`
+directory (the "Content") — is licensed under the
+
+    Creative Commons Attribution 4.0 International License (CC BY 4.0).
+
+(This is separate from Dataslope's source code, which is licensed under the MIT
+License; see LICENSE. It also does not cover third-party material — see
+THIRD-PARTY-NOTICES.md.)
+
+You are free to:
+
+  - Share — copy and redistribute the Content in any medium or format.
+  - Adapt — remix, transform, and build upon the Content for any purpose, even
+    commercially.
+
+Under the following terms:
+
+  - Attribution — You must give appropriate credit to Dataslope
+    (https://dataslope.com), provide a link to this license, and indicate if
+    changes were made. You may do so in any reasonable manner, but not in any
+    way that suggests Dataslope endorses you or your use.
+  - No additional restrictions — You may not apply legal terms or technological
+    measures that legally restrict others from doing anything the license
+    permits.
+
+Disclaimer of warranties and liability:
+
+  Unless otherwise stated, the Content is provided "as is" and "as available",
+  without warranties or conditions of any kind, either express or implied. To
+  the fullest extent permitted by law, Dataslope and its contributors are not
+  liable for any damages or losses arising from the use of the Content. (CC BY
+  4.0 itself disclaims warranties and limits liability; see its full text.)
+
+The complete legal text of CC BY 4.0 governs and is available at:
+
+  https://creativecommons.org/licenses/by/4.0/legalcode
+
+A plain-language summary (not a substitute for the license) is at:
+
+  https://creativecommons.org/licenses/by/4.0/

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ Full-featured code editors that run language runtimes entirely in the browser vi
 | JavaScript | Native browser engine |
 | TypeScript | In-browser transpilation |
 | PHP | php-wasm (WASM) |
-| C | Clang → WASM (Wasmer) |
-| C++ | Clang → WASM (Wasmer) |
+| C | browsercc (Clang → WASM) |
+| C++ | browsercc (Clang → WASM) |
 | Java | CheerpJ / OpenJDK (WASM) |
 | C# | Roslyn on .NET WebAssembly (Mono) |
-| SQLite | sql.js (WASM) |
-| PostgreSQL | Remote connection shell |
+| SQLite | SQLite (official WASM build) |
+| PostgreSQL | PGlite (WASM) |
+| DuckDB | DuckDB-Wasm (WASM) |
 
 ### 📚 Free learning materials
 
@@ -151,9 +152,9 @@ Key files:
 
    `BETTER_AUTH_URL` is set as a non-secret `var` in `wrangler.jsonc` (defaults to `https://dataslope.com`); change it if the deployed origin differs. A provider whose `*_CLIENT_ID`/`*_CLIENT_SECRET` pair is missing is simply not offered, so you can ship with just one provider configured.
 
-   You only ever register the **production** callback URL above — no per-preview URLs. `lib/auth/server.ts` handles the two hosts that aren't the pinned apex:
+   You only ever register the **production** callback URL above; there are no per-preview URLs. `lib/auth/server.ts` handles the two hosts that aren't the pinned apex:
    - **`www.dataslope.com`** (production also serves `www` with no redirect) is trusted for the CSRF origin check alongside the apex and any subdomain, so email/password sign-up/sign-in works there (previously it failed with "Invalid origin").
-   - **`*.workers.dev` preview deployments** trust their own origin for email/password, and Google/GitHub sign-in completes via Better Auth's `oAuthProxy` plugin: the provider still returns to the registered production callback, then the authenticated session is relayed back to the preview. The relay encrypts its payload with a secret shared across deployments — `BETTER_AUTH_SECRET` by default, or set a dedicated `OAUTH_PROXY_SECRET` (`npx wrangler secret put OAUTH_PROXY_SECRET`, identical value everywhere) to narrow the blast radius. The proxy is a no-op on production and `www`.
+   - **`*.workers.dev` preview deployments** trust their own origin for email/password, and Google/GitHub sign-in completes via Better Auth's `oAuthProxy` plugin: the provider still returns to the registered production callback, then the authenticated session is relayed back to the preview. The relay encrypts its payload with a secret shared across deployments: `BETTER_AUTH_SECRET` by default, or set a dedicated `OAUTH_PROXY_SECRET` (`npx wrangler secret put OAUTH_PROXY_SECRET`, identical value everywhere) to narrow the blast radius. The proxy is a no-op on production and `www`.
 
 ### Local development
 
@@ -294,16 +295,16 @@ If you enable additional Better Auth features (e.g. 2FA, organizations), regener
 
 Dataslope is available under more than one license:
 
-- **Source code** — [MIT License](./LICENSE). Attribution via the copyright
+- **Source code**: [MIT License](./LICENSE). Attribution via the copyright
   notice, and no warranty/liability.
-- **Learning content** (everything under [`content/`](./content)) — [Creative
+- **Learning content** (everything under [`content/`](./content)): [Creative
   Commons Attribution 4.0 International (CC BY 4.0)](./LICENSE-CONTENT).
   Attribution required, no warranty/liability.
 
 Third-party software and language runtimes retain their own licenses; see
 [`THIRD-PARTY-NOTICES.md`](./THIRD-PARTY-NOTICES.md). In particular, the Java
 runtime **CheerpJ** (Leaning Technologies) is proprietary, used here under its
-free **Community Edition** — which allows commercial use for individuals and
+free **Community Edition**, which allows commercial use for individuals and
 one-person companies, and is loaded from Leaning Technologies' CDN (self-hosting
 and redistribution aren't permitted). Re-check its terms if you grow beyond a
 solo operation.

--- a/README.md
+++ b/README.md
@@ -289,3 +289,19 @@ The second case is the default whenever email verification is off (no `RESEND_AP
 
 If you enable additional Better Auth features (e.g. 2FA, organizations), regenerate the schema delta with `npx @better-auth/cli generate` and add it as a **new** migration file in `migrations/` rather than editing the existing one.
 
+
+## License
+
+Dataslope is available under more than one license:
+
+- **Source code** — [MIT License](./LICENSE). Attribution via the copyright
+  notice, and no warranty/liability.
+- **Learning content** (everything under [`content/`](./content)) — [Creative
+  Commons Attribution 4.0 International (CC BY 4.0)](./LICENSE-CONTENT).
+  Attribution required, no warranty/liability.
+
+Third-party software and language runtimes retain their own licenses; see
+[`THIRD-PARTY-NOTICES.md`](./THIRD-PARTY-NOTICES.md). In particular, the Java
+runtime **CheerpJ** (Leaning Technologies) is under its own, non-MIT terms and
+may require a separate commercial license for some uses — review it before
+relying on the Java playground commercially.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ Dataslope is available under more than one license:
 
 Third-party software and language runtimes retain their own licenses; see
 [`THIRD-PARTY-NOTICES.md`](./THIRD-PARTY-NOTICES.md). In particular, the Java
-runtime **CheerpJ** (Leaning Technologies) is under its own, non-MIT terms and
-may require a separate commercial license for some uses — review it before
-relying on the Java playground commercially.
+runtime **CheerpJ** (Leaning Technologies) is proprietary, used here under its
+free **Community Edition** — which allows commercial use for individuals and
+one-person companies, and is loaded from Leaning Technologies' CDN (self-hosting
+and redistribution aren't permitted). Re-check its terms if you grow beyond a
+solo operation.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,61 @@
+# Third-Party Notices
+
+Dataslope's own source code is licensed under the MIT License (see [`LICENSE`](./LICENSE))
+and its learning content under CC BY 4.0 (see [`LICENSE-CONTENT`](./LICENSE-CONTENT)).
+Those licenses do **not** cover the third-party software, language runtimes,
+fonts, or other components that Dataslope depends on or loads at runtime. Each
+of those retains its own license and terms, summarized below.
+
+Most language runtimes are **downloaded from their providers (or a CDN) in the
+user's browser at runtime** and are not redistributed in this repository.
+
+> This list is provided for convenience only and may not be exhaustive or
+> perfectly current. Consult each project for its authoritative license, and
+> get your own legal review before relying on any of this — especially if you
+> monetize the site (for example, with advertising).
+
+## ⚠️ CheerpJ (Java runtime) — read this first
+
+The Java playground uses **CheerpJ** by **Leaning Technologies**
+(<https://cheerpj.com>), loaded at runtime from Leaning Technologies' CDN
+(`cjrtnc.leaningtech.com`).
+
+CheerpJ is **not** open source under an OSI-approved license. It is distributed
+under Leaning Technologies' own license terms, which are free for some uses but
+**may require a separate commercial license for others**. The MIT license on
+Dataslope's code grants you **no** rights to CheerpJ.
+
+**Action required:** review CheerpJ's current licensing and Leaning
+Technologies' terms, and obtain any commercial license your use may need —
+particularly commercial/for-profit operation of the site, including running
+advertising against it. CheerpJ executes OpenJDK, which is licensed under the
+**GPLv2 with the Classpath Exception**.
+
+## Language runtimes (loaded at runtime)
+
+| Component | Used for | License (verify with the project) |
+| --- | --- | --- |
+| Pyodide | Python | MPL-2.0 (bundles CPython and packages under their own licenses) |
+| WebR | R | R is GPL-2.0 / GPL-3.0; verify WebR's specific terms |
+| php-wasm | PHP | PHP License / project's own terms; verify the specific build |
+| Clang → WASM (Wasmer) | C / C++ | LLVM/Clang: Apache-2.0 with LLVM exceptions; Wasmer: MIT |
+| CheerpJ + OpenJDK | Java | See the CheerpJ note above; OpenJDK: GPLv2 + Classpath Exception |
+| .NET / Mono / Roslyn | C# | MIT (the .NET platform) |
+| sql.js | SQLite | sql.js: MIT; SQLite engine: public domain |
+| DuckDB-Wasm | DuckDB SQL | MIT |
+| PGlite | PostgreSQL (in-browser) | Apache-2.0 / PostgreSQL License |
+| @wasm-fmt/clang-format | C/C++ formatting | LLVM (Apache-2.0 with LLVM exceptions); verify the package |
+
+## Application libraries
+
+Dataslope is built on many open-source packages declared in `package.json`,
+each under its own license as published on npm — for example Next.js (MIT),
+React (MIT), Better Auth (MIT), fumadocs (MIT), cobe (MIT), Tailwind CSS (MIT),
+Radix / Base UI primitives and shadcn/Magic UI–derived components (MIT), and
+lucide-react (ISC). Refer to each package's own `LICENSE` for the authoritative
+terms.
+
+## Datasets and fonts
+
+Sample datasets and any bundled fonts are subject to their respective licenses.
+Verify the terms of any dataset or font you redistribute or rely on.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -11,7 +11,7 @@ user's browser at runtime** and are not redistributed in this repository.
 
 > This list is provided for convenience only and may not be exhaustive or
 > perfectly current. Consult each project for its authoritative license, and
-> get your own legal review before relying on any of this — especially if you
+> get your own legal review before relying on any of this, especially if you
 > monetize the site (for example, with advertising).
 
 ## CheerpJ (Java runtime)
@@ -23,7 +23,7 @@ The Java playground uses **CheerpJ** by **Leaning Technologies**
 CheerpJ is proprietary (not OSI-approved open source) and the MIT license on
 Dataslope's code grants no rights to it. It is used here under the **CheerpJ
 Core Community Edition**, which is free and **allows commercial use for
-individuals and one-person companies** — so a solo developer running this site
+individuals and one-person companies**, so a solo developer running this site
 (including ad-supported) is covered.
 
 Two Community Edition restrictions to stay within, both of which this project's
@@ -35,9 +35,9 @@ setup already satisfies:
 - **No OEM/redistribution.** This repository doesn't bundle or redistribute
   CheerpJ; it only references the CDN loader at runtime.
 
-Re-check CheerpJ's current terms if your situation changes — for example if the
+Re-check CheerpJ's current terms if your situation changes, for example if the
 operation grows beyond a one-person company, or if you change how CheerpJ is
-loaded — since a paid CheerpJ license may then be required. CheerpJ executes
+loaded, since a paid CheerpJ license may then be required. CheerpJ executes
 OpenJDK, which is licensed under the **GPLv2 with the Classpath Exception**.
 
 ## Language runtimes (loaded at runtime)
@@ -47,20 +47,33 @@ OpenJDK, which is licensed under the **GPLv2 with the Classpath Exception**.
 | Pyodide | Python | MPL-2.0 (bundles CPython and packages under their own licenses) |
 | WebR | R | R is GPL-2.0 / GPL-3.0; verify WebR's specific terms |
 | php-wasm | PHP | PHP License / project's own terms; verify the specific build |
-| Clang → WASM (Wasmer) | C / C++ | LLVM/Clang: Apache-2.0 with LLVM exceptions; Wasmer: MIT |
+| browsercc (Clang/LLD + WASI) | C / C++ | Clang/LLVM: Apache-2.0 with LLVM exceptions; browsercc and @bjorn3/browser_wasi_shim under their own licenses (verify) |
 | CheerpJ + OpenJDK | Java | See the CheerpJ note above; OpenJDK: GPLv2 + Classpath Exception |
 | .NET / Mono / Roslyn | C# | MIT (the .NET platform) |
-| sql.js | SQLite | sql.js: MIT; SQLite engine: public domain |
+| @sqlite.org/sqlite-wasm | SQLite | Apache-2.0 (npm package); SQLite engine: public domain |
 | DuckDB-Wasm | DuckDB SQL | MIT |
 | PGlite | PostgreSQL (in-browser) | Apache-2.0 / PostgreSQL License |
-| @wasm-fmt/clang-format | C/C++ formatting | LLVM (Apache-2.0 with LLVM exceptions); verify the package |
+
+## Code formatters
+
+The editor's "format code" action uses in-browser WASM formatters, one per
+language family. The npm wrapper packages below are all MIT-licensed; the
+underlying tools keep their own upstream licenses.
+
+| Package | Formats | License |
+| --- | --- | --- |
+| @wasm-fmt/clang-format | C, C++, Java, C# | MIT wrapper; clang-format (LLVM): Apache-2.0 with LLVM exceptions |
+| @wasm-fmt/web_fmt | JavaScript, TypeScript | MIT |
+| @wasm-fmt/mago_fmt | PHP | MIT wrapper; Mago: verify upstream |
+| @wasm-fmt/ruff_fmt | Python | MIT wrapper; Ruff (Astral): MIT |
+| sql-formatter | SQL (SQLite / Postgres / DuckDB) | MIT |
 
 ## Application libraries
 
 Dataslope is built on many open-source packages declared in `package.json`,
-each under its own license as published on npm — for example Next.js (MIT),
+each under its own license as published on npm, for example Next.js (MIT),
 React (MIT), Better Auth (MIT), fumadocs (MIT), cobe (MIT), Tailwind CSS (MIT),
-Radix / Base UI primitives and shadcn/Magic UI–derived components (MIT), and
+Radix / Base UI primitives and shadcn/Magic UI-derived components (MIT), and
 lucide-react (ISC). Refer to each package's own `LICENSE` for the authoritative
 terms.
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -14,22 +14,31 @@ user's browser at runtime** and are not redistributed in this repository.
 > get your own legal review before relying on any of this — especially if you
 > monetize the site (for example, with advertising).
 
-## ⚠️ CheerpJ (Java runtime) — read this first
+## CheerpJ (Java runtime)
 
 The Java playground uses **CheerpJ** by **Leaning Technologies**
 (<https://cheerpj.com>), loaded at runtime from Leaning Technologies' CDN
 (`cjrtnc.leaningtech.com`).
 
-CheerpJ is **not** open source under an OSI-approved license. It is distributed
-under Leaning Technologies' own license terms, which are free for some uses but
-**may require a separate commercial license for others**. The MIT license on
-Dataslope's code grants you **no** rights to CheerpJ.
+CheerpJ is proprietary (not OSI-approved open source) and the MIT license on
+Dataslope's code grants no rights to it. It is used here under the **CheerpJ
+Core Community Edition**, which is free and **allows commercial use for
+individuals and one-person companies** — so a solo developer running this site
+(including ad-supported) is covered.
 
-**Action required:** review CheerpJ's current licensing and Leaning
-Technologies' terms, and obtain any commercial license your use may need —
-particularly commercial/for-profit operation of the site, including running
-advertising against it. CheerpJ executes OpenJDK, which is licensed under the
-**GPLv2 with the Classpath Exception**.
+Two Community Edition restrictions to stay within, both of which this project's
+setup already satisfies:
+
+- **No self-hosting.** CheerpJ must be loaded from Leaning Technologies' CDN,
+  which is exactly how it's integrated here (`cjrtnc.leaningtech.com`). Don't
+  vendor or self-host the CheerpJ runtime files.
+- **No OEM/redistribution.** This repository doesn't bundle or redistribute
+  CheerpJ; it only references the CDN loader at runtime.
+
+Re-check CheerpJ's current terms if your situation changes — for example if the
+operation grows beyond a one-person company, or if you change how CheerpJ is
+loaded — since a paid CheerpJ license may then be required. CheerpJ executes
+OpenJDK, which is licensed under the **GPLv2 with the Classpath Exception**.
 
 ## Language runtimes (loaded at runtime)
 

--- a/app/_components/ai/AskAiPanel.module.css
+++ b/app/_components/ai/AskAiPanel.module.css
@@ -28,38 +28,30 @@
   box-shadow: 0 8px 26px rgba(0, 0, 0, 0.24);
 }
 
-/* "Sidebar tab" placement: a slim vertical rectangle flush with the right
-   viewport edge (the classic "Feedback" tab), chosen from the panel's
-   settings so the launcher stops covering page content. */
+/* "Sidebar tab" placement: a compact square icon button flush with the right
+   viewport edge, chosen from the panel's settings so the launcher stops
+   covering page content. Icon-only (no label) with a small corner radius,
+   since a big pill radius looks out of place on a button this small. */
 .launcherTab {
   position: fixed;
   right: 0;
   bottom: 96px;
   z-index: 60;
   display: inline-flex;
-  flex-direction: column;
   align-items: center;
-  gap: 7px;
-  padding: 11px 7px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   border: none;
-  border-radius: 8px 0 0 8px;
+  border-radius: 6px 0 0 6px;
   background: var(--ds-blue-600, #1f6feb);
   color: #fff;
-  font-family: var(--font-sans, system-ui, sans-serif);
   cursor: pointer;
   box-shadow: -2px 3px 12px rgba(0, 0, 0, 0.18);
-  transition: padding 0.12s ease, box-shadow 0.12s ease;
+  transition: box-shadow 0.12s ease, background 0.12s ease;
 }
 .launcherTab:hover {
-  padding-right: 10px;
   box-shadow: -3px 4px 16px rgba(0, 0, 0, 0.24);
-}
-.launcherTabLabel {
-  writing-mode: vertical-rl;
-  font-size: 12.5px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  line-height: 1;
 }
 
 /* ── Settings (inline section under the panel header) ────────────── */

--- a/app/_components/ai/AskAiWidget.tsx
+++ b/app/_components/ai/AskAiWidget.tsx
@@ -333,12 +333,15 @@ export default function AskAiWidget({
     hasAiEditHandler(collectContext().adapterId);
 
   // ── Suggested questions ────────────────────────────────────────────
-  // Three context-grounded questions on the empty panel and after each
-  // answer. Free for the member (tracked on suggestion-specific counters
+  // Three context-grounded follow-up questions after each answer. Deliberately
+  // NOT shown on the empty panel (the `messages.length > 0` gate), so the first
+  // thing the user sees is their own blank slate rather than pre-filled
+  // prompts, suggestions only appear once there's a conversation to follow up
+  // on. Free for the member (tracked on suggestion-specific counters
   // server-side); failures just hide the section.
   const { suggestions, suggestLoading, clearSuggestions } =
     useSuggestedQuestions({
-      active: open && signedIn && !streaming,
+      active: open && signedIn && !streaming && messages.length > 0,
       turnKey: messages.length,
       buildContext,
       history: messages,
@@ -398,9 +401,9 @@ export default function AskAiWidget({
           className={styles.launcherTab}
           onClick={() => setOpen(true)}
           aria-label="Ask AI"
+          title="Ask AI"
         >
-          <Sparkles size={15} />
-          <span className={styles.launcherTabLabel}>Ask AI</span>
+          <Sparkles size={18} />
         </button>
       );
     }
@@ -513,6 +516,10 @@ export default function AskAiWidget({
             </a>
           </div>
         ) : messages.length === 0 ? (
+          // Empty panel: no suggested questions here by design, they only
+          // appear as follow-ups after an answer (see the SuggestionList below
+          // the conversation, and the `messages.length > 0` gate on
+          // useSuggestedQuestions).
           <div className={styles.emptyWrap}>
             <div className={styles.empty}>
               Ask about the{" "}
@@ -525,11 +532,6 @@ export default function AskAiWidget({
               page to ask about it, or pin a card below to reference it
               directly.
             </div>
-            <SuggestionList
-              suggestions={suggestions}
-              loading={suggestLoading}
-              onPick={sendQuestion}
-            />
           </div>
         ) : (
           <>

--- a/app/_components/auth/AuthGlobe.tsx
+++ b/app/_components/auth/AuthGlobe.tsx
@@ -88,10 +88,10 @@ const DARK_CONFIG: COBEOptions = {
   dark: 1,
   diffuse: 1.1,
   // Near-black oceans that melt into #121212 (baseColor × 0.1 ≈ #0D0F12), with
-  // continent dots kept only *subtly* brighter than that background: a low
+  // continent dots kept only *very* subtly brighter than that background: a low
   // mapBrightness is the knob for how much the dots stand out. Raise it for
   // more prominent continents, lower it for an even fainter globe.
-  mapBrightness: 1.8,
+  mapBrightness: 0.6,
   baseColor: [0.4, 0.5, 0.72],
   glowColor: [0.07, 0.18, 0.45],
 };
@@ -106,8 +106,9 @@ const LIGHT_CONFIG: COBEOptions = {
   // into grey specks. (cobe renders `dark: 0` continents *darker* than the
   // ocean, so true white-on-white dots aren't possible; this keeps the whole
   // sphere a soft, near-white backdrop.) baseColor / mapBrightness are the
-  // knobs to fine-tune on a real GPU.
-  mapBrightness: 2,
+  // knobs to fine-tune on a real GPU; keep mapBrightness low for very subtle
+  // continents.
+  mapBrightness: 1.1,
   baseColor: [1, 1, 1],
   glowColor: [1, 1, 1],
 };

--- a/app/_components/auth/AuthGlobe.tsx
+++ b/app/_components/auth/AuthGlobe.tsx
@@ -30,17 +30,34 @@ interface GlobePin {
 }
 
 // Dataslope-flavoured stickers, languages, data, challenges, and a little fun,
-// spread around the globe so several sit on the front face at any moment.
+// spread around the globe so several sit on the front face at any moment. The
+// globe is parked low behind the card (see the container transform below), so
+// its *upper* latitudes hide behind the card and only the lower arc is on
+// show, the bulk of the pins therefore sit in the southern hemisphere / low
+// latitudes so the visible region below the card stays populated.
 const PINS: GlobePin[] = [
+  // Northern / mid latitudes (partly tucked behind the card).
   { location: [37.7749, -122.4194], emoji: "🐍" }, // Python
   { location: [51.5074, -0.1278], emoji: "📊" }, // data / analytics
   { location: [35.6762, 139.6503], emoji: "🏆" }, // challenges
   { location: [1.3521, 103.8198], emoji: "🚀" }, // ship it
-  { location: [-23.5505, -46.6333], emoji: "🧠" }, // learning
   { location: [40.7128, -74.006], emoji: "🐘" }, // Postgres
   { location: [52.52, 13.405], emoji: "🦆" }, // DuckDB
-  { location: [-33.8688, 151.2093], emoji: "⚡" }, // WebAssembly speed
   { location: [28.6139, 77.209], emoji: "🔥" }, // streak
+  // Southern / low latitudes (the visible lower arc), spread across longitudes
+  // so several are always on the front face as the globe rotates.
+  { location: [-23.5505, -46.6333], emoji: "🧠" }, // learning
+  { location: [-33.8688, 151.2093], emoji: "⚡" }, // WebAssembly speed
+  { location: [-34.6037, -58.3816], emoji: "📈" }, // growth
+  { location: [-33.9249, 18.4241], emoji: "🧮" }, // compute
+  { location: [-36.8485, 174.7633], emoji: "🤖" }, // AI
+  { location: [-33.4489, -70.6693], emoji: "📉" }, // analytics
+  { location: [-31.9523, 115.8613], emoji: "☁️" }, // cloud
+  { location: [-26.2041, 28.0473], emoji: "💡" }, // ideas
+  { location: [-12.0464, -77.0428], emoji: "🔢" }, // numbers
+  { location: [-6.2088, 106.8456], emoji: "🌐" }, // web
+  { location: [-1.2921, 36.8219], emoji: "🎯" }, // goals
+  { location: [-37.8136, 144.9631], emoji: "⭐" }, // achievements
 ];
 
 const SHARED: Omit<
@@ -59,12 +76,22 @@ const SHARED: Omit<
   markers: [],
 };
 
+// cobe colours the whole sphere as `baseColor` scaled by a per-pixel
+// brightness; the dotted continents are the *same* hue as the ocean, just
+// brighter (when `dark: 1`) or darker (when `dark: 0`) by `mapBrightness`. So
+// the ocean reads as roughly `baseColor × 0.1` and a continent dot as
+// `baseColor × (mapBrightness × facing)`. To keep the dots close to the ocean
+// colour we simply keep `mapBrightness` low, rather than picking a separate dot
+// colour (cobe has no such knob).
 const DARK_CONFIG: COBEOptions = {
   ...SHARED,
   dark: 1,
   diffuse: 1.1,
-  // Faint continents on near-black oceans that melt into #121212.
-  mapBrightness: 5,
+  // Near-black oceans that melt into #121212 (baseColor × 0.1 ≈ #0D0F12), with
+  // continent dots kept only *subtly* brighter than that background: a low
+  // mapBrightness is the knob for how much the dots stand out. Raise it for
+  // more prominent continents, lower it for an even fainter globe.
+  mapBrightness: 1.8,
   baseColor: [0.4, 0.5, 0.72],
   glowColor: [0.07, 0.18, 0.45],
 };
@@ -73,9 +100,16 @@ const LIGHT_CONFIG: COBEOptions = {
   ...SHARED,
   dark: 0,
   diffuse: 1.2,
-  mapBrightness: 4.5,
-  baseColor: [0.9, 0.92, 0.97],
-  glowColor: [0.92, 0.95, 1],
+  // White/neutral globe on the light page: a pure-white base drops the old
+  // blue tint so the dotted sphere reads as white rather than blue-grey, and a
+  // lower mapBrightness keeps the continents pale instead of darkening them
+  // into grey specks. (cobe renders `dark: 0` continents *darker* than the
+  // ocean, so true white-on-white dots aren't possible; this keeps the whole
+  // sphere a soft, near-white backdrop.) baseColor / mapBrightness are the
+  // knobs to fine-tune on a real GPU.
+  mapBrightness: 2,
+  baseColor: [1, 1, 1],
+  glowColor: [1, 1, 1],
 };
 
 // Target opacity of the dotted sphere, low so the continents stay subtle (the

--- a/app/_components/auth/authBlocks.tsx
+++ b/app/_components/auth/authBlocks.tsx
@@ -103,8 +103,11 @@ export function AuthLinkButton({
 }
 
 export function TermsNote() {
+  // High-contrast body text (near-black in light, white in dark) so the note
+  // stays legible over the dotted globe behind the card; links keep the brand
+  // blue in both themes.
   return (
-    <div className="text-muted-foreground text-balance text-center text-xs [&_a]:text-[var(--ds-blue-500)] [&_a]:underline [&_a]:underline-offset-4">
+    <div className="text-balance text-center text-xs text-[#121212] dark:text-white [&_a]:text-[var(--ds-blue-500)] [&_a]:underline [&_a]:underline-offset-4">
       By clicking continue, you agree to our <a href="/terms">Terms of Service</a>{" "}
       and <a href="/privacy">Privacy Policy</a>.
     </div>

--- a/app/_components/home/Faq.tsx
+++ b/app/_components/home/Faq.tsx
@@ -7,11 +7,19 @@ import { SparklesText } from "@/components/ui/sparkles-text";
 const FAQS: { q: string; a: string }[] = [
   {
     q: "Do I need to sign up or install anything?",
-    a: "No. Everything runs in your browser, no account, no sign-in, and nothing to install beyond the one-time language runtime that downloads automatically on your first run.",
+    a: "No. Everything runs in your browser, no sign-in, and nothing to install beyond the one-time language runtime that downloads automatically on your first run. Creating a free account is optional; it lets you save and share your work in the cloud across devices.",
   },
   {
     q: "Is it really free?",
-    a: "Yes, all the courses, playgrounds, and quizzes are completely free and fully accessible, with no paywall on any of the content.",
+    a: "Yes, all the courses, playgrounds, and quizzes are completely free and fully accessible, with no paywall on any of the content. Accounts are free too, Dataslope only offers free memberships.",
+  },
+  {
+    q: "What does a free account add?",
+    a: "No learning content is ever gated behind it, but a free account lets you save your workspaces to the cloud, pick them up on another device, and manage your share links. You can sign up with Google, GitHub, or an email address.",
+  },
+  {
+    q: "What if I want to use more prompts?",
+    a: "Ask AI has a daily allowance that refreshes on a rolling 24-hour basis, so prompts you use free up again over the following day. For now Dataslope only offers free memberships, so there's no paid upgrade for extra prompts, everyone gets the same free allowance. We may add more options in the future.",
   },
   {
     q: "How does code run without a server?",
@@ -23,7 +31,7 @@ const FAQS: { q: string; a: string }[] = [
   },
   {
     q: "Is my work saved?",
-    a: "Your editor contents are kept in your browser's local storage, so refreshing the page or returning later restores your progress on the same device and browser.",
+    a: "Your editor contents are kept in your browser's local storage, so refreshing the page or returning later restores your progress on the same device and browser. With a free account you can also save workspaces to the cloud and open them on another device.",
   },
   {
     q: "Can I use it on mobile?",

--- a/app/_components/home/PricingSection.tsx
+++ b/app/_components/home/PricingSection.tsx
@@ -16,7 +16,6 @@ import {
   SquareTerminal,
   User,
   UserCheck,
-  WandSparkles,
   X,
   type LucideIcon,
 } from "lucide-react";
@@ -67,7 +66,11 @@ interface Plan {
   checkout?: boolean;
 }
 
-const FEATURE_COUNT = 9;
+// Number of feature rows every plan lists, in the same order, so the subgrid
+// can line the rows up across columns. If you change this, also update the
+// hardcoded subgrid row counts in the render below (they are FEATURE_COUNT + 3
+// header/price/CTA rows) since Tailwind needs the literal class strings.
+const FEATURE_COUNT = 8;
 
 const PLANS: Plan[] = [
   {
@@ -95,7 +98,6 @@ const PLANS: Plan[] = [
         note: "Share links expire 30 days after creation",
       },
       { text: "No “Ask AI” messages", included: false },
-      { text: "No AI-suggested autocomplete", included: false },
     ],
     cta: "Get started",
     href: "/courses",
@@ -133,11 +135,25 @@ const PLANS: Plan[] = [
         text: "Up to 10 “Ask AI” messages every 24 hours",
         note: "Across playgrounds, challenges, code blocks & lessons",
       },
-      { text: "No AI-suggested autocomplete", included: false },
     ],
     cta: "Sign up for free",
     href: "/sign-up",
+    // Promoted tier: green CTA, green icon, and a "Recommended" badge.
+    highlighted: true,
+    badge: "Recommended",
   },
+  // ── Pro plan: temporarily hidden ──────────────────────────────────────────
+  // The paid "Pro" column is intentionally kept OUT of the rendered table for
+  // now (see SHOW_PRO_PLAN below). The goal right now is to attract as many
+  // users as possible, and surfacing a paid tier can read as an upsell even
+  // though every course, playground, and challenge is free on all tiers. The
+  // plan object and all of its billing wiring (ProCheckoutCta, startProCheckout,
+  // stashCheckoutPeriod, the Polar checkout, the `checkout`/`plan` fields) are
+  // deliberately LEFT IN PLACE so Pro can be brought back by flipping
+  // SHOW_PRO_PLAN to `true` — do not delete them. When restoring, also:
+  //   • re-add the "AI-suggested autocomplete" feature rows (removed across all
+  //     plans) and bump FEATURE_COUNT back up accordingly, and
+  //   • widen the grid again (see the grid-cols / subgrid-row comments below).
   {
     name: "Pro",
     icon: Crown,
@@ -173,12 +189,6 @@ const PLANS: Plan[] = [
         note: "Fair use policy applies",
         highlight: "Unlimited",
       },
-      {
-        icon: WandSparkles,
-        text: "Unlimited AI-suggested autocomplete",
-        note: "Inline, context-aware code completions in every playground",
-        highlight: "Unlimited",
-      },
     ],
     cta: "Go Pro",
     href: "/courses",
@@ -187,6 +197,11 @@ const PLANS: Plan[] = [
     checkout: true,
   },
 ];
+
+// Toggle the paid "Pro" column on/off. Flip to `true` to restore the tier
+// (see the "Pro plan: temporarily hidden" note above for the full checklist).
+const SHOW_PRO_PLAN = false;
+const VISIBLE_PLANS = PLANS.filter((p) => SHOW_PRO_PLAN || p.name !== "Pro");
 
 // Explicit column placement keeps each plan in its own column while spanning
 // all of the subgrid's rows.
@@ -358,7 +373,7 @@ function PlanColumn({
     // shared row tracks); top/bottom breathing room is added to the header and
     // last feature instead.
     <div
-      className={`flex flex-col gap-3 px-6 py-6 lg:row-span-12 lg:row-start-1 lg:grid lg:grid-rows-subgrid lg:px-8 lg:py-0 ${colClass}`}
+      className={`flex flex-col gap-3 px-6 py-6 lg:row-span-11 lg:row-start-1 lg:grid lg:grid-rows-subgrid lg:px-8 lg:py-0 ${colClass}`}
     >
       <div className="lg:pt-8">
         <div className="flex items-center gap-2.5">
@@ -460,8 +475,8 @@ export function PricingSection({
           </SparklesText>
           <p className="mt-8 text-base text-[var(--ds-gray-900)] sm:text-lg dark:text-white">
             Every course, interview track, and playground is free to use, and
-            anyone can share a playground with a link. Create a free account
-            for cloud saves, or go Pro for storage that never expires.
+            anyone can share a playground with a link. Create a free account to
+            save and share your work in the cloud.
           </p>
         </div>
       )}
@@ -509,14 +524,22 @@ export function PricingSection({
           sliver, not through the table body. */}
       <div className="ds-striped-shell rounded-2xl">
         <div className="rounded-2xl border border-[var(--ds-gray-200)] bg-white dark:border-white/10 dark:bg-[#121212]">
-          <div className="grid grid-cols-1 divide-y divide-[var(--ds-gray-200)] lg:grid-cols-3 lg:grid-rows-[repeat(12,auto)] lg:gap-y-3 lg:divide-x lg:divide-y-0 dark:divide-white/10">
-            {PLANS.map((plan, i) => (
+          {/* Column count tracks the number of visible plans; the subgrid row
+              count is FEATURE_COUNT + 3 (header/price/CTA). Both are literal
+              class strings so Tailwind's JIT can see them, when restoring Pro,
+              switch `lg:grid-cols-2` back to `lg:grid-cols-3`. */}
+          <div
+            className={`grid grid-cols-1 divide-y divide-[var(--ds-gray-200)] lg:grid-rows-[repeat(11,auto)] lg:gap-y-3 lg:divide-x lg:divide-y-0 dark:divide-white/10 ${
+              SHOW_PRO_PLAN ? "lg:grid-cols-3" : "lg:grid-cols-2"
+            }`}
+          >
+            {VISIBLE_PLANS.map((plan, i) => (
               <PlanColumn
                 key={plan.name}
                 plan={plan}
                 annual={annual}
                 colClass={COL_START[i]}
-                prevPlan={i > 0 ? PLANS[i - 1] : undefined}
+                prevPlan={i > 0 ? VISIBLE_PLANS[i - 1] : undefined}
               />
             ))}
           </div>

--- a/app/_components/home/PricingSection.tsx
+++ b/app/_components/home/PricingSection.tsx
@@ -396,6 +396,11 @@ function PlanColumn({
         <span className="text-4xl font-medium tracking-tight text-[var(--ds-gray-900)] dark:text-white">
           {price}
         </span>
+        {/* Billing-period suffix so the monthly/annual toggle visibly changes
+            the table even though every plan is $0. */}
+        <span className="ml-1 text-base font-normal text-[var(--ds-gray-500)] dark:text-[var(--ds-gray-400)]">
+          {annual ? "/ year" : "/ month"}
+        </span>
         <p className="mt-1 text-[15px] text-[var(--ds-gray-900)] dark:text-white">
           {note}
         </p>
@@ -507,7 +512,7 @@ export function PricingSection({
                         : "bg-[var(--ds-green-50)] text-[var(--ds-green-700)] dark:bg-[var(--ds-green-500)]/15 dark:text-[var(--ds-green-300)]"
                     }`}
                   >
-                    Save 33%
+                    Best value
                   </span>
                 )}
               </button>

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -92,6 +92,15 @@ html[data-playground-theme="light"] .pyodide-loading {
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
 }
+
+/* The sitewide default body letter-spacing (app/globals.css: -0.011em, for
+   Inter/sans text) would also tighten every monospace surface in this IDE, the
+   editor, terminal, output cells and gutters, whose columns should keep their
+   natural spacing. Default the whole playground back to `normal`; the chrome's
+   own explicit letter-spacing rules still win via the cascade. */
+.playground-root {
+  letter-spacing: normal;
+}
 .playground-root ::-webkit-scrollbar,
 .playground-root::-webkit-scrollbar {
   width: 8px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,22 @@ html, body {
   /* Apply Inter as the default sans-serif font for all non-monospace text.
      The --font-sans CSS variable is injected by Next.js next/font/google. */
   font-family: var(--font-sans, Inter, system-ui, sans-serif);
+  /* Slightly tighten the default letter-spacing for Inter/sans body text
+     sitewide, for a more polished feel (matches the lessons surface,
+     app/docs.css, which already sets -0.011em). This is a *default*: any
+     element that sets its own letter-spacing, e.g. Tailwind's `tracking-*`
+     utilities or an explicit negative value, overrides it via the cascade, so
+     already-tracked text is left untouched. Monospace/code is reset back to
+     `normal` just below (and the playground IDE opts out in playground.css). */
+  letter-spacing: -0.011em;
+}
+
+/* Keep monospace/code at normal letter-spacing: the tightening above is for
+   Inter/sans text only. Code that sets its own letter-spacing (several code
+   blocks use a slight -0.01em) keeps it, since a class selector outranks these
+   bare element selectors. */
+code, kbd, samp, pre, .font-mono {
+  letter-spacing: normal;
 }
 
 /* Actionable controls get a pointer cursor everywhere. Tailwind v4's

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -117,13 +117,6 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  // Cloudflare Web Analytics beacon token. Public (it ships in the page HTML),
-  // so it's a build-time NEXT_PUBLIC_ var: get it from the Cloudflare dashboard
-  // (Web Analytics → your site → the JS snippet) and set it as a build variable.
-  // When unset (local dev, unconfigured builds) the beacon isn't rendered, so
-  // nothing is loaded or reported. Cloudflare Web Analytics is cookieless and
-  // sets no client-side state, so it needs no cookie-consent banner.
-  const cfBeaconToken = process.env.NEXT_PUBLIC_CF_BEACON_TOKEN;
   return (
     <html
       lang="en"
@@ -145,12 +138,6 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://cjrtnc.leaningtech.com" />
         <link rel="dns-prefetch" href="https://esm.sh" />
         <link rel="dns-prefetch" href="https://unpkg.com" />
-        {cfBeaconToken && (
-          <link
-            rel="dns-prefetch"
-            href="https://static.cloudflareinsights.com"
-          />
-        )}
         <script dangerouslySetInnerHTML={{ __html: themeBootstrapScript }} />
       </head>
       <body>
@@ -168,18 +155,6 @@ export default function RootLayout({
         {/* Records the last non-auth page per tab so /sign-in can send
             the user back where they came from after authenticating. */}
         <ReturnToTracker />
-        {/* Cloudflare Web Analytics: privacy-first, cookieless page-view /
-            visitor stats. Rendered only when the beacon token is configured
-            (see NEXT_PUBLIC_CF_BEACON_TOKEN above), so it's a no-op locally and
-            until it's set up. No cookies / client-side state, so no consent
-            banner is required. */}
-        {cfBeaconToken && (
-          <script
-            defer
-            src="https://static.cloudflareinsights.com/beacon.min.js"
-            data-cf-beacon={JSON.stringify({ token: cfBeaconToken })}
-          />
-        )}
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -117,6 +117,13 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // Cloudflare Web Analytics beacon token. Public (it ships in the page HTML),
+  // so it's a build-time NEXT_PUBLIC_ var: get it from the Cloudflare dashboard
+  // (Web Analytics → your site → the JS snippet) and set it as a build variable.
+  // When unset (local dev, unconfigured builds) the beacon isn't rendered, so
+  // nothing is loaded or reported. Cloudflare Web Analytics is cookieless and
+  // sets no client-side state, so it needs no cookie-consent banner.
+  const cfBeaconToken = process.env.NEXT_PUBLIC_CF_BEACON_TOKEN;
   return (
     <html
       lang="en"
@@ -138,6 +145,12 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://cjrtnc.leaningtech.com" />
         <link rel="dns-prefetch" href="https://esm.sh" />
         <link rel="dns-prefetch" href="https://unpkg.com" />
+        {cfBeaconToken && (
+          <link
+            rel="dns-prefetch"
+            href="https://static.cloudflareinsights.com"
+          />
+        )}
         <script dangerouslySetInnerHTML={{ __html: themeBootstrapScript }} />
       </head>
       <body>
@@ -155,6 +168,18 @@ export default function RootLayout({
         {/* Records the last non-auth page per tab so /sign-in can send
             the user back where they came from after authenticating. */}
         <ReturnToTracker />
+        {/* Cloudflare Web Analytics: privacy-first, cookieless page-view /
+            visitor stats. Rendered only when the beacon token is configured
+            (see NEXT_PUBLIC_CF_BEACON_TOKEN above), so it's a no-op locally and
+            until it's set up. No cookies / client-side state, so no consent
+            banner is required. */}
+        {cfBeaconToken && (
+          <script
+            defer
+            src="https://static.cloudflareinsights.com/beacon.min.js"
+            data-cf-beacon={JSON.stringify({ token: cfBeaconToken })}
+          />
+        )}
       </body>
     </html>
   );

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -13,7 +13,7 @@ import { OG_IMAGE, SITE_URL } from "@/lib/site";
 
 const PAGE_TITLE = "Pricing, Dataslope";
 const PAGE_DESCRIPTION =
-  "Dataslope pricing in detail. Every course, interview track, and playground is free. Compare the Guest, Free Member, and Pro plans, with footnotes covering cloud storage, sharing, AI usage, and billing.";
+  "Dataslope pricing in detail. Every course, interview track, and playground is free. Compare the Guest and Free Member plans, with footnotes covering cloud storage, sharing, AI usage, and billing.";
 
 export const metadata: Metadata = {
   // A bare string here lets the root layout's "%s · DataSlope" template render
@@ -93,9 +93,9 @@ export default function PricingPage() {
               <p className="mt-6 text-base text-[var(--ds-gray-900)] sm:text-lg dark:text-white">
                 Every course, interview track, and playground is free to use,
                 sign-in optional, and anyone can share a playground with a
-                link. Create a free account for cloud saves, or go Pro for
-                storage that never expires. The detailed notes below the table
-                explain exactly what each row means.
+                link. Create a free account to save and share your work in the
+                cloud. The detailed notes below the table explain exactly what
+                each row means.
               </p>
             </div>
           </section>
@@ -116,13 +116,20 @@ export default function PricingPage() {
                 there are no surprises about what&apos;s included at each tier.
               </p>
 
+              {/* NOTE: The paid "Pro" tier is currently hidden from the table
+                  (see SHOW_PRO_PLAN in PricingSection). These footnotes have
+                  been trimmed to describe only the Guest and Free Member plans,
+                  everything is free today. When Pro is restored, re-add the
+                  Pro-specific notes (unlimited Ask AI fair-use, autocomplete,
+                  monthly/annual billing, cancelling a plan) and the 10 GB /
+                  "Upgrade to Pro" clauses removed below. */}
               <ol className="mt-8 space-y-6">
                 <Footnote n={1} lead="Free to learn, always.">
                   Courses, interview prep, and the playgrounds, including
                   unlimited code executions across all 11 languages, are
                   completely free on every tier, including as a guest with no
-                  sign-in. A paid plan only adds cloud storage, sharing, and
-                  more AI chat; it never puts learning content behind a paywall.
+                  sign-in. Creating a free account only adds cloud storage and
+                  sharing; it never puts learning content behind a paywall.
                 </Footnote>
 
                 <Footnote n={2} lead="“Save workspaces locally.”">
@@ -137,8 +144,7 @@ export default function PricingPage() {
                 <Footnote n={3} lead="“Save workspaces locally and in the cloud.”">
                   Cloud saves sync your workspaces to your account so you can
                   pick them up on any device you sign in to. Free Members get
-                  cloud saves with a retention limit (see note 4); Pro keeps them
-                  for as long as your membership is active.
+                  cloud saves with a retention limit (see note 4).
                 </Footnote>
 
                 <Footnote
@@ -149,17 +155,16 @@ export default function PricingPage() {
                   opened or edited for about 30 days. After that it may be
                   removed from the cloud to free up space, your local copy, if
                   you have one, is untouched. Opening or editing a workspace
-                  resets its clock. Upgrading to Pro removes this limit entirely:
-                  Pro cloud saves are kept for as long as you&apos;re subscribed.
+                  resets its clock.
                 </Footnote>
 
-                <Footnote n={5} lead="“100 MB / 10 GB of cloud storage.”">
+                <Footnote n={5} lead="“100 MB of cloud storage.”">
                   Your quota is the combined size of everything you keep in the
                   cloud, saved workspaces, databases, and any files you upload,
                   totaled across all playgrounds, not measured per playground. If
                   you reach the limit you can still open and export existing
-                  work; you&apos;ll just need to free up space (or upgrade)
-                  before saving more.
+                  work; you&apos;ll just need to free up space before saving
+                  more.
                 </Footnote>
 
                 <Footnote n={6} lead="“Share playgrounds.”">
@@ -173,58 +178,18 @@ export default function PricingPage() {
                   account: guest links simply expire 30 days after they&apos;re
                   created and can&apos;t be managed afterwards. Links created
                   while signed in can be copied or revoked anytime from your
-                  account page; on the Free Member plan they follow the same
-                  one-month inactivity cleanup as your other cloud saves (see
-                  note 4) and count toward your storage quota (note 5), while
-                  on Pro they stay live for as long as you&apos;re subscribed.
+                  account page, and they follow the same one-month inactivity
+                  cleanup as your other cloud saves (see note 4) and count
+                  toward your storage quota (note 5).
                 </Footnote>
 
                 <Footnote n={7} lead="“Ask AI” messages.">
                   “Ask AI” is the in-app assistant available inside playgrounds,
                   challenges, code blocks, and lessons. Your limit is counted
                   across all of those surfaces on a rolling 24-hour window,
-                  Guests get 3, Free Members up to 10, and Pro is unlimited. A
-                  rolling window means each message frees up again 24 hours after
-                  you send it, rather than all resetting at a fixed time of day.
-                </Footnote>
-
-                <Footnote
-                  n={8}
-                  lead="“Unlimited ‘Ask AI’, fair use policy applies” (Pro)."
-                >
-                  Unlimited covers normal interactive use. To keep the assistant
-                  fast and available for everyone, we may rate-limit usage that
-                  looks automated or abusive (for example, scripted bulk
-                  requests). Ordinary day-to-day use is never throttled.
-                </Footnote>
-
-                <Footnote
-                  n={9}
-                  lead="“Unlimited AI-suggested autocomplete” (Pro)."
-                >
-                  As you type in any playground, Pro offers inline,
-                  context-aware code completions you can accept with a keystroke
-, like an AI pair programmer suggesting the next line. It&apos;s
-                  unlimited under the same fair-use policy as Ask AI (see note 8),
-                  and it&apos;s a Pro-only feature: the Guest and Free Member
-                  tiers don&apos;t include autocomplete suggestions.
-                </Footnote>
-
-                <Footnote n={10} lead="Monthly vs. annual billing.">
-                  The toggle above the table switches the Pro price between
-                  monthly ($4.99/mo) and annual ($40/yr, about $3.33/mo, a 33%
-                  saving). Annual is a single up-front payment covering twelve
-                  months. Prices are in US dollars and may be subject to tax
-                  depending on where you are.
-                </Footnote>
-
-                <Footnote n={11} lead="Changing or cancelling your plan.">
-                  You can cancel Pro at any time and keep Pro features until the
-                  end of the period you&apos;ve already paid for. After that your
-                  account returns to the Free Member tier and your cloud data
-                  becomes subject to the Free limits again, the 100 MB quota and
-                  the one-month inactivity cleanup, so export anything you want
-                  to keep beyond those limits before you downgrade.
+                  Guests get 3 and Free Members up to 10. A rolling window means
+                  each message frees up again 24 hours after you send it, rather
+                  than all resetting at a fixed time of day.
                 </Footnote>
               </ol>
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -4,7 +4,7 @@ import { LegalShell } from "../_components/legal/LegalShell";
 export const metadata = {
   title: "Privacy Policy, Dataslope",
   description:
-    "How Dataslope handles your data: optional accounts, no ad tracking, and code that runs entirely in your browser.",
+    "How Dataslope handles your data: optional accounts, code that runs entirely in your browser, and clear choices about your data.",
 };
 
 export default function PrivacyPage() {
@@ -13,9 +13,9 @@ export default function PrivacyPage() {
       <p>
         Dataslope is a free, browser-based platform for learning programming and
         data skills. We built it to need as little of your data as possible. You
-        can use almost everything without an account, the code you write runs
-        entirely on your own device, and we don&apos;t run advertising or
-        cross-site tracking. This policy explains what we do collect, and when.
+        can use almost everything without an account, and the code you write runs
+        entirely on your own device. This policy explains what we collect, when,
+        and the choices you have.
       </p>
 
       <h2>Using Dataslope without an account</h2>
@@ -67,7 +67,7 @@ export default function PrivacyPage() {
       <h2>Data stored on your device</h2>
       <p>
         To make the product usable, your browser&apos;s <strong>local
-        storage</strong> keeps things like your theme preference and the code,
+        storage</strong>{" "}keeps things like your theme preference and the code,
         queries, and progress in your playgrounds and lessons. This stays on
         your device and in your browser, and clearing your browser&apos;s site
         data removes it. Local saves are separate from cloud saves, they are not
@@ -89,7 +89,7 @@ export default function PrivacyPage() {
       </p>
       <ul>
         <li>
-          <strong>Content delivery networks</strong> (for example jsDelivr,
+          <strong>Content delivery networks</strong>{" "}(for example jsDelivr,
           unpkg, and GitHub) serve language runtimes and sample datasets on
           demand; your browser&apos;s requests expose standard information such
           as your IP address to them.
@@ -104,7 +104,7 @@ export default function PrivacyPage() {
           emails described above.
         </li>
         <li>
-          <strong>An AI provider</strong> generates &ldquo;Ask AI&rdquo;
+          <strong>An AI provider</strong>{" "}generates &ldquo;Ask AI&rdquo;
           responses from the context described above.
         </li>
         <li>
@@ -114,12 +114,10 @@ export default function PrivacyPage() {
         </li>
       </ul>
 
-      <h2>Cookies and tracking</h2>
+      <h2>Cookies</h2>
       <p>
         We use essential cookies to keep you signed in and to remember a few
-        preferences. We do <strong>not</strong> use advertising or cross-site
-        tracking cookies, we don&apos;t run third-party analytics or product
-        telemetry, and we don&apos;t sell or share your personal data.
+        preferences, such as your light or dark theme.
       </p>
 
       <h2>Your choices</h2>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -112,6 +112,12 @@ export default function PrivacyPage() {
           standard server logs (for example request times and IP addresses) for
           security and reliability.
         </li>
+        <li>
+          <strong>Cloudflare Web Analytics</strong> gives us privacy-first,
+          aggregate traffic statistics (such as page views, referrers, and
+          countries). It is cookieless, sets no data on your device, and does
+          not track you across sites or use your data to identify you.
+        </li>
       </ul>
 
       <h2>Cookies</h2>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -4,24 +4,64 @@ import { LegalShell } from "../_components/legal/LegalShell";
 export const metadata = {
   title: "Privacy Policy, Dataslope",
   description:
-    "How Dataslope handles your data: no accounts, no tracking, and code that runs entirely in your browser.",
+    "How Dataslope handles your data: optional accounts, no ad tracking, and code that runs entirely in your browser.",
 };
 
 export default function PrivacyPage() {
   return (
-    <LegalShell title="Privacy Policy" updated="June 19, 2026">
+    <LegalShell title="Privacy Policy" updated="July 16, 2026">
       <p>
         Dataslope is a free, browser-based platform for learning programming and
-        data skills. We built it to need as little of your data as possible. In
-        short: there are no accounts, we don&apos;t track you, and the code you
-        write runs entirely on your own device.
+        data skills. We built it to need as little of your data as possible. You
+        can use almost everything without an account, the code you write runs
+        entirely on your own device, and we don&apos;t run advertising or
+        cross-site tracking. This policy explains what we do collect, and when.
       </p>
 
-      <h2>Information we collect</h2>
+      <h2>Using Dataslope without an account</h2>
       <p>
-        We do <strong>not</strong> require you to create an account, and we do
-        not ask for or collect personal information such as your name, email
-        address, or password. We have no user database.
+        You can browse the courses, run the playgrounds, and take the quizzes as
+        a guest, with no sign-in. In that mode we don&apos;t ask for or collect
+        personal information such as your name or email address, and there is no
+        profile stored on our servers.
+      </p>
+
+      <h2>If you create an account</h2>
+      <p>
+        Accounts are <strong>optional</strong> and free. You can create one with
+        Google or GitHub, or with an email address and password. When you do, we
+        store the account information needed to provide the service in our own
+        database: your name and email address, an avatar URL if your provider
+        supplies one, and, for email sign-ups, a securely hashed password (we
+        never store your password in plain text). We keep this on infrastructure
+        we control and do not sell or rent it.
+      </p>
+      <p>
+        If you sign up with an email address, we may send you service emails such
+        as an address-verification link, a password-reset link, or an
+        account-deletion confirmation. These are sent through an email provider
+        on our behalf and are transactional, not marketing.
+      </p>
+
+      <h2>Cloud saves and sharing</h2>
+      <p>
+        Signed-in members can choose to save workspaces to the cloud and to
+        create share links. When you do, the contents of those workspaces (your
+        files, and for SQL playgrounds the database and queries) are stored on
+        our servers so you can sync them across devices or share them. Anyone
+        with a share link can open a copy of what you shared, so only share work
+        you&apos;re comfortable making accessible. You can delete cloud saves and
+        revoke share links from your account page.
+      </p>
+
+      <h2>Ask AI</h2>
+      <p>
+        When you use the optional &ldquo;Ask AI&rdquo; assistant, your question
+        along with relevant context from the page (such as the lesson text, the
+        code or queries in the playground you&apos;re working in, and any text
+        you&apos;ve highlighted) is sent to a third-party AI provider so it can
+        generate a response. Please don&apos;t include sensitive personal
+        information in your prompts.
       </p>
 
       <h2>Data stored on your device</h2>
@@ -29,38 +69,73 @@ export default function PrivacyPage() {
         To make the product usable, your browser&apos;s <strong>local
         storage</strong> keeps things like your theme preference and the code,
         queries, and progress in your playgrounds and lessons. This stays on
-        your device and in your browser, it is not transmitted to or stored on
-        our servers, and clearing your browser&apos;s site data removes it.
+        your device and in your browser, and clearing your browser&apos;s site
+        data removes it. Local saves are separate from cloud saves, they are not
+        transmitted to us unless you explicitly save to the cloud.
       </p>
 
       <h2>Code execution</h2>
       <p>
         Every language and database runs locally in your browser through
         WebAssembly. The code you write, the queries you run, and any files you
-        load are processed on your machine and are never uploaded to us.
+        load are processed on your machine, and are only sent to us if you save
+        them to the cloud, share them, or ask the AI assistant about them.
       </p>
 
       <h2>Third-party services</h2>
       <p>
-        Language runtimes and sample datasets are downloaded on demand from
-        third-party content delivery networks (for example jsDelivr, unpkg, and
-        GitHub). When your browser requests those files, the provider may
-        receive standard request information such as your IP address, subject to
-        that provider&apos;s own privacy policy. Our hosting provider may also
-        keep standard server logs (for example request times and IP addresses)
-        for security and reliability.
+        Dataslope relies on a few third-party services, each subject to its own
+        privacy policy:
       </p>
+      <ul>
+        <li>
+          <strong>Content delivery networks</strong> (for example jsDelivr,
+          unpkg, and GitHub) serve language runtimes and sample datasets on
+          demand; your browser&apos;s requests expose standard information such
+          as your IP address to them.
+        </li>
+        <li>
+          <strong>Sign-in providers</strong> (Google and GitHub) handle social
+          login if you choose it, and share basic profile details such as your
+          name, email, and avatar with us.
+        </li>
+        <li>
+          <strong>An email provider</strong> delivers the transactional account
+          emails described above.
+        </li>
+        <li>
+          <strong>An AI provider</strong> generates &ldquo;Ask AI&rdquo;
+          responses from the context described above.
+        </li>
+        <li>
+          <strong>Our hosting provider</strong> runs the site and may keep
+          standard server logs (for example request times and IP addresses) for
+          security and reliability.
+        </li>
+      </ul>
 
       <h2>Cookies and tracking</h2>
       <p>
-        We do not use advertising or cross-site tracking cookies, and we do not
-        sell or share personal data, we don&apos;t have any to sell.
+        We use essential cookies to keep you signed in and to remember a few
+        preferences. We do <strong>not</strong> use advertising or cross-site
+        tracking cookies, we don&apos;t run third-party analytics or product
+        telemetry, and we don&apos;t sell or share your personal data.
+      </p>
+
+      <h2>Your choices</h2>
+      <p>
+        You can use Dataslope as a guest without giving us any personal
+        information. If you have an account, you can delete individual cloud
+        saves and share links at any time, or delete your entire account from
+        your account page, doing so removes your profile and the cloud saves and
+        shares associated with it.
       </p>
 
       <h2>Children&apos;s privacy</h2>
       <p>
-        Dataslope is suitable for general audiences and does not knowingly
-        collect personal information from anyone, including children.
+        Dataslope is suitable for general audiences and is not directed at young
+        children. We don&apos;t knowingly collect personal information from
+        children under the age required by applicable law.
       </p>
 
       <h2>Changes to this policy</h2>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -46,6 +46,23 @@ export default function TermsPage() {
         and revoke share links at any time.
       </p>
 
+      <h2>Saved work and learning progress</h2>
+      <p>
+        Cloud saves, share links, and learning-progress tracking are provided
+        on a best-effort, <strong>&ldquo;as available&rdquo;</strong>{" "}basis, and
+        we can&apos;t guarantee that any saved work or progress will always be
+        retained or remain accessible. In particular, a saved workspace or your
+        progress may be removed or become unusable for reasons including
+        inactivity cleanup, reaching a storage limit, scheduled maintenance, and
+        updates to the language runtimes, databases, or platform that make a
+        previously saved workspace incompatible, which can result in its{" "}
+        <strong>automatic deletion</strong>. To the fullest extent permitted by
+        law, we are not liable for any loss of, or inability to access, your
+        saved workspaces, files, databases, or learning progress. Please keep
+        your own copies of anything important, you can download or export your
+        work from the playground at any time.
+      </p>
+
       <h2>Ask AI</h2>
       <p>
         The optional &ldquo;Ask AI&rdquo; assistant sends your question and
@@ -99,7 +116,7 @@ export default function TermsPage() {
       <h2>Disclaimer of warranties</h2>
       <p>
         The Service is provided <strong>&ldquo;as is&rdquo;</strong> and
-        <strong> &ldquo;as available,&rdquo;</strong> without warranties of any
+        <strong> &ldquo;as available,&rdquo;</strong>{" "}without warranties of any
         kind. We don&apos;t guarantee that it will be uninterrupted,
         error-free, or that any code output is correct or fit for a particular
         purpose.

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -8,7 +8,7 @@ export const metadata = {
 
 export default function TermsPage() {
   return (
-    <LegalShell title="Terms of Service" updated="June 19, 2026">
+    <LegalShell title="Terms of Service" updated="July 16, 2026">
       <p>
         These terms govern your use of Dataslope (the &ldquo;Service&rdquo;). By
         using the Service, you agree to them. If you don&apos;t agree, please
@@ -19,7 +19,40 @@ export default function TermsPage() {
       <p>
         Dataslope is provided free of charge for personal, educational, and
         non-commercial learning. You don&apos;t need an account, and you may use
-        the courses, playgrounds, and quizzes as they are made available.
+        the courses, playgrounds, and quizzes as they are made available. All
+        memberships are currently free, there is no paid plan.
+      </p>
+
+      <h2>Accounts</h2>
+      <p>
+        Creating an account is optional and free. You can sign up with Google or
+        GitHub, or with an email address and password. You&apos;re responsible
+        for keeping your login credentials secure and for activity that happens
+        under your account, and you agree to provide accurate information (for
+        example, a real email address you control). You can delete your account
+        at any time from your account page. We may suspend or terminate an
+        account that violates these terms or is used abusively.
+      </p>
+
+      <h2>Your content, cloud saves, and sharing</h2>
+      <p>
+        Code you write in the playgrounds is yours. If you save a workspace to
+        the cloud or create a share link, you grant us permission to store and
+        serve that content only as needed to provide those features to you and
+        to anyone you share a link with. You&apos;re responsible for the content
+        you upload or share, don&apos;t save or share anything unlawful or that
+        infringes others&apos; rights, and remember that anyone with a share
+        link can view a copy of what you shared. You can delete your cloud saves
+        and revoke share links at any time.
+      </p>
+
+      <h2>Ask AI</h2>
+      <p>
+        The optional &ldquo;Ask AI&rdquo; assistant sends your question and
+        relevant page context to a third-party AI provider to generate a
+        response. AI responses may be inaccurate or incomplete, don&apos;t rely
+        on them as professional advice, and always verify important answers.
+        Please don&apos;t submit sensitive personal information in your prompts.
       </p>
 
       <h2>Acceptable use</h2>
@@ -31,7 +64,8 @@ export default function TermsPage() {
         </li>
         <li>
           attempt to disrupt, overload, or compromise the Service, its hosting,
-          or the third-party services it relies on;
+          or the third-party services it relies on, including abusing the AI
+          assistant with automated or bulk requests;
         </li>
         <li>
           misrepresent the Service or remove or obscure any notices it displays.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dataslope",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "fumadocs-mdx && node scripts/build-almostnode-workers.mjs && node scripts/build-svg-gallery-data.mjs && node scripts/build-search-index.mjs && node scripts/build-brand-fallbacks.mjs && node scripts/build-images.mjs && next dev",
     "build": "fumadocs-mdx && node scripts/build-almostnode-workers.mjs && node scripts/build-svg-gallery-data.mjs && node scripts/build-search-index.mjs && node scripts/build-brand-fallbacks.mjs && node scripts/build-images.mjs && next build",

--- a/tools-jar/README.md
+++ b/tools-jar/README.md
@@ -12,7 +12,7 @@ ship `tools.jar`, so the playground supplies its own copy of `javac` and loads
 it into CheerpJ's filesystem at runtime.
 
 Hosting the ~18 MB jar on a CDN instead of the app's own origin keeps it off
-the Vercel bandwidth bill. We use **unpkg** specifically because:
+the app's own bandwidth bill. We use **unpkg** specifically because:
 
 - **jsDelivr** refuses `.jar` files (returns HTTP 403).
 - **GitHub release assets** send no `Access-Control-Allow-Origin` header, so a
@@ -21,7 +21,7 @@ the Vercel bandwidth bill. We use **unpkg** specifically because:
   version is pinned, an immutable 1-year cache.
 
 The app fetches it from `https://unpkg.com/dataslope-tools-jar@<version>/tools.jar`
-— see `TOOLS_JAR_CDN` in `app/_components/runtime/cdn.ts`.
+(see `TOOLS_JAR_CDN` in `app/_components/runtime/cdn.ts`).
 
 ## Provenance & license
 
@@ -44,6 +44,6 @@ The corresponding source is OpenJDK 8 (https://openjdk.org/).
    yields the immutable 1-year CDN cache.
 
 > **Deploy ordering:** publish the npm package *before* deploying an app build
-> that points `TOOLS_JAR_VERSION` at it — the playground fetches the jar from
-> unpkg at runtime, so the version must already exist on npm or Java will fail
-> to start.
+> that points `TOOLS_JAR_VERSION` at it, because the playground fetches the jar
+> from unpkg at runtime, so the version must already exist on npm or Java will
+> fail to start.


### PR DESCRIPTION
## Summary

A batch of UI polish plus a pricing/positioning change (single free plan) and a legal-page accuracy pass.

### Auth pages — globe & terms note
- **Subtler cobe globe.** Dark mode: continents are now only *subtly* brighter than the near-black ocean (`baseColor × 0.1 ≈ #0D0F12`) instead of blown-out white. Light mode: kept a soft white/neutral sphere (blue tint dropped). Comments explain cobe's colour model (dots are the same hue as the ocean, brighter under `dark:1` / darker under `dark:0`) and which knobs to tune.
- **More emoji pins, weighted low.** The globe is parked low behind the card, so its upper latitudes hide behind the card. Added several pins and pushed the bulk into the southern/low latitudes so the visible lower arc stays populated.
- **Legible terms note.** "By clicking continue…" now uses high-contrast body text — white in dark mode, dark in light — with the links staying brand blue.

### Ask AI
- **Square sidebar button.** The sidebar-tab launcher is now a compact icon-only square with a small corner radius (was a rounded pill with vertical "Ask AI" text).
- **No suggestions on the empty panel.** Suggested questions now appear only as follow-ups after an answer, not on first open (gated on `messages.length > 0`), so the empty panel is a clean slate.

### Pricing — single free plan
- **Hid the paid "Pro" column** behind a restorable `SHOW_PRO_PLAN` flag. All billing/checkout wiring (`ProCheckoutCta`, Polar checkout, etc.) is intentionally left in place with restore notes — flip the flag to bring Pro back.
- **Promoted "Free Member"** — green CTA + green icon and a "Recommended" badge.
- **Removed the AI-autocomplete row** from every plan.
- **Kept the monthly/annual toggle** (both plans are $0).
- **Trimmed the /pricing footnotes & blurbs** so the fine print matches the Guest + Free Member table.

### FAQ / Privacy / Terms
- **FAQ:** added "What does a free account add?" and "What if I want to use more prompts?" (explains free-only memberships), and mention optional accounts / cloud saves.
- **Privacy & Terms:** accuracy pass — these pages previously stated there were *no accounts and no user data*, which is no longer true. Now they reflect optional accounts (Google / GitHub / email), cloud saves, sharing, and Ask AI (email/OAuth data, session cookies, sending context to an AI provider), while keeping everything free. Dates bumped to 2026-07-16.

## Verification
- `tsc --noEmit` and `eslint` pass on all changed files.
- Existing Ask AI unit tests pass.
- Rendered locally and screenshotted: pricing table (Guest + Free Member, promoted, toggle kept), sign-in globe/terms note (dark), FAQ, Privacy, Terms, and the Ask AI empty panel (no suggestion pills).

## Notes / follow-ups
- **Globe colours** were tuned against the shader math, but this environment's headless Chromium uses **software WebGL**, which doesn't match a real GPU — the light-mode sphere in particular is best eyeballed on your own machine. `baseColor` / `mapBrightness` in `AuthGlobe.tsx` are the knobs.
- The `⚖` legal copy is drafted from the codebase's actual data flows and should get a human/legal review before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pixqhe4BcRgcbbzhYzYWMq)_