### PR TITLE
Stop chart labels colliding with the plot, and let Escape drop search highlights

### DIFF
--- a/app/_components/SearchHighlight.tsx
+++ b/app/_components/SearchHighlight.tsx
@@ -22,6 +22,14 @@
  * side) add their text after the first pass, so mutations re-trigger the
  * pass during the same settle window HashScrollFix uses; after that the
  * highlights stay put until navigation.
+ *
+ * Escape dismisses them, the way it leaves a browser's find bar. Highlights
+ * are a *view* of a search, not part of the lesson, and a reader who has found
+ * their answer is otherwise stuck with a yellow-flecked page until they
+ * navigate away: the API paints every prefix match, so a common word can light
+ * up a page dozens of times. Dismissing also drops `?hl=` from the URL, so a
+ * reload, a copied link or a step back through history does not repaint what
+ * was just dismissed.
  */
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
@@ -67,6 +75,21 @@ function collectRanges(root: Node, terms: string[]): Range[] {
   return ranges;
 }
 
+/** Whether Escape belongs to something else on the page: a field being typed
+ *  in, an editor, or an open dialog (the search dialog itself closes on it). */
+function escapeIsClaimed(): boolean {
+  const el = document.activeElement;
+  if (
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement ||
+    (el instanceof HTMLElement && el.isContentEditable)
+  ) {
+    return true;
+  }
+  return document.querySelector('[role="dialog"]') !== null;
+}
+
 export default function SearchHighlight() {
   const pathname = usePathname();
 
@@ -75,7 +98,10 @@ export default function SearchHighlight() {
     const terms = highlightTerms();
     if (terms.length === 0) return;
 
+    let dismissed = false;
+
     const apply = () => {
+      if (dismissed) return;
       const root =
         document.querySelector("article") ??
         document.querySelector("main") ??
@@ -98,11 +124,32 @@ export default function SearchHighlight() {
       apply();
     }, SETTLE_MS);
 
-    return () => {
+    const stop = () => {
+      dismissed = true;
       observer.disconnect();
       window.clearTimeout(debounce);
       window.clearTimeout(settleTimer);
       CSS.highlights.delete(HIGHLIGHT_NAME);
+    };
+
+    const onKey = (e: KeyboardEvent) => {
+      // `defaultPrevented` first: a component that has already claimed this
+      // keypress (a closing overlay, a CodeMirror keymap) gets to keep it.
+      if (e.key !== "Escape" || e.defaultPrevented || dismissed) return;
+      if (escapeIsClaimed()) return;
+      stop();
+      // Not `router.replace`: this is a purely local dismissal, and going
+      // through the router would re-run the route's data fetching to change a
+      // query parameter nothing on the server reads.
+      const url = new URL(window.location.href);
+      url.searchParams.delete("hl");
+      window.history.replaceState(window.history.state, "", url);
+    };
+    document.addEventListener("keydown", onKey);
+
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      stop();
     };
   }, [pathname]);
 

--- a/app/_components/mdx/Chart.module.css
+++ b/app/_components/mdx/Chart.module.css
@@ -128,28 +128,188 @@
        *with* the content (`local`), sitting on top of two shadows pinned to
        the frame (`scroll`), so each shadow is masked exactly while that end
        is flush and revealed as soon as it is not. No JavaScript and no
-       resize observer. */
+       resize observer.
+
+       The weights are the point of this rule, not the mechanism. At 20% of
+       the foreground over 11px these were invisible in practice — on a phone
+       the reader saw a chart that looked cropped rather than one that looked
+       scrollable, which is the failure the shadows exist to prevent. 38% over
+       16px is still quiet against the drawing and actually legible on a
+       near-black page. The covers stay wider than the shadows so each one is
+       fully masked when that end is flush. */
     background:
-      linear-gradient(to right, var(--color-fd-background) 40%, transparent) left center /
-        22px 100% no-repeat local,
-      linear-gradient(to left, var(--color-fd-background) 40%, transparent) right center /
-        22px 100% no-repeat local,
+      linear-gradient(to right, var(--color-fd-background) 45%, transparent) left center /
+        30px 100% no-repeat local,
+      linear-gradient(to left, var(--color-fd-background) 45%, transparent) right center /
+        30px 100% no-repeat local,
       radial-gradient(
           farthest-side at 0 50%,
-          color-mix(in srgb, var(--color-fd-foreground) 20%, transparent),
+          color-mix(in srgb, var(--color-fd-foreground) 38%, transparent),
           transparent
         )
-        left center / 11px 100% no-repeat scroll,
+        left center / 16px 100% no-repeat scroll,
       radial-gradient(
           farthest-side at 100% 50%,
-          color-mix(in srgb, var(--color-fd-foreground) 20%, transparent),
+          color-mix(in srgb, var(--color-fd-foreground) 38%, transparent),
           transparent
         )
