### PR TITLE
Search: rank the current course first, land on the exact component, highlight the match

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,19 @@ Three build steps produce it, all wired into `npm run build`:
 
 | Step | Output |
 | --- | --- |
-| `scripts/build-search-corpus.mjs` | `lib/generated/search-corpus.json` — one row per `(page, heading)` |
+| `scripts/build-search-corpus.mjs` | `lib/generated/search-corpus.json` — one row per `(page, heading)`, plus one per anchored component |
 | `scripts/build-search-sql.mjs` | `lib/generated/search-seed.sql` — the `DELETE` + batched `INSERT`s |
 | `npm run db:seed:search[:remote]` | the rows, in D1 — skipped when unchanged |
 
 These run **after** `build:charts`, and the order is load-bearing: chart titles and captions live in the generated chart manifest rather than in the MDX, so a corpus built before it silently omits every one of them. That is worth ~264 kB of prose across ~250 charts, and it produced an index with no chart captions in it at all the first time the steps were ordered the other way. `build-search-corpus.mjs` now warns loudly when the manifest is missing or empty rather than quietly indexing less.
 
 The corpus is extracted from the MDX **ASTs**, not the rendered HTML, which is what lets it reach content that never exists in the DOM until a learner interacts: `<ChallengeCard>` instructions and solutions, `<MultipleChoice>` questions and per-choice explanations, fenced and `<CodeBlock>` source, Mermaid definitions, `<Chart>` titles and captions, and the whole of `content/interview/`, which the previous index omitted entirely. Prose and code land in separate columns so `bm25()` can weight prose about seven to one over code — that ratio is what makes indexing code safe, since a search for a common identifier should surface the lesson that *explains* it above the dozen that merely use it in a starter file.
+
+Three query-time behaviours sit on top of that index (`lib/search/ranking.ts`):
+
+- **Component anchors.** Content components get deterministic DOM ids (`#x-mcq-2`, `#x-code-1`) injected at compile time by `remarkComponentAnchors`, and the corpus carries a narrow extra row per component under the same id, so a hit on quiz or challenge text deep-links to the component itself instead of the heading somewhere above it. `lib/search/anchors.mjs` is the single source both sides derive the ids from; `__tests__/searchAnchors.test.ts` pins the contract.
+- **Current-course boost.** The docs layouts send the course / interview track being read as `?tag=` (see `DocsRootProvider`), and the route *boosts* — not filters — rows from that course (×2) and collection (×1.15), so "bar" typed inside the Plotly course surfaces Plotly's bar-chart lesson above ggplot2's while the rest of the site stays reachable.
+- **Landing-page highlights.** Result URLs carry the searched tokens as `?hl=`; `SearchHighlight` paints them browser-find style via the CSS Custom Highlight API, and `HashScrollFix` keeps the viewport pinned to the anchor while CodeMirror/KaTeX/Mermaid finish mounting underneath it.
 
 ### One-time setup
 
@@ -112,7 +118,7 @@ The database and its schema already exist. To recreate them from scratch:
 ```bash
 npx wrangler d1 create dataslope-search   # paste database_id into wrangler.jsonc
 npm run db:migrate:search:remote          # migrations/search/0001_create_docs_fts.sql
-npm run db:seed:search:remote             # ~9k rows
+npm run db:seed:search:remote             # ~19k rows
 ```
 
 **The Workers Builds API token needs `D1 (edit)` added to it.** The token Cloudflare generates for Workers Builds is scoped to Account Settings (read), Workers Scripts (edit), Workers KV (edit), Workers R2 (edit) and Workers Routes (edit) — D1 is not in that set, so the deploy-time seed fails to authorize until it is added under **My Profile → API Tokens → (the Workers Builds token) → Edit → Account → D1 → Edit**. Because the seed is chained after `deploy` with `&&`, the symptom is a Worker that ships fine and a build that goes red on the last step, with the index never updating.

--- a/__tests__/searchAnchors.test.ts
+++ b/__tests__/searchAnchors.test.ts
@@ -1,0 +1,138 @@
+/**
+ * The anchor-id contract between the render pipeline and the search indexer.
+ *
+ * `remarkComponentAnchors` (lib/search/anchors.mjs) injects DOM ids into
+ * anchored MDX components at compile time; `extractComponents`
+ * (scripts/lib/search-extract.mjs) stamps ids on the corpus rows at index
+ * time. Search deep links only work while both derive identical ids from the
+ * same authored MDX, so that equivalence is what this file pins down.
+ */
+import { describe, expect, it } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkMdx from "remark-mdx";
+import remarkMath from "remark-math";
+import { structure } from "fumadocs-core/mdx-plugins";
+import {
+  ANCHOR_COMPONENTS,
+  remarkComponentAnchors,
+  walkTree,
+} from "@/lib/search/anchors.mjs";
+import {
+  CONTENT_COMPONENTS,
+  extractComponents,
+} from "@/scripts/lib/search-extract.mjs";
+
+const MDX = `# Intro
+
+An opening paragraph.
+
+<MultipleChoice
+  markdown={\`Which chart counts rows per category?
+
+- [o] Bar chart
+  > geom_bar counts rows per category.
+- Scatter plot\`}
+/>
+
+## Position adjustments
+
+Stack, dodge, fill.
+
+<CodeBlock adapter="python" files={[{ filename: "main.py", starterCode: \`print("hello")\` }]} />
+
+<MultipleChoice id="custom-quiz" markdown={\`Explicitly anchored question\`} />
+
+<MultipleChoice markdown={\`Purely for historical reasons with no practical effect.\`} />
+
+<Callout title="A note">
+
+Some advice, with a nested block:
+
+<CodeBlock adapter="r" files={[{ filename: "main.R", starterCode: \`plot(1)\` }]} />
+
+</Callout>
+`;
+
+/** The ids the render pipeline ends up with, in document order. */
+function renderedAnchorIds(source: string): (string | undefined)[] {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkMath)
+    .use(remarkMdx)
+    .use(remarkComponentAnchors);
+  const tree = processor.runSync(processor.parse(source));
+  const ids: (string | undefined)[] = [];
+  walkTree(tree, (node: { type?: string; name?: string; attributes?: { type: string; name: string; value?: unknown }[] }) => {
+    if (node.type !== "mdxJsxFlowElement" || !node.name || !ANCHOR_COMPONENTS.has(node.name)) return;
+    const id = node.attributes?.find(
+      (a) => a.type === "mdxJsxAttribute" && a.name === "id",
+    );
+    ids.push(typeof id?.value === "string" ? id.value : undefined);
+  });
+  return ids;
+}
+
+function extract(source: string) {
+  const sd = structure(source, [remarkMath, remarkMdx], {
+    types: ["heading", "paragraph", "blockquote", "tableCell"],
+  });
+  const headingIds = sd.headings.map((h) => h.id);
+  return { ...extractComponents(source, headingIds, {}), headingIds };
+}
+
+describe("anchor id contract", () => {
+  it("every anchored component is also a content component", () => {
+    for (const name of ANCHOR_COMPONENTS.keys()) {
+      expect(CONTENT_COMPONENTS.has(name), name).toBe(true);
+    }
+  });
+
+  it("render-side ids and index-side anchors agree, in order", () => {
+    const rendered = renderedAnchorIds(MDX);
+    const { perComponent } = extract(MDX);
+    expect(rendered).toEqual([
+      "x-mcq-1",
+      "x-code-1",
+      "custom-quiz", // author-written id wins and consumes no counter
+      "x-mcq-2",
+      "x-note-1",
+      "x-code-2", // nested inside the Callout, still numbered in document order
+    ]);
+    expect([...perComponent.keys()]).toEqual(rendered);
+  });
+
+  it("component content lands under the component's own anchor", () => {
+    const { perComponent } = extract(MDX);
+    expect(perComponent.get("x-mcq-1")?.prose.join("\n")).toContain(
+      "Which chart counts rows per category?",
+    );
+    expect(perComponent.get("x-mcq-2")?.prose.join("\n")).toContain(
+      "historical reasons with no practical effect",
+    );
+    expect(perComponent.get("x-code-1")?.code.join("\n")).toContain('print("hello")');
+    expect(perComponent.get("custom-quiz")?.prose.join("\n")).toContain(
+      "Explicitly anchored question",
+    );
+  });
+
+  it("component content also stays in its section bucket, so multi-term queries spanning a paragraph and a component keep matching one row", () => {
+    const { perHeading } = extract(MDX);
+    const section = perHeading.get("position-adjustments");
+    expect(section?.prose.join("\n")).toContain(
+      "historical reasons with no practical effect",
+    );
+    expect(section?.code.join("\n")).toContain('print("hello")');
+    // Pre-first-heading content buckets under the page key ("") …
+    expect(perHeading.get("intro")?.prose.join("\n")).toContain(
+      "Bar chart",
+    );
+  });
+
+  it("an id attribute is only injected where the author wrote none", () => {
+    const rendered = renderedAnchorIds(
+      '<MultipleChoice id="mine" markdown={`Q`} />\n\n<MultipleChoice markdown={`Q2`} />\n',
+    );
+    expect(rendered).toEqual(["mine", "x-mcq-1"]);
+  });
+});

