### PR TITLE
Split the MDX widget bundle per lesson (919 kB → 391 kB), cache R2 reads per colo, fix vanishing MCQ choices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,6 +559,43 @@ the plot rather than in a legend, and the page's own Inter tracked slightly
 tight. Chart junk is the enemy; the data is the ink.
 
 
+## Registering a new MDX widget
+
+An interactive (`"use client"`) widget gets a lazy wrapper in
+`app/_components/mdx/lazyWidgets.ts`, and `mdx-components.tsx` imports that
+wrapper into the component map:
+
+```ts
+// app/_components/mdx/lazyWidgets.ts  ("use client" — that matters, see below)
+export const MyWidget = lazyWidget(() => import("@/app/_components/MyWidget"));
+```
+
+The map is handed to `<MDX>` on every lesson render, so a statically imported
+client component joins the bundle of every page of every course whether or not
+a lesson mentions it. Before this was split (2026-08-09), a prose-only lesson
+downloaded a byte-identical 41 chunks / 3.1 MB to a lesson with eight runnable
+code blocks: the whole CodeMirror stack, the SQL cards, all 33 React demos.
+That JavaScript is the dominant cost of a lesson load — the incremental cache
+never touches it — so one static import hands the regression back.
+
+**The wrapper has to live in that `"use client"` module.** Calling `dynamic()`
+directly from `mdx-components.tsx` type-checks, builds green, and splits
+nothing: in the App Router a client component reached from a Server Component
+becomes a client *reference*, and every client reference in a route's server
+graph joins that route's client entry however it was imported. Measured, that
+version left all 41 chunks as eager `<script src>` tags and added a 42nd. Only
+an `import()` evaluated inside the client graph is a split point.
+
+Server Components are the exception and stay statically imported in
+`mdx-components.tsx`: `Figure`, `Chart` and `SvgLabel` render to markup on the
+server and ship no client code, so splitting them would only add a Suspense
+boundary. The test is whether the component's own module carries
+`"use client"`.
+
+Server rendering is unaffected either way. `lazyWidget()` leaves SSR on
+(`dynamic()`'s default), so the prerendered HTML still contains every widget
+and search still indexes it.
+
 ## Generated files and the build cache
 
 `dev` and `build` both run the same chain of generators before Next starts —

--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ npx wrangler r2 bucket create dataslope-inc-cache
 
 The bucket is bound as `NEXT_INC_CACHE_R2_BUCKET` in `wrangler.jsonc`. It is **populated at deploy time**, so the deploy command must run `opennextjs-cloudflare deploy` (which `npm run cf:deploy` does), a bare `wrangler deploy` skips the populate step and leaves the cache empty. If you deploy via Cloudflare Workers Builds (the CI path that builds production and per-branch previews), configure its build settings as shown below.
 
+### Recommended: a Cache Rule for lesson HTML
+
+A Worker runs *ahead* of Cloudflare's CDN cache, and its response is not stored there unless something explicitly puts it there. Next sets `s-maxage=31536000` on every prerendered page, but that header buys nothing on the first hop: page responses come back with **no `cf-cache-status` header at all**, while `/_next/static/*` (served by the assets binding, not the Worker) reports `cf-cache-status: HIT`. So today every visitor to a lesson costs a Worker invocation plus an R2 read, and two readers of the same page share nothing.
+
+`open-next.config.ts` closes half of that gap in code: `withRegionalCache` fronts R2 with the per-data-centre Cache API, so the first reader in a colo pays the R2 round trip and everyone behind them is served locally. The Worker invocation itself can only be skipped from the origin side, which is dashboard configuration:
+
+> Caching → Cache Rules → **Create rule**
+> - **If** URI Path starts with `/courses/` (add `/interview-prep/` and `/fumadocs-dev/` to taste)
+> - **Then** Eligible for cache, Edge TTL → *Use cache-control header if present*
+
+This is safe here because lesson content only changes on deploy and every asset URL is build-ID-scoped, so a new deploy can never be served the previous build's HTML. Leave `/api/*` out of the rule: those routes are `force-dynamic` and several are per-user.
+
 ### Cloudflare Workers Builds configuration
 
 Production and preview deploys run through Cloudflare Workers Builds rather than the local `npm run cf:*` scripts, so its build settings (Workers → the `dataslope` worker → Settings → Build) must populate the R2 cache on **both** paths. The non-production (preview) command is the easy one to get wrong: a bare `npx wrangler versions upload` builds the Worker but skips the cache populate step, leaving previews with an empty cache that 500s the home page and `/courses/*`.

--- a/__tests__/mcqRuntimeParse.test.ts
+++ b/__tests__/mcqRuntimeParse.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { extractMcqBlocks, findMcqFiles } from "../scripts/check-mcq.mjs";
+import { parseQuestion } from "../app/_components/multipleChoice/parseQuestion";
+
+/**
+ * Runs the REAL runtime parser over the authored MCQ corpus.
+ *
+ * `mcqContent.test.ts` guards the same corpus for authoring rules, but through
+ * `check-mcq.mjs`'s own loose reimplementation of the parser ("mirrors
+ * parseQuestion.ts closely enough for linting purposes"). The two drifted, and
+ * the gap shipped: `beginners-javascript/promises-and-async-await` authored its
+ * four choices as a bare `- ` marker with the code fence on the line below,
+ * which the linter read as four choices and `parseQuestion` read as one empty
+ * one. The lesson rendered a question with a single blank radio button in
+ * production, and every check was green.
+ *
+ * So this file deliberately imports the component's own parser: whatever the
+ * linter believes, these are the assertions that describe what a learner
+ * actually sees.
+ *
+ * Each block is checked twice, as authored and with one level of indentation
+ * removed, because MDX strips the template literal's indent before the parser
+ * runs (verified against `@mdx-js/mdx`: `  ```js` inside `markdown={` … `}`
+ * reaches the runtime at column 0). Asserting both means the corpus stays
+ * valid whether or not that behaviour holds in a future MDX release, without
+ * this test having to model it exactly.
+ */
+describe("<MultipleChoice> corpus through the runtime parser", () => {
+  const files = [
+    ...findMcqFiles(path.join(process.cwd(), "content", "courses")),
+    ...findMcqFiles(path.join(process.cwd(), "content", "interview")),
+    ...findMcqFiles(path.join(process.cwd(), "content", "fumadocs-dev")),
+  ];
+
+  /** How MDX dedents a `markdown={` … `}` literal authored at indent 2. */
+  const dedent = (block: string) =>
+    block
+      .split("\n")
+      .map((line) => line.replace(/^ {2}/, ""))
+      .join("\n");
+
+  const cases: { file: string; block: string; variant: string }[] = [];
+  for (const file of files) {
+    for (const block of extractMcqBlocks(readFileSync(file, "utf8"))) {
+      cases.push({ file, block, variant: "as authored" });
+      cases.push({ file, block: dedent(block), variant: "dedented by MDX" });
+    }
+  }
+
+  it("locates the MCQ corpus", () => {
+    expect(cases.length).toBeGreaterThan(200);
+  });
+
+  it("parses every question into answerable choices", () => {
+    const failures: string[] = [];
+    for (const { file, block, variant } of cases) {
+      const q = parseQuestion(block);
+      const where = `${path.relative(process.cwd(), file)} (${variant})`;
+      const stem = q.body.split("\n").find((l) => l.trim())?.slice(0, 60) ?? "";
+
+      if (q.choices.length < 2) {
+        failures.push(`${where}: ${q.choices.length} choice(s) — "${stem}"`);
+        continue;
+      }
+      const blank = q.choices.filter((c) => c.text.trim() === "").length;
+      if (blank > 0) {
+        // The exact shape the promises lesson shipped: a radio with no label.
+        failures.push(`${where}: ${blank} blank choice(s) — "${stem}"`);
+      }
+      if (q.correctId === null) {
+        failures.push(`${where}: no choice marked [o] — "${stem}"`);
+      }
+    }
+    expect(failures, `Unanswerable questions:\n  ${failures.join("\n  ")}`).toEqual(
+      [],
+    );
+  });
+});

--- a/app/_components/mdx/lazyReactDemos.ts
+++ b/app/_components/mdx/lazyReactDemos.ts
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * Lazily-loaded versions of the React-course demo components.
+ *
+ * `"use client"` is load-bearing, for the reason spelled out in
+ * `lazyWidgets.ts`: an `import()` only becomes a split point when it is
+ * evaluated inside the client graph. These 33 demos are spread into the MDX
+ * component map for EVERY lesson, so statically imported they rode along on
+ * every Python, SQL and C++ page that will never render one.
+ *
+ * They all resolve to the same module, so the split costs a single shared
+ * async chunk that only a React-course lesson ever fetches.
+ *
+ * `reactDemoComponents.ts` is what collects these into the spreadable object
+ * the component map wants; see that file for why the object cannot live here.
+ */
+
+import { lazyWidget } from "./lazyWidget";
+
+export const GreetingDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.GreetingDemo),
+);
+export const StarRatingDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.StarRatingDemo),
+);
+export const AvatarDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.AvatarDemo),
+);
+export const UserCardDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.UserCardDemo),
+);
+export const BadgeDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.BadgeDemo),
+);
+export const ListDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.ListDemo),
+);
+export const FilterListDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.FilterListDemo),
+);
+export const CounterDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.CounterDemo),
+);
+export const ToggleDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.ToggleDemo),
+);
+export const ColorPickerDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.ColorPickerDemo),
+);
+export const LikeButtonDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.LikeButtonDemo),
+);
+export const KeyPressDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.KeyPressDemo),
+);
+export const TextMirrorDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.TextMirrorDemo),
+);
+export const SignupFormDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.SignupFormDemo),
+);
+export const TemperatureDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.TemperatureDemo),
+);
+export const ClockDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.ClockDemo),
+);
+export const WindowWidthDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.WindowWidthDemo),
+);
+export const DataFetchDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.DataFetchDemo),
+);
+export const PanelDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.PanelDemo),
+);
+export const SlotsDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.SlotsDemo),
+);
+export const TabsDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.TabsDemo),
+);
+export const ChildrenCountDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.ChildrenCountDemo),
+);
+export const UseToggleDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.UseToggleDemo),
+);
+export const StopwatchDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.StopwatchDemo),
+);
+export const UseLocalStorageDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.UseLocalStorageDemo),
+);
+export const TodoDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.TodoDemo),
+);
+export const AuthToggleDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.AuthToggleDemo),
+);
+export const CartBadgeDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.CartBadgeDemo),
+);
+export const ImmutableListDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.ImmutableListDemo),
+);
+export const SettingsObjectDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.SettingsObjectDemo),
+);
+export const FocusInputDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.FocusInputDemo),
+);
+export const SilentCounterDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.SilentCounterDemo),
+);
+export const ThemeContextDemo = lazyWidget(() =>
+  import("./reactDemos").then((mod) => mod.ThemeContextDemo),
+);

