### PR TITLE
Static charts, Plotly simple_white, animated-figure fix, tighter sticky header

### DIFF
--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -55,7 +55,6 @@ import type {
   LanguageRuntime,
   OutputCell,
   PackageInfo,
-  PlotlyFigure,
   RunOptions,
 } from "./types";
 import { PLAYGROUNDS } from "./playgrounds";
@@ -190,7 +189,7 @@ import {
   retainRuntime,
   RuntimeScope,
 } from "./runtimeRegistry";
-import { PLOTLY_CDN } from "./runtime/cdn";
+import { PlotlyChart } from "./PlotlyChart";
 
 const MOBILE_EDITOR_TAB = "editor" as const;
 
@@ -201,17 +200,6 @@ const CODE_CLEAR_BEFORE_RUN_DEFAULT = false;
 // Minimum time (ms) the "running" overlay is shown so the 180ms CSS
 // transition can complete and be clearly visible to the user.
 const MIN_ANIMATION_MS = 300;
-
-/** Minimal Plotly surface we use for rendering chart cells. */
-interface PlotlyAPI {
-  newPlot(
-    el: HTMLElement,
-    data: unknown[],
-    layout?: Record<string, unknown>,
-    config?: Record<string, unknown>,
-  ): Promise<unknown>;
-}
-
 
 /** Build the empty-state output-panel blurb based on what the runtime
  *  can actually produce. Every runtime supports plain text; richer
@@ -390,41 +378,6 @@ function computeRunButtonState(
       },
     ],
   };
-}
-
-const PLOTLY_MARGIN = { l: 48, r: 24, t: 48, b: 48 };
-
-function PlotlyChart({ figure }: { figure: PlotlyFigure }) {
-  const ref = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    let cancelled = false;
-    void (async () => {
-      // Plotly is heavy and only needed when a chart actually renders, so we
-      // lazy-load it from jsDelivr on demand, keeping it out of the client
-      // bundle and the OpenNext Worker bundle (see PLOTLY_CDN in runtime/cdn).
-      const mod = await import(
-        /* webpackIgnore: true */ /* turbopackIgnore: true */ PLOTLY_CDN
-      );
-      if (cancelled || !ref.current) return;
-      const Plotly = (mod.default ?? mod) as unknown as PlotlyAPI;
-      // The Python runtime bakes the theme-appropriate template (plotly_dark in
-      // dark mode, plotly in light mode) into figure.layout.template, so we only
-      // set a default margin here and otherwise render the figure as-is.
-      const layout = { margin: PLOTLY_MARGIN, ...(figure.layout ?? {}) };
-      void Plotly.newPlot(el, figure.data, layout, {
-        responsive: true,
-        displayModeBar: true,
-        displaylogo: false,
-        modeBarButtonsToRemove: ["sendDataToCloud", "lasso2d"],
-      });
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [figure]);
-  return <div ref={ref} className="plotly-chart" />;
 }
 
 interface PackagesDrawerProps {
@@ -5112,7 +5065,10 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                               className="out-seg out-seg-plot"
                               data-cell-type="plot"
                             >
-                              <PlotlyChart figure={cell.plot} />
+                              <PlotlyChart
+                                figure={cell.plot}
+                                className="plotly-chart"
+                              />
                             </div>
                           ) : (
                             <div

--- a/app/_components/PlotlyChart.tsx
+++ b/app/_components/PlotlyChart.tsx
@@ -29,6 +29,7 @@ interface PlotlyAPI {
     layout?: Record<string, unknown>,
     config?: Record<string, unknown>,
   ): Promise<unknown>;
+  addFrames(el: HTMLElement, frames: unknown[]): Promise<unknown>;
 }
 
 /** Tighter than Plotly's default so a figure in a narrow output panel spends
@@ -58,12 +59,19 @@ export function PlotlyChart({
       // in dark mode, plotly in light mode) into figure.layout.template, so
       // only the margin is defaulted here and the figure renders as-is.
       const layout = { margin: PLOTLY_MARGIN, ...(figure.layout ?? {}) };
-      void Plotly.newPlot(el, figure.data, layout, {
+      await Plotly.newPlot(el, figure.data, layout, {
         responsive: true,
         displayModeBar: true,
         displaylogo: false,
         modeBarButtonsToRemove: ["sendDataToCloud", "lasso2d"],
       });
+      // `animation_frame=` puts the play button and the slider in `layout`
+      // and the thing they animate in `frames`, which newPlot's positional
+      // form has no parameter for. Without this the controls draw, and both
+      // the play button and the slider are inert: their handlers look up
+      // frames by name and find none registered on the graph.
+      if (cancelled || !ref.current) return;
+      if (figure.frames?.length) await Plotly.addFrames(el, figure.frames);
     })();
     return () => {
       cancelled = true;

--- a/app/_components/home/HomeNav.tsx
+++ b/app/_components/home/HomeNav.tsx
@@ -303,11 +303,25 @@ export function HomeNav() {
     // compositing layer, so hover repaints inside it (nav-link colour
     // transitions, the logo's group-hover transform) stay isolated from the
     // continuously-animating hero marquee below. Combined with the fixed
-    // h-14/16 box (see above), it makes the header a constant-size opaque
-    // occluder over the marquee.
-    <header className="sticky top-0 z-40 h-14 transform-gpu bg-white md:h-16 dark:bg-[#121212]">
+    // h-14/16 box (see above), it keeps that layer a constant size over the
+    // marquee; the opaque occluder itself is the background div inside it.
+    <header className="sticky top-0 z-40 h-14 transform-gpu md:h-16">
+      {/* The opaque background, tracking the nav's height rather than the
+          header box's. The box has to stay h-14/16 (see above), so painting
+          the background across all of it left the compacted header carrying a
+          16px band of dead white below the content before the fade began.
+          Painting only as far as the nav puts the fade directly under the
+          logo/menu row, and costs the occluder nothing the fade doesn't
+          immediately cover. This is a repaint inside the header's existing
+          layer, not a resize of the layer itself. */}
+      <div
+        aria-hidden="true"
+        className={`pointer-events-none absolute inset-x-0 top-0 bg-white transition-[height] duration-200 dark:bg-[#121212] ${
+          scrolled ? "h-11 md:h-12" : "h-14 md:h-16"
+        }`}
+      />
       <nav
