### PR TITLE
Illustration prompts: GPT Image 2 risograph pilot for Python Basics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ script-runner-src/__pycache__/
 
 # Playground audit output (e2e/playground-audit.spec.ts)
 audit-results/
+
+# GPT Image 2 output from scripts/generate-illustrations.mjs
+generated-illustrations/

--- a/__tests__/illustrationPrompt.test.ts
+++ b/__tests__/illustrationPrompt.test.ts
@@ -13,15 +13,15 @@ import {
 // The `/illustration-prompts` gallery, the in-lesson `<IllustrationPrompt>`
 // card, and the batch generator (scripts/generate-illustrations.mjs) all key
 // off these pure helpers and the shared JSON, so their output is pinned here:
-// the prompt text must match the authored GPT Image 2 template exactly, and the
-// file name must be a stable PNG slug.
+// the prompt text must match the authored GPT Image 2 template exactly (always
+// "No text."), and the file name must be a stable PNG slug.
 
 describe("buildIllustrationPrompt", () => {
-  it("formats a risograph prompt with the four brand colors", () => {
+  it("formats a risograph prompt with the four brand colors and No text.", () => {
     expect(
       buildIllustrationPrompt({ subject: "a logistics center full of packages" }),
     ).toBe(
-      "A risograph of a logistics center full of packages.\n\n" +
+      "A risograph of a logistics center full of packages. No text.\n\n" +
         "Blue: #148cff\n" +
         "Green: #20c621\n" +
         "Red: #ff4f59\n" +
@@ -29,28 +29,19 @@ describe("buildIllustrationPrompt", () => {
     );
   });
 
-  it("appends the abstract/no-text clause when noText is set", () => {
-    expect(
-      buildIllustrationPrompt({ subject: "a programmer duck", noText: true }),
-    ).toBe(
-      "A risograph of a programmer duck. No text. Just an abstract art.\n\n" +
-        "Blue: #148cff\n" +
-        "Green: #20c621\n" +
-        "Red: #ff4f59\n" +
-        "Yellow: #ffdd6c",
-    );
-  });
-
-  it("honours a custom style and custom colors", () => {
+  it("uses 'An' for a vowel-initial style and honours custom styles/colors", () => {
     expect(
       buildIllustrationPrompt(
-        { subject: "a duck", style: "line art" },
+        { subject: "a marmot on a track", style: "isometric illustration" },
         { blue: "#000", green: "#111", red: "#222", yellow: "#333" },
       ),
     ).toBe(
-      "A line art of a duck.\n\n" +
+      "An isometric illustration of a marmot on a track. No text.\n\n" +
         "Blue: #000\nGreen: #111\nRed: #222\nYellow: #333",
     );
+    expect(
+      buildIllustrationPrompt({ subject: "a duck", style: "line art illustration" }),
+    ).toContain("A line art illustration of a duck. No text.");
   });
 
   it("exposes the canonical brand palette", () => {
@@ -84,19 +75,29 @@ describe("getIllustrationPrompts", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
+  it("carries a style and mascot flag on every entry", () => {
+    for (const e of data.entries) {
+      expect(e.style.length).toBeGreaterThan(0);
+      expect(typeof e.mascot).toBe("boolean");
+      expect(e.prompt).toContain("No text.");
+    }
+  });
+
   it("collapses an index lesson to the course landing route", () => {
     const thumb = getIllustrationPromptById("python-basics-thumbnail");
     expect(thumb).toBeDefined();
     expect(thumb?.route).toBe("/courses/python-basics");
     expect(thumb?.file).toBe("python-basics-thumbnail.png");
+    expect(thumb?.prompt).toContain("A risograph of");
   });
 
-  it("deep-links a lesson-embedded illustration to its lesson anchor", () => {
-    const hello = getIllustrationPromptById("python-basics-hello-world");
-    expect(hello?.href).toBe(
-      "/courses/python-basics/hello-world#python-basics-hello-world",
+  it("deep-links a lesson-embedded illustration and reflects its style", () => {
+    const loops = getIllustrationPromptById("python-basics-loops");
+    expect(loops?.href).toBe(
+      "/courses/python-basics/loops#python-basics-loops",
     );
-    expect(hello?.prompt).toContain("A risograph of");
-    expect(hello?.prompt).toContain("Blue: #148cff");
+    expect(loops?.mascot).toBe(true);
+    expect(loops?.prompt).toContain("An isometric illustration of");
+    expect(loops?.prompt).toContain("Blue: #148cff");
   });
 });

--- a/__tests__/illustrationPrompt.test.ts
+++ b/__tests__/illustrationPrompt.test.ts
@@ -1,91 +1,102 @@
 import { describe, expect, it } from "vitest";
 import {
+  BRAND_COLORS,
   buildIllustrationPrompt,
   illustrationFileName,
   illustrationFileSlug,
-  personImageSearchUrl,
 } from "../lib/illustrationPrompt";
+import {
+  getIllustrationPrompts,
+  getIllustrationPromptById,
+} from "../lib/illustrationPromptsGallery";
 
-// The `/illustration-prompts` gallery, the on-page placeholder anchor, and the
-// eventual SVG asset all key off these pure helpers, so their output is pinned
-// here: the prompt text must match the authored template exactly, and the file
-// slug must be stable and collision-free for distinct subjects.
+// The `/illustration-prompts` gallery, the in-lesson `<IllustrationPrompt>`
+// card, and the batch generator (scripts/generate-illustrations.mjs) all key
+// off these pure helpers and the shared JSON, so their output is pinned here:
+// the prompt text must match the authored GPT Image 2 template exactly, and the
+// file name must be a stable PNG slug.
 
 describe("buildIllustrationPrompt", () => {
-  it("appends '(photo attached)' for people and omits it otherwise", () => {
-    expect(buildIllustrationPrompt("Brendan Eich", true)).toBe(
-      "Create a line art-styled illustration of Brendan Eich (photo attached). " +
-        "Use Recraft Vector V4.1. Use a transparent background. " +
-        "The illustration should work well in both light (#ffffff) and dark backgrounds (#121212).",
+  it("formats a risograph prompt with the four brand colors", () => {
+    expect(
+      buildIllustrationPrompt({ subject: "a logistics center full of packages" }),
+    ).toBe(
+      "A risograph of a logistics center full of packages.\n\n" +
+        "Blue: #148cff\n" +
+        "Green: #20c621\n" +
+        "Red: #ff4f59\n" +
+        "Yellow: #ffdd6c",
     );
-    expect(buildIllustrationPrompt("a Gentoo penguin standing on Antarctic ice", false)).toBe(
-      "Create a line art-styled illustration of a Gentoo penguin standing on Antarctic ice. " +
-        "Use Recraft Vector V4.1. Use a transparent background. " +
-        "The illustration should work well in both light (#ffffff) and dark backgrounds (#121212).",
+  });
+
+  it("appends the abstract/no-text clause when noText is set", () => {
+    expect(
+      buildIllustrationPrompt({ subject: "a programmer duck", noText: true }),
+    ).toBe(
+      "A risograph of a programmer duck. No text. Just an abstract art.\n\n" +
+        "Blue: #148cff\n" +
+        "Green: #20c621\n" +
+        "Red: #ff4f59\n" +
+        "Yellow: #ffdd6c",
+    );
+  });
+
+  it("honours a custom style and custom colors", () => {
+    expect(
+      buildIllustrationPrompt(
+        { subject: "a duck", style: "line art" },
+        { blue: "#000", green: "#111", red: "#222", yellow: "#333" },
+      ),
+    ).toBe(
+      "A line art of a duck.\n\n" +
+        "Blue: #000\nGreen: #111\nRed: #222\nYellow: #333",
+    );
+  });
+
+  it("exposes the canonical brand palette", () => {
+    expect(BRAND_COLORS).toEqual({
+      blue: "#148cff",
+      green: "#20c621",
+      red: "#ff4f59",
+      yellow: "#ffdd6c",
+    });
+  });
+});
+
+describe("illustration file names", () => {
+  it("normalises an id to a slug and a .png file name", () => {
+    expect(illustrationFileSlug("Python Basics Thumbnail")).toBe(
+      "python-basics-thumbnail",
+    );
+    expect(illustrationFileName("python-basics-hello-world")).toBe(
+      "python-basics-hello-world.png",
     );
   });
 });
 
-describe("illustrationFileSlug", () => {
-  it("turns a person into a '<name>-portrait' slug", () => {
-    expect(illustrationFileSlug("Leland Wilkinson", true)).toBe(
-      "leland-wilkinson-portrait",
-    );
+describe("getIllustrationPrompts", () => {
+  const data = getIllustrationPrompts();
+
+  it("builds one entry per JSON prompt with unique ids", () => {
+    expect(data.entries.length).toBe(data.totalIllustrations);
+    expect(data.entries.length).toBeGreaterThan(0);
+    const ids = data.entries.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("strips diacritics and a trailing descriptor after a comma/colon", () => {
-    expect(illustrationFileSlug("Karen Spärck Jones", true)).toBe(
-      "karen-sparck-jones-portrait",
-    );
-    expect(
-      illustrationFileSlug("Fred Brooks, author of The Mythical Man-Month", true),
-    ).toBe("fred-brooks-portrait");
-    expect(
-      illustrationFileSlug(
-        "the Gang of Four: Erich Gamma, Richard Helm, Ralph Johnson, and John Vlissides",
-        true,
-      ),
-    ).toBe("gang-of-four-portrait");
+  it("collapses an index lesson to the course landing route", () => {
+    const thumb = getIllustrationPromptById("python-basics-thumbnail");
+    expect(thumb).toBeDefined();
+    expect(thumb?.route).toBe("/courses/python-basics");
+    expect(thumb?.file).toBe("python-basics-thumbnail.png");
   });
 
-  it("maps the two Dahl & Nygaard phrasings to one shared portrait", () => {
-    expect(illustrationFileSlug("Ole-Johan Dahl and Kristen Nygaard", true)).toBe(
-      illustrationFileSlug(
-        "Ole-Johan Dahl and Kristen Nygaard, the creators of Simula",
-        true,
-      ),
+  it("deep-links a lesson-embedded illustration to its lesson anchor", () => {
+    const hello = getIllustrationPromptById("python-basics-hello-world");
+    expect(hello?.href).toBe(
+      "/courses/python-basics/hello-world#python-basics-hello-world",
     );
-  });
-
-  it("uses curated slugs for objects, unifying the two Datasaurus phrasings", () => {
-    expect(
-      illustrationFileSlug(
-        "a duck (the DuckDB mascot) perched on a stack of database disks",
-        false,
-      ),
-    ).toBe("duckdb-duck-mascot");
-    expect(
-      illustrationFileSlug("the Datasaurus dinosaur-shaped scatter plot", false),
-    ).toBe("datasaurus");
-    expect(
-      illustrationFileSlug(
-        "a scatter of points forming a cartoon dinosaur (the Datasaurus)",
-        false,
-      ),
-    ).toBe("datasaurus");
-  });
-
-  it("exposes the full file name with extension", () => {
-    expect(illustrationFileName("Florence Nightingale", true)).toBe(
-      "florence-nightingale-portrait.svg",
-    );
-  });
-});
-
-describe("personImageSearchUrl", () => {
-  it("builds a Google Images search URL for the display name", () => {
-    expect(personImageSearchUrl("Alan Kay")).toBe(
-      "https://www.google.com/search?q=Alan%20Kay&tbm=isch",
-    );
+    expect(hello?.prompt).toContain("A risograph of");
+    expect(hello?.prompt).toContain("Blue: #148cff");
   });
 });

--- a/app/_components/mdx/IllustrationPrompt.tsx
+++ b/app/_components/mdx/IllustrationPrompt.tsx
@@ -1,57 +1,51 @@
 "use client";
 
 /**
- * A placeholder slot for a custom line-art illustration that hasn't been
- * drawn yet. Authored inline in a lesson wherever an illustration of a person
- * or object would fit:
+ * A placeholder slot for a custom illustration that hasn't been drawn yet.
+ * Authored inline in a lesson by referencing a prompt id defined in
+ * `data/illustration-prompts.json`:
  *
  * ```mdx
- * <IllustrationPrompt subject="Brendan Eich" photo />
- * <IllustrationPrompt subject="a Gentoo penguin standing on ice" />
+ * <IllustrationPrompt id="python-basics-hello-world" />
  * ```
  *
- * It renders a dashed "to be illustrated" card carrying the exact generation
- * prompt plus a copy button, so the prompt can be dropped straight into the
- * image tool. Centralising the prompt template here keeps every request
- * consistent (Recraft Vector V4.1, transparent background, light/dark safe);
- * authors only supply the subject and whether a reference photo is attached.
+ * It renders a dashed "to be illustrated" card carrying the exact GPT Image 2
+ * generation prompt (a risograph of the subject, in the four brand colors) plus
+ * a copy button, so the prompt can be dropped straight into the image tool or
+ * generated in bulk with scripts/generate-illustrations.mjs. Centralising the
+ * definitions in the JSON keeps the lesson card, the `/illustration-prompts`
+ * gallery, and the generator perfectly in sync; authors only supply the id.
  */
 import { useCallback, useState } from "react";
 import { Check, Copy, ImageIcon } from "lucide-react";
-import {
-  buildIllustrationPrompt,
-  illustrationFileSlug,
-} from "@/lib/illustrationPrompt";
+import { getIllustrationPromptById } from "@/lib/illustrationPromptsGallery";
 import styles from "./IllustrationPrompt.module.css";
 
 interface IllustrationPromptProps {
-  /** What to illustrate, phrased to read naturally after "illustration of"
-   *  (e.g. "Brendan Eich", "a person punching holes in a paper punch card"). */
-  subject: string;
-  /** Set for a specific real person, appends "(photo attached)" so the prompt
-   *  signals that a reference photo accompanies the request. Omit for generic
-   *  objects/scenes that need no reference image. */
-  photo?: boolean;
+  /** Prompt id defined in `data/illustration-prompts.json` (e.g.
+   *  "python-basics-hello-world"). */
+  id: string;
 }
 
-export function IllustrationPrompt({ subject, photo = false }: IllustrationPromptProps) {
-  const prompt = buildIllustrationPrompt(subject, photo);
-  // Deep-link target: the `/illustration-prompts` gallery links back here using
-  // the same semantic file slug, so each placeholder is addressable by anchor.
-  const slug = illustrationFileSlug(subject, photo);
+export function IllustrationPrompt({ id }: IllustrationPromptProps) {
+  const entry = getIllustrationPromptById(id);
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
-    void navigator.clipboard.writeText(prompt).then(() => {
+    if (!entry) return;
+    void navigator.clipboard.writeText(entry.prompt).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
-  }, [prompt]);
+  }, [entry]);
+
+  // An unknown id renders nothing rather than breaking the lesson build.
+  if (!entry) return null;
 
   return (
     <div
-      id={slug}
-      data-illustration-file={`${slug}.svg`}
+      id={entry.id}
+      data-illustration-file={entry.file}
       className={styles.placeholder}
       role="group"
       aria-label="Illustration placeholder"
@@ -75,7 +69,7 @@ export function IllustrationPrompt({ subject, photo = false }: IllustrationPromp
           )}
         </button>
       </div>
-      <p className={styles.prompt}>{prompt}</p>
+      <p className={styles.prompt}>{entry.prompt}</p>
     </div>
   );
 }

--- a/app/illustration-prompts/IllustrationPromptsClient.tsx
+++ b/app/illustration-prompts/IllustrationPromptsClient.tsx
@@ -2,14 +2,13 @@
 
 /**
  * Interactive shell for the `/illustration-prompts` gallery. The entry data is
- * collected at build time by the server component (see `page.tsx` and
- * `lib/illustrationPromptsGallery.ts`) and passed in as a prop, the payload is
- * small (~80 short prompts), so unlike the SVG gallery there is no static JSON
- * asset or client fetch. Everything here, the light/dark toggle and the
- * per-card copy buttons, is client-side.
+ * built from `data/illustration-prompts.json` by the server component (see
+ * `page.tsx` and `lib/illustrationPromptsGallery.ts`) and passed in as a prop.
+ * Everything here, the light/dark toggle and the per-card copy buttons, is
+ * client-side.
  */
-import { useCallback, useState, useSyncExternalStore } from "react";
-import { Check, Copy, Moon, Search, Sun } from "lucide-react";
+import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
+import { Check, Copy, Moon, Sun } from "lucide-react";
 import type {
   IllustrationPromptEntry,
   IllustrationPromptsData,
@@ -57,10 +56,10 @@ function PromptCard({
   copiedKey: string | null;
   onCopy: (key: string, text: string) => void;
 }) {
-  const fileKey = `${entry.slug}:file`;
-  const promptKey = `${entry.slug}:prompt`;
+  const fileKey = `${entry.id}:file`;
+  const promptKey = `${entry.id}:prompt`;
   return (
-    <figure id={entry.slug} className={styles.card}>
+    <figure id={entry.id} className={styles.card}>
       <div className={styles.cardTop}>
         <span className={styles.fileWrap}>
           <code className={styles.file}>{entry.file}</code>
@@ -74,40 +73,19 @@ function PromptCard({
             {copiedKey === fileKey ? <Check size={13} /> : <Copy size={13} />}
           </button>
         </span>
-        <span
-          className={`${styles.badge} ${entry.photo ? styles.badgePhoto : styles.badgeNoPhoto}`}
-        >
-          {entry.photo ? "photo attached" : "no reference"}
-        </span>
+        <span className={`${styles.badge} ${styles.badgeMuted}`}>{entry.size}</span>
       </div>
 
+      <p className={styles.cardTitle}>{entry.title}</p>
       <p className={styles.prompt}>{entry.prompt}</p>
-
-      {entry.photo && entry.imageSearchUrl ? (
-        <div className={styles.refLinks}>
-          <a
-            className={styles.refLink}
-            href={entry.imageSearchUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Search size={13} aria-hidden="true" />
-            Google Images
-          </a>
-        </div>
-      ) : null}
 
       <div className={styles.cardBottom}>
         <div className={styles.usages}>
-          <span className={styles.usagesLabel}>
-            Used on {entry.usages.length} page{entry.usages.length === 1 ? "" : "s"}
-          </span>
-          {entry.usages.map((u) => (
-            <a key={u.href} className={styles.usage} href={u.href}>
-              <span className={styles.usageCourse}>{u.courseTitle}</span> ·{" "}
-              {u.route} →
-            </a>
-          ))}
+          <span className={styles.usagesLabel}>Used on</span>
+          <a className={styles.usage} href={entry.href}>
+            <span className={styles.usageCourse}>{entry.courseTitle}</span> ·{" "}
+            {entry.route} →
+          </a>
         </div>
         <button
           type="button"
@@ -146,33 +124,16 @@ export function IllustrationPromptsClient({
       });
   }, []);
 
-  const people = data.entries.filter((e) => e.photo);
-  const objects = data.entries.filter((e) => !e.photo);
-
-  const section = (
-    title: string,
-    entries: IllustrationPromptEntry[],
-  ) =>
-    entries.length === 0 ? null : (
-      <section className={styles.section}>
-        <h2 className={styles.sectionHeading}>
-          {title}
-          <span className={styles.sectionCount}>
-            {entries.length} illustration{entries.length === 1 ? "" : "s"}
-          </span>
-        </h2>
-        <div className={styles.list}>
-          {entries.map((entry) => (
-            <PromptCard
-              key={entry.slug}
-              entry={entry}
-              copiedKey={copiedKey}
-              onCopy={onCopy}
-            />
-          ))}
-        </div>
-      </section>
-    );
+  // Group entries by category label, preserving the pre-sorted order.
+  const groups = useMemo(() => {
+    const byLabel = new Map<string, IllustrationPromptEntry[]>();
+    for (const entry of data.entries) {
+      const list = byLabel.get(entry.categoryLabel);
+      if (list) list.push(entry);
+      else byLabel.set(entry.categoryLabel, [entry]);
+    }
+    return [...byLabel.entries()];
+  }, [data.entries]);
 
   return (
     <div className={`${styles.page} ${theme === "dark" ? styles.dark : ""}`}>
@@ -192,23 +153,41 @@ export function IllustrationPromptsClient({
             </button>
           </div>
           <p className={styles.subtitle}>
-            Placeholder prompts for the custom line-art illustrations across the{" "}
-            <code>/learn</code> and <code>/interview</code> pages,{" "}
+            GPT Image 2 prompts for the custom risograph illustrations across the
+            Dataslope courses and interview prep, rendered in the four brand
+            colors.{" "}
             <span className={styles.count}>{data.totalIllustrations}</span>{" "}
-            illustration{data.totalIllustrations === 1 ? "" : "s"} to draw,
-            placed in <span className={styles.count}>{data.totalLessons}</span>{" "}
-            lesson{data.totalLessons === 1 ? "" : "s"}. Each card carries its
-            target file name and the exact generation prompt.
+            illustration{data.totalIllustrations === 1 ? "" : "s"} to draw across{" "}
+            <span className={styles.count}>{data.totalCourses}</span> course
+            {data.totalCourses === 1 ? "" : "s"}. Each card carries its target
+            file name and the exact generation prompt. Batch-generate them with{" "}
+            <code>scripts/generate-illustrations.mjs</code>.
           </p>
         </header>
 
         {data.totalIllustrations === 0 ? (
           <p className={styles.empty}>No illustration prompts found.</p>
         ) : (
-          <>
-            {section("People (portraits)", people)}
-            {section("Objects & scenes", objects)}
-          </>
+          groups.map(([label, entries]) => (
+            <section key={label} className={styles.section}>
+              <h2 className={styles.sectionHeading}>
+                {label}
+                <span className={styles.sectionCount}>
+                  {entries.length} illustration{entries.length === 1 ? "" : "s"}
+                </span>
+              </h2>
+              <div className={styles.list}>
+                {entries.map((entry) => (
+                  <PromptCard
+                    key={entry.id}
+                    entry={entry}
+                    copiedKey={copiedKey}
+                    onCopy={onCopy}
+                  />
+                ))}
+              </div>
+            </section>
+          ))
         )}
       </div>
     </div>

--- a/app/illustration-prompts/IllustrationPromptsClient.tsx
+++ b/app/illustration-prompts/IllustrationPromptsClient.tsx
@@ -58,6 +58,8 @@ function PromptCard({
 }) {
   const fileKey = `${entry.id}:file`;
   const promptKey = `${entry.id}:prompt`;
+  // Trim the generic tail ("… illustration"/"… schematic") for a tidy badge.
+  const styleLabel = entry.style.replace(/ (illustration|schematic)$/i, "");
   return (
     <figure id={entry.id} className={styles.card}>
       <div className={styles.cardTop}>
@@ -73,7 +75,13 @@ function PromptCard({
             {copiedKey === fileKey ? <Check size={13} /> : <Copy size={13} />}
           </button>
         </span>
-        <span className={`${styles.badge} ${styles.badgeMuted}`}>{entry.size}</span>
+        <span className={styles.badges}>
+          <span className={`${styles.badge} ${styles.badgeAccent}`}>{styleLabel}</span>
+          {entry.mascot ? (
+            <span className={`${styles.badge} ${styles.badgeMuted}`}>marmot</span>
+          ) : null}
+          <span className={`${styles.badge} ${styles.badgeMuted}`}>{entry.size}</span>
+        </span>
       </div>
 
       <p className={styles.cardTitle}>{entry.title}</p>
@@ -153,9 +161,9 @@ export function IllustrationPromptsClient({
             </button>
           </div>
           <p className={styles.subtitle}>
-            GPT Image 2 prompts for the custom risograph illustrations across the
-            Dataslope courses and interview prep, rendered in the four brand
-            colors.{" "}
+            GPT Image 2 prompts for the custom illustrations across the Dataslope
+            courses and interview prep, a mix of styles (risograph, flat vector,
+            line art, isometric, blueprint) rendered in the four brand colors.{" "}
             <span className={styles.count}>{data.totalIllustrations}</span>{" "}
             illustration{data.totalIllustrations === 1 ? "" : "s"} to draw across{" "}
             <span className={styles.count}>{data.totalCourses}</span> course

--- a/app/illustration-prompts/illustration-prompts.module.css
+++ b/app/illustration-prompts/illustration-prompts.module.css
@@ -186,16 +186,21 @@
   font-weight: 600;
   letter-spacing: 0.01em;
   white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono, ui-monospace, monospace);
 }
 
-.badgePhoto {
-  background: var(--badge-bg);
-  color: var(--badge-fg);
-}
-
-.badgeNoPhoto {
+.badgeMuted {
   background: var(--badge-muted-bg);
   color: var(--badge-muted-fg);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--fg);
 }
 
 .prompt {
@@ -206,26 +211,6 @@
   color: var(--muted);
   white-space: pre-wrap;
   word-break: break-word;
-}
-
-.refLinks {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-}
-
-.refLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  color: var(--link);
-  font-size: 0.78rem;
-  font-weight: 500;
-  text-decoration: none;
-}
-
-.refLink:hover {
-  text-decoration: underline;
 }
 
 .cardBottom {

--- a/app/illustration-prompts/illustration-prompts.module.css
+++ b/app/illustration-prompts/illustration-prompts.module.css
@@ -178,6 +178,14 @@
   user-select: all;
 }
 
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
 .badge {
   flex-shrink: 0;
   padding: 0.15rem 0.5rem;
@@ -188,6 +196,11 @@
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
   font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+.badgeAccent {
+  background: var(--badge-bg);
+  color: var(--badge-fg);
 }
 
 .badgeMuted {

--- a/app/illustration-prompts/page.tsx
+++ b/app/illustration-prompts/page.tsx
@@ -1,6 +1,7 @@
 /**
- * `/illustration-prompts`, a build-time review page for the custom risograph
- * illustrations authored across the courses and interview prep.
+ * `/illustration-prompts`, a build-time review page for the custom illustrations
+ * (a mix of styles: risograph, flat vector, line art, isometric, blueprint)
+ * authored across the courses and interview prep.
  *
  * The prompt definitions live in `data/illustration-prompts.json`; each one
  * gets a card here with its target PNG file name (e.g.
@@ -22,7 +23,7 @@ export const dynamic = "force-static";
 export const metadata: Metadata = {
   title: "Illustration prompts",
   description:
-    "GPT Image 2 prompts for the custom risograph illustrations across the Dataslope courses and interview prep.",
+    "GPT Image 2 prompts for the custom illustrations across the Dataslope courses and interview prep.",
   robots: { index: false, follow: false },
 };
 

--- a/app/illustration-prompts/page.tsx
+++ b/app/illustration-prompts/page.tsx
@@ -1,17 +1,17 @@
 /**
- * `/illustration-prompts`, a build-time review page for the custom line-art
- * illustration placeholders (`<IllustrationPrompt>`) authored across the
- * `/courses`, `/fumadocs-dev`, and `/interview-prep` pages.
+ * `/illustration-prompts`, a build-time review page for the custom risograph
+ * illustrations authored across the courses and interview prep.
  *
- * Each distinct illustration gets one card with its semantic target file name
- * (e.g. `leland-wilkinson-portrait.svg`), the exact generation prompt and a
- * copy button, and deep links to every lesson that uses it, so the full set of
- * illustrations to draw can be skimmed and copied from one place.
+ * The prompt definitions live in `data/illustration-prompts.json`; each one
+ * gets a card here with its target PNG file name (e.g.
+ * `python-basics-thumbnail.png`), the exact GPT Image 2 generation prompt and a
+ * copy button, and a deep link to the lesson that embeds it, so the full set of
+ * illustrations to draw can be skimmed and copied from one place, or generated
+ * in bulk with `scripts/generate-illustrations.mjs`.
  *
- * Unlike `/svg-gallery`, the payload is tiny (~80 short prompts), so the data
- * is collected at build time and prerendered straight into this static page
- * (no separate JSON asset / client fetch needed). Interactivity (theme toggle,
- * copy buttons) lives in the client child.
+ * The payload is tiny, so the data is built at request time and prerendered
+ * straight into this static page. Interactivity (theme toggle, copy buttons)
+ * lives in the client child.
  */
 import type { Metadata } from "next";
 import { getIllustrationPrompts } from "@/lib/illustrationPromptsGallery";
@@ -22,7 +22,7 @@ export const dynamic = "force-static";
 export const metadata: Metadata = {
   title: "Illustration prompts",
   description:
-    "Placeholder prompts for the custom line-art illustrations across the Dataslope courses and interview prep.",
+    "GPT Image 2 prompts for the custom risograph illustrations across the Dataslope courses and interview prep.",
   robots: { index: false, follow: false },
 };
 

--- a/content/courses/beginners-javascript/birth-of-javascript.mdx
+++ b/content/courses/beginners-javascript/birth-of-javascript.mdx
@@ -160,8 +160,6 @@ computing, in miniature. Now: why did a language like this end up
 
 ## The web before JavaScript
 
-<IllustrationPrompt subject="Tim Berners-Lee" photo />
-
 In the late 1980s, a researcher at CERN named **Tim Berners-Lee**
 designed a system for sharing scientific documents. It had three
 pieces we still use today: **HTML** (documents with links),
@@ -223,8 +221,6 @@ with competitors, it had to ship in the *next browser release*.
 That is the job Brendan Eich was hired for.
 
 ## Ten days in May
-
-<IllustrationPrompt subject="Brendan Eich" photo />
 
 Eich joined Netscape in April 1995. He was 33, with a background in
 operating systems and compilers, and a deep fondness for **Scheme**,

--- a/content/courses/beginners-javascript/javascript-today.mdx
+++ b/content/courses/beginners-javascript/javascript-today.mdx
@@ -98,8 +98,6 @@ of software.
 
 ## Libraries, then a jailbreak
 
-<IllustrationPrompt subject="John Resig" photo />
-
 Even after AJAX, raw browser programming was rough, so the
 community built layers to smooth it over. The most famous was
 **jQuery**, released by John Resig in 2006, one line of jQuery
@@ -107,8 +105,6 @@ replaced fifty lines of cross-browser plumbing, and for years it
 was the most-used library on the web. Hundreds of libraries
 followed. The lesson stuck: when the platform lags, the JavaScript
 community builds what's missing rather than waiting.
-
-<IllustrationPrompt subject="Ryan Dahl" photo />
 
 The real turning point came in 2009, when **Ryan Dahl** took V8,
 the high-performance JavaScript engine Google built for Chrome,

--- a/content/courses/c-programming-for-beginners/story-of-c.mdx
+++ b/content/courses/c-programming-for-beginners/story-of-c.mdx
@@ -3,8 +3,6 @@ title: From Counting Machines to C
 description: Two centuries of trying to talk to machines, and how a video game at Bell Labs gave the world its most influential programming language
 ---
 
-<IllustrationPrompt subject="Ken Thompson" photo />
-
 In 1969, in a small office at **Bell Telephone Laboratories** in New
 Jersey, a programmer named **Ken Thompson** wanted to play a game.
 
@@ -23,8 +21,6 @@ deal, you need to know what programming was like before it. So let's
 rewind, briefly, about a hundred and thirty years.
 
 ## The long road to "just type instructions"
-
-<IllustrationPrompt subject="Charles Babbage's Analytical Engine, a Victorian-era mechanical computer of brass gears and cylinders" />
 
 For most of human history, "computing" meant moving beads on an
 abacus or doing arithmetic on paper. In the 1800s, **Charles
@@ -179,8 +175,6 @@ Which brings us back to that office in New Jersey.
   </g>
 </svg>
 
-<IllustrationPrompt subject="a PDP-11 minicomputer, an early 1970s refrigerator-sized machine with switches and blinking lights" />
-
 The first version of UNIX was written entirely in **assembly
 language** for the PDP-7, then rewritten in assembly for a newer
 machine called the **PDP-11**. Each time UNIX moved to a new
@@ -193,8 +187,6 @@ data **types**, every value was a single machine word. That made it
 hopeless for code that needed to deal with bytes, characters, and
 structures of mixed-size data, which is most of what an operating
 system does.
-
-<IllustrationPrompt subject="Dennis Ritchie" photo />
 
 So between 1969 and 1973, Dennis Ritchie did something quietly
 historic. He took B, added **types** (`int`, `char`, `float`,

--- a/content/courses/csharp-linq-functional/birth-of-linq.mdx
+++ b/content/courses/csharp-linq-functional/birth-of-linq.mdx
@@ -291,8 +291,6 @@ Each arrow was a different language stitched into C#. None of them
 could see the others. A typo inside a SQL string failed at runtime,
 in production, sometimes hours after deployment.
 
-<IllustrationPrompt subject="Erik Meijer" photo />
-
 The Microsoft team, with Anders Hejlsberg, C#'s lead architect, and
 Erik Meijer among the central figures, asked a deceptively simple
 question: *"What if `where` and `select` were part of the C#

--- a/content/courses/csharp-linq-functional/why-declarative-won.mdx
+++ b/content/courses/csharp-linq-functional/why-declarative-won.mdx
@@ -87,8 +87,6 @@ had already solved.
 
 ## The free lunch ends
 
-<IllustrationPrompt subject="Herb Sutter" photo />
-
 So why did the mainstream suddenly start borrowing in the 2000s?
 Two pressures arrived at almost the same time.
 

--- a/content/courses/data-analysis-python-pandas/data-disasters.mdx
+++ b/content/courses/data-analysis-python-pandas/data-disasters.mdx
@@ -43,8 +43,6 @@ miniature whenever floating-point arithmetic surprises us.)
 
 ## The Mars Climate Orbiter and the missing unit (1999)
 
-<IllustrationPrompt subject="the Mars Climate Orbiter spacecraft approaching Mars" />
-
 NASA's Mars Climate Orbiter, a spacecraft that cost roughly $327
 million, reached Mars in September 1999 and was never heard from
 again. The investigation found a heartbreakingly simple cause: one
@@ -80,8 +78,6 @@ exactly why this course nags you to check `df.dtypes` after every
 load, and why we read ZIP codes and IDs as strings on purpose.
 
 ## The London Whale and the copy-paste model (2012)
-
-<IllustrationPrompt subject="a whale surfacing beside the City of London skyline" />
 
 In 2012 JPMorgan lost billions of dollars in the trading episode
 nicknamed the "London Whale." The post-mortem revealed that a key

--- a/content/courses/data-analysis-python-pandas/deep-history-of-data.mdx
+++ b/content/courses/data-analysis-python-pandas/deep-history-of-data.mdx
@@ -11,8 +11,6 @@ None of it is required. All of it is true.
 
 ## The first dataset was a bone
 
-<IllustrationPrompt subject="the Ishango bone, an ancient notched tally bone" />
-
 The oldest object that arguably qualifies as a *dataset* is the
 **Ishango bone**, found near a volcano in central Africa and dated
 to roughly 20,000 years ago. Along three rows of its surface are
@@ -25,8 +23,6 @@ record of it.* To externalize counting so you can return to it
 later is the seed of every CSV file you will ever open.
 
 ## Punch cards, Hollerith, and the column
-
-<IllustrationPrompt subject="Herman Hollerith" photo />
 
 The 1890 US Census is the hinge between hand-tabulation and
 machines. The country had grown so fast that the *previous* census

--- a/content/courses/data-analysis-python-pandas/history-of-data.mdx
+++ b/content/courses/data-analysis-python-pandas/history-of-data.mdx
@@ -201,8 +201,6 @@ conclusion built on top of it.
 
 ## One frustrated researcher, one library
 
-<IllustrationPrompt subject="Wes McKinney" photo />
-
 Which brings us to the library this course is named for. By 2007 you
 could *technically* do data analysis in Python. **NumPy** (unified
 by Travis Oliphant around 2005–2006 from two earlier array

--- a/content/courses/data-analysis-python-pandas/spreadsheets-vs-code.mdx
+++ b/content/courses/data-analysis-python-pandas/spreadsheets-vs-code.mdx
@@ -18,8 +18,6 @@ justify austerity: countries whose public debt crossed 90% of GDP
 suffered sharply negative average growth. It was influential enough
 to be quoted in budget debates on two continents.
 
-<IllustrationPrompt subject="Thomas Herndon" photo />
-
 In 2013 a graduate student named **Thomas Herndon**, trying to
 reproduce the finding for a class assignment, asked for the original
 spreadsheet. When he finally got it, he found that an Excel formula

--- a/content/courses/database-design-postgresql/from-ingres-to-postgresql.mdx
+++ b/content/courses/database-design-postgresql/from-ingres-to-postgresql.mdx
@@ -10,8 +10,6 @@ running inside this course.
 
 ## Berkeley reads the papers
 
-<IllustrationPrompt subject="Michael Stonebraker" photo />
-
 In the early 1970s, Michael Stonebraker and Eugene Wong at the
 University of California, Berkeley read Codd's relational papers and
 decided to build their own relational database. The result, developed

--- a/content/courses/database-design-postgresql/the-relational-revolution.mdx
+++ b/content/courses/database-design-postgresql/the-relational-revolution.mdx
@@ -29,8 +29,6 @@ program, and only programmers could ask questions at all.
 
 ## Codd's heresy
 
-<IllustrationPrompt subject="Edgar F. Codd" photo />
-
 Edgar F. "Ted" Codd was a British-born mathematician working at
 IBM's San Jose research laboratory. In June 1970 he published
 "A Relational Model of Data for Large Shared Data Banks" in

--- a/content/courses/from-zero-to-cpp/a-brief-history.mdx
+++ b/content/courses/from-zero-to-cpp/a-brief-history.mdx
@@ -100,8 +100,6 @@ should be written in something more portable than assembly.
 
 ## The creation of C
 
-<IllustrationPrompt subject="Dennis Ritchie" photo />
-
 In 1972, **Dennis Ritchie** at Bell Labs designed the **C language**
 to rewrite the **Unix** operating system in something more portable
 than the assembly it had originally been written in. C was a
@@ -153,8 +151,6 @@ started building informal conventions on top of it, naming schemes,
 tricks. The patterns were powerful but brittle.
 
 ## Bjarne Stroustrup and "C with Classes"
-
-<IllustrationPrompt subject="Bjarne Stroustrup" photo />
 
 In 1979, a Danish computer scientist named **Bjarne Stroustrup**,
 also at Bell Labs, started extending C with features inspired by an

--- a/content/courses/from-zero-to-cpp/debugging-and-reasoning.mdx
+++ b/content/courses/from-zero-to-cpp/debugging-and-reasoning.mdx
@@ -8,8 +8,6 @@ craft of figuring out *why* a program does what it does, is at
 least half of professional programming. The good news is that it's a
 learnable skill, not a talent.
 
-<IllustrationPrompt subject="the 1947 Harvard Mark II logbook page with the first computer bug, an actual moth, taped onto it" />
-
 The word itself comes with a story. On September 9, 1947, operators
 of the Harvard Mark II, an electromechanical computer built of
 relays, traced a malfunction to an actual moth crushed between the

--- a/content/courses/functional-programming-typescript/roots-of-functional-thinking.mdx
+++ b/content/courses/functional-programming-typescript/roots-of-functional-thinking.mdx
@@ -60,8 +60,6 @@ This chapter is the cliff-notes version of that history.
 
 ## Lambda calculus: the math underneath
 
-<IllustrationPrompt subject="Alonzo Church" photo />
-
 In 1936, the logician **Alonzo Church** introduced the **lambda
 calculus**: a tiny formal system in which the only things that exist
 are *functions* and *applications of functions*.
@@ -120,8 +118,6 @@ seriously.
 
 ## Lisp: functions become a programming language (1958)
 
-<IllustrationPrompt subject="John McCarthy" photo />
-
 In 1958, **John McCarthy** designed **Lisp** at MIT. Lisp took the
 lambda calculus and turned it into a programmable language. Lists
 were the universal data structure. Code was data (you could pass
@@ -150,8 +146,6 @@ interpreter. Modern functional programming did not begin with Lisp,
 but it became *usable* with Lisp.
 
 ## ML and Haskell: the type-theory branch (1973, 1990)
-
-<IllustrationPrompt subject="Robin Milner" photo />
 
 In 1973, **Robin Milner** designed **ML** to write proofs about
 programs. ML introduced the world to **Hindley–Milner type
@@ -204,8 +198,6 @@ TypeScript cannot fully express these patterns, its type system lacks
 
 ## Erlang: functional concurrency (1986)
 
-<IllustrationPrompt subject="Joe Armstrong" photo />
-
 While the academy refined types, **Joe Armstrong** and colleagues at
 Ericsson built **Erlang** to run telephone switches. The problem was
 not type safety but *uptime*: switches must run for years without
@@ -241,8 +233,6 @@ that were once "academic": immutable collections, pattern matching,
 algebraic data types, persistent data structures.
 
 ## JavaScript discovers functional programming
-
-<IllustrationPrompt subject="Brendan Eich" photo />
 
 JavaScript had functions as first-class values from day one, and
 that is not an accident. When Netscape recruited Brendan Eich in

--- a/content/courses/intro-data-viz-plotly/a-brief-history-of-data-pictures.mdx
+++ b/content/courses/intro-data-viz-plotly/a-brief-history-of-data-pictures.mdx
@@ -93,8 +93,6 @@ disagreement is often more honest than a single number.**
 
 ## Playfair invents the charts you already know
 
-<IllustrationPrompt subject="William Playfair" photo />
-
 If van Langren is the great-grandfather of statistical graphics, the
 *father* is **William Playfair**, a Scottish engineer and political
 economist. In a single 1786 book, the *Commercial and Political
@@ -111,8 +109,6 @@ from his argument that pictures of data are a legitimate way to know
 things.
 
 ## Florence Nightingale: a chart that changed a war
-
-<IllustrationPrompt subject="Florence Nightingale" photo />
 
 The most consequential early chart was not made by a mathematician.
 In 1854, an English nurse named **Florence Nightingale** arrived at
@@ -182,8 +178,6 @@ and it *traveled*. Sometimes the best chart for *exploration* is not
 the best chart for *advocacy*. We return to this tension throughout
 the course.
 </Callout>
-
-<IllustrationPrompt subject="Napoleon's 1812 march flow-map" />
 
 Two contemporaries deserve a sentence each, because they round out
 the founding generation. In **1854**, physician **John Snow** mapped

--- a/content/courses/intro-data-viz-plotly/always-look-at-the-data.mdx
+++ b/content/courses/intro-data-viz-plotly/always-look-at-the-data.mdx
@@ -52,8 +52,6 @@ different.
 
 ## Anscombe's quartet (1973)
 
-<IllustrationPrompt subject="Francis Anscombe" photo />
-
 In 1973, the statistician **Francis Anscombe** built four small
 datasets specifically to make a point. All four share, to two
 decimal places, the same mean of x, the same mean of y, the same
@@ -124,8 +122,6 @@ comes from one stray point. The correlation coefficient, 0.82 for
 all of them, sees none of this.
 
 ## The Datasaurus Dozen (2017)
-
-<IllustrationPrompt subject="the Datasaurus dinosaur-shaped scatter plot" />
 
 Anscombe's point was so good that, in **2017**, Justin Matejka and
 George Fitzmaurice at Autodesk pushed it to its logical extreme.

--- a/content/courses/intro-data-viz-plotly/bubble-charts.mdx
+++ b/content/courses/intro-data-viz-plotly/bubble-charts.mdx
@@ -42,8 +42,6 @@ gives you *three* variables in one picture: x, y, and bubble size.
 Add `color` and you have *four*. Add `facet_col` and you have
 *five*. This information density is the bubble chart's superpower.
 
-<IllustrationPrompt subject="Hans Rosling" photo />
-
 The most famous bubble chart is **Hans Rosling's Gapminder**
 animation, life expectancy vs GDP per capita, with population as
 bubble size and continent as color, animated over time.

--- a/content/courses/intro-modern-csharp/anders-and-birth-of-csharp.mdx
+++ b/content/courses/intro-modern-csharp/anders-and-birth-of-csharp.mdx
@@ -39,8 +39,6 @@ the way it does, it helps to know the story of its chief designer:
 
 ## A short biography of Anders
 
-<IllustrationPrompt subject="Anders Hejlsberg" photo />
-
 Anders Hejlsberg is a Danish software engineer. He started his
 career in the early 1980s writing compilers, small programs that
 translate human-readable source code into machine code.

--- a/content/courses/intro-modern-csharp/evolution-of-dotnet.mdx
+++ b/content/courses/intro-modern-csharp/evolution-of-dotnet.mdx
@@ -106,8 +106,6 @@ A Windows-only .NET could not credibly serve either trend.
 
 ## Mono: a community runs ahead
 
-<IllustrationPrompt subject="Miguel de Icaza" photo />
-
 A determined developer named **Miguel de Icaza** had already seen
 this coming. In 2004 he led a project called **Mono**, an
 open-source, cross-platform implementation of .NET that ran on

--- a/content/courses/intro-modern-csharp/java-and-managed-runtimes.mdx
+++ b/content/courses/intro-modern-csharp/java-and-managed-runtimes.mdx
@@ -53,8 +53,6 @@ the need to build its own answer.
 
 ## Java in one paragraph
 
-<IllustrationPrompt subject="James Gosling" photo />
-
 **Java** was created by **James Gosling** and his team at **Sun
 Microsystems**, starting in 1991. It was originally aimed at small
 embedded devices (set-top boxes for cable TV), but by the time it

--- a/content/courses/intro-modern-csharp/rise-of-oop.mdx
+++ b/content/courses/intro-modern-csharp/rise-of-oop.mdx
@@ -70,8 +70,6 @@ how software is structured.
 
 ## Simula: simulating the real world
 
-<IllustrationPrompt subject="Ole-Johan Dahl and Kristen Nygaard" photo />
-
 The first object-oriented language was **Simula**, designed in
 Norway by **Ole-Johan Dahl** and **Kristen Nygaard** in the 1960s.
 Simula was created to simulate real-world systems, ships docking in
@@ -100,8 +98,6 @@ behavior with it. That single idea, packaging data and behavior
 together, is the heart of OOP.
 
 ## Smalltalk: everything is an object
-
-<IllustrationPrompt subject="Alan Kay" photo />
 
 A few years later in California, **Alan Kay** and his colleagues at
 **Xerox PARC** built **Smalltalk**, a language and environment that

--- a/content/courses/intro-sql-postgres/why-sql-exists.mdx
+++ b/content/courses/intro-sql-postgres/why-sql-exists.mdx
@@ -12,8 +12,6 @@ arbitrary syntax and more like the punchline of a very good idea.
 
 ## 1970: Codd's dangerous idea
 
-<IllustrationPrompt subject="Edgar F. Codd" photo />
-
 In the late 1960s, databases already existed, and they were
 miserable to use. Data was stored in rigid hierarchies and
 networks, where the *paths* between records were baked into the
@@ -93,8 +91,6 @@ out to be a trademark of Hawker Siddeley, a British aircraft
 company, so the language's name was shortened to **SQL**. The
 ghost of the old name lives on in how many people pronounce it:
 you will hear both "sequel" and "S-Q-L," and both are fine.
-
-<IllustrationPrompt subject="Larry Ellison" photo />
 
 Meanwhile, the published System R papers were being read very
 carefully in California by a young programmer named **Larry
@@ -220,8 +216,6 @@ dialect quirks, but the heart of the language, `SELECT`, `WHERE`,
 can talk to almost any relational database on Earth.
 
 ## Berkeley's answer: from Ingres to Postgres
-
-<IllustrationPrompt subject="Michael Stonebraker" photo />
 
 So where does **PostgreSQL** fit into this story? Across the bay
 from IBM's lab, at the University of California, Berkeley,

--- a/content/courses/java-collections-and-generics-deep-dive/the-collections-framework.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/the-collections-framework.mdx
@@ -8,8 +8,6 @@ changed how everyone wrote Java. It was called the **Java Collections
 Framework** (JCF), and it was the answer to every complaint about
 `Vector` and `Hashtable`.
 
-<IllustrationPrompt subject="Joshua Bloch" photo />
-
 The framework was deliberately designed by a single architect, **Josh
 Bloch**, with a specific goal: a small set of *interfaces* that
 describe what a container *is*, and a small set of high-quality

--- a/content/courses/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
@@ -213,8 +213,6 @@ prevents whole categories of mistake.
 
 ## Where Java's generics actually came from
 
-<IllustrationPrompt subject="the GJ team: Philip Wadler, Martin Odersky, Gilad Bracha, and Dave Stoutamire" photo />
-
 Generics took six years to arrive after the JCF, and the gap was not
 procrastination, it was research. In 1998, programming-language
 researchers **Philip Wadler**, **Martin Odersky**, **Gilad Bracha**,

--- a/content/courses/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
+++ b/content/courses/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
@@ -141,8 +141,6 @@ A list of 1 million elements is fully searched in **20** comparisons
   ]}
 />
 
-<IllustrationPrompt subject="Joshua Bloch" photo />
-
 Look closely at the line `int mid = lo + (hi - lo) / 2;`. The
 "obvious" way to take a midpoint is `(lo + hi) / 2`, and that
 obvious way is a famous bug. In 2006, Joshua Bloch (author of

--- a/content/courses/java-programming-for-beginners/birth-of-oop.mdx
+++ b/content/courses/java-programming-for-beginners/birth-of-oop.mdx
@@ -107,8 +107,6 @@ not occasionally, but chronically. Projects shipped years late and
 far over budget, full of bugs, and so tangled that nobody, including
 the original authors, could safely change them.
 
-<IllustrationPrompt subject="Fred Brooks, author of The Mythical Man-Month" photo />
-
 The most famous casualty was IBM's **OS/360**, the operating system
 for its System/360 mainframes. It consumed thousands of
 programmer-years and shipped late anyway. Its manager, **Fred
@@ -222,8 +220,6 @@ what a program *is*.
   <rect x="466" y="110" width="18" height="10" rx="5" fill="var(--ds-blue-500)" transform="rotate(45 475 115)" />
 </svg>
 
-<IllustrationPrompt subject="Ole-Johan Dahl and Kristen Nygaard, the creators of Simula" photo />
-
 In 1960s Oslo, two Norwegian researchers, **Ole-Johan Dahl** and
 **Kristen Nygaard**, were building software to *simulate* physical
 systems: ships moving through a harbor, customers queuing at a bank.
@@ -253,8 +249,6 @@ eventually received the 2001 Turing Award, computing's highest
 honor, for it. A program was no longer just "code that manipulates
 data." A program was a *population of small things*, each holding
 its own data and offering its own behavior.
-
-<IllustrationPrompt subject="Alan Kay" photo />
 
 In the 1970s, at Xerox PARC in California, **Alan Kay** and his team
 pushed the idea to its limit in a language called **Smalltalk**:

--- a/content/courses/java-programming-for-beginners/computational-thinking.mdx
+++ b/content/courses/java-programming-for-beginners/computational-thinking.mdx
@@ -9,8 +9,6 @@ the machine can do it*. The set of mental habits that get you from
 a fuzzy English description to a working program is called
 **computational thinking**.
 
-<IllustrationPrompt subject="Jeannette Wing" photo />
-
 The term was popularized by Jeannette Wing in 2006, but the habits
 are far older. There are four of them. Each is worth a lifetime of
 practice.

--- a/content/courses/java-programming-for-beginners/debugging-and-reasoning.mdx
+++ b/content/courses/java-programming-for-beginners/debugging-and-reasoning.mdx
@@ -51,8 +51,6 @@ principle, trace.
 
 Debugging is the disciplined process of finding that chain.
 
-<IllustrationPrompt subject="Grace Hopper" photo />
-
 The word itself comes with a museum piece. On September 9, 1947,
 operators of the Harvard Mark II computer, a team that included
 computing pioneer Grace Hopper, traced a malfunction to an actual

--- a/content/courses/java-programming-for-beginners/gosling-and-java.mdx
+++ b/content/courses/java-programming-for-beginners/gosling-and-java.mdx
@@ -3,8 +3,6 @@ title: James Gosling and the Language Built for Toasters
 description: How a secret Sun Microsystems project for smart appliances accidentally produced the language that runs the modern internet, and the bytecode idea that made it possible
 ---
 
-<IllustrationPrompt subject="Bjarne Stroustrup" photo />
-
 By the late 1980s, the object-oriented ideas from the last page had
 finally reached industry, mostly through **C++**, created by
 **Bjarne Stroustrup** at Bell Labs, which grafted classes onto the
@@ -44,8 +42,6 @@ ruin everyone's week, and regularly did.
 Hold those two pains in mind. Now for the toasters.
 
 ## The Green Project
-
-<IllustrationPrompt subject="James Gosling" photo />
 
 In 1991, a small team inside **Sun Microsystems** set up a secret
 project, code-named **Green**. The goal had nothing to do with

--- a/content/courses/java-programming-for-beginners/javas-influence.mdx
+++ b/content/courses/java-programming-for-beginners/javas-influence.mdx
@@ -111,8 +111,6 @@ default in *every* major ecosystem: npm (JavaScript), pip/PyPI
 
 ## 7. "Test-driven development with JUnit"
 
-<IllustrationPrompt subject="Kent Beck and Erich Gamma, creators of JUnit" photo />
-
 **JUnit** made automated unit testing easy in Java, and it began as
 an in-flight hack. In 1997, Kent Beck and Erich Gamma found
 themselves on the same long flight to the OOPSLA conference in

--- a/content/courses/machine-learning-scikit-learn/ensembles-and-random-forests.mdx
+++ b/content/courses/machine-learning-scikit-learn/ensembles-and-random-forests.mdx
@@ -37,8 +37,6 @@ of the most valuable intuitions in classical machine learning.
 
 ## The intuition: the wisdom of crowds
 
-<IllustrationPrompt subject="a prize ox at a country fair weight-guessing contest (Galton's wisdom of crowds)" />
-
 There is a famous story. At a 1906 country fair, the statistician Francis
 Galton collected the roughly 800 entries in a contest to guess the weight of
 an ox. No individual guess was exact, but the *middle* of all the guesses

--- a/content/courses/machine-learning-scikit-learn/your-first-model.mdx
+++ b/content/courses/machine-learning-scikit-learn/your-first-model.mdx
@@ -100,8 +100,6 @@ set, and you *predict* on the real world.
 
 ## Move 1: load the data
 
-<IllustrationPrompt subject="a Palmer penguin" />
-
 We will use the **Palmer Penguins** dataset: body measurements of penguins
 observed near Palmer Station, Antarctica. Each penguin has four
 measurements, bill length, bill depth, flipper length, body mass, and

--- a/content/courses/mastering-dsa-cpp/shortest-paths.mdx
+++ b/content/courses/mastering-dsa-cpp/shortest-paths.mdx
@@ -5,8 +5,6 @@ description: Learn source-to-all shortest paths in non-negative weighted graphs 
 
 BFS told us the path with the fewest *edges*. But real edges have costs, kilometers, milliseconds, tolls, and the route with the fewest hops is frequently not the cheapest one. The shortest path problem asks for the minimum total edge *weight* from a source vertex to others, and it is one of the most-run computations on Earth: every map query, every network packet's route, every game character pathing around an obstacle.
 
-<IllustrationPrompt subject="Edsger Dijkstra" photo />
-
 The algorithm at the heart of it has the best origin story in computer science. One morning in 1956, the 26-year-old Edsger Dijkstra was shopping in Amsterdam with his fiancée; tired, they sat down on a café terrace for coffee, and he worked out the shortest-path algorithm in about twenty minutes, in his head. He later credited part of the design's elegance to having no pencil and paper, "you are almost forced to avoid all avoidable complexities." He had been hunting for a problem the public could understand, to demonstrate the new ARMAC computer; the demo found shortest routes between Dutch cities. The algorithm was published in 1959, three pages long, and it still runs the world's routing. This page focuses on that algorithm: **single-source shortest paths** in weighted graphs with **non-negative** edge weights.
 
 <svg

--- a/content/courses/mastering-dsa-cpp/sorting-efficient.mdx
+++ b/content/courses/mastering-dsa-cpp/sorting-efficient.mdx
@@ -104,8 +104,6 @@ int main() {
 
 ## Quicksort
 
-<IllustrationPrompt subject="Tony Hoare" photo />
-
 In 1960, a 26-year-old Tony Hoare was a visiting student at Moscow State University, working on a machine-translation project that needed to sort the words of Russian sentences before looking them up on a dictionary tape. He thought of the partitioning idea, pick a *pivot*, sweep everything smaller to its left and everything larger to its right, but couldn't express the "sort the two sides the same way" step in the languages he knew. Soon after, he learned ALGOL 60, one of the first languages to support recursion, and the algorithm finally fit on a page. He published it in 1961 as a half-column algorithm in the *Communications of the ACM*; in 1980 he received the Turing Award. Quicksort remains, six decades on, the backbone of most standard-library sorts.
 
 The mechanism: choose a pivot, partition values around it, and recursively sort both sides. Unlike merge sort, all the real work happens *before* the recursive calls, and no merge buffer is needed, quicksort rearranges in place. The version below uses the Lomuto partition scheme (pivot at the end, one sweep with a write frontier `i`); after `partition` returns, the pivot sits at its final sorted position, with smaller values on its left and larger on its right.

--- a/content/courses/mastering-dsa-cpp/why-cpp-for-dsa.mdx
+++ b/content/courses/mastering-dsa-cpp/why-cpp-for-dsa.mdx
@@ -7,8 +7,6 @@ When a game engine has 16 milliseconds to draw a frame, when a trading system me
 
 That second property is why this course uses it. C++ is not the easiest first language, but for learning **data structures and algorithms** it is both a practical tool and a microscope: you will solve problems efficiently while *seeing* how arrays, linked structures, heaps, hash tables, trees, and graphs really behave, where the bytes live, what a pointer costs, why two O(n) loops can differ by a factor of fifty.
 
-<IllustrationPrompt subject="Alexander Stepanov" photo />
-
 The language has been sharpening this dual nature for a long time. Bjarne Stroustrup began C++ at Bell Labs in 1979 as "C with Classes," wanting Simula's abstractions without giving up C's speed. And the Standard Template Library you will lean on throughout this course has its own origin story: Alexander Stepanov had spent years pursuing the idea of generic programming, algorithms written once, independent of the container they run on, and when his STL design was presented to the C++ standards committee in 1993, it was voted into the standard with unusual speed. Every `std::sort` and `std::vector` you call is that idea, industrialized.
 
 <svg

--- a/content/courses/mastering-ggplot2/interesting-discussions.mdx
+++ b/content/courses/mastering-ggplot2/interesting-discussions.mdx
@@ -57,8 +57,6 @@ into a quirk of the name.
 
 ## The penguins you have been plotting
 
-<IllustrationPrompt subject="a Gentoo penguin standing on Antarctic ice" />
-
 Several examples in this course use the **Palmer Penguins** data set,
 body measurements for three penguin species in Antarctica. It is worth
 knowing where it comes from. The measurements were collected by
@@ -81,8 +79,6 @@ ggplot(penguins, aes(bill_length_mm, bill_depth_mm, color = species)) +
 ` }]} />
 
 ## Anscombe's quartet: the case for plotting at all
-
-<IllustrationPrompt subject="Francis Anscombe" photo />
 
 Of every story in this course, this is the one to remember. In 1973 the
 statistician **Francis Anscombe** published four small data sets, now

--- a/content/courses/mastering-ggplot2/origins-of-the-grammar.mdx
+++ b/content/courses/mastering-ggplot2/origins-of-the-grammar.mdx
@@ -40,8 +40,6 @@ real ggplot.
 
 ## A grammar, by analogy
 
-<IllustrationPrompt subject="Leland Wilkinson" photo />
-
 The phrase **"Grammar of Graphics"** comes from a 1999 book of the same
 name by the statistician **Leland Wilkinson**. The book is dense and
 theoretical, but its central idea is simple enough to change how you
@@ -96,8 +94,6 @@ Wilkinson's grammar was exactly that, a *theory*. Theories are
 wonderful, but you cannot run a theory on a data frame. Someone had to
 turn it into a tool real analysts could use. That someone was **Hadley
 Wickham**.
-
-<IllustrationPrompt subject="Hadley Wickham" photo />
 
 In 2005, as a graduate student, Wickham built **ggplot**, a direct
 attempt to implement Wilkinson's grammar in R. A couple of years later

--- a/content/courses/natural-language-processing-python/interesting-discussions.mdx
+++ b/content/courses/natural-language-processing-python/interesting-discussions.mdx
@@ -31,8 +31,6 @@ knowing, each tied to something you now understand.
 
 ## 1950, Turing frames the goal
 
-<IllustrationPrompt subject="Alan Turing" photo />
-
 Before there were any tools, there was a target. In 1950 **Alan Turing** posed
 the "imitation game", now called the **Turing test**, asking whether a machine
 could hold a text conversation indistinguishable from a human's. It reframed the
@@ -61,8 +59,6 @@ just the clean example.
 </Callout>
 
 ## 1948, Shannon and the n-gram
-
-<IllustrationPrompt subject="Claude Shannon" photo />
 
 In 1948 **Claude Shannon** published "A Mathematical Theory of Communication",
 the paper that founded information theory. Tucked inside was an idea you met on
@@ -112,8 +108,6 @@ ran.
 
 ## 1966, ELIZA and the effect named after it
 
-<IllustrationPrompt subject="Joseph Weizenbaum" photo />
-
 At MIT in 1966, **Joseph Weizenbaum** wrote **ELIZA**, a program that imitated a
 Rogerian psychotherapist using nothing but simple pattern-matching and canned
 responses, spotting a keyword and reflecting it back as a question. It had no
@@ -132,7 +126,6 @@ then type a couple of sentences into the `inputs` list.
       filename: "main.py",
       starterCode: `import re
 
-
 def eliza_reply(text):
     text = text.lower().strip().rstrip(".!")
     # A few hand-written reflection rules, exactly ELIZA's style.
@@ -146,7 +139,6 @@ def eliza_reply(text):
     if m:
         return f"Tell me more about feeling {m.group(1)}."
     return "Please, go on."
-
 
 inputs = ["I need a break", "I am tired", "I feel stuck", "The weather is fine"]
 for line in inputs:
@@ -164,8 +156,6 @@ is precisely the warning the "What is NLP?" page raised: **processing** text and
 the first for the second.
 
 ## 1972, Spärck Jones and IDF
-
-<IllustrationPrompt subject="Karen Spärck Jones" photo />
 
 When you ran the TF-IDF page, you used a weighting introduced by **Karen Spärck
 Jones** in 1972. Her paper argued that a term's value for retrieval should grow

--- a/content/courses/oop-blueprint-java/birth-of-oop.mdx
+++ b/content/courses/oop-blueprint-java/birth-of-oop.mdx
@@ -56,8 +56,6 @@ This page is the story of how object-oriented programming was born.
 
 ## Simula: classes for simulating the world (1962–1967)
 
-<IllustrationPrompt subject="Ole-Johan Dahl and Kristen Nygaard, the creators of Simula" photo />
-
 In Oslo, Norway, two researchers, **Ole-Johan Dahl** and **Kristen
 Nygaard**, were trying to write simulations of complex real-world
 systems: ships in a harbor, customers in a queue, traffic at an
@@ -95,8 +93,6 @@ program is to understand and change.
 </Callout>
 
 ## Smalltalk and Alan Kay: "everything is an object" (1972–1980)
-
-<IllustrationPrompt subject="Alan Kay" photo />
 
 At Xerox PARC in California, **Alan Kay** and his colleagues
 **Dan Ingalls** and **Adele Goldberg** took Simula's idea and pushed

--- a/content/courses/oop-blueprint-java/gang-of-four.mdx
+++ b/content/courses/oop-blueprint-java/gang-of-four.mdx
@@ -60,8 +60,6 @@ hallways like folklore.
 
 ## The book that gave the folklore a voice
 
-<IllustrationPrompt subject="the Gang of Four: Erich Gamma, Richard Helm, Ralph Johnson, and John Vlissides" photo />
-
 In **1994**, four authors, **Erich Gamma, Richard Helm, Ralph
 Johnson, and John Vlissides**, published a book called
 ***Design Patterns: Elements of Reusable Object-Oriented Software***.

--- a/content/courses/oop-blueprint-java/responsibility-driven-design.mdx
+++ b/content/courses/oop-blueprint-java/responsibility-driven-design.mdx
@@ -63,8 +63,6 @@ acting as a central coordinator and should probably be broken up.
 
 ## CRC cards: a 5-minute design tool
 
-<IllustrationPrompt subject="Kent Beck and Ward Cunningham, who introduced CRC cards" photo />
-
 The classic tool for this style of thinking is the **CRC card**,
 *Class–Responsibility–Collaborator*. Kent Beck and Ward Cunningham
 introduced CRC cards in a 1989 OOPSLA paper with the disarming title

--- a/content/courses/oop-blueprint-java/software-crisis.mdx
+++ b/content/courses/oop-blueprint-java/software-crisis.mdx
@@ -71,8 +71,6 @@ after the original authors had left. The tools of the previous decade,
 global variables, GOTO statements, subroutines that all shared the
 same data, simply did not scale to that size.
 
-<IllustrationPrompt subject="Fred Brooks, author of The Mythical Man-Month" photo />
-
 The most famous casualty was IBM's **OS/360**, the operating system
 for the System/360 mainframe family, and one of the largest software
 projects ever attempted at the time. It consumed thousands of

--- a/content/courses/practical-r-for-beginners/from-s-to-r.mdx
+++ b/content/courses/practical-r-for-beginners/from-s-to-r.mdx
@@ -3,8 +3,6 @@ title: "Deeper History: From S to R"
 description: The unlikely story of two New Zealand statisticians who wrote a teaching tool that quietly grew into the language of modern statistics, displacing the commercial system it was originally meant to imitate.
 ---
 
-<IllustrationPrompt subject="Ross Ihaka" photo />
-
 In 1991, Ross Ihaka and Robert Gentleman were colleagues in the
 statistics department at the University of Auckland, New Zealand.
 They were both interested in computing, Ihaka had a PhD in
@@ -53,8 +51,6 @@ So they decided to write their own.
 </svg>
 
 ## A weekend project that wouldn't end
-
-<IllustrationPrompt subject="Robert Gentleman" photo />
 
 They began on what they later described as a small experiment. They
 took inspiration from S in *syntax*, they wanted the language to

--- a/content/courses/practical-r-for-beginners/index.mdx
+++ b/content/courses/practical-r-for-beginners/index.mdx
@@ -155,8 +155,6 @@ run; after that, it is instant for the rest of the session.
 
 ## A taste of what's coming
 
-<IllustrationPrompt subject="a Palmer penguin" />
-
 Here is a small example of the kind of analysis we will build
 toward, on a real dataset, the **Palmer penguins**: body
 measurements of 333 penguins from three species, collected at a

--- a/content/courses/practical-r-for-beginners/rise-of-statistical-computing.mdx
+++ b/content/courses/practical-r-for-beginners/rise-of-statistical-computing.mdx
@@ -134,8 +134,6 @@ theory** (Shannon), **Unix** (Thompson, Ritchie), and the **C
 programming language** (Ritchie). Its statistics group was equally
 ambitious.
 
-<IllustrationPrompt subject="John Chambers" photo />
-
 That group included **John Chambers**, **Rick Becker**, **Allan
 Wilks**, and others. They were interactive thinkers, they wanted
 to *play with data*, not write batch jobs and wait for output. They

--- a/content/courses/python-basics/booleans.mdx
+++ b/content/courses/python-basics/booleans.mdx
@@ -5,6 +5,8 @@ description: True and False, truthiness, comparison, and the and / or / not oper
 
 `bool` has exactly two values: `True` and `False`. Both are written capitalized, and both are singleton objects. Understanding how Python evaluates truthiness-what counts as true or false in a boolean context-is key to writing idiomatic code.
 
+<IllustrationPrompt id="python-basics-booleans" />
+
 Every snippet on this page runs in your browser-no setup required.
 
 <Figure

--- a/content/courses/python-basics/classes.mdx
+++ b/content/courses/python-basics/classes.mdx
@@ -5,6 +5,8 @@ description: Defining your own types with attributes, methods, and dataclasses
 
 A **class** bundles data and behavior. Every value in Python is an instance of some class, `42` is an `int`, `"hello"` is a `str`, `[1, 2, 3]` is a `list`. Classes let you define your own types to model the problem you're solving.
 
+<IllustrationPrompt id="python-basics-classes" />
+
 <svg
   viewBox="0 0 640 220"
   role="img"

--- a/content/courses/python-basics/control-flow.mdx
+++ b/content/courses/python-basics/control-flow.mdx
@@ -5,6 +5,8 @@ description: if, elif, else, the conditional expression, and structural pattern 
 
 Every decision in software is a conditional. From "should I cache this result?" to "is the user authorized?" to "which HTTP status code do I return?", control flow is the engine that routes execution through different paths. Python's control flow is straightforward: `if`, `elif`, `else`, and (since Python 3.10) a `match` statement for pattern matching.
 
+<IllustrationPrompt id="python-basics-control-flow" />
+
 Every snippet on this page runs in your browser, no setup required.
 
 <svg

--- a/content/courses/python-basics/data-types.mdx
+++ b/content/courses/python-basics/data-types.mdx
@@ -5,6 +5,8 @@ description: A tour of Python's built-in types and how to convert between them
 
 Python comes with a small, focused set of built-in types. You'll spend 99% of your time juggling these. Each one gets its own page later; this is the map.
 
+<IllustrationPrompt id="python-basics-data-types" />
+
 Every snippet on this page runs in your browser-no setup required.
 
 <svg

--- a/content/courses/python-basics/decorators.mdx
+++ b/content/courses/python-basics/decorators.mdx
@@ -5,6 +5,8 @@ description: Functions that wrap other functions, and the @ syntax
 
 A **decorator** is just a function that takes another function and returns a new one. The `@decorator` syntax is sugar for that pattern. Decorators power Flask's `@app.route`, Django's `@login_required`, dataclasses, `@property`, caching, logging, retry logic, and countless other patterns in production Python.
 
+<IllustrationPrompt id="python-basics-decorators" />
+
 <svg
   viewBox="0 0 640 210"
   role="img"

--- a/content/courses/python-basics/dictionaries.mdx
+++ b/content/courses/python-basics/dictionaries.mdx
@@ -5,6 +5,8 @@ description: Key-value mappings, the most-used data structure in Python
 
 A `dict` maps **keys** to **values**. Lookups, insertions, and deletions are all average-case O(1). Dictionaries are everywhere in Python: JSON decoding produces dicts, function `**kwargs` are dicts, object `__dict__` attributes are dicts, module globals live in a dict, configuration files parse to dicts. **Dictionaries _are_ Python.** Understanding them deeply is not optional.
 
+<IllustrationPrompt id="python-basics-dictionaries" />
+
 Every snippet on this page runs in your browser, no setup required.
 
 <Figure

--- a/content/courses/python-basics/exceptions.mdx
+++ b/content/courses/python-basics/exceptions.mdx
@@ -7,6 +7,8 @@ When something goes wrong, Python raises an **exception**. If nothing catches it
 
 Exceptions are Python's way of encoding **expected failure paths**: file not found, network down, invalid input, permission denied. They let you separate "happy path" logic from error handling.
 
+<IllustrationPrompt id="python-basics-exceptions" />
+
 <svg
   viewBox="0 0 640 210"
   role="img"

--- a/content/courses/python-basics/functions.mdx
+++ b/content/courses/python-basics/functions.mdx
@@ -5,6 +5,8 @@ description: def, parameters, defaults, *args, **kwargs, return values, and type
 
 Functions package code so it can be reused, named, and tested. Every program is a tree of function calls. The keyword is `def`, the body is indented, and a function ends as soon as its indentation does.
 
+<IllustrationPrompt id="python-basics-functions" />
+
 <svg
   viewBox="0 0 640 200"
   role="img"

--- a/content/courses/python-basics/hello-world.mdx
+++ b/content/courses/python-basics/hello-world.mdx
@@ -7,6 +7,8 @@ There is a tradition, almost as old as programming itself, that the first
 program you write in any language should print the words "Hello, World!".
 Python makes that exactly as short as you would hope.
 
+<IllustrationPrompt id="python-basics-hello-world" />
+
 <CodeBlock
   adapter="python"
   files={[

--- a/content/courses/python-basics/index.mdx
+++ b/content/courses/python-basics/index.mdx
@@ -15,6 +15,8 @@ decorators. By the end you will be comfortable enough with the language to
 move on to data science, web frameworks, automation, or whatever pulls you in
 next.
 
+<IllustrationPrompt id="python-basics-thumbnail" />
+
 There is one thing to get out of the way before anything else: **this whole
 course runs in your browser.** You do not have to install Python. You do not
 have to set up an editor, a terminal, or a single configuration file. The code

--- a/content/courses/python-basics/lists.mdx
+++ b/content/courses/python-basics/lists.mdx
@@ -5,6 +5,8 @@ description: Python's general-purpose ordered, mutable sequence
 
 A `list` is Python's workhorse collection: an ordered, mutable sequence that can hold values of any type. Lists are everywhere in real-world Python, search results from an API, user records from a database, file paths for batch processing, task queues, log messages, and more. If you need to store multiple things and might change them later, a list is usually your first choice.
 
+<IllustrationPrompt id="python-basics-lists" />
+
 Every snippet on this page runs in your browser, no setup required.
 
 <svg

--- a/content/courses/python-basics/loops.mdx
+++ b/content/courses/python-basics/loops.mdx
@@ -5,6 +5,8 @@ description: for, while, range, break, continue, and the for-else surprise
 
 Iteration is the engine of automation. Every batch job, every data pipeline, every web scraper, every game loop, every file processor, they all loop. Python has two looping constructs: `for` iterates over any iterable; `while` repeats while a condition holds true. Mastering loops means writing efficient, readable code that processes data at scale.
 
+<IllustrationPrompt id="python-basics-loops" />
+
 Every snippet on this page runs in your browser, no setup required.
 
 <svg

--- a/content/courses/python-basics/modules.mdx
+++ b/content/courses/python-basics/modules.mdx
@@ -7,6 +7,8 @@ A **module** is just a `.py` file. A **package** is a directory of modules (usua
 
 Modules are the backbone of Python's ecosystem: every library you `pip install`, **requests**, **numpy**, **pandas**, is a package made of modules.
 
+<IllustrationPrompt id="python-basics-modules" />
+
 <svg
   viewBox="0 0 640 220"
   role="img"

--- a/content/courses/python-basics/numbers.mdx
+++ b/content/courses/python-basics/numbers.mdx
@@ -5,6 +5,8 @@ description: Integers, floats, complex numbers, arithmetic, and the math module
 
 Python ships with three numeric types: arbitrary-precision integers, IEEE 754 floats, and complex numbers. The operators are familiar, but there are a few surprises-especially around floating-point precision.
 
+<IllustrationPrompt id="python-basics-numbers" />
+
 Every snippet on this page runs in your browser-no setup required.
 
 <svg

--- a/content/courses/python-basics/python-history.mdx
+++ b/content/courses/python-basics/python-history.mdx
@@ -36,7 +36,7 @@ you know them, the language stops feeling arbitrary.
 
 ## A holiday project
 
-<IllustrationPrompt subject="Guido van Rossum" photo />
+<IllustrationPrompt id="python-basics-history" />
 
 In late December 1989, a programmer named **Guido van Rossum** found himself
 with a quiet week. His office at CWI, the Centrum Wiskunde & Informatica, a
@@ -45,8 +45,6 @@ holidays, and he was looking for a project to occupy the time. He had recently
 worked on a teaching language called **ABC**, and while he admired its ideas, he
 had a long list of things he would have done differently. So over that holiday
 he began building a successor.
-
-<IllustrationPrompt subject="the Monty Python foot, nodding to Python's name" />
 
 He needed a name. He was, at the time, reading the published scripts of *Monty
 Python's Flying Circus*, the British comedy series, and he wanted something

--- a/content/courses/python-basics/sets.mdx
+++ b/content/courses/python-basics/sets.mdx
@@ -5,6 +5,8 @@ description: Unordered collections of unique, hashable items
 
 A `set` is an unordered collection of unique, hashable items. Membership testing is O(1) on average, which makes sets the right tool for deduplication, fast lookups, and mathematical set operations. In data work, sets are everywhere: removing duplicate IDs, checking if a user is in an allowed list, finding the intersection of two tag lists, filtering out stop words, and more.
 
+<IllustrationPrompt id="python-basics-sets" />
+
 Every snippet on this page runs in your browser, no setup required.
 
 <svg

--- a/content/courses/python-basics/strings.mdx
+++ b/content/courses/python-basics/strings.mdx
@@ -5,6 +5,8 @@ description: Literals, indexing, slicing, methods, and f-strings
 
 A `str` in Python 3 is an immutable sequence of Unicode code points. Strings are one of the most-used types in the language-text is everywhere-and Python gives you a rich toolkit for working with them.
 
+<IllustrationPrompt id="python-basics-strings" />
+
 Every snippet on this page runs in your browser-no setup required.
 
 <Figure

--- a/content/courses/python-basics/syntax-and-indentation.mdx
+++ b/content/courses/python-basics/syntax-and-indentation.mdx
@@ -6,7 +6,9 @@ description: How Python uses whitespace, PEP 8 style, and the tabs vs spaces con
 On the last page we met the Zen of Python, "Readability counts." This page
 is where that aphorism becomes a law of the language. Python uses **indentation
 itself** to delimit blocks of code, which means whitespace is not cosmetic in
-Python; it is syntax. Here we cover what counts as a block, what PEP 8 has to
+Python; it is syntax.
+
+<IllustrationPrompt id="python-basics-syntax" /> Here we cover what counts as a block, what PEP 8 has to
 say about style, and how to keep your editor honest. (The deeper story, why
 Guido van Rossum made this divisive choice, and the legendary tabs-versus-spaces
 war it touched off, waits for you in *The Story of Python* near the end of the

--- a/content/courses/python-basics/tuples.mdx
+++ b/content/courses/python-basics/tuples.mdx
@@ -5,6 +5,8 @@ description: Immutable sequences, unpacking, and named tuples
 
 A `tuple` is an ordered, **immutable** sequence. Tuples are typically used for fixed-size, heterogeneous records, "a point is an `(x, y)`" or "a database row is `(id, name, email)`", where a list would be the wrong semantic choice. Tuples also serve as dictionary keys, multiple return values, and anywhere you need an immutable, hashable sequence.
 
+<IllustrationPrompt id="python-basics-tuples" />
+
 Every snippet on this page runs in your browser, no setup required.
 
 <svg

--- a/content/courses/python-basics/variables.mdx
+++ b/content/courses/python-basics/variables.mdx
@@ -5,6 +5,8 @@ description: Names, assignment, and Python's dynamic typing
 
 In Python, a **variable** is a name that references an object in memory. There's no `let`, `var`, or type declaration-assignment with `=` creates the binding. This simplicity is powerful, but it comes with subtleties you need to understand to avoid surprises.
 
+<IllustrationPrompt id="python-basics-variables" />
+
 Every snippet on this page runs in your browser-no setup required.
 
 <CodeBlock

--- a/content/courses/scientific-computing-python/interesting-discussions.mdx
+++ b/content/courses/scientific-computing-python/interesting-discussions.mdx
@@ -89,8 +89,6 @@ partner to theory and experiment.
 
 ## William Kahan, the father of floating point
 
-<IllustrationPrompt subject="William Kahan" photo />
-
 The reason `0.1 + 0.2` behaves identically on your phone, your
 laptop, and a supercomputer is a 1985 standard called **IEEE 754**.
 Its principal architect, the mathematician **William Kahan**, won the
@@ -105,8 +103,6 @@ quiet reason numerical results are portable at all. The next three
 stories are about what happens when its rules are ignored.
 
 ## Three disasters caused by rounding error
-
-<IllustrationPrompt subject="the Ariane 5 rocket" />
 
 Floating point is not an abstract concern. Each of these is a
 documented failure with real consequences, and each maps onto an idea

--- a/content/courses/scientific-computing-python/python-in-science.mdx
+++ b/content/courses/scientific-computing-python/python-in-science.mdx
@@ -50,8 +50,6 @@ This chapter is that lineage, three languages, one continuous idea.
 
 ## FORTRAN: scientists' first compiler
 
-<IllustrationPrompt subject="John Backus" photo />
-
 A team led by **John Backus** at IBM started work on FORTRAN, the
 **FOR**mula **TRAN**slator, in 1954 and released the first compiler
 in 1957 for the IBM 704. The goal was radical for its time: a
@@ -100,8 +98,6 @@ as the primary data type**, **fast numerical inner loops**, and
 the workhorses inside SciPy).
 
 ## MATLAB: a calculator that thought in matrices
-
-<IllustrationPrompt subject="Cleve Moler" photo />
 
 In the late 1970s, **Cleve Moler** was teaching numerical analysis at
 the University of New Mexico. He wanted students to use the new
@@ -158,8 +154,6 @@ support for strings, file formats, plotting, or the gluework that
 surrounds real science.
 
 ## Why Python won
-
-<IllustrationPrompt subject="Travis Oliphant" photo />
 
 In 1995, scientific Python did not exist. By 2015 it was the most
 widely used language in computational research. The transformation
@@ -260,10 +254,8 @@ noisy = clean + 0.5 * np.sin(2 * np.pi * 20 * t) + 0.4 * rng.standard_normal(t.s
 sos = signal.butter(N=4, Wn=5, btype="low", fs=400, output="sos")
 filtered = signal.sosfiltfilt(sos, noisy)
 
-
 def snr(x, ref):
     return 10 * np.log10(np.var(ref) / np.var(x - ref))
-
 
 print(pd.Series({"noisy_SNR_dB": snr(noisy, clean),
                  "filtered_SNR_dB": snr(filtered, clean)}).round(2))

--- a/content/courses/seaborn-foundations/the-eda-workflow.mdx
+++ b/content/courses/seaborn-foundations/the-eda-workflow.mdx
@@ -9,8 +9,6 @@ it, you have to get to know it, and the fastest way to do that is to *look*.
 with summaries and plots to learn its structure, spot its quirks, and let it
 suggest the questions worth asking.
 
-<IllustrationPrompt subject="John Tukey" photo />
-
 The statistician **John Tukey** championed this idea in the 1970s, arguing
 that data analysis should start with open-ended exploration rather than
 jumping straight to formal tests. His line is the spirit of this whole page:

--- a/content/courses/seaborn-foundations/the-grammar-of-seaborn.mdx
+++ b/content/courses/seaborn-foundations/the-grammar-of-seaborn.mdx
@@ -463,8 +463,6 @@ both.`}
 Two small pieces of lore make the "Seaborn sits on matplotlib" relationship
 more memorable.
 
-<IllustrationPrompt subject="John D. Hunter" photo />
-
 **Where matplotlib came from.** The library underneath Seaborn began as one
 scientist's tool for his own work. John D. Hunter created matplotlib in 2003
 while doing epilepsy research, to visualize the brain's electrical activity

--- a/content/courses/seaborn-foundations/why-visualize-statistical-data.mdx
+++ b/content/courses/seaborn-foundations/why-visualize-statistical-data.mdx
@@ -74,8 +74,6 @@ information that summaries compress away.** Let's prove it.
 
 ## Meet Anscombe's quartet
 
-<IllustrationPrompt subject="Francis Anscombe" photo />
-
 In 1973 the statistician Francis Anscombe built four small datasets to make
 exactly this point. Each has 11 `(x, y)` pairs. They are now a rite of
 passage. We load them from a tidy table where every row carries a `dataset`
@@ -239,8 +237,6 @@ it reveal, what does it hide, and when would it break?
 </Callout>
 
 ## It is not a fluke: the Datasaurus
-
-<IllustrationPrompt subject="the Datasaurus dinosaur-shaped scatter plot" />
 
 If you suspect Anscombe rigged a rare special case in 1973, a modern sequel
 puts that to rest. In 2017 Justin Matejka and George Fitzmaurice published

--- a/content/courses/sql-analytics-duckdb/why-duckdb.mdx
+++ b/content/courses/sql-analytics-duckdb/why-duckdb.mdx
@@ -9,8 +9,6 @@ analysis, and the one this whole course runs on. This page is the short
 version of *where it came from* and *why it became so popular*, so the
 tool you are about to use stops feeling like a black box.
 
-<IllustrationPrompt subject="a duck (the DuckDB mascot) perched on a stack of database disks" />
-
 <Callout type="info" title="A database named after a duck">
 DuckDB was created by **Mark Raasveldt** and **Hannes Mühleisen** at the
 **CWI** research institute in Amsterdam, the same lab that produced the

--- a/content/courses/sqlite-for-beginners/what-is-a-database.mdx
+++ b/content/courses/sqlite-for-beginners/what-is-a-database.mdx
@@ -185,8 +185,6 @@ networks of pointers, and to fetch anything, a programmer had to
 know the physical layout and navigate it step by step. Change the
 layout, and every program that touched the data broke.
 
-<IllustrationPrompt subject="Edgar F. Codd" photo />
-
 In June 1970, an IBM researcher named **Edgar F. Codd** published
 a paper with the unglamorous title *"A Relational Model of Data
 for Large Shared Data Banks."* Its proposal was radical in its

--- a/content/courses/sqlite-for-beginners/why-sqlite.mdx
+++ b/content/courses/sqlite-for-beginners/why-sqlite.mdx
@@ -11,8 +11,6 @@ of all places, on a warship.
 
 ## A database born on a destroyer program
 
-<IllustrationPrompt subject="D. Richard Hipp" photo />
-
 In 2000, a software engineer named **D. Richard Hipp** was working
 on a contract for General Dynamics, writing software used aboard
 the U.S. Navy's guided-missile destroyers. His program needed a

--- a/content/courses/statistics-for-data-science-python/conditional-probability.mdx
+++ b/content/courses/statistics-for-data-science-python/conditional-probability.mdx
@@ -469,8 +469,6 @@ medicine, and analytics.
 
 ## The Monty Hall problem: conditioning that fooled the experts
 
-<IllustrationPrompt subject="the three doors of the Monty Hall problem, one ajar with a goat behind it" />
-
 Conditional probability is so counterintuitive that it once triggered a
 public uproar. In 1990, the columnist Marilyn vos Savant answered a
 reader's question in *Parade* magazine about the game show *Let's Make a

--- a/content/courses/statistics-for-data-science-python/hypothesis-testing.mdx
+++ b/content/courses/statistics-for-data-science-python/hypothesis-testing.mdx
@@ -79,8 +79,6 @@ one ("something is going on"). H₀ is specific enough to compute with,
 it gives us an exact picture of what "just noise" looks like.
 </Callout>
 
-<IllustrationPrompt subject="a cup of tea for Fisher's Lady Tasting Tea experiment" />
-
 <Callout type="info" title="A true story: the lady tasting tea">
 This whole framework traces to a 1935 afternoon described by the
 statistician **R.A. Fisher**. A colleague, Muriel Bristol, claimed she

--- a/content/courses/statistics-for-data-science-python/index.mdx
+++ b/content/courses/statistics-for-data-science-python/index.mdx
@@ -139,8 +139,6 @@ you'll use constantly as a working data scientist:
 
 ## Try it now: the most famous warning in statistics
 
-<IllustrationPrompt subject="Francis Anscombe" photo />
-
 In 1973 the statistician Francis Anscombe published four small
 datasets in a paper called *Graphs in Statistical Analysis*. They have
 become legendary, because they share almost the *exact same* summary

--- a/content/courses/statistics-for-data-science-python/p-values.mdx
+++ b/content/courses/statistics-for-data-science-python/p-values.mdx
@@ -433,8 +433,6 @@ significant result you ask "how big?"; after a non-significant one you ask
 "did I have the power to see it?". The p-value opens the conversation; it
 does not close it.
 
-<IllustrationPrompt subject="Ronald Fisher" photo />
-
 <Callout type="info" title="Where did 0.05 come from? (a true story)">
 The famous 0.05 threshold is not a law of nature, it's a convention that
 hardened into a rule. **R.A. Fisher** suggested it in the 1920s as a
@@ -456,8 +454,6 @@ p-value is essentially a uniform random number between 0 and 1. So if you
 test **20 independent things** that are all truly null, you *expect* one
 of them to come up "significant" at α = 0.05, by pure luck. Hunt
 through enough comparisons and you will always find a "discovery."
-
-<IllustrationPrompt subject="a jar of green jelly beans (the xkcd #882 significance comic)" />
 
 <Callout type="info" title="The green jelly beans">
 The canonical illustration of this is the webcomic *xkcd* #882,

--- a/content/courses/statistics-for-data-science-python/populations-and-samples.mdx
+++ b/content/courses/statistics-for-data-science-python/populations-and-samples.mdx
@@ -241,8 +241,6 @@ the statistic and the parameter into one number is how overconfident
 claims are born.
 </Callout>
 
-<IllustrationPrompt subject="a captured tank marked with a serial number (the German tank problem)" />
-
 <Callout type="info" title="A true story: the German tank problem">
 In World War II the Allies wanted to know a hidden population parameter:
 how many tanks Germany was producing. The population size `N` was a

--- a/content/courses/statistics-for-data-science-python/statistical-fallacies.mdx
+++ b/content/courses/statistics-for-data-science-python/statistical-fallacies.mdx
@@ -367,8 +367,6 @@ modern, financial version of the bullet-hole map.
 
 ## Regression to the mean
 
-<IllustrationPrompt subject="Francis Galton" photo />
-
 **What it is.** Extreme measurements tend to be followed by less extreme
 ones, simply because part of any extreme value was *luck*, and luck
 doesn't repeat. An unusually high reading is high partly because the
@@ -563,8 +561,6 @@ slanted clouds.
 
 Run this on the real **Datasaurus Dozen**: thirteen datasets, one set of
 summary statistics.
-
-<IllustrationPrompt subject="a scatter of points forming a cartoon dinosaur (the Datasaurus)" />
 
 <CodeBlock
   adapter="python"

--- a/content/courses/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/courses/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -86,8 +86,6 @@ not magic, just a library function managing a big region of memory
 with ordinary data structures, free lists, size bins, boundary
 tags. Anyone can write one, and one person famously did.
 
-<IllustrationPrompt subject="Doug Lea" photo />
-
 In 1987,
 computer science professor Doug Lea began writing a general-purpose
 allocator, **dlmalloc**, and placed it in the public domain. It was

--- a/content/courses/systems-programming-c/real-world-disasters.mdx
+++ b/content/courses/systems-programming-c/real-world-disasters.mdx
@@ -27,8 +27,6 @@ flowchart LR
 
 ## 1. The Morris Worm (1988), gets() and a buffer overflow
 
-<IllustrationPrompt subject="Robert Morris" photo />
-
 In November 1988, a graduate student named Robert Morris released a
 self-replicating program that within hours infected an estimated 10%
 of all computers on the internet, roughly 6,000 machines at the
@@ -323,8 +321,6 @@ a board-level conversation at many enterprises.
 
 ## 10. The Therac-25 (1985–87), race conditions, reused state, six deaths
 
-<IllustrationPrompt subject="a Therac-25 radiation therapy machine, a 1980s hospital medical linear accelerator with a patient couch" />
-
 The Therac-25 was a radiation therapy machine produced by Atomic
 Energy of Canada Limited. Between 1985 and 1987 it gave at least six
 patients massive radiation overdoses, hundreds of times the
@@ -416,8 +412,6 @@ different environment"*, applies directly to porting C code across
 architectures.
 
 ## 12. PlayStation 3 hypervisor break (2010), a glitch and a dangling mapping
-
-<IllustrationPrompt subject="George Hotz" photo />
 
 In January 2010, George Hotz (geohot) published an attack on the
 PS3's hypervisor, the privileged layer that kept the console's

--- a/content/courses/systems-programming-c/why-c-for-systems.mdx
+++ b/content/courses/systems-programming-c/why-c-for-systems.mdx
@@ -34,8 +34,6 @@ the language, and what *not* to expect.
 
 ## A language named after its predecessor
 
-<IllustrationPrompt subject="Ken Thompson" photo />
-
 C did not appear from nowhere, it is the third draft of an idea.
 At Bell Labs in the late 1960s, Ken Thompson wrote **B**, a
 stripped-down descendant of the British language BCPL, to program a

--- a/content/courses/time-series-analysis-python/index.mdx
+++ b/content/courses/time-series-analysis-python/index.mdx
@@ -82,8 +82,6 @@ page is a real Python interpreter (pandas, NumPy, matplotlib, statsmodels)
 running *inside this page*. Edit a block, press **Run**, and the output
 appears underneath.
 
-<IllustrationPrompt subject="the Mauna Loa Observatory atmospheric monitoring station on a Hawaiian volcano summit" />
-
 So let's start with the most famous time series in science. Since 1958,
 an observatory near the summit of Mauna Loa, Hawaii, has measured the
 carbon dioxide in Earth's atmosphere, month after month, without a break.
@@ -135,8 +133,6 @@ regular **annual sawtooth**: every year the curve dips and rises by a few
 ppm as Northern-Hemisphere plants inhale CO₂ each growing season and
 release it each winter. Change the `window` from 12 to 1 to see the raw
 sawtooth, or to 60 to smooth it into the bare trend, and re-run.
-
-<IllustrationPrompt subject="Charles David Keeling" photo />
 
 <Callout type="info" title="A true story you can verify from the data itself">
 **Charles David Keeling** began these continuous measurements in 1958 and

--- a/content/courses/typescript-from-scratch/birth-of-typescript.mdx
+++ b/content/courses/typescript-from-scratch/birth-of-typescript.mdx
@@ -151,8 +151,6 @@ Both tools pointed toward the same insight: **JavaScript developers wanted types
 
 ## Enter Anders Hejlsberg
 
-<IllustrationPrompt subject="Anders Hejlsberg" photo />
-
 In 2010, a small team at Microsoft started sketching a solution. Leading the project was **Anders Hejlsberg**, a legendary language designer. Hejlsberg had created **Turbo Pascal** in the 1980s, a fast, elegant compiler that made programming accessible to a generation of developers. At Borland, he built **Delphi**, a visual development environment beloved for its productivity. At Microsoft, he was the chief architect of **C#**, a statically typed language designed for the .NET platform.
 
 Hejlsberg understood types deeply. He also understood *pragmatism*. C# had shown that a well-designed type system could catch bugs early, enable powerful tooling, and scale to massive codebases, all without getting in the developer's way.

--- a/content/courses/typescript-from-scratch/evolution-of-javascript.mdx
+++ b/content/courses/typescript-from-scratch/evolution-of-javascript.mdx
@@ -13,8 +13,6 @@ ten-day prototype into the substrate of modern software.
 
 In 1995, the web was young. Websites were static documents, text, images, and hyperlinks. Netscape Communications, riding high on the success of its Navigator browser, saw an opportunity: what if pages could *respond* to the user? What if forms could validate themselves before submission? What if you could build interactive experiences without waiting for a server round-trip?
 
-<IllustrationPrompt subject="Brendan Eich" photo />
-
 Netscape hired a programmer named **Brendan Eich** and gave him ten days to create a scripting language that would run inside the browser. The constraints were tight: it had to be easy to learn, forgiving, and fast to prototype. It had to appeal to amateur programmers, not just systems engineers. It had to complement Java, Netscape's bet for "serious" programming on the web.
 
 In May 1995, Eich delivered **Mocha** (soon renamed JavaScript), a small, dynamic language inspired by Scheme, Self, and Java. It was never meant to scale beyond a few hundred lines of form validation. It was a *prototype*, and it showed.
@@ -67,8 +65,6 @@ timeline
 ```
 
 ## Node.js and the explosion
-
-<IllustrationPrompt subject="Ryan Dahl" photo />
 
 In 2009, **Ryan Dahl** unveiled **Node.js** at JSConf EU. JavaScript could now run *outside* the browser, on the server, in build tools, in command-line utilities. Suddenly, JavaScript was a general-purpose language. npm (Node Package Manager) became the largest package ecosystem in the world. Developers built REST APIs, real-time chat servers, build pipelines, and desktop apps (Electron) in JavaScript.
 

--- a/data/illustration-prompts.json
+++ b/data/illustration-prompts.json
@@ -1,0 +1,140 @@
+{
+  "meta": {
+    "model": "gpt-image-2",
+    "defaultStyle": "risograph",
+    "brandColors": {
+      "blue": "#148cff",
+      "green": "#20c621",
+      "red": "#ff4f59",
+      "yellow": "#ffdd6c"
+    },
+    "sizes": {
+      "course-thumbnail": "1536x1024",
+      "course-illustration": "1024x1024",
+      "interview-thumbnail": "1536x1024",
+      "interview-illustration": "1024x1024"
+    }
+  },
+  "prompts": [
+    {
+      "id": "python-basics-thumbnail",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "index",
+      "category": "course-thumbnail",
+      "title": "Python Basics — course thumbnail",
+      "style": "risograph",
+      "subject": "a friendly python snake gently coiled into a smooth loop around a glowing computer monitor, with floating rounded code blocks, a steaming coffee mug, and small sparkles orbiting the scene",
+      "noText": true
+    },
+    {
+      "id": "python-basics-hello-world",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "hello-world",
+      "category": "course-illustration",
+      "title": "Hello, World",
+      "style": "risograph",
+      "subject": "a cheerful retro desktop computer monitor displaying a single glowing speech bubble as if greeting the world for the first time, with a small blinking cursor",
+      "noText": true
+    },
+    {
+      "id": "python-basics-variables",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "variables",
+      "category": "course-illustration",
+      "title": "Variables",
+      "style": "risograph",
+      "subject": "a tidy row of labeled storage jars and boxes on a wooden shelf, each container holding a different simple geometric object, with paper name tags tied to them",
+      "noText": true
+    },
+    {
+      "id": "python-basics-strings",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "strings",
+      "category": "course-illustration",
+      "title": "Strings",
+      "style": "risograph",
+      "subject": "a long ribbon of individual letter beads threaded on a string, curling gracefully across the frame like a necklace of characters",
+      "noText": true
+    },
+    {
+      "id": "python-basics-lists",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "lists",
+      "category": "course-illustration",
+      "title": "Lists",
+      "style": "risograph",
+      "subject": "a little train of connected open boxcars on a track seen from the side, each numbered car carrying a different small parcel in sequence",
+      "noText": true
+    },
+    {
+      "id": "python-basics-dictionaries",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "dictionaries",
+      "category": "course-illustration",
+      "title": "Dictionaries",
+      "style": "risograph",
+      "subject": "a wall of small labeled mailboxes, each with a numbered key hanging in its lock and a few boxes open to reveal a rolled letter inside, evoking keys mapping to values",
+      "noText": true
+    },
+    {
+      "id": "python-basics-loops",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "loops",
+      "category": "course-illustration",
+      "title": "Loops",
+      "style": "risograph",
+      "subject": "a looping roller-coaster track shaped like a smooth circular arrow with a single cart riding repeatedly around the same curve, motion lines trailing behind it",
+      "noText": true
+    },
+    {
+      "id": "python-basics-functions",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "functions",
+      "category": "course-illustration",
+      "title": "Functions",
+      "style": "risograph",
+      "subject": "a whimsical factory machine with an input funnel on top and an output chute below, gears turning inside as plain shapes go in one side and finished shapes come out the other",
+      "noText": true
+    },
+    {
+      "id": "python-basics-classes",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "classes",
+      "category": "course-illustration",
+      "title": "Classes",
+      "style": "risograph",
+      "subject": "an architect's blueprint scroll unrolled on a table showing the outline of a small robot, with a finished toy robot standing beside it, evoking a blueprint and the object built from it",
+      "noText": true
+    },
+    {
+      "id": "python-basics-history",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "python-history",
+      "category": "course-illustration",
+      "title": "The story of Python",
+      "style": "risograph",
+      "subject": "a cozy Dutch canal house in winter at dusk with warm light glowing in one window that reveals a tiny desk holding an early personal computer, snow gently falling, evoking a holiday coding project in the Netherlands",
+      "noText": true
+    }
+  ]
+}

--- a/data/illustration-prompts.json
+++ b/data/illustration-prompts.json
@@ -2,6 +2,7 @@
   "meta": {
     "model": "gpt-image-2",
     "defaultStyle": "risograph",
+    "mascot": "the Dataslope marmot mascot, a friendly round alpine marmot with a cream belly, rosy cheeks, and small rounded ears",
     "brandColors": {
       "blue": "#148cff",
       "green": "#20c621",
@@ -25,8 +26,8 @@
       "category": "course-thumbnail",
       "title": "Python Basics — course thumbnail",
       "style": "risograph",
-      "subject": "a friendly python snake gently coiled into a smooth loop around a glowing computer monitor, with floating rounded code blocks, a steaming coffee mug, and small sparkles orbiting the scene",
-      "noText": true
+      "mascot": true,
+      "subject": "the Dataslope marmot mascot, a friendly round alpine marmot with a cream belly and small rounded ears, sitting cross-legged with a laptop on a grassy hillside, playful rounded code shapes and a rising sun behind it"
     },
     {
       "id": "python-basics-hello-world",
@@ -35,10 +36,22 @@
       "courseTitle": "Python Basics",
       "lesson": "hello-world",
       "category": "course-illustration",
-      "title": "Hello, World",
-      "style": "risograph",
-      "subject": "a cheerful retro desktop computer monitor displaying a single glowing speech bubble as if greeting the world for the first time, with a small blinking cursor",
-      "noText": true
+      "title": "Your first program",
+      "style": "flat geometric vector illustration",
+      "mascot": true,
+      "subject": "the Dataslope marmot mascot cheerfully waving beside a retro computer monitor that shows a single glowing speech bubble, standing on a small green hill"
+    },
+    {
+      "id": "python-basics-syntax",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "syntax-and-indentation",
+      "category": "course-illustration",
+      "title": "Syntax & indentation",
+      "style": "blueprint schematic",
+      "mascot": false,
+      "subject": "neatly nested indented blocks stepping inward like an architectural floor plan, thin guide lines marking each indentation level of a code structure"
     },
     {
       "id": "python-basics-variables",
@@ -48,9 +61,33 @@
       "lesson": "variables",
       "category": "course-illustration",
       "title": "Variables",
-      "style": "risograph",
-      "subject": "a tidy row of labeled storage jars and boxes on a wooden shelf, each container holding a different simple geometric object, with paper name tags tied to them",
-      "noText": true
+      "style": "isometric illustration",
+      "mascot": false,
+      "subject": "a tidy isometric shelf of storage boxes and jars, each holding a different simple geometric object, small blank paper tags tied to them"
+    },
+    {
+      "id": "python-basics-data-types",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "data-types",
+      "category": "course-illustration",
+      "title": "Data types",
+      "style": "flat geometric vector illustration",
+      "mascot": false,
+      "subject": "an assortment of distinct objects grouped by kind, a stack of coins, a ribbon, a toggle switch, and a bundle of boxes, each standing for a different category of value"
+    },
+    {
+      "id": "python-basics-numbers",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "numbers",
+      "category": "course-illustration",
+      "title": "Numbers",
+      "style": "line art illustration",
+      "mascot": false,
+      "subject": "a wooden abacus beside a smooth number line arrow, a few counting beads sliding along a rod"
     },
     {
       "id": "python-basics-strings",
@@ -61,8 +98,20 @@
       "category": "course-illustration",
       "title": "Strings",
       "style": "risograph",
-      "subject": "a long ribbon of individual letter beads threaded on a string, curling gracefully across the frame like a necklace of characters",
-      "noText": true
+      "mascot": false,
+      "subject": "a long ribbon threaded with small blank rounded tiles like a bead necklace, curling gracefully across the frame"
+    },
+    {
+      "id": "python-basics-booleans",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "booleans",
+      "category": "course-illustration",
+      "title": "Booleans",
+      "style": "flat geometric vector illustration",
+      "mascot": true,
+      "subject": "the Dataslope marmot mascot flipping a large two-position toggle switch, one side glowing on and the other dim off"
     },
     {
       "id": "python-basics-lists",
@@ -72,9 +121,21 @@
       "lesson": "lists",
       "category": "course-illustration",
       "title": "Lists",
-      "style": "risograph",
-      "subject": "a little train of connected open boxcars on a track seen from the side, each numbered car carrying a different small parcel in sequence",
-      "noText": true
+      "style": "isometric illustration",
+      "mascot": false,
+      "subject": "an isometric train of connected open boxcars on a curved track, each car carrying a different small coloured parcel in sequence"
+    },
+    {
+      "id": "python-basics-tuples",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "tuples",
+      "category": "course-illustration",
+      "title": "Tuples",
+      "style": "line art illustration",
+      "mascot": false,
+      "subject": "two small padlocked rings linked together as an unbreakable fixed pair, a sealed wax stamp resting beside them"
     },
     {
       "id": "python-basics-dictionaries",
@@ -85,8 +146,32 @@
       "category": "course-illustration",
       "title": "Dictionaries",
       "style": "risograph",
-      "subject": "a wall of small labeled mailboxes, each with a numbered key hanging in its lock and a few boxes open to reveal a rolled letter inside, evoking keys mapping to values",
-      "noText": true
+      "mascot": false,
+      "subject": "a wall of small mailbox doors, each with a little key in its lock and a couple of doors ajar to reveal a rolled scroll inside, evoking keys mapping to values"
+    },
+    {
+      "id": "python-basics-sets",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "sets",
+      "category": "course-illustration",
+      "title": "Sets",
+      "style": "flat geometric vector illustration",
+      "mascot": false,
+      "subject": "three overlapping translucent circles forming a Venn diagram, distinct little shapes sorted into the unique and shared regions"
+    },
+    {
+      "id": "python-basics-control-flow",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "control-flow",
+      "category": "course-illustration",
+      "title": "Control flow",
+      "style": "blueprint schematic",
+      "mascot": true,
+      "subject": "the Dataslope marmot mascot standing at a railway switch lever, choosing between two diverging tracks under a signal light"
     },
     {
       "id": "python-basics-loops",
@@ -96,9 +181,9 @@
       "lesson": "loops",
       "category": "course-illustration",
       "title": "Loops",
-      "style": "risograph",
-      "subject": "a looping roller-coaster track shaped like a smooth circular arrow with a single cart riding repeatedly around the same curve, motion lines trailing behind it",
-      "noText": true
+      "style": "isometric illustration",
+      "mascot": true,
+      "subject": "the Dataslope marmot mascot happily riding a small cart around a looping isometric roller-coaster track, motion lines trailing behind"
     },
     {
       "id": "python-basics-functions",
@@ -108,9 +193,33 @@
       "lesson": "functions",
       "category": "course-illustration",
       "title": "Functions",
+      "style": "flat geometric vector illustration",
+      "mascot": false,
+      "subject": "a whimsical machine with an input funnel on top and an output chute below, plain shapes going in one side and finished shapes coming out the other"
+    },
+    {
+      "id": "python-basics-modules",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "modules",
+      "category": "course-illustration",
+      "title": "Modules",
+      "style": "line art illustration",
+      "mascot": true,
+      "subject": "the Dataslope marmot mascot slotting plain modular crates together into a neat interlocking shelf"
+    },
+    {
+      "id": "python-basics-exceptions",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "exceptions",
+      "category": "course-illustration",
+      "title": "Exceptions",
       "style": "risograph",
-      "subject": "a whimsical factory machine with an input funnel on top and an output chute below, gears turning inside as plain shapes go in one side and finished shapes come out the other",
-      "noText": true
+      "mascot": false,
+      "subject": "a safety net stretched out catching a falling tumbling object mid-air, a soft burst where it lands safely"
     },
     {
       "id": "python-basics-classes",
@@ -120,9 +229,21 @@
       "lesson": "classes",
       "category": "course-illustration",
       "title": "Classes",
-      "style": "risograph",
-      "subject": "an architect's blueprint scroll unrolled on a table showing the outline of a small robot, with a finished toy robot standing beside it, evoking a blueprint and the object built from it",
-      "noText": true
+      "style": "blueprint schematic",
+      "mascot": false,
+      "subject": "an architect's blueprint of a small robot pinned on a drafting board, with a finished toy robot standing beside it"
+    },
+    {
+      "id": "python-basics-decorators",
+      "collection": "courses",
+      "course": "python-basics",
+      "courseTitle": "Python Basics",
+      "lesson": "decorators",
+      "category": "course-illustration",
+      "title": "Decorators",
+      "style": "cut-paper collage",
+      "mascot": true,
+      "subject": "the Dataslope marmot mascot tying a ribbon and bow around a plain gift box that contains a smaller box, layered cut-paper shapes"
     },
     {
       "id": "python-basics-history",
@@ -133,8 +254,8 @@
       "category": "course-illustration",
       "title": "The story of Python",
       "style": "risograph",
-      "subject": "a cozy Dutch canal house in winter at dusk with warm light glowing in one window that reveals a tiny desk holding an early personal computer, snow gently falling, evoking a holiday coding project in the Netherlands",
-      "noText": true
+      "mascot": false,
+      "subject": "a cozy Dutch canal house in winter at dusk, warm light glowing in one window that reveals a tiny desk holding an early personal computer, snow gently falling"
     }
   ]
 }

--- a/lib/illustrationPrompt.ts
+++ b/lib/illustrationPrompt.ts
@@ -42,33 +42,39 @@ export const DEFAULT_STYLE = "risograph";
 /** The minimal shape needed to build a generation prompt. */
 export interface IllustrationSpec {
   /** What to illustrate, phrased to read naturally after "A risograph of "
-   *  (e.g. "a friendly python snake coiled around a monitor"). */
+   *  (e.g. "the Dataslope marmot mascot waving beside a monitor"). */
   subject: string;
-  /** Illustration style, e.g. "risograph" (default) or "line art". */
+  /** Illustration style descriptor, inserted after the article, e.g.
+   *  "risograph" (default), "flat geometric vector illustration",
+   *  "line art illustration", "isometric illustration", "blueprint schematic". */
   style?: string;
-  /** When set, appends "No text. Just an abstract art." so the model avoids
-   *  baking in (usually garbled) lettering. */
-  noText?: boolean;
+}
+
+/** "An" before a vowel-initial style ("isometric"), "A" otherwise. */
+function article(style: string): string {
+  return /^[aeiou]/i.test(style) ? "An" : "A";
 }
 
 /**
  * Build the exact GPT Image 2 generation prompt for an illustration spec, e.g.
  *
- *   A risograph of a programmer duck. No text. Just an abstract art.
+ *   A risograph of the Dataslope marmot mascot waving beside a monitor. No text.
  *
  *   Blue: #148cff
  *   Green: #20c621
  *   Red: #ff4f59
  *   Yellow: #ffdd6c
+ *
+ * "No text." is always appended: none of the illustrations should carry
+ * lettering (the model tends to bake in garbled text otherwise).
  */
 export function buildIllustrationPrompt(
   spec: IllustrationSpec,
   colors: BrandColors = BRAND_COLORS,
 ): string {
   const style = spec.style?.trim() || DEFAULT_STYLE;
-  const abstract = spec.noText ? " No text. Just an abstract art." : "";
   return (
-    `A ${style} of ${spec.subject}.${abstract}\n\n` +
+    `${article(style)} ${style} of ${spec.subject}. No text.\n\n` +
     `Blue: ${colors.blue}\n` +
     `Green: ${colors.green}\n` +
     `Red: ${colors.red}\n` +

--- a/lib/illustrationPrompt.ts
+++ b/lib/illustrationPrompt.ts
@@ -1,83 +1,83 @@
 /**
- * Shared, dependency-free helpers for the `<IllustrationPrompt>` MDX component
- * (app/_components/mdx/IllustrationPrompt.tsx) and the `/illustration-prompts`
- * gallery collector (lib/illustrationPromptsGallery.ts).
+ * Shared, dependency-free helpers for the illustration-prompt system:
  *
- * Keeping the prompt template AND the semantic-filename logic here means the
- * lesson card, the gallery card, and the deep-link anchor all agree on the
- * exact prompt text and the exact file slug for a given subject, there is one
- * source of truth, and no per-instance `name` prop has to be authored into the
- * 100+ MDX call sites.
+ *   - the in-lesson `<IllustrationPrompt>` MDX card
+ *     (app/_components/mdx/IllustrationPrompt.tsx),
+ *   - the `/illustration-prompts` review gallery
+ *     (lib/illustrationPromptsGallery.ts), and
+ *   - the batch image generator (scripts/generate-illustrations.mjs).
+ *
+ * All three read the same prompt definitions from `data/illustration-prompts.json`
+ * and build the exact generation prompt through `buildIllustrationPrompt` here,
+ * so the card, the gallery, and the generated PNG all agree on the prompt text
+ * and the target file name. One source of truth, no per-call-site duplication.
+ *
+ * The prompts target OpenAI's GPT Image 2 and follow the Dataslope house style:
+ * a risograph illustration of a subject, rendered in the four brand colors. See
+ * `data/illustration-prompts.json` `meta.brandColors`.
  *
  * Pure (no Node/DOM APIs) so it can be imported from a client component, a
- * server component, and the esbuild-bundled gallery collector alike.
+ * server component, and a plain Node build script alike.
  */
 
-/** Build the exact image-generation prompt for a subject. A specific named
- *  real person gets "(photo attached)" via `photo`; objects/animals/scenes
- *  do not. */
-export function buildIllustrationPrompt(subject: string, photo: boolean): string {
-  const reference = photo ? " (photo attached)" : "";
-  return (
-    `Create a line art-styled illustration of ${subject}${reference}. ` +
-    `Use Recraft Vector V4.1. Use a transparent background. ` +
-    `The illustration should work well in both light (#ffffff) and dark backgrounds (#121212).`
-  );
+/** The four Dataslope brand colors, as named in every generation prompt. */
+export interface BrandColors {
+  blue: string;
+  green: string;
+  red: string;
+  yellow: string;
+}
+
+/** Default Dataslope brand palette (see app/brand.css `--ds-*-500` tokens). */
+export const BRAND_COLORS: BrandColors = {
+  blue: "#148cff",
+  green: "#20c621",
+  red: "#ff4f59",
+  yellow: "#ffdd6c",
+};
+
+/** The house illustration style when a prompt does not name its own. */
+export const DEFAULT_STYLE = "risograph";
+
+/** The minimal shape needed to build a generation prompt. */
+export interface IllustrationSpec {
+  /** What to illustrate, phrased to read naturally after "A risograph of "
+   *  (e.g. "a friendly python snake coiled around a monitor"). */
+  subject: string;
+  /** Illustration style, e.g. "risograph" (default) or "line art". */
+  style?: string;
+  /** When set, appends "No text. Just an abstract art." so the model avoids
+   *  baking in (usually garbled) lettering. */
+  noText?: boolean;
 }
 
 /**
- * Curated slugs for the concrete-object/scene subjects (the ones without a
- * `photo` reference). Their authored subjects are long descriptive phrases, so
- * a naive slug would be unwieldy; these give each a short, stable filename.
- * Two Datasaurus phrasings intentionally map to the same file (one drawing).
+ * Build the exact GPT Image 2 generation prompt for an illustration spec, e.g.
+ *
+ *   A risograph of a programmer duck. No text. Just an abstract art.
+ *
+ *   Blue: #148cff
+ *   Green: #20c621
+ *   Red: #ff4f59
+ *   Yellow: #ffdd6c
  */
-const OBJECT_SLUGS: Record<string, string> = {
-  "Charles Babbage's Analytical Engine, a Victorian-era mechanical computer of brass gears and cylinders":
-    "analytical-engine",
-  "Napoleon's 1812 march flow-map": "napoleon-1812-march-map",
-  "a Gentoo penguin standing on Antarctic ice": "gentoo-penguin",
-  "a PDP-11 minicomputer, an early 1970s refrigerator-sized machine with switches and blinking lights":
-    "pdp-11-minicomputer",
-  "a Palmer penguin": "palmer-penguin",
-  "a Therac-25 radiation therapy machine, a 1980s hospital medical linear accelerator with a patient couch":
-    "therac-25",
-  "a captured tank marked with a serial number (the German tank problem)":
-    "german-tank-problem",
-  "a cup of tea for Fisher's Lady Tasting Tea experiment": "lady-tasting-tea",
-  "a duck (the DuckDB mascot) perched on a stack of database disks":
-    "duckdb-duck-mascot",
-  "a jar of green jelly beans (the xkcd #882 significance comic)":
-    "xkcd-jelly-beans",
-  "a prize ox at a country fair weight-guessing contest (Galton's wisdom of crowds)":
-    "galton-ox-weight-guessing",
-  "a scatter of points forming a cartoon dinosaur (the Datasaurus)": "datasaurus",
-  "a whale surfacing beside the City of London skyline": "london-whale",
-  "the 1947 Harvard Mark II logbook page with the first computer bug, an actual moth, taped onto it":
-    "first-computer-bug-moth",
-  "the Ariane 5 rocket": "ariane-5-rocket",
-  "the Datasaurus dinosaur-shaped scatter plot": "datasaurus",
-  "the Ishango bone, an ancient notched tally bone": "ishango-bone",
-  "the Mars Climate Orbiter spacecraft approaching Mars": "mars-climate-orbiter",
-  "the Mauna Loa Observatory atmospheric monitoring station on a Hawaiian volcano summit":
-    "mauna-loa-observatory",
-  "the Monty Python foot, nodding to Python's name": "monty-python-foot",
-  "the three doors of the Monty Hall problem, one ajar with a goat behind it":
-    "monty-hall-doors",
-};
-
-/** Display name for a person subject: drops a trailing descriptor after a
- *  comma/colon (so "Fred Brooks, author of …" → "Fred Brooks") and a leading
- *  "the " (so "the Gang of Four: …" → "Gang of Four"). Shared by the file-slug
- *  logic and the gallery's reference-photo links. */
-function personDisplayName(subject: string): string {
-  return subject
-    .split(/[,:(]/)[0]
-    .trim()
-    .replace(/^the\s+/i, "");
+export function buildIllustrationPrompt(
+  spec: IllustrationSpec,
+  colors: BrandColors = BRAND_COLORS,
+): string {
+  const style = spec.style?.trim() || DEFAULT_STYLE;
+  const abstract = spec.noText ? " No text. Just an abstract art." : "";
+  return (
+    `A ${style} of ${spec.subject}.${abstract}\n\n` +
+    `Blue: ${colors.blue}\n` +
+    `Green: ${colors.green}\n` +
+    `Red: ${colors.red}\n` +
+    `Yellow: ${colors.yellow}`
+  );
 }
 
 /** Lowercase, strip diacritics, and hyphenate to a URL/file-safe slug. */
-function slugify(value: string): string {
+export function slugify(value: string): string {
   return value
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "")
@@ -87,32 +87,14 @@ function slugify(value: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-/**
- * Semantic file-name stem (no extension) for a subject, e.g.
- * "Leland Wilkinson" → "leland-wilkinson-portrait",
- * "a duck (the DuckDB mascot)…" → "duckdb-duck-mascot".
- *
- * People (`photo`) become "<name>-portrait", dropping any trailing descriptor
- * after a comma/colon (so "Fred Brooks, author of …" → "fred-brooks-portrait")
- * and a leading "the " (so "the Gang of Four: …" → "gang-of-four-portrait").
- * Objects use the curated map above, with a truncated slug as a fallback.
- */
-export function illustrationFileSlug(subject: string, photo: boolean): string {
-  if (!photo) {
-    const mapped = OBJECT_SLUGS[subject];
-    if (mapped) return mapped;
-    return slugify(subject).split("-").slice(0, 5).join("-");
-  }
-  return `${slugify(personDisplayName(subject))}-portrait`;
+/** Stable file stem (no extension) for a prompt id, e.g.
+ *  "python-basics-thumbnail". Ids are authored slug-like already; this just
+ *  normalises any stray casing/spacing. */
+export function illustrationFileSlug(id: string): string {
+  return slugify(id);
 }
 
-/** Full file name (with `.svg`) for a subject. */
-export function illustrationFileName(subject: string, photo: boolean): string {
-  return `${illustrationFileSlug(subject, photo)}.svg`;
-}
-
-/** Google Images search link for a person subject. */
-export function personImageSearchUrl(subject: string): string {
-  const query = encodeURIComponent(personDisplayName(subject));
-  return `https://www.google.com/search?q=${query}&tbm=isch`;
+/** Target asset file name. GPT Image 2 returns raster PNGs. */
+export function illustrationFileName(id: string): string {
+  return `${illustrationFileSlug(id)}.png`;
 }

--- a/lib/illustrationPromptsGallery.ts
+++ b/lib/illustrationPromptsGallery.ts
@@ -61,13 +61,15 @@ interface RawPrompt {
   title: string;
   style?: string;
   subject: string;
-  noText?: boolean;
+  /** Whether the illustration features the Dataslope marmot mascot. */
+  mascot?: boolean;
 }
 
 interface PromptsFile {
   meta: {
     model: string;
     defaultStyle: string;
+    mascot?: string;
     brandColors: BrandColors;
     sizes: Record<string, string>;
   };
@@ -85,8 +87,10 @@ export interface IllustrationPromptEntry {
   title: string;
   /** The subject phrase (what is drawn). */
   subject: string;
-  /** Illustration style, e.g. "risograph". */
+  /** Illustration style, e.g. "risograph" or "isometric illustration". */
   style: string;
+  /** Whether the illustration features the marmot mascot. */
+  mascot: boolean;
   /** Asset category. */
   category: Category;
   /** Human-readable category label. */
@@ -134,10 +138,11 @@ function buildEntry(p: RawPrompt): IllustrationPromptEntry {
     title: p.title,
     subject: p.subject,
     style: p.style ?? data.meta.defaultStyle,
+    mascot: p.mascot ?? false,
     category: p.category,
     categoryLabel: CATEGORY_LABEL[p.category] ?? p.category,
     prompt: buildIllustrationPrompt(
-      { subject: p.subject, style: p.style, noText: p.noText },
+      { subject: p.subject, style: p.style },
       data.meta.brandColors,
     ),
     size: data.meta.sizes[p.category] ?? "1024x1024",

--- a/lib/illustrationPromptsGallery.ts
+++ b/lib/illustrationPromptsGallery.ts
@@ -1,278 +1,185 @@
 /**
- * Build-time collector for the `/illustration-prompts` gallery.
+ * Data layer for the `/illustration-prompts` review gallery and the in-lesson
+ * `<IllustrationPrompt>` card.
  *
- * Walks every lesson under `content/courses/`, `content/fumadocs-dev/`, and
- * `content/interview/`, finds
- * each `<IllustrationPrompt …>` placeholder, and groups the placements by their
- * semantic file slug (see `lib/illustrationPrompt.ts`) so the gallery shows one
- * card per distinct illustration to be drawn, with its target file name, the
- * exact generation prompt, and deep links to every lesson that uses it.
+ * The prompt definitions live in `data/illustration-prompts.json` (the single
+ * source of truth, also consumed by scripts/generate-illustrations.mjs). This
+ * module turns each raw definition into a fully-built entry, the exact GPT
+ * Image 2 prompt via `buildIllustrationPrompt`, the target PNG file name, and a
+ * deep link to the lesson that embeds it, so the gallery, the card, and the
+ * generator all agree.
  *
- * Unlike the SVG gallery (a multi-hundred-kB payload that had to be offloaded to
- * a static JSON asset to stay off the ISR read meter), this data set is tiny,
- * ~80 short prompts, so the page renders it directly as a prerendered server
- * component (see `app/illustration-prompts/page.tsx`); no separate data file or
- * client fetch is needed.
- *
- * Deliberately free of any Fumadocs `source` dependency: lesson URLs come from
- * file paths and course/role titles from each folder's `meta.json`, the same
- * approach as `lib/svgGallery.ts`. That keeps the module trivially testable and
- * importable from a server component.
+ * Deliberately free of Node/DOM APIs (it just imports the JSON), so it can be
+ * imported from the server component that prerenders the gallery page AND from
+ * the client component that renders the in-lesson card.
  */
-import { readdirSync, readFileSync } from "node:fs";
-import path from "node:path";
+import promptsData from "@/data/illustration-prompts.json";
 import {
   buildIllustrationPrompt,
-  illustrationFileSlug,
-  personImageSearchUrl,
+  illustrationFileName,
+  type BrandColors,
 } from "./illustrationPrompt";
 
-const CONTENT_ROOT = path.join(process.cwd(), "content");
-
-/** Content collections: directory name under content/ → public URL base
- *  (mirrors the loader baseUrls in lib/source.ts). */
-type Collection = "courses" | "fumadocs-dev" | "interview";
+/** Content collections: which public URL base each maps to. */
+export type Collection = "courses" | "interview";
 const URL_BASE: Record<Collection, string> = {
   courses: "/courses",
-  "fumadocs-dev": "/fumadocs-dev",
   interview: "/interview-prep",
 };
 
-export interface PromptUsage {
-  /** Lesson URL (e.g. /courses/mastering-ggplot2/interesting-discussions). */
-  route: string;
-  /** Same URL anchored to this illustration's slug. */
-  href: string;
+/** Asset categories, in the order they are shown on the gallery page. */
+export type Category =
+  | "course-thumbnail"
+  | "course-illustration"
+  | "interview-thumbnail"
+  | "interview-illustration";
+
+const CATEGORY_LABEL: Record<Category, string> = {
+  "course-thumbnail": "Course thumbnails",
+  "course-illustration": "Course illustrations",
+  "interview-thumbnail": "Interview prep thumbnails",
+  "interview-illustration": "Interview prep illustrations",
+};
+
+const CATEGORY_ORDER: Category[] = [
+  "course-thumbnail",
+  "course-illustration",
+  "interview-thumbnail",
+  "interview-illustration",
+];
+
+/** One raw prompt definition, as authored in the JSON. */
+interface RawPrompt {
+  id: string;
+  collection: Collection;
+  course: string;
+  courseTitle: string;
+  /** Lesson slug the card is embedded in; "index" (or absent) collapses to the
+   *  course/role landing page. */
+  lesson?: string | null;
+  category: Category;
+  title: string;
+  style?: string;
+  subject: string;
+  noText?: boolean;
+}
+
+interface PromptsFile {
+  meta: {
+    model: string;
+    defaultStyle: string;
+    brandColors: BrandColors;
+    sizes: Record<string, string>;
+  };
+  prompts: RawPrompt[];
+}
+
+const data = promptsData as PromptsFile;
+
+export interface IllustrationPromptEntry {
+  /** Stable id, used as the file stem and the on-page anchor. */
+  id: string;
+  /** Target asset file name, e.g. "python-basics-thumbnail.png". */
+  file: string;
+  /** Short human-readable title for the card. */
+  title: string;
+  /** The subject phrase (what is drawn). */
+  subject: string;
+  /** Illustration style, e.g. "risograph". */
+  style: string;
+  /** Asset category. */
+  category: Category;
+  /** Human-readable category label. */
+  categoryLabel: string;
+  /** The exact GPT Image 2 generation prompt (brand colors included). */
+  prompt: string;
+  /** Recommended output size (from meta.sizes for the category). */
+  size: string;
   /** Course/role folder slug. */
-  courseSlug: string;
+  course: string;
   /** Human-readable course/role title. */
   courseTitle: string;
   /** Which collection the lesson lives in. */
   collection: Collection;
-}
-
-export interface IllustrationPromptEntry {
-  /** Semantic file stem, e.g. "leland-wilkinson-portrait". */
-  slug: string;
-  /** Target asset file name, e.g. "leland-wilkinson-portrait.svg". */
-  file: string;
-  /** Representative subject (the most descriptive phrasing seen). */
-  subject: string;
-  /** Whether a reference photo is attached (specific named real people). */
-  photo: boolean;
-  /** The exact image-generation prompt. */
-  prompt: string;
-  /** Google Images search link (people only). */
-  imageSearchUrl?: string;
-  /** Every lesson that embeds this illustration. */
-  usages: PromptUsage[];
+  /** Lesson URL the card is embedded in. */
+  route: string;
+  /** Same URL anchored to this illustration's id. */
+  href: string;
 }
 
 export interface IllustrationPromptsData {
   entries: IllustrationPromptEntry[];
   /** Number of distinct illustrations (= entries.length). */
   totalIllustrations: number;
-  /** Number of `<IllustrationPrompt>` placements across all lessons. */
-  totalPlacements: number;
-  /** Number of distinct lessons that contain at least one placement. */
-  totalLessons: number;
+  /** Number of distinct courses/roles the illustrations belong to. */
+  totalCourses: number;
+  /** The four brand colors named in every prompt. */
+  brandColors: BrandColors;
 }
 
-// `<IllustrationPrompt … />` (self-closing) with a subject attribute and an
-// optional bare `photo` flag, in any attribute order.
-const TAG_RE = /<IllustrationPrompt\b([^>]*?)\/>/gs;
-const SUBJECT_RE = /subject="([^"]*)"/;
-const PHOTO_RE = /(^|\s)photo(\s|=|\/|$)/;
-
-/** Recursively collect lesson files, as /-separated paths relative to `dir`. */
-function walkLessonFiles(dir: string, prefix = ""): string[] {
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  const out: string[] = [];
-  for (const entry of entries) {
-    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
-    if (entry.isDirectory()) {
-      out.push(...walkLessonFiles(path.join(dir, entry.name), rel));
-    } else if (/\.mdx?$/i.test(entry.name)) {
-      out.push(rel);
-    }
-  }
-  return out.sort();
+/** `courses` + `python-basics` + `hello-world` → `/courses/python-basics/hello-world`;
+ *  a missing/"index" lesson collapses to the course landing page. */
+function lessonRoute(p: RawPrompt): string {
+  const base = URL_BASE[p.collection];
+  const courseUrl = `${base}/${p.course}`;
+  if (!p.lesson || p.lesson === "index") return courseUrl;
+  return `${courseUrl}/${p.lesson}`;
 }
 
-/** `course/lesson.mdx` → `<urlBase>/course/lesson`; `index` collapses away. */
-function lessonUrl(collection: Collection, rel: string): string {
-  const base = URL_BASE[collection];
-  const stem = rel.replace(/\.mdx?$/i, "").replace(/(^|\/)index$/i, "");
-  return stem ? `${base}/${stem}` : base;
-}
-
-/** Pull `title:` out of a leading YAML frontmatter block, if present. */
-function frontmatterTitle(raw: string): string | undefined {
-  const block = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw);
-  if (!block) return undefined;
-  const line = /^title:[ \t]*(.+?)[ \t]*$/m.exec(block[1]);
-  if (!line) return undefined;
-  const title = line[1].replace(/^(["'])(.*)\1$/, "$2").trim();
-  return title || undefined;
-}
-
-/** Course/role title from `content/<base>/<slug>/meta.json`, if present. */
-function metaTitle(base: string, slug: string): string | undefined {
-  try {
-    const raw = readFileSync(
-      path.join(CONTENT_ROOT, base, slug, "meta.json"),
-      "utf8",
-    );
-    const meta = JSON.parse(raw) as { title?: unknown };
-    return typeof meta.title === "string" && meta.title ? meta.title : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function readCourseIndex(base: string, slug: string): string | undefined {
-  for (const name of ["index.mdx", "index.md"]) {
-    try {
-      return readFileSync(path.join(CONTENT_ROOT, base, slug, name), "utf8");
-    } catch {
-      // try the next candidate
-    }
-  }
-  return undefined;
-}
-
-interface RawPlacement {
-  subject: string;
-  photo: boolean;
-  slug: string;
-  route: string;
-  courseSlug: string;
-  courseTitle: string;
-  collection: Collection;
-}
-
-function collectPlacements(base: Collection): RawPlacement[] {
-  const dir = path.join(CONTENT_ROOT, base);
-  const titles = new Map<string, string>();
-  const out: RawPlacement[] = [];
-
-  for (const rel of walkLessonFiles(dir)) {
-    let raw: string;
-    try {
-      raw = readFileSync(path.join(dir, rel), "utf8");
-    } catch {
-      continue;
-    }
-    if (!raw.includes("<IllustrationPrompt")) continue;
-
-    // Nested lessons group under their course/role folder; loose pages directly
-    // under the collection group under their own file stem.
-    const nested = rel.includes("/");
-    const courseSlug = nested ? rel.split("/")[0] : rel.replace(/\.mdx?$/i, "");
-    if (!titles.has(courseSlug)) {
-      const title = nested
-        ? (metaTitle(base, courseSlug) ??
-          frontmatterTitle(readCourseIndex(base, courseSlug) ?? "") ??
-          courseSlug)
-        : (frontmatterTitle(raw) ?? courseSlug);
-      titles.set(courseSlug, title);
-    }
-
-    const route = lessonUrl(base, rel);
-    for (const m of raw.matchAll(TAG_RE)) {
-      const attrs = m[1];
-      const subjectMatch = SUBJECT_RE.exec(attrs);
-      if (!subjectMatch) continue;
-      const subject = subjectMatch[1];
-      const photo = PHOTO_RE.test(attrs);
-      out.push({
-        subject,
-        photo,
-        slug: illustrationFileSlug(subject, photo),
-        route,
-        courseSlug,
-        courseTitle: titles.get(courseSlug) ?? courseSlug,
-        collection: base,
-      });
-    }
-  }
-  return out;
+function buildEntry(p: RawPrompt): IllustrationPromptEntry {
+  const route = lessonRoute(p);
+  return {
+    id: p.id,
+    file: illustrationFileName(p.id),
+    title: p.title,
+    subject: p.subject,
+    style: p.style ?? data.meta.defaultStyle,
+    category: p.category,
+    categoryLabel: CATEGORY_LABEL[p.category] ?? p.category,
+    prompt: buildIllustrationPrompt(
+      { subject: p.subject, style: p.style, noText: p.noText },
+      data.meta.brandColors,
+    ),
+    size: data.meta.sizes[p.category] ?? "1024x1024",
+    course: p.course,
+    courseTitle: p.courseTitle,
+    collection: p.collection,
+    route,
+    href: `${route}#${p.id}`,
+  };
 }
 
 let cache: IllustrationPromptsData | null = null;
 
 /**
- * Collect every `<IllustrationPrompt>` placement across the courses,
- * fumadocs-dev, and interview
- * collections, deduplicated into one entry per distinct illustration (semantic
- * file slug). Memoised so the scan runs once per build.
+ * Every illustration prompt, built and sorted for the gallery: grouped by the
+ * fixed category order, then by course title, then by title. Memoised.
  */
 export function getIllustrationPrompts(): IllustrationPromptsData {
   if (cache) return cache;
 
-  const placements = [
-    ...collectPlacements("courses"),
-    ...collectPlacements("fumadocs-dev"),
-    ...collectPlacements("interview"),
-  ];
-
-  const bySlug = new Map<string, IllustrationPromptEntry>();
-  const routes = new Set<string>();
-
-  for (const p of placements) {
-    routes.add(p.route);
-    let entry = bySlug.get(p.slug);
-    if (!entry) {
-      entry = {
-        slug: p.slug,
-        file: `${p.slug}.svg`,
-        subject: p.subject,
-        photo: p.photo,
-        prompt: buildIllustrationPrompt(p.subject, p.photo),
-        imageSearchUrl: p.photo ? personImageSearchUrl(p.subject) : undefined,
-        usages: [],
-      };
-      bySlug.set(p.slug, entry);
-    } else if (p.subject.length > entry.subject.length) {
-      // Keep the most descriptive phrasing as the representative prompt when a
-      // slug is shared (e.g. two Datasaurus wordings → one drawing).
-      entry.subject = p.subject;
-      entry.prompt = buildIllustrationPrompt(p.subject, entry.photo);
-      if (entry.photo) {
-        entry.imageSearchUrl = personImageSearchUrl(p.subject);
-      }
+  const entries = data.prompts.map(buildEntry).sort((a, b) => {
+    const ca = CATEGORY_ORDER.indexOf(a.category);
+    const cb = CATEGORY_ORDER.indexOf(b.category);
+    if (ca !== cb) return ca - cb;
+    if (a.courseTitle !== b.courseTitle) {
+      return a.courseTitle.localeCompare(b.courseTitle);
     }
-    // Record the usage, deduping repeated placements on the same route.
-    if (!entry.usages.some((u) => u.route === p.route)) {
-      entry.usages.push({
-        route: p.route,
-        href: `${p.route}#${p.slug}`,
-        courseSlug: p.courseSlug,
-        courseTitle: p.courseTitle,
-        collection: p.collection,
-      });
-    }
-  }
-
-  const entries = [...bySlug.values()].sort((a, b) => {
-    // People (portraits) first, then objects; alphabetical within each group.
-    if (a.photo !== b.photo) return a.photo ? -1 : 1;
-    return a.subject.localeCompare(b.subject);
+    return a.title.localeCompare(b.title);
   });
-  for (const e of entries) {
-    e.usages.sort((a, b) => a.route.localeCompare(b.route));
-  }
 
   cache = {
     entries,
     totalIllustrations: entries.length,
-    totalPlacements: placements.length,
-    totalLessons: routes.size,
+    totalCourses: new Set(entries.map((e) => `${e.collection}/${e.course}`)).size,
+    brandColors: data.meta.brandColors,
   };
   return cache;
+}
+
+/** Look up a single built entry by id (used by the in-lesson card). */
+export function getIllustrationPromptById(
+  id: string,
+): IllustrationPromptEntry | undefined {
+  return getIllustrationPrompts().entries.find((e) => e.id === id);
 }

--- a/scripts/generate-illustrations.mjs
+++ b/scripts/generate-illustrations.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * Batch-generate the Dataslope course/interview illustrations with OpenAI's
+ * GPT Image 2 API (https://developers.openai.com/api/docs/models/gpt-image-2).
+ *
+ * Reads the prompt definitions from `data/illustration-prompts.json` (the same
+ * source of truth the `/illustration-prompts` gallery and the in-lesson
+ * `<IllustrationPrompt>` cards render), builds each generation prompt in the
+ * Dataslope house style (a risograph of the subject, in the four brand colors),
+ * calls the Images API, and writes one PNG per prompt named `<id>.png`.
+ *
+ * Usage:
+ *   OPENAI_API_KEY=sk-... node scripts/generate-illustrations.mjs [options]
+ *
+ * Options:
+ *   --out <dir>          Output directory (default: ./generated-illustrations)
+ *   --only <id[,id...]>  Generate only these prompt ids
+ *   --category <cat>     Generate only this category
+ *                        (course-thumbnail | course-illustration | ...)
+ *   --size <WxH|auto>    Override the per-category size for every prompt
+ *   --background <mode>  auto | transparent | opaque (default: auto)
+ *   --quality <q>        auto | low | medium | high (default: auto)
+ *   --model <name>       Override the model (default: from JSON meta.model)
+ *   --concurrency <n>    Parallel requests (default: 3)
+ *   --force              Overwrite existing PNGs (default: skip ones present)
+ *   --dry-run            Print the prompts and targets; make no API calls
+ *   -h, --help           Show this help
+ *
+ * Notes:
+ *   - GPT Image 2 returns base64 PNG data (no URL), decoded and written here.
+ *   - `--background transparent` asks the model for an alpha channel, handy for
+ *     content-decoration art that overlays the light/dark lesson backgrounds.
+ *   - The prompt text is built the same way as lib/illustrationPrompt.ts
+ *     (buildIllustrationPrompt); keep the two in sync if the house style
+ *     changes.
+ */
+import { readFileSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const DATA_FILE = join(ROOT, "data", "illustration-prompts.json");
+const API_URL = "https://api.openai.com/v1/images/generations";
+
+// ── CLI parsing ────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const opts = {
+    out: join(process.cwd(), "generated-illustrations"),
+    only: null,
+    category: null,
+    size: null,
+    background: "auto",
+    quality: "auto",
+    model: null,
+    concurrency: 3,
+    force: false,
+    dryRun: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case "--out": opts.out = next(); break;
+      case "--only": opts.only = next().split(",").map((s) => s.trim()).filter(Boolean); break;
+      case "--category": opts.category = next(); break;
+      case "--size": opts.size = next(); break;
+      case "--background": opts.background = next(); break;
+      case "--quality": opts.quality = next(); break;
+      case "--model": opts.model = next(); break;
+      case "--concurrency": opts.concurrency = Math.max(1, Number(next()) || 1); break;
+      case "--force": opts.force = true; break;
+      case "--dry-run": opts.dryRun = true; break;
+      case "-h":
+      case "--help": opts.help = true; break;
+      default:
+        console.error(`Unknown option: ${a}`);
+        process.exit(1);
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  // The banner at the top of this file is the canonical help text.
+  const src = readFileSync(fileURLToPath(import.meta.url), "utf8");
+  const banner = src.slice(src.indexOf("/**"), src.indexOf("*/") + 2);
+  console.log(banner.replace(/^\/\*\*?|\*\/$|^ \* ?/gm, "").trim());
+}
+
+// ── Prompt building (mirror of lib/illustrationPrompt.ts) ────────────────────
+function buildPrompt(spec, colors) {
+  const style = (spec.style && spec.style.trim()) || "risograph";
+  const abstract = spec.noText ? " No text. Just an abstract art." : "";
+  return (
+    `A ${style} of ${spec.subject}.${abstract}\n\n` +
+    `Blue: ${colors.blue}\n` +
+    `Green: ${colors.green}\n` +
+    `Red: ${colors.red}\n` +
+    `Yellow: ${colors.yellow}`
+  );
+}
+
+// ── One request ──────────────────────────────────────────────────────────────
+async function generateOne(entry, opts, apiKey) {
+  const body = {
+    model: opts.model,
+    prompt: entry.prompt,
+    size: opts.size || entry.size,
+    n: 1,
+  };
+  if (opts.background && opts.background !== "auto") body.background = opts.background;
+  if (opts.quality && opts.quality !== "auto") body.quality = opts.quality;
+
+  const res = await fetch(API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`HTTP ${res.status} ${res.statusText}${detail ? ` - ${detail}` : ""}`);
+  }
+
+  const json = await res.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) throw new Error("Response contained no image data (b64_json).");
+  writeFileSync(entry.outPath, Buffer.from(b64, "base64"));
+}
+
+// ── Simple bounded-concurrency runner ────────────────────────────────────────
+async function runPool(items, limit, worker) {
+  let i = 0;
+  let ok = 0;
+  let failed = 0;
+  async function next() {
+    while (i < items.length) {
+      const idx = i++;
+      try {
+        await worker(items[idx]);
+        ok++;
+      } catch (err) {
+        failed++;
+        console.error(`  ✗ ${items[idx].id}: ${err.message}`);
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, next));
+  return { ok, failed };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) return printHelp();
+
+  const data = JSON.parse(readFileSync(DATA_FILE, "utf8"));
+  const { meta } = data;
+  const model = opts.model || meta.model;
+  opts.model = model;
+
+  let prompts = data.prompts;
+  if (opts.only) prompts = prompts.filter((p) => opts.only.includes(p.id));
+  if (opts.category) prompts = prompts.filter((p) => p.category === opts.category);
+
+  if (prompts.length === 0) {
+    console.error("No prompts matched the given filters.");
+    process.exit(1);
+  }
+
+  mkdirSync(opts.out, { recursive: true });
+
+  const entries = prompts.map((p) => ({
+    id: p.id,
+    category: p.category,
+    size: (meta.sizes && meta.sizes[p.category]) || "1024x1024",
+    prompt: buildPrompt(p, meta.brandColors),
+    outPath: join(opts.out, `${p.id}.png`),
+  }));
+
+  console.log(
+    `${opts.dryRun ? "[dry-run] " : ""}${entries.length} prompt(s) · model ${model} · ` +
+      `background ${opts.background} · quality ${opts.quality} · out ${opts.out}\n`,
+  );
+
+  if (opts.dryRun) {
+    for (const e of entries) {
+      console.log(`── ${e.id}.png  (${opts.size || e.size})`);
+      console.log(e.prompt.replace(/^/gm, "   "));
+      console.log();
+    }
+    return;
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.error("OPENAI_API_KEY is not set. Export it and re-run.");
+    process.exit(1);
+  }
+
+  const todo = [];
+  for (const e of entries) {
+    if (!opts.force && existsSync(e.outPath)) {
+      console.log(`  • skip ${e.id} (exists; use --force to overwrite)`);
+      continue;
+    }
+    todo.push(e);
+  }
+  if (todo.length === 0) {
+    console.log("\nNothing to generate.");
+    return;
+  }
+
+  const { ok, failed } = await runPool(todo, opts.concurrency, async (e) => {
+    await generateOne(e, opts, apiKey);
+    console.log(`  ✓ ${e.id}.png`);
+  });
+
+  console.log(`\nDone: ${ok} generated, ${failed} failed.`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/generate-illustrations.mjs
+++ b/scripts/generate-illustrations.mjs
@@ -1,60 +1,92 @@
 #!/usr/bin/env node
 /**
  * Batch-generate the Dataslope course/interview illustrations with OpenAI's
- * GPT Image 2 API (https://developers.openai.com/api/docs/models/gpt-image-2).
+ * GPT Image 2 (https://developers.openai.com/api/docs/models/gpt-image-2).
  *
  * Reads the prompt definitions from `data/illustration-prompts.json` (the same
  * source of truth the `/illustration-prompts` gallery and the in-lesson
  * `<IllustrationPrompt>` cards render), builds each generation prompt in the
  * Dataslope house style (a risograph of the subject, in the four brand colors),
- * calls the Images API, and writes one PNG per prompt named `<id>.png`.
+ * and writes one PNG per prompt named `<id>.png`.
+ *
+ * By default it uses the OpenAI **Batch API** (~50% cheaper, async, up to a 24h
+ * completion window): it packs every prompt into one JSONL job against the
+ * `/v1/images/generations` endpoint, uploads it, and creates a single batch.
+ * A `sync` mode is available for quick one-off runs.
  *
  * Usage:
- *   OPENAI_API_KEY=sk-... node scripts/generate-illustrations.mjs [options]
+ *   OPENAI_API_KEY=sk-... node scripts/generate-illustrations.mjs <command> [options]
+ *
+ * Commands:
+ *   run        submit a batch, poll until it finishes, then download the PNGs
+ *   submit     build + upload the JSONL batch and create it; prints the batch id
+ *   status     show a batch's status (--batch <id>, or the last one submitted)
+ *   download   download a completed batch's images into --out
+ *   sync       generate immediately, one request per prompt (bounded concurrency)
+ *   dry-run    print the prompts and targets; make no API calls
  *
  * Options:
  *   --out <dir>          Output directory (default: ./generated-illustrations)
- *   --only <id[,id...]>  Generate only these prompt ids
- *   --category <cat>     Generate only this category
- *                        (course-thumbnail | course-illustration | ...)
+ *   --only <id[,id...]>  Only these prompt ids
+ *   --category <cat>     Only this category (course-thumbnail | course-illustration | ...)
  *   --size <WxH|auto>    Override the per-category size for every prompt
- *   --background <mode>  auto | transparent | opaque (default: auto)
  *   --quality <q>        auto | low | medium | high (default: auto)
- *   --model <name>       Override the model (default: from JSON meta.model)
- *   --concurrency <n>    Parallel requests (default: 3)
- *   --force              Overwrite existing PNGs (default: skip ones present)
- *   --dry-run            Print the prompts and targets; make no API calls
+ *   --background <mode>  auto | opaque (default: auto)
+ *                        gpt-image-2 has no transparent background; for cut-outs
+ *                        post-process with a background-removal service.
+ *   --model <name>       Override the model (default: JSON meta.model)
+ *   --completion-window  Batch window: 24h (default)
+ *   --batch <id>         Target batch id for `status` / `download`
+ *   --poll-interval <s>  `run` poll seconds (default: 30)
+ *   --concurrency <n>    `sync` parallel requests (default: 3)
+ *   --force              Overwrite existing PNGs (default: skip present)
  *   -h, --help           Show this help
  *
  * Notes:
- *   - GPT Image 2 returns base64 PNG data (no URL), decoded and written here.
- *   - `--background transparent` asks the model for an alpha channel, handy for
- *     content-decoration art that overlays the light/dark lesson backgrounds.
+ *   - GPT Image 2 returns base64 PNG data (no URL); it is decoded and written.
  *   - The prompt text is built the same way as lib/illustrationPrompt.ts
- *     (buildIllustrationPrompt); keep the two in sync if the house style
- *     changes.
+ *     (buildIllustrationPrompt); keep the two in sync if the house style changes.
  */
-import { readFileSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const DATA_FILE = join(ROOT, "data", "illustration-prompts.json");
-const API_URL = "https://api.openai.com/v1/images/generations";
+const API_BASE = "https://api.openai.com/v1";
+const IMAGES_ENDPOINT = "/v1/images/generations";
 
 // ── CLI parsing ────────────────────────────────────────────────────────────
+const COMMANDS = new Set([
+  "run",
+  "submit",
+  "status",
+  "download",
+  "sync",
+  "dry-run",
+]);
+
 function parseArgs(argv) {
   const opts = {
+    command: null,
     out: join(process.cwd(), "generated-illustrations"),
     only: null,
     category: null,
     size: null,
-    background: "auto",
     quality: "auto",
+    background: "auto",
     model: null,
+    completionWindow: "24h",
+    batch: null,
+    pollInterval: 30,
     concurrency: 3,
     force: false,
-    dryRun: false,
+    help: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -64,24 +96,29 @@ function parseArgs(argv) {
       case "--only": opts.only = next().split(",").map((s) => s.trim()).filter(Boolean); break;
       case "--category": opts.category = next(); break;
       case "--size": opts.size = next(); break;
-      case "--background": opts.background = next(); break;
       case "--quality": opts.quality = next(); break;
+      case "--background": opts.background = next(); break;
       case "--model": opts.model = next(); break;
+      case "--completion-window": opts.completionWindow = next(); break;
+      case "--batch": opts.batch = next(); break;
+      case "--poll-interval": opts.pollInterval = Math.max(5, Number(next()) || 30); break;
       case "--concurrency": opts.concurrency = Math.max(1, Number(next()) || 1); break;
       case "--force": opts.force = true; break;
-      case "--dry-run": opts.dryRun = true; break;
       case "-h":
       case "--help": opts.help = true; break;
       default:
-        console.error(`Unknown option: ${a}`);
-        process.exit(1);
+        if (!a.startsWith("-") && opts.command === null && COMMANDS.has(a)) {
+          opts.command = a;
+        } else {
+          console.error(`Unknown argument: ${a}`);
+          process.exit(1);
+        }
     }
   }
   return opts;
 }
 
 function printHelp() {
-  // The banner at the top of this file is the canonical help text.
   const src = readFileSync(fileURLToPath(import.meta.url), "utf8");
   const banner = src.slice(src.indexOf("/**"), src.indexOf("*/") + 2);
   console.log(banner.replace(/^\/\*\*?|\*\/$|^ \* ?/gm, "").trim());
@@ -100,127 +137,305 @@ function buildPrompt(spec, colors) {
   );
 }
 
-// ── One request ──────────────────────────────────────────────────────────────
-async function generateOne(entry, opts, apiKey) {
+/** The request body sent to /v1/images/generations for one prompt. */
+function requestBody(entry, opts, model) {
   const body = {
-    model: opts.model,
+    model,
     prompt: entry.prompt,
     size: opts.size || entry.size,
     n: 1,
   };
-  if (opts.background && opts.background !== "auto") body.background = opts.background;
   if (opts.quality && opts.quality !== "auto") body.quality = opts.quality;
+  if (opts.background && opts.background !== "auto") body.background = opts.background;
+  return body;
+}
 
-  const res = await fetch(API_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify(body),
-  });
+// ── OpenAI helpers ───────────────────────────────────────────────────────────
+function requireKey() {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error("OPENAI_API_KEY is not set. Export it and re-run.");
+    process.exit(1);
+  }
+  return key;
+}
 
+async function api(path, { method = "GET", key, json, form } = {}) {
+  const headers = { Authorization: `Bearer ${key}` };
+  let body;
+  if (json !== undefined) {
+    headers["Content-Type"] = "application/json";
+    body = JSON.stringify(json);
+  } else if (form !== undefined) {
+    body = form; // fetch sets the multipart boundary itself
+  }
+  const res = await fetch(`${API_BASE}${path}`, { method, headers, body });
   if (!res.ok) {
     const detail = await res.text().catch(() => "");
     throw new Error(`HTTP ${res.status} ${res.statusText}${detail ? ` - ${detail}` : ""}`);
   }
-
-  const json = await res.json();
-  const b64 = json?.data?.[0]?.b64_json;
-  if (!b64) throw new Error("Response contained no image data (b64_json).");
-  writeFileSync(entry.outPath, Buffer.from(b64, "base64"));
+  return res;
 }
 
-// ── Simple bounded-concurrency runner ────────────────────────────────────────
-async function runPool(items, limit, worker) {
-  let i = 0;
-  let ok = 0;
-  let failed = 0;
-  async function next() {
-    while (i < items.length) {
-      const idx = i++;
-      try {
-        await worker(items[idx]);
-        ok++;
-      } catch (err) {
-        failed++;
-        console.error(`  ✗ ${items[idx].id}: ${err.message}`);
-      }
-    }
-  }
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, next));
-  return { ok, failed };
-}
+const BATCH_STATE_FILE = (out) => join(out, "last-batch.json");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// ── Main ─────────────────────────────────────────────────────────────────────
-async function main() {
-  const opts = parseArgs(process.argv.slice(2));
-  if (opts.help) return printHelp();
-
-  const data = JSON.parse(readFileSync(DATA_FILE, "utf8"));
+// ── Entry selection ──────────────────────────────────────────────────────────
+function selectEntries(data, opts) {
   const { meta } = data;
-  const model = opts.model || meta.model;
-  opts.model = model;
-
   let prompts = data.prompts;
   if (opts.only) prompts = prompts.filter((p) => opts.only.includes(p.id));
   if (opts.category) prompts = prompts.filter((p) => p.category === opts.category);
-
   if (prompts.length === 0) {
     console.error("No prompts matched the given filters.");
     process.exit(1);
   }
-
-  mkdirSync(opts.out, { recursive: true });
-
-  const entries = prompts.map((p) => ({
+  return prompts.map((p) => ({
     id: p.id,
     category: p.category,
     size: (meta.sizes && meta.sizes[p.category]) || "1024x1024",
     prompt: buildPrompt(p, meta.brandColors),
     outPath: join(opts.out, `${p.id}.png`),
   }));
+}
 
-  console.log(
-    `${opts.dryRun ? "[dry-run] " : ""}${entries.length} prompt(s) · model ${model} · ` +
-      `background ${opts.background} · quality ${opts.quality} · out ${opts.out}\n`,
-  );
+/** Decode a base64 image payload from an images response body and write it. */
+function writeImage(outPath, respBody) {
+  const b64 = respBody?.data?.[0]?.b64_json;
+  if (!b64) throw new Error("response contained no image data (b64_json)");
+  writeFileSync(outPath, Buffer.from(b64, "base64"));
+}
 
-  if (opts.dryRun) {
-    for (const e of entries) {
-      console.log(`── ${e.id}.png  (${opts.size || e.size})`);
-      console.log(e.prompt.replace(/^/gm, "   "));
-      console.log();
-    }
-    return;
+// ── Commands ─────────────────────────────────────────────────────────────────
+async function cmdDryRun(entries, opts) {
+  console.log(`[dry-run] ${entries.length} prompt(s) · background ${opts.background} · quality ${opts.quality}\n`);
+  for (const e of entries) {
+    console.log(`── ${e.id}.png  (${opts.size || e.size})`);
+    console.log(e.prompt.replace(/^/gm, "   "));
+    console.log();
   }
+}
 
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    console.error("OPENAI_API_KEY is not set. Export it and re-run.");
+async function cmdSubmit(entries, opts, model, key) {
+  const jsonl = entries
+    .map((e) =>
+      JSON.stringify({
+        custom_id: e.id,
+        method: "POST",
+        url: IMAGES_ENDPOINT,
+        body: requestBody(e, opts, model),
+      }),
+    )
+    .join("\n");
+
+  // 1. Upload the JSONL as a batch input file.
+  const form = new FormData();
+  form.append("purpose", "batch");
+  form.append(
+    "file",
+    new Blob([jsonl], { type: "application/jsonl" }),
+    "illustration-batch.jsonl",
+  );
+  const fileRes = await api("/files", { method: "POST", key, form });
+  const file = await fileRes.json();
+  console.log(`Uploaded ${entries.length}-request input file ${file.id}`);
+
+  // 2. Create the batch.
+  const batchRes = await api("/batches", {
+    method: "POST",
+    key,
+    json: {
+      input_file_id: file.id,
+      endpoint: IMAGES_ENDPOINT,
+      completion_window: opts.completionWindow,
+    },
+  });
+  const batch = await batchRes.json();
+
+  mkdirSync(opts.out, { recursive: true });
+  writeFileSync(
+    BATCH_STATE_FILE(opts.out),
+    JSON.stringify({ batchId: batch.id, model, count: entries.length }, null, 2),
+  );
+  console.log(`Created batch ${batch.id} (status: ${batch.status}).`);
+  console.log(`Track it with:  node scripts/generate-illustrations.mjs status --out ${opts.out}`);
+  return batch;
+}
+
+function resolveBatchId(opts) {
+  if (opts.batch) return opts.batch;
+  const stateFile = BATCH_STATE_FILE(opts.out);
+  if (existsSync(stateFile)) {
+    return JSON.parse(readFileSync(stateFile, "utf8")).batchId;
+  }
+  console.error("No --batch id given and no last-batch.json in --out.");
+  process.exit(1);
+}
+
+async function retrieveBatch(id, key) {
+  const res = await api(`/batches/${id}`, { key });
+  return res.json();
+}
+
+async function cmdStatus(opts, key) {
+  const id = resolveBatchId(opts);
+  const batch = await retrieveBatch(id, key);
+  const c = batch.request_counts || {};
+  console.log(
+    `Batch ${batch.id}: ${batch.status} · ${c.completed ?? 0}/${c.total ?? "?"} done, ${c.failed ?? 0} failed`,
+  );
+  return batch;
+}
+
+async function downloadFileText(fileId, key) {
+  const res = await api(`/files/${fileId}/content`, { key });
+  return res.text();
+}
+
+/** Parse a batch output JSONL and write every successful image. */
+function writeBatchOutputs(text, opts) {
+  let ok = 0;
+  let failed = 0;
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    const row = JSON.parse(line);
+    const outPath = join(opts.out, `${row.custom_id}.png`);
+    if (row.error || row.response?.status_code !== 200) {
+      failed++;
+      const msg = row.error?.message || row.response?.body?.error?.message || "unknown error";
+      console.error(`  ✗ ${row.custom_id}: ${msg}`);
+      continue;
+    }
+    if (!opts.force && existsSync(outPath)) {
+      console.log(`  • skip ${row.custom_id} (exists; use --force)`);
+      continue;
+    }
+    try {
+      writeImage(outPath, row.response.body);
+      ok++;
+      console.log(`  ✓ ${row.custom_id}.png`);
+    } catch (err) {
+      failed++;
+      console.error(`  ✗ ${row.custom_id}: ${err.message}`);
+    }
+  }
+  return { ok, failed };
+}
+
+async function cmdDownload(opts, key, batch) {
+  const b = batch || (await retrieveBatch(resolveBatchId(opts), key));
+  if (b.status !== "completed") {
+    console.error(`Batch ${b.id} is ${b.status}, not completed. Try again later.`);
+    process.exit(1);
+  }
+  mkdirSync(opts.out, { recursive: true });
+  if (b.error_file_id) {
+    const errText = await downloadFileText(b.error_file_id, key);
+    for (const line of errText.split("\n")) {
+      if (!line.trim()) continue;
+      const row = JSON.parse(line);
+      console.error(`  ! ${row.custom_id}: ${row.response?.body?.error?.message || "request errored"}`);
+    }
+  }
+  if (!b.output_file_id) {
+    console.error("Batch completed but has no output file.");
+    process.exit(1);
+  }
+  const text = await downloadFileText(b.output_file_id, key);
+  const { ok, failed } = writeBatchOutputs(text, opts);
+  console.log(`\nDone: ${ok} written, ${failed} failed. Output in ${opts.out}`);
+  if (failed > 0) process.exitCode = 1;
+}
+
+const TERMINAL = new Set(["completed", "failed", "expired", "cancelled"]);
+
+async function cmdRun(entries, opts, model, key) {
+  const submitted = await cmdSubmit(entries, opts, model, key);
+  let batch = submitted;
+  while (!TERMINAL.has(batch.status)) {
+    await sleep(opts.pollInterval * 1000);
+    batch = await retrieveBatch(batch.id, key);
+    const c = batch.request_counts || {};
+    console.log(`  … ${batch.status} (${c.completed ?? 0}/${c.total ?? "?"})`);
+  }
+  if (batch.status !== "completed") {
+    console.error(`Batch ended as ${batch.status}.`);
+    process.exit(1);
+  }
+  await cmdDownload(opts, key, batch);
+}
+
+async function cmdSync(entries, opts, model, key) {
+  mkdirSync(opts.out, { recursive: true });
+  const todo = entries.filter((e) => {
+    if (!opts.force && existsSync(e.outPath)) {
+      console.log(`  • skip ${e.id} (exists; use --force)`);
+      return false;
+    }
+    return true;
+  });
+  if (todo.length === 0) return console.log("Nothing to generate.");
+
+  let i = 0;
+  let ok = 0;
+  let failed = 0;
+  async function worker() {
+    while (i < todo.length) {
+      const e = todo[i++];
+      try {
+        const res = await api(IMAGES_ENDPOINT, {
+          method: "POST",
+          key,
+          json: requestBody(e, opts, model),
+        });
+        writeImage(e.outPath, await res.json());
+        ok++;
+        console.log(`  ✓ ${e.id}.png`);
+      } catch (err) {
+        failed++;
+        console.error(`  ✗ ${e.id}: ${err.message}`);
+      }
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(opts.concurrency, todo.length) }, worker),
+  );
+  console.log(`\nDone: ${ok} generated, ${failed} failed. Output in ${opts.out}`);
+  if (failed > 0) process.exitCode = 1;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help || !opts.command) return printHelp();
+
+  if (opts.background === "transparent") {
+    console.error(
+      "gpt-image-2 does not support transparent backgrounds. Generate opaque\n" +
+        "art and remove the background afterwards with a background-removal service.",
+    );
     process.exit(1);
   }
 
-  const todo = [];
-  for (const e of entries) {
-    if (!opts.force && existsSync(e.outPath)) {
-      console.log(`  • skip ${e.id} (exists; use --force to overwrite)`);
-      continue;
-    }
-    todo.push(e);
-  }
-  if (todo.length === 0) {
-    console.log("\nNothing to generate.");
-    return;
-  }
+  const data = JSON.parse(readFileSync(DATA_FILE, "utf8"));
+  const model = opts.model || data.meta.model;
 
-  const { ok, failed } = await runPool(todo, opts.concurrency, async (e) => {
-    await generateOne(e, opts, apiKey);
-    console.log(`  ✓ ${e.id}.png`);
-  });
+  // Commands that operate on an existing batch don't need the prompt set.
+  if (opts.command === "status") return cmdStatus(opts, requireKey());
+  if (opts.command === "download") return cmdDownload(opts, requireKey());
 
-  console.log(`\nDone: ${ok} generated, ${failed} failed.`);
-  if (failed > 0) process.exit(1);
+  const entries = selectEntries(data, opts);
+
+  if (opts.command === "dry-run") return cmdDryRun(entries, opts);
+
+  console.log(
+    `${entries.length} prompt(s) · model ${model} · background ${opts.background} · ` +
+      `quality ${opts.quality} · out ${opts.out}\n`,
+  );
+  const key = requireKey();
+  if (opts.command === "sync") return cmdSync(entries, opts, model, key);
+  if (opts.command === "submit") { await cmdSubmit(entries, opts, model, key); return; }
+  if (opts.command === "run") return cmdRun(entries, opts, model, key);
 }
 
 main().catch((err) => {

--- a/scripts/generate-illustrations.mjs
+++ b/scripts/generate-illustrations.mjs
@@ -127,9 +127,9 @@ function printHelp() {
 // ── Prompt building (mirror of lib/illustrationPrompt.ts) ────────────────────
 function buildPrompt(spec, colors) {
   const style = (spec.style && spec.style.trim()) || "risograph";
-  const abstract = spec.noText ? " No text. Just an abstract art." : "";
+  const article = /^[aeiou]/i.test(style) ? "An" : "A";
   return (
-    `A ${style} of ${spec.subject}.${abstract}\n\n` +
+    `${article} ${style} of ${spec.subject}. No text.\n\n` +
     `Blue: ${colors.blue}\n` +
     `Green: ${colors.green}\n` +
     `Red: ${colors.red}\n` +


### PR DESCRIPTION
## What & why

Pilots a new illustration-prompt workflow for the courses/interview art, built around **OpenAI GPT Image 2** and the four Dataslope brand colors. As requested, this clears out the old prompt set and seeds a **20-prompt Python Basics pilot** — a mix of illustration styles and a recurring **marmot mascot** — shown in both the course and the `/illustration-prompts` page, with a **Batch API** script to generate the images.

## Key change: one JSON source of truth

`data/illustration-prompts.json` now drives everything, so the in-lesson card, the review gallery, and the generator can never drift:

- **`<IllustrationPrompt id="…" />`** (in-lesson card) looks the prompt up by id.
- **`/illustration-prompts`** builds its gallery from the JSON (no more MDX scanning), grouped by category, with **style + mascot badges** per card.
- **`scripts/generate-illustrations.mjs`** reads the same JSON to call the Images API.

Each prompt renders as, e.g.:

```
An isometric illustration of the Dataslope marmot mascot happily riding a small cart around a looping roller-coaster track… No text.

Blue: #148cff
Green: #20c621
Red: #ff4f59
Yellow: #ffdd6c
```

## The pilot (20 prompts)

- **1 course thumbnail + 19 lesson illustrations**, one per Python Basics lesson.
- **Mixed styles:** risograph ×5, flat geometric vector ×5, isometric ×3, line art ×3, blueprint schematic ×3, cut-paper collage ×1.
- **Marmot mascot** in 7, **no-mascot** in 13 (a deliberate mix).
- **No text in any illustration** — the builder always appends `No text.` and every subject avoids readable labels.

## Changes

- **`data/illustration-prompts.json`** — source of truth: meta (model, brand colors, per-category sizes, shared marmot descriptor) + the 20 prompts, each with `style` and `mascot`.
- **`lib/illustrationPrompt.ts`** — `buildIllustrationPrompt` emits `A/An {style} of {subject}. No text.` + the brand colors; stable `<id>.png` file names.
- **`lib/illustrationPromptsGallery.ts`** — builds gallery data from the JSON; carries `style`/`mascot`; client- & server-safe.
- **`app/_components/mdx/IllustrationPrompt.tsx`** — card takes an `id`.
- **`app/illustration-prompts/*`** — regrouped by category; style + mascot badges; copy generalised across styles.
- **Content** — removed all **105** old subject-based placements across the courses; added the **20** id-based Python Basics placements.
- **`scripts/generate-illustrations.mjs`** — **Batch API** generator (`run` / `submit` / `status` / `download`, ~50% cheaper, one JSONL job against `/v1/images/generations`), plus a `sync` fallback and `dry-run`.
- **Tests** — cover the builder (No text., a/an), slugs, and the gallery.

## How to generate

```bash
OPENAI_API_KEY=sk-… node scripts/generate-illustrations.mjs run        # batch: submit → poll → download
node scripts/generate-illustrations.mjs dry-run                        # preview every prompt
node scripts/generate-illustrations.mjs sync --only python-basics-thumbnail
```

Output PNGs land in `./generated-illustrations/` (gitignored).

## Notes

- **Aspect ratios** live per category in the JSON (`meta.sizes`): thumbnails `1536×1024` (3:2), decorations `1024×1024` (1:1).
- **GPT Image 2 has no transparent background** (opaque/auto only) — for cut-outs, post-process with a background-removal service.

## Validation

- `vitest run` — **961 passed** (8 in the rewritten illustration suite)
- `tsc --noEmit` — clean
- `eslint` on all touched files — clean
- `fumadocs-mdx` recompiles all content cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)