### PR TITLE
Mermaid dash lint, mobile layout fixes, linkable course filters, and capacity terms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1085,6 +1085,44 @@ Two kinds of `>` line are deliberately out of scope. An **indented** one is a
 page and no quotes are drawn. One inside a **fenced block** is a sample, a
 prompt or a mermaid edge rather than a quotation.
 
+### Mermaid labels take a plain hyphen
+
+**Every dash inside a mermaid label is a plain ASCII hyphen.** Mermaid renders
+label text verbatim, so a `--` typed as a dash reaches the reader as two
+hyphens sitting in the node box:
+
+````markdown
+<!-- Bad -->
+```mermaid
+flowchart LR
+    Q -->|"only the PAST value"| FF["ffill -- safe as a live feature"]
+```
+
+<!-- Good -->
+```mermaid
+flowchart LR
+    Q -->|"only the PAST value"| FF["ffill - safe as a live feature"]
+```
+````
+
+This is stricter than the en dash rule above, which keeps `1815–1864`
+unspaced. A label is a few words in a box, so there is no typographic case to
+weigh, and one flat rule beats a distinction nobody can see at label size. The
+`mermaid-dash` check rejects `–`, `—` and the Unicode minus `−` anywhere in a
+diagram, and a whitespace-flanked run of two or more hyphens in a label.
+
+A label is not the same thing as a line, because nearly every mermaid link is
+built from the hyphens the rule looks for. Only two spans are read for hyphen
+runs: **quoted labels** (`A["text"]`, `-->|"text"|`), which is where a label
+holding `--` has to live anyway since mermaid would otherwise parse it as the
+link it resembles, and **the text after a colon** in the diagram kinds where a
+colon introduces free text (`sequenceDiagram`, `timeline`, `stateDiagram`, …),
+which is why `A((a: 1,2,3)) --- I((3))` in a flowchart is left alone. Links
+(`---`, `<-->`), ER cardinality (`}|--|{`), class associations (`Animal -- Dog`)
+and `%%` comments are all out of scope, as is a hyphen run that is code rather
+than punctuation: `--save-dev`, `i--` and `--comment` have no flanking space on
+both sides and pass.
+
 ---
 
 ## Multiple-choice question explanations

--- a/__tests__/coursesCatalogFilters.test.ts
+++ b/__tests__/coursesCatalogFilters.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  readFilters,
+  writeFilters,
+} from "../app/courses/_components/catalogFilters";
+
+// The `/courses` catalog keeps its language and level selection in the query
+// string so a filtered catalog can be linked. These are the two ends of that:
+// what a URL means when someone arrives on one, and what the address bar should
+// say once they start clicking. See app/courses/_components/catalogFilters.ts.
+const LANGUAGES = ["python", "sql", "javascript", "r"];
+const LEVELS = ["beginner", "intermediate", "advanced"];
+const read = (search: string) => readFilters(search, LANGUAGES, LEVELS);
+
+describe("reading catalog filters from a URL", () => {
+  it("has no filters when the query string is empty", () => {
+    expect(read("")).toEqual({ langs: [], levels: [] });
+    expect(read("?")).toEqual({ langs: [], levels: [] });
+  });
+
+  it("reads a language, a level, or both", () => {
+    expect(read("?lang=python")).toEqual({ langs: ["python"], levels: [] });
+    expect(read("?level=beginner")).toEqual({ langs: [], levels: ["beginner"] });
+    expect(read("?lang=sql&level=advanced")).toEqual({
+      langs: ["sql"],
+      levels: ["advanced"],
+    });
+  });
+
+  it("reads the parameters in either order, and past unrelated ones", () => {
+    expect(read("?level=beginner&lang=r")).toEqual({
+      langs: ["r"],
+      levels: ["beginner"],
+    });
+    expect(read("?utm_source=newsletter&lang=python&ref=x")).toEqual({
+      langs: ["python"],
+      levels: [],
+    });
+  });
+
+  // A stale or hand-typed link should land on the whole catalog rather than on
+  // an empty list filtered by something with no sidebar row to switch off.
+  it("ignores values this catalog does not have", () => {
+    expect(read("?lang=cobol")).toEqual({ langs: [], levels: [] });
+    expect(read("?level=expert")).toEqual({ langs: [], levels: [] });
+    expect(read("?lang=cobol&level=beginner")).toEqual({
+      langs: [],
+      levels: ["beginner"],
+    });
+  });
+
+  it("ignores an empty or valueless parameter", () => {
+    expect(read("?lang=&level=")).toEqual({ langs: [], levels: [] });
+    expect(read("?lang")).toEqual({ langs: [], levels: [] });
+  });
+
+  // Matching is exact: the sidebar's ids are lowercase, and a near miss is a
+  // value the catalog cannot act on.
+  it("does not match on case or whitespace", () => {
+    expect(read("?lang=Python")).toEqual({ langs: [], levels: [] });
+    expect(read("?lang=%20python")).toEqual({ langs: [], levels: [] });
+  });
+});
+
+describe("writing catalog filters to a URL", () => {
+  it("is empty when nothing is selected", () => {
+    expect(writeFilters("", [], [])).toBe("");
+  });
+
+  it("writes the selection", () => {
+    expect(writeFilters("", ["python"], [])).toBe("lang=python");
+    expect(writeFilters("", [], ["beginner"])).toBe("level=beginner");
+    expect(writeFilters("", ["sql"], ["advanced"])).toBe(
+      "lang=sql&level=advanced",
+    );
+  });
+
+  it("replaces a previous selection rather than appending to it", () => {
+    expect(writeFilters("?lang=python", ["sql"], [])).toBe("lang=sql");
+    expect(writeFilters("?lang=python&level=beginner", ["sql"], ["advanced"]))
+      .toBe("lang=sql&level=advanced");
+  });
+
+  it("drops a parameter when its filter is cleared", () => {
+    expect(writeFilters("?lang=python&level=beginner", [], ["beginner"])).toBe(
+      "level=beginner",
+    );
+    expect(writeFilters("?lang=python&level=beginner", [], [])).toBe("");
+  });
+
+  // Somebody arriving from a campaign link and then clicking a filter should
+  // keep their campaign tag.
+  it("leaves parameters that are not ours alone", () => {
+    expect(writeFilters("?utm_source=newsletter", ["python"], [])).toBe(
+      "utm_source=newsletter&lang=python",
+    );
+    expect(writeFilters("?utm_source=newsletter&lang=python", [], [])).toBe(
+      "utm_source=newsletter",
+    );
+  });
+
+  // The pair has to compose: what is written must read back identically, or
+  // the address bar and the list would drift apart as someone clicks around.
+  it("round-trips with readFilters", () => {
+    for (const [langs, levels] of [
+      [[], []],
+      [["python"], []],
+      [[], ["advanced"]],
+      [["sql"], ["beginner"]],
+    ] as const) {
+      const query = writeFilters("", langs, levels);
+      expect(read(query ? `?${query}` : "")).toEqual({
+        langs: [...langs],
+        levels: [...levels],
+      });
+    }
+  });
+});

