### PR TITLE
Fix R2 illustrations lifecycle AccessDenied, and name the R2 secrets per bucket

### DIFF
--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -54,9 +54,20 @@ name: R2 incremental-cache cleanup
 # manually with dry_run=true to preview deletions.
 #
 # Required repository secrets (Settings → Secrets and variables → Actions):
-#   CLOUDFLARE_ACCOUNT_ID Cloudflare account ID (the R2 S3 endpoint host)
-#   R2_ACCESS_KEY_ID      R2 API token access key id (Object Read & Write)
-#   R2_SECRET_ACCESS_KEY  R2 API token secret access key
+#   CLOUDFLARE_ACCOUNT_ID           Cloudflare account ID (the R2 S3 endpoint host)
+#   R2_INC_CACHE_ACCESS_KEY_ID      R2 API token access key id (Object Read & Write)
+#   R2_INC_CACHE_SECRET_ACCESS_KEY  R2 API token secret access key
+#
+# The R2_INC_CACHE_* pair is named for the bucket it belongs to. It is an
+# Object Read & Write token, deliberately: this job deletes objects on a
+# schedule and never needs bucket-level rights. Editing bucket configuration
+# needs an Admin Read & Write token, which lives in R2_ADMIN_* and is used only
+# by r2-illustrations-lifecycle.yml — admin tokens are account-wide and cannot
+# be scoped to one bucket, so keeping one out of this unattended delete job is
+# the point of the split. (Renamed 2026-07-30 from R2_ACCESS_KEY_ID /
+# R2_SECRET_ACCESS_KEY, which read as "the" R2 credentials once a second pair
+# existed. Unrelated to the identically-named local env vars the illustration
+# scripts use, see scripts/lib/r2.mjs.)
 
 on:
   schedule:
@@ -113,8 +124,11 @@ jobs:
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
       # For `gh pr list` (see step 2). GITHUB_TOKEN with pull-requests: read.
       GH_TOKEN: ${{ github.token }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_INC_CACHE_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_INC_CACHE_SECRET_ACCESS_KEY }}
+      # Secrets cannot be tested from inside `run:` (an unset one arrives as
+      # empty, indistinguishable from a set-but-empty one), so resolve it here.
+      CREDS_SET: ${{ secrets.R2_INC_CACHE_ACCESS_KEY_ID != '' && secrets.R2_INC_CACHE_SECRET_ACCESS_KEY != '' }}
       AWS_DEFAULT_REGION: auto
       AWS_EC2_METADATA_DISABLED: "true"
       # R2 intermittently returns a transient 500 InternalError on DeleteObject.
@@ -142,6 +156,18 @@ jobs:
           #    hold it under the old name.)
           if [[ "$ENDPOINT" == "https://.r2.cloudflarestorage.com" ]]; then
             echo "::error::Repository secret CLOUDFLARE_ACCOUNT_ID is not set (it was previously named CF_ACCOUNT_ID). Aborting without deleting."
+            exit 1
+          fi
+
+          # 0b) Missing credentials fail exactly the same silent way, and there
+          #     is no malformed ENDPOINT to catch them by: unsigned requests are
+          #     rejected, the `|| true` in step 3 swallows it, and the run goes
+          #     green having pruned nothing. This is a live risk right now — the
+          #     secrets were renamed to R2_INC_CACHE_* on 2026-07-30, and a
+          #     scheduled run firing between deleting the old pair and creating
+          #     the new one would otherwise report success while the bucket grew.
+          if [[ "$CREDS_SET" != "true" ]]; then
+            echo "::error::Repository secrets R2_INC_CACHE_ACCESS_KEY_ID and R2_INC_CACHE_SECRET_ACCESS_KEY are not both set (renamed 2026-07-30 from R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY). Aborting without deleting."
             exit 1
           fi
 

--- a/.github/workflows/r2-illustrations-lifecycle.yml
+++ b/.github/workflows/r2-illustrations-lifecycle.yml
@@ -37,12 +37,14 @@ name: R2 illustrations lifecycle
 # where it returns a bare AccessDenied.
 # https://developers.cloudflare.com/r2/api/tokens/#permissions
 #
-# Hence the dedicated R2_ADMIN_* pair below. R2 admin tokens cannot be scoped to
-# a single bucket (they are account-wide by definition), so confining one to the
-# single workflow that needs it beats upgrading the shared token that
-# r2-cache-cleanup.yml and every local illustration script also hold — that
-# would hand account-wide bucket-delete rights to jobs whose whole safety story
-# is that they cannot touch dataslope-inc-cache or dataslope-workspaces.
+# Hence the dedicated R2_ADMIN_* pair below, used by this workflow and nothing
+# else. R2 admin tokens cannot be scoped to a single bucket (they are
+# account-wide by definition), so confining one to the single job that needs it
+# beats handing the same rights to r2-cache-cleanup.yml, which deletes objects
+# unattended every six hours and whose whole safety story is that it cannot
+# reach dataslope-workspaces (live user data, bound to the app Worker) or
+# destroy dataslope-inc-cache outright. That job keeps its own object-scoped
+# R2_INC_CACHE_* pair.
 #
 # NOTE: PutBucketLifecycleConfiguration REPLACES a bucket's entire lifecycle
 # configuration. This job targets `dataslope-illustrations` only and that bucket