--- a/__tests__/searchRanking.test.ts
+++ b/__tests__/searchRanking.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Query-time search behaviour: scope parsing/boosting SQL and the row → result
+ * grouping in lib/search/ranking.ts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  parseScope,
+  searchScopeFor,
+  searchSql,
+  toResults,
+  type SearchRow,
+} from "@/lib/search/ranking";
+
+function row(overrides: Partial<SearchRow>): SearchRow {
+  return {
+    url: "/courses/a/lesson#sec",
+    page: "/courses/a/lesson",
+    anchor: "sec",
+    section: "Course A",
+    title: "Lesson",
+    heading: "Section",
+    excerpt: "…around the <mark>match</mark>…",
+    codeExcerpt: "",
+    ...overrides,
+  };
+}
+
+describe("parseScope", () => {
+  it("parses course and interview scopes", () => {
+    expect(parseScope("courses/mastering-ggplot2")).toEqual({
+      collection: "courses",
+      page: "/courses/mastering-ggplot2",
+      pagePrefix: "/courses/mastering-ggplot2/%",
+    });
+    expect(parseScope("interview/data-scientist")).toEqual({
+      collection: "interview",
+      page: "/interview-prep/data-scientist",
+      pagePrefix: "/interview-prep/data-scientist/%",
+    });
+  });
+
+  it("rejects anything that is not a clean scope", () => {
+    expect(parseScope(null)).toBeNull();
+    expect(parseScope("")).toBeNull();
+    expect(parseScope("blog/foo")).toBeNull();
+    expect(parseScope("courses/Weird Slug")).toBeNull();
+    expect(parseScope("courses/has_underscore")).toBeNull(); // LIKE metachar
+    expect(parseScope("courses/a/b")).toBeNull();
+    expect(parseScope("courses/-leading")).toBeNull();
+  });
+
+  it("round-trips what the dialog derives from a pathname", () => {
+    const paths = [
+      "/courses/plotly-express/bar-charts",
+      "/courses/mastering-ggplot2",
+      "/interview-prep/data-scientist/multiple-choice-questions",
+    ];
+    for (const p of paths) {
+      const tag = searchScopeFor(p);
+      expect(tag).toBeDefined();
+      const scope = parseScope(tag!);
+      expect(scope).not.toBeNull();
+      expect(p === scope!.page || p.startsWith(`${scope!.page}/`)).toBe(true);
+    }
+    expect(searchScopeFor("/pricing")).toBeUndefined();
+    expect(searchScopeFor("/courses")).toBeUndefined();
+  });
+});
+
+describe("searchSql", () => {
+  it("only the scoped variant carries the boost parameters", () => {
+    expect(searchSql(true)).toContain("?5");
+    expect(searchSql(false)).not.toContain("?3");
+    expect(searchSql(false)).not.toContain("?4");
+    expect(searchSql(false)).not.toContain("?5");
+  });
+
+  it("both variants damp component rows", () => {
+    expect(searchSql(true)).toContain("heading = ''");
+    expect(searchSql(false)).toContain("heading = ''");
+  });
+});
+
+describe("toResults", () => {
+  it("groups rows page-first and keeps the first-seen page position", () => {
+    const out = toResults(
+      [
+        row({ page: "/courses/a/x", url: "/courses/a/x#one", anchor: "one", heading: "One", excerpt: "…first <mark>match</mark> in a stacked chart…" }),
+        row({ page: "/courses/b/y", url: "/courses/b/y#two", anchor: "two", heading: "Two", section: "Course B", excerpt: "…second <mark>match</mark> about dodging…" }),
+        row({ page: "/courses/a/x", url: "/courses/a/x#three", anchor: "three", heading: "Three", excerpt: "…third <mark>match</mark> on filled bars…" }),
+      ],
+      24,
+    );
+    expect(out.map((r) => [r.type, r.url])).toEqual([
+      ["page", "/courses/a/x"],
+      ["heading", "/courses/a/x#one"],
+      ["text", "/courses/a/x#one"],
+      ["page", "/courses/b/y"],
+      ["heading", "/courses/b/y#two"],
+      ["text", "/courses/b/y#two"],
+      ["heading", "/courses/a/x#three"],
+      ["text", "/courses/a/x#three"],
+    ]);
+    expect(out[0].breadcrumbs).toEqual(["Course A"]);
+  });
+
+  it("a null-anchor row is the page-level result and adds no child entry", () => {
+    const out = toResults([row({ anchor: null, url: "/courses/a/lesson", heading: "" })], 24);
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("page");
+  });
+
+  it("component rows become text entries at the component's anchor", () => {
+    const out = toResults(
+      [row({ url: "/courses/a/lesson#x-mcq-2", anchor: "x-mcq-2", heading: "" })],
+      24,
+      ["historical", "reasons"],
+    );
+    expect(out.map((r) => r.type)).toEqual(["page", "text"]);
+    expect(out[1].url).toBe("/courses/a/lesson?hl=historical%20reasons#x-mcq-2");
+    expect(out[0].url).toBe("/courses/a/lesson?hl=historical%20reasons");
+  });
+
+  it("collapses the section-row duplicate of a component match onto the component's anchor", () => {
+    const excerpt = "…Purely for <mark>historical</mark> reasons with no practical effect…";
+    const rows = [
+      row({ url: "/courses/a/lesson#x-mcq-2", anchor: "x-mcq-2", heading: "", excerpt }),
+      row({ url: "/courses/a/lesson#stats", anchor: "stats", heading: "Every Geom Has a Stat", excerpt }),
+    ];
+    for (const ordered of [rows, [...rows].reverse()]) {
+      const out = toResults(ordered, 24);
+      const texts = out.filter((r) => r.type === "text");
+      expect(texts).toHaveLength(1);
+      expect(texts[0].url).toBe("/courses/a/lesson#x-mcq-2");
+      // The heading entry itself survives; only the duplicated snippet folds.
+      expect(out.filter((r) => r.type === "heading")).toHaveLength(1);
+    }
+  });
+
+  it("keeps distinct snippets from the same page separate", () => {
+    const out = toResults(
+      [
+        row({ url: "/courses/a/lesson#x-mcq-1", anchor: "x-mcq-1", heading: "", excerpt: "…the <mark>stat</mark> creates new variables and you can use them…" }),
+        row({ url: "/courses/a/lesson#x-mcq-2", anchor: "x-mcq-2", heading: "", excerpt: "…a completely different <mark>stat</mark>ement about geoms…" }),
+      ],
+      24,
+    );
+    expect(out.filter((r) => r.type === "text")).toHaveLength(2);
+  });
+
+  it("falls back to the code snippet when only code matched", () => {
+    const out = toResults(
+      [
+        row({
+          heading: "Setup",
+          excerpt: "plain prose without a match",
+          codeExcerpt: "…<mark>geom_bar</mark>(stat = 'identity')…",
+        }),
+      ],
+      24,
+    );
+    const text = out.find((r) => r.type === "text");
+    expect(text?.content).toContain("<mark>geom_bar</mark>");
+  });
+
+  it("emits no text entry when nothing highlighted", () => {
+    const out = toResults(
+      [row({ heading: "Heading Match", excerpt: "leading prose, no mark", codeExcerpt: "" })],
+      24,
+    );
+    expect(out.map((r) => r.type)).toEqual(["page", "heading"]);
+  });
+
+  it("caps how many rows one page may spend, so other pages still surface", () => {
+    const hog = Array.from({ length: 8 }, (_, i) =>
+      row({
+        page: "/courses/a/hog",
+        url: `/courses/a/hog#h${i}`,
+        anchor: `h${i}`,
+        heading: `H${i}`,
+        excerpt: `…<mark>match</mark> number ${i} entirely unlike the others ${"pad".repeat(i + 1)}…`,
+      }),
+    );
+    const other = row({
+      page: "/courses/b/other",
+      url: "/courses/b/other#sec",
+      section: "Course B",
+      heading: "Other",
+    });
+    const out = toResults([...hog, other], 8);
+    expect(out.filter((r) => r.type === "heading" && r.url.includes("/hog#"))).toHaveLength(4);
+    expect(out.some((r) => r.type === "page" && r.url === "/courses/b/other")).toBe(true);
+  });
+
+  it("skips component rows whose match is invisible (title-only), without spending budget", () => {
+    const invisible = row({
+      url: "/courses/a/lesson#x-note-1",
+      anchor: "x-note-1",
+      heading: "",
+      excerpt: "no mark anywhere here",
+      codeExcerpt: "",
+    });
+    // Alone, it produces nothing at all: its page will surface via the other
+    // rows the same (title) match necessarily hit.
+    expect(toResults([invisible], 24)).toEqual([]);
+    // And it does not consume the row budget ahead of visible rows.
+    const visible = row({ page: "/courses/b/y", url: "/courses/b/y#sec", section: "Course B" });
+    const out = toResults([invisible, visible], 1);
+    expect(out.some((r) => r.url === "/courses/b/y#sec")).toBe(true);
+  });
+
+  it("keeps section rows that matched only via title: the heading entry still routes the reader", () => {
+    const out = toResults(
+      [row({ heading: "Bars and Histograms", excerpt: "no mark", codeExcerpt: "" })],
+      24,
+    );
+    expect(out.map((r) => r.type)).toEqual(["page", "heading"]);
+  });
+
+  it("adds no hl parameter when there are no tokens", () => {
+    const out = toResults([row({})], 24);
+    expect(out.every((r) => !r.url.includes("hl="))).toBe(true);
+  });
+});

