### PR TITLE
Courses sidebar/title, mobile auth, footer playgrounds column, CC BY-NC content license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,41 @@
 Dataslope is made available under more than one license:
 
   - Source code:      MIT License (the full text below).
-  - Learning content: the courses, lessons, exercises, and other written
-                      materials in the `content/` directory are licensed under
-                      Creative Commons Attribution 4.0 International
-                      (CC BY 4.0). See LICENSE-CONTENT.
+  - Learning content: the courses, lessons, exercises, quizzes, and the
+                      illustrative teaching materials drawn for them are
+                      licensed under Creative Commons
+                      Attribution-NonCommercial 4.0 International
+                      (CC BY-NC 4.0). See LICENSE-CONTENT.
 
-Third-party software and language runtimes that Dataslope depends on or loads
-at runtime are NOT covered by the licenses above and retain their own terms.
-See THIRD-PARTY-NOTICES.md. In particular, the Java runtime (CheerpJ, by
-Leaning Technologies) is distributed under its own, non-MIT license and may
-require a separate commercial license for some uses.
+WHAT THE MIT LICENSE BELOW DOES AND DOES NOT COVER
+
+The MIT license below applies only to Dataslope's own source code: the
+application, its build and tooling scripts, and the other first-party code in
+this repository. It is not a license to anything else in or loaded by this
+project. In particular, it grants you no rights to:
+
+  - The learning content. Everything described as "the Content" in
+    LICENSE-CONTENT is licensed under CC BY-NC 4.0, not MIT. The MIT permission
+    to "use, copy, modify, merge, publish, distribute, sublicense, and/or sell"
+    does not reach it, and in particular does not permit commercial use of it.
+    A file being tracked in this repository does not put it under MIT.
+
+  - Third-party software and language runtimes that Dataslope depends on,
+    bundles, or downloads in the browser at runtime. Each retains its own terms;
+    see THIRD-PARTY-NOTICES.md. In particular, the Java runtime (CheerpJ, by
+    Leaning Technologies) is proprietary, is distributed under its own, non-MIT
+    license, and may require a separate commercial license for some uses.
+
+  - Third-party datasets, fonts, and bundled artwork, which likewise keep their
+    own licenses (see THIRD-PARTY-NOTICES.md).
+
+  - The Dataslope name, logo, and other brand assets, which are not licensed by
+    either the MIT license or CC BY-NC 4.0. Neither license grants trademark
+    rights; you may not use them in a way that suggests Dataslope endorses you.
+
+The last three bullets cut both ways: CC BY-NC 4.0 does not cover third-party
+material either. Nothing Dataslope licenses can enlarge what a third party has
+granted you, so consult each project, dataset, and font for its own terms.
 
 --------------------------------------------------------------------------------
 

--- a/LICENSE-CONTENT
+++ b/LICENSE-CONTENT
@@ -1,21 +1,47 @@
 Dataslope Learning Content License
 ==================================
 
-The learning content in this repository, i.e. the courses, lessons, exercises,
-quizzes, and other written or illustrative teaching materials in the `content/`
-directory (the "Content"), is licensed under the
+The learning content in this repository (the "Content") is licensed under the
 
-    Creative Commons Attribution 4.0 International License (CC BY 4.0).
+    Creative Commons Attribution-NonCommercial 4.0 International License
+    (CC BY-NC 4.0).
 
-(This is separate from Dataslope's source code, which is licensed under the MIT
-License; see LICENSE. It also does not cover third-party material; see
-THIRD-PARTY-NOTICES.md.)
+The Content is:
+
+  - The courses, lessons, exercises, challenges, quizzes, and other written
+    teaching material in the `content/` directory, including the MDX prose,
+    the code samples embedded in it, the exercise starter code and reference
+    solutions, and the quiz questions, answers, and explanations.
+
+  - The illustrative teaching materials made for that written material, i.e.
+    the drawings that teach rather than decorate. Concretely: the lesson
+    illustrations and course/interview artwork generated from the prompts in
+    `data/illustration-prompts.json` and served from `public/images/`
+    (including the thumbnails and cut-outs derived from them), and the figures,
+    diagrams, and charts that accompany the lessons, whether they are committed
+    as image files or drawn at build time from the chart definitions in
+    `charts/`. Where such a drawing is produced by a script, the *script* is
+    source code under MIT (see LICENSE) and the *drawing it produces* is
+    Content under this license.
+
+The Content is not:
+
+  - Dataslope's source code, which is licensed under the MIT License; see
+    LICENSE. Being tracked in this repository does not make a file Content, and
+    a file being Content does not put it under MIT.
+
+  - The Dataslope name, logo, and other brand assets (e.g. `public/logo-files/`,
+    `brand-assets/`). No trademark rights are granted here; CC BY-NC 4.0
+    explicitly does not license them.
+
+  - Third-party material: datasets, fonts, language runtimes, and bundled
+    artwork such as the Microsoft Fluent Emoji images, each of which keeps its
+    own license. See THIRD-PARTY-NOTICES.md.
 
 You are free to:
 
   - Share: copy and redistribute the Content in any medium or format.