@@ -51,13 +53,9 @@ name: R2 illustrations lifecycle
 #
 # Required repository secrets (Settings → Secrets and variables → Actions):
 #   CLOUDFLARE_ACCOUNT_ID       Cloudflare account ID (the R2 S3 endpoint host),
-#                               already used by r2-cache-cleanup.yml
+#                               shared with r2-cache-cleanup.yml
 #   R2_ADMIN_ACCESS_KEY_ID      R2 API token access key id (Admin Read & Write)
 #   R2_ADMIN_SECRET_ACCESS_KEY  R2 API token secret access key
-#
-# If the admin pair is absent the job falls back to R2_ACCESS_KEY_ID /
-# R2_SECRET_ACCESS_KEY, which only works if you chose to upgrade that shared
-# token to Admin Read & Write instead of minting a separate one.
 
 on:
   # Re-apply whenever the retention policy itself changes.
@@ -93,15 +91,12 @@ jobs:
       EXPIRE_DAYS: "14"
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
       # Editing bucket configuration needs an R2 Admin Read & Write token; the
-      # shared Object Read & Write pair is denied (see the header). Falls back
-      # to the shared pair so an upgraded-in-place token also works.
-      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ADMIN_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_ADMIN_SECRET_ACCESS_KEY || secrets.R2_SECRET_ACCESS_KEY }}
-      # Which pair was picked. Secrets cannot be tested from inside `run:`
-      # (they are masked, and an unset one is indistinguishable from empty
-      # there), so resolve it in the expression and pass the answer through.
-      ADMIN_KEY_ID_SET: ${{ secrets.R2_ADMIN_ACCESS_KEY_ID != '' }}
-      ADMIN_SECRET_SET: ${{ secrets.R2_ADMIN_SECRET_ACCESS_KEY != '' }}
+      # object-scoped R2_INC_CACHE_* pair is denied here (see the header).
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ADMIN_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_ADMIN_SECRET_ACCESS_KEY }}
+      # Secrets cannot be tested from inside `run:` (an unset one arrives as
+      # empty, indistinguishable from a set-but-empty one), so resolve it here.
+      ADMIN_CREDS_SET: ${{ secrets.R2_ADMIN_ACCESS_KEY_ID != '' && secrets.R2_ADMIN_SECRET_ACCESS_KEY != '' }}
       AWS_DEFAULT_REGION: auto
       AWS_EC2_METADATA_DISABLED: "true"
       AWS_RETRY_MODE: standard
@@ -130,11 +125,11 @@ jobs:
             exit 1
           fi
 
-          # Both admin secrets or neither. Setting one half signs requests with
-          # a mismatched key/secret, which fails as an opaque
-          # SignatureDoesNotMatch rather than "you forgot the other one".
-          if [[ "$ADMIN_KEY_ID_SET" != "$ADMIN_SECRET_SET" ]]; then
-            echo "::error::Set BOTH R2_ADMIN_ACCESS_KEY_ID and R2_ADMIN_SECRET_ACCESS_KEY, or neither. Only one of the two is set, which signs requests with a mismatched credential pair."
+          # Say which secret is missing. Half a pair signs requests with a
+          # mismatched key/secret and fails as an opaque SignatureDoesNotMatch;
+          # neither fails as an equally opaque unsigned-request error.
+          if [[ "$ADMIN_CREDS_SET" != "true" ]]; then
+            echo "::error::Repository secrets R2_ADMIN_ACCESS_KEY_ID and R2_ADMIN_SECRET_ACCESS_KEY are not both set. This job needs an R2 'Admin Read & Write' token; see https://developers.cloudflare.com/r2/api/tokens/#permissions"
             exit 1
           fi
 
@@ -152,12 +147,11 @@ jobs:
               echo "the bucket's configuration."
               echo "  https://developers.cloudflare.com/r2/api/tokens/#permissions"
               echo
