### PR TITLE
Drop the typed quote pairs from wholly-quoted blockquotes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1005,6 +1005,33 @@ way. Words that are ordinary technical vocabulary here must stay out of it:
 **underscore** (the `_` character) and **crucial** all have real meanings in
 this material, and a linter that fires on correct prose gets ignored.
 
+### Blockquotes do not type their own quotation marks
+
+**A blockquote that is a quotation must not be wrapped in typed double
+quotes.** The stylesheet already draws them: Fumadocs' bundled typography sets
+`blockquote p:first-of-type::before { content: open-quote }` (and a matching
+`close-quote` on the last paragraph), so a typed pair renders as a *second*
+pair and the reader sees `""like this""`.
+
+```markdown
+<!-- Bad -->
+> "Take `mpg`; map engine displacement to x and highway MPG to y."
+
+<!-- Good -->
+> Take `mpg`; map engine displacement to x and highway MPG to y.
+```
+
+Quoting a *term* inside a blockquote is fine and stays, the rule is about a
+pair that wraps the whole body. `blockquote-quotes` in the checker fires only
+when a blockquote holds exactly two quote characters and they sit at the two
+ends, which is the one arrangement that can only be a wrapper.
+
+Two kinds of `>` line are deliberately out of scope. An **indented** one is a
+`<MultipleChoice>` per-choice explanation, which `parseQuestion.ts` strips the
+`>` from and renders through `MarkdownInline`, so no `<blockquote>` reaches the
+page and no quotes are drawn. One inside a **fenced block** is a sample, a
+prompt or a mermaid edge rather than a quotation.
+
 ---
 
 ## Multiple-choice question explanations

--- a/__tests__/proseStyle.test.ts
+++ b/__tests__/proseStyle.test.ts
@@ -46,4 +46,33 @@ describe("authored prose style", () => {
   it("allows a padded dash as an empty markdown table cell", () => {
     expect(lintSource("| start | – | 0 |", "x.mdx", "mdx")).toEqual([]);
   });
+
+  // The stylesheet draws quotation marks around every blockquote, so a
+  // blockquote that types its own renders them doubled: ""like this"".
+  it("flags a blockquote wrapped in a typed pair of double quotes", () => {
+    const one = lintSource('> "Take `mpg` and draw a point for each row."', "x.mdx", "mdx");
+    expect(one.map((v) => v.rule)).toEqual(["blockquote-quotes"]);
+
+    const many = lintSource('> "Take `mpg`; map displacement to x,\n> and draw a point."', "x.mdx", "mdx");
+    expect(many.map((v) => v.rule)).toEqual(["blockquote-quotes"]);
+    expect(many[0].line).toBe(1);
+  });
+
+  it("flags a wrapped blockquote that also carries emphasis, and curly quotes", () => {
+    expect(lintSource('> *"Always leave the code better than you found it."*', "x.mdx", "mdx")).toHaveLength(1);
+    expect(lintSource("> “Always leave the code better than you found it.”", "x.mdx", "mdx")).toHaveLength(1);
+  });
+
+  it("allows a blockquote that quotes terms rather than wrapping the whole body", () => {
+    expect(lintSource('> "Dense" describes the rank sequence, not "sparse"', "x.mdx", "mdx")).toEqual([]);
+    expect(lintSource("> Take `mpg` and draw a point for each row.", "x.mdx", "mdx")).toEqual([]);
+  });
+
+  it("ignores an indented blockquote, which is an MCQ explanation and gets no styled quotes", () => {
+    expect(lintSource('- [o] A choice.\n  > "The whole explanation, quoted."', "x.mdx", "mdx")).toEqual([]);
+  });
+
+  it("ignores a blockquote inside fenced code, which is a sample rather than a quotation", () => {
+    expect(lintSource('```markdown\n> "A quoted blockquote."\n```', "x.mdx", "mdx")).toEqual([]);
+  });
 });