--- a/app/_components/DocsRootProvider.tsx
+++ b/app/_components/DocsRootProvider.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * Shared `RootProvider` wrapper for the two learner-facing docs layouts
+ * (/courses, /interview-prep). Adds two things the plain provider lacks:
+ *
+ * 1. The current course / interview track as the search dialog's
+ *    `defaultTag`. Fumadocs's fetch client forwards it to `/api/search` as
+ *    `?tag=…`, where it *boosts* (not filters) rows from the same course and
+ *    collection, so searching "bar" inside the Plotly course surfaces the
+ *    Plotly bar-chart lesson above ggplot2's. Derived from `usePathname()` in
+ *    a client component because layouts do not re-render on navigation, so a
+ *    params-derived value there would go stale when the reader moves between
+ *    courses.
+ *
+ * 2. `<HashScrollFix>`, which keeps deep links (search results included)
+ *    pointed at their target while late-mounting components (CodeMirror,
+ *    KaTeX, Mermaid) shift the page under the initial scroll position, and
+ *    `<SearchHighlight>`, which paints the searched words carried on result
+ *    URLs as `?hl=…`.
+ */
+import type { ComponentProps, ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { RootProvider } from "fumadocs-ui/provider/next";
+import { searchScopeFor } from "@/lib/search/ranking";
+import HashScrollFix from "./HashScrollFix";
+import SearchHighlight from "./SearchHighlight";
+
+export function DocsRootProvider({
+  theme,
+  children,
+}: {
+  theme?: ComponentProps<typeof RootProvider>["theme"];
+  children: ReactNode;
+}) {
+  const scope = searchScopeFor(usePathname());
+  return (
+    <RootProvider
+      theme={theme}
+      search={scope ? { options: { defaultTag: scope } } : undefined}
+    >
+      <HashScrollFix />
+      <SearchHighlight />
+      {children}
+    </RootProvider>
+  );
+}

--- a/app/_components/HashScrollFix.tsx
+++ b/app/_components/HashScrollFix.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * Keeps `#hash` navigation pointed at its target while the page settles.
+ *
+ * The browser (and Next's router) scroll to the hash target as soon as the
+ * HTML is there, but lesson pages keep changing height for a while after
+ * that: `<CodeBlock>` mounts CodeMirror, `<MultipleChoice>` renders its
+ * markdown through KaTeX, Mermaid draws asynchronously. Every one of those
+ * mounts above the target pushes it away from where the browser left the
+ * viewport, which is exactly the "search result lands screens away from the
+ * match" bug for deep links into long lessons.
+ *
+ * So: while a hash target exists, re-align the viewport to it every time the
+ * document resizes, for a short settle window. The user stays in charge; any
+ * scroll intent (wheel, touch, arrow keys, page keys) cancels the window
+ * immediately.
+ *
+ * Keyed on `pathname` only, deliberately: in-page hash navigation (a TOC
+ * click) happens long after layout has settled and needs no correction, so
+ * re-running there would only fight the native jump.
+ */
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+/** How long after arrival late-mounting components may still shift layout. */
+const SETTLE_MS = 3000;
+
+/** Keys that express scroll intent; anything else (typing in Ask AI, tabbing)
+ *  should not cancel the correction window. */
+const SCROLL_KEYS = new Set([
+  "ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " ", "Spacebar",
+]);
+
+export default function HashScrollFix() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const hash = decodeURIComponent(window.location.hash.slice(1));
+    if (!hash) return;
+    const target = document.getElementById(hash);
+    if (!target) return;
+
+    const align = () => target.scrollIntoView({ block: "start", behavior: "instant" });
+
+    align();
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(align);
+    const controller = new AbortController();
+    const cancel = () => {
+      observer.disconnect();
+      controller.abort();
+    };
+    const { signal } = controller;
+    window.addEventListener("wheel", cancel, { passive: true, signal });
+    window.addEventListener("touchstart", cancel, { passive: true, signal });
+    window.addEventListener(
+      "keydown",
+      (e) => {
+        if (SCROLL_KEYS.has(e.key)) cancel();
+      },
+      { signal },
+    );
+    observer.observe(document.body);
+    const timer = window.setTimeout(cancel, SETTLE_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+      cancel();
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/app/_components/SearchHighlight.tsx
+++ b/app/_components/SearchHighlight.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+/**
+ * Paints the searched words on a lesson a reader arrived at from the search
+ * dialog, browser-find style.
+ *
+ * `/api/search` puts the sanitised query tokens on every result URL as
+ * `?hl=…` (see lib/search/ranking.ts). This component reads them back and
+ * marks every word starting with one of those tokens via the CSS Custom
+ * Highlight API: ranges in `CSS.highlights`, painted by the
+ * `::highlight(ds-search-match)` rule in docs.css. No DOM mutation, so
+ * CodeMirror, KaTeX and hydration are never disturbed; browsers without the
+ * API (or visitors who arrived without `?hl=`) get exactly the page they had
+ * before.
+ *
+ * Prefix matching (not whole-word) is deliberate: FTS5 porter-stems its
+ * index and prefix-matches the final token, so the query "reason" may have
+ * matched the page's "reasons"; highlighting only exact words would light up
+ * nothing on the very page the API said matches.
+ *
+ * Late-mounting components (`<MultipleChoice>` renders its markdown client
+ * side) add their text after the first pass, so mutations re-trigger the
+ * pass during the same settle window HashScrollFix uses; after that the
+ * highlights stay put until navigation.
+ */
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+const HIGHLIGHT_NAME = "ds-search-match";
+const SETTLE_MS = 4000;
+const REAPPLY_DEBOUNCE_MS = 150;
+/** Bounds one pass: enough for any real query, cheap even on huge lessons. */
+const MAX_RANGES = 1500;
+const WORD_CHAR = /[\p{L}\p{N}_]/u;
+
+function highlightTerms(): string[] {
+  const hl = new URLSearchParams(window.location.search).get("hl");
+  if (!hl) return [];
+  return [...new Set(hl.toLowerCase().split(/\s+/))]
+    .filter((t) => t.length >= 2) // single letters over-highlight ("r", "x")
+    .slice(0, 12);
+}
+
+function collectRanges(root: Node, terms: string[]): Range[] {
+  const ranges: Range[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const text = node.nodeValue;
+    if (!text || !text.trim()) continue;
+    const lower = text.toLowerCase();
+    for (const term of terms) {
+      for (
+        let i = lower.indexOf(term);
+        i !== -1;
+        i = lower.indexOf(term, i + term.length)
+      ) {
+        // Word-start matches only: "bar" lights up "bars", not "sidebar".
+        if (i > 0 && WORD_CHAR.test(lower[i - 1])) continue;
+        const range = new Range();
+        range.setStart(node, i);
+        range.setEnd(node, i + term.length);
+        ranges.push(range);
+        if (ranges.length >= MAX_RANGES) return ranges;
+      }
+    }
+  }
+  return ranges;
+}
+
+export default function SearchHighlight() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (typeof CSS === "undefined" || !("highlights" in CSS)) return;
+    const terms = highlightTerms();
+    if (terms.length === 0) return;
+
+    const apply = () => {
+      const root =
+        document.querySelector("article") ??
+        document.querySelector("main") ??
+        document.body;
+      CSS.highlights.set(HIGHLIGHT_NAME, new Highlight(...collectRanges(root, terms)));
+    };
+
+    apply();
+
+    // Re-apply while late-mounting components are still adding text.
+    let debounce: number | undefined;
+    const observer = new MutationObserver(() => {
+      window.clearTimeout(debounce);
+      debounce = window.setTimeout(apply, REAPPLY_DEBOUNCE_MS);
+    });
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+    const settleTimer = window.setTimeout(() => {
+      observer.disconnect();
+      window.clearTimeout(debounce);
+      apply();
+    }, SETTLE_MS);
+
+    return () => {
+      observer.disconnect();
+      window.clearTimeout(debounce);
+      window.clearTimeout(settleTimer);
+      CSS.highlights.delete(HIGHLIGHT_NAME);
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/app/_components/mdx/withSearchAnchor.tsx
+++ b/app/_components/mdx/withSearchAnchor.tsx
@@ -1,0 +1,34 @@
+/**
+ * Renders the search-anchor id that `remarkComponentAnchors` injects into
+ * anchored MDX components (see lib/search/anchors.mjs).
+ *
+ * The plugin adds an `id` attribute to the JSX element, which MDX delivers as
+ * an `id` prop. None of the wrapped components render an `id` themselves, so
+ * this HOC lifts it onto a neutral wrapper `<div>` instead of threading an
+ * extra prop through a dozen component signatures. The wrapper carries no
+ * styling of its own; `data-search-anchor` exists so docs.css can give these
+ * targets the same scroll offset as Fumadocs headings (`scroll-m-28`), keeping
+ * the sticky navbar from covering the component a search link lands on.
+ *
+ * Components rendered without an injected id (anything outside MDX, or the
+ * plugin being absent) pass through unwrapped.
+ */
+import type { ComponentType, JSX } from "react";
+
+export function withSearchAnchor<P extends object>(
+  Component: ComponentType<P>,
+): (props: P & { id?: string }) => JSX.Element {
+  function WithSearchAnchor({ id, ...props }: P & { id?: string }) {
+    const inner = <Component {...(props as P)} />;
+    if (!id) return inner;
+    return (
+      <div id={id} data-search-anchor="">
+        {inner}
+      </div>
+    );
+  }
+  WithSearchAnchor.displayName = `WithSearchAnchor(${
+    Component.displayName ?? Component.name ?? "Component"
+  })`;
+  return WithSearchAnchor;
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -17,13 +17,22 @@
  *
  * This route no longer uses `createSearchAPI`, so it owns the contract that
  * Fumadocs's default fetch client expects (fumadocs-core/dist/endpoint):
- * `GET ?query=…&limit=…` returning `SortedResult[]`, and `[]` for an empty
- * query. Results are ordered page-first-then-sections so the dialog groups
- * naturally: a `page` result carrying the lesson title, followed by `heading`
- * results linking to the `#anchor` that actually matched.
+ * `GET ?query=…&limit=…&tag=…` returning `SortedResult[]`, and `[]` for an
+ * empty query. Results are ordered page-first-then-sections so the dialog
+ * groups naturally: a `page` result carrying the lesson title, followed by
+ * `heading`/`text` results linking to the `#anchor` that actually matched;
+ * for text that lives inside a component (`<MultipleChoice>`, `<CodeBlock>`,
+ * …) that anchor is the component's own id, not the heading above it (see
+ * lib/search/anchors.mjs).
+ *
+ * `tag` is the dialog's current course / interview track. Stock Fumadocs
+ * treats tags as filters; here it *boosts* (see lib/search/ranking.ts), so
+ * the reader's own course rises without hiding the rest of the site.
  *
  * Snippets come back with `<mark>` around the matched terms, which is the form
- * Fumadocs renders highlights in.
+ * Fumadocs renders highlights in, and every result URL carries the searched
+ * tokens as `?hl=…` so the lesson page can highlight them after navigation
+ * (app/_components/SearchHighlight.tsx).
  *
  * ── Read replication ────────────────────────────────────────────────────────
  *
@@ -38,91 +47,13 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 
-import { toMatchQuery } from "@/lib/search/query";
-
-/** Fumadocs's result shape (fumadocs-core `SortedResult`). */
-interface SortedResult {
-  id: string;
-  url: string;
-  type: "page" | "heading" | "text";
-  content: string;
-  breadcrumbs?: string[];
-}
-
-interface Row {
-  url: string;
-  page: string;
-  anchor: string;
-  section: string;
-  title: string;
-  heading: string;
-  excerpt: string;
-}
-
-/**
- * BM25 column weights, in the table's column order. The five UNINDEXED columns
- * lead and take 0, because `bm25()` wants one weight per column and they carry
- * no tokens.
- *
- * Prose outranks code by roughly seven to one. That ratio is what makes
- * indexing code safe: a search for a common identifier should surface the
- * lesson that *explains* it above the dozen that merely use it in a starter
- * file, and without the split there is no way to express that.
- */
-const WEIGHTS = "0, 0, 0, 0, 0, 8.0, 6.0, 4.0, 1.0, 0.15";
-
-const SQL = `
-  SELECT url, page, anchor, section, title, heading,
-         snippet(docs, 8, '<mark>', '</mark>', '…', 24) AS excerpt
-  FROM docs
-  WHERE docs MATCH ?
-  ORDER BY bm25(docs, ${WEIGHTS})
-  LIMIT ?
-`;
+import { searchTokens, toMatchQuery } from "@/lib/search/query";
+import { parseScope, searchSql, toResults, type SearchRow } from "@/lib/search/ranking";
 
 function db() {
   const env = getCloudflareContext().env as unknown as { SEARCH_DB?: D1Database };
   if (!env.SEARCH_DB) throw new Error("SEARCH_DB binding is not configured");
   return env.SEARCH_DB;
-}
-
-/**
- * Group the flat section rows into Fumadocs's page-then-headings shape.
- *
- * Sections arrive already ranked. The first section seen for a page fixes that
- * page's position in the output, so a lesson whose best section ranked third
- * overall lands third, rather than every page floating to wherever its
- * strongest and weakest sections happen to be.
- */
-function toResults(rows: Row[]): SortedResult[] {
-  const out: SortedResult[] = [];
-  const seenPage = new Set<string>();
-
-  for (const row of rows) {
-    if (!seenPage.has(row.page)) {
-      seenPage.add(row.page);
-      out.push({
-        id: row.page,
-        url: row.page,
-        type: "page",
-        content: row.title,
-        breadcrumbs: row.section ? [row.section] : undefined,
-      });
-    }
-    // The pre-heading chunk of a page has no anchor; its content is already
-    // represented by the page result above, so it adds no second entry.
-    if (!row.anchor) continue;
-    out.push({
-      id: row.url,
-      url: row.url,
-      type: "heading",
-      content: row.heading || row.excerpt,
-    });
-    if (row.excerpt && row.heading) {
-      out.push({ id: `${row.url}-text`, url: row.url, type: "text", content: row.excerpt });
-    }
-  }
-  return out;
 }
 
 export async function GET(request: Request) {
@@ -137,11 +68,21 @@ export async function GET(request: Request) {
 
   const limitParam = Number(url.searchParams.get("limit"));
   const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 50) : 24;
+  const scope = parseScope(url.searchParams.get("tag"));
 
-  let rows: Row[];
+  // Fetch more rows than the response spends: the per-page cap in
+  // `toResults` skips rows, and skipped rows must be replaceable by
+  // lower-ranked pages rather than shrinking the result list.
+  const fetchLimit = Math.min(limit * 3, 120);
+
+  let rows: SearchRow[];
   try {
     const session = db().withSession("first-unconstrained");
-    const result = await session.prepare(SQL).bind(match, limit).all<Row>();
+    const stmt = session.prepare(searchSql(scope !== null));
+    const bound = scope
+      ? stmt.bind(match, fetchLimit, scope.page, scope.pagePrefix, scope.collection)
+      : stmt.bind(match, fetchLimit);
+    const result = await bound.all<SearchRow>();
     rows = result.results ?? [];
   } catch (err) {
     // A malformed MATCH should be impossible after sanitising, so anything
@@ -151,11 +92,12 @@ export async function GET(request: Request) {
     return Response.json({ error: `search unavailable: ${message}` }, { status: 503 });
   }
 
-  const response = Response.json(toResults(rows));
+  const response = Response.json(toResults(rows, limit, searchTokens(raw)));
   // The index only changes on deploy, so a repeat of the same query inside a
   // day is a CDN hit rather than another Worker invocation *and* another D1
   // round trip. This is also what keeps the primary-region latency off the
-  // common path when read replication is not enabled.
+  // common path when read replication is not enabled. `tag` and `query` are
+  // both in the cache key, so scoped and unscoped answers never mix.
   response.headers.set(
     "Cache-Control",
     "public, s-maxage=86400, stale-while-revalidate=604800",

--- a/app/courses/[...slug]/layout.tsx
+++ b/app/courses/[...slug]/layout.tsx
@@ -17,10 +17,10 @@
  */
 import "../../docs.css";
 import type { ReactNode } from "react";
-import { RootProvider } from "fumadocs-ui/provider/next";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { courseSource } from "@/lib/source";
 import { ThemePillToggleSlot } from "@/app/_components/ThemePillToggle";
+import { DocsRootProvider } from "@/app/_components/DocsRootProvider";
 
 export default function CourseLessonLayout({
   children,
@@ -34,7 +34,11 @@ export default function CourseLessonLayout({
     // binary "light" | "dark" with a light default, so without this a dark-OS
     // visitor with no stored choice would get dark docs but light pages
     // everywhere else.
-    <RootProvider theme={{ defaultTheme: "light", enableSystem: false }}>
+    //
+    // DocsRootProvider (not the bare RootProvider) so the search dialog knows
+    // the current course and deep links stay aligned + highlighted; see that
+    // component's header.
+    <DocsRootProvider theme={{ defaultTheme: "light", enableSystem: false }}>
       <DocsLayout
         tree={courseSource.pageTree}
         tabs={false}
@@ -80,6 +84,6 @@ export default function CourseLessonLayout({
       >
         {children}
       </DocsLayout>
-    </RootProvider>
+    </DocsRootProvider>
   );
 }

--- a/app/docs.css
+++ b/app/docs.css
@@ -668,3 +668,25 @@ code.hljs {
   font-variation-settings: normal;
   letter-spacing: -0.011em;
 }
+
+/* ── Search-result anchors on custom components ──────────────────────────────
+   `remarkComponentAnchors` (lib/search/anchors.mjs) gives every anchored MDX
+   component (<MultipleChoice>, <CodeBlock>, …) a DOM id, rendered by
+   `withSearchAnchor` as a wrapper div carrying this attribute, so /api/search
+   results can deep-link straight to the component that matched. Match the
+   scroll offset Fumadocs gives headings (`scroll-m-28`, 7rem): without it the
+   sticky navbar covers the top of the component the link lands on. */
+[data-search-anchor] {
+  scroll-margin-top: 7rem;
+}
+
+/* Matched-word highlights painted by app/_components/SearchHighlight.tsx
+   (CSS Custom Highlight API) after arriving from a search result. Brand
+   yellow at an opacity that reads as a marker stroke over both page
+   surfaces without crushing text contrast. */
+::highlight(ds-search-match) {
+  background-color: color-mix(in srgb, var(--ds-yellow-500) 45%, transparent);
+}
+.dark ::highlight(ds-search-match) {
+  background-color: color-mix(in srgb, var(--ds-yellow-500) 28%, transparent);
+}

--- a/app/interview-prep/[...slug]/layout.tsx
+++ b/app/interview-prep/[...slug]/layout.tsx
@@ -19,16 +19,18 @@
  */
 import "../../docs.css";
 import type { ReactNode } from "react";
-import { RootProvider } from "fumadocs-ui/provider/next";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { interviewSource } from "@/lib/source";
 import { ThemePillToggleSlot } from "@/app/_components/ThemePillToggle";
+import { DocsRootProvider } from "@/app/_components/DocsRootProvider";
 
 export default function InterviewLayout({ children }: { children: ReactNode }) {
   return (
     // Match the site-wide binary light/dark contract (light default); see the
-    // note in app/courses/[...slug]/layout.tsx.
-    <RootProvider theme={{ defaultTheme: "light", enableSystem: false }}>
+    // note in app/courses/[...slug]/layout.tsx. DocsRootProvider additionally
+    // scopes the search dialog to the current interview track and keeps deep
+    // links aligned + highlighted; see that component's header.
+    <DocsRootProvider theme={{ defaultTheme: "light", enableSystem: false }}>
       <DocsLayout
         tree={interviewSource.pageTree}
         tabs={false}
@@ -68,6 +70,6 @@ export default function InterviewLayout({ children }: { children: ReactNode }) {
       >
         {children}
       </DocsLayout>
-    </RootProvider>
+    </DocsRootProvider>
   );
 }

--- a/lib/search/anchors.mjs
+++ b/lib/search/anchors.mjs
@@ -1,0 +1,125 @@
+/**
+ * Deterministic anchor ids for the content components the search index reaches
+ * into (`<MultipleChoice>`, `<CodeBlock>`, `<ChallengeCard>`, …).
+ *
+ * ── The problem this solves ─────────────────────────────────────────────────
+ *
+ * Only headings render with DOM ids, so a search hit on text that lives inside
+ * a component could only ever link to the heading *above* the component. On
+ * long lessons the component often sits several screens below that heading
+ * (three `<MultipleChoice>` blocks routinely share one "Check your
+ * understanding" section), so clicking the result landed the reader nowhere
+ * near the text that matched.
+ *
+ * ── How the two sides stay in sync ──────────────────────────────────────────
+ *
+ * Two independent consumers must agree on every id, or search links point at
+ * elements that do not exist:
+ *
+ *   - `remarkComponentAnchors` (this file) runs in the MDX compile
+ *     (source.config.ts) and injects the id as a JSX `id` attribute, which
+ *     `withSearchAnchor` in mdx-components.tsx renders as a real DOM id.
+ *   - `scripts/lib/search-extract.mjs` runs at index build time and stamps the
+ *     same id on the component's search row.
+ *
+ * They agree because both import THIS module and both walk the authored MDX in
+ * document order with the same traversal (`walkTree`, a plain pre-order walk,
+ * used instead of `unist-util-visit` so the two contexts cannot drift on a
+ * library's visiting rules). Ids are `x-<prefix>-<n>` with one counter per
+ * prefix per page: inserting a Callout does not renumber the MCQs below it,
+ * and the `x-` namespace keeps clear of heading slugs (a heading would have to
+ * literally read "X mcq 2" to collide). Renumbering within a type only happens
+ * when a component of that type is added/removed/moved, and the index and the
+ * pages redeploy together (README: deploy = `opennextjs-cloudflare deploy &&
+ * db:seed:search:remote`), so index and DOM cannot disagree in production.
+ *
+ * Components synthesised by other plugins (`<Mermaid>` from ```mermaid fences,
+ * `<SvgLabel>` from remarkSvgLabels) are deliberately absent: they do not
+ * exist in the authored tree the indexer parses, so anchoring them would
+ * desync the counters. Their content stays attributed to the enclosing
+ * heading, as before.
+ *
+ * An author-written `id="…"` attribute wins: it becomes the anchor on both
+ * sides and does not consume a counter.
+ */
+
+/** Anchored component name → id prefix. Every name here must also be in
+ *  CONTENT_COMPONENTS (scripts/lib/search-extract.mjs), or the indexer would
+ *  assign ids to components whose content it never indexes. */
+export const ANCHOR_COMPONENTS = new Map([
+  ["MultipleChoice", "mcq"],
+  ["CodeBlock", "code"],
+  ["SqlCodeBlock", "sql"],
+  ["ChallengeCard", "challenge"],
+  ["SqlChallengeCard", "sqlchallenge"],
+  ["Chart", "chart"],
+  ["Figure", "figure"],
+  ["Callout", "note"],
+  ["LivePreview", "live"],
+  ["ReactPreview", "react"],
+]);
+
+/** Plain pre-order walk over an mdast/MDX tree. Shared by the remark plugin
+ *  and the index extractor so both see components in the same order. */
+export function walkTree(node, fn) {
+  fn(node);
+  const children = node?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) walkTree(child, fn);
+  }
+}
+
+/** Per-page id assigner: one counter per prefix, `x-mcq-1`, `x-mcq-2`, … */
+export function createAnchorAssigner() {
+  const counters = new Map();
+  return function assign(componentName) {
+    const prefix = ANCHOR_COMPONENTS.get(componentName);
+    if (!prefix) return null;
+    const n = (counters.get(prefix) ?? 0) + 1;
+    counters.set(prefix, n);
+    return `x-${prefix}-${n}`;
+  };
+}
+
+/** The author-written string `id` attribute of a JSX element, or null. */
+export function explicitAnchorId(node) {
+  for (const attr of node.attributes ?? []) {
+    if (
+      attr.type === "mdxJsxAttribute" &&
+      attr.name === "id" &&
+      typeof attr.value === "string" &&
+      attr.value.trim()
+    ) {
+      return attr.value;
+    }
+  }
+  return null;
+}
+
+/**
+ * The anchor id for a node, or null when the node is not an anchored
+ * component. Consumes a counter from `assign` exactly when the render-side
+ * plugin would, which is the invariant that keeps both sides aligned.
+ */
+export function anchorIdFor(node, assign) {
+  if (node.type !== "mdxJsxFlowElement") return null;
+  if (!ANCHOR_COMPONENTS.has(node.name)) return null;
+  return explicitAnchorId(node) ?? assign(node.name);
+}
+
+/**
+ * Remark plugin: inject `id="x-<prefix>-<n>"` into every anchored component.
+ * Registered in source.config.ts, so it runs for every collection (the
+ * fumadocs-dev gallery included, harmlessly: it is not indexed).
+ */
+export function remarkComponentAnchors() {
+  return (tree) => {
+    const assign = createAnchorAssigner();
+    walkTree(tree, (node) => {
+      const id = anchorIdFor(node, assign);
+      if (!id || explicitAnchorId(node)) return;
+      node.attributes ??= [];
+      node.attributes.push({ type: "mdxJsxAttribute", name: "id", value: id });
+    });
+  };
+}

--- a/lib/search/query.ts
+++ b/lib/search/query.ts
@@ -48,14 +48,14 @@ const STOP = new Set([
 ]);
 
 /**
- * Build an FTS5 `MATCH` expression, or `null` when the input has no searchable
- * tokens at all (empty, whitespace, pure punctuation). Callers should treat
- * `null` as "return no results" rather than as an error: it is what a user gets
- * for typing `***`, and that is not a failure worth reporting.
+ * The tokens a query actually searches for: lowercased word tokens, stop words
+ * dropped (unless they are all there is), capped at 12. This is the list the
+ * MATCH expression is built from, and it is also what result URLs carry in
+ * their `hl` parameter so the landing page can highlight the matched words.
  */
-export function toMatchQuery(raw: string): string | null {
+export function searchTokens(raw: string): string[] {
   const tokens = raw.toLowerCase().match(TOKEN);
-  if (!tokens || tokens.length === 0) return null;
+  if (!tokens || tokens.length === 0) return [];
 
   // Keep the stop words when they are *all* there is, so searching "how to" or
   // "why" still looks for those words rather than silently returning nothing.
@@ -64,7 +64,18 @@ export function toMatchQuery(raw: string): string | null {
 
   // A very long query is not more useful than its first several terms, and
   // every extra AND clause costs a scan.
-  const capped = kept.slice(0, 12);
+  return kept.slice(0, 12);
+}
+
+/**
+ * Build an FTS5 `MATCH` expression, or `null` when the input has no searchable
+ * tokens at all (empty, whitespace, pure punctuation). Callers should treat
+ * `null` as "return no results" rather than as an error: it is what a user gets
+ * for typing `***`, and that is not a failure worth reporting.
+ */
+export function toMatchQuery(raw: string): string | null {
+  const capped = searchTokens(raw);
+  if (capped.length === 0) return null;
 
   return capped
     .map((token, i) => (i === capped.length - 1 ? `"${token}"*` : `"${token}"`))

--- a/lib/search/ranking.ts
+++ b/lib/search/ranking.ts
@@ -1,0 +1,285 @@
+/**
+ * Query-time ranking and shaping for `/api/search`: the SQL the route runs,
+ * and the transform from ranked FTS5 rows to the result list Fumadocs's
+ * search dialog renders. Split out of the route so it is testable without a
+ * Cloudflare context.
+ */
+
+/** Fumadocs's result shape (fumadocs-core `SortedResult`). */
+export interface SortedResult {
+  id: string;
+  url: string;
+  type: "page" | "heading" | "text";
+  content: string;
+  breadcrumbs?: string[];
+}
+
+/** One FTS5 row, as selected by `searchSql`. */
+export interface SearchRow {
+  url: string;
+  page: string;
+  anchor: string | null;
+  section: string;
+  title: string;
+  heading: string;
+  excerpt: string;
+  codeExcerpt: string;
+}
+
+/**
+ * The reader's current course or interview track, sent by the search dialog
+ * as `?tag=courses/<slug>` / `?tag=interview/<slug>` (see DocsRootProvider).
+ *
+ * Unlike Fumadocs's stock APIs, the tag does not *filter*: it re-weights.
+ * Someone searching "bar" inside the Plotly course almost always wants the
+ * Plotly bar-chart lesson, but the ggplot2 lesson must stay reachable for
+ * when they do not.
+ */
+export interface SearchScope {
+  collection: "courses" | "interview";
+  /** The scope's landing page, e.g. `/courses/mastering-ggplot2`. */
+  page: string;
+  /** SQL LIKE pattern matching every lesson under the scope. */
+  pagePrefix: string;
+}
+
+const SCOPE_RE = /^(courses|interview)\/([a-z0-9][a-z0-9-]*)$/;
+const COLLECTION_BASE = { courses: "/courses", interview: "/interview-prep" } as const;
+
+/**
+ * The tag the search dialog should send for a page: `/courses/<slug>/…` →
+ * `courses/<slug>`, `/interview-prep/<slug>/…` → `interview/<slug>` (the
+ * collection names the index uses), anything else → undefined. The client
+ * half of `parseScope` (used by DocsRootProvider); kept beside it so the two
+ * cannot drift.
+ */
+export function searchScopeFor(pathname: string): string | undefined {
+  const m = /^\/(courses|interview-prep)\/([^/]+)/.exec(pathname);
+  if (!m) return undefined;
+  return `${m[1] === "courses" ? "courses" : "interview"}/${m[2]}`;
+}
+
+/**
+ * Parse the dialog's `tag` parameter into a boost scope, or null for
+ * anything that does not look like one (absent, malformed, or a slug outside
+ * `[a-z0-9-]`, which also keeps LIKE metacharacters out of the pattern).
+ */
+export function parseScope(tag: string | null): SearchScope | null {
+  if (!tag) return null;
+  const m = SCOPE_RE.exec(tag);
+  if (!m) return null;
+  const collection = m[1] as SearchScope["collection"];
+  const page = `${COLLECTION_BASE[collection]}/${m[2]}`;
+  return { collection, page, pagePrefix: `${page}/%` };
+}
+
+/**
+ * BM25 column weights, in the table's column order. The five UNINDEXED columns
+ * lead and take 0, because `bm25()` wants one weight per column and they carry
+ * no tokens.
+ *
+ * Prose outranks code by roughly seven to one. That ratio is what makes
+ * indexing code safe: a search for a common identifier should surface the
+ * lesson that *explains* it above the dozen that merely use it in a starter
+ * file, and without the split there is no way to express that.
+ */
+export const WEIGHTS = "0, 0, 0, 0, 0, 8.0, 6.0, 4.0, 1.0, 0.15";
+
+/**
+ * Scope multipliers. `bm25()` returns negative scores (more negative = more
+ * relevant), so multiplying a row's score amplifies it: ×2 means a lesson in
+ * the reader's current course wins unless a foreign lesson is more than twice
+ * as relevant, which is exactly the "twice as good to interrupt me" bar a
+ * context switch should have to clear. The collection nudge is mild: reading
+ * a course signals little about which interview track is relevant.
+ */
+const COURSE_BOOST = "2.0";
+const COLLECTION_BOOST = "1.15";
+
+/**
+ * Component rows (empty `heading`, non-empty anchor) are deliberately tiny
+ * (one quiz, one figure caption), and BM25's length normalisation rewards
+ * tiny documents heavily: unchecked, a figure's eight-word alt text outranks
+ * the section that actually teaches the term. Shrinking their score keeps
+ * sections on top while the component row still ranks close behind, and when
+ * both quote the same match the response collapses them onto the component's
+ * anchor anyway (`toResults`), so nothing precise is lost.
+ */
+const COMPONENT_ROW_DAMP = "0.75";
+
+/**
+ * The search statement. Two snippets, because `snippet()` reads one column:
+ * a match that lives only in `code` produces a highlight-less prose snippet,
+ * and the code one is the fallback that keeps the dialog's excerpt honest
+ * (see `bestExcerpt`).
+ *
+ * The trailing `page, url` keeps equal-score rows in a stable order across
+ * replicas, so the CDN-cached response does not depend on which replica
+ * answered first.
+ *
+ * Parameters, in order: ?1 MATCH, ?2 LIMIT, and for the scoped variant
+ * ?3 scope page, ?4 scope LIKE prefix, ?5 scope collection.
+ */
+export function searchSql(scoped: boolean): string {
+  const damp = `(CASE WHEN heading = '' AND anchor != '' THEN ${COMPONENT_ROW_DAMP} ELSE 1.0 END)`;
+  const rank = scoped
+    ? `bm25(docs, ${WEIGHTS}) * ${damp} * (CASE
+         WHEN page = ?3 OR page LIKE ?4 THEN ${COURSE_BOOST}
+         WHEN collection = ?5 THEN ${COLLECTION_BOOST}
+         ELSE 1.0 END)`
+    : `bm25(docs, ${WEIGHTS}) * ${damp}`;
+  return `
+    SELECT url, page, anchor, section, title, heading,
+           snippet(docs, 8, '<mark>', '</mark>', '…', 24) AS excerpt,
+           snippet(docs, 9, '<mark>', '</mark>', '…', 24) AS codeExcerpt
+    FROM docs
+    WHERE docs MATCH ?1
+    ORDER BY ${rank}, page, url
+    LIMIT ?2
+  `;
+}
+
+/** How many section/component rows one page may spend from the row budget.
+ *  Without a cap, a page whose every section matches a common term eats the
+ *  whole result list and the second-best page never appears. */
+const PAGE_ROW_CAP = 4;
+
+/** The dialog's excerpt: the prose snippet when it actually highlights
+ *  something, else the code snippet, else nothing worth showing. */
+function bestExcerpt(row: SearchRow): string {
+  if (row.excerpt.includes("<mark>")) return row.excerpt;
+  if (row.codeExcerpt.includes("<mark>")) return row.codeExcerpt;
+  return "";
+}
+
+/** Excerpt text reduced to its content for duplicate detection: markup,
+ *  ellipses and casing are presentation, not identity. */
+function normalizeExcerpt(s: string): string {
+  return s
+    .replaceAll("<mark>", "")
+    .replaceAll("</mark>", "")
+    .replaceAll("…", " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+/** Two snippets show "the same" text when one contains the other: the section
+ *  row and the component row snip the same source region, differing only in
+ *  how much leading/trailing context fit the window. */
+function sameText(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a.length < 12 || b.length < 12) return false;
+  return a.includes(b) || b.includes(a);
+}
+
+interface TextEntry {
+  page: string;
+  norm: string;
+  /** True when the entry's URL points at a component anchor (the more precise
+   *  target), which is what a duplicate from a section row must not displace. */
+  fromComponent: boolean;
+  entry: SortedResult;
+}
+
+/**
+ * Group ranked rows into Fumadocs's page-then-children shape.
+ *
+ * Sections arrive already ranked. The first row seen for a page fixes that
+ * page's position in the output, so a lesson whose best section ranked third
+ * overall lands third, rather than every page floating to wherever its
+ * strongest and weakest sections happen to be.
+ *
+ * Component rows (empty `heading`, non-null anchor; see
+ * scripts/build-search-corpus.mjs) render as text entries linking to the
+ * component's own anchor. Because component content is indexed twice (in its
+ * section row and in its component row), the same match often arrives as two
+ * near-identical snippets; they are collapsed here, keeping the component's
+ * anchor, which is the one that scrolls to the matched text rather than to
+ * the heading above it.
+ *
+ * `hl` (the query's searched tokens) is carried on every result URL so the
+ * lesson page can highlight the matched words after navigation.
+ */
+export function toResults(
+  rows: SearchRow[],
+  limit: number,
+  hl: string[] = [],
+): SortedResult[] {
+  const hlQuery = hl.length > 0 ? `?hl=${encodeURIComponent(hl.join(" "))}` : "";
+  const link = (page: string, anchor: string | null) =>
+    anchor ? `${page}${hlQuery}#${anchor}` : `${page}${hlQuery}`;
+
+  const out: SortedResult[] = [];
+  const seenPage = new Set<string>();
+  const perPage = new Map<string, number>();
+  const textEntries: TextEntry[] = [];
+  let spent = 0;
+
+  const pushText = (row: SearchRow, excerpt: string, fromComponent: boolean) => {
+    const norm = normalizeExcerpt(excerpt);
+    const dup = textEntries.find((t) => t.page === row.page && sameText(t.norm, norm));
+    if (dup) {
+      // Same text twice: keep one entry, pointed at the more precise anchor.
+      if (fromComponent && !dup.fromComponent) {
+        dup.entry.id = row.url;
+        dup.entry.url = link(row.page, row.anchor);
+        dup.fromComponent = true;
+      }
+      return;
+    }
+    const entry: SortedResult = {
+      id: row.url,
+      url: link(row.page, row.anchor),
+      type: "text",
+      content: excerpt,
+    };
+    textEntries.push({ page: row.page, norm, fromComponent, entry });
+    out.push(entry);
+  };
+
+  for (const row of rows) {
+    if (spent >= limit) break;
+
+    // A component row with nothing to quote matched only through its `title`
+    // column (component rows carry no heading/description). Such a match also
+    // matched every other row of the same page, its page row included, so
+    // dropping this one costs nothing and frees its slot for a row a reader
+    // can actually see.
+    const isComponentRow = !row.heading && row.anchor !== null && row.anchor !== "";
+    if (isComponentRow && !bestExcerpt(row)) continue;
+
+    const used = perPage.get(row.page) ?? 0;
+    if (used >= PAGE_ROW_CAP) continue;
+    perPage.set(row.page, used + 1);
+    spent++;
+
+    if (!seenPage.has(row.page)) {
+      seenPage.add(row.page);
+      out.push({
+        id: row.page,
+        url: link(row.page, null),
+        type: "page",
+        content: row.title,
+        breadcrumbs: row.section ? [row.section] : undefined,
+      });
+    }
+    // The pre-heading chunk of a page has no anchor; its content is already
+    // represented by the page result above, so it adds no second entry.
+    if (!row.anchor) continue;
+
+    const excerpt = bestExcerpt(row);
+    if (row.heading) {
+      out.push({
+        id: row.url,
+        url: link(row.page, row.anchor),
+        type: "heading",
+        content: row.heading,
+      });
+      if (excerpt) pushText({ ...row, url: `${row.url}-text` }, excerpt, false);
+    } else if (excerpt) {
+      pushText(row, excerpt, true);
+    }
+  }
+  return out;
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -28,20 +28,27 @@ import RuntimeLoadingStates from "@/app/_components/RuntimeBootNotice";
 import { LivePreview } from "@/app/_components/mdx/LivePreview";
 import { ReactPreview } from "@/app/_components/mdx/ReactPreview";
 import { reactDemoComponents } from "@/app/_components/mdx/reactDemoComponents";
+import { withSearchAnchor } from "@/app/_components/mdx/withSearchAnchor";
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
+  // `withSearchAnchor` renders the deterministic `id` that
+  // `remarkComponentAnchors` (lib/search/anchors.mjs) injects into these
+  // components, so search results can deep-link to the exact quiz, code
+  // block, or figure that matched rather than to the heading above it. The
+  // wrapped set must mirror ANCHOR_COMPONENTS in that module.
   return {
     ...defaultMdxComponents,
-    CodeBlock: MdxCodeBlock,
-    ChallengeCard: MdxChallengeCard,
-    SqlChallengeCard: MdxSqlChallengeCard,
-    SqlCodeBlock: MdxSqlCodeBlock,
-    MultipleChoice: MdxMultipleChoiceQuestion,
+    CodeBlock: withSearchAnchor(MdxCodeBlock),
+    ChallengeCard: withSearchAnchor(MdxChallengeCard),
+    SqlChallengeCard: withSearchAnchor(MdxSqlChallengeCard),
+    SqlCodeBlock: withSearchAnchor(MdxSqlCodeBlock),
+    MultipleChoice: withSearchAnchor(MdxMultipleChoiceQuestion),
+    Callout: withSearchAnchor(defaultMdxComponents.Callout),
     Mermaid,
     SvgLabel,
     IllustrationPrompt,
-    Figure,
-    Chart,
+    Figure: withSearchAnchor(Figure),
+    Chart: withSearchAnchor(Chart),
     LoadingAnimationsGallery,
     RuntimeLoadingStates,
     // Live, no-Run lesson widgets: <LivePreview> renders HTML/CSS in a
@@ -49,8 +56,8 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     // interactive component with its TSX shown below (React course). The
     // React demo components are spread in so lessons can use e.g.
     // <CounterDemo /> as <ReactPreview>'s child without an import.
-    LivePreview,
-    ReactPreview,
+    LivePreview: withSearchAnchor(LivePreview),
+    ReactPreview: withSearchAnchor(ReactPreview),
     ...reactDemoComponents,
     // Fumadocs Steps/Step, a numbered vertical walkthrough. Registered
     // globally so lessons can drop `<Steps>…<Step>` in without an import,

--- a/scripts/build-search-corpus.mjs
+++ b/scripts/build-search-corpus.mjs
@@ -32,6 +32,20 @@
  * Content before the first heading becomes a row with a null anchor, which is
  * the page-level result.
  *
+ * ── …and one extra row per anchored component ───────────────────────────────
+ *
+ * A section row's anchor is its heading, but a `<MultipleChoice>` often sits
+ * several screens below its heading, so a hit on quiz text used to land the
+ * reader far above the text that matched. Anchored components (the set in
+ * lib/search/anchors.mjs) therefore get a second, narrower row whose anchor is
+ * the component's own DOM id (injected at render time by
+ * `remarkComponentAnchors`; both sides derive identical ids from the authored
+ * MDX). The component's content stays in the section row too, so queries whose
+ * terms span a paragraph and a component keep matching; the resulting
+ * near-duplicate entries are collapsed at query time in favour of the
+ * component's anchor (lib/search/ranking.ts). Rows with an empty `heading`
+ * column and a non-empty anchor are exactly these component rows.
+ *
  * ── Prose and code are separate columns ─────────────────────────────────────
  *
  * Both are indexed, but a match in prose should outrank a match in a code
@@ -43,14 +57,8 @@
  *
  * ── How component content is reached ────────────────────────────────────────
  *
- * `remark-mdx` attaches an ESTree to every expression attribute, so the values
- * inside `files={[{ starterCode: `…` }]}` and `markdown={`…`}` are read from
- * the parsed tree by property name rather than scraped with a regex. Property
- * keys are classified (see PROSE_KEYS / CODE_KEYS) so an instruction lands in
- * prose and a starter file lands in code.
- *
- * `<Chart>` is the exception: its caption is not in the MDX at all, it lives in
- * the generated chart manifest, so the slug is resolved against that.
+ * See scripts/lib/search-extract.mjs (split out so the anchor-id contract is
+ * testable against the render-side plugin).
  *
  * Output: `lib/generated/search-corpus.json` (gitignored), consumed by
  * `scripts/build-search-sql.mjs` to produce the D1 seed.
@@ -59,12 +67,10 @@ import { readFileSync, readdirSync, mkdirSync, writeFileSync, existsSync } from 
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { structure } from "fumadocs-core/mdx-plugins";
-import { unified } from "unified";
-import remarkParse from "remark-parse";
 import remarkMdx from "remark-mdx";
 import remarkMath from "remark-math";
-import { visit } from "unist-util-visit";
 import { freshness } from "./lib/build-cache.mjs";
+import { extractComponents } from "./lib/search-extract.mjs";
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -78,27 +84,6 @@ const SECTIONS = [
 ];
 
 const OUT_FILE = join(ROOT, "lib", "generated", "search-corpus.json");
-
-/** Prose the reader reads. Weighted as body text. */
-const PROSE_KEYS = new Set([
-  "instructions", "markdown", "title", "name", "description", "alt", "label",
-  "caption", "prompt", "question", "explanation", "hint", "note",
-]);
-
-/** Code and identifiers. Indexed, but weighted well below prose. */
-const CODE_KEYS = new Set([
-  "starterCode", "initCode", "solutionCode", "code", "source", "schema",
-  "setup", "filename", "sql", "html", "css", "js", "tsx", "jsx", "expected",
-]);
-
-/** Components whose attributes carry content worth indexing. Anything else
- *  (layout wrappers, demo components) contributes only its child prose, which
- *  `structure()` already collects. */
-const CONTENT_COMPONENTS = new Set([
-  "CodeBlock", "SqlCodeBlock", "ChallengeCard", "SqlChallengeCard",
-  "MultipleChoice", "Chart", "Figure", "Callout", "Mermaid", "SvgLabel",
-  "LivePreview", "ReactPreview", "IllustrationPrompt",
-]);
 
 /**
  * Chart titles and captions live in the generated manifest, not in the MDX, so
@@ -189,122 +174,6 @@ function sectionTitle(sectionDir, slug) {
   return title;
 }
 
-/**
- * Pull every string out of an ESTree, tagged prose or code by the property key
- * that encloses it.
- *
- * A bare value (an attribute that is just a template literal, like
- * `markdown={`…`}`) inherits `fallback`, which the caller sets from the
- * attribute's own name.
- */
-function harvestEstree(node, fallback, out, key = fallback) {
-  if (!node || typeof node !== "object") return;
-
-  if (node.type === "TemplateLiteral") {
-    const text = (node.quasis ?? []).map((q) => q.value?.cooked ?? "").join(" ");
-    if (text.trim()) out[key === "code" ? "code" : "prose"].push(text);
-    // Interpolations can hold strings too.
-    for (const e of node.expressions ?? []) harvestEstree(e, fallback, out, key);
-    return;
-  }
-  if (node.type === "Literal") {
-    if (typeof node.value === "string" && node.value.trim()) {
-      out[key === "code" ? "code" : "prose"].push(node.value);
-    }
-    return;
-  }
-  if (node.type === "Property") {
-    const name = node.key?.name ?? node.key?.value;
-    const next = CODE_KEYS.has(name) ? "code" : PROSE_KEYS.has(name) ? "prose" : key;
-    harvestEstree(node.value, fallback, out, next);
-    return;
-  }
-
-  for (const v of Object.values(node)) {
-    if (Array.isArray(v)) for (const child of v) harvestEstree(child, fallback, out, key);
-    else if (v && typeof v === "object" && typeof v.type === "string") {
-      harvestEstree(v, fallback, out, key);
-    }
-  }
-}
-
-/** `remarkMath` is not decoration here. Without it, MDX reads the braces in
- *  `$$p_i = \frac{e^{z_i}}{…}$$` as a JSX expression and acorn rejects the
- *  file, which silently dropped 31 lessons from the previous index. The real
- *  render pipeline (source.config.ts) has always had it; the indexer did not. */
-const processor = unified().use(remarkParse).use(remarkMath).use(remarkMdx);
-const charts = loadChartManifest();
-
-/**
- * Walk the MDX for everything `structure()` does not return: fenced code,
- * mermaid sources, and the content carried in component attributes. Each find
- * is attributed to the heading it sits under, matched to `structure()`'s
- * heading ids by document order.
- */
-function extractComponents(body, headingIds) {
-  const perHeading = new Map();
-  let headingIndex = -1;
-
-  const bucket = () => {
-    const id = headingIndex >= 0 ? headingIds[headingIndex] : null;
-    const k = id ?? "";
-    if (!perHeading.has(k)) perHeading.set(k, { prose: [], code: [] });
-    return perHeading.get(k);
-  };
-
-  let tree;
-  try {
-    tree = processor.parse(body);
-  } catch {
-    return perHeading;
-  }
-
-  visit(tree, (node) => {
-    if (node.type === "heading") {
-      headingIndex++;
-      return;
-    }
-    // Fenced blocks, including ```mermaid diagram sources.
-    if (node.type === "code") {
-      if (node.value?.trim()) bucket().code.push(node.value);
-      return;
-    }
-    if (node.type !== "mdxJsxFlowElement" && node.type !== "mdxJsxTextElement") return;
-    if (!CONTENT_COMPONENTS.has(node.name)) return;
-
-    const out = bucket();
-
-    for (const attr of node.attributes ?? []) {
-      if (attr.type !== "mdxJsxAttribute") continue;
-      const name = attr.name;
-
-      // A plain string attribute: alt="…", title="…".
-      if (typeof attr.value === "string") {
-        if (CODE_KEYS.has(name)) out.code.push(attr.value);
-        else if (PROSE_KEYS.has(name)) out.prose.push(attr.value);
-        // `<Chart slug>` and `<Figure slug>` name an asset, not content, but a
-        // chart's title and caption are real prose held in the manifest.
-        else if (name === "slug" && node.name === "Chart") {
-          const entry = charts[attr.value];
-          if (entry?.title) out.prose.push(entry.title);
-          if (entry?.caption) out.prose.push(entry.caption);
-        }
-        continue;
-      }
-
-      // An expression attribute: read its ESTree rather than its source text.
-      const estree = attr.value?.data?.estree;
-      const fallback = CODE_KEYS.has(name) ? "code" : "prose";
-      if (estree) harvestEstree(estree, fallback, out, fallback);
-      else if (typeof attr.value?.value === "string") {
-        out[fallback].push(attr.value.value);
-      }
-    }
-  });
-
-  return perHeading;
-}
-
 // Parsing ~900 lessons through remark is the single most expensive step in
 // `dev` and `build` — 26 seconds, every run, for an answer that only changes
 // when a lesson (or the chart manifest it reads captions from) does. The gate
@@ -312,6 +181,11 @@ function extractComponents(body, headingIds) {
 const cache = freshness(ROOT, "search-corpus", {
   inputs: [
     fileURLToPath(import.meta.url),
+    // The extractor and the anchor-id scheme are inputs too: a change to
+    // either must rebuild the corpus, or its rows drift from the DOM ids the
+    // render pipeline emits.
+    join(ROOT, "scripts", "lib", "search-extract.mjs"),
+    join(ROOT, "lib", "search", "anchors.mjs"),
     join(ROOT, "lib", "generated", "charts.js"),
     ...SECTIONS.flatMap(({ dir }) => walk(dir).map((rel) => join(dir, rel))),
   ],
@@ -322,9 +196,11 @@ if (cache.fresh) {
   process.exit(0);
 }
 
+const charts = loadChartManifest();
 const rows = [];
 let files = 0;
 let failed = 0;
+let componentRows = 0;
 
 for (const { dir, base, collection } of SECTIONS) {
   for (const rel of walk(dir)) {
@@ -351,7 +227,7 @@ for (const { dir, base, collection } of SECTIONS) {
 
     const headingIds = sd.headings.map((h) => h.id);
     const headingText = new Map(sd.headings.map((h) => [h.id, h.content]));
-    const components = extractComponents(body, headingIds);
+    const { perHeading: components, perComponent } = extractComponents(body, headingIds, charts);
 
     // Prose from structure(), grouped by the heading it sits under.
     const proseByHeading = new Map();
@@ -381,6 +257,29 @@ for (const { dir, base, collection } of SECTIONS) {
         code,
       });
     }
+
+    // One narrow row per anchored component: same page metadata, the
+    // component's own id as the anchor, and an empty `heading` column (that
+    // emptiness is how the API recognises these rows, and it keeps the
+    // heading's words from matching once per component under it).
+    for (const [anchor, comp] of perComponent) {
+      const prose = comp.prose.join("\n");
+      const code = comp.code.join("\n");
+      if (!prose.trim() && !code.trim()) continue;
+      componentRows++;
+      rows.push({
+        url: `${url}#${anchor}`,
+        page: url,
+        anchor,
+        title: pageTitle,
+        heading: "",
+        description: "",
+        section: crumb ?? "",
+        collection,
+        prose,
+        code,
+      });
+    }
   }
 }
 
@@ -392,7 +291,8 @@ cache.commit();
 const proseChars = rows.reduce((n, r) => n + r.prose.length, 0);
 const codeChars = rows.reduce((n, r) => n + r.code.length, 0);
 console.log(
-  `[search-corpus] ${files} lesson(s) → ${rows.length} section rows ` +
-    `(${Math.round(proseChars / 1000)}k prose, ${Math.round(codeChars / 1000)}k code, ` +
-    `${Math.round(json.length / 1024)} kB)${failed ? `, ${failed} unparsed` : ""}`,
+  `[search-corpus] ${files} lesson(s) → ${rows.length} rows ` +
+    `(${componentRows} component rows, ${Math.round(proseChars / 1000)}k prose, ` +
+    `${Math.round(codeChars / 1000)}k code, ${Math.round(json.length / 1024)} kB)` +
+    `${failed ? `, ${failed} unparsed` : ""}`,
 );

--- a/scripts/lib/search-extract.mjs
+++ b/scripts/lib/search-extract.mjs
@@ -1,0 +1,194 @@
+/**
+ * MDX content extraction for the search corpus: everything `structure()` does
+ * not return. Split out of scripts/build-search-corpus.mjs so the anchor
+ * consistency contract (see lib/search/anchors.mjs) is testable: the ids this
+ * module stamps on component rows must equal the DOM ids the
+ * `remarkComponentAnchors` plugin injects at render time.
+ *
+ * ── What is collected, and where it lands ───────────────────────────────────
+ *
+ * Fenced code, mermaid sources, and the content carried in component
+ * attributes (`remark-mdx` attaches an ESTree to every expression attribute,
+ * so `files={[{ starterCode: `…` }]}` and `markdown={`…`}` are read from the
+ * parsed tree by property name rather than scraped with a regex; keys are
+ * classified by PROSE_KEYS / CODE_KEYS).
+ *
+ * Everything is attributed to the heading it sits under (`perHeading`), which
+ * is what the per-section rows are built from. Content inside an *anchored*
+ * component (lib/search/anchors.mjs) is ALSO collected under the component's
+ * own anchor id (`perComponent`), from which the corpus builds one extra row
+ * per component. The duplication is deliberate:
+ *
+ *   - the per-section row keeps matching queries whose terms span a paragraph
+ *     AND a component under the same heading (FTS5 ANDs terms within one row,
+ *     so splitting the content would stop those queries matching anything);
+ *   - the per-component row is shorter, so BM25's length normalisation ranks
+ *     it above the section row for matches inside the component, and its
+ *     anchor scrolls the reader to the component itself rather than to the
+ *     heading somewhere above it.
+ *
+ * The near-duplicate result entries this produces are collapsed at query time
+ * (lib/search/ranking.ts), keeping the component's more precise anchor.
+ */
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkMdx from "remark-mdx";
+import remarkMath from "remark-math";
+import { anchorIdFor, createAnchorAssigner, walkTree } from "../../lib/search/anchors.mjs";
+
+/** Prose the reader reads. Weighted as body text. */
+export const PROSE_KEYS = new Set([
+  "instructions", "markdown", "title", "name", "description", "alt", "label",
+  "caption", "prompt", "question", "explanation", "hint", "note",
+]);
+
+/** Code and identifiers. Indexed, but weighted well below prose. */
+export const CODE_KEYS = new Set([
+  "starterCode", "initCode", "solutionCode", "code", "source", "schema",
+  "setup", "filename", "sql", "html", "css", "js", "tsx", "jsx", "expected",
+]);
+
+/** Components whose attributes carry content worth indexing. Anything else
+ *  (layout wrappers, demo components) contributes only its child prose, which
+ *  `structure()` already collects. */
+export const CONTENT_COMPONENTS = new Set([
+  "CodeBlock", "SqlCodeBlock", "ChallengeCard", "SqlChallengeCard",
+  "MultipleChoice", "Chart", "Figure", "Callout", "Mermaid", "SvgLabel",
+  "LivePreview", "ReactPreview", "IllustrationPrompt",
+]);
+
+/**
+ * Pull every string out of an ESTree, tagged prose or code by the property key
+ * that encloses it.
+ *
+ * A bare value (an attribute that is just a template literal, like
+ * `markdown={`…`}`) inherits `fallback`, which the caller sets from the
+ * attribute's own name.
+ */
+export function harvestEstree(node, fallback, out, key = fallback) {
+  if (!node || typeof node !== "object") return;
+
+  if (node.type === "TemplateLiteral") {
+    const text = (node.quasis ?? []).map((q) => q.value?.cooked ?? "").join(" ");
+    if (text.trim()) out[key === "code" ? "code" : "prose"].push(text);
+    // Interpolations can hold strings too.
+    for (const e of node.expressions ?? []) harvestEstree(e, fallback, out, key);
+    return;
+  }
+  if (node.type === "Literal") {
+    if (typeof node.value === "string" && node.value.trim()) {
+      out[key === "code" ? "code" : "prose"].push(node.value);
+    }
+    return;
+  }
+  if (node.type === "Property") {
+    const name = node.key?.name ?? node.key?.value;
+    const next = CODE_KEYS.has(name) ? "code" : PROSE_KEYS.has(name) ? "prose" : key;
+    harvestEstree(node.value, fallback, out, next);
+    return;
+  }
+
+  for (const v of Object.values(node)) {
+    if (Array.isArray(v)) for (const child of v) harvestEstree(child, fallback, out, key);
+    else if (v && typeof v === "object" && typeof v.type === "string") {
+      harvestEstree(v, fallback, out, key);
+    }
+  }
+}
+
+/** `remarkMath` is not decoration here. Without it, MDX reads the braces in
+ *  `$$p_i = \frac{e^{z_i}}{…}$$` as a JSX expression and acorn rejects the
+ *  file, which silently dropped 31 lessons from the previous index. The real
+ *  render pipeline (source.config.ts) has always had it; the indexer did not. */
+const processor = unified().use(remarkParse).use(remarkMath).use(remarkMdx);
+
+/**
+ * Walk the MDX for everything `structure()` does not return. Each find is
+ * attributed to the heading it sits under, matched to `structure()`'s heading
+ * ids by document order; content inside an anchored component additionally
+ * lands under the component's own id (see the header comment).
+ *
+ * `charts` is the generated chart manifest: `<Chart slug>` names an asset, and
+ * the asset's title/caption are real prose that live there, not in the MDX.
+ *
+ * Returns `{ perHeading, perComponent }`, both Map<key, {prose[], code[]}>.
+ */
+export function extractComponents(body, headingIds, charts = {}) {
+  const perHeading = new Map();
+  const perComponent = new Map();
+  let headingIndex = -1;
+  const assign = createAnchorAssigner();
+
+  const headingBucket = () => {
+    const id = headingIndex >= 0 ? headingIds[headingIndex] : null;
+    const k = id ?? "";
+    if (!perHeading.has(k)) perHeading.set(k, { prose: [], code: [] });
+    return perHeading.get(k);
+  };
+
+  let tree;
+  try {
+    tree = processor.parse(body);
+  } catch {
+    return { perHeading, perComponent };
+  }
+
+  walkTree(tree, (node) => {
+    if (node.type === "heading") {
+      headingIndex++;
+      return;
+    }
+    // Fenced blocks, including ```mermaid diagram sources.
+    if (node.type === "code") {
+      if (node.value?.trim()) headingBucket().code.push(node.value);
+      return;
+    }
+    if (node.type !== "mdxJsxFlowElement" && node.type !== "mdxJsxTextElement") return;
+
+    // The assigner must tick for every anchored component, content or not,
+    // because the render-side plugin assigns ids unconditionally.
+    const anchor = anchorIdFor(node, assign);
+
+    if (!CONTENT_COMPONENTS.has(node.name)) return;
+
+    const heading = headingBucket();
+    let component = null;
+    if (anchor) {
+      component = perComponent.get(anchor) ?? { prose: [], code: [] };
+      perComponent.set(anchor, component);
+    }
+    const out = {
+      prose: { push: (v) => { heading.prose.push(v); component?.prose.push(v); } },
+      code: { push: (v) => { heading.code.push(v); component?.code.push(v); } },
+    };
+
+    for (const attr of node.attributes ?? []) {
+      if (attr.type !== "mdxJsxAttribute") continue;
+      const name = attr.name;
+
+      // A plain string attribute: alt="…", title="…".
+      if (typeof attr.value === "string") {
+        if (CODE_KEYS.has(name)) out.code.push(attr.value);
+        else if (PROSE_KEYS.has(name)) out.prose.push(attr.value);
+        // `<Chart slug>` and `<Figure slug>` name an asset, not content, but a
+        // chart's title and caption are real prose held in the manifest.
+        else if (name === "slug" && node.name === "Chart") {
+          const entry = charts[attr.value];
+          if (entry?.title) out.prose.push(entry.title);
+          if (entry?.caption) out.prose.push(entry.caption);
+        }
+        continue;
+      }
+
+      // An expression attribute: read its ESTree rather than its source text.
+      const estree = attr.value?.data?.estree;
+      const fallback = CODE_KEYS.has(name) ? "code" : "prose";
+      if (estree) harvestEstree(estree, fallback, out, fallback);
+      else if (typeof attr.value?.value === "string") {
+        out[fallback].push(attr.value.value);
+      }
+    }
+  });
+
+  return { perHeading, perComponent };
+}

--- a/source.config.ts
+++ b/source.config.ts
@@ -33,6 +33,7 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import { remarkPreserveCodeIndent } from "./lib/remarkPreserveCodeIndent";
 import { remarkSvgLabels } from "./lib/remarkSvgLabels";
+import { remarkComponentAnchors } from "./lib/search/anchors.mjs";
 
 export const courses = defineDocs({
   dir: "content/courses",
@@ -80,7 +81,19 @@ export default defineConfig({
     // display formatted code: @mdx-js strips the authored indentation from
     // multi-line `starterCode`/`solutionCode`/… template literals during
     // tokenization, and this restores it from the original source offsets.
-    remarkPlugins: [remarkPreserveCodeIndent, remarkMath, remarkMdxMermaid, remarkSvgLabels],
+    //
+    // `remarkComponentAnchors` MUST run before `remarkMdxMermaid` and
+    // `remarkSvgLabels`: it numbers the *authored* components in document
+    // order, and the search indexer replays the same numbering over the raw
+    // MDX (lib/search/anchors.mjs), so components synthesised by later
+    // plugins must not be visible to it.
+    remarkPlugins: [
+      remarkPreserveCodeIndent,
+      remarkComponentAnchors,
+      remarkMath,
+      remarkMdxMermaid,
+      remarkSvgLabels,
+    ],
     rehypePlugins: (plugins) => [
       [rehypeKatex, { throwOnError: false, errorColor: "#ef4444" }],
       ...plugins,


### PR DESCRIPTION
Fixes the two reported search problems and adds a ranking-quality pass on top.

## 1. The current course ranks first

Searching "bar" inside the Plotly Express course used to show the ggplot2 lesson as the top suggestion. The docs layouts now send the course / interview track being read as `?tag=courses/<slug>` (via a new `DocsRootProvider` that derives it from `usePathname()`, since layouts don't re-render on navigation), and `/api/search` **boosts** instead of filters: bm25 ×2 for rows in the same course, ×1.15 for the same collection. The rest of the site stays reachable; it just has to be more than twice as relevant to interrupt.

Validated against the real corpus in SQLite FTS5: scoped to the Plotly course, "bar" now returns *The simplest bar chart*, *When to reach for a bar chart*, *Stacked bars…* from that course first; scoped to ggplot2, its own *Bar charts: counts across categories* leads.

## 2. Search results land on the component that matched

Text inside `<MultipleChoice>`, `<CodeBlock>`, `<ChallengeCard>`, … could only anchor to the heading above it, often several screens of CodeMirror editors away. Now:

- `remarkComponentAnchors` (registered in `source.config.ts`) injects deterministic ids (`#x-mcq-2`, `#x-code-1`) into anchored components, rendered as a neutral wrapper div by `withSearchAnchor` in `mdx-components.tsx`.
- The corpus gains one narrow row per component under that same id (10,124 rows across 889 lessons), so the MCQ from the screenshot ("historical reasons with no practical effect.") now links to `…/every-geom-has-a-stat#x-mcq-3` — the quiz itself.
- `lib/search/anchors.mjs` is the **single module both sides derive ids from** (same pre-order walk, same counters); `__tests__/searchAnchors.test.ts` pins the contract, and I verified a dev-server render of the lesson emits exactly the ids the corpus indexed. Index and pages redeploy together (`deploy && db:seed:search:remote`), so they can't disagree in production.
- `HashScrollFix` re-aligns the viewport to the hash target while late-mounting components (CodeMirror, KaTeX, Mermaid) shift layout under it, for a 3 s settle window that any user scroll intent cancels immediately.

## 3. Ranking review

- **Snippet honesty**: a match living only in code used to produce a highlight-less prose snippet; the route now selects two snippets and falls back to the code column.
- **Tiny-row damping**: component rows are deliberately short, and bm25's length normalisation let an eight-word figure alt outrank the section that teaches the term; component rows are damped ×0.75.
- **Invisible matches dropped**: component rows carry the page title in an indexed column, so a title-word query matched every component row of the page with nothing to quote; such rows are skipped without spending the row budget (the same match necessarily also hit the page's own rows, so nothing is lost).
- **Page diversity**: one page can spend at most 4 rows of the result budget (the route overfetches 3× to backfill), so a lesson matching a common term everywhere no longer erases the second-best page.
- **Duplicate collapse**: component content is indexed twice by design (its section row keeps multi-term queries spanning a paragraph + a component matching in one FTS5 row); near-identical snippets are collapsed at response time onto the component's more precise anchor.
- **Deterministic ordering**: a `page, url` tie-break keeps CDN-cached responses independent of which D1 replica answered.

## Bonus: the matched words are highlighted after navigation

Result URLs carry the sanitised query tokens as `?hl=…`; `SearchHighlight` paints every word starting with one of them (browser-find style) via the CSS Custom Highlight API — no DOM mutation, re-applied while client components finish mounting, and a silent no-op on browsers without the API or visits without `?hl=`.

## Notes

- Corpus grows from ~9k to 19,088 rows (~19 MB seed); D1 seeding stays batch-budgeted under the 100 KB statement cap (largest statement 78 kB) and still no-ops when the content hash is unchanged.
- `npm test` (1134 tests, 83 files), `tsc --noEmit`, and `eslint` on the touched files all pass; corpus + seed SQL build clean, and the seed applies to an in-memory SQLite FTS5 database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWrNzTwAsExR4MEbSF82sE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWrNzTwAsExR4MEbSF82sE)_