### PR TITLE
Improve Ask AI / Fill-with-AI UX and quota display

### DIFF
--- a/app/_components/ai/AskAiPanel.module.css
+++ b/app/_components/ai/AskAiPanel.module.css
@@ -34,8 +34,9 @@
   box-shadow: 0 8px 26px rgba(8, 120, 221, 0.36);
 }
 
-/* Edge-tab placement: a slim button docked flush with the right viewport
-   edge, out of the content's way (the square marker in Settings' preview). */
+/* Edge-tab placement: a compact square button docked flush with the right
+   viewport edge, out of the content's way (the square marker in Settings'
+   preview). Square shape with just a slight rounding on the inner corners. */
 .launcherTab {
   position: fixed;
   right: 0;
@@ -44,10 +45,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   border: none;
-  border-radius: 8px 0 0 8px;
+  border-radius: 6px 0 0 6px;
   background: var(--ds-blue-600, #0878dd);
   color: #fff;
   cursor: pointer;

--- a/app/_components/ai/AskAiWidget.tsx
+++ b/app/_components/ai/AskAiWidget.tsx
@@ -32,7 +32,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Popover } from "@base-ui/react/popover";
 import {
-  Sparkles,
+  Sparkle,
   X,
   Send,
   RotateCcw,
@@ -91,8 +91,8 @@ import {
 import styles from "./AskAiPanel.module.css";
 
 /** Where the closed-state launcher sits, chosen from Settings → "Where the
- *  button lives": the floating pill in the bottom-right corner (default), or a
- *  slim tab docked to the right viewport edge. Persisted in localStorage. */
+ *  button lives": a slim square tab docked to the right viewport edge (default),
+ *  or the floating pill in the bottom-right corner. Persisted in localStorage. */
 type LauncherPlacement = "floating" | "tab";
 const LAUNCHER_PLACEMENT_KEY = "dataslope:ask-ai-placement";
 
@@ -342,7 +342,7 @@ export default function AskAiWidget({
 
   // ── Remembered preferences (global) ────────────────────────────────
   const [placement, setPlacement] = useState<LauncherPlacement>(() =>
-    readStored(LAUNCHER_PLACEMENT_KEY) === "tab" ? "tab" : "floating",
+    readStored(LAUNCHER_PLACEMENT_KEY) === "floating" ? "floating" : "tab",
   );
   const [contextMode, setContextMode] = useState<ContextMode>(() => {
     const v = readStored(CONTEXT_MODE_KEY);
@@ -812,7 +812,7 @@ export default function AskAiWidget({
           aria-label="Ask AI"
           title="Ask AI"
         >
-          <Sparkles size={18} />
+          <Sparkle size={18} />
         </button>
       );
     }
@@ -823,7 +823,7 @@ export default function AskAiWidget({
         onClick={() => setOpen(true)}
         aria-label="Ask AI"
       >
-        <Sparkles size={16} />
+        <Sparkle size={16} />
         Ask AI
       </button>
     );
@@ -837,7 +837,7 @@ export default function AskAiWidget({
     <div className={styles.panel} role="dialog" aria-label="Ask AI" ref={panelRef}>
       <div className={`${styles.chatArea} ${sheetOpen ? styles.dimmed : ""}`}>
         <div className={styles.header}>
-          <Sparkles className={styles.sparkle} size={17} />
+          <Sparkle className={styles.sparkle} size={17} />
           <span className={styles.title}>Ask AI</span>
           {tier && (
             <span
@@ -882,7 +882,7 @@ export default function AskAiWidget({
           {!signedIn ? (
             <div className={styles.signedOut}>
               <span className={styles.emptyBadge}>
-                <Sparkles size={20} />
+                <Sparkle size={20} />
               </span>
               <p>Sign in to ask AI about this {subject}.</p>
               {/* target="_top" breaks out of the home page's embedded
@@ -916,7 +916,7 @@ export default function AskAiWidget({
           ) : messages.length === 0 ? (
             <div className={styles.emptyWrap}>
               <span className={styles.emptyBadge}>
-                <Sparkles size={20} />
+                <Sparkle size={20} />
               </span>
               <div className={styles.emptyText}>
                 <span className={styles.emptyTitle}>
@@ -1052,7 +1052,7 @@ export default function AskAiWidget({
                             className={styles.followupBtn}
                             onClick={() => sendQuestion(q)}
                           >
-                            <Sparkles size={12} aria-hidden />
+                            <Sparkle size={12} aria-hidden />
                             <span>{q}</span>
                           </button>
                         ))}

--- a/app/_components/home/PricingSection.tsx
+++ b/app/_components/home/PricingSection.tsx
@@ -12,7 +12,7 @@ import {
   HardDrive,
   Play,
   Share2,
-  Sparkles,
+  Sparkle,
   SquareTerminal,
   User,
   UserCheck,
@@ -131,7 +131,7 @@ const PLANS: Plan[] = [
         note: "Shared playgrounds deleted after a month of inactivity",
       },
       {
-        icon: Sparkles,
+        icon: Sparkle,
         text: "Up to 10 “Ask AI” messages every 24 hours",
         note: "Across playgrounds, challenges, code blocks & lessons",
       },
@@ -184,7 +184,7 @@ const PLANS: Plan[] = [
         note: "Shared playgrounds never deleted while subscribed",
       },
       {
-        icon: Sparkles,
+        icon: Sparkle,
         text: "Unlimited “Ask AI” messages",
         note: "Fair use policy applies",
         highlight: "Unlimited",

--- a/app/dashboard/_studio/AiDraftBar.tsx
+++ b/app/dashboard/_studio/AiDraftBar.tsx
@@ -1,57 +1,41 @@
 "use client";
 
 /**
- * The "Fill with AI" bar shown at the top of each builder form. Typing a
- * description and pressing Enter (or clicking the button) drafts the whole item
- * via useStudioAi().draft, which fills the form below and opens the assist
- * panel. A thin wrapper over the shared AI state so every builder gets the same
- * affordance with one line.
+ * The "Fill with AI" bar shown at the top of each builder form. It is a
+ * non-input affordance: clicking "Fill with AI" opens the AI Assist panel
+ * WITHOUT drafting anything. Generation only starts once the user actually
+ * types a description in that panel and sends it, so opening the panel never
+ * spends a provider request (and can't surface a "the assistant is unavailable"
+ * error before the user has asked for anything). A thin wrapper over the shared
+ * AI state so every builder gets the same affordance with one line.
  */
 
-import { useState } from "react";
-import { Sparkles } from "lucide-react";
+import { Sparkle } from "lucide-react";
 import { useStudioAi } from "./StudioAiContext";
 
-export function AiDraftBar({ placeholder }: { placeholder: string }) {
-  const { draft, busy } = useStudioAi();
-  const [value, setValue] = useState("");
-
-  const go = () => {
-    if (busy) return;
-    const p = value.trim();
-    setValue("");
-    void draft(p);
-  };
+export function AiDraftBar() {
+  const { openPanel } = useStudioAi();
 
   return (
     <div
       className="mt-5 flex items-center gap-2 rounded-2xl py-2 pl-3.5 pr-2"
       style={{ background: "var(--ai-soft)" }}
     >
-      <Sparkles size={15} className="flex-shrink-0" style={{ color: "var(--ai-text)" }} />
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            go();
-          }
-        }}
-        placeholder={placeholder}
-        className="ds-ai-input h-9 min-w-0 flex-1 bg-transparent text-[13px] outline-none"
-        style={{ color: "var(--ai-text)" }}
-      />
+      <Sparkle size={15} className="flex-shrink-0" style={{ color: "var(--ai-text)" }} />
+      <span
+        className="flex h-9 min-w-0 flex-1 items-center text-[13px]"
+        style={{ color: "var(--ai-text)", opacity: 0.6 }}
+      >
+        Let AI fill every field
+      </span>
       <button
         type="button"
-        onClick={go}
-        disabled={busy}
-        className="inline-flex h-[34px] flex-shrink-0 items-center gap-1.5 rounded-lg px-3.5 text-[13px] font-semibold transition-opacity disabled:opacity-60"
+        onClick={openPanel}
+        className="inline-flex h-[34px] flex-shrink-0 items-center gap-1.5 rounded-lg px-3.5 text-[13px] font-semibold transition-opacity"
         style={{ background: "var(--ai)", color: "var(--ai-btn-fg)" }}
       >
-        <Sparkles size={13} />
-        {busy ? "Drafting…" : "Fill with AI"}
+        <Sparkle size={13} />
+        Fill with AI
       </button>
     </div>
   );

--- a/app/dashboard/_studio/BuilderHeader.tsx
+++ b/app/dashboard/_studio/BuilderHeader.tsx
@@ -8,11 +8,9 @@ import { AiDraftBar } from "./AiDraftBar";
 export function BuilderHeader({
   title,
   lede,
-  aiPlaceholder,
 }: {
   title: string;
   lede: string;
-  aiPlaceholder: string;
 }) {
   return (
     <div className="mb-6">
@@ -20,7 +18,7 @@ export function BuilderHeader({
       <p className="mt-2.5 text-[15px] leading-relaxed" style={{ color: "var(--muted)" }}>
         {lede}
       </p>
-      <AiDraftBar placeholder={aiPlaceholder} />
+      <AiDraftBar />
     </div>
   );
 }

--- a/app/dashboard/_studio/StudioAiContext.tsx
+++ b/app/dashboard/_studio/StudioAiContext.tsx
@@ -4,12 +4,13 @@
  * Shared state for the Studio "Fill with AI" feature.
  *
  * A builder registers its kind + an `applyDraft` handler (the function that
- * writes a drafted item into that builder's form). The AI assist panel and the
- * in-form "Fill with AI" bar both call `draft(prompt)`, which POSTs to
- * /api/ai/draft and, on success, hands the validated draft to whatever builder
- * is currently registered. Keeping this at the shell level lets the assist
- * panel live in the chrome (full-height, beside the content) while still
- * driving the form the user is looking at.
+ * writes a drafted item into that builder's form). The in-form "Fill with AI"
+ * bar just opens the AI Assist panel; the panel's composer calls `draft(prompt)`
+ * once the user submits a description, which POSTs to /api/ai/draft and, on
+ * success, hands the validated draft to whatever builder is currently
+ * registered. Keeping this at the shell level lets the assist panel live in the
+ * chrome (full-height, beside the content) while still driving the form the
+ * user is looking at.
  */
 
 import {
@@ -40,8 +41,11 @@ interface StudioAiValue {
   messages: ChatMessage[];
   /** The builder currently able to receive a draft, or null on non-builder routes. */
   activeKind: DraftKind | null;
-  /** Draft the active builder's item from a free-text description. */
-  draft: (prompt: string) => Promise<void>;
+  /** Draft the active builder's item from a free-text description. Resolves to
+   *  `true` when the request was billed against the daily Ask AI budget (the
+   *  provider was actually invoked), so callers can optimistically decrement a
+   *  quota display. */
+  draft: (prompt: string) => Promise<boolean>;
   /** Builders call this (in an effect) to register themselves. */
   register: (kind: DraftKind, apply: ApplyDraft) => void;
   unregister: (kind: DraftKind) => void;
@@ -82,15 +86,21 @@ export function StudioAiProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  const draft = useCallback(async (prompt: string) => {
+  const draft = useCallback(async (prompt: string): Promise<boolean> => {
     const active = applyRef.current;
-    if (!active) return;
+    if (!active) return false;
+    // Generation only starts once the user actually enters a message. An empty
+    // prompt (e.g. opening the panel) must never spend a provider request, so
+    // it can't surface a spurious "assistant is unavailable" error before the
+    // user has asked for anything.
+    const trimmed = prompt.trim();
+    if (!trimmed) {
+      setOpen(true);
+      return false;
+    }
     setOpen(true);
     setBusy(true);
-    const trimmed = prompt.trim();
-    if (trimmed) {
-      setMessages((m) => [...m, { who: "user", text: trimmed }]);
-    }
+    setMessages((m) => [...m, { who: "user", text: trimmed }]);
     try {
       const res = await fetch("/api/ai/draft", {
         method: "POST",
@@ -100,13 +110,17 @@ export function StudioAiProvider({ children }: { children: React.ReactNode }) {
       const body = (await res.json().catch(() => null)) as
         | (AiDraftResponse & { error?: string })
         | null;
+      // The server bills the daily Ask AI budget whenever it actually reached
+      // the provider — a drafted 200 or an unparseable 422. Pre-provider
+      // rejections (429 over-budget, 401/403, 502 provider-down) are not billed.
+      const counted = res.ok || res.status === 422;
       if (!res.ok || !body?.draft) {
         const message =
           body && typeof body.error === "string"
             ? body.error
             : "Couldn't draft that, try again.";
         setMessages((m) => [...m, { who: "ai", text: message }]);
-        return;
+        return counted;
       }
       // Only apply if the same builder is still mounted (the user may have
       // navigated away mid-request).
@@ -114,11 +128,13 @@ export function StudioAiProvider({ children }: { children: React.ReactNode }) {
         applyRef.current.apply(body.draft);
         setMessages((m) => [...m, { who: "ai", text: DONE_MESSAGE[active.kind] }]);
       }
+      return counted;
     } catch {
       setMessages((m) => [
         ...m,
         { who: "ai", text: "Network error reaching the assistant, try again." },
       ]);
+      return false;
     } finally {
       setBusy(false);
     }

--- a/app/dashboard/_studio/StudioAiPanel.tsx
+++ b/app/dashboard/_studio/StudioAiPanel.tsx
@@ -1,17 +1,23 @@
 "use client";
 
 /**
- * The Studio AI assist panel: a full-height column beside the builder content.
+ * The Studio AI Assist panel: a full-height column beside the builder content.
  * Shows the drafting conversation, per-builder quick actions, and a prompt box.
  * Everything routes through useStudioAi().draft, which fills the active
  * builder's form. Rendered by the shell as a flex sibling of the main column so
  * it sits to the right, matching the design.
+ *
+ * Drafting spends the member's shared daily Ask AI budget (same counter as the
+ * "Ask AI" chat), so the composer shows a "N left today" quota ring for free
+ * members: fetched from /api/ai/usage on open and decremented optimistically as
+ * drafts are billed.
  */
 
-import { useState } from "react";
-import { Sparkles, X, ArrowUp } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Sparkle, X, ArrowUp } from "lucide-react";
 import { useStudioAi } from "./StudioAiContext";
 import type { DraftKind } from "@/lib/ai/draft";
+import type { AskAiUsageResponse } from "@/lib/ai/types";
 
 const QUICK_ACTIONS: Record<DraftKind, string[]> = {
   code: [
@@ -53,31 +59,71 @@ export function StudioAiPanel() {
   const { open, activeKind, messages, busy, draft, closePanel } = useStudioAi();
   const [prompt, setPrompt] = useState("");
 
+  // ── Daily prompt quota (shared with Ask AI chat) ───────────────────────
+  const [usage, setUsage] = useState<AskAiUsageResponse | null>(null);
+  // Optimistic decrement: bumped once per billed draft so the ring updates
+  // immediately, without waiting for the server's usage write to land.
+  const [sentSinceFetch, setSentSinceFetch] = useState(0);
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/ai/usage");
+        if (!res.ok) return;
+        const body = (await res.json()) as AskAiUsageResponse;
+        if (!cancelled) {
+          setUsage(body);
+          // Reset the optimistic counter exactly when the fresh count lands.
+          setSentSinceFetch(0);
+        }
+      } catch {
+        // display-only; the counter just doesn't render
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const isFreeTier = usage ? usage.tier !== "pro" : false;
+  const promptsLeft = usage
+    ? Math.max(0, usage.requestsRemaining - sentSinceFetch)
+    : null;
+  const outOfPrompts = usage !== null && isFreeTier && promptsLeft === 0;
+
   if (!open || !activeKind) return null;
 
+  // Run a draft and, when the server billed it, decrement the local quota.
+  const runDraft = (text: string) => {
+    void draft(text).then((counted) => {
+      if (counted) setSentSinceFetch((n) => n + 1);
+    });
+  };
+
   const send = () => {
-    if (busy) return;
+    if (busy || outOfPrompts) return;
     const p = prompt.trim();
     if (!p) return;
     setPrompt("");
-    void draft(p);
+    runDraft(p);
   };
 
   return (
     <aside
-      aria-label="AI assist"
+      aria-label="AI Assist"
       className="flex w-[340px] flex-shrink-0 flex-col overflow-hidden"
       style={{ background: "var(--side-bg2)", borderRadius: "var(--main-radius, 0px)" }}
     >
       <div className="flex items-center gap-2 px-4 pb-3 pt-4">
-        <Sparkles size={16} style={{ color: "var(--ai)" }} />
+        <Sparkle size={16} style={{ color: "var(--ai)" }} />
         <span className="text-sm font-semibold" style={{ color: "var(--ink)" }}>
-          AI assist
+          AI Assist
         </span>
         <button
           type="button"
           onClick={closePanel}
-          aria-label="Close AI assist"
+          aria-label="Close AI Assist"
           className="ml-auto inline-flex h-7 w-7 items-center justify-center rounded-md"
           style={{ color: "var(--muted)" }}
         >
@@ -99,19 +145,19 @@ export function StudioAiPanel() {
             className="inline-flex items-center gap-2 self-start rounded-xl px-3 py-2 text-[13px]"
             style={{ background: "var(--input)", color: "var(--muted)" }}
           >
-            <Sparkles size={13} className="ds-pulse" style={{ color: "var(--ai)" }} />
+            <Sparkle size={13} className="ds-pulse" style={{ color: "var(--ai)" }} />
             Drafting…
           </div>
         ) : null}
       </div>
 
-      {!busy && messages.length === 0 ? (
+      {!busy && !outOfPrompts && messages.length === 0 ? (
         <div className="flex flex-wrap gap-1.5 px-4 pb-2">
           {QUICK_ACTIONS[activeKind].map((label) => (
             <button
               key={label}
               type="button"
-              onClick={() => void draft(label)}
+              onClick={() => runDraft(label)}
               className="h-7 rounded-full px-2.5 text-left text-xs font-medium"
               style={{ background: "var(--input)", color: "var(--text)" }}
             >
@@ -133,18 +179,37 @@ export function StudioAiPanel() {
                 send();
               }
             }}
-            placeholder={PLACEHOLDER[activeKind]}
-            className="w-full resize-none bg-transparent text-[13px] leading-normal outline-none"
+            placeholder={
+              outOfPrompts
+                ? "You're out of prompts for today."
+                : PLACEHOLDER[activeKind]
+            }
+            disabled={outOfPrompts}
+            className="w-full resize-none bg-transparent text-[13px] leading-normal outline-none disabled:opacity-60"
             style={{ color: "var(--ink)" }}
           />
           <div className="flex items-center gap-2 pt-1">
             <span className="text-[11px]" style={{ color: "var(--faint)" }}>
               ⏎ to send
             </span>
+            {usage && isFreeTier && promptsLeft !== null ? (
+              <span
+                className="inline-flex items-center gap-1 text-[11px] font-medium"
+                style={{ color: outOfPrompts ? "var(--danger)" : "var(--muted)" }}
+                title={`${promptsLeft} of ${usage.requestsLimit} free Ask AI prompts left today. Resets at midnight UTC.`}
+              >
+                <QuotaRing
+                  remaining={promptsLeft}
+                  total={usage.requestsLimit}
+                  out={outOfPrompts}
+                />
+                {promptsLeft} left today
+              </span>
+            ) : null}
             <button
               type="button"
               onClick={send}
-              disabled={busy || !prompt.trim()}
+              disabled={busy || !prompt.trim() || outOfPrompts}
               className="ml-auto inline-flex h-7 items-center gap-1.5 rounded-md px-3 text-xs font-semibold disabled:opacity-50"
               style={{ background: "var(--ai)", color: "var(--ai-btn-fg)" }}
             >
@@ -155,6 +220,46 @@ export function StudioAiPanel() {
         </div>
       </div>
     </aside>
+  );
+}
+
+/** Circular quota ring (r=6, circumference ≈ 37.7), mirroring the Ask AI
+ *  widget's ring. `remaining/total` drives the dash offset; `out` swaps the
+ *  progress stroke to the danger color. */
+function QuotaRing({
+  remaining,
+  total,
+  out,
+}: {
+  remaining: number;
+  total: number;
+  out: boolean;
+}) {
+  const frac = total > 0 ? Math.min(1, Math.max(0, remaining / total)) : 0;
+  const offset = 37.7 * (1 - frac);
+  return (
+    <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden>
+      <circle
+        cx="8"
+        cy="8"
+        r="6"
+        fill="none"
+        strokeWidth="2.5"
+        stroke="var(--divider)"
+      />
+      <circle
+        cx="8"
+        cy="8"
+        r="6"
+        fill="none"
+        strokeWidth="2.5"
+        stroke={out ? "var(--danger)" : "var(--ai)"}
+        strokeDasharray="37.7"
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        transform="rotate(-90 8 8)"
+      />
+    </svg>
   );
 }
 

--- a/app/dashboard/_studio/studio.css
+++ b/app/dashboard/_studio/studio.css
@@ -386,12 +386,6 @@
   border-top: 1px solid var(--divider);
 }
 
-/* AI-draft input placeholder tint (the "Fill with AI" bar). */
-.ds-studio .ds-ai-input::placeholder {
-  color: var(--ai-text);
-  opacity: 0.6;
-}
-
 /* Icon-rail hover tooltip. */
 .ds-rail-item {
   position: relative;

--- a/app/dashboard/admin/_components/AdminTabs.tsx
+++ b/app/dashboard/admin/_components/AdminTabs.tsx
@@ -6,13 +6,13 @@
 // shell's semantic tokens so it matches the rest of the dashboard in both
 // themes.
 import { usePathname } from "next/navigation";
-import { FlaskConical, Sparkles, Users, type LucideIcon } from "lucide-react";
+import { FlaskConical, Sparkle, Users, type LucideIcon } from "lucide-react";
 import Link from "@/app/_components/Link";
 
 const NAV: { href: string; label: string; icon: LucideIcon }[] = [
   { href: "/dashboard/admin", label: "Users", icon: Users },
   { href: "/dashboard/admin/test-users", label: "Test users", icon: FlaskConical },
-  { href: "/dashboard/admin/ai-usage", label: "AI usage", icon: Sparkles },
+  { href: "/dashboard/admin/ai-usage", label: "AI usage", icon: Sparkle },
 ];
 
 export function AdminTabs() {

--- a/app/dashboard/create/challenge/CodeChallengeBuilder.tsx
+++ b/app/dashboard/create/challenge/CodeChallengeBuilder.tsx
@@ -423,7 +423,6 @@ export default function CodeChallengeBuilder() {
       <BuilderHeader
         title="New code challenge"
         lede="Write the instructions, starter code, and tests. Recipients solve it right in their browser, no setup, no server."
-        aiPlaceholder="Describe the challenge and AI fills every field below"
       />
       <GuestNotice />
 

--- a/app/dashboard/create/mcq/McqBuilder.tsx
+++ b/app/dashboard/create/mcq/McqBuilder.tsx
@@ -219,7 +219,6 @@ export default function McqBuilder() {
       <BuilderHeader
         title="New multiple-choice question"
         lede="Write the question and choices, mark the correct answer, and add feedback."
-        aiPlaceholder="Describe the question and AI fills every field below"
       />
       <GuestNotice />
 

--- a/app/dashboard/create/quiz/QuizSetBuilder.tsx
+++ b/app/dashboard/create/quiz/QuizSetBuilder.tsx
@@ -240,7 +240,6 @@ export default function QuizSetBuilder() {
       <BuilderHeader
         title="New quiz set"
         lede="Pick the challenges and questions, put them in order, and share one link to the whole quiz."
-        aiPlaceholder="Describe the quiz and AI drafts a title and description"
       />
       <GuestNotice />
 

--- a/app/dashboard/create/sql/SqlChallengeBuilder.tsx
+++ b/app/dashboard/create/sql/SqlChallengeBuilder.tsx
@@ -337,7 +337,6 @@ export default function SqlChallengeBuilder() {
       <BuilderHeader
         title="New SQL challenge"
         lede="Define the tables and seed data, write the task, and pick the checks. Recipients query a real database in their browser."
-        aiPlaceholder="Describe the exercise and AI fills every field below"
       />
       <GuestNotice />
 


### PR DESCRIPTION
## Summary

Addresses four UX asks around the "Ask AI" launcher and the Studio "Fill with AI" / "AI Assist" experience.

### A1 — Ask AI launcher
- Default the closed-state launcher to the **Edge tab** instead of the floating pill. An explicit `floating` preference in `localStorage` is still honored; only the unset default changes.
- Swap the lucide **`Sparkles` → `Sparkle`** icon across all AI-related items: the Ask AI widget, the Studio AI Assist panel, the Fill with AI bar, the pricing "Ask AI" feature rows, and the admin "AI usage" tab. (The decorative `SparklesText` heading effect is unrelated and left as-is.)
- Make the edge tab a **compact 40×40 square** with a smaller corner radius (`6px 0 0 6px`), matching the square marker already shown in the Settings preview.

### A2 — Fill with AI
- Replace the purple **text input with a non-input label** ("Let AI fill every field"), keeping the existing colors and layout so the section reads as an affordance rather than an empty text field.
- Clicking **"Fill with AI" now just opens the AI Assist panel** — it no longer fires a draft. Generation only starts once the user submits a description in the panel.
- **502 fix:** opening the panel previously called `draft("")`, which hit `/api/ai/draft` with an empty/fallback prompt and surfaced transient upstream provider failures as "The assistant is unavailable right now" (`502 Bad Gateway`) before the user had asked for anything. With no request fired on open, that spurious error can no longer appear on open. A guard in the shared `draft()` also makes an empty prompt a no-op as defense-in-depth.

### A3 — Capitalization
- `AI assist` → **`AI Assist`** in the panel heading and its aria-labels.

### A4 — Daily budget
- "Fill with AI" **already bills** the shared daily Ask AI request budget (the `/api/ai/draft` route calls `recordUsage`, incrementing the same `requests` counter that chat uses and `/api/ai/usage` reads, and `checkBudget` enforces the cap). This PR **surfaces** it: the AI Assist composer now shows the same **"N left today" quota ring** as the Ask AI widget, fetched from `/api/ai/usage` on open and decremented optimistically per billed draft. The composer locks (input + Generate disabled, quick actions hidden) once the daily prompts are spent.

## Files
- `app/_components/ai/AskAiWidget.tsx`, `AskAiPanel.module.css` — default placement, Sparkle icon, square edge tab.
- `app/dashboard/_studio/AiDraftBar.tsx`, `BuilderHeader.tsx`, `StudioAiContext.tsx`, `StudioAiPanel.tsx`, `studio.css` — non-input bar, open-without-generating, `AI Assist` label, quota ring, `draft()` now returns whether the request was billed.
- `app/dashboard/create/{sql,challenge,mcq,quiz}/*Builder.tsx` — drop the now-unused `aiPlaceholder` prop.
- `app/_components/home/PricingSection.tsx`, `app/dashboard/admin/_components/AdminTabs.tsx` — Sparkle icon in AI-related items.

## Testing
- `tsc --noEmit`: no new errors in changed files (only the pre-existing generated `@/.source/dynamic` module, unrelated).
- `eslint` on all changed files: clean.
- `vitest run` on the AI + custom-content suites (`aiDraft`, `aiContext`, `aiModels`, `aiSuggest`, `customContent`, `aiWidgetSnapshots`): all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KD3VFh9z142hHWJMdbxn5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01KD3VFh9z142hHWJMdbxn5m)_