### PR TITLE
Footer Courses column, and a hover on the interview-prep thumbnail

### DIFF
--- a/__tests__/coursesCatalogFilters.test.ts
+++ b/__tests__/coursesCatalogFilters.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  COURSE_LANGUAGES,
+  courseLanguageHref,
   readFilters,
   writeFilters,
 } from "../app/courses/_components/catalogFilters";
+import { readCourseCatalog } from "../scripts/build-course-catalog.mjs";
+import { TAG_LABELS } from "../lib/tagLabels";
 
 // The `/courses` catalog keeps its language and level selection in the query
 // string so a filtered catalog can be linked. These are the two ends of that:
@@ -59,6 +63,67 @@ describe("reading catalog filters from a URL", () => {
   it("does not match on case or whitespace", () => {
     expect(read("?lang=Python")).toEqual({ langs: [], levels: [] });
     expect(read("?lang=%20python")).toEqual({ langs: [], levels: [] });
+  });
+});
+
+// `COURSE_LANGUAGES` is hand-kept, and one of its two consumers cannot notice
+// when it falls behind. The /courses sidebar derives its rows from the courses
+// it is handed and uses the list only to order them, so a language missing
+// from it still gets a row. The footer's Courses column has no catalog to
+// derive from and renders the list verbatim, so the same omission is simply a
+// language the footer never links to. These are that gap, closed.
+describe("the catalog's language vocabulary", () => {
+  const inContent = [
+    ...new Set(
+      readCourseCatalog()
+        .map((c) => c.tags.language?.[0])
+        .filter(Boolean) as string[],
+    ),
+  ].sort();
+
+  it("names every language content/courses actually uses", () => {
+    const missing = inContent.filter((l) => !COURSE_LANGUAGES.includes(l));
+    expect(
+      missing,
+      `add these to COURSE_LANGUAGES in app/courses/_components/catalogFilters.ts, ` +
+        `in the position the /courses sidebar should show them: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  // The reverse: a language listed with no courses behind it would be a footer
+  // link to an empty catalog, and a sidebar row that never renders.
+  it("names nothing content/courses has stopped using", () => {
+    const stale = COURSE_LANGUAGES.filter((l) => !inContent.includes(l));
+    expect(
+      stale,
+      `these have no courses left and would link to an empty catalog: ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("has no duplicates", () => {
+    expect([...new Set(COURSE_LANGUAGES)]).toHaveLength(
+      COURSE_LANGUAGES.length,
+    );
+  });
+
+  // The footer labels these with `formatTagLabel`. Its fallback title-cases the
+  // slug, which is wrong for every language whose name is an acronym or carries
+  // punctuation ("Cpp Courses", "Sql Courses"), and silently so.
+  it("has a proper display label for every language", () => {
+    for (const lang of COURSE_LANGUAGES) {
+      expect(TAG_LABELS[lang], `${lang} needs a TAG_LABELS entry`).toBeTruthy();
+    }
+  });
+
+  // Each footer row is a link the catalog must read back as that language.
+  it("builds hrefs the catalog reads back", () => {
+    for (const lang of COURSE_LANGUAGES) {
+      const href = courseLanguageHref(lang);
+      expect(href.startsWith("/courses?")).toBe(true);
+      expect(
+        readFilters(href.slice(href.indexOf("?")), COURSE_LANGUAGES, LEVELS),
+      ).toEqual({ langs: [lang], levels: [] });
+    }
   });
 });
 

--- a/app/_components/home/HomeFooter.tsx
+++ b/app/_components/home/HomeFooter.tsx
@@ -3,10 +3,12 @@ import Link from "../Link";
 import { GitHubIcon } from "./icons";
 import { FooterPattern } from "./FooterPattern";
 import { PLAYGROUNDS } from "../playgrounds";
+import { LangIcon } from "../languageIcons";
 import {
-  LANGUAGE_ICONS,
-  LANGUAGE_ICON_SIZE_FACTOR,
-} from "../languageIcons";
+  COURSE_LANGUAGES,
+  courseLanguageHref,
+} from "@/app/courses/_components/catalogFilters";
+import { formatTagLabel } from "@/lib/tagLabels";
 
 const GITHUB_URL = "https://github.com/dataslope/dataslope/";
 
@@ -45,34 +47,48 @@ const RESOURCE_LINKS = [
   },
 ];
 
+// One row per language the /courses sidebar filters by, in the sidebar's own
+// order, from the list that sidebar orders itself with — so the two agree on
+// what the catalog is sorted into and in what sequence. Each row is the
+// catalog pre-filtered, the same state a visitor reaches by clicking that
+// language in the sidebar.
+//
+// `documentNav` on every one of them, and it is load-bearing rather than a
+// preference. The catalog reads its filter out of the query string with a
+// `useSyncExternalStore` subscribed to `popstate` (see `CoursesCatalog`), and
+// a Next `<Link>` navigates with `pushState`, which fires no `popstate`. From
+// any other page that is invisible — the catalog mounts fresh and reads the
+// URL on the way up — but this footer is *on* `/courses`, where the component
+// is already mounted. A `<Link>` there would swap the address bar to
+// `?lang=r` and leave all 32 courses on screen. A document navigation
+// re-mounts the page, so every row filters from wherever it is clicked.
+//
+// It also settles the prefetch question by construction: these eleven hrefs
+// are one document (the filtering happens in the browser), so viewport-
+// prefetching them would fetch `/courses` — which the Explore column has
+// already prefetched — eleven more times on every page of the site.
+const COURSE_LINKS = COURSE_LANGUAGES.map((lang) => ({
+  id: lang,
+  href: courseLanguageHref(lang),
+  label: `${formatTagLabel(lang)} Courses`,
+  external: false,
+  documentNav: true,
+}));
+
 // Every language playground gets its own row, from the same registry the
 // header switcher and the /playground index read, so a new playground appears
 // here without anyone remembering to add it. Labels are spelled out ("Python
 // Playground") because in a footer the column heading is skimmed past, and a
 // bare "Python" would be ambiguous next to the Courses column.
+//
+// These keep prefetching, unlike the Courses rows above: fourteen distinct
+// pages, one payload each.
 const PLAYGROUND_LINKS = PLAYGROUNDS.map((p) => ({
   id: p.id,
   href: p.href,
   label: `${p.label} Playground`,
   external: false,
 }));
-
-/** The /playground page's language glyph at footer-link size. `currentColor`,
- *  not the brand tint that page uses on its tiles: here the icon is a lead-in
- *  to a text link and should travel with the link's own hover colour. */
-function PlaygroundIcon({ id }: { id: string }) {
-  const Icon = LANGUAGE_ICONS[id];
-  if (!Icon) return null;
-  const factor = LANGUAGE_ICON_SIZE_FACTOR[id] ?? 1;
-  return (
-    <span
-      className="inline-flex size-4 shrink-0 items-center justify-center"
-      aria-hidden="true"
-    >
-      <Icon size={Math.round(16 * factor)} />
-    </span>
-  );
-}
 
 // `inline-flex w-fit` so each link shrinks to its text: as a stretched flex
 // item (`block`) the trailing whitespace across the column was clickable too.
@@ -91,12 +107,17 @@ function FooterLink({
   label,
   external,
   icon,
+  documentNav,
 }: {
   href: string;
   label: string;
   external: boolean;
-  /** Optional lead-in glyph (the playground column's language icons). */
+  /** Optional lead-in glyph (the language columns' icons). */
   icon?: ReactNode;
+  /** Navigate this row as a document load rather than a client-side route
+   *  change — same tab, unlike `external`. Only the Courses rows need it, and
+   *  they need it to work at all; see `COURSE_LINKS` for why. */
+  documentNav?: boolean;
 }) {
   if (external) {
     return (
@@ -106,6 +127,14 @@ function FooterLink({
         rel="noopener noreferrer"
         className={linkClass}
       >
+        {icon}
+        {label}
+      </a>
+    );
+  }
+  if (documentNav) {
+    return (
+      <a href={href} className={linkClass}>
         {icon}
         {label}
       </a>
@@ -176,29 +205,51 @@ export function HomeFooter() {
             </a>
           </div>
 
-          {/* Column 2, where to go next on the site. */}
-          <div className="flex flex-col gap-1">
-            <h3 className={headingClass}>Explore</h3>
-            {EXPLORE_LINKS.map((link) => (
-              <FooterLink key={link.href} {...link} />
-            ))}
+          {/* Column 2, the two short lists: where to go next on the site, then
+              the legal/support rows under it.
+
+              Stacked in one column rather than sitting side by side, because
+              the two lists that follow are eleven and fourteen rows long. Two
+              five-row columns beside them left the footer reading as two
+              full-height columns and two stubs; paired vertically they make
+              one column of comparable weight. `gap-10` between the groups
+              matches the grid's own column gap, so the heading of the second
+              is as clearly separated from the list above it as it would be
+              from a neighbouring column. */}
+          <div className="flex flex-col gap-10">
+            <div className="flex flex-col gap-1">
+              <h3 className={headingClass}>Explore</h3>
+              {EXPLORE_LINKS.map((link) => (
+                <FooterLink key={link.href} {...link} />
+              ))}
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <h3 className={headingClass}>Resources</h3>
+              {RESOURCE_LINKS.map((link) => (
+                <FooterLink key={link.label} {...link} />
+              ))}
+            </div>
           </div>
 
-          {/* Column 3, resources. */}
+          {/* Column 3, one row per language the catalog can be filtered to.
+              Carries the same glyphs as the Playgrounds column beside it, and
+              as the /courses sidebar these rows land in — a language reads as
+              the same thing on all three surfaces. */}
           <div className="flex flex-col gap-1">
-            <h3 className={headingClass}>Resources</h3>
-            {RESOURCE_LINKS.map((link) => (
-              <FooterLink key={link.label} {...link} />
+            <h3 className={headingClass}>Courses</h3>
+            {COURSE_LINKS.map(({ id, ...link }) => (
+              <FooterLink key={id} {...link} icon={<LangIcon id={id} />} />
             ))}
           </div>
 
           {/* Column 4, one row per language playground. The longest column by
-              far, which is why the grid is `align-items: start` — the other
-              three sit at the top of the row rather than spreading down it. */}
+              far, which is why the grid is `align-items: start` — the others
+              sit at the top of the row rather than spreading down it. */}
           <div className="flex flex-col gap-1">
             <h3 className={headingClass}>Playgrounds</h3>
             {PLAYGROUND_LINKS.map(({ id, ...link }) => (
-              <FooterLink key={id} {...link} icon={<PlaygroundIcon id={id} />} />
+              <FooterLink key={id} {...link} icon={<LangIcon id={id} />} />
             ))}
           </div>
         </div>

--- a/app/_components/languageIcons.tsx
+++ b/app/_components/languageIcons.tsx
@@ -7,8 +7,14 @@
  * stay visually consistent.
  *
  * Looked up by language adapter `id` (e.g. `"python"`, `"javascript"`).
+ *
+ * `LangIcon` at the bottom is the rendered form of all this: the registry
+ * lookup, the per-glyph size factor, and a fixed square box, in the one
+ * component every mono-icon surface uses (the /courses catalog cards and
+ * filter sidebar, the footer's Courses and Playgrounds columns).
  */
 
+import type { ReactNode } from "react";
 import type { IconType } from "react-icons";
 import {
   SiPython,
@@ -103,3 +109,52 @@ export const LANGUAGE_ICON_COLORS: Record<string, string> = {
   web: "#e34f26",
   react: "#61dafb",
 };
+
+/** Neutral database glyph for "sql", the registry above only has per-engine
+ *  marks (SQLite/PostgreSQL/DuckDB); path from the mockup.
+ *
+ *  Deliberately not an entry in `LANGUAGE_ICONS`: that map is keyed by
+ *  playground adapter id, no adapter is called "sql", and adding one would
+ *  put this glyph on any code block tagged `sql` — a surface that has never
+ *  asked for it. `LangIcon` handles the content tag instead. */
+function SqlIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
+      <path d="M12 2C7.58 2 4 3.79 4 6s3.58 4 8 4 8-1.79 8-4-3.58-4-8-4zM4 8.5V12c0 2.21 3.58 4 8 4s8-1.79 8-4V8.5c-1.72 1.5-4.7 2.5-8 2.5s-6.28-1-8-2.5zM4 14.5V18c0 2.21 3.58 4 8 4s8-1.79 8-4v-3.5c-1.72 1.5-4.7 2.5-8 2.5s-6.28-1-8-2.5z" />
+    </svg>
+  );
+}
+
+/** Mono (currentColor) language icon at the mockup's optical sizes.
+ *
+ *  Takes a language *or* playground id: the two vocabularies overlap on
+ *  everything except `sql` (a content tag with no playground) and the
+ *  engine/framework ids (`sqlite`, `web`, `react`, …), which no course is
+ *  tagged with. Unknown ids render nothing, so a new tag is a missing glyph
+ *  rather than a crash — callers that need a visible fallback supply their
+ *  own (see `CourseThumb`'s `CourseGlyph`).
+ *
+ *  `currentColor` throughout rather than the brand tint `LANGUAGE_ICON_COLORS`
+ *  carries: every surface using this puts the glyph beside text it should
+ *  travel with, including that text's hover colour. */
+export function LangIcon({ id, size = 16 }: { id: string; size?: number }) {
+  let glyph: ReactNode;
+  if (id === "sql") {
+    // Drawn to fill its box, so it takes no size factor.
+    glyph = <SqlIcon size={size} />;
+  } else {
+    const Icon: IconType | undefined = LANGUAGE_ICONS[id];
+    if (!Icon) return null;
+    const factor = LANGUAGE_ICON_SIZE_FACTOR[id] ?? 1;
+    glyph = <Icon size={Math.round(size * factor)} />;
+  }
+  return (
+    <span
+      className="inline-flex shrink-0 items-center justify-center"
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    >
+      {glyph}
+    </span>
+  );
+}

--- a/app/courses/_components/CourseCard.tsx
+++ b/app/courses/_components/CourseCard.tsx
@@ -4,15 +4,15 @@
  * description, then a difficulty + language meta line aligned on a fixed
  * grid column (so language icons line up across rows).
  *
- * `LangIcon` and `LevelBars` are exported too, the catalog's filter sidebar
- * reuses them as row glyphs.
+ * `LevelBars` is exported too, the catalog's filter sidebar reuses it as a row
+ * glyph. Its language counterpart, `LangIcon`, used to live here and be
+ * re-exported for the same reason; it now sits in the shared icon registry
+ * (`app/_components/languageIcons.tsx`) beside the map it reads, so the footer
+ * can render a language glyph without importing this card and dragging the
+ * image manifest and the course artwork into the bundle with it.
  */
-import type { IconType } from "react-icons";
 import Link from "@/app/_components/Link";
-import {
-  LANGUAGE_ICONS,
-  LANGUAGE_ICON_SIZE_FACTOR,
-} from "@/app/_components/languageIcons";
+import { LangIcon } from "@/app/_components/languageIcons";
 import { formatTagLabel } from "@/lib/tagLabels";
 import type { CatalogCourse } from "@/lib/courseCatalog";
 import imageManifest from "@/lib/generated/images";
@@ -31,43 +31,6 @@ const HOVER_GLYPH =
 // whole-card affordance without competing with the title's blue.
 const HOVER_DESC =
   "transition-colors group-hover:text-[var(--ds-gray-600)] dark:group-hover:text-[var(--ds-gray-300)]";
-
-/** Neutral database glyph for "sql", the shared language-icon registry only
- *  has per-engine marks (SQLite/PostgreSQL/DuckDB); path from the mockup. */
-function SqlIcon({ size = 16 }: { size?: number }) {
-  return (
-    <svg viewBox="0 0 24 24" width={size} height={size} fill="currentColor">
-      <path d="M12 2C7.58 2 4 3.79 4 6s3.58 4 8 4 8-1.79 8-4-3.58-4-8-4zM4 8.5V12c0 2.21 3.58 4 8 4s8-1.79 8-4V8.5c-1.72 1.5-4.7 2.5-8 2.5s-6.28-1-8-2.5zM4 14.5V18c0 2.21 3.58 4 8 4s8-1.79 8-4v-3.5c-1.72 1.5-4.7 2.5-8 2.5s-6.28-1-8-2.5z" />
-    </svg>
-  );
-}
-
-/** Mono (currentColor) language icon at the mockup's optical sizes. */
-export function LangIcon({ id, size = 16 }: { id: string; size?: number }) {
-  if (id === "sql") {
-    return (
-      <span
-        className="inline-flex shrink-0 items-center justify-center"
-        style={{ width: size, height: size }}
-        aria-hidden="true"
-      >
-        <SqlIcon size={size} />
-      </span>
-    );
-  }
-  const Icon: IconType | undefined = LANGUAGE_ICONS[id];
-  if (!Icon) return null;
-  const factor = LANGUAGE_ICON_SIZE_FACTOR[id] ?? 1;
-  return (
-    <span
-      className="inline-flex shrink-0 items-center justify-center"
-      style={{ width: size, height: size }}
-      aria-hidden="true"
-    >
-      <Icon size={Math.round(size * factor)} />
-    </span>
-  );
-}
 
 /** The mockup's bar-style level meter: three 11×4 bars, 1 green / 2 blue /
  *  3 red filled left-to-right, the rest on the neutral track. */

--- a/app/courses/_components/CoursesCatalog.tsx
+++ b/app/courses/_components/CoursesCatalog.tsx
@@ -24,22 +24,9 @@ import {
 } from "lucide-react";
 import { formatTagLabel } from "@/lib/tagLabels";
 import type { CatalogCourse } from "@/lib/courseCatalog";
-import { CourseCard, LangIcon, LevelBars } from "./CourseCard";
-import { readFilters, writeFilters } from "./catalogFilters";
-
-// Sidebar language order, from the mockup. Languages found in the catalog but
-// missing here (future additions) are appended alphabetically.
-const LANG_ORDER = [
-  "python",
-  "sql",
-  "javascript",
-  "typescript",
-  "c",
-  "cpp",
-  "csharp",
-  "java",
-  "r",
-];
+import { LangIcon } from "@/app/_components/languageIcons";
+import { CourseCard, LevelBars } from "./CourseCard";
+import { COURSE_LANGUAGES, readFilters, writeFilters } from "./catalogFilters";
 
 const LEVELS = ["beginner", "intermediate", "advanced"] as const;
 type Level = (typeof LEVELS)[number];
@@ -228,14 +215,17 @@ export function CoursesCatalog({ courses }: { courses: CatalogCourse[] }) {
   const selectOne = (arr: string[], v: string) =>
     arr[0] === v ? [] : [v];
 
-  // Sidebar rows: fixed mockup order, restricted to languages that actually
-  // occur; unknown future languages append alphabetically.
+  // Sidebar rows: fixed mockup order (`COURSE_LANGUAGES`, shared with the
+  // footer's Courses column), restricted to languages that actually occur;
+  // unknown future languages append alphabetically.
   const languages = useMemo(() => {
     const present = new Set(
       courses.map((c) => c.tags.language?.[0]).filter(Boolean) as string[],
     );
-    const ordered = LANG_ORDER.filter((l) => present.has(l));
-    const extras = [...present].filter((l) => !LANG_ORDER.includes(l)).sort();
+    const ordered = COURSE_LANGUAGES.filter((l) => present.has(l));
+    const extras = [...present]
+      .filter((l) => !COURSE_LANGUAGES.includes(l))
+      .sort();
     return [...ordered, ...extras];
   }, [courses]);
 

--- a/app/courses/_components/catalogFilters.ts
+++ b/app/courses/_components/catalogFilters.ts
@@ -14,6 +14,71 @@
 export const PARAM = { lang: "lang", level: "level" } as const;
 
 /**
+ * Every language the catalog sidebar offers a row for, in the order it offers
+ * them. Two consumers, and they need it for different reasons.
+ *
+ * `CoursesCatalog` uses it as an *order*: its rows are the languages that
+ * actually occur in the courses it was handed, sorted by this list, with
+ * anything unlisted appended alphabetically. So a language missing from here
+ * still gets a row — just last.
+ *
+ * The footer's Courses column uses it as the *list itself*, because it has no
+ * courses to derive one from. `HomeFooter` renders on every route and inside
+ * the home page's client tree, so importing the generated catalog there to
+ * count languages would ship every course's title, description, and tags to
+ * the browser to produce eleven links.
+ *
+ * That second use is what makes this hand-kept list able to go stale: add a
+ * course in a language not named here and the sidebar absorbs it silently
+ * while the footer never learns about it. `__tests__/coursesCatalogFilters.
+ * test.ts` fails in exactly that case.
+ *
+ * Not wired into `readFilters` as its default: that function validates
+ * against the languages a given catalog actually has, which is narrower than
+ * this and is the whole point of the check (see its doc comment).
+ */
+export const COURSE_LANGUAGES: readonly string[] = [
+  "python",
+  "sql",
+  "javascript",
+  "typescript",
+  "c",
+  "cpp",
+  "csharp",
+  "java",
+  "r",
+  "css",
+  "html",
+];
+
+/**
+ * The catalog filtered to one language, in the form `readFilters` reads back
+ * out.
+ *
+ * ── Link these as document navigations, not `<Link>` ───────────────────────
+ *
+ * Every one of these hrefs is the same document: the filter is applied in the
+ * browser from the query string, so `?lang=r` and `?lang=sql` are `/courses`
+ * with different reading instructions. `CoursesCatalog` picks those up with a
+ * `useSyncExternalStore` subscribed to `popstate`, which means it notices a
+ * new query string when it mounts, and when the visitor uses Back/Forward.
+ *
+ * A Next `<Link>` navigates with `pushState`, which fires neither. Linking one
+ * of these from a page that is *not* `/courses` still works, because the
+ * catalog mounts fresh and reads the URL on its way up — but from `/courses`
+ * itself the component is already mounted, so the address bar would change to
+ * `?lang=r` and the unfiltered list would stay on screen. The footer's Courses
+ * column is exactly that case (it renders on `/courses`), so it links these
+ * with a plain `<a>`. Do the same for any new caller.
+ *
+ * The one-document property also makes these bad prefetch candidates: eleven
+ * links, one payload, already fetched by any plain `/courses` link nearby.
+ */
+export function courseLanguageHref(language: string): string {
+  return `/courses?${PARAM.lang}=${encodeURIComponent(language)}`;
+}
+
+/**
  * The selection encoded in `search`, as the 0-or-1-element arrays the catalog
  * keeps its filter state in.
  *

--- a/app/home.css
+++ b/app/home.css
@@ -114,9 +114,10 @@ html.dark .ds-home {
  * leading icon; at sm each of four columns is ~118px and every one of them
  * wraps.
  *
- * `align-items: start` because that fourth column is ~14 rows against the
- * others' 5: without it the short columns stretch and their content drifts
- * apart down the row.
+ * `align-items: start` because the columns are wildly uneven — the logo, then
+ * Explore over Resources, then 11 course rows, then ~14 playground rows:
+ * without it the short columns stretch and their content drifts apart down
+ * the row.
  *
  * Driven by a scoped rule (rather than Tailwind grid utilities) so a leaked
  * `.grid`/`grid-cols-*` from /learn can't collapse it back to the wrong

--- a/app/interview-prep/_components/InterviewCatalog.tsx
+++ b/app/interview-prep/_components/InterviewCatalog.tsx
@@ -143,7 +143,14 @@ function TrackThumb({ slug, alt }: { slug: string; alt: string }) {
         loading="lazy"
         decoding="async"
         sizes="(min-width: 640px) 30vw, 65vw"
-        className="block aspect-[3/2] w-full rounded-xl object-contain"
+        // The row's hover affordance on the artwork itself, matched to the
+        // `/courses` thumbnail so the two catalogs answer a pointer the same
+        // way. A transform rather than a width: the 3:2 box keeps its measured
+        // size, so the art paints slightly larger over the row's padding and
+        // the gap beneath it without moving a single line of copy — which is
+        // the only way six rows on a grid can grow without their neighbours
+        // shifting.
+        className="block aspect-[3/2] w-full rounded-xl object-contain transition-transform duration-200 group-hover:scale-105"
       />
     </picture>
   );


### PR DESCRIPTION
Two changes to the catalog surfaces.

## 1. Footer: Resources under Explore, and a new Courses column

Resources moves into column two beneath Explore, and the column it vacates becomes **Courses** — one row per language the `/courses` sidebar filters by, linking to that catalog pre-filtered (`/courses?lang=python`). Eleven rows, in the sidebar's own order, carrying the sidebar's own glyphs.

Verified end-to-end against `content/courses/`: every row lands on `/courses` and filters to the expected count.

| Row | href | Courses shown |
|---|---|---|
| Python Courses | `?lang=python` | 11 |
| SQL Courses | `?lang=sql` | 4 |
| JavaScript Courses | `?lang=javascript` | 1 |
| TypeScript Courses | `?lang=typescript` | 3 |
| C Courses | `?lang=c` | 2 |
| C++ Courses | `?lang=cpp` | 2 |
| C# Courses | `?lang=csharp` | 2 |
| Java Courses | `?lang=java` | 3 |
| R Courses | `?lang=r` | 2 |
| CSS Courses | `?lang=css` | 1 |
| HTML Courses | `?lang=html` | 1 |

### One list behind both surfaces

`COURSE_LANGUAGES` moves into `catalogFilters.ts`, which already owns the `?lang=` contract, and the sidebar now orders itself with it. Naming `css` and `html` explicitly changes no ordering — they were already landing in those positions via the alphabetical append for unlisted languages, so the rendered sidebar is byte-identical.

The footer can't derive the list the way the sidebar does: it renders inside the home page's client tree, so importing the generated catalog to count languages would ship every course's title, description, and tags to the browser to produce eleven links. A hand-kept list can fall behind the content instead, so `coursesCatalogFilters.test.ts` now fails when `content/courses/` carries a language the list has never heard of, when the list names one no course uses any more, and when a language has no proper display label (which would render "Cpp Courses").

### The rows navigate as documents, not through `<Link>`

This is load-bearing rather than a preference, and it's the one thing worth a close look in review.

The catalog reads its filter with a `useSyncExternalStore` subscribed to `popstate`. A Next `<Link>` navigates with `pushState`, which fires none. From any other page that goes unnoticed, because the catalog mounts fresh and reads the URL on its way up — but this footer renders **on `/courses`**, where the component is already mounted. Measured before the fix:

| Case | URL after | Courses shown |
|---|---|---|
| direct load `?lang=cpp` | `?lang=cpp` | 2 ✅ |
| client-nav from `/pricing` | `?lang=cpp` | 2 ✅ |
| client-nav from `/courses` | `?lang=cpp` | **32** ❌ |

A plain `<a>` re-mounts the page, so every row filters from wherever it's clicked. It also settles prefetching by construction: the eleven hrefs are one document, already fetched by the Explore column's `/courses` link.

`courseLanguageHref`'s doc comment records the constraint for the next caller.

### Supporting change: `LangIcon` moves to the shared icon registry

The footer needs a language glyph, and importing it from `CourseCard` would have dragged the image manifest and the course artwork in behind it. Moved to `app/_components/languageIcons.tsx`, beside the map it reads. It also subsumes the footer's own `PlaygroundIcon`, which was the same component minus the `sql` case — no playground is called `sql`, so the fourteen playground rows render identically.

## 2. `/interview-prep`: thumbnail grows on row hover

Each track row already tinted its background and nudged its arrow, but the artwork — the largest thing in the row — stayed inert. Scales 5% on hover, matching what `CourseCard` already does.

A transform, not a size change, so nothing reflows: the `<img>` keeps `aspect-[3/2] w-full` inside its `w-[65%]` `<picture>`, and the art paints over the row's existing `py-4` and the `gap-5` below it. `gap-x-10` between the grid columns absorbs the horizontal growth, and no ancestor clips.

## Testing

- `npx vitest run` — 92 files, 1262 tests passing (5 new).
- `npx tsc --noEmit` — clean.
- `npx eslint app __tests__ lib` — 0 errors (62 pre-existing warnings, all in `lib/generated/`).
- Rendered against a dev server and checked at 1440 / 800 / 420px: four columns, 11 rows with glyphs, no horizontal overflow; `/courses` sidebar still renders its 11 language rows in the same order with the same counts.

Confirmed the new drift guard actually fires by dropping `html` from the list — it fails with the language named and where to add it.

One thing to eyeball: at the `sm` breakpoint the footer is two columns, so pairing Explore with Resources makes row one taller and leaves more whitespace under the logo than before. Harmless, but it's the visible consequence of the stacking and easy to change if you'd rather.