### PR TITLE
Mobile playground header, desktop-parity save menu, an Account group in the ⋯ menu

### DIFF
--- a/app/_components/MobileMenuSheet.tsx
+++ b/app/_components/MobileMenuSheet.tsx
@@ -109,7 +109,7 @@ export function MobileMenuSheet({
         <Drawer.Backdrop className="pkg-overlay mobile-menu-backdrop" />
         <Drawer.Viewport className="mobile-drawer-viewport">
           <Drawer.Popup className="mobile-menu-drawer" aria-label={title}>
-            <Drawer.Content>
+            <Drawer.Content className="mobile-menu-drawer-content">
               <div className="mobile-menu-handle" aria-hidden="true" />
               <div className="mobile-menu-drawer-header">
                 <Drawer.Title className="mobile-menu-drawer-title">
@@ -345,7 +345,7 @@ export function MobileMenuSubSheet({
             className="mobile-menu-drawer mobile-menu-nested-drawer"
             aria-label={ariaLabel ?? (typeof label === "string" ? label : undefined)}
           >
-            <Drawer.Content>
+            <Drawer.Content className="mobile-menu-drawer-content">
               <div className="mobile-menu-handle" aria-hidden="true" />
               <div className="mobile-menu-drawer-header">
                 <Drawer.Title className="mobile-menu-drawer-title">

--- a/app/_components/MobileMenuSheet.tsx
+++ b/app/_components/MobileMenuSheet.tsx
@@ -155,21 +155,68 @@ export function useMobileMenuClose() {
   return useContext(MobileMenuContext).closeRoot;
 }
 
-/** Leading icon + label cluster shared by action rows and sub-sheet rows. */
-function RowMain({ icon: Icon, label }: { icon?: LucideIcon; label: ReactNode }) {
+/** True while the `MobileMenuSubSheet` with this id is the open one. Lets a
+ *  row that owns a sub-sheet react to it opening (e.g. refetch the cloud
+ *  backup list) from *outside* the sheet, where the hooks stay mounted. */
+export function useMobileMenuSubSheetOpen(id: string) {
+  return useContext(MobileMenuContext).activeSubmenu === id;
+}
+
+/** Leading icon + label cluster shared by action rows and sub-sheet rows.
+ *  `sub` adds the desktop menus' second, dimmer line under the label. */
+function RowMain({
+  icon: Icon,
+  label,
+  sub,
+}: {
+  icon?: LucideIcon;
+  label: ReactNode;
+  sub?: ReactNode;
+}) {
   return (
     <span className="mobile-menu-main">
       {Icon && <Icon size={15} strokeWidth={1.8} aria-hidden="true" />}
-      <span>{label}</span>
+      {sub === undefined ? (
+        <span>{label}</span>
+      ) : (
+        <span className="mobile-menu-text">
+          <span>{label}</span>
+          <span className="mobile-menu-sub">{sub}</span>
+        </span>
+      )}
     </span>
+  );
+}
+
+/** Non-interactive note row, the drawer counterpart of the desktop save
+ *  menu's "Auto-saves in this browser as you work" strip. */
+export function MobileMenuNote({
+  icon: Icon,
+  children,
+}: {
+  icon?: LucideIcon;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mobile-menu-note">
+      {Icon && <Icon size={13} strokeWidth={2} aria-hidden="true" />}
+      <span>{children}</span>
+    </div>
   );
 }
 
 export interface MobileMenuActionProps {
   label: ReactNode;
-  onClick: () => void;
+  /** Fired on tap. Optional only for `href` rows, which navigate instead. */
+  onClick?: () => void;
+  /** Renders the row as a link to this URL instead of a button (e.g. the
+   *  save menu's "Sign in to back up"). */
+  href?: string;
   /** Leading icon, mirroring the desktop ⋯ menu rows. */
   icon?: LucideIcon;
+  /** Second, dimmer line under the label, mirroring the desktop save
+   *  menu's item subtitles. */
+  sub?: ReactNode;
   /** Small trailing count/status chip (e.g. example counts, "Saved"). */
   hint?: ReactNode;
   disabled?: boolean;
@@ -184,24 +231,18 @@ export interface MobileMenuActionProps {
 export function MobileMenuAction({
   label,
   onClick,
+  href,
   icon,
+  sub,
   hint,
   disabled,
   chevron,
   keepOpen,
 }: MobileMenuActionProps) {
   const { closeRoot } = useContext(MobileMenuContext);
-  return (
-    <button
-      type="button"
-      className="mobile-menu-action"
-      disabled={disabled}
-      onClick={() => {
-        onClick();
-        if (!keepOpen) closeRoot();
-      }}
-    >
-      <RowMain icon={icon} label={label} />
+  const body = (
+    <>
+      <RowMain icon={icon} label={label} sub={sub} />
       <span className="mobile-menu-trailing">
         {hint !== undefined && (
           <span className="mobile-menu-hint">{hint}</span>
@@ -212,6 +253,33 @@ export function MobileMenuAction({
           </span>
         )}
       </span>
+    </>
+  );
+  if (href) {
+    return (
+      <a
+        className="mobile-menu-action"
+        href={href}
+        onClick={() => {
+          onClick?.();
+          closeRoot();
+        }}
+      >
+        {body}
+      </a>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className="mobile-menu-action"
+      disabled={disabled}
+      onClick={() => {
+        onClick?.();
+        if (!keepOpen) closeRoot();
+      }}
+    >
+      {body}
     </button>
   );
 }

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -73,8 +73,6 @@ import { Drawer } from "@base-ui/react/drawer";
 import {
   Library,
   ArrowDownToLine,
-  Cloud,
-  CloudUpload,
   Package,
   Share2,
   Eraser,
@@ -150,6 +148,7 @@ import { ShareControls } from "./cloud/ShareControls";
 import {
   HeaderDivider,
   MobileMoreSections,
+  MobileSaveMenu,
   MoreMenu,
   NewWorkspaceControl,
   SaveControl,
@@ -4029,24 +4028,17 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
               same sections the desktop ⋯ menu shows. */}
           <MobileMenuSheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
             <MobileMenuLabel>Workspace</MobileMenuLabel>
-            {workspaceReady &&
-              (!workspaceSaved && workspaceDirty ? (
-                <MobileMenuAction
-                  icon={CloudUpload}
-                  label="Save"
-                  onClick={() => {
-                    void handleSaveWorkspace(workspaceName || "Workspace");
-                    showToast("Workspace saved");
-                  }}
-                />
-              ) : (
-                <MobileMenuAction
-                  icon={Cloud}
-                  label="Saved"
-                  disabled
-                  onClick={() => {}}
-                />
-              ))}
+            {workspaceReady && (
+              <MobileSaveMenu
+                playgroundId={adapter.id}
+                workspaceId={workspaceId}
+                workspaceName={workspaceName}
+                unsaved={!workspaceSaved && workspaceDirty}
+                onSave={handleSaveWorkspace}
+                buildBundle={buildCloudBundle}
+                onNotify={showToast}
+              />
+            )}
             <MobileMenuAction
               icon={Share2}
               label="Share"

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -153,6 +153,7 @@ import {
   NewWorkspaceControl,
   SaveControl,
   WorkspaceNameControl,
+  useAccountMenuSection,
   type MoreMenuSection,
 } from "./PlaygroundHeaderControls";
 import {
@@ -3593,7 +3594,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   // ⋯ menu: everything secondary folds into one place — labelled sections
   // whose items either act (Packages dialog, Settings tab, Workspaces
   // manager) or slide to a sub-panel (Examples, Export, Runtime info).
-  const moreMenuSections = useMemo<MoreMenuSection[]>(
+  const playgroundMoreSections = useMemo<MoreMenuSection[]>(
     () => [
       {
         label: "Resources",
@@ -3704,6 +3705,20 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       },
     ],
     [adapter, requestExample, exportCode, openSettingsTab],
+  );
+
+  // Auth had no entry point inside a playground at all. It lands as the ⋯
+  // menu's last group rather than a header control: the header is down to
+  // five controls by design and has no room on a phone, and signing in
+  // isn't something anyone reaches for mid-session. Null while the first
+  // session fetch is in flight, so nothing flashes.
+  const accountSection = useAccountMenuSection();
+  const moreMenuSections = useMemo<MoreMenuSection[]>(
+    () =>
+      accountSection
+        ? [...playgroundMoreSections, accountSection]
+        : playgroundMoreSections,
+    [playgroundMoreSections, accountSection],
   );
 
   // Rotate through the witty loading messages while the runtime is

--- a/app/_components/PlaygroundHeaderControls.tsx
+++ b/app/_components/PlaygroundHeaderControls.tsx
@@ -32,6 +32,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { useRouter } from "next/navigation";
 import { Dialog } from "@base-ui/react/dialog";
 import { Menu } from "@base-ui/react/menu";
 import { Popover } from "@base-ui/react/popover";
@@ -42,10 +43,12 @@ import {
   Download,
   FilePlus2,
   LogIn,
+  LogOut,
   Pencil,
+  UserRound,
   type LucideIcon,
 } from "lucide-react";
-import { useSession } from "@/lib/auth/client";
+import { signOut, useSession } from "@/lib/auth/client";
 import { switchActiveWorkspace } from "./opfs/activeWorkspace";
 import {
   createWorkspace,
@@ -767,6 +770,137 @@ export function MoreMenu({ sections }: { sections: MoreMenuSection[] }) {
       </Popover.Portal>
     </Popover.Root>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Account section (sign in · account · sign out)
+// ---------------------------------------------------------------------------
+
+/**
+ * Body of the "Sign out" sub-panel. Signing out is a one-click, silent
+ * action everywhere else on the site, but in a playground the obvious
+ * thing to fear is that the code goes with it — so this says, before the
+ * fact, that it doesn't. (It really doesn't: workspaces live in OPFS in
+ * this browser. What stops is the cloud backup sync.)
+ *
+ * A panel rather than a Dialog because it works unchanged on both
+ * surfaces: the desktop ⋯ menu slides to it, the mobile drawer opens it
+ * as a nested sheet.
+ */
+function SignOutPanel({
+  email,
+  close,
+}: {
+  email?: string | null;
+  close: () => void;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  const confirm = useCallback(async () => {
+    setBusy(true);
+    try {
+      await signOut();
+      close();
+      // Re-render everything reading the session (the save menu's cloud
+      // rows, the workspace manager's backup list).
+      router.refresh();
+    } catch {
+      // Network failure: leave the session alone and re-enable the button.
+      setBusy(false);
+    }
+  }, [close, router]);
+
+  return (
+    <div className="ph-signout-panel">
+      <p className="ph-signout-note">
+        {email && (
+          <>
+            Signed in as <strong>{email}</strong>.{" "}
+          </>
+        )}
+        Your workspaces stay in this browser. Signing out only stops backing
+        them up to your account.
+      </p>
+      <div className="confirm-actions">
+        <button
+          type="button"
+          className="confirm-btn confirm-btn-secondary"
+          onClick={close}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="confirm-btn confirm-btn-primary"
+          disabled={busy}
+          onClick={() => void confirm()}
+        >
+          {busy ? "Signing out…" : "Sign out"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The ⋯ menu's Account group, as a `MoreMenuSection` each playground
+ * appends to its own sections. Auth had no entry point in the playgrounds
+ * at all; it goes here rather than in the header because the header is
+ * deliberately down to five controls and has no room on a phone, and
+ * because signing in isn't something anyone reaches for mid-session.
+ *
+ * Returns `null` while the first session fetch is in flight, so a
+ * signed-in visitor never sees "Sign in" flash before their account rows
+ * resolve (same reasoning as the site header's `AuthMenu` skeleton).
+ *
+ * Sign-in links to plain `/sign-in`: the root layout's `ReturnToTracker`
+ * has already recorded the playground URL, so the flow returns here on
+ * its own — a hand-built `?next=` would only lose the query and hash.
+ */
+export function useAccountMenuSection(): MoreMenuSection | null {
+  const { data: session, isPending } = useSession();
+  const router = useRouter();
+  const email = session?.user?.email;
+
+  return useMemo<MoreMenuSection | null>(() => {
+    if (isPending) return null;
+    if (!session) {
+      return {
+        label: "Account",
+        items: [
+          {
+            key: "sign-in",
+            label: "Sign in",
+            icon: LogIn,
+            onSelect: () => router.push("/sign-in"),
+          },
+        ],
+      };
+    }
+    return {
+      label: "Account",
+      items: [
+        {
+          key: "account",
+          label: "Account settings",
+          icon: UserRound,
+          onSelect: () => router.push("/dashboard/account"),
+        },
+        {
+          key: "sign-out",
+          label: "Sign out",
+          icon: LogOut,
+          panel: {
+            title: "Sign out",
+            render: (close: () => void) => (
+              <SignOutPanel email={email} close={close} />
+            ),
+          },
+        },
+      ],
+    };
+  }, [isPending, session, email, router]);
 }
 
 // ---------------------------------------------------------------------------

--- a/app/_components/PlaygroundHeaderControls.tsx
+++ b/app/_components/PlaygroundHeaderControls.tsx
@@ -63,8 +63,10 @@ import {
 import {
   MobileMenuAction,
   MobileMenuLabel,
+  MobileMenuNote,
   MobileMenuSubSheet,
   useMobileMenuClose,
+  useMobileMenuSubSheetOpen,
 } from "./MobileMenuSheet";
 
 /** The 9px chevron used by the switcher, save menu and badge in the mock. */
@@ -300,15 +302,7 @@ export function NewWorkspaceControl({
 // Save split button + menu
 // ---------------------------------------------------------------------------
 
-export function SaveControl({
-  playgroundId,
-  workspaceId,
-  workspaceName,
-  unsaved,
-  onSave,
-  buildBundle,
-  onNotify,
-}: {
+export interface SaveControlProps {
   playgroundId: string;
   workspaceId: string | null;
   workspaceName: string;
@@ -319,8 +313,28 @@ export function SaveControl({
   buildBundle?: () => Promise<WorkspaceBundle | null>;
   /** Toast hook so saves/backups flash the host's confirmation. */
   onNotify?: (message: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
+}
+
+/**
+ * The three save actions and the copy that describes them, shared by the
+ * desktop dropdown (`SaveControl`) and the mobile drawer's sub-sheet
+ * (`MobileSaveMenu`) so the two menus can't drift apart.
+ *
+ * `menuOpen` is the "refresh the cloud list now" signal — pass whether the
+ * surface hosting the rows is open.
+ */
+function useSaveMenu(
+  {
+    playgroundId,
+    workspaceId,
+    workspaceName,
+    unsaved,
+    onSave,
+    buildBundle,
+    onNotify,
+  }: SaveControlProps,
+  open: boolean,
+) {
   const cloud = useCloudBackups(playgroundId, open);
   const [backupBusy, setBackupBusy] = useState(false);
 
@@ -387,6 +401,32 @@ export function SaveControl({
   }, [workspaceId, unsaved, onSave, workspaceName, onNotify]);
 
   const showCloudRows = cloud.available && !cloud.signedOut;
+
+  return {
+    doSave,
+    doBackup,
+    doDownload,
+    backupBusy,
+    backupSub,
+    /** Signed in with cloud storage configured: show backup + download. */
+    showCloudRows,
+    /** Cloud storage exists at all (drives the sign-in row for guests). */
+    cloudAvailable: cloud.available,
+  };
+}
+
+export function SaveControl(props: SaveControlProps) {
+  const { unsaved } = props;
+  const [open, setOpen] = useState(false);
+  const {
+    doSave,
+    doBackup,
+    doDownload,
+    backupBusy,
+    backupSub,
+    showCloudRows,
+    cloudAvailable,
+  } = useSaveMenu(props, open);
 
   return (
     <Menu.Root open={open} onOpenChange={setOpen}>
@@ -463,7 +503,7 @@ export function SaveControl({
               </>
             ) : (
               <>
-                {cloud.available && (
+                {cloudAvailable && (
                   <Menu.Item
                     className="ph-save-menu-item"
                     render={<a href="/sign-in" />}
@@ -497,6 +537,92 @@ export function SaveControl({
         </Menu.Positioner>
       </Menu.Portal>
     </Menu.Root>
+  );
+}
+
+/** Sub-sheet identity for the save panel (sub-sheets are mutually
+ *  exclusive and keyed by id). */
+const SAVE_SUBSHEET_ID = "save";
+
+/**
+ * Mobile drawer counterpart of `SaveControl`: the Save/Saved row opens a
+ * sub-sheet holding the very same items as the desktop chevron menu — the
+ * "auto-saves in this browser" note, "Back up to cloud" (or "Sign in to
+ * back up" for guests) and "Download copy" — plus the split button's own
+ * Save action, which on desktop lives in the button half.
+ *
+ * The rows and their copy come from `useSaveMenu`, the same hook the
+ * desktop menu uses. Must render inside a `MobileMenuSheet`.
+ */
+export function MobileSaveMenu(props: SaveControlProps) {
+  const { unsaved } = props;
+  // The whole drawer body only mounts while the hamburger sheet is open, so
+  // this hook's first fetch already happens on open; the sub-sheet's own
+  // open state re-reads the list when the user drills into it.
+  const open = useMobileMenuSubSheetOpen(SAVE_SUBSHEET_ID);
+  const {
+    doSave,
+    doBackup,
+    doDownload,
+    backupBusy,
+    backupSub,
+    showCloudRows,
+    cloudAvailable,
+  } = useSaveMenu(props, open);
+
+  return (
+    <MobileMenuSubSheet
+      id={SAVE_SUBSHEET_ID}
+      icon={unsaved ? CloudUpload : Cloud}
+      label={unsaved ? "Save" : "Saved"}
+      title={unsaved ? "Save" : "Saved"}
+    >
+      <MobileMenuNote icon={Check}>
+        Auto-saves in this browser as you work
+      </MobileMenuNote>
+      {unsaved && (
+        <MobileMenuAction
+          icon={CloudUpload}
+          label="Save workspace"
+          sub="Add it to your saved workspaces"
+          onClick={doSave}
+        />
+      )}
+      {showCloudRows ? (
+        <>
+          <MobileMenuAction
+            icon={CloudUpload}
+            label={backupBusy ? "Backing up…" : "Back up to cloud"}
+            sub={backupSub}
+            disabled={backupBusy}
+            onClick={() => void doBackup()}
+          />
+          <MobileMenuAction
+            icon={Download}
+            label="Download copy"
+            sub="Workspace files as a .zip"
+            onClick={() => void doDownload()}
+          />
+        </>
+      ) : (
+        <>
+          {cloudAvailable && (
+            <MobileMenuAction
+              icon={LogIn}
+              href="/sign-in"
+              label="Sign in to back up"
+              sub="Keep snapshots on your account, free"
+            />
+          )}
+          <MobileMenuAction
+            icon={Download}
+            label="Download copy"
+            sub="Workspace files as a .zip"
+            onClick={() => void doDownload()}
+          />
+        </>
+      )}
+    </MobileMenuSubSheet>
   );
 }
 

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -35,8 +35,6 @@ import { Toast } from "@base-ui/react/toast";
 import {
   ArrowDownToLine,
   Share2,
-  CloudUpload,
-  Cloud,
   ArrowUpFromLine,
   FolderOpen,
   Info,
@@ -133,6 +131,7 @@ import { ShareControls } from "../cloud/ShareControls";
 import {
   HeaderDivider,
   MobileMoreSections,
+  MobileSaveMenu,
   MoreMenu,
   SaveControl,
   NewWorkspaceControl,
@@ -4454,27 +4453,20 @@ function DuckDbPlaygroundInner() {
         <>
           <div className="mobile-menu-db-selector">{databaseSelector}</div>
           <MobileMenuLabel>Workspace</MobileMenuLabel>
-          {activeWorkspace &&
-            (!workspaceSaved &&
-            tabs.some((t) => !t.kind && t.code !== t.pristineCode) ? (
-              <MobileMenuAction
-                icon={CloudUpload}
-                label="Save"
-                onClick={() => {
-                  void handleSaveWorkspace(
-                    activeWorkspace.name || "Workspace",
-                  );
-                  showToast("Workspace saved");
-                }}
-              />
-            ) : (
-              <MobileMenuAction
-                icon={Cloud}
-                label="Saved"
-                disabled
-                onClick={() => {}}
-              />
-            ))}
+          {activeWorkspace && (
+            <MobileSaveMenu
+              playgroundId={PLAYGROUND_ID}
+              workspaceId={activeWorkspace.id}
+              workspaceName={activeWorkspace.name}
+              unsaved={
+                !workspaceSaved &&
+                tabs.some((t) => !t.kind && t.code !== t.pristineCode)
+              }
+              onSave={handleSaveWorkspace}
+              buildBundle={buildCloudBundle}
+              onNotify={showToast}
+            />
+          )}
           <MobileMenuAction
             icon={Share2}
             label="Share"

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -136,6 +136,7 @@ import {
   SaveControl,
   NewWorkspaceControl,
   WorkspaceNameControl,
+  useAccountMenuSection,
   type MoreMenuSection,
 } from "../PlaygroundHeaderControls";
 import { applyEntryFocus } from "../playgroundEntryFocus";
@@ -4207,7 +4208,7 @@ function DuckDbPlaygroundInner() {
 
   // One definition drives both the desktop ⋯ menu and the mobile
   // drawer's sectioned rows.
-  const moreSections: MoreMenuSection[] = [
+  const baseMoreSections: MoreMenuSection[] = [
                 {
                   label: "Data",
                   items: [
@@ -4382,6 +4383,16 @@ function DuckDbPlaygroundInner() {
                   ],
                 },
               ];
+
+  // Auth had no entry point inside a playground at all. It lands as the ⋯
+  // menu's last group rather than a header control: the header is down to
+  // five controls by design and has no room on a phone, and signing in
+  // isn't something anyone reaches for mid-session. Null while the first
+  // session fetch is in flight, so nothing flashes.
+  const accountSection = useAccountMenuSection();
+  const moreSections: MoreMenuSection[] = accountSection
+    ? [...baseMoreSections, accountSection]
+    : baseMoreSections;
 
   return (
     <SqlPlaygroundShell

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -195,11 +195,20 @@ body.playground-active {
   color: var(--text);
   letter-spacing: -0.01em;
 }
+/* The mark is the one thing in the header that must never give: the group
+   is allowed to shrink on a phone (see the `min-width: 0` in the mobile
+   block), and without this its link would be the flex item that absorbs
+   the squeeze, collapsing the image to nothing. The switcher beside it
+   shrinks instead — it has already dropped its label by then. */
+.logo > a {
+  flex: none;
+}
 
 .brand-logo {
   height: 11px;
   width: auto;
   display: block;
+  flex: none;
 }
 
 .header-sep {
@@ -2783,18 +2792,16 @@ input[type="range"].fs-slider:disabled {
 
   /* The workspace name is the one elastic thing in the row, so it is what
      gives when the name is long: it truncates instead of pushing the
-     Dataslope mark off the left edge (which is what used to happen).
-     The two icon buttons beside it never shrink. */
-  .ph-name {
-    max-width: 40vw;
-  }
+     Dataslope mark off the left edge. The two icon buttons beside it
+     never shrink.
+
+     Its width ceiling is *not* here, it sits beside the desktop `.ph-name`
+     rule further down the sheet. `.ph-name` here is no more specific than
+     the base rule, so a cap written at this point loses to it — which is
+     how the mobile ceiling ended up dead and a long name kept its 220px
+     desktop width on a phone. */
   .ph-name-wrap > button {
     flex-shrink: 0;
-  }
-  /* The rename input needs the same ceiling or editing a long name
-     reflows the header mid-type. */
-  .ph-rename-input {
-    max-width: 44vw;
   }
 
   /* Hide the CodeMirror line-number gutter on mobile so the code takes
@@ -3017,6 +3024,9 @@ input[type="range"].fs-slider:disabled {
   user-select: none;
   text-align: left;
   width: 100%;
+  /* The row is an <a> when it navigates (the save panel's "Sign in to back
+     up"), so it must not pick up link underline/colour. */
+  text-decoration: none;
 }
 .mobile-menu-action:hover,
 .mobile-menu-action:focus-visible {
@@ -3052,6 +3062,43 @@ input[type="range"].fs-slider:disabled {
 }
 .mobile-menu-main > svg {
   color: var(--menu-icon, var(--text-dim));
+  flex: none;
+}
+/* Two-line rows (the save sub-sheet mirrors the desktop menu's title +
+   subtitle), so the icon stays with the title rather than centring
+   against both lines. */
+.mobile-menu-main:has(.mobile-menu-sub) {
+  align-items: flex-start;
+}
+.mobile-menu-main:has(.mobile-menu-sub) > svg {
+  margin-top: 2px;
+}
+.mobile-menu-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.mobile-menu-sub {
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--text-dim);
+  text-wrap: pretty;
+}
+/* Non-interactive note strip at the top of a sub-sheet (the save panel's
+   "Auto-saves in this browser as you work"). */
+.mobile-menu-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px 12px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12.5px;
+  color: var(--text-dim);
+}
+.mobile-menu-note > svg {
+  color: var(--green);
   flex: none;
 }
 .mobile-menu-trailing {
@@ -5153,6 +5200,25 @@ html[data-playground-theme="dark"] {
   padding: 3px 8px;
   width: 200px;
   outline: none;
+}
+
+/* Mobile ceilings for the two rules above. They have to sit *after* those
+   rules (same specificity, last one wins) — the copies in the big mobile
+   block higher up in this file were losing to the desktop widths, which is
+   what let a long name run to 220px on a phone and squeeze the Dataslope
+   mark out of the header. Truncating a good deal earlier than the row
+   strictly needs leaves the mark room to breathe on the narrowest phones. */
+@media (max-width: 768px) {
+  /* `min(…)` so the desktop ceiling still applies on the wide end of the
+     range — a plain 36vw would be *looser* than 220px above ~610px. */
+  .ph-name {
+    max-width: min(36vw, 220px);
+  }
+  /* The rename input needs the same ceiling or editing a long name
+     reflows the header mid-type. */
+  .ph-rename-input {
+    max-width: 40vw;
+  }
 }
 
 /* ─── Header: quiet ghost buttons (Save · Share) ─── */

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -2971,6 +2971,19 @@ input[type="range"].fs-slider:disabled {
   letter-spacing: -0.01em;
 }
 
+/* `Drawer.Content` is the sheet's only child, so it has to relay the
+   popup's height cap to the scrolling body — exactly what
+   `.pkg-drawer-content` does for the packages/workspaces drawers. Without
+   it the body sizes to its content and the popup's `max-height` just
+   clips: a menu longer than 85dvh (a signed-in Postgres one, say) left
+   its last rows below the fold with no way to scroll to them. */
+.mobile-menu-drawer-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 .mobile-menu-drawer-body {
   flex: 1;
   /* Allow the flex item to shrink below its content size so
@@ -5516,6 +5529,29 @@ html[data-playground-theme="dark"] {
   margin-top: 10px;
   padding-top: 10px;
   border-top: 1px solid var(--border);
+}
+
+/* The ⋯ menu's "Sign out" sub-panel: a line of reassurance above the
+   confirm row. Same box metrics as the Runtime info panel, so the two
+   sub-panels sit at the same inset on both the desktop menu and the
+   mobile sheet. */
+.ph-signout-panel {
+  padding: 14px 16px 16px;
+}
+.ph-signout-note {
+  font-size: 13px;
+  color: var(--text-dim);
+  line-height: 1.55;
+  margin: 0;
+  text-wrap: pretty;
+}
+.ph-signout-note strong {
+  color: var(--text);
+  font-weight: 600;
+  word-break: break-all;
+}
+.ph-signout-panel .confirm-actions {
+  margin-top: 14px;
 }
 
 /* ─── Output pane: stacked run history ─── */

--- a/app/_components/playgrounds.ts
+++ b/app/_components/playgrounds.ts
@@ -24,7 +24,10 @@ export const PLAYGROUNDS: PlaygroundEntry[] = [
   { id: "cpp", label: "C++", href: "/playground/cpp" },
   { id: "java", label: "Java", href: "/playground/java" },
   { id: "csharp", label: "C#", href: "/playground/csharp" },
-  { id: "sqlite", label: "SQLite", href: "/playground/sqlite" },
+  // Databases, always in this order (PostgreSQL · SQLite · DuckDB) — the
+  // playground index and the dashboard read the same list, so the switcher
+  // and those grids can't drift apart.
   { id: "postgres", label: "PostgreSQL", href: "/playground/postgres" },
+  { id: "sqlite", label: "SQLite", href: "/playground/sqlite" },
   { id: "duckdb", label: "DuckDB", href: "/playground/duckdb" },
 ];

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -35,8 +35,6 @@ import { Toast } from "@base-ui/react/toast";
 import {
   ArrowDownToLine,
   Share2,
-  CloudUpload,
-  Cloud,
   ArrowUpFromLine,
   FolderOpen,
   Info,
@@ -127,6 +125,7 @@ import { ShareControls } from "../cloud/ShareControls";
 import {
   HeaderDivider,
   MobileMoreSections,
+  MobileSaveMenu,
   MoreMenu,
   SaveControl,
   NewWorkspaceControl,
@@ -3980,27 +3979,20 @@ function PostgresPlaygroundInner() {
         <>
           <div className="mobile-menu-db-selector">{databaseSelector}</div>
           <MobileMenuLabel>Workspace</MobileMenuLabel>
-          {activeWorkspace &&
-            (!workspaceSaved &&
-            tabs.some((t) => !t.kind && t.code !== t.pristineCode) ? (
-              <MobileMenuAction
-                icon={CloudUpload}
-                label="Save"
-                onClick={() => {
-                  void handleSaveWorkspace(
-                    activeWorkspace.name || "Workspace",
-                  );
-                  showToast("Workspace saved");
-                }}
-              />
-            ) : (
-              <MobileMenuAction
-                icon={Cloud}
-                label="Saved"
-                disabled
-                onClick={() => {}}
-              />
-            ))}
+          {activeWorkspace && (
+            <MobileSaveMenu
+              playgroundId={PLAYGROUND_ID}
+              workspaceId={activeWorkspace.id}
+              workspaceName={activeWorkspace.name}
+              unsaved={
+                !workspaceSaved &&
+                tabs.some((t) => !t.kind && t.code !== t.pristineCode)
+              }
+              onSave={handleSaveWorkspace}
+              buildBundle={buildCloudBundle}
+              onNotify={showToast}
+            />
+          )}
           <MobileMenuAction
             icon={Share2}
             label="Share"

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -130,6 +130,7 @@ import {
   SaveControl,
   NewWorkspaceControl,
   WorkspaceNameControl,
+  useAccountMenuSection,
   type MoreMenuSection,
 } from "../PlaygroundHeaderControls";
 import { applyEntryFocus } from "../playgroundEntryFocus";
@@ -3732,7 +3733,7 @@ function PostgresPlaygroundInner() {
 
   // One definition drives both the desktop ⋯ menu and the mobile
   // drawer's sectioned rows.
-  const moreSections: MoreMenuSection[] = [
+  const baseMoreSections: MoreMenuSection[] = [
                 {
                   label: "Data",
                   items: [
@@ -3907,6 +3908,16 @@ function PostgresPlaygroundInner() {
                   ],
                 },
               ];
+
+  // Auth had no entry point inside a playground at all. It lands as the ⋯
+  // menu's last group rather than a header control: the header is down to
+  // five controls by design and has no room on a phone, and signing in
+  // isn't something anyone reaches for mid-session. Null while the first
+  // session fetch is in flight, so nothing flashes.
+  const accountSection = useAccountMenuSection();
+  const moreSections: MoreMenuSection[] = accountSection
+    ? [...baseMoreSections, accountSection]
+    : baseMoreSections;
 
   return (
     <SqlPlaygroundShell

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -110,6 +110,7 @@ import {
   SaveControl,
   NewWorkspaceControl,
   WorkspaceNameControl,
+  useAccountMenuSection,
   type MoreMenuSection,
 } from "../PlaygroundHeaderControls";
 import { applyEntryFocus } from "../playgroundEntryFocus";
@@ -1997,7 +1998,7 @@ function SqlPlaygroundInner() {
 
   // ⋯ menu (simplified header): Data / Tools / Playground sections with
   // Import & Export sliding to sub-panels, mirroring the design handoff.
-  const sqlMoreSections = useMemo<MoreMenuSection[]>(
+  const sqlBaseSections = useMemo<MoreMenuSection[]>(
     () => [
       {
         label: "Data",
@@ -2204,6 +2205,18 @@ function SqlPlaygroundInner() {
       setImportParquetOpen,
       setImportParquetDragging,
     ],
+  );
+
+  // Auth had no entry point inside a playground at all. It lands as the ⋯
+  // menu's last group rather than a header control: the header is down to
+  // five controls by design and has no room on a phone, and signing in
+  // isn't something anyone reaches for mid-session. Null while the first
+  // session fetch is in flight, so nothing flashes.
+  const accountSection = useAccountMenuSection();
+  const sqlMoreSections = useMemo<MoreMenuSection[]>(
+    () =>
+      accountSection ? [...sqlBaseSections, accountSection] : sqlBaseSections,
+    [sqlBaseSections, accountSection],
   );
 
   // Defined once and rendered in both the sidebar and the mobile drawer

--- a/app/_components/sql/SqlPlayground.tsx
+++ b/app/_components/sql/SqlPlayground.tsx
@@ -43,8 +43,6 @@ import { Toast } from "@base-ui/react/toast";
 import {
   ArrowDownToLine,
   Share2,
-  CloudUpload,
-  Cloud,
   ArrowUpFromLine,
   CircleHelp,
   FolderOpen,
@@ -107,6 +105,7 @@ import { ShareControls } from "../cloud/ShareControls";
 import {
   HeaderDivider,
   MobileMoreSections,
+  MobileSaveMenu,
   MoreMenu,
   SaveControl,
   NewWorkspaceControl,
@@ -2323,27 +2322,20 @@ function SqlPlaygroundInner() {
         <>
           <div className="mobile-menu-db-selector">{databaseSelector}</div>
           <MobileMenuLabel>Workspace</MobileMenuLabel>
-          {activeWorkspace &&
-            (!workspaceSaved &&
-            tabs.some((t) => !t.kind && t.code !== t.pristineCode) ? (
-              <MobileMenuAction
-                icon={CloudUpload}
-                label="Save"
-                onClick={() => {
-                  void handleSaveWorkspace(
-                    activeWorkspace.name || "Workspace",
-                  );
-                  showToast("Workspace saved");
-                }}
-              />
-            ) : (
-              <MobileMenuAction
-                icon={Cloud}
-                label="Saved"
-                disabled
-                onClick={() => {}}
-              />
-            ))}
+          {activeWorkspace && (
+            <MobileSaveMenu
+              playgroundId={PLAYGROUND_ID}
+              workspaceId={activeWorkspace.id}
+              workspaceName={activeWorkspace.name}
+              unsaved={
+                !workspaceSaved &&
+                tabs.some((t) => !t.kind && t.code !== t.pristineCode)
+              }
+              onSave={handleSaveWorkspace}
+              buildBundle={buildCloudBundle}
+              onNotify={showToast}
+            />
+          )}
           <MobileMenuAction
             icon={Share2}
             label="Share"

--- a/app/_components/sql/components/SqlPlaygroundSwitcher.tsx
+++ b/app/_components/sql/components/SqlPlaygroundSwitcher.tsx
@@ -72,7 +72,11 @@ export function SqlPlaygroundSwitcher({
               </span>
             ) : null;
           })()}
-          <Select.Value>
+          {/* The label is hidden below 768px (the icon already identifies
+              the dialect) so the header has room for the logo; the dropdown
+              items keep their icons and labels either way. Same class, and
+              so the same rule, as the language playgrounds' switcher. */}
+          <Select.Value className="playground-switcher-label">
             {PLAYGROUNDS.find((p) => p.id === playgroundId)?.label ??
               playgroundId}
           </Select.Value>

--- a/app/playground/_components/LanguageCategories.tsx
+++ b/app/playground/_components/LanguageCategories.tsx
@@ -64,8 +64,9 @@ const CATEGORIES: Category[] = [
     description:
       "A full SQL workbench in the browser. Load data, run queries, and inspect results against embedded or remote engines.",
     items: [
-      { id: "sqlite", label: "SQLite", version: "3.53" },
+      // Same order as `PLAYGROUNDS`: PostgreSQL · SQLite · DuckDB.
       { id: "postgres", label: "PostgreSQL", version: "17" },
+      { id: "sqlite", label: "SQLite", version: "3.53" },
       { id: "duckdb", label: "DuckDB", version: "1.32" },
     ],
   },


### PR DESCRIPTION
Five changes to the playground chrome: four mobile fixes, plus the auth entry point the playgrounds never had.

## A1 — a long workspace name no longer pushes the Dataslope mark out of the header

The mobile ceilings for `.ph-name` and `.ph-rename-input` were dead code. Both live in the big `@media (max-width: 768px)` block near the top of `playground.css`, but the *desktop* rules for the same selectors are declared **later** in the same sheet at the same specificity — so `max-width: 220px` won, and a long name kept its full desktop width on a 390px screen.

- Moved the two ceilings to sit immediately after the rules they override, with a comment on why the position matters.
- Tightened the name to `max-width: min(36vw, 220px)` so it ellipsises earlier (140px instead of 183px at 390px wide). `min()` keeps the desktop ceiling on the wide end of the range, where a plain `36vw` would have been *looser* than 220px.
- Pinned the mark itself: `flex: none` on `.logo > a` and `.brand-logo`. The logo group carries `min-width: 0` on mobile, so without this the link is the flex item that absorbs any remaining squeeze and collapses the image. The switcher beside it gives instead — it has already dropped its label by then.

## A2 — the SQL playgrounds' switcher drops its label on mobile

`SqlPlaygroundSwitcher`'s `Select.Value` had no class, so the dialect name stayed in the header on a phone while the language playgrounds' switcher hid it. It now carries the same `playground-switcher-label` class, and so the same rule. Tapping the switcher still opens a dropdown listing every playground with its icon *and* its name.

The A1 truncation is shared CSS, so the SQL headers pick it up too — both header layouts now measure identically at 320/390/600/767px.

## A3 — the mobile drawer's "Saved" row does something

It was a `disabled` row with a no-op handler. It now opens a sub-sheet carrying the same items as the desktop chevron menu:

- the "Auto-saves in this browser as you work" note
- "Back up to cloud" (with the last-backup time) or "Sign in to back up" for guests
- "Download copy"
- plus the split button's own Save action, which on desktop lives in the button half

The actions and their copy come from a new `useSaveMenu` hook extracted from `SaveControl`, so the desktop dropdown and the drawer read one source of truth and can't drift. `MobileMenuAction` grows two props to carry the rows: `sub` (the dimmer second line) and `href` (renders the row as a link, for "Sign in to back up"). `MobileMenuNote` is the new note strip, and `useMobileMenuSubSheetOpen` lets the row refresh the cloud list when the user drills into it.

Applied to all four hosts: `Playground.tsx`, `SqlPlayground.tsx`, `PostgresPlayground.tsx`, `DuckDbPlayground.tsx`.

## A4 — PostgreSQL sorts before SQLite

Reordered in `PLAYGROUNDS` (which drives both switchers, `/dashboard/playground`, and the playground index's JSON-LD) and in `LanguageCategories`' Databases row. The order is now PostgreSQL · SQLite · DuckDB everywhere.

## A5 — an Account group in the ⋯ menu

A playground had no way to sign in or out at all. The entry point goes in the ⋯ menu's last group rather than the header: the header is deliberately down to five controls and has no room for a sixth on a phone, and signing in isn't something anyone reaches for mid-session. `useAccountMenuSection` returns it as an ordinary `MoreMenuSection`, so the desktop menu and the mobile drawer both pick it up from the array they already render.

- **Signed out:** "Sign in", linking to plain `/sign-in`. The root layout's `ReturnToTracker` has already recorded the playground URL, so the flow comes back on its own; a hand-built `?next=` would only lose the query and hash.
- **Signed in:** "Account settings", and "Sign out" behind a confirm panel. Signing out is one silent click everywhere else on the site, but in an editor the obvious thing to fear is that the code goes with it, so the panel says up front that it doesn't (workspaces live in OPFS in the browser; what stops is the cloud backup sync). A panel rather than a Dialog, because it then works unchanged on both surfaces — the desktop menu slides to it, the drawer opens it as a nested sheet.
- Nothing renders while the first session fetch is in flight, so a signed-in visitor never sees "Sign in" flash before their rows resolve.

### A drawer-scrolling bug this surfaced

Two extra rows pushed the longest drawer (a signed-in Postgres menu) past its `85dvh` cap, which exposed a latent bug: `Drawer.Content` sits between the height-capped popup and the scrolling body, and without `display: flex` + `min-height: 0` it sized to its own content — so the popup's cap just clipped, and the last rows had no way to be scrolled to. It now carries the same rule `.pkg-drawer-content` already uses for the packages and workspace drawers. A short menu still hugs its content (694px against the 717px cap on the Python playground).

## Verification

- `npx tsc --noEmit` clean; `eslint` reports 0 errors and no new warnings (the files with substantive changes report none at all).
- `vitest run` — 1201 tests / 89 files pass, including the prose-style linter.
- `playwright test playground-mobile` — 5/5 pass.
- Drove a real Chromium against all four playgrounds:
  - the save sub-sheet renders the three desktop rows on each;
  - the logo holds at 18px with a 67-character workspace name from 220px to 900px wide, with no horizontal page overflow at any width;
  - with a stubbed session, the ⋯ menu and the drawer both show ACCOUNT → "Account settings" / "Sign out", the sign-out panel renders on both surfaces, and both menus scroll to reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnjYJhtJP3BkUSaQtwkTbf