--- a/app/_components/mdx/lazyWidget.ts
+++ b/app/_components/mdx/lazyWidget.ts
@@ -1,0 +1,29 @@
+/**
+ * `next/dynamic` for a component registered in the MDX component map.
+ *
+ * Why the map's widgets are lazy at all is documented at the top of
+ * `mdx-components.tsx`; this module exists only to keep one type assertion in
+ * one explained place.
+ *
+ * The assertion: `dynamic()` returns `ComponentType`, a union whose
+ * `ComponentClass` half MDX's `MDXComponents` map rejects (it wants something
+ * callable, and a class has no string index signature). Every component routed
+ * through here is a function component, so narrowing the type back loses
+ * nothing and is checked by the `load` parameter, which still has to resolve to
+ * a real component module.
+ *
+ * CALL THIS FROM A `"use client"` MODULE — `lazyWidgets.ts` or
+ * `lazyReactDemos.ts`, which is where the split points live. The `import()`
+ * has to be evaluated inside the client graph to become one; called from a
+ * Server Component it type-checks, builds, and splits nothing. That module has
+ * the full explanation. This file carries no directive of its own so either
+ * graph can pull it in.
+ */
+import dynamic from "next/dynamic";
+import type { ComponentType, JSX } from "react";
+
+export function lazyWidget<P>(
+  load: () => Promise<ComponentType<P> | { default: ComponentType<P> }>,
+): (props: P) => JSX.Element {
+  return dynamic(load) as (props: P) => JSX.Element;
+}

