### PR TITLE
Fix R2 cache-cleanup race that deleted the incoming production build (prod 500s)

### DIFF
--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -16,10 +16,24 @@ name: R2 incremental-cache cleanup
 # open pull request (branch) it belongs to and keep only the latest commit per
 # branch, impossible with Next's default random build IDs.
 #
-# What it does: always keeps the live production build, a site that sits
-# unchanged for months must never lose its cache, which would 500 the home page
-# and /courses/* (see open-next.config.ts). Every OTHER folder is kept only
-# while ALL of these hold:
+# What it does: always keeps
+#   • the live production build (probed from the running Worker), a site that
+#     sits unchanged for months must never lose its cache, which would 500 the
+#     home page and /courses/* (see open-next.config.ts), AND
+#   • any folder written within the last GRACE_HOURS, whatever it matches. A
+#     deploy populates its cache folder BEFORE the Worker switches to serving
+#     that build, so for some minutes the incoming production folder is
+#     protected by neither the probe (which still reports the outgoing build)
+#     nor the open-PR rule below (a merge commit's PR closed on merge). A
+#     scheduled run that fired inside that window deleted the incoming
+#     production cache mid-deploy and 500'd the site (2026-07-16), AND
+#   • any folder built from one of the MAIN_COMMITS most recent commits on the
+#     default branch. Production builds only ever come from that branch, so
+#     this keeps the incoming/just-switched production build even when a
+#     deploy stalls past the grace window; the THRESHOLD_HOURS age rule still
+#     retires these once they are old enough to be long superseded.
+#
+# Every OTHER folder is kept only while ALL of these hold:
 #   • younger than THRESHOLD_HOURS, AND
 #   • its commit is the current head of an OPEN pull request, i.e. the most
 #     recent commit on an active branch. Superseded commits (an older head of a
@@ -30,12 +44,14 @@ name: R2 incremental-cache cleanup
 # Net effect: the live production build, plus at most one preview per active
 # branch, capped at MAX_BRANCHES. Merging a PR (or pushing a newer commit to it)
 # drops the stale preview folder on the next run. Worst case is
-# (MAX_BRANCHES + 1) build folders.
+# (MAX_BRANCHES + 1) build folders, plus the transient grace-window and
+# recent-main keeps, which the age rule bounds to a THRESHOLD_HOURS-deep tail.
 #
 # Safety: the job aborts WITHOUT deleting anything if it cannot (a) positively
-# identify the live production build folder, or (b) list the repo's open pull
-# requests, so a transient error can never leave every preview "unmatched" and
-# wipe the bucket. Run manually with dry_run=true to preview deletions.
+# identify the live production build folder, (b) list the repo's open pull
+# requests, or (c) list the default branch's recent commits, so a transient
+# error can never leave every preview "unmatched" and wipe the bucket. Run
+# manually with dry_run=true to preview deletions.
 #
 # Required repository secrets (Settings → Secrets and variables → Actions):
 #   CF_ACCOUNT_ID         Cloudflare account ID (the R2 S3 endpoint host)
@@ -79,6 +95,19 @@ jobs:
       # (MAX_BRANCHES + 1) build folders total on busy days.
       THRESHOLD_HOURS: "24"
       MAX_BRANCHES: "10"
+      # Never delete a folder written within the last GRACE_HOURS, no matter
+      # what it matches. A deploy populates its R2 folder minutes before the
+      # Worker starts serving that build, so a brand-new folder can belong to
+      # an in-flight production deploy that the build-ID probe can't see yet
+      # (it still reports the outgoing build) and that no open PR matches (a
+      # merge commit's PR closed on merge). 2h comfortably covers populate +
+      # switchover, including Workers Builds queueing.
+      GRACE_HOURS: "2"
+      # Also keep folders built from any of the last MAIN_COMMITS commits on
+      # the default branch (production builds only come from there), so a
+      # production deploy that stalls past the grace window still can't lose
+      # its cache. The THRESHOLD_HOURS age rule retires these eventually.
+      MAIN_COMMITS: "30"
       # Scheduled runs delete for real; manual runs honor the dry_run input
       # (default true).
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
@@ -153,6 +182,32 @@ jobs:
           pr_shas=("${!pr_branch[@]}")
           echo "Open PRs (active branches): ${#pr_shas[@]}"
 