-  - Adapt: remix, transform, and build upon the Content for any purpose, even
-    commercially.
+  - Adapt: remix, transform, and build upon the Content.
 
 Under the following terms:
 
@@ -23,6 +49,14 @@ Under the following terms:
     (https://dataslope.com), provide a link to this license, and indicate if
     changes were made. You may do so in any reasonable manner, but not in any
     way that suggests Dataslope endorses you or your use.
+  - NonCommercial: You may not use the Content for commercial purposes. A
+    commercial purpose is one primarily intended for, or directed toward,
+    commercial advantage or monetary compensation, for example reselling the
+    lessons, putting them behind a paid course or subscription, or republishing
+    them on an ad-supported or lead-generating site. Teaching from them in a
+    classroom, study group, or workplace, and sharing or adapting them
+    non-commercially, is fine. If you want to use the Content commercially, ask
+    us: https://github.com/dataslope/dataslope/discussions
   - No additional restrictions: You may not apply legal terms or technological
     measures that legally restrict others from doing anything the license
     permits.
@@ -32,13 +66,14 @@ Disclaimer of warranties and liability:
   Unless otherwise stated, the Content is provided "as is" and "as available",
   without warranties or conditions of any kind, either express or implied. To
   the fullest extent permitted by law, Dataslope and its contributors are not
-  liable for any damages or losses arising from the use of the Content. (CC BY
-  4.0 itself disclaims warranties and limits liability; see its full text.)
+  liable for any damages or losses arising from the use of the Content.
+  (CC BY-NC 4.0 itself disclaims warranties and limits liability; see its full
+  text.)
 
-The complete legal text of CC BY 4.0 governs and is available at:
+The complete legal text of CC BY-NC 4.0 governs and is available at:
 
-  https://creativecommons.org/licenses/by/4.0/legalcode
+  https://creativecommons.org/licenses/by-nc/4.0/legalcode
 
 A plain-language summary (not a substitute for the license) is at:
 
-  https://creativecommons.org/licenses/by/4.0/
+  https://creativecommons.org/licenses/by-nc/4.0/

--- a/README.md
+++ b/README.md
@@ -392,10 +392,21 @@ If you enable additional Better Auth features (e.g. 2FA, organizations), regener
 Dataslope is available under more than one license:
 
 - **Source code**: [MIT License](./LICENSE). Attribution via the copyright
-  notice, and no warranty/liability.
-- **Learning content** (everything under [`content/`](./content)): [Creative
-  Commons Attribution 4.0 International (CC BY 4.0)](./LICENSE-CONTENT).
-  Attribution required, no warranty/liability.
+  notice, and no warranty/liability. The MIT license covers Dataslope's own
+  code **only** — not the learning content, and not the third-party software,
+  runtimes, datasets, fonts, or artwork the project depends on or loads at
+  runtime, each of which keeps its own terms.
+- **Learning content**: [Creative Commons Attribution-NonCommercial 4.0
+  International (CC BY-NC 4.0)](./LICENSE-CONTENT). Attribution required,
+  non-commercial use only, no warranty/liability. This covers the courses,
+  lessons, exercises, and quizzes under [`content/`](./content) **and** the
+  illustrative teaching materials made for them — the generated lesson and
+  course illustrations in `public/images/`, and the figures, diagrams, and
+  charts that accompany the lessons (including the ones rendered at build time
+  from [`charts/`](./charts)). The chart *scripts* are code under MIT; the
+  drawings they produce are content. See [`LICENSE-CONTENT`](./LICENSE-CONTENT)
+  for the exact boundary, including what is excluded (brand assets,
+  third-party material).
 
 Third-party software and language runtimes retain their own licenses; see
 [`THIRD-PARTY-NOTICES.md`](./THIRD-PARTY-NOTICES.md). In particular, the Java

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,10 +1,12 @@
 # Third-Party Notices
 
 Dataslope's own source code is licensed under the MIT License (see [`LICENSE`](./LICENSE))
-and its learning content under CC BY 4.0 (see [`LICENSE-CONTENT`](./LICENSE-CONTENT)).
+and its learning content under CC BY-NC 4.0 (see [`LICENSE-CONTENT`](./LICENSE-CONTENT)).
 Those licenses do **not** cover the third-party software, language runtimes,
-fonts, or other components that Dataslope depends on or loads at runtime. Each
-of those retains its own license and terms, summarized below.
+fonts, datasets, or other components that Dataslope depends on or loads at
+runtime. Each of those retains its own license and terms, summarized below.
+Nothing in the MIT license grants any rights to the material on this page, and
+nothing here can be relied on to enlarge what a third party has granted you.
 
 Most language runtimes are **downloaded from their providers (or a CDN) in the
 user's browser at runtime** and are not redistributed in this repository.

--- a/app/_components/auth/AuthGlobe.tsx
+++ b/app/_components/auth/AuthGlobe.tsx
@@ -17,6 +17,13 @@
 // `.dark` class the shared toggle flips; cobe bakes colours in at creation, so
 // a theme change tears down and rebuilds the globe.
 //
+// Desktop only. On a phone the sphere is mostly off-screen behind the form
+// anyway, and the auth pages there are a flat, card-less surface (see
+// AuthPageShell) that the globe would only clutter. This is a render-time
+// opt-out rather than a `hidden` class on purpose: nothing is created, so a
+// mobile visitor pays for no WebGL context, no rAF loop, and none of the
+// sticker images.
+//
 // Non-interactive (pointer-events off, aria-hidden): a pure backdrop.
 
 import { useEffect, useRef, useState } from "react";
@@ -149,8 +156,24 @@ function useIsDark(): boolean {
   return dark;
 }
 
+/** The `md` breakpoint, read live so a resize across it mounts or tears down
+ *  the globe. Starts `false`, which also keeps the server render and the first
+ *  client render globe-free (it needs a canvas and JS either way). */
+function useIsDesktop(): boolean {
+  const [desktop, setDesktop] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    const read = () => setDesktop(mq.matches);
+    read();
+    mq.addEventListener("change", read);
+    return () => mq.removeEventListener("change", read);
+  }, []);
+  return desktop;
+}
+
 export function AuthGlobe() {
   const dark = useIsDark();
+  const desktop = useIsDesktop();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const pinRefs = useRef<Array<HTMLSpanElement | null>>([]);
@@ -238,7 +261,11 @@ export function AuthGlobe() {
       globe.destroy();
       window.removeEventListener("resize", onResize);
     };
-  }, [dark]);
+    // `desktop` is in the deps because the canvas it reads only exists while
+    // the globe is rendered; crossing the breakpoint has to re-run this.
+  }, [dark, desktop]);
+
+  if (!desktop) return null;
 
   return (
     <div

--- a/app/_components/auth/AuthPageShell.tsx
+++ b/app/_components/auth/AuthPageShell.tsx
@@ -8,6 +8,13 @@
 // Dark mode paints the page and the card the same near-black (#121212) and
 // floats a decorative globe (AuthGlobe) at the bottom, behind the card. The
 // shared light/dark toggle sits top-right, mirroring the site header.
+//
+// Mobile is deliberately plainer: no globe (AuthGlobe skips small viewports
+// entirely, so the WebGL sphere is never even created there) and no card —
+// the page paints one flat white/near-black surface and the form sits
+// directly on it. A card inside a 360px viewport is two nested boxes of
+// padding around a column of full-width inputs; dropping it buys back the
+// horizontal room without changing anything about the form itself.
 import "@/app/tailwind.css";
 import type { ReactNode } from "react";
 import Link from "../Link";
@@ -25,8 +32,14 @@ export function AuthPageShell({ children }: { children: ReactNode }) {
       <script dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP }} />
       {/* `dark:[--ui-card:#121212]` repaints every `bg-card` descendant (the
           card body + the "or continue with" separator) so they match the page,
-          keeping the dark surface seamless. */}
-      <div className="relative isolate flex min-h-svh flex-col items-center justify-center gap-6 overflow-hidden bg-muted p-6 md:p-10 dark:bg-[#121212] dark:[--ui-card:#121212]">
+          keeping the dark surface seamless.
+
+          Light mode does the same thing at mobile widths from the other side:
+          the card is already white, so painting the *page* white (rather than
+          the muted grey) below `md` is what dissolves it. Both themes then
+          have a single flat surface on mobile, and `bg-card` keeps working
+          unchanged for the "or continue with" separator's knockout. */}
+      <div className="relative isolate flex min-h-svh flex-col items-center justify-center gap-6 overflow-hidden bg-white px-5 py-8 md:bg-muted md:p-10 dark:bg-[#121212] dark:[--ui-card:#121212]">
         {/* Shared light/dark toggle, same control as the site header. */}
         <div className="absolute right-4 top-4 z-20">
           <ThemePillToggle />

