### PR TITLE
Correct the stale assets-binding comment in wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,9 +15,18 @@
   // makes the worker's own fetch() calls go out over the public internet
   // rather than looping back into the worker, the OpenNext-recommended flag.
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
-  // Prerendered pages and /_next/static/* are uploaded as free static assets
-  // (unlimited bandwidth, no per-request meter) and served before the worker
-  // ever runs, so a cold hit on a prerendered page costs nothing at all.
+  // /_next/static/* and public/ are uploaded as free static assets (unlimited
+  // bandwidth, no per-request meter) and served by this binding before the
+  // worker ever runs, so they cost nothing and they do land in Cloudflare's CDN
+  // (`cf-cache-status: HIT`, measured 2026-08-09).
+  //
+  // Prerendered page HTML is NOT here: OpenNext writes it to the incremental
+  // cache (the R2 bucket below) instead, and the worker runs ahead of the CDN
+  // cache, so every page view costs one worker invocation — page responses come
+  // back with no `cf-cache-status` header at all. `withRegionalCache` in
+  // open-next.config.ts keeps that from also costing an R2 read per visitor;
+  // skipping the invocation itself needs an origin Cache Rule (see
+  // "Recommended: a Cache Rule for lesson HTML" in README.md).
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"


### PR DESCRIPTION
Comment-only change to `wrangler.jsonc`. No configuration values were touched.

## The problem

The comment above the `assets` binding read:

> Prerendered pages and /\_next/static/\* are uploaded as free static assets (unlimited bandwidth, no per-request meter) and served before the worker ever runs, so a cold hit on a prerendered page costs nothing at all.

That is wrong on the part about pages, and it already contradicted two other places in the repo that record the measured behaviour:

- OpenNext writes prerendered page HTML to the **incremental cache** — the R2 bucket declared a few lines further down in this same file — not to `.open-next/assets`. That is the whole reason the bucket exists, as the comment on `NEXT_INC_CACHE_R2_BUCKET` and the header of `open-next.config.ts` both explain.
- The worker runs *ahead* of Cloudflare's CDN cache, so a page response is not stored there unless something explicitly puts it there. `open-next.config.ts` and the "Recommended: a Cache Rule for lesson HTML" section of `README.md` both record the measurement (2026-08-09): page responses come back with **no `cf-cache-status` header at all**, while `/_next/static/*` reports `cf-cache-status: HIT`.

So a page view is not free — it costs a worker invocation, and (absent the regional cache) an R2 read. Anyone sizing worker request volume or reasoning about first-visit latency from this comment would have started from a false premise.

## The change

The claim is split into the two things that are actually true:

- What the assets binding really serves — `/_next/static/*` and `public/` — which is free, runs before the worker, and does land in the CDN.
- Where prerendered page HTML actually lives, why every page view still costs an invocation, and what mitigates each half: `withRegionalCache` in `open-next.config.ts` for the per-visitor R2 read, and an origin Cache Rule for the invocation itself, cross-referencing the README section that describes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeWDtc99ai6UzKLqbksfUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeWDtc99ai6UzKLqbksfUh)_