### PR TITLE
Render the shared site footer on the Fumadocs routes

### DIFF
--- a/app/_components/DocsFooter.tsx
+++ b/app/_components/DocsFooter.tsx
@@ -1,0 +1,42 @@
+import { HomeFooter } from "./home/HomeFooter";
+
+/**
+ * The site-wide footer (`HomeFooter`, Tabbied band and all) on the Fumadocs
+ * routes: course lessons, interview-prep pages, and the /fumadocs-dev gallery.
+ *
+ * A thin wrapper around the shared footer, but the wrapping is the point: it
+ * gives the three docs layouts one import to render and one place to state
+ * WHERE it has to be rendered, which is load-bearing.
+ *
+ * ── Rendered as a SIBLING of `DocsLayout`, after it, never as its child ──
+ *
+ * That placement is what keeps the sidebar pinned for the length of the lesson
+ * and then lets it go as the footer arrives, with no scroll listener and no
+ * measuring:
+ *
+ *   Fumadocs's layout container (`#nd-docs-layout`) is a CSS grid, and the
+ *   sidebar's column is a single grid area spanning every row of it. The
+ *   sidebar inside that area is `position: sticky` at the top and exactly one
+ *   viewport tall (`h-[calc(var(--fd-docs-height) - …)]`), so it stays pinned
+ *   while its grid area scrolls past, and unpins precisely when the grid's
+ *   bottom edge meets the bottom of the viewport. Keeping the footer outside
+ *   the grid makes the grid's bottom edge the top of the footer: the sidebar
+ *   holds still for the whole lesson, then scrolls up with the page as the
+ *   footer comes in. The table of contents, sticky in its own column the same
+ *   way, releases with it.
+ *
+ *   Passing the footer to `DocsLayout` as `children` instead makes it a grid
+ *   item, which costs both halves of that: the sidebar's area now spans it, so
+ *   the sidebar stays pinned right through the footer, and the footer is laid
+ *   into the grid's columns rather than across the page (~900px of a 1440px
+ *   window, wearing the docs content's left margin).
+ *
+ * The footer's own styling needs nothing route-specific: the shared @source
+ * list (app/tailwind.shared.css) scans `_components/home`, so the docs
+ * Tailwind root compiles the same utilities the home root does, and the
+ * layout rules that must be unlayered live in app/footer.css, which
+ * app/docs.css imports.
+ */
+export function DocsFooter() {
+  return <HomeFooter />;
+}

--- a/app/courses/[...slug]/layout.tsx
+++ b/app/courses/[...slug]/layout.tsx
@@ -21,6 +21,7 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { courseSource } from "@/lib/source";
 import { ThemePillToggleSlot } from "@/app/_components/ThemePillToggle";
 import { DocsRootProvider } from "@/app/_components/DocsRootProvider";
