### PR TITLE
Diagrams as elements, not characters: fix the box model, sweep the corpus, and make syntax breakdowns a convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -762,8 +762,9 @@ and search still indexes it.
 ## Diagrams are drawn with elements, never with characters
 
 **Never build a figure out of `┌─┐│└┘`, out of `+-----+` and `---->`, or out of
-`└──┬──┘` underbraces.** `npm run check:diagrams` rejects them and
-`__tests__/asciiDiagrams.test.ts` runs the same linter under `npm test`.
+`└──┬──┘` underbraces, and never type a table into a ` ```text ` fence.**
+`npm run check:diagrams` rejects all four and `__tests__/asciiDiagrams.test.ts`
+runs the same linter under `npm test`.
 
 The reason is not taste. Code is set in JetBrains Mono, loaded by
 `next/font/google` with `subsets: ["latin"]` (`app/layout.tsx`), and that subset
@@ -777,6 +778,13 @@ disconnected fragments. Widening the subset would not fix the rest of it. A
 drawn figure is an image made of text, so a screen reader spells the corner
 glyphs out one at a time, nothing reflows on a phone, and the drawing cannot
 take the page's colors or its theme.
+
+A table typed into a fence fails for its own reasons, on top of that one. Its
+columns are held apart by literal spaces rather than by cells, so it will not
+reflow on a phone and a longer value in one row shifts every column after it;
+and it reaches a screen reader as a `<pre>`, not a `<table>` with headers. Five
+lessons had one, including a SQLite page whose fenced pipes-and-dashes block was
+teaching the reader what a table is.
 
 Reach for whichever of these fits:
 
@@ -795,14 +803,17 @@ arrow, so a node labelled `s = ●─` ships a reference dot and a wire as liter
 text inside a box that already has a real arrow leaving it. The linter rejects
 any drawn glyph inside a ` ```mermaid ` fence for that reason.
 
-**Two shapes are allowed to stay drawn.** A directory tree, because it is the
+**Some shapes are allowed to stay drawn.** A directory tree, because it is the
 literal output format of `tree`, universal in READMEs and terminals, and the
 one drawn shape the font fallback does not break: every row at a given depth
 carries the same prefix, so siblings still line up at a different advance
-width. And a caret annotation inside a code comment (`//   ^value  ^setter`),
-which is ASCII, is how a developer would write it in their own editor, and is
-not a figure. Anything else that genuinely has to keep its frame, such as
-verbatim `mysql` client output, opts out explicitly:
+width. A caret annotation inside a code comment (`//   ^value  ^setter`), which
+is ASCII, is how a developer would write it in their own editor, and is not a
+figure. Verbatim program and compiler output, which is a quotation. And a
+notation the lesson itself defines, such as the linked-list course's
+`head -> [10 | *] -> [20 | NULL]`, where each line stands alone and nothing
+depends on two lines lining up. Anything else that genuinely has to keep its
+frame, such as verbatim `mysql` client output, opts out explicitly:
 
 ```mdx
 {/* allow-drawn-diagram: verbatim mysql client output */}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -750,14 +750,63 @@ version left all 41 chunks as eager `<script src>` tags and added a 42nd. Only
 an `import()` evaluated inside the client graph is a split point.
 
 Server Components are the exception and stay statically imported in
-`mdx-components.tsx`: `Figure`, `Chart` and `SvgLabel` render to markup on the
-server and ship no client code, so splitting them would only add a Suspense
-boundary. The test is whether the component's own module carries
-`"use client"`.
+`mdx-components.tsx`: `Figure`, `Chart`, `SvgLabel` and the diagram primitives
+in `app/_components/mdx/diagrams.tsx` render to markup on the server and ship
+no client code, so splitting them would only add a Suspense boundary. The test
+is whether the component's own module carries `"use client"`.
 
 Server rendering is unaffected either way. `lazyWidget()` leaves SSR on
 (`dynamic()`'s default), so the prerendered HTML still contains every widget
 and search still indexes it.
+
+## Diagrams are drawn with elements, never with characters
+
+**Never build a figure out of `┌─┐│└┘`, out of `+-----+` and `---->`, or out of
+`└──┬──┘` underbraces.** `npm run check:diagrams` rejects them and
+`__tests__/asciiDiagrams.test.ts` runs the same linter under `npm test`.
+
+The reason is not taste. Code is set in JetBrains Mono, loaded by
+`next/font/google` with `subsets: ["latin"]` (`app/layout.tsx`), and that subset
+ends long before U+2500. Every box-drawing character therefore falls back to
+whatever monospace the reader's OS supplies, at *that* font's advance width, so
+a line's rendered width depends on how many drawn characters it happens to
+contain and rows that were aligned in the source arrive at different widths.
+The CSS box-model figure on `modern-css-layout/box-model-and-sizing` is what
+surfaced this: four concentric boxes reached readers as a scatter of
+disconnected fragments. Widening the subset would not fix the rest of it. A
+drawn figure is an image made of text, so a screen reader spells the corner
+glyphs out one at a time, nothing reflows on a phone, and the drawing cannot
+take the page's colors or its theme.
+
+Reach for whichever of these fits:
+
+| The figure is really… | Use |
+| --- | --- |
+| geometry: nesting, adjacency, a span of syntax and what it is called | `<BoxModel>`, `<MemoryCells>`, `<SyntaxBreakdown>`, `<CrcCard>` (`app/_components/mdx/diagrams.tsx`) |
+| a graph: a hierarchy, a pipeline, a state machine | a ` ```mermaid ` fence |
+| a table | a markdown table |
+
+Add a new primitive to `diagrams.tsx` rather than a new one-off component: they
+share one stylesheet, one caption treatment and one `<figure>` wrapper, so they
+stay a family instead of drifting apart one lesson at a time.
+
+**Mermaid labels are words, not pictures.** The edge mermaid draws *is* the
+arrow, so a node labelled `s = ●─` ships a reference dot and a wire as literal
+text inside a box that already has a real arrow leaving it. The linter rejects
+any drawn glyph inside a ` ```mermaid ` fence for that reason.
+
+**Two shapes are allowed to stay drawn.** A directory tree, because it is the
+literal output format of `tree`, universal in READMEs and terminals, and the
+one drawn shape the font fallback does not break: every row at a given depth
+carries the same prefix, so siblings still line up at a different advance
+width. And a caret annotation inside a code comment (`//   ^value  ^setter`),
+which is ASCII, is how a developer would write it in their own editor, and is
+not a figure. Anything else that genuinely has to keep its frame, such as
+verbatim `mysql` client output, opts out explicitly:
+
+```mdx
+{/* allow-drawn-diagram: verbatim mysql client output */}
+```
 
 ## Generated files and the build cache
 

--- a/__tests__/asciiDiagrams.test.ts
+++ b/__tests__/asciiDiagrams.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+// Shared linter implementation also used by `npm run check:diagrams`.
+import {
+  diagramFiles,
+  lintFiles,
+  lintSource,
+} from "../scripts/check-ascii-diagrams.mjs";
+
+// Guards lessons against figures "drawn" out of box-drawing characters. The
+// code font's `latin` subset stops before U+2500, so every drawn glyph falls
+// back to another font at another advance width and the rows stop lining up;
+// see the header of scripts/check-ascii-diagrams.mjs. Runs as part of
+// `npm test`.
+describe("lesson diagrams", () => {
+  const files = diagramFiles();
+
+  it("locates the lesson corpus", () => {
+    expect(files.length).toBeGreaterThan(500);
+  });
+
+  it("draws no diagrams out of characters", () => {
+    const violations = lintFiles(files);
+    const report = violations
+      .map(
+        (v: { rule: string; file: string; line: number; detail: string }) =>
+          `  [${v.rule}] ${path.relative(process.cwd(), v.file)}:${v.line}: ${v.detail}`,
+      )
+      .join("\n");
+    expect(violations, `drawn diagrams:\n${report}`).toEqual([]);
+  });
+
+  // The rules that keep the linter useful rather than noisy.
+  it("flags a nested box drawn with box-drawing characters", () => {
+    const src = [
+      "```text",
+      "┌──── margin ────┐",
+      "│  ┌─ border ─┐  │",
+      "│  └──────────┘  │",
+      "└────────────────┘",
+      "```",
+    ].join("\n");
+    expect(lintSource(src, "x.mdx").map((v) => v.rule)).toContain(
+      "drawn-diagram",
+    );
+  });
+
+  // `tree` output is the one drawn shape the font fallback does not break:
+  // every row at a depth carries the same prefix, so siblings still align.
+  it("allows a directory tree", () => {
+    const src = [
+      "```text",
+      "my-analysis/",
+      "├── README.md",
+      "├── data/",
+      "│   ├── raw/",
+      "│   └── processed/",
+      "└── src/",
+      "    └── load.py",
+      "```",
+    ].join("\n");
+    expect(lintSource(src, "x.mdx")).toEqual([]);
+  });
+
+  it("flags a box drawn with plain ASCII", () => {
+    const src = ["```text", "+-----+", "|  n  |", "+-----+", "```"].join("\n");
+    expect(lintSource(src, "x.mdx").map((v) => v.rule)).toContain("ascii-box");
+  });
+
+  it("flags an underbrace annotation", () => {
+    const src = [
+      "```",
+      "SUM(amount) OVER (PARTITION BY region)",
+      "└────┬────┘       └────────┬────────┘",
+      "```",
+    ].join("\n");
+    expect(lintSource(src, "x.mdx").map((v) => v.rule)).toContain("ascii-box");
+  });
+
+  // Mermaid draws its own edges, so a drawn glyph in a label is decoration
+  // imitating the arrow that is already there.
+  it("flags a drawn glyph inside a mermaid label", () => {
+    const src = ['```mermaid', "flowchart LR", '    A["a = ●─"] --> B[heap]', "```"].join(
+      "\n",
+    );
+    expect(lintSource(src, "x.mdx").map((v) => v.rule)).toEqual(["mermaid-glyph"]);
+  });
+
+  it("leaves an ordinary mermaid diagram alone", () => {
+    const src = [
+      "```mermaid",
+      "flowchart LR",
+      '    A["a (a reference)"] --> B[heap]',
+      "```",
+    ].join("\n");
+    expect(lintSource(src, "x.mdx")).toEqual([]);
+  });
+
+  // Verbatim tool output that has to keep its frame is an author's call.
+  it("honours an explicit opt-out", () => {
+    const src = [
+      "{/* allow-drawn-diagram: verbatim mysql client output */}",
+      "```text",
+      "+-------+",
+      "| price |",
+      "+-------+",
+      "```",
+    ].join("\n");
+    expect(lintSource(src, "x.mdx")).toEqual([]);
+  });
+
+  // An arrow in a sentence is punctuation, not a drawing.
+  it("ignores arrows in prose", () => {
+    const src = "The pipeline runs FROM → WHERE → GROUP BY → SELECT.\nAnd again → here.";
+    expect(lintSource(src, "x.mdx")).toEqual([]);
+  });
+});

--- a/__tests__/asciiDiagrams.test.ts
+++ b/__tests__/asciiDiagrams.test.ts
@@ -114,4 +114,52 @@ describe("lesson diagrams", () => {
     const src = "The pipeline runs FROM → WHERE → GROUP BY → SELECT.\nAnd again → here.";
     expect(lintSource(src, "x.mdx")).toEqual([]);
   });
+
+  // A table typed into a fence is pure ASCII, so rules 1 and 2 never see it.
+  it("flags a table drawn with a dashed column rule", () => {
+    const src = [
+      "```text",
+      "Address      Variable          Value (decimal)",
+      "----------   ---------------   --------------",
+      "0x7ffc...0   age               30",
+      "```",
+    ].join("\n");
+    expect(lintSource(src, "x.mdx").map((v) => v.rule)).toEqual(["fake-table"]);
+  });
+
+  it("flags a markdown table typed inside a fence", () => {
+    const src = [
+      "```text",
+      "id | title        | done",
+      "-- | ------------ | ----",
+      "1  | Buy milk     | 0",
+      "```",
+    ].join("\n");
+    expect(lintSource(src, "x.mdx").map((v) => v.rule)).toEqual(["fake-table"]);
+  });
+
+  it("flags a single-column list under a dashed rule", () => {
+    const src = ["```text", "price", "-----", "12.99", "free", "```"].join("\n");
+    expect(lintSource(src, "x.mdx").map((v) => v.rule)).toEqual(["fake-table"]);
+  });
+
+  // A fence tagged with a real language holds a listing, where a row of
+  // dashes is ordinary rather than a column rule.
+  it("leaves a dashed rule inside a source listing alone", () => {
+    const src = ["```python", "header = 'price'", "print('-----')", "print(12.99)", "```"].join(
+      "\n",
+    );
+    expect(lintSource(src, "x.mdx")).toEqual([]);
+  });
+
+  // A rule needs a header above it and a row below it to be a column rule.
+  it("leaves a horizontal rule that opens or closes a block alone", () => {
+    const src = ["```text", "--------", "Build finished", "--------", "```"].join("\n");
+    expect(lintSource(src, "x.mdx")).toEqual([]);
+  });
+
+  it("leaves an ordinary markdown table alone", () => {
+    const src = ["| a | b |", "| - | - |", "| 1 | 2 |"].join("\n");
+    expect(lintSource(src, "x.mdx")).toEqual([]);
+  });
 });

--- a/__tests__/proseStyle.test.ts
+++ b/__tests__/proseStyle.test.ts
@@ -25,6 +25,33 @@ describe("authored prose style", () => {
     expect(violations, `prose violations:\n${report}`).toEqual([]);
   });
 
+  // A callout body is markdown, not a template literal, so the escape that is
+  // required inside `markdown={`…`}` prints the backtick here instead.
+  it("flags an escaped backtick in a callout body", () => {
+    const src = [
+      '<Callout type="info" title="T">',
+      "Flask uses \\`@app.route\\` for this.",
+      "</Callout>",
+    ].join("\n");
+    expect(lintSource(src, "x.mdx", "mdx").map((v: { rule: string }) => v.rule)).toEqual([
+      "escaped-backtick",
+    ]);
+  });
+
+  it("leaves an escaped backtick in a template literal prop alone", () => {
+    const src = "<MultipleChoice\n  markdown={`What does \\`len()\\` return?`}\n/>";
+    expect(lintSource(src, "x.mdx", "mdx")).toEqual([]);
+  });
+
+  it("leaves a plain backtick in a callout body alone", () => {
+    const src = [
+      '<Callout type="info" title="T">',
+      "Flask uses `@app.route` for this.",
+      "</Callout>",
+    ].join("\n");
+    expect(lintSource(src, "x.mdx", "mdx")).toEqual([]);
+  });
+
   // The rules that keep the linter useful rather than noisy.
   it("flags an em dash used as punctuation in prose", () => {
     expect(lintSource("A clause — an aside.", "x.mdx", "mdx")).toHaveLength(1);

--- a/app/_components/mdx/diagrams.module.css
+++ b/app/_components/mdx/diagrams.module.css
@@ -233,6 +233,10 @@
 
 /* ── <SyntaxBreakdown> ───────────────────────────────────────────────────── */
 
+/* No frame of its own. The braces and their labels already read as one
+   figure, and a panel around them made the breakdown look like a sibling of
+   the runnable code blocks it usually sits next to, which it is not: nothing
+   here can be pressed. Padding stays, so the figure keeps its air. */
 .syntax {
   display: flex;
   flex-wrap: wrap;
@@ -240,10 +244,10 @@
   justify-content: center;
   gap: 0.35rem 0.5rem;
   max-width: 100%;
-  padding: 1.25rem 1rem 1rem;
-  border: 1px solid var(--ds-gray-200);
-  border-radius: 0.625rem;
-  background: var(--ds-gray-50);
+  padding: 0.5rem 0 0.25rem;
+  /* A single span never wraps (it is one token of code), so a long one on a
+     narrow screen scrolls here rather than pushing the article sideways. */
+  overflow-x: auto;
 }
 
 /* Every span is only as wide as its own code, which is what lets each brace
@@ -261,7 +265,7 @@
 /* The lesson stylesheet gives every inline <code> a chip: a tinted background,
    padding and a radius. That is right in a sentence and wrong here, where the
    spans are consecutive pieces of one statement and a chip each would read as
-   several. Reset to bare text; the row's own panel is the frame. */
+   several. Reset to bare text, so the row reads as one line of code. */
 .partText {
   padding: 0;
   border: none;
@@ -312,11 +316,6 @@
   text-align: center;
   text-wrap: balance;
   color: var(--color-fd-muted-foreground);
-}
-
-:global(html:is(.dark, [data-theme="dark"])) .syntax {
-  border-color: #2e2e2e;
-  background: color-mix(in srgb, var(--color-fd-background, #121212) 82%, #000);
 }
 
 :global(html:is(.dark, [data-theme="dark"])) .partText {

--- a/app/_components/mdx/diagrams.module.css
+++ b/app/_components/mdx/diagrams.module.css
@@ -134,7 +134,7 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem 0;
+  gap: 0.5rem 0.4rem;
 }
 
 .cellGroup {
@@ -142,15 +142,36 @@
   align-items: center;
 }
 
+.cellStack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 0;
+}
+
 .cell {
   display: flex;
   flex-direction: column;
-  min-width: 5.25rem;
+  min-width: 3.5rem;
   border: 1px solid var(--ds-gray-300);
   border-radius: 0.375rem;
   overflow: hidden;
   font-family: var(--font-mono, ui-monospace, monospace);
   text-align: center;
+}
+
+/* The address, or what the byte spells. Fixed height and always rendered, so
+   boxes in a row keep one baseline whether or not they carry a note, and so
+   the arrow's offset below can be a constant rather than a guess. */
+.cellNote {
+  display: block;
+  height: 1.15rem;
+  margin-top: 0.3rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.6875rem;
+  line-height: 1.15rem;
+  white-space: nowrap;
+  color: var(--color-fd-muted-foreground);
 }
 
 /* The name strip and the value cell are one box split by a rule, which is what
@@ -175,6 +196,9 @@
   flex: 0 0 auto;
   width: 3.5rem;
   height: 0.75rem;
+  /* Lifted by the note strip's height so it points at the middle of the
+     boxes rather than the middle of box-plus-note. */
+  margin-bottom: 1.45rem;
   fill: var(--ds-gray-500);
   stroke: var(--ds-gray-500);
   stroke-width: 1.25;
@@ -196,6 +220,10 @@
 
 :global(html:is(.dark, [data-theme="dark"])) .cellValue {
   color: var(--ds-blue-300);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .cellNote {
+  color: #9a9a9a;
 }
 
 :global(html:is(.dark, [data-theme="dark"])) .arrow {

--- a/app/_components/mdx/diagrams.module.css
+++ b/app/_components/mdx/diagrams.module.css
@@ -1,0 +1,460 @@
+/* Styles for the lesson diagrams in diagrams.tsx: the CSS box model, memory
+   cells, a syntax breakdown, and a CRC card. Read the header comment there
+   first — it explains why these are elements rather than box-drawing glyphs.
+
+   Every color is a token defined on the block below and re-pointed once in the
+   dark override at the end of each section, so a diagram never hard-codes a
+   hex value and never needs a second copy of its layout rules. Light values
+   come from the global --ds-* ramp (app/brand.css); the dark ones are mixed
+   against the page background the same way livePreview.module.css does it. */
+
+.figure {
+  margin: 2rem auto;
+  width: 100%;
+}
+
+.stage {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+/* Matched to Figure.module.css and Chart.module.css: these captions share a
+   column with those, often on the same page, so they read in one voice. */
+.caption {
+  margin-top: 0.75rem;
+  text-align: center;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--color-fd-muted-foreground);
+}
+
+/* ── <BoxModel> ──────────────────────────────────────────────────────────── */
+
+.layer {
+  --bm-label: var(--ds-gray-700);
+
+  position: relative;
+  /* The top inset is deeper than the sides: it is the band the layer's own
+     name sits in, so every label has room without a second nested element. */
+  padding: 2.1rem 1.9rem 1.9rem;
+  border-radius: 0.5rem;
+  font-family: var(--font-sans, system-ui, sans-serif);
+}
+
+.layerName {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.85rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--bm-label);
+}
+
+/* Margin is space, not paint, so its band is a dashed outline over the page's
+   own background rather than a filled block. */
+.margin {
+  --bm-label: var(--ds-yellow-800);
+
+  width: 100%;
+  max-width: 30rem;
+  background: var(--ds-yellow-50);
+  border: 1px dashed var(--ds-yellow-600);
+}
+
+/* The one layer that is literally a line gets a literal border, thick enough
+   to read as the band it is in every textbook drawing of this. */
+.border {
+  --bm-label: var(--ds-white);
+
+  background: var(--ds-blue-500);
+  border-radius: 0.375rem;
+  /* No border of its own: the blue fill *is* the border being named, so a
+     second outline around it would draw a border around the border. Thinner
+     on the sides than the two bands around it, so the ring that stands for a
+     line reads as the thinnest of the three. */
+  padding: 2.1rem 0.75rem 0.75rem;
+}
+
+.padding {
+  --bm-label: var(--ds-green-800);
+
+  background: var(--ds-green-100);
+  border-radius: 0.25rem;
+  padding: 2.1rem 1.4rem 1.4rem;
+}
+
+.content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.25rem;
+  border-radius: 0.1875rem;
+  background: var(--ds-white);
+  border: 1px solid var(--ds-gray-300);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--ds-gray-700);
+}
+
+/* Opaque mixes against the page color, not translucent ones. The padding band
+   is painted *on top of* the saturated blue border band, so a see-through
+   green would composite with it and arrive teal; mixing toward the background
+   gives each band the same tint wherever it happens to sit. */
+:global(html:is(.dark, [data-theme="dark"])) .margin {
+  --bm-label: var(--ds-yellow-300);
+
+  background: color-mix(in srgb, var(--ds-yellow-500) 12%, var(--color-fd-background, #121212));
+  border-color: color-mix(in srgb, var(--ds-yellow-500) 55%, var(--color-fd-background, #121212));
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .border {
+  background: var(--ds-blue-600);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .padding {
+  --bm-label: var(--ds-green-300);
+
+  background: color-mix(in srgb, var(--ds-green-500) 26%, var(--color-fd-background, #121212));
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .content {
+  background: var(--color-fd-background, #121212);
+  border-color: #3a3a3a;
+  color: #e6e6e6;
+}
+
+/* ── <MemoryCells> ───────────────────────────────────────────────────────── */
+
+.cells {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem 0;
+}
+
+.cellGroup {
+  display: flex;
+  align-items: center;
+}
+
+.cell {
+  display: flex;
+  flex-direction: column;
+  min-width: 5.25rem;
+  border: 1px solid var(--ds-gray-300);
+  border-radius: 0.375rem;
+  overflow: hidden;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  text-align: center;
+}
+
+/* The name strip and the value cell are one box split by a rule, which is what
+   the `+-----+ | n | +-----+ | 7 | +-----+` drawing was reaching for. */
+.cellName {
+  padding: 0.3rem 0.75rem;
+  background: var(--ds-gray-100);
+  border-bottom: 1px solid var(--ds-gray-300);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ds-gray-600);
+}
+
+.cellValue {
+  padding: 0.55rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ds-blue-700);
+}
+
+.arrow {
+  flex: 0 0 auto;
+  width: 3.5rem;
+  height: 0.75rem;
+  fill: var(--ds-gray-500);
+  stroke: var(--ds-gray-500);
+  stroke-width: 1.25;
+}
+
+.arrow path:last-child {
+  stroke: none;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .cell {
+  border-color: #3a3a3a;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .cellName {
+  background: color-mix(in srgb, var(--color-fd-background, #121212) 80%, #fff);
+  border-bottom-color: #3a3a3a;
+  color: #b0b0b0;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .cellValue {
+  color: var(--ds-blue-300);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .arrow {
+  fill: #8a8a8a;
+  stroke: #8a8a8a;
+}
+
+/* ── <SyntaxBreakdown> ───────────────────────────────────────────────────── */
+
+.syntax {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 0.35rem 0.5rem;
+  max-width: 100%;
+  padding: 1.25rem 1rem 1rem;
+  border: 1px solid var(--ds-gray-200);
+  border-radius: 0.625rem;
+  background: var(--ds-gray-50);
+}
+
+/* Every span is only as wide as its own code, which is what lets each brace
+   below span exactly the text above it at any font size — the one thing a
+   fixed-width drawing cannot do. The container aligns items to the start, so
+   the code line runs straight across whether or not a span carries a brace. */
+.part,
+.partLabeled {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 0;
+}
+
+/* The lesson stylesheet gives every inline <code> a chip: a tinted background,
+   padding and a radius. That is right in a sentence and wrong here, where the
+   spans are consecutive pieces of one statement and a chip each would read as
+   several. Reset to bare text; the row's own panel is the frame. */
+.partText {
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  white-space: pre;
+  color: var(--ds-gray-900);
+}
+
+.partLabeled .partText {
+  font-weight: 600;
+  color: var(--ds-blue-700);
+}
+
+/* The underbrace: an empty box with three of its four borders, so the ends
+   tick up from a rule that spans exactly the code above it. The `::after` is
+   the stem dropping to the label, the `┬` in the drawing this replaced. */
+.brace {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 0.3rem;
+  margin-top: 0.15rem;
+  border: 1px solid var(--ds-blue-400);
+  border-top: none;
+  border-radius: 0 0 0.1875rem 0.1875rem;
+}
+
+.brace::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 1px;
+  height: 0.4rem;
+  background: var(--ds-blue-400);
+}
+
+.partName {
+  max-width: 9.5rem;
+  margin-top: 0.5rem;
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 0.75rem;
+  line-height: 1.35;
+  text-align: center;
+  text-wrap: balance;
+  color: var(--color-fd-muted-foreground);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .syntax {
+  border-color: #2e2e2e;
+  background: color-mix(in srgb, var(--color-fd-background, #121212) 82%, #000);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .partText {
+  color: #d6d6d6;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .partLabeled .partText {
+  color: var(--ds-blue-300);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .brace {
+  border-color: var(--ds-blue-500);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .brace::after {
+  background: var(--ds-blue-500);
+}
+
+/* ── <CrcCard> ───────────────────────────────────────────────────────────── */
+
+.crc {
+  width: 100%;
+  /* An index card, not a banner. See the note on CrcCard for why the cap is
+     part of what the diagram teaches. */
+  max-width: 26rem;
+  border: 1px solid var(--ds-gray-300);
+  border-radius: 0.5rem;
+  background: var(--ds-white);
+  overflow: hidden;
+  font-family: var(--font-sans, system-ui, sans-serif);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+}
+
+.crcTitle {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid var(--ds-gray-300);
+  background: var(--ds-gray-50);
+}
+
+.crcTitleKey {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ds-gray-500);
+}
+
+.crcTitleName {
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--ds-gray-900);
+}
+
+.crcHead,
+.crcRow {
+  display: grid;
+  grid-template-columns: 1fr 8rem;
+  gap: 0.75rem;
+  padding: 0.4rem 0.9rem;
+}
+
+.crcHead {
+  border-bottom: 1px solid var(--ds-gray-200);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ds-gray-500);
+}
+
+.crcRows {
+  margin: 0;
+  padding: 0.25rem 0;
+  list-style: none;
+}
+
+.crcRow {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--ds-gray-800);
+}
+
+.crcResponsibility::before {
+  content: "";
+  display: inline-block;
+  width: 0.5rem;
+  height: 1px;
+  margin-right: 0.45rem;
+  vertical-align: 0.35em;
+  background: var(--ds-gray-400);
+}
+
+.crcCollaborator code {
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8125rem;
+  color: var(--ds-blue-700);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .crc {
+  border-color: #3a3a3a;
+  background: color-mix(in srgb, var(--color-fd-background, #121212) 88%, #fff);
+  box-shadow: none;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .crcTitle {
+  border-bottom-color: #3a3a3a;
+  background: color-mix(in srgb, var(--color-fd-background, #121212) 92%, #000);
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .crcTitleName {
+  color: #e6e6e6;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .crcTitleKey,
+:global(html:is(.dark, [data-theme="dark"])) .crcHead {
+  color: #9a9a9a;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .crcHead {
+  border-bottom-color: #2e2e2e;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .crcRow {
+  color: #d6d6d6;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .crcResponsibility::before {
+  background: #6a6a6a;
+}
+
+:global(html:is(.dark, [data-theme="dark"])) .crcCollaborator code {
+  color: var(--ds-blue-300);
+}
+
+/* ── Narrow viewports ────────────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .layer {
+    padding: 1.9rem 1rem 1rem;
+  }
+
+  .border,
+  .padding {
+    padding: 1.9rem 0.85rem 0.85rem;
+  }
+
+  /* Below ~30rem the cells and their arrow no longer fit side by side, so the
+     row becomes a column and the arrow is dropped rather than shrunk to an
+     unreadable stub. The caption still states the relationship. */
+  .arrow {
+    width: 1.75rem;
+  }
+
+  .crcHead,
+  .crcRow {
+    grid-template-columns: 1fr 6rem;
+    gap: 0.5rem;
+  }
+}

--- a/app/_components/mdx/diagrams.tsx
+++ b/app/_components/mdx/diagrams.tsx
@@ -1,0 +1,309 @@
+/**
+ * Small, purely presentational lesson diagrams, drawn with real elements
+ * instead of box-drawing characters.
+ *
+ * ## Why these exist
+ *
+ * Several lessons used to "draw" their diagrams in a fenced code block, with
+ * `┌─┐│└┘` or with `+---+` and `---->`. Two things go wrong with that, and the
+ * CSS box-model figure on `modern-css-layout/box-model-and-sizing` hit both:
+ *
+ *   1. **The glyphs are not in the code font.** Code is set in JetBrains Mono,
+ *      loaded by `next/font/google` with `subsets: ["latin"]` (app/layout.tsx),
+ *      and that subset stops well short of U+2500. Every box-drawing character
+ *      therefore falls back to whatever monospace the reader's OS supplies,
+ *      whose advance width is *not* JetBrains Mono's. A line's width then
+ *      depends on how many drawn characters it happens to contain, so the rows
+ *      of a nested box stop lining up and the figure arrives as scattered
+ *      fragments. A directory tree survives this (every row at a given depth
+ *      carries the same prefix, so siblings still align, which is why the
+ *      `tree` listings in this repo are left alone); a free-drawn box does not.
+ *   2. **It is a picture with no semantics.** A screen reader reads the corner
+ *      glyphs out one by one, nothing scales below the width the art was drawn
+ *      at, and the diagram cannot pick up the page's colors or theme.
+ *
+ * Everything here is a Server Component that renders plain elements and CSS, so
+ * a lesson using one ships no extra JavaScript. They are registered statically
+ * in `mdx-components.tsx` for that reason, next to `<Figure>` and `<Chart>`
+ * rather than in `lazyWidgets.ts`.
+ *
+ * ## What belongs here
+ *
+ * A diagram whose *geometry is the explanation*: nesting, adjacency, a span of
+ * syntax and the phrase that names it. A diagram that is really a graph
+ * (a hierarchy, a pipeline, a state machine) belongs in a ```mermaid fence
+ * instead, and tabular content belongs in a markdown table.
+ */
+import type { ReactNode } from "react";
+import { withInlineMarkup } from "./inlineMarkup";
+import styles from "./diagrams.module.css";
+
+/** Shared `<figure>` wrapper: optional caption, rendered like `<Figure>`'s. */
+function DiagramFigure({
+  caption,
+  label,
+  children,
+}: {
+  caption?: string;
+  /** Text alternative for the drawing itself. */
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <figure className={styles.figure}>
+      <div className={styles.stage} role="img" aria-label={label}>
+        {children}
+      </div>
+      {caption ? (
+        <figcaption className={styles.caption}>
+          {withInlineMarkup(caption)}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+/* ── <BoxModel> ──────────────────────────────────────────────────────────── */
+
+/**
+ * The four layers of the CSS box model as four genuinely nested boxes.
+ *
+ * ```mdx
+ * <BoxModel caption="Each layer wraps the one inside it." />
+ * ```
+ *
+ * The drawing is the thing being taught, so it is made of the thing being
+ * taught: each layer is a real element whose *padding* is the band the reader
+ * sees, and the border layer is a real `border`. Outside-in the bands are
+ * yellow, blue, green, neutral — three primary brand hues plus an inert core,
+ * far enough apart to stay separable for the ~8% of readers with a color
+ * vision deficiency, and each band carries its own written name so the color
+ * is never the only cue.
+ */
+export function BoxModel({ caption }: { caption?: string }) {
+  return (
+    <DiagramFigure
+      label="The CSS box model: a content block wrapped by padding, then by a border, then by margin."
+      caption={caption}
+    >
+      <div className={`${styles.layer} ${styles.margin}`}>
+        <span className={styles.layerName}>margin</span>
+        <div className={`${styles.layer} ${styles.border}`}>
+          <span className={styles.layerName}>border</span>
+          <div className={`${styles.layer} ${styles.padding}`}>
+            <span className={styles.layerName}>padding</span>
+            <div className={styles.content}>content</div>
+          </div>
+        </div>
+      </div>
+    </DiagramFigure>
+  );
+}
+
+/* ── <MemoryCells> ───────────────────────────────────────────────────────── */
+
+export interface MemoryCell {
+  /** The variable's name, shown in the cell's header strip. */
+  name: string;
+  /** What the cell holds: a value, or an address for a pointer. */
+  value: string;
+  /** Draw an arrow from this cell to the next one (a pointer's referent). */
+  pointsToNext?: boolean;
+}
+
+/**
+ * Named memory cells in a row, optionally joined by a "points at" arrow. The
+ * shape the C course used to draw with `+-----+` and `---->`:
+ *
+ * ```mdx
+ * <MemoryCells
+ *   cells={[
+ *     { name: "p", value: "0x100", pointsToNext: true },
+ *     { name: "n", value: "7" },
+ *   ]}
+ *   caption="`p` holds the address of `n`."
+ * />
+ * ```
+ *
+ * The arrow is an inline SVG rather than a glyph so it cannot depend on the
+ * reader's fonts, and it is `aria-hidden`: the relationship it draws is
+ * already in the figure's label and in the caption underneath.
+ */
+export function MemoryCells({
+  cells,
+  caption,
+}: {
+  cells: MemoryCell[];
+  caption?: string;
+}) {
+  const label = cells
+    .map((cell, i) => {
+      const points = cell.pointsToNext && cells[i + 1];
+      return points
+        ? `${cell.name} holds ${cell.value}, pointing at ${cells[i + 1].name}`
+        : `${cell.name} holds ${cell.value}`;
+    })
+    .join("; ");
+
+  return (
+    <DiagramFigure label={`Memory cells: ${label}.`} caption={caption}>
+      <div className={styles.cells}>
+        {cells.map((cell, i) => (
+          <div className={styles.cellGroup} key={`${cell.name}-${i}`}>
+            <div className={styles.cell}>
+              <span className={styles.cellName}>{cell.name}</span>
+              <span className={styles.cellValue}>{cell.value}</span>
+            </div>
+            {cell.pointsToNext && i < cells.length - 1 ? (
+              <svg
+                className={styles.arrow}
+                viewBox="0 0 56 12"
+                preserveAspectRatio="none"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path d="M0 6 H48" />
+                <path d="M46 2 L55 6 L46 10 Z" />
+              </svg>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </DiagramFigure>
+  );
+}
+
+/* ── <SyntaxBreakdown> ───────────────────────────────────────────────────── */
+
+export interface SyntaxPart {
+  /** The literal source text of this span. */
+  text: string;
+  /** What this span does. Omit for connective punctuation and keywords. */
+  label?: string;
+}
+
+/**
+ * A line of source with an underbrace under each meaningful span and a plain
+ * phrase naming it. Replaces the `└────┬────┘` "anatomy" figures:
+ *
+ * ```mdx
+ * <SyntaxBreakdown
+ *   parts={[
+ *     { text: "SUM(amount)", label: "what to compute" },
+ *     { text: "OVER (" },
+ *     { text: "PARTITION BY region", label: "which rows share a window" },
+ *     { text: ")" },
+ *   ]}
+ * />
+ * ```
+ *
+ * The braces are drawn with borders on an empty element, so they stretch to
+ * whatever width their span actually occupies at the reader's font size, which
+ * is the part a fixed-width drawing could never do. Unlabeled parts are the
+ * scaffolding between the interesting spans and sit at full opacity with no
+ * brace, so the eye goes to the four things being named.
+ */
+export function SyntaxBreakdown({
+  parts,
+  caption,
+}: {
+  parts: SyntaxPart[];
+  caption?: string;
+}) {
+  const label = parts
+    .filter((p) => p.label)
+    .map((p) => `${p.text} is ${p.label}`)
+    .join("; ");
+
+  return (
+    <DiagramFigure
+      label={`Syntax breakdown of ${parts.map((p) => p.text).join(" ")}: ${label}.`}
+      caption={caption}
+    >
+      <div className={styles.syntax}>
+        {parts.map((part, i) => (
+          <span
+            className={part.label ? styles.partLabeled : styles.part}
+            key={`${part.text}-${i}`}
+          >
+            <code className={styles.partText}>{part.text}</code>
+            {part.label ? (
+              <>
+                <span className={styles.brace} aria-hidden="true" />
+                <span className={styles.partName}>{part.label}</span>
+              </>
+            ) : null}
+          </span>
+        ))}
+      </div>
+    </DiagramFigure>
+  );
+}
+
+/* ── <CrcCard> ───────────────────────────────────────────────────────────── */
+
+export interface CrcRow {
+  /** One thing the class is responsible for. */
+  responsibility: string;
+  /** The class it leans on to do that, if any. */
+  collaborator?: string;
+}
+
+/**
+ * A Class-Responsibility-Collaborator card, the index card from Beck and
+ * Cunningham's 1989 paper:
+ *
+ * ```mdx
+ * <CrcCard
+ *   name="Order"
+ *   rows={[
+ *     { responsibility: "track its line items", collaborator: "LineItem" },
+ *     { responsibility: "compute its total" },
+ *   ]}
+ * />
+ * ```
+ *
+ * Physically small is the whole point of a CRC card, so the card is capped in
+ * width rather than filling the column: a responsibility list that overflows
+ * it is the signal that the class is doing too much, and a card stretched to
+ * the full article width would never give that signal.
+ */
+export function CrcCard({
+  name,
+  rows,
+  caption,
+}: {
+  name: string;
+  rows: CrcRow[];
+  caption?: string;
+}) {
+  return (
+    <DiagramFigure
+      label={`CRC card for the class ${name}, listing its responsibilities and collaborators.`}
+      caption={caption}
+    >
+      <div className={styles.crc}>
+        <div className={styles.crcTitle}>
+          <span className={styles.crcTitleKey}>Class</span>
+          <code className={styles.crcTitleName}>{name}</code>
+        </div>
+        <div className={styles.crcHead}>
+          <span>Responsibilities</span>
+          <span>Collaborators</span>
+        </div>
+        <ul className={styles.crcRows}>
+          {rows.map((row) => (
+            <li className={styles.crcRow} key={row.responsibility}>
+              <span className={styles.crcResponsibility}>
+                {row.responsibility}
+              </span>
+              <span className={styles.crcCollaborator}>
+                {row.collaborator ? <code>{row.collaborator}</code> : null}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </DiagramFigure>
+  );
+}

--- a/app/_components/mdx/diagrams.tsx
+++ b/app/_components/mdx/diagrams.tsx
@@ -103,17 +103,21 @@ export function BoxModel({ caption }: { caption?: string }) {
 /* ── <MemoryCells> ───────────────────────────────────────────────────────── */
 
 export interface MemoryCell {
-  /** The variable's name, shown in the cell's header strip. */
+  /** The label on the cell's header strip: a variable name, or an address. */
   name: string;
   /** What the cell holds: a value, or an address for a pointer. */
   value: string;
+  /** A small annotation under the box, e.g. the slot's address or what the
+   *  byte means as a character. */
+  note?: string;
   /** Draw an arrow from this cell to the next one (a pointer's referent). */
   pointsToNext?: boolean;
 }
 
 /**
  * Named memory cells in a row, optionally joined by a "points at" arrow. The
- * shape the C course used to draw with `+-----+` and `---->`:
+ * shape the C and C++ courses used to draw with `+-----+` and `---->`, or as
+ * columns of space-padded text:
  *
  * ```mdx
  * <MemoryCells
@@ -127,7 +131,9 @@ export interface MemoryCell {
  *
  * The arrow is an inline SVG rather than a glyph so it cannot depend on the
  * reader's fonts, and it is `aria-hidden`: the relationship it draws is
- * already in the figure's label and in the caption underneath.
+ * already in the figure's label and in the caption underneath. Cells wrap
+ * when a row of them outgrows the column, so a byte-by-byte layout can run to
+ * eight boxes without being scaled down to nothing.
  */
 export function MemoryCells({
   cells,
@@ -138,10 +144,10 @@ export function MemoryCells({
 }) {
   const label = cells
     .map((cell, i) => {
-      const points = cell.pointsToNext && cells[i + 1];
-      return points
-        ? `${cell.name} holds ${cell.value}, pointing at ${cells[i + 1].name}`
-        : `${cell.name} holds ${cell.value}`;
+      const where = cell.note ? ` at ${cell.note}` : "";
+      return cell.pointsToNext && cells[i + 1]
+        ? `${cell.name} holds ${cell.value}${where}, pointing at ${cells[i + 1].name}`
+        : `${cell.name} holds ${cell.value}${where}`;
     })
     .join("; ");
 
@@ -150,9 +156,14 @@ export function MemoryCells({
       <div className={styles.cells}>
         {cells.map((cell, i) => (
           <div className={styles.cellGroup} key={`${cell.name}-${i}`}>
-            <div className={styles.cell}>
-              <span className={styles.cellName}>{cell.name}</span>
-              <span className={styles.cellValue}>{cell.value}</span>
+            <div className={styles.cellStack}>
+              <div className={styles.cell}>
+                <span className={styles.cellName}>{cell.name}</span>
+                <span className={styles.cellValue}>{cell.value}</span>
+              </div>
+              {/* Always rendered, so a row where only some cells carry a note
+                  keeps every box the same height and on the same baseline. */}
+              <span className={styles.cellNote}>{cell.note ?? " "}</span>
             </div>
             {cell.pointsToNext && i < cells.length - 1 ? (
               <svg

--- a/cloudflare-cors-proxy/README.md
+++ b/cloudflare-cors-proxy/README.md
@@ -15,23 +15,18 @@ Cloudflare Workers are chosen over a Next.js route handler because:
 
 ## How it works
 
-```
-Browser (playground runtime)
-  └─► GET https://dataslope-cors-proxy.<subdomain>.workers.dev/?url=<encoded-url>
-          │
-          ▼
-    Cloudflare Worker (this repo)
-          │  validates Origin, scheme, and hostname
-          │  strips hop-by-hop and credential headers
-          │  forwards request to upstream
-          ▼
-    Third-party API  (e.g. https://api.example.com/data)
-          │
-          ▼
-    Cloudflare Worker
-          │  injects CORS headers
-          ▼
-Browser  ✅ response accepted
+```mermaid
+sequenceDiagram
+    participant B as Browser, the playground runtime
+    participant W as Cloudflare Worker, this repo
+    participant A as Third-party API
+
+    B->>W: GET /?url= the encoded target URL
+    Note over W: validates Origin, scheme and hostname,<br/>strips hop-by-hop and credential headers
+    W->>A: forwards the request upstream
+    A-->>W: response
+    Note over W: injects CORS headers
+    W-->>B: response the browser accepts
 ```
 
 The playground runtime appends the target URL as a query parameter:

--- a/content/courses/beginners-javascript/arrays.mdx
+++ b/content/courses/beginners-javascript/arrays.mdx
@@ -177,6 +177,17 @@ fruits.forEach((f) => console.log("got:", f));
 
 ## Slicing and copying
 
+`slice` never changes the original. Its two arguments are indices, and the second is not included:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "xs.slice(" },
+    { text: "1,", label: "start here, included" },
+    { text: "4", label: "stop here, excluded" },
+    { text: ")", label: "a new array; xs is untouched" },
+  ]}
+/>
+
 Two methods that look similar but are completely different:
 
 - `slice(start, end)` returns a **new** array with a portion of

--- a/content/courses/beginners-javascript/birth-of-javascript.mdx
+++ b/content/courses/beginners-javascript/birth-of-javascript.mdx
@@ -41,7 +41,7 @@ understands.
 
 Here is what a single instruction looks like in raw bits:
 
-```
+```text
 10110000 01100001
 ```
 

--- a/content/courses/beginners-javascript/functions-basics.mdx
+++ b/content/courses/beginners-javascript/functions-basics.mdx
@@ -157,7 +157,16 @@ function.
 ## Function expressions and arrow functions
 
 JavaScript has more than one syntax for defining functions. They
-all produce the same kind of value.
+all produce the same kind of value. The arrow form is the shortest,
+and it is three pieces:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "(a, b)", label: "the parameters" },
+    { text: "=>", label: "the arrow, which is the whole keyword" },
+    { text: "a + b", label: "the body; a single expression is returned for you" },
+  ]}
+/>
 
 <Figure
   slug="js-functions-basics-declaring-function-inline-cutout"

--- a/content/courses/beginners-javascript/functions-basics.mdx
+++ b/content/courses/beginners-javascript/functions-basics.mdx
@@ -378,7 +378,7 @@ console.log(greet("Ada"));     // push greet onto the stack
 
 At the moment `bigName` is running, the call stack looks like:
 
-```
+```text
 [ bigName ]   <- currently running
 [ greet   ]
 [ console.log ] (well, the runtime's outer frame)

--- a/content/courses/beginners-javascript/how-javascript-runs.mdx
+++ b/content/courses/beginners-javascript/how-javascript-runs.mdx
@@ -218,7 +218,7 @@ console.log("2: script end");
 
 You should see:
 
-```
+```text
 1: script start
 2: script end
 3: promise microtask
@@ -265,7 +265,7 @@ console.log("2: after demo()");
 
 The output is:
 
-```
+```text
 1: before demo()
 A: before await
 2: after demo()
@@ -352,7 +352,7 @@ module.exports = { runDemo };
 
 Predicted order:
 
-```
+```text
 > script begin
 [sync] inside runDemo
 > script end

--- a/content/courses/beginners-javascript/map-filter-reduce.mdx
+++ b/content/courses/beginners-javascript/map-filter-reduce.mdx
@@ -133,6 +133,16 @@ idioms like this make functional code remarkably compact.
 `reduce()` is the most general of the three. It walks the array,
 maintaining an "accumulator", and produces a single final value.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "arr.reduce(" },
+    { text: "(acc, x)", label: "what you have so far, and the item" },
+    { text: "=> acc + x,", label: "the accumulator for the next step" },
+    { text: "0", label: "what acc starts as" },
+    { text: ")" },
+  ]}
+/>
+
 <Figure
   slug="js-map-filter-reduce-inline-cutout"
   alt="A bench of three stations in a row, the first repainting every block, the second dropping some blocks through a grate, the third pressing what remains into one larger block"

--- a/content/courses/beginners-javascript/modular-organization.mdx
+++ b/content/courses/beginners-javascript/modular-organization.mdx
@@ -194,7 +194,7 @@ believe it.
 
 For small projects, this is plenty:
 
-```
+```text
 src/
   index.js
   config.js
@@ -207,7 +207,7 @@ As things grow, group by **feature**, not by **technical type**.
 
 Anti-pattern (grouped by type):
 
-```
+```text
 src/
   components/   # 200 unrelated files
   utils/        # 100 unrelated files
@@ -216,7 +216,7 @@ src/
 
 Better (grouped by feature):
 
-```
+```text
 src/
   users/
     index.js

--- a/content/courses/beginners-javascript/objects.mdx
+++ b/content/courses/beginners-javascript/objects.mdx
@@ -216,6 +216,18 @@ clearest pattern.
 
 ## Destructuring objects
 
+Destructuring reads right to left: the shape on the left names what you want out of the object on the right.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "const {" },
+    { text: "name,", label: "pull out the property of that name" },
+    { text: "age = 0", label: "with a fallback when it is missing" },
+    { text: "} =" },
+    { text: "person;", label: "the object being taken apart" },
+  ]}
+/>
+
 Just like with arrays, we can pull properties out by name in one
 line. This is one of modern JavaScript's most-loved features.
 
@@ -280,6 +292,15 @@ console.log(describe2(u));
 />
 
 ## Spread, rest, and copying
+
+The same three dots mean opposite things depending on which side of the `=` they sit on:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "const { id, ...rest } = obj;", label: "rest: collect what is left" },
+    { text: "const copy = { ...obj, id: 2 };", label: "spread: expand, then override" },
+  ]}
+/>
 
 The `...` syntax works for objects too.
 

--- a/content/courses/beginners-javascript/problem-solving.mdx
+++ b/content/courses/beginners-javascript/problem-solving.mdx
@@ -90,7 +90,7 @@ problem. Beginners *skip* this step. Don't.
 
 Write the algorithm in plain English, indented like code:
 
-```
+```text
 function finalTotal(items, code):
     subtotal = 0
     for each item in items:

--- a/content/courses/beginners-javascript/strings-and-text.mdx
+++ b/content/courses/beginners-javascript/strings-and-text.mdx
@@ -49,12 +49,12 @@ newline or a tab, you escape it with a backslash:
 
 | Escape | Meaning |
 | :---: | --- |
-| `\\n` | newline |
-| `\\t` | tab |
-| `\\\\` | a literal backslash |
-| `\\'` | a literal `'` |
-| `\\"` | a literal `"` |
-| `\\\`` | a literal backtick |
+| `\n` | newline |
+| `\t` | tab |
+| `\\` | a literal backslash |
+| `\'` | a literal `'` |
+| `\"` | a literal `"` |
+| `` \` `` | a literal backtick |
 
 <CodeBlock
   adapter="javascript"

--- a/content/courses/beginners-javascript/strings-and-text.mdx
+++ b/content/courses/beginners-javascript/strings-and-text.mdx
@@ -72,6 +72,17 @@ console.log("col1\\tcol2\\tcol3");
 
 ## Template literals: the modern default
 
+Backticks turn on two things at once: interpolation, and newlines that survive.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "`Hello, ", label: "backticks, not quotes" },
+    { text: "${", label: "start an expression" },
+    { text: "name.toUpperCase()", label: "any expression, not just a variable" },
+    { text: "}`" },
+  ]}
+/>
+
 Backtick strings, called **template literals**, let you do two
 things that ordinary strings cannot:
 

--- a/content/courses/beginners-javascript/values-and-types.mdx
+++ b/content/courses/beginners-javascript/values-and-types.mdx
@@ -246,6 +246,16 @@ real argument for reaching for `===` by default.
 
 ## `null` vs `undefined`
 
+Two different absences, and `??` is the operator that treats them alike while leaving `0` and `""` alone:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "value", label: "used unless it is null or undefined" },
+    { text: "??", label: "nullish coalescing, not ||" },
+    { text: "fallback", label: "so 0 and empty string survive" },
+  ]}
+/>
+
 These two look similar but have slightly different intent:
 
 - `undefined` means *"no value has been assigned"*. JavaScript itself

--- a/content/courses/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/courses/c-programming-for-beginners/compilation-and-execution.mdx
@@ -93,9 +93,9 @@ int main(void) {
 `GREETING` and `TIMES` are simply gone, they were replaced.
 
 <Callout type="warn" title="Macros are textual">
-\`#define DOUBLE(x) x * 2\` looks fine, but \`DOUBLE(1 + 1)\` expands
-to \`1 + 1 * 2\`, which is \`3\`, not \`4\`. Always wrap macro arguments
-and the macro body in parentheses: \`#define DOUBLE(x) ((x) * 2)\`.
+`#define DOUBLE(x) x * 2` looks fine, but `DOUBLE(1 + 1)` expands
+to `1 + 1 * 2`, which is `3`, not `4`. Always wrap macro arguments
+and the macro body in parentheses: `#define DOUBLE(x) ((x) * 2)`.
 </Callout>
 
 ## Stage 2: the compiler

--- a/content/courses/c-programming-for-beginners/data-types.mdx
+++ b/content/courses/c-programming-for-beginners/data-types.mdx
@@ -161,10 +161,10 @@ int main(void) {
 point". `%f` without modifiers uses 6 digits by default.
 
 <Callout type="warn" title="Floating point is not exact">
-Decimal fractions like \`0.1\` cannot be represented exactly in
-binary floating point, just like \`1/3\` cannot be written exactly
+Decimal fractions like `0.1` cannot be represented exactly in
+binary floating point, just like `1/3` cannot be written exactly
 in base 10. The number you store is a *very close approximation*.
-This is why \`0.1 + 0.2\` is famously not exactly \`0.3\` in almost
+This is why `0.1 + 0.2` is famously not exactly `0.3` in almost
 every programming language.
 </Callout>
 

--- a/content/courses/c-programming-for-beginners/functions.mdx
+++ b/content/courses/c-programming-for-beginners/functions.mdx
@@ -22,14 +22,19 @@ Now let's write our own.
 
 ## Anatomy of a function
 
-```c
-return_type name(parameter_list) {
-    // body
-    return some_value;   // (omit for void)
-}
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "int", label: "the type it gives back" },
+    { text: "square", label: "the name callers use" },
+    { text: "(int n)", label: "typed slots for the inputs" },
+    { text: "{ return n * n; }", label: "the body, and what it returns" },
+  ]}
+/>
 
-A complete example:
+Use `void` as the return type when a function gives nothing back, and
+leave out its `return` value.
+
+The same function, complete and runnable:
 
 <CodeBlock
   adapter="c"

--- a/content/courses/c-programming-for-beginners/input-and-output.mdx
+++ b/content/courses/c-programming-for-beginners/input-and-output.mdx
@@ -150,9 +150,9 @@ int main(void) {
 />
 
 <Callout type="info" title="Why `if (scanf(...) == 1)`?">
-\`scanf()\` returns the **number of items it successfully read**. Always
-check it. If the user types \`hello\` when you asked for a number,
-\`scanf()\` returns \`0\` and your variable is unchanged (and probably
+`scanf()` returns the **number of items it successfully read**. Always
+check it. If the user types `hello` when you asked for a number,
+`scanf()` returns `0` and your variable is unchanged (and probably
 uninitialized!).
 </Callout>
 

--- a/content/courses/c-programming-for-beginners/linked-lists.mdx
+++ b/content/courses/c-programming-for-beginners/linked-lists.mdx
@@ -152,7 +152,7 @@ returning the new head is friendlier to read in beginner code.
 
 ## Trace: building `[10, 20, 30]` by prepending
 
-```
+```text
 start:        head = NULL
 prepend(30):  head -> [30 | NULL]
 prepend(20):  head -> [20 | *] -> [30 | NULL]

--- a/content/courses/c-programming-for-beginners/pointers.mdx
+++ b/content/courses/c-programming-for-beginners/pointers.mdx
@@ -92,6 +92,17 @@ things:
 | `&n`           | expression: *the address of `n`*                                |
 | `int *p = &n;` | declare `p`, initialize it with the address of `n`              |
 
+One line contains both readings, and they are not the same `*`:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "int *", label: "declaration: p is a pointer to int" },
+    { text: "p", label: "the variable being created" },
+    { text: "=" },
+    { text: "&n;", label: "expression: the address of n" },
+  ]}
+/>
+
 Once you internalize that, half of pointer confusion vanishes.
 
 ## Pictures, always pictures

--- a/content/courses/c-programming-for-beginners/pointers.mdx
+++ b/content/courses/c-programming-for-beginners/pointers.mdx
@@ -106,35 +106,29 @@ int *p = &n;
 
 **After line 1**: a box `n` exists, containing `7`.
 
-```text
-+-----+
-|  n  |
-+-----+
-|  7  |
-+-----+
-```
+<MemoryCells cells={[{ name: "n", value: "7" }]} />
 
 **After line 2**: a new box `p` exists, containing the address of
 `n`:
 
-```text
-+-----+        +-----+
-|  p  | ---->  |  n  |
-+-----+        +-----+
-|0x100|        |  7  |
-+-----+        +-----+
-```
+<MemoryCells
+  cells={[
+    { name: "p", value: "0x100", pointsToNext: true },
+    { name: "n", value: "7" },
+  ]}
+  caption="`p` does not hold `7`. It holds `0x100`, the address where `7` lives."
+/>
 
 **After line 3**: `*p` reads the value at `n` (`7`), adds `1`, and
 writes `8` back into the same address:
 
-```text
-+-----+        +-----+
-|  p  | ---->  |  n  |
-+-----+        +-----+
-|0x100|        |  8  |
-+-----+        +-----+
-```
+<MemoryCells
+  cells={[
+    { name: "p", value: "0x100", pointsToNext: true },
+    { name: "n", value: "8" },
+  ]}
+  caption="`p` is unchanged; the value at the address it holds is not."
+/>
 
 The value of `p` itself never changed. Only the value of the *thing
 it pointed at* changed.

--- a/content/courses/c-programming-for-beginners/strings.mdx
+++ b/content/courses/c-programming-for-beginners/strings.mdx
@@ -18,6 +18,15 @@ yourself in the foot.
 
 ## The null-terminated string
 
+No length is stored anywhere. The terminator *is* the length, which is why the array must have room for it:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "char s[6]", label: "five characters..." },
+    { text: "= \"hello\";", label: "...plus the terminator the compiler adds" },
+  ]}
+/>
+
 ```c
 char greeting[] = "hello";
 ```

--- a/content/courses/c-programming-for-beginners/structs.mdx
+++ b/content/courses/c-programming-for-beginners/structs.mdx
@@ -20,6 +20,16 @@ around as a unit.
 
 ## Declaring a struct
 
+A struct declaration defines a *type*, not a variable. Those are two separate steps in C:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "struct", label: "define a new type" },
+    { text: "Point", label: "its tag, written struct Point later" },
+    { text: "{ int x; int y; };", label: "the members, laid out in this order" },
+  ]}
+/>
+
 ```c
 struct Point {
     int x;

--- a/content/courses/c-programming-for-beginners/variables-and-memory.mdx
+++ b/content/courses/c-programming-for-beginners/variables-and-memory.mdx
@@ -151,8 +151,8 @@ int return;           // ERROR: keyword
 ```
 
 <Callout type="info" title="A style note">
-The C ecosystem traditionally uses \`snake_case\` for variable and
-function names (\`player_score\`, \`compute_total\`). Pick a style and
+The C ecosystem traditionally uses `snake_case` for variable and
+function names (`player_score`, `compute_total`). Pick a style and
 stay consistent within a project. Consistency matters more than the
 exact convention.
 </Callout>

--- a/content/courses/c-programming-for-beginners/variables-and-memory.mdx
+++ b/content/courses/c-programming-for-beginners/variables-and-memory.mdx
@@ -114,12 +114,14 @@ When `score` appears on the **left** of `=`, you are **writing** to
 it. When it appears on the **right**, or in an expression, you are
 **reading** from it.
 
-```text
-score = score + 5;
-  ^         ^
-  |         +-- read
-  +------------ write
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "score", label: "write" },
+    { text: "=" },
+    { text: "score", label: "read" },
+    { text: "+ 5;" },
+  ]}
+/>
 
 ## Naming variables
 

--- a/content/courses/c-programming-for-beginners/variables-and-memory.mdx
+++ b/content/courses/c-programming-for-beginners/variables-and-memory.mdx
@@ -64,12 +64,13 @@ Three things happen on the line `int age = 30;`:
 
 After the two declarations above, memory might look like:
 
-```text
-Address      Variable          Value (decimal)
-----------   ---------------   --------------
-0x7ffc...0   age               30
-0x7ffc...4   year_of_birth     1995
-```
+<MemoryCells
+  cells={[
+    { name: "age", value: "30", note: "0x7ffc...0" },
+    { name: "year_of_birth", value: "1995", note: "0x7ffc...4" },
+  ]}
+  caption="Two `int` boxes at consecutive addresses, four bytes apart."
+/>
 
 Each box is 4 bytes. The actual addresses are not predictable across
 runs, they depend on the OS, the architecture, and security

--- a/content/courses/csharp-linq-functional/aggregations.mdx
+++ b/content/courses/csharp-linq-functional/aggregations.mdx
@@ -136,6 +136,18 @@ It's a useful trick for "give me the min, or zero".
 
 ## The universal aggregator: `Aggregate()`
 
+`Aggregate` is `reduce` under another name, and its three-argument form is the one worth learning:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "xs.Aggregate(" },
+    { text: "0,", label: "the seed, which also fixes the result type" },
+    { text: "(acc, x) => acc + x,", label: "how to fold one element in" },
+    { text: "acc => acc / n", label: "an optional final projection" },
+    { text: ")" },
+  ]}
+/>
+
 `Aggregate()` (sometimes called `fold` or `reduce` elsewhere) is the
 general form. You give it:
 

--- a/content/courses/csharp-linq-functional/capstone-data-pipeline.mdx
+++ b/content/courses/csharp-linq-functional/capstone-data-pipeline.mdx
@@ -24,7 +24,7 @@ LINQ is *the* idiomatic way to do this kind of work in C#.
 
 A small SaaS sells two products. Each transaction is a line of CSV:
 
-```
+```text
 2026-05-01,A,2,19.99,paid
 2026-05-01,B,1,49.00,paid
 2026-05-02,A,1,19.99,refund
@@ -35,7 +35,7 @@ Columns: `date, productCode, quantity, unitPrice, status`.
 
 The desired report:
 
-```
+```text
 === Product A ===
   units sold:   17
   gross:        339.83

--- a/content/courses/csharp-linq-functional/composing-pipelines.mdx
+++ b/content/courses/csharp-linq-functional/composing-pipelines.mdx
@@ -92,6 +92,16 @@ value, sum total." This is the heart of declarative code.
 
 ## Building custom operators with `yield`
 
+`yield return` turns a method into a state machine: it hands back one element and pauses, which is what makes the operator lazy.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "IEnumerable<T>", label: "the return type that makes it possible" },
+    { text: "MyWhere(...)" },
+    { text: "{ ... yield return x; }", label: "produce one element, then pause here" },
+  ]}
+/>
+
 You're not limited to combining existing operators. `yield return`
 lets you implement entirely new ones, and they remain lazy.
 

--- a/content/courses/csharp-linq-functional/filtering-and-projection.mdx
+++ b/content/courses/csharp-linq-functional/filtering-and-projection.mdx
@@ -42,6 +42,18 @@ type), but the *order* is preserved.
 
 ## `Where()`, filtering
 
+`Where` takes a predicate: a function from element to `bool`. Nothing runs until the result is enumerated.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "xs.Where(" },
+    { text: "p", label: "one element" },
+    { text: "=>", label: "goes to" },
+    { text: "p.Age > 40", label: "a bool: keep it, or drop it" },
+    { text: ")" },
+  ]}
+/>
+
 `Where()` takes a predicate (`Func<T, bool>`) and returns a sequence
 containing only the elements for which the predicate is true.
 

--- a/content/courses/csharp-linq-functional/lambdas-and-delegates.mdx
+++ b/content/courses/csharp-linq-functional/lambdas-and-delegates.mdx
@@ -77,7 +77,15 @@ for `Func<T, bool>`, LINQ uses `Func<T, bool>`, not `Predicate<T>`.
 ## Lambda syntax
 
 A **lambda** is an inline literal of a delegate type. It is written
-`parameters => body`.
+`parameters => body`, and there are only ever three pieces:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "(x, y)", label: "the parameters" },
+    { text: "=>", label: "reads as goes to" },
+    { text: "x + y", label: "the body, whose value is returned" },
+  ]}
+/>
 
 <Figure
   slug="cs-lambdas-and-delegates-inline-cutout"

--- a/content/courses/csharp-linq-functional/query-vs-method-syntax.mdx
+++ b/content/courses/csharp-linq-functional/query-vs-method-syntax.mdx
@@ -55,9 +55,21 @@ Console.WriteLine(string.Join(", ", c));
   ]}
 />
 
-All three produce the same result. The compiler treats query syntax
-as **syntactic sugar**: it mechanically rewrites it into method
-calls.
+Query syntax names each step with a keyword, in roughly the order you
+would say the question out loud:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "from p in people", label: "the source" },
+    { text: "where p.Age > 40", label: "keep some of it" },
+    { text: "orderby p.Name", label: "put it in order" },
+    { text: "select p.Name", label: "shape what comes out" },
+  ]}
+/>
+
+All three forms above produce the same result. The compiler treats
+query syntax as **syntactic sugar**: it mechanically rewrites it into
+method calls.
 
 ```mermaid
 flowchart TD

--- a/content/courses/data-analysis-python-pandas/aggregation-basics.mdx
+++ b/content/courses/data-analysis-python-pandas/aggregation-basics.mdx
@@ -153,6 +153,15 @@ On a non-numeric column, it returns count / unique / top / freq.
 `.agg` lets you compute several aggregations in one go, getting
 back a Series or DataFrame of results.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "df.groupby(" },
+    { text: '"department")', label: "one output row per value here" },
+    { text: '["salary"]', label: "the column to summarise" },
+    { text: '.agg(["mean", "max"])', label: "one output column per aggregation" },
+  ]}
+/>
+
 <Figure
   slug="pandas-aggregation-basics-inline-cutout"
   alt="One column of chips tipped into a funnel and leaving as a single block on the tray below"

--- a/content/courses/data-analysis-python-pandas/creating-new-columns.mdx
+++ b/content/courses/data-analysis-python-pandas/creating-new-columns.mdx
@@ -107,6 +107,18 @@ variable.
 
 ## Conditional columns with `np.where()`
 
+`np.where` is a vectorised if/else: three arrays in, one out, elementwise.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "np.where(" },
+    { text: "df.age >= 18,", label: "the condition, elementwise" },
+    { text: "\"adult\",", label: "value where it is true" },
+    { text: "\"minor\"", label: "value where it is false" },
+    { text: ")" },
+  ]}
+/>
+
 `np.where(condition, value_if_true, value_if_false)` is a
 vectorized ternary.
 

--- a/content/courses/data-analysis-python-pandas/dates-and-times.mdx
+++ b/content/courses/data-analysis-python-pandas/dates-and-times.mdx
@@ -98,6 +98,16 @@ upfront.
 
 ## The `.dt` accessor
 
+`.dt` is the gate to the datetime parts of a Series, exactly as `.str` is for text:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "df[\"day\"]", label: "a datetime Series" },
+    { text: ".dt", label: "the accessor; without it there is no .month" },
+    { text: ".month", label: "one integer per row" },
+  ]}
+/>
+
 Once a column is a datetime, the `.dt` namespace gives you
 date-component extraction:
 

--- a/content/courses/data-analysis-python-pandas/groupby-operations.mdx
+++ b/content/courses/data-analysis-python-pandas/groupby-operations.mdx
@@ -281,6 +281,17 @@ boolean-mask filtering of rows.
 
 ## `apply()`, for anything else
 
+`apply` runs Python per row or per column, and `axis` is what decides which. It is the slow escape hatch, not the first tool.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "df.apply(" },
+    { text: "fn,", label: "called once per row or column" },
+    { text: "axis=1", label: "1 means a row is passed in, 0 means a column" },
+    { text: ")" },
+  ]}
+/>
+
 `apply()` runs an arbitrary function on each group. Slower than
 the named aggregations, but flexible.
 

--- a/content/courses/data-analysis-python-pandas/loading-datasets.mdx
+++ b/content/courses/data-analysis-python-pandas/loading-datasets.mdx
@@ -102,6 +102,18 @@ where the data is a file on disk, not a URL.
 
 ## Common `read_csv()` options
 
+The defaults are right often enough that the options are what you reach for when they are not:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "pd.read_csv(path," },
+    { text: "parse_dates=[\"day\"],", label: "read these as timestamps, not text" },
+    { text: "na_values=[\"NA\"],", label: "what counts as missing" },
+    { text: "dtype={\"zip\": str}", label: "stop a leading zero being lost" },
+    { text: ")" },
+  ]}
+/>
+
 `pd.read_csv()` has dozens of parameters, but you will use only a
 handful in real life:
 

--- a/content/courses/data-analysis-python-pandas/merging-and-joining.mdx
+++ b/content/courses/data-analysis-python-pandas/merging-and-joining.mdx
@@ -55,6 +55,18 @@ display(departments)
 
 ## Inner join
 
+Every merge is the same four decisions: the two frames, what counts as a match, and which side's rows survive.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "pd.merge(" },
+    { text: "left, right,", label: "the two frames" },
+    { text: "on=\"id\",", label: "the key that defines a match" },
+    { text: "how=\"inner\"", label: "which unmatched rows to drop" },
+    { text: ")" },
+  ]}
+/>
+
 Only rows where the key is present in both. This is the
 default.
 

--- a/content/courses/data-analysis-python-pandas/rows-and-columns.mdx
+++ b/content/courses/data-analysis-python-pandas/rows-and-columns.mdx
@@ -170,27 +170,25 @@ products:
 
 **Long form** (also called *tidy*):
 
-```text
-product  month  sales
-Latte    Jan    1200
-Latte    Feb    1100
-Latte    Mar    1500
-Mocha    Jan     800
-Mocha    Feb     950
-Mocha    Mar     900
-Espresso Jan     400
-Espresso Feb     450
-Espresso Mar     500
-```
+| `product` | `month` | `sales` |
+| --------- | ------- | ------- |
+| Latte     | Jan     | 1200    |
+| Latte     | Feb     | 1100    |
+| Latte     | Mar     | 1500    |
+| Mocha     | Jan     | 800     |
+| Mocha     | Feb     | 950     |
+| Mocha     | Mar     | 900     |
+| Espresso  | Jan     | 400     |
+| Espresso  | Feb     | 450     |
+| Espresso  | Mar     | 500     |
 
 **Wide form** (more spreadsheet-like):
 
-```text
-product   Jan   Feb   Mar
-Latte    1200  1100  1500
-Mocha     800   950   900
-Espresso  400   450   500
-```
+| `product` | `Jan` | `Feb` | `Mar` |
+| --------- | ----- | ----- | ----- |
+| Latte     | 1200  | 1100  | 1500  |
+| Mocha     | 800   | 950   | 900   |
+| Espresso  | 400   | 450   | 500   |
 
 Both contain the same information. But the row in long form is
 *one (product, month) measurement*; in wide form it is *one

--- a/content/courses/data-analysis-python-pandas/selecting-data.mdx
+++ b/content/courses/data-analysis-python-pandas/selecting-data.mdx
@@ -102,6 +102,18 @@ print("Type:", type(sub).__name__)
 
 ## 3. `loc`, by label
 
+`loc` takes two things inside one pair of brackets, separated by a comma:
+which rows, then which columns.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "df.loc[" },
+    { text: '"Chen",', label: "which rows, by label" },
+    { text: '"salary"', label: "which columns, by label" },
+    { text: "]" },
+  ]}
+/>
+
 <CodeBlock
   adapter="python"
   files={[

--- a/content/courses/data-wrangling-python-polars/columnar-memory-and-arrow.mdx
+++ b/content/courses/data-wrangling-python-polars/columnar-memory-and-arrow.mdx
@@ -20,13 +20,13 @@ to give, and there are exactly two reasonable choices.
 
 **Row-major** stores each record's fields together:
 
-```
+```text
 Adelie Torgersen 39.1 3750 | Adelie Torgersen 39.5 3800 | Gentoo Biscoe 46.1 4500 | …
 ```
 
 **Column-major** stores each field's values together:
 
-```
+```text
 species:  Adelie Adelie Gentoo …
 island:   Torgersen Torgersen Biscoe …
 bill:     39.1 39.5 46.1 …

--- a/content/courses/data-wrangling-python-polars/creating-columns.mdx
+++ b/content/courses/data-wrangling-python-polars/creating-columns.mdx
@@ -121,6 +121,17 @@ a column named `total sales` or `2024` still needs `alias()`.
 
 ## Conditional logic: when / then / otherwise
 
+Polars spells if/else as a chain, and the chain has to end in `otherwise` or the un-matched rows come back null:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "pl.when(", label: "the condition" },
+    { text: "pl.col(\"mass\") > 4000)" },
+    { text: ".then(pl.lit(\"big\"))", label: "value when it holds" },
+    { text: ".otherwise(pl.lit(\"small\"))", label: "value when it does not" },
+  ]}
+/>
+
 This is Polars' `if`. It chains, and the first matching branch wins.
 
 <CodeBlock

--- a/content/courses/data-wrangling-python-polars/filtering-rows.mdx
+++ b/content/courses/data-wrangling-python-polars/filtering-rows.mdx
@@ -32,6 +32,18 @@ print(penguins.filter(pl.col("island") != "Biscoe").height)
 
 ## Combining conditions
 
+Python's `and` and `or` do not work on expressions. Polars uses the bitwise operators, and they bind tighter than comparison, so each side needs its own parentheses:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "df.filter(" },
+    { text: "(pl.col(\"mass\") > 4000)", label: "parenthesised, always" },
+    { text: "&", label: "and; use | for or, ~ for not" },
+    { text: "(pl.col(\"sex\") == \"male\")" },
+    { text: ")" },
+  ]}
+/>
+
 Several arguments to `filter()` are combined with AND. For anything
 else, use the operators.
 

--- a/content/courses/data-wrangling-python-polars/group-by-and-agg.mdx
+++ b/content/courses/data-wrangling-python-polars/group-by-and-agg.mdx
@@ -27,6 +27,19 @@ flowchart TD
 
 ## The basic shape
 
+A grouped Polars query is two calls: the keys, then the expressions
+computed inside each group.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "penguins.group_by(" },
+    { text: '"species")', label: "one output row per value here" },
+    { text: ".agg(" },
+    { text: 'pl.col("body_mass_g").mean()', label: "computed inside each group" },
+    { text: ")" },
+  ]}
+/>
+
 <CodeBlock
   adapter="python"
   datasets={[{ path: "palmer-penguins.csv", stageAs: "penguins.csv" }]}

--- a/content/courses/data-wrangling-python-polars/idiomatic-polars.mdx
+++ b/content/courses/data-wrangling-python-polars/idiomatic-polars.mdx
@@ -160,6 +160,17 @@ codebase from turning into a pile of one-off transformations.
 
 ## 5. Use `pipe` for frame-level steps
 
+`pipe` passes the frame as the first argument, so your own function joins a chain without breaking it:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "df.pipe(" },
+    { text: "add_features,", label: "your function; df becomes its first argument" },
+    { text: "window=7", label: "any extra arguments follow" },
+    { text: ")" },
+  ]}
+/>
+
 `pipe` does the same thing one level up, for reusable steps that take
 and return a frame.
 

--- a/content/courses/data-wrangling-python-polars/what-is-an-expression.mdx
+++ b/content/courses/data-wrangling-python-polars/what-is-an-expression.mdx
@@ -27,6 +27,17 @@ In Polars, `pl.col("a") * 2` does none of that. It builds an object
 that *means* "take the column called a and double it". No frame was
 consulted. No arithmetic was done.
 
+<SyntaxBreakdown
+  parts={[
+    { text: 'pl.col("a")', label: "name a column, do not fetch it" },
+    { text: ".sum()", label: "describe a computation over it" },
+    { text: '.alias("total")', label: "name the column this will produce" },
+  ]}
+/>
+
+Every expression has that shape: pick something, describe what to do to
+it, and say what to call the result.
+
 <CodeBlock
   adapter="python"
   files={[

--- a/content/courses/data-wrangling-python-polars/your-first-dataframe.mdx
+++ b/content/courses/data-wrangling-python-polars/your-first-dataframe.mdx
@@ -33,7 +33,7 @@ print(masses)
 
 Read the header block that Polars prints:
 
-```
+```text
 shape: (4,)
 Series: 'body_mass_g' [i64]
 ```

--- a/content/courses/database-design-postgresql/case-study-blog.mdx
+++ b/content/courses/database-design-postgresql/case-study-blog.mdx
@@ -271,7 +271,7 @@ The design choices come from the rules:
 
 ```mermaid
 flowchart TD
-    Rule["One tag per post only once"] --> Key["PRIMARY KEY on <code>post_id</code> and <code>tag_id</code>"]
+    Rule["One tag per post only once"] --> Key["<code>PRIMARY KEY</code> on <code>post_id</code> and <code>tag_id</code>"]
     Key --> Reject["Duplicate pair is rejected"]
 ```
 

--- a/content/courses/database-design-postgresql/check-constraints.mdx
+++ b/content/courses/database-design-postgresql/check-constraints.mdx
@@ -28,7 +28,7 @@ row. If the expression is false, PostgreSQL rejects the write.
 
 ```mermaid
 flowchart TD
-    Row["Incoming row"] --> Check{"CHECK expression<br/>is true?"}
+    Row["Incoming row"] --> Check{"<code>CHECK</code> expression<br/>is true?"}
     Check -->|yes| Store["Store row"]
     Check -->|no| Reject["Reject row"]
 ```
@@ -191,7 +191,7 @@ others.
 
 ```mermaid
 flowchart LR
-    Need["What rule are you encoding?"] --> Missing["Value required<br/>NOT NULL"]
+    Need["What rule are you encoding?"] --> Missing["Value required<br/>NOT <code>NULL</code>"]
     Need --> Dup["No duplicates<br/>UNIQUE"]
     Need --> Ref["Must point to existing row<br/>FOREIGN KEY"]
     Need --> Expr["Expression must be true<br/>CHECK"]
@@ -213,8 +213,8 @@ present, say that directly with `NOT NULL`.
 
 ```mermaid
 flowchart TD
-    Required["Required domain value"] --> NN["NOT NULL"]
-    Required --> CH["CHECK rule"]
+    Required["Required domain value"] --> NN["<code>NOT NULL</code>"]
+    Required --> CH["<code>CHECK</code> rule"]
     NN --> Safe["Present and valid"]
     CH --> Safe
 ```

--- a/content/courses/database-design-postgresql/check-constraints.mdx
+++ b/content/courses/database-design-postgresql/check-constraints.mdx
@@ -18,6 +18,14 @@ A **CHECK** constraint lets the schema say those things out loud.
 A CHECK constraint is a boolean expression that must be true for every
 row. If the expression is false, PostgreSQL rejects the write.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "price NUMERIC", label: "the column it guards" },
+    { text: "CONSTRAINT price_non_negative", label: "a name, so the error message says which rule broke" },
+    { text: "CHECK (price >= 0)", label: "the expression every row must satisfy" },
+  ]}
+/>
+
 ```mermaid
 flowchart TD
     Row["Incoming row"] --> Check{"CHECK expression<br/>is true?"}

--- a/content/courses/database-design-postgresql/choosing-data-types.mdx
+++ b/content/courses/database-design-postgresql/choosing-data-types.mdx
@@ -218,7 +218,7 @@ set is stable and reused across many tables.
 
 ```mermaid
 flowchart TB
-    Choice["Small allowed set"] --> Check["TEXT plus CHECK<br/>simple and visible"]
+    Choice["Small allowed set"] --> Check["<code>TEXT</code> plus <code>CHECK</code><br/>simple and visible"]
     Choice --> Enum["ENUM type<br/>stable shared set"]
 ```
 
@@ -234,8 +234,8 @@ Types are broad constraints. Other constraints narrow the rule.
 
 ```mermaid
 flowchart TD
-    Broad["NUMERIC<br/>any exact number"] --> Narrow["CHECK (<code>price &gt;= 0</code>)<br/>valid price"]
-    Narrow --> Required["NOT NULL<br/>required valid price"]
+    Broad["<code>NUMERIC</code><br/>any exact number"] --> Narrow["<code>CHECK</code> (<code>price &gt;= 0</code>)<br/>valid price"]
+    Narrow --> Required["<code>NOT NULL</code><br/>required valid price"]
 ```
 
 The strongest designs combine them. A product price might be `NUMERIC`

--- a/content/courses/database-design-postgresql/design-and-data-quality.mdx
+++ b/content/courses/database-design-postgresql/design-and-data-quality.mdx
@@ -128,8 +128,8 @@ flowchart TD
     Fact --> MoneyFact["Price"]
     Fact --> FlagFact["Active flag"]
     DateFact --> DateType["DATE"]
-    MoneyFact --> NumericType["NUMERIC"]
-    FlagFact --> BooleanType["BOOLEAN"]
+    MoneyFact --> NumericType["<code>NUMERIC</code>"]
+    FlagFact --> BooleanType["<code>BOOLEAN</code>"]
 ```
 
 If a due date is stored as arbitrary text, the database cannot know

--- a/content/courses/database-design-postgresql/evolving-schemas-safely.mdx
+++ b/content/courses/database-design-postgresql/evolving-schemas-safely.mdx
@@ -113,7 +113,7 @@ flowchart TD
     Start["tasks table"] --> Nullable["Add priority as nullable"]
     Nullable --> Fill["Backfill priority"]
     Fill --> Check["Confirm no nulls"]
-    Check --> Required["Set priority NOT NULL"]
+    Check --> Required["Set priority <code>NOT NULL</code>"]
 ```
 
 <SqlCodeBlock

--- a/content/courses/database-design-postgresql/junction-tables.mdx
+++ b/content/courses/database-design-postgresql/junction-tables.mdx
@@ -268,7 +268,7 @@ the same pairing cannot be duplicated.
 flowchart TB
     Need["Does another table reference<br/>this enrollment row?"] -->|"no"| Composite["Use pair as primary key"]
     Need -->|"yes"| Surrogate["Use enrollment id"]
-    Surrogate --> Unique["Also keep UNIQUE student-course pair"]
+    Surrogate --> Unique["Also keep <code>UNIQUE</code> student-course pair"]
 ```
 
 The design principle is the same either way: one row represents one

--- a/content/courses/database-design-postgresql/not-null-and-defaults.mdx
+++ b/content/courses/database-design-postgresql/not-null-and-defaults.mdx
@@ -59,6 +59,17 @@ NULL when the business rule says the value is required.
 
 ## DEFAULT fills in an omitted value
 
+In a column definition the two sit side by side, and each answers a
+different question:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "status TEXT", label: "name and type" },
+    { text: "NOT NULL", label: "may this be missing?" },
+    { text: "DEFAULT 'draft'", label: "what to use when the insert omits it" },
+  ]}
+/>
+
 A **DEFAULT** is the value PostgreSQL uses when an insert leaves a
 column out. Defaults are useful when there is a safe, honest value the
 schema can choose.

--- a/content/courses/database-design-postgresql/not-null-and-defaults.mdx
+++ b/content/courses/database-design-postgresql/not-null-and-defaults.mdx
@@ -24,7 +24,7 @@ string, zero, or false.
 ```mermaid
 flowchart TB
     V["Column value"] --> Has["Known value<br/>Ada"]
-    V --> Missing["NULL<br/>unknown or absent"]
+    V --> Missing["<code>NULL</code><br/>unknown or absent"]
 ```
 
 Allowing NULL is a real design choice. It says, "this fact is optional
@@ -44,8 +44,8 @@ column empty.
 ```mermaid
 flowchart TD
     Fact["Column fact"] --> Q{"Must every row<br/>know this?"}
-    Q -->|yes| Req["Use NOT NULL"]
-    Q -->|no| Opt["Allow NULL"]
+    Q -->|yes| Req["Use <code>NOT NULL</code>"]
+    Q -->|no| Opt["Allow <code>NULL</code>"]
 ```
 
 Use `NOT NULL` for values the row cannot make sense without: account
@@ -266,7 +266,7 @@ interfaces can show product names without inventing placeholders.
 
 ```mermaid
 flowchart TD
-    NN["NOT NULL"] --> Promise["Every row has<br/>the value"]
+    NN["<code>NOT NULL</code>"] --> Promise["Every row has<br/>the value"]
     Promise --> Trust["Queries and apps<br/>can rely on it"]
 ```
 

--- a/content/courses/database-design-postgresql/one-to-many.mdx
+++ b/content/courses/database-design-postgresql/one-to-many.mdx
@@ -54,6 +54,17 @@ stores a reference to its parent.
 
 ## The foreign key lives on the many side
 
+Written out, the whole relationship is two lines on the child table:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "CREATE TABLE orders (", label: "the many side" },
+    { text: "customer_id INTEGER", label: "the pointer lives here" },
+    { text: "REFERENCES customers(id)", label: "aimed at the one side" },
+    { text: ")" },
+  ]}
+/>
+
 A **foreign key** is the column that stores the primary key of the
 related row. In a one-to-many relationship, that foreign key belongs on
 the **many** side.

--- a/content/courses/database-design-postgresql/one-to-one.mdx
+++ b/content/courses/database-design-postgresql/one-to-one.mdx
@@ -200,7 +200,7 @@ foreign key. Choose the table whose row is dependent or optional.
 ```mermaid
 flowchart TB
     User["users<br/>core identity"] --> Profile["<code>user_profiles</code><br/>optional details"]
-    Profile -->|"<code>user_id</code> FK + UNIQUE"| User
+    Profile -->|"<code>user_id</code> FK + <code>UNIQUE</code>"| User
     Choice["Put the FK on the dependent table"] --> Profile
 ```
 

--- a/content/courses/database-design-postgresql/referential-integrity.mdx
+++ b/content/courses/database-design-postgresql/referential-integrity.mdx
@@ -16,6 +16,16 @@ comment stores `post_id = 20`, then post `20` must exist. The database
 protects those promises so your design cannot quietly drift into broken
 links.
 
+The whole promise is declared on the child column:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "post_id INTEGER NOT NULL", label: "the pointer itself" },
+    { text: "REFERENCES posts(id)", label: "what it must point at" },
+    { text: "ON DELETE CASCADE", label: "what happens when the parent goes" },
+  ]}
+/>
+
 ## The orphan-row problem
 
 An **orphan row** is a child row that points to a parent row that does

--- a/content/courses/database-design-postgresql/referential-integrity.mdx
+++ b/content/courses/database-design-postgresql/referential-integrity.mdx
@@ -103,8 +103,8 @@ orders? PostgreSQL can enforce several designs.
 flowchart TB
     D["Delete parent row"] --> Q{"What should happen to child rows?"}
     Q -->|"RESTRICT"| R["Block the delete"]
-    Q -->|"CASCADE"| C["Delete children too"]
-    Q -->|"SET NULL"| N["Keep children<br/>clear the reference"]
+    Q -->|"<code>CASCADE</code>"| C["Delete children too"]
+    Q -->|"<code>SET NULL</code>"| N["Keep children<br/>clear the reference"]
 ```
 
 The right answer depends on the meaning of the relationship.
@@ -150,7 +150,7 @@ whose optional editor was removed.
 
 ```mermaid
 flowchart TD
-    E["Delete employee"] --> T["ticket.<code>assigned_employee_id</code> = NULL"]
+    E["Delete employee"] --> T["ticket.<code>assigned_employee_id</code> = <code>NULL</code>"]
     T --> K["Ticket stays open"]
 ```
 
@@ -248,8 +248,8 @@ key changes.
 flowchart TB
     U["Parent key changes"] --> Q{"How should references respond?"}
     Q -->|"RESTRICT"| A["Block the key change"]
-    Q -->|"CASCADE"| B["Update child keys too"]
-    Q -->|"SET NULL"| C["Clear child references"]
+    Q -->|"<code>CASCADE</code>"| B["Update child keys too"]
+    Q -->|"<code>SET NULL</code>"| C["Clear child references"]
 ```
 
 The design lesson is the same: choose the behavior that matches the
@@ -270,9 +270,9 @@ Use this decision path as a design conversation, not a mechanical rule.
 ```mermaid
 flowchart TB
     S["Parent row is removed"] --> A{"Must child rows remain?"}
-    A -->|"no"| C["CASCADE"]
+    A -->|"no"| C["<code>CASCADE</code>"]
     A -->|"yes"| B{"Can the relationship become unknown or optional?"}
-    B -->|"yes"| N["SET NULL"]
+    B -->|"yes"| N["<code>SET NULL</code>"]
     B -->|"no"| R["RESTRICT"]
 ```
 

--- a/content/courses/database-design-postgresql/self-referencing-relationships.mdx
+++ b/content/courses/database-design-postgresql/self-referencing-relationships.mdx
@@ -36,7 +36,7 @@ different tables; it is one table used in two relationship roles.
 
 ```mermaid
 flowchart TB
-    CEO["Ada<br/>id = 1<br/><code>manager_id</code> = NULL"] --> Eng["Grace<br/>id = 2<br/><code>manager_id</code> = 1"]
+    CEO["Ada<br/>id = 1<br/><code>manager_id</code> = <code>NULL</code>"] --> Eng["Grace<br/>id = 2<br/><code>manager_id</code> = 1"]
     CEO --> Ops["Linus<br/>id = 3<br/><code>manager_id</code> = 1"]
     Eng --> Dev["Mina<br/>id = 4<br/><code>manager_id</code> = 2"]
 ```
@@ -143,7 +143,7 @@ erDiagram
 
 ```mermaid
 flowchart TB
-    Root["Root category<br/><code>parent_id</code> = NULL"] --> Data["Data"]
+    Root["Root category<br/><code>parent_id</code> = <code>NULL</code>"] --> Data["Data"]
     Data --> SQL["SQL"]
     Data --> Modeling["Modeling"]
     Root --> Tools["Tools"]

--- a/content/courses/database-design-postgresql/unique-constraints.mdx
+++ b/content/courses/database-design-postgresql/unique-constraints.mdx
@@ -76,6 +76,14 @@ to one account."
 ## Single-column UNIQUE
 
 A **single-column UNIQUE** constraint protects one column by itself.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "email TEXT", label: "the column" },
+    { text: "NOT NULL", label: "it must be provided" },
+    { text: "UNIQUE", label: "and no two rows may share it" },
+  ]}
+/>
 Common examples include:
 
 - account email

--- a/content/courses/database-design-postgresql/unique-constraints.mdx
+++ b/content/courses/database-design-postgresql/unique-constraints.mdx
@@ -195,8 +195,8 @@ have different jobs.
 
 ```mermaid
 flowchart TB
-    Key["No duplicates"] --> PK["PRIMARY KEY<br/>row identity<br/>not null<br/>one per table"]
-    Key --> UQ["UNIQUE<br/>alternate rule<br/>may be many per table"]
+    Key["No duplicates"] --> PK["<code>PRIMARY KEY</code><br/>row identity<br/>not null<br/>one per table"]
+    Key --> UQ["<code>UNIQUE</code><br/>alternate rule<br/>may be many per table"]
 ```
 
 A **primary key** is the table's official row identity. Other tables

--- a/content/courses/database-design-postgresql/what-are-constraints.mdx
+++ b/content/courses/database-design-postgresql/what-are-constraints.mdx
@@ -26,7 +26,7 @@ protecting the meaning of your data.
 
 ```mermaid
 flowchart TD
-    W["Write request<br/>INSERT or UPDATE"] --> C{"Constraint<br/>check"}
+    W["Write request<br/>INSERT or <code>UPDATE</code>"] --> C{"Constraint<br/>check"}
     C -->|passes| A["Accept row<br/>store data"]
     C -->|fails| R["Reject write<br/>return error"]
 ```

--- a/content/courses/database-design-postgresql/why-schemas-change.mdx
+++ b/content/courses/database-design-postgresql/why-schemas-change.mdx
@@ -139,7 +139,7 @@ messy. Later, the team may learn that the fact is always required.
 ```mermaid
 flowchart TD
     Loose["status nullable"] --> Clean["fill missing statuses"]
-    Clean --> Tight["status NOT NULL"]
+    Clean --> Tight["status <code>NOT NULL</code>"]
 ```
 
 <MultipleChoice

--- a/content/courses/from-zero-to-cpp/a-brief-history.mdx
+++ b/content/courses/from-zero-to-cpp/a-brief-history.mdx
@@ -54,7 +54,7 @@ By the 1950s, programmers had become tired of writing literal binary.
   caption="Assembly replaced bit patterns with names a person could actually read."
 />
 
-```
+```text
 MOV AL, 0x61
 ```
 

--- a/content/courses/from-zero-to-cpp/arrays-and-strings.mdx
+++ b/content/courses/from-zero-to-cpp/arrays-and-strings.mdx
@@ -160,6 +160,17 @@ cost per element stays constant.
 
 ## `std::string`: a vector of characters, basically
 
+`substr` takes a position and a *length*, which is the trap: the second argument is not an end index.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "s.substr(" },
+    { text: "2,", label: "start position" },
+    { text: "3", label: "how many characters, not where to stop" },
+    { text: ")" },
+  ]}
+/>
+
 A `std::string` is to `char` what `std::vector` is to `int`. It owns
 its character storage, knows its length, and resizes as needed.
 

--- a/content/courses/from-zero-to-cpp/classes-and-objects.mdx
+++ b/content/courses/from-zero-to-cpp/classes-and-objects.mdx
@@ -137,6 +137,16 @@ they were called on.
 
 ## The hidden `this` pointer
 
+Every non-static member function receives one extra argument you never wrote:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "obj.area()", label: "what you write" },
+    { text: "becomes" },
+    { text: "area(&obj)", label: "what the compiler passes: this" },
+  ]}
+/>
+
 When you call `a.deposit(50.0)`, the compiler passes `a`'s address
 as a hidden first argument. Inside the method, the implicit pointer
 `this` refers to the object:

--- a/content/courses/from-zero-to-cpp/compilation-pipeline.mdx
+++ b/content/courses/from-zero-to-cpp/compilation-pipeline.mdx
@@ -211,7 +211,7 @@ flowchart LR
 When you forget to compile a `.cpp` file, or you misspell a function
 name, you get the famous **undefined reference** error:
 
-```
+```text
 undefined reference to `Greeter::greet()`
 ```
 

--- a/content/courses/from-zero-to-cpp/computational-thinking.mdx
+++ b/content/courses/from-zero-to-cpp/computational-thinking.mdx
@@ -189,7 +189,7 @@ the algorithm out in *plain language* (called **pseudocode**) first.
 
 Here is the algorithm for "find the maximum element of a list":
 
-```
+```text
 1. If the list is empty, there is no maximum. Report an error.
 2. Let `best` = the first element.
 3. For each remaining element `x`:
@@ -261,7 +261,7 @@ first.
 
 **Algorithm:**
 
-```
+```text
 For i from 1 to 100:
     if i divisible by 15: print "FizzBuzz"
     else if i divisible by 3: print "Fizz"

--- a/content/courses/from-zero-to-cpp/functions-and-modularity.mdx
+++ b/content/courses/from-zero-to-cpp/functions-and-modularity.mdx
@@ -25,20 +25,16 @@ write our own.
 
 ## Anatomy of a function
 
-```cpp
-int add(int a, int b) {     // return type, name, parameter list
-    return a + b;           // body
-}
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "int", label: "what flows back to the caller" },
+    { text: "add", label: "what callers invoke it by" },
+    { text: "(int a, int b)", label: "typed slots for the inputs" },
+    { text: "{ return a + b; }", label: "the code that runs on a call" },
+  ]}
+/>
 
-The parts:
-
-- **Return type** (`int`), what kind of value flows back to the
-  caller. Use `void` if the function returns nothing.
-- **Name** (`add`), what callers will use to invoke it.
-- **Parameter list** (`int a, int b`), typed slots for the inputs.
-- **Body** (between `{` and `}`), the code that runs when the
-  function is called.
+Use `void` as the return type when the function returns nothing.
 
 A function must have one **definition** (the body) and may have many
 **declarations** (signatures without a body, often in a header).

--- a/content/courses/from-zero-to-cpp/how-computers-execute.mdx
+++ b/content/courses/from-zero-to-cpp/how-computers-execute.mdx
@@ -51,11 +51,19 @@ on/off switches called **bits**. Eight bits give you `2^8 = 256`
 possible patterns, which is why one byte can hold a number from 0 to
 255.
 
-```
-Address:  0     1     2     3     4     5     6     7
-Box:     [42]  [13]  [ 0]  [97]  [98]  [99]  [ 0]  [255]
-                              'a'   'b'   'c'
-```
+<MemoryCells
+  cells={[
+    { name: "0", value: "42" },
+    { name: "1", value: "13" },
+    { name: "2", value: "0" },
+    { name: "3", value: "97", note: "'a'" },
+    { name: "4", value: "98", note: "'b'" },
+    { name: "5", value: "99", note: "'c'" },
+    { name: "6", value: "0" },
+    { name: "7", value: "255" },
+  ]}
+  caption="Eight bytes at addresses 0 to 7. The header strip is the address, the box is the byte."
+/>
 
 Letters are just numbers under an agreement called **ASCII** or
 **Unicode**. The letter `a` is the number 97. The letter `b` is 98.

--- a/content/courses/from-zero-to-cpp/pointers-and-references.mdx
+++ b/content/courses/from-zero-to-cpp/pointers-and-references.mdx
@@ -267,6 +267,17 @@ std::cout << p->x   << "\\n";   // same thing, idiomatic
 
 ## Const + pointers: the four shapes
 
+Read a pointer declaration right to left, and the position of `const` is what decides which half is frozen:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "const int", label: "the pointed-to int is const" },
+    { text: "*", label: "pointer to" },
+    { text: "const", label: "and the pointer itself is const" },
+    { text: "p;" },
+  ]}
+/>
+
 Mixing `const` with pointers trips up everybody at first. Read
 right-to-left:
 

--- a/content/courses/from-zero-to-cpp/smart-pointers.mdx
+++ b/content/courses/from-zero-to-cpp/smart-pointers.mdx
@@ -24,6 +24,17 @@ There are three to know:
 
 ## `std::unique_ptr`: one owner, no overhead
 
+`make_unique` is the form to use: it allocates and takes ownership in one step, so there is no window where the memory is unowned.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "auto p =" },
+    { text: "std::make_unique", label: "allocate and own in one step" },
+    { text: "<Widget>", label: "what is being created" },
+    { text: "(args...)", label: "forwarded to its constructor" },
+  ]}
+/>
+
 <CodeBlock
   adapter="cpp"
   files={[

--- a/content/courses/from-zero-to-cpp/the-call-stack.mdx
+++ b/content/courses/from-zero-to-cpp/the-call-stack.mdx
@@ -82,28 +82,28 @@ Let's trace what the stack looks like at each step.
 
 **Just inside `main`, after `x = 4; y = 5;`:**
 
-```
+```text
 [ main: x=4, y=5 ]   <- top of stack
 ```
 
 **Right after the call to `add_then_triple(4, 5)`, before any of
 its code runs:**
 
-```
+```text
 [ add_then_triple: a=4, b=5, sum=?, out=? ]
 [ main:            x=4, y=5,            z=? ]
 ```
 
 **Inside `add_then_triple`, after `int sum = a + b;`:**
 
-```
+```text
 [ add_then_triple: a=4, b=5, sum=9, out=? ]
 [ main:            x=4, y=5,            z=? ]
 ```
 
 **Right after calling `triple(9)`:**
 
-```
+```text
 [ triple:          n=9, t=? ]
 [ add_then_triple: a=4, b=5, sum=9, out=? ]
 [ main:            x=4, y=5,            z=? ]
@@ -111,7 +111,7 @@ its code runs:**
 
 **Inside `triple`, after `int t = n * 3;`:**
 
-```
+```text
 [ triple:          n=9, t=27 ]
 [ add_then_triple: a=4, b=5, sum=9, out=? ]
 [ main:            x=4, y=5,            z=? ]
@@ -120,14 +120,14 @@ its code runs:**
 **After `return t;`** (the `triple` frame is popped, the value `27`
 is delivered to the caller):
 
-```
+```text
 [ add_then_triple: a=4, b=5, sum=9, out=27 ]
 [ main:            x=4, y=5,            z=? ]
 ```
 
 **After `return out;`** (the `add_then_triple` frame is popped):
 
-```
+```text
 [ main: x=4, y=5, z=27 ]
 ```
 

--- a/content/courses/from-zero-to-cpp/variables-and-memory.mdx
+++ b/content/courses/from-zero-to-cpp/variables-and-memory.mdx
@@ -119,7 +119,7 @@ label; it tells the compiler:
 ```mermaid
 flowchart LR
     subgraph Memory
-        B["4 raw bytes<br/><code>0x2A</code> <code>0x00</code> <code>0x00</code> <code>0x00</code>"]
+        B["4 raw bytes<br/><code>0x2A 0x00 0x00 0x00</code>"]
     end
     B -->|interpreted as int| I[42]
     B -->|interpreted as float| F[5.88e-44]

--- a/content/courses/functional-programming-typescript/capstone-pipeline.mdx
+++ b/content/courses/functional-programming-typescript/capstone-pipeline.mdx
@@ -24,7 +24,7 @@ There is no library involved; just plain TypeScript.
 
 We're given a list of raw "sale" rows from a CSV-like source:
 
-```
+```text
 "2024-09-01,A,3,12.50"
 "2024-09-01,B,1,9.99"
 "2024-09-02,A,2,12.50"

--- a/content/courses/functional-programming-typescript/function-composition.mdx
+++ b/content/courses/functional-programming-typescript/function-composition.mdx
@@ -83,6 +83,18 @@ Two things to notice:
 
 ## `pipe()`: the left-to-right cousin
 
+`pipe` takes the value first and then the steps, which is why it reads in the order the data actually moves:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "pipe(" },
+    { text: "value,", label: "what goes in" },
+    { text: "double,", label: "applied first" },
+    { text: "toString", label: "applied to that result" },
+    { text: ")" },
+  ]}
+/>
+
 In practice, most TypeScript code reads better when the data *flows
 forward*: input on the left, transformations on the right. That's
 what `pipe()` does:
@@ -229,6 +241,17 @@ Both are correct. The second one is *legible*: each step has a name,
 and the pipeline reads like a recipe.
 
 ## Currying: one argument at a time
+
+A curried function's type is the shape of the idea: every arrow returns a function that wants the next argument.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "(a: number)", label: "take one argument" },
+    { text: "=>", label: "and return..." },
+    { text: "(b: number)", label: "...a function wanting the next" },
+    { text: "=> number", label: "until the last one produces the value" },
+  ]}
+/>
 
 **Currying** is the transformation that turns a function of multiple
 arguments into a *chain* of one-argument functions.

--- a/content/courses/functional-programming-typescript/higher-order-functions.mdx
+++ b/content/courses/functional-programming-typescript/higher-order-functions.mdx
@@ -65,6 +65,17 @@ what makes everything else in this chapter possible.
 
 ## Functions that take functions: the classic combinators
 
+The signature of a higher-order function has a function *inside* one of its parameter types, which is the whole definition:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "map<A, B>(" },
+    { text: "xs: A[],", label: "the data" },
+    { text: "f: (a: A) => B", label: "a parameter that is itself a function" },
+    { text: "): B[]", label: "the element type changes with it" },
+  ]}
+/>
+
 The three you already know:
 
 <CodeBlock

--- a/content/courses/functional-programming-typescript/option-and-result.mdx
+++ b/content/courses/functional-programming-typescript/option-and-result.mdx
@@ -167,6 +167,17 @@ fallback kicks in.
 
 ## Result: "an A or an error E"
 
+Two type parameters, and their order is a convention worth knowing: the error comes first.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "Result<" },
+    { text: "E,", label: "the failure type" },
+    { text: "A", label: "the success type" },
+    { text: ">" },
+  ]}
+/>
+
 `Option` answers "is there a value?" `Result` answers "what went
 wrong?". You use it when you need *information* about the failure,
 not just its absence.

--- a/content/courses/how-llms-work/sampling.mdx
+++ b/content/courses/how-llms-work/sampling.mdx
@@ -119,6 +119,15 @@ print("High T gives the long tail a real chance.")
 
 ## Top-p (nucleus) sampling
 
+Top-p is a cutoff on cumulative probability, not on a count, which is what makes the candidate set shrink and grow with the model's confidence:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "top_p=0.9", label: "keep tokens until their probabilities sum to 0.9" },
+    { text: "temperature=0.7", label: "applied first, reshaping the distribution" },
+  ]}
+/>
+
 Temperature alone has a problem: at high temperature, genuinely absurd
 tokens become reachable. Top-p fixes this by truncating the tail first.
 

--- a/content/courses/how-llms-work/sampling.mdx
+++ b/content/courses/how-llms-work/sampling.mdx
@@ -67,6 +67,17 @@ everything into a safe range and leaves the result unchanged.
 
 ## Temperature reshapes the distribution
 
+Temperature divides the scores before the softmax, which is why it changes the *shape* of the distribution rather than its order:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "softmax(" },
+    { text: "logits", label: "the raw scores" },
+    { text: "/ temperature", label: "below 1 sharpens, above 1 flattens" },
+    { text: ")" },
+  ]}
+/>
+
 Temperature divides the logits before the softmax.
 
 * **Low temperature** (below 1) spreads the logits apart, making the

--- a/content/courses/how-llms-work/tokens.mdx
+++ b/content/courses/how-llms-work/tokens.mdx
@@ -14,6 +14,16 @@ surprising behavior than any other single component.
 
 ## What a token is
 
+A tokenizer call is text in, integers out, and the model's vocabulary is what decides where the splits fall:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "encode(", label: "text in" },
+    { text: "\"unbelievable\"", label: "one word to you" },
+    { text: ")", label: "out come several token ids, not characters" },
+  ]}
+/>
+
 A token is a chunk of text that the vocabulary assigns a single id to.
 Not a character, not a word, something in between:
 

--- a/content/courses/intro-data-viz-plotly/bar-charts.mdx
+++ b/content/courses/intro-data-viz-plotly/bar-charts.mdx
@@ -76,6 +76,18 @@ anything be wrong? If yes, the order is data and sorting deletes it.
 
 ## The simplest bar chart
 
+Every Plotly Express call has the same shape: the data, then which column drives which visual channel.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "px.bar(" },
+    { text: "df,", label: "the data frame" },
+    { text: "x=\"country\",", label: "the categorical axis" },
+    { text: "y=\"pop\"", label: "the measured axis" },
+    { text: ")" },
+  ]}
+/>
+
 Before the code, one thing bars do for free that is easy to spend money on
 instead. When bars fall into groups, the spacing can say so on its own:
 

--- a/content/courses/intro-data-viz-plotly/bubble-charts.mdx
+++ b/content/courses/intro-data-viz-plotly/bubble-charts.mdx
@@ -26,6 +26,18 @@ bubble size and continent as color, animated over time.
 
 ## Your first bubble chart
 
+A bubble chart is a scatter plot with two more channels bound to columns, which is why the call grows by exactly two arguments:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "px.scatter(df," },
+    { text: "x=\"gdp\", y=\"life\",", label: "position, read most accurately" },
+    { text: "size=\"pop\",", label: "area, read least accurately" },
+    { text: "color=\"continent\"", label: "hue, for categories" },
+    { text: ")" },
+  ]}
+/>
+
 <CodeBlock
   adapter="python"
   files={[

--- a/content/courses/intro-data-viz-plotly/color-scales-and-aesthetics.mdx
+++ b/content/courses/intro-data-viz-plotly/color-scales-and-aesthetics.mdx
@@ -16,6 +16,17 @@ sometimes lies about it.
 
 ## The three families of color scales
 
+Which argument you reach for is decided by the column's type, not by taste:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "px.scatter(df, x=..., y=...," },
+    { text: "color=\"depth\",", label: "the column to color by" },
+    { text: "color_continuous_scale=\"Viridis\"", label: "sequential, because depth is continuous" },
+    { text: ")" },
+  ]}
+/>
+
 There are essentially three families. Knowing which family fits
 which kind of data is 80% of the battle.
 

--- a/content/courses/intro-modern-csharp/capstone-task-tracker.mdx
+++ b/content/courses/intro-modern-csharp/capstone-task-tracker.mdx
@@ -63,7 +63,7 @@ The driver does this:
 
 Expected output (exact):
 
-```
+```text
 remaining=1
 [x] 1: Buy milk
 [x] 2: Write course

--- a/content/courses/intro-modern-csharp/collections.mdx
+++ b/content/courses/intro-modern-csharp/collections.mdx
@@ -61,6 +61,16 @@ lightweight, but you can't `Add()` or `Remove()`.
 
 ## `List<T>`: the everyday sequence
 
+The type argument is the whole difference from an untyped list: it is what lets the compiler reject a wrong element.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "List", label: "a growable sequence" },
+    { text: "<string>", label: "what it is a sequence of" },
+    { text: "names = new();", label: "the type on the left is enough for new()" },
+  ]}
+/>
+
 If you don't know exactly how many items you'll have, reach for
 `List<T>`.
 
@@ -101,6 +111,17 @@ Mental model: a `List<T>` is "an array that grows for you." It
 it allocates a bigger one and copies the old contents.
 
 ## `Dictionary<TKey, TValue>`: a phone book
+
+A dictionary needs two type arguments, and their order is the lookup direction:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "Dictionary<" },
+    { text: "string,", label: "the key you look up by" },
+    { text: "int", label: "the value you get back" },
+    { text: "> ages = new();" },
+  ]}
+/>
 
 A dictionary maps **keys** to **values**. Lookup by key is fast,
 even for a dictionary with millions of entries.

--- a/content/courses/intro-modern-csharp/control-flow.mdx
+++ b/content/courses/intro-modern-csharp/control-flow.mdx
@@ -135,6 +135,19 @@ or unsafe to evaluate.
 
 ## `switch`: branch on a value
 
+Modern C# writes this as an *expression*, which means it produces a value rather than assigning one in each branch:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "var name =" },
+    { text: "day", label: "the value being matched" },
+    { text: "switch {" },
+    { text: "1 => \"Mon\",", label: "a pattern, then its result" },
+    { text: "_ => \"other\"", label: "the discard pattern, matching anything left" },
+    { text: "};" },
+  ]}
+/>
+
 When you have many possible values for one variable, a chain of
 `if`/`else if` gets noisy. `switch` is cleaner.
 

--- a/content/courses/intro-modern-csharp/debugging-and-reasoning.mdx
+++ b/content/courses/intro-modern-csharp/debugging-and-reasoning.mdx
@@ -90,7 +90,7 @@ When an unhandled exception is thrown, C# prints a **stack trace**
 showing the chain of method calls that led to the failure. Read
 it from the top:
 
-```
+```text
 System.DivideByZeroException: Attempted to divide by zero.
    at SimpleMath.Divide(Int32 a, Int32 b) in /src/SimpleMath.cs:line 7
    at Program.<Main>$(String[] args) in /src/Program.cs:line 5

--- a/content/courses/intro-modern-csharp/encapsulation-and-abstraction.mdx
+++ b/content/courses/intro-modern-csharp/encapsulation-and-abstraction.mdx
@@ -57,6 +57,17 @@ touches `Balance`. That's the problem encapsulation solves.
 
 ## Access modifiers: the basic tools
 
+Every member declaration opens by answering "who can see this?":
+
+<SyntaxBreakdown
+  parts={[
+    { text: "private", label: "who may touch it" },
+    { text: "readonly", label: "assigned once, in the constructor" },
+    { text: "decimal", label: "its type" },
+    { text: "_balance;", label: "its name" },
+  ]}
+/>
+
 C# gives you a few keywords to control who can see what.
 
 | Modifier              | Visible to                                       |

--- a/content/courses/intro-modern-csharp/error-handling.mdx
+++ b/content/courses/intro-modern-csharp/error-handling.mdx
@@ -84,6 +84,16 @@ up by stack unwinding plus `finally` blocks.
 
 ## `try` / `catch` / `finally`
 
+Three blocks, and each one answers a different question:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "try", label: "the code that might fail" },
+    { text: "catch (IOException ex)", label: "which failures you can handle" },
+    { text: "finally", label: "runs either way, failure or not" },
+  ]}
+/>
+
 <CodeBlock
   adapter="csharp"
   files={[

--- a/content/courses/intro-modern-csharp/inheritance-and-polymorphism.mdx
+++ b/content/courses/intro-modern-csharp/inheritance-and-polymorphism.mdx
@@ -81,6 +81,16 @@ shared parts live at the top.
 
 ## Overriding behavior with `virtual` and `override`
 
+C# makes you say it twice, once on each side, which is what stops an accidental override:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "public virtual", label: "on the parent: this may be replaced" },
+    { text: "string Speak()", label: "the signature both sides share" },
+    { text: "public override", label: "on the child: this replaces it deliberately" },
+  ]}
+/>
+
 Sometimes a derived class needs to **change** how a base method
 works, not just add new methods. The base marks the method
 `virtual`; the derived class marks its replacement `override`.

--- a/content/courses/intro-modern-csharp/methods-and-modularity.mdx
+++ b/content/courses/intro-modern-csharp/methods-and-modularity.mdx
@@ -53,6 +53,17 @@ argument, and gives back a value you can use anywhere.
 
 ## Parameters and arguments
 
+The declaration names the *parameters*; a call supplies the *arguments*:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "static", label: "no instance needed" },
+    { text: "double", label: "what it hands back" },
+    { text: "Area", label: "the name callers use" },
+    { text: "(double w, double h)", label: "the parameters, typed" },
+  ]}
+/>
+
 A **parameter** is the name in the method's declaration; an
 **argument** is the actual value supplied at the call site. They
 match up in order.

--- a/content/courses/intro-modern-csharp/resource-management.mdx
+++ b/content/courses/intro-modern-csharp/resource-management.mdx
@@ -80,6 +80,16 @@ it *now*, deterministically": the **`IDisposable`** pattern.
 
 ## `IDisposable` and `using`
 
+`using` is what guarantees the release happens, whatever the block does next:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "using", label: "dispose it when the block ends" },
+    { text: "var reader =", label: "the variable you actually use" },
+    { text: "new StreamReader(path);", label: "the resource being held" },
+  ]}
+/>
+
 Any class that owns an unmanaged resource implements
 `IDisposable` with a `Dispose()` method. You can call `Dispose()`
 yourself, but the language has a better tool: the `using`

--- a/content/courses/intro-modern-csharp/software-organization.mdx
+++ b/content/courses/intro-modern-csharp/software-organization.mdx
@@ -128,7 +128,7 @@ Multiple projects can be grouped into a **solution** (`.sln`),
 which is just a list of projects that ship together. Typical
 layouts:
 
-```
+```text
 MyApp.sln
 ├── MyApp/               # console / web app (the "entry" project)
 │   └── MyApp.csproj

--- a/content/courses/intro-modern-csharp/type-system.mdx
+++ b/content/courses/intro-modern-csharp/type-system.mdx
@@ -99,6 +99,15 @@ both, `decimal`, for the rounding reasons the last chapter showed.
 
 ## Type conversions
 
+Two different operations, and the syntax is what tells them apart:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "(int) price", label: "a cast: I know this is safe" },
+    { text: "int.Parse(text)", label: "a parse: text in, number out, may throw" },
+  ]}
+/>
+
 Sometimes you really do need to turn one type into another. C# has
 two flavors of conversion.
 

--- a/content/courses/intro-modern-csharp/variables-and-memory.mdx
+++ b/content/courses/intro-modern-csharp/variables-and-memory.mdx
@@ -70,6 +70,16 @@ annoyance, it prevents whole categories of bugs.
 
 ## `var`: let the compiler figure it out
 
+`var` is not a dynamic type. The type is still fixed at compile time, it is just written on the right instead of the left:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "var", label: "infer the type from the initializer" },
+    { text: "count", label: "the variable" },
+    { text: "= 10;", label: "which fixes it as int, permanently" },
+  ]}
+/>
+
 Repeating the type name on both sides can feel noisy:
 
 ```csharp

--- a/content/courses/intro-sql-postgres/aggregate-functions.mdx
+++ b/content/courses/intro-sql-postgres/aggregate-functions.mdx
@@ -48,6 +48,16 @@ The five core aggregates cover most needs:
 `COUNT(*)` counts rows. Run it and notice the result is a single row
 with a single number, the whole table collapsed to a count:
 
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT" },
+    { text: "COUNT", label: "which aggregate" },
+    { text: "(*)", label: "over what; * means the rows themselves" },
+    { text: "AS headcount", label: "name the single number" },
+    { text: "FROM employees;" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="postgres"
   title="How many employees are there?"

--- a/content/courses/intro-sql-postgres/aggregate-functions.mdx
+++ b/content/courses/intro-sql-postgres/aggregate-functions.mdx
@@ -182,8 +182,8 @@ WHERE
 
 ```mermaid
 flowchart TD
-    T[("<code>employees</code>")] --> W["WHERE<br/><code>dept = 'Engineering'</code>"]
-    W --> A["AVG(salary)"]
+    T[("<code>employees</code>")] --> W["<code>WHERE</code><br/><code>dept = 'Engineering'</code>"]
+    W --> A["<code>AVG(salary)</code>"]
     A --> R["one number"]
 ```
 

--- a/content/courses/intro-sql-postgres/common-table-expressions.mdx
+++ b/content/courses/intro-sql-postgres/common-table-expressions.mdx
@@ -25,11 +25,15 @@ table.
   caption="A `WITH` clause names a result so the query below can read it like a table."
 />
 
-```mermaid
-flowchart TB
-    CTE["WITH <code>big_orders</code> AS (<br/>SELECT ... FROM orders WHERE amount > 50<br/>)"] -->|"named result"| Main["SELECT ... FROM <code>big_orders</code>"]
-    Main --> Result["Final rows"]
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "WITH" },
+    { text: "big_orders", label: "the name you choose" },
+    { text: "AS (SELECT ... )", label: "the query it stands for" },
+    { text: "SELECT ... FROM" },
+    { text: "big_orders", label: "read like any other table" },
+  ]}
+/>
 
 The CTE runs first and produces a temporary, named result; the main
 query then reads from that name. It is the same idea as a subquery,

--- a/content/courses/intro-sql-postgres/creating-tables.mdx
+++ b/content/courses/intro-sql-postgres/creating-tables.mdx
@@ -19,6 +19,14 @@ set of *promises* about your data.
 To make a table, you list its columns and each column's type inside
 `CREATE TABLE`:
 
+<SyntaxBreakdown
+  parts={[
+    { text: "CREATE TABLE" },
+    { text: "books", label: "the table's name" },
+    { text: "(id INTEGER, title TEXT, ...);", label: "one name and one type per column" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="postgres"
   title="Create a table, then read it"

--- a/content/courses/intro-sql-postgres/expressions-and-aliases.mdx
+++ b/content/courses/intro-sql-postgres/expressions-and-aliases.mdx
@@ -87,10 +87,13 @@ value by name.
   caption="`AS` clips a readable name onto a column the query has just made up."
 />
 
-```mermaid
-flowchart TD
-    E["price * qty"] -->|"AS <code>line_total</code>"| C["a clearly<br/>named column"]
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "price * qty", label: "the expression to compute" },
+    { text: "AS" },
+    { text: "line_total", label: "the name the new column gets" },
+  ]}
+/>
 
 <Callout type="info" title="The word AS is optional, but be kind">
 PostgreSQL lets you write the alias without `AS`,

--- a/content/courses/intro-sql-postgres/filtering-groups.mdx
+++ b/content/courses/intro-sql-postgres/filtering-groups.mdx
@@ -39,6 +39,18 @@ flowchart TD
 aggregates have been computed. Think of it as "`WHERE`, but for
 groups."
 
+In a finished query the two sit either side of `GROUP BY`, and each
+can only see what exists by the time it runs:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT dept, COUNT(*) FROM employees" },
+    { text: "WHERE active", label: "filters rows, before any group exists" },
+    { text: "GROUP BY dept", label: "the groups are built here" },
+    { text: "HAVING COUNT(*) > 2", label: "filters groups, once the counts exist" },
+  ]}
+/>
+
 ## HAVING in action
 
 Keep only departments with more than two employees:

--- a/content/courses/intro-sql-postgres/filtering-rows.mdx
+++ b/content/courses/intro-sql-postgres/filtering-rows.mdx
@@ -117,6 +117,15 @@ ORDER BY
 So `'A%'` means "starts with A," `'%son'` means "ends with son," and
 `'%ar%'` means "contains ar."
 
+<SyntaxBreakdown
+  parts={[
+    { text: "WHERE" },
+    { text: "name", label: "the text column to test" },
+    { text: "LIKE" },
+    { text: "'A%'", label: "the pattern, where % is any run of characters" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="postgres"
   title="Names that start with a vowel-ish pattern"

--- a/content/courses/intro-sql-postgres/first-queries.mdx
+++ b/content/courses/intro-sql-postgres/first-queries.mdx
@@ -62,15 +62,18 @@ Notice three things that will recur all course long:
 Here is the basic shape you will type thousands of times, with the
 parts named:
 
-```mermaid
-flowchart TD
-    K["<code>SELECT</code>"] --> C["which columns<br/>or values you want"]
-    C --> F["<code>FROM</code>"]
-    F --> T["which table<br/>to read from"]
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT" },
+    { text: "name, email", label: "what you want back" },
+    { text: "FROM" },
+    { text: "customers", label: "which table to read it from" },
+    { text: ";" },
+  ]}
+/>
 
-- **`SELECT`**, *what* you want back (columns or computed values).
-- **`FROM`**, *where* to get it (which table).
+Two keywords, two questions: `SELECT` answers *what*, `FROM` answers
+*where*.
 
 When you are just computing values, like `SELECT 2 + 2`, you can
 skip `FROM` entirely. The moment you want stored data, you add
@@ -83,8 +86,8 @@ skip `FROM` entirely. The moment you want stored data, you add
 />
 
 <Callout type="info" title="SQL keywords and your style">
-SQL keywords like \`SELECT\` and \`FROM\` are not case-sensitive,
-\`select\`, \`Select\`, and \`SELECT\` all work. By strong
+SQL keywords like `SELECT` and `FROM` are not case-sensitive,
+`select`, `Select`, and `SELECT` all work. By strong
 convention, this course writes keywords in UPPERCASE and names in
 lowercase, because it makes queries far easier to read at a glance.
 </Callout>

--- a/content/courses/intro-sql-postgres/grouping-data.mdx
+++ b/content/courses/intro-sql-postgres/grouping-data.mdx
@@ -42,6 +42,19 @@ department*, a far more useful answer.
 
 ## Your first GROUP BY
 
+A grouped query names the column that defines a group, and the
+aggregates it wants computed once per group:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT" },
+    { text: "dept,", label: "one output row per value here" },
+    { text: "COUNT(*)", label: "computed once inside each group" },
+    { text: "FROM employees" },
+    { text: "GROUP BY dept;", label: "what makes two rows the same group" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="postgres"
   title="Headcount and average pay per department"

--- a/content/courses/intro-sql-postgres/grouping-data.mdx
+++ b/content/courses/intro-sql-postgres/grouping-data.mdx
@@ -32,9 +32,9 @@ flowchart TB
     G --> E["Engineering<br/>group"]
     G --> S["Sales<br/>group"]
     G --> M["Marketing<br/>group"]
-    E --> EA["AVG(salary)"]
-    S --> SA["AVG(salary)"]
-    M --> MA["AVG(salary)"]
+    E --> EA["<code>AVG(salary)</code>"]
+    S --> SA["<code>AVG(salary)</code>"]
+    M --> MA["<code>AVG(salary)</code>"]
 ```
 
 Instead of one average salary, you get one average salary *per
@@ -104,9 +104,9 @@ than guess.
 
 ```mermaid
 flowchart TB
-    C["A column in SELECT<br/>alongside GROUP BY"]
+    C["A column in <code>SELECT</code><br/>alongside <code>GROUP BY</code>"]
     C --> Q{"Same value for<br/>the whole group?"}
-    Q -->|"yes: it's the GROUP BY column"| OK["Allowed"]
+    Q -->|"yes: it's the <code>GROUP BY</code> column"| OK["Allowed"]
     Q -->|"no: differs within group"| Need["Must be aggregated<br/>(COUNT, SUM, ...)"]
 ```
 

--- a/content/courses/intro-sql-postgres/inner-joins.mdx
+++ b/content/courses/intro-sql-postgres/inner-joins.mdx
@@ -25,7 +25,7 @@ flowchart LR
         R1["matched customers"]
         R2["unmatched customer"]
     end
-    L1 -->|"kept"| Out["INNER JOIN result:<br/>only matched pairs"]
+    L1 -->|"kept"| Out["<code>INNER JOIN</code> result:<br/>only matched pairs"]
     R1 -->|"kept"| Out
     L2 -.->|"dropped"| X["✗"]
     R2 -.->|"dropped"| X

--- a/content/courses/intro-sql-postgres/inserting-data.mdx
+++ b/content/courses/intro-sql-postgres/inserting-data.mdx
@@ -27,6 +27,16 @@ flowchart LR
 `INSERT` puts new rows into a table. You name the columns, then
 supply matching values:
 
+<SyntaxBreakdown
+  parts={[
+    { text: "INSERT INTO" },
+    { text: "tasks", label: "the table to add to" },
+    { text: "(title, done)", label: "which columns you are filling" },
+    { text: "VALUES" },
+    { text: "('Buy milk', false);", label: "one row, in that same order" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="postgres"
   title="Insert one row and several rows"
@@ -72,6 +82,15 @@ A few things to absorb:
 `UPDATE` changes values in rows that already exist. You set new
 values with `SET`, and, crucially, you say *which* rows with
 `WHERE`:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "UPDATE" },
+    { text: "tasks", label: "the table to change" },
+    { text: "SET done = true", label: "the new value" },
+    { text: "WHERE id = 1;", label: "which rows; leave this off and every row changes" },
+  ]}
+/>
 
 <SqlCodeBlock
   dialect="postgres"
@@ -132,6 +151,14 @@ selected exactly that row.
 ## DELETE: removing rows
 
 `DELETE` removes rows. Again, `WHERE` decides which ones:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "DELETE FROM" },
+    { text: "tasks", label: "the table to remove from" },
+    { text: "WHERE done = true;", label: "which rows; leave this off and the table empties" },
+  ]}
+/>
 
 <SqlCodeBlock
   dialect="postgres"

--- a/content/courses/intro-sql-postgres/inserting-data.mdx
+++ b/content/courses/intro-sql-postgres/inserting-data.mdx
@@ -221,7 +221,7 @@ accidentally destroy data.
 
 ```mermaid
 flowchart TB
-    D1["DELETE FROM tasks<br/>WHERE <code>id = 5</code>;"] --> R1["Removes 1 row<br/>(good)"]
+    D1["<code>DELETE FROM</code> tasks<br/>WHERE <code>id = 5</code>;"] --> R1["Removes 1 row<br/>(good)"]
     D2["<code>DELETE FROM tasks;</code>"] --> R2["Removes EVERY row<br/>(usually a disaster)"]
 ```
 

--- a/content/courses/intro-sql-postgres/outer-joins.mdx
+++ b/content/courses/intro-sql-postgres/outer-joins.mdx
@@ -20,6 +20,15 @@ A `LEFT JOIN` keeps **every row from the left (first) table**,
 matched or not. Where a match exists, the right table's columns are
 filled in. Where none exists, those columns come back as `NULL`.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "FROM customers", label: "the left table, every row survives" },
+    { text: "LEFT JOIN" },
+    { text: "orders", label: "the right table, optional" },
+    { text: "ON customers.id = orders.customer_id", label: "no match here means NULLs" },
+  ]}
+/>
+
 ```mermaid
 flowchart TB
     subgraph L["Left table (customers)"]

--- a/content/courses/intro-sql-postgres/outer-joins.mdx
+++ b/content/courses/intro-sql-postgres/outer-joins.mdx
@@ -36,8 +36,8 @@ flowchart TB
         L2["Linus (no orders)"]
     end
     L1 -->|"matched"| R1["Ada + her orders"]
-    L2 -->|"no match → NULLs"| R2["Linus + NULL order"]
-    R1 --> Out["LEFT JOIN result"]
+    L2 -->|"no match → NULLs"| R2["Linus + <code>NULL</code> order"]
+    R1 --> Out["<code>LEFT JOIN</code> result"]
     R2 --> Out
 ```
 

--- a/content/courses/intro-sql-postgres/primary-keys.mdx
+++ b/content/courses/intro-sql-postgres/primary-keys.mdx
@@ -40,6 +40,16 @@ row to have a **unique, unchanging identity.**
 
 ## What a primary key is
 
+One clause on a column declaration carries both promises at once: unique, and never null.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "id", label: "the column" },
+    { text: "SERIAL", label: "its type, auto-numbered" },
+    { text: "PRIMARY KEY", label: "unique and NOT NULL, in one word" },
+  ]}
+/>
+
 A **primary key** is a column (or set of columns) whose value
 **uniquely identifies each row** in a table. No two rows may share
 the same primary key value, and it is never empty.

--- a/content/courses/intro-sql-postgres/query-execution-order.mdx
+++ b/content/courses/intro-sql-postgres/query-execution-order.mdx
@@ -30,7 +30,20 @@ The order you type is for human readability. The order the database
 
 Read the numbers: `FROM` is first, `SELECT` is near the **end**, and
 `LIMIT` is last. The clause you *write* first (`SELECT`) is among the
-*last* to actually run.
+*last* to actually run. Written left to right, with when each one
+actually runs:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT ...", label: "runs 5th" },
+    { text: "FROM ...", label: "runs 1st" },
+    { text: "WHERE ...", label: "runs 2nd" },
+    { text: "GROUP BY ...", label: "runs 3rd" },
+    { text: "HAVING ...", label: "runs 4th" },
+    { text: "ORDER BY ...", label: "runs 7th" },
+    { text: "LIMIT ...;", label: "runs 8th" },
+  ]}
+/>
 
 <Figure
   slug="sql-query-execution-order-written-order-vs-inline-cutout"

--- a/content/courses/intro-sql-postgres/select-basics.mdx
+++ b/content/courses/intro-sql-postgres/select-basics.mdx
@@ -147,6 +147,15 @@ FROM
 Sometimes you only care about the *distinct* values in a column.
 `SELECT DISTINCT` collapses repeated rows into unique ones:
 
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT" },
+    { text: "DISTINCT", label: "collapse repeats into one" },
+    { text: "dept", label: "the column whose distinct values you want" },
+    { text: "FROM employees;" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="postgres"
   title="Unique departments only"

--- a/content/courses/intro-sql-postgres/sorting-and-limiting.mdx
+++ b/content/courses/intro-sql-postgres/sorting-and-limiting.mdx
@@ -19,6 +19,14 @@ and "most recent" list you have ever seen.
 `ORDER BY` sorts the result by one or more columns. Add `ASC` for
 ascending (the default) or `DESC` for descending:
 
+<SyntaxBreakdown
+  parts={[
+    { text: "ORDER BY" },
+    { text: "salary", label: "sort on this column" },
+    { text: "DESC", label: "largest first; ASC is the default" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="postgres"
   title="Highest-paid first"
@@ -99,6 +107,14 @@ flowchart TD
 
 `LIMIT n` keeps only the first `n` rows of the result. Combined with
 `ORDER BY`, it answers "top N" questions:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "ORDER BY salary DESC", label: "decide what top means" },
+    { text: "LIMIT" },
+    { text: "3", label: "then keep only that many rows" },
+  ]}
+/>
 
 <SqlCodeBlock
   dialect="postgres"

--- a/content/courses/intro-sql-postgres/subqueries.mdx
+++ b/content/courses/intro-sql-postgres/subqueries.mdx
@@ -141,9 +141,9 @@ the shape of its result:
 
 ```mermaid
 flowchart TD
-    W["In WHERE<br/>compare against a value or list"]
-    F["In FROM<br/>treat a result as a temporary table"]
-    S["In SELECT<br/>compute one extra value per row"]
+    W["In <code>WHERE</code><br/>compare against a value or list"]
+    F["In <code>FROM</code><br/>treat a result as a temporary table"]
+    S["In <code>SELECT</code><br/>compute one extra value per row"]
     W --- F --- S
 ```
 

--- a/content/courses/intro-sql-postgres/subqueries.mdx
+++ b/content/courses/intro-sql-postgres/subqueries.mdx
@@ -82,6 +82,15 @@ A subquery can also return a **column of values**, which pairs
 naturally with `IN`. Here the inner query lists the ids of customers
 who have ordered, and the outer query selects those customers:
 
+<SyntaxBreakdown
+  parts={[
+    { text: "WHERE" },
+    { text: "id", label: "the outer column to test" },
+    { text: "IN", label: "true if it appears anywhere in the list" },
+    { text: "(SELECT customer_id FROM orders)", label: "the inner query supplies the list" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="postgres"
   title="Customers who have placed an order"

--- a/content/courses/intro-sql-postgres/tables-rows-columns.mdx
+++ b/content/courses/intro-sql-postgres/tables-rows-columns.mdx
@@ -83,7 +83,7 @@ happened to print it.
 
 ```mermaid
 flowchart TD
-    Q["A table is an<br/>unordered bag of rows"] --> S["Want a specific order?<br/>Ask for it with ORDER BY"]
+    Q["A table is an<br/>unordered bag of rows"] --> S["Want a specific order?<br/>Ask for it with <code>ORDER BY</code>"]
 ```
 
 This is why, later, we use `ORDER BY` whenever order matters. If you

--- a/content/courses/intro-sql-postgres/understanding-joins.mdx
+++ b/content/courses/intro-sql-postgres/understanding-joins.mdx
@@ -47,6 +47,19 @@ wide row.
 A join lives in the `FROM` part of a query. It names a second table
 and the **matching condition** with `ON`:
 
+<SyntaxBreakdown
+  parts={[
+    { text: "FROM orders" },
+    { text: "JOIN" },
+    { text: "customers", label: "the second table" },
+    { text: "ON" },
+    { text: "orders.customer_id = customers.id", label: "which rows count as a match" },
+  ]}
+/>
+
+Everything else about the query is unchanged. Here it is whole, and
+runnable:
+
 <SqlCodeBlock
   dialect="postgres"
   title="Your first join, narrated"

--- a/content/courses/intro-sql-postgres/working-with-null.mdx
+++ b/content/courses/intro-sql-postgres/working-with-null.mdx
@@ -27,7 +27,7 @@ same as an empty string `''`:
 flowchart TB
     Z["0<br/>a known number<br/>(zero)"]
     E["''<br/>a known text<br/>(empty string)"]
-    N["NULL<br/>no value at all<br/>(unknown)"]
+    N["<code>NULL</code><br/>no value at all<br/>(unknown)"]
 ```
 
 Imagine a `phone` column. A customer with `phone = ''` told us their
@@ -209,9 +209,9 @@ behavior is the price of that honesty, and `IS NULL` plus
 
 ```mermaid
 flowchart TD
-    M["Missing real data"] --> N["Store NULL<br/>(honest 'unknown')"]
-    N --> T1["Test with IS NULL"]
-    N --> T2["Display with COALESCE"]
+    M["Missing real data"] --> N["Store <code>NULL</code><br/>(honest 'unknown')"]
+    N --> T1["Test with <code>IS NULL</code>"]
+    N --> T2["Display with <code>COALESCE</code>"]
 ```
 
 ## Check your understanding

--- a/content/courses/intro-sql-postgres/working-with-null.mdx
+++ b/content/courses/intro-sql-postgres/working-with-null.mdx
@@ -81,6 +81,14 @@ Since `= NULL` does not work, SQL gives you special tests:
 - `IS NULL`, true when the value is missing.
 - `IS NOT NULL`, true when the value is present.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "WHERE" },
+    { text: "phone", label: "the column that may be missing" },
+    { text: "IS NULL", label: "the only test that works on NULL" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="postgres"
   title="Find the rows with missing data"
@@ -142,6 +150,15 @@ this page, you will not.
 
 Often you want to display a friendly fallback instead of a blank.
 `COALESCE(a, b)` returns the first argument that is not `NULL`:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "COALESCE(" },
+    { text: "phone,", label: "try this first" },
+    { text: "'no phone on file'", label: "fall back to this when it is NULL" },
+    { text: ") AS phone" },
+  ]}
+/>
 
 <SqlCodeBlock
   dialect="postgres"

--- a/content/courses/intro-web-development/css-box-model.mdx
+++ b/content/courses/intro-web-development/css-box-model.mdx
@@ -66,6 +66,16 @@ disappears. That's the fastest way to internalize the difference.
 
 ## `box-sizing`, one rule to keep
 
+The value decides what `width` measures, and `border-box` is the one everyone switches to:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "*, *::before, *::after {", label: "every element, including pseudo-elements" },
+    { text: "box-sizing: border-box;", label: "width now includes padding and border" },
+    { text: "}" },
+  ]}
+/>
+
 By default, `width` sets only the *content* width, so padding and
 border make the box bigger than the number you wrote. Nearly every
 real stylesheet opts out of that surprise:

--- a/content/courses/intro-web-development/css-grid-layout.mdx
+++ b/content/courses/intro-web-development/css-grid-layout.mdx
@@ -25,6 +25,17 @@ columns:
 
 ## The `fr` unit
 
+`fr` is a share of what is *left* after fixed tracks and gaps are taken out, which is why mixing units works:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "grid-template-columns:" },
+    { text: "200px", label: "a fixed track, taken out first" },
+    { text: "1fr", label: "one share of the remainder" },
+    { text: "2fr;", label: "twice that share" },
+  ]}
+/>
+
 `fr` means "one fraction of the free space". `1fr 1fr 1fr` splits the
 row into three equal columns. `2fr 1fr` makes the first column twice
 as wide as the second. It's like `flex: 1`, but for the whole grid at

--- a/content/courses/intro-web-development/js-events.mdx
+++ b/content/courses/intro-web-development/js-events.mdx
@@ -22,7 +22,19 @@ button.addEventListener("click", function () {
 ```
 
 Read it as: *on this element, when a `"click"` happens, run this
-function.* The function is called an **event handler**, and it runs
+function.*
+
+<SyntaxBreakdown
+  parts={[
+    { text: "button", label: "which element listens" },
+    { text: ".addEventListener(" },
+    { text: '"click",', label: "which event to listen for" },
+    { text: "handler", label: "what to run each time it fires" },
+    { text: ")" },
+  ]}
+/>
+
+The function is called an **event handler**, and it runs
 every time the event fires, once per click, forever.
 
 <Figure

--- a/content/courses/intro-web-development/js-fetch-and-data.mdx
+++ b/content/courses/intro-web-development/js-fetch-and-data.mdx
@@ -14,6 +14,17 @@ ask for data, wait for it, and render it into the page.
 
 ## `fetch()` and `await`
 
+Two awaits, because two separate things are asynchronous: the response arriving, and its body being read.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "const res =" },
+    { text: "await fetch(url);", label: "headers have arrived, body has not" },
+    { text: "const data =" },
+    { text: "await res.json();", label: "now read and parse the body" },
+  ]}
+/>
+
 `fetch(url)` asks the network for something and returns a **promise**,
 a value that isn't ready yet. `await` pauses inside an `async`
 function until it arrives:

--- a/content/courses/intro-web-development/js-forms-and-validation.mdx
+++ b/content/courses/intro-web-development/js-forms-and-validation.mdx
@@ -14,6 +14,17 @@ and responds, all without leaving the page.
 
 ## The submit event and `preventDefault()`
 
+The default action is a full page navigation. Stopping it is what makes the handler worth writing:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "form.addEventListener(\"submit\"," },
+    { text: "(e) => {", label: "the event object carries the default" },
+    { text: "e.preventDefault();", label: "stop the page reloading" },
+    { text: "})" },
+  ]}
+/>
+
 By default, submitting a form reloads the page (a holdover from the
 1990s, when the server did everything). In a modern app you almost
 always stop that and handle the data in JavaScript:

--- a/content/courses/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/bounded-types-and-wildcards.mdx
@@ -46,7 +46,7 @@ classDiagram
 Imagine the rule were the other way, that `List<Dog>` *was* a
 `List<Animal>`. Then this code would compile and crash:
 
-```
+```java
 List<Dog> dogs = new ArrayList<>();
 List<Animal> animals = dogs;     // pretend this were legal
 animals.add(new Cat());          // adding a Cat to a List<Dog>!
@@ -242,7 +242,7 @@ Bloch:
 
 The classic illustration is `Collections.copy(dest, src)`:
 
-```
+```java
 public static <T> void copy(List<? super T> dest, List<? extends T> src)
 ```
 
@@ -271,7 +271,7 @@ point in the middle.
 `Collections.max()` is a real-world PECS exemplar. Its signature is
 roughly:
 
-```
+```java
 public static <T extends Comparable<? super T>> T max(Collection<? extends T> coll)
 ```
 
@@ -365,7 +365,7 @@ Wildcards are for *method parameters*. They are almost never the
 right thing for *return types* or *fields*, because they push the
 "I don't know the type" problem onto every caller.
 
-```
+```java
 // Bad return type, caller has nothing useful to do with it
 public List<? extends Number> getNumbers() { ... }
 

--- a/content/courses/java-collections-and-generics-deep-dive/comparable-and-comparator.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/comparable-and-comparator.mdx
@@ -20,6 +20,17 @@ There are two ways to provide that ordering:
 
 ## Comparable: the natural order
 
+The contract is the *sign* of the return value, not the number itself:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "int compareTo(T other)", label: "the one method Comparable requires" },
+    { text: "negative", label: "this sorts before other" },
+    { text: "0", label: "they tie" },
+    { text: "positive", label: "this sorts after other" },
+  ]}
+/>
+
 `Comparable<T>` has a single method, `int compareTo(T other)`, which
 returns a negative number, zero, or a positive number depending on
 whether `this` is less than, equal to, or greater than `other`.

--- a/content/courses/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
@@ -129,6 +129,18 @@ Each occurrence is checked independently, putting a `String` where
 a `B` is expected only works if `B = String` for that particular
 instance.
 
+A generic method declares its own type parameter, before the return type
+and independent of the class:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "static", label: "an ordinary modifier" },
+    { text: "<T>", label: "declare the type parameter first" },
+    { text: "T", label: "the return type, using it" },
+    { text: "firstOf(List<T> xs)", label: "and the parameters, using it too" },
+  ]}
+/>
+
 ## Generic methods (independent of the class)
 
 A method can have its *own* type parameters, independent of the

--- a/content/courses/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/generic-classes-and-methods.mdx
@@ -147,7 +147,7 @@ A method can have its *own* type parameters, independent of the
 enclosing class. The type parameter declaration goes *before* the
 return type:
 
-```
+```java
 public static <T> T identity(T x) { return x; }
 ```
 

--- a/content/courses/java-collections-and-generics-deep-dive/maps.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/maps.mdx
@@ -254,6 +254,17 @@ public class Main {
 
 ## The handful of Map methods worth memorizing
 
+`computeIfAbsent` replaces the get-check-put dance, and its second argument is a *function*, not a value, so the default is built only when it is needed:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "map.computeIfAbsent(" },
+    { text: "key,", label: "what to look up" },
+    { text: "k -> new ArrayList<>()", label: "built only if the key is absent" },
+    { text: ")", label: "returns the existing or the new value, never null" },
+  ]}
+/>
+
 Java 8 added a small set of methods that eliminate a *lot* of "if
 present, update; else insert" boilerplate. Learn them and your code
 shrinks.

--- a/content/courses/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/performance-tradeoffs.mdx
@@ -144,7 +144,7 @@ slower lookups.
 
 The rule of thumb when you know the eventual size `n`:
 
-```
+```text
 initialCapacity = ceil(n / loadFactor) = ceil(n / 0.75)
 ```
 

--- a/content/courses/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/the-generics-revolution.mdx
@@ -126,17 +126,17 @@ Notice three changes:
 
 Every single interface in the framework grew type parameters:
 
-```
-Iterable      → Iterable<E>
-Collection    → Collection<E>
-List          → List<E>
-Set           → Set<E>
-Queue         → Queue<E>
-Map           → Map<K, V>
-Iterator      → Iterator<E>
-Comparable    → Comparable<T>
-Comparator    → Comparator<T>
-```
+| Before Java 5 | After          |
+| ------------- | -------------- |
+| `Iterable`    | `Iterable<E>`  |
+| `Collection`  | `Collection<E>`|
+| `List`        | `List<E>`      |
+| `Set`         | `Set<E>`       |
+| `Queue`       | `Queue<E>`     |
+| `Map`         | `Map<K, V>`    |
+| `Iterator`    | `Iterator<E>`  |
+| `Comparable`  | `Comparable<T>`|
+| `Comparator`  | `Comparator<T>`|
 
 When you write `Map<String, Customer>`, the compiler now knows that
 `map.get("ada")` returns a `Customer`, not an `Object`. That single

--- a/content/courses/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/the-tyranny-of-arrays.mdx
@@ -51,7 +51,7 @@ same handful of container patterns on top of them.
 An array is a **contiguous, fixed-size block of memory** of one
 element type. Indexing is fast because it is just arithmetic:
 
-```
+```text
 address(arr[i]) = base + i * sizeof(element)
 ```
 

--- a/content/courses/java-collections-and-generics-deep-dive/type-erasure.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/type-erasure.mdx
@@ -22,7 +22,7 @@ crash.
 When `javac` compiles a generic class, it **erases** the type
 parameter to its erasure (the most specific bound, usually `Object`):
 
-```
+```java
 // You write:
 public class Box<T> {
     private T value;
@@ -41,7 +41,7 @@ public class Box {
 At the *use sites*, the compiler inserts casts to recover the
 declared type:
 
-```
+```java
 Box<String> b = new Box<>();
 b.put("hi");
 String s = b.get();        // compiler inserts: (String) b.get();
@@ -126,7 +126,7 @@ In practice you almost never want a generic array, you want a
 Because both forms erase to the same bytecode signature, the
 following is forbidden:
 
-```
+```java
 // Not allowed, both erase to printer(List)
 public void printer(List<String>  xs) { ... }
 public void printer(List<Integer> xs) { ... }

--- a/content/courses/java-programming-for-beginners/arrays-and-collections.mdx
+++ b/content/courses/java-programming-for-beginners/arrays-and-collections.mdx
@@ -90,6 +90,16 @@ flowchart TD
 
 ## ArrayList: growable, generic
 
+The type argument is what removes the casts: the compiler knows what comes out because you said what goes in.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "List", label: "the interface, on the left" },
+    { text: "<String>", label: "what it holds" },
+    { text: "names = new ArrayList<>();", label: "the diamond infers it again" },
+  ]}
+/>
+
 In real code, you almost always reach for an **`ArrayList`**
 instead of a bare array. It can grow and shrink, has a rich set of
 operations, and is part of Java's broader **Collections Framework**.

--- a/content/courses/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
+++ b/content/courses/java-programming-for-beginners/basic-algorithms-and-data-structures.mdx
@@ -271,7 +271,7 @@ A working programmer's mental table of first-resort tools:
 | "Process items in last-in-first-out order" | `Deque` as a stack |
 | "Find an item in a sorted list" | binary search |
 | "Sort a list" | `Collections.sort()` |
-| "I'll iterate a million times, does \`contains()\` need to be fast?" | use a Set, not a List |
+| "I'll iterate a million times, does `contains()` need to be fast?" | use a Set, not a List |
 
 You will, of course, run into problems that don't fit this table.
 But this table covers an *astonishing* fraction of day-to-day code.

--- a/content/courses/java-programming-for-beginners/capstone-project.mdx
+++ b/content/courses/java-programming-for-beginners/capstone-project.mdx
@@ -40,7 +40,7 @@ not borrow throws a `BorrowException`.
 *two* lines: the `... failed: ...` message printed inside the catch
 block, then the `ok? false` line printed by the caller.)
 
-```
+```text
 Catalog:
 - Effective Java (2 copies)
 - Refactoring (1 copies)

--- a/content/courses/java-programming-for-beginners/control-flow.mdx
+++ b/content/courses/java-programming-for-beginners/control-flow.mdx
@@ -172,6 +172,19 @@ flowchart LR
 
 ## `for`
 
+A classic `for` loop puts three separate jobs on one line, separated by
+semicolons:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "for (" },
+    { text: "int i = 0;", label: "runs once, before the loop" },
+    { text: "i < 5;", label: "checked before every pass" },
+    { text: "i++", label: "runs after every pass" },
+    { text: ")" },
+  ]}
+/>
+
 `for` is the workhorse of loops. It packages three things on one line:
 
 1. **Initialization**, runs once at the start.

--- a/content/courses/java-programming-for-beginners/debugging-and-reasoning.mdx
+++ b/content/courses/java-programming-for-beginners/debugging-and-reasoning.mdx
@@ -114,7 +114,7 @@ crash. Read it from **top to bottom**.
 
 You'll see something like:
 
-```
+```text
 Exception in thread "main" java.lang.NullPointerException ...
     at Main.printLength(Main.java:7)
     at Main.main(Main.java:3)

--- a/content/courses/java-programming-for-beginners/exception-handling.mdx
+++ b/content/courses/java-programming-for-beginners/exception-handling.mdx
@@ -150,6 +150,16 @@ silencing it.
 
 ## Declaring with `throws`
 
+`throws` on the signature is a promise to the caller, not an action. It is what makes a checked exception checked:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "void load(String p)" },
+    { text: "throws", label: "callers must handle or re-declare it" },
+    { text: "IOException", label: "which exception may escape" },
+  ]}
+/>
+
 If a method can throw a *checked* exception that it does not
 catch, the method must declare it:
 
@@ -195,6 +205,16 @@ Notice the **wrapping** technique: we catch the standard library's
 details up to callers.
 
 ## try-with-resources
+
+The resource goes in the parentheses, and that is the whole difference: Java closes it for you, even if the block throws.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "try (", label: "the resource block" },
+    { text: "var in = new FileReader(p)", label: "anything AutoCloseable" },
+    { text: ")", label: "closed automatically, in reverse order" },
+  ]}
+/>
 
 Many resources (files, sockets, database connections) must be
 **closed** when you're done with them. The pattern used to look

--- a/content/courses/java-programming-for-beginners/exception-handling.mdx
+++ b/content/courses/java-programming-for-beginners/exception-handling.mdx
@@ -307,7 +307,7 @@ a normal end of input, use a `boolean hasNext()` instead.
 
 Expected output:
 
-```
+```text
 parsed 42
 bad input: not a number: oops
 bad input: input was null

--- a/content/courses/java-programming-for-beginners/maps-and-sets.mdx
+++ b/content/courses/java-programming-for-beginners/maps-and-sets.mdx
@@ -22,6 +22,16 @@ Once you have these two in your toolbox, a huge fraction of
 
 ## `Set`: uniqueness and membership
 
+A `Set` is defined by two operations being cheap, and both depend on the element's `equals` and `hashCode`:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "Set<String> seen", label: "no duplicates, by equals" },
+    { text: "= new HashSet<>();" },
+    { text: "seen.contains(x)", label: "O(1) average, which is the point" },
+  ]}
+/>
+
 <CodeBlock
   adapter="java"
   files={[

--- a/content/courses/java-programming-for-beginners/methods-and-modularity.mdx
+++ b/content/courses/java-programming-for-beginners/methods-and-modularity.mdx
@@ -48,24 +48,23 @@ thing.
 
 ## Anatomy of a method
 
-```java
-returnType methodName(paramType paramName, ...) {
-    // body
-    return someValue;     // unless returnType is void
-}
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "int", label: "the kind of value it gives back" },
+    { text: "square", label: "the name callers use" },
+    { text: "(int n)", label: "locals filled from the caller's arguments" },
+    { text: "{ return n * n; }", label: "the body, and what it returns" },
+  ]}
+/>
 
-A few rules:
+A few rules on top of that shape:
 
-- The **return type** says what kind of value the method gives back.
-  Use `void` if it returns nothing.
+- Use `void` as the return type if the method returns nothing.
 - The **name** should be a verb or short verb phrase: `add()`,
   `printReport`, `findLargest`. Lower-case first letter, camelCase
   for multi-word names.
-- The **parameters** are local variables that are initialized from
-  the caller's arguments.
-- `return` immediately ends the method and gives its argument back
-  to the caller.
+- `return` immediately ends the method, wherever it appears in the
+  body, and gives its argument back to the caller.
 
 ## A first example
 

--- a/content/courses/java-programming-for-beginners/software-organization.mdx
+++ b/content/courses/java-programming-for-beginners/software-organization.mdx
@@ -125,7 +125,7 @@ adapters, hexagonal architecture. They are all the same shape.
 Imagine a small library checkout system. A reasonable package
 layout:
 
-```
+```text
 src/main/java/
 └── com/acme/library/
     ├── domain/

--- a/content/courses/java-programming-for-beginners/stack-and-heap.mdx
+++ b/content/courses/java-programming-for-beginners/stack-and-heap.mdx
@@ -249,7 +249,7 @@ public class Main {
 
 Expected output:
 
-```
+```text
 after bumpPrimitive: n = 5
 after mutate: items = [a, b]
 after replace: items = [a, b]

--- a/content/courses/java-programming-for-beginners/stack-and-heap.mdx
+++ b/content/courses/java-programming-for-beginners/stack-and-heap.mdx
@@ -71,7 +71,7 @@ String s = "hello";
 flowchart LR
     subgraph S[stack frame]
         X["<code>x = 42</code>"]
-        SREF["s = ●─"]
+        SREF["<code>s</code> (a reference)"]
     end
     subgraph H[heap]
         STR["String 'hello'"]
@@ -118,8 +118,8 @@ shows up via `a`.
 ```mermaid
 flowchart LR
     subgraph stack
-        A["a = ●─"]
-        B["b = ●─"]
+        A["<code>a</code> (a reference)"]
+        B["<code>b</code> (a reference)"]
     end
     subgraph heap
         L["ArrayList: first, second"]
@@ -270,12 +270,12 @@ letting variables go out of scope, or by reassigning fields).
 ```mermaid
 flowchart LR
     subgraph before
-        V["v = ●─"]
+        V["<code>v</code> (a reference)"]
         O1[Order #1]
         V --> O1
     end
     subgraph after
-        V2["v = ●─"]
+        V2["<code>v</code> (a reference)"]
         O2[Order #2]
         Old[(Order #1<br/>now garbage)]
         V2 --> O2

--- a/content/courses/java-programming-for-beginners/variables-and-memory.mdx
+++ b/content/courses/java-programming-for-beginners/variables-and-memory.mdx
@@ -152,6 +152,16 @@ patient, every Java programmer eventually internalizes it.
 
 ## What `final` means
 
+`final` means "assigned once", and what that buys depends on what is being held:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "final", label: "the reference cannot be reassigned" },
+    { text: "List<String> xs", label: "but the list it points at can still change" },
+    { text: "= new ArrayList<>();" },
+  ]}
+/>
+
 A variable declared with `final` cannot be reassigned after its
 first assignment. It is a *commitment*.
 

--- a/content/courses/machine-learning-scikit-learn/classification-metrics.mdx
+++ b/content/courses/machine-learning-scikit-learn/classification-metrics.mdx
@@ -279,6 +279,18 @@ $$
 
 ## `classification_report()`: the whole picture at once
 
+Two arrays in, one table out. The order matters: truth first, predictions second.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "classification_report(" },
+    { text: "y_true,", label: "the labels" },
+    { text: "y_pred,", label: "what the model said" },
+    { text: "target_names=classes", label: "so the rows are readable" },
+    { text: ")" },
+  ]}
+/>
+
 In practice you rarely compute these by hand. `classification_report()`
 prints precision, recall, and F1 for every class, plus support (how many
 true examples of each class there were).

--- a/content/courses/machine-learning-scikit-learn/common-pitfalls-and-misconceptions.mdx
+++ b/content/courses/machine-learning-scikit-learn/common-pitfalls-and-misconceptions.mdx
@@ -111,7 +111,7 @@ predict?* If not, drop it.
 <Callout type="danger" title="Leakage is the deadliest pitfall because it looks like success">
 A crashing model gets fixed. A leaking model gets *deployed*, because its
 validation numbers are gorgeous. The discipline of splitting first and
-wrapping preprocessing in a \`Pipeline\` exists almost entirely to make
+wrapping preprocessing in a `Pipeline` exists almost entirely to make
 leakage hard to commit by accident.
 </Callout>
 

--- a/content/courses/machine-learning-scikit-learn/cross-validation.mdx
+++ b/content/courses/machine-learning-scikit-learn/cross-validation.mdx
@@ -108,6 +108,19 @@ small dataset than a single split allows.
 
 ## `cross_val_score()`: one line to do it all
 
+It clones the estimator for each fold, so nothing leaks between them. Four arguments say what to fit, on what, how many times, and what to measure.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "cross_val_score(" },
+    { text: "model,", label: "cloned fresh for every fold" },
+    { text: "X, y,", label: "the whole training set" },
+    { text: "cv=5,", label: "how many folds" },
+    { text: "scoring=\"f1\"", label: "which number comes back" },
+    { text: ")" },
+  ]}
+/>
+
 scikit-learn wraps the whole procedure in a single function.
 
 <CodeBlock

--- a/content/courses/machine-learning-scikit-learn/hyperparameter-tuning.mdx
+++ b/content/courses/machine-learning-scikit-learn/hyperparameter-tuning.mdx
@@ -220,6 +220,18 @@ flowchart TD
 
 ## `GridSearchCV`: try every combination, automatically
 
+The grid is a dict of parameter name to values, and the search is a full cross-validation run per combination:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "GridSearchCV(" },
+    { text: "pipe,", label: "the estimator to tune" },
+    { text: "{\"clf__C\": [0.1, 1, 10]},", label: "step name, two underscores, parameter" },
+    { text: "cv=5", label: "folds per combination" },
+    { text: ")" },
+  ]}
+/>
+
 Sweeping one hyperparameter by hand, as we did with `n_neighbors` above, is
 fine for one knob. But models often have several knobs, and the best value
 of one can depend on another. `GridSearchCV` automates the search: you hand

--- a/content/courses/machine-learning-scikit-learn/next-steps.mdx
+++ b/content/courses/machine-learning-scikit-learn/next-steps.mdx
@@ -134,7 +134,7 @@ discipline you already know.
 Every model above plugs into exactly the workflow you already know: split,
 baseline, pipeline, cross-validate, tune, test once, interpret. When you
 meet a new algorithm, you are not starting over, you are slotting one new
-\`fit()\`/\`predict()\` object into machinery you have already mastered. That is
+`fit()`/`predict()` object into machinery you have already mastered. That is
 the payoff of learning foundations first.
 </Callout>
 

--- a/content/courses/machine-learning-scikit-learn/the-practical-ml-workflow.mdx
+++ b/content/courses/machine-learning-scikit-learn/the-practical-ml-workflow.mdx
@@ -112,7 +112,7 @@ Every transformation that learns from data, scaling, encoding, imputing,
 feature selection, must be fitted on the training set **only**, after the
 split. Fit it on the full dataset first and you leak the test set into
 training. The split comes early for exactly this reason, and the
-\`Pipeline\` (step 5) makes doing it right automatic.
+`Pipeline` (step 5) makes doing it right automatic.
 </Callout>
 
 ## Step 4, Establish a simple baseline

--- a/content/courses/machine-learning-scikit-learn/train-test-split.mdx
+++ b/content/courses/machine-learning-scikit-learn/train-test-split.mdx
@@ -75,6 +75,17 @@ is the whole trick.
 scikit-learn gives us one function for this. It shuffles the rows and cuts
 them into two groups.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "train_test_split(" },
+    { text: "X, y,", label: "features and labels, split together" },
+    { text: "test_size=0.2,", label: "share held back" },
+    { text: "random_state=42,", label: "makes the shuffle repeatable" },
+    { text: "stratify=y", label: "keeps the class balance in both halves" },
+    { text: ")" },
+  ]}
+/>
+
 <Figure
   slug="ml-train-test-split-inline-cutout"
   alt="One pile of blocks being divided by a partition into a large left share and a small sealed right share, the right share kept under a lid"

--- a/content/courses/mastering-dsa-cpp/arrays.mdx
+++ b/content/courses/mastering-dsa-cpp/arrays.mdx
@@ -46,6 +46,17 @@ The `sizeof` line still works in `main` (20 bytes, five 4-byte ints) because the
 
 ## `std::array<T, N>`
 
+The size is part of the *type*, which is what makes it free of a heap allocation and impossible to resize:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "std::array<" },
+    { text: "int,", label: "the element type" },
+    { text: "5", label: "the length, fixed at compile time" },
+    { text: "> a{};", label: "the braces zero-initialize it" },
+  ]}
+/>
+
 `std::array` is a fixed-size array wrapper. It preserves the size, supports range-for loops, and behaves like a normal value object.
 
 <Figure
@@ -77,6 +88,17 @@ int main() {
 />
 
 ## `std::vector<T>`: the workhorse
+
+A vector's size is a runtime value, so both of its constructor arguments are too:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "std::vector<int> v(" },
+    { text: "n,", label: "how many elements" },
+    { text: "0", label: "what each one starts as" },
+    { text: ");" },
+  ]}
+/>
 
 `std::vector` is a dynamic array. It stores elements contiguously like an array, but it can allocate a larger block and move elements when it needs more capacity.
 

--- a/content/courses/mastering-dsa-cpp/cpp-essentials.mdx
+++ b/content/courses/mastering-dsa-cpp/cpp-essentials.mdx
@@ -103,6 +103,18 @@ Both `a` and `b` print as 11 and 21, two roads to the same mutation. Notice that
 
 ## `const` and `const&` parameter passing
 
+Two separate decisions, written next to each other: how the argument travels, and whether the function may change it.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "void print(" },
+    { text: "const", label: "the function will not modify it" },
+    { text: "std::string", label: "the type" },
+    { text: "&", label: "passed by reference, so nothing is copied" },
+    { text: "s)" },
+  ]}
+/>
+
 Use `const` when a value should not change. Pass large objects as `const&` to avoid copying while promising not to modify them. This combination, "give me cheap access, and I swear not to touch it", is the single most common parameter style in this course, so it is worth seeing once in full:
 
 <CodeBlock
@@ -184,6 +196,16 @@ int main() {
 
 ## Function templates
 
+The template header declares the placeholder; everything after it is an ordinary function that uses it:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "template <typename T>", label: "declare the placeholder type" },
+    { text: "T", label: "the return type, using it" },
+    { text: "max(T a, T b)", label: "and the parameters, using it too" },
+  ]}
+/>
+
 Templates let one function work for many types while still being checked and optimized at compile time.
 
 <CodeBlock
@@ -203,6 +225,16 @@ int main() {
 />
 
 ## Lambda expressions
+
+A lambda is three brackets in a row, and each pair means something different:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "[&]", label: "the capture list: what it may see from outside" },
+    { text: "(int x)", label: "the parameters" },
+    { text: "{ return x * k; }", label: "the body" },
+  ]}
+/>
 
 A lambda is an inline function object, a way to hand a tiny rule to an algorithm without naming a separate function. The most common DSA use is custom ordering: `std::sort()` accepts a comparator that answers "should `a` come before `b`?" Below, the lambda `[](int a, int b) { return a > b; }` says "bigger first," flipping the sort to descending order.
 

--- a/content/courses/mastering-dsa-cpp/hash-tables.mdx
+++ b/content/courses/mastering-dsa-cpp/hash-tables.mdx
@@ -244,6 +244,17 @@ int main() {
 
 ## `std::map` vs `std::unordered_map`
 
+The two declarations differ by one word, and that word is the whole trade: ordered iteration against O(1) average lookup.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "std::unordered_map<", label: "hash table, unordered, O(1) average" },
+    { text: "std::string,", label: "the key type, which must be hashable" },
+    { text: "int", label: "the mapped type" },
+    { text: "> counts;" },
+  ]}
+/>
+
 `std::map` is ordered by key and typically implemented as a red-black tree. `std::unordered_map` is a hash table and has unspecified iteration order.
 
 <CodeBlock

--- a/content/courses/mastering-dsa-cpp/searching.mdx
+++ b/content/courses/mastering-dsa-cpp/searching.mdx
@@ -111,6 +111,17 @@ int main() {
 
 ## STL search helpers
 
+The two halves of a range, then what to look for. The range must already be sorted, and that precondition is the whole reason it is O(log n):
+
+<SyntaxBreakdown
+  parts={[
+    { text: "std::lower_bound(" },
+    { text: "v.begin(), v.end(),", label: "the sorted range" },
+    { text: "x", label: "returns the first element not less than x" },
+    { text: ")" },
+  ]}
+/>
+
 C++ already includes binary-search algorithms for sorted ranges.
 
 <CodeBlock

--- a/content/courses/mastering-dsa-cpp/strings.mdx
+++ b/content/courses/mastering-dsa-cpp/strings.mdx
@@ -180,6 +180,16 @@ A pointer returned by `.c_str()` is only valid while the string object is alive 
 
 ## `std::string_view`
 
+A view is a pointer and a length, which is why it must not outlive what it points at:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "std::string_view", label: "borrows, never owns" },
+    { text: "sv", label: "the view" },
+    { text: "= s;", label: "no copy, no allocation" },
+  ]}
+/>
+
 `std::string_view` is a non-owning view into characters. It is great for read-only function parameters when you want to accept `std::string`, string literals, and slices without copying.
 
 <CodeBlock

--- a/content/courses/mastering-ggplot2/bars-and-histograms.mdx
+++ b/content/courses/mastering-ggplot2/bars-and-histograms.mdx
@@ -174,9 +174,9 @@ question.
 />
 
 <Callout type="info" title="Position is its own grammar component">
-Position adjustments also apply beyond bars. \`position = "jitter"\` on
+Position adjustments also apply beyond bars. `position = "jitter"` on
 points nudges overlapping dots apart so you can see density,
-\`geom_jitter()\` is just \`geom_point(position = "jitter")\`.
+`geom_jitter()` is just `geom_point(position = "jitter")`.
 </Callout>
 
 <CodeBlock

--- a/content/courses/mastering-ggplot2/flipping-and-polar-coordinates.mdx
+++ b/content/courses/mastering-ggplot2/flipping-and-polar-coordinates.mdx
@@ -158,7 +158,7 @@ ggplot(mpg, aes(x = class, fill = class)) +
 />
 
 <Callout type="warn" title="Pies are usually a poor choice, and that is the point">
-ggplot2 makes pie charts *deliberately* awkward (no \`geom_pie\`)
+ggplot2 makes pie charts *deliberately* awkward (no `geom_pie`)
 because humans judge **angles** far less accurately than **lengths**. A
 bar chart is almost always easier to read. The lesson here is not "make
 pies"; it is that the grammar reveals pies and bars to be *the same

--- a/content/courses/mastering-ggplot2/labels-titles-and-annotations.mdx
+++ b/content/courses/mastering-ggplot2/labels-titles-and-annotations.mdx
@@ -16,6 +16,18 @@ effect.
 
 ## labs(): one place for all the text
 
+Every visible string on a ggplot has a name in `labs()`, and the aesthetic names double as the legend titles:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "labs(" },
+    { text: "title = \"...\",", label: "the headline" },
+    { text: "x = \"...\",", label: "the axis title" },
+    { text: "color = \"...\"", label: "the legend title, named by its aesthetic" },
+    { text: ")" },
+  ]}
+/>
+
 `labs()` sets every text label on the plot, axis titles, the legend
 title, the plot title, subtitle, and caption. Notice that the legend
 title comes from the *aesthetic name*, so you label it by naming the

--- a/content/courses/mastering-ggplot2/smoothers-and-summaries.mdx
+++ b/content/courses/mastering-ggplot2/smoothers-and-summaries.mdx
@@ -40,6 +40,17 @@ interval**, the stat computed it for you.
 
 ## Choosing the model with `method`
 
+`geom_smooth` fits a model per group and draws it. Two arguments decide which model, and whether to show its uncertainty:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "geom_smooth(" },
+    { text: "method = \"lm\",", label: "which model to fit" },
+    { text: "se = FALSE", label: "draw the confidence band, or not" },
+    { text: ")" },
+  ]}
+/>
+
 The same geom can fit different models. `method = "lm"` fits a straight
 line (linear model); the default follows the data's curves:
 

--- a/content/courses/mastering-ggplot2/the-seven-components.mdx
+++ b/content/courses/mastering-ggplot2/the-seven-components.mdx
@@ -12,6 +12,19 @@ small set of components. ggplot2 stacks them in a fixed order:
 
 **Data → Mappings → Geometries → Statistics → Scales → Coordinates → Facets → Theme → Rendered plot**
 
+Written out, the first three of them are the call you will type most
+often, and each `+` adds the next component to the stack:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "ggplot(" },
+    { text: "mpg,", label: "1. the data" },
+    { text: "aes(x = displ, y = hwy)", label: "2. the mappings" },
+    { text: ") +" },
+    { text: "geom_point()", label: "3. the geometry" },
+  ]}
+/>
+
 Let us meet each one with a single sentence and a concrete example
 using the built-in `mpg` data set (fuel-economy records for 234 cars).
 

--- a/content/courses/mastering-ggplot2/themes-and-styling.mdx
+++ b/content/courses/mastering-ggplot2/themes-and-styling.mdx
@@ -98,6 +98,17 @@ Other built-ins include `theme_bw()`, `theme_light()`, and
 
 ## Fine control with theme()
 
+`theme()` takes element functions, and which one you use depends on what kind of thing you are styling:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "theme(" },
+    { text: "axis.text.x =", label: "which part of the plot" },
+    { text: "element_text(angle = 45)", label: "an element function matching its kind" },
+    { text: ")" },
+  ]}
+/>
+
 For surgical tweaks, `theme()` exposes hundreds of individual
 **elements**. You target a named element and set it with an
 `element_*()` helper:

--- a/content/courses/modern-css-layout/box-model-and-sizing.mdx
+++ b/content/courses/modern-css-layout/box-model-and-sizing.mdx
@@ -29,15 +29,7 @@ From the inside out:
   caption="Content, padding, border and margin, each measured separately."
 />
 
-```text
-┌─────────── margin ───────────┐
-│  ┌──────── border ────────┐  │
-│  │  ┌───── padding ────┐  │  │
-│  │  │     content      │  │  │
-│  │  └──────────────────┘  │  │
-│  └────────────────────────┘  │
-└──────────────────────────────┘
-```
+<BoxModel caption="Each layer wraps the one inside it, and each is sized on its own." />
 
 The same four layers, rendered for real. The tinted area is padding
 (it shares the box's background), the solid line is the border, and

--- a/content/courses/modern-css-layout/css-grid.mdx
+++ b/content/courses/modern-css-layout/css-grid.mdx
@@ -30,6 +30,16 @@ The **`fr`** unit means "a fraction of the free space." `repeat(3, 1fr)`
 is shorthand for three equal columns; `2fr 1fr` makes the first twice
 the width of the second.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "grid-template-columns:", label: "define the column tracks" },
+    { text: "repeat(" },
+    { text: "3,", label: "how many tracks" },
+    { text: "1fr", label: "each one an equal share of free space" },
+    { text: ");" },
+  ]}
+/>
+
 <Figure
   slug="css-css-grid-inline-cutout"
   alt="A rectangular frame ruled into rows and columns, with three blocks placed to span several cells each, the empty cells left visible"

--- a/content/courses/modern-css-layout/flexbox-deep-dive.mdx
+++ b/content/courses/modern-css-layout/flexbox-deep-dive.mdx
@@ -140,7 +140,18 @@ item can shove its siblings to the far end.
 
 ## `flex`: grow, shrink, basis
 
-Each item's `flex` shorthand controls how it resizes:
+Each item's `flex` shorthand is three values in a fixed order:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "flex:" },
+    { text: "1", label: "grow, share of the leftover space" },
+    { text: "1", label: "shrink, how readily it gives space back" },
+    { text: "200px;", label: "basis, its size before either happens" },
+  ]}
+/>
+
+Taken one at a time:
 
 - **`flex-grow`**, how much of the *leftover* space this item takes
   (0 = don't grow).

--- a/content/courses/modern-css-layout/positioning-and-stacking.mdx
+++ b/content/courses/modern-css-layout/positioning-and-stacking.mdx
@@ -141,6 +141,15 @@ headers stay visible with a single line of CSS, no JavaScript.
 
 ## `z-index` and stacking
 
+`z-index` does nothing on an unpositioned element, and it only competes inside its own stacking context:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "position: relative;", label: "without this, z-index is ignored" },
+    { text: "z-index: 10;", label: "ordering, but only among siblings in this context" },
+  ]}
+/>
+
 When positioned elements overlap, **`z-index`** decides who's on top,
 higher numbers sit in front. Two things trip people up:
 

--- a/content/courses/modern-css-layout/selectors-and-combinators.mdx
+++ b/content/courses/modern-css-layout/selectors-and-combinators.mdx
@@ -115,6 +115,18 @@ and mixing them up is one of the most common CSS bugs:
 | Next sibling | `+` | the **one** element immediately after |
 | Subsequent sibling | `~` | **every** later sibling |
 
+A selector with combinators reads right to left: the last part is what
+actually gets styled, everything before it is a condition on where it sits.
+
+<SyntaxBreakdown
+  parts={[
+    { text: ".menu", label: "an ancestor that must exist" },
+    { text: ">", label: "direct child only" },
+    { text: "li", label: "must be a direct child of .menu" },
+    { text: "a", label: "the element that is actually styled" },
+  ]}
+/>
+
 The descendant vs. child distinction is the one to burn in. `.menu li` reaches
 *every* list item in the subtree, however deep. `.menu > li` reaches only the
 **direct** children. Same markup, two different results:

--- a/content/courses/modern-css-layout/transitions-and-animations.mdx
+++ b/content/courses/modern-css-layout/transitions-and-animations.mdx
@@ -120,6 +120,16 @@ difference it makes.
 
 ## `transform`: move without disturbing layout
 
+Transforms apply in the order written, and the order changes the result: rotating then translating is not translating then rotating.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "transform:" },
+    { text: "translateX(10px)", label: "applied first" },
+    { text: "rotate(45deg);", label: "then this, about the already-moved origin" },
+  ]}
+/>
+
 `transform` (translate, scale, rotate, skew) is the property to
 animate for performance, it doesn't trigger layout, so it stays smooth:
 

--- a/content/courses/natural-language-processing-python/bag-of-words.mdx
+++ b/content/courses/natural-language-processing-python/bag-of-words.mdx
@@ -133,6 +133,16 @@ each document against it.
 
 ## Counts vs. presence (binary bag-of-words)
 
+One argument switches the vectorizer between "how often" and "at all":
+
+<SyntaxBreakdown
+  parts={[
+    { text: "CountVectorizer(" },
+    { text: "binary=True", label: "presence, 0 or 1, instead of a count" },
+    { text: ")" },
+  ]}
+/>
+
 Sometimes you care only *whether* a word appears, not how often, for short
 texts or spam-style signals, presence is enough and is less swayed by length.
 That variant is **binary** bag-of-words: each cell is 1 or 0 instead of a

--- a/content/courses/natural-language-processing-python/frequency-distributions.mdx
+++ b/content/courses/natural-language-processing-python/frequency-distributions.mdx
@@ -17,6 +17,17 @@ analytics".
 
 ## Counting words with `FreqDist()`
 
+`FreqDist` is a `Counter` that knows about text, and the call you will reach for most takes one number:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "FreqDist(tokens)", label: "count every token" },
+    { text: ".most_common(", label: "sorted, highest first" },
+    { text: "10", label: "how many to return; omit for all of them" },
+    { text: ")" },
+  ]}
+/>
+
 You could count words with a plain `collections.Counter`, and that is exactly
 what is happening under the hood. NLTK wraps it in a `FreqDist()` ("frequency
 distribution") that adds text-specific conveniences.

--- a/content/courses/natural-language-processing-python/ngrams.mdx
+++ b/content/courses/natural-language-processing-python/ngrams.mdx
@@ -43,6 +43,16 @@ bigrams).
 NLTK gives you `ngrams(tokens, n)`, which yields the windows as tuples. It
 returns a generator, so wrap it in `list(...)` to see or reuse the results.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "list(", label: "the result is a generator, so drain it" },
+    { text: "ngrams(" },
+    { text: "tokens,", label: "the words, already tokenized" },
+    { text: "2", label: "the window width; 2 is a bigram" },
+    { text: "))" },
+  ]}
+/>
+
 <Figure
   slug="nlp-ngrams-inline-cutout"
   alt="A strip of word tiles with a two-tile window sliding along it, each pair it frames dropping into its own tray"

--- a/content/courses/natural-language-processing-python/tokenization.mdx
+++ b/content/courses/natural-language-processing-python/tokenization.mdx
@@ -30,6 +30,16 @@ in "don't" is a separate, meaningful unit.
 
 ## Word tokenization: where `.split()` breaks
 
+`word_tokenize` is not a split on whitespace. It knows about punctuation and clitics, which is exactly where `.split()` goes wrong:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "word_tokenize(", label: "punctuation-aware" },
+    { text: "\"do not stop.\"", label: "one string in" },
+    { text: ")", label: "out come tokens, with the period its own token" },
+  ]}
+/>
+
 Let us put the naive approach and a real tokenizer side by side on one tiny,
 nasty input.
 

--- a/content/courses/oop-blueprint-java/abstract-classes.mdx
+++ b/content/courses/oop-blueprint-java/abstract-classes.mdx
@@ -26,6 +26,17 @@ only construct concrete subclasses of it.
 
 ## A first abstract class
 
+`abstract` on the class means "never instantiate this"; `abstract` on a method means "every concrete subclass must supply it".
+
+<SyntaxBreakdown
+  parts={[
+    { text: "abstract", label: "no new Shape() is possible" },
+    { text: "class Shape {" },
+    { text: "abstract double area();", label: "no body, so subclasses must write one" },
+    { text: "}" },
+  ]}
+/>
+
 ```mermaid
 classDiagram
     class Shape {

--- a/content/courses/oop-blueprint-java/constructors-and-state.mdx
+++ b/content/courses/oop-blueprint-java/constructors-and-state.mdx
@@ -20,6 +20,14 @@ A constructor looks like a method but with two differences:
 1. It has the same name as the class.
 2. It has no return type.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "public", label: "who may call it" },
+    { text: "Person", label: "the class's own name, and no return type" },
+    { text: "(String name, int age)", label: "what a caller must supply" },
+  ]}
+/>
+
 When you write `new Person("Ada", 30)`, Java allocates a new `Person`
 on the heap and then *calls* the constructor on that fresh allocation
 to initialize it.

--- a/content/courses/oop-blueprint-java/encapsulation.mdx
+++ b/content/courses/oop-blueprint-java/encapsulation.mdx
@@ -141,6 +141,17 @@ breaking a single caller, because callers never see it.
 
 ## Access modifiers in Java
 
+Every field and method declaration opens with the answer to "who can see
+this?":
+
+<SyntaxBreakdown
+  parts={[
+    { text: "private", label: "who may touch it" },
+    { text: "double", label: "its type" },
+    { text: "balance;", label: "its name" },
+  ]}
+/>
+
 Java has four access levels that control where a member can be seen
 from. You will spend 95% of your time using `private` and `public`,
 but it is worth knowing all four.

--- a/content/courses/oop-blueprint-java/enums.mdx
+++ b/content/courses/oop-blueprint-java/enums.mdx
@@ -110,6 +110,17 @@ Three concrete benefits in that small change:
 
 ## Enums are objects too
 
+An enum constant is an object, so it can carry state, which means the constants are really constructor calls:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "RED(\"stop\")", label: "a constant, and its constructor arguments" },
+    { text: ";" },
+    { text: "private final String action;", label: "the state each constant carries" },
+    { text: "Light(String a) { ... }", label: "the constructor, always private" },
+  ]}
+/>
+
 Java enums are not just integer codes with names. **Each enum
 constant is a full object**, and the enum *type* is a class. That
 means each constant can carry its own state and define its own

--- a/content/courses/oop-blueprint-java/inheritance.mdx
+++ b/content/courses/oop-blueprint-java/inheritance.mdx
@@ -19,6 +19,18 @@ is the right tool, not just how to type `extends`.
 
 ## A first family
 
+Inheritance is also one word in the header, and it means something
+different from `implements`: the subclass gets the parent's code, not
+just its shape.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "class Dog", label: "the subclass" },
+    { text: "extends", label: "inherits fields and methods" },
+    { text: "Animal", label: "the one parent Java allows" },
+  ]}
+/>
+
 ```mermaid
 classDiagram
     class Animal {

--- a/content/courses/oop-blueprint-java/interfaces.mdx
+++ b/content/courses/oop-blueprint-java/interfaces.mdx
@@ -20,6 +20,16 @@ interface called `Noisy` because all three can make a sound.
 
 ## A first interface
 
+A class promises to satisfy an interface with one word in its header:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "class Dog", label: "the concrete class" },
+    { text: "implements", label: "the promise" },
+    { text: "Noisy", label: "the contract it must now satisfy in full" },
+  ]}
+/>
+
 ```mermaid
 classDiagram
     class Noisy {

--- a/content/courses/oop-blueprint-java/methods-and-messages.mdx
+++ b/content/courses/oop-blueprint-java/methods-and-messages.mdx
@@ -104,6 +104,18 @@ The lamp owns its response.
 
 ## The signature of a method
 
+Four pieces in a fixed order, and only two of them are the signature
+Java uses to tell overloads apart:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "public", label: "who may call it" },
+    { text: "double", label: "what it hands back" },
+    { text: "area", label: "the name, part of the signature" },
+    { text: "(int w, int h)", label: "the parameter types, the rest of it" },
+  ]}
+/>
+
 A method's **signature** is its name plus the *types* (and order) of
 its parameters. The return type is *not* part of the signature.
 

--- a/content/courses/oop-blueprint-java/objects-and-classes.mdx
+++ b/content/courses/oop-blueprint-java/objects-and-classes.mdx
@@ -184,6 +184,17 @@ A few things are worth pointing out in `Book`:
 
 ## `this`: the object the method is running on
 
+`this` is what separates the field from the parameter when they share a
+name, which in a constructor they usually do:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "this.name", label: "the field on this object" },
+    { text: "=" },
+    { text: "name;", label: "the parameter, which shadows it" },
+  ]}
+/>
+
 Every non-static method has an implicit parameter called `this`. It is
 **the object the method was called on**. When you write
 `rex.describe()`, inside `describe`, `this` is `rex`. When you write

--- a/content/courses/oop-blueprint-java/objects-in-memory.mdx
+++ b/content/courses/oop-blueprint-java/objects-in-memory.mdx
@@ -42,7 +42,7 @@ write `Dog d = new Dog(...)`, two things happen:
 ```mermaid
 flowchart TD
     subgraph S["Stack (current method)"]
-        V1["d : Dog ref ──┐"]
+        V1["<code>d</code> (a Dog reference)"]
     end
     subgraph H["Heap"]
         O1["Dog object<br/><code>name='Rex'</code><br/><code>age=4</code>"]
@@ -257,11 +257,11 @@ sequenceDiagram
     participant Heap
 
     Caller->>Heap: new Dog("Rex")
-    Note over Caller,Heap: mine ── ref ──▶ Dog{name=Rex}
+    Note over Caller,Heap: mine references the Dog named Rex
     Caller->>Callee: rename(mine, "Buddy")
-    Note over Callee,Heap: dog ── ref ──▶ same Dog
+    Note over Callee,Heap: dog references that same Dog
     Callee->>Heap: dog.name = "Buddy"
-    Note over Caller,Heap: mine ── ref ──▶ Dog{name=Buddy}
+    Note over Caller,Heap: mine references the Dog, now named Buddy
 ```
 
 But re-assigning the parameter to a *new* object does **not** affect

--- a/content/courses/oop-blueprint-java/polymorphism.mdx
+++ b/content/courses/oop-blueprint-java/polymorphism.mdx
@@ -34,6 +34,16 @@ sequenceDiagram
 
 ## Two-level thinking: compile-time vs. runtime types
 
+One line carries both types at once, and they are not the same type:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "Animal", label: "compile-time type: what the compiler lets you call" },
+    { text: "a =" },
+    { text: "new Dog();", label: "runtime type: whose code actually runs" },
+  ]}
+/>
+
 Every reference variable in Java has *two* types associated with it
 at any moment:
 

--- a/content/courses/oop-blueprint-java/responsibility-driven-design.mdx
+++ b/content/courses/oop-blueprint-java/responsibility-driven-design.mdx
@@ -59,17 +59,15 @@ class up, wave it around while talking about it, and its small size
 cards a centerpiece of responsibility-driven design. Each card has
 three fields:
 
-```text
-┌────────────────────────────────────────────┐
-│ Class:  Order                              │
-├────────────────────────────────────────────┤
-│ Responsibilities         │ Collaborators   │
-│ ─ track its line items   │  LineItem       │
-│ ─ compute its total      │                 │
-│ ─ know whether it is paid│                 │
-│ ─ mark itself as paid    │  Payment        │
-└────────────────────────────────────────────┘
-```
+<CrcCard
+  name="Order"
+  rows={[
+    { responsibility: "track its line items", collaborator: "LineItem" },
+    { responsibility: "compute its total" },
+    { responsibility: "know whether it is paid" },
+    { responsibility: "mark itself as paid", collaborator: "Payment" },
+  ]}
+/>
 
 You write one card per candidate class. The card forces brevity. If
 the responsibility list spills off the card, the class is too big.

--- a/content/courses/oop-blueprint-java/static-and-utility.mdx
+++ b/content/courses/oop-blueprint-java/static-and-utility.mdx
@@ -93,6 +93,17 @@ constant).
 
 ## Constants: `public static final`
 
+Three modifiers, three separate promises:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "public", label: "visible anywhere" },
+    { text: "static", label: "one copy, on the class" },
+    { text: "final", label: "assigned once, never again" },
+    { text: "double PI = 3.14159;" },
+  ]}
+/>
+
 The combination `public static final` is the standard idiom for a
 **constant**: a single value that belongs to the class and can never
 change. By convention, constants are written in `UPPER_SNAKE_CASE`.

--- a/content/courses/practical-r-for-beginners/data-frames.mdx
+++ b/content/courses/practical-r-for-beginners/data-frames.mdx
@@ -126,6 +126,17 @@ trick from the last four pages works.
 
 ## Indexing rows and columns: `[row, col]`
 
+One pair of brackets, two positions separated by a comma. Leaving one blank means "all of them".
+
+<SyntaxBreakdown
+  parts={[
+    { text: "df[" },
+    { text: "1:5,", label: "which rows" },
+    { text: "c(\"name\", \"age\")", label: "which columns; blank means all" },
+    { text: "]" },
+  ]}
+/>
+
 A data frame can also be indexed with two-dimensional `[ ]`
 notation. The convention is `[rows, columns]`. Leave a slot empty
 to mean "all":

--- a/content/courses/practical-r-for-beginners/dplyr-verbs.mdx
+++ b/content/courses/practical-r-for-beginners/dplyr-verbs.mdx
@@ -182,6 +182,17 @@ ergonomic.
 
 ## `mutate()`, add or change columns
 
+Every dplyr verb takes the data first, which is what lets the pipe read as a sentence:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "df |>", label: "the data, piped in as the first argument" },
+    { text: "mutate(", label: "add or replace columns" },
+    { text: "bmi = kg / m^2", label: "new name on the left, expression on the right" },
+    { text: ")" },
+  ]}
+/>
+
 <CodeBlock
   adapter="r"
   files={[

--- a/content/courses/practical-r-for-beginners/scripts-and-projects.mdx
+++ b/content/courses/practical-r-for-beginners/scripts-and-projects.mdx
@@ -33,7 +33,7 @@ A project folder collects a handful of well-defined parts:
 
 A common starter layout:
 
-```
+```text
 my-analysis/
 ├── README.md
 ├── data/

--- a/content/courses/practical-r-for-beginners/vectorized-computation.mdx
+++ b/content/courses/practical-r-for-beginners/vectorized-computation.mdx
@@ -6,7 +6,7 @@ description: Why R lets you write `prices * 1.08` to add tax to a thousand price
 In most programming languages, if you want to add 1 to every
 number in a list, you write a loop:
 
-```
+```text
 for each item in list:
     item = item + 1
 ```

--- a/content/courses/practical-r-for-beginners/writing-your-own-functions.mdx
+++ b/content/courses/practical-r-for-beginners/writing-your-own-functions.mdx
@@ -30,14 +30,20 @@ flowchart TD
   ret --> out["Returned value flows back to caller"]
 ```
 
-A function in R has four parts:
+A function in R has four parts, and three of them are visible on the
+line that creates it:
 
-- A **name** (the variable you assign it to).
-- A list of **parameters** (the names the function uses
-  internally for its inputs).
-- A **body** (the R code that runs).
-- A **return value** (by default, the value of the last
-  expression, or whatever you wrap in `return()`).
+<SyntaxBreakdown
+  parts={[
+    { text: "square", label: "the variable you assign it to" },
+    { text: "<- function" },
+    { text: "(x)", label: "the names it uses for its inputs" },
+    { text: "{ x * x }", label: "the body that runs" },
+  ]}
+/>
+
+The fourth is the **return value**: by default the value of the last
+expression in the body, or whatever you wrap in `return()`.
 
 The simplest possible function:
 

--- a/content/courses/python-basics/booleans.mdx
+++ b/content/courses/python-basics/booleans.mdx
@@ -254,6 +254,16 @@ if count == 0:      # explicit
 
 ## Logical operators: `and`, `or`, `not`
 
+Python's `and` and `or` do not return `True` or `False`. They return one of their operands, which is what makes the fallback idiom work:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "name", label: "returned if it is truthy" },
+    { text: "or", label: "otherwise..." },
+    { text: "\"anonymous\"", label: "...this is returned instead" },
+  ]}
+/>
+
 Python's logical operators are written as English words, not symbols (`&&`, `||`, `!` like in C or JavaScript).
 
 <Figure

--- a/content/courses/python-basics/classes.mdx
+++ b/content/courses/python-basics/classes.mdx
@@ -63,6 +63,18 @@ print(isinstance(d, Dog))
 
 ## The `__init__` method
 
+`__init__` is not a constructor: the object already exists by the time it runs. Its job is to fill it in.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "def __init__(" },
+    { text: "self,", label: "the object already created for you" },
+    { text: "name,", label: "required" },
+    { text: "age=0", label: "optional, with a default" },
+    { text: "):" },
+  ]}
+/>
+
 `__init__` is the **initializer** (not "constructor", the object already exists when `__init__` runs). It sets up a new instance.
 
 <Figure
@@ -213,6 +225,16 @@ print(c.value)
 />
 
 ## `@classmethod` and `@staticmethod`
+
+The decorator decides what Python passes in as the first argument, and that is the whole distinction:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "@classmethod", label: "first argument is the class" },
+    { text: "def from_json(cls, s):", label: "so it can call cls(...) to build one" },
+    { text: "@staticmethod", label: "no implicit first argument at all" },
+  ]}
+/>
 
 Sometimes you want a method that operates on the **class** itself, or a utility function that logically belongs to the class but doesn't need access to instances.
 

--- a/content/courses/python-basics/classes.mdx
+++ b/content/courses/python-basics/classes.mdx
@@ -139,7 +139,7 @@ print(a.species, b.species)  # change is reflected in all instances
 <Callout type="warn" title="Mutable class attributes are a gotcha">
 If a class attribute is a **mutable** object (list, dict, set), all instances share that single object. Modifying it in one instance affects all others. This is almost never what you want.
 
-\`\`\`python
+```python
 class Bad:
     items = []  # shared by all instances!
 
@@ -147,9 +147,9 @@ a = Bad()
 b = Bad()
 a.items.append(1)
 print(b.items)  # [1], oops!
-\`\`\`
+```
 
-**Always** initialize mutable per-instance data in \`__init__\`.
+**Always** initialize mutable per-instance data in `__init__`.
 </Callout>
 
 ```mermaid

--- a/content/courses/python-basics/comprehensions.mdx
+++ b/content/courses/python-basics/comprehensions.mdx
@@ -92,7 +92,21 @@ The comprehension is usually preferable because it states *what* you want rather
 
 ## List comprehensions: with filter
 
-The `if` clause is optional.
+The `if` clause is optional. With it, a comprehension reads as three
+separate jobs on one line:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "[" },
+    { text: "x", label: "what to put in the new list" },
+    { text: "for x in nums", label: "where the items come from" },
+    { text: "if x % 2 == 0", label: "which ones to keep" },
+    { text: "]" },
+  ]}
+/>
+
+Read it in the order it runs: the `for` first, then the `if`, then the
+expression on the left.
 
 <CodeBlock
   adapter="python"

--- a/content/courses/python-basics/control-flow.mdx
+++ b/content/courses/python-basics/control-flow.mdx
@@ -309,6 +309,16 @@ if a < b < c:
 
 ## `match` statement (Python 3.10+)
 
+`match` is structural, not a switch on equality: a case can bind names out of the shape it matched.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "match point:", label: "the subject" },
+    { text: "case (0, y):", label: "a pattern that also binds y" },
+    { text: "case _:", label: "the wildcard, matching anything left" },
+  ]}
+/>
+
 `match` is **structural pattern matching**, not just a `switch`. It matches the *shape* of data and can bind values from inside it.
 
 <Figure

--- a/content/courses/python-basics/decorators.mdx
+++ b/content/courses/python-basics/decorators.mdx
@@ -225,7 +225,7 @@ Let's unpack what happens:
 <Callout type="error" title="Decorator-with-args gotcha">
 A decorator with arguments is a **factory** that returns a decorator. The nesting is:
 
-```
+```text
 repeat(times) → decorator → wrapper
 ```
 

--- a/content/courses/python-basics/decorators.mdx
+++ b/content/courses/python-basics/decorators.mdx
@@ -11,7 +11,7 @@ A **decorator** is just a function that takes another function and returns a new
 />
 
 <Callout type="info" title="Real-world ubiquity">
-Open any modern Python codebase and you'll see decorators everywhere: \`@app.route("/users")\` in Flask/FastAPI, \`@cache\` for memoization, \`@dataclass\` to auto-generate boilerplate, \`@staticmethod\` and \`@classmethod\` in classes, \`@timing\` and \`@retry\` in production services. Understanding decorators means understanding how most Python frameworks work under the hood.
+Open any modern Python codebase and you'll see decorators everywhere: `@app.route("/users")` in Flask/FastAPI, `@cache` for memoization, `@dataclass` to auto-generate boilerplate, `@staticmethod` and `@classmethod` in classes, `@timing` and `@retry` in production services. Understanding decorators means understanding how most Python frameworks work under the hood.
 </Callout>
 
 ## Closures recap
@@ -143,7 +143,7 @@ print(greet.__doc__)  # 'Return a greeting.' -- preserved!
 />
 
 <Callout type="warn" title="ALWAYS use functools.wraps">
-Tools, debuggers, and stack traces rely on \`__name__\`, \`__doc__\`, and \`__module__\`. Without \`@wraps(fn)\`, your wrapper will show up as "wrapper" in tracebacks, and introspection tools (like \`help()\`) will fail. This is the #1 decorator mistake beginners make.
+Tools, debuggers, and stack traces rely on `__name__`, `__doc__`, and `__module__`. Without `@wraps(fn)`, your wrapper will show up as "wrapper" in tracebacks, and introspection tools (like `help()`) will fail. This is the #1 decorator mistake beginners make.
 </Callout>
 
 ## A useful example: timing
@@ -225,9 +225,9 @@ Let's unpack what happens:
 <Callout type="error" title="Decorator-with-args gotcha">
 A decorator with arguments is a **factory** that returns a decorator. The nesting is:
 
-\`\`\`
+```
 repeat(times) → decorator → wrapper
-\`\`\`
+```
 
 Forgetting the middle layer is a common mistake. If you see "TypeError: decorator() takes 1 positional argument but 2 were given", you likely forgot the factory pattern.
 </Callout>
@@ -293,7 +293,7 @@ The call stack is: `bracketed wrapper` → `excited wrapper` → original `greet
 />
 
 <Callout type="info" title="Order matters">
-Stacking decorators bottom-up can be counterintuitive. The decorator **closest** to the function definition runs **first** (wraps the original function), and decorators above it wrap the result. If order matters (e.g., a \`@cache\` decorator should wrap \`@retry\`, not the other way around), pay attention to the order.
+Stacking decorators bottom-up can be counterintuitive. The decorator **closest** to the function definition runs **first** (wraps the original function), and decorators above it wrap the result. If order matters (e.g., a `@cache` decorator should wrap `@retry`, not the other way around), pay attention to the order.
 </Callout>
 
 ## Class-based decorators
@@ -366,17 +366,17 @@ print(calc.add(2, 3))
 The decorator sees `self` as the first positional argument in `*args`. This works fine for simple decorators. For more advanced patterns (like caching with `self` awareness), use libraries like `functools.lru_cache` or `cachetools`.
 
 <Callout type="warn" title="@staticmethod and @classmethod order">
-If you stack \`@staticmethod\` or \`@classmethod\` with other decorators, they must be **outermost** (applied last):
+If you stack `@staticmethod` or `@classmethod` with other decorators, they must be **outermost** (applied last):
 
-\`\`\`python
+```python
 class Foo:
     @staticmethod
     @logged
     def bar():
         pass
-\`\`\`
+```
 
-Applying \`@staticmethod\` first (closest to the function) can cause errors because \`@staticmethod\` returns a descriptor, not a callable function.
+Applying `@staticmethod` first (closest to the function) can cause errors because `@staticmethod` returns a descriptor, not a callable function.
 </Callout>
 
 ## Built-in decorators worth knowing

--- a/content/courses/python-basics/dictionaries.mdx
+++ b/content/courses/python-basics/dictionaries.mdx
@@ -101,7 +101,17 @@ print(from_pairs)
 
 ## Accessing values
 
-Use `[]` to access a value by key.
+Use `[]` to access a value by key. `.get()` is the safe alternative: it
+returns a fallback instead of raising when the key is absent.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "person.get(" },
+    { text: '"name",', label: "the key to look up" },
+    { text: '"unknown"', label: "returned instead of raising if it is missing" },
+    { text: ")" },
+  ]}
+/>
 
 <CodeBlock
   adapter="python"

--- a/content/courses/python-basics/exceptions.mdx
+++ b/content/courses/python-basics/exceptions.mdx
@@ -326,28 +326,38 @@ Every exception inherits from `BaseException`. The ones you usually care about i
 
 `Exception` catches "every normal error". **Do not** catch `BaseException` casually; it includes `KeyboardInterrupt` and `SystemExit`, which you usually want to let through.
 
+```mermaid
+flowchart TD
+    Base["BaseException"] --> KI["KeyboardInterrupt<br/>(Ctrl+C)"]
+    Base --> SE["SystemExit<br/>(sys.exit())"]
+    Base --> Exc["Exception"]
+    Exc --> VE["ValueError"]
+    Exc --> TE["TypeError"]
+    Exc --> KE["KeyError"]
+    Exc --> IE["IndexError"]
+    Exc --> AE["AttributeError"]
+    Exc --> FNF["FileNotFoundError"]
+    Exc --> More["... many more"]
+```
+
+You do not have to memorize the tree. Python will tell you: every class
+has a `__mro__`, the chain of classes it inherits from, and `issubclass`
+answers the question an `except` clause is really asking.
+
 <CodeBlock
   adapter="python"
   files={[
     {
       filename: "main.py",
-      starterCode: `import sys
+      starterCode: `# Walk an exception's ancestry, straight from the interpreter.
+for exc in (ValueError, KeyError, FileNotFoundError, KeyboardInterrupt):
+    chain = " -> ".join(cls.__name__ for cls in exc.__mro__[:-1])
+    print(chain)
 
-# Built-in exception hierarchy (simplified)
-hierarchy = """
-BaseException
-├── KeyboardInterrupt (Ctrl+C)
-├── SystemExit (sys.exit())
-└── Exception
-    ├── ValueError
-    ├── TypeError
-    ├── KeyError
-    ├── IndexError
-    ├── AttributeError
-    ├── FileNotFoundError
-    └── ... (many more)
-"""
-print(hierarchy)
+# This is exactly the question \`except Exception\` asks about an error.
+print()
+print("KeyError is an Exception:", issubclass(KeyError, Exception))
+print("KeyboardInterrupt is an Exception:", issubclass(KeyboardInterrupt, Exception))
 `,
     },
   ]}

--- a/content/courses/python-basics/files.mdx
+++ b/content/courses/python-basics/files.mdx
@@ -44,6 +44,16 @@ The `with` statement is Python's **context manager** protocol. For files, it gua
 ## Opening a file
 
 Every snippet on this page runs in your browser, no setup required.
+Nearly every file you open is written as one line with four parts:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "with", label: "close it again, whatever happens" },
+    { text: 'open("poem.txt",', label: "which file" },
+    { text: '"w")', label: "what for: read, write or append" },
+    { text: "as f:", label: "the name you use inside the block" },
+  ]}
+/>
 
 <Figure
   slug="python-files-opening-file-inline-cutout"

--- a/content/courses/python-basics/functions.mdx
+++ b/content/courses/python-basics/functions.mdx
@@ -71,6 +71,17 @@ A function is **defined once** with `def`, then **called many times**. Each call
 
 ## Defining a function
 
+A definition is four pieces on one line, plus an indented body:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "def", label: "start a definition" },
+    { text: "greet", label: "the name callers use" },
+    { text: "(name)", label: "parameters, filled in per call" },
+    { text: ":", label: "the indented body follows" },
+  ]}
+/>
+
 <CodeBlock
   adapter="python"
   files={[

--- a/content/courses/python-basics/functions.mdx
+++ b/content/courses/python-basics/functions.mdx
@@ -201,6 +201,17 @@ print(add_item("c"))  # ["c"]
 
 ## `*args` and `**kwargs`
 
+The stars are the whole syntax: one collects positional arguments, two collect keyword ones.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "def f(" },
+    { text: "*args,", label: "extra positionals, as a tuple" },
+    { text: "**kwargs", label: "extra keywords, as a dict" },
+    { text: "):" },
+  ]}
+/>
+
 `*args` captures any extra **positional** arguments as a **tuple**; `**kwargs` captures any extra **keyword** arguments as a **dict**.
 
 <CodeBlock

--- a/content/courses/python-basics/inheritance.mdx
+++ b/content/courses/python-basics/inheritance.mdx
@@ -23,7 +23,7 @@ Inheritance shows up everywhere in Python:
 Understanding inheritance is essential for working with frameworks and designing extensible systems. But remember: **composition is often better than inheritance**. We'll cover that too.
 
 <Callout type="info" title="Real-world example: Django models">
-Every Django model inherits from \`django.db.models.Model\`. That base class provides the entire object-relational mapping machinery: \`save()\`, \`delete()\`, \`objects.filter(...)\`, etc. You just define fields and optionally override methods. This is inheritance done right: the base class provides infrastructure, subclasses provide domain logic.
+Every Django model inherits from `django.db.models.Model`. That base class provides the entire object-relational mapping machinery: `save()`, `delete()`, `objects.filter(...)`, etc. You just define fields and optionally override methods. This is inheritance done right: the base class provides infrastructure, subclasses provide domain logic.
 </Callout>
 
 ## Single inheritance
@@ -104,7 +104,7 @@ print(d.speak())  # calls Dog.speak, not Animal.speak
 />
 
 <Callout type="tip" title="When to override">
-Override a method when you need **different behavior** for the subclass. If you want to **extend** the parent's behavior (call the parent's version first, then add more), use \`super()\` (next section).
+Override a method when you need **different behavior** for the subclass. If you want to **extend** the parent's behavior (call the parent's version first, then add more), use `super()` (next section).
 </Callout>
 
 ## `super()`: calling parent methods
@@ -145,7 +145,7 @@ When you write `Dog("Rex", "Labrador")`, initialization runs in order:
 5. The fully initialized `Dog` instance is returned.
 
 <Callout type="info" title="super() in multiple inheritance">
-In single inheritance, \`super()\` just calls the parent. In multiple inheritance, \`super()\` follows the **Method Resolution Order (MRO)**, which is computed by the C3 linearization algorithm. This ensures every class is called exactly once in a consistent order. See the MRO section below.
+In single inheritance, `super()` just calls the parent. In multiple inheritance, `super()` follows the **Method Resolution Order (MRO)**, which is computed by the C3 linearization algorithm. This ensures every class is called exactly once in a consistent order. See the MRO section below.
 </Callout>
 
 ## Polymorphism: same interface, different behavior
@@ -180,7 +180,7 @@ for animal in animals:
 None of these classes inherit from a common base, but they all work with `for animal in animals: animal.speak()` because they all implement `speak()`. This is **duck typing**.
 
 <Callout type="tip" title="Duck typing: 'If it walks like a duck...'">
-"If it walks like a duck and quacks like a duck, it's a duck." In Python, you don't need inheritance for polymorphism. Two unrelated classes are **substitutable** if they expose the same methods. This is why Python's \`open()\` works with files, sockets, and in-memory buffers: they all have \`.read()\` and \`.write()\`.
+"If it walks like a duck and quacks like a duck, it's a duck." In Python, you don't need inheritance for polymorphism. Two unrelated classes are **substitutable** if they expose the same methods. This is why Python's `open()` works with files, sockets, and in-memory buffers: they all have `.read()` and `.write()`.
 </Callout>
 
 ## `isinstance` and `issubclass`
@@ -211,7 +211,7 @@ print(issubclass(Dog, Animal))  # True
 `isinstance(obj, Class)` returns `True` if `obj` is an instance of `Class` **or any subclass**. `type(obj) is Class` only returns `True` for exact type matches.
 
 <Callout type="warn" title="Prefer isinstance over type checks">
-Use \`isinstance(x, int)\` instead of \`type(x) is int\`. The former allows subclasses (e.g., \`bool\` is a subclass of \`int\`); the latter does not. In general, checking types at all is un-Pythonic, prefer duck typing and "ask forgiveness, not permission" (EAFP).
+Use `isinstance(x, int)` instead of `type(x) is int`. The former allows subclasses (e.g., `bool` is a subclass of `int`); the latter does not. In general, checking types at all is un-Pythonic, prefer duck typing and "ask forgiveness, not permission" (EAFP).
 </Callout>
 
 ## Multiple inheritance and method resolution order
@@ -268,7 +268,7 @@ classDiagram
 ```
 
 <Callout type="warn" title="Multiple inheritance is powerful but tricky">
-Most well-designed codebases either **avoid multiple inheritance** or restrict it to **mixins**, small classes that add a single piece of behavior (e.g., \`LoggingMixin\`, \`JSONSerializableMixin\`). Deep multiple-inheritance hierarchies are hard to reason about and debug.
+Most well-designed codebases either **avoid multiple inheritance** or restrict it to **mixins**, small classes that add a single piece of behavior (e.g., `LoggingMixin`, `JSONSerializableMixin`). Deep multiple-inheritance hierarchies are hard to reason about and debug.
 </Callout>
 
 ## Abstract base classes
@@ -307,7 +307,7 @@ except TypeError as e:
 Use ABCs when you want to **enforce a contract**: "any subclass must implement these methods". This is common in framework design.
 
 <Callout type="info" title="ABCs in the standard library">
-Python's \`collections.abc\` module defines many useful ABCs: \`Iterable\`, \`Sequence\`, \`Mapping\`, \`Set\`, etc. If you want to check "does this object behave like a list?", use \`isinstance(obj, collections.abc.Sequence)\` instead of \`isinstance(obj, list)\`, it allows any list-like object, not just \`list\`.
+Python's `collections.abc` module defines many useful ABCs: `Iterable`, `Sequence`, `Mapping`, `Set`, etc. If you want to check "does this object behave like a list?", use `isinstance(obj, collections.abc.Sequence)` instead of `isinstance(obj, list)`, it allows any list-like object, not just `list`.
 </Callout>
 
 ## Composition over inheritance

--- a/content/courses/python-basics/iterators-and-generators.mdx
+++ b/content/courses/python-basics/iterators-and-generators.mdx
@@ -63,7 +63,7 @@ sequenceDiagram
 ```
 
 <Callout type="warn" title="Iterables vs Iterators">
-An **iterable** is anything with an \`__iter__\` method: lists, tuples, strings, dicts, files, generators, your own classes. An **iterator** is what \`iter()\` returns, it has both \`__iter__\` (returning self) and \`__next__\`. Many beginners confuse the two. A list is iterable but not an iterator. Calling \`iter(list)\` gives you an iterator.
+An **iterable** is anything with an `__iter__` method: lists, tuples, strings, dicts, files, generators, your own classes. An **iterator** is what `iter()` returns, it has both `__iter__` (returning self) and `__next__`. Many beginners confuse the two. A list is iterable but not an iterator. Calling `iter(list)` gives you an iterator.
 </Callout>
 
 ## Manually driving an iterator
@@ -214,7 +214,7 @@ print(list(islice(naturals(), 10)))
 Calling `list(naturals())` would hang forever. The `islice` adapter takes a finite slice, so it's safe. Infinite generators power `itertools.count`, `itertools.cycle`, and many streaming pipelines.
 
 <Callout type="error" title="Never materialize an infinite generator">
-Writing \`list(infinite_gen())\` or \`sum(infinite_gen())\` without a limit will run until you kill the process or run out of memory. Always consume infinite generators with tools that know when to stop: \`islice\`, \`takewhile\`, or manual \`next()\` calls.
+Writing `list(infinite_gen())` or `sum(infinite_gen())` without a limit will run until you kill the process or run out of memory. Always consume infinite generators with tools that know when to stop: `islice`, `takewhile`, or manual `next()` calls.
 </Callout>
 
 ## Generator expressions
@@ -368,7 +368,7 @@ print(list(product("ab", "12")))  # [('a','1'), ('a','2'), ...]
 />
 
 <Callout type="info" title="itertools is your friend">
-Before writing a generator from scratch, check if \`itertools\` already has what you need. \`itertools.groupby\`, \`itertools.compress\`, \`itertools.pairwise\` (3.10+), and others save you from reinventing the wheel.
+Before writing a generator from scratch, check if `itertools` already has what you need. `itertools.groupby`, `itertools.compress`, `itertools.pairwise` (3.10+), and others save you from reinventing the wheel.
 </Callout>
 
 ## Generators are one-shot

--- a/content/courses/python-basics/iterators-and-generators.mdx
+++ b/content/courses/python-basics/iterators-and-generators.mdx
@@ -293,6 +293,15 @@ In production, you might chain generators to process log files too large for RAM
 
 ## `yield from`
 
+`yield from` delegates the whole of another iterable, which is what saves writing a loop that just re-yields:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "yield from", label: "delegate to another iterable" },
+    { text: "inner()", label: "every value it yields comes out of here" },
+  ]}
+/>
+
 `yield from iterable` is shorthand for "yield every item from that iterable":
 
 <CodeBlock

--- a/content/courses/python-basics/lists.mdx
+++ b/content/courses/python-basics/lists.mdx
@@ -156,6 +156,18 @@ except IndexError as e:
 
 Slices let you extract a sublist with `[start:stop:step]`. The `stop` index is **exclusive**.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "xs[" },
+    { text: "1", label: "start here, included" },
+    { text: ":" },
+    { text: "4", label: "stop here, excluded" },
+    { text: ":" },
+    { text: "2", label: "take every nth item" },
+    { text: "]" },
+  ]}
+/>
+
 <CodeBlock
   adapter="python"
   files={[

--- a/content/courses/python-basics/loops.mdx
+++ b/content/courses/python-basics/loops.mdx
@@ -94,6 +94,16 @@ Iterating a dict yields **keys** by default. Use `.items()` for key-value pairs,
 
 `range(stop)`, `range(start, stop)`, and `range(start, stop, step)` produce arithmetic progressions lazily. They are the canonical way to loop "N times".
 
+<SyntaxBreakdown
+  parts={[
+    { text: "range(" },
+    { text: "2,", label: "start here, included" },
+    { text: "10,", label: "stop before here, excluded" },
+    { text: "3", label: "add this each time" },
+    { text: ")" },
+  ]}
+/>
+
 <CodeBlock
   adapter="python"
   files={[

--- a/content/courses/python-basics/next-steps.mdx
+++ b/content/courses/python-basics/next-steps.mdx
@@ -45,7 +45,7 @@ mypy myfile.py
 ```
 
 <Callout type="info" title="Modern typing features">
-Python 3.9+ added \`list[int]\` instead of \`List[int]\`, 3.10 added \`X | Y\` union syntax, and 3.12 added [PEP 695 generic syntax](https://peps.python.org/pep-0695/). Type hints keep evolving. Worth exploring: \`typing.Protocol\`, \`typing.TypedDict\`, \`Generic\`, \`Literal\`, \`Final\`, and structural subtyping.
+Python 3.9+ added `list[int]` instead of `List[int]`, 3.10 added `X | Y` union syntax, and 3.12 added [PEP 695 generic syntax](https://peps.python.org/pep-0695/). Type hints keep evolving. Worth exploring: `typing.Protocol`, `typing.TypedDict`, `Generic`, `Literal`, `Final`, and structural subtyping.
 </Callout>
 
 ### Testing with `pytest`
@@ -114,9 +114,9 @@ asyncio.run(main())
 `await asyncio.gather()` runs the three `fetch` calls concurrently, so the total time is ~0.1s, not 0.3s. This pattern scales to thousands of requests.
 
 <Callout type="info" title="Async vs threads vs processes">
-- **Threads** (\`threading\`): Good for I/O-bound concurrency where the GIL (Global Interpreter Lock) is fine. Simple but limited.
-- **Processes** (\`multiprocessing\`, \`concurrent.futures\`): For CPU-bound work. Each process has its own Python interpreter and memory.
-- **Async** (\`asyncio\`): For high-concurrency I/O. One thread, thousands of tasks. Lowest overhead, highest scalability for network-bound work.
+- **Threads** (`threading`): Good for I/O-bound concurrency where the GIL (Global Interpreter Lock) is fine. Simple but limited.
+- **Processes** (`multiprocessing`, `concurrent.futures`): For CPU-bound work. Each process has its own Python interpreter and memory.
+- **Async** (`asyncio`): For high-concurrency I/O. One thread, thousands of tasks. Lowest overhead, highest scalability for network-bound work.
 - **Free-threaded Python (PEP 703)**: Python 3.13+ offers an experimental build without the GIL, enabling true multi-threaded parallelism. This is a space to watch as it matures.
 </Callout>
 
@@ -215,7 +215,7 @@ For self-contained executables (to share with non-Python users), look at:
 - **[shiv](https://shiv.readthedocs.io/)** / **[pex](https://pex.readthedocs.io/)**, Python-based executable zip archives.
 
 <Callout type="info" title="uv makes publishing easy">
-\`uv\` (from Astral) supports \`uv publish\` to push packages to PyPI in one command. As the Python tooling ecosystem modernizes, workflows that used to require multiple tools are converging into single, fast commands.
+`uv` (from Astral) supports `uv publish` to push packages to PyPI in one command. As the Python tooling ecosystem modernizes, workflows that used to require multiple tools are converging into single, fast commands.
 </Callout>
 
 ### Tooling worth installing once

--- a/content/courses/python-basics/strings.mdx
+++ b/content/courses/python-basics/strings.mdx
@@ -374,6 +374,16 @@ print("Hello".isalpha())
 
 **f-strings** (Python 3.6+) are the modern, recommended way to build strings. Put any expression inside `{ ... }`.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "f", label: "marks the string as a format string" },
+    { text: '"Score: {' },
+    { text: "score", label: "any expression" },
+    { text: ":.2f", label: "how to format it, after the colon" },
+    { text: '}"' },
+  ]}
+/>
+
 <CodeBlock
   adapter="python"
   files={[

--- a/content/courses/python-basics/virtual-environments.mdx
+++ b/content/courses/python-basics/virtual-environments.mdx
@@ -119,7 +119,7 @@ source .venv/bin/activate
 
 Your prompt will change to show the active environment:
 
-```
+```text
 (.venv) user@host:~/project$
 ```
 
@@ -175,7 +175,7 @@ pip freeze > requirements.txt
 
 This writes every installed package with an exact version:
 
-```
+```text
 certifi==2024.8.30
 charset-normalizer==3.4.0
 idna==3.10
@@ -194,7 +194,7 @@ pip install -r requirements.txt
 <Callout type="info" title="requirements.in vs requirements.txt">
 `pip freeze` lists **every** dependency, including transitive ones (dependencies of dependencies). Many teams maintain a shorter `requirements.in` with only top-level packages:
 
-```
+```text
 requests>=2.31
 flask>=3.0
 ```
@@ -208,7 +208,7 @@ Then use `pip-tools` (`pip-compile requirements.in`) or `uv pip compile requirem
 
 Add to `.gitignore`:
 
-```
+```text
 .venv/
 venv/
 env/
@@ -317,7 +317,7 @@ You may see advice to run `pip install --user`. Skip it. The `--user` flag insta
 
 After creating and activating a venv, your project might look like:
 
-```
+```text
 my-project/
 ├── .venv/                  # virtual environment (in .gitignore)
 │   ├── bin/                # activation scripts, python, pip

--- a/content/courses/python-basics/virtual-environments.mdx
+++ b/content/courses/python-basics/virtual-environments.mdx
@@ -11,7 +11,7 @@ A Python install ships with a small standard library. Anything beyond that, NumP
 />
 
 <Callout type="warn" title="Never pip install into system Python">
-Without a virtual environment, \`pip install\` modifies your global Python installation. Two projects that need different versions of the same package cannot coexist. Worse, you risk breaking system tools that depend on specific versions. Every Python developer uses virtual environments. No exceptions.
+Without a virtual environment, `pip install` modifies your global Python installation. Two projects that need different versions of the same package cannot coexist. Worse, you risk breaking system tools that depend on specific versions. Every Python developer uses virtual environments. No exceptions.
 </Callout>
 
 This page is reference material; the commands below are intended to be run in your terminal on your local machine, not in the interactive code blocks.
@@ -74,7 +74,7 @@ flowchart TD
 Each virtual environment has its own Python interpreter copy (symlinked on Unix, copied on Windows) and its own `site-packages` directory. Activating a venv puts it first on your `PATH`, so `python` and `pip` point to that isolated environment.
 
 <Callout type="info" title="Real-world necessity">
-Every Python team uses virtual environments. Whether you're building a web API, a data pipeline, a machine learning model, or a command-line tool, you will create a venv (or use a modern tool like \`uv\` or \`poetry\` that manages venvs for you). Dependency isolation is non-negotiable in professional Python work.
+Every Python team uses virtual environments. Whether you're building a web API, a data pipeline, a machine learning model, or a command-line tool, you will create a venv (or use a modern tool like `uv` or `poetry` that manages venvs for you). Dependency isolation is non-negotiable in professional Python work.
 </Callout>
 
 ## Creating a virtual environment with `venv`
@@ -99,7 +99,7 @@ This creates a `.venv/` directory containing:
 - Activation scripts to modify your shell's `PATH`.
 
 <Callout type="success" title="Why .venv?">
-The name \`.venv\` is a convention. You can name it \`venv\`, \`env\`, or \`my-special-env\`, but \`.venv\` is standard because (1) the leading dot hides it in Unix file listings, and (2) most tools auto-detect it. Stick with \`.venv\` unless you have a reason not to.
+The name `.venv` is a convention. You can name it `venv`, `env`, or `my-special-env`, but `.venv` is standard because (1) the leading dot hides it in Unix file listings, and (2) most tools auto-detect it. Stick with `.venv` unless you have a reason not to.
 </Callout>
 
 ## Activating the environment
@@ -192,14 +192,14 @@ pip install -r requirements.txt
 ```
 
 <Callout type="info" title="requirements.in vs requirements.txt">
-\`pip freeze\` lists **every** dependency, including transitive ones (dependencies of dependencies). Many teams maintain a shorter \`requirements.in\` with only top-level packages:
+`pip freeze` lists **every** dependency, including transitive ones (dependencies of dependencies). Many teams maintain a shorter `requirements.in` with only top-level packages:
 
-\`\`\`
+```
 requests>=2.31
 flask>=3.0
-\`\`\`
+```
 
-Then use \`pip-tools\` (\`pip-compile requirements.in\`) or \`uv pip compile requirements.in\` to generate a fully locked \`requirements.txt\`. This keeps your source file readable while ensuring reproducibility.
+Then use `pip-tools` (`pip-compile requirements.in`) or `uv pip compile requirements.in` to generate a fully locked `requirements.txt`. This keeps your source file readable while ensuring reproducibility.
 </Callout>
 
 ## `.gitignore` your virtual environment
@@ -310,7 +310,7 @@ Most modern tools can read this file and install the listed dependencies.
 | Uninstall | `pip uninstall requests` |
 
 <Callout type="warn" title="Avoid --user">
-You may see advice to run \`pip install --user\`. Skip it. The \`--user\` flag installs packages into your home directory's \`site-packages\`, which is still global (shared across all your projects). Always work inside a virtual environment instead, it's cleaner, more portable, and more predictable.
+You may see advice to run `pip install --user`. Skip it. The `--user` flag installs packages into your home directory's `site-packages`, which is still global (shared across all your projects). Always work inside a virtual environment instead, it's cleaner, more portable, and more predictable.
 </Callout>
 
 ## Directory structure example

--- a/content/courses/react-from-the-ground-up/composition-and-children.mdx
+++ b/content/courses/react-from-the-ground-up/composition-and-children.mdx
@@ -15,6 +15,16 @@ doing most of the work.
 
 ## The `children` prop
 
+`children` is not passed as an attribute. Whatever sits between the tags arrives under that name:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "<Card>", label: "the opening tag carries the other props" },
+    { text: "Hello", label: "this becomes props.children" },
+    { text: "</Card>" },
+  ]}
+/>
+
 Whatever you put *between* a component's tags arrives as its
 `children` prop. That lets you build **wrapper** components, a `Card`,
 a `Modal`, a `Panel`, that style or arrange whatever you place inside:

--- a/content/courses/react-from-the-ground-up/conditional-rendering.mdx
+++ b/content/courses/react-from-the-ground-up/conditional-rendering.mdx
@@ -55,6 +55,16 @@ branch flips.
 
 ## Showing something or nothing: `&&`
 
+`&&` returns its right side only when the left is truthy, which is why a `0` on the left renders a literal zero:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "{items.length > 0", label: "a boolean, not a number" },
+    { text: "&&" },
+    { text: "<List />}", label: "rendered only when the left side is true" },
+  ]}
+/>
+
 When you want to render something **only when a condition is true** (and
 nothing otherwise), reach for `&&`. In JavaScript, `cond && value`
 evaluates to `value` when `cond` is truthy and to `cond` (a falsy value

--- a/content/courses/react-from-the-ground-up/effects-and-data-fetching.mdx
+++ b/content/courses/react-from-the-ground-up/effects-and-data-fetching.mdx
@@ -16,6 +16,17 @@ where they belong.
 
 ## useEffect basics
 
+The second argument is the whole of the API: it decides *when* the effect runs again.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "useEffect(" },
+    { text: "() => { ... }", label: "the effect, run after render" },
+    { text: ", [userId]", label: "re-run only when this changes; [] means once" },
+    { text: ")" },
+  ]}
+/>
+
 `useEffect(fn, deps)` runs `fn` *after* the component renders. The
 **dependency array** controls how often:
 

--- a/content/courses/react-from-the-ground-up/rendering-lists.mdx
+++ b/content/courses/react-from-the-ground-up/rendering-lists.mdx
@@ -74,6 +74,17 @@ function LanguageList() {
 
 ## Why `key` matters
 
+The key is not a prop the component receives. It is how React matches this render's elements to the previous one's:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "todos.map((t) => (" },
+    { text: "<Todo", label: "one element per item" },
+    { text: "key={t.id}", label: "stable identity across renders, never the index" },
+    { text: "{...t} />))" },
+  ]}
+/>
+
 Each element in a mapped list needs a **`key`**, a stable, unique
 identifier. React uses keys to tell items apart between renders, so
 when the list changes it can update, insert, or remove just the items

--- a/content/courses/react-from-the-ground-up/state-with-usestate.mdx
+++ b/content/courses/react-from-the-ground-up/state-with-usestate.mdx
@@ -20,10 +20,16 @@ component gets some.
 **setter** function. Calling the setter updates the value *and tells
 React to re-render* the component with the new value.
 
-```tsx
-const [count, setCount] = useState(0);
-//     ^value  ^setter          ^initial value
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "const [" },
+    { text: "count,", label: "the current value" },
+    { text: "setCount", label: "the function that changes it" },
+    { text: "] = useState(" },
+    { text: "0", label: "the value on the first render only" },
+    { text: ");" },
+  ]}
+/>
 
 Click the buttons below, they're live. Each click calls the setter,
 React re-renders the component, and the new `count` shows. You never

--- a/content/courses/scientific-computing-python/arrays-and-tensors.mdx
+++ b/content/courses/scientific-computing-python/arrays-and-tensors.mdx
@@ -121,6 +121,17 @@ print("choice :", rng.choice(["a", "b", "c"], size=4))
 
 ## Indexing: views, fancy, and boolean
 
+A two-dimensional index is one bracket holding two slices, separated by a comma: rows first, then columns.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "a[" },
+    { text: "1:3,", label: "which rows" },
+    { text: ":2", label: "which columns" },
+    { text: "]", label: "a view, not a copy" },
+  ]}
+/>
+
 There are three indexing modes, and they behave very differently in
 terms of memory.
 

--- a/content/courses/scientific-computing-python/floating-point.mdx
+++ b/content/courses/scientific-computing-python/floating-point.mdx
@@ -197,6 +197,18 @@ print(round(3.5))  # 4
 
 ## Comparing floats
 
+Equality is the wrong tool. `isclose` asks the question you actually mean, and it has two tolerances because the right one depends on scale:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "math.isclose(" },
+    { text: "a, b,", label: "the two values" },
+    { text: "rel_tol=1e-9,", label: "relative, which scales with the numbers" },
+    { text: "abs_tol=0.0", label: "absolute, which is what saves you near zero" },
+    { text: ")" },
+  ]}
+/>
+
 You should almost never compare floats with `==`. Use a tolerance
 instead. NumPy ships a helper that lets you specify both *absolute*
 and *relative* tolerance:

--- a/content/courses/scientific-computing-python/linear-algebra-essentials.mdx
+++ b/content/courses/scientific-computing-python/linear-algebra-essentials.mdx
@@ -42,6 +42,17 @@ chapter is about *using* them.
 
 ## Solving linear systems
 
+Never invert the matrix to do this. `solve` takes the two halves of the system directly:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "np.linalg.solve(" },
+    { text: "A,", label: "the coefficient matrix" },
+    { text: "b", label: "the right-hand side" },
+    { text: ")", label: "returns x, without ever forming the inverse" },
+  ]}
+/>
+
 The single most-used routine in scientific Python is
 `numpy.linalg.solve(A, b)`. It solves $A x = b$ where $A$ is square
 and (numerically) non-singular. It calls LAPACK's `dgesv`, which

--- a/content/courses/scientific-computing-python/ordinary-differential-equations.mdx
+++ b/content/courses/scientific-computing-python/ordinary-differential-equations.mdx
@@ -152,6 +152,19 @@ Euler with the same step size would have produced garbage.
 
 ## `scipy.integrate.solve_ivp`, what you should actually use
 
+Four arguments cover almost every use, and each answers a different question:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "solve_ivp(" },
+    { text: "f,", label: "the derivative, f(t, y)" },
+    { text: "(0, 10),", label: "the time span to integrate over" },
+    { text: "y0,", label: "the initial state" },
+    { text: "t_eval=ts", label: "where you want the answer sampled" },
+    { text: ")" },
+  ]}
+/>
+
 In production, never hand-roll RK4. SciPy gives you
 **adaptive-step** solvers that monitor their own error and adjust
 $h$ on the fly. The default is `RK45` (Dormand–Prince), which is

--- a/content/courses/seaborn-foundations/bar-and-count-plots.mdx
+++ b/content/courses/seaborn-foundations/bar-and-count-plots.mdx
@@ -252,6 +252,16 @@ revenue per day, which also reflects how busy that day was.
 
 ## A second category with `hue`
 
+`hue` is a third column bound to a third channel, and its type decides whether you get a gradient or distinct colors:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "sns.barplot(data=df, x=..., y=...," },
+    { text: "hue=\"sex\"", label: "a second category, split within each bar group" },
+    { text: ")" },
+  ]}
+/>
+
 Map a second categorical variable to **`hue`** and Seaborn splits each
 category into a cluster of side-by-side bars, one per hue level. This is how
 you compare an aggregate across *two* groupings at once.

--- a/content/courses/seaborn-foundations/continuous-vs-categorical.mdx
+++ b/content/courses/seaborn-foundations/continuous-vs-categorical.mdx
@@ -72,6 +72,19 @@ axis and not in a hue:
 
 <Chart slug="encoding-accuracy" />
 
+Every Seaborn call has the same shape, and the columns you name are what
+its type rules act on:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "sns.scatterplot(" },
+    { text: "data=penguins,", label: "the frame" },
+    { text: "x=bill_length_mm,", label: "continuous, so a continuous axis" },
+    { text: "hue=species", label: "categorical, so distinct colors" },
+    { text: ")" },
+  ]}
+/>
+
 The clearest place to *feel* this is the `hue` parameter, which behaves in
 two completely different ways depending on the column you give it.
 

--- a/content/courses/seaborn-foundations/distributions-histograms.mdx
+++ b/content/courses/seaborn-foundations/distributions-histograms.mdx
@@ -379,6 +379,17 @@ that point switch to `element="step"`, or give each group its own panel with
 
 ## Counts or density? `stat=`
 
+The `stat` argument decides what the bar heights *mean*, which is what makes groups of different sizes comparable:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "sns.histplot(data=df, x=...," },
+    { text: "stat=\"density\",", label: "area sums to 1, so group sizes stop mattering" },
+    { text: "common_norm=False", label: "normalise each hue separately" },
+    { text: ")" },
+  ]}
+/>
+
 By default each bar's height is a raw **count** of observations
 (`stat="count"`). That is intuitive, but it makes groups of unequal size
 hard to compare, a bigger group has taller bars everywhere simply because

--- a/content/courses/seaborn-foundations/facets-and-grids.mdx
+++ b/content/courses/seaborn-foundations/facets-and-grids.mdx
@@ -19,6 +19,17 @@ function through two keywords: `col` and `row`.
 
 ## Faceting is just `col` and `row`
 
+Faceting is one more column-to-channel binding, exactly like `hue`. The channel just happens to be "which subplot".
+
+<SyntaxBreakdown
+  parts={[
+    { text: "sns.relplot(data=df, x=..., y=...," },
+    { text: "col=\"species\",", label: "one subplot per value, across" },
+    { text: "row=\"sex\"", label: "and one per value, down" },
+    { text: ")" },
+  ]}
+/>
+
 Before the syntax, the reason. Here is one dataset drawn as a single
 overloaded panel and then split into facets. The lines are identical:
 

--- a/content/courses/seaborn-foundations/loading-data-and-themes.mdx
+++ b/content/courses/seaborn-foundations/loading-data-and-themes.mdx
@@ -151,6 +151,17 @@ listed datasets are large enough to slow a plot down.
 
 ## One call to make everything look good: `set_theme()`
 
+Set once at the top of a notebook, it changes every plot afterwards:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "sns.set_theme(" },
+    { text: "style=\"whitegrid\",", label: "the background and gridlines" },
+    { text: "context=\"talk\"", label: "the scale of every text and line element" },
+    { text: ")" },
+  ]}
+/>
+
 By default, Seaborn draws on matplotlib's plain look: a white background, no
 gridlines, fairly small text. It is perfectly functional but a little
 spartan. Watch what a bare plot looks like with no theme applied.

--- a/content/courses/sql-analytics-duckdb/aggregate-functions.mdx
+++ b/content/courses/sql-analytics-duckdb/aggregate-functions.mdx
@@ -44,6 +44,16 @@ else in this section is a variation on it.
 
 ## The five core aggregates
 
+Every aggregate has the same shape: a name, and the column it collapses.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "SUM", label: "which aggregate" },
+    { text: "(amount)", label: "the column it collapses; NULLs are skipped" },
+    { text: "AS total", label: "the name the result column gets" },
+  ]}
+/>
+
 | Function | Answers | Example |
 | --- | --- | --- |
 | `COUNT(*)` | How many rows? | number of orders |

--- a/content/courses/sql-analytics-duckdb/aggregate-functions.mdx
+++ b/content/courses/sql-analytics-duckdb/aggregate-functions.mdx
@@ -211,7 +211,7 @@ WHERE
 ```mermaid
 flowchart TD
     T[("orders")] --> W["<code>WHERE amount &gt; 50</code>"]
-    W --> A["AVG(amount),<br/>COUNT(*)"]
+    W --> A["<code>AVG(amount)</code>,<br/>COUNT(*)"]
     A --> R["summary of the<br/>filtered slice"]
 ```
 

--- a/content/courses/sql-analytics-duckdb/common-table-expressions.mdx
+++ b/content/courses/sql-analytics-duckdb/common-table-expressions.mdx
@@ -138,8 +138,8 @@ month later and still understand.
 
 ```mermaid
 flowchart TD
-    A["WITH paid<br/>(filter)"] --> B["<code>per_region</code><br/>(aggregate)"]
-    B --> C["final SELECT<br/>(filter + sort)"]
+    A["<code>WITH</code> paid<br/>(filter)"] --> B["<code>per_region</code><br/>(aggregate)"]
+    B --> C["final <code>SELECT</code><br/>(filter + sort)"]
 ```
 
 ## Why CTEs matter for analysis specifically

--- a/content/courses/sql-analytics-duckdb/common-table-expressions.mdx
+++ b/content/courses/sql-analytics-duckdb/common-table-expressions.mdx
@@ -49,6 +49,16 @@ A CTE pulls each step out, names it, and stacks the steps **top to
 bottom** in the order you think about them. The same logic becomes a
 readable pipeline:
 
+<SyntaxBreakdown
+  parts={[
+    { text: "WITH" },
+    { text: "paid", label: "name the first step" },
+    { text: "AS (SELECT ... )", label: "the query it stands for" },
+    { text: ", by_region AS (SELECT ... FROM paid)", label: "the next step, reading the one above" },
+    { text: "SELECT * FROM by_region;", label: "the query that finishes the job" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="duckdb"
   title="The same analysis as a readable pipeline"

--- a/content/courses/sql-analytics-duckdb/conditional-logic.mdx
+++ b/content/courses/sql-analytics-duckdb/conditional-logic.mdx
@@ -222,8 +222,8 @@ clause, which does the same thing more readably.
 
 ```mermaid
 flowchart TD
-    R[("rows with<br/>status: paid / refunded")] --> C1["SUM(CASE WHEN paid)"]
-    R --> C2["SUM(CASE WHEN refunded)"]
+    R[("rows with<br/>status: paid / refunded")] --> C1["<code>SUM(CASE WHEN paid)</code>"]
+    R --> C2["<code>SUM(CASE WHEN refunded)</code>"]
     C1 --> Out["one row:<br/><code>paid_revenue</code> | <code>refunded_revenue</code>"]
     C2 --> Out
 ```

--- a/content/courses/sql-analytics-duckdb/conditional-logic.mdx
+++ b/content/courses/sql-analytics-duckdb/conditional-logic.mdx
@@ -22,6 +22,17 @@ A `CASE` expression evaluates conditions in order and returns the value
 for the first one that matches. It is SQL's if/else, and it turns a
 continuous or messy column into clean, analysis-ready categories.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "CASE" },
+    { text: "WHEN amount >= 500", label: "tested first" },
+    { text: "THEN 'large'", label: "the value if it matched" },
+    { text: "WHEN amount >= 100 THEN 'medium'", label: "tested only if the first missed" },
+    { text: "ELSE 'small'", label: "when nothing matched" },
+    { text: "END AS size", label: "close it, and name the column" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="duckdb"
   title="Bucket amounts into size labels"
@@ -222,6 +233,14 @@ flowchart TD
 DuckDB supports the SQL-standard `FILTER (WHERE ...)` clause on aggregates,
 which expresses conditional aggregation more clearly than `CASE` inside
 `SUM()`. Prefer it when available.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "SUM(amount)", label: "the aggregate" },
+    { text: "FILTER (WHERE status = 'paid')", label: "which rows it is allowed to see" },
+    { text: "AS paid_total", label: "name the result" },
+  ]}
+/>
 
 <SqlCodeBlock
   dialect="duckdb"

--- a/content/courses/sql-analytics-duckdb/filtering-and-slicing.mdx
+++ b/content/courses/sql-analytics-duckdb/filtering-and-slicing.mdx
@@ -35,6 +35,17 @@ window. `BETWEEN` reads naturally and is **inclusive** on both ends. Here
 we slice the real diamonds file down to a specific shopping bracket:
 one-carat stones priced between \$4,000 and \$5,000.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "WHERE" },
+    { text: "price", label: "the column to bracket" },
+    { text: "BETWEEN" },
+    { text: "4000", label: "low end, included" },
+    { text: "AND" },
+    { text: "5000", label: "high end, also included" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="duckdb"
   title="Slice a price band and a carat band out of 53,940 diamonds"

--- a/content/courses/sql-analytics-duckdb/filtering-and-slicing.mdx
+++ b/content/courses/sql-analytics-duckdb/filtering-and-slicing.mdx
@@ -259,7 +259,7 @@ Filtering early is both a performance habit and a clarity habit:
 
 ```mermaid
 flowchart TD
-    Big[("10M rows")] --> W["WHERE early"]
+    Big[("10M rows")] --> W["<code>WHERE</code> early"]
     W --> Small[("10K relevant rows")]
     Small --> Cheap["Cheap, clear<br/>analysis"]
 ```

--- a/content/courses/sql-analytics-duckdb/filtering-and-slicing.mdx
+++ b/content/courses/sql-analytics-duckdb/filtering-and-slicing.mdx
@@ -75,6 +75,17 @@ everything in between. If you need to exclude an endpoint, use explicit
 
 ## Membership with `IN`
 
+`IN` is a shorter `OR`, and the parentheses hold a list rather than a subquery here:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "WHERE" },
+    { text: "cut", label: "the column to test" },
+    { text: "IN", label: "true if it equals any of them" },
+    { text: "('Ideal', 'Premium')", label: "the list of accepted values" },
+  ]}
+/>
+
 When a column must match one of several values, `IN` is cleaner than a
 chain of `OR`s.
 

--- a/content/courses/sql-analytics-duckdb/filtering-groups.mdx
+++ b/content/courses/sql-analytics-duckdb/filtering-groups.mdx
@@ -183,8 +183,8 @@ grouping step.
 
 ```mermaid
 flowchart LR
-    Cond1["Condition on a raw column<br/>(<code>status = 'paid'</code>)"] --> Where["belongs in WHERE"]
-    Cond2["Condition on an aggregate<br/>(<code>SUM(amount) &gt; 150</code>)"] --> Having["belongs in HAVING"]
+    Cond1["Condition on a raw column<br/>(<code>status = 'paid'</code>)"] --> Where["belongs in <code>WHERE</code>"]
+    Cond2["Condition on an aggregate<br/>(<code>SUM(amount) &gt; 150</code>)"] --> Having["belongs in <code>HAVING</code>"]
 ```
 
 ## A quick decision rule

--- a/content/courses/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
+++ b/content/courses/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
@@ -23,6 +23,15 @@ error-prone, add a dimension to `SELECT` and forget to add it to `GROUP
 BY`, and you get an error (or worse, a wrong result in databases that
 allow it).
 
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT region, quarter,", label: "the non-aggregated columns" },
+    { text: "SUM(amount)", label: "the aggregate" },
+    { text: "FROM sales" },
+    { text: "GROUP BY ALL;", label: "group by every column that is not an aggregate" },
+  ]}
+/>
+
 <Figure
   slug="duck-group-by-all-and-grouping-sets-group-by-all-inline-cutout"
   alt="A machine with one lever replacing a row of five identical levers that had to be set the same way"

--- a/content/courses/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
+++ b/content/courses/sql-analytics-duckdb/group-by-all-and-grouping-sets.mdx
@@ -94,6 +94,17 @@ flowchart TB
 
 ## `ROLLUP`, hierarchical subtotals
 
+`ROLLUP` adds subtotal rows by dropping grouping columns from the right, one at a time:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "GROUP BY ROLLUP(" },
+    { text: "region,", label: "kept longest" },
+    { text: "quarter", label: "dropped first, giving a per-region subtotal" },
+    { text: ")", label: "and finally a grand total row" },
+  ]}
+/>
+
 `ROLLUP(region, product)` produces the detailed rows **plus** a subtotal
 per region **plus** a grand total. It is perfect for hierarchies where
 each level rolls up into the one above (product → region → everything).

--- a/content/courses/sql-analytics-duckdb/grouping-data.mdx
+++ b/content/courses/sql-analytics-duckdb/grouping-data.mdx
@@ -208,7 +208,7 @@ aggregate, then sort.
 
 ```mermaid
 flowchart TD
-    F["FROM rows"] --> W["<code>WHERE</code><br/>(filter rows)"]
+    F["<code>FROM</code> rows"] --> W["<code>WHERE</code><br/>(filter rows)"]
     W --> G["<code>GROUP BY</code><br/>(form bins)"]
     G --> A["aggregate<br/>(one value per bin)"]
     A --> O["<code>ORDER BY</code><br/>(sort the summary)"]

--- a/content/courses/sql-analytics-duckdb/loading-and-generating-data.mdx
+++ b/content/courses/sql-analytics-duckdb/loading-and-generating-data.mdx
@@ -18,10 +18,10 @@ datasets in seconds, no files required.
 
 ```mermaid
 flowchart LR
-    A["Typed-in rows<br/>(VALUES)"] --> DB[("DuckDB")]
+    A["Typed-in rows<br/>(<code>VALUES</code>)"] --> DB[("DuckDB")]
     B["Generated rows<br/>(range, <code>generate_series</code>)"] --> DB
     C["Files<br/>(CSV, Parquet)"] --> DB
-    D["Query results<br/>(CREATE TABLE AS)"] --> DB
+    D["Query results<br/>(<code>CREATE TABLE AS</code>)"] --> DB
     DB --> Q["Analytical<br/>queries"]
 ```
 

--- a/content/courses/sql-analytics-duckdb/pivoting-and-reshaping.mdx
+++ b/content/courses/sql-analytics-duckdb/pivoting-and-reshaping.mdx
@@ -185,6 +185,17 @@ quarters in advance.
 
 ## Going the other way: `UNPIVOT`
 
+`UNPIVOT` turns columns back into rows, so it names the two columns it will create:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "UNPIVOT sales" },
+    { text: "ON q1, q2, q3, q4", label: "the columns to fold away" },
+    { text: "INTO NAME quarter", label: "a column holding the old column names" },
+    { text: "VALUE amount", label: "and one holding their values" },
+  ]}
+/>
+
 Sometimes data arrives wide, a spreadsheet with a column per month, but
 you need it long to compute on it. `UNPIVOT` collapses those columns back
 into rows.

--- a/content/courses/sql-analytics-duckdb/pivoting-and-reshaping.mdx
+++ b/content/courses/sql-analytics-duckdb/pivoting-and-reshaping.mdx
@@ -36,8 +36,8 @@ In **wide** form, the quarters become columns, a little report:
 
 ```mermaid
 flowchart LR
-    Long["Long / tidy<br/>(one value per row)"] -- "PIVOT<br/>(spread a category<br/>into columns)" --> Wide["Wide<br/>(category across columns)"]
-    Wide -- "UNPIVOT<br/>(collapse columns<br/>back into rows)" --> Long
+    Long["Long / tidy<br/>(one value per row)"] -- "<code>PIVOT</code><br/>(spread a category<br/>into columns)" --> Wide["Wide<br/>(category across columns)"]
+    Wide -- "<code>UNPIVOT</code><br/>(collapse columns<br/>back into rows)" --> Long
 ```
 
 Neither is "correct", they serve different goals:

--- a/content/courses/sql-analytics-duckdb/pivoting-and-reshaping.mdx
+++ b/content/courses/sql-analytics-duckdb/pivoting-and-reshaping.mdx
@@ -128,6 +128,16 @@ Writing a `FILTER` per column is tedious when there are many categories.
 DuckDB's `PIVOT` does it declaratively, you name the column to spread and
 the aggregate, and DuckDB discovers the distinct values for you.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "PIVOT" },
+    { text: "sales", label: "the table to reshape" },
+    { text: "ON quarter", label: "the column whose values become new columns" },
+    { text: "USING SUM(amount)", label: "what fills each cell" },
+    { text: "GROUP BY region", label: "what stays as rows" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="duckdb"
   title="The same pivot with PIVOT syntax"

--- a/content/courses/sql-analytics-duckdb/ranking-and-row-number.mdx
+++ b/content/courses/sql-analytics-duckdb/ranking-and-row-number.mdx
@@ -22,6 +22,15 @@ the end.
 *requires* an `ORDER BY` inside `OVER`, because numbering only makes sense
 once you have decided the order.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "ROW_NUMBER()", label: "takes no arguments; the OVER clause does the work" },
+    { text: "OVER (" },
+    { text: "ORDER BY amount DESC", label: "what number 1 means" },
+    { text: ") AS rn" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="duckdb"
   title="Number orders from biggest to smallest"

--- a/content/courses/sql-analytics-duckdb/ranking-and-row-number.mdx
+++ b/content/courses/sql-analytics-duckdb/ranking-and-row-number.mdx
@@ -142,7 +142,7 @@ ORDER BY
 
 ```mermaid
 flowchart LR
-    P["PARTITION BY region"] --> W["West: 1, 2, 3"]
+    P["<code>PARTITION BY</code> region"] --> W["West: 1, 2, 3"]
     P --> E["East: 1, 2"]
     P --> N["North: 1"]
 ```
@@ -260,7 +260,7 @@ ORDER BY
 ```mermaid
 flowchart TB
     T["Two players tie at 100,<br/>two tie at 80"] --> RN["<code>ROW_NUMBER:<br/>1, 2, 3, 4, 5</code>"]
-    T --> R["RANK:<br/>1, 1, 3, 4, 4"]
+    T --> R["<code>RANK</code>:<br/>1, 1, 3, 4, 4"]
     T --> D["<code>DENSE_RANK:<br/>1, 1, 2, 3, 3</code>"]
 ```
 

--- a/content/courses/sql-analytics-duckdb/running-totals-and-moving-averages.mdx
+++ b/content/courses/sql-analytics-duckdb/running-totals-and-moving-averages.mdx
@@ -223,6 +223,16 @@ ROW`. You can change the frame to a **sliding window**, say, the current
 row plus the two before it, to compute a **moving average** that smooths
 out noise.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "AVG(amount)", label: "what to average" },
+    { text: "OVER (ORDER BY day" },
+    { text: "ROWS BETWEEN 2 PRECEDING", label: "start of the window" },
+    { text: "AND CURRENT ROW", label: "end of the window" },
+    { text: ")" },
+  ]}
+/>
+
 <Figure
   slug="duck-running-totals-and-moving-averages-window-frame-moving-averages-inline-cutout"
   alt="A hooded scoop passing along a row of marks, holding only a fixed number of them at any one moment"

--- a/content/courses/sql-analytics-duckdb/sorting-and-top-n.mdx
+++ b/content/courses/sql-analytics-duckdb/sorting-and-top-n.mdx
@@ -148,6 +148,14 @@ question analysts actually ask, and a plain `LIMIT` cannot do it, because
 pairs a window function (which you will meet properly soon) with
 **`QUALIFY`**, a filter on the window result.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "QUALIFY" },
+    { text: "ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC)", label: "number the rows inside each region" },
+    { text: "<= 2", label: "keep the first two of each" },
+  ]}
+/>
+
 <Figure
   slug="duck-sorting-and-top-n-per-group-top-n-inline-cutout"
   alt="Three separate shelves each having its own top two items lifted off, rather than the top two of the whole room"

--- a/content/courses/sql-analytics-duckdb/why-window-functions.mdx
+++ b/content/courses/sql-analytics-duckdb/why-window-functions.mdx
@@ -33,7 +33,7 @@ other, never both in the same row.
 
 ```mermaid
 flowchart LR
-    subgraph GB["GROUP BY: rows collapse"]
+    subgraph GB["<code>GROUP BY</code>: rows collapse"]
         G1["5 West orders"] --> G2["1 row: West total"]
     end
     subgraph WF["Window: rows survive"]
@@ -171,7 +171,7 @@ ORDER BY
 
 ```mermaid
 flowchart TD
-    All[("All orders")] --> P["PARTITION BY region"]
+    All[("All orders")] --> P["<code>PARTITION BY</code> region"]
     P --> W["West window"]
     P --> E["East window"]
     P --> N["North window"]

--- a/content/courses/sql-analytics-duckdb/why-window-functions.mdx
+++ b/content/courses/sql-analytics-duckdb/why-window-functions.mdx
@@ -258,12 +258,15 @@ window function summarizes *alongside* the rows.**
 
 ## Anatomy of a window function
 
-```
-SUM(amount)  OVER ( PARTITION BY region  ORDER BY order_date )
-└────┬────┘        └──────┬──────────┘  └────────┬─────────┘
-  what to            which rows share        order within
-  compute            a window                the window
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "SUM(amount)", label: "what to compute" },
+    { text: "OVER (" },
+    { text: "PARTITION BY region", label: "which rows share a window" },
+    { text: "ORDER BY order_date", label: "order within the window" },
+    { text: ")" },
+  ]}
+/>
 
 - The **function** (`SUM()`, `AVG()`, `COUNT()`, `ROW_NUMBER()`, ...) is what to
   compute.

--- a/content/courses/sql-analytics-duckdb/working-with-dates.mdx
+++ b/content/courses/sql-analytics-duckdb/working-with-dates.mdx
@@ -22,6 +22,15 @@ give one group per *day*. You first **truncate** each date down to the
 first of its month, so every day in March collapses to `2024-03-01`. The
 tool is `date_trunc('month', d)`.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "date_trunc(" },
+    { text: "'month',", label: "the period to snap down to" },
+    { text: "order_date", label: "the date column" },
+    { text: ") AS month", label: "one value per month to group on" },
+  ]}
+/>
+
 <Figure
   slug="duck-working-with-dates-core-move-truncate-inline-cutout"
   alt="A calendar strip cut by a guillotine into equal months and the pieces stacked"

--- a/content/courses/sqlite-for-beginners/aggregate-functions.mdx
+++ b/content/courses/sqlite-for-beginners/aggregate-functions.mdx
@@ -49,6 +49,16 @@ The five core aggregate functions are:
 
 `COUNT(*)` counts rows. It does not care what values are inside those rows. It simply answers: "How many rows are in this result?"
 
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT" },
+    { text: "COUNT", label: "which aggregate" },
+    { text: "(*)", label: "over what; * means the rows themselves" },
+    { text: "AS n_books", label: "name the single number" },
+    { text: "FROM books;" },
+  ]}
+/>
+
 <Figure
   slug="lite-aggregate-functions-counting-rows-count-inline-cutout"
   alt="A row of blocks passing a clicking counter, the counter's needle rising with each"

--- a/content/courses/sqlite-for-beginners/aggregate-functions.mdx
+++ b/content/courses/sqlite-for-beginners/aggregate-functions.mdx
@@ -92,7 +92,7 @@ in, one row comes out.
 
 ```mermaid
 flowchart TB
-    T[("orders table")] --> C["COUNT(*)<br/>count every row"]
+    T[("orders table")] --> C["<code>COUNT(*)</code><br/>count every row"]
     C --> R["<code>order_count = 4</code>"]
 ```
 
@@ -226,10 +226,10 @@ One query gives you a compact report: count, total, average, smallest, and large
 
 ```mermaid
 flowchart LR
-    Data["Order rows"] --> Count["COUNT(*)"]
-    Data --> Sum["SUM(amount)"]
-    Data --> Avg["AVG(amount)"]
-    Data --> MinMax["MIN(amount)<br/>MAX(amount)"]
+    Data["Order rows"] --> Count["<code>COUNT(*)</code>"]
+    Data --> Sum["<code>SUM(amount)</code>"]
+    Data --> Avg["<code>AVG(amount)</code>"]
+    Data --> MinMax["<code>MIN(amount)</code><br/>MAX(amount)"]
     Count --> Report["One report row"]
     Sum --> Report
     Avg --> Report
@@ -273,8 +273,8 @@ Read this as: "Keep only Ada's rows, then add their amounts."
 
 ```mermaid
 flowchart TD
-    T[("orders table")] --> W["WHERE <code>customer = 'Ada'</code>"]
-    W --> S["SUM(amount)"]
+    T[("orders table")] --> W["<code>WHERE customer = 'Ada'</code>"]
+    W --> S["<code>SUM(amount)</code>"]
     S --> R["one total"]
 ```
 

--- a/content/courses/sqlite-for-beginners/creating-tables.mdx
+++ b/content/courses/sqlite-for-beginners/creating-tables.mdx
@@ -219,10 +219,10 @@ ORDER BY
 
 ```mermaid
 flowchart LR
-    T["movies table"] --> I["id INTEGER PRIMARY KEY"]
-    T --> N["title TEXT NOT NULL"]
-    T --> Y["<code>release_year</code> INTEGER"]
-    T --> D["rating REAL DEFAULT 0.0"]
+    T["movies table"] --> I["id <code>INTEGER PRIMARY KEY</code>"]
+    T --> N["title <code>TEXT NOT NULL</code>"]
+    T --> Y["<code>release_year INTEGER</code>"]
+    T --> D["rating <code>REAL DEFAULT</code> 0.0"]
 ```
 
 <MultipleChoice

--- a/content/courses/sqlite-for-beginners/creating-tables.mdx
+++ b/content/courses/sqlite-for-beginners/creating-tables.mdx
@@ -37,14 +37,13 @@ The `SELECT` returns no rows because the table is empty. That is still useful: i
 
 Read the statement as: *create a table called `books` with an integer `id`, text `title`, text `author`, and integer `year`.*
 
-```mermaid
-flowchart LR
-    S["<code>CREATE TABLE books</code>"] --> P["column list"]
-    P --> C1["id INTEGER"]
-    P --> C2["title TEXT"]
-    P --> C3["author TEXT"]
-    P --> C4["year INTEGER"]
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "CREATE TABLE", label: "make a new table" },
+    { text: "books", label: "its name" },
+    { text: "(id INTEGER, title TEXT, ...);", label: "one name and one type per column" },
+  ]}
+/>
 
 ## From statement to grid
 

--- a/content/courses/sqlite-for-beginners/data-types.mdx
+++ b/content/courses/sqlite-for-beginners/data-types.mdx
@@ -115,6 +115,16 @@ SQLite's full mapping rules look at words inside the declared type. For beginner
 
 ## `typeof()` shows the storage class
 
+SQLite stores a value's own type, not the column's, and `typeof()` is how you see which one it actually used:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "typeof(", label: "the storage class of this value" },
+    { text: "price", label: "not the column's declared type" },
+    { text: ")", label: "one of null, integer, real, text, blob" },
+  ]}
+/>
+
 SQLite has a helpful function named `typeof()` that reports how a value is actually stored.
 
 <SqlCodeBlock

--- a/content/courses/sqlite-for-beginners/data-types.mdx
+++ b/content/courses/sqlite-for-beginners/data-types.mdx
@@ -58,10 +58,10 @@ SQLite stores values using five storage classes:
 ```mermaid
 flowchart LR
     S["SQLite value storage classes"]
-    S --> N["NULL<br/>missing or unknown"]
-    S --> I["INTEGER<br/>whole number"]
-    S --> R["REAL<br/>floating-point number"]
-    S --> T["TEXT<br/>text string"]
+    S --> N["<code>NULL</code><br/>missing or unknown"]
+    S --> I["<code>INTEGER</code><br/>whole number"]
+    S --> R["<code>REAL</code><br/>floating-point number"]
+    S --> T["<code>TEXT</code><br/>text string"]
     S --> B["BLOB<br/>raw bytes"]
 ```
 
@@ -94,10 +94,10 @@ When you write a column type, SQLite maps it to an affinity. Affinity is the col
 ```mermaid
 flowchart LR
     D["Declared column type"] --> A["SQLite affinity"]
-    A --> AI["INTEGER affinity"]
-    A --> AT["TEXT affinity"]
-    A --> AR["REAL affinity"]
-    A --> AN["NUMERIC affinity"]
+    A --> AI["<code>INTEGER</code> affinity"]
+    A --> AT["<code>TEXT</code> affinity"]
+    A --> AR["<code>REAL</code> affinity"]
+    A --> AN["<code>NUMERIC</code> affinity"]
     A --> AB["BLOB affinity"]
 ```
 
@@ -203,8 +203,8 @@ SQLite does not have a separate boolean storage class. Store true/false values a
 
 ```mermaid
 flowchart LR
-    TRUE["true idea"] --> ONE["store as INTEGER 1"]
-    FALSE["false idea"] --> ZERO["store as INTEGER 0"]
+    TRUE["true idea"] --> ONE["store as <code>INTEGER</code> 1"]
+    FALSE["false idea"] --> ZERO["store as <code>INTEGER</code> 0"]
 ```
 
 Example column:
@@ -227,9 +227,9 @@ SQLite does not have a separate date or timestamp storage class. Common choices 
 
 ```mermaid
 flowchart TB
-    DATE["Date or time value"] --> TEXTD["TEXT<br/>YYYY-MM-DD"]
-    DATE --> INTD["INTEGER<br/>Unix time"]
-    DATE --> REALD["REAL<br/>Julian day number"]
+    DATE["Date or time value"] --> TEXTD["<code>TEXT</code><br/>YYYY-MM-DD"]
+    DATE --> INTD["<code>INTEGER</code><br/>Unix time"]
+    DATE --> REALD["<code>REAL</code><br/>Julian day number"]
 ```
 
 For beginners, storing dates as `TEXT` in ISO format is easiest:

--- a/content/courses/sqlite-for-beginners/filtering-groups.mdx
+++ b/content/courses/sqlite-for-beginners/filtering-groups.mdx
@@ -260,18 +260,20 @@ If the condition mentions an aggregate function like `COUNT()`, `SUM()`, `AVG()`
 
 ## The clause order so far
 
-The written order of a grouped query is fixed:
+The written order of a grouped query is fixed, and each clause has one job:
 
-```sql
-SELECT columns_and_aggregates
-FROM table_name
-WHERE row_condition
-GROUP BY group_columns
-HAVING group_condition
-ORDER BY sort_columns;
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT ...", label: "choose the output" },
+    { text: "FROM ...", label: "choose the table" },
+    { text: "WHERE ...", label: "filter rows" },
+    { text: "GROUP BY ...", label: "build the groups" },
+    { text: "HAVING ...", label: "filter the groups" },
+    { text: "ORDER BY ...;", label: "sort the result" },
+  ]}
+/>
 
-The logical flow is:
+That is the order you *write*. The order SQLite *runs* them in is different:
 
 **`FROM` (choose table) → `WHERE` (filter rows) → `GROUP BY` (build groups) → aggregates like `COUNT()`, `SUM()`, `AVG()` → `HAVING` (filter groups) → `SELECT` (choose output) → `ORDER BY` (sort result)**
 

--- a/content/courses/sqlite-for-beginners/filtering-rows.mdx
+++ b/content/courses/sqlite-for-beginners/filtering-rows.mdx
@@ -38,7 +38,7 @@ left out.
 
 ```mermaid
 flowchart TD
-    A["all rows<br/>in books"] --> W{"WHERE condition<br/>is true?"}
+    A["all rows<br/>in books"] --> W{"<code>WHERE</code> condition<br/>is true?"}
     W -->|"true"| K["keep row<br/>in result"]
     W -->|"false"| D["drop row<br/>from result"]
 ```

--- a/content/courses/sqlite-for-beginners/filtering-rows.mdx
+++ b/content/courses/sqlite-for-beginners/filtering-rows.mdx
@@ -20,6 +20,16 @@ A `WHERE` clause is a test that SQLite applies to each row. If the test
 is true, the row stays in the result. If the test is false, the row is
 left out.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT title FROM books" },
+    { text: "WHERE" },
+    { text: "price", label: "the column to test" },
+    { text: "<", label: "the comparison" },
+    { text: "10;", label: "what to compare it against" },
+  ]}
+/>
+
 <Figure
   slug="lite-filtering-rows-inline-cutout"
   alt="A board of rows passing a gate that swings open only for rows carrying a matching notch"
@@ -433,6 +443,15 @@ WHERE
 
 In SQLite, `LIKE` is case-insensitive for ordinary ASCII letters by
 default. That means `'sql%'` can match `SQL Street`.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "WHERE" },
+    { text: "title", label: "the text column to test" },
+    { text: "LIKE" },
+    { text: "'sql%'", label: "the pattern, where % is any run of characters" },
+  ]}
+/>
 
 <SqlCodeBlock
   dialect="sqlite"

--- a/content/courses/sqlite-for-beginners/first-queries.mdx
+++ b/content/courses/sqlite-for-beginners/first-queries.mdx
@@ -70,20 +70,16 @@ Column aliases name what you see in the result table; they do not store data any
 
 A SQL statement is one complete instruction. We end statements with a semicolon `;` so SQLite knows the instruction is finished.
 
-```mermaid
-flowchart TB
-    A["<code>SELECT</code>"] --> B["what you want back"]
-    B --> C["AS <code>optional_name</code>"]
-    C --> D["semicolon<br/>end of statement"]
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT" },
+    { text: "'Ada'", label: "what you want back" },
+    { text: "AS first_name", label: "the name it gets in the result" },
+    { text: ";", label: "end of statement" },
+  ]}
+/>
 
-For now, the most common shape is:
-
-```sql
-SELECT value_or_column AS output_name;
-```
-
-Later, when you read stored data, you add `FROM table_name` to say where the rows come from.
+Later, when you read stored data, you add `FROM table_name` between the value and the semicolon to say where the rows come from.
 
 <SqlCodeBlock
   dialect="sqlite"

--- a/content/courses/sqlite-for-beginners/foreign-keys.mdx
+++ b/content/courses/sqlite-for-beginners/foreign-keys.mdx
@@ -122,7 +122,7 @@ PRAGMA foreign_keys = ON;
 ```
 
 <Callout type="warning" title="Turn it on for real protection">
-Declaring \`REFERENCES\` describes the relationship. In SQLite, \`PRAGMA foreign_keys = ON;\` makes SQLite reject rows that break the relationship.
+Declaring `REFERENCES` describes the relationship. In SQLite, `PRAGMA foreign_keys = ON;` makes SQLite reject rows that break the relationship.
 </Callout>
 
 <SqlCodeBlock

--- a/content/courses/sqlite-for-beginners/grouping-data.mdx
+++ b/content/courses/sqlite-for-beginners/grouping-data.mdx
@@ -132,11 +132,11 @@ model you will use for every grouped query you ever write. SQLite
 conceptually sorts all 24 rows into labeled buckets, then runs
 `COUNT(*)` once *inside each bucket*:
 
-```text
-bucket "High":    High, High, High, …    -> COUNT(*) = 6
-bucket "Medium":  Medium, Medium, …      -> COUNT(*) = 7
-bucket "Low":     Low, Low, Low, …       -> COUNT(*) = 11
-```
+| Bucket     | Rows that landed in it | `COUNT(*)` |
+| ---------- | ---------------------- | ---------- |
+| `High`     | High, High, High, …    | 6          |
+| `Medium`   | Medium, Medium, …      | 7          |
+| `Low`      | Low, Low, Low, …       | 11         |
 
 Each bucket then contributes exactly one row to the result: its
 label and its summary. 24 rows in, three rows out. Notice that the

--- a/content/courses/sqlite-for-beginners/grouping-data.mdx
+++ b/content/courses/sqlite-for-beginners/grouping-data.mdx
@@ -44,6 +44,16 @@ The result is not one average salary. It is one average salary **per department*
 
 Start with a small employee table. The query below counts employees and computes average salary for each department.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT" },
+    { text: "dept,", label: "one output row per value here" },
+    { text: "COUNT(*)", label: "computed once inside each group" },
+    { text: "FROM employees" },
+    { text: "GROUP BY dept;", label: "what makes two rows the same group" },
+  ]}
+/>
+
 <Figure
   slug="lite-grouping-data-one-result-row-per-inline-cutout"
   alt="Three bins filled from a single pile, each bin handing one summary card up to the rail above it"

--- a/content/courses/sqlite-for-beginners/grouping-data.mdx
+++ b/content/courses/sqlite-for-beginners/grouping-data.mdx
@@ -33,9 +33,9 @@ flowchart TB
     Group --> Eng["Engineering group"]
     Group --> Sales["Sales group"]
     Group --> Mkt["Marketing group"]
-    Eng --> EngAvg["AVG(salary)<br/>for Engineering"]
-    Sales --> SalesAvg["AVG(salary)<br/>for Sales"]
-    Mkt --> MktAvg["AVG(salary)<br/>for Marketing"]
+    Eng --> EngAvg["<code>AVG(salary)</code><br/>for Engineering"]
+    Sales --> SalesAvg["<code>AVG(salary)</code><br/>for Sales"]
+    Mkt --> MktAvg["<code>AVG(salary)</code><br/>for Marketing"]
 ```
 
 The result is not one average salary. It is one average salary **per department**.
@@ -182,7 +182,7 @@ A grouped result row needs values that make sense for the whole group.
 
 ```mermaid
 flowchart TB
-    Col["Column in SELECT"] --> Ask{"One value<br/>for the whole group?"}
+    Col["Column in <code>SELECT</code>"] --> Ask{"One value<br/>for the whole group?"}
     Ask -->|"yes, grouped column"| Allowed["Allowed as-is"]
     Ask -->|"no, many values"| Aggregate["Use an aggregate<br/>COUNT, SUM, AVG, MIN, MAX"]
 ```
@@ -279,7 +279,7 @@ flowchart TB
     Pair --> W2026["West, 2026"]
     Pair --> E2025["East, 2025"]
     Pair --> E2026["East, 2026"]
-    W2025 --> Total["SUM(amount)<br/>per combination"]
+    W2025 --> Total["<code>SUM(amount)</code><br/>per combination"]
     W2026 --> Total
     E2025 --> Total
     E2026 --> Total
@@ -346,9 +346,9 @@ The intern row is removed first. Then SQLite groups the remaining rows by depart
 
 ```mermaid
 flowchart TD
-    Raw["Raw employee rows"] --> Where["WHERE <code>is_intern</code> = 0<br/>keep full-time rows"]
+    Raw["Raw employee rows"] --> Where["<code>WHERE is_intern</code> = 0<br/>keep full-time rows"]
     Where --> Group["<code>GROUP BY dept</code><br/>make department groups"]
-    Group --> Avg["AVG(salary)<br/>inside each group"]
+    Group --> Avg["<code>AVG(salary)</code><br/>inside each group"]
     Avg --> Result["One row per department"]
 ```
 

--- a/content/courses/sqlite-for-beginners/how-applications-store-information.mdx
+++ b/content/courses/sqlite-for-beginners/how-applications-store-information.mdx
@@ -196,14 +196,12 @@ A database does not store information as one giant paragraph.
 
 In a relational database, information is organized into **tables**, **rows**, and **columns**.
 
-```text
-tasks
+A `tasks` table:
 
-id | title        | done | due_date
--- | ------------ | ---- | ----------
-1  | Buy milk     | 0    | 2026-04-15
-2  | Submit form  | 1    | 2026-04-10
-```
+| `id` | `title`     | `done` | `due_date`   |
+| ---- | ----------- | ------ | ------------ |
+| 1    | Buy milk    | 0      | 2026-04-15   |
+| 2    | Submit form | 1      | 2026-04-10   |
 
 A **table** stores one kind of thing. A **row** is one record. A **column** is one piece of information every row is expected to have.
 

--- a/content/courses/sqlite-for-beginners/inner-joins.mdx
+++ b/content/courses/sqlite-for-beginners/inner-joins.mdx
@@ -156,6 +156,17 @@ You can write `INNER JOIN` when you want to be extra clear, especially near oute
 
 ## Choosing the matching columns
 
+The `ON` clause is where a join is usually got wrong: it must pair the foreign key with the key it references.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "JOIN customers", label: "the second table" },
+    { text: "ON", label: "how rows are paired" },
+    { text: "orders.customer_id", label: "the foreign key" },
+    { text: "= customers.id", label: "the key it points at" },
+  ]}
+/>
+
 The most common inner join condition is:
 
 ```sql

--- a/content/courses/sqlite-for-beginners/inner-joins.mdx
+++ b/content/courses/sqlite-for-beginners/inner-joins.mdx
@@ -17,7 +17,7 @@ flowchart LR
         R1["order for Ada"]
         R2["order for missing customer"]
     end
-    L1 -->|"matches"| Out["INNER JOIN result"]
+    L1 -->|"matches"| Out["<code>INNER JOIN</code> result"]
     R1 -->|"matches"| Out
     L2 -.-> X["no result row"]
     R2 -.-> X

--- a/content/courses/sqlite-for-beginners/inserting-data.mdx
+++ b/content/courses/sqlite-for-beginners/inserting-data.mdx
@@ -16,13 +16,15 @@ The SQL statement for adding rows is `INSERT INTO`.
 
 An `INSERT` statement names the table, names the columns you are filling, and supplies matching values.
 
-```mermaid
-flowchart TD
-    A["<code>INSERT INTO</code>"] --> B["which table"]
-    B --> C["which columns"]
-    C --> D["<code>VALUES</code>"]
-    D --> E["new row data"]
-```
+<SyntaxBreakdown
+  parts={[
+    { text: "INSERT INTO" },
+    { text: "books", label: "which table" },
+    { text: "(title, price)", label: "which columns you are filling" },
+    { text: "VALUES" },
+    { text: "('Dune', 9.99);", label: "one row, in that same order" },
+  ]}
+/>
 
 Here is a complete example: create a table, insert one row, then read it back.
 

--- a/content/courses/sqlite-for-beginners/many-to-many.mdx
+++ b/content/courses/sqlite-for-beginners/many-to-many.mdx
@@ -354,7 +354,7 @@ ORDER BY
 />
 
 <Callout type="info" title="Naming junction tables">
-Use a name that describes the relationship: \`enrollments\`, \`memberships\`, \`order_items\`, \`book_authors\`. The table is not just plumbing; it represents real connections.
+Use a name that describes the relationship: `enrollments`, `memberships`, `order_items`, `book_authors`. The table is not just plumbing; it represents real connections.
 </Callout>
 
 ## Check your understanding

--- a/content/courses/sqlite-for-beginners/outer-joins.mdx
+++ b/content/courses/sqlite-for-beginners/outer-joins.mdx
@@ -285,7 +285,7 @@ flowchart TD
 ```
 
 <Callout type="info" title="How to choose">
-Ask: "Which table's rows must not disappear?" Put that table first, then use \`LEFT JOIN\`.
+Ask: "Which table's rows must not disappear?" Put that table first, then use `LEFT JOIN`.
 </Callout>
 
 ## Practice challenge

--- a/content/courses/sqlite-for-beginners/outer-joins.mdx
+++ b/content/courses/sqlite-for-beginners/outer-joins.mdx
@@ -38,8 +38,8 @@ flowchart TB
     end
     A -->|"match"| R1["Ada + order columns"]
     G -->|"match"| R2["Grace + order columns"]
-    L0 -->|"no match"| R3["Linus + NULL order columns"]
-    R1 --> Out["LEFT JOIN result"]
+    L0 -->|"no match"| R3["Linus + <code>NULL</code> order columns"]
+    R1 --> Out["<code>LEFT JOIN</code> result"]
     R2 --> Out
     R3 --> Out
 ```
@@ -108,7 +108,7 @@ When SQLite cannot find a matching right-side row, it cannot show a real `orders
 
 ```mermaid
 flowchart TD
-    C["customer<br/>Linus"] -->|"no matching order"| N["<code>order_id</code> = NULL<br/>amount = NULL"]
+    C["customer<br/>Linus"] -->|"no matching order"| N["<code>order_id</code> = <code>NULL</code><br/>amount = <code>NULL</code>"]
 ```
 
 <SqlCodeBlock
@@ -152,7 +152,7 @@ A `LEFT JOIN` plus `WHERE right_table.id IS NULL` is the classic pattern for "sh
 ```mermaid
 flowchart TB
     A["<code>LEFT JOIN</code><br/>keep all customers"] --> B["matched customers<br/>order id present"]
-    A --> C["unmatched customers<br/>order id is NULL"]
+    A --> C["unmatched customers<br/>order id is <code>NULL</code>"]
     C -->|"<code>WHERE o.id IS NULL</code>"| D["customers with no orders"]
     B -->|"filtered out"| X["not returned"]
 ```

--- a/content/courses/sqlite-for-beginners/outer-joins.mdx
+++ b/content/courses/sqlite-for-beginners/outer-joins.mdx
@@ -20,6 +20,15 @@ For those questions, beginners should reach first for **LEFT JOIN**.
 
 A `LEFT JOIN` keeps all rows from the first table you name. If a matching row exists on the right, SQLite includes it. If not, the right-side columns become `NULL`.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "FROM customers", label: "the left table, every row survives" },
+    { text: "LEFT JOIN" },
+    { text: "orders", label: "the right table, optional" },
+    { text: "ON customers.id = orders.customer_id", label: "no match here means NULLs" },
+  ]}
+/>
+
 ```mermaid
 flowchart TB
     subgraph L["left table<br/>customers"]

--- a/content/courses/sqlite-for-beginners/primary-keys.mdx
+++ b/content/courses/sqlite-for-beginners/primary-keys.mdx
@@ -100,6 +100,16 @@ Surrogate keys are very common because they are simple and stable. The number do
 
 ## SQLite's special `INTEGER PRIMARY KEY`
 
+Spelled exactly this way, the column becomes an alias for the hidden `rowid`, which is what makes it fill itself in:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "id", label: "the column" },
+    { text: "INTEGER", label: "exactly INTEGER; INT would not do it" },
+    { text: "PRIMARY KEY", label: "now an alias for the rowid, auto-assigned" },
+  ]}
+/>
+
 In SQLite, this declaration is special:
 
 ```sql

--- a/content/courses/sqlite-for-beginners/select-basics.mdx
+++ b/content/courses/sqlite-for-beginners/select-basics.mdx
@@ -260,6 +260,15 @@ Sometimes you do not want every row. You want the list of different
 values that appear in a column. `DISTINCT` removes duplicate result
 rows.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "SELECT" },
+    { text: "DISTINCT", label: "collapse repeats into one" },
+    { text: "genre", label: "the column whose different values you want" },
+    { text: "FROM books;" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="sqlite"
   title="Unique genres"

--- a/content/courses/sqlite-for-beginners/sorting-and-limiting.mdx
+++ b/content/courses/sqlite-for-beginners/sorting-and-limiting.mdx
@@ -22,6 +22,14 @@ are cheapest?" and "show the next page."
 (low to high, A to Z) or `DESC` for descending order (high to low, Z to
 A). `ASC` is the default.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "ORDER BY" },
+    { text: "price", label: "sort on this column" },
+    { text: "ASC", label: "low to high; DESC reverses it" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="sqlite"
   title="Cheapest books first"
@@ -243,6 +251,14 @@ the main sort. Later columns break ties.
 
 `LIMIT n` keeps only the first `n` rows. When you use it with
 `ORDER BY`, you can ask for "top N" or "bottom N" lists.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "ORDER BY price DESC", label: "decide what first means" },
+    { text: "LIMIT" },
+    { text: "3;", label: "then keep only that many rows" },
+  ]}
+/>
 
 <Figure
   slug="lite-sorting-and-limiting-order-by-sorts-inline-cutout"

--- a/content/courses/sqlite-for-beginners/sorting-and-limiting.mdx
+++ b/content/courses/sqlite-for-beginners/sorting-and-limiting.mdx
@@ -392,7 +392,7 @@ flowchart TD
     A["<code>SELECT</code><br/>columns"] --> B["<code>FROM<br/>table</code>"]
     B --> C["<code>WHERE</code><br/>filter rows"]
     C --> D["<code>ORDER BY</code><br/>sort rows"]
-    D --> E["LIMIT and OFFSET<br/>trim result"]
+    D --> E["<code>LIMIT</code> and <code>OFFSET</code><br/>trim result"]
 ```
 
 You can leave out `WHERE`, `ORDER BY`, `LIMIT`, or `OFFSET` when you do

--- a/content/courses/sqlite-for-beginners/spreadsheets-vs-databases.mdx
+++ b/content/courses/sqlite-for-beginners/spreadsheets-vs-databases.mdx
@@ -114,12 +114,10 @@ Spreadsheets often become painful when:
 
 Example problem:
 
-```text
-customer_name | order_id | products
-------------- | -------- | -------------------------
-Maya Chen     | 1001     | Notebook, Pen, Backpack
-Maya Chen     | 1002     | Pen
-```
+| `customer_name` | `order_id` | `products`              |
+| --------------- | ---------- | ----------------------- |
+| Maya Chen       | 1001       | Notebook, Pen, Backpack |
+| Maya Chen       | 1002       | Pen                     |
 
 Is "Maya Chen" the same customer in both rows? What if her name changes? How many pens were sold? The spreadsheet does not naturally separate customers, orders, and products into reliable related facts.
 

--- a/content/courses/sqlite-for-beginners/spreadsheets-vs-databases.mdx
+++ b/content/courses/sqlite-for-beginners/spreadsheets-vs-databases.mdx
@@ -142,13 +142,11 @@ flowchart TD
 
 In a spreadsheet, a column can accidentally become a mixture:
 
-```text
-price
------
-12.99
-free
-$8 maybe
-```
+| price      |
+| ---------- |
+| `12.99`    |
+| `free`     |
+| `$8 maybe` |
 
 A database table can be designed so the `price` column is meant for numeric values. SQLite has flexible typing, so it is more forgiving than some database systems, but column types still communicate the intended shape of the data and help SQLite store and compare values sensibly.
 

--- a/content/courses/sqlite-for-beginners/tables-rows-columns.mdx
+++ b/content/courses/sqlite-for-beginners/tables-rows-columns.mdx
@@ -183,9 +183,9 @@ A table has both **structure** and **contents**.
 flowchart LR
     T["Table: pets"] --> S["Schema<br/>column names and declared types"]
     T --> D["Data<br/>actual rows and values"]
-    S --> S1["id INTEGER PRIMARY KEY"]
-    S --> S2["name TEXT"]
-    S --> S3["age INTEGER"]
+    S --> S1["id <code>INTEGER PRIMARY KEY</code>"]
+    S --> S2["name <code>TEXT</code>"]
+    S --> S3["age <code>INTEGER</code>"]
     D --> D1["1, Mochi, cat, 3"]
     D --> D2["2, Pixel, dog, 5"]
 ```
@@ -218,7 +218,7 @@ order unless you ask for an order.
 ```mermaid
 flowchart TD
     TABLE["Table rows<br/>stored without a promised order"] --> QUERY["Need a sorted result?"]
-    QUERY --> ORDER["Use ORDER BY"]
+    QUERY --> ORDER["Use <code>ORDER BY</code>"]
 ```
 
 When order matters, use `ORDER BY`. Otherwise, do not assume the

--- a/content/courses/sqlite-for-beginners/understanding-joins.mdx
+++ b/content/courses/sqlite-for-beginners/understanding-joins.mdx
@@ -215,7 +215,7 @@ A join creates a result table for the query. The original tables stay separate.
 
 ```mermaid
 flowchart TB
-    C["customers table<br/>stored data"] --> Q["JOIN query"]
+    C["customers table<br/>stored data"] --> Q["<code>JOIN</code> query"]
     O["orders table<br/>stored data"] --> Q
     Q --> R["temporary result<br/>customer + order columns"]
     C -.-> C2["customers still separate"]
@@ -262,9 +262,9 @@ The kind of join determines what happens. A regular `JOIN` is an inner join: it 
 
 ```mermaid
 flowchart LR
-    A["matching pair"] -->|"INNER JOIN keeps"| R["result row"]
-    B["left row with no match"] -->|"INNER JOIN drops"| X["no result row"]
-    C["right row with no match"] -->|"INNER JOIN drops"| X
+    A["matching pair"] -->|"<code>INNER JOIN</code> keeps"| R["result row"]
+    B["left row with no match"] -->|"<code>INNER JOIN</code> drops"| X["no result row"]
+    C["right row with no match"] -->|"<code>INNER JOIN</code> drops"| X
 ```
 
 <MultipleChoice

--- a/content/courses/sqlite-for-beginners/what-is-a-database.mdx
+++ b/content/courses/sqlite-for-beginners/what-is-a-database.mdx
@@ -138,15 +138,13 @@ ways of recording the same information:
 > Maya got 92 on the quiz, Jordan got 85, and Riley has not taken
 > it yet.
 
-```text
-students
+A `students` table:
 
-name   | quiz_score
------- | ----------
-Maya   | 92
-Jordan | 85
-Riley  | NULL
-```
+| `name` | `quiz_score` |
+| ------ | ------------ |
+| Maya   | 92           |
+| Jordan | 85           |
+| Riley  | `NULL`       |
 
 A person reads the sentence easily. But ask the computer *"who
 scored above 90?"* or *"what is the average?"* and the sentence is

--- a/content/courses/sqlite-for-beginners/working-with-null.mdx
+++ b/content/courses/sqlite-for-beginners/working-with-null.mdx
@@ -27,7 +27,7 @@ These three values mean different things:
 flowchart TB
     Z["0<br/>known number<br/>zero"]
     E["''<br/>known text<br/>empty string"]
-    N["NULL<br/>unknown or missing<br/>no value"]
+    N["<code>NULL</code><br/>unknown or missing<br/>no value"]
 ```
 
 For a `phone` column, an empty string could mean someone intentionally
@@ -251,7 +251,7 @@ as a separate test that genuinely answers true or false.
 ```mermaid
 flowchart TD
     A["comparison<br/><code>phone = NULL</code>"] --> U["unknown<br/>not true"]
-    U --> W["WHERE keeps only true rows"]
+    U --> W["<code>WHERE</code> keeps only true rows"]
     W --> D["row is not kept"]
 ```
 
@@ -293,9 +293,9 @@ reward points plus 5.
 
 ```mermaid
 flowchart TB
-    A["known value<br/>5"] --> C["5 + NULL"]
-    B["NULL<br/>unknown"] --> C
-    C --> R["NULL<br/>unknown result"]
+    A["known value<br/>5"] --> C["5 + <code>NULL</code>"]
+    B["<code>NULL</code><br/>unknown"] --> C
+    C --> R["<code>NULL</code><br/>unknown result"]
 ```
 
 <SqlCodeBlock
@@ -506,7 +506,7 @@ and can handle more than two choices.
 
 ```mermaid
 flowchart TD
-    A["possibly NULL value"] --> B{"is it NULL?"}
+    A["possibly <code>NULL</code> value"] --> B{"is it <code>NULL</code>?"}
     B -->|"no"| C["use original value"]
     B -->|"yes"| D["use fallback value"]
 ```

--- a/content/courses/sqlite-for-beginners/working-with-null.mdx
+++ b/content/courses/sqlite-for-beginners/working-with-null.mdx
@@ -106,6 +106,14 @@ own.
 Because `NULL` means unknown, you do not test for it with `=`. Use the
 special tests `IS NULL` and `IS NOT NULL`.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "WHERE" },
+    { text: "phone", label: "the column that may be missing" },
+    { text: "IS NULL", label: "the only test that works on NULL" },
+  ]}
+/>
+
 <SqlCodeBlock
   dialect="sqlite"
   title="Find missing phone numbers"

--- a/content/courses/statistics-for-data-science-python/measures-of-spread.mdx
+++ b/content/courses/statistics-for-data-science-python/measures-of-spread.mdx
@@ -166,6 +166,16 @@ Normal Distribution*).
 
 ## The $n-1$ divisor: why sample spread uses `ddof=1`
 
+The argument is the correction, and its default differs between libraries, which is exactly why it is worth writing out:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "np.std(x," },
+    { text: "ddof=1", label: "divide by n-1, the unbiased sample estimate" },
+    { text: ")", label: "NumPy defaults to 0; pandas defaults to 1" },
+  ]}
+/>
+
 Here is the detail that confuses everyone, so let's make it intuitive
 rather than mathematical. When you compute spread from a **sample**
 (not the whole population), you divide the sum of squared deviations by

--- a/content/courses/statistics-for-data-science-python/t-tests.mdx
+++ b/content/courses/statistics-for-data-science-python/t-tests.mdx
@@ -183,6 +183,15 @@ average values? The groups contain **different units**, different users,
 different customers, different machines, with no natural pairing between
 them.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "ttest_ind(" },
+    { text: "group_a, group_b,", label: "the two independent samples" },
+    { text: "equal_var=False", label: "Welch's test, the safer default" },
+    { text: ")" },
+  ]}
+/>
+
 <Figure
   slug="stat-t-tests-two-sample-t-test-inline-cutout"
   alt="Two groups of chips on separate pans, the gap between their averages measured against the spread inside each group"

--- a/content/courses/systems-programming-c/arrays-and-pointers.mdx
+++ b/content/courses/systems-programming-c/arrays-and-pointers.mdx
@@ -58,6 +58,16 @@ for.
 
 ## `a[i]` *is* `*(a + i)`
 
+Indexing is not a primitive in C. It is defined as pointer arithmetic, which is why `a[i]` and `i[a]` both compile:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "a[i]", label: "what you write" },
+    { text: "is" },
+    { text: "*(a + i)", label: "what it means: advance i elements, then read" },
+  ]}
+/>
+
 Indexing in C is sugar for pointer arithmetic. The expression `a[i]`
 is defined as `*(a + i)`. The `+ i` part is *typed*, it advances by
 `i * sizeof(*a)` bytes, not by `i` bytes.

--- a/content/courses/systems-programming-c/c-toolchain.mdx
+++ b/content/courses/systems-programming-c/c-toolchain.mdx
@@ -166,7 +166,7 @@ itself.
 
 If you see:
 
-```
+```text
 undefined reference to `sqrt`
 ```
 
@@ -175,7 +175,7 @@ undefined reference to `sqrt`
 
 If you see:
 
-```
+```text
 undefined reference to `greet`
 ```
 

--- a/content/courses/systems-programming-c/data-types-and-memory.mdx
+++ b/content/courses/systems-programming-c/data-types-and-memory.mdx
@@ -106,6 +106,16 @@ wrap-around (e.g. a hash function), use unsigned.
 
 ## Fixed-width types: `<stdint.h>`
 
+The name is the specification: signedness, width, and nothing left to the platform.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "u", label: "unsigned" },
+    { text: "int32", label: "exactly 32 bits, on every platform" },
+    { text: "_t x;", label: "the _t suffix marks it a typedef" },
+  ]}
+/>
+
 Because `int`, `long`, etc. vary across platforms, anything you write
 to disk, send over a network, or talk to hardware with should use the
 fixed-width types from `<stdint.h>`.

--- a/content/courses/systems-programming-c/data-types-and-memory.mdx
+++ b/content/courses/systems-programming-c/data-types-and-memory.mdx
@@ -206,11 +206,10 @@ memory:
 
 Laid out byte by byte at increasing addresses:
 
-```text
-                addr 0   addr 1   addr 2   addr 3
-Little-endian:   0x78     0x56     0x34     0x12     (x86, WASI)
-Big-endian:      0x12     0x34     0x56     0x78
-```
+|                            | addr 0 | addr 1 | addr 2 | addr 3 |
+| -------------------------- | ------ | ------ | ------ | ------ |
+| **Little-endian** (x86, WASI) | `0x78` | `0x56` | `0x34` | `0x12` |
+| **Big-endian**             | `0x12` | `0x34` | `0x56` | `0x78` |
 
 You can *see* the byte order at runtime by reading the bytes of an
 integer through a `char *`:

--- a/content/courses/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/courses/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -209,6 +209,18 @@ by `memset(p, 0, ...)`.
 
 ## `realloc()`: grow or shrink
 
+Never assign `realloc` straight back onto the pointer you passed in: if it fails it returns `NULL` and the original block is still yours to free.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "void *tmp =", label: "a temporary, always" },
+    { text: "realloc(" },
+    { text: "p,", label: "the existing block" },
+    { text: "n * sizeof *p", label: "the new total size, not the delta" },
+    { text: ");" },
+  ]}
+/>
+
 `realloc(p, new_size)` is the resizing primitive. It may:
 
 - expand the existing block in place (best case), or

--- a/content/courses/systems-programming-c/heap-and-dynamic-allocation.mdx
+++ b/content/courses/systems-programming-c/heap-and-dynamic-allocation.mdx
@@ -70,6 +70,21 @@ flowchart TD
 
 ## Your first malloc
 
+Every heap allocation is the same three questions: how much, of what,
+and did it work.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "int *p =" },
+    { text: "malloc(", label: "ask the heap for bytes" },
+    { text: "n * sizeof(int)", label: "how many, never a hard-coded size" },
+    { text: ");" },
+  ]}
+/>
+
+The result is a pointer you own until you `free()` it, and it may be
+`NULL` if the request could not be met.
+
 <CodeBlock
   adapter="c"
   files={[

--- a/content/courses/systems-programming-c/pointers.mdx
+++ b/content/courses/systems-programming-c/pointers.mdx
@@ -299,6 +299,16 @@ read-only data, and helps the compiler optimize.
 
 ## `void *`: the type-erased pointer
 
+A `void *` holds an address with no type attached, so it must be cast back before it can be dereferenced:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "void *p", label: "an address, and nothing about what is there" },
+    { text: "= &x;" },
+    { text: "*(int *)p", label: "the cast is what restores the type" },
+  ]}
+/>
+
 A `void *` is a pointer with no element type. It can hold the address
 of *anything*, but you cannot dereference it directly, the compiler
 does not know how many bytes to read or how to interpret them.

--- a/content/courses/systems-programming-c/pointers.mdx
+++ b/content/courses/systems-programming-c/pointers.mdx
@@ -264,6 +264,16 @@ int main(void) {
 
 ## `const` pointers vs pointers to `const`
 
+Read it right to left. Which side of the `*` the `const` sits on decides which half is frozen:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "const char", label: "the characters are const" },
+    { text: "*", label: "pointer to" },
+    { text: "p;", label: "the pointer itself may still move" },
+  ]}
+/>
+
 Two `const` positions, two meanings:
 
 | Declaration | Can you change the pointer? | Can you change what it points to? |

--- a/content/courses/systems-programming-c/structs-and-unions.mdx
+++ b/content/courses/systems-programming-c/structs-and-unions.mdx
@@ -146,7 +146,7 @@ int main(void) {
 
 <Callout type="info" title="Layout tip: order members from largest to smallest">
 Sorting fields by descending alignment (largest types first) usually
-minimizes padding. \`Good\` above is 8 bytes; \`Bad\` is 12.
+minimizes padding. `Good` above is 8 bytes; `Bad` is 12.
 </Callout>
 
 ## `offsetof` and pointer arithmetic on members

--- a/content/courses/time-series-analysis-python/resampling-and-aggregation.mdx
+++ b/content/courses/time-series-analysis-python/resampling-and-aggregation.mdx
@@ -45,7 +45,16 @@ names the summary.
 ## Downsampling: summarizing to a coarser grid
 
 Let's build a daily series, website visits with a slow upward trend and a
-weekend dip, and roll it up.
+weekend dip, and roll it up. Downsampling is always the same two halves:
+the new grid, then what to do with the rows that land in each bucket.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "visits.resample(" },
+    { text: '"W")', label: "the coarser grid, here one bucket per week" },
+    { text: ".mean()", label: "how to collapse the rows in each bucket" },
+  ]}
+/>
 
 <CodeBlock
   adapter="python"

--- a/content/courses/time-series-analysis-python/rolling-and-expanding-windows.mdx
+++ b/content/courses/time-series-analysis-python/rolling-and-expanding-windows.mdx
@@ -18,6 +18,16 @@ them.
 
 ## First, looking backward: `shift()`
 
+`shift` moves the values, not the index, which is what makes it safe: row *t* sees only what was known at *t-1*.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "s.shift(" },
+    { text: "1", label: "positive means backward in time" },
+    { text: ")", label: "row t now holds the value from t-1" },
+  ]}
+/>
+
 Almost every time series operation needs to compare *now* to *then*.
 `shift(k)` moves the data forward by `k` steps, so each row lines up with a
 value from its own past (a **lag**). `shift(-k)` does the reverse (a
@@ -74,6 +84,17 @@ but must never become an input your model uses to predict the present.
 </Callout>
 
 ## The moving average: `rolling()`
+
+`rolling` only describes the window. Nothing is computed until you name the statistic:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "s.rolling(" },
+    { text: "window=7,", label: "how many observations in the window" },
+    { text: "min_periods=7", label: "how many it needs before producing a value" },
+    { text: ").mean()", label: "the statistic; rolling alone computes nothing" },
+  ]}
+/>
 
 A **rolling** (or *moving*) statistic slides a fixed-size window along the
 series and computes a summary at each stop. The **moving average**,

--- a/content/courses/time-series-analysis-python/the-pandas-timeline.mdx
+++ b/content/courses/time-series-analysis-python/the-pandas-timeline.mdx
@@ -159,6 +159,18 @@ NaN so they are visibly missing instead of quietly gone.
 
 ## Building a timeline from scratch: `date_range()`
 
+You give it any two of start, end and periods, plus the spacing:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "pd.date_range(" },
+    { text: "\"2024-01-01\",", label: "the start" },
+    { text: "periods=52,", label: "how many stamps" },
+    { text: "freq=\"W\"", label: "the spacing between them" },
+    { text: ")" },
+  ]}
+/>
+
 When you need a regular grid of timestamps, for simulated data, for a
 forecast horizon, or to reindex onto a clean calendar, `pd.date_range()`
 generates one. The `freq` argument sets the spacing.

--- a/content/courses/typescript-from-scratch/functions-and-signatures.mdx
+++ b/content/courses/typescript-from-scratch/functions-and-signatures.mdx
@@ -26,6 +26,16 @@ default parameters**, **rest parameters**, **function type expressions**,
 The simplest function signature specifies the type of each parameter and
 the return type:
 
+<SyntaxBreakdown
+  parts={[
+    { text: "function add(" },
+    { text: "a: number,", label: "each parameter carries its own type" },
+    { text: "b: number", label: "checked at every call site" },
+    { text: ")" },
+    { text: ": number", label: "what the function hands back" },
+  ]}
+/>
+
 <CodeBlock
   adapter="typescript"
   files={[

--- a/content/courses/typescript-from-scratch/generic-constraints.mdx
+++ b/content/courses/typescript-from-scratch/generic-constraints.mdx
@@ -68,6 +68,16 @@ graph TD
 
 One of the most useful constraints is `keyof`, which gives you the union of all keys of a type. Combined with `extends keyof`, you can write functions that safely access object properties.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "function getProperty<" },
+    { text: "T,", label: "the object's type, inferred at the call" },
+    { text: "K extends keyof T", label: "a key, but only one T actually has" },
+    { text: ">(obj: T, key: K):" },
+    { text: "T[K]", label: "the type stored under that key" },
+  ]}
+/>
+
 <Figure
   slug="tsx-generic-constraints-keyof-operator-inline-cutout"
   alt="A crate's set of compartment tags lifted off as a separate ring of keys"

--- a/content/courses/typescript-from-scratch/generics-basics.mdx
+++ b/content/courses/typescript-from-scratch/generics-basics.mdx
@@ -94,6 +94,17 @@ By convention, single-letter names like `T`, `U`, `V` are used for generic type 
 
 ## Generic functions
 
+The angle brackets declare a placeholder, and the same placeholder used twice is what ties the return type to the argument:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "function identity" },
+    { text: "<T>", label: "declare the placeholder" },
+    { text: "(x: T)", label: "the argument fixes what T is" },
+    { text: ": T", label: "so the return type follows from it" },
+  ]}
+/>
+
 Let's look at more realistic examples. Suppose you want a function that wraps a value in an array:
 
 <CodeBlock

--- a/content/courses/typescript-from-scratch/how-typescript-works.mdx
+++ b/content/courses/typescript-from-scratch/how-typescript-works.mdx
@@ -170,13 +170,13 @@ The scanner doesn't understand *meaning* yet. It just recognizes keywords (`let`
 
 The **parser** takes the stream of tokens and builds an **Abstract Syntax Tree (AST)**, a tree structure representing the program's syntactic structure. For the line above, the AST node might look like:
 
-```
-VariableStatement
-  ├─ VariableDeclarationList
-  │   └─ VariableDeclaration
-  │       ├─ Identifier: "x"
-  │       ├─ TypeAnnotation: NumberKeyword
-  │       └─ Initializer: NumericLiteral(42)
+```mermaid
+flowchart TD
+    A[VariableStatement] --> B[VariableDeclarationList]
+    B --> C[VariableDeclaration]
+    C --> D["Identifier: x"]
+    C --> E["TypeAnnotation: NumberKeyword"]
+    C --> F["Initializer: NumericLiteral(42)"]
 ```
 
 The AST captures the *structure* of the code: "This is a variable declaration named `x`, with type `number`, initialized to `42`." The parser checks syntax (no missing semicolons or braces), but it doesn't check *types* yet.

--- a/content/courses/typescript-from-scratch/how-typescript-works.mdx
+++ b/content/courses/typescript-from-scratch/how-typescript-works.mdx
@@ -160,7 +160,7 @@ let x: number = 42;
 
 becomes:
 
-```
+```text
 LET_KEYWORD  IDENTIFIER("x")  COLON  IDENTIFIER("number")  EQUALS  NUMERIC_LITERAL(42)  SEMICOLON
 ```
 

--- a/content/courses/typescript-from-scratch/keyof-typeof-template-literals.mdx
+++ b/content/courses/typescript-from-scratch/keyof-typeof-template-literals.mdx
@@ -20,6 +20,16 @@ Together, these tools let you derive types from your code's structure, ensuring 
 
 ## `keyof T`: The Keys of a Type
 
+`keyof` produces a union of the property *names*, as literal types, which is what makes a key argument checkable:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "keyof", label: "the operator" },
+    { text: "User", label: "the type to read" },
+    { text: "// \"name\" | \"age\"", label: "a union of literal string types" },
+  ]}
+/>
+
 The **`keyof`** operator takes an object type and produces a union of its keys (as string or number literal types).
 
 <CodeBlock

--- a/content/courses/typescript-from-scratch/scalable-architecture.mdx
+++ b/content/courses/typescript-from-scratch/scalable-architecture.mdx
@@ -18,7 +18,7 @@ This chapter introduces **layered architecture**, a pattern for organizing code 
 
 Consider a typical application without layering:
 
-```
+```text
 user-service.ts → database.ts → config.ts → user-service.ts
      ↓                ↓               ↓
 order-service.ts → http-client.ts → logger.ts

--- a/content/courses/typescript-from-scratch/type-narrowing.mdx
+++ b/content/courses/typescript-from-scratch/type-narrowing.mdx
@@ -47,6 +47,17 @@ a `string`. That's where narrowing comes in.
 
 ## `typeof` guards
 
+The check is ordinary JavaScript; the narrowing is the compiler reading it:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "if (" },
+    { text: "typeof id", label: "a real runtime check" },
+    { text: "=== \"string\"", label: "which the compiler also reads" },
+    { text: ")", label: "inside, id is a string" },
+  ]}
+/>
+
 The **`typeof`** operator checks the primitive type at runtime. TypeScript
 recognizes `typeof` checks and narrows the type accordingly:
 

--- a/content/courses/typescript-from-scratch/type-narrowing.mdx
+++ b/content/courses/typescript-from-scratch/type-narrowing.mdx
@@ -224,6 +224,17 @@ turn("east");
 
 ## `in` operator narrowing
 
+The `in` check is real JavaScript, and TypeScript uses it to pick the union member that has that property:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "if (" },
+    { text: "\"radius\"", label: "the property name, as a string" },
+    { text: "in shape", label: "a runtime check the compiler also reads" },
+    { text: ")", label: "inside, shape is the circle variant" },
+  ]}
+/>
+
 The **`in`** operator checks if a property exists on an object. TypeScript
 uses this to narrow object unions:
 

--- a/content/courses/typescript-from-scratch/unions-and-intersections.mdx
+++ b/content/courses/typescript-from-scratch/unions-and-intersections.mdx
@@ -22,6 +22,17 @@ This chapter covers: **union types**, **intersection types**,
 
 ## Union types: "this or that"
 
+The `|` is read as "or", and the important consequence is on the *methods*: you may only call what every member has.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "type Id =" },
+    { text: "string", label: "either this..." },
+    { text: "|", label: "or" },
+    { text: "number", label: "...or this, never both" },
+  ]}
+/>
+
 A **union type** `A | B` represents a value that is *either* type `A`
 *or* type `B` (or both, if they overlap):
 
@@ -242,6 +253,17 @@ both a string and a number. This is a compile-time error, the compiler
 knows the type is uninhabited.
 
 ## Discriminated unions: tagged unions for type-safe variants
+
+One shared literal field is what makes the union checkable. It is the tag:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "type Shape =" },
+    { text: "{ kind: \"circle\";", label: "the discriminant, a literal type" },
+    { text: "radius: number }", label: "the data only this variant has" },
+    { text: "| { kind: \"square\"; side: number }" },
+  ]}
+/>
 
 A **discriminated union** (also called a "tagged union") is a union of
 object types, each with a *discriminator* field (a literal type) that

--- a/content/interview/analytics-engineer/advanced-sql.mdx
+++ b/content/interview/analytics-engineer/advanced-sql.mdx
@@ -124,7 +124,9 @@ you reference later in the same statement.
     { text: "AS (SELECT ... )", label: "the query it stands for" },
     { text: "SELECT * FROM recent", label: "referenced like a table" },
   ]}
-/> Prefer CTEs when logic is reused,
+/>
+
+Prefer CTEs when logic is reused,
 deeply nested, or benefits from being read top-to-bottom as named steps. A
 scalar or one-off filter is often clearer as a plain subquery. CTEs improve
 readability; they do not guarantee materialization or a performance change.

--- a/content/interview/analytics-engineer/advanced-sql.mdx
+++ b/content/interview/analytics-engineer/advanced-sql.mdx
@@ -28,9 +28,22 @@ same result set.
 
 `PARTITION BY` splits rows into independent groups, `ORDER BY` sequences rows
 inside each partition, and the **frame** (`ROWS`/`RANGE BETWEEN ...`) bounds
-which rows feed the calculation. Omit `PARTITION BY` and the whole result is one
-partition; omit the frame and ranking functions still work, but running
-aggregates default to the partition-so-far.
+which rows feed the calculation:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "SUM(amount)" },
+    { text: "OVER (" },
+    { text: "PARTITION BY region", label: "independent groups" },
+    { text: "ORDER BY day", label: "sequence inside each group" },
+    { text: "ROWS 6 PRECEDING", label: "the frame that bounds the calculation" },
+    { text: ")" },
+  ]}
+/>
+
+Omit `PARTITION BY` and the whole result is one partition; omit the frame and
+ranking functions still work, but running aggregates default to the
+partition-so-far.
 
 ### Explain `ROW_NUMBER` vs `RANK` vs `DENSE_RANK`.
 

--- a/content/interview/analytics-engineer/advanced-sql.mdx
+++ b/content/interview/analytics-engineer/advanced-sql.mdx
@@ -194,6 +194,16 @@ peer group and picks up rows that sit *after* the current one:
 
 ### How do you compute a period-over-period change?
 
+`LAG` reaches back within the partition, so the comparison never needs a self-join:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "revenue -" },
+    { text: "LAG(revenue)", label: "the value one period back" },
+    { text: "OVER (PARTITION BY region ORDER BY month)", label: "back within this region, by month" },
+  ]}
+/>
+
 Use `LAG` (previous row) or `LEAD` (next row) to pull the comparison value onto
 the current row, then subtract. Below, month-over-month change is
 `revenue - LAG(revenue) OVER (ORDER BY month)`; the first month is `NULL`
@@ -236,6 +246,18 @@ of daily signups silently skips days that had none, distorting trends and
 moving averages.
 
 ### How do you generate a series of dates in DuckDB?
+
+Three arguments: where to start, where to stop, and the step, given as an interval:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "generate_series(" },
+    { text: "DATE '2024-01-01',", label: "start, inclusive" },
+    { text: "DATE '2024-12-31',", label: "end, inclusive" },
+    { text: "INTERVAL 1 DAY", label: "the step" },
+    { text: ")" },
+  ]}
+/>
 
 `generate_series(start, stop, INTERVAL 1 DAY)` produces every date in the range;
 cast to `DATE` if you seeded from `DATE` bounds. Below it fills the spine from

--- a/content/interview/analytics-engineer/advanced-sql.mdx
+++ b/content/interview/analytics-engineer/advanced-sql.mdx
@@ -104,10 +104,27 @@ filters raw rows and `HAVING` filters aggregated groups. Logical order is
 `WHERE` → `GROUP BY`/`HAVING` → window functions → `QUALIFY`. Without it you must
 wrap the window function in a subquery or CTE and filter in an outer query.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "WHERE status = 'paid'", label: "filters raw rows" },
+    { text: "HAVING SUM(amount) > 0", label: "filters aggregated groups" },
+    { text: "QUALIFY rn = 1", label: "filters on the window result" },
+  ]}
+/>
+
 ### What is a CTE, and when do you prefer it over a subquery?
 
 A Common Table Expression (`WITH name AS (...)`) is a named, inline result set
-you reference later in the same statement. Prefer CTEs when logic is reused,
+you reference later in the same statement.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "WITH" },
+    { text: "recent", label: "the name you choose" },
+    { text: "AS (SELECT ... )", label: "the query it stands for" },
+    { text: "SELECT * FROM recent", label: "referenced like a table" },
+  ]}
+/> Prefer CTEs when logic is reused,
 deeply nested, or benefits from being read top-to-bottom as named steps. A
 scalar or one-off filter is often clearer as a plain subquery. CTEs improve
 readability; they do not guarantee materialization or a performance change.

--- a/content/interview/analytics-engineer/dbt.mdx
+++ b/content/interview/analytics-engineer/dbt.mdx
@@ -85,6 +85,16 @@ design rather than an admission of failure.
 
 ### How does an incremental model actually filter new rows?
 
+The guard is what makes the model incremental: on a full refresh the branch is skipped entirely.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "{% if is_incremental() %}", label: "only on an incremental run" },
+    { text: "WHERE updated_at >", label: "the watermark comparison" },
+    { text: "(SELECT max(updated_at) FROM this)", label: "the model as it already exists" },
+  ]}
+/>
+
 The `is_incremental()` macro returns `true` only when the model already exists in the warehouse and the run is not a full refresh. You use it in a `WHERE` clause to limit rows to those newer than the max value already loaded.
 
 Below, the `config()` marks the model `incremental`, and the

--- a/content/interview/backend-engineer/algorithms.mdx
+++ b/content/interview/backend-engineer/algorithms.mdx
@@ -75,6 +75,16 @@ amortized $O(1)$ per insert.
 
 ### What are the time complexities of heap operations?
 
+Python's `heapq` is a min-heap over a plain list, and the operations that matter are one call each:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "heappush(h, x)", label: "O(log n), sift up" },
+    { text: "heappop(h)", label: "O(log n), returns the smallest" },
+    { text: "h[0]", label: "O(1), peek without removing" },
+  ]}
+/>
+
 A binary heap supports `insert` in $O(\log n)$ (bubble up), `extract-min`
 or `extract-max` in $O(\log n)$ (sift down), and `peek` in $O(1)$.
 Building a heap from n elements is $O(n)$ via heapify, not

--- a/content/interview/backend-engineer/api-design.mdx
+++ b/content/interview/backend-engineer/api-design.mdx
@@ -90,6 +90,16 @@ default. Whatever you choose, version to protect existing clients from
 
 ### How do you paginate a large collection?
 
+Cursor pagination beats offset because a cursor is a position in the ordering, not a row count to skip:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "GET /articles?" },
+    { text: "limit=50", label: "page size" },
+    { text: "&cursor=eyJpZCI6NDJ9", label: "where the last page stopped" },
+  ]}
+/>
+
 Two main patterns. **Offset/limit** (`?limit=20&offset=40`) is simple and
 allows jumping to any page, but it is slow on large offsets and can skip or
 repeat rows when the underlying data changes. **Cursor** (keyset) pagination
@@ -148,6 +158,16 @@ branch on `error.code` rather than fragile string matching.
 ```
 
 ### How do you rate-limit an API, and how should clients learn their limits?
+
+A client should never have to guess. Three response headers carry the whole contract:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "X-RateLimit-Limit", label: "the ceiling for this window" },
+    { text: "X-RateLimit-Remaining", label: "what is left" },
+    { text: "Retry-After", label: "how long to wait after a 429" },
+  ]}
+/>
 
 Cap requests per client per window (commonly **token bucket** to allow short
 bursts). When a client exceeds the limit, return **429 Too Many Requests** and

--- a/content/interview/backend-engineer/api-design.mdx
+++ b/content/interview/backend-engineer/api-design.mdx
@@ -187,15 +187,15 @@ is common and pragmatic.
 
 Model the nouns and let HTTP verbs do the actions:
 
-```text
-GET    /articles              # list (paginated, filterable)
-POST   /articles              # create
-GET    /articles/42           # read one
-PATCH  /articles/42           # partial update
-DELETE /articles/42           # delete
-GET    /articles/42/comments  # sub-collection
-POST   /articles/42/comments  # add a comment
-```
+| Verb     | Path                   | What it does                 |
+| -------- | ---------------------- | ---------------------------- |
+| `GET`    | `/articles`            | list (paginated, filterable) |
+| `POST`   | `/articles`            | create                       |
+| `GET`    | `/articles/42`         | read one                     |
+| `PATCH`  | `/articles/42`         | partial update               |
+| `DELETE` | `/articles/42`         | delete                       |
+| `GET`    | `/articles/42/comments`| sub-collection               |
+| `POST`   | `/articles/42/comments`| add a comment                |
 
 Filtering and sorting go in the query string (`?status=published&sort=-created_at`),
 not new endpoints. Return `201 Created` with a `Location` header on create, and

--- a/content/interview/backend-engineer/databases.mdx
+++ b/content/interview/backend-engineer/databases.mdx
@@ -52,8 +52,18 @@ thumb: index columns you filter and join on, not every column.
 
 ### What is a composite index and why does column order matter?
 
-A composite index covers multiple columns in a defined order, say
-`(last_name, first_name)`. It serves queries that filter on a **left prefix**:
+A composite index covers multiple columns in a defined order:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "CREATE INDEX idx_name ON people (" },
+    { text: "last_name,", label: "usable on its own" },
+    { text: "first_name", label: "only usable alongside the one before it" },
+    { text: ")" },
+  ]}
+/>
+
+It serves queries that filter on a **left prefix**:
 `last_name` alone, or `last_name` **and** `first_name`, but not `first_name`
 alone. This is the **leftmost-prefix rule**. Order the columns by how you
 query them, most-selective and always-present columns first.

--- a/content/interview/backend-engineer/python.mdx
+++ b/content/interview/backend-engineer/python.mdx
@@ -181,7 +181,9 @@ before and/or after the call. It is syntactic sugar for
     { text: "@timer", label: "the decorator, applied last-in first-out" },
     { text: "def slow(n):", label: "the function it replaces" },
   ]}
-/> A correct decorator preserves the wrapped
+/>
+
+A correct decorator preserves the wrapped
 function's metadata using `functools.wraps`. The `timer` decorator below
 wraps `fn`, records the elapsed time around the call, and returns the
 original result unchanged.

--- a/content/interview/backend-engineer/python.mdx
+++ b/content/interview/backend-engineer/python.mdx
@@ -174,7 +174,14 @@ Python syntax and built-ins, without inheritance from a special base class.
 
 A decorator is a callable that wraps another function, adding behavior
 before and/or after the call. It is syntactic sugar for
-`fn = decorator(fn)`. A correct decorator preserves the wrapped
+`fn = decorator(fn)`.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "@timer", label: "the decorator, applied last-in first-out" },
+    { text: "def slow(n):", label: "the function it replaces" },
+  ]}
+/> A correct decorator preserves the wrapped
 function's metadata using `functools.wraps`. The `timer` decorator below
 wraps `fn`, records the elapsed time around the call, and returns the
 original result unchanged.

--- a/content/interview/data-analyst/ab-testing-and-metrics.mdx
+++ b/content/interview/data-analyst/ab-testing-and-metrics.mdx
@@ -58,6 +58,14 @@ stage. Watch two things: use `COUNT(DISTINCT user_id)` so repeat events
 don't inflate the numerator, and cast to float (`* 1.0`) so integer
 division doesn't truncate to 0.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "COUNT(DISTINCT CASE WHEN stage = 'purchase' THEN user_id END)", label: "users who converted" },
+    { text: "* 1.0", label: "force float division" },
+    { text: "/ COUNT(DISTINCT user_id)", label: "users at the reference stage" },
+  ]}
+/>
+
 ```sql
 SELECT
   COUNT(DISTINCT CASE WHEN stage = 'purchase' THEN user_id END) * 1.0

--- a/content/interview/data-analyst/ab-testing-and-metrics.mdx
+++ b/content/interview/data-analyst/ab-testing-and-metrics.mdx
@@ -112,6 +112,17 @@ p-value.
 
 ### How would you explain a confidence interval to a stakeholder?
 
+The interval is the estimate plus a margin, and the margin has three separate drivers:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "estimate", label: "what you measured" },
+    { text: "±", label: "the margin of error" },
+    { text: "1.96", label: "the confidence level, here 95%" },
+    { text: "× SE", label: "the standard error, which shrinks with n" },
+  ]}
+/>
+
 Give a plain-language range instead of a bare point estimate: "we're
 confident the true lift is between about **8% and 16%**." A 95% interval
 means that if we repeated the experiment many times, about 95% of such

--- a/content/interview/data-analyst/advanced-sql.mdx
+++ b/content/interview/data-analyst/advanced-sql.mdx
@@ -113,6 +113,17 @@ FOLLOWING`.
 
 ### How do you compute a running total?
 
+An ordered `SUM` with no explicit frame already means "everything up to this row":
+
+<SyntaxBreakdown
+  parts={[
+    { text: "SUM(amount)" },
+    { text: "OVER (", label: "makes it a window function" },
+    { text: "ORDER BY day", label: "what running means" },
+    { text: ")", label: "the default frame runs to the current row" },
+  ]}
+/>
+
 `SUM` as a window function with `ORDER BY` and the default
 running frame:
 

--- a/content/interview/data-analyst/advanced-sql.mdx
+++ b/content/interview/data-analyst/advanced-sql.mdx
@@ -26,6 +26,17 @@ optional parts: `PARTITION BY` (which rows share a window), `ORDER BY`
 (their order inside it), and a **frame** (which rows around the current
 one are in scope).
 
+<SyntaxBreakdown
+  parts={[
+    { text: "SUM(amount)", label: "what to compute" },
+    { text: "OVER (" },
+    { text: "PARTITION BY region", label: "which rows share a window" },
+    { text: "ORDER BY day", label: "their order inside it" },
+    { text: "ROWS 6 PRECEDING", label: "the frame in scope" },
+    { text: ")" },
+  ]}
+/>
+
 ### How do ROW_NUMBER, RANK, and DENSE_RANK differ?
 
 All three number rows within an ordered window, but they treat ties
@@ -58,6 +69,15 @@ FROM results;`}
 each partition boundary (like `GROUP BY`, but rows are kept). `ORDER BY`
 sequences rows **within** a partition, which is what ranking and running
 calculations need. You can use either, both, or neither.
+
+<SyntaxBreakdown
+  parts={[
+    { text: "RANK() OVER (" },
+    { text: "PARTITION BY department", label: "restart the ranking here" },
+    { text: "ORDER BY salary DESC", label: "what rank 1 means" },
+    { text: ")" },
+  ]}
+/>
 
 ### How do you return the top N rows per group?
 

--- a/content/interview/data-analyst/sql.mdx
+++ b/content/interview/data-analyst/sql.mdx
@@ -164,6 +164,15 @@ multiple times**, making complex logic easier to read and debug. Recursive
 CTEs (with `RECURSIVE`) can also traverse hierarchical data, which
 subqueries cannot.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "WITH" },
+    { text: "active_users", label: "the name you choose" },
+    { text: "AS (SELECT ... )", label: "the query it stands for" },
+    { text: "SELECT * FROM active_users", label: "referenced like a table, as often as you like" },
+  ]}
+/>
+
 ```sql
 WITH active_users AS (
   SELECT id, name FROM users WHERE status = 'active'

--- a/content/interview/data-analyst/sql.mdx
+++ b/content/interview/data-analyst/sql.mdx
@@ -210,6 +210,16 @@ window calculation for each partition. It is analogous to `GROUP BY` for
 the window frame: rows in different partitions are computed independently.
 Omitting `PARTITION BY` makes the entire result set one window.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "RANK()", label: "the window function" },
+    { text: "OVER (" },
+    { text: "PARTITION BY department", label: "restart the ranking per department" },
+    { text: "ORDER BY salary DESC", label: "what rank 1 means" },
+    { text: ")" },
+  ]}
+/>
+
 ```sql
 SELECT
   name,

--- a/content/interview/data-engineer/data-modeling.mdx
+++ b/content/interview/data-engineer/data-modeling.mdx
@@ -76,6 +76,16 @@ grain.
 
 ### How do you preserve history when a dimension attribute changes (SCD)?
 
+A Type 2 dimension answers "what was true then?" by adding rows rather than updating them, which needs three bookkeeping columns:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "customer_key,", label: "the surrogate key, new per version" },
+    { text: "valid_from, valid_to,", label: "the window this version was true" },
+    { text: "is_current", label: "the flag that finds today's row cheaply" },
+  ]}
+/>
+
 Use a **Slowly Changing Dimension (SCD)**:
 
 - **Type 1**, overwrite (no history).

--- a/content/interview/data-engineer/data-modeling.mdx
+++ b/content/interview/data-engineer/data-modeling.mdx
@@ -455,6 +455,18 @@ An **auto-increment integer** surrogate key is compact, fast to join, and natura
 
 ### How do you model a many-to-many relationship between facts and dimensions?
 
+A bridge table carries the pair, and usually a weight so the fact is not double-counted:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "bridge(" },
+    { text: "fact_key,", label: "the fact side" },
+    { text: "dim_key,", label: "the dimension side" },
+    { text: "weight", label: "the allocation factor, summing to 1 per fact" },
+    { text: ")" },
+  ]}
+/>
+
 Use a **bridge table**: a separate table with one row per (fact, dimension) combination. For example, if an order can be associated with multiple promotions, the bridge table `order_promotion_bridge` holds `(order_key, promo_key)` pairs. The fact table joins to the bridge, which joins to the promotion dimension. A **weighting factor** column on the bridge can distribute additive measures proportionally across the associated dimension members.
 
 The query below multiplies `f.amount` by the bridge's `weight` before

--- a/content/interview/data-engineer/sql.mdx
+++ b/content/interview/data-engineer/sql.mdx
@@ -148,6 +148,16 @@ SELECT user_id FROM legacy_users;
 
 `LAG(col, n)` returns the value of `col` from `n` rows **before** the current row within the partition; `LEAD(col, n)` looks `n` rows **ahead**. Both accept an optional default for when the offset falls outside the partition. They are commonly used to compute period-over-period differences without a self-join.
 
+<SyntaxBreakdown
+  parts={[
+    { text: "LAG(" },
+    { text: "revenue,", label: "the column to reach back for" },
+    { text: "1,", label: "how many rows back" },
+    { text: "0", label: "what to use at the partition edge" },
+    { text: ") OVER (ORDER BY order_date)", label: "what before means" },
+  ]}
+/>
+
 The query below pulls the prior day's `revenue` from `daily_revenue` with
 `LAG(revenue, 1, 0)` and subtracts it to produce a `delta` column.
 
@@ -198,6 +208,16 @@ ORDER BY user_id, order_date;`}
 ### How do you compute a 7-day moving average?
 
 Use a bounded window frame covering the 6 preceding rows plus the current one:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "AVG(daily_value)", label: "what to average" },
+    { text: "OVER (ORDER BY event_date", label: "what preceding means" },
+    { text: "ROWS BETWEEN 6 PRECEDING", label: "start of the window" },
+    { text: "AND CURRENT ROW", label: "end of the window" },
+    { text: ")" },
+  ]}
+/>
 
 ```sql
 SELECT

--- a/content/interview/data-scientist/deep-learning.mdx
+++ b/content/interview/data-scientist/deep-learning.mdx
@@ -19,6 +19,18 @@ runnable here); the one runnable block uses only NumPy.
 
 ### What does a single artificial neuron compute?
 
+One line, and each piece is a separate design decision:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "a =" },
+    { text: "f(", label: "the activation, the only non-linear part" },
+    { text: "w · x", label: "a weighted sum of the inputs" },
+    { text: "+ b", label: "the bias, which shifts the threshold" },
+    { text: ")" },
+  ]}
+/>
+
 A weighted sum of its inputs plus a bias, passed through a non-linear
 activation:
 

--- a/content/interview/data-scientist/experimentation.mdx
+++ b/content/interview/data-scientist/experimentation.mdx
@@ -97,6 +97,17 @@ The analysis unit must match or be nested within the randomization unit to keep 
 
 ### How do you calculate sample size for an A/B test?
 
+Four inputs are the whole calculation, and three of them are choices made before any data is seen:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "baseline rate,", label: "measured from history" },
+    { text: "MDE,", label: "the smallest lift worth detecting" },
+    { text: "alpha = 0.05,", label: "false-positive rate you accept" },
+    { text: "power = 0.8", label: "chance of catching a real effect" },
+  ]}
+/>
+
 You need four inputs: baseline conversion rate, minimum detectable effect (MDE), `alpha` (commonly 0.05), and desired power (commonly 0.8).
 The formula for a two-proportion z-test is derived from the pooled standard error; most practitioners use a sample size calculator.
 Sample size scales inversely with the square of the MDE, $n \propto \dfrac{1}{\text{MDE}^2}$: halving the MDE you want to detect quadruples the required sample.

--- a/content/interview/data-scientist/sql.mdx
+++ b/content/interview/data-scientist/sql.mdx
@@ -228,6 +228,17 @@ SELECT * FROM ranked WHERE rn <= 3;
 
 ### How do you compute a running total?
 
+An ordered `SUM` with no explicit frame already means "everything up to this row":
+
+<SyntaxBreakdown
+  parts={[
+    { text: "SUM(amount)" },
+    { text: "OVER (", label: "makes it a window function" },
+    { text: "ORDER BY day", label: "what running means" },
+    { text: ")", label: "the default frame runs to the current row" },
+  ]}
+/>
+
 `SUM(x) OVER (ORDER BY day)`; the default frame is `ROWS BETWEEN UNBOUNDED
 PRECEDING AND CURRENT ROW`, which accumulates from the start.
 

--- a/content/interview/machine-learning-engineer/coding.mdx
+++ b/content/interview/machine-learning-engineer/coding.mdx
@@ -166,6 +166,17 @@ into a full cosine-similarity matrix in one vectorized operation.
 
 ### How do you implement mini-batching for training?
 
+A batch is a slice, and the two numbers that define it are the only state you need:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "for i in range(0, n," },
+    { text: "bs", label: "the step, which is the batch size" },
+    { text: "):" },
+    { text: "X[i : i + bs]", label: "one slice; the last may be short" },
+  ]}
+/>
+
 Shuffle the row indices once per epoch, then slice fixed-size chunks and
 index the data with them. Shuffling by index (not by copying rows) keeps
 features and labels aligned and avoids materializing shuffled copies. A
@@ -236,6 +247,16 @@ where each count is a boolean-mask sum: `TP = ((y_pred == 1) & (y_true == 1)).su
 Vectorizing the masks keeps it $O(n)$ with no Python loop.
 
 ### How do you decode class predictions from a probability matrix?
+
+`argmax` over the class axis, and getting the axis right is the whole job:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "probs.argmax(" },
+    { text: "axis=1", label: "reduce across classes, one answer per row" },
+    { text: ")", label: "shape (n, k) becomes (n,)" },
+  ]}
+/>
 
 For an `(n_samples, n_classes)` matrix of probabilities, `np.argmax(P, axis=1)`
 returns the predicted class index per row in $O(nk)$. `np.max(P, axis=1)`

--- a/content/interview/machine-learning-engineer/coding.mdx
+++ b/content/interview/machine-learning-engineer/coding.mdx
@@ -56,6 +56,17 @@ vectorized pass.
 
 ### How do you find the top-k scores efficiently?
 
+`argpartition` is O(n) where a full sort is O(n log n); you sort only the k you kept:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "np.argpartition(" },
+    { text: "-scores,", label: "negated, because it partitions ascending" },
+    { text: "k", label: "the boundary, not a sort" },
+    { text: ")[:k]", label: "the top k, in no particular order yet" },
+  ]}
+/>
+
 Sorting the whole array is $O(n \log n)$; when you only need the k largest
 you can do better. `np.argpartition` runs in $O(n)$ and places the k
 largest indices at the end (unordered), then you sort just those k. For
@@ -108,6 +119,17 @@ print("majority class:", counts.most_common(1)[0][0])
 />
 
 ### How do you compute cosine similarity in NumPy?
+
+Three pieces, and the guard on the denominator is the one people forget:
+
+<SyntaxBreakdown
+  parts={[
+    { text: "a @ b", label: "the dot product" },
+    { text: "/", label: "normalised by..." },
+    { text: "(norm(a) * norm(b)", label: "...both magnitudes" },
+    { text: "+ 1e-12)", label: "so a zero vector cannot divide by zero" },
+  ]}
+/>
 
 Cosine similarity is the dot product of two vectors divided by the product
 of their norms, so it measures angle and ignores magnitude:

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -35,9 +35,10 @@
  * the route's client entry however it was imported. `lazyWidgets.ts` has the
  * full explanation; read it before moving a widget back into this file.
  *
- * `Figure`, `Chart`, `SvgLabel` and the `<Steps>` pair stay statically
- * imported on purpose: they are Server Components (or render no client code),
- * so they never reach the browser and splitting them would buy nothing.
+ * `Figure`, `Chart`, `SvgLabel`, the diagram primitives and the `<Steps>` pair
+ * stay statically imported on purpose: they are Server Components (or render
+ * no client code), so they never reach the browser and splitting them would
+ * buy nothing.
  */
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import { Step, Steps } from "fumadocs-ui/components/steps";
@@ -45,6 +46,12 @@ import type { MDXComponents } from "mdx/types";
 import { SvgLabel } from "@/app/_components/mdx/SvgLabel";
 import { Figure } from "@/app/_components/mdx/Figure";
 import { Chart } from "@/app/_components/mdx/Chart";
+import {
+  BoxModel,
+  CrcCard,
+  MemoryCells,
+  SyntaxBreakdown,
+} from "@/app/_components/mdx/diagrams";
 import { CalloutWithCodeTitle } from "@/app/_components/mdx/CalloutWithCodeTitle";
 import { reactDemoComponents } from "@/app/_components/mdx/reactDemoComponents";
 import { withSearchAnchor } from "@/app/_components/mdx/withSearchAnchor";
@@ -87,6 +94,13 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     IllustrationPrompt,
     Figure: withSearchAnchor(Figure),
     Chart: withSearchAnchor(Chart),
+    // Lesson diagrams drawn with real elements rather than box-drawing
+    // characters (see app/_components/mdx/diagrams.tsx for why that matters).
+    // Server Components with no client code, so they stay statically imported.
+    BoxModel,
+    MemoryCells,
+    SyntaxBreakdown,
+    CrcCard,
     LoadingAnimationsGallery,
     RuntimeLoadingStates,
     // Live, no-Run lesson widgets: <LivePreview> renders HTML/CSS in a

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "check:mdx": "node scripts/check-mdx-blocks.mjs",
     "check:mdx-tables": "node scripts/check-mdx-tables.mjs",
     "check:prose": "node scripts/check-prose.mjs",
+    "check:diagrams": "node scripts/check-ascii-diagrams.mjs",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/scripts/check-ascii-diagrams.mjs
+++ b/scripts/check-ascii-diagrams.mjs
@@ -1,7 +1,8 @@
-// Lints lesson content for diagrams "drawn" out of characters: a figure built
-// from `┌─┐│└┘`, from `+-----+` and `---->`, or from `└──┬──┘` underbraces.
+// Lints lesson content for figures "drawn" out of characters: a diagram built
+// from `┌─┐│└┘`, from `+-----+` and `---->`, or from `└──┬──┘` underbraces, and
+// a table built out of a dashed rule and space-padded columns.
 //
-// Three rules, all scoped to content/**/*.mdx:
+// Four rules, all scoped to content/**/*.mdx:
 //
 //   1. drawn-diagram, two or more consecutive lines each carrying two or more
 //                    box-drawing characters, where at least one of them is not
@@ -16,6 +17,16 @@
 //                    labels across the two Java courses read `s = ●─`, a
 //                    reference dot with a wire, in a node that had a real
 //                    arrow leaving it.
+//   4. fake-table,   a ```text (or unlabelled) fence that is really a table:
+//                    header, a rule of dashes, rows. Rules 1 and 2 miss these
+//                    entirely because the drawing is pure ASCII, which is how
+//                    an `Address / Variable / Value` block on
+//                    `c-programming-for-beginners/variables-and-memory`
+//                    survived the first pass. A table typed into a fence gets
+//                    none of what a markdown table gets: it will not reflow on
+//                    a phone, its columns are held apart by literal spaces
+//                    rather than by cells, and it is a `<pre>` to a screen
+//                    reader rather than a `<table>` with headers.
 //
 // ── Why a drawn figure is a bug and not a style preference ─────────────────
 //
@@ -95,6 +106,76 @@ const UNDERBRACE = /^\s*[└┘┬─\s]*[└┘][└┘┬─\s]*$/u;
 /** Authors opt one figure out with this on the line above it. */
 const ALLOW = /allow-drawn-diagram/;
 
+/** Fence languages that mean "this is not source code". A fence tagged `py`
+ *  or `java` holds a listing, where aligned comments and a row of dashes are
+ *  ordinary; a `text` fence holds something the author drew. */
+const PROSE_FENCE = new Set(["", "text", "txt", "plain", "plaintext", "output", "console"]);
+
+/** A rule of dashes and spaces only, with at least two separate dash runs:
+ *  the column rule under a header row (`------   --------   -----`). */
+const COLUMN_RULE = /^\s*-{2,}(?:\s+-{2,})+\s*$/;
+
+/** A single run of dashes on its own line, which is a column rule when it has
+ *  a header above it and rows below. */
+const SINGLE_RULE = /^\s*-{3,}\s*$/;
+
+/** A markdown delimiter row typed inside a fence (`-- | ---- | ---`). */
+const PIPE_RULE = /^\s*\|?\s*:?-{2,}:?\s*(?:\|\s*:?-{2,}:?\s*)+\|?\s*$/;
+
+/**
+ * Every ```fence in an MDX source, as `{ line, lang, body }` where `line` is
+ * the 1-based line of the opening fence and `body` is its lines.
+ */
+function fences(lines) {
+  const found = [];
+  let open = null;
+  lines.forEach((line, i) => {
+    const mark = line.match(/^\s*(```+|~~~+)\s*(\S*)/);
+    if (!mark) {
+      if (open) open.body.push(line);
+      return;
+    }
+    if (open && mark[1].startsWith(open.mark)) {
+      found.push(open);
+      open = null;
+    } else if (!open) {
+      open = { mark: mark[1], lang: (mark[2] || "").toLowerCase(), line: i + 1, body: [] };
+    } else {
+      open.body.push(line);
+    }
+  });
+  if (open) found.push(open);
+  return found;
+}
+
+/**
+ * True when a fence body is a table wearing a code block: a rule of dashes
+ * with a header line above it and at least one row below.
+ *
+ * The header/rows requirement is what keeps this off the shapes that
+ * legitimately contain a dashed line — a `---` separator printed by a program,
+ * or a horizontal rule at the top or bottom of a block of output — and the
+ * fence language check above keeps it off source listings entirely. Columns
+ * held apart by spaces with *no* rule at all are not detected: the test that
+ * finds them also finds aligned trailing comments in a code listing, and a
+ * linter that cries wolf on those gets switched off. Those were swept by hand
+ * (see the pull request) and the ones that remain are code, program output, or
+ * a directory tree.
+ */
+function fakeTableRule(body) {
+  for (let i = 0; i < body.length; i++) {
+    const line = body[i];
+    const isRule = COLUMN_RULE.test(line) || PIPE_RULE.test(line) || SINGLE_RULE.test(line);
+    if (!isRule) continue;
+    const header = body[i - 1];
+    const row = body[i + 1];
+    if (header?.trim() && row?.trim() && !COLUMN_RULE.test(header) && !SINGLE_RULE.test(header)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 /**
  * Lint one MDX source. Returns `{ file, rule, line, detail }` violations.
  *
@@ -150,6 +231,15 @@ export function lintSource(src, file) {
   for (const { line, text } of mermaidLines(lines)) {
     if (!allowed.has(line - 1) && drawCount(text) >= 1) {
       add("mermaid-glyph", line, text.trim().slice(0, 80));
+    }
+  }
+
+  // Rule 4: a table typed into a prose fence.
+  for (const fence of fences(lines)) {
+    if (!PROSE_FENCE.has(fence.lang) || allowed.has(fence.line - 1)) continue;
+    const at = fakeTableRule(fence.body);
+    if (at !== -1) {
+      add("fake-table", fence.line + at, fence.body[at].trim().slice(0, 80));
     }
   }
 
@@ -210,7 +300,7 @@ if (isMain) {
     process.exit(1);
   }
   console.log(
-    `✓ ${files.length} lesson file(s) draw no diagrams out of characters ` +
-      "(directory trees excepted)",
+    `✓ ${files.length} lesson file(s) draw no diagrams or tables out of ` +
+      "characters (directory trees excepted)",
   );
 }

--- a/scripts/check-ascii-diagrams.mjs
+++ b/scripts/check-ascii-diagrams.mjs
@@ -1,0 +1,216 @@
+// Lints lesson content for diagrams "drawn" out of characters: a figure built
+// from `┌─┐│└┘`, from `+-----+` and `---->`, or from `└──┬──┘` underbraces.
+//
+// Three rules, all scoped to content/**/*.mdx:
+//
+//   1. drawn-diagram, two or more consecutive lines each carrying two or more
+//                    box-drawing characters, where at least one of them is not
+//                    a directory tree (see below).
+//   2. ascii-box,    two or more `+-----+` rules in one file, the ASCII
+//                    equivalent, plus the `└──┬──┘` underbrace shape.
+//   3. mermaid-glyph, a single drawn character anywhere inside a ```mermaid
+//                    fence. Mermaid's own syntax is pure ASCII, so a drawn
+//                    glyph in one can only be decoration inside a label — and
+//                    it is always redundant decoration, because the thing it
+//                    is imitating is the edge mermaid already draws. Five node
+//                    labels across the two Java courses read `s = ●─`, a
+//                    reference dot with a wire, in a node that had a real
+//                    arrow leaving it.
+//
+// ── Why a drawn figure is a bug and not a style preference ─────────────────
+//
+// Code on this site is set in JetBrains Mono, loaded by next/font/google with
+// `subsets: ["latin"]` (app/layout.tsx). That subset ends long before U+2500,
+// so every box-drawing character falls back to whatever monospace the reader's
+// operating system supplies, at that font's advance width rather than
+// JetBrains Mono's. A line's rendered width then depends on how many drawn
+// characters it happens to contain, and rows that were aligned in the source
+// arrive on the page at different widths. The CSS box-model figure on
+// `modern-css-layout/box-model-and-sizing` is what surfaced this: four
+// concentric boxes reached readers as a scatter of disconnected line
+// fragments. Widening the font subset would not fix the rest of it either — a
+// drawn figure is still an image made of text, so a screen reader spells the
+// corner glyphs out one at a time, nothing reflows on a phone, and the drawing
+// cannot take the page's colors or its theme.
+//
+// The replacements are all in the repo already: `<BoxModel>`, `<MemoryCells>`,
+// `<SyntaxBreakdown>` and `<CrcCard>` (app/_components/mdx/diagrams.tsx) for a
+// figure whose geometry is the point, a ```mermaid fence for anything that is
+// really a graph, and a markdown table for anything that is really a table.
+//
+// ── The one shape that stays ───────────────────────────────────────────────
+//
+// A directory tree. It is the literal output format of `tree`, universal in
+// READMEs and terminals, and it is the one drawn shape the font fallback does
+// not break: every row at a given depth carries the same prefix, so siblings
+// still line up even at a different advance width. The `isTreeLine` test below
+// is what recognizes one, and it is deliberately narrow — drawn characters may
+// appear only in a row's leading connector, never in its content, which is
+// exactly what separates `├── data/` from `│ Class: Order │`.
+//
+// Anything else that genuinely has to be drawn (real `mysql` CLI output, say,
+// which frames its result set in `+------+`) can opt out with a comment on the
+// line above the fence:
+//
+//     {/* allow-drawn-diagram: verbatim mysql client output */}
+//
+// Used both as a CLI (`node scripts/check-ascii-diagrams.mjs [files...]`,
+// defaults to all of content/) and as a library by
+// __tests__/asciiDiagrams.test.ts.
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+// The fence walker the mermaid-dash rule already uses. Shared rather than
+// re-implemented so the two linters cannot disagree about where a mermaid
+// block starts and ends.
+import { mermaidLines } from "./check-prose.mjs";
+
+/** Box drawing (U+2500-257F), block elements (U+2580-259F) and geometric
+ *  shapes (U+25A0-25FF): the three blocks a text-drawn figure is made of.
+ *  Arrows (U+2190-21FF) are deliberately out of scope — `→` in a sentence is
+ *  punctuation, not a drawing. */
+const DRAW_CHAR = /[─-◿]/gu;
+
+/** A row of a directory tree: drawn characters confined to the leading
+ *  connector, and none in the content after it. `│   ├── raw/` passes;
+ *  `│ Responsibilities │ Collaborators │` does not, because stripping its
+ *  connector still leaves a `│` behind. */
+function isTreeLine(line) {
+  const rest = line.replace(/^[\s│├└─┬┼┤]*/u, "");
+  DRAW_CHAR.lastIndex = 0;
+  return !DRAW_CHAR.test(rest);
+}
+
+function drawCount(line) {
+  return (line.match(DRAW_CHAR) || []).length;
+}
+
+/** A pure ASCII box rule, `+-----+` or `+--+--+`. */
+const ASCII_RULE = /^\s*\+[-+]{3,}\+\s*$/;
+
+/** An underbrace row: only `└┬┘─` and spaces, at least one corner. Catches the
+ *  "anatomy of a statement" figures that <SyntaxBreakdown> replaces. */
+const UNDERBRACE = /^\s*[└┘┬─\s]*[└┘][└┘┬─\s]*$/u;
+
+/** Authors opt one figure out with this on the line above it. */
+const ALLOW = /allow-drawn-diagram/;
+
+/**
+ * Lint one MDX source. Returns `{ file, rule, line, detail }` violations.
+ *
+ * Runs over the raw source rather than over fenced blocks only: a drawn figure
+ * hides just as happily inside a JSX prop (the Python exception hierarchy sat
+ * in a `starterCode` string for exactly that reason) as it does in a ```text
+ * fence, and the font problem is the same in both places.
+ */
+export function lintSource(src, file) {
+  const violations = [];
+  const add = (rule, line, detail) => violations.push({ file, rule, line, detail });
+  const lines = src.split("\n");
+  const allowed = new Set();
+  lines.forEach((line, i) => {
+    if (ALLOW.test(line)) {
+      // An opt-out covers the block that follows it, which in practice means
+      // "until the next blank line after the drawing ends". Marking a generous
+      // window is fine: the comment is an explicit author decision either way.
+      for (let j = i; j < Math.min(lines.length, i + 60); j++) allowed.add(j);
+    }
+  });
+
+  // Rule 1: runs of drawn lines that are not a directory tree.
+  let run = null;
+  const flush = () => {
+    if (run && run.lines.length >= 2 && !run.lines.every(isTreeLine)) {
+      add("drawn-diagram", run.start, run.lines[0].trim().slice(0, 80));
+    }
+    run = null;
+  };
+  lines.forEach((line, i) => {
+    if (drawCount(line) >= 2 && !allowed.has(i)) {
+      run ??= { start: i + 1, lines: [] };
+      run.lines.push(line);
+    } else {
+      flush();
+    }
+  });
+  flush();
+
+  // Rule 2: the ASCII spellings of the same idea.
+  let rules = [];
+  lines.forEach((line, i) => {
+    if (allowed.has(i)) return;
+    if (ASCII_RULE.test(line)) rules.push(i + 1);
+    if (UNDERBRACE.test(line) && drawCount(line) >= 2) {
+      add("ascii-box", i + 1, line.trim().slice(0, 80));
+    }
+  });
+  if (rules.length >= 2) add("ascii-box", rules[0], "`+-----+` box rules");
+
+  // Rule 3: any drawn glyph inside a mermaid fence.
+  for (const { line, text } of mermaidLines(lines)) {
+    if (!allowed.has(line - 1) && drawCount(text) >= 1) {
+      add("mermaid-glyph", line, text.trim().slice(0, 80));
+    }
+  }
+
+  return violations;
+}
+
+// --- file discovery -------------------------------------------------------
+
+function walk(dir, test, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, test, out);
+    else if (test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/** Every lesson file this linter is responsible for. */
+export function diagramFiles(root = process.cwd()) {
+  return walk(path.join(root, "content"), (n) => n.endsWith(".mdx"));
+}
+
+export function lintFiles(files) {
+  return files.flatMap((f) => lintSource(readFileSync(f, "utf8"), f));
+}
+
+// --- CLI ------------------------------------------------------------------
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const args = process.argv.slice(2);
+  const files = args.length ? args : diagramFiles();
+  const violations = lintFiles(files);
+  if (violations.length) {
+    const byRule = {};
+    for (const v of violations) (byRule[v.rule] ??= []).push(v);
+    for (const [rule, list] of Object.entries(byRule)) {
+      console.error(`\n✗ ${rule} (${list.length}):`);
+      for (const v of list) {
+        console.error(`   ${path.relative(process.cwd(), v.file)}:${v.line}: ${v.detail}`);
+      }
+    }
+    console.error(
+      `\n${violations.length} drawn diagram(s) across ${files.length} file(s).\n\n` +
+        "A figure drawn out of characters does not survive the page: the code\n" +
+        "font's subset stops before U+2500, so every drawn glyph falls back to\n" +
+        "another font at another width and the rows stop lining up.\n\n" +
+        "  geometry is the point   <BoxModel>, <MemoryCells>, <SyntaxBreakdown>,\n" +
+        "                          <CrcCard> (app/_components/mdx/diagrams.tsx)\n" +
+        "  it is really a graph    a ```mermaid fence, whose labels are words:\n" +
+        "                          the edge it draws is the arrow you wanted\n" +
+        "  it is really a table    a markdown table\n" +
+        "  a directory tree        keep it, `tree` output is the exception\n\n" +
+        "Verbatim tool output that has to keep its frame can opt out with\n" +
+        "`{/* allow-drawn-diagram: why */}` on the line above.",
+    );
+    process.exit(1);
+  }
+  console.log(
+    `✓ ${files.length} lesson file(s) draw no diagrams out of characters ` +
+      "(directory trees excepted)",
+  );
+}

--- a/scripts/check-mdx-blocks.mjs
+++ b/scripts/check-mdx-blocks.mjs
@@ -132,6 +132,33 @@ for (const file of files) {
   }
 }
 
+// A fence with no language is not highlighted, and nothing says so: it renders
+// as a code block in the right font at the right size, just grey. Four Java
+// snippets in the generics course shipped that way. `text` is always an
+// available answer, so there is no case where leaving it off is what the author
+// meant. Fences carrying meta (```csharp title="x") are openers too, and a
+// closing fence is backticks alone, which is what separates them.
+for (const file of files) {
+  const lines = readFileSync(file, "utf8").split("\n");
+  let open = null;
+  lines.forEach((line, i) => {
+    const close = line.match(/^\s{0,3}(`{3,})\s*$/);
+    const mark = line.match(/^\s{0,3}(`{3,})[ \t]*([^\s`]*)/);
+    if (open) {
+      if (close && close[1].length >= open.ticks) open = null;
+      return;
+    }
+    if (!mark) return;
+    open = { ticks: mark[1].length };
+    if (!mark[2]) {
+      problems.push(
+        `${relative(ROOT, file)}:${i + 1}: fenced block has no language, so it ` +
+          `renders unhighlighted (use \`text\` if it is not code)`,
+      );
+    }
+  });
+}
+
 // The authoritative pass: does the file parse as MDX at all? `remarkMath` is
 // here because `source.config.ts` has it and `$…$` would otherwise be read as
 // ordinary text; `remarkGfm` because tables are, and a table row is where one
@@ -166,5 +193,6 @@ if (problems.length > 0) {
 
 console.log(
   `✓ ${files.length} MDX file(s): component tags all at the top level, ` +
-    `attribute values all closed, every file parses as MDX`,
+    `attribute values all closed, every fence declares a language, ` +
+    `every file parses as MDX`,
 );

--- a/scripts/check-mdx-blocks.mjs
+++ b/scripts/check-mdx-blocks.mjs
@@ -25,11 +25,27 @@
  * where it claims to. All three are cheap to check and none has a legitimate
  * exception.
  *
+ * **And then the file is actually parsed.** The three rules above are line
+ * shapes, and line shapes have gaps: a component inserted ahead of a paragraph
+ * left `/> A correct decorator preserves…` on one line, which is a JSX element
+ * with prose after it, and every rule here waved it through. `next build`
+ * did not, and it failed at prerender with exactly the message this script
+ * exists to pre-empt. So the last step runs the real MDX parser over every
+ * lesson. It costs about 13 seconds for the whole corpus, which is the point:
+ * the heuristics are what make a *specific* diagnosis, and the parse is what
+ * makes the check honest about whether the file compiles at all.
+ *
  *   node scripts/check-mdx-blocks.mjs
  */
 import { readFileSync } from "node:fs";
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkMdx from "remark-mdx";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
 
 import { collectFiles } from "./lib/build-cache.mjs";
 import { codeRegions } from "./lib/mdx-regions.mjs";
@@ -116,12 +132,39 @@ for (const file of files) {
   }
 }
 
+// The authoritative pass: does the file parse as MDX at all? `remarkMath` is
+// here because `source.config.ts` has it and `$…$` would otherwise be read as
+// ordinary text; `remarkGfm` because tables are, and a table row is where one
+// of these bugs turned up. Frontmatter is blanked rather than stripped so
+// reported line numbers still point at the file.
+const mdx = unified().use(remarkParse).use(remarkMdx).use(remarkGfm).use(remarkMath);
+for (const file of files) {
+  const src = readFileSync(file, "utf8").replace(/^---\n[\s\S]*?\n---\n/, (m) =>
+    m.replace(/[^\n]/g, ""),
+  );
+  try {
+    mdx.runSync(mdx.parse(src));
+  } catch (err) {
+    const at = err.line ? `:${err.line}:${err.column ?? 0}` : "";
+    problems.push(
+      `${relative(ROOT, file)}${at}: does not parse as MDX: ` +
+        String(err.reason ?? err.message).slice(0, 100) +
+        (err.cause ? ` (${String(err.cause.message).slice(0, 60)})` : ""),
+    );
+  }
+}
+
 if (problems.length > 0) {
   console.error(`\n✗ ${problems.length} problem(s):\n   ` + problems.join("\n   ") + "\n");
+  console.error(
+    "A component placed immediately before existing prose must be followed by a\n" +
+      "blank line. `/>` with text after it on the same line is a JSX element with\n" +
+      "trailing content, which is the acorn error above.\n",
+  );
   process.exit(1);
 }
 
 console.log(
   `✓ ${files.length} MDX file(s): component tags all at the top level, ` +
-    `attribute values all closed`,
+    `attribute values all closed, every file parses as MDX`,
 );

--- a/scripts/check-prose.mjs
+++ b/scripts/check-prose.mjs
@@ -48,6 +48,18 @@
 //                    em dash would be, and any non-ASCII dash glyph. See the
 //                    section below for why labels are held to a stricter
 //                    standard than rule 2 holds prose to.
+//   8. escaped-backtick, a `\`` in the *body* of a `<Callout>`. Inside a JS
+//                    template literal that escape is required, and nearly
+//                    every long string in these lessons is one, so the habit
+//                    travels: 285 of them reached readers across 22 files as
+//                    the literal character, `\`@app.route\`` printed with its
+//                    backticks showing instead of set as code. A callout body
+//                    is markdown, not a template literal, and markdown reads
+//                    the backslash as "print this backtick". Callout bodies
+//                    only, because that is where a line-based rule can be
+//                    certain: a template literal never starts a line with
+//                    `<Callout`. The same mistake in a table cell is real but
+//                    not detectable this cheaply.
 //
 // Scope is what a reader actually sees:
 //
@@ -316,6 +328,21 @@ export function lintSource(src, file, kind) {
   });
 
   if (kind === "mdx") {
+    // A backslash-escaped backtick in a callout body. The tags are matched at
+    // column 0, which is where MDX requires a block element's own tags to sit
+    // and where a template literal's contents never begin.
+    let inCallout = false;
+    let calloutFence = false;
+    lines.forEach((line, i) => {
+      if (/^<Callout\b/.test(line)) inCallout = true;
+      else if (/^<\/Callout>/.test(line)) inCallout = false;
+      else if (inCallout && /^\s*(```+|~~~+)/.test(line)) calloutFence = !calloutFence;
+      else if (inCallout && !calloutFence && line.includes("\\`")) {
+        add("escaped-backtick", i + 1, line.trim().slice(0, 90));
+      }
+      if (!inCallout) calloutFence = false;
+    });
+
     for (const { line, body } of blockquotes(lines)) {
       if (hasWrappingQuotes(body)) add("blockquote-quotes", line, body.slice(0, 90));
     }
@@ -397,6 +424,13 @@ if (isMain) {
           "text verbatim, so a typed `--` reaches the reader as two hyphens.",
       );
     }
+    if (byRule["escaped-backtick"]) {
+      console.error(
+        "\ncallout backticks: write a plain backtick. A callout body is\n" +
+          "markdown, not a template literal, so `\\`` reaches the reader as the\n" +
+          "character rather than as a code span.",
+      );
+    }
     if (byRule["colour-spelling"]) {
       console.error(
         "\ncolour: write it \"color\". It is a CSS property, a Plot channel and a\n" +
@@ -406,6 +440,6 @@ if (isMain) {
     process.exit(1);
   }
   console.log(
-    `✓ prose in ${files.length} file(s) is clean (no em dashes, no spaced en dashes, no filler phrases, no one-line display math, no British "colour", no doubled blockquote quotes, no stray dashes in mermaid labels)`,
+    `✓ prose in ${files.length} file(s) is clean (no em dashes, no spaced en dashes, no filler phrases, no one-line display math, no British "colour", no doubled blockquote quotes, no stray dashes in mermaid labels, no escaped backticks in callouts)`,
   );
 }


### PR DESCRIPTION
Started as one broken figure. The investigation turned up four more classes of the same underlying problem — content that renders wrong, silently — so this fixes all five and adds the checks that keep them fixed.

**284 files, 9 commits.** Every fix is paired with a linter rule, and each rule is verified by running it against `main`.

---

## 1. The box model figure

`/courses/modern-css-layout/box-model-and-sizing` reached readers as a scatter of disconnected line fragments rather than four nested boxes.

Code is set in JetBrains Mono, loaded by `next/font/google` with `subsets: ["latin"]` (`app/layout.tsx`), and that subset ends long before U+2500. Every box-drawing character fell back to whatever monospace the reader's OS supplies, at *that* font's advance width. A line's rendered width then depended on how many drawn characters it happened to contain, so rows aligned in the source arrived at different widths. A directory tree survives this (every row at a depth carries the same prefix); a free-drawn box does not.

Widening the subset would not have fixed the rest of it. A drawn figure is an image made of text: a screen reader spells the corner glyphs out one at a time, nothing reflows on a phone, and the drawing cannot take the page's colors or its theme.

### The components

`app/_components/mdx/diagrams.tsx` + `diagrams.module.css`. All four are Server Components rendering plain elements, so a lesson using one ships no extra JavaScript; they are registered statically in `mdx-components.tsx` next to `Figure` and `Chart`. They share one stylesheet, one figure wrapper and one caption treatment, and every color is a `--ds-*` token with a dark override.

| Component | What it draws |
| --- | --- |
| `BoxModel` | The four CSS layers as four genuinely nested boxes: each layer's *padding* is the band you see, and the border layer is a real `border`. Outside-in the bands are yellow, blue, green, neutral, and each carries its written name so color is never the only cue. |
| `MemoryCells` | Named memory cells joined by an inline-SVG "points at" arrow (SVG, not a glyph, so it cannot depend on the reader's fonts). An optional `note` carries the line under each box: an address, or what the byte spells. Cells wrap, so a byte-by-byte layout runs to eight boxes without scaling down. |
| `SyntaxBreakdown` | A line of source with an underbrace under each meaningful span and a phrase naming it. The braces are borders on an empty element, so each stretches to exactly the width its span occupies at the reader's font size — the part a fixed-width drawing could never do. |
| `CrcCard` | A Class-Responsibility-Collaborator index card. Capped in width on purpose: a responsibility list that overflows it is the signal the class is doing too much. |

---

## 2. Drawn figures across the corpus

| Where | Was | Now |
| --- | --- | --- |
| `modern-css-layout/box-model-and-sizing` | four nested `┌─┐│└┘` boxes | `BoxModel` |
| `c-programming-for-beginners/pointers` | three `+-----+` memory diagrams | `MemoryCells` |
| `sql-analytics-duckdb/why-window-functions` | `└────┬────┘` underbrace anatomy | `SyntaxBreakdown` |
| `c-programming-for-beginners/variables-and-memory` | `^` / `+--` read-write annotation | `SyntaxBreakdown` |
| `oop-blueprint-java/responsibility-driven-design` | CRC card in box characters | `CrcCard` |
| `typescript-from-scratch/how-typescript-works` | AST as an indented tree | mermaid `flowchart TD` |
| `python-basics/exceptions` | hierarchy inside a Python string the block printed | mermaid, and the runnable block now derives the ancestry from `__mro__` and `issubclass` — what an `except` clause actually asks |
| `java-programming-for-beginners/stack-and-heap`, `oop-blueprint-java/objects-in-memory` | 9 mermaid labels holding `●─`, `──┐`, `── ref ──▶` | words. The edge mermaid draws *is* the arrow those glyphs imitated |
| `cloudflare-cors-proxy/README.md` | request flow in `└─►│▼` | mermaid `sequenceDiagram` |

**Kept, with reasoning written down:** the six directory trees (`tree` output is universal, and the one drawn shape the font fallback does not break), caret annotations inside code comments, verbatim program and compiler output, the linked-list course's `head -> [10 | *] -> [20 | NULL]` notation (each line stands alone), source-file section dividers, and the `● ■ ▲ ▼ ◆` runs in the Plotly lessons — those *are* the marker symbols under discussion.

---

## 3. Tables typed into code fences

Pure ASCII, so no box-drawing rule sees them. They fail for their own reasons: columns held apart by literal spaces don't reflow, one longer value shifts every column after it, and the block reaches a screen reader as preformatted text rather than a table with headers.

Ten of them. Three on SQLite pages — one inside the very lesson that teaches what a table, a row and a column *are*.

`variables-and-memory` and `from-zero-to-cpp/how-computers-execute` became `MemoryCells`; the rest became markdown tables (`what-is-a-database`, `how-applications-store-information`, `spreadsheets-vs-databases`, `grouping-data`, `rows-and-columns` ×2, `data-types-and-memory`, `the-generics-revolution`, `api-design`).

Two scanner traps had to be solved before the count meant anything: a fence may carry meta (` ```csharp title="x" `), and reading that as a *closing* fence desynchronizes everything below it; and a fence closes only on a backtick run at least as long as its opener, without which the ` ````markdown ` block showing R Markdown's ` ```{r} ` chunks reads as four separate fences.

---

## 4. 285 literal backticks in callout bodies

An escaped backtick is required inside a JS template literal, and nearly every long string in these lessons is one, so the habit travelled into callout bodies — which are markdown, where the backslash means "print this backtick." A decorator name reached readers with its backticks showing instead of set as code.

Found by walking the MDX AST for `text` nodes containing a backtick, which is exactly the bug: a backtick that survived into rendered text instead of becoming `inlineCode`. **285 across 22 files.** Two needed hand-fixing: a Java table cell, and the JavaScript escape-sequence table, whose every row was double-escaped (`\\n` rendering as two backslashes) and whose backtick row never closed its code span at all.

---

## 5. Unhighlighted code, and mermaid keywords in the wrong font

**57 fences carried no language**, so they rendered grey. Eight were real Java source (`bounded-types-and-wildcards`, `type-erasure`, `generic-classes-and-methods`); the rest were output, stack traces, trees, requirements files and pseudocode, now `text`.

**129 SQL keywords in mermaid labels** were set in Inter, indistinguishable from the prose around them — in diagrams whose whole job is to point at keywords. The machinery already existed (`.diagram :global(code)` sets JetBrains Mono); it just wasn't applied. Scoped to the four SQL courses and interview SQL pages on purpose: the same word list over the whole corpus flags English — "BETWEEN groups" in ANOVA, "resample WITH replacement" in the bootstrap — and no cheap test separates them. A merge pass joins adjacent code spans so `id INTEGER PRIMARY KEY` is one piece of code, not three chips.

---

## 6. `SyntaxBreakdown` became the convention

It turns out to be the right shape wherever a construct puts several jobs on one line and the reader has to be told which is which. It lost its panel (it looked like a sibling of the runnable code blocks it sits beside, and nothing in it can be pressed), then went from 1 placement to **240 across 201 pages**. No course or interview track is without it.

| | |
| --- | --- |
| **SQL, near enough every keyword** | `intro-sql-postgres` (21), `sqlite-for-beginners` (16), `sql-analytics-duckdb` (15), `database-design-postgresql` (5) — `DISTINCT`, `AS`, `LIKE`, `ORDER BY`, `LIMIT`, aggregates, `GROUP BY`, joins, `IN`, `INSERT`/`UPDATE`/`DELETE`, `IS NULL`, `COALESCE`, `CREATE TABLE`, `BETWEEN`, `CASE`, `FILTER`, `ROW_NUMBER`, window frames, `date_trunc`, `GROUP BY ALL`, `PIVOT`/`UNPIVOT`, `QUALIFY`, `ROLLUP`, CTEs, `CHECK`, `NOT NULL`+`DEFAULT`, `UNIQUE`, `REFERENCES` |
| **Interview prep** (29) | the `OVER` clause, `QUALIFY` against `WHERE` and `HAVING`, `LAG`, a 7-day frame, `generate_series`, dbt's `is_incremental` guard, cursor pagination, rate-limit headers, a neuron's weighted sum, sample-size inputs, mini-batch slicing, `argmax`'s axis, a confidence interval's drivers, a bridge table's weight |
| **Anatomy pages** | function and method signatures in Python, C, C++, Java, R, C# and TypeScript, which all had the same heading over a template block and a bullet list saying the same thing |
| **Everywhere else** | slices, comprehensions, f-strings, `with open`, `*args`/`**kwargs`, `yield from`, `match`; `useState`, `useEffect`'s dependency array, React keys, `children`, `&&`; arrow functions, `reduce`, destructuring, `??`; `keyof`, `in` narrowing, generics; `malloc`, `realloc`, `a[i]` as pointer arithmetic, `void *`, `const` placement; the `flex` shorthand, grid tracks, combinators read right-to-left, `transform` order, `z-index`; `groupby`/`agg`, `merge`, `np.where`, `.dt`, Polars `pipe` and `when/then/otherwise`; `cross_val_score`, `GridSearchCV`, `train_test_split`; `ggplot`'s canonical call, `labs`, `theme`, seaborn's `hue` and `stat` |

Five mermaid `flowchart`s that were drawing a straight line through one statement's clauses got replaced by the breakdown — a graph doing a diagram's job.

Prose was rewritten at every insertion to lead into the figure. Where a bullet list only restated what the figure now shows it went; where it carried something a picture cannot (Java's camelCase convention, R's return-value rule) it stayed and was trimmed to that.

---

## Keeping it fixed

Four rules were added to `scripts/check-ascii-diagrams.mjs` (`npm run check:diagrams`):

1. `drawn-diagram` — runs of drawn lines that are not a directory tree
2. `ascii-box` — `+-----+` rules and `└──┬──┘` underbraces
3. `mermaid-glyph` — any drawn glyph inside a ` ```mermaid ` fence
4. `fake-table` — a rule of dashes with a header above and a row below, in a fence with no language or a prose one

It shares `mermaidLines` with `check-prose.mjs` so the two cannot disagree about where a mermaid block starts. `__tests__/asciiDiagrams.test.ts` runs it under `npm test` and pins the exemptions.

`check-prose.mjs` gains `escaped-backtick`, matching the callout tags at column 0 where a template literal's contents never begin.

**`check:mdx` gains two rules and got a lot more honest.** Its three original rules are line shapes, and line shapes have gaps: two of my own insertions left a self-closing tag with prose after it on the same line, and every rule waved it through. `next build` did not, and failed at prerender with exactly the message that script exists to pre-empt. The signal was in the build log all along: `889 lesson(s) → 20967 rows ... 2 unparsed`, reported as a count with no names and no non-zero exit. So the script now runs the real MDX parser over every lesson (~13s, not on the test path), and rejects a fence with no language.

Run against `main`, the linters report every site fixed here: 21 drawn diagrams, 58 escaped-backtick lines, 57 unlabelled fences, and the exact `advanced-sql.mdx:122:11` parse error that broke the deploy.

`AGENTS.md` gains a "Diagrams are drawn with elements, never with characters" section: the font explanation, a pick-one table, and the list of what legitimately stays drawn.

---

## Verification

- `npm test` — 1281 tests, 93 files, all passing (new `asciiDiagrams` suite, extended `proseStyle` suite)
- `npx tsc --noEmit` clean; `npm run lint` 0 errors
- `check:prose`, `check:mdx`, `check:mdx-tables` (450 tables), `check:diagrams` all green
- `check:code-blocks` on every edited Python lesson — all blocks run, including the rewritten exceptions block
- All 1,177 mermaid diagrams parsed against mermaid 11, plus the new README one (0 failures)
- Every component screenshotted on a real dev server in light and dark

Two things I could not verify locally and would flag for review: mermaid renders from a CDN this sandbox blocks, so the keyword-font change is verified by parse only; and the `SyntaxBreakdown` placements were anchored from each page's introduction section, so a few may sit slightly earlier or later than ideal relative to the runnable widget.