-              echo "Fix: create an R2 API token with 'Admin Read & Write' permission and add its"
-              echo "keys as repository secrets R2_ADMIN_ACCESS_KEY_ID and R2_ADMIN_SECRET_ACCESS_KEY,"
-              echo "which this workflow prefers over the shared pair. R2 admin tokens are"
-              echo "account-wide, so keep them to this workflow rather than upgrading the"
-              echo "R2_ACCESS_KEY_ID pair that r2-cache-cleanup.yml and the local illustration"
-              echo "scripts also use."
+              echo "Fix: check that R2_ADMIN_ACCESS_KEY_ID / R2_ADMIN_SECRET_ACCESS_KEY really hold"
+              echo "an 'Admin Read & Write' token — an object-scoped one reaches this far and then"
+              echo "fails exactly here. R2 admin tokens are account-wide, so keep them to this"
+              echo "workflow rather than reusing them for r2-cache-cleanup.yml, which has its own"
+              echo "object-scoped R2_INC_CACHE_* pair."
               echo "::error::Access denied ${what} '$BUCKET' — these credentials are not an R2 'Admin Read & Write' token. See the log above for the fix."
             else
               echo "::error::Failed ${what} '$BUCKET'."
@@ -190,11 +184,7 @@ jobs:
           echo "Bucket:  $BUCKET"
           echo "Rule:    delete objects under '${PREFIX}' after ${EXPIRE_DAYS} days"
           echo "Dry run: $DRY_RUN"
-          if [[ "$ADMIN_KEY_ID_SET" == "true" ]]; then
-            echo "Token:   R2_ADMIN_* (dedicated Admin Read & Write token)"
-          else
-            echo "Token:   R2_* (shared pair; works only if that token is Admin Read & Write)"
-          fi
+          echo "Token:   R2_ADMIN_* (Admin Read & Write)"
           echo "---"
           cat /tmp/lifecycle.json
 

--- a/.github/workflows/r2-illustrations-lifecycle.yml
+++ b/.github/workflows/r2-illustrations-lifecycle.yml
@@ -27,19 +27,37 @@ name: R2 illustrations lifecycle
 # different quality without paying to regenerate. Raise EXPIRE_DAYS if a batch
 # needs to sit through a longer review.
 #
-# Uses the S3 API with the same credentials as r2-cache-cleanup.yml rather than
-# wrangler, so no additional secret or `wrangler login` is required.
+# Uses the S3 API rather than wrangler, so no `wrangler login` and no separate
+# Cloudflare API token are needed — but NOT the same credentials as
+# r2-cache-cleanup.yml, which is what made the first run of this workflow fail.
+# A lifecycle rule is bucket *configuration*, and R2 lets only an
+# "Admin Read & Write" API token edit that. The "Object Read & Write" token the
+# rest of the pipeline shares can list, read and write objects, and even
+# head-bucket succeeds with it, so everything looks fine right up to the write,
+# where it returns a bare AccessDenied.
+# https://developers.cloudflare.com/r2/api/tokens/#permissions
+#
+# Hence the dedicated R2_ADMIN_* pair below. R2 admin tokens cannot be scoped to
+# a single bucket (they are account-wide by definition), so confining one to the
+# single workflow that needs it beats upgrading the shared token that
+# r2-cache-cleanup.yml and every local illustration script also hold — that
+# would hand account-wide bucket-delete rights to jobs whose whole safety story
+# is that they cannot touch dataslope-inc-cache or dataslope-workspaces.
 #
 # NOTE: PutBucketLifecycleConfiguration REPLACES a bucket's entire lifecycle
 # configuration. This job targets `dataslope-illustrations` only and that bucket
 # has no other rules; it must never be pointed at dataslope-inc-cache or
 # dataslope-workspaces, whose contents are not disposable.
 #
-# Required repository secrets (Settings → Secrets and variables → Actions),
-# all three already used by r2-cache-cleanup.yml:
-#   CLOUDFLARE_ACCOUNT_ID  Cloudflare account ID (the R2 S3 endpoint host)
-#   R2_ACCESS_KEY_ID       R2 API token access key id (Object Read & Write)
-#   R2_SECRET_ACCESS_KEY   R2 API token secret access key
+# Required repository secrets (Settings → Secrets and variables → Actions):
+#   CLOUDFLARE_ACCOUNT_ID       Cloudflare account ID (the R2 S3 endpoint host),
+#                               already used by r2-cache-cleanup.yml
+#   R2_ADMIN_ACCESS_KEY_ID      R2 API token access key id (Admin Read & Write)
+#   R2_ADMIN_SECRET_ACCESS_KEY  R2 API token secret access key
+#
+# If the admin pair is absent the job falls back to R2_ACCESS_KEY_ID /
+# R2_SECRET_ACCESS_KEY, which only works if you chose to upgrade that shared
+# token to Admin Read & Write instead of minting a separate one.
 
 on:
   # Re-apply whenever the retention policy itself changes.