--- a/content/courses/beginners-javascript/maintainable-code.mdx
+++ b/content/courses/beginners-javascript/maintainable-code.mdx
@@ -385,7 +385,7 @@ try {
 
 ## The Boy Scout Rule
 
-> *"Always leave the code a little better than you found it."*
+> *Always leave the code a little better than you found it.*
 
 If you touch a file to fix a bug, rename a confusing variable
 along the way. If you add a feature, delete the dead code next to

--- a/content/courses/c-programming-for-beginners/debugging-and-reasoning.mdx
+++ b/content/courses/c-programming-for-beginners/debugging-and-reasoning.mdx
@@ -66,9 +66,9 @@ unknowns and you lose track of what you were trying to test.
 
 Instead, every time you face a bug, complete this sentence first:
 
-> "I believe the bug is *here*, because *this evidence* suggests
+> I believe the bug is *here*, because *this evidence* suggests
 > *that cause*. To test the hypothesis I will *do this*, and if I'm
-> right I should see *that result*."
+> right I should see *that result*.
 
 That single sentence converts you from a flailing tinkerer into a
 scientist. The fix often becomes obvious before you even run the

--- a/content/courses/c-programming-for-beginners/your-first-program.mdx
+++ b/content/courses/c-programming-for-beginners/your-first-program.mdx
@@ -60,7 +60,7 @@ Lines starting with `#` are not C statements; they are
 **preprocessor** directives. They run before the real compilation
 step. `#include <stdio.h>` means:
 
-> "Paste the contents of the standard header file `stdio.h` here."
+> Paste the contents of the standard header file `stdio.h` here.
 
 `stdio.h` (short for *standard input/output header*) is part of the
 **C standard library**. It tells the compiler what `printf()` is, its

--- a/content/courses/csharp-linq-functional/generic-abstractions.mdx
+++ b/content/courses/csharp-linq-functional/generic-abstractions.mdx
@@ -22,8 +22,8 @@ It is also a fantastic case study in how generics enable
 
 `IEnumerable<T>` says one thing:
 
-> "I can give you a *one-direction*, *one-element-at-a-time* iterator
-> over values of type `T`."
+> I can give you a *one-direction*, *one-element-at-a-time* iterator
+> over values of type `T`.
 
 That's it. No indexing, no length, no mutation. The minimum
 necessary to *walk* a sequence.

--- a/content/courses/csharp-linq-functional/ienumerable-and-iteration.mdx
+++ b/content/courses/csharp-linq-functional/ienumerable-and-iteration.mdx
@@ -38,9 +38,9 @@ public interface IEnumerator<T> : IDisposable
 
 That's it. The contract is:
 
-> "You can ask me for an *enumerator*, which lets you walk through
+> You can ask me for an *enumerator*, which lets you walk through
 > my elements one at a time. Each `MoveNext()` either advances and
-> returns `true`, or returns `false` if we've reached the end."
+> returns `true`, or returns `false` if we've reached the end.
 
 Notice what's *not* there:
 

--- a/content/courses/csharp-linq-functional/selectmany-and-flattening.mdx
+++ b/content/courses/csharp-linq-functional/selectmany-and-flattening.mdx
@@ -13,8 +13,8 @@ constantly in real data:
   alt="SelectMany and flattening, an isometric illustration"
 />
 
-> *"I have a list of things, each of which has a list inside it.
-> How do I get one flat list out?"*
+> *I have a list of things, each of which has a list inside it.
+> How do I get one flat list out?*
 
 That question is everywhere, orders with line items, blog posts
 with tags, departments with employees, files with lines, paragraphs

--- a/content/courses/data-analysis-python-pandas/debugging-analysis-code.mdx
+++ b/content/courses/data-analysis-python-pandas/debugging-analysis-code.mdx
@@ -103,8 +103,8 @@ result = orders.merge(customers, on="customer_id")
 
 what you *mean* is:
 
-> "Each order has exactly one customer; the result should have
-> the same number of rows as `orders`."
+> Each order has exactly one customer; the result should have
+> the same number of rows as `orders`.
 
 Encode that assumption:
 

--- a/content/courses/data-analysis-python-pandas/what-is-data-analysis.mdx
+++ b/content/courses/data-analysis-python-pandas/what-is-data-analysis.mdx
@@ -131,14 +131,14 @@ the right question**.
 
 A bad analytical question is vague:
 
-> "How is the marketing campaign doing?"
+> How is the marketing campaign doing?
 
 A *good* analytical question is specific:
 
-> "Of users who saw the new banner ad between March 1 and March
+> Of users who saw the new banner ad between March 1 and March
 > 15, what fraction made a purchase within 7 days, and how does
 > that compare with users who saw the old banner during the same
-> window?"
+> window?
 
 The second question has a single, computable, defensible answer.
 The first does not.

--- a/content/courses/intro-data-viz-plotly/dashboard-intuition.mdx
+++ b/content/courses/intro-data-viz-plotly/dashboard-intuition.mdx
@@ -230,8 +230,8 @@ Express is the foundation for both.
 
 When you're tempted to add a chart to a dashboard, ask:
 
-> *"If the value on this chart changes, will someone do something
-> different?"*
+> *If the value on this chart changes, will someone do something
+> different?*
 
 If yes, add it. If no, delete it. That single question prevents
 ~80% of dashboard bloat.

--- a/content/courses/intro-data-viz-plotly/graphical-encodings.mdx
+++ b/content/courses/intro-data-viz-plotly/graphical-encodings.mdx
@@ -95,8 +95,8 @@ fig.show()
 
 Read the call out loud:
 
-> "Scatter plot. **GDP** on x. **Life expectancy** on y. Color by
-> **continent**. Size by **population**."
+> Scatter plot. **GDP** on x. **Life expectancy** on y. Color by
+> **continent**. Size by **population**.
 
 The function call *is* the chart specification. There is nothing
 hidden.

--- a/content/courses/intro-sql-postgres/thinking-in-entities.mdx
+++ b/content/courses/intro-sql-postgres/thinking-in-entities.mdx
@@ -49,8 +49,8 @@ Data modeling often begins with a plain-English description. The
 **nouns** are your candidate entities; the facts about them are
 their **attributes**. Read this sentence:
 
-> "A **bookstore** sells **books** to **customers**, who place
-> **orders**."
+> A **bookstore** sells **books** to **customers**, who place
+> **orders**.
 
 The nouns, bookstore, book, customer, order, are candidate
 entities. Now ask of each: *what do we need to know about it?* Those
@@ -105,8 +105,8 @@ and junction tables.
 
 Let's turn a short description into a model. Imagine a library:
 
-> "A library lends **books** to **members**. Each loan records when
-> a book was borrowed and when it is due."
+> A library lends **books** to **members**. Each loan records when
+> a book was borrowed and when it is due.
 
 Working through it:
 

--- a/content/courses/mastering-ggplot2/plotting-systems-that-dont-scale.mdx
+++ b/content/courses/mastering-ggplot2/plotting-systems-that-dont-scale.mdx
@@ -97,8 +97,8 @@ fused, every change means editing drawing instructions by hand.
 Notice that when you *describe* a chart to a colleague, you do not
 read out drawing commands. You say something like:
 
-> "Plot weight against MPG, color the points by cylinder count, and
-> fit a line through each color group."
+> Plot weight against MPG, color the points by cylinder count, and
+> fit a line through each color group.
 
 That sentence is **structured**. It names a data set, some
 *mappings* from columns to visual properties, and a couple of *kinds

--- a/content/courses/mastering-ggplot2/your-first-ggplot.mdx
+++ b/content/courses/mastering-ggplot2/your-first-ggplot.mdx
@@ -74,8 +74,8 @@ ggplot(mpg, aes(x = displ, y = hwy)) +
 
 Read this aloud as a sentence:
 
-> "Take `mpg`; map engine displacement to x and highway MPG to y; draw
-> a **point** for each row."
+> Take `mpg`; map engine displacement to x and highway MPG to y; draw
+> a **point** for each row.
 
 Every row of `mpg` becomes one dot positioned by its `displ` and `hwy`.
 That is the entire chart.

--- a/content/courses/natural-language-processing-python/what-is-nlp.mdx
+++ b/content/courses/natural-language-processing-python/what-is-nlp.mdx
@@ -6,7 +6,7 @@ description: Why human text is genuinely hard for computers, lexical, structural
 Imagine you hand a computer this sentence and ask, innocently, "how many
 words is that?"
 
-> "I can't believe Dr. Smith's startup raised \$2.5M, it's unreal!"
+> I can't believe Dr. Smith's startup raised \$2.5M, it's unreal!
 
 You already sense the trouble. Is "can't" one word or two ("can" + "not")?
 Does the period after "Dr" end a sentence? Is "\$2.5M" a word? Is the em dash

--- a/content/courses/practical-r-for-beginners/from-s-to-r.mdx
+++ b/content/courses/practical-r-for-beginners/from-s-to-r.mdx
@@ -128,10 +128,10 @@ written by the original inventor of the method.
 Crucially, R was never advertised as "better than S." Ihaka and
 Gentleman wrote in their famous 1996 paper:
 
-> *"We have developed a language for data analysis and graphics
+> *We have developed a language for data analysis and graphics
 > which is closely related to the S language… The new language,
 > which we call R, attempts to be both compatible with S and
-> different in important ways."*
+> different in important ways.*
 
 The intentional compatibility meant that code written in S could
 often run in R with little or no change. Books written for S were

--- a/content/courses/practical-r-for-beginners/reproducible-analysis.mdx
+++ b/content/courses/practical-r-for-beginners/reproducible-analysis.mdx
@@ -328,8 +328,8 @@ You are given the small dataframe `sales` (already loaded).
 A coworker did the following analysis by clicking around in a
 spreadsheet:
 
-> "I filtered to rows where `region` is `'East'` or `'West'`, then
-> computed `total = units * price`, then summed `total` by region."
+> I filtered to rows where `region` is `'East'` or `'West'`, then
+> computed `total = units * price`, then summed `total` by region.
 
 Reproduce this in R as a single piped pipeline and store the final
 two-row data frame in a variable called `by_region`.

--- a/content/courses/seaborn-foundations/index.mdx
+++ b/content/courses/seaborn-foundations/index.mdx
@@ -27,8 +27,8 @@ positioning bars, building legends by hand, instead of on *seeing*.
 Seaborn flips that around. You hand it a **tidy table** and describe your
 chart in the vocabulary of statistics:
 
-> "Put `total_bill` on x, `tip` on y, color by `time`, and split into one
-> panel per `day`."
+> Put `total_bill` on x, `tip` on y, color by `time`, and split into one
+> panel per `day`.
 
 Seaborn does the grouping, the aggregation, the color mapping, the legend,
 and sensible defaults, so the code you write looks like the *question you

--- a/content/courses/sql-analytics-duckdb/why-window-functions.mdx
+++ b/content/courses/sql-analytics-duckdb/why-window-functions.mdx
@@ -24,8 +24,8 @@ you want to *keep every row* and *also* show a summary beside it.
 
 Consider a deceptively simple request:
 
-> "Show every order, and next to each one, what percentage of its
-> region's total it represents."
+> Show every order, and next to each one, what percentage of its
+> region's total it represents.
 
 You need **both** at once: the individual order (a row-level fact) *and*
 the region total (a group-level fact). `GROUP BY` can give you one or the

--- a/scripts/check-prose.mjs
+++ b/scripts/check-prose.mjs
@@ -17,6 +17,12 @@
 //                    NOT include words that are ordinary technical vocabulary
 //                    here (robust, leverage, underscore all have real
 //                    meanings in statistics, regression and Python).
+//   4. blockquote-quotes, a blockquote whose whole body is wrapped in a typed
+//                    pair of double quotes. The stylesheet already puts
+//                    typographic quotes around one (Fumadocs' bundled
+//                    typography sets `blockquote p:first-of-type::before {
+//                    content: open-quote }`), so the typed pair renders as a
+//                    second one and the reader sees ""like this"".
 //
 // Scope is what a reader actually sees:
 //
@@ -58,6 +64,67 @@ const AI_FILLER = [
   [/\bwhen it comes to\b/i, "when it comes to"],
 ];
 
+// --- blockquotes ----------------------------------------------------------
+
+const QUOTE_CHAR = /["“”]/g;
+/** A leading emphasis run, `*` or `_`, one or two of them. */
+const LEADING_EMPHASIS = /^[*_]{1,2}/;
+const TRAILING_EMPHASIS = /[*_]{1,2}$/;
+
+/** Every unindented blockquote in an MDX body, as `{ line, body }`, where
+ *  `body` is the `>` markers stripped and the lines joined into one string.
+ *
+ *  Unindented is the whole point: a blockquote indented by two spaces is a
+ *  `<MultipleChoice>` per-choice explanation, which parseQuestion.ts strips
+ *  the `>` from and renders through MarkdownInline. No <blockquote> element
+ *  reaches the page, so no stylesheet quotes are added and a typed pair is
+ *  the only pair there is. Fenced code is skipped, a `>` inside it is a
+ *  sample, a prompt, or a mermaid edge rather than a quotation. */
+function blockquotes(lines) {
+  const found = [];
+  let fence = null;
+  let block = null;
+  const flush = () => {
+    if (block) found.push({ line: block.line, body: block.parts.join(" ").trim() });
+    block = null;
+  };
+
+  lines.forEach((line, i) => {
+    const fenceMark = line.match(/^\s*(```+|~~~+)/);
+    if (fenceMark) {
+      flush();
+      if (fence && fenceMark[1].startsWith(fence)) fence = null;
+      else if (!fence) fence = fenceMark[1];
+      return;
+    }
+    if (fence) return;
+
+    const quoted = line.match(/^>\s?(.*)$/);
+    if (!quoted) {
+      flush();
+      return;
+    }
+    if (!block) block = { line: i + 1, parts: [] };
+    block.parts.push(quoted[1].trim());
+  });
+  flush();
+  return found;
+}
+
+/** True when a blockquote body carries its own wrapping pair of double
+ *  quotes, on top of the pair the stylesheet draws.
+ *
+ *  Requiring the body to hold exactly two quote characters is what keeps
+ *  this from firing on correct prose: `"Dense" describes the rank sequence,
+ *  not "sparse"` also opens and closes on a quote, but its four quotes mark
+ *  two quoted terms rather than one wrapped quotation. Two quotes sitting at
+ *  the two ends can only be a wrapper. */
+export function hasWrappingQuotes(body) {
+  const inner = body.replace(LEADING_EMPHASIS, "").replace(TRAILING_EMPHASIS, "").trim();
+  if ((inner.match(QUOTE_CHAR) || []).length !== 2) return false;
+  return /^["“]/.test(inner) && /["”]$/.test(inner);
+}
+
 // --- comment stripping (TS/TSX only) --------------------------------------
 
 /** Blank out //, /* *\/ and {/* *\/} comments, preserving line structure so
@@ -96,6 +163,12 @@ export function lintSource(src, file, kind) {
       if (re.test(line)) add("ai-filler", n, `"${label}", ${snippet}`);
     }
   });
+
+  if (kind === "mdx") {
+    for (const { line, body } of blockquotes(lines)) {
+      if (hasWrappingQuotes(body)) add("blockquote-quotes", line, body.slice(0, 90));
+    }
+  }
 
   return violations;
 }
@@ -153,7 +226,15 @@ if (isMain) {
       "\nem dashes: use a comma or parentheses for an aside, a colon before an\n" +
         "elaboration, and a semicolon or full stop between two clauses.",
     );
+    if (byRule["blockquote-quotes"]) {
+      console.error(
+        "\nblockquote quotes: drop the typed pair. The stylesheet draws the\n" +
+          "quotation marks, so a blockquote that types its own renders doubled.",
+      );
+    }
     process.exit(1);
   }
-  console.log(`✓ prose in ${files.length} file(s) is clean (no em dashes, no spaced en dashes, no filler phrases)`);
+  console.log(
+    `✓ prose in ${files.length} file(s) is clean (no em dashes, no spaced en dashes, no filler phrases, no doubled blockquote quotes)`,
+  );
 }


### PR DESCRIPTION
## What

The blockquote on `/courses/mastering-ggplot2/your-first-ggplot` rendered with two pairs of double quotes around it. It was not alone: 20 blockquotes across `content/` had the same problem.

## Why it happened

The MDX typed its own quotes:

```markdown
> "Take `mpg`; map engine displacement to x and highway MPG to y; draw
> a **point** for each row."
```

but the stylesheet already draws a pair. The Fumadocs typography preset (`@fumadocs/tailwind`, loaded via `fumadocs-ui/css/preset.css`) sets

```js
blockquote: { quotes: '"\201C""\201D""\2018""\2019"' },
"blockquote p:first-of-type::before": { content: "open-quote" },
"blockquote p:last-of-type::after":  { content: "close-quote" },
```

so the typed straight pair rendered *inside* the drawn curly pair and the reader saw `""like this""`.

## The fix

Removed the typed pair from all 20 wholly-quoted blockquotes and left the styled ones to do the work. Only the quote characters moved; wording, emphasis and line breaks are untouched.

Added a `blockquote-quotes` rule to `scripts/check-prose.mjs` (and a section to AGENTS.md) so the pattern cannot come back. Three deliberate limits keep it from firing on correct prose:

- It fires only when a blockquote holds **exactly two** quote characters and they sit at the two ends, the one arrangement that can only be a wrapper. A blockquote quoting a term, `"Dense" describes the rank sequence, not "sparse"`, also opens and closes on a quote and keeps passing.
- **Indented** `>` lines are skipped. Those are `<MultipleChoice>` per-choice explanations, which `parseQuestion.ts` strips the marker from and renders through `MarkdownInline`, so no `<blockquote>` reaches the page and no quotes are drawn.
- `>` lines inside **fenced blocks** are skipped: a sample, a prompt or a mermaid edge rather than a quotation.

## Verification

- `npm run check:prose` → clean across 1627 files, and the new rule flags all 20 originals when reverted.
- `npx vitest run` → 1206 tests in 89 files pass, including 6 new cases in `__tests__/proseStyle.test.ts` covering the wrapped, emphasized, curly-quoted, term-quoting, indented and fenced shapes.
- `npm run check:mdx` and `npm run check:mcq` → clean.
- Rendered the ggplot2 lesson in Chromium against the dev server: the blockquote now shows one pair of curly quotes, with `::before`/`::after` still resolving to `open-quote`/`close-quote`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj4Ujoo9pX6NrxT9GMdtUn)_