--- a/app/_components/auth/authBlocks.tsx
+++ b/app/_components/auth/authBlocks.tsx
@@ -21,15 +21,20 @@ export function AuthCard({
   description: string;
   children: React.ReactNode;
 }) {
+  // Below `md` there is no card: `bg-card` is painted the same colour as the
+  // page (see AuthPageShell), and the padding + corner radius are dropped so
+  // the form sits directly on the page surface. That is worth ~48px of width
+  // on a narrow phone, which the inputs and buttons take up instead. From `md`
+  // the card comes back exactly as before.
   return (
-    <div className="bg-card text-card-foreground rounded-xl">
-      <div className="flex flex-col gap-1.5 p-6 text-center">
+    <div className="bg-card text-card-foreground md:rounded-xl">
+      <div className="flex flex-col gap-1.5 pb-6 text-center md:p-6">
         <h1 className="text-xl font-semibold">{title}</h1>
         <p className="text-muted-foreground text-balance text-sm">
           {description}
         </p>
       </div>
-      <div className="p-6 pt-0">{children}</div>
+      <div className="md:p-6 md:pt-0">{children}</div>
     </div>
   );
 }

--- a/app/_components/home/HomeFooter.tsx
+++ b/app/_components/home/HomeFooter.tsx
@@ -1,6 +1,12 @@
+import type { ReactNode } from "react";
 import Link from "../Link";
 import { GitHubIcon } from "./icons";
 import { FooterPattern } from "./FooterPattern";