-        right center / 11px 100% no-repeat scroll;
+        right center / 16px 100% no-repeat scroll;
   }
 
   .chart svg {
     min-width: var(--ds-chart-min-width, 0);
+  }
+}
+
+/* ── Expand to full screen ───────────────────────────────────────────────
+   A 680px drawing pinned at its legibility floor inside a 358px phone
+   column shows about two thirds of itself, and no amount of scrolling puts
+   the two halves of a comparison in front of the reader at once. Rotating a
+   phone gives ~844px, which fits the whole chart at full size, so the useful
+   thing is a view that uses the entire viewport and lets the reader turn the
+   device. Pinch-zoom is left to the browser — the site sets no maximum-scale,
+   so it already works and needs no gesture handling of ours.
+   ────────────────────────────────────────────────────────────────────── */
+.stage {
+  position: relative;
+}
+
+.expandBtn {
+  /* Off by default; the media query below turns it on. It has to come *after*
+     this declaration to win — both rules are one class deep, so source order
+     decides, and a `display: inline-flex` written up in the narrow-screen
+     block above would silently lose to this line. */
+  display: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-fd-background) 88%, transparent);
+  color: var(--color-fd-muted-foreground);
+  cursor: pointer;
+  z-index: 1;
+}
+
+.expandBtn:hover {
+  color: var(--color-fd-foreground);
+  background: var(--color-fd-background);
+}
+
+/* The affordance only exists where the chart is actually clipped — the same
+   breakpoint that turns the figure into a scroll container. Above it the whole
+   drawing is already on screen and a button offering to show it would be
+   furniture.
+
+   The strip above the chart is what the button sits in, and it is not
+   decoration. The button cannot float over the drawing: it is pinned to the
+   scroll *viewport* while the chart slides underneath, so wherever it is
+   parked it covers whatever happens to be scrolled under it — in a two-panel
+   chart scrolled right, that is the second panel's title. Reserving 34px
+   guarantees it never hides a label, and vertical space is the one thing a
+   phone has plenty of. */
+@media (max-width: 64rem) {
+  .stage {
+    padding-top: 34px;
+  }
+
+  .expandBtn {
+    display: inline-flex;
+  }
+}
+
+.expandIcon {
+  width: 16px;
+  height: 16px;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: var(--color-fd-background);
+  color: var(--color-fd-foreground);
+}
+
+.closeBtn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 999px;
+  background: var(--color-fd-card, var(--color-fd-background));
+  color: var(--color-fd-foreground);
+  cursor: pointer;
+}
+
+/* The stage takes the whole viewport, and the close button and hint are laid
+   *over* it rather than above and below it. That is the difference between the
+   overlay being worth opening and not: in landscape a phone is only ~390px
+   tall, so a reserved 56px header plus a line of hint text was taking a third
+   of the height the chart is scaled against, and the "full screen" view came
+   out narrower than the scrolling one on the page.
+
+   Both classes are on this element deliberately. `.chart` carries the
+   `--ds-chart-*` tokens and the `currentColor` foreground the SVG is painted
+   with, so without it the chart opens colourless — but `.chart` also carries
+   the narrow-screen scroll rules, which are exactly wrong here. Hence the
+   doubled selectors below: two classes deep (0-2-0) beats the media query's
+   one (0-1-0) at any source order, so the scroll container, its edge shadows
+   and the `min-width` floor are all switched back off. */
+.lightboxStage.chart {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  overflow: visible;
+  background: none;
+}
+
+/* `width: auto` against the SVG's own 680×340 attributes, capped at the box:
+   the element ends up exactly the size of the drawing, scaled to the largest
+   that fits either dimension. No letterboxed dead zone inside the element, so
+   a tap beside the chart reaches the backdrop instead of the chart. */
+.lightboxStage.chart svg {
+  display: block;
+  width: auto;
+  height: auto;
+  min-width: 0;
+  max-width: 100%;
+  max-height: 100%;
+  overflow: visible;
+}
+
+.lightboxHint {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 8px 16px 10px;
+  text-align: center;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--color-fd-muted-foreground);
+}
+
+/* The hint says to turn the phone sideways. Once it is sideways the advice is
+   spent, and the height it occupies is the height the chart wants. */
+@media (orientation: landscape) {
+  .lightboxHint {
+    display: none;
   }
 }
 

--- a/app/_components/mdx/Chart.module.css
+++ b/app/_components/mdx/Chart.module.css
@@ -153,11 +153,17 @@
   }
 }
 
+/* A chart caption here is not a photo credit — several of them run to a
+   paragraph, and they carry the argument the figure is making. So they are set
+   to read like the prose around them: 15px against the body's 16px, and the
+   body's own 1.7-ish leading rather than the tight 1.5 a one-line credit
+   wants. The muted colour and the centring keep the hierarchy; the size no
+   longer punishes anyone for reading it. */
 .caption {
   margin-top: 0.75rem;
   text-align: center;
-  font-size: 0.8125rem;
-  line-height: 1.5;
+  font-size: 0.9375rem;
+  line-height: 1.7;
   color: var(--color-fd-muted-foreground);
 }
 

--- a/app/_components/mdx/Chart.tsx
+++ b/app/_components/mdx/Chart.tsx
@@ -28,6 +28,7 @@
 import type { CSSProperties } from "react";
 import { ChartLine } from "lucide-react";
 import chartManifest from "@/lib/generated/charts";
