### PR TITLE
Persist guest playground work across sign-in / sign-up

### DIFF
--- a/__tests__/opfs.activeWorkspace.test.ts
+++ b/__tests__/opfs.activeWorkspace.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for app/_components/opfs/activeWorkspace.ts — focused on the
+ * sign-in resume handoff that keeps a guest's unsaved playground work across
+ * signing in / signing up.
+ *
+ * Uses the in-memory OPFS mock plus per-tab (sessionStorage) and durable
+ * (localStorage) storage stubs so the "lost per-tab pointer" scenario can be
+ * simulated by clearing sessionStorage while localStorage + OPFS survive.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { makeOpfsRoot } from "./opfsMock";
+
+const ACTIVE_WS = "../app/_components/opfs/activeWorkspace";
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+function makeStorageStub() {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      map.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      map.delete(k);
+    },
+    clear: () => {
+      map.clear();
+    },
+  };
+}
+
+let local: ReturnType<typeof makeStorageStub>;
+let session: ReturnType<typeof makeStorageStub>;
+
+/** `opfs: false` drops `navigator.storage.getDirectory`, so isOpfsSupported()
+ *  reports false (an environment where content can't be persisted). */
+function setupStubs(opts: { opfs?: boolean } = {}) {
+  const opfs = opts.opfs ?? true;
+  local = makeStorageStub();
+  session = makeStorageStub();
+  const root = makeOpfsRoot();
+  vi.stubGlobal(
+    "navigator",
+    opfs
+      ? { storage: { getDirectory: () => Promise.resolve(root) }, locks: undefined }
+      : { locks: undefined },
+  );
+  vi.stubGlobal("localStorage", local); // workspace.ts registry uses bare localStorage
+  vi.stubGlobal("sessionStorage", session);
+  vi.stubGlobal("window", {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    localStorage: local, // activeWorkspace.ts uses window.localStorage
+    sessionStorage: session,
+  });
+}
+
+beforeEach(() => {
+  setupStubs();
+  vi.resetModules();
+});
+
+// ---------------------------------------------------------------------------
+// Resume handoff
+// ---------------------------------------------------------------------------
+
+describe("sign-in resume handoff", () => {
+  it("resumes the stashed draft after the per-tab pointer is lost", async () => {
+    const aw = await import(ACTIVE_WS);
+    const ws1 = await aw.ensureActiveWorkspace("sqlite");
+    expect(ws1.saved).toBe(false);
+
+    // User clicks "Sign in": stash, then the auth round trip drops this tab's
+    // sessionStorage (fresh tab / re-mounted embed).
+    aw.stashActiveWorkspaceForResume("sqlite");
+    session.clear();
+
+    const ws2 = await aw.ensureActiveWorkspace("sqlite");
+    expect(ws2.id).toBe(ws1.id);
+    expect(ws2.saved).toBe(false);
+  });
+
+  it("resumes a saved workspace, preserving its saved flag", async () => {
+    const aw = await import(ACTIVE_WS);
+    const ws1 = await aw.ensureActiveWorkspace("sqlite");
+    const saved = aw.saveDraftWorkspace("sqlite", "My Workspace");
+    expect(saved?.id).toBe(ws1.id);
+
+    aw.stashActiveWorkspaceForResume("sqlite");
+    session.clear();
+
+    const ws2 = await aw.ensureActiveWorkspace("sqlite");
+    expect(ws2.id).toBe(ws1.id);
+    expect(ws2.saved).toBe(true);
+  });
+
+  it("is single-use: a second lost-session bootstrap starts a fresh draft", async () => {
+    const aw = await import(ACTIVE_WS);
+    const ws1 = await aw.ensureActiveWorkspace("sqlite");
+    aw.stashActiveWorkspaceForResume("sqlite");
+
+    session.clear();
+    const ws2 = await aw.ensureActiveWorkspace("sqlite");
+    expect(ws2.id).toBe(ws1.id); // resumed
+
+    session.clear();
+    const ws3 = await aw.ensureActiveWorkspace("sqlite");
+    expect(ws3.id).not.toBe(ws1.id); // stash already consumed → new draft
+  });
+
+  it("ignores a stash for a different playground", async () => {
+    const aw = await import(ACTIVE_WS);
+    const sqlite = await aw.ensureActiveWorkspace("sqlite");
+    aw.stashActiveWorkspaceForResume("sqlite");
+    session.clear();
+
+    // Opening a *different* playground must not adopt sqlite's workspace.
+    const python = await aw.ensureActiveWorkspace("python");
+    expect(python.id).not.toBe(sqlite.id);
+  });
+
+  it("ignores an expired stash", async () => {
+    const aw = await import(ACTIVE_WS);
+    const ws1 = await aw.ensureActiveWorkspace("sqlite");
+    aw.stashActiveWorkspaceForResume("sqlite");
+
+    // Age the stash beyond the 24h TTL.
+    const raw = JSON.parse(local.getItem("playground_signin_resume")!);
+    raw.ts = Date.now() - 25 * 60 * 60 * 1000;
+    local.setItem("playground_signin_resume", JSON.stringify(raw));
+
+    session.clear();
+    const ws2 = await aw.ensureActiveWorkspace("sqlite");
+    expect(ws2.id).not.toBe(ws1.id);
+  });
+
+  it("does not stash when OPFS is unavailable (nothing to resume)", async () => {
+    setupStubs({ opfs: false });
+    vi.resetModules();
+    const aw = await import(ACTIVE_WS);
+    await aw.ensureActiveWorkspace("python");
+    aw.stashActiveWorkspaceForResume("python");
+    expect(local.getItem("playground_signin_resume")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence assessment (drives the confirmation dialog)
+// ---------------------------------------------------------------------------
+
+describe("guestWorkNeedsSignInWarning", () => {
+  it("is false when there is no active workspace", async () => {
+    const aw = await import(ACTIVE_WS);
+    expect(aw.guestWorkNeedsSignInWarning("python")).toBe(false);
+  });
+
+  it("is false when the active workspace can be persisted", async () => {
+    const aw = await import(ACTIVE_WS);
+    await aw.ensureActiveWorkspace("python");
+    expect(aw.canPersistGuestWork()).toBe(true);
+    expect(aw.guestWorkNeedsSignInWarning("python")).toBe(false);
+  });
+
+  it("is true when the active workspace cannot be persisted (no OPFS)", async () => {
+    setupStubs({ opfs: false });
+    vi.resetModules();
+    const aw = await import(ACTIVE_WS);
+    await aw.ensureActiveWorkspace("python");
+    expect(aw.canPersistGuestWork()).toBe(false);
+    expect(aw.guestWorkNeedsSignInWarning("python")).toBe(true);
+  });
+});

--- a/app/_components/ai/AskAi.tsx
+++ b/app/_components/ai/AskAi.tsx
@@ -80,6 +80,12 @@ export default function AskAi() {
 
   if (!onLesson && !onPlayground) return null;
 
+  // The active playground id (e.g. "sqlite"), so the widget's sign-in CTA can
+  // preserve the guest's unsaved workspace across the auth round trip.
+  const playgroundId = onPlayground
+    ? (pathname.split("/").filter(Boolean)[1] ?? "")
+    : undefined;
+
   return (
     <AskAiWidget
       surface={onLesson ? "learn" : "playground"}
@@ -88,6 +94,7 @@ export default function AskAi() {
       subjectNoun={
         onInterviewPrep ? "question set" : onLesson ? "lesson" : "playground"
       }
+      playgroundId={playgroundId}
       collectContext={collectContext}
     />
   );

--- a/app/_components/ai/AskAiWidget.tsx
+++ b/app/_components/ai/AskAiWidget.tsx
@@ -27,10 +27,16 @@ import {
   useState,
   useSyncExternalStore,
   type KeyboardEvent,
+  type MouseEvent,
 } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Popover } from "@base-ui/react/popover";
+import { AlertDialog } from "@base-ui/react/alert-dialog";
+import {
+  guestWorkNeedsSignInWarning,
+  stashActiveWorkspaceForResume,
+} from "../opfs/activeWorkspace";
 import {
   Sparkle,
   X,
@@ -108,6 +114,9 @@ interface Props {
    *  pages, "question set" on interview-prep (which mounts as surface
    *  "learn" but isn't a lesson), "playground" elsewhere. */
   subjectNoun?: string;
+  /** Active playground id (e.g. "sqlite") when on a playground surface, so the
+   *  sign-in CTA can preserve the guest's unsaved workspace across auth. */
+  playgroundId?: string;
   collectContext: () => AskAiClientContext;
 }
 
@@ -331,6 +340,7 @@ function formatResetsIn(ms: number): string {
 export default function AskAiWidget({
   surface,
   subjectNoun,
+  playgroundId,
   collectContext,
 }: Props) {
   const subject =
@@ -339,6 +349,41 @@ export default function AskAiWidget({
   const [draft, setDraft] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [contextSheetOpen, setContextSheetOpen] = useState(false);
+  // Confirmation shown when signing in would discard guest work this browser
+  // can't persist (no OPFS / storage blocked).
+  const [signInConfirmOpen, setSignInConfirmOpen] = useState(false);
+
+  // Navigate to sign-in. `target="_top"` semantics: break out of the home
+  // page's embedded playground iframe so auth loads in the top-level window.
+  const goToSignIn = useCallback(() => {
+    if (typeof window === "undefined") return;
+    try {
+      (window.top ?? window).location.href = "/sign-in";
+    } catch {
+      window.location.href = "/sign-in";
+    }
+  }, []);
+
+  // Intercept the sign-in CTA on playground surfaces: stash the active
+  // workspace so it resumes after auth, or, when it can't be persisted, confirm
+  // before leaving. Learn surfaces (no workspace) fall through to the plain
+  // link, as do modified clicks (open-in-new-tab, etc.).
+  const handleSignInClick = useCallback(
+    (e: MouseEvent<HTMLAnchorElement>) => {
+      if (!playgroundId) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+        return;
+      }
+      e.preventDefault();
+      if (guestWorkNeedsSignInWarning(playgroundId)) {
+        setSignInConfirmOpen(true);
+        return;
+      }
+      stashActiveWorkspaceForResume(playgroundId);
+      goToSignIn();
+    },
+    [playgroundId, goToSignIn],
+  );
 
   // ── Remembered preferences (global) ────────────────────────────────
   const [placement, setPlacement] = useState<LauncherPlacement>(() =>
@@ -754,7 +799,7 @@ export default function AskAiWidget({
   const composerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!sheetOpen) return;
-    const onDown = (e: MouseEvent) => {
+    const onDown = (e: globalThis.MouseEvent) => {
       const t = e.target as Node;
       if (
         sheetRef.current?.contains(t) ||
@@ -886,8 +931,15 @@ export default function AskAiWidget({
               </span>
               <p>Sign in to ask AI about this {subject}.</p>
               {/* target="_top" breaks out of the home page's embedded
-                  playground iframe so sign-in loads in the top-level window. */}
-              <a className={styles.signInLink} href="/sign-in" target="_top">
+                  playground iframe so sign-in loads in the top-level window.
+                  On playground surfaces, onClick first preserves the guest's
+                  workspace (or confirms, when it can't be persisted). */}
+              <a
+                className={styles.signInLink}
+                href="/sign-in"
+                target="_top"
+                onClick={handleSignInClick}
+              >
                 <LogIn size={15} />
                 Sign in
               </a>
@@ -1409,6 +1461,40 @@ export default function AskAiWidget({
           </div>
         </div>
       )}
+
+      {/* Confirm before signing in when this browser can't persist the guest's
+          work (no OPFS / storage blocked), so it isn't lost without warning.
+          When it *can* be persisted, the CTA stashes + navigates directly and
+          this never opens. Uses the shared confirm-dialog styles from
+          playground.css (loaded on every playground route). */}
+      <AlertDialog.Root
+        open={signInConfirmOpen}
+        onOpenChange={setSignInConfirmOpen}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Backdrop className="confirm-backdrop" />
+          <AlertDialog.Popup className="confirm-popup">
+            <AlertDialog.Title className="confirm-title">
+              Sign in without saving your work?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="confirm-desc">
+              This browser can&apos;t save your {subject} work, so it will be
+              lost when you sign in. Continue anyway?
+            </AlertDialog.Description>
+            <div className="confirm-actions">
+              <AlertDialog.Close className="confirm-btn confirm-btn-secondary">
+                Keep working
+              </AlertDialog.Close>
+              <AlertDialog.Close
+                className="confirm-btn confirm-btn-danger"
+                onClick={goToSignIn}
+              >
+                Sign in anyway
+              </AlertDialog.Close>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
     </div>
   );
 }

--- a/app/_components/opfs/activeWorkspace.ts
+++ b/app/_components/opfs/activeWorkspace.ts
@@ -26,8 +26,10 @@ import {
   getWorkspaceRegistry,
   openWorkspace,
   registerWorkspace,
+  workspaceExistsInOpfs,
   type WorkspaceEntry,
 } from "./workspace";
+import { isOpfsSupported } from "./featureDetect";
 
 const SESSION_KEY_PREFIX = "playground_active_ws_";
 // Per-tab store for a *draft* (unsaved) workspace, one that has OPFS backing
@@ -171,6 +173,179 @@ function clearDraftWorkspace(playgroundId: string): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Sign-in resume handoff
+// ---------------------------------------------------------------------------
+// The active-workspace pointer lives in per-tab `sessionStorage`, and a guest's
+// auto-created workspace is an unregistered draft (kept out of the localStorage
+// registry until Save). Signing in navigates the whole tab away (the Ask AI CTA
+// uses `target="_top"` to escape the home page's playground iframe) and can
+// return in a context where that per-tab pointer is gone — a fresh tab, a
+// dropped session, or the home page re-mounting its embed — at which point
+// `ensureActiveWorkspace` would spin up a blank default and the guest's work
+// (still sitting in OPFS) looks lost.
+//
+// The fix is a durable, single-use handoff written to `localStorage` (which,
+// unlike sessionStorage, survives the round trip and is visible across
+// contexts) right before we leave for the auth flow. On the first bootstrap
+// after returning, `ensureActiveWorkspace` consumes it and re-points the tab at
+// the same workspace, so the work resumes.
+
+const RESUME_STASH_KEY = "playground_signin_resume";
+// A stash older than this is treated as abandoned (the user walked away without
+// completing sign-in) and ignored, so it can't hijack an unrelated later visit.
+const RESUME_STASH_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface ResumeStash {
+  playground: string;
+  id: string;
+  name: string;
+  createdAt: number;
+  /** When the stash was written, for TTL expiry. */
+  ts: number;
+}
+
+function writeResumeStash(stash: ResumeStash): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(RESUME_STASH_KEY, JSON.stringify(stash));
+  } catch {
+    /* storage unavailable (private mode / quota); resume just won't happen. */
+  }
+}
+
+function readResumeStash(): ResumeStash | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(RESUME_STASH_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as ResumeStash;
+    if (
+      parsed &&
+      typeof parsed.playground === "string" &&
+      typeof parsed.id === "string"
+    ) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function clearResumeStash(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(RESUME_STASH_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** True when localStorage can be written (false in private mode / when blocked),
+ *  a precondition for recording the resume handoff. */
+function canWriteLocalStorage(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const probe = "__ds_persist_probe__";
+    window.localStorage.setItem(probe, "1");
+    window.localStorage.removeItem(probe);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether the current active workspace's content can survive a sign-in round
+ * trip: OPFS must hold the content, and localStorage must be writable so the
+ * resume handoff (and the workspace registry) can be recorded.
+ */
+export function canPersistGuestWork(): boolean {
+  return isOpfsSupported() && canWriteLocalStorage();
+}
+
+/**
+ * True when signing in right now would lose the guest's current playground work
+ * because this browser can't persist it across the auth navigation. Callers use
+ * it to show a confirmation before leaving the page. Returns false when there is
+ * no active workspace (nothing to lose).
+ */
+export function guestWorkNeedsSignInWarning(playgroundId: string): boolean {
+  if (!playgroundId) return false;
+  if (getActiveWorkspaceId(playgroundId) == null) return false;
+  return !canPersistGuestWork();
+}
+
+/**
+ * Record a durable, single-use pointer to the playground's active workspace so
+ * it can be resumed after the sign-in / sign-up flow. Call this right before
+ * navigating to the auth pages. No-op when there is no active workspace, or when
+ * OPFS can't hold the content to return to (in which case there is nothing to
+ * resume — the caller warns the user instead).
+ */
+export function stashActiveWorkspaceForResume(playgroundId: string): void {
+  if (!playgroundId || typeof window === "undefined") return;
+  const activeId = getActiveWorkspaceId(playgroundId);
+  if (!activeId) return;
+  if (!isOpfsSupported()) return;
+  const saved = getWorkspaceRegistry().find((e) => e.id === activeId);
+  const draft = getDraftWorkspace(playgroundId);
+  const source = saved ?? (draft && draft.id === activeId ? draft : null);
+  const name =
+    source?.name ?? DEFAULT_NAMES[playgroundId] ?? `Default ${playgroundId}`;
+  const createdAt = source?.createdAt ?? Date.now();
+  writeResumeStash({
+    playground: playgroundId,
+    id: activeId,
+    name,
+    createdAt,
+    ts: Date.now(),
+  });
+}
+
+/**
+ * Consume a pending sign-in resume handoff for this playground, if any, and
+ * re-adopt the stashed workspace as active. Single-use: the stash is cleared up
+ * front so it can never hijack a later fresh-tab open. Returns the resumed
+ * workspace, or null when there's no (valid, unexpired) stash or its content is
+ * gone.
+ */
+async function consumeResumeStash(
+  playgroundId: string,
+): Promise<ActiveWorkspace | null> {
+  const stash = readResumeStash();
+  if (!stash || stash.playground !== playgroundId) return null;
+  clearResumeStash();
+  if (Date.now() - (stash.ts ?? 0) > RESUME_STASH_TTL_MS) return null;
+
+  // A saved (registry) workspace: re-point this tab at it and reuse.
+  const saved = getWorkspaceRegistry().find(
+    (e) => e.id === stash.id && e.playground === playgroundId,
+  );
+  if (saved) {
+    setActiveWorkspaceId(playgroundId, saved.id);
+    const opened = await openWorkspace(saved.id);
+    return { ...(opened ?? saved), saved: true };
+  }
+
+  // Otherwise an unsaved draft: resumable only while its OPFS content is still
+  // present (that's where the guest's work lives).
+  if (await workspaceExistsInOpfs(stash.id)) {
+    const entry: WorkspaceEntry = {
+      id: stash.id,
+      name: stash.name,
+      playground: playgroundId,
+      createdAt: stash.createdAt,
+      lastUsedAt: Date.now(),
+    };
+    setActiveWorkspaceId(playgroundId, entry.id);
+    setDraftWorkspace(playgroundId, entry);
+    return { ...entry, saved: false };
+  }
+  return null;
+}
+
 /**
  * Resolve (or create) the active workspace for a playground.
  *
@@ -183,6 +358,11 @@ function clearDraftWorkspace(playgroundId: string): void {
 export async function ensureActiveWorkspace(
   playgroundId: string,
 ): Promise<ActiveWorkspace> {
+  // A guest who just signed in / signed up resumes the workspace they left,
+  // even if this tab's sessionStorage pointer didn't survive the round trip.
+  const resumed = await consumeResumeStash(playgroundId);
+  if (resumed) return resumed;
+
   const storedId = getActiveWorkspaceId(playgroundId);
   if (storedId) {
     const registry = getWorkspaceRegistry();

--- a/app/_components/opfs/workspace.ts
+++ b/app/_components/opfs/workspace.ts
@@ -138,6 +138,24 @@ async function getWorkspaceDir(
   return wsDir.getDirectoryHandle(workspaceId, { create });
 }
 
+/**
+ * True when a workspace's OPFS directory still exists (i.e. its content is
+ * available to reopen). Used by the sign-in resume path to confirm a stashed
+ * draft's work is really there before re-adopting it, rather than pointing the
+ * playground at an id whose files were since evicted. Returns false when OPFS
+ * is unavailable (no persisted content to recover in that case).
+ */
+export async function workspaceExistsInOpfs(id: string): Promise<boolean> {
+  if (!isOpfsSupported()) return false;
+  try {
+    const wsDir = await getWorkspacesDir();
+    await wsDir.getDirectoryHandle(id, { create: false });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Workspace CRUD
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a guest creates a playground and signs in while working (e.g. via the **Ask AI → Sign in** link inside the playground), their in-progress work appears to be lost after authenticating.

The content itself is durable — every edit is written to **OPFS**. But a guest's auto-created workspace is an unregistered **draft** whose only pointer lives in **per-tab `sessionStorage`**. Signing in navigates the whole tab away (the Ask AI CTA uses `target="_top"` to escape the home page's playground iframe) and can return in a context where that per-tab pointer is gone — a fresh tab, a dropped session, or the home page re-mounting its embed. `ensureActiveWorkspace` then spins up a blank default, and the guest's work (still sitting in OPFS) looks lost.

## Fix

**Durable resume handoff.** Right before leaving for the auth pages, the sign-in CTA records a single-use pointer to the active workspace in `localStorage` — which, unlike `sessionStorage`, survives the round trip and is visible across browsing contexts. On the first bootstrap after returning, `ensureActiveWorkspace` consumes it and re-points the tab at the same workspace (draft **or** saved), so the work resumes. The handoff has a 24h TTL and is cleared on consume, so it can't hijack a later fresh-tab open.

**Confirmation when work can't be persisted.** When the browser can't persist the work (no OPFS, or storage is blocked), the CTA instead shows a confirmation dialog warning that the work will be lost, and only navigates if the user confirms.

Works uniformly for code **and** SQL playgrounds (both route through `ensureActiveWorkspace`), and composes with the existing post-sign-in cloud auto-backup for code playgrounds.

## Changes

- **`opfs/workspace.ts`** — `workspaceExistsInOpfs()` to confirm a stashed draft's OPFS content is still present before re-adopting it.
- **`opfs/activeWorkspace.ts`** — the resume stash (write / read / consume with TTL + single-use), `canPersistGuestWork()`, `guestWorkNeedsSignInWarning()`, `stashActiveWorkspaceForResume()`; the stash is consumed at the top of `ensureActiveWorkspace`.
- **`ai/AskAi.tsx` + `ai/AskAiWidget.tsx`** — pass the active playground id and intercept the sign-in CTA to stash-and-go, or confirm (Base UI `AlertDialog`) when the work can't be persisted. Modified clicks (open-in-new-tab) and learn surfaces fall through to the plain link.
- **`__tests__/opfs.activeWorkspace.test.ts`** — new coverage: resume after a lost per-tab pointer, saved-workspace resume, single-use, playground scoping, TTL expiry, no-stash-without-OPFS, and the persistence-warning assessment.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on all changed files — clean
- `npx vitest run` on the new suite (9) plus the workspace / cloud / manifest / ai-context / auth-return-to suites (84) — all passing

No behavior change for signed-in users or for the same-tab happy path; the resume path only engages when the per-tab pointer didn't survive, and the dialog only appears when persistence genuinely isn't possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhdKRfRE5ukib7euB8R7RR

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhdKRfRE5ukib7euB8R7RR)_