--- a/__tests__/proseStyle.test.ts
+++ b/__tests__/proseStyle.test.ts
@@ -75,4 +75,71 @@ describe("authored prose style", () => {
   it("ignores a blockquote inside fenced code, which is a sample rather than a quotation", () => {
     expect(lintSource('```markdown\n> "A quoted blockquote."\n```', "x.mdx", "mdx")).toEqual([]);
   });
+
+  // Mermaid labels are prose the reader sees, but they live in a fenced block,
+  // so every rule above skips them. This rule reaches inside the fence, which
+  // means it has to tell a label from mermaid's own link syntax: nearly every
+  // way of drawing a link is made of the same hyphens the rule is looking for.
+  describe("mermaid labels", () => {
+    const mermaid = (...body: string[]) => ["```mermaid", ...body, "```"].join("\n");
+    const rules = (src: string) => lintSource(src, "x.mdx", "mdx").map((v) => v.rule);
+
+    it("flags `--` used as a dash in a label, which mermaid renders verbatim", () => {
+      const src = mermaid("flowchart LR", '  Q -->|"the PAST"| FF["ffill -- safe as a live feature"]');
+      expect(rules(src)).toEqual(["mermaid-dash"]);
+    });
+
+    it("flags any non-ASCII dash in a label, quoted or not", () => {
+      expect(rules(mermaid("flowchart LR", '  NF[".NET (2002–2019)"] --> W[Windows]'))).toEqual(["mermaid-dash"]);
+      expect(rules(mermaid("flowchart LR", "  R1[Bug is in 16–30] --> E[done]"))).toEqual(["mermaid-dash"]);
+      expect(rules(mermaid("flowchart TD", '  A["x"] -->|"z = (x − mu) / s"| B["z"]'))).toEqual(["mermaid-dash"]);
+    });
+
+    // A label can trip both halves of the rule at once. The fix is the same
+    // either way, so it is reported once, against the line it sits on.
+    it("reports one violation per line and points at the source line", () => {
+      const src = mermaid("flowchart LR", "  A --> B", '  B --> C["16–30 -- see below"]');
+      const found = lintSource(src, "x.mdx", "mdx");
+      expect(found.map((v: { rule: string }) => v.rule)).toEqual(["mermaid-dash"]);
+      expect(found[0].line).toBe(4);
+    });
+
+    // Everything below is a link, a cardinality marker or a code sample. Each
+    // one held real hyphen runs in the corpus before the rule existed.
+    it("allows mermaid's own link syntax, which is made of the same hyphens", () => {
+      expect(rules(mermaid("flowchart TD", '  P["prev"] -- "before" --> A["[ A | * ]"] --> B["[ B | * ]"]'))).toEqual([]);
+      expect(rules(mermaid("flowchart LR", "  A ----> B ---- C", "  D <--> E"))).toEqual([]);
+      expect(rules(mermaid("erDiagram", "  CUSTOMER }|--|{ ORDER : places"))).toEqual([]);
+      expect(rules(mermaid("classDiagram", "  Animal -- Dog", "  Duck --|> Animal"))).toEqual([]);
+      expect(rules(mermaid("stateDiagram-v2", "  [*] --> Still", "  Still --> [*]"))).toEqual([]);
+    });
+
+    it("allows a hyphen run that is code rather than punctuation", () => {
+      expect(rules(mermaid("flowchart LR", '  A["npm i --save-dev vitest"] --> B["done"]'))).toEqual([]);
+      expect(rules(mermaid("flowchart LR", '  A["SELECT 1 --comment"] --> B["ok"]'))).toEqual([]);
+      expect(rules(mermaid("flowchart LR", '  A["i--"] --> B["loop"]'))).toEqual([]);
+    });
+
+    // A colon runs to end-of-line as label text in a sequence diagram, but in a
+    // flowchart it is just a character inside a node, and reading the rest of
+    // the line as its label picks up the link that follows it.
+    it("reads text after a colon only where a colon introduces a label", () => {
+      expect(rules(mermaid("sequenceDiagram", "  Alice->>Bob: parse it -- then render"))).toEqual(["mermaid-dash"]);
+      expect(rules(mermaid("flowchart LR", "  A((a: 1,2,3)) --- I((3)) --- B((b: 3,4))"))).toEqual([]);
+      expect(rules(mermaid("flowchart LR", '  A["ratio: x:y"] --> B["ok"]'))).toEqual([]);
+    });
+
+    it("ignores mermaid comments and non-mermaid fences", () => {
+      // A `%%` comment never reaches the rendered diagram. (An em dash would
+      // still trip rule 1, which reads the whole file; an unspaced en dash is
+      // the dash those rules allow, so it isolates this rule.)
+      expect(rules(mermaid("flowchart LR", "  %% spans 2002–2019, not drawn", "  A --> B"))).toEqual([]);
+      expect(rules("```python\nx = 1 -- 2  # not a diagram\n```")).toEqual([]);
+      expect(rules("```\nffill -- safe\n```")).toEqual([]);
+    });
+
+    it("leaves the same dash alone outside a fence, where other rules own it", () => {
+      expect(rules("The fill reads only the past -- so it is safe.")).toEqual([]);
+    });
+  });
 });

