### PR TITLE
Rename CF_ACCOUNT_ID secret to CLOUDFLARE_ACCOUNT_ID

### DIFF
--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -54,7 +54,7 @@ name: R2 incremental-cache cleanup
 # manually with dry_run=true to preview deletions.
 #
 # Required repository secrets (Settings → Secrets and variables → Actions):
-#   CF_ACCOUNT_ID         Cloudflare account ID (the R2 S3 endpoint host)
+#   CLOUDFLARE_ACCOUNT_ID Cloudflare account ID (the R2 S3 endpoint host)
 #   R2_ACCESS_KEY_ID      R2 API token access key id (Object Read & Write)
 #   R2_SECRET_ACCESS_KEY  R2 API token secret access key
 
@@ -124,13 +124,26 @@ jobs:
       # retry loop (see delete_folder) even has to intervene.
       AWS_RETRY_MODE: standard
       AWS_MAX_ATTEMPTS: "10"
-      ENDPOINT: https://${{ secrets.CF_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
     steps:
       - name: Prune stale build folders
         shell: bash
         run: |
           set -euo pipefail
           aws() { command aws --endpoint-url "$ENDPOINT" "$@"; }
+
+          # 0) An unset CLOUDFLARE_ACCOUNT_ID collapses ENDPOINT to
+          #    "https://.r2.cloudflarestorage.com": every aws call then fails,
+          #    and the `|| true` on the listing in step 3 turns that into an
+          #    empty folder list, i.e. a green run that silently stopped pruning
+          #    and lets the bucket grow unbounded. Fail loudly instead. (Worth
+          #    guarding because this secret was named CF_ACCOUNT_ID until
+          #    Cloudflare deprecated the CF_* prefix, so an older repo may still
+          #    hold it under the old name.)
+          if [[ "$ENDPOINT" == "https://.r2.cloudflarestorage.com" ]]; then
+            echo "::error::Repository secret CLOUDFLARE_ACCOUNT_ID is not set (it was previously named CF_ACCOUNT_ID). Aborting without deleting."
+            exit 1
+          fi
 
           # Delete a folder, tolerating R2's intermittent 500 InternalError on
           # DeleteObject. `aws s3 rm --recursive` re-lists the folder on every

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ It needs three repository secrets (Settings → Secrets and variables → Action
 
 | Secret | Value |
 | --- | --- |
-| `CF_ACCOUNT_ID` | Cloudflare account ID (the R2 S3 endpoint host) |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID (the R2 S3 endpoint host) |
 | `R2_ACCESS_KEY_ID` | R2 API token access key ID |
 | `R2_SECRET_ACCESS_KEY` | R2 API token secret access key |
 


### PR DESCRIPTION
## Action required before merging

**Rename the repository secret** (Settings → Secrets and variables → Actions): `CF_ACCOUNT_ID` → `CLOUDFLARE_ACCOUNT_ID`. GitHub has no rename, so add a new secret with the same value and delete the old one. Until that's done the R2 cleanup job will abort (loudly — see below).

## Why

`CF_ACCOUNT_ID` is Cloudflare's deprecated spelling. Wrangler v2 replaced the `CF_*` prefix with `CLOUDFLARE_*`, and [Cloudflare's system environment variables docs](https://developers.cloudflare.com/workers/wrangler/system-environment-variables/) list `CF_ACCOUNT_ID` (alongside `CF_API_TOKEN`, `CF_API_KEY`, `CF_EMAIL`, `CF_API_BASE_URL`) under *"The following variables are deprecated. Use the new variables listed above to prevent any issues or unwanted messaging."*

Nothing was broken: this secret is a repo-chosen name consumed only by `r2-cache-cleanup.yml` to build the R2 S3 endpoint host, never handed to Wrangler, so no deprecation warning was firing. It's a naming-convention alignment — `agent-outputs/20260620-1640-cloudflare-deploy-runbook.md` already uses `CLOUDFLARE_ACCOUNT_ID`.

## Changes

- `.github/workflows/r2-cache-cleanup.yml` — the `ENDPOINT` secret reference and the required-secrets comment block.
- `README.md` — the secrets table under *Incremental cache cleanup*.
- `.github/workflows/r2-cache-cleanup.yml` — **new guard** that aborts when the account ID is empty.

## Why the guard

Worth calling out, since it's the one behavioral change. An unset account ID collapses `ENDPOINT` to `https://.r2.cloudflarestorage.com`; every `aws` call then fails, and the `|| true` on the folder listing in step 3 turns that into an empty folder list. The job hits *"No build folders under `incremental-cache/`, nothing to do"* and **exits 0** — a green run that pruned nothing, while the bucket keeps growing ~1–1.4 GB per deploy.

That failure mode already existed, but this rename is exactly when it would bite: if the secret rename is missed or mistyped, the cleanup silently stops. The guard makes it an `::error::` + `exit 1` instead, matching the file's existing convention of aborting loudly rather than proceeding on bad state.

## Testing

- Workflow YAML parses; the extracted `run` script passes `bash -n`.
- Guard checked against both an empty and a populated account ID — fires only on empty.
- No other `CF_*` references remain in the repo (`rg '\bCF_[A-Z_]+'` is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8nFZStwc5Y6ppnePb8Aio

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8nFZStwc5Y6ppnePb8Aio)_