+import { DocsFooter } from "@/app/_components/DocsFooter";
 
 export default function CourseLessonLayout({
   children,
@@ -84,6 +85,10 @@ export default function CourseLessonLayout({
       >
         {children}
       </DocsLayout>
+      {/* Outside <DocsLayout>, deliberately: the footer sits below the docs
+          grid so the sidebar (and the TOC) stay pinned until the lesson runs
+          out and then release into it. See DocsFooter. */}
+      <DocsFooter />
     </DocsRootProvider>
   );
 }

--- a/app/docs.css
+++ b/app/docs.css
@@ -35,6 +35,14 @@
    definition (byte-identical to the one Fumadocs registers) is the one in
    effect, keeping `dark:*` utilities identical across both Tailwind roots. */
 @import "./tailwind.shared.css";
+/* The shared site footer's layout rules. These routes render the same footer
+   the rest of the site does, below the Fumadocs layout, see
+   app/_components/DocsFooter.tsx. The Tailwind utilities the footer authors
+   already compile into this root (the @source list above scans
+   `_components/home`); this adds the few rules that have to be unlayered to
+   survive, including one that counteracts the global heading rule further
+   down this file. Shared with app/home.css so both surfaces agree. */
+@import "./footer.css";
 
 /* ── Tailwind v4 border-color default hardening (intermittent black borders) ──
    Tailwind v4's preflight resets every element to `border: 0 solid`, which

--- a/app/footer.css
+++ b/app/footer.css
@@ -1,0 +1,64 @@
+/* ============================================================================
+ * footer.css, the rules the shared site footer (`HomeFooter`) needs wherever
+ * it renders.
+ * ----------------------------------------------------------------------------
+ * The footer is authored in Tailwind, and the shared @source list
+ * (app/tailwind.shared.css) scans `_components/home`, so BOTH Tailwind roots
+ * already emit its utilities, nothing here has to restate them.
+ *
+ * What does belong here is the handful of rules that must beat a *stylesheet*
+ * rather than a utility. Tailwind's utilities live in `@layer utilities`, and
+ * every unlayered rule outranks a layered one no matter which sheet the App
+ * Router ordered last (the cascade problem app/tailwind.shared.css and
+ * app/docs.css both open with). app/docs.css carries several such unlayered
+ * element rules, and on the Fumadocs routes the footer now renders *under*
+ * them; on the Tailwind routes the same sheet can leak in after a client-side
+ * navigation out of a lesson. So these are written unlayered too.
+ *
+ * Imported by app/home.css (the footer's home on the Tailwind routes) and by
+ * app/docs.css (the Fumadocs routes, see app/_components/DocsFooter.tsx), so
+ * the two surfaces lay the footer out identically.
+ * ==========================================================================*/
+
+/* Footer columns: one on mobile, two from sm, four from lg, the twelve-column
+ * bed went from 4+4+4 to 3+3+3+3 when the Playgrounds column was added. The
+ * jump to four waits for lg rather than landing at sm because the playground
+ * rows carry the longest labels in the footer ("TypeScript Playground") plus a
+ * leading icon; at sm each of four columns is ~118px and every one of them
+ * wraps.
+ *
+ * `align-items: start` because the columns are wildly uneven, the logo, then
+ * Explore over Resources, then 11 course rows, then ~14 playground rows:
+ * without it the short columns stretch and their content drifts apart down
+ * the row.
+ *
+ * Driven by this rule rather than by Tailwind grid utilities so a leaked
+ * `.grid`/`grid-cols-*` from another sheet can't collapse it to the wrong
+ * column count. */
+.ds-footer-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 2.5rem;
+}
+@media (min-width: 640px) {
+  .ds-footer-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (min-width: 1024px) {
+  .ds-footer-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+/* Column headings ("Explore", "Resources", …). They ask for Tailwind's
+ * `tracking-wide`, which app/docs.css's global `h1..h6 { letter-spacing:
+ * -0.02em }` would otherwise win against, it's unlayered and the utility
+ * isn't. Uppercase 12px labels are exactly the text that needs the extra
+ * tracking rather than the display tracking, so restate it here (same
+ * 0.025em `tracking-wide` compiles to) where being unlayered makes it hold on
+ * the docs routes and on any Tailwind route that sheet leaked into. */
+.ds-footer-grid :is(h1, h2, h3, h4, h5, h6) {
+  letter-spacing: 0.025em;
+}

--- a/app/fumadocs-dev/layout.tsx
+++ b/app/fumadocs-dev/layout.tsx
@@ -18,6 +18,7 @@ import { RootProvider } from "fumadocs-ui/provider/next";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { devSource } from "@/lib/source";
 import { ThemePillToggleSlot } from "@/app/_components/ThemePillToggle";
+import { DocsFooter } from "@/app/_components/DocsFooter";
 
 export default function FumadocsDevLayout({
   children,
@@ -73,6 +74,10 @@ export default function FumadocsDevLayout({
       >
         {children}
       </DocsLayout>
+      {/* Outside <DocsLayout>, deliberately: the footer sits below the docs
+          grid so the sidebar (and the TOC) stay pinned until the page runs out
+          and then release into it. See DocsFooter. */}
+      <DocsFooter />
     </RootProvider>
   );
 }

--- a/app/home.css
+++ b/app/home.css
@@ -24,6 +24,12 @@
  * `body`/`h1..h6` typography) still relies on them.
  * ========================================================================== */
 
+/* The shared footer's own layout rules. They used to live at the bottom of
+ * this file, scoped under `.ds-home`; they moved to their own stylesheet when
+ * the Fumadocs routes started rendering the same footer (app/docs.css imports
+ * it too), so both surfaces lay it out from one source. */
+@import "./footer.css";
+
 /* Keep the whole page, and every heading in it, on the home page's own
  * Inter styling, immune to learn.css's global `h1..h6` heading rule. */
 .ds-home,
@@ -105,36 +111,4 @@ html.dark .ds-home {
 .ds-home [data-anims="paused"],
 .ds-home [data-anims="paused"] * {
   animation-play-state: paused !important;
-}
-
-/* Footer: one column on mobile, two from sm, four from lg — the twelve-column
- * bed went from 4+4+4 to 3+3+3+3 when the Playgrounds column was added. The
- * jump to four waits for lg rather than landing at sm because the playground
- * rows carry the longest labels in the footer ("TypeScript Playground") plus a
- * leading icon; at sm each of four columns is ~118px and every one of them
- * wraps.
- *
- * `align-items: start` because the columns are wildly uneven — the logo, then
- * Explore over Resources, then 11 course rows, then ~14 playground rows:
- * without it the short columns stretch and their content drifts apart down
- * the row.
- *
- * Driven by a scoped rule (rather than Tailwind grid utilities) so a leaked
- * `.grid`/`grid-cols-*` from /learn can't collapse it back to the wrong
- * column count. */
-.ds-home .ds-footer-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  align-items: start;
-  gap: 2.5rem;
-}
-@media (min-width: 640px) {
-  .ds-home .ds-footer-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-@media (min-width: 1024px) {
-  .ds-home .ds-footer-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
 }

--- a/app/interview-prep/[...slug]/layout.tsx
+++ b/app/interview-prep/[...slug]/layout.tsx
@@ -23,6 +23,7 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { interviewSource } from "@/lib/source";
 import { ThemePillToggleSlot } from "@/app/_components/ThemePillToggle";
 import { DocsRootProvider } from "@/app/_components/DocsRootProvider";
+import { DocsFooter } from "@/app/_components/DocsFooter";
 
 export default function InterviewLayout({ children }: { children: ReactNode }) {
   return (
@@ -70,6 +71,10 @@ export default function InterviewLayout({ children }: { children: ReactNode }) {
       >
         {children}
       </DocsLayout>
+      {/* Outside <DocsLayout>, deliberately: the footer sits below the docs
+          grid so the sidebar (and the TOC) stay pinned until the page runs out
+          and then release into it. See DocsFooter. */}
+      <DocsFooter />
     </DocsRootProvider>
   );
 }

--- a/e2e/docs-footer.spec.ts
+++ b/e2e/docs-footer.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * The shared site footer on the Fumadocs routes (course lessons,
+ * interview-prep pages, /fumadocs-dev), and the sidebar behaviour that
+ * depends on where it is rendered.
+ *
+ * The footer is rendered as a SIBLING of `DocsLayout`, below Fumadocs's grid
+ * container (`#nd-docs-layout`), not as its child, see
+ * app/_components/DocsFooter.tsx. That placement is what makes the sidebar
+ * hold still for the length of the page and then let go as the footer arrives:
+ * the sidebar is `position: sticky`, one viewport tall, inside a grid area
+ * that spans the whole grid, so it unpins exactly when the grid's bottom edge,
+ * i.e. the top of the footer, reaches the bottom of the viewport.
+ *
+ * Move the footer inside `DocsLayout` and it becomes a grid item instead: the
+ * sidebar's area spans it and stays pinned right through the footer, and the
+ * footer is laid into the grid's columns rather than across the page. Those
+ * two are the regression these tests exist to catch.
+ */
+
+const DOCS_PAGE = "/fumadocs-dev";
+
+test("docs routes render the shared footer, with the Tabbied band, below the docs layout", async ({
+  page,
+}) => {
+  await page.goto(DOCS_PAGE);
+  await expect(page.locator("#nd-page")).toBeVisible();
+
+  const footer = page.locator("footer");
+  await expect(footer).toHaveCount(1);
+
+  // Below the Fumadocs grid, not inside it. Both halves matter: inside, the
+  // sticky sidebar would cover it (see the scroll test below).
+  const placement = await footer.evaluate((el) => ({
+    afterLayout: el.previousElementSibling?.id ?? null,
+    insideLayout: !!el.closest("#nd-docs-layout"),
+  }));
+  expect(placement).toEqual({
+    afterLayout: "nd-docs-layout",
+    insideLayout: false,
+  });
+
+  // The decorative Tabbied band at the top of the footer (`FooterPattern`
+  // renders it into a canvas/SVG) and the four link columns.
+  await expect(footer.locator("canvas, svg").first()).toBeAttached();
+  await expect(
+    footer.getByRole("heading", { name: "Playgrounds" }),
+  ).toBeVisible();
+
+  // The columns come from the `.ds-footer-grid` rule in app/footer.css, which
+  // app/docs.css imports; without it the grid collapses to a single column.
+  const columns = await footer
+    .locator(".ds-footer-grid")
+    .evaluate((el) => getComputedStyle(el).gridTemplateColumns.split(" ").length);
+  expect(columns).toBe(4);
+});
+
+test("docs routes: the sidebar stays pinned through the page, then releases into the footer", async ({
+  page,
+}) => {
+  await page.goto(DOCS_PAGE);
+  await expect(page.locator("#nd-page")).toBeVisible();
+
+  const probe = () =>
+    page.evaluate(() => {
+      const sidebar = document.getElementById("nd-sidebar")!;
+      const layout = document.getElementById("nd-docs-layout")!;
+      const footer = document.querySelector("footer")!;
+      return {
+        sidebarTop: Math.round(sidebar.getBoundingClientRect().top),
+        sidebarBottom: Math.round(sidebar.getBoundingClientRect().bottom),
+        layoutBottom: Math.round(layout.getBoundingClientRect().bottom),
+        footerTop: Math.round(footer.getBoundingClientRect().top),
+        // The scroll offset at which the docs grid's bottom edge reaches the
+        // bottom of the viewport, i.e. where the sidebar is due to let go.
+        releaseAt: Math.round(
+          layout.getBoundingClientRect().height - window.innerHeight,
+        ),
+        maxScroll: document.documentElement.scrollHeight - window.innerHeight,
+      };
+    });
+
+  const { maxScroll, releaseAt, footerTop } = await probe();
+  // The footer is genuinely below the fold, and the docs content is taller
+  // than the viewport, otherwise the assertions below would pass for the
+  // wrong reason.
+  expect(footerTop).toBeGreaterThan(0);
+  expect(releaseAt).toBeGreaterThan(200);
+
+  // Deep into the docs content, but before the grid runs out: still pinned.
+  await page.evaluate((y) => window.scrollTo(0, y), releaseAt - 100);
+  await page.waitForTimeout(150);
+  const middle = await probe();
+  expect(middle.sidebarTop, "sidebar must stay pinned while the page scrolls").toBe(0);
+  expect(middle.footerTop).toBeGreaterThan(0);
+
+  // At the bottom of the page it has released: it scrolled up with the docs
+  // grid instead of hanging over the footer.
+  await page.evaluate((y) => window.scrollTo(0, y), maxScroll);
+  await page.waitForTimeout(150);
+  const bottom = await probe();
+  expect(bottom.sidebarTop, "sidebar must unpin once the docs content ends").toBeLessThan(0);
+  // It comes to rest flush with the end of the docs grid, i.e. the top of the
+  // footer, rather than overlapping it.
+  expect(Math.abs(bottom.sidebarBottom - bottom.layoutBottom)).toBeLessThanOrEqual(1);
+  expect(bottom.sidebarBottom).toBeLessThanOrEqual(bottom.footerTop);
+});


### PR DESCRIPTION
The course lessons, interview-prep pages, and the `/fumadocs-dev` gallery were the only surfaces on the site with no footer: every other route already renders `HomeFooter`, Tabbied band and all. They render it now too, through a `DocsFooter` seam the three docs layouts share.

## Where it goes, and why that is the whole trick

The footer is a **sibling** of `DocsLayout`, below Fumadocs's grid container, never a child of it:

- Fumadocs's sidebar is `position: sticky`, exactly one viewport tall, inside a grid area that spans the whole grid. Keeping the footer out of that grid makes the grid's bottom edge the top of the footer, so the sidebar stays pinned for the length of the lesson and unpins precisely as the footer scrolls in — no scroll listener, no measuring. The table of contents, sticky in its own column the same way, releases with it.
- As a *child* it becomes a grid item instead, and both halves break: the sidebar's area spans it and stays pinned right through the footer, and the footer is laid into the grid's columns rather than across the page (~900px of a 1440px window, wearing the docs content's left margin). Measured, not assumed — that is what the second e2e test guards.

## Styling

Almost nothing was needed. The shared `@source` list already scans `_components/home`, so the docs Tailwind root compiles the same utilities the home root does; the footer's colors, spacing, and dark variants come out identical on both surfaces (a footer link computes `rgb(18, 18, 18)` on `/` and on a lesson alike).

The exception is the handful of rules that have to beat a *stylesheet* rather than a utility. Those move out of `home.css` into a new `app/footer.css`, imported by both roots:

- the column grid (1 / 2 / 4 columns), previously `.ds-home`-scoped and therefore unavailable to the docs bundle;
- the column headings' `tracking-wide`, which `docs.css`'s unlayered global `h1..h6 { letter-spacing: -0.02em }` would otherwise win against. Restating it unlayered also fixes it on the Tailwind routes that sheet leaks into after a client-side navigation out of a lesson.

## Verification

- New `e2e/docs-footer.spec.ts`: the footer renders below `#nd-docs-layout` with its four columns and its Tabbied band, and the sidebar stays pinned deep into the content, then comes to rest flush with the end of the docs grid rather than overlapping the footer. Both pass.
- Checked in a real browser on `/courses/<lesson>`, `/interview-prep/<role>`, and `/fumadocs-dev`, at 1440 / 800 / 390px and in both themes: four → two → one column, no horizontal overflow, pattern band present, dark mode picks up the white logo and link colors.
- `npx tsc --noEmit`, `npm run lint` (0 errors), `npx vitest run` (1281 passed, including `cssCascadeParity`), and the existing `learn-layout-cutoff` / `learn-border-color` docs-layout specs all pass.
- `e2e/mobile-menu.spec.ts` fails in this sandbox, but it fails identically on the base commit (the `/playground` routes can't fetch their WASM runtimes from jsDelivr here) — unrelated to this change.

One thing worth a reviewer's opinion: the footer brings its usual ~22 prefetching `<Link>`s to the docs routes, which deliberately turn sidebar prefetch off. They only fire once the footer is scrolled into view, and it is the same footer `/courses`, `/pricing`, and `/playground` already carry, so this keeps it consistent rather than special-casing it — say the word if you'd rather it opted out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kLEoHGTAtFfQ9uHJ7KcR9

---
_Generated by [Claude Code](https://claude.ai/code/session_016kLEoHGTAtFfQ9uHJ7KcR9)_