--- a/app/_components/mdx/lazyWidgets.ts
+++ b/app/_components/mdx/lazyWidgets.ts
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * Lazily-loaded versions of the interactive widgets registered in
+ * `mdx-components.tsx`. Why they are lazy at all is documented there.
+ *
+ * ## Why this module has to be `"use client"`
+ *
+ * The obvious version of this — calling `dynamic()` straight from
+ * `mdx-components.tsx` — does nothing, and silently. In the App Router a
+ * client component reached from a Server Component becomes a *client
+ * reference*, and every client reference in a route's server graph joins that
+ * route's client entry whether it was imported statically or through
+ * `dynamic()`. Tried on 2026-08-09, it left all 41 chunks as eager
+ * `<script src>` tags in the prerendered HTML and added a 42nd.
+ *
+ * The `import()` has to be evaluated inside the *client* graph for the bundler
+ * to treat it as a split point, which is what the directive above buys: these
+ * calls now run in a client module, so each widget becomes its own async chunk
+ * that a lesson fetches only when it actually renders that widget.
+ *
+ * So: add new widgets HERE, not as a `dynamic()` call in a Server Component.
+ *
+ * Server rendering is unaffected. `ssr: true` is `dynamic()`'s default, so the
+ * prerendered HTML still contains every widget — no SEO loss, no blank frame,
+ * and Next preloads the chunks for widgets present in the RSC payload, so a
+ * lesson that does use `<CodeBlock>` fetches it in parallel rather than in a
+ * waterfall behind hydration.
+ */
+
+import { lazyWidget } from "./lazyWidget";
+
+export const MdxCodeBlock = lazyWidget(
+  () => import("@/app/_components/MdxCodeBlock"),
+);
+export const MdxChallengeCard = lazyWidget(
+  () => import("@/app/_components/MdxChallengeCard"),
+);
+export const MdxSqlChallengeCard = lazyWidget(
+  () => import("@/app/_components/MdxSqlChallengeCard"),
+);
+export const MdxSqlCodeBlock = lazyWidget(
+  () => import("@/app/_components/MdxSqlCodeBlock"),
+);
+export const MdxMultipleChoiceQuestion = lazyWidget(
+  () => import("@/app/_components/multipleChoice/MdxMultipleChoiceQuestion"),
+);
+export const Mermaid = lazyWidget(() =>
+  import("@/app/_components/mdx/mermaid").then((mod) => mod.Mermaid),
+);
+export const IllustrationPrompt = lazyWidget(
+  () => import("@/app/_components/mdx/IllustrationPrompt"),
+);
+export const LoadingAnimationsGallery = lazyWidget(
+  () => import("@/app/_components/mdx/loadingAnimations"),
+);
+export const RuntimeLoadingStates = lazyWidget(
+  () => import("@/app/_components/RuntimeBootNotice"),
+);
+export const LivePreview = lazyWidget(() =>
+  import("@/app/_components/mdx/LivePreview").then((mod) => mod.LivePreview),
+);
+export const ReactPreview = lazyWidget(() =>
+  import("@/app/_components/mdx/ReactPreview").then((mod) => mod.ReactPreview),
+);