+          # 2b) Recent default-branch commits: production builds come from the
+          #     default branch, and between "cache populated" and "Worker
+          #     switched" the incoming build is invisible to the probe in
+          #     step 1 and matches no open PR (its PR just merged) — the race
+          #     that wiped the live cache mid-deploy on 2026-07-16. Protect
+          #     these SHAs outright. Abort on API failure for the same reason
+          #     as step 2.
+          if ! default_branch="$(gh api "repos/$GITHUB_REPOSITORY" --jq .default_branch)" \
+             || [[ -z "$default_branch" ]]; then
+            echo "::error::Could not resolve the default branch from GitHub. Aborting without deleting."
+            exit 1
+          fi
+          if ! main_shas_raw="$(gh api "repos/$GITHUB_REPOSITORY/commits?sha=${default_branch}&per_page=${MAIN_COMMITS}" \
+                --jq '.[].sha')"; then
+            echo "::error::Could not list recent '$default_branch' commits from GitHub. Aborting without deleting."
+            exit 1
+          fi
+          declare -A main_sha   # commit SHA -> 1, recent default-branch commits
+          while IFS= read -r sha; do
+            [[ -z "$sha" ]] && continue
+            main_sha["$sha"]=1
+          done <<< "$main_shas_raw"
+          # Same empty-associative-array/`set -u` dance as pr_branch above.
+          main_keys=("${!main_sha[@]}")
+          echo "Recent '$default_branch' commits protected: ${#main_keys[@]}"
+
           # 3) Enumerate the build folders in the bucket.
           mapfile -t folders < <(
             aws s3api list-objects-v2 \
@@ -172,8 +227,10 @@ jobs:
             exit 1
           fi
 
-          cutoff=$(( $(date -u +%s) - THRESHOLD_HOURS * 3600 ))
-          echo "Policy: keep live production + the latest commit of up to $MAX_BRANCHES open-PR branches, each younger than ${THRESHOLD_HOURS}h (cutoff $(date -u -d "@$cutoff" '+%Y-%m-%d %H:%M:%SZ'))"
+          now=$(date -u +%s)
+          cutoff=$(( now - THRESHOLD_HOURS * 3600 ))
+          grace_cutoff=$(( now - GRACE_HOURS * 3600 ))
+          echo "Policy: keep live production + anything written in the last ${GRACE_HOURS}h + recent '$default_branch' builds + the latest commit of up to $MAX_BRANCHES open-PR branches, each younger than ${THRESHOLD_HOURS}h (cutoff $(date -u -d "@$cutoff" '+%Y-%m-%d %H:%M:%SZ'))"
           echo "Dry run: $DRY_RUN"
 
           # 5) Timestamp every non-production folder so active-branch previews
@@ -206,10 +263,19 @@ jobs:
             # Folder name is the commit SHA: strip the prefix and trailing slash.
             sha="${folder#"$PREFIX"}"; sha="${sha%/}"
 
-            # Order matters: age retires everything first (the 24h floor applies
-            # even to an open PR's head), then per-branch keep, then the cap.
-            if (( ts < cutoff )); then
+            # Order matters: the grace window shields everything first (a
+            # freshly written folder may be an in-flight deploy that nothing
+            # else matches), then age retires old folders (the 24h floor
+            # applies even to an open PR's head), then the default-branch and
+            # per-branch keeps, then the cap.
+            if (( ts >= grace_cutoff )); then
+              echo "KEEP  $folder (last written $newest, inside the ${GRACE_HOURS}h grace window, possibly an in-flight deploy)"
+              kept=$((kept+1)); continue
+            elif (( ts < cutoff )); then
               echo "DELETE $folder (last written $newest, older than ${THRESHOLD_HOURS}h)"
+            elif [[ -n "${main_sha[$sha]+set}" ]]; then
+              echo "KEEP  $folder (recent '$default_branch' commit, current or recent production build)"
+              kept=$((kept+1)); continue
             elif [[ -n "${pr_branch[$sha]+set}" ]]; then
               branches=$((branches+1))
               if (( branches <= MAX_BRANCHES )); then


### PR DESCRIPTION
## What happened

Production (www.dataslope.com) has been returning **500 Internal Server Error** since the deploy of `f07389e` (#604), with Workers observability showing `[unenv] fs.readdir is not implemented yet!`, while open-PR previews kept working.

Root cause: the scheduled R2 cache cleanup ([run 29528437764](https://github.com/dataslope/dataslope/actions/runs/29528437764/job/87722590078), 2026-07-16 19:32 UTC) fired while the Workers Builds **production deploy for `f07389e` was still in flight**:

1. The deploy's populate step writes `incremental-cache/f07389e…/` to R2 **before** the Worker switches to serving that build.
2. The cleanup probed `/api/cache-build-id` and got the **outgoing** build (`11bb623`), so the probe didn't protect the new folder.
3. `f07389e` is a merge commit whose PR closed on merge, so it matched no open-PR keep rule either → the folder was deleted seconds after being written (`last written 19:33:39`, deleted 19:33:44).
4. The deploy then switched the Worker to `f07389e` with an empty cache. Every prerendered route (`/`, `/courses/*`) now misses the incremental cache and falls back to a request-time re-render, which touches `node:fs` in workerd (`app/page.tsx` reads the content tree via `readdir`) → 500.

Previews are unaffected because their branches have open PRs, so their cache folders are kept.

## The fix

Two new keep rules in `.github/workflows/r2-cache-cleanup.yml`, checked before the existing delete rules:

- **`GRACE_HOURS` (2h):** never delete a folder whose newest object is younger than the grace window, regardless of what it matches. A freshly written folder can be an in-flight deploy that neither the probe nor the open-PR rule can see yet.
- **`MAIN_COMMITS` (30):** keep folders built from recent default-branch commits (production builds only ever come from `main`), so a deploy that stalls past the grace window still can't lose its cache. The existing `THRESHOLD_HOURS` age rule retires these once superseded. If the commits listing fails, the job aborts without deleting — same safety posture as the existing PR-list guard.

Decision order is now: grace window → age (24h) → recent-main keep → open-PR keep/cap → delete.

## Verification

Replayed the incident against the extracted script with stubbed `aws`/`gh`/`curl` (probe returns the old build; the bucket contains a freshly written merge-commit folder):

- incoming production folder (2 min old, closed PR) → **KEPT** (grace window) — previously deleted
- 3h-old main build → **KEPT** (recent-main rule)
- open-PR head preview → kept; 30h-old and merged/unmatched folders → still deleted
- commits-API failure → aborts with an error **before any delete**
- `yaml` parse + `bash -n` pass

## Note on restoring production

Merging this PR also **fixes the live 500s** as a side effect: the merge triggers a fresh production deploy whose populate step rewrites the missing `incremental-cache/<sha>/` folder. (Until then, scheduled cleanup runs are failing safe — the probe's folder is absent, so the job aborts without deleting.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbknYfcbv6KcD5EEMU2Xd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbknYfcbv6KcD5EEMU2Xd8)_