### PR TITLE
Move every GitHub Action to its Node 24 major

### DIFF
--- a/.github/workflows/cloudflare-build-pr-comments.yml
+++ b/.github/workflows/cloudflare-build-pr-comments.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post build-status comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const cr = context.payload.check_run;

--- a/.github/workflows/content-sweeps.yml
+++ b/.github/workflows/content-sweeps.yml
@@ -152,7 +152,7 @@ jobs:
       run: ${{ steps.decide.outputs.run }}
       label: ${{ steps.decide.outputs.label }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Needed to diff against the base branch.
           fetch-depth: 0
@@ -239,9 +239,9 @@ jobs:
     # which hangs past its own 30s budget cannot burn a runner for six hours.
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -252,7 +252,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Restore dataset cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .dataset-cache
           key: dataset-cache-v1-${{ hashFiles('content/**/*.mdx') }}
@@ -270,7 +270,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: challenges-report
           path: challenges-report.json
@@ -285,9 +285,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -296,7 +296,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Restore dataset cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .dataset-cache
           key: dataset-cache-v1-${{ hashFiles('content/**/*.mdx') }}
@@ -314,7 +314,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: code-blocks-report
           path: code-blocks-report.json
@@ -332,9 +332,9 @@ jobs:
     # cheapest of the three by a wide margin: 619 items in well under a minute.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -354,7 +354,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: js-report
           path: js-report.json
@@ -370,15 +370,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Restore dataset cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .dataset-cache
           key: dataset-cache-v1-${{ hashFiles('content/**/*.mdx') }}
@@ -394,7 +394,7 @@ jobs:
           fi
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sql-report
           path: sql-report.json
@@ -410,15 +410,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Restore dataset cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .dataset-cache
           key: dataset-cache-v1-${{ hashFiles('content/**/*.mdx') }}
@@ -434,7 +434,7 @@ jobs:
           fi
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: r-report
           path: r-report.json
@@ -456,8 +456,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -506,7 +506,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: browser-report
           path: browser-report.json

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -47,12 +47,12 @@ jobs:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm


### PR DESCRIPTION
## Why

Every workflow step that runs a Node 20 action now logs:

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable.

The warning surfaced on the **Cloudflare build PR comments** job because that workflow's only step pins `actions/github-script@v7` — but the source is not that workflow specifically. Per [GitHub's changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), runners already default to Node 24 and Node 20 is removed from runners in the fall, so every `@v4`-era action in this repo is on the same clock. This bumps all of them rather than silencing one job.

## What changed

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v4` | `v7` |
| `actions/setup-node` | `v4` | `v7` |
| `actions/cache` | `v4` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/github-script` | `v7` | `v9` |

Files touched: `cloudflare-build-pr-comments.yml`, `content-sweeps.yml`, `optimize-images.yml`. (`r2-cache-cleanup.yml` and `r2-illustrations-lifecycle.yml` use no third-party actions, so they were already clean.) Each target tag was verified to declare `using: node24` in its `action.yml`; these are the current majors, not just the first Node 24 ones.

## Compatibility check

Every input passed anywhere in the repo still exists in the new majors — `fetch-depth`/`ref` (checkout), `node-version`/`cache` (setup-node), `path`/`key`/`restore-keys` (cache), `name`/`path`/`if-no-files-found` (upload-artifact), inline `script` (github-script).

The breaking changes in the majors being jumped over don't apply here:

- **checkout v7** blocks checking out fork PRs under `pull_request_target` / `workflow_run` — neither trigger is used in this repo.
- **checkout v6** moves persisted credentials into a separate file; `optimize-images.yml` pushes with `git push origin`, which still uses them.
- **setup-node v6** narrows automatic caching to npm — moot, every step sets `cache: npm` explicitly.
- **github-script v9** makes `@actions/github` ESM-only, so `require('@actions/github')` fails and `getOctokit` can't be redeclared with `const`/`let`. The Cloudflare comment script does neither; it uses `github.rest.*`, `context`, and `core`, all unchanged.

These majors require Actions Runner 2.327.1+, which GitHub-hosted runners exceed — everything here runs on `ubuntu-latest`.

## Verification

- All five workflow files still parse as valid YAML.
- No `actions/*@v4` or `github-script@v7` references remain anywhere under `.github/`.
- Behavior of `cloudflare-build-pr-comments.yml` is otherwise untouched; note that, being `check_run`-triggered, it only takes effect from `main`, so the warning disappears once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVmcnCfiLLVreJbe6d6Ffv)_