--- a/app/_components/mdx/reactDemoComponents.ts
+++ b/app/_components/mdx/reactDemoComponents.ts
@@ -1,17 +1,17 @@
 /**
  * Server-safe registry of the React-course demo components.
  *
- * This module is deliberately NOT `"use client"`. The demos themselves live in
- * `reactDemos.tsx` (which is a client module); here we import them by name and
- * group them into a plain object that `mdx-components.tsx` spreads into the MDX
- * component map.
+ * This module is deliberately NOT `"use client"`. The lazy demo wrappers live
+ * in `lazyReactDemos.ts` (which is a client module); here we import them by
+ * name and group them into a plain object that `mdx-components.tsx` spreads
+ * into the MDX component map.
  *
- * Why the object can't live in `reactDemos.tsx`: React Server Components turn
- * every export of a `"use client"` module into an opaque client *reference*, so
- * an object exported from that file spreads to nothing on the server. Named
- * component references survive individual import, though, so re-collecting them
- * in this ordinary module produces a real, spreadable object whose values are
- * valid client references.
+ * Why the object cannot live in that client module: React Server Components
+ * turn every export of a `"use client"` module into an opaque client
+ * *reference*, so an object exported from there spreads to nothing on the
+ * server. Named component references survive individual import, though, so
+ * re-collecting them in this ordinary module produces a real, spreadable
+ * object whose values are valid client references.
  */
 
 import {
@@ -48,7 +48,7 @@ import {
   FocusInputDemo,
   SilentCounterDemo,
   ThemeContextDemo,
-} from "./reactDemos";
+} from "./lazyReactDemos";
 
 export const reactDemoComponents = {
   GreetingDemo,

--- a/app/_components/multipleChoice/parseQuestion.ts
+++ b/app/_components/multipleChoice/parseQuestion.ts
@@ -14,10 +14,11 @@
  *     continuation lines indented by 2+ spaces extend the choice text
  *
  *   Fenced code blocks inside a choice are fully supported. The opening
- *   fence (e.g. ```python) may appear right after `- ` or as an indented
- *   continuation line. All lines, including blank lines, inside the
- *   fence are captured verbatim as part of the choice text; the fence is
- *   closed when an indented ``` or ~~~ line (matching 3+ chars) appears.
+ *   fence (e.g. ```python) may appear right after `- `, or on the line
+ *   below it (indented when authored, though MDX strips that indent
+ *   before this parser sees it). All lines, including blank lines,
+ *   inside the fence are captured verbatim as part of the choice text;
+ *   the fence is closed when a ``` or ~~~ line (3+ chars) appears.
  *
  *   Overall explanation paragraph(s) appear after the final choice and
  *   are written without any special marker.
@@ -208,6 +209,38 @@ export function parseQuestion(source: string): ParsedQuestion {
           inChoiceFence = false;
         }
         pendingBlanks = 0;
+        continue;
+      }
+
+      // A fence that opens on the line AFTER the choice marker, rather than
+      // on the marker line itself:
+      //
+      //   - [o]
+      //     ```javascript
+      //     const pa = fetchA();
+      //     ```
+      //
+      // Authored that way the fence is indented, but MDX strips the template
+      // literal's indentation before this parser ever runs (see the note in
+      // the `inChoiceFence` branch above), so it arrives at column 0 and the
+      // indented-continuation rule below cannot match it. Without this branch
+      // the fence falls through to "unindented text ends the choices block",
+      // which silently swallows every remaining choice into the overall
+      // explanation and renders a question with one empty option — the shape
+      // `promises-and-async-await` shipped with.
+      //
+      // `pendingBlanks === 0` is what keeps this from capturing a genuine
+      // overall explanation that happens to start with a code block: that is
+      // always separated from the last choice by a blank line, while a
+      // continuation fence directly abuts its choice.
+      if (
+        choices.length > 0 &&
+        pendingBlanks === 0 &&
+        FENCE_OPEN_RE.test(trimmed)
+      ) {
+        appendToChoiceText(trimmed);
+        inChoiceFence = true;
+        pendingFenceBlanks = 0;
         continue;
       }
 

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -9,26 +9,60 @@
  * ```mdx
  * <CodeBlock adapter="python" starterCode={`print("hello")`} />
  * ```
+ *
+ * ## Why the interactive widgets are loaded with `next/dynamic`
+ *
+ * This map names every component a lesson *may* use, and it is handed to
+ * `<MDX>` on every render, so a statically imported widget joins the route's
+ * client bundle whether or not the lesson mentions it. That put the entire
+ * widget surface — the CodeMirror editor stack behind `<CodeBlock>` and the
+ * challenge cards, the SQL variants, the 33 React-course demos — on every
+ * page of every course. Measured on 2026-08-09, a prose-only lesson
+ * (`modern-css-layout/next-steps`, zero widgets) shipped a byte-identical
+ * 41 chunks / 3.1 MB (919 kB gzipped) to a lesson with eight runnable code
+ * blocks. That JavaScript is the dominant cost of a lesson load: it is
+ * parsed and hydrated on the main thread, and the incremental cache cannot
+ * touch it.
+ *
+ * `app/_components/mdx/lazyWidgets.ts` puts each widget in its own async
+ * chunk, so a lesson downloads only the widgets it actually renders. Server
+ * rendering stays ON, so the prerendered HTML still contains every widget: no
+ * SEO loss, no blank frame, no layout shift.
+ *
+ * Those `dynamic()` calls have to live in that `"use client"` module and not
+ * here — calling `dynamic()` from this file type-checks, builds, and splits
+ * nothing, because a client reference reached from a Server Component joins
+ * the route's client entry however it was imported. `lazyWidgets.ts` has the
+ * full explanation; read it before moving a widget back into this file.
+ *
+ * `Figure`, `Chart`, `SvgLabel` and the `<Steps>` pair stay statically
+ * imported on purpose: they are Server Components (or render no client code),
+ * so they never reach the browser and splitting them would buy nothing.
  */
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import type { MDXComponents } from "mdx/types";
-import MdxCodeBlock from "@/app/_components/MdxCodeBlock";
-import MdxChallengeCard from "@/app/_components/MdxChallengeCard";
-import MdxSqlChallengeCard from "@/app/_components/MdxSqlChallengeCard";
-import MdxSqlCodeBlock from "@/app/_components/MdxSqlCodeBlock";
-import MdxMultipleChoiceQuestion from "@/app/_components/multipleChoice/MdxMultipleChoiceQuestion";
-import { Mermaid } from "@/app/_components/mdx/mermaid";
 import { SvgLabel } from "@/app/_components/mdx/SvgLabel";
-import { IllustrationPrompt } from "@/app/_components/mdx/IllustrationPrompt";
 import { Figure } from "@/app/_components/mdx/Figure";
 import { Chart } from "@/app/_components/mdx/Chart";
-import LoadingAnimationsGallery from "@/app/_components/mdx/loadingAnimations";
-import RuntimeLoadingStates from "@/app/_components/RuntimeBootNotice";
-import { LivePreview } from "@/app/_components/mdx/LivePreview";
-import { ReactPreview } from "@/app/_components/mdx/ReactPreview";
 import { reactDemoComponents } from "@/app/_components/mdx/reactDemoComponents";
 import { withSearchAnchor } from "@/app/_components/mdx/withSearchAnchor";
+// Interactive widgets, one async chunk each. The `dynamic()` calls live in
+// that module rather than here because the directive at its top is what makes
+// them split at all; see the note there before moving one back.
+import {
+  MdxCodeBlock,
+  MdxChallengeCard,
+  MdxSqlChallengeCard,
+  MdxSqlCodeBlock,
+  MdxMultipleChoiceQuestion,
+  Mermaid,
+  IllustrationPrompt,
+  LoadingAnimationsGallery,
+  RuntimeLoadingStates,
+  LivePreview,
+  ReactPreview,
+} from "@/app/_components/mdx/lazyWidgets";
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   // `withSearchAnchor` renders the deterministic `id` that

--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,5 +1,6 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache";
+import { withRegionalCache } from "@opennextjs/cloudflare/overrides/incremental-cache/regional-cache";
 
 // OpenNext (Cloudflare) build configuration.
 //
@@ -24,8 +25,36 @@ import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cac
 // render correctly too. Each deploy's populate step writes a full copy of the
 // cache under a new build ID, ~1–1.4 GB (one HTML+RSC `.cache` object per
 // prerendered page), so stale build folders are pruned on a schedule by
-// .github/workflows/r2-cache-cleanup.yml. Reads are rare behind the edge
-// `s-maxage` cache.
+// .github/workflows/r2-cache-cleanup.yml.
+//
+// Reads are NOT rare, which this comment used to claim. Next sets
+// `s-maxage=31536000` on the prerendered responses, but a Worker runs *ahead*
+// of Cloudflare's CDN cache and its response is not stored there unless the
+// Worker or a Cache Rule puts it there: page responses come back with no
+// `cf-cache-status` header at all, while `/_next/static/*` (served by the
+// assets binding) reports `cf-cache-status: HIT` (measured 2026-08-09). So
+// every visitor to a lesson costs one Worker invocation and one R2 GET, and
+// nothing is shared between two readers of the same page.
+//
+// `withRegionalCache` is the fix that lives in this repo: it fronts R2 with
+// the per-data-centre Cache API, so the first reader in a colo pays the R2
+// round trip and everyone behind them is served locally. It does not remove
+// the Worker invocation — only an origin-side Cache Rule on `/courses/*` can
+// do that, which is dashboard configuration rather than code (see the
+// "Incremental cache cleanup" section of README.md).
+//
+// The two non-default options are both safe *because* the regional key is
+// scoped by build ID (`getCacheUrlKey` prefixes `OPEN_NEXT_BUILD_ID`, i.e. the
+// deployed commit SHA), which makes an entry immutable for the life of a
+// deploy and unreachable from the next one:
+//   - `long-lived` + a 24 h TTL: nothing here revalidates, so there is no
+//     staleness for a long TTL to expose. Colo eviction, not this number, is
+//     what actually bounds an entry's life.
+//   - `shouldLazilyUpdateOnCacheHit: false`: the default re-fetches from R2 in
+//     the background on every regional hit to catch out-of-band changes. With
+//     build-ID-scoped, write-once entries there is nothing to catch, and
+//     leaving it on would keep paying the R2 read this wrapper exists to
+//     avoid.
 //
 // IMPORTANT: the R2 cache must be POPULATED at deploy time. `npm run cf:deploy`
 // (`opennextjs-cloudflare deploy`) and `npm run cf:preview` do this; if you
@@ -39,6 +68,10 @@ import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cac
 // cache is configured because nothing here revalidates; add one alongside this
 // only when a server feature that revalidates is introduced.
 export default defineCloudflareConfig({
-  incrementalCache: r2IncrementalCache,
+  incrementalCache: withRegionalCache(r2IncrementalCache, {
+    mode: "long-lived",
+    defaultLongLivedTtlSec: 24 * 60 * 60,
+    shouldLazilyUpdateOnCacheHit: false,
+  }),
   enableCacheInterception: true,
 });

--- a/scripts/check-mcq.mjs
+++ b/scripts/check-mcq.mjs
@@ -50,7 +50,21 @@ export function extractMcqBlocks(src) {
 }
 
 // Parse one block into { body, choices:[{ correct, text, explanation }] }.
-// Mirrors parseQuestion.ts closely enough for linting purposes.
+//
+// A LOOSE approximation of parseQuestion.ts, kept separate so this script stays
+// dependency-free plain JS. It is deliberately more permissive than the real
+// parser — notably it drops fenced code rather than capturing it as choice
+// text, so `choices[].text` is empty for any fenced choice, which is why the
+// duplicate-choice rule below skips empty keys.
+//
+// That permissiveness has bitten once: `promises-and-async-await` authored its
+// choices as a bare `- ` with the fence on the next line, which this parser
+// read as four choices and parseQuestion read as one empty one. Every check was
+// green while the lesson rendered a single blank radio button in production.
+//
+// So do not treat a green run here as proof a question is answerable. The
+// authoritative guard is __tests__/mcqRuntimeParse.test.ts, which runs the
+// component's own parser over this same corpus; add structural rules there.
 export function parseChoices(md) {
   const lines = md.replace(/\r\n?/g, "\n").split("\n");
   const choices = [];


### PR DESCRIPTION
Two independent changes. **Commit 1** is the bundle/caching work; **commit 2** is an unrelated content-rendering bug caught while spot-checking the preview. Say the word and I'll split commit 2 into its own PR.

---

# 1. Lesson bundle and R2 caching

Lesson pages took a few seconds to become interactive. The cause was not render time or the incremental cache — it was client JavaScript.

## What was wrong

The MDX component map in `mdx-components.tsx` names every widget a lesson *may* use and is handed to `<MDX>` on every render, so a statically imported client component joined the route's client bundle whether or not the lesson mentioned it.

Measured on the deployed site and reproduced locally: a prose-only lesson (`modern-css-layout/next-steps`, zero widgets) downloaded a **byte-identical** bundle to a lesson with eight runnable code blocks — the whole CodeMirror stack, the SQL and challenge cards, all 33 React-course demos.

| | chunks | raw | gzip |
|---|---|---|---|
| before | 41 | 3125 kB | 919 kB |
| after | 23 | 1211 kB | **391 kB** |

A **57% cut** to the gzipped JavaScript on the critical path of every lesson, `/courses/*` and `/interview-prep/*` alike.

## The part that is easy to get wrong

The `dynamic()` calls live in new `"use client"` modules rather than in the component map, and that placement is the whole trick.

Calling `dynamic()` directly from `mdx-components.tsx` type-checks and builds green while splitting **nothing**: in the App Router a client component reached from a Server Component becomes a client *reference*, and every client reference in a route's server graph joins that route's client entry however it was imported. That version was built and measured first — it left all 41 chunks as eager `<script src>` tags and added a 42nd. Only an `import()` evaluated inside the client graph is a split point.

`lazyWidgets.ts` and AGENTS.md both record this, so the next widget added does not quietly hand the regression back.

## Trade-off worth naming

Widget chunks are not preloaded, so a lesson that uses `<CodeBlock>` fetches CodeMirror after hydration begins rather than alongside the page. The widget is server-rendered and the runtime warm-up is already idle-scheduled (`warmup.ts`), so the page is interactive sooner and the editor arrives shortly after. Prose lessons stop paying for it entirely.

## R2 reads are now shared within a data centre

A Worker runs *ahead* of Cloudflare's CDN cache and its response is not stored there. Despite Next's `s-maxage=31536000`, page responses come back with **no `cf-cache-status` header at all**, while `/_next/static/*` (served by the assets binding) reports `cf-cache-status: HIT`. So every visitor to a lesson cost a Worker invocation *and* an R2 GET, with nothing shared between two readers of the same page.

`withRegionalCache` fronts R2 with the per-data-centre Cache API: the first reader in a colo pays the R2 round trip, everyone behind them is served locally. `long-lived` with a 24 h TTL and `shouldLazilyUpdateOnCacheHit: false` are both safe here because `getCacheUrlKey` prefixes the regional key with `OPEN_NEXT_BUILD_ID`, which makes an entry immutable for the life of a deploy and unreachable from the next one.

Removing the Worker invocation as well needs an origin Cache Rule, which is dashboard configuration rather than code — README.md now documents the rule and why it is safe for this site.

---

# 2. MCQ choices vanishing when the fence opens below the marker

**Pre-existing, not caused by commit 1** — production renders this question with a single blank radio too.

`beginners-javascript/promises-and-async-await` authors its four choices as a bare `- ` marker with the code fence on the line below:

```
- [o]
  ```javascript
  const pa = fetchA();
  ```
```

`parseQuestion` documents that form as supported and reads it through the "indented continuation line" rule. But MDX strips a `markdown={` … `}` template literal's indentation before the parser runs — confirmed against `@mdx-js/mdx`, where `  ```js` inside the literal reaches the runtime at column 0 — so that rule can never match. The fence hit the "unindented text ends the choices block" fallback instead, swallowing every remaining choice into the overall explanation and leaving one choice with empty text and no correct answer.

The parser now accepts a fence opening on the line after the marker whether or not its indent survived. The lesson prerenders **4 radios instead of 1**. Only that one lesson authored choices this way; the rest open the fence on the marker line and were never affected.

**Why every check was green.** `check-mcq.mjs` carries its own loose reimplementation of the parser, which drops fenced code instead of capturing it, so it counted four choices where the real parser found one — and its duplicate-choice rule then skipped all four as empty keys. Rather than teach that approximation to agree (the drift *is* the bug), `__tests__/mcqRuntimeParse.test.ts` now runs the component's own `parseQuestion` over the whole corpus and asserts every question is answerable: ≥2 choices, none blank, exactly one correct. Reverted against the parser fix, it fails naming this exact file and symptom.

---

## Verification

- `npm run build` green; bundle measurements taken from the prerendered HTML in `.next/server/app`, comparing the same lessons before and after.
- SSR output unchanged by commit 1: widget markup is byte-comparable to the pre-change build (`cm-editor` was absent before too — CodeMirror has always mounted client-side), so no SEO or CLS change.
- `npm test` — 1136 tests across 84 files pass.
- `npx tsc --noEmit`, `npx eslint .`, `npm run check:mcq` — clean (the 84 eslint warnings are pre-existing, all in `lib/generated/`).

Not verified from here: the regional cache is runtime behaviour on Cloudflare, so it wants a look at a preview deployment before merge.