+import ChartExpand from "./ChartExpand";
 import styles from "./Chart.module.css";
 
 // The slug printed under each chart is an authoring handle (which spec file to
@@ -76,19 +77,23 @@ export function Chart({ slug, caption, maxWidth }: ChartProps) {
       {/* `--ds-chart-min-width` is the narrowest width this chart's smallest
           label survives (computed by the build, see charts.d.ts). On a wide
           column nothing consumes it; on a phone the stylesheet lets the
-          figure scroll rather than scale its type into the ground. */}
-      <div
-        className={styles.chart}
-        role="img"
-        aria-label={entry.title}
-        style={
-          entry.minWidth
-            ? ({ "--ds-chart-min-width": `${entry.minWidth}px` } as CSSProperties)
-            : undefined
-        }
-        // Build-time output from our own spec files, never user input.
-        dangerouslySetInnerHTML={{ __html: entry.svg }}
-      />
+          figure scroll rather than scale its type into the ground — and
+          <ChartExpand> offers the whole drawing at once for the comparisons
+          that scrolling cannot serve. */}
+      <ChartExpand label={entry.title}>
+        <div
+          className={styles.chart}
+          role="img"
+          aria-label={entry.title}
+          style={
+            entry.minWidth
+              ? ({ "--ds-chart-min-width": `${entry.minWidth}px` } as CSSProperties)
+              : undefined
+          }
+          // Build-time output from our own spec files, never user input.
+          dangerouslySetInnerHTML={{ __html: entry.svg }}
+        />
+      </ChartExpand>
       {text ? <figcaption className={styles.caption}>{text}</figcaption> : null}
       {SHOW_CHART_ID ? (
         <figcaption className={styles.caption} style={{ opacity: 0.55, fontSize: "0.6875rem" }}>

--- a/app/_components/mdx/ChartExpand.tsx
+++ b/app/_components/mdx/ChartExpand.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/**
+ * "See the whole chart" for narrow screens.
+ *
+ * A chart is one fixed 680px drawing that stops scaling at the width its
+ * smallest label needs (see `legibleMinWidth` in scripts/build-charts.mjs), so
+ * on a phone it sits at ~578px inside a ~358px column and its container
+ * scrolls. That bargain keeps the type readable, and it works for reading one
+ * end of a chart at a time — but most of these figures are comparisons, and no
+ * amount of sideways scrolling puts both panels in front of the reader at
+ * once.
+ *
+ * This offers the other half of the bargain: a view that uses the whole
+ * viewport, where the entire drawing is on screen at the largest size that
+ * fits. In portrait that is small; turned sideways a phone gives about 844px,
+ * which is more than the chart's own width, so the whole thing lands at full
+ * size and full legibility. The hint says so, because "rotate your phone" is
+ * not a thing readers think to try.
+ *
+ * The button only exists below the breakpoint where the chart is clipped
+ * (Chart.module.css decides that, not this component) — above it the whole
+ * drawing is already on screen.
+ *
+ * ── Why the markup is cloned from the DOM ───────────────────────────────────
+ *
+ * The obvious shape is to pass the SVG string in as a prop, and it is the
+ * wrong one: the markup averages ~13KB per chart and would then cross into the
+ * client payload a second time, doubling every chart's cost on a lesson that
+ * carries six of them. The chart is already in the document, so the overlay
+ * reads `innerHTML` off the rendered node when it opens. It is our own
+ * build-time markup either way.
+ *
+ * The clone is given the same `.chart` class as the original, which is where
+ * the `--ds-chart-*` role tokens live — without it the SVG's `var()` colours
+ * resolve to nothing and the chart opens blank.
+ */
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { Maximize2, X } from "lucide-react";
+import styles from "./Chart.module.css";
+
+interface ChartExpandProps {
+  /** The chart's accessible name; becomes the dialog's label. */
+  label: string;
+  /** The rendered chart, as `<Chart>` builds it. */
+  children: React.ReactNode;
+}
+
+export default function ChartExpand({ label, children }: ChartExpandProps) {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const openerRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const [markup, setMarkup] = useState<string | null>(null);
+  const hintId = useId();
+
+  const open = useCallback(() => {
+    const svgHost = stageRef.current?.querySelector(`.${styles.chart}`);
+    if (svgHost) setMarkup(svgHost.innerHTML);
+  }, []);
+
+  const close = useCallback(() => {
+    setMarkup(null);
+    // Hand focus back to the control that opened the overlay, or the reader is
+    // returned to the top of the document.
+    openerRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (markup === null) return;
+    closeRef.current?.focus();
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !e.defaultPrevented) {
+        e.preventDefault(); // claim it, so nothing underneath also closes
+        close();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [markup, close]);
+
+  return (
+    <div className={styles.stage} ref={stageRef}>
+      {children}
+      <button
+        type="button"
+        ref={openerRef}
+        className={styles.expandBtn}
+        onClick={open}
+        title="View the whole chart"
+        aria-label="View the whole chart full screen"
+      >
+        <Maximize2 className={styles.expandIcon} strokeWidth={2} aria-hidden="true" />
+      </button>
+
+      {markup !== null ? (
+        <div
+          className={styles.backdrop}
+          role="dialog"
+          aria-modal="true"
+          aria-label={label}
+          aria-describedby={hintId}
+        >
+          <button
+            type="button"
+            ref={closeRef}
+            className={styles.closeBtn}
+            onClick={close}
+            title="Close (Esc)"
+            aria-label="Close"
+          >
+            <X size={18} strokeWidth={2} aria-hidden="true" />
+          </button>
+          <div
+            className={`${styles.chart} ${styles.lightboxStage}`}
+            role="img"
+            aria-label={label}
+            // Cloned from the node above, which <Chart> filled with build-time
+            // output from our own spec files. Never user input.
+            dangerouslySetInnerHTML={{ __html: markup }}
+          />
+          <p className={styles.lightboxHint} id={hintId}>
+            Turn your phone sideways for the chart at full size, or pinch to zoom.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/_components/mdx/Figure.module.css
+++ b/app/_components/mdx/Figure.module.css
@@ -23,11 +23,16 @@
   margin: 0 auto;
 }
 
+/* Matched to the chart caption in Chart.module.css: 15px against the body's
+   16px, and the body's leading rather than a one-line credit's 1.5. The two
+   captions sit in the same column, often on the same page, so they have to be
+   the same voice — and an illustration caption that explains what the art is
+   showing deserves the same reading comfort as the prose it sits under. */
 .caption {
   margin-top: 0.75rem;
   text-align: center;
-  font-size: 0.8125rem;
-  line-height: 1.5;
+  font-size: 0.9375rem;
+  line-height: 1.7;
   color: var(--color-fd-muted-foreground);
 }
 

--- a/charts/_theme.mjs
+++ b/charts/_theme.mjs
@@ -103,10 +103,15 @@ export const HALO = {
  * beside a magnified tail) collapse: whichever has the narrower range is
  * squeezed into a corner of the union of both. Plot has no per-facet scale.
  * When the quantities differ, write two charts.
+ *
+ * **The top margin is sized here, not by the spec.** See `topMarginFor()`:
+ * Plot stacks up to three things above the frame and reserves room for none of
+ * them, so a spec asking for `marginTop: 34` silently gets its axis label and
+ * its panel titles printed on adjacent baselines.
  */
 export function plot(options = {}) {
   const { x, y, color, style, marks = [], ...rest } = options;
-  return Plot.plot({
+  const spec = {
     document,
     width: 680,
     height: 320,
@@ -143,7 +148,62 @@ export function plot(options = {}) {
     y: { tickSize: 0, tickPadding: 8, labelArrow: "none", grid: true, ...y },
     color: { ...color },
     marks,
+  };
+
+  // Draw once to see what actually landed above the frame, then redraw with a
+  // top margin that fits it. Asking Plot is the only reliable test: whether an
+  // axis label exists depends on `y.label`, on the channel Plot can name it
+  // from, and on whether the scale drew an axis at all.
+  const first = Plot.plot(spec);
+  const needed = topMarginFor(first);
+  const marginTop = spec.marginTop ?? 20;
+  if (needed <= marginTop) return first;
+  // Grow the height by the same amount, so the extra band is added *above* the
+  // plot rather than taken out of it: every spec's frame keeps the size and
+  // aspect its author chose.
+  return Plot.plot({
+    ...spec,
+    marginTop: needed,
+    height: (spec.height ?? 320) + (needed - marginTop),
   });
+}
+
+/**
+ * The top margin a rendered plot needs, given what Plot put up there.
+ *
+ * Three things can occupy the band above the frame, and Plot positions each
+ * one independently of the others:
+ *
+ *   • the y-axis label, pinned 3px from the top of the SVG regardless of how
+ *     much room there is — a 15px box at y ∈ [0, 15] at this theme's 13px;
+ *   • the facet titles (an `fx` scale's tick labels), which hang 23px above
+ *     the frame edge, so their top sits at `marginTop - 23`;
+ *   • the topmost y tick label, centred *on* the frame edge, so it reaches
+ *     8px above it whenever the scale's last tick is the domain maximum.
+ *
+ * None of those is measured against the others, so a spec with `marginTop: 34`
+ * gets its axis label at [0, 15] and its panel titles at [11, 26]: two lines
+ * of type 4px apart, reading as one collided block. `marginTop: 20` (the
+ * default here) puts the topmost tick label at [12, 27] and does the same
+ * thing. The fix is a floor on the margin rather than a nudge per spec, since
+ * every faceted chart in the folder hits it and so would the next one.
+ *
+ * The band is only claimed when there is a y-axis label to clear. Without one
+ * the frame can sit as high as the spec likes.
+ *
+ * `FACET_TITLE_LIFT` assumes a one-line panel title, which is every one in the
+ * folder: Plot does not wrap tick labels unless a spec asks it to. A wrapped
+ * title would reach a line higher and want another 15px per extra line.
+ */
+const LABEL_BAND = 15; // the y-axis label's own box, at 13px type
+const CLEAR_GAP = 7; // air between it and whatever is under it
+const FACET_TITLE_LIFT = 23; // how far a facet title hangs above the frame
+const TOP_TICK_RISE = 8; // how far the topmost tick label rises above it
+
+function topMarginFor(svg) {
+  if (!svg.querySelector('[aria-label="y-axis label"]')) return 0;
+  const facetTitles = svg.querySelector('[aria-label="fx-axis tick label"]');
+  return LABEL_BAND + CLEAR_GAP + (facetTitles ? FACET_TITLE_LIFT : TOP_TICK_RISE);
 }
 
 /**

--- a/charts/bundle-parse-cost.mjs
+++ b/charts/bundle-parse-cost.mjs
@@ -40,7 +40,7 @@ export function render() {
   return plot({
     height: 320,
     marginTop: 32,
-    marginLeft: 62,
+    marginLeft: 29,
     marginRight: 110,
     marginBottom: 48,
     ariaLabel: title,

--- a/charts/cache-stride-cost.mjs
+++ b/charts/cache-stride-cost.mjs
@@ -45,7 +45,7 @@ export function render() {
   return plot({
     height: 320,
     marginTop: 32,
-    marginLeft: 62,
+    marginLeft: 30,
     marginRight: 34,
     marginBottom: 48,
     ariaLabel: title,

--- a/charts/connection-pool-saturation.mjs
+++ b/charts/connection-pool-saturation.mjs
@@ -42,7 +42,7 @@ export function render() {
   return plot({
     height: 320,
     marginTop: 32,
-    marginLeft: 62,
+    marginLeft: 30,
     marginRight: 96,
     marginBottom: 48,
     ariaLabel: title,

--- a/charts/core-web-vitals.mjs
+++ b/charts/core-web-vitals.mjs
@@ -49,7 +49,7 @@ export function render() {
   return plot({
     height: 300,
     marginTop: 44,
-    marginLeft: 88,
+    marginLeft: 38,
     marginRight: 116,
     marginBottom: 40,
     ariaLabel: title,

--- a/charts/deferred-reevaluation.mjs
+++ b/charts/deferred-reevaluation.mjs
@@ -34,7 +34,7 @@ export function render() {
   return plot({
     height: 300,
     marginTop: 26,
-    marginLeft: 62,
+    marginLeft: 22,
     marginRight: 158,
     marginBottom: 46,
     ariaLabel: title,

--- a/charts/groupby-vectorized-speedup.mjs
+++ b/charts/groupby-vectorized-speedup.mjs
@@ -38,7 +38,7 @@ export function render() {
   return plot({
     height: 300,
     marginTop: 26,
-    marginLeft: 176,
+    marginLeft: 144,
     marginRight: 196,
     marginBottom: 46,
     ariaLabel: title,

--- a/charts/grouped-vs-stacked-bars.mjs
+++ b/charts/grouped-vs-stacked-bars.mjs
@@ -63,6 +63,8 @@ const TOTALS = QUARTERS.map((q, i) => ({
   total: CHANNELS.reduce((s, c) => s + c.values[i], 0),
 }));
 
+const MAX_TOTAL = Math.max(...TOTALS.map((d) => d.total));
+
 const MOBILE = CHANNELS[0];
 const GROWTH = MOBILE.values.at(-1) - MOBILE.values[0];
 
@@ -83,7 +85,13 @@ export function render() {
       ticks: QUARTERS.map((_, i) => i),
       tickFormat: (i) => QUARTERS[i],
     },
-    y: { label: "Orders (thousands)", domain: [0, 78], ticks: 4 },
+    // The domain has to clear the tallest *stack*, not the tallest number in
+    // the data: Q4 totals 83, so a domain stopping at 78 drew that bar and its
+    // printed total straight through the panel title above it. Plot does not
+    // clip marks to the frame, so an under-sized domain is not a visible
+    // truncation — it is a mark in the margin. `MAX_TOTAL` plus room for the
+    // label keeps the arithmetic tied to the data.
+    y: { label: "Orders (thousands)", domain: [0, MAX_TOTAL + 10], ticks: 4 },
     marks: [
       Plot.rect(rows, {
         fx: "panel",
@@ -112,15 +120,17 @@ export function render() {
         stroke: GUIDE,
         strokeDasharray: "4 3",
       }),
+      // Centred over the bar that did the growing, rather than trailing right
+      // from it: a `start` anchor here runs out of the frame and into the
+      // legend sitting in the right margin.
       Plot.text([{}], {
         fx: () => GROUPED,
-        x: QUARTERS.length - 1.4,
+        x: QUARTERS.length - 1 - 0.36 + 0.72 / CHANNELS.length / 2,
         y: MOBILE.values.at(-1),
         text: () => `Mobile: +${GROWTH}`,
         fill: MUTED,
         fontSize: 10.5,
         fontWeight: 600,
-        textAnchor: "start",
         dy: -10,
         ...HALO,
       }),

--- a/charts/hashmap-load-factor.mjs
+++ b/charts/hashmap-load-factor.mjs
@@ -39,7 +39,7 @@ export function render() {
   return plot({
     height: 320,
     marginTop: 26,
-    marginLeft: 66,
+    marginLeft: 30,
     marginRight: 172,
     marginBottom: 46,
     ariaLabel: title,

--- a/charts/horizontal-bars-long-labels.mjs
+++ b/charts/horizontal-bars-long-labels.mjs
@@ -50,8 +50,14 @@ const H = 340;
    is the claim the caption makes about them: rotation is the polite failure,
    not an unreadable one. Nine names at 10px on a 45 degree diagonal need
    about 24px of bar pitch to clear each other, so 216px of panel. */
-const LEFT = { x0: 96, x1: 312, y0: 44, y1: 210 };
+const LEFT = { x0: 96, x1: 312, y0: 44, y1: 204 };
 const RIGHT = { x0: 448, x1: 636, y0: 40, y1: 300 };
+
+/** How far the diagonal names hang below the axis: as deep as the longest one
+ *  is wide, over √2. "Timezone wrong on report" sets ~130 units at 10px, so
+ *  ~110 of descent, which is why the left panel's baseline sits higher than
+ *  the right panel's and why the note underneath is placed clear of this. */
+const LABEL_DESCENT = 110;
 
 const MAX = Math.max(...ITEMS.map((d) => d.v));
 
@@ -116,6 +122,13 @@ export function render() {
         stroke: "currentColor",
         strokeOpacity: 0.35,
       }),
+      // `rotate` turns the text clockwise about its anchor, and the anchor is
+      // the *end* of the string, so a positive angle sends every name up and
+      // to the left — across the bars, which is what a rotated label must
+      // never do. Negative sends the same string down and to the left, ending
+      // under its own bar: the convention every plotting library uses for
+      // diagonal category labels, and the one this panel is arguing against.
+      // The names have to be readable for that argument to land.
       Plot.text(vertical, {
         x: "cx",
         y: LEFT.y1 + 7,
@@ -123,11 +136,11 @@ export function render() {
         fill: MUTED,
         fontSize: 10,
         textAnchor: "end",
-        rotate: 45,
+        rotate: -45,
       }),
       Plot.text([{}], {
         x: 14,
-        y: LEFT.y1 + 106,
+        y: LEFT.y1 + LABEL_DESCENT + 20,
         text: () => "nine names, each read at an angle",
         fill: MUTED,
         fontSize: 10.5,

--- a/charts/hover-is-the-detail-layer.mjs
+++ b/charts/hover-is-the-detail-layer.mjs
@@ -19,7 +19,13 @@ import { Plot, plot, ACCENT, HALO, MUTED, PRIMARY, rng } from "./_theme.mjs";
 
 /** The 7.5px value labels are the subject: this chart exists to show what a
  *  panel looks like when every number is printed on it, and printing them at
- *  a readable size would be a different chart making the opposite point. */
+ *  a readable size would be a different chart making the opposite point.
+ *
+ *  The exemption covers *only* that layer. Everything a reader is meant to
+ *  read here — the axes, the annotation, the tooltip's own text — is at the
+ *  authoring floor or above, so `legibleMinWidth` in scripts/build-charts.mjs
+ *  sizes this chart from the floor rather than from the 7.5px: type that is
+ *  deliberately illegible must not also decide how far the drawing shrinks. */
 export const smallTypeAllowed =
   "the left panel's unreadably small value labels are the thing being shown";
 
@@ -117,7 +123,11 @@ export function render() {
         y: (d) => d.y - 6,
         text: (d) => `${DAY(d.x)}\n${d.y.toFixed(1)}k sessions\n+12% on last week`,
         fill: MUTED,
-        fontSize: 8.5,
+        // At the authoring floor, not below it. The tooltip is the half of
+        // this chart the reader is supposed to be able to read — it is the
+        // *printed* layer opposite that is meant to defeat them — so it has no
+        // business riding in on the small-type exemption above.
+        fontSize: 10,
         lineHeight: 1.45,
         textAnchor: "start",
         lineAnchor: "top",

--- a/charts/image-format-bytes.mjs
+++ b/charts/image-format-bytes.mjs
@@ -37,7 +37,7 @@ export function render() {
   return plot({
     height: 290,
     marginTop: 36,
-    marginLeft: 118,
+    marginLeft: 88,
     marginRight: 152,
     marginBottom: 46,
     ariaLabel: title,

--- a/charts/inheritance-vs-composition.mjs
+++ b/charts/inheritance-vs-composition.mjs
@@ -39,7 +39,7 @@ export function render() {
   return plot({
     height: 320,
     marginTop: 26,
-    marginLeft: 62,
+    marginLeft: 30,
     marginRight: 176,
     marginBottom: 46,
     ariaLabel: title,

--- a/charts/integer-type-ranges.mjs
+++ b/charts/integer-type-ranges.mjs
@@ -42,7 +42,7 @@ export function render() {
   return plot({
     height: 320,
     marginTop: 34,
-    marginLeft: 132,
+    marginLeft: 98,
     marginRight: 172,
     marginBottom: 46,
     ariaLabel: title,

--- a/charts/join-fanout-rows.mjs
+++ b/charts/join-fanout-rows.mjs
@@ -35,7 +35,7 @@ export function render() {
   return plot({
     height: 320,
     marginTop: 34,
-    marginLeft: 74,
+    marginLeft: 38,
     marginRight: 118,
     marginBottom: 48,
     ariaLabel: title,

--- a/charts/langren-longitude-1644.mjs
+++ b/charts/langren-longitude-1644.mjs
@@ -78,7 +78,7 @@ export function render() {
   return plot({
     height: 360,
     marginTop: 30,
-    marginLeft: 112,
+    marginLeft: 126,
     marginRight: 54,
     marginBottom: 44,
     ariaLabel: title,

--- a/charts/mae-vs-rmse.mjs
+++ b/charts/mae-vs-rmse.mjs
@@ -49,7 +49,7 @@ export function render() {
   return plot({
     height: 330,
     marginTop: 26,
-    marginLeft: 54,
+    marginLeft: 22,
     marginRight: 106,
     ariaLabel: title,
     x: {

--- a/charts/pipeline-laziness.mjs
+++ b/charts/pipeline-laziness.mjs
@@ -46,7 +46,7 @@ export function render() {
   return plot({
     height: 320,
     marginTop: 30,
-    marginLeft: 128,
+    marginLeft: 51,
     marginRight: 168,
     marginBottom: 46,
     ariaLabel: title,

--- a/charts/pipeline-laziness.mjs
+++ b/charts/pipeline-laziness.mjs
@@ -47,10 +47,14 @@ export function render() {
     height: 320,
     marginTop: 30,
     marginLeft: 128,
-    marginRight: 150,
+    marginRight: 168,
     marginBottom: 46,
     ariaLabel: title,
-    fy: { label: null, domain: STAGES.map((s) => s.key) },
+    // The stage names hang off the right edge, in the same lane the bars'
+    // value labels spill into: a bar reaching 1,000,000 of a 3,000,000 domain
+    // ends near the frame edge and its label carries on past it. The pad puts
+    // the names clear of the longest of those.
+    fy: { label: null, tickPadding: 40, domain: STAGES.map((s) => s.key) },
     x: {
       label: "Elements processed",
       labelAnchor: "center",

--- a/charts/quantization-size-quality.mjs
+++ b/charts/quantization-size-quality.mjs
@@ -42,7 +42,7 @@ export function render() {
   return plot({
     height: 330,
     marginTop: 32,
-    marginLeft: 62,
+    marginLeft: 30,
     marginRight: 138,
     marginBottom: 48,
     ariaLabel: title,

--- a/charts/set-ops-vs-nested-loops.mjs
+++ b/charts/set-ops-vs-nested-loops.mjs
@@ -130,6 +130,11 @@ export function render() {
     y: {
       label: "Element operations",
       type: "log",
+      // Pinned to the end ticks. An explicit `ticks` list is drawn wherever
+      // the scale puts each value, inside the domain or not, so an inferred
+      // domain (the data tops out around 450k) hung the 1000k label above the
+      // frame, into the axis label, and the 10 label below it.
+      domain: [10, 1000000],
       ticks: [10, 100, 1000, 10000, 100000, 1000000],
       tickFormat: (d) => (d >= 1000 ? `${Math.round(d / 1000)}k` : String(d)),
     },

--- a/charts/t-test-two-groups.mjs
+++ b/charts/t-test-two-groups.mjs
@@ -91,7 +91,7 @@ export function render() {
   return plot({
     height: 340,
     marginTop: 32,
-    marginLeft: 132,
+    marginLeft: 23,
     marginRight: 138,
     marginBottom: 46,
     ariaLabel: title,

--- a/charts/token-cost-stack.mjs
+++ b/charts/token-cost-stack.mjs
@@ -45,7 +45,7 @@ export function render() {
   return plot({
     height: 340,
     marginTop: 34,
-    marginLeft: 62,
+    marginLeft: 30,
     marginRight: 26,
     marginBottom: 46,
     ariaLabel: title,

--- a/charts/window-frame-rows-range.mjs
+++ b/charts/window-frame-rows-range.mjs
@@ -65,7 +65,7 @@ export function render() {
   return plot({
     height: 300,
     marginTop: 54,
-    marginLeft: 200,
+    marginLeft: 226,
     marginRight: 20,
     marginBottom: 46,
     ariaLabel: title,

--- a/scripts/build-charts.mjs
+++ b/scripts/build-charts.mjs
@@ -316,12 +316,21 @@ const MIN_LEGIBLE_PX = 8.5;
  *  narrowest phone column with room to spare. */
 const IGNORE_BELOW_PX = 340;
 
-function legibleMinWidth(svg, width) {
+function legibleMinWidth(svg, width, smallTypeAllowed = false) {
   const sizes = [...svg.matchAll(/font-size[=:]\s*"?([0-9.]+)/g)].map((m) =>
     Number(m[1]),
   );
   if (sizes.length === 0) return 0;
-  const smallest = Math.min(...sizes);
+  // A spec that exempted itself from the authoring floor drew type it *wants*
+  // illegible. Sizing the chart from that type is the wrong bargain twice
+  // over: the drawing is pinned at full width, forcing the most horizontal
+  // scrolling of anything in the library, in order to protect labels whose
+  // whole point is that they cannot be read. Size it from the floor every
+  // other spec is held to, so the type a reader is meant to read is safe and
+  // the chart shrinks like its neighbours.
+  const smallest = smallTypeAllowed
+    ? Math.max(MIN_AUTHORED_PX, Math.min(...sizes))
+    : Math.min(...sizes);
   // Scaling the SVG scales its type by the same factor, so a label of
   // `smallest` px renders at `smallest * (w / width)`. Solve that for the w
   // where it reaches the floor. Never ask for more than the chart's own
@@ -425,7 +434,7 @@ for (const file of specs) {
   }
 
   const width = Number(el.getAttribute("width"));
-  const minWidth = legibleMinWidth(svg, width);
+  const minWidth = legibleMinWidth(svg, width, Boolean(mod.smallTypeAllowed));
 
   charts[slug] = {
     title: mod.title,


### PR DESCRIPTION
Four reported defects, each of which turned out to have a cause worth fixing rather than a nudge worth applying.

## The top margin was never sized for what goes in it

Plot puts three things in the band above the frame and measures none of them against the others:

| what | where Plot puts it |
| --- | --- |
| y-axis label | pinned 3px from the top of the SVG — a 15px box at `y ∈ [0, 15]` |
| facet titles (`fx` tick labels) | 23px above the frame edge, so their top is at `marginTop - 23` |
| topmost y tick label | centred *on* the frame edge, reaching 8px above it |

So `marginTop: 34` put the axis label at `[0, 15]` and the panel titles at `[11, 26]`: two lines of type 4px apart, which is the reported "title too close to the chart body". The theme default of `20` did the same thing with the topmost tick label. Every faceted chart in the folder hit it.

`plot()` now draws once, asks the rendered SVG what actually landed above the frame, and redraws with a margin that fits it — and grows the height by the same amount, so the band is added *above* the plot rather than taken out of it. **104 of 269 charts gain 2–21px of top margin; nothing inside a frame moves.** Verified by diffing rendered tick positions against `main`: every affected frame is translated down by exactly the delta, with tick spacing identical to two decimal places.

A floor in the theme rather than a nudge per spec, because the next faceted chart would hit it too.

## Four specs had defects a margin cannot fix

- **`grouped-vs-stacked-bars`** — Q4 totals 83 against a domain stopping at 78. Plot does not clip marks to the frame, so an undersized domain is not a visible truncation, it is a bar in the margin: the Q4 stack and its printed total ran straight through the panel title. The domain now follows the tallest stack. The wider domain moved the `Mobile: +21` annotation into the legend lane, so it is centred over the bar it describes instead of trailing right from it.
- **`horizontal-bars-long-labels`** — `rotate` turns text clockwise about its anchor, and the anchor is the *end* of the string, so a positive angle sent all nine names up and to the left, across the bars. Negative sends them down-left, ending under their own bar: the convention every plotting library uses, and the one this panel is arguing against — the argument only lands if the names are readable. The panel baseline moved up to reserve the diagonal band, and the note underneath now clears it.
- **`set-ops-vs-nested-loops`** — an explicit `ticks` list is drawn wherever the scale maps each value, inside the domain or not. The data tops out near 450k, so the `1000k` label hung above the frame into the axis label and the `10` label below it. Pinned the domain to the end ticks.
- **`pipeline-laziness`** — a bar reaching 1,000,000 of a 3,000,000 domain ends near the frame edge and its value label carries on past it, into the lane the `fy` stage names sit in.

## Chart captions

Several of these run to a paragraph and carry the argument the figure is making, so they are set to read like the prose around them: 15px against the body's 16px, and the body's leading rather than the 1.5 a one-line photo credit wants.

## Escape dismisses search highlights

Arriving from search paints every prefix match on the page, and a common word can light up a lesson dozens of times; there was no way out but to navigate away. Escape now clears them, the way it leaves a browser's find bar, and drops `?hl=` from the URL so a reload, a copied link or a step back through history does not repaint what was just dismissed. The param is dropped with `history.replaceState` rather than the router, since nothing on the server reads it.

Escape is left alone when something has a better claim on it: a focused field, a CodeMirror editor, an open dialog, or any handler that already called `preventDefault`.

## Verification

- `tsc --noEmit` clean; `eslint` clean on changed files; `vitest run` — 1134 tests, 83 files, all passing.
- Wrote a geometric audit that renders all 269 specs in Chromium and reports real bounding-box collisions between label text and both other labels and data marks. It found every reported defect plus the four above; after the fixes, no axis-label or facet-title collisions remain (the residual hits are path-bounding-box artifacts on curves, checked by eye).
- Charts checked in both themes — the light/dark token mapping means one SVG serves both, so a fix that only reads in one is not a fix.
- Highlight dismissal driven against the dev server: 55 ranges on load → 0 after Escape with the param stripped → still 0 after reload, and highlights correctly survive Escape when the search dialog owns the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVp8o1WSrEKgxq5sgdtsSQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVp8o1WSrEKgxq5sgdtsSQ)_