-        className={`mx-auto grid max-w-6xl grid-cols-[1fr_auto] items-center gap-3 px-4 transition-[height] duration-200 sm:px-6 md:grid-cols-[1fr_auto_1fr] ${
+        className={`relative mx-auto grid max-w-6xl grid-cols-[1fr_auto] items-center gap-3 px-4 transition-[height] duration-200 sm:px-6 md:grid-cols-[1fr_auto_1fr] ${
           scrolled ? "h-11 md:h-12" : "h-14 md:h-16"
         }`}
       >
@@ -345,16 +359,19 @@ export function HomeNav() {
       </nav>
       {/* Short fade below the compacted header so its solid background melts
           into the page instead of slicing through content scrolling under it
-          (most visible against the hero marquee). Hidden while the page is at
-          the top, where the header sits in normal flow above the content.
+          (most visible against the hero marquee). It sits at the background's
+          bottom edge, not the header box's, so it moves up with the shrink
+          instead of leaving a gap of flat colour behind it. Hidden while the
+          page is at the top, where the header sits in normal flow above the
+          content.
           `will-change-[opacity]` keeps this strip permanently on its own
           compositor layer: without it, the opacity transition creates and
           destroys a layer on every scroll-threshold crossing, right at the
           band under the header where stale marquee raster has ghosted. */}
       <div
         aria-hidden="true"
-        className={`pointer-events-none absolute inset-x-0 top-full h-3 bg-gradient-to-b from-white to-transparent transition-opacity duration-200 will-change-[opacity] dark:from-[#121212] ${
-          scrolled ? "opacity-100" : "opacity-0"
+        className={`pointer-events-none absolute inset-x-0 h-3 bg-gradient-to-b from-white to-transparent transition-[opacity,top] duration-200 will-change-[opacity] dark:from-[#121212] ${
+          scrolled ? "top-11 opacity-100 md:top-12" : "top-full opacity-0"
         }`}
       />
     </header>

--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -934,6 +934,9 @@ if _plt is not None:
           const fig = JSON.parse(out.json) as {
             data: unknown[];
             layout?: Record<string, unknown>;
+            // `animation_frame=` figures carry their frames here; the
+            // renderer needs them or the play button and slider are inert.
+            frames?: unknown[];
           };
           post({ kind: "output", id, cell: { type: "plot", content: out.json, plot: fig } });
         } catch {

--- a/app/_components/types.ts
+++ b/app/_components/types.ts
@@ -24,6 +24,11 @@ export interface OutputCell {
 export interface PlotlyFigure {
   data: unknown[];
   layout?: Record<string, unknown>;
+  /** Animation frames, present whenever the figure was built with
+   *  `animation_frame=`. The play button and the slider live in `layout`
+   *  and are drawn without these, so a figure rendered from `data` and
+   *  `layout` alone looks animated and does nothing when clicked. */
+  frames?: unknown[];
 }
 
 export interface EntryFileInfo {

--- a/content/courses/data-analysis-python-pandas/visualization-basics.mdx
+++ b/content/courses/data-analysis-python-pandas/visualization-basics.mdx
@@ -40,7 +40,10 @@ df = pd.DataFrame(
     }
 )
 
-fig = px.bar(df, x="department", y="headcount", color="year", barmode="group")
+fig = px.bar(
+    df, x="department", y="headcount", color="year", barmode="group",
+    template="simple_white",
+)
 fig.show()
 `,
     },
@@ -71,7 +74,8 @@ it changes the answer:
 import plotly.express as px
 penguins = pd.read_csv("penguins.csv")`,
       starterCode: `fig = px.histogram(
-    penguins, x="body_mass_g", nbins=30, title="Distribution of penguin body mass"
+    penguins, x="body_mass_g", nbins=30, title="Distribution of penguin body mass",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -104,7 +108,8 @@ produce the same one:
 import plotly.express as px
 penguins = pd.read_csv("penguins.csv")`,
       starterCode: `fig = px.box(
-    penguins, x="species", y="body_mass_g", title="Body mass by species"
+    penguins, x="species", y="body_mass_g", title="Body mass by species",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -138,6 +143,7 @@ penguins = pd.read_csv("penguins.csv")`,
     color="species",
     opacity=0.7,
     title="Flipper length vs body mass, by species",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -172,7 +178,8 @@ df = pd.DataFrame(
 )
 
 fig = px.line(
-    df, x="date", y="value", color="metric", title="Daily visits and sign-ups"
+    df, x="date", y="value", color="metric", title="Daily visits and sign-ups",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -210,6 +217,7 @@ penguins = pd.read_csv("penguins.csv")`,
     facet_col="species",
     nbins=30,
     title="Body mass distribution by species",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -335,7 +343,10 @@ fig
 `,
       solutionCode: `import plotly.express as px
 
-fig = px.histogram(sales, x="amount", nbins=20, title="Sales amount distribution")
+fig = px.histogram(
+    sales, x="amount", nbins=20, title="Sales amount distribution",
+    template="simple_white",
+)
 fig
 `,
     },

--- a/content/courses/statistics-for-data-science-python/ab-testing.mdx
+++ b/content/courses/statistics-for-data-science-python/ab-testing.mdx
@@ -263,6 +263,7 @@ fig = px.bar(
     color="group",
     title="Conversion rate by arm (bars = 95% confidence interval)",
     labels={"rate": "conversion rate"},
+    template="simple_white",
 )
 fig.show()
 

--- a/content/courses/statistics-for-data-science-python/central-limit-theorem.mdx
+++ b/content/courses/statistics-for-data-science-python/central-limit-theorem.mdx
@@ -100,6 +100,7 @@ fig = px.histogram(
     nbins=50,
     height=620,
     title="Exponential population: sampling distribution of x-bar normalizes as n grows",
+    template="simple_white",
 )
 fig.update_xaxes(matches=None)
 fig.show()
@@ -183,6 +184,7 @@ fig.update_layout(
     barmode="overlay",
     title=f"Three very different populations -> same normal mean (n={n})",
     xaxis_title="standardized x-bar",
+    template="simple_white",
 )
 fig.show()
 
@@ -322,6 +324,7 @@ fig = px.line(
     markers=True,
     labels={"x": "sample size n", "y": "SD of x-bar"},
     title="SD of x-bar follows sigma / sqrt(n)",
+    template="simple_white",
 )
 fig.add_scatter(
     x=ns,

--- a/content/courses/statistics-for-data-science-python/confidence-intervals.mdx
+++ b/content/courses/statistics-for-data-science-python/confidence-intervals.mdx
@@ -252,6 +252,7 @@ fig.update_layout(
     title=f"100 separate 95% CIs, {n_miss} missed the true mu (red)",
     xaxis_title="value",
     yaxis_title="interval number",
+    template="simple_white",
 )
 fig.show()
 

--- a/content/courses/statistics-for-data-science-python/continuous-distributions.mdx
+++ b/content/courses/statistics-for-data-science-python/continuous-distributions.mdx
@@ -112,6 +112,7 @@ fig = px.line(
     y=d.pdf(x),
     labels={"x": "x", "y": "density"},
     title="Uniform(0, 10) PDF, flat; area, not height, is probability",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -167,6 +168,7 @@ fig = px.line(
     y=d.pdf(x),
     labels={"x": "minutes until next event", "y": "density"},
     title="Exponential(mean=5): wait times, most short, a long right tail",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -228,6 +230,7 @@ fig = px.line(
     y=d.pdf(x),
     labels={"x": "score", "y": "density"},
     title="Normal(mean=100, sd=15) PDF",
+    template="simple_white",
 )
 fig.show()
 `,

--- a/content/courses/statistics-for-data-science-python/correlation-and-nonparametric.mdx
+++ b/content/courses/statistics-for-data-science-python/correlation-and-nonparametric.mdx
@@ -250,6 +250,7 @@ aq = pd.read_csv("anscombe.csv")`,
 fig = px.scatter(
     aq, x="x", y="y", facet_col="dataset", facet_col_wrap=2,
     trendline="ols", title="Anscombe's quartet, identical correlation, four pictures",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -331,6 +332,7 @@ fig = px.scatter(
     y=score,
     labels={"x": "hours studied", "y": "exam score"},
     title="Exam score vs hours studied (with least-squares fit)",
+    template="simple_white",
 )
 fig.add_scatter(x=xline, y=yline, mode="lines", name="fit line")
 fig.show()

--- a/content/courses/statistics-for-data-science-python/discrete-distributions.mdx
+++ b/content/courses/statistics-for-data-science-python/discrete-distributions.mdx
@@ -169,6 +169,7 @@ fig = px.bar(
     y=pmf,
     labels={"x": "number of conversions", "y": "P(X = k)"},
     title="Binomial(n=200, p=0.03): how many of 200 visitors convert?",
+    template="simple_white",
 )
 fig.show()
 

--- a/content/courses/statistics-for-data-science-python/errors-and-power.mdx
+++ b/content/courses/statistics-for-data-science-python/errors-and-power.mdx
@@ -212,6 +212,7 @@ fig = px.line(
     y=power_by_n,
     markers=True,
     title="Power rises with sample size (true effect = 0.5)",
+    template="simple_white",
 )
 fig.add_hline(y=0.8, line_dash="dash", line_color="green")
 fig.update_layout(
@@ -264,6 +265,7 @@ fig = px.line(
     y=power_by_effect,
     markers=True,
     title="Power rises with effect size (n = 40 per group)",
+    template="simple_white",
 )
 fig.add_hline(y=0.8, line_dash="dash", line_color="green")
 fig.update_layout(

--- a/content/courses/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
+++ b/content/courses/statistics-for-data-science-python/exploratory-statistical-analysis.mdx
@@ -205,6 +205,7 @@ fig = px.histogram(
     x="total_bill",
     nbins=30,
     title="Distribution of total bill (note the right skew)",
+    template="simple_white",
 )
 fig.show()
 
@@ -212,6 +213,7 @@ fig2 = px.box(
     tips,
     x="total_bill",
     title="Total bill: center, spread, and high outliers",
+    template="simple_white",
 )
 fig2.show()
 `,
@@ -410,6 +412,7 @@ fig = px.imshow(
     zmin=-1,
     zmax=1,
     title="Correlation matrix of numeric columns",
+    template="simple_white",
 )
 fig.show()
 

--- a/content/courses/statistics-for-data-science-python/index.mdx
+++ b/content/courses/statistics-for-data-science-python/index.mdx
@@ -154,12 +154,18 @@ aq = pd.read_csv("anscombe.csv")`,
 fig = px.scatter(
     aq, x="x", y="y", facet_col="dataset", facet_col_wrap=2,
     trendline="ols", title="Anscombe's quartet, same stats, different data",
+    template="simple_white",
 )
 fig.show()
 `,
     },
   ]}
 />
+
+Here is what comes out, four pictures that no summary table could
+tell apart:
+
+<Chart slug="anscombes-quartet" />
 
 That single comparison is the whole argument for this course in one
 screen. A data scientist who trusts the summary numbers alone calls all

--- a/content/courses/statistics-for-data-science-python/p-values.mdx
+++ b/content/courses/statistics-for-data-science-python/p-values.mdx
@@ -196,7 +196,8 @@ observed_diff = 0.45  # a gap we supposedly saw in a real experiment
 p_value = (np.abs(null_diffs) >= abs(observed_diff)).mean()
 
 fig = px.histogram(
-    null_diffs, nbins=60, title="Null distribution of the difference in means"
+    null_diffs, nbins=60, title="Null distribution of the difference in means",
+    template="simple_white",
 )
 fig.add_vline(x=observed_diff, line_color="red", line_width=2)
 fig.add_vline(x=-observed_diff, line_color="red", line_width=2, line_dash="dash")

--- a/content/courses/statistics-for-data-science-python/populations-and-samples.mdx
+++ b/content/courses/statistics-for-data-science-python/populations-and-samples.mdx
@@ -220,6 +220,7 @@ fig = px.histogram(
     nbins=40,
     labels={"value": "Sample mean (x-bar)"},
     title="x-bar is a random variable: 1000 samples, 1000 means",
+    template="simple_white",
 )
 fig.add_vline(x=MU_TRUE, line_dash="dash", annotation_text="true mu = 100")
 fig.show()
@@ -288,6 +289,7 @@ fig = px.line(
     log_x=True,
     labels={"x": "Sample size n (log scale)", "y": "|x-bar - mu| (estimation error)"},
     title="Bigger samples sharpen the estimate",
+    template="simple_white",
 )
 fig.show()
 

--- a/content/courses/statistics-for-data-science-python/probability-basics.mdx
+++ b/content/courses/statistics-for-data-science-python/probability-basics.mdx
@@ -263,6 +263,7 @@ fig = px.line(
     y=running_prop,
     labels={"x": "Number of flips", "y": "Running proportion of heads"},
     title="Law of Large Numbers: running proportion converges to 0.5",
+    template="simple_white",
 )
 fig.add_hline(y=0.5, line_dash="dash", line_color="red")
 fig.show()

--- a/content/courses/statistics-for-data-science-python/sampling-and-bias.mdx
+++ b/content/courses/statistics-for-data-science-python/sampling-and-bias.mdx
@@ -207,6 +207,7 @@ fig = px.line(
     log_x=True,
     title="More data fixes noise, not bias",
     labels={"n": "Sample size n (log scale)", "estimate": "Estimated mean"},
+    template="simple_white",
 )
 fig.add_hline(y=true_mean, line_dash="dash", annotation_text="true mean")
 fig.show()

--- a/content/courses/statistics-for-data-science-python/sampling-distributions.mdx
+++ b/content/courses/statistics-for-data-science-python/sampling-distributions.mdx
@@ -108,6 +108,7 @@ fig = px.histogram(
     nbins=50,
     title=f"Sampling distribution of x-bar  (n={n}, {n_samples} samples)",
     labels={"value": "Sample mean (x-bar)"},
+    template="simple_white",
 )
 fig.add_vline(x=MU, line_dash="dash", annotation_text="true mu = 50")
 fig.show()
@@ -186,6 +187,7 @@ fig = px.histogram(
     nbins=50,
     height=650,
     title="Three different distributions on the same axis",
+    template="simple_white",
 )
 fig.add_vline(x=MU, line_dash="dash")
 fig.show()
@@ -263,6 +265,7 @@ fig = px.histogram(
     opacity=0.6,
     title="Bigger n -> narrower sampling distribution (same center)",
     labels={"x_bar": "Sample mean (x-bar)"},
+    template="simple_white",
 )
 fig.add_vline(x=MU, line_dash="dash", annotation_text="mu = 50")
 fig.show()
@@ -402,6 +405,7 @@ fig = px.histogram(
     facet_col_wrap=3,
     height=400,
     title=f"Each statistic has its OWN sampling distribution (n={n})",
+    template="simple_white",
 )
 fig.update_xaxes(matches=None)
 fig.show()

--- a/content/courses/statistics-for-data-science-python/shape-and-outliers.mdx
+++ b/content/courses/statistics-for-data-science-python/shape-and-outliers.mdx
@@ -119,6 +119,7 @@ fig = px.histogram(
     nbins=50,
     title="One column, two hidden groups (bimodal)",
     labels={"value": "height (cm)"},
+    template="simple_white",
 )
 fig.update_layout(showlegend=False)
 fig.show()
@@ -312,6 +313,7 @@ fig = px.box(
     y="income",
     points="outliers",
     title="Box plot: whiskers = 1.5xIQR fences, dots = flagged outliers",
+    template="simple_white",
 )
 fig.show()
 

--- a/content/courses/statistics-for-data-science-python/standard-error.mdx
+++ b/content/courses/statistics-for-data-science-python/standard-error.mdx
@@ -216,6 +216,7 @@ fig = px.line(
     markers=True,
     title="Standard error vs sample size: steep, then flat (diminishing returns)",
     labels={"x": "sample size n", "y": "standard error (sigma/sqrt(n))"},
+    template="simple_white",
 )
 fig.show()
 

--- a/content/courses/statistics-for-data-science-python/statistical-fallacies.mdx
+++ b/content/courses/statistics-for-data-science-python/statistical-fallacies.mdx
@@ -551,6 +551,7 @@ dd = pd.read_csv("datasaurus.csv")`,
 fig = px.scatter(
     dd, x="x", y="y", facet_col="dataset", facet_col_wrap=4,
     height=700, title="The Datasaurus Dozen, identical statistics, wildly different shapes",
+    template="simple_white",
 )
 fig.update_xaxes(matches=None, showticklabels=False)
 fig.update_yaxes(matches=None, showticklabels=False)

--- a/content/courses/statistics-for-data-science-python/statistical-thinking.mdx
+++ b/content/courses/statistics-for-data-science-python/statistical-thinking.mdx
@@ -142,6 +142,7 @@ fig = px.line(
     markers=True,
     labels={"x": "Month", "y": "Metric"},
     title="A 'trend' that is 100% noise",
+    template="simple_white",
 )
 fig.add_hline(y=100, line_dash="dash", annotation_text="the actual truth (flat)")
 fig.show()
@@ -311,6 +312,7 @@ fig = px.histogram(
     nbins=40,
     labels={"value": "Sample mean (ms)"},
     title="The mean is not a point, it's a distribution",
+    template="simple_white",
 )
 fig.add_vline(
     x=point_estimate, line_dash="dash", annotation_text="your one sample's mean"

--- a/content/courses/statistics-for-data-science-python/the-bootstrap.mdx
+++ b/content/courses/statistics-for-data-science-python/the-bootstrap.mdx
@@ -197,6 +197,7 @@ fig = px.histogram(
     nbins=50,
     labels={"value": "bootstrap median"},
     title="Bootstrap distribution of the median",
+    template="simple_white",
 )
 fig.add_vline(x=np.median(data), line_dash="dash", annotation_text="observed median")
 fig.add_vline(x=ci_low, line_color="red")

--- a/content/courses/statistics-for-data-science-python/the-normal-distribution.mdx
+++ b/content/courses/statistics-for-data-science-python/the-normal-distribution.mdx
@@ -93,6 +93,7 @@ fig = px.line(
     y="density",
     color="distribution",
     title="The normal: mu moves the center, sigma sets the width",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -129,6 +130,7 @@ grid = np.linspace(flippers.min(), flippers.max(), 200)
 fig = px.histogram(
     flippers, x="flipper_length_mm", histnorm="probability density", nbins=20,
     title=f"Adelie flipper length vs a fitted normal (mu={mu:.0f}, sigma={sigma:.1f})",
+    template="simple_white",
 )
 fig.add_scatter(x=grid, y=stats.norm(mu, sigma).pdf(grid), mode="lines", name="normal fit")
 fig.show()
@@ -220,6 +222,7 @@ fig.update_layout(
     title="Normal(100, 15): the central ~95% band",
     xaxis_title="score",
     yaxis_title="density",
+    template="simple_white",
 )
 fig.show()
 
@@ -518,6 +521,7 @@ fig.update_layout(
     title="A normal forced onto skewed income data, it doesn't fit",
     xaxis_title="income",
     yaxis_title="density",
+    template="simple_white",
 )
 fig.show()
 

--- a/content/courses/statistics-for-data-science-python/visualizing-distributions.mdx
+++ b/content/courses/statistics-for-data-science-python/visualizing-distributions.mdx
@@ -93,12 +93,15 @@ aq = pd.read_csv("anscombe.csv")`,
       starterCode: `fig = px.scatter(
     aq, x="x", y="y", facet_col="dataset", facet_col_wrap=2,
     title="Anscombe's quartet, identical summaries, four shapes",
+    template="simple_white",
 )
 fig.show()
 `,
     },
   ]}
 />
+
+<Chart slug="anscombes-quartet" />
 
 <Callout type="danger" title="Misconception: a mean and standard deviation fully describe a distribution">
 They describe *center and spread* and nothing else, not the number of
@@ -138,7 +141,8 @@ tips = px.data.tips()
 # The SAME column, three bin counts, three different impressions.
 for nbins in [5, 20, 80]:
     fig = px.histogram(
-        tips, x="total_bill", nbins=nbins, title=f"total_bill with nbins={nbins}"
+        tips, x="total_bill", nbins=nbins, title=f"total_bill with nbins={nbins}",
+        template="simple_white",
     )
     fig.show()
 
@@ -187,6 +191,8 @@ outlier dots. Box plots are compact and *brilliant for comparing
 groups* side by side, but they hide modality, because a box plot of a
 two-humped distribution looks just like a box plot of a one-humped one.
 
+<Chart slug="box-plot-anatomy" />
+
 <CodeBlock
   adapter="python"
   files={[
@@ -204,6 +210,7 @@ fig = px.box(
     color="day",
     points="outliers",
     title="total_bill by day (box = IQR, line = median, dots = outliers)",
+    template="simple_white",
 )
 fig.update_layout(showlegend=False)
 fig.show()
@@ -231,6 +238,8 @@ while still comparing groups. The cost is that the smooth outline
 depends on a smoothing choice, so very small samples can look smoother
 and more reliable than they are.
 
+<Chart slug="violin-vs-box" />
+
 <CodeBlock
   adapter="python"
   files={[
@@ -248,6 +257,7 @@ fig = px.violin(
     box=True,  # draw the box plot inside the violin
     points=False,
     title="total_bill by day (violin shows the full shape)",
+    template="simple_white",
 )
 fig.update_layout(showlegend=False)
 fig.show()
@@ -309,6 +319,7 @@ fig = px.ecdf(
     x="total_bill",
     color="sex",
     title="ECDF of total_bill: fraction of bills at or below each value",
+    template="simple_white",
 )
 fig.show()
 

--- a/content/courses/statistics-for-data-science-python/working-with-distributions.mdx
+++ b/content/courses/statistics-for-data-science-python/working-with-distributions.mdx
@@ -237,6 +237,7 @@ fig.update_layout(
     title="Histogram with fitted normal overlay, shapes match well",
     xaxis_title="score",
     yaxis_title="density",
+    template="simple_white",
 )
 fig.show()
 `,
@@ -304,6 +305,7 @@ fig = px.scatter(
     y=samp,
     labels={"x": "theoretical quantiles (fitted normal)", "y": "sample quantiles"},
     title="Q-Q plot: skewed data vs a fitted normal, note the curve",
+    template="simple_white",
 )
 lo, hi = min(theo.min(), samp.min()), max(theo.max(), samp.max())
 fig.add_shape(type="line", x0=lo, y0=lo, x1=hi, y1=hi, line=dict(dash="dash"))

--- a/content/fumadocs-dev/code-blocks-python.mdx
+++ b/content/fumadocs-dev/code-blocks-python.mdx
@@ -147,7 +147,7 @@ t = np.linspace(0, 10, 200)
 fig = go.Figure()
 fig.add_trace(go.Scatter(x=t, y=np.sin(t), name="sin", mode="lines"))
 fig.add_trace(go.Scatter(x=t, y=np.cos(t), name="cos", mode="lines"))
-fig.update_layout(title="Hover, zoom, and pan")
+fig.update_layout(title="Hover, zoom, and pan", template="simple_white")
 fig.show()
 `,
     },
@@ -167,7 +167,7 @@ t = np.linspace(0, 10, 200)
 fig = go.Figure()
 fig.add_trace(go.Scatter(x=t, y=np.sin(t), name="sin", mode="lines"))
 fig.add_trace(go.Scatter(x=t, y=np.cos(t), name="cos", mode="lines"))
-fig.update_layout(title="Hover, zoom, and pan")
+fig.update_layout(title="Hover, zoom, and pan", template="simple_white")
 fig.show()
 `,
     },


### PR DESCRIPTION
## Fix: dead band under the compacted sticky header

The sticky header's box is a fixed `h-14`/`md:h-16` and only the inner `<nav>` shrinks on scroll — deliberately, per the comment in `HomeNav.tsx`: moving the height transition onto the box reflows the page and resizes the sticky compositing layer, which has left stale marquee raster in the strip it vacated. The bottom spacing was the side effect. Compacted, the nav ends at 48px, the box still painted solid to 64px, and the fade only started there, so 16px of flat colour (12px on mobile) sat between the logo row and the melt into the page.

The background comes off the `<header>` and onto an absolutely positioned div that tracks the nav's height, and the fade moves from the box's bottom edge to the background's, so both follow the shrink. The box keeps its `h-14`/`md:h-16`, so the flow and the layer are the size they were — this is a repaint inside the existing layer, not a resize of it.

Measured on `/pricing`, scrolled:

| | header box | nav | background | fade | chrome ends |
| --- | --- | --- | --- | --- | --- |
| 1280px, before | 0→64 | 0→48 | 0→64 | 64→76 | **76px** |
| 1280px, after | 0→64 | 0→48 | 0→48 | 48→60 | **60px** |
| 390px, after | 0→56 | 0→44 | 0→44 | 44→56 | **56px** (the box's own height) |

Top of page is unchanged, and both themes were checked.

## Fix: animated Plotly figures never animated

`animation_frame=` splits an animated figure in two: the play button and the slider are `layout.updatemenus` / `layout.sliders`, and the thing they animate is a sibling `frames` array. `fig.to_json()` returns all three — the gapminder figure on the Plotly course landing page has 12 frames — but `PlotlyFigure` declared only `data` and `layout`, and both renderers called the positional `Plotly.newPlot(el, data, layout, config)`, which has no parameter for frames.

So the controls drew from `layout` and did nothing: their handlers resolve frames by name against the graph and found none registered. The figure looked animated and was a still.

`PlotlyChart` now awaits `newPlot` and follows it with `Plotly.addFrames` when the figure has any. Measured on the lesson's own figure JSON (generated through `scripts/lib/pyodide-runner.mjs`), rendered both ways in one page and driven with Playwright:

| | frames registered | slider step after pressing play |
| --- | --- | --- |
| before | 0 | 0 → 0 (inert) |
| after | 12 | 0 → 9 |

`Playground.tsx` kept a private copy of this component — the one surface the earlier de-duplication missed, which is exactly how this would have been half-fixed — so it now renders through the shared one and the copy is gone.

## Static charts on two statistics pages

`charts/anscombes-quartet.mjs` already existed and was placed on nine lessons, but the statistics course's own landing page and its **Visualizing Distributions** lesson both made the Anscombe argument in prose and left the picture behind a **Run** button. Both now show it next to the runnable version. The distributions lesson also had two sections with no static figure while its histogram, KDE and ECDF sections each had one:

| Section | Chart added |
| --- | --- |
| Why summaries lie: always plot first | `anscombes-quartet` |
| Box plots: five-number summary and outliers at a glance | `box-plot-anatomy` |
| Violin plots: shape plus summary | `violin-vs-box` |

All three are existing specs, reused as-is — no new chart files.

## Plotly blocks standardised on `simple_white`

The Pyodide runtime sets `pio.templates.default` to `plotly` / `plotly_dark`, so any block that did not pass `template=` rendered in the stock template, while the 119 calls in the Plotly course pass `template="simple_white"` explicitly. The 53 remaining figure calls across the courses now pass it too:

- as a keyword on each `px.*` call, and
- inside the existing `fig.update_layout(...)` for the `go.Figure()` blocks that build a figure trace by trace.

Only code that actually runs was touched — the `initCode` / `starterCode` / `solutionCode` / test bodies behind `<CodeBlock>` and `<ChallengeCard>`. Pseudo-code in prose and fenced snippets (`px.bar(...)`, `px.scatter(..., log_y=True)`) keeps its shape, and the Plotly course's pre-template lessons, which deliberately show the default before `the-simple-white-template` introduces the override, are untouched.

One consequence worth a look: `simple_white` is a light template with no dark counterpart, so these figures now render light-on-dark for a reader in dark mode, exactly as the Plotly course's 119 existing calls already do. If that is not wanted, the alternative is a one-line change to `plotlyDefaultTemplate` in `app/_components/runtime/pyodide-worker.ts` rather than per-call keywords.

## Verification

- `npm test` — 1113 tests in 81 files pass
- `npx tsc --noEmit` and `npx eslint` clean on the changed components
- `npm run check:mdx` — component tags in 923 MDX files are all top-level
- `npm run check:code-blocks` — all 1657 checkable Python blocks run without raising
- `npm run check:challenges` — all 304 checkable Python challenge cards pass their own tests
- `npm run build:charts` — 269 charts render; the usage index picks up the three new placements
- Header geometry and the animation fix both driven in Chromium as described above