+import { PLAYGROUNDS } from "../playgrounds";
+import {
+  LANGUAGE_ICONS,
+  LANGUAGE_ICON_SIZE_FACTOR,
+} from "../languageIcons";
 
 const GITHUB_URL = "https://github.com/dataslope/dataslope/";
 
@@ -24,7 +30,7 @@ const RESOURCE_LINKS = [
   { href: "/privacy", label: "Privacy Policy", external: false },
   { href: "/terms", label: "Terms", external: false },
   // The on-site license summary rather than the raw LICENSE file on GitHub:
-  // it covers the code (MIT), the learning content (CC BY 4.0), and the
+  // it covers the code (MIT), the learning content (CC BY-NC 4.0), and the
   // third-party runtimes in one place.
   { href: "/license", label: "License", external: false },
   {
@@ -39,10 +45,41 @@ const RESOURCE_LINKS = [
   },
 ];
 
-// `inline-block w-fit` so each link shrinks to its text: as a stretched flex
+// Every language playground gets its own row, from the same registry the
+// header switcher and the /playground index read, so a new playground appears
+// here without anyone remembering to add it. Labels are spelled out ("Python
+// Playground") because in a footer the column heading is skimmed past, and a
+// bare "Python" would be ambiguous next to the Courses column.
+const PLAYGROUND_LINKS = PLAYGROUNDS.map((p) => ({
+  id: p.id,
+  href: p.href,
+  label: `${p.label} Playground`,
+  external: false,
+}));
+
+/** The /playground page's language glyph at footer-link size. `currentColor`,
+ *  not the brand tint that page uses on its tiles: here the icon is a lead-in
+ *  to a text link and should travel with the link's own hover colour. */
+function PlaygroundIcon({ id }: { id: string }) {
+  const Icon = LANGUAGE_ICONS[id];
+  if (!Icon) return null;
+  const factor = LANGUAGE_ICON_SIZE_FACTOR[id] ?? 1;
+  return (
+    <span
+      className="inline-flex size-4 shrink-0 items-center justify-center"
+      aria-hidden="true"
+    >
+      <Icon size={Math.round(16 * factor)} />
+    </span>
+  );
+}
+
+// `inline-flex w-fit` so each link shrinks to its text: as a stretched flex
 // item (`block`) the trailing whitespace across the column was clickable too.
+// (`inline-flex` rather than the original `inline-block` so a link can carry a
+// leading icon; same shrink-to-content behaviour.)
 const linkClass =
-  "inline-block w-fit py-1.5 text-sm text-[#121212] transition-[color,translate] hover:translate-x-0.5 hover:text-[var(--ds-blue-700)] dark:text-white dark:hover:text-[var(--ds-blue-400)]";
+  "inline-flex w-fit items-center gap-2 py-1.5 text-sm text-[#121212] transition-[color,translate] hover:translate-x-0.5 hover:text-[var(--ds-blue-700)] dark:text-white dark:hover:text-[var(--ds-blue-400)]";
 
 // `mb-2` on top of the column's `gap-1`: the heading sat almost flush against
 // its first link, so it read as another list item rather than as a label.
@@ -53,10 +90,13 @@ function FooterLink({
   href,
   label,
   external,
+  icon,
 }: {
   href: string;
   label: string;
   external: boolean;
+  /** Optional lead-in glyph (the playground column's language icons). */
+  icon?: ReactNode;
 }) {
   if (external) {
     return (
@@ -66,12 +106,14 @@ function FooterLink({
         rel="noopener noreferrer"
         className={linkClass}
       >
+        {icon}
         {label}
       </a>
     );
   }
   return (
     <Link href={href} className={linkClass}>
+      {icon}
       {label}
     </Link>
   );
@@ -93,8 +135,15 @@ export function HomeFooter() {
           drawn rather than padded. */}
       <div className="mx-auto max-w-6xl px-4 pt-14 pb-20 sm:px-6 sm:pt-16 sm:pb-28">
         <div className="ds-footer-grid">
-          {/* Column 1, logo (no wordmark) + GitHub at the bottom. */}
-          <div className="flex flex-col justify-between gap-8">
+          {/* Column 1, logo (no wordmark) + GitHub.
+              One row on mobile — logo left, GitHub hard right — rather than
+              two stacked lines that left the icon orphaned on its own row.
+              From `sm`, where the grid splits into columns, they stack again.
+              The negative margins cancel the icon button's own padding (a 28px
+              glyph in a 40px hit target) so the mark, not the box, lines up
+              with the edge the logo sits on: the right edge of the column on
+              mobile, the left edge of the column once it stacks. */}
+          <div className="flex flex-row items-center justify-between gap-8 sm:flex-col sm:items-start sm:justify-start sm:gap-6">
             <Link
               href="/"
               aria-label="Dataslope home"
@@ -119,9 +168,11 @@ export function HomeFooter() {
               rel="noopener noreferrer"
               aria-label="View source on GitHub"
               title="GitHub"
-              className="inline-flex size-10 items-center justify-center rounded-lg text-[#121212] transition-colors hover:bg-[var(--ds-gray-100)] dark:text-white dark:hover:bg-white/[0.06]"
+              className="-mr-1.5 inline-flex size-10 items-center justify-center rounded-lg text-[#121212] transition-colors hover:bg-[var(--ds-gray-100)] sm:-ml-1.5 sm:mr-0 dark:text-white dark:hover:bg-white/[0.06]"
             >
-              <GitHubIcon size={26} />
+              {/* 28px, so the mark carries the same weight on the row as the
+                  h-5 logo beside it (which is ~32px wide at its 1.59:1). */}
+              <GitHubIcon size={28} />
             </a>
           </div>
 
@@ -138,6 +189,16 @@ export function HomeFooter() {
             <h3 className={headingClass}>Resources</h3>
             {RESOURCE_LINKS.map((link) => (
               <FooterLink key={link.label} {...link} />
+            ))}
+          </div>
+
+          {/* Column 4, one row per language playground. The longest column by
+              far, which is why the grid is `align-items: start` — the other
+              three sit at the top of the row rather than spreading down it. */}
+          <div className="flex flex-col gap-1">
+            <h3 className={headingClass}>Playgrounds</h3>
+            {PLAYGROUND_LINKS.map(({ id, ...link }) => (
+              <FooterLink key={id} {...link} icon={<PlaygroundIcon id={id} />} />
             ))}
           </div>
         </div>

--- a/app/courses/_components/CourseCard.tsx
+++ b/app/courses/_components/CourseCard.tsx
@@ -175,8 +175,8 @@ const LAYOUT = {
     text: "gap-2",
     // One size at every breakpoint: the catalog row is the same shape on a
     // phone as on a desktop, so the title has no reason to step down. The
-    // tighter tracking is what keeps 19px from reading loose at this weight.
-    title: "text-[19px] tracking-[-0.02em]",
+    // tighter tracking is what keeps 18px from reading loose at this weight.
+    title: "text-[18px] tracking-[-0.02em]",
     desc: "text-[16px] leading-[1.7]",
   },
   preview: {

--- a/app/courses/_components/CourseCard.tsx
+++ b/app/courses/_components/CourseCard.tsx
@@ -158,8 +158,9 @@ function CourseThumb({ course }: { course: CatalogCourse }) {
  *
  * `catalog` is /courses: one row per line at full width, where the page IS the
  * list and a visitor is reading it to choose. It gets the larger art, the
- * looser rhythm, and a description set at reading size and never truncated —
- * the catalog is the one place the full sentence is the point.
+ * larger title, the looser rhythm, and a description set at reading size and
+ * never truncated — the catalog is the one place the full sentence is the
+ * point.
  *
  * `preview` is the home page's Courses section: four rows in two columns,
  * inside a page that has other things to say. It stays denser, and clamps the
@@ -172,11 +173,16 @@ const LAYOUT = {
   catalog: {
     row: "grid-cols-[86px_1fr] gap-5 py-8 sm:grid-cols-[104px_1fr] sm:gap-6",
     text: "gap-2",
+    // One size at every breakpoint: the catalog row is the same shape on a
+    // phone as on a desktop, so the title has no reason to step down. The
+    // tighter tracking is what keeps 19px from reading loose at this weight.
+    title: "text-[19px] tracking-[-0.02em]",
     desc: "text-[16px] leading-[1.7]",
   },
   preview: {
     row: "grid-cols-[84px_1fr] gap-5 py-6",
     text: "gap-[5px]",
+    title: "text-[17px] tracking-[-0.01em]",
     desc: "line-clamp-2 text-[15px] leading-[1.6]",
   },
 } as const satisfies Record<CourseCardLayout, Record<string, string>>;
@@ -202,7 +208,7 @@ export function CourseCard({
       <CourseThumb course={course} />
       <span className={`flex min-w-0 flex-col ${l.text}`}>
         <span
-          className={`text-[17px] font-semibold tracking-[-0.01em] ${HEADING} ${HOVER_TEXT}`}
+          className={`font-semibold ${l.title} ${HEADING} ${HOVER_TEXT}`}
         >
           {course.title}
         </span>

--- a/app/courses/_components/CoursesCatalog.tsx
+++ b/app/courses/_components/CoursesCatalog.tsx
@@ -323,8 +323,19 @@ export function CoursesCatalog({ courses }: { courses: CatalogCourse[] }) {
       </div>
 
       <div className="mt-8 grid grid-cols-1 items-start gap-10 md:mt-10 md:grid-cols-[224px_1fr] md:gap-14">
-        {/* ── Filter sidebar (desktop only) ── */}
-        <aside className="hidden flex-col gap-7 pt-0.5 md:flex">
+        {/* ── Filter sidebar (desktop only) ──
+            Sticks to the top of the viewport once the page scrolls, so the
+            filters stay reachable next to a long course list. Only from `md`
+            up, below that the sidebar is replaced by the dropdown bar above,
+            which has its own `sticky`.
+
+            `top-[68px]` clears the compacted header (48px) plus its 12px fade
+            (see HomeNav). The `max-h` + `overflow-y-auto` keep the tail of the
+            language list reachable on short viewports rather than letting it
+            run off the bottom of a pinned column; `pr-2 -mr-2` gives the rows'
+            `hover:translate-x-0.5` room inside that scroll box (and parks any
+            scrollbar in the column gap) without narrowing the column. */}
+        <aside className="hidden flex-col gap-7 pt-0.5 md:sticky md:top-[68px] md:flex md:max-h-[calc(100svh-84px)] md:-mr-2 md:overflow-y-auto md:pr-2">
         <label
           className={`flex items-center gap-[9px] border-b px-0.5 pb-2.5 pt-1.5 focus-within:border-[var(--ds-blue-400)] dark:focus-within:border-[var(--ds-blue-500)] ${HAIRLINE}`}
         >

--- a/app/home.css
+++ b/app/home.css
@@ -107,16 +107,33 @@ html.dark .ds-home {
   animation-play-state: paused !important;
 }
 
-/* Footer: one column on mobile, three from sm up. Driven by a scoped rule
- * (rather than Tailwind grid utilities) so a leaked `.grid`/`grid-cols-*`
- * from /learn can't collapse it back to the wrong column count. */
+/* Footer: one column on mobile, two from sm, four from lg — the twelve-column
+ * bed went from 4+4+4 to 3+3+3+3 when the Playgrounds column was added. The
+ * jump to four waits for lg rather than landing at sm because the playground
+ * rows carry the longest labels in the footer ("TypeScript Playground") plus a
+ * leading icon; at sm each of four columns is ~118px and every one of them
+ * wraps.
+ *
+ * `align-items: start` because that fourth column is ~14 rows against the
+ * others' 5: without it the short columns stretch and their content drifts
+ * apart down the row.
+ *
+ * Driven by a scoped rule (rather than Tailwind grid utilities) so a leaked
+ * `.grid`/`grid-cols-*` from /learn can't collapse it back to the wrong
+ * column count. */
 .ds-home .ds-footer-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
+  align-items: start;
   gap: 2.5rem;
 }
 @media (min-width: 640px) {
   .ds-home .ds-footer-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (min-width: 1024px) {
+  .ds-home .ds-footer-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }

--- a/app/license/page.tsx
+++ b/app/license/page.tsx
@@ -4,7 +4,7 @@ import { LegalShell } from "../_components/legal/LegalShell";
 export const metadata = {
   title: "License, Dataslope",
   description:
-    "How Dataslope is licensed: MIT for the source code, CC BY 4.0 for the learning content, and the third-party runtimes that keep their own terms.",
+    "How Dataslope is licensed: MIT for the source code, CC BY-NC 4.0 for the learning content, and the third-party runtimes that keep their own terms.",
 };
 
 const REPO = "https://github.com/dataslope/dataslope";
@@ -79,19 +79,21 @@ SOFTWARE.`;
 
 export default function LicensePage() {
   return (
-    <LegalShell title="License" updated="August 6, 2026">
+    <LegalShell title="License" updated="August 11, 2026">
       <p>
         Dataslope is made available under more than one license, because the
         site is made of more than one kind of thing. The short version:
       </p>
       <ul>
         <li>
-          <strong>Source code</strong>: MIT License.
+          <strong>Source code</strong>: MIT License. Dataslope&apos;s own code,
+          and nothing else.
         </li>
         <li>
           <strong>Learning content</strong> (courses, lessons, exercises,
-          quizzes): Creative Commons Attribution 4.0 International (CC BY
-          4.0).
+          quizzes, and the illustrations, figures, diagrams, and charts drawn
+          for them): Creative Commons Attribution-NonCommercial 4.0
+          International (CC BY-NC 4.0).
         </li>
         <li>
           <strong>Third-party software and language runtimes</strong>: not
@@ -128,25 +130,57 @@ export default function LicensePage() {
 
       <h2>Source code (MIT)</h2>
       <p>
-        Dataslope&apos;s own source code is open source under the MIT License.
-        You may use, copy, modify, merge, publish, distribute, sublicense, and
-        sell copies of it, provided the copyright notice and permission notice
-        below travel with it.
+        Dataslope&apos;s own source code is open source under the MIT License:
+        the application, its build and tooling scripts, and the other
+        first-party code in the repository. You may use, copy, modify, merge,
+        publish, distribute, sublicense, and sell copies of it, provided the
+        copyright notice and permission notice below travel with it.
       </p>
+      <p>
+        <strong>What MIT does not cover.</strong> It is a license to the code,
+        not to everything the project contains or loads. It grants you no rights
+        to:
+      </p>
+      <ul>
+        <li>
+          the <strong>learning content</strong>, which is CC BY-NC 4.0 (next
+          section); MIT&apos;s permission to &ldquo;sell copies&rdquo; does not
+          reach it, and does not permit commercial use of it;
+        </li>
+        <li>
+          <strong>third-party software, language runtimes, datasets, fonts, or
+          bundled artwork</strong>, each of which keeps its own terms (see
+          below); CheerpJ, the Java runtime, is proprietary and may require a
+          paid license for some uses;
+        </li>
+        <li>
+          the <strong>Dataslope name, logo, and brand assets</strong>: neither
+          license grants trademark rights.
+        </li>
+      </ul>
       <pre>{MIT_TEXT}</pre>
 
-      <h2>Learning content (CC BY 4.0)</h2>
+      <h2>Learning content (CC BY-NC 4.0)</h2>
       <p>
-        The courses, lessons, exercises, quizzes, and other written or
-        illustrative teaching materials are licensed under the{" "}
+        The courses, lessons, exercises, and quizzes are licensed under the{" "}
         <a
-          href="https://creativecommons.org/licenses/by/4.0/"
+          href="https://creativecommons.org/licenses/by-nc/4.0/"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Creative Commons Attribution 4.0 International License
+          Creative Commons Attribution-NonCommercial 4.0 International License
         </a>
         . This is separate from the MIT license on the code above.
+      </p>
+      <p>
+        <strong>Illustrative teaching materials</strong> are covered too, and by
+        that we mean the drawings that teach rather than decorate: the lesson
+        and course illustrations, and the figures, diagrams, and charts that
+        accompany the lessons, including the ones rendered at build time. The
+        script that draws a chart is source code under MIT; the drawing it
+        produces is content under this license. Brand assets and third-party
+        material (datasets, fonts, the bundled emoji artwork) are excluded from
+        both licenses and keep their own terms.
       </p>
       <p>You are free to:</p>
       <ul>
@@ -155,8 +189,7 @@ export default function LicensePage() {
           medium or format.
         </li>
         <li>
-          <strong>Adapt</strong>: remix, transform, and build upon it for any
-          purpose, even commercially.
+          <strong>Adapt</strong>: remix, transform, and build upon it.
         </li>
       </ul>
       <p>Under the following terms:</p>
@@ -176,6 +209,24 @@ export default function LicensePage() {
           Dataslope endorses you or your use.
         </li>
         <li>
+          <strong>NonCommercial</strong>: you may not use the content for
+          commercial purposes, meaning use primarily intended for or directed
+          toward commercial advantage or monetary compensation. That covers
+          reselling the lessons, putting them behind a paid course or
+          subscription, and republishing them on an ad-supported or
+          lead-generating site. Teaching from them in a classroom, study group,
+          or workplace, and sharing or adapting them non-commercially, is fine.
+          For commercial use,{" "}
+          <a
+            href={`${REPO}/discussions`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ask us
+          </a>
+          .
+        </li>
+        <li>
           <strong>No additional restrictions</strong>: you may not apply legal
           terms or technological measures that legally restrict others from
           doing anything the license permits.
@@ -184,11 +235,11 @@ export default function LicensePage() {
       <p>
         The{" "}
         <a
-          href="https://creativecommons.org/licenses/by/4.0/legalcode"
+          href="https://creativecommons.org/licenses/by-nc/4.0/legalcode"
           target="_blank"
           rel="noopener noreferrer"
         >
-          full legal text of CC BY 4.0
+          full legal text of CC BY-NC 4.0
         </a>{" "}
         governs; the summary above is not a substitute for it. Unless otherwise
         stated the content is provided <strong>&ldquo;as is&rdquo;</strong> and{" "}


### PR DESCRIPTION
Seven changes across `/courses`, the auth pages, the shared footer, and the licensing docs.

## `/courses`

**Sticky filter sidebar (desktop).** The `md`+ sidebar is now `position: sticky` at `top: 68px`, which clears the compacted header (48px) plus its 12px fade. It caps at `calc(100svh - 84px)` and scrolls internally, so a short window can still reach the tail of the language list instead of having it run off the bottom of a pinned column; `pr-2 -mr-2` gives the rows' `hover:translate-x-0.5` room inside that scroll box and parks any scrollbar in the column gap. Below `md` nothing changes: the sidebar is already replaced by the sticky dropdown bar.

**Larger course titles.** 17px → 18px, with tracking tightened from `-0.01em` to `-0.02em`. The size was uniform across breakpoints before and stays uniform, so mobile gets the same 18px. Title size is now a per-layout property (like the description already was), so the home page's preview cards keep their 17px.

## Auth pages on mobile

**No globe.** `AuthGlobe` returns `null` below `md`, gated on a live `matchMedia("(min-width: 768px)")`. This is a render-time opt-out rather than a `hidden` class, so a phone never creates the WebGL context, the rAF loop, or the sticker images. Desktop is unchanged.

**No card.** The page paints white in light mode below `md` (dark already painted page and card the same `#121212`), and the card's padding and corner radius are dropped, so the form sits directly on one flat surface. That is ~48px of horizontal room handed back to the inputs on a 390px viewport. `bg-card` still resolves to the page colour, so the "or continue with" separator's knockout keeps working untouched. From `md` the card comes back exactly as before.

## Shared footer

**New Playgrounds column.** One row per language playground, built from the shared `PLAYGROUNDS` registry the header switcher and `/playground` already read, so a new playground appears here automatically. Each row carries the `/playground` page's language glyph in `currentColor`, so the icon travels with the link's hover colour rather than introducing 14 brand tints into the footer.

**Grid 4+4+4 → 3+3+3+3.** One column on mobile, two from `sm`, four from `lg`. Four columns wait for `lg` rather than landing at `sm` because the playground rows carry the footer's longest labels ("TypeScript Playground") plus an icon; at `sm` each of four columns is ~118px and every one wraps. The grid also aligns to `start`, since the new column is ~14 rows against the others' 5.

**Logo + GitHub on one row (mobile).** They were stacking onto two lines. Now they share a row with GitHub hard right, stacking again from `sm`. The GitHub mark goes 26px → 28px to match the `h-5` logo beside it, with negative margins cancelling the button's own padding so the glyph rather than its 40px hit target lines up with the content edge.

## Licensing

**Learning content: CC BY 4.0 → CC BY-NC 4.0.** The "Adapt … even commercially" grant is replaced with a NonCommercial term that says concretely what that rules out (reselling, paywalling, ad-supported republishing) and what it does not (classroom, study group, workplace teaching; non-commercial sharing and adaptation), with a pointer to Discussions for commercial requests.

**"Illustrative teaching materials" spelled out.** It now names what it covers: the generated lesson and course illustrations served from `public/images/`, and the figures, diagrams, and charts that accompany the lessons, including the ones rendered at build time from `charts/`. A chart's *script* is code under MIT; the *drawing it produces* is content. It also states what is not content: brand assets and third-party material.

**MIT scope clarified.** `LICENSE` and the `/license` page now say what the MIT license does not cover: the learning content (a file being tracked in this repo does not put it under MIT), third-party software and language runtimes, third-party datasets/fonts/artwork, and the Dataslope brand. The exclusion is noted as cutting both ways, since CC BY-NC does not cover third-party material either.

Updated in `LICENSE`, `LICENSE-CONTENT`, `README.md`, `THIRD-PARTY-NOTICES.md`, the `/license` page (including its metadata description and "updated" date), and the footer's `RESOURCE_LINKS` comment.

## Verification

- `npx tsc --noEmit` clean.
- `npm run lint`: 0 errors (84 pre-existing warnings in `charts/` and `lib/generated/`).
- `npx vitest run`: 1221 passed / 90 files. The prose-style linter caught 5 em dashes in the new `/license` copy; rewritten with semicolons, colons, and full stops, and `npm run check:prose` is clean.
- Checked in a real browser at 1280/1024/700/390 widths in both themes: sidebar computes `position: sticky` / `top: 68px` and pins at y=68 after scroll; the catalog title is scoped away from the home page's preview cards, which stay 17px / -0.17px; `/sign-up` has 0 canvases at 390px and 1 at 1280px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dXqMZi4sfGwuiWuKEvPm2