--- a/app/_components/home/PricingSection.tsx
+++ b/app/_components/home/PricingSection.tsx
@@ -399,7 +399,34 @@ function PlanColumn({
             reviewer liked the marmot breaking the border rather than sitting
             inside it. -40% rather than -50% drops it a little further into the
             card so it reads as resting on the edge instead of floating over
-            it. `pointer-events-none` keeps it from swallowing clicks. */}
+            it. `pointer-events-none` keeps it from swallowing clicks.
+
+            Below `lg` all three values change, because the same box lands
+            somewhere else once the column becomes a full-width row:
+
+            - `-right-6` instead of `right-0`. Each cut-out carries a wide
+              transparent margin (the free-member art paints across 605 of its
+              1024px canvas), so `right-0` aligns the *box* to the content edge
+              and leaves the marmot itself ~24px short of it, reading as
+              floated left of where it belongs. Pulling the box out by the
+              column's own padding puts the drawing where `right-0` looks like
+              it should have put it, flush with the card edge.
+            - `-translate-y-[60%]` instead of -40%. The desktop header carries
+              `lg:pt-8` and the column has no vertical padding, while a phone
+              row has neither — `top-1/2` is measured against a 28px title row
+              sitting 24px into the card, which dropped the marmot ~10px lower
+              than on desktop and left it resting *inside* the top edge rather
+              than breaking it, hanging down over the price instead.
+            - `size-24` instead of 120px, which is the part a move alone could
+              not fix. A phone row is a third the width of the table it came
+              from, but the art was still drawn at desktop size, so on a 360px
+              screen it reached back across the title line and painted over the
+              "Recommended" badge (~45px of it, enough to cut the word in
+              half). Lifting it makes that worse rather than better: the badge
+              line then crosses the marmot's middle, which is the widest part
+              of the silhouette. At 96px the drawing meets the badge's rounded
+              end and leaves its text clear by ~9px, on the narrowest phone
+              worth designing for. */}
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={`/images/${plan.iconSlug}-cutout.webp`}
@@ -407,7 +434,7 @@ function PlanColumn({
           aria-hidden="true"
           loading="lazy"
           decoding="async"
-          className="pointer-events-none absolute right-0 top-1/2 size-[120px] -translate-y-[40%] object-contain"
+          className="pointer-events-none absolute -right-6 top-1/2 size-24 -translate-y-[60%] object-contain lg:right-0 lg:size-[120px] lg:-translate-y-[40%]"
         />
       </div>
 

--- a/app/_components/home/PricingSection.tsx
+++ b/app/_components/home/PricingSection.tsx
@@ -207,6 +207,13 @@ const PLANS: Plan[] = [
 const SHOW_PRO_PLAN = false;
 const VISIBLE_PLANS = PLANS.filter((p) => SHOW_PRO_PLAN || p.name !== "Pro");
 
+// Shown above the table in place of the billing toggle while Pro is hidden.
+// Three sentences, because a table of $0s raises exactly three suspicions: that
+// a card is wanted up front, that the free run is a trial, and that access
+// lapses. Phrased as the denials a visitor is already half-expecting, rather
+// than as a claim ("Free forever") the price column has made twice already.
+const NO_CATCH = ["No credit card", "No trial period", "No expiry"];
+
 // Explicit column placement keeps each plan in its own column while spanning
 // all of the subgrid's rows.
 const COL_START = ["lg:col-start-1", "lg:col-start-2", "lg:col-start-3"];
@@ -442,8 +449,12 @@ function PlanColumn({
         <span className="text-4xl font-medium tracking-tight text-[var(--ds-gray-900)] dark:text-white">
           {price}
         </span>
-        {/* Billing-period suffix so the monthly/annual toggle visibly changes
-            the table even though every plan is $0. */}
+        {/* Billing-period suffix, moved by the toggle when there is one. With
+            Pro hidden there is no toggle, so this always reads "/ month" above
+            two $0 columns and one of them says "Free forever" underneath —
+            vestigial, and a fair candidate for dropping while nothing is
+            billed. Left alone for now so the price line stays a deliberate
+            copy decision rather than a side effect of removing a control. */}
         <span className="ml-1 text-base font-normal text-[var(--ds-gray-500)] dark:text-[var(--ds-gray-400)]">
           {annual ? "/ year" : "/ month"}
         </span>
@@ -529,7 +540,26 @@ export function PricingSection({
         </div>
       )}
 
-      {/* Monthly / annual billing toggle, only the paid tier's price reacts. */}
+      {/* The slot above the table: the billing toggle when there is something
+          to bill for, the "no catch" strip when there isn't.
+
+          With Pro hidden the toggle was a dead control. Both remaining columns
+          are $0 with the same sub-line, so the only thing it changed was the
+          "/ month" suffix, and the "Best value" badge on Annual promised a
+          discount that could not exist — a visitor who clicked to find the
+          saving got $0 → $0.
+
+          The strip answers the question the toggle never could. Somebody
+          reading a table where every price is $0 is not working out a billing
+          period, they are looking for the catch, and "No credit card / No
+          trial period / No expiry" names all three catches they are expecting.
+          Each one carries the same green check the feature rows use for an
+          included capability, so the mark that means "you get this" is the
+          same mark on both sides of the table's top edge.
+
+          Restoring Pro is still one flag: flip SHOW_PRO_PLAN and the toggle
+          comes back with its state and checkout wiring untouched. */}
+      {SHOW_PRO_PLAN ? (
       <div className="mb-10 flex items-center justify-center">
         <div className="inline-flex items-center rounded-full border border-[var(--ds-gray-200)] bg-white p-1 dark:border-white/15 dark:bg-[#121212]">
           {(["monthly", "annual"] as const).map((option) => {
@@ -563,6 +593,24 @@ export function PricingSection({
           })}
         </div>
       </div>
+      ) : (
+        <ul className="mb-10 flex flex-wrap items-center justify-center gap-2.5">
+          {NO_CATCH.map((assurance) => (
+            <li
+              key={assurance}
+              className="inline-flex items-center gap-2 rounded-full border border-[var(--ds-gray-200)] bg-white py-1.5 pr-4 pl-2 text-[15px] font-medium text-[var(--ds-gray-900)] dark:border-white/15 dark:bg-[#121212] dark:text-white"
+            >
+              <span
+                className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--ds-green-500)]"
+                aria-hidden="true"
+              >
+                <Check size={12} strokeWidth={2.5} className="text-white" />
+              </span>
+              {assurance}
+            </li>
+          ))}
+        </ul>
+      )}
 
       {/* Comparison: bordered, no gaps between plans, thin dividers between
           them, and feature rows aligned via subgrid. The striped-shell gives

--- a/app/courses/_components/CourseCard.tsx
+++ b/app/courses/_components/CourseCard.tsx
@@ -128,7 +128,10 @@ function CourseThumb({ course }: { course: CatalogCourse }) {
         slug={course.slug}
         tags={course.tags}
         size={22}
-        className={`mt-0.5 justify-self-center text-[var(--ds-gray-900)] dark:text-white ${HOVER_GLYPH}`}
+        // Centred in its own column, but left-aligned once the catalog row
+        // stacks on a phone, where the cell is the full width of the card and
+        // centring would park the glyph in the middle of the row.
+        className={`mt-0.5 justify-self-start text-[var(--ds-gray-900)] sm:justify-self-center dark:text-white ${HOVER_GLYPH}`}
       />
     );
   }
@@ -158,26 +161,33 @@ function CourseThumb({ course }: { course: CatalogCourse }) {
  *
  * `catalog` is /courses: one row per line at full width, where the page IS the
  * list and a visitor is reading it to choose. It gets the larger art, the
- * larger title, the looser rhythm, and a description set at reading size and
- * never truncated — the catalog is the one place the full sentence is the
- * point.
+ * larger title and the looser rhythm.
+ *
+ * On a phone it also changes *shape*. A thumbnail column beside the copy costs
+ * the same 86px on a 390px screen that it costs on a 1200px one, and what it
+ * takes comes out of the text: the title wraps to two lines, and a description
+ * that reads as one sentence on a desktop runs to six lines on a phone. So
+ * below `sm` the row stacks, and the art gets the full width instead of a
+ * sliver of it. The description is clamped there and only there — the catalog
+ * is still the place the full sentence is the point, but a phone cannot spend
+ * six lines on it and stay a list you can scan.
  *
  * `preview` is the home page's Courses section: four rows in two columns,
  * inside a page that has other things to say. It stays denser, and clamps the
- * description, so four of them still read as a taste of the catalog rather
- * than as the catalog.
+ * description at every width, so four of them still read as a taste of the
+ * catalog rather than as the catalog.
  */
 export type CourseCardLayout = "catalog" | "preview";
 
 const LAYOUT = {
   catalog: {
-    row: "grid-cols-[86px_1fr] gap-5 py-8 sm:grid-cols-[104px_1fr] sm:gap-6",
+    row: "grid-cols-1 gap-4 py-8 sm:grid-cols-[104px_1fr] sm:gap-6",
     text: "gap-2",
     // One size at every breakpoint: the catalog row is the same shape on a
     // phone as on a desktop, so the title has no reason to step down. The
     // tighter tracking is what keeps 18px from reading loose at this weight.
     title: "text-[18px] tracking-[-0.02em]",
-    desc: "text-[16px] leading-[1.7]",
+    desc: "line-clamp-2 text-[16px] leading-[1.7] sm:line-clamp-none",
   },
   preview: {
     row: "grid-cols-[84px_1fr] gap-5 py-6",

--- a/app/courses/_components/CourseCard.tsx
+++ b/app/courses/_components/CourseCard.tsx
@@ -119,7 +119,13 @@ const THUMB_MIME: Record<string, string> = {
  * The column's width comes from `LAYOUT` above — the art is sized by the
  * surface, not by the image.
  */
-function CourseThumb({ course }: { course: CatalogCourse }) {
+function CourseThumb({
+  course,
+  thumbClass,
+}: {
+  course: CatalogCourse;
+  thumbClass: string;
+}) {
   const slug = `${course.slug}-thumbnail-cutout`;
   const entry = imageManifest[slug];
   if (!entry) {
@@ -128,17 +134,18 @@ function CourseThumb({ course }: { course: CatalogCourse }) {
         slug={course.slug}
         tags={course.tags}
         size={22}
-        // Centred in its own column, but left-aligned once the catalog row
-        // stacks on a phone, where the cell is the full width of the card and
-        // centring would park the glyph in the middle of the row.
-        className={`mt-0.5 justify-self-start text-[var(--ds-gray-900)] sm:justify-self-center dark:text-white ${HOVER_GLYPH}`}
+        className={`mt-0.5 justify-self-center text-[var(--ds-gray-900)] dark:text-white ${HOVER_GLYPH}`}
       />
     );
   }
   const fallback = entry.formats[entry.formats.length - 1];
   const sources = entry.formats.slice(0, -1);
   return (
-    <picture>
+    // `block` is stated rather than relied on: a <picture> is inline by
+    // default and is only blockified here because it happens to be a grid
+    // item, which is not a property worth depending on for the width and auto
+    // margins `thumbClass` sets.
+    <picture className={`block ${thumbClass}`}>
       {sources.map((ext) => (
         <source key={ext} srcSet={`/images/${slug}.${ext}`} type={THUMB_MIME[ext]} />
       ))}
@@ -181,17 +188,29 @@ export type CourseCardLayout = "catalog" | "preview";
 
 const LAYOUT = {
   catalog: {
-    row: "grid-cols-1 gap-4 py-8 sm:grid-cols-[104px_1fr] sm:gap-6",
+    // `gap-5` rather than `gap-4` is the space under the stacked thumbnail;
+    // once the art is centred and no longer touches either edge, the old gap
+    // read as the title crowding it.
+    row: "grid-cols-1 gap-5 py-8 sm:grid-cols-[104px_1fr] sm:gap-6",
     text: "gap-2",
+    // Two thirds of the row, centred, once the row stacks on a phone. Full
+    // width is more art than a title and two lines of description can carry,
+    // and it pushed the meta line off the bottom of the screen. On a desktop
+    // the thumbnail is back in its own 104px column, where `w-full` *is* the
+    // column and the auto margins do nothing.
+    thumb: "w-[65%] mx-auto sm:w-full",
     // One size at every breakpoint: the catalog row is the same shape on a
     // phone as on a desktop, so the title has no reason to step down. The
-    // tighter tracking is what keeps 18px from reading loose at this weight.
-    title: "text-[18px] tracking-[-0.02em]",
+    // tighter tracking is what keeps 18px from reading loose at this weight,
+    // and the leading matches the description's so the two blocks share a
+    // rhythm instead of the title sitting tight above looser copy.
+    title: "text-[18px] leading-[1.7] tracking-[-0.02em]",
     desc: "line-clamp-2 text-[16px] leading-[1.7] sm:line-clamp-none",
   },
   preview: {
     row: "grid-cols-[84px_1fr] gap-5 py-6",
     text: "gap-[5px]",
+    thumb: "w-full",
     title: "text-[17px] tracking-[-0.01em]",
     desc: "line-clamp-2 text-[15px] leading-[1.6]",
   },
@@ -215,7 +234,7 @@ export function CourseCard({
       prefetch={false}
       className={`group -mx-3 grid items-start px-3 ${l.row}`}
     >
-      <CourseThumb course={course} />
+      <CourseThumb course={course} thumbClass={l.thumb} />
       <span className={`flex min-w-0 flex-col ${l.text}`}>
         <span
           className={`font-semibold ${l.title} ${HEADING} ${HOVER_TEXT}`}

--- a/app/courses/_components/CoursesCatalog.tsx
+++ b/app/courses/_components/CoursesCatalog.tsx
@@ -10,7 +10,7 @@
  * server page passes in; the sidebar counts are totals over the whole
  * catalog (not the filtered list), matching the mockup.
  */
-import { useMemo, useState } from "react";
+import { useMemo, useState, useSyncExternalStore } from "react";
 import { Select } from "@base-ui/react/select";
 import {
   ArrowDownAZ,
@@ -25,6 +25,7 @@ import {
 import { formatTagLabel } from "@/lib/tagLabels";
 import type { CatalogCourse } from "@/lib/courseCatalog";
 import { CourseCard, LangIcon, LevelBars } from "./CourseCard";
+import { readFilters, writeFilters } from "./catalogFilters";
 
 // Sidebar language order, from the mockup. Languages found in the catalog but
 // missing here (future additions) are appended alphabetically.
@@ -62,6 +63,26 @@ const FAINT = "text-[var(--ds-gray-400)] dark:text-[var(--ds-gray-500)]";
 const MUTED = "text-[var(--ds-gray-600)] dark:text-[var(--ds-gray-400)]";
 const HEADING = "text-[var(--ds-gray-900)] dark:text-white";
 const ACCENT = "text-[var(--ds-blue-700)] dark:text-[var(--ds-blue-400)]";
+
+// The store behind `useSyncExternalStore` below: the page's own query string.
+// `history.replaceState` fires no event, so writes announce themselves with
+// this one; `popstate` covers the browser's back and forward buttons.
+const URL_FILTERS_CHANGED = "courses:filters";
+
+function subscribeToUrl(onChange: () => void) {
+  window.addEventListener("popstate", onChange);
+  window.addEventListener(URL_FILTERS_CHANGED, onChange);
+  return () => {
+    window.removeEventListener("popstate", onChange);
+    window.removeEventListener(URL_FILTERS_CHANGED, onChange);
+  };
+}
+// A string, so React's identity check on the snapshot is a value comparison and
+// an unchanged URL cannot loop.
+const getSearch = () => window.location.search;
+// Prerendering has no URL. Returning "" makes the static HTML the unfiltered
+// catalog, which is what hydration then matches.
+const getServerSearch = () => "";
 
 /** One sidebar filter row: leading glyph, label, trailing count. */
 function SideRow({
@@ -199,8 +220,6 @@ function courseSearchText(c: CatalogCourse): string {
 
 export function CoursesCatalog({ courses }: { courses: CatalogCourse[] }) {
   const [q, setQ] = useState("");
-  const [langs, setLangs] = useState<string[]>([]);
-  const [levels, setLevels] = useState<string[]>([]);
   const [sort, setSort] = useState<Sort>("popular");
 
   // Single-select per category: clicking the active row clears it, clicking
@@ -219,6 +238,47 @@ export function CoursesCatalog({ courses }: { courses: CatalogCourse[] }) {
     const extras = [...present].filter((l) => !LANG_ORDER.includes(l)).sort();
     return [...ordered, ...extras];
   }, [courses]);
+
+  // ── Linkable filters ────────────────────────────────────────────────────
+  //
+  // The language and level selection is not React state: the URL holds it, and
+  // this reads it. That makes /courses?lang=python a link, and it removes the
+  // question of which of the two is right when they disagree, because there is
+  // only one of them.
+  //
+  // `useSyncExternalStore` rather than `useSearchParams`: this page is
+  // statically prerendered, and `useSearchParams` opts the whole route out of
+  // that unless it sits behind a Suspense boundary, in which case the fallback
+  // is what gets prerendered. Nothing is gained by either — the query string is
+  // unknown at build time, so the filtering happens on the client whichever API
+  // reads it — and this keeps the catalog's HTML static exactly as before.
+  //
+  // The server snapshot is "", so prerendered HTML is the unfiltered catalog
+  // and hydration matches it; React then re-renders with the real query string.
+  // This is the sanctioned way to read something that only exists on the
+  // client, as opposed to seeding state in an effect, which is a second copy of
+  // the truth that has to be kept in step with the first.
+  const search = useSyncExternalStore(subscribeToUrl, getSearch, getServerSearch);
+  const { langs, levels } = useMemo(
+    () => readFilters(search, languages, LEVELS),
+    [search, languages],
+  );
+
+  // Writing goes through the URL too, so a click and a pasted link take exactly
+  // the same path. `replaceState` rather than a router navigation: nothing needs
+  // re-fetching, and pushing an entry per filter click would bury the page the
+  // visitor arrived from under a stack of filter states. It does not notify
+  // anyone by itself, hence the event that wakes the store above.
+  const setFilters = (nextLangs: string[], nextLevels: string[]) => {
+    const query = writeFilters(window.location.search, nextLangs, nextLevels);
+    const { pathname } = window.location;
+    window.history.replaceState(null, "", query ? `${pathname}?${query}` : pathname);
+    window.dispatchEvent(new Event(URL_FILTERS_CHANGED));
+  };
+  // Same signatures the call sites already used, so the sidebar rows and the
+  // mobile dropdowns are unchanged.
+  const setLangs = (next: string[]) => setFilters(next, levels);
+  const setLevels = (next: string[]) => setFilters(langs, next);
 
   const langCount = (l: string) =>
     courses.filter((c) => c.tags.language?.[0] === l).length;
@@ -261,8 +321,10 @@ export function CoursesCatalog({ courses }: { courses: CatalogCourse[] }) {
   const hasFilters = Boolean(q || langs.length || levels.length);
   const reset = () => {
     setQ("");
-    setLangs([]);
-    setLevels([]);
+    // Both at once, not setLangs([]) then setLevels([]): each of those writes
+    // the whole query string from the values this render closed over, so the
+    // second call would put the language back.
+    setFilters([], []);
   };
   const countText = list.length === 1 ? "1 course" : `${list.length} courses`;
 

--- a/app/courses/_components/catalogFilters.ts
+++ b/app/courses/_components/catalogFilters.ts
@@ -1,0 +1,58 @@
+/**
+ * Encoding the `/courses` catalog's language and level selection in the query
+ * string, so a filtered catalog is a link someone can send:
+ * `/courses?lang=python`, `/courses?level=beginner`, or both together.
+ *
+ * Kept apart from `CoursesCatalog.tsx` because it is the only part of the
+ * feature with branches worth testing: which values are accepted, which are
+ * ignored, and what happens to parameters that belong to somebody else. The
+ * component holds the two effects that call these, which are mechanical.
+ *
+ * Both functions take the query string rather than reading `window`, so they
+ * are pure and run in the Node test environment.
+ */
+export const PARAM = { lang: "lang", level: "level" } as const;
+
+/**
+ * The selection encoded in `search`, as the 0-or-1-element arrays the catalog
+ * keeps its filter state in.
+ *
+ * Values the catalog does not have are ignored rather than applied. Applying
+ * `?lang=cobol` would show an empty catalog filtered by a language with no row
+ * in the sidebar to switch off again, which is a dead end; dropping it shows
+ * the full catalog, which is what a visitor following a stale link wants.
+ */
+export function readFilters(
+  search: string,
+  languages: readonly string[],
+  levels: readonly string[],
+): { langs: string[]; levels: string[] } {
+  const params = new URLSearchParams(search);
+  const lang = params.get(PARAM.lang);
+  const level = params.get(PARAM.level);
+  return {
+    langs: lang && languages.includes(lang) ? [lang] : [],
+    levels: level && levels.includes(level) ? [level] : [],
+  };
+}
+
+/**
+ * The query string for a selection, as it should appear in the address bar.
+ *
+ * Starts from the URL's existing parameters so anything that is not ours
+ * survives: someone arriving on `?lang=python&utm_source=newsletter` and then
+ * clearing the filter should keep their campaign tag. Returns "" when nothing
+ * is left, which the caller turns into a bare path rather than a trailing "?".
+ */
+export function writeFilters(
+  search: string,
+  langs: readonly string[],
+  levels: readonly string[],
+): string {
+  const params = new URLSearchParams(search);
+  if (langs[0]) params.set(PARAM.lang, langs[0]);
+  else params.delete(PARAM.lang);
+  if (levels[0]) params.set(PARAM.level, levels[0]);
+  else params.delete(PARAM.level);
+  return params.toString();
+}

--- a/app/interview-prep/_components/InterviewCatalog.tsx
+++ b/app/interview-prep/_components/InterviewCatalog.tsx
@@ -1,6 +1,6 @@
 /**
  * The `/interview-prep` catalog body: two columns of role-track rows (each a
- * full-width banner, a short description of what the track drills, its topic
+ * centred banner, a short description of what the track drills, its topic
  * count, and a "Start track" link), and a footer line with the totals and a
  * pointer to /courses.
  *
@@ -17,11 +17,12 @@
  * all the talking and the six *sentences* that actually tell a visitor which
  * track is theirs were the quietest thing on the page.
  *
- * Now each track is a borderless row: the banner across the full width of the
- * row with its text beneath, so the artwork is legible at the size it was
- * drawn for while the frames and the second-print shadow stay gone. The glyphs
- * went with the cards — they were a device for straddling the banner edge, and
- * above a banner of the same role they were a second icon for one idea.
+ * Now each track is a borderless row: the banner centred above its text at
+ * two thirds of the row's width, so the artwork is legible at the size it was
+ * drawn for without outweighing the sentence under it, and the frames and the
+ * second-print shadow stay gone. The glyphs went with the cards — they were a
+ * device for straddling the banner edge, and above a banner of the same role
+ * they were a second icon for one idea.
  *
  * The track list (title, topics, links) is content-driven, passed in from
  * `getInterviewTracks` (see `lib/interviewCatalog.ts`). The per-role
@@ -33,6 +34,7 @@
  * No client interactivity, the hover affordances are pure CSS, so this stays a
  * server component (the banners read the build-time image manifest directly).
  */
+import { Layers } from "lucide-react";
 import Link from "@/app/_components/Link";
 import imageManifest from "@/lib/generated/images";
 import type { InterviewTrack } from "@/lib/interviewCatalog";
@@ -96,9 +98,9 @@ const MIME: Record<string, string> = {
   avif: "image/avif",
 };
 
-/** The track's illustration, running the full width of its row. Served
- *  WebP-first with a raster fallback from the build-time image manifest (the
- *  same source `<Figure>` reads).
+/** The track's illustration, centred above its row's copy at two thirds of the
+ *  row width. Served WebP-first with a raster fallback from the build-time
+ *  image manifest (the same source `<Figure>` reads).
  *
  *  The 3:2 box is kept — six thumbnails the same shape is what makes this read
  *  as a list rather than a scrapbook — but the art no longer fills it exactly.
@@ -111,22 +113,27 @@ const MIME: Record<string, string> = {
  *  used to carry inside the box is gone. That is the whole point of cropping a
  *  thumbnail on both axes: the box is fixed, so every margin removed from the
  *  file is width the subject gets back. The fixed 3:2 box is what keeps the
- *  six rows the same height now that the banner is full width and sits above
- *  the copy rather than beside it: without it, six differently-cropped files
- *  would each set their own row height.
+ *  six rows the same height now that the banner sits above the copy rather
+ *  than beside it: without it, six differently-cropped files would each set
+ *  their own row height.
  *
  *  `sizes` describes the painted width so the browser can pick the cheap
- *  decode: the full row on a phone, and half the grid (less the column gap) on
- *  a desktop, where the rows sit two to a line. */
+ *  decode: two thirds of the row, which is two thirds of the screen on a
+ *  phone and a third of the grid on a desktop, where rows sit two to a line. */
 function TrackThumb({ slug, alt }: { slug: string; alt: string }) {
   const entry = imageManifest[slug];
   if (!entry) return null;
   const fallback = entry.formats[entry.formats.length - 1];
   const sources = entry.formats.slice(0, -1);
   return (
-    <picture>
+    // Two thirds of the row rather than all of it: at full width the banner
+    // outweighed the sentence that actually tells a visitor whether the track
+    // is theirs. `block` is stated rather than relied on — a <picture> is
+    // inline by default and is only blockified here because it happens to be a
+    // flex item, which is not a property of this element worth depending on.
+    <picture className="mx-auto block w-[65%]">
       {sources.map((ext) => (
-        <source key={ext} srcSet={`/images/${slug}.${ext}`} type={MIME[ext]} sizes="(min-width: 640px) 45vw, 100vw" />
+        <source key={ext} srcSet={`/images/${slug}.${ext}`} type={MIME[ext]} sizes="(min-width: 640px) 30vw, 65vw" />
       ))}
       <img
         src={`/images/${slug}.${fallback}`}
@@ -135,7 +142,7 @@ function TrackThumb({ slug, alt }: { slug: string; alt: string }) {
         height={entry.height}
         loading="lazy"
         decoding="async"
-        sizes="(min-width: 640px) 45vw, 100vw"
+        sizes="(min-width: 640px) 30vw, 65vw"
         className="block aspect-[3/2] w-full rounded-xl object-contain"
       />
     </picture>
@@ -158,35 +165,38 @@ function TrackRow({ track }: { track: InterviewTrack }) {
       // Six-row index, don't viewport-prefetch every track (same opt-out the
       // courses grid uses).
       prefetch={false}
-      // Stacked, not a thumbnail column: the banner runs the full width of the
-      // row and the copy sits under it. Same shape at every breakpoint, since
-      // the two-column grid below already halves the row on a desktop, so a
-      // full-width banner there is about the width one column of the old
-      // side-by-side layout would have been at its widest.
-      className="group -mx-3 flex flex-col gap-3 rounded-2xl px-3 py-4 transition-colors hover:bg-[var(--ds-gray-50)] dark:hover:bg-white/[0.035]"
+      // Stacked, not a thumbnail column: the banner sits centred above the
+      // copy. Same shape at every breakpoint, and `gap-5` is the space beneath
+      // it — enough that the centred art reads as its own block rather than as
+      // something the title is crowding.
+      className="group -mx-3 flex flex-col gap-5 rounded-2xl px-3 py-4 transition-colors hover:bg-[var(--ds-gray-50)] dark:hover:bg-white/[0.035]"
     >
       {p ? <TrackThumb slug={p.banner} alt={p.bannerAlt} /> : null}
 
-      <span className="flex min-w-0 flex-col">
-        <span className="text-[17px] font-semibold tracking-[-0.01em] text-[var(--ds-gray-900)] transition-colors group-hover:text-[var(--ds-blue-700)] dark:text-white dark:group-hover:text-[var(--ds-blue-400)]">
+      {/* Type matched to a `/courses` catalog row: 18px title, 16px body, and
+          a single 1.7 leading on every line in the row. The two pages are the
+          same kind of list one click apart, and they were set at different
+          sizes and rhythms, which read as two different designs. */}
+      <span className="flex min-w-0 flex-col leading-[1.7]">
+        <span className="text-[18px] font-semibold leading-[1.7] tracking-[-0.02em] text-[var(--ds-gray-900)] transition-colors group-hover:text-[var(--ds-blue-700)] dark:text-white dark:group-hover:text-[var(--ds-blue-400)]">
           {track.title}
         </span>
 
         {/* `line-clamp-3` is the guard against a future entry running long and
             pushing one row taller than the rest of its grid line. */}
         {p ? (
-          <span className="mt-1.5 line-clamp-3 text-[15px] leading-[1.6] text-[#8a8a8a] dark:text-[var(--ds-gray-400)]">
+          <span className="mt-1.5 line-clamp-3 text-[16px] leading-[1.7] text-[#8a8a8a] dark:text-[var(--ds-gray-400)]">
             {p.description}
           </span>
         ) : null}
 
-        <span className="mt-2.5 flex items-center gap-2.5 text-[14px]">
+        <span className="mt-2.5 flex items-center gap-2.5 text-[16px] leading-[1.7]">
           <span className="font-semibold text-[var(--ds-blue-700)] dark:text-[var(--ds-blue-400)]">
             Start track
           </span>
           <svg
-            width="13"
-            height="13"
+            width="15"
+            height="15"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -199,10 +209,14 @@ function TrackRow({ track }: { track: InterviewTrack }) {
             <path d="M5 12h14" />
             <path d="m12 5 7 7-7 7" />
           </svg>
-          <span aria-hidden="true" className="text-[var(--ds-gray-300)] dark:text-[var(--ds-gray-600)]">
-            ·
-          </span>
-          <span className="text-[var(--ds-gray-400)] dark:text-[var(--ds-gray-500)]">
+          {/* `Layers` for the topic count, in place of the middle dot that used
+              to separate the two halves of this line. A track's topics are a
+              stack of subject areas, which is the sense this glyph already
+              carries elsewhere in the app (the playgrounds use it for a stack
+              of schemas). It reads as a label for the number rather than as
+              punctuation between two unrelated facts. */}
+          <span className="inline-flex items-center gap-1.5 text-[var(--ds-gray-400)] dark:text-[var(--ds-gray-500)]">
+            <Layers size={15} aria-hidden="true" />
             {track.topics.length} topics
           </span>
         </span>

--- a/app/interview-prep/_components/InterviewCatalog.tsx
+++ b/app/interview-prep/_components/InterviewCatalog.tsx
@@ -1,8 +1,8 @@
 /**
  * The `/interview-prep` catalog body: two columns of role-track rows (each a
- * small banner thumbnail, a short description of what the track drills, its
- * topic count, and a "Start track" link), and a footer line with the totals
- * and a pointer to /courses.
+ * full-width banner, a short description of what the track drills, its topic
+ * count, and a "Start track" link), and a footer line with the totals and a
+ * pointer to /courses.
  *
  * The centered page header lives in the server page
  * (`app/interview-prep/page.tsx`), mirroring how `/courses` splits its header
@@ -17,10 +17,11 @@
  * all the talking and the six *sentences* that actually tell a visitor which
  * track is theirs were the quietest thing on the page.
  *
- * Now each track is a borderless row: a small thumbnail beside its text, at a
- * size that identifies the track without competing with it. The glyphs went
- * with the cards — they were a device for straddling the banner edge, and
- * beside a thumbnail of the same role they were a second icon for one idea.
+ * Now each track is a borderless row: the banner across the full width of the
+ * row with its text beneath, so the artwork is legible at the size it was
+ * drawn for while the frames and the second-print shadow stay gone. The glyphs
+ * went with the cards — they were a device for straddling the banner edge, and
+ * above a banner of the same role they were a second icon for one idea.
  *
  * The track list (title, topics, links) is content-driven, passed in from
  * `getInterviewTracks` (see `lib/interviewCatalog.ts`). The per-role
@@ -95,9 +96,9 @@ const MIME: Record<string, string> = {
   avif: "image/avif",
 };
 
-/** The track's illustration, at thumbnail size. Served WebP-first with a
- *  raster fallback from the build-time image manifest (the same source
- *  `<Figure>` reads).
+/** The track's illustration, running the full width of its row. Served
+ *  WebP-first with a raster fallback from the build-time image manifest (the
+ *  same source `<Figure>` reads).
  *
  *  The 3:2 box is kept — six thumbnails the same shape is what makes this read
  *  as a list rather than a scrapbook — but the art no longer fills it exactly.
@@ -109,11 +110,14 @@ const MIME: Record<string, string> = {
  *  paints *larger* than an untrimmed version would, since the blank the frame
  *  used to carry inside the box is gone. That is the whole point of cropping a
  *  thumbnail on both axes: the box is fixed, so every margin removed from the
- *  file is width the subject gets back. The row's height is set by its three
- *  lines of copy either way, so nothing moves.
+ *  file is width the subject gets back. The fixed 3:2 box is what keeps the
+ *  six rows the same height now that the banner is full width and sits above
+ *  the copy rather than beside it: without it, six differently-cropped files
+ *  would each set their own row height.
  *
- *  `sizes` tells the browser it is only ever painted a few hundred CSS pixels
- *  wide, so it can pick the cheap decode. */
+ *  `sizes` describes the painted width so the browser can pick the cheap
+ *  decode: the full row on a phone, and half the grid (less the column gap) on
+ *  a desktop, where the rows sit two to a line. */
 function TrackThumb({ slug, alt }: { slug: string; alt: string }) {
   const entry = imageManifest[slug];
   if (!entry) return null;
@@ -122,7 +126,7 @@ function TrackThumb({ slug, alt }: { slug: string; alt: string }) {
   return (
     <picture>
       {sources.map((ext) => (
-        <source key={ext} srcSet={`/images/${slug}.${ext}`} type={MIME[ext]} sizes="160px" />
+        <source key={ext} srcSet={`/images/${slug}.${ext}`} type={MIME[ext]} sizes="(min-width: 640px) 45vw, 100vw" />
       ))}
       <img
         src={`/images/${slug}.${fallback}`}
@@ -131,7 +135,7 @@ function TrackThumb({ slug, alt }: { slug: string; alt: string }) {
         height={entry.height}
         loading="lazy"
         decoding="async"
-        sizes="160px"
+        sizes="(min-width: 640px) 45vw, 100vw"
         className="block aspect-[3/2] w-full rounded-xl object-contain"
       />
     </picture>
@@ -154,9 +158,14 @@ function TrackRow({ track }: { track: InterviewTrack }) {
       // Six-row index, don't viewport-prefetch every track (same opt-out the
       // courses grid uses).
       prefetch={false}
-      className="group -mx-3 grid grid-cols-[104px_1fr] items-start gap-4 rounded-2xl px-3 py-4 transition-colors hover:bg-[var(--ds-gray-50)] sm:grid-cols-[132px_1fr] sm:gap-5 dark:hover:bg-white/[0.035]"
+      // Stacked, not a thumbnail column: the banner runs the full width of the
+      // row and the copy sits under it. Same shape at every breakpoint, since
+      // the two-column grid below already halves the row on a desktop, so a
+      // full-width banner there is about the width one column of the old
+      // side-by-side layout would have been at its widest.
+      className="group -mx-3 flex flex-col gap-3 rounded-2xl px-3 py-4 transition-colors hover:bg-[var(--ds-gray-50)] dark:hover:bg-white/[0.035]"
     >
-      {p ? <TrackThumb slug={p.banner} alt={p.bannerAlt} /> : <span />}
+      {p ? <TrackThumb slug={p.banner} alt={p.bannerAlt} /> : null}
 
       <span className="flex min-w-0 flex-col">
         <span className="text-[17px] font-semibold tracking-[-0.01em] text-[var(--ds-gray-900)] transition-colors group-hover:text-[var(--ds-blue-700)] dark:text-white dark:group-hover:text-[var(--ds-blue-400)]">

--- a/app/playground/_components/LanguageCategories.tsx
+++ b/app/playground/_components/LanguageCategories.tsx
@@ -1,8 +1,14 @@
 /**
  * The playground landing page's language chooser: three categories
- * (Languages / Web / Databases), each a two-column row of a label + blurb
- * beside a grid of language tiles. Implements the "Playground Page" handoff
- * mock's category grid.
+ * (Code Editors / Web Sandboxes / SQL Workbench), each a two-column row of a
+ * label + blurb beside a grid of language tiles. Implements the "Playground
+ * Page" handoff mock's category grid.
+ *
+ * The three headings name the *workspace*, not the language, which is the axis
+ * the blurbs were already written on ("editors", "sandbox", "workbench"). The
+ * previous set (Languages / Web / Databases) put one group on a different axis
+ * from the other two and implied the others were not languages, when HTML, CSS
+ * and SQL are languages too.
  *
  * Server component, the data is static. Each tile links to its
  * `/playground/<id>` route and, on hover, tints its glyph with the language's
@@ -35,9 +41,9 @@ interface Category {
 // `/playground/<id>` routes and the shared `LANGUAGE_ICONS` registry.
 const CATEGORIES: Category[] = [
   {
-    name: "Languages",
+    name: "Code Editors",
     description:
-      "General-purpose editors for writing, running, and debugging real programs without leaving the tab.",
+      "General-purpose languages for writing, running, and debugging real programs without leaving the tab.",
     items: [
       { id: "python", label: "Python", version: "3.14" },
       { id: "r", label: "R", version: "4.6" },
@@ -51,18 +57,18 @@ const CATEGORIES: Category[] = [
     ],
   },
   {
-    name: "Web",
+    name: "Web Sandboxes",
     description:
-      "A live HTML, CSS, and JavaScript preview, plus a React sandbox with instant in-browser JSX transpilation.",
+      "A live HTML, CSS, and JavaScript preview, plus React with instant in-browser JSX transpilation.",
     items: [
       { id: "web", label: "HTML", version: "HTML5 · CSS3" },
       { id: "react", label: "React", version: "19.2" },
     ],
   },
   {
-    name: "Databases",
+    name: "SQL Workbench",
     description:
-      "A full SQL workbench in the browser. Load data, run queries, and inspect results against embedded or remote engines.",
+      "Load data, run queries, and inspect results against embedded or remote engines, all in the browser.",
     items: [
       // Same order as `PLAYGROUNDS`: PostgreSQL · SQLite · DuckDB.
       { id: "postgres", label: "PostgreSQL", version: "17" },

--- a/app/playground/_components/LanguageCategories.tsx
+++ b/app/playground/_components/LanguageCategories.tsx
@@ -111,8 +111,15 @@ export function LanguageCategories() {
           key={cat.name}
           className="grid gap-x-14 gap-y-6 py-8 sm:py-10 md:grid-cols-[minmax(0,264px)_1fr]"
         >
-          <div>
-            <h2 className="text-sm font-medium text-[#121212] dark:text-white">
+          {/* `md:pt-5` is the tile's own top padding, borrowed. A tile starts
+              its icon 20px down (`pt-5` in LanguageTile), so at the top of a
+              row the heading sat level with the tile's empty padding rather
+              than with the first glyph, and the label column read as floating
+              above the grid it belongs to. Only from `md`, where the two are
+              side by side; stacked on a phone the heading is the row's top
+              edge and has nothing to align to. */}
+          <div className="md:pt-5">
+            <h2 className="text-[18px] font-medium text-[#121212] dark:text-white">
               {cat.name}
             </h2>
             <p className="mt-2.5 text-sm leading-relaxed text-[var(--ds-gray-500)] [text-wrap:pretty] dark:text-[var(--ds-gray-400)]">

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -190,6 +190,28 @@ export default function PricingPage() {
                   window means each message frees up again 24 hours after you
                   send it, rather than all resetting at a fixed time of day.
                 </Footnote>
+
+                <Footnote n={8} lead="Free plans depend on available capacity.">
+                  Everything above is free because it runs on a limited pool of
+                  shared capacity, and it is provided on that basis. Where
+                  capacity requires it we may, at any time and without notice,
+                  withdraw or restrict features, lower quotas, including cloud
+                  storage and the &ldquo;Ask AI&rdquo; allowance, and remove
+                  cloud workspaces or share links, including before the
+                  one-month inactivity window in note 4. The learning content
+                  itself stays free, that commitment is in note 1 and in the
+                  terms. Local saves in your browser aren&apos;t affected, and
+                  you can export your work from any playground at any time, so
+                  keep your own copy of anything you&apos;d be sorry to lose.
+                  The{" "}
+                  <Link
+                    href="/terms"
+                    className="font-medium text-[var(--ds-blue-700)] hover:underline dark:text-[var(--ds-blue-400)]"
+                  >
+                    Terms of Service
+                  </Link>{" "}
+                  set this out in full.
+                </Footnote>
               </ol>
 
               <p className="mt-10 border-t border-[var(--ds-gray-200)] pt-6 text-[15px] leading-relaxed text-[var(--ds-gray-600)] dark:border-white/10 dark:text-[var(--ds-gray-400)]">

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -8,7 +8,7 @@ export const metadata = {
 
 export default function TermsPage() {
   return (
-    <LegalShell title="Terms of Service" updated="July 16, 2026">
+    <LegalShell title="Terms of Service" updated="August 12, 2026">
       <p>
         These terms govern your use of Dataslope (the &ldquo;Service&rdquo;). By
         using the Service, you agree to them. If you don&apos;t agree, please
@@ -53,7 +53,8 @@ export default function TermsPage() {
         we can&apos;t guarantee that any saved work or progress will always be
         retained or remain accessible. In particular, a saved workspace or your
         progress may be removed or become unusable for reasons including
-        inactivity cleanup, reaching a storage limit, scheduled maintenance, and
+        inactivity cleanup, reaching a storage limit,{" "}
+        <strong>capacity constraints</strong>, scheduled maintenance, and
         updates to the language runtimes, databases, or platform that make a
         previously saved workspace incompatible, which can result in its{" "}
         <strong>automatic deletion</strong>. To the fullest extent permitted by
@@ -128,6 +129,19 @@ export default function TermsPage() {
         available today is completely free; we may introduce additional or
         optional paid features in the future, but doing so will not require
         payment to access the content that is currently free.
+      </p>
+      <p>
+        Free plans depend on available capacity, and the account features that
+        come with them are provided on that basis. Where capacity requires it,
+        we may, at any time and without notice, withdraw or restrict features,
+        reduce quotas, including cloud storage and the &ldquo;Ask AI&rdquo;
+        allowance, and remove cloud workspaces or share links, including before
+        the inactivity period described above. This does not change the
+        commitment in the paragraph above: the learning content that is free
+        today, the courses, the interview tracks, and running code in the
+        playgrounds, stays free. Workspaces saved locally in your browser are
+        not affected, and you can export your work from any playground at any
+        time.
       </p>
 
       <h2>Changes to these terms</h2>

--- a/content/courses/data-analysis-python-pandas/debugging-analysis-code.mdx
+++ b/content/courses/data-analysis-python-pandas/debugging-analysis-code.mdx
@@ -178,8 +178,8 @@ step 15, the bug is in 1–15. Bisect again.
 ```mermaid
 flowchart LR
   S["Step 1"] --> M["Step 15<br/>(check here)"] --> E["Step 30"]
-  M -- "Right" --> R1["Bug is in 16–30"]
-  M -- "Wrong" --> R2["Bug is in 1–15"]
+  M -- "Right" --> R1["Bug is in 16-30"]
+  M -- "Wrong" --> R2["Bug is in 1-15"]
 ```
 
 This $O(\log n)$ approach beats $O(n)$ re-reading every time.

--- a/content/courses/intro-modern-csharp/evolution-of-dotnet.mdx
+++ b/content/courses/intro-modern-csharp/evolution-of-dotnet.mdx
@@ -26,7 +26,7 @@ transformation properly, because it shapes the C# you write today.
 
 ```mermaid
 flowchart LR
-    NF[".NET Framework<br/>(2002–2019)"] --> W[Windows only]
+    NF[".NET Framework<br/>(2002-2019)"] --> W[Windows only]
     NF --> CL[Closed source]
     NF --> Big[Bundled with Windows updates]
 ```

--- a/content/courses/statistics-for-data-science-python/the-normal-distribution.mdx
+++ b/content/courses/statistics-for-data-science-python/the-normal-distribution.mdx
@@ -267,7 +267,7 @@ arguments.
 
 ```mermaid
 flowchart TD
-  A["raw value x<br/>(score, height, ...)"] -->|"z = (x − mu) / sigma"| B["z-score<br/>(SDs from the mean)"]
+  A["raw value x<br/>(score, height, ...)"] -->|"z = (x - mu) / sigma"| B["z-score<br/>(SDs from the mean)"]
   B -->|"<code>norm.cdf(z)</code>"| C["percentile<br/>(fraction below)"]
   C -->|"<code>norm.ppf(p)</code>"| B
   B -->|"x = mu + z·sigma"| A

--- a/content/courses/time-series-analysis-python/handling-missing-temporal-data.mdx
+++ b/content/courses/time-series-analysis-python/handling-missing-temporal-data.mdx
@@ -198,9 +198,9 @@ Look again at *what each method reads*:
 ```mermaid
 flowchart LR
     G["Gap at time t"] --> Q{"Which neighbors<br/>does the fill read?"}
-    Q -->|"only the PAST value"| FF["ffill -- safe as a live feature"]
-    Q -->|"the FUTURE value"| BF["bfill -- leaks the future"]
-    Q -->|"PAST and FUTURE values"| IN["interpolate -- leaks the future"]
+    Q -->|"only the PAST value"| FF["ffill - safe as a live feature"]
+    Q -->|"the FUTURE value"| BF["bfill - leaks the future"]
+    Q -->|"PAST and FUTURE values"| IN["interpolate - leaks the future"]
 ```
 
 Seeing all four drawn across the same gap makes the asymmetry concrete. A

--- a/content/courses/typescript-from-scratch/evolution-of-javascript.mdx
+++ b/content/courses/typescript-from-scratch/evolution-of-javascript.mdx
@@ -40,7 +40,7 @@ The **jQuery era** followed. jQuery, released in 2006, smoothed over browser inc
 
 ```mermaid
 timeline
-    title JavaScript's Journey (1995–2020)
+    title JavaScript's Journey (1995-2020)
     1995 : Brendan Eich creates JavaScript in 10 days
          : Netscape Navigator ships Mocha (later JavaScript)
     1996 : Microsoft reverse-engineers JScript for IE3

--- a/scripts/check-prose.mjs
+++ b/scripts/check-prose.mjs
@@ -38,6 +38,16 @@
 //                    dialect. Other British spellings in this repo (behaviour,
 //                    centre, favour) have no such collision and are not
 //                    touched.
+//   7. mermaid-dash, a dash inside a mermaid diagram label that is not a plain
+//                    ASCII hyphen. Diagram labels are prose the reader sees,
+//                    but they sit in a fenced block, so every rule above skips
+//                    them and they drifted: a flowchart shipped with
+//                    "ffill -- safe as a live feature" in a node, where mermaid
+//                    renders label text verbatim and the reader saw a literal
+//                    double hyphen. Two shapes are caught, `--` used the way an
+//                    em dash would be, and any non-ASCII dash glyph. See the
+//                    section below for why labels are held to a stricter
+//                    standard than rule 2 holds prose to.
 //
 // Scope is what a reader actually sees:
 //
@@ -144,6 +154,116 @@ export function hasWrappingQuotes(body) {
   return /^["“]/.test(inner) && /["”]$/.test(inner);
 }
 
+// --- mermaid labels -------------------------------------------------------
+
+/** Any dash that is not a plain ASCII hyphen: em dash, horizontal bar, en
+ *  dash, and the Unicode minus sign.
+ *
+ *  Stricter than rule 2, which keeps unspaced en dashes because they are
+ *  correct in a numeric range. A diagram label is a few words in a box, so
+ *  there is no typographic case to weigh, and one flat "hyphens only" rule
+ *  beats a spaced/unspaced distinction nobody can see at label size. */
+const NON_ASCII_DASH = /[—―–−]/;
+
+/** A run of two or more hyphens used the way an em dash would be, with
+ *  whitespace on at least one side. Mermaid renders label text verbatim, so
+ *  this reaches the reader as the literal characters that were typed.
+ *
+ *  The whitespace is what keeps the rule off real content: `--verbose` names a
+ *  CLI flag, `i--` is a decrement, and `-- comment` opens a SQL line comment.
+ *  All three are things the lessons here legitimately draw in a diagram, and
+ *  none of them is a dash standing in for punctuation. */
+const HYPHEN_RUN_AS_DASH = /(^|\s)-{2,}(\s|$)/;
+
+/** Mermaid's own line kinds whose colon introduces a style declaration or a
+ *  layout keyword rather than label text (`style A fill:#f9f`). */
+const MERMAID_DIRECTIVE = /^\s*(style|classDef|class|click|linkStyle|direction)\b/;
+
+/** The diagram kinds where a colon introduces free text that runs to the end
+ *  of the line: a sequence message, a note, a state description, a timeline
+ *  event. In a flowchart it means nothing of the sort, and reading it that way
+ *  is wrong in a way that bites, `A((a: 1,2,3,4,5)) --- I((4,5))` is a node
+ *  label holding a colon, and taking the rest of the line as its text picks up
+ *  the `---` link that follows. */
+const COLON_LABEL_DIAGRAMS = new Set([
+  "sequenceDiagram",
+  "stateDiagram",
+  "stateDiagram-v2",
+  "timeline",
+  "journey",
+  "erDiagram",
+  "classDiagram",
+  "pie",
+]);
+
+/** Every line inside a ```mermaid fence, as `{ line, text, diagram }`, where
+ *  `diagram` is the block's opening keyword (`flowchart`, `sequenceDiagram`).
+ *
+ *  Mermaid's `%%` comments are dropped: they never reach the rendered diagram,
+ *  so a dash in one is as invisible as a dash in a TS comment (which
+ *  stripComments already exempts). Dropping them first also means the diagram
+ *  keyword is read off the first line that actually declares one, rather than
+ *  off a leading `%%{init: ...}%%` directive. */
+export function mermaidLines(lines) {
+  const found = [];
+  let fence = null;
+  let isMermaid = false;
+  let diagram = null;
+
+  lines.forEach((line, i) => {
+    const fenceMark = line.match(/^\s*(```+|~~~+)\s*(\w*)/);
+    if (fenceMark) {
+      if (fence && fenceMark[1].startsWith(fence)) {
+        fence = null;
+        isMermaid = false;
+      } else if (!fence) {
+        fence = fenceMark[1];
+        isMermaid = fenceMark[2] === "mermaid";
+        diagram = null;
+      }
+      return;
+    }
+    if (!isMermaid || /^\s*%%/.test(line) || !line.trim()) return;
+    diagram ??= line.trim().match(/^[\w-]+/)?.[0] ?? "";
+    found.push({ line: i + 1, text: line, diagram });
+  });
+  return found;
+}
+
+/** The label text on one mermaid line, for the hyphen-run rule.
+ *
+ *  Only the spans where a hyphen run can be *label* rather than *syntax*:
+ *
+ *    - quoted labels, `A["text"]` and `-->|"text"|`. A label holding two
+ *      hyphens has to be quoted, since mermaid would otherwise read them as
+ *      the link they look like, so this is where the rule earns its keep.
+ *    - the free text after the first colon on a sequence message, a note, or a
+ *      timeline event (`Alice->>Bob: text`), which runs to end of line and is
+ *      the one unquoted label that can hold a hyphen run. Only in the diagram
+ *      kinds where a colon means that (COLON_LABEL_DIAGRAMS).
+ *
+ *  Deliberately NOT the unquoted node labels (`A[text]`) or the bare edge
+ *  labels (`A -->|text| B`): a hyphen run inside one is a link, not a label,
+ *  and reading those spans is how you end up flagging `}|--|{` in an ER
+ *  diagram or the `[ A | * ]` pointer boxes in the linked-list lesson.
+ *
+ *  The non-ASCII dash rule needs none of this and runs on the whole line, so
+ *  it catches unquoted labels too: mermaid's syntax is pure ASCII, so any en
+ *  dash on the line is already inside label text wherever it sits. */
+export function mermaidLabelText(line, diagram) {
+  const spans = [];
+  for (const m of line.matchAll(/"([^"]*)"/g)) spans.push(m[1]);
+
+  if (COLON_LABEL_DIAGRAMS.has(diagram) && !MERMAID_DIRECTIVE.test(line)) {
+    // Quoted runs are blanked first so a colon *inside* a label cannot split
+    // it: `A["ratio: x:y"] --> B` must not contribute ` x:y"] --> B`.
+    const blanked = line.replace(/"[^"]*"/g, (m) => " ".repeat(m.length));
+    const colon = blanked.indexOf(":");
+    if (colon !== -1) spans.push(line.slice(colon + 1));
+  }
+  return spans.filter((s) => s.trim());
+}
+
 // --- comment stripping (TS/TSX only) --------------------------------------
 
 /** Blank out //, /* *\/ and {/* *\/} comments, preserving line structure so
@@ -198,6 +318,14 @@ export function lintSource(src, file, kind) {
   if (kind === "mdx") {
     for (const { line, body } of blockquotes(lines)) {
       if (hasWrappingQuotes(body)) add("blockquote-quotes", line, body.slice(0, 90));
+    }
+    // One violation per line: a label can trip both halves of the rule, and
+    // the fix ("write a plain hyphen") is the same either way.
+    for (const { line, text, diagram } of mermaidLines(lines)) {
+      const offender = NON_ASCII_DASH.test(text)
+        ? text
+        : mermaidLabelText(text, diagram).find((label) => HYPHEN_RUN_AS_DASH.test(label));
+      if (offender) add("mermaid-dash", line, text.trim().slice(0, 90));
     }
   }
 
@@ -263,6 +391,12 @@ if (isMain) {
           "quotation marks, so a blockquote that types its own renders doubled.",
       );
     }
+    if (byRule["mermaid-dash"]) {
+      console.error(
+        "\nmermaid labels: write a plain ASCII hyphen. Mermaid renders label\n" +
+          "text verbatim, so a typed `--` reaches the reader as two hyphens.",
+      );
+    }
     if (byRule["colour-spelling"]) {
       console.error(
         "\ncolour: write it \"color\". It is a CSS property, a Plot channel and a\n" +
@@ -272,6 +406,6 @@ if (isMain) {
     process.exit(1);
   }
   console.log(
-    `✓ prose in ${files.length} file(s) is clean (no em dashes, no spaced en dashes, no filler phrases, no one-line display math, no British "colour", no doubled blockquote quotes)`,
+    `✓ prose in ${files.length} file(s) is clean (no em dashes, no spaced en dashes, no filler phrases, no one-line display math, no British "colour", no doubled blockquote quotes, no stray dashes in mermaid labels)`,
   );
 }


### PR DESCRIPTION
Thirteen commits, 17 files. Started as a one-character fix to a mermaid label and grew a lint rule; the rest is layout, typography and copy across `/pricing`, `/courses`, `/interview-prep` and `/playground`, plus URL-linkable catalog filters.

## Mermaid dashes, and a rule so they stay fixed

The leakage-twist flowchart in `/time-series-analysis-python/handling-missing-temporal-data` labelled its three fill methods with `--`. Mermaid renders label text verbatim, so it reached the reader as two literal hyphens.

Swept the other 1181 mermaid blocks: no further literal `--`, but five spans in four lessons used non-ASCII dashes (en dashes in `(2002-2019)`, `(1995-2020)`, `16-30`/`1-15`, and a Unicode minus in `z = (x - mu) / sigma`). Those rendered correctly but contradict the house style `check:prose` already enforces. All normalized. The `--` in `linked-lists.mdx` is mermaid's own `-- "label" -->` edge syntax and is left alone.

`check:prose` skips fenced code by design, which is how diagram labels drifted, so a new `mermaid-dash` rule reaches inside the fence. The work is telling a label from mermaid's syntax, since nearly every link is built from the same hyphens:

- Hyphen runs are read only from quoted labels, and from the text after a colon in the diagram kinds where a colon introduces free text. Keying that on diagram kind is not a precaution: reading it in a flowchart flagged `A((a: 1,2,3,4,5)) --- I((4,5))` in the LINQ set-operations lesson.
- Unquoted node labels and bare edge labels are not read at all — a hyphen run in one is syntax, which is what `}|--|{` and the `[ A | * ]` pointer boxes would otherwise trip on.
- Non-ASCII dashes are checked per line instead; mermaid's syntax is pure ASCII, so an en dash is already label text wherever it sits.
- `--save-dev`, `i--` and `-- comment` keep their hyphens; `%%` comments are exempt.

Documented in AGENTS.md under "Prose style".

## Pricing

**The marmot on a phone** sat too far left and too far down, and at 360px painted over the "Recommended" badge. Three values change below `lg`: `-right-6` (each cut-out carries a wide transparent margin — the free-member art paints across 605 of its 1024px canvas — so `right-0` leaves the drawing ~24px short of the edge it looks aligned to), `-translate-y-[60%]` (`top-1/2` measures against a header that has `lg:pt-8` on desktop and nothing on a phone), and `size-24`. The size is the part a move alone could not fix: lifting the marmot makes the overlap worse, because the badge line then crosses the widest part of the silhouette.

**The billing toggle is gone while Pro is hidden.** It was a dead control — both columns are $0 with the same sub-line, so the only thing it changed anywhere was the `/ month` suffix, and the "Best value" badge on Annual promised a discount that could not exist. The slot now carries three assurances: *No credit card · No trial period · No expiry*, each with the same green check the feature rows use for an included capability. Scoped to `SHOW_PRO_PLAN` rather than deleted, so the toggle, its state and the Polar checkout path are untouched and restoring Pro is still one flag.

## Courses

- **Below `sm` the catalog row stacks**: thumbnail at two thirds of the row and centred, then title, description and meta line each full width. Description clamps to two lines with an ellipsis on phones only.
- **Title leading matches the description** (1.7) at both breakpoints, so an 18px title no longer sits on default leading above 16px copy at 1.7.
- **The language and level filters live in the URL.** `/courses?lang=python`, `?level=beginner`, or both. See below.

## Interview prep

Banner centred above the copy at two thirds of the row at both breakpoints; the two-column desktop grid is unchanged. The row's type now matches a `/courses` catalog row — the same kind of list one click apart, previously set at different sizes and rhythms: title 17→18px and tracking -0.01→-0.02em, description 15→16px, "Start track" and the topic count 14→16px, 1.7 leading throughout. Both descriptions end up with identical letter-spacing without setting one, since the global rule is em-based and the sizes now agree. The middle dot before the topic count becomes a Lucide `Layers`, which labels the number rather than punctuating between two unrelated facts.

## Playground

Category headings are 18px, and from `md` they sit 20px lower — the tiles' own `pt-5`, borrowed, so a heading aligns with the first glyph instead of with the tile's empty padding.

Renamed to **Code Editors / Web Sandboxes / SQL Workbench**. The old set put one group on a different axis from the other two and implied the others were not languages, when HTML, CSS and SQL are languages too. The new set is the axis the blurbs were already written on ("editors", "sandbox", "workbench"). Each blurb drops the word its heading now carries.

## Linkable catalog filters

The selection is not React state: the URL holds it, and the component reads it through `useSyncExternalStore`. Writes go through the same path — `replaceState` plus an event to wake the store — so a click and a pasted link are handled identically, and `popstate` is subscribed so back and forward work.

Reading `window.location` rather than `useSearchParams` is deliberate: the page is statically prerendered, and that hook opts the route out unless it sits behind a Suspense boundary whose fallback is then what gets prerendered. Neither buys anything, since the query string is unknown at build time. The server snapshot is `""`, so the prerendered HTML is the unfiltered catalog and hydration matches it.

Parsing lives in `catalogFilters.ts`, because it holds the branches worth testing: unknown values are ignored (a stale `?lang=cobol` shows the whole catalog rather than an empty one filtered by a language with no sidebar row to clear it), parameters belonging to someone else survive a filter click (`?utm_source` is kept), and the two halves round-trip.

## Capacity terms

Free tiers run on a fixed pool of shared capacity and neither page said what happens when that runs short. Pricing gets a note 8; the terms get "capacity constraints" in the list of reasons saved work can be removed, plus a paragraph under "Availability and future changes" covering features, quotas and workspaces. Both restate the boundary rather than widening it silently: the learning content that is free today stays free, local browser saves are unaffected, and work can be exported at any time. The terms' "Last updated" moves to today, since the document promises that on revision.

## Verification

- `npx vitest run`: 92 files, 1253 tests passing — 7 new for `mermaid-dash`, 12 new for the catalog filters.
- `npm run check:prose`: clean across 1737 files, so the new rule has no false positives on the 1181 diagrams in the repo. Replayed against the pre-fix content, it flags all five corrected labels.
- `npx tsc --noEmit` and `npx eslint`: clean.
- Layout measured and screenshotted in headless Chromium at 360px, 412px and 1280px. Computed type confirmed on both catalogs (title 18px/30.6px, description 16px/27.2px, tracking identical to the digit); playground headings confirmed level with the first glyph (delta 0) on desktop and unchanged on mobile; the pricing marmot confirmed on `/pricing`, badge legible.

**Two things are not verified end to end, both blocked by the same environment fault.** This dev server never hydrates client components — several Turbopack chunks return 403 to the browser, though the same URLs return 200 to curl and to `fetch` from inside the page. With no hydration, effects never run and clicks do nothing, which is pre-existing and not caused by anything here (the home page renders blank on an unmodified checkout too, and the catalog's existing filters are equally dead). So:

1. The **catalog filter wiring** (`useSyncExternalStore` + `setFilters`) is type-checked and lint-clean but unexercised; only the pure parsing is covered by tests. The repo's e2e harness runs against `next dev`, so it hits the same wall, and there is no jsdom or testing-library to mount the component in Node.
2. The **home page's** copy of the pricing table could not be screenshotted, though `/pricing` renders the same component and was verified there.

Both are worth a click-through on the preview deploy before merge.

## Left deliberately alone

`$0 / month` on the price line. Its only stated purpose was giving the billing toggle something visible to change; with the toggle gone it is vestigial, and on the Free Member column it reads directly above "Free forever". Flagged in a comment rather than changed, since it is a copy decision on the most important text on the page.