### PR TITLE
Fix Pyodide 314 boot failure: spawn the Python worker as a module worker

### DIFF
--- a/app/_components/RuntimeBootNotice.tsx
+++ b/app/_components/RuntimeBootNotice.tsx
@@ -314,7 +314,7 @@ function SimulatedCodeBlock() {
   return (
     <CodeBlockLoadingPreview
       language="Python"
-      version="3.13.2"
+      version="3.14.2"
       langId="python"
       code={SAMPLE_CODE}
       statusMessage={message}
@@ -352,7 +352,7 @@ function codeBlockItems(): ShowcaseItem[] {
         "Exactly what a learner sees on a first Run, the full code-block card frozen in its loading state: a disabled Run button, the staged status beside it, and the boot notice in the output panel. The loader and bar are animating; the rest is a static preview (no runtime).",
       jsx: `<CodeBlockLoadingPreview
   language="Python"
-  version="3.13.2"
+  version="3.14.2"
   code={pandasSnippet}
   statusMessage="Loading Python runtime…"
   cold
@@ -367,7 +367,7 @@ function codeBlockItems(): ShowcaseItem[] {
         "A fresh page: the worker has started and the runtime is downloading. The output panel hosts the same notice the live block renders.",
       jsx: `<CodeBlockLoadingPreview
   language="Python"
-  version="3.13.2"
+  version="3.14.2"
   code={pandasSnippet}
   statusMessage="Starting Python runtime…"
   cold
@@ -377,7 +377,7 @@ function codeBlockItems(): ShowcaseItem[] {
       node: (
         <CodeBlockLoadingPreview
           language="Python"
-          version="3.13.2"
+          version="3.14.2"
           langId="python"
           code={SAMPLE_CODE}
           statusMessage="Starting Python runtime…"
@@ -393,7 +393,7 @@ function codeBlockItems(): ShowcaseItem[] {
         "Two-phase Pyodide: a stdlib-only block runs immediately, but the first block that imports pandas pauses here while the data stack finishes downloading.",
       jsx: `<CodeBlockLoadingPreview
   language="Python"
-  version="3.13.2"
+  version="3.14.2"
   code={pandasSnippet}
   statusMessage="Installing data packages, first run only…"
   cold
@@ -402,7 +402,7 @@ function codeBlockItems(): ShowcaseItem[] {
       node: (
         <CodeBlockLoadingPreview
           language="Python"
-          version="3.13.2"
+          version="3.14.2"
           langId="python"
           code={SAMPLE_CODE}
           statusMessage="Installing data packages, first run only…"

--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -478,7 +478,7 @@ _PG_PROTECTED_NAMES |= {
 async function loadHeavyPackages(): Promise<void> {
   if (!pyodide) throw new Error("Pyodide is not initialised");
 
-  // Pyodide 0.29's package loader writes its progress messages
+  // Pyodide's package loader writes its progress messages
   // ("Loading numpy, …", "pandas already loaded from default channel",
   // "No new packages to load", …) through Python's `sys.stdout`. Once
   // `runCode()` installs a `setStdout({ batched })` capture, those

--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -8,7 +8,9 @@
 //      `import()` carrying webpackIgnore/turbopackIgnore comments, the
 //      same pattern postgres-worker.ts uses for PGlite. (Pyodide 314
 //      dropped the classic-script `pyodide.js` + global `loadPyodide`
-//      entry point that importScripts used to load.)
+//      entry point that importScripts used to load. It also refuses to
+//      boot in a classic worker scope entirely, so python.tsx must
+//      spawn this worker with `{ type: "module" }`.)
 //   2. Heavy Python execution (numpy, pandas, plot rendering, …) doesn't
 //      block the main thread, so the UI stays responsive while user code
 //      is running.

--- a/app/_components/runtime/python.tsx
+++ b/app/_components/runtime/python.tsx
@@ -12,13 +12,13 @@ import type {
 } from "../types";
 import { getRuffFmt } from "./ruffFmt";
 
-// Pyodide is loaded inside a dedicated Web Worker (see
-// `runtime/pyodide-worker.ts`). The worker pulls `pyodide.js` from the
-// CDN via `importScripts`, which keeps the Next.js / Turbopack bundler
-// from ever touching Pyodide's internal `await import(e)` (which would
-// otherwise fail with "Cannot find module as expression is too dynamic")
-// AND keeps Python execution off the main thread so the UI stays
-// responsive while user code runs.
+// Pyodide is loaded inside a dedicated module Web Worker (see
+// `runtime/pyodide-worker.ts`). The worker pulls `pyodide.mjs` from the
+// CDN via a bundler-ignored dynamic `import()`, which keeps the
+// Next.js / Turbopack bundler from ever touching Pyodide's internal
+// `await import(e)` (which would otherwise fail with "Cannot find
+// module as expression is too dynamic") AND keeps Python execution off
+// the main thread so the UI stays responsive while user code runs.
 
 const EXAMPLES: ExampleSnippet[] = [
   {
@@ -878,14 +878,17 @@ export const pythonAdapter: LanguageAdapter = {
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
     setLoadingMessage("Starting Python runtime…", 0.02);
-    // Standard Web Worker construction pattern that Next.js / Turbopack
-    // recognises: it bundles the worker as a separate chunk. The worker
-    // itself loads Pyodide's `pyodide.mjs` from the CDN via a dynamic
-    // `import()` the bundler is told to ignore (same pattern as the
-    // PGlite worker), so no `{ type: "module" }` is required here.
-    const worker = new Worker(
-      new URL("./pyodide-worker.ts", import.meta.url),
-    );
+    // Pre-bundled by `scripts/build-almostnode-workers.mjs` and served
+    // as a static asset, the same pattern as the JS/TS workers. Pyodide
+    // 314's environment detection throws "Classic web workers are not
+    // supported" when `importScripts` works (i.e. in a classic worker
+    // scope), so this worker MUST run with a real `{ type: "module" }`
+    // — and Turbopack strips the `type` option from workers it bundles
+    // itself (`new Worker(new URL(...), ...)`), which is why the
+    // bundler-analyzed construction can't be used here.
+    const worker = new Worker("/_workers/pyodide-worker.js", {
+      type: "module",
+    });
 
     return new Promise<LanguageRuntime>((resolve, reject) => {
       const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {

--- a/app/_components/runtime/python.tsx
+++ b/app/_components/runtime/python.tsx
@@ -824,11 +824,12 @@ export const pythonAdapter: LanguageAdapter = {
   displayName: "Python Playground",
   logoText: "py",
   documentTitle: "Python Playground",
-  readyStatus: "Python 3.13.2 ready",
+  readyStatus: "Python 3.14.2 ready",
   runtimeInfo: {
     language: "Python",
-    version: "3.13.2",
-    engine: "Pyodide 0.29.4",
+    version: "3.14.2",
+    // Keep in sync with PYODIDE_VERSION in pyodide-worker.ts.
+    engine: "Pyodide 314.0.2",
     engineUrl: "https://pyodide.org",
     notes: "Runs in a Web Worker so the UI stays responsive while your code executes.",
   },

--- a/app/_components/types.ts
+++ b/app/_components/types.ts
@@ -252,7 +252,7 @@ export interface LanguageAdapter {
   /** Status text shown after init succeeds. */
   readyStatus: string;
   /** Human-readable runtime details shown by the header's info popup
-   *  (e.g. "Python 3.13 via Pyodide", "R 4.4 via WebR"). */
+   *  (e.g. "Python 3.14 via Pyodide", "R 4.4 via WebR"). */
   runtimeInfo: RuntimeInfo;
   /** CodeMirror language mode (e.g. "python", "r"). */
   codeMirrorMode: string;

--- a/content/courses/data-analysis-python-pandas/notebooks-and-environments.mdx
+++ b/content/courses/data-analysis-python-pandas/notebooks-and-environments.mdx
@@ -239,7 +239,7 @@ industries (pharma, finance, healthcare).
 
 For the entirety of this course:
 
-- The Python interpreter is **Pyodide**, a build of CPython 3.13
+- The Python interpreter is **Pyodide**, a build of CPython 3.14
   compiled to WebAssembly. It runs inside your browser.
 - The package set is fixed and curated, pandas, NumPy, SciPy,
   matplotlib, plotly, scikit-learn, and others.

--- a/content/courses/intro-data-viz-plotly/index.mdx
+++ b/content/courses/intro-data-viz-plotly/index.mdx
@@ -160,7 +160,7 @@ The course is organized as a journey:
 
 You already ran one chart above. Every Python code block on these
 pages works the same way: it runs **in your browser** via
-[Pyodide](https://pyodide.org), a full CPython 3.13 build compiled to
+[Pyodide](https://pyodide.org), a full CPython 3.14 build compiled to
 WebAssembly. Plotly, Pandas, and NumPy all ship with the runtime, and
 larger datasets (penguins, diamonds, and a few others) are loaded for
 you when a page needs them.

--- a/content/courses/python-basics/index.mdx
+++ b/content/courses/python-basics/index.mdx
@@ -89,7 +89,7 @@ You should be able to use a computer, open a web browser, and read English.
 That is all. No prior programming experience is assumed. If you have written a
 little code before, you will still get value here, because we spend our time on
 the *why* and the mental model, not just the syntax. The real Python under the
-hood is **Python 3.13**, running in your browser through WebAssembly, the same
+hood is **Python 3.14**, running in your browser through WebAssembly, the same
 Python that powers data science and web servers, just without the install.
 </Callout>
 

--- a/content/courses/python-basics/virtual-environments.mdx
+++ b/content/courses/python-basics/virtual-environments.mdx
@@ -42,7 +42,7 @@ This page is reference material; the commands below are intended to be run in yo
 Everything you have done so far ran in the browser, with no install at all. The
 moment you want to run scripts on your own machine, install third-party
 libraries, and connect Python to your editor, you need a local Python. Install
-the **latest stable Python 3** (3.13 at the time of writing) unless a specific
+the **latest stable Python 3** (3.14 at the time of writing) unless a specific
 project pins you to an older version, and never use the Python 2 you might find
 lurking on an older system, which reached end-of-life in 2020.
 

--- a/content/courses/scientific-computing-python/index.mdx
+++ b/content/courses/scientific-computing-python/index.mdx
@@ -161,7 +161,7 @@ The course has six pillars:
 ## How the interactive widgets work
 
 Every code block runs in your browser via **Pyodide**, a full
-CPython 3.13 build compiled to WebAssembly that ships NumPy, SciPy,
+CPython 3.14 build compiled to WebAssembly that ships NumPy, SciPy,
 pandas, Matplotlib, SymPy, and Plotly. There is nothing to install.
 
 You will see three kinds of widgets:

--- a/content/fumadocs-dev/code-blocks-python.mdx
+++ b/content/fumadocs-dev/code-blocks-python.mdx
@@ -3,7 +3,7 @@ title: "Code Blocks: Python"
 description: Run Python in the browser via Pyodide. NumPy, Pandas, Matplotlib, and Plotly are all available.
 ---
 
-The Python runtime is **Pyodide 3.13** running inside a Web Worker so
+The Python runtime is **Pyodide 3.14** running inside a Web Worker so
 your code doesn't block the UI. Each block below runs against a fresh
 global scope, variables you define in one block won't leak into the
 next.

--- a/content/fumadocs-dev/index.mdx
+++ b/content/fumadocs-dev/index.mdx
@@ -15,7 +15,7 @@ are loaded on demand.
 
 ## Languages
 
-- Python, Pyodide 3.13 with NumPy, Pandas, Matplotlib, Plotly
+- Python, Pyodide 3.14 with NumPy, Pandas, Matplotlib, Plotly
 - R, WebR 4.5 with rich graphics and data frames
 - JavaScript, native browser execution
 - TypeScript, TypeScript transpiled in the browser

--- a/content/fumadocs-dev/runtime-loading-states.mdx
+++ b/content/fumadocs-dev/runtime-loading-states.mdx
@@ -45,7 +45,7 @@ import {
 // The whole code-block layout, frozen loading (static preview, no runtime):
 <CodeBlockLoadingPreview
   language="Python"
-  version="3.13.2"
+  version="3.14.2"
   code={`import pandas as pd\n# …`}
   statusMessage="Loading Pyodide…"
   cold

--- a/scripts/build-almostnode-workers.mjs
+++ b/scripts/build-almostnode-workers.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * Pre-bundle the almostnode-backed JS/TS playground workers as
- * standalone ES module files served from `/public/_workers/`.
+ * Pre-bundle the playground workers that must run as genuine module
+ * workers (the almostnode-backed JS/TS workers and the Pyodide worker)
+ * as standalone ES module files served from `/public/_workers/`.
  *
  * Why this exists:
  *
@@ -33,6 +34,12 @@
  *
  * which Turbopack treats as a regular URL string (no static analysis,
  * no bundling).
+ *
+ * The Pyodide worker is bundled here for consequence 1 alone: Pyodide
+ * 314's environment detection throws "Classic web workers are not
+ * supported" at import time when `importScripts` works (i.e. in a
+ * classic worker scope), so the worker MUST be spawned with a real
+ * `{ type: "module" }` — which Turbopack-bundled workers can never be.
  *
  * Idempotent. Safe to run from `postinstall`, `prebuild`, and `predev`.
  */
@@ -111,6 +118,16 @@ const targets = [
   {
     entry: join(SRC_DIR, "typescript-worker.ts"),
     out: join(OUT_DIR, "typescript-worker.js"),
+  },
+  {
+    // Pyodide 314 refuses to boot in classic workers, and Turbopack
+    // strips `{ type: "module" }` from workers it bundles itself, so
+    // this worker is pre-bundled and spawned from a static URL (see
+    // the docblock above). Its only imports are a type-only `pyodide`
+    // import (erased) and a bundler-opaque dynamic `import()` of
+    // pyodide.mjs from the CDN, so the bundle is tiny.
+    entry: join(SRC_DIR, "pyodide-worker.ts"),
+    out: join(OUT_DIR, "pyodide-worker.js"),
   },
 ];
 


### PR DESCRIPTION
## Problem

Since the Pyodide version bump to v314, every Python surface (playground, lesson code blocks, challenges) fails to initialize with:

```
Uncaught (in promise) Error: Classic web workers are not supported
    at oe (cdn.jsdelivr.net/pyodide/v314.0.2/full/pyodide.mjs:3:1656)
    at getGlobalRuntimeEnv (cdn.jsdelivr.net/pyodide/v314.0.2/full/pyodide.mjs:3:1065)
```

## Root cause

Pyodide 314's environment detection probes `globalThis.importScripts("data:text/javascript,")` at import time. That probe only succeeds in a **classic** worker scope, and when it does, Pyodide throws "Classic web workers are not supported". Our worker was spawned via the bundler-analyzed `new Worker(new URL("./pyodide-worker.ts", import.meta.url))` pattern **without** `{ type: "module" }`, so it ran as a classic worker.

Simply adding `{ type: "module" }` doesn't work: Turbopack's worker runtime explicitly strips the `type` option from workers it bundles (its generated code says *"Remove type: 'module' from options since our worker entrypoint is not a module"*), so a Turbopack-bundled worker is always classic.

## Fix

Reuse the pattern that already solved this exact problem for the almostnode JS/TS workers:

- Add `pyodide-worker.ts` to the `scripts/build-almostnode-workers.mjs` esbuild targets, producing a self-contained ~21 KB ES module at `public/_workers/pyodide-worker.js` (Pyodide itself still arrives from the CDN through the bundler-opaque dynamic `import()`; the output dir is already gitignored and rebuilt on `postinstall`/`dev`/`build`).
- Spawn it in `python.tsx` from the static URL with a real `{ type: "module" }`, which Turbopack treats as a plain string and leaves untouched.

## Also: stale Python version displays

Pyodide 314 ships CPython 3.14.2, but the code-block badge, runtime info panel, boot-notice showcase, and several course/docs passages still said 3.13 (and the info panel named the pre-rename "Pyodide 0.29.4"). The second commit bumps every display that describes what the site actually runs to 3.14 / Pyodide 314.0.2. Historical facts (Python 3.13's free-threaded build in the history lesson) and the `pyproject.toml` example are intentionally untouched.

## Bundle size impact

None on the Cloudflare Worker: `public/_workers/pyodide-worker.js` (21 KB raw, ~7.6 KB gzipped) is served as a static asset alongside the existing JS/TS worker bundles, and it replaces the Turbopack-emitted client chunk that previously carried the same code — Pyodide itself still loads from jsDelivr.

## Verification

Ran the dev server and drove real Chromium via Playwright:

- `/playground/python` boots (Python 3.14.2) and runs the default example to completion ("Done in 1.11s", correct stdout).
- The originally-reported page `/courses/python-basics/control-flow` runs its code blocks (first block prints `positive` in 37 ms) with zero page errors — the "Classic web workers are not supported" error is gone.
- `eslint`, `tsc --noEmit`, `fumadocs-mdx`, and a full production `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4HzVJkaZU3PeAsK8s7skX