@@ -74,8 +92,16 @@ jobs:
       # thousand rejected candidates never sit around being billed.
       EXPIRE_DAYS: "14"
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      # Editing bucket configuration needs an R2 Admin Read & Write token; the
+      # shared Object Read & Write pair is denied (see the header). Falls back
+      # to the shared pair so an upgraded-in-place token also works.
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ADMIN_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_ADMIN_SECRET_ACCESS_KEY || secrets.R2_SECRET_ACCESS_KEY }}
+      # Which pair was picked. Secrets cannot be tested from inside `run:`
+      # (they are masked, and an unset one is indistinguishable from empty
+      # there), so resolve it in the expression and pass the answer through.
+      ADMIN_KEY_ID_SET: ${{ secrets.R2_ADMIN_ACCESS_KEY_ID != '' }}
+      ADMIN_SECRET_SET: ${{ secrets.R2_ADMIN_SECRET_ACCESS_KEY != '' }}
       AWS_DEFAULT_REGION: auto
       AWS_EC2_METADATA_DISABLED: "true"
       AWS_RETRY_MODE: standard
@@ -104,10 +130,47 @@ jobs:
             exit 1
           fi
 
+          # Both admin secrets or neither. Setting one half signs requests with
+          # a mismatched key/secret, which fails as an opaque
+          # SignatureDoesNotMatch rather than "you forgot the other one".
+          if [[ "$ADMIN_KEY_ID_SET" != "$ADMIN_SECRET_SET" ]]; then
+            echo "::error::Set BOTH R2_ADMIN_ACCESS_KEY_ID and R2_ADMIN_SECRET_ACCESS_KEY, or neither. Only one of the two is set, which signs requests with a mismatched credential pair."
+            exit 1
+          fi
+
+          # Turn an AWS CLI failure into an annotation that says what to do.
+          # AccessDenied on a bucket-configuration call means one specific
+          # thing here, and the CLI's one-liner does not hint at it.
+          fail_aws() {
+            local what="$1" err="$2"
+            printf '%s\n' "$err"
+            if grep -q 'AccessDenied' <<<"$err"; then
+              echo
+              echo "A lifecycle rule is bucket configuration, and R2 lets only an 'Admin Read &"
+              echo "Write' API token edit that. An 'Object Read & Write' token can list, read and"
+              echo "write objects — head-bucket above even succeeds with one — but is denied on"
+              echo "the bucket's configuration."
+              echo "  https://developers.cloudflare.com/r2/api/tokens/#permissions"
+              echo
+              echo "Fix: create an R2 API token with 'Admin Read & Write' permission and add its"
+              echo "keys as repository secrets R2_ADMIN_ACCESS_KEY_ID and R2_ADMIN_SECRET_ACCESS_KEY,"
+              echo "which this workflow prefers over the shared pair. R2 admin tokens are"
+              echo "account-wide, so keep them to this workflow rather than upgrading the"
+              echo "R2_ACCESS_KEY_ID pair that r2-cache-cleanup.yml and the local illustration"
+              echo "scripts also use."
+              echo "::error::Access denied ${what} '$BUCKET' — these credentials are not an R2 'Admin Read & Write' token. See the log above for the fix."
+            else
+              echo "::error::Failed ${what} '$BUCKET'."
+            fi
+            exit 1
+          }
+
           # Confirm the bucket exists before touching its configuration, so a
           # typo or a not-yet-created bucket fails here with a clear message.
+          # Note this passes with an object-scoped token too — reachability
+          # says nothing about the right to edit the configuration below.
           if ! aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
-            echo "::error::Bucket '$BUCKET' is not reachable with these credentials. Create it, or check the R2 token covers it (Object Read & Write)."
+            echo "::error::Bucket '$BUCKET' is not reachable with these credentials. Create it, or check the R2 token covers it."
             exit 1
           fi
 
@@ -127,27 +190,47 @@ jobs:
           echo "Bucket:  $BUCKET"
           echo "Rule:    delete objects under '${PREFIX}' after ${EXPIRE_DAYS} days"
           echo "Dry run: $DRY_RUN"
+          if [[ "$ADMIN_KEY_ID_SET" == "true" ]]; then
+            echo "Token:   R2_ADMIN_* (dedicated Admin Read & Write token)"
+          else
+            echo "Token:   R2_* (shared pair; works only if that token is Admin Read & Write)"
+          fi
           echo "---"
           cat /tmp/lifecycle.json
 
           if [[ "$DRY_RUN" == "true" ]]; then
             echo "---"
             echo "Dry run: existing configuration left untouched. Current rules:"
-            aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" 2>/dev/null || echo "(none set)"
+            # Reading the configuration needs the same admin-tier token the
+            # write does, so this used to be the one path that hid the problem:
+            # `|| echo "(none set)"` reported a *denied read* as an empty
+            # policy, an all-green dry run that proved nothing. Only a genuine
+            # "this bucket has no rules" may print that now.
+            if current="$(aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" 2>&1)"; then
+              printf '%s\n' "$current"
+            elif grep -q 'NoSuchLifecycleConfiguration' <<<"$current"; then
+              echo "(none set)"
+            else
+              fail_aws "reading the lifecycle configuration of" "$current"
+            fi
             exit 0
           fi
 
-          aws s3api put-bucket-lifecycle-configuration \
-            --bucket "$BUCKET" \
-            --lifecycle-configuration file:///tmp/lifecycle.json
+          if ! put_out="$(aws s3api put-bucket-lifecycle-configuration \
+                --bucket "$BUCKET" \
+                --lifecycle-configuration file:///tmp/lifecycle.json 2>&1)"; then
+            fail_aws "applying the lifecycle rule to" "$put_out"
+          fi
 
           # Read back rather than trusting the write: a silently-empty policy
           # would mean candidates accumulate forever, which is the one failure
           # this job exists to prevent and the one that shows no symptom.
           echo "---"
           echo "Applied. Current configuration:"
-          applied="$(aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET")"
-          echo "$applied"
+          if ! applied="$(aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" 2>&1)"; then
+            fail_aws "reading back the lifecycle configuration of" "$applied"
+          fi
+          printf '%s\n' "$applied"
           if ! grep -q '"expire-illustration-candidates"' <<<"$applied"; then
             echo "::error::Rule was not present after applying it."
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,18 +207,30 @@ configuration. See the [R2 token
 permissions](https://developers.cloudflare.com/r2/api/tokens/#permissions)
 table.
 
-So this one workflow reads `R2_ADMIN_ACCESS_KEY_ID` /
-`R2_ADMIN_SECRET_ACCESS_KEY` (falling back to the shared pair if unset).
-Create an Admin Read & Write R2 API token, add those two repository secrets,
-then run the workflow. **R2 admin tokens are account-wide** — they cannot be
-scoped to one bucket — which is exactly why they stay confined to this
-workflow instead of upgrading the shared token: `r2-cache-cleanup.yml` and the
-local scripts would otherwise gain account-wide bucket-delete rights they have
-no use for.
+So this one workflow reads the repository secrets `R2_ADMIN_ACCESS_KEY_ID` /
+`R2_ADMIN_SECRET_ACCESS_KEY`, holding the account's Admin Read & Write token.
+**R2 admin tokens are account-wide** — they cannot be scoped to one bucket —
+so they stay confined to this workflow. `r2-cache-cleanup.yml` keeps its own
+object-scoped pair, `R2_INC_CACHE_ACCESS_KEY_ID` /
+`R2_INC_CACHE_SECRET_ACCESS_KEY` (renamed 2026-07-30 from `R2_ACCESS_KEY_ID` /
+`R2_SECRET_ACCESS_KEY` once a second credential made "the" R2 secrets
+ambiguous). That job deletes objects unattended every six hours and has once
+deleted more than intended; handing it bucket-delete rights over
+`dataslope-workspaces` — live user work, bound to the app Worker — buys
+nothing.
 
-Everything else here still runs on the shared Object Read & Write pair
-(`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY`, already repository secrets for
-`r2-cache-cleanup.yml`), which needs to cover `dataslope-illustrations`.
+Two R2 credentials, then, and the names now say which is which:
+
+| Where | Secret | Tier | Reaches |
+| --- | --- | --- | --- |
+| `r2-illustrations-lifecycle.yml` | `R2_ADMIN_*` | Admin Read & Write | every bucket, plus their configuration |
+| `r2-cache-cleanup.yml` | `R2_INC_CACHE_*` | Object Read & Write | objects only |
+
+**Local scripts are unaffected by that rename.** `scripts/lib/r2.mjs` reads
+`R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` from the *session
+environment* — a separate Object Read & Write token that must cover
+`dataslope-illustrations`. Same variable names, different credential, nothing
+to do with repository secrets.
 
 ### Non-negotiables
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,15 +193,32 @@ keepers inside a fortnight. Promotion writes its own encoded copy into
 serves fine — what you lose is the pristine PNG, and with it the ability to
 re-promote at a different quality without paying to regenerate.
 
-**The rule is not applied until this workflow runs at least once.** It has
-never run (the file has to be on `main` before `workflow_dispatch` appears),
-so nothing has expired yet and the bucket keeps every run. Trigger it once
-after merging, or candidates accumulate indefinitely.
+**The rule is not applied until this workflow runs successfully at least
+once.** Its first run (on #612 landing) failed: `AccessDenied` on
+`PutBucketLifecycleConfiguration`. Nothing has expired yet and the bucket
+still keeps every run.
 
-The same R2 credentials back the Actions workflows and the local scripts
+**That failure is a token-tier problem, not a bug in the rule.** A lifecycle
+rule is bucket *configuration*, and R2 lets only an **Admin Read & Write** API
+token edit that; the **Object Read & Write** token the rest of the pipeline
+shares can list, read and write objects — `head-bucket` even succeeds with it,
+so the job looks healthy right up to the write — and is denied on the
+configuration. See the [R2 token
+permissions](https://developers.cloudflare.com/r2/api/tokens/#permissions)
+table.
+
+So this one workflow reads `R2_ADMIN_ACCESS_KEY_ID` /
+`R2_ADMIN_SECRET_ACCESS_KEY` (falling back to the shared pair if unset).
+Create an Admin Read & Write R2 API token, add those two repository secrets,
+then run the workflow. **R2 admin tokens are account-wide** — they cannot be
+scoped to one bucket — which is exactly why they stay confined to this
+workflow instead of upgrading the shared token: `r2-cache-cleanup.yml` and the
+local scripts would otherwise gain account-wide bucket-delete rights they have
+no use for.
+
+Everything else here still runs on the shared Object Read & Write pair
 (`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY`, already repository secrets for
-`r2-cache-cleanup.yml`). The token needs Object Read & Write covering
-`dataslope-illustrations`.
+`r2-cache-cleanup.yml`), which needs to cover `dataslope-illustrations`.
 
 ### Non-negotiables
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ It needs three repository secrets (Settings → Secrets and variables → Action
 | Secret | Value |
 | --- | --- |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID (the R2 S3 endpoint host) |
-| `R2_ACCESS_KEY_ID` | R2 API token access key ID |
-| `R2_SECRET_ACCESS_KEY` | R2 API token secret access key |
+| `R2_INC_CACHE_ACCESS_KEY_ID` | R2 API token access key ID |
+| `R2_INC_CACHE_SECRET_ACCESS_KEY` | R2 API token secret access key |
+
+The `R2_INC_CACHE_*` pair is named for the bucket it belongs to, because a second R2 credential now exists: `.github/workflows/r2-illustrations-lifecycle.yml` needs an **Admin Read & Write** token (`R2_ADMIN_*`) to edit bucket configuration, which is a tier this job deliberately does not get — it deletes objects unattended every six hours, and admin tokens are account-wide, so one here could destroy `dataslope-workspaces` (live user data) or `dataslope-inc-cache` itself. The job aborts rather than running credential-less, so a missing or half-renamed secret fails loudly instead of reporting a green run that pruned nothing.
 
 To change how long stale/preview cache lingers, edit `THRESHOLD_HOURS` (age limit) and `MAX_BRANCHES` (how many active-branch previews may coexist) in the workflow. At ~1–1.4 GB per retained build, retention is what decides whether the bucket sits near R2's 10 GB free tier or balloons, storage beyond it is cheap ($0.015/GB-month), but there's no reason to pay for dead previews.
 

--- a/agent-outputs/20260730-1200-illustration-pipeline-handoff.md
+++ b/agent-outputs/20260730-1200-illustration-pipeline-handoff.md
@@ -512,10 +512,10 @@ Retention is **14 days** (raised from 7 on 2026-07-30), applied by
 **The rule has never actually been applied.** #612 has since merged, which triggered the
 workflow, and that first run failed: `AccessDenied` on `PutBucketLifecycleConfiguration`.
 A lifecycle rule is bucket configuration, which R2 lets only an **Admin Read & Write**
-token edit — the shared **Object Read & Write** token gets as far as `head-bucket` and is
-then denied. The workflow now takes `R2_ADMIN_ACCESS_KEY_ID` /
-`R2_ADMIN_SECRET_ACCESS_KEY`; until those secrets exist and the job is re-run, nothing has
-expired and all 9 runs remain:
+token edit — an **Object Read & Write** token gets as far as `head-bucket` and is then
+denied. The workflow now takes `R2_ADMIN_ACCESS_KEY_ID` / `R2_ADMIN_SECRET_ACCESS_KEY`
+(the `dataslope-github-admin` token, created 2026-07-30 along with those secrets). Until
+the job is re-run, nothing has expired and all 9 runs remain:
 
 | Run | Objects |
 |---|---|
@@ -566,20 +566,10 @@ Branch for this work: `claude/gpt-image-2-api-test-v4memq`, PR **#612**.
 
 ## Open items
 
-1. **Add an admin R2 token, then run the lifecycle workflow successfully once.**
-   Mandatory: until it applies, candidates accumulate indefinitely. This is blocked on a
-   human — the first run failed `AccessDenied` because editing bucket configuration needs
-   an R2 **Admin Read & Write** token, and only an account owner can mint one
-   ([permissions table](https://developers.cloudflare.com/r2/api/tokens/#permissions)).
-
-   a. Cloudflare dashboard → R2 → **Manage API Tokens** → create a token with
-      **Admin Read & Write**. (This tier is account-wide; it cannot be bucket-scoped.)
-   b. Add its two keys as repository secrets `R2_ADMIN_ACCESS_KEY_ID` and
-      `R2_ADMIN_SECRET_ACCESS_KEY` — the workflow prefers them over the shared
-      `R2_ACCESS_KEY_ID` pair, deliberately, so the account-wide token stays out of
-      `r2-cache-cleanup.yml` and the local scripts. Set both or neither; the job rejects
-      a half-set pair rather than failing as `SignatureDoesNotMatch`.
-   c. Then an agent can run it:
+1. **Run the lifecycle workflow successfully once.** Mandatory: until it applies,
+   candidates accumulate indefinitely. The `dataslope-github-admin` token
+   (**Admin Read & Write**) and its `R2_ADMIN_*` repository secrets exist as of
+   2026-07-30, so this is now unblocked — an agent can run it:
 
    ```
    mcp__github__actions_run_trigger   owner=dataslope repo=dataslope
@@ -590,6 +580,11 @@ Branch for this work: `claude/gpt-image-2-api-test-v4memq`, PR **#612**.
    reads the config back and fails if the rule is absent, so a silent no-op is already
    guarded — and a dry run that cannot read the configuration now fails instead of
    reporting `(none set)`. Verify with `mcp__github__actions_get`.
+
+   The `R2_INC_CACHE_*` secrets that `r2-cache-cleanup.yml` uses are the **object-scoped**
+   pair (renamed 2026-07-30 from `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY`). Do not point
+   this workflow at them, and do not point that one at `R2_ADMIN_*`: admin tokens are
+   account-wide, and that job deletes on a schedule.
 
 2. **Guard the silent-stale-cut-out failure** (gotcha 1). Offered to the user, not built.
    In `promote-illustrations.mjs`, warn when promoting an original whose cut-out is

--- a/agent-outputs/20260730-1200-illustration-pipeline-handoff.md
+++ b/agent-outputs/20260730-1200-illustration-pipeline-handoff.md
@@ -509,8 +509,13 @@ against the S3 API, keeping content authoring decoupled from deploying the app.
 Retention is **14 days** (raised from 7 on 2026-07-30), applied by
 `.github/workflows/r2-illustrations-lifecycle.yml`.
 
-**The rule has never actually been applied.** `workflow_dispatch` only appears once the
-file is on `main`, and #612 is unmerged, so nothing has expired and all 9 runs remain:
+**The rule has never actually been applied.** #612 has since merged, which triggered the
+workflow, and that first run failed: `AccessDenied` on `PutBucketLifecycleConfiguration`.
+A lifecycle rule is bucket configuration, which R2 lets only an **Admin Read & Write**
+token edit — the shared **Object Read & Write** token gets as far as `head-bucket` and is
+then denied. The workflow now takes `R2_ADMIN_ACCESS_KEY_ID` /
+`R2_ADMIN_SECRET_ACCESS_KEY`; until those secrets exist and the job is re-run, nothing has
+expired and all 9 runs remain:
 
 | Run | Objects |
 |---|---|
@@ -561,8 +566,20 @@ Branch for this work: `claude/gpt-image-2-api-test-v4memq`, PR **#612**.
 
 ## Open items
 
-1. **Trigger the lifecycle workflow once after #612 merges.** Mandatory: until it runs,
-   candidates accumulate indefinitely. An agent can do this directly:
+1. **Add an admin R2 token, then run the lifecycle workflow successfully once.**
+   Mandatory: until it applies, candidates accumulate indefinitely. This is blocked on a
+   human — the first run failed `AccessDenied` because editing bucket configuration needs
+   an R2 **Admin Read & Write** token, and only an account owner can mint one
+   ([permissions table](https://developers.cloudflare.com/r2/api/tokens/#permissions)).
+
+   a. Cloudflare dashboard → R2 → **Manage API Tokens** → create a token with
+      **Admin Read & Write**. (This tier is account-wide; it cannot be bucket-scoped.)
+   b. Add its two keys as repository secrets `R2_ADMIN_ACCESS_KEY_ID` and
+      `R2_ADMIN_SECRET_ACCESS_KEY` — the workflow prefers them over the shared
+      `R2_ACCESS_KEY_ID` pair, deliberately, so the account-wide token stays out of
+      `r2-cache-cleanup.yml` and the local scripts. Set both or neither; the job rejects
+      a half-set pair rather than failing as `SignatureDoesNotMatch`.
+   c. Then an agent can run it:
 
    ```
    mcp__github__actions_run_trigger   owner=dataslope repo=dataslope
@@ -571,7 +588,8 @@ Branch for this work: `claude/gpt-image-2-api-test-v4memq`, PR **#612**.
    Run it once with the `dry_run` input `true` to print the rule without applying it,
    confirm the output shows `"Days": 14`, then run again with `dry_run` false. The job
    reads the config back and fails if the rule is absent, so a silent no-op is already
-   guarded. Verify with `mcp__github__actions_get`.
+   guarded — and a dry run that cannot read the configuration now fails instead of
+   reporting `(none set)`. Verify with `mcp__github__actions_get`.
 
 2. **Guard the silent-stale-cut-out failure** (gotcha 1). Offered to the user, not built.
    In `promote-illustrations.mjs`, warn when promoting an original whose cut-out is


### PR DESCRIPTION
## What broke

The first run of `r2-illustrations-lifecycle.yml` (triggered by #612 landing) failed:

```
aws: [ERROR]: An error occurred (AccessDenied) when calling the PutBucketLifecycleConfiguration operation: Access Denied
Error: Process completed with exit code 254.
```

## Why

A lifecycle rule is bucket **configuration**, and R2 lets only an **Admin Read & Write** API token edit that. The workflow borrowed the Object Read & Write token from `r2-cache-cleanup.yml`, which can list, read and write objects — `head-bucket` succeeds with it, which is why the job got as far as printing the rule — and is then denied on the configuration write. Cloudflare's [R2 token permissions table](https://developers.cloudflare.com/r2/api/tokens/#permissions) draws the line explicitly:

| Permission | Covers |
| --- | --- |
| Admin Read & Write | create/list/delete buckets, **edit bucket configuration**, read/write/list objects |
| Object Read & Write | read, write, and list objects in specific buckets |

Nothing is wrong with the rule itself, and nothing was applied — `AccessDenied` means the request never took effect.

## Two R2 credentials, named for what they reach

The lifecycle workflow now uses `R2_ADMIN_ACCESS_KEY_ID` / `R2_ADMIN_SECRET_ACCESS_KEY` (the `dataslope-github-admin` token), and `r2-cache-cleanup.yml`'s secrets are renamed from `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` to `R2_INC_CACHE_ACCESS_KEY_ID` / `R2_INC_CACHE_SECRET_ACCESS_KEY`, mirroring `dataslope-inc-cache`:

| Where | Secret | Tier | Reaches |
| --- | --- | --- | --- |
| `r2-illustrations-lifecycle.yml` | `R2_ADMIN_*` | Admin Read & Write | every bucket, plus their configuration |
| `r2-cache-cleanup.yml` | `R2_INC_CACHE_*` | Object Read & Write | objects only |

Consolidating both onto the admin token would work — it's a strict superset — but the split is deliberate. `r2-cache-cleanup.yml` deletes objects unattended every six hours and has once deleted more than intended (the 2026-07-16 race in #605). R2 admin tokens are account-wide and cannot be scoped to a bucket, so an admin token there could destroy `dataslope-workspaces` — live user playground work, bound to the app Worker as `WORKSPACES_BUCKET` — or `dataslope-inc-cache` itself. Object-level damage is bounded and largely regenerable; bucket-level damage is not, and nothing that job does needs bucket-level rights.

**Local scripts are unaffected by the rename.** `scripts/lib/r2.mjs` reads `R2_ACCESS_KEY_ID` from the *session environment* — a separate token that happens to share the old name, not a repository secret.

## Failures that used to be silent or illegible

- **`AccessDenied` on either the read or the write** now prints what to do about it and fails with an annotation naming the cause, instead of a bare CLI one-liner and exit 254.
- **The dry-run path no longer reports a denied read as `(none set)`.** Reading the configuration needs the same admin-tier token the write does, so `|| echo "(none set)"` turned the one command that could have diagnosed this into an all-green run that proved nothing. Only a genuine `NoSuchLifecycleConfiguration` prints that now.
- **`r2-cache-cleanup.yml` aborts when its credentials are unset.** It never validated them, and the folder listing ends in `|| true`, so empty credentials collapse to "no folders found" and a green run that pruned nothing — the same silent failure its `CLOUDFLARE_ACCOUNT_ID` guard already covers. A scheduled run firing between deleting the old secrets and creating the new ones would hit exactly that.
- **Missing/half-set secrets** are named in both jobs, rather than failing as an opaque `SignatureDoesNotMatch`.

## Action required

Merging this makes `r2-cache-cleanup.yml` depend on the renamed secrets. Create `R2_INC_CACHE_ACCESS_KEY_ID` and `R2_INC_CACHE_SECRET_ACCESS_KEY` (same values as the old pair) before or shortly after merge; the old pair can then be deleted. If a scheduled run lands in the gap it now fails loudly instead of pruning nothing quietly.

Merging also re-triggers the lifecycle workflow, which watches its own path on `main`. The ~1,616 candidate objects in `dataslope-illustrations` keep accumulating until it succeeds once.

## Testing

No CI covers these workflows, so both step scripts were extracted and run against a stubbed `aws`. The lifecycle job was exercised across every branch — happy path, `AccessDenied` on put, `AccessDenied` on a dry run, a bucket with genuinely no rules, a non-permission put failure, a read-back missing the rule, unset admin secrets, an unreachable bucket, the wrong-bucket guard, and an unset `CLOUDFLARE_ACCOUNT_ID` — all exiting as intended. The cache-cleanup credential guard was verified both ways: unset aborts immediately, set passes through to the existing production-build check. Both files parse as YAML and `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdfEjHtdGczY4kfsuGS21f