### PR TITLE
Mono for code in mermaid labels, and citations for figures and prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1425,6 +1425,51 @@ subgraph Hand[ "By hand" ]
 subgraph Hand["By hand"]
 ```
 
+### 8. Code inside a label is wrapped in `<code>`
+
+Code in a diagram label is set in JetBrains Mono, the same face it has in the
+code block on the same page, by wrapping that span of the label in a `<code>`
+tag. Without one it arrives in Inter, which is how `System.out` came to sit in
+an actor box in the prose face three paragraphs below the same name in a code
+block.
+
+```
+<!-- Bad -->
+flowchart LR
+    Doc[report.qmd] --> Render[quarto render]
+
+<!-- Good -->
+flowchart LR
+    Doc["<code>report.qmd</code>"] --> Render[quarto render]
+```
+
+A bracketed label that holds no quotes needs them the moment it holds a tag
+(rule 1): mermaid reads an unquoted `<` as syntax. Labels that are not
+bracketed take the tag as they are:
+
+```
+sequenceDiagram
+    participant SO as <code>System.out</code>
+    JVM->>Main: call <code>main(args)</code>
+```
+
+Class and ER diagrams need none of this: they are code end to end, so the
+renderer sets the whole diagram in mono. Everything else marks its code spans,
+including the kinds whose labels mermaid paints as SVG text rather than HTML
+(sequence, pie, gantt, journey) — those cannot carry the tag through mermaid,
+so `app/_components/mdx/mermaid.tsx` strips it before the render and puts the
+face back on the rendered text afterwards. The authoring rule is the same
+either way.
+
+Mathematical notation is not code and stays in the prose face: mermaid cannot
+typeset it, so `P(A given B)`, `y(t-1)` and `ARIMA(p, d, q)` are prose written
+in symbols.
+
+Enforced by `npm run check:mermaid-code` (`scripts/check-mermaid-code.mjs`) and
+by `__tests__/mermaidCode.test.ts`, which flag a call, a dotted name and a
+snake_case identifier left unmarked. A label that really wants the prose face
+opts out with `{/* allow-unmarked-code: why */}` on a line above the fence.
+
 ### Quick checklist before committing a Mermaid block
 
 - [ ] Every node label with special chars is quoted
@@ -1434,6 +1479,7 @@ subgraph Hand["By hand"]
 - [ ] Participant aliases contain only plain words
 - [ ] Dotted edge labels have spaces: `-. label .->`
 - [ ] `subgraph` labels have no extra spaces inside the brackets
+- [ ] Every code span in a label is wrapped in `<code>`
 
 <!-- BEGIN:nextjs-agent-rules -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -574,8 +574,9 @@ chart library shipped to the browser.
 ### The pipeline
 
 1. **Author** a spec at `charts/<slug>.mjs`. It exports `title` (the figure's
-   accessible name, required), an optional `caption`, and `render()` returning
-   `plot({...})` from `charts/_theme.mjs`.
+   accessible name, required), an optional `caption`, an optional `sources`
+   (see [Citations and sources](#citations-and-sources)), and `render()`
+   returning `plot({...})` from `charts/_theme.mjs`.
 2. **Build** — `npm run build:charts` renders every spec into
    `lib/generated/charts.js` (gitignored; its committed `.d.ts` types it). Runs
    from `dev`, `build`, and `postinstall`.
@@ -739,6 +740,67 @@ Academic-minimal, in the spirit of ggplot2's `theme_minimal()`: transparent
 panel, no frame, no tick marks, faint horizontal rules only, labels placed in
 the plot rather than in a legend, and the page's own Inter tracked slightly
 tight. Chart junk is the enemy; the data is the ink.
+
+
+## Citations and sources
+
+A lesson that reports someone else's measurement says whose. There are two
+places for that, and which one applies depends on whether the claim is made in
+prose or in a figure.
+
+### A claim in prose takes a footnote
+
+`remark-gfm` is the first plugin in fumadocs-mdx's preset (our own
+`remarkPlugins` in `source.config.ts` are appended to it), so GFM footnote
+syntax works in a lesson body with no configuration:
+
+```mdx
+The multipliers vary by an order of magnitude between studies.[^boehm]
+
+[^boehm]: Boehm, *Software Engineering Economics* (Prentice Hall, 1981).
+```
+
+It reaches the page as a superscript link and a references section at the foot
+of the lesson, styled in `app/docs.css` (fumadocs renders the section's
+"Footnotes" heading `sr-only`, which leaves the definitions looking like an
+orphaned numbered list; the stylesheet puts the heading back and rules the
+section off).
+
+### A figure takes a credit line
+
+A caption is a JSX string prop, so markdown never touches it and a `[^1]`
+written in one arrives on the page as those four characters. A figure also
+wants its credit *in place* rather than at the foot of the page: the source of
+a chart is part of reading it. Both take a `sources` list, rendered under the
+caption by `<FigureSources>`:
+
+```mdx
+<Figure slug="…" alt="…" sources={[{ text: "…", href: "https://…" }]} />
+```
+
+For a chart, put it on the **spec**, not the tag, so the credit follows the
+chart to every lesson that places it (`bug-cost-by-stage` is on three):
+
+```js
+// charts/bug-cost-by-stage.mjs
+export const sources = [
+  {
+    text: "Boehm, *Software Engineering Economics* (Prentice Hall, 1981)",
+    href: "https://openlibrary.org/works/OL6034830W",
+  },
+];
+```
+
+`text` takes the same inline markup a caption does, so a title goes in
+`*asterisks*`. `href` is optional and checked by `npm run build:charts`: prefer
+a landing page for the work itself (a publisher, Open Library, a DOI) over a
+copy that can move, and leave it off rather than link something that will rot.
+
+Cite the disagreement too where there is one. `bug-cost-by-stage` lists
+Bossavit's *The Leprechauns of Software Engineering* next to Boehm and the NIST
+report, because the most-reproduced version of that chart traces back to no
+published study anyone can find — which is exactly what the caption's "vary by
+an order of magnitude" is standing on.
 
 
 ## Registering a new MDX widget

--- a/__tests__/figureSources.test.tsx
+++ b/__tests__/figureSources.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { FigureSources } from "../app/_components/mdx/FigureSources";
+
+// The credit line under a figure. A claim made in lesson *prose* takes a GFM
+// footnote instead (remark-gfm is on by default; see app/docs.css); this is
+// for a figure, whose caption is a JSX string prop markdown never touches.
+
+/** The rendered tree as plain data: strings stay strings, elements become
+ *  `tag:<children>`, with an href appended when the element carries one. */
+function shape(node: ReactNode): unknown {
+  if (Array.isArray(node)) return node.map(shape);
+  if (isValidElement(node)) {
+    const el = node as ReactElement<{ children?: ReactNode; href?: string }>;
+    const tag = typeof el.type === "string" ? el.type : "component";
+    const label = el.props.href ? `${tag}[${el.props.href}]` : tag;
+    return { [label]: shape(el.props.children) };
+  }
+  return node;
+}
+
+/** Every string in the rendered tree, flattened, which is what the reader
+ *  actually sees regardless of how the spans nest. */
+function text(node: ReactNode): string {
+  if (typeof node === "string") return node;
+  if (Array.isArray(node)) return node.map(text).join("");
+  if (isValidElement(node)) {
+    return text((node as ReactElement<{ children?: ReactNode }>).props.children);
+  }
+  return "";
+}
+
+describe("FigureSources", () => {
+  it("renders nothing when a figure has no sources", () => {
+    expect(FigureSources({ sources: [] })).toBeNull();
+  });
+
+  it("labels one reference in the singular and several in the plural", () => {
+    expect(text(FigureSources({ sources: [{ text: "Boehm (1981)" }] }))).toContain(
+      "Source",
+    );
+    expect(
+      text(FigureSources({ sources: [{ text: "Boehm (1981)" }] })),
+    ).not.toContain("Sources");
+    expect(
+      text(
+        FigureSources({
+          sources: [{ text: "Boehm (1981)" }, { text: "NIST (2002)" }],
+        }),
+      ),
+    ).toContain("Sources");
+  });
+
+  it("links a reference that has a home and leaves one that does not as text", () => {
+    const rendered = shape(
+      FigureSources({
+        sources: [
+          { text: "Boehm (1981)", href: "https://openlibrary.org/works/OL6034830W" },
+          { text: "Internal measurement" },
+        ],
+      }),
+    );
+    const dump = JSON.stringify(rendered);
+    expect(dump).toContain("a[https://openlibrary.org/works/OL6034830W]");
+    // The unlinked one is still rendered, just not as an anchor.
+    expect(dump).toContain("Internal measurement");
+    expect((dump.match(/"a\[/g) ?? []).length).toBe(1);
+  });
+
+  it("honours the inline markup a caption takes, so a title can be italic", () => {
+    const dump = JSON.stringify(
+      shape(FigureSources({ sources: [{ text: "Boehm, *Software Engineering Economics*" }] })),
+    );
+    expect(dump).toContain("em");
+    expect(dump).not.toContain("*Software");
+  });
+
+  it("keeps every reference, so a list cannot be silently truncated", () => {
+    const sources = [
+      { text: "Boehm (1981)" },
+      { text: "NIST (2002)" },
+      { text: "Bossavit (2015)" },
+    ];
+    const rendered = text(FigureSources({ sources }));
+    for (const source of sources) expect(rendered).toContain(source.text);
+  });
+});

--- a/__tests__/mermaidCode.test.ts
+++ b/__tests__/mermaidCode.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+// Shared linter implementation also used by `npm run check:mermaid-code`.
+import {
+  diagramFiles,
+  lintFiles,
+  lintSource,
+  mermaidLabels,
+  unmarkedCode,
+} from "../scripts/check-mermaid-code.mjs";
+
+// Guards lessons against code in a diagram label that is left in the prose
+// face. A `<code>` span in a label is set in JetBrains Mono, the same face the
+// identifier has in the code block on the same page; without one, `System.out`
+// arrives in Inter. See the header of scripts/check-mermaid-code.mjs for what
+// counts as code and why the rules are narrow. Runs as part of `npm test`.
+describe("mermaid diagram labels", () => {
+  const files = diagramFiles();
+
+  it("locates the lesson corpus", () => {
+    expect(files.length).toBeGreaterThan(500);
+  });
+
+  it("marks the code in every mermaid label", () => {
+    const violations = lintFiles(files);
+    const report = violations
+      .map(
+        (v: { rule: string; file: string; line: number; detail: string }) =>
+          `  [${v.rule}] ${path.relative(process.cwd(), v.file)}:${v.line}: ${v.detail}`,
+      )
+      .join("\n");
+    expect(violations, `unmarked code in mermaid labels:\n${report}`).toEqual([]);
+  });
+
+  // --- what the rules read ------------------------------------------------
+
+  it("reads a node label out of every bracket shape mermaid spells", () => {
+    const line = 'A[plain] --> B([stadium]) --> C[(cylinder)] --> D{{hexagon}}';
+    expect(mermaidLabels(line, "flowchart")).toEqual([
+      "plain",
+      "stadium",
+      "cylinder",
+      "hexagon",
+    ]);
+  });
+
+  // The `>` closing every `-->` sits after a hyphen; reading it as the opener
+  // of an asymmetric `A>text]` node swallows the rest of the line.
+  it("does not mistake a link arrow for an asymmetric node", () => {
+    expect(mermaidLabels('D -->|Ok| E([Final result])', "flowchart")).toEqual([
+      "Final result",
+      "Ok",
+    ]);
+  });
+
+  // `A --- B` is an unlabelled link, and its closing `-` is the same character
+  // that closes a labelled `-- text ---`.
+  it("does not read a node as the label of an unlabelled link", () => {
+    const line = "A((a: 1,2,3)) --- I((4,5)) --- B((b: 4,5))";
+    expect(mermaidLabels(line, "flowchart")).not.toContain("I((4,5))");
+  });
+
+  it("reads a sequence message and a participant alias", () => {
+    expect(mermaidLabels("    participant SO as System.out", "sequenceDiagram")).toContain(
+      "System.out",
+    );
+    expect(mermaidLabels("    JVM->>Main: call main(args)", "sequenceDiagram")).toContain(
+      "call main(args)",
+    );
+  });
+
+  it("ignores style declarations, which are not labels", () => {
+    expect(mermaidLabels("    style my_node fill:#f9f", "flowchart")).toEqual([]);
+  });
+
+  // --- what counts as code ------------------------------------------------
+
+  it("flags a call, a qualified name and a snake_case identifier", () => {
+    expect(unmarkedCode("call println(x)").map((c) => c.token)).toEqual(["println("]);
+    expect(unmarkedCode("hand over Main.class").map((c) => c.token)).toEqual(["Main.class"]);
+    expect(unmarkedCode("read_csv").map((c) => c.token)).toEqual(["read_csv"]);
+  });
+
+  it("says nothing about a span that is already marked", () => {
+    expect(unmarkedCode("<code>System.out</code>")).toEqual([]);
+    expect(unmarkedCode("run <code>main()</code> now")).toEqual([]);
+  });
+
+  // A parenthetical aside is how nearly every lesson label opens a paren, and
+  // every one of them has a space in front of it.
+  it("leaves a parenthetical aside alone", () => {
+    expect(unmarkedCode("Reality (infinite detail)")).toEqual([]);
+    expect(unmarkedCode("Wide form (humans love this)")).toEqual([]);
+  });
+
+  // Mermaid cannot typeset math in a label, so notation stays in the prose
+  // face: a one-letter name in front of a paren is never a call in a lesson.
+  it("leaves mathematical notation alone", () => {
+    expect(unmarkedCode("P(A given B) = P(A)?")).toEqual([]);
+    expect(unmarkedCode("first difference: y(t) - y(t-1)")).toEqual([]);
+    expect(unmarkedCode("ARIMA(p, d, q)")).toEqual([]);
+    expect(unmarkedCode("Poisson(lambda)")).toEqual([]);
+  });
+
+  it("leaves a full stop and a product name alone", () => {
+    expect(unmarkedCode("The program ends. That is it.")).toEqual([]);
+    expect(unmarkedCode("Node.js released")).toEqual([]);
+  });
+
+  // The domain half of a sample address is data, not an identifier.
+  it("leaves an email address alone", () => {
+    expect(unmarkedCode("ada@example.com")).toEqual([]);
+  });
+
+  it("reads no label out of a class or ER diagram, which render in mono", () => {
+    const src = ["```mermaid", "classDiagram", "  class Dog {", "    +bark()", "  }", "```"].join(
+      "\n",
+    );
+    expect(lintSource(src, "x.mdx")).toEqual([]);
+  });
+
+  it("honours an opt-out above the fence", () => {
+    const body = ["```mermaid", "flowchart LR", "  A[read_csv] --> B[done]", "```"].join("\n");
+    expect(lintSource(body, "x.mdx")).not.toEqual([]);
+    expect(lintSource(`{/* allow-unmarked-code: why */}\n${body}`, "x.mdx")).toEqual([]);
+  });
+});

--- a/app/_components/mdx/Chart.tsx
+++ b/app/_components/mdx/Chart.tsx
@@ -29,6 +29,7 @@ import type { CSSProperties } from "react";
 import { ChartLine } from "lucide-react";
 import chartManifest from "@/lib/generated/charts";
 import { withInlineMarkup } from "./inlineMarkup";
+import { FigureSources, type FigureSource } from "./FigureSources";
 import ChartExpand from "./ChartExpand";
 import styles from "./Chart.module.css";
 
@@ -50,13 +51,20 @@ interface ChartProps {
    */
   caption?: string | null;
   /**
+   * Where the chart's numbers came from, rendered as a credit line under the
+   * caption. Defaults to the spec's own `sources` export, which is where it
+   * belongs when the same chart is placed on several lessons; pass `null` to
+   * render none, or a list here to override.
+   */
+  sources?: readonly FigureSource[] | null;
+  /**
    * Optional cap on display width in px. Omitted by default so the chart
    * fills the content column.
    */
   maxWidth?: number;
 }
 
-export function Chart({ slug, caption, maxWidth }: ChartProps) {
+export function Chart({ slug, caption, sources, maxWidth }: ChartProps) {
   const entry = chartManifest[slug];
 
   if (!entry) {
@@ -73,6 +81,7 @@ export function Chart({ slug, caption, maxWidth }: ChartProps) {
   }
 
   const text = caption === undefined ? entry.caption : caption;
+  const credits = (sources === undefined ? entry.sources : sources) ?? [];
 
   return (
     <figure
@@ -99,9 +108,12 @@ export function Chart({ slug, caption, maxWidth }: ChartProps) {
           dangerouslySetInnerHTML={{ __html: entry.svg }}
         />
       </ChartExpand>
-      {text ? (
+      {/* One <figcaption> per <figure>: the credit line renders inside it
+          rather than as a second one. */}
+      {text || credits.length > 0 ? (
         <figcaption className={styles.caption}>
-          {withInlineMarkup(text)}
+          {text ? withInlineMarkup(text) : null}
+          <FigureSources sources={credits} />
         </figcaption>
       ) : null}
       {SHOW_CHART_ID ? (

--- a/app/_components/mdx/Figure.tsx
+++ b/app/_components/mdx/Figure.tsx
@@ -32,6 +32,7 @@
 import { ImageIcon } from "lucide-react";
 import imageManifest from "@/lib/generated/images";
 import { withInlineMarkup } from "./inlineMarkup";
+import { FigureSources, type FigureSource } from "./FigureSources";
 import styles from "./Figure.module.css";
 
 const PUBLIC_BASE = "/images";
@@ -63,6 +64,13 @@ interface FigureProps {
    */
   caption?: string;
   /**
+   * Where the image or the data behind it came from, rendered as a credit
+   * line under the caption. The pipeline illustrations are the site's own, so
+   * most figures need none; a photograph, a screenshot of someone else's
+   * software, or a redrawn figure does.
+   */
+  sources?: readonly FigureSource[];
+  /**
    * Optional cap on display width in px. Omitted by default so the figure
    * fills the full content width; pass a value only to deliberately hold a
    * single figure narrower than the column.
@@ -76,6 +84,7 @@ export function Figure({
   slug,
   alt,
   caption,
+  sources = [],
   maxWidth,
   priority = false,
 }: FigureProps) {
@@ -104,7 +113,7 @@ export function Figure({
 
   // The last format is the <img> fallback; any earlier ones are <source>s.
   const fallback = entry.formats[entry.formats.length - 1];
-  const sources = entry.formats.slice(0, -1);
+  const altFormats = entry.formats.slice(0, -1);
 
   return (
     <figure
@@ -112,7 +121,7 @@ export function Figure({
       style={maxWidth ? { maxWidth: `${maxWidth}px` } : undefined}
     >
       <picture>
-        {sources.map((ext) => (
+        {altFormats.map((ext) => (
           <source
             key={ext}
             srcSet={`${PUBLIC_BASE}/${slug}.${ext}`}
@@ -130,9 +139,12 @@ export function Figure({
           fetchPriority={priority ? "high" : "auto"}
         />
       </picture>
-      {caption ? (
+      {/* One <figcaption> per <figure>: the credit line renders inside it
+          rather than as a second one. */}
+      {caption || sources.length > 0 ? (
         <figcaption className={styles.caption}>
-          {withInlineMarkup(caption)}
+          {caption ? withInlineMarkup(caption) : null}
+          <FigureSources sources={sources} />
         </figcaption>
       ) : null}
       {/* Regeneration handle. The prompt id is the slug with the `-cutout`

--- a/app/_components/mdx/FigureSources.module.css
+++ b/app/_components/mdx/FigureSources.module.css
@@ -1,0 +1,53 @@
+/* The credit line under a figure. Rendered inside the figure's own
+   <figcaption> (a <figure> may hold only one), so it inherits the caption's
+   centering and muted color and only has to set what differs: a size below the
+   caption's, and a little air between the two. */
+.sources {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--color-fd-muted-foreground);
+}
+
+/* A figure may carry a credit and no caption, and then this is the only line
+   in the figcaption and the air above it would be dead space. */
+.sources:only-child {
+  margin-top: 0;
+}
+
+/* "Source" / "Sources". Set apart from the references themselves so the eye
+   can skip the whole line, which is what a reader who is not chasing a
+   citation wants to do. */
+.label {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.label::after {
+  content: ":";
+  margin-right: 0.35em;
+}
+
+/* References run on rather than stacking: two or three short ones are a line
+   of text, and a list would give the credit more weight on the page than the
+   figure it credits. The separator is a middot on every entry but the first,
+   and it is decorative, so it is drawn rather than typed. */
+.entry + .entry::before {
+  content: "·";
+  margin: 0 0.45em;
+  opacity: 0.6;
+}
+
+.sources a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
+  text-underline-offset: 0.2em;
+  transition: color 0.12s, text-decoration-color 0.12s;
+}
+
+.sources a:hover {
+  color: var(--color-fd-primary);
+  text-decoration-color: currentColor;
+}

--- a/app/_components/mdx/FigureSources.tsx
+++ b/app/_components/mdx/FigureSources.tsx
@@ -1,0 +1,73 @@
+/**
+ * The credit line under a figure: where its numbers came from.
+ *
+ * ```mdx
+ * <Chart
+ *   slug="bug-cost-by-stage"
+ *   sources={[
+ *     { text: "Boehm, *Software Engineering Economics* (1981)", href: "https://…" },
+ *   ]}
+ * />
+ * ```
+ *
+ * A chart spec usually carries its own (`export const sources` in
+ * `charts/<slug>.mjs`), so the credit travels with the figure to every lesson
+ * that embeds it rather than being re-typed on each one — `bug-cost-by-stage`
+ * appears on three.
+ *
+ * ## Why this is not a footnote
+ *
+ * GFM footnotes work in a lesson body (`remark-gfm` is first in the fumadocs
+ * preset), and a claim made in *prose* should use one: the reference belongs
+ * at the foot of the page with a numbered link back to the sentence. A figure
+ * is different in two ways. Its caption is a JSX string prop, which markdown
+ * never touches, so a `[^1]` written in one arrives on the page as those four
+ * characters. And a figure is a quotation of someone's data: the credit is
+ * part of reading it, not an aside to look up later, which is why this renders
+ * in place under the caption.
+ *
+ * A Server Component rendering plain elements, like the rest of the figure
+ * family, so a lesson using one ships no extra JavaScript.
+ */
+import { withInlineMarkup } from "./inlineMarkup";
+import styles from "./FigureSources.module.css";
+
+export interface FigureSource {
+  /**
+   * How the reference reads on the page: author, title, publisher, year. The
+   * same inline markup a caption takes, so a title goes in `*asterisks*` and
+   * an identifier in backticks.
+   */
+  text: string;
+  /**
+   * Where it lives, when it has a stable public home. Prefer a landing page
+   * for the work itself (a publisher, Open Library, a DOI) over a copy that
+   * can move; omit it rather than link something that will rot.
+   */
+  href?: string;
+}
+
+export function FigureSources({ sources }: { sources: readonly FigureSource[] }) {
+  if (sources.length === 0) return null;
+
+  return (
+    <span className={styles.sources}>
+      <span className={styles.label}>
+        {sources.length > 1 ? "Sources" : "Source"}
+      </span>
+      {sources.map((source, i) => (
+        <span className={styles.entry} key={`${source.href ?? source.text}-${i}`}>
+          {source.href ? (
+            <a href={source.href} target="_blank" rel="noreferrer">
+              {withInlineMarkup(source.text)}
+            </a>
+          ) : (
+            withInlineMarkup(source.text)
+          )}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export default FigureSources;

--- a/app/_components/mdx/mermaid.module.css
+++ b/app/_components/mdx/mermaid.module.css
@@ -36,6 +36,18 @@
   white-space: inherit;
 }
 
+/* Code runs inside an SVG <text> label. Sequence, pie and gantt diagrams paint
+   their labels as SVG text rather than as HTML, so an author's <code> tag
+   cannot reach the DOM as an element (Mermaid writes it out as literal
+   characters). mermaid.tsx strips the tag before the render and splits the
+   rendered text node back into <tspan>s afterwards; this is the class it puts
+   on the code runs, and it names the same face as the <code> rule above.
+   Applies to both the inline diagram and the fullscreen stage. */
+.codeSpan {
+  font-family: var(--font-mono), "JetBrains Mono", "Fira Code", ui-monospace,
+    SFMono-Regular, Menlo, monospace;
+}
+
 /* Render the diagram at its natural (intrinsic) size, centered in the column.
    Mermaid emits the SVG with width="100%" plus an inline `max-width:<W>px`
    cap equal to the diagram's intrinsic width. Leaving that cap intact keeps

--- a/app/_components/mdx/mermaid.tsx
+++ b/app/_components/mdx/mermaid.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useId,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -125,17 +126,70 @@ function resolvedStacks(): { sans: string; mono: string } {
   };
 }
 
-// Class diagrams (class names, fields, method signatures) and ER diagrams (tables,
-// typed columns, keys) are entirely code, so they render wholesale in mono. Other
-// types stay sans, flowcharts tag individual code spans with <code> instead, and
-// state/sequence/mindmap/timeline labels are prose. Detected from the first line.
-function isCodeDiagram(chart: string): boolean {
+/** The keyword the chart opens with (`flowchart`, `sequenceDiagram`, …), read
+ *  off the first line that is neither blank nor a `%%` comment. */
+function diagramKeyword(chart: string): string {
   const first = chart
     .replace(/\\n/g, "\n")
     .split("\n")
     .map((l) => l.trim())
-    .find(Boolean);
-  return first != null && /^(classDiagram(?:-v2)?|erDiagram)\b/.test(first);
+    .find((l) => l && !l.startsWith("%%"));
+  return first ?? "";
+}
+
+// Class diagrams (class names, fields, method signatures) and ER diagrams (tables,
+// typed columns, keys) are entirely code, so they render wholesale in mono. Other
+// types stay sans and tag individual code spans with <code> instead.
+function isCodeDiagram(chart: string): boolean {
+  return /^(classDiagram(?:-v2)?|erDiagram)\b/.test(diagramKeyword(chart));
+}
+
+/**
+ * Diagram kinds whose labels Mermaid paints as SVG `<text>` rather than as
+ * HTML in a `<foreignObject>`.
+ *
+ * A flowchart, class, state, ER or mindmap label goes through Mermaid's HTML
+ * label path, so an author's `<code>` tag survives into the DOM as an element
+ * and mermaid.module.css sets it in the mono face. These kinds instead hand
+ * the label to d3's `.text()`, which writes it as a text node: by the time it
+ * reaches the page the tag is not markup, it is the literal characters
+ * `<code>System.out</code>` sitting inside the actor box. That is how the
+ * sequence diagram on `java-programming-for-beginners/your-first-java-program`
+ * came to show `System.out` in Inter — there was no way to ask for anything
+ * else. (Checked against mermaid 11.16.1, including `sequence.textPlacement:
+ * "fo"`, whose foreignObject path calls `.text()` too, so it escapes the tag
+ * just the same.)
+ *
+ * For these, `stripCodeTags` takes the tags out before Mermaid measures the
+ * label, and `applyCodeFont` puts the mono face back on the rendered text.
+ */
+const SVG_TEXT_LABELS =
+  /^(sequenceDiagram|pie\b|gantt|journey|quadrantChart|xychart|sankey|gitGraph)/;
+
+function hasSvgTextLabels(chart: string): boolean {
+  return SVG_TEXT_LABELS.test(diagramKeyword(chart));
+}
+
+/**
+ * Remove the `<code>` markers from a chart, returning the plain chart Mermaid
+ * should measure and render plus the text of every span that was marked.
+ *
+ * The spans are matched back against the rendered text by value rather than by
+ * position: Mermaid rewrites labels on the way through (it splits on `<br/>`,
+ * wraps long text, drops the participant alias) and there is no id on the
+ * output to carry an index. Matching on the string is what survives all of
+ * that, and a code span is a distinctive enough run (`System.out`,
+ * `println("Hello, Java!")`) that a chance collision would have to be a label
+ * quoting the identifier it is naming, which is the same face either way.
+ */
+function stripCodeTags(chart: string): { chart: string; spans: string[] } {
+  const spans: string[] = [];
+  const plain = chart.replace(/<code>([\s\S]*?)<\/code>/gi, (_, inner: string) => {
+    const text = inner.trim();
+    if (text) spans.push(text);
+    return inner;
+  });
+  return { chart: plain, spans };
 }
 
 // Mermaid init directive that switches a single diagram to the mono face. It
@@ -555,6 +609,122 @@ function adaptNodes(root: Element | null, isDark: boolean): void {
   });
 }
 
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/**
+ * Put the mono face back on the code spans of a diagram whose labels are SVG
+ * text (see SVG_TEXT_LABELS), by splitting each rendered text node into
+ * `<tspan>`s and marking the runs the author wrapped in `<code>`.
+ *
+ * A `<tspan>` with no `x` of its own continues the text chunk it sits in, so
+ * the runs stay on one line and a `text-anchor: middle` label stays centered
+ * on the same point it was centered on before, which is what keeps a message
+ * over its arrow and an actor's name inside its box.
+ *
+ * Mermaid measured the label in the sans face, so a code run is painted a
+ * little wider than the width the layout reserved for it (JetBrains Mono's
+ * advance is roughly a sixth wider than Inter's at the same size). Sequence
+ * diagrams absorb that on their own: an actor box is at least 150px wide
+ * against names that measure well under 100, and a message label is
+ * free-floating text centered over its arrow, so the growth is split evenly to
+ * either side rather than pushing anything. What it can do is push a label
+ * past the edge of the SVG, which is a hard clip, so `growToFitText` widens
+ * the viewport afterwards. Nothing here moves a shape, for the same reason
+ * `adaptNodes` does not: the layout is Mermaid's and re-deriving it from the
+ * outside goes wrong in more ways than it fixes.
+ *
+ * Idempotent: a run split by an earlier pass is already inside a marked
+ * `<tspan>`, and those are skipped.
+ */
+function applyCodeFont(root: Element | null, spans: readonly string[]): void {
+  if (!root || spans.length === 0) return;
+  const doc = root.ownerDocument;
+  let split = false;
+
+  // Longest first, so `println("Hello, Java!")` claims its characters before a
+  // shorter span that happens to sit inside it.
+  const wanted = [...new Set(spans)].sort((a, b) => b.length - a.length);
+
+  const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const texts: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) texts.push(n as Text);
+
+  for (const node of texts) {
+    const text = node.nodeValue ?? "";
+    if (!text.trim()) continue;
+    const parent = node.parentElement;
+    if (!parent) continue;
+    // An HTML label already carries the author's real <code> element, which the
+    // stylesheet handles; only SVG text needs splitting.
+    if (parent.closest("foreignObject")) continue;
+    if (styles.codeSpan && parent.closest(`.${styles.codeSpan}`)) continue;
+
+    const claimed: Array<[number, number]> = [];
+    for (const span of wanted) {
+      for (let at = text.indexOf(span); at !== -1; at = text.indexOf(span, at + span.length)) {
+        const end = at + span.length;
+        if (claimed.some(([from, to]) => at < to && from < end)) continue;
+        claimed.push([at, end]);
+      }
+    }
+    if (claimed.length === 0) continue;
+    claimed.sort((a, b) => a[0] - b[0]);
+
+    const rebuilt = doc.createDocumentFragment();
+    let cursor = 0;
+    for (const [from, to] of claimed) {
+      if (from > cursor) rebuilt.appendChild(doc.createTextNode(text.slice(cursor, from)));
+      const run = doc.createElementNS(SVG_NS, "tspan");
+      run.setAttribute("class", styles.codeSpan);
+      run.textContent = text.slice(from, to);
+      rebuilt.appendChild(run);
+      cursor = to;
+    }
+    if (cursor < text.length) rebuilt.appendChild(doc.createTextNode(text.slice(cursor)));
+    node.replaceWith(rebuilt);
+    split = true;
+  }
+
+  if (split) growToFitText(root);
+}
+
+/**
+ * Widen the SVG's viewport until every label fits inside it.
+ *
+ * An SVG clips at its viewport, so a label that Mermaid sized in the sans face
+ * and `applyCodeFont` then repainted wider can lose its last characters. The
+ * gantt chart on `from-zero-to-cpp/memory-model` is the one in the lessons
+ * that does: `global_counter` runs 6px past the left edge.
+ *
+ * The `max-width` cap Mermaid writes inline grows by the same number of user
+ * units as the viewBox, so the diagram keeps its scale and only the frame
+ * around it gets bigger.
+ */
+function growToFitText(root: Element): void {
+  root.querySelectorAll("svg").forEach((svg) => {
+    const box = svg.viewBox.baseVal;
+    if (!box || box.width <= 0) return;
+
+    let left = box.x;
+    let right = box.x + box.width;
+    svg.querySelectorAll<SVGGraphicsElement>("text").forEach((text) => {
+      const bounds = text.getBBox();
+      if (bounds.width <= 0) return;
+      left = Math.min(left, bounds.x);
+      right = Math.max(right, bounds.x + bounds.width);
+    });
+
+    const grown = right - left;
+    const extra = grown - box.width;
+    if (extra <= 0.5) return;
+
+    const capped = Number.parseFloat(svg.style.maxWidth);
+    box.x = left;
+    box.width = grown;
+    if (Number.isFinite(capped)) svg.style.maxWidth = `${capped + extra}px`;
+  });
+}
+
 function MermaidContent({ chart }: { chart: string }) {
   const id = useId();
   const { resolvedTheme } = useTheme();
@@ -570,6 +740,19 @@ function MermaidContent({ chart }: { chart: string }) {
   );
 
   const stacks = resolvedStacks();
+
+  // Diagrams whose labels are SVG text cannot carry the author's <code> tag
+  // through Mermaid, so it comes out before the render and the mono face goes
+  // back on afterwards (see SVG_TEXT_LABELS / applyCodeFont). Memoised because
+  // `codeSpans` is a dependency of the fullscreen stage's callback ref, which
+  // re-injects the SVG whenever it changes identity.
+  const { chart: renderedChart, spans: codeSpans } = useMemo(
+    () =>
+      hasSvgTextLabels(chart)
+        ? stripCodeTags(chart)
+        : { chart, spans: [] as string[] },
+    [chart],
+  );
 
   mermaid.initialize({
     startOnLoad: false,
@@ -614,7 +797,7 @@ function MermaidContent({ chart }: { chart: string }) {
         }),
       );
       const prefix = isCodeDiagram(chart) ? monoDirective(stacks.mono) : "";
-      return mermaid.render(id, prefix + chart.replaceAll("\\n", "\n"));
+      return mermaid.render(id, prefix + renderedChart.replaceAll("\\n", "\n"));
     }),
   );
 
@@ -628,6 +811,7 @@ function MermaidContent({ chart }: { chart: string }) {
           if (container) {
             bindFunctions?.(container);
             adaptNodes(container, resolvedTheme === "dark");
+            applyCodeFont(container, codeSpans);
           }
         }}
         dangerouslySetInnerHTML={{ __html: svg }}
@@ -645,6 +829,7 @@ function MermaidContent({ chart }: { chart: string }) {
         <MermaidFullscreen
           svg={svg}
           isDark={resolvedTheme === "dark"}
+          codeSpans={codeSpans}
           onClose={() => setFullscreen(false)}
         />
       )}
@@ -665,10 +850,12 @@ function clamp(value: number, min: number, max: number): number {
 function MermaidFullscreen({
   svg,
   isDark,
+  codeSpans,
   onClose,
 }: {
   svg: string;
   isDark: boolean;
+  codeSpans: readonly string[];
   onClose: () => void;
 }) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
@@ -690,8 +877,9 @@ function MermaidFullscreen({
       if (!node) return;
       node.innerHTML = svg;
       adaptNodes(node, isDark);
+      applyCodeFont(node, codeSpans);
     },
-    [svg, isDark],
+    [svg, isDark, codeSpans],
   );
 
   const [scale, setScale] = useState(1);

--- a/app/_components/mdx/timeline.tsx
+++ b/app/_components/mdx/timeline.tsx
@@ -83,19 +83,38 @@ export function parseMermaidTimeline(chart: string): ParsedTimeline {
   return { title, entries };
 }
 
+/** A `<code>` span, the marker lesson authors use for code inside a diagram
+ *  label (see `applyCodeFont` in mermaid.tsx for the Mermaid-rendered side of
+ *  the same convention). Everything else in a label is plain author prose. */
+const CODE_TAG = /<code>([\s\S]*?)<\/code>/gi;
+
 /**
- * Render Mermaid `<br>` separators inside event text as real line breaks.
- * Event text is plain author prose (no HTML), so this is the only inline
- * markup we need to honour.
+ * Render one label: Mermaid's `<br>` separators become real line breaks, and a
+ * `<code>` span becomes a real `<code>` element, which `app/docs.css` sets in
+ * JetBrains Mono. Those two are the only markup a timeline label carries.
  */
-function renderEventText(text: string): ReactNode {
-  const parts = text.split(/<br\s*\/?>/i);
-  return parts.map((part, i) => (
-    <Fragment key={i}>
-      {i > 0 && <br />}
-      {part}
-    </Fragment>
-  ));
+function renderLabel(text: string): ReactNode {
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  const pushProse = (run: string, at: number) => {
+    if (!run) return;
+    run.split(/<br\s*\/?>/i).forEach((line, i) => {
+      parts.push(
+        <Fragment key={`p${at}-${i}`}>
+          {i > 0 && <br />}
+          {line}
+        </Fragment>,
+      );
+    });
+  };
+
+  for (const match of text.matchAll(CODE_TAG)) {
+    pushProse(text.slice(cursor, match.index), cursor);
+    parts.push(<code key={`c${match.index}`}>{match[1]}</code>);
+    cursor = match.index + match[0].length;
+  }
+  pushProse(text.slice(cursor), cursor);
+  return parts;
 }
 
 /**
@@ -113,7 +132,9 @@ export function Timeline({ chart }: { chart: string }) {
 
   return (
     <figure className={styles.timeline}>
-      {title && <figcaption className={styles.title}>{title}</figcaption>}
+      {title && (
+        <figcaption className={styles.title}>{renderLabel(title)}</figcaption>
+      )}
       <ol className={styles.track}>
         {entries.map((entry, i) => (
           <li
@@ -122,10 +143,10 @@ export function Timeline({ chart }: { chart: string }) {
           >
             <span className={styles.marker} aria-hidden="true" />
             <div className={styles.card}>
-              <p className={styles.period}>{entry.period}</p>
+              <p className={styles.period}>{renderLabel(entry.period)}</p>
               {entry.events.map((event, j) => (
                 <p key={j} className={styles.event}>
-                  {renderEventText(event)}
+                  {renderLabel(event)}
                 </p>
               ))}
             </div>

--- a/app/docs.css
+++ b/app/docs.css
@@ -690,3 +690,74 @@ code.hljs {
 .dark ::highlight(ds-search-match) {
   background-color: color-mix(in srgb, var(--ds-yellow-500) 28%, transparent);
 }
+
+/* ── Footnotes ───────────────────────────────────────────────────────────
+   `remark-gfm` is the first plugin in fumadocs-mdx's preset (our own
+   remarkPlugins in source.config.ts are appended to it), so GFM footnote
+   syntax works in a lesson body with no configuration:
+
+     The multipliers vary by an order of magnitude.[^boehm]
+
+     [^boehm]: Boehm, *Software Engineering Economics* (1981).
+
+   It reaches the page as a `<sup>` link and a `<section data-footnotes>` of
+   definitions at the end, which is the right shape. What it does not reach
+   the page with is a visible heading: fumadocs renders the "Footnotes" <h2>
+   with `sr-only`, so the definitions arrive as an unexplained numbered list
+   hanging off the bottom of the lesson. Undo that and give the section a
+   rule above it, so a reader can see where the lesson ends and its
+   references begin. The id beats `sr-only` on specificity.
+
+   A figure's credit line is a different thing and does not come through here:
+   a caption is a JSX string prop that markdown never touches, and the source
+   of a chart is part of reading it rather than an aside. That is
+   <FigureSources> (app/_components/mdx/FigureSources.tsx).
+   ─────────────────────────────────────────────────────────────────────── */
+.prose .footnotes {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-fd-border);
+  color: var(--color-fd-muted-foreground);
+}
+
+/* References are not body copy: set them a step below it so the lesson keeps
+   the last word. Has to name <p> and <li> rather than sit on the section,
+   because the prose rule above pins those at 1rem. */
+.prose .footnotes :where(p, li) {
+  font-size: 0.9375rem;
+  line-height: 1.7;
+}
+
+.prose .footnotes #footnote-label {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0 0 1rem;
+  padding: 0;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+  white-space: normal;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-fd-muted-foreground);
+}
+
+/* The reference marker in the running text. Superscripts inherit the
+   paragraph's line-height by default, which opens the leading of the line
+   they sit on; `line-height: 0` takes the marker out of that calculation so
+   a cited sentence keeps the rhythm of the paragraph around it. */
+.prose [data-footnote-ref] {
+  padding-left: 0.1em;
+  font-size: 0.75em;
+  line-height: 0;
+  text-decoration: none;
+}
+
+/* The ↩ that jumps back to the sentence. */
+.prose [data-footnote-backref] {
+  margin-left: 0.4em;
+  text-decoration: none;
+}

--- a/charts/bug-cost-by-stage.mjs
+++ b/charts/bug-cost-by-stage.mjs
@@ -12,6 +12,13 @@
  * study's numbers, which vary by an order of magnitude depending on what is
  * counted. What is not in dispute is that the axis is logarithmic, and that
  * the first two bars are the ones a type system moves work into.
+ *
+ * Bossavit is in the sources deliberately. The single most-reproduced version
+ * of this chart, a table of 1x/6.5x/15x/100x attributed to an "IBM Systems
+ * Sciences Institute", is one of the leprechauns his book chases: it is cited
+ * everywhere and traces back to no published study anyone can find. Citing the
+ * critique next to the measurements is what earns the caption's hedge, and it
+ * is why the bars here are drawn as a shape rather than as four decimals.
  */
 import { Plot, plot, ACCENT, HALO, MUTED, PRIMARY } from "./_theme.mjs";
 
@@ -30,6 +37,21 @@ const STAGES = [
 const MAX = STAGES.at(-1).cost;
 
 export const caption = `The cost of a defect is the fix plus everything that happened between writing it and finding it, which is why the axis is logarithmic. A static type checker does not catch every bug; what it does is move a whole class of them from the right-hand end of this chart to the left-hand end, where a fix costs a keystroke and no one else's day. The multipliers vary by an order of magnitude between studies; the shape does not.`;
+
+export const sources = [
+  {
+    text: "Boehm, *Software Engineering Economics* (Prentice Hall, 1981)",
+    href: "https://openlibrary.org/works/OL6034830W",
+  },
+  {
+    text: "RTI for NIST, *The Economic Impacts of Inadequate Infrastructure for Software Testing*, Planning Report 02-3 (2002)",
+    href: "https://www.nist.gov/document/report02-3pdf",
+  },
+  {
+    text: "Bossavit, *The Leprechauns of Software Engineering* (2015), on their provenance",
+    href: "https://leanpub.com/leprechauns",
+  },
+];
 
 export function render() {
   return plot({

--- a/content/courses/beginners-javascript/birth-of-javascript.mdx
+++ b/content/courses/beginners-javascript/birth-of-javascript.mdx
@@ -4,8 +4,8 @@ description: Why programming languages exist, why the early web desperately need
 ---
 
 In May 1995, a programmer named Brendan Eich wrote a programming
-language in **ten days**. Today that language runs on every phone,
-laptop, server farm, and smart television on Earth. It is, by most
+language in **ten days**.[^hopl-js] Today that language runs on every
+phone, laptop, server farm, and smart television on Earth. It is, by most
 measures, the most widely used programming language ever created,
 and it was built in less time than most teams spend naming a
 project.
@@ -114,8 +114,9 @@ computing, in miniature. Now: why did a language like this end up
 
 ## The web before JavaScript
 
-In the late 1980s, a researcher at CERN named **Tim Berners-Lee**
-designed a system for sharing scientific documents. It had three
+In the late 1980s, a researcher at CERN named **Tim
+Berners-Lee**[^proposal] designed a system for sharing scientific
+documents. It had three
 pieces we still use today: **HTML** (documents with links),
 **HTTP** (a way to ask another computer for a document), and
 **URLs** (a way to name any document anywhere). That is *all* the
@@ -293,8 +294,8 @@ Microsoft noticed. In 1996 they reverse-engineered the language and
 shipped their own version, **JScript**, in Internet Explorer 3. Two
 similar-but-not-identical implementations in two warring browsers
 was a nightmare for developers, so the language was submitted to a
-standards body, **Ecma International**. The standardized language
-was named **ECMAScript**, "JavaScript" was trademarked, and
+standards body, **Ecma International**.[^ecma] The standardized
+language was named **ECMAScript**, "JavaScript" was trademarked, and
 politics demanded a different word. To this day the specification
 says ECMAScript and everyone on Earth says JavaScript.
 
@@ -362,3 +363,24 @@ tours the surprising places JavaScript runs today.
 
 Knowing this history makes JavaScript's mix of Java-flavoured syntax and Scheme-style flexibility much easier to understand.`}
 />
+
+[^hopl-js]:
+    Allen Wirfs-Brock and Brendan Eich,
+    [*JavaScript: The First 20 Years*](https://zenodo.org/records/3707008)
+    (HOPL IV, 2020). A 190-page history co-written by the language's
+    designer, and the source to prefer over any retelling: it is
+    careful about what "ten days" covers (a working prototype, not the
+    finished language) and about which decisions were his rather than
+    Netscape's.
+
+[^proposal]:
+    Tim Berners-Lee,
+    [*Information Management: A Proposal*](https://www.w3.org/History/1989/proposal.html)
+    (CERN, March 1989). His manager's note on the front page reads
+    "Vague but exciting."
+
+[^ecma]:
+    [ECMA-262](https://ecma-international.org/publications-and-standards/standards/ecma-262/),
+    first edition June 1997. Ecma publishes every edition free, so the
+    specification behind the language is one click away, which is not
+    true of most standards a working programmer relies on.

--- a/content/courses/beginners-javascript/promises-and-async-await.mdx
+++ b/content/courses/beginners-javascript/promises-and-async-await.mdx
@@ -34,8 +34,8 @@ changes.
 ```mermaid
 stateDiagram-v2
     [*] --> pending
-    pending --> fulfilled: resolve(value)
-    pending --> rejected: reject(error)
+    pending --> fulfilled: <code>resolve(value)</code>
+    pending --> rejected: <code>reject(error)</code>
     fulfilled --> [*]
     rejected --> [*]
 ```
@@ -427,7 +427,7 @@ sequenceDiagram
     participant Caller
     participant AsyncFn as async function
     participant Promise
-    Caller->>AsyncFn: call()
+    Caller->>AsyncFn: <code>call()</code>
     AsyncFn->>Promise: await ...
     AsyncFn-->>Caller: returns a pending Promise
     Promise-->>AsyncFn: settles → resume as microtask

--- a/content/courses/c-programming-for-beginners/compilation-and-execution.mdx
+++ b/content/courses/c-programming-for-beginners/compilation-and-execution.mdx
@@ -240,7 +240,7 @@ least one definition per used symbol, no more, no less.
 
 ```mermaid
 flowchart TD
-    H["greetings.h<br/>void <code>say_hello(...)</code>"] -->|included by| M["<code>main.c</code>"]
+    H["<code>greetings.h</code><br/>void <code>say_hello(...)</code>"] -->|included by| M["<code>main.c</code>"]
     H -->|included by| G["<code>greetings.c</code>"]
     G -->|defines| BODY["body of<br/><code>say_hello</code>"]
     M -->|calls| BODY

--- a/content/courses/c-programming-for-beginners/story-of-c.mdx
+++ b/content/courses/c-programming-for-beginners/story-of-c.mdx
@@ -33,8 +33,8 @@ Babbage** designed mechanical machines, the *Difference Engine* and
 the *Analytical Engine*, that could in principle calculate
 automatically by turning gears, and his collaborator **Ada Lovelace**
 wrote what is widely considered the first algorithm intended for a
-machine. The machines were never fully built in their lifetimes, but
-the idea was planted: one machine, fed a list of instructions, could
+machine.[^lovelace] The machines were never fully built in their
+lifetimes, but the idea was planted: one machine, fed a list of instructions, could
 perform *any* calculation.
 
 Electricity made it real. Machines like **ENIAC** (1945) and the
@@ -164,15 +164,15 @@ Several deliberate decisions made C uniquely well suited to its job:
    different vendors.
 
 In 1973, Ken Thompson and Dennis Ritchie rewrote the UNIX kernel in
-C. This was the first time anyone had written a serious operating
-system in a high-level language. Most experts at the time said it
+C.[^unix] This was the first time anyone had written a serious
+operating system in a high-level language. Most experts at the time said it
 couldn't be done, the result, they predicted, would be too slow and
 too bulky. They were wrong.
 
 <Callout type="info" title="The book that taught the world">
 In 1978, **Brian Kernighan and Dennis Ritchie** published a slim,
 elegant book called *The C Programming Language*, now universally
-known as **K&R**. For more than a decade it served as both the
+known as **K&R**.[^knr] For more than a decade it served as both the
 tutorial and the de-facto specification of C. It is still in print and
 still worth reading after this course.
 </Callout>
@@ -320,3 +320,24 @@ C's first big customer was UNIX itself: rewriting the UNIX kernel in C in 1973 w
 
 C and C++ dominate the layer of software that other software is built on top of: operating systems, databases, browsers, and language runtimes.`}
 />
+
+[^lovelace]:
+    L. F. Menabrea, "Sketch of the Analytical Engine Invented by
+    Charles Babbage", translated with notes by Ada Augusta, Countess of
+    Lovelace, *Scientific Memoirs* vol. 3 (1843). The programme is in
+    Note G, and Lovelace's notes run to roughly three times the length
+    of the paper she was translating.
+
+[^unix]:
+    Dennis M. Ritchie and Ken Thompson, "The UNIX Time-Sharing System",
+    *Communications of the ACM* 17(7), July 1974, the paper that
+    introduced Unix to the world and reports the kernel rewrite. Their
+    own estimate of the cost is worth knowing: the C kernel came out
+    about a third larger than the assembly one.
+
+[^knr]:
+    Brian W. Kernighan and Dennis M. Ritchie,
+    [*The C Programming Language*](https://openlibrary.org/works/OL4617640W)
+    (Prentice Hall, 1978). The first edition doubles as the language's
+    de-facto specification, which is why "K&R C" names a dialect and
+    not just a book.

--- a/content/courses/csharp-linq-functional/filtering-and-projection.mdx
+++ b/content/courses/csharp-linq-functional/filtering-and-projection.mdx
@@ -229,7 +229,7 @@ pipeline above:
 
 ```mermaid
 flowchart TD
-    O1["Order(Widget, 9.99, 3)"] --> W1{"Where: <code>Product == 'Widget'</code>"}
+    O1["<code>Order(Widget, 9.99, 3)</code>"] --> W1{"Where: <code>Product == 'Widget'</code>"}
     W1 -->|"pass"| W2{"Where: <code>Quantity &gt; 0</code>"}
     W2 -->|"pass"| S["Select: new <code>{ Price=9.99, Total=29.97 }</code>"]
     S --> R[Output]

--- a/content/courses/data-analysis-python-pandas/data-disasters.mdx
+++ b/content/courses/data-analysis-python-pandas/data-disasters.mdx
@@ -25,8 +25,8 @@ situation?", at exactly the moment it can save them.
 
 ## The Vancouver Stock Exchange index that melted (1982)
 
-When the Vancouver Stock Exchange launched a new index in 1982, it
-started, as indices do, at a round 1000.00 points. Over the next 22
+When the Vancouver Stock Exchange launched a new index in 1982,[^vse]
+it started, as indices do, at a round 1000.00 points. Over the next 22
 months the market broadly rose, and yet the index drifted
 steadily *downward*, reaching about 520. The exchange was, by its
 own published number, losing nearly half its value while the
@@ -56,7 +56,7 @@ miniature whenever floating-point arithmetic surprises us.)
 
 NASA's Mars Climate Orbiter, a spacecraft that cost roughly $327
 million, reached Mars in September 1999 and was never heard from
-again. The investigation found a heartbreakingly simple cause: one
+again.[^mco] The investigation found a heartbreakingly simple cause: one
 piece of ground software produced a thrust figure in **pound-force
 seconds** (imperial units), while the spacecraft's navigation
 software expected **newton-seconds** (metric). Nobody converted
@@ -84,7 +84,7 @@ helpful, auto-converts text that *looks* like a date into an actual
 date. Several human gene symbols look exactly like dates, the gene
 `SEPT2` becomes "2-Sep," `MARCH1` becomes "1-Mar," and so on. A
 2016 study found this corruption in roughly **one in five** genetics
-papers with Excel supplementary files. The problem was so
+papers with Excel supplementary files.[^gene-names] The problem was so
 persistent and so hard to stamp out that in 2020 the body that names
 human genes officially **renamed the affected genes**, it was
 easier to rename the biology than to fix the spreadsheets.
@@ -103,8 +103,8 @@ load, and why we read ZIP codes and IDs as strings on purpose.
 ## The London Whale and the copy-paste model (2012)
 
 In 2012 JPMorgan lost billions of dollars in the trading episode
-nicknamed the "London Whale." The post-mortem revealed that a key
-risk model ran on a chain of spreadsheets in which data was
+nicknamed the "London Whale."[^whale] The post-mortem revealed that a
+key risk model ran on a chain of spreadsheets in which data was
 **manually copied and pasted** from one sheet to another, and at
 least one formula divided by a *sum* where it should have divided by
 an *average*, understating the apparent risk. No single villain;
@@ -177,3 +177,36 @@ A "negligible" per-operation error stops being negligible when you repeat it a f
 
 Penguins' \`body_mass_g\` and \`flipper_length_mm\` are good examples of units traveling with the data.`}
 />
+
+[^vse]:
+    Reported at the time in the Canadian press and recounted since in
+    the numerical-computing literature, including Nicholas J. Higham,
+    *Accuracy and Stability of Numerical Algorithms* (SIAM, 2nd ed.
+    2002), which collects this kind of arithmetic failure. The index was
+    recomputed from scratch and reopened at roughly double its published
+    value, which is the part that makes the error legible.
+
+[^mco]:
+    *Mars Climate Orbiter Mishap Investigation Board Phase I Report*
+    (NASA, 10 November 1999). The board's finding is narrower than the
+    usual telling: the units mismatch was the proximate cause, but the
+    report spends most of its pages on the navigation-team processes
+    that let a known trajectory anomaly go unresolved for weeks. The
+    $327.6 million figure is the cost of the whole mission, orbiter and
+    lander together.
+
+[^gene-names]:
+    Mark Ziemann, Yotam Eren and Assam El-Osta,
+    ["Gene name errors are widespread in the scientific literature"](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-1044-7),
+    *Genome Biology* 17:177 (2016). The 2020 renaming was carried out by
+    the HUGO Gene Nomenclature Committee, which is the body that assigns
+    human gene symbols; `SEPT1` became `SEPTIN1` and `MARCH1` became
+    `MARCHF1` for exactly the reason the page gives.
+
+[^whale]:
+    *Report of JPMorgan Chase & Co. Management Task Force Regarding 2012
+    CIO Losses* (January 2013), the bank's own account, and the US
+    Senate Permanent Subcommittee on Investigations report
+    *JPMorgan Chase Whale Trades: A Case History of Derivatives Risks
+    and Abuses* (March 2013). The spreadsheet detail, including the
+    divide-by-sum, is in both.

--- a/content/courses/data-analysis-python-pandas/deep-history-of-data.mdx
+++ b/content/courses/data-analysis-python-pandas/deep-history-of-data.mdx
@@ -130,11 +130,11 @@ from:
 
 ```mermaid
 flowchart LR
-    A["CSV"] --> P["read_csv"]
-    B["Excel .xlsx"] --> P2["read_excel"]
-    C["JSON / API"] --> P3["read_json"]
-    D["Parquet"] --> P4["read_parquet"]
-    E["SQL database"] --> P5["read_sql"]
+    A["CSV"] --> P["<code>read_csv</code>"]
+    B["Excel .xlsx"] --> P2["<code>read_excel</code>"]
+    C["JSON / API"] --> P3["<code>read_json</code>"]
+    D["Parquet"] --> P4["<code>read_parquet</code>"]
+    E["SQL database"] --> P5["<code>read_sql</code>"]
     P --> DF[("DataFrame")]
     P2 --> DF
     P3 --> DF

--- a/content/courses/data-analysis-python-pandas/history-of-data.mdx
+++ b/content/courses/data-analysis-python-pandas/history-of-data.mdx
@@ -63,7 +63,7 @@ water pump. These were not just numbers; they were *analyses with a
 conclusion* that changed policy.
 
 One more lineage matters. In 1970 an IBM researcher named **Edgar
-F. Codd** proposed the **relational model**: store data as
+F. Codd** proposed the **relational model**:[^codd] store data as
 relations, sets of rows, each a tuple of typed values, and query
 them with a mathematical algebra. That model underlies every SQL
 database today, and Pandas quietly borrows its vocabulary. When we
@@ -333,3 +333,10 @@ Knowing the origin explains why pandas takes labeled, multi-dimensional data so 
 
 The continuity between databases and DataFrames is why the same words keep reappearing in this course.`}
 />
+
+[^codd]:
+    E. F. Codd,
+    ["A Relational Model of Data for Large Shared Data Banks"](https://www.seas.upenn.edu/~zives/03f/cis550/codd.pdf),
+    *Communications of the ACM* 13(6), June 1970. Fourteen pages, and
+    the ancestor of both the SQL you will meet later and the vocabulary
+    Pandas borrows for joins and group-bys.

--- a/content/courses/data-wrangling-python-polars/group-by-and-agg.mdx
+++ b/content/courses/data-wrangling-python-polars/group-by-and-agg.mdx
@@ -17,7 +17,7 @@ flowchart TD
     A[("one frame")] -->|split by key| B[("group: Adelie")]
     A --> C[("group: Gentoo")]
     A --> D[("group: Chinstrap")]
-    B -->|"apply: mean(mass)"| B2["one value"]
+    B -->|"apply: <code>mean(mass)</code>"| B2["one value"]
     C --> C2["one value"]
     D --> D2["one value"]
     B2 -->|combine| R[("one row per group")]

--- a/content/courses/data-wrangling-python-polars/the-four-contexts.mdx
+++ b/content/courses/data-wrangling-python-polars/the-four-contexts.mdx
@@ -15,10 +15,10 @@ of knowing Polars.
 
 ```mermaid
 flowchart LR
-    E["an expression<br/>pl.col('mass').mean()"] --> S["select()<br/>result IS the frame"]
-    E --> W["with_columns()<br/>result is ADDED to the frame"]
-    E --> F["filter()<br/>result must be Boolean, picks rows"]
-    E --> G["group_by().agg()<br/>result is computed per group"]
+    E["an expression<br/><code>pl.col('mass').mean()</code>"] --> S["<code>select()</code><br/>result IS the frame"]
+    E --> W["<code>with_columns()</code><br/>result is ADDED to the frame"]
+    E --> F["<code>filter()</code><br/>result must be Boolean, picks rows"]
+    E --> G["<code>group_by().agg()</code><br/>result is computed per group"]
 ```
 
 ## select: the result is the whole frame

--- a/content/courses/data-wrangling-python-polars/window-expressions.mdx
+++ b/content/courses/data-wrangling-python-polars/window-expressions.mdx
@@ -49,7 +49,7 @@ it. The frame still has 344 rows.
 
 ```mermaid
 flowchart LR
-    A[("344 rows")] -->|"group_by().agg()"| B[("3 rows<br/>one per species")]
+    A[("344 rows")] -->|"<code>group_by().agg()</code>"| B[("3 rows<br/>one per species")]
     A -->|".over('species')"| C[("344 rows<br/>each carrying its group value")]
 ```
 

--- a/content/courses/database-design-postgresql/check-constraints.mdx
+++ b/content/courses/database-design-postgresql/check-constraints.mdx
@@ -126,7 +126,7 @@ CHECK constraints can compare columns in the same row. For an event,
 ```mermaid
 flowchart TD
     Start["<code>start_date</code>"] --> Rule{"<code>end_date &gt; start_date</code>"}
-    End["end_date"] --> Rule
+    End["<code>end_date</code>"] --> Rule
     Rule -->|true| Valid["Valid event"]
     Rule -->|false| Invalid["Reject event"]
 ```

--- a/content/courses/database-design-postgresql/choosing-data-types.mdx
+++ b/content/courses/database-design-postgresql/choosing-data-types.mdx
@@ -105,7 +105,7 @@ names, descriptions, titles, notes. Use `VARCHAR(20)` only when "at most
 ```mermaid
 flowchart LR
     String["String value"] --> Free["No meaningful max<br/>TEXT"]
-    String --> Limited["Real max length rule<br/>VARCHAR(n)"]
+    String --> Limited["Real max length rule<br/><code>VARCHAR(n)</code>"]
 ```
 
 A product description probably does not have a meaningful database-level

--- a/content/courses/database-design-postgresql/from-ingres-to-postgresql.mdx
+++ b/content/courses/database-design-postgresql/from-ingres-to-postgresql.mdx
@@ -45,7 +45,7 @@ relational model's practical limits, among them, that commercial
 systems of the day handled only a fixed menu of simple types. In 1986
 he launched a new Berkeley project to build a database that could be
 *extended*: user-defined types, rules, smarter handling of complex
-data. He named it **POSTGRES**, literally "after Ingres."
+data. He named it **POSTGRES**, literally "after Ingres."[^postgres]
 
 <Figure
   slug="db-ingres-to-postgresql-postgres95-cutout"
@@ -125,3 +125,12 @@ rejected a bad row in this course.
 Tools shape habits. It is easier to design carefully on a database
 that takes your declared rules seriously, and now you know why this
 one does.
+
+[^postgres]:
+    Michael Stonebraker and Lawrence A. Rowe,
+    ["The Design of POSTGRES"](https://dsf.berkeley.edu/papers/ERL-M85-95.pdf)
+    (UC Berkeley ERL memo M85/95, 1986). The opening section is a list
+    of what the authors thought Ingres and the commercial relational
+    systems had got wrong, which makes it the clearest statement of why
+    the project existed at all. Stonebraker received the ACM Turing
+    Award in 2014 for this line of work.

--- a/content/courses/database-design-postgresql/the-relational-revolution.mdx
+++ b/content/courses/database-design-postgresql/the-relational-revolution.mdx
@@ -43,7 +43,7 @@ program, and only programmers could ask questions at all.
 Edgar F. "Ted" Codd was a British-born mathematician working at
 IBM's San Jose research laboratory. In June 1970 he published
 "A Relational Model of Data for Large Shared Data Banks" in
-*Communications of the ACM*. Its core proposal sounds almost too
+*Communications of the ACM*.[^codd70] Its core proposal sounds almost too
 plain to be revolutionary: store all data in **relations**, what we
 now call tables, and connect records not with pointers but with
 *values*. An order finds its customer not by following a physical
@@ -179,11 +179,11 @@ papers and academic debate.
 To settle the performance question, IBM's San Jose lab launched the
 **System R** project in the mid-1970s: build a real, working
 relational database and see whether it could be made efficient. It
-could. System R pioneered much of the machinery production databases
-still use, and along the way two of its researchers, Donald
+could.[^systemr] System R pioneered much of the machinery production
+databases still use, and along the way two of its researchers, Donald
 Chamberlin and Raymond Boyce, designed a query language meant to be
 readable by non-programmers. They called it **SEQUEL**, Structured
-English Query Language. The name turned out to collide with a
+English Query Language.[^sequel] The name turned out to collide with a
 trademark held by an aircraft company, so the vowels were dropped,
 and the language became **SQL**.
 
@@ -213,10 +213,10 @@ become one of the longest-lived languages in all of computing.
 Codd received the Turing Award, computing's highest honor, in
 1981, cited for his fundamental contributions to database theory and
 practice. He spent much of his later career as the relational
-model's sternest defender, famously publishing twelve rules (1985)
-for what a database must do before it deserves to be called
-relational, largely because so many products had started using the
-word as a marketing label.
+model's sternest defender, famously publishing twelve rules
+(1985)[^codd-rules] for what a database must do before it deserves to
+be called relational, largely because so many products had started
+using the word as a marketing label.
 
 ## Why this matters to your designs
 
@@ -239,3 +239,30 @@ people said the same thing about the model itself.
 The next page follows the other thread of this history, the one
 that starts at Berkeley, passes through a system called Ingres, and
 ends with the engine executing your queries on this very page.
+
+[^codd70]:
+    E. F. Codd,
+    ["A Relational Model of Data for Large Shared Data Banks"](https://www.seas.upenn.edu/~zives/03f/cis550/codd.pdf),
+    *Communications of the ACM* 13(6), June 1970. Fourteen pages, and
+    worth reading once: the argument for data independence is made in
+    the first two, before any algebra appears.
+
+[^systemr]:
+    Donald D. Chamberlin et al.,
+    ["A History and Evaluation of System R"](https://people.eecs.berkeley.edu/~brewer/cs262/SystemR.pdf),
+    *Communications of the ACM* 24(10), 1981. Written by the team
+    itself, and candid about what did not work; this is also the open
+    publication that competitors read.
+
+[^sequel]:
+    Donald D. Chamberlin and Raymond F. Boyce,
+    ["SEQUEL: A Structured English Query Language"](https://www.sigmod.org/publications/dblp/db/conf/sigmod/ChamberlinB74.html),
+    ACM SIGFIDET Workshop, 1974. Boyce died later that year; the
+    trademark collision that cost the language its vowels is recounted
+    in Chamberlin's later retrospectives rather than in the paper.
+
+[^codd-rules]:
+    E. F. Codd, "Is Your DBMS Really Relational?" and "Does Your DBMS
+    Run By the Rules?", *Computerworld*, 14 and 21 October 1985. He
+    published them in a trade weekly rather than a journal on purpose:
+    the audience he wanted was the buyers being sold the word.

--- a/content/courses/database-design-postgresql/what-are-relationships.mdx
+++ b/content/courses/database-design-postgresql/what-are-relationships.mdx
@@ -54,7 +54,7 @@ points to it.
 ```mermaid
 flowchart TD
     Real["Real world:<br/>Ada placed order 101"] --> Model["Model:<br/>customer relates to order"]
-    Model --> Schema["Schema:<br/>orders.<code>customer_id</code> points to customers.id"]
+    Model --> Schema["Schema:<br/><code>orders.customer_id</code> points to <code>customers.id</code>"]
 ```
 
 The relationship is the idea. The foreign key is the database

--- a/content/courses/from-zero-to-cpp/a-brief-history.mdx
+++ b/content/courses/from-zero-to-cpp/a-brief-history.mdx
@@ -155,7 +155,7 @@ also at Bell Labs, started extending C with features inspired by an
 older language called **Simula**, a Norwegian research language
 that had pioneered the concept of *classes* and *objects*. He
 called his extension **"C with Classes"**, and by 1983 it had been
-renamed **C++** (a play on the C `++` operator, which means
+renamed **C++**[^stroustrup] (a play on the C `++` operator, which means
 *increment by one*).
 
 <Figure
@@ -335,3 +335,12 @@ syntactic detail, is what this course will teach you.
 
 Next, we'll zoom in on the machine itself: what actually happens
 when you "run" a program?
+
+[^stroustrup]:
+    Bjarne Stroustrup,
+    [*A History of C++: 1979-1991*](https://www.stroustrup.com/hopl2.pdf)
+    (HOPL II, 1993), and at book length in
+    [*The Design and Evolution of C++*](https://openlibrary.org/works/OL53182W)
+    (Addison-Wesley, 1994). Both are the designer's own account, and
+    both spend more time on the constraints he was working under than
+    on the features, which is the more useful half.

--- a/content/courses/from-zero-to-cpp/compilation-pipeline.mdx
+++ b/content/courses/from-zero-to-cpp/compilation-pipeline.mdx
@@ -205,7 +205,7 @@ flowchart LR
     M["<code>main.o</code><br/>defines: main<br/>needs: greet"] --> L[Linker]
     G["<code>greet.o</code><br/>defines: greet<br/>needs: printf"] --> L
     S["libc / libc++<br/>defines: printf,<br/><code>std::cout</code>, ..."] --> L
-    L --> E[a.out / .exe<br/>complete, runnable]
+    L --> E["<code>a.out</code> / .exe<br/>complete, runnable"]
 ```
 
 When you forget to compile a `.cpp` file, or you misspell a function

--- a/content/courses/from-zero-to-cpp/how-computers-execute.mdx
+++ b/content/courses/from-zero-to-cpp/how-computers-execute.mdx
@@ -148,7 +148,7 @@ sequenceDiagram
     participant Disk as Disk
     participant Mem as RAM
     participant CPU
-    U->>OS: Run hello.exe
+    U->>OS: Run <code>hello.exe</code>
     OS->>Disk: Read the program file
     Disk-->>OS: Bytes of the program
     OS->>Mem: Copy program into a fresh region of memory

--- a/content/courses/from-zero-to-cpp/index.mdx
+++ b/content/courses/from-zero-to-cpp/index.mdx
@@ -75,7 +75,7 @@ access matters.
 ```mermaid
 flowchart TD
     A["Your C++ source<br/><code>file.cpp</code>"] --> B[Compiler<br/>clang++ / g++]
-    B --> C[Machine code<br/>.exe / a.out]
+    B --> C["Machine code<br/>.exe / <code>a.out</code>"]
     C --> D[Operating system<br/>loads + runs]
     D --> E[CPU executes<br/>instructions]
 ```

--- a/content/courses/from-zero-to-cpp/memory-model.mdx
+++ b/content/courses/from-zero-to-cpp/memory-model.mdx
@@ -155,7 +155,7 @@ gantt
     dateFormat X
     axisFormat %s
     section Globals & statics
-    global_counter      :a1, 0, 100
+    <code>global_counter</code>      :a1, 0, 100
     section main locals
     x in main           :b1, 10, 90
     section Heap (via new)

--- a/content/courses/from-zero-to-cpp/the-call-stack.mdx
+++ b/content/courses/from-zero-to-cpp/the-call-stack.mdx
@@ -139,11 +139,11 @@ function call is a *miniature lifecycle* on the stack.
 ```mermaid
 sequenceDiagram
     participant M as main
-    participant A as add_then_triple
+    participant A as <code>add_then_triple</code>
     participant T as triple
-    M->>A: call(a=4, b=5)
+    M->>A: <code>call(a=4, b=5)</code>
     activate A
-    A->>T: call(n=9)
+    A->>T: <code>call(n=9)</code>
     activate T
     T-->>A: return 27
     deactivate T

--- a/content/courses/from-zero-to-cpp/variables-and-memory.mdx
+++ b/content/courses/from-zero-to-cpp/variables-and-memory.mdx
@@ -24,7 +24,7 @@ you are telling the compiler:
 
 ```mermaid
 flowchart LR
-    subgraph "Stack frame for main()"
+    subgraph "Stack frame for <code>main()</code>"
         X["x : int<br/>4 bytes<br/><code>value = 42</code>"]
     end
 ```

--- a/content/courses/functional-programming-typescript/category-theory-intuitions.mdx
+++ b/content/courses/functional-programming-typescript/category-theory-intuitions.mdx
@@ -98,9 +98,9 @@ identity law.
 
 ```mermaid
 flowchart TD
-    A["<code>F&lt;A&gt;</code>"] -- "map(f)" --> B["<code>F&lt;B&gt;</code>"]
-    B -- "map(g)" --> C["<code>F&lt;C&gt;</code>"]
-    A -- "map(g ∘ f)" --> C
+    A["<code>F&lt;A&gt;</code>"] -- "<code>map(f)</code>" --> B["<code>F&lt;B&gt;</code>"]
+    B -- "<code>map(g)</code>" --> C["<code>F&lt;C&gt;</code>"]
+    A -- "<code>map(g ∘ f)</code>" --> C
 ```
 
 The two paths must give the same result. Always.

--- a/content/courses/functional-programming-typescript/functional-state-management.mdx
+++ b/content/courses/functional-programming-typescript/functional-state-management.mdx
@@ -311,9 +311,9 @@ Treating state as a value gives you:
 
 ```mermaid
 flowchart TD
-    S0["State <code>t=0</code>"] -- "reducer(s, a0)" --> S1["State <code>t=1</code>"]
-    S1 -- "reducer(s, a1)" --> S2["State <code>t=2</code>"]
-    S2 -- "reducer(s, a2)" --> S3["State <code>t=3</code>"]
+    S0["State <code>t=0</code>"] -- "<code>reducer(s, a0)</code>" --> S1["State <code>t=1</code>"]
+    S1 -- "<code>reducer(s, a1)</code>" --> S2["State <code>t=2</code>"]
+    S2 -- "<code>reducer(s, a2)</code>" --> S3["State <code>t=3</code>"]
     H((history)) --> S0 & S1 & S2 & S3
 ```
 

--- a/content/courses/functional-programming-typescript/option-and-result.mdx
+++ b/content/courses/functional-programming-typescript/option-and-result.mdx
@@ -311,7 +311,7 @@ computation". Every later chapter will use it for some `M<A>`:
 
 ```mermaid
 flowchart TD
-    A["<code>M&lt;A&gt;</code>"] -- "flatMap(f)" --> B["<code>M&lt;B&gt;</code>"]
+    A["<code>M&lt;A&gt;</code>"] -- "<code>flatMap(f)</code>" --> B["<code>M&lt;B&gt;</code>"]
     A -.->|"if 'none'/'err' or empty"| B
     A -->|"if 'some'/'ok' value a"| C["f(a) = <code>M&lt;B&gt;</code>"] --> B
 ```

--- a/content/courses/functional-programming-typescript/roots-of-functional-thinking.mdx
+++ b/content/courses/functional-programming-typescript/roots-of-functional-thinking.mdx
@@ -21,8 +21,8 @@ This chapter is the cliff-notes version of that history.
 ## Lambda calculus: the math underneath
 
 In 1936, the logician **Alonzo Church** introduced the **lambda
-calculus**: a tiny formal system in which the only things that exist
-are *functions* and *applications of functions*.
+calculus**:[^church] a tiny formal system in which the only things
+that exist are *functions* and *applications of functions*.
 
 <Figure
   slug="fp-roots-lambda-calculus-cutout"
@@ -84,8 +84,8 @@ seriously.
 
 ## Lisp: functions become a programming language (1958)
 
-In 1958, **John McCarthy** designed **Lisp** at MIT. Lisp took the
-lambda calculus and turned it into a programmable language. Lists
+In 1958, **John McCarthy** designed **Lisp** at MIT.[^mccarthy] Lisp
+took the lambda calculus and turned it into a programmable language. Lists
 were the universal data structure. Code was data (you could pass
 functions around, build them at runtime, and even evaluate strings as
 programs). Recursion replaced loops.
@@ -121,7 +121,7 @@ but it became *usable* with Lisp.
 
 In 1973, **Robin Milner** designed **ML** to write proofs about
 programs. ML introduced the world to **Hindley–Milner type
-inference**, the idea that a compiler can figure out the types of
+inference**,[^milner] the idea that a compiler can figure out the types of
 your program *automatically*, even without annotations, and reject
 any program that doesn't type-check.
 
@@ -156,9 +156,10 @@ console.log(unwrapOr(none<number>(), 0));
   ]}
 />
 
-In 1990, **Haskell** went further. It is a pure, lazy, statically
-typed functional language. *Pure* means it has no side effects in
-the language itself, every function returns a value and that's it.
+In 1990, **Haskell** went further.[^haskell] It is a pure, lazy,
+statically typed functional language. *Pure* means it has no side
+effects in the language itself, every function returns a value and
+that's it.
 Effects (I/O, randomness, mutation) are modeled as *data* and
 sequenced by a special abstraction called a `Monad`. We will explore
 this idea, gently, much later.
@@ -370,3 +371,32 @@ third is the style we will spend the rest of the course mastering.
 
 The lambda calculus is the conceptual root of functional programming: it shows that "function as a value" is sufficient on its own to express all computation.`}
 />
+
+[^church]:
+    Alonzo Church, "An Unsolvable Problem of Elementary Number
+    Theory", *American Journal of Mathematics* 58(2), 1936. The lambda
+    calculus is introduced here as machinery for a proof about
+    decidability, not as a programming idea; the programming came
+    twenty years later.
+
+[^mccarthy]:
+    John McCarthy,
+    ["Recursive Functions of Symbolic Expressions and Their
+    Computation by Machine, Part I"](http://www-formal.stanford.edu/jmc/recursive.pdf),
+    *Communications of the ACM* 3(4), 1960. The language dates from
+    1958; this is the paper that describes it, and the `eval` in
+    section 4 is the one a student later hand-compiled into the first
+    Lisp interpreter.
+
+[^milner]:
+    Robin Milner,
+    ["A Theory of Type Polymorphism in Programming"](https://homepages.inf.ed.ac.uk/wadler/papers/papers-we-love/milner-type-polymorphism.pdf),
+    *Journal of Computer and System Sciences* 17(3), 1978. ML grew out
+    of Edinburgh's LCF proof assistant in the early 1970s; the
+    inference algorithm was written down formally in this paper.
+
+[^haskell]:
+    Paul Hudak, John Hughes, Simon Peyton Jones and Philip Wadler,
+    [*A History of Haskell: Being Lazy With Class*](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/07/history.pdf)
+    (HOPL III, 2007), by four of the people in the room. The committee
+    convened in 1987 and the first report is dated 1990.

--- a/content/courses/intro-data-viz-plotly/a-brief-history-of-data-pictures.mdx
+++ b/content/courses/intro-data-viz-plotly/a-brief-history-of-data-pictures.mdx
@@ -36,10 +36,10 @@ roughly 32,000 years old.
   caption="A chart was an argument from the start, and arguments invite disagreement."
 />
 
-But the first true *statistical* chart came much later. In **1644**,
-the Flemish astronomer **Michael van Langren** was wrestling with a
-fierce open problem: the longitude difference between Toledo and
-Rome. Twelve astronomers had published estimates ranging from 17° to
+But the first true *statistical* chart came much later. In
+**1644**,[^langren] the Flemish astronomer **Michael van Langren**
+was wrestling with a fierce open problem: the longitude difference
+between Toledo and Rome. Twelve astronomers had published estimates ranging from 17° to
 30°. Instead of averaging them into one false-confident number, van
 Langren drew each estimate as a dot on a single horizontal line. Here
 are his twelve values, with one thing he could not have added:
@@ -62,8 +62,9 @@ If van Langren is the great-grandfather of statistical graphics, the
 *father* is **William Playfair**, a Scottish engineer and political
 economist. In a single 1786 book, the *Commercial and Political
 Atlas*, Playfair invented or popularized the **line chart** (for
-change over time) and the **bar chart** (for comparing categories).
-A few years later, in 1801, he added the **pie chart**.
+change over time) and the **bar chart** (for comparing
+categories).[^playfair] A few years later, in 1801, he added the **pie
+chart**.[^breviary]
 
 <Figure
   slug="viz-history-playfair-cutout"
@@ -142,7 +143,7 @@ something almost unprecedented for a woman, or for anyone, in the
 mid-19th century: **she drew a chart.**
 
 The chart she published in 1858 is now famous as the **Coxcomb** or
-**rose diagram**. Each month of the war is a wedge fanning out from a
+**rose diagram**.[^nightingale] Each month of the war is a wedge fanning out from a
 center; the *area* of each wedge encodes the number of deaths, and
 the *color* encodes the cause, blue for preventable disease, red
 for wounds. The blue wedges were *enormous*. The red wedges were
@@ -204,10 +205,10 @@ claim, and it is only available because time runs left to right.
 Two contemporaries deserve a sentence each, because they round out
 the founding generation. In **1854**, physician **John Snow** mapped
 cholera deaths around the Broad Street pump in London, a founding
-act of data-driven, spatial epidemiology. And in **1869**, the
+act of data-driven, spatial epidemiology.[^snow] And in **1869**, the
 engineer **Charles Minard** drew a flow map of Napoleon's
 catastrophic 1812 Russian campaign that Edward Tufte would later
-call "probably the best statistical graphic ever drawn."
+call "probably the best statistical graphic ever drawn."[^tufte]
 
 ## From parliamentary foldouts to your browser
 
@@ -400,3 +401,40 @@ The chart's purpose was to provoke a specific *action*: clean up the hospitals. 
 
 If you remember one rule about interactive design, make it this one.`}
 />
+
+[^langren]:
+    Michael Friendly's history of statistical graphics is the standard
+    source for the claim that van Langren's 1644 diagram is the first
+    known statistical graph; see Friendly, "A Brief History of Data
+    Visualization", in *Handbook of Data Visualization* (Springer,
+    2008), and the Milestones Project he maintains.
+
+[^playfair]:
+    William Playfair, *The Commercial and Political Atlas* (London,
+    1786). Worth knowing that Playfair felt he had to argue for the
+    format at all: the book opens by explaining to the reader what a
+    chart is and why it beats a table.
+
+[^breviary]:
+    William Playfair, *The Statistical Breviary* (London, 1801), which
+    carries both the first pie chart and the first circle chart scaled
+    by area.
+
+[^nightingale]:
+    Florence Nightingale, *Notes on Matters Affecting the Health,
+    Efficiency, and Hospital Administration of the British Army*
+    (London, 1858). The diagram sits inside an 800-page statistical
+    report; she also had it printed separately so it could be handed to
+    people who would never open the report.
+
+[^snow]:
+    John Snow, *On the Mode of Communication of Cholera*, 2nd edition
+    (London, 1855), which is where the Broad Street map is published.
+    The map was drawn after Snow had already argued his case and had the
+    pump handle removed, so it is better read as evidence marshalled
+    than as a discovery made.
+
+[^tufte]:
+    Edward R. Tufte, *The Visual Display of Quantitative Information*
+    (Graphics Press, 1983), where the Minard figure is reproduced and
+    the judgement quoted here is made.

--- a/content/courses/intro-data-viz-plotly/interesting-discussions.mdx
+++ b/content/courses/intro-data-viz-plotly/interesting-discussions.mdx
@@ -28,8 +28,9 @@ dramatic gesture to the everyday language of business.
 
 The first stop on that road is a set of plates almost nobody saw for ninety
 years. For the 1900 Paris Exposition, **W.E.B. Du Bois** and his students at
-Atlanta University hand-drew sixty-odd charts on Black American life. One of
-them runs into a problem every chart of growth runs into, and answers it in a
+Atlanta University hand-drew sixty-odd charts on Black American
+life.[^dubois] One of them runs into a problem every chart of growth
+runs into, and answers it in a
 way no chart library will offer you:
 
 <Chart slug="du-bois-1900-spiral" />
@@ -63,8 +64,8 @@ timeline
     2015 : Power BI released
 ```
 
-The phrase **"business intelligence"** was coined in a 1958 IBM paper
-by Hans Peter Luhn, but it took 30 years to catch on. In the late
+The phrase **"business intelligence"** was coined in a 1958 IBM
+paper by Hans Peter Luhn,[^luhn] but it took 30 years to catch on. In the late
 1980s, the Gartner analyst **Howard Dresner** popularized it to
 describe software that let *managers*, not statisticians, ask
 questions of corporate data. Its promise has never changed:
@@ -127,7 +128,7 @@ chapter.)
 
 In **2003**, three Stanford researchers, Chris Stolte, Pat Hanrahan,
 and Christian Chabot, founded **Tableau**, based on a PhD thesis
-about a "visual query language" called VizQL. Its pitch: drag a
+about a "visual query language" called VizQL.[^polaris] Its pitch: drag a
 column onto a chart and Tableau picks a reasonable visualization.
 This was a turning point, **visualization stopped being the *output*
 of an analysis and became the *interface* to the data.** Tableau,
@@ -247,3 +248,22 @@ dashboard frameworks like **Dash** support true selection events.
 You won't need linked brushing for most beginner analysis, but it's
 worth knowing the term, you'll meet it again in any serious
 dashboard course.
+
+[^dubois]:
+    The plates are held by the Library of Congress, which has digitised
+    the full set, and are reproduced with commentary in *W. E. B. Du
+    Bois's Data Portraits: Visualizing Black America* (Princeton
+    Architectural Press, 2018).
+
+[^luhn]:
+    H. P. Luhn, "A Business Intelligence System", *IBM Journal of
+    Research and Development* 2(4), October 1958. Luhn's system is an
+    automatic document-abstracting and routing service, which is closer
+    to a search engine than to what the phrase came to mean.
+
+[^polaris]:
+    Chris Stolte, Diane Tang and Pat Hanrahan, "Polaris: A System for
+    Query, Analysis and Visualization of Multidimensional Relational
+    Databases", *IEEE Transactions on Visualization and Computer
+    Graphics* 8(1), 2002. Polaris is the research system; VizQL and
+    Tableau are what it became.

--- a/content/courses/intro-data-viz-plotly/why-plotly-express.mdx
+++ b/content/courses/intro-data-viz-plotly/why-plotly-express.mdx
@@ -62,10 +62,10 @@ precise:
 
 ```mermaid
 flowchart TB
-    PX["Plotly Express<br/>(2019, Python)"] --> PY["plotly.py<br/>(Python wrapper)"]
-    PY --> JS["Plotly.js<br/>(2015, JavaScript)"]
+    PX["Plotly Express<br/>(2019, Python)"] --> PY["<code>plotly.py</code><br/>(Python wrapper)"]
+    PY --> JS["<code>Plotly.js</code><br/>(2015, JavaScript)"]
     JS --> D3["D3.js"]
-    JS --> GL["stack.gl / WebGL"]
+    JS --> GL["<code>stack.gl</code> / WebGL"]
 ```
 
 For most of this course, "Plotly" means **Plotly Express**. It is

--- a/content/courses/intro-modern-csharp/encapsulation-and-abstraction.mdx
+++ b/content/courses/intro-modern-csharp/encapsulation-and-abstraction.mdx
@@ -145,7 +145,7 @@ owns its rules.
 
 ```mermaid
 flowchart TD
-    Out["outside code"] -->|"Deposit(50)"| API["public methods<br/>(Deposit / Withdraw)"]
+    Out["outside code"] -->|"<code>Deposit(50)</code>"| API["public methods<br/>(Deposit / Withdraw)"]
     API --> State["private state<br/>(Balance)"]
     Out -. "cannot reach" .-> State
 ```

--- a/content/courses/intro-modern-csharp/how-programs-execute.mdx
+++ b/content/courses/intro-modern-csharp/how-programs-execute.mdx
@@ -155,7 +155,7 @@ sequenceDiagram
     participant CLR as NET runtime
     participant JIT as JIT compiler
     participant CPU as CPU
-    U->>CLR: run Program.dll
+    U->>CLR: run <code>Program.dll</code>
     CLR->>CLR: load DLL, type check
     CLR->>JIT: please compile Main to native
     JIT-->>CLR: returns machine code
@@ -238,14 +238,14 @@ Here is what happens in the stack while this runs:
 sequenceDiagram
     participant Stack as Stack
     Note right of Stack: top-level statements run
-    Stack->>Stack: push frame: main_local=5
-    Note right of Stack: call Square(5)
+    Stack->>Stack: push frame: <code>main_local=5</code>
+    Note right of Stack: call <code>Square(5)</code>
     Stack->>Stack: push frame: x=5
     Stack->>Stack: compute result = 5 * 5 = 25
     Stack-->>Stack: pop Square's frame, return 25
     Note right of Stack: back in caller
     Stack->>Stack: answer = 25
-    Stack->>Stack: call Console.WriteLine with square=25
+    Stack->>Stack: call <code>Console.WriteLine</code> with <code>square=25</code>
 ```
 
 Two things to notice:

--- a/content/courses/intro-modern-csharp/inheritance-and-polymorphism.mdx
+++ b/content/courses/intro-modern-csharp/inheritance-and-polymorphism.mdx
@@ -70,10 +70,10 @@ free" because every `Dog` *is* an `Animal`.
 
 ```mermaid
 flowchart TD
-    A["Animal<br/>+ Name<br/>+ Eat()"]
-    A --> D["Dog<br/>+ Bark()"]
-    A --> C["Cat<br/>+ Purr()"]
-    A --> B["Bird<br/>+ Fly()"]
+    A["Animal<br/>+ Name<br/>+ <code>Eat()</code>"]
+    A --> D["Dog<br/>+ <code>Bark()</code>"]
+    A --> C["Cat<br/>+ <code>Purr()</code>"]
+    A --> B["Bird<br/>+ <code>Fly()</code>"]
 ```
 
 The arrow always points "up" toward the more general type. The

--- a/content/courses/intro-modern-csharp/methods-and-modularity.mdx
+++ b/content/courses/intro-modern-csharp/methods-and-modularity.mdx
@@ -134,7 +134,7 @@ That picture is worth pinning to the wall:
 sequenceDiagram
     participant Main as top level
     participant Sq as Square
-    Main->>Sq: call Square(5), new stack frame with x=5
+    Main->>Sq: call <code>Square(5)</code>, new stack frame with x=5
     Sq->>Sq: compute 5 * 5 = 25
     Sq-->>Main: return 25, frame is destroyed
     Main->>Main: continue with the 25

--- a/content/courses/intro-modern-csharp/resource-management.mdx
+++ b/content/courses/intro-modern-csharp/resource-management.mdx
@@ -42,7 +42,7 @@ the GC eventually reclaims the space:
 
 ```mermaid
 flowchart TD
-    A["new Person()"] --> H["heap allocation"]
+    A["<code>new Person()</code>"] --> H["heap allocation"]
     H --> R["program holds reference"]
     R -->|reference dropped| O["object becomes unreachable"]
     O --> G["GC reclaims memory at some later point"]
@@ -221,7 +221,7 @@ impossible to forget. Reach for it every time.
 flowchart TD
     R["resource"] --> M{"managed by GC?"}
     M -- "memory" --> GC["yes, just let the<br/>object become unreachable"]
-    M -- "file / socket / handle / lock" --> D["no, wrap usage in 'using'<br/>so Dispose() runs deterministically"]
+    M -- "file / socket / handle / lock" --> D["no, wrap usage in 'using'<br/>so <code>Dispose()</code> runs deterministically"]
 ```
 
 Beginners often misremember this and think the GC handles

--- a/content/courses/intro-modern-csharp/the-road-to-csharp.mdx
+++ b/content/courses/intro-modern-csharp/the-road-to-csharp.mdx
@@ -95,7 +95,7 @@ one corner corrupted data in another. Adding a feature broke three
 others.
 
 It got bad enough that in 1968, NATO convened a conference of
-senior engineers in Garmisch, Germany, where the industry admitted
+senior engineers in Garmisch, Germany,[^nato] where the industry admitted
 something embarrassing in public: **we do not actually know how to
 build large software reliably.** They named the problem the
 **software crisis**, and the phrase stuck.
@@ -380,3 +380,11 @@ thinking**.
 - Modern .NET dropped support for C#
   > C# remains the flagship language.`}
 />
+
+[^nato]:
+    Peter Naur and Brian Randell (eds.),
+    [*Software Engineering: Report on a Conference Sponsored by the NATO
+    Science Committee*](http://homepages.cs.ncl.ac.uk/brian.randell/NATO/nato1968.PDF),
+    Garmisch, October 1968. The transcripts are the evidence for the
+    sentence above: the participants really do say, on the record, that
+    nobody knows how to build large systems reliably.

--- a/content/courses/intro-sql-postgres/understanding-joins.mdx
+++ b/content/courses/intro-sql-postgres/understanding-joins.mdx
@@ -166,7 +166,7 @@ keeping the ones where the `ON` condition is true:
 
 ```mermaid
 flowchart TB
-    P["Consider pairings of<br/>(order, customer)"] --> T{"ON condition true?<br/>order.<code>customer_id</code> = customer.id"}
+    P["Consider pairings of<br/>(order, customer)"] --> T{"ON condition true?<br/><code>order.customer_id</code> = <code>customer.id</code>"}
     T -->|"yes"| K["Combine into<br/>one wide row"]
     T -->|"no"| D["Discard pairing"]
 ```

--- a/content/courses/intro-sql-postgres/why-sql-exists.mdx
+++ b/content/courses/intro-sql-postgres/why-sql-exists.mdx
@@ -29,7 +29,7 @@ have to restructure everything.
 Then, in June 1970, a British-born mathematician at IBM's San Jose
 research lab named **Edgar F. Codd** published a paper with the
 unglamorous title *"A Relational Model of Data for Large Shared
-Data Banks."* Its idea was radical in its simplicity: store all
+Data Banks."*[^codd70] Its idea was radical in its simplicity: store all
 data in plain tables, what mathematicians call **relations**, and
 let people ask *any* question later, in a logical language, without
 knowing or caring how the data is physically stored.
@@ -89,7 +89,7 @@ could actually work. Two researchers on the project, **Donald
 Chamberlin** and **Raymond Boyce**, designed a query language for
 it that ordinary people, not just programmers, might read and
 write. They called it **SEQUEL**: *Structured English Query
-Language*.
+Language*.[^sequel]
 
 <Figure
   slug="sql-why-sql-exists-sequel-trademark-race-ibm-inline-cutout"
@@ -339,3 +339,17 @@ A shared standard means your SQL knowledge carries over from one relational data
 
 PostgreSQL is the relational database management system this course uses to store data and run SQL.`}
 />
+
+[^codd70]:
+    E. F. Codd,
+    ["A Relational Model of Data for Large Shared Data Banks"](https://www.seas.upenn.edu/~zives/03f/cis550/codd.pdf),
+    *Communications of the ACM* 13(6), June 1970. Fourteen pages, and
+    the ancestor of every query you will write in this course.
+
+[^sequel]:
+    Donald D. Chamberlin and Raymond F. Boyce, "SEQUEL: A Structured
+    English Query Language", ACM SIGFIDET Workshop, 1974. The team's
+    own retrospective,
+    ["A History and Evaluation of System R"](https://people.eecs.berkeley.edu/~brewer/cs262/SystemR.pdf)
+    (*Communications of the ACM* 24(10), 1981), is the paper Ellison's
+    company could read, because IBM published it.

--- a/content/courses/java-collections-and-generics-deep-dive/iteration-patterns.mdx
+++ b/content/courses/java-collections-and-generics-deep-dive/iteration-patterns.mdx
@@ -276,11 +276,11 @@ sequenceDiagram
     participant Code
     participant List
     participant Iter as Iterator
-    Code->>List: iterator()
+    Code->>List: <code>iterator()</code>
     Iter->>List: record modCount = 5
-    Code->>Iter: next()
-    Code->>List: add("x")        # modCount = 6
-    Code->>Iter: next()
+    Code->>Iter: <code>next()</code>
+    Code->>List: <code>add("x")</code>        # modCount = 6
+    Code->>Iter: <code>next()</code>
     Iter-->>Code: ConcurrentModificationException
 ```
 

--- a/content/courses/java-programming-for-beginners/birth-of-oop.mdx
+++ b/content/courses/java-programming-for-beginners/birth-of-oop.mdx
@@ -255,8 +255,8 @@ flowchart TB
         M2[deposit / withdraw]
         M2 --- D2
     end
-    User[Outside code] -- "deposit(20)" --> M1
-    User -- "withdraw(10)" --> M2
+    User[Outside code] -- "<code>deposit(20)</code>" --> M1
+    User -- "<code>withdraw(10)</code>" --> M2
 ```
 
 Outside code can *ask* an account to deposit or withdraw, but it

--- a/content/courses/java-programming-for-beginners/birth-of-oop.mdx
+++ b/content/courses/java-programming-for-beginners/birth-of-oop.mdx
@@ -106,14 +106,14 @@ The most famous casualty was IBM's **OS/360**, the operating system
 for its System/360 mainframes. It consumed thousands of
 programmer-years and shipped late anyway. Its manager, **Fred
 Brooks**, distilled the experience into the 1975 classic *The
-Mythical Man-Month*, including the observation now known as
+Mythical Man-Month*,[^brooks] including the observation now known as
 **Brooks's law**: *adding manpower to a late software project makes
 it later*, because every new person multiplies the communication
 overhead among everyone else.
 
-In October 1968, NATO sponsored a conference in Garmisch, Germany,
-to confront the problem head-on. The attendees put a name to it,
-the **software crisis**, and proposed, half as aspiration, a new
+In October 1968, NATO sponsored a conference in Garmisch,
+Germany,[^nato] to confront the problem head-on. The attendees put a
+name to it, the **software crisis**, and proposed, half as aspiration, a new
 discipline to fix it: *software engineering*. The profession you are
 now entering was invented, in real time, in response to a disaster.
 
@@ -189,8 +189,9 @@ procedures. It came from a totally different way of thinking about
 what a program *is*.
 
 In 1960s Oslo, two Norwegian researchers, **Ole-Johan Dahl** and
-**Kristen Nygaard**, were building software to *simulate* physical
-systems: ships moving through a harbor, customers queuing at a bank.
+**Kristen Nygaard**,[^simula] were building software to *simulate*
+physical systems: ships moving through a harbor, customers queuing at
+a bank.
 They noticed something. The most natural way to write a simulation
 is to model each *thing in the world* as a *thing in the program*: a
 ship in the harbor becomes a `Ship` in the code, carrying its own
@@ -222,7 +223,7 @@ In the 1970s, at Xerox PARC in California, **Alan Kay** and his team
 pushed the idea to its limit in a language called **Smalltalk**:
 *everything* is an object, even numbers, even `true` and `false`,
 and objects interact only by sending each other messages. Kay coined
-the very phrase "object-oriented programming." (He later quipped, at
+the very phrase "object-oriented programming."[^kay] (He later quipped, at
 the 1997 OOPSLA conference, "I made up the term 'object-oriented',
 and I can tell you I did not have C++ in mind.") The same PARC group
 invented overlapping windows, the bitmapped graphical interface, and
@@ -316,3 +317,32 @@ In the early 1990s, all three conditions were met at once, by a
 secret project at Sun Microsystems whose actual goal was to program
 *television set-top boxes and smart appliances*. That gloriously
 sideways origin story is the next page.
+
+[^brooks]:
+    Frederick P. Brooks Jr.,
+    [*The Mythical Man-Month*](https://openlibrary.org/works/OL3510570W)
+    (Addison-Wesley, 1975). Brooks managed OS/360, so the book is a
+    participant's account rather than an outsider's diagnosis, which is
+    why it is still quoted fifty years on.
+
+[^nato]:
+    Peter Naur and Brian Randell (eds.),
+    [*Software Engineering: Report on a Conference Sponsored by the
+    NATO Science Committee*](http://homepages.cs.ncl.ac.uk/brian.randell/NATO/nato1968.PDF),
+    Garmisch, October 1968. Randell has kept the scanned proceedings
+    online ever since. The transcripts are unusually frank, and the
+    phrase "software crisis" is used in them as a description of the
+    present, not a slogan.
+
+[^simula]:
+    Ole-Johan Dahl and Kristen Nygaard, "SIMULA: an ALGOL-based
+    simulation language", *Communications of the ACM* 9(9), 1966, and
+    their own retrospective "The development of the SIMULA languages"
+    (HOPL, 1978). Both men received the ACM Turing Award in 2001 for
+    the ideas in this section.
+
+[^kay]:
+    Alan C. Kay,
+    [*The Early History of Smalltalk*](http://worrydream.com/EarlyHistoryOfSmalltalk/)
+    (HOPL II, 1993). Kay's own account of where the term came from, and
+    of how much of it he thinks the industry then got wrong.

--- a/content/courses/java-programming-for-beginners/gosling-and-java.mdx
+++ b/content/courses/java-programming-for-beginners/gosling-and-java.mdx
@@ -49,7 +49,7 @@ Hold those two pains in mind. Now for the toasters.
 ## The Green Project
 
 In 1991, a small team inside **Sun Microsystems** set up a secret
-project, code-named **Green**. The goal had nothing to do with
+project, code-named **Green**.[^green] The goal had nothing to do with
 enterprise software or the web, the web barely existed. The goal
 was software for **consumer electronics**: TVs, set-top boxes, the
 "interactive devices" that everyone in Silicon Valley believed were
@@ -230,9 +230,9 @@ what kind of computer would receive it. Sound familiar?
 
 The exact properties Java had grown for toasters, compact,
 portable, sandboxed, safe to run on a stranger's device, were
-precisely what the web needed. In 1995 Sun released Java publicly,
-along with a browser called HotJava that could run small Java
-programs ("applets") embedded in web pages. Netscape, the dominant
+precisely what the web needed. In 1995 Sun released Java
+publicly,[^java-wp] along with a browser called HotJava that could run
+small Java programs ("applets") embedded in web pages. Netscape, the dominant
 browser of the era, licensed Java within months. For the first time
 in history, clicking a link could deliver a running *program*, not
 just a page. People had never seen anything like it.
@@ -263,3 +263,18 @@ You now know *why* Java looks the way it does, why everything lives
 in a class, why there is no `delete`, why there is a virtual machine
 under your code. From here on, we set the history aside and start
 building the thinking skills the rest of the course runs on.
+
+[^green]:
+    The Green Project, the `*7` handheld it produced and the Oak
+    language that became Java are documented in Sun's own retrospective
+    materials and in Patrick Naughton's contemporaneous account. The
+    detail worth carrying forward is that the design targets (portable
+    bytecode, no pointer arithmetic, a sandbox) were chosen for set-top
+    boxes, years before anyone applied them to a browser.
+
+[^java-wp]:
+    James Gosling and Henry McGilton, *The Java Language Environment: A
+    White Paper* (Sun Microsystems, May 1996). The famous list of
+    adjectives, "simple, object-oriented, distributed, interpreted,
+    robust, secure, architecture-neutral, portable, high-performance,
+    multithreaded, dynamic", comes from this document.

--- a/content/courses/java-programming-for-beginners/how-programs-execute.mdx
+++ b/content/courses/java-programming-for-beginners/how-programs-execute.mdx
@@ -77,9 +77,9 @@ sequenceDiagram
     participant H as Heap + Stack
 
     CLI->>CL: load class "Main"
-    CL->>V: hand over Main.class bytecode
+    CL->>V: hand over <code>Main.class</code> bytecode
     V->>V: check it's well-formed and safe
-    V->>I: ok, run main()
+    V->>I: ok, run <code>main()</code>
     I->>H: allocate, push frames, run instructions
     Note over I: lazily compiles "hot" code<br/>to native via JIT
     I-->>CLI: program exits

--- a/content/courses/java-programming-for-beginners/inheritance-and-polymorphism.mdx
+++ b/content/courses/java-programming-for-beginners/inheritance-and-polymorphism.mdx
@@ -140,13 +140,13 @@ sequenceDiagram
     participant JVM
     participant C as Circle area
     participant R as Rectangle area
-    Iter->>JVM: s.area(), s is a Circle
-    JVM->>C: invoke Circle.area
+    Iter->>JVM: <code>s.area()</code>, s is a Circle
+    JVM->>C: invoke <code>Circle.area</code>
     C-->>JVM: 12.566
     JVM-->>Iter: 12.566
 
-    Iter->>JVM: s.area(), s is a Rectangle
-    JVM->>R: invoke Rectangle.area
+    Iter->>JVM: <code>s.area()</code>, s is a Rectangle
+    JVM->>R: invoke <code>Rectangle.area</code>
     R-->>JVM: 12.0
     JVM-->>Iter: 12.0
 ```

--- a/content/courses/java-programming-for-beginners/java-conquers-the-world.mdx
+++ b/content/courses/java-programming-for-beginners/java-conquers-the-world.mdx
@@ -47,7 +47,7 @@ identically on a student's laptop and the professor's office
 machine. Through the early 2000s, university after university
 switched their introductory computer science course to Java, and the
 College Board moved the **AP Computer Science** exam to Java
-starting with the 2003–04 school year.
+starting with the 2003-04 school year.[^apcs]
 
 The result was a self-reinforcing loop, and that loop, more than
 any single technical feature, is why Java remained one of the
@@ -94,7 +94,8 @@ millions of people first heard the word.
 ## Era 2: the enterprise stack (2000–2010)
 
 While applets faded in the browser, Java quietly conquered the
-server. **Servlets** (1997) let Java respond to web requests, and on
+server. **Servlets** (1997)[^servlets] let Java respond to web
+requests, and on
 top of them grew a bewildering ecosystem of enterprise standards,
 J2EE, EJB, JMS, and a parade of other acronyms. Banks, insurers,
 airlines, and government departments built entire platforms on these
@@ -226,3 +227,16 @@ Very few technology investments age that well.
 The next discussion zooms out one more step: never mind Java's
 products, how did Java change *programming itself*? The fingerprints
 are on nearly every language you will ever use.
+
+[^apcs]:
+    The College Board's AP Computer Science A exam moved from C++ to
+    Java for the 2003-04 school year; the change is recorded in its
+    course descriptions for that year. A single exam board's syllabus
+    decision is a small thing that moved a very large number of first
+    programming languages.
+
+[^servlets]:
+    The Java Servlet API was published by Sun in 1997 and became a
+    JCP-maintained specification (JSR 53 onward). Its descendants,
+    Jakarta Servlet and everything layered on it, still sit under most
+    enterprise Java on the server.

--- a/content/courses/java-programming-for-beginners/jvm-conceptually.mdx
+++ b/content/courses/java-programming-for-beginners/jvm-conceptually.mdx
@@ -103,12 +103,12 @@ sequenceDiagram
     participant JIT
     participant Native as Native code cache
     Note over Code,Native: Method first runs in interpreter
-    Code->>Interp: run method()
+    Code->>Interp: run <code>method()</code>
     Interp->>Prof: counts: this method is now "hot"
-    Prof->>JIT: please compile method()
+    Prof->>JIT: please compile <code>method()</code>
     JIT->>Native: deposit native version
     Note over Code,Native: Next call uses the native version
-    Code->>Native: run method() (fast)
+    Code->>Native: run <code>method()</code> (fast)
 ```
 
 You don't have to do anything to get this. The JVM watches your

--- a/content/courses/java-programming-for-beginners/methods-and-modularity.mdx
+++ b/content/courses/java-programming-for-beginners/methods-and-modularity.mdx
@@ -106,11 +106,11 @@ Notice:
 sequenceDiagram
     participant main
     participant square
-    main->>square: square(5)
+    main->>square: <code>square(5)</code>
     square-->>main: 25
-    main->>square: square(7)
+    main->>square: <code>square(7)</code>
     square-->>main: 49
-    main->>square: square(25 + 49) → square(74)
+    main->>square: <code>square(25 + 49)</code> → <code>square(74)</code>
     square-->>main: 5476
 ```
 

--- a/content/courses/java-programming-for-beginners/your-first-java-program.mdx
+++ b/content/courses/java-programming-for-beginners/your-first-java-program.mdx
@@ -56,11 +56,17 @@ on classes soon. For now, all you need to know is that **there is no
 such thing as a "free-standing" function in Java**. Every method
 belongs to some class.
 
-- `public`, this class is visible to any other code.
-- `class`, the keyword that declares a class.
-- `Main`, the *name* of the class. By convention class names use
-  PascalCase (capital letter for every word).
-- `{`, opens the body of the class.
+<SyntaxBreakdown
+  parts={[
+    { text: "public", label: "visible to any other code" },
+    { text: "class", label: "the keyword that declares a class" },
+    { text: "Main", label: "the name, in PascalCase" },
+    { text: "{", label: "opens the class body" },
+  ]}
+/>
+
+PascalCase means a capital letter for every word, so a class holding a
+bank account would be `BankAccount`.
 
 > By convention, the file is named exactly `Main.java`. Java is
 > picky about this: a `public class Main` *must* live in a file
@@ -75,29 +81,44 @@ exactly one method that looks (almost) exactly like this.
 
 Break it down:
 
-- `public`, callable from anywhere (including by the JVM).
-- `static`, belongs to the class itself, not to an instance. This
-  matters because the JVM needs to call `main` *before* it has
-  built any objects. (More on this in the classes chapter.)
-- `void`, returns nothing. When the method ends, the program ends.
-- `main`, the special name the JVM looks for.
-- `(String[] args)`, accepts an array of strings; the command-line
-  arguments. In our browser environment this is empty, but on a real
-  computer running `java Main hello world`, `args` would be
-  `["hello", "world"]`.
+<SyntaxBreakdown
+  parts={[
+    { text: "public", label: "callable from anywhere" },
+    { text: "static", label: "belongs to the class, not to an instance" },
+    { text: "void", label: "hands nothing back" },
+    { text: "main", label: "the name the JVM looks for" },
+    { text: "(String[] args)", label: "the command-line arguments" },
+    { text: "{", label: "opens the method body" },
+  ]}
+/>
+
+`static` is the one worth sitting with. It means the method belongs to
+the class itself rather than to any particular object, which is what
+lets the JVM call `main` *before* it has built a single object. (More
+on this in the classes chapter.) `void` means the method hands nothing
+back, and when it ends, so does the program.
+
+`args` really is filled in: run `java Main hello world` on a real
+computer and it arrives as `["hello", "world"]`. In your browser it is
+empty.
 
 ### `System.out.println("Hello, Java!");`
 
 This is the only line that *does* anything. It prints text.
 
-- `System`, a class from the Java standard library. It exposes
-  things related to the running program.
-- `out`, a field of `System` that is the standard output (the
-  console).
-- `println()`, a method on `out` that prints its argument followed by
-  a newline.
-- `"Hello, Java!"`, a **string literal**, a value of type `String`.
-- `;`, the semicolon that ends every statement in Java.
+<SyntaxBreakdown
+  parts={[
+    { text: "System", label: "a class in the standard library" },
+    { text: ".out", label: "its standard output, the console" },
+    { text: ".println(", label: "print the argument, then a newline" },
+    { text: '"Hello, Java!"', label: "a string literal, of type String" },
+    { text: ");", label: "the semicolon ends every statement" },
+  ]}
+/>
+
+Read left to right, it is a chain of ownership: `System` is a class,
+`out` is a field on it, and `println()` is a method on whatever `out`
+holds. Every dotted name in Java reads the same way.
 
 ### The closing braces
 
@@ -111,9 +132,9 @@ Java does not care about whitespace. But you very much should.
 sequenceDiagram
     participant JVM
     participant Main as Main class
-    participant SO as System.out
-    JVM->>Main: call main(args)
-    Main->>SO: println("Hello, Java!")
+    participant SO as <code>System.out</code>
+    JVM->>Main: call <code>main(args)</code>
+    Main->>SO: <code>println("Hello, Java!")</code>
     SO-->>Main: returns void
     Main-->>JVM: returns void
     Note over JVM: Program ends

--- a/content/courses/machine-learning-scikit-learn/pipelines-and-columntransformer.mdx
+++ b/content/courses/machine-learning-scikit-learn/pipelines-and-columntransformer.mdx
@@ -84,7 +84,7 @@ set, because you never touch the steps individually.
 
 ```mermaid
 flowchart LR
-    subgraph Training ["Training: pipeline.fit(X_train, y_train)"]
+    subgraph Training ["Training: <code>pipeline.fit(X_train, y_train)</code>"]
         A["<code>X_train</code>"] --> B["StandardScaler<br/>fit + transform"]
         B --> C["LogisticRegression<br/>fit"]
         C --> D["fitted pipeline"]
@@ -93,7 +93,7 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-    subgraph Prediction ["Prediction: pipeline.predict(X_new)"]
+    subgraph Prediction ["Prediction: <code>pipeline.predict(X_new)</code>"]
         E["<code>X_new</code>"] --> F["StandardScaler<br/>transform only"]
         F --> G["LogisticRegression<br/>predict"]
         G --> H["predictions"]

--- a/content/courses/machine-learning-scikit-learn/the-scikit-learn-api.mdx
+++ b/content/courses/machine-learning-scikit-learn/the-scikit-learn-api.mdx
@@ -59,7 +59,7 @@ flowchart TD
     A["Raw training data<br/>(<code>X_train</code>, <code>y_train</code>)"] -->|"<code>fit(X_train, y_train)</code>"| B["Fitted estimator<br/>(holds what it learned)"]
     C["New data<br/>(<code>X_new</code>)"] -->|"<code>predict(X_new)</code>"| B
     B --> D["Predictions<br/>(numbers, labels, or groups)"]
-    B -. "score(X_test, y_test)" .-> E["A quality number"]
+    B -. "<code>score(X_test, y_test)</code>" .-> E["A quality number"]
 ```
 
 <Callout type="tip" title="The lifecycle never changes">

--- a/content/courses/mastering-dsa-cpp/recursion.mdx
+++ b/content/courses/mastering-dsa-cpp/recursion.mdx
@@ -45,9 +45,9 @@ sequenceDiagram
     participant F2 as factorial 2
     participant F1 as factorial 1
     participant F0 as factorial 0
-    F3->>F2: needs 3 * factorial(2)
-    F2->>F1: needs 2 * factorial(1)
-    F1->>F0: needs 1 * factorial(0)
+    F3->>F2: needs 3 * <code>factorial(2)</code>
+    F2->>F1: needs 2 * <code>factorial(1)</code>
+    F1->>F0: needs 1 * <code>factorial(0)</code>
     F0-->>F1: returns 1
     F1-->>F2: returns 1
     F2-->>F3: returns 2

--- a/content/courses/mastering-ggplot2/origins-of-the-grammar.mdx
+++ b/content/courses/mastering-ggplot2/origins-of-the-grammar.mdx
@@ -16,10 +16,10 @@ real ggplot.
 
 ## A grammar, by analogy
 
-The phrase **"Grammar of Graphics"** comes from a 1999 book of the same
-name by the statistician **Leland Wilkinson**. The book is dense and
-theoretical, but its central idea is simple enough to change how you
-see every chart for the rest of your life.
+The phrase **"Grammar of Graphics"** comes from a 1999 book of the
+same name by the statistician **Leland Wilkinson**.[^wilkinson] The
+book is dense and theoretical, but its central idea is simple enough
+to change how you see every chart for the rest of your life.
 
 <Figure
   slug="gg-origins-layered-grammar-cutout"
@@ -88,7 +88,8 @@ attempt to implement Wilkinson's grammar in R. A couple of years later
 he rewrote it from scratch with a cleaner, more consistent interface.
 That rewrite is **ggplot2**, first released on CRAN, R's package archive, in 2007, and it is
 the version everyone uses today. In 2010 he described its design in a
-paper with a perfect title: *"A Layered Grammar of Graphics."*
+paper with a perfect title: *"A Layered Grammar of
+Graphics."*[^layered]
 
 So the name decodes literally: **gg** for **g**rammar of **g**raphics,
 and **2** because it is the second version, a full rewrite, not a
@@ -222,3 +223,18 @@ over traditional APIs.`}
 - Its defining trait: you describe *what a chart is*; ggplot2 handles
   *how it is drawn*. The legend is a *consequence* of a mapping, so it
   never falls out of sync.
+
+[^wilkinson]:
+    Leland Wilkinson,
+    [*The Grammar of Graphics*](https://openlibrary.org/works/OL16964990W)
+    (Springer, 1999; second edition 2005). Wilkinson wrote it while
+    building SYSTAT and later nViZn, so the grammar was an
+    implementation specification before it was a book.
+
+[^layered]:
+    Hadley Wickham,
+    ["A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf),
+    *Journal of Computational and Graphical Statistics* 19(1), 2010.
+    Reading it next to Wilkinson shows what the word "layered" is doing:
+    it is where Wickham departs from the original, not where he restates
+    it.

--- a/content/courses/natural-language-processing-python/interesting-discussions.mdx
+++ b/content/courses/natural-language-processing-python/interesting-discussions.mdx
@@ -17,8 +17,9 @@ knowing, each tied to something you now understand.
 ## 1950, Turing frames the goal
 
 Before there were any tools, there was a target. In 1950 **Alan Turing** posed
-the "imitation game", now called the **Turing test**, asking whether a machine
-could hold a text conversation indistinguishable from a human's. It reframed the
+the "imitation game", now called the **Turing test**,[^turing] asking
+whether a machine could hold a text conversation indistinguishable from
+a human's. It reframed the
 vague question "can machines think?" into something concrete and language-shaped:
 can a program *use language* convincingly? Every chatbot, assistant, and
 sentiment model since has been chasing some slice of that goal. It is worth
@@ -38,8 +39,8 @@ demonstrated machine translation, converting a few dozen Russian sentences into
 English. The demo was small and carefully chosen, but it ignited enormous
 optimism, some believed general-purpose translation was just a few years away.
 It was not. Useful translation proved far harder than the demo suggested, and
-after the sobering **ALPAC report in 1966**, much U.S. funding for machine
-translation dried up.
+after the sobering **ALPAC report in 1966**,[^alpac] much U.S. funding
+for machine translation dried up.
 
 <Figure
   slug="nlp-discussions-georgetown-ibm-cutout"
@@ -58,8 +59,8 @@ just the clean example.
 ## 1948, Shannon and the n-gram
 
 In 1948 **Claude Shannon** published "A Mathematical Theory of Communication",
-the paper that founded information theory. Tucked inside was an idea you met on
-the n-grams page: model language by the probability of the next symbol given the
+the paper that founded information theory.[^shannon] Tucked inside was
+an idea you met on the n-grams page: model language by the probability of the next symbol given the
 previous ones. Shannon even generated text by sampling letters and words
 according to those probabilities, producing eerily English-looking nonsense. That
 "predict the next token from the previous ones" framing, the **n-gram model**,
@@ -105,8 +106,8 @@ ran.
 
 ## 1966, ELIZA and the effect named after it
 
-At MIT in 1966, **Joseph Weizenbaum** wrote **ELIZA**, a program that imitated a
-Rogerian psychotherapist using nothing but simple pattern-matching and canned
+At MIT in 1966, **Joseph Weizenbaum** wrote **ELIZA**,[^eliza] a
+program that imitated a Rogerian psychotherapist using nothing but simple pattern-matching and canned
 responses, spotting a keyword and reflecting it back as a question. It had no
 understanding of anything. And yet people confided in it, attributed empathy to
 it, and asked to be left alone with it, even while knowing it was a program.
@@ -161,8 +162,9 @@ the first for the second.
 ## 1972, Spärck Jones and IDF
 
 When you ran the TF-IDF page, you used a weighting introduced by **Karen Spärck
-Jones** in 1972. Her paper argued that a term's value for retrieval should grow
-as the term becomes *rarer* across a collection, the **inverse document
+Jones** in 1972.[^sparck-jones] Her paper argued that a term's value
+for retrieval should grow as the term becomes *rarer* across a
+collection, the **inverse document
 frequency** idea. It is hard to overstate how durable this turned out to be: IDF
 sits at the heart of classic information retrieval and still shapes how search
 engines weigh your query words half a century later. A simple, well-chosen idea
@@ -291,3 +293,36 @@ Next-token prediction from prior context is the n-gram idea, traceable to Shanno
 
 This is the lineage your foundations sit in. The final page maps where you can
 take them next.
+
+[^turing]:
+    A. M. Turing, "Computing Machinery and Intelligence", *Mind* 59(236),
+    October 1950. Turing spends most of the paper answering objections
+    rather than describing the test, which takes up barely two pages.
+
+[^alpac]:
+    Automatic Language Processing Advisory Committee,
+    *Language and Machines: Computers in Translation and Linguistics*
+    (National Academy of Sciences, 1966). Its conclusion, that machine
+    translation was slower and more expensive than human translation and
+    showed no near-term prospect of improving, is the document usually
+    credited with ending the first wave of funding.
+
+[^shannon]:
+    Claude E. Shannon, "A Mathematical Theory of Communication", *Bell
+    System Technical Journal* 27, July and October 1948. The n-gram
+    text-generation experiments are in Part I, section 3, and Shannon
+    generated them by opening a book at random and copying letters,
+    which is worth picturing.
+
+[^eliza]:
+    Joseph Weizenbaum, "ELIZA: A Computer Program For the Study of
+    Natural Language Communication Between Man And Machine",
+    *Communications of the ACM* 9(1), 1966. Weizenbaum wrote his 1976
+    book *Computer Power and Human Reason* largely because he was
+    alarmed by how people reacted to it.
+
+[^sparck-jones]:
+    Karen Sparck Jones, "A Statistical Interpretation of Term Specificity
+    and Its Application in Retrieval", *Journal of Documentation* 28(1),
+    1972. Eleven pages, and the weighting is still in the default
+    configuration of every search engine you use.

--- a/content/courses/oop-blueprint-java/abstract-classes.mdx
+++ b/content/courses/oop-blueprint-java/abstract-classes.mdx
@@ -152,8 +152,8 @@ sequenceDiagram
     participant TaxReturn as TaxReturn (abstract)
     participant Concrete as USTaxReturn
 
-    Caller->>Concrete: file()
-    Note over Concrete: file() inherited from TaxReturn:<br/>1. gatherIncome()<br/>2. computeTax()<br/>3. submit()
+    Caller->>Concrete: <code>file()</code>
+    Note over Concrete: <code>file()</code> inherited from TaxReturn:<br/>1. <code>gatherIncome()</code><br/>2. <code>computeTax()</code><br/>3. <code>submit()</code>
     Concrete-->>Caller: receipt
 ```
 

--- a/content/courses/oop-blueprint-java/birth-of-oop.mdx
+++ b/content/courses/oop-blueprint-java/birth-of-oop.mdx
@@ -100,10 +100,10 @@ sequenceDiagram
     participant Cart
     participant Item
 
-    Order->>Cart: total()
-    Cart->>Item: price()
+    Order->>Cart: <code>total()</code>
+    Cart->>Item: <code>price()</code>
     Item-->>Cart: 9.99
-    Cart->>Item: price()
+    Cart->>Item: <code>price()</code>
     Item-->>Cart: 4.50
     Cart-->>Order: 14.49
 ```

--- a/content/courses/oop-blueprint-java/capstone-library-system.mdx
+++ b/content/courses/oop-blueprint-java/capstone-library-system.mdx
@@ -130,13 +130,13 @@ sequenceDiagram
     participant M as Member
     participant Loan
 
-    Caller->>L: borrow(member, book)
-    L->>P: mayBorrow(member)
-    P->>M: loanCount()
+    Caller->>L: <code>borrow(member, book)</code>
+    L->>P: <code>mayBorrow(member)</code>
+    P->>M: <code>loanCount()</code>
     M-->>P: 1
     P-->>L: true
-    L->>Loan: new Loan(book, member, due=+14d)
-    L->>M: addLoan(loan)
+    L->>Loan: <code>new Loan(book, member, due=+14d)</code>
+    L->>M: <code>addLoan(loan)</code>
     L-->>Caller: loan
 ```
 

--- a/content/courses/oop-blueprint-java/constructors-and-state.mdx
+++ b/content/courses/oop-blueprint-java/constructors-and-state.mdx
@@ -37,12 +37,12 @@ sequenceDiagram
     participant Caller
     participant JVM
     participant Heap
-    participant Constructor as "Person(...)"
+    participant Constructor as "<code>Person(...)</code>"
 
-    Caller->>JVM: new Person(Ada, 30)
+    Caller->>JVM: <code>new Person(Ada, 30)</code>
     JVM->>Heap: allocate Person
     JVM->>Constructor: run with this = newly-allocated Person
-    Constructor->>Heap: this.name = Ada, this.age = 30
+    Constructor->>Heap: <code>this.name = Ada</code>, <code>this.age = 30</code>
     Constructor-->>JVM: done
     JVM-->>Caller: reference to the initialized Person
 ```
@@ -173,8 +173,8 @@ shorter one that fills in defaults by calling the real one with
 
 ```mermaid
 flowchart TD
-    A["new Point()"] -->|delegates| C["new Point(0,0)"]
-    B["new Point(5)"] -->|delegates| C
+    A["<code>new Point()</code>"] -->|delegates| C["<code>new Point(0,0)</code>"]
+    B["<code>new Point(5)</code>"] -->|delegates| C
     C --> S["sets <code>this.x</code> and <code>this.y</code>"]
 ```
 
@@ -276,7 +276,7 @@ work.
 flowchart LR
     P["price : Money<br/><code>cents=1999</code><br/><code>currency='USD'</code>"]
     T["taxed : Money<br/><code>cents=2159</code><br/><code>currency='USD'</code>"]
-    O["new Money(160,'USD')"]
+    O["<code>new Money(160,'USD')</code>"]
 
     P -. unchanged .-> P
     O --> T

--- a/content/courses/oop-blueprint-java/gang-of-four.mdx
+++ b/content/courses/oop-blueprint-java/gang-of-four.mdx
@@ -30,7 +30,8 @@ hallways like folklore.
 
 In **1994**, four authors, **Erich Gamma, Richard Helm, Ralph
 Johnson, and John Vlissides**, published a book called
-***Design Patterns: Elements of Reusable Object-Oriented Software***.
+***Design Patterns: Elements of Reusable Object-Oriented
+Software***.[^gof]
 They became known, with affection, as the **Gang of Four**, or
 **GoF**, a tongue-in-cheek nickname borrowed from the infamous
 Chinese political faction, pinned on them because nobody wanted to
@@ -307,3 +308,10 @@ We will return to this exercise more formally later in the course.
 - Because a new class always runs faster than a \`switch\`
   > Performance is not the point here; clarity and change-safety are.`}
 />
+
+[^gof]:
+    Erich Gamma, Richard Helm, Ralph Johnson and John Vlissides,
+    [*Design Patterns: Elements of Reusable Object-Oriented Software*](https://openlibrary.org/works/OL6030812W)
+    (Addison-Wesley, 1994). The idea of a written pattern catalogue is
+    borrowed openly from the architect Christopher Alexander's *A
+    Pattern Language* (1977), which the book cites on its first page.

--- a/content/courses/oop-blueprint-java/inheritance.mdx
+++ b/content/courses/oop-blueprint-java/inheritance.mdx
@@ -156,8 +156,8 @@ parent's version for instances of the subclass.
 sequenceDiagram
     participant Caller
     participant Rex as rex : Dog
-    Caller->>Rex: speak()
-    Note over Rex: Rex is a Dog so Dog.speak() runs<br/>not Animal.speak()
+    Caller->>Rex: <code>speak()</code>
+    Note over Rex: Rex is a Dog so <code>Dog.speak()</code> runs<br/>not <code>Animal.speak()</code>
     Rex-->>Caller: "Woof!"
 ```
 

--- a/content/courses/oop-blueprint-java/methods-and-messages.mdx
+++ b/content/courses/oop-blueprint-java/methods-and-messages.mdx
@@ -41,11 +41,11 @@ fulfill the request.
 sequenceDiagram
     participant App
     participant Light as light : Lamp
-    App->>Light: turnOn()
+    App->>Light: <code>turnOn()</code>
     Light-->>App: (returns)
-    App->>Light: brightness()
+    App->>Light: <code>brightness()</code>
     Light-->>App: 0.8
-    App->>Light: setBrightness(0.4)
+    App->>Light: <code>setBrightness(0.4)</code>
     Light-->>App: (returns)
 ```
 

--- a/content/courses/oop-blueprint-java/objects-in-memory.mdx
+++ b/content/courses/oop-blueprint-java/objects-in-memory.mdx
@@ -256,11 +256,11 @@ sequenceDiagram
     participant Callee as rename (stack frame)
     participant Heap
 
-    Caller->>Heap: new Dog("Rex")
+    Caller->>Heap: <code>new Dog("Rex")</code>
     Note over Caller,Heap: mine references the Dog named Rex
-    Caller->>Callee: rename(mine, "Buddy")
+    Caller->>Callee: <code>rename(mine, "Buddy")</code>
     Note over Callee,Heap: dog references that same Dog
-    Callee->>Heap: dog.name = "Buddy"
+    Callee->>Heap: <code>dog.name = "Buddy"</code>
     Note over Caller,Heap: mine references the Dog, now named Buddy
 ```
 
@@ -306,7 +306,7 @@ moment its memory comes back:
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Allocated: new Dog(...)
+    [*] --> Allocated: <code>new Dog(...)</code>
     Allocated --> Reachable: assigned to a variable
     Reachable --> Reachable: passed/copied to other refs
     Reachable --> Unreachable: all refs go out of scope or set to null

--- a/content/courses/oop-blueprint-java/polymorphism.mdx
+++ b/content/courses/oop-blueprint-java/polymorphism.mdx
@@ -22,12 +22,12 @@ object, not the variable's declared type.
 sequenceDiagram
     participant Main
     participant Var as n : Noisy
-    Main->>Var: n.sound()
+    Main->>Var: <code>n.sound()</code>
     alt n is Dog
-        Note over Var: dispatches to Dog.sound()
+        Note over Var: dispatches to <code>Dog.sound()</code>
         Var-->>Main: "Woof!"
     else n is Doorbell
-        Note over Var: dispatches to Doorbell.sound()
+        Note over Var: dispatches to <code>Doorbell.sound()</code>
         Var-->>Main: "Ding-dong"
     end
 ```
@@ -62,7 +62,7 @@ at any moment:
 
 ```mermaid
 flowchart LR
-    V["Noisy n = new Dog()"] --> CT["compile-time type:<br/>Noisy"]
+    V["Noisy n = <code>new Dog()</code>"] --> CT["compile-time type:<br/>Noisy"]
     V --> RT["runtime type:<br/>Dog"]
 ```
 

--- a/content/courses/practical-r-for-beginners/from-s-to-r.mdx
+++ b/content/courses/practical-r-for-beginners/from-s-to-r.mdx
@@ -47,7 +47,7 @@ The first internal version ran in late 1991. For several years it
 was used only by themselves and their students. Then, in 1993, they
 made a fateful decision: they posted the source code to the
 **StatLib** archive at Carnegie Mellon, freely available, and sent
-a quiet announcement to the `s-news` mailing list.
+a quiet announcement to the `s-news` mailing list.[^ihaka]
 
 People started using it.
 
@@ -95,7 +95,7 @@ write a function, package it up, and share it with the world.
 
 **CRAN.** In 1997, Kurt Hornik and Friedrich Leisch, Austrian
 statisticians collaborating with the R team, launched the
-**Comprehensive R Archive Network**. CRAN was a single, central
+**Comprehensive R Archive Network**.[^cran] CRAN was a single, central
 repository where anyone could submit a package, and where anyone
 could install one with a single command. Combined with R's
 extensibility, this turned R into a *platform*, a place where the
@@ -345,3 +345,16 @@ slope <- unname(coef(model)["height"])
 In the next chapter we will zoom out one more time and answer the
 "so what?" question, why R, specifically, matters in 2025, even in
 a world that also has Python, Julia, and a thousand other tools.
+
+[^ihaka]:
+    Ross Ihaka and Robert Gentleman, "R: A Language for Data Analysis
+    and Graphics", *Journal of Computational and Graphical Statistics*
+    5(3), 1996. Ihaka's later talk "R: Past and Future History" is the
+    candid version, including how close the project came to being
+    abandoned before anyone outside Auckland used it.
+
+[^cran]:
+    The [R FAQ](https://cran.r-project.org/doc/FAQ/R-FAQ.html),
+    maintained by Hornik himself, records CRAN's origins and its
+    submission rules. Those rules, not the archive, are the reason a
+    twenty-year-old package still installs.

--- a/content/courses/practical-r-for-beginners/statistics-before-computers.mdx
+++ b/content/courses/practical-r-for-beginners/statistics-before-computers.mdx
@@ -45,10 +45,10 @@ small group of mathematicians began studying games of chance.
 - **John Graunt** published *Natural and Political Observations Made
   upon the Bills of Mortality* in 1662, using parish death records
   to argue, for the first time, that you could learn things about
-  populations by carefully counting them.
+  populations by carefully counting them.[^graunt]
 - **Jakob Bernoulli** proved (around 1700) the **law of large
-  numbers**: if you flip a fair coin enough times, the proportion
-  of heads will reliably approach one half. This sounds obvious now,
+  numbers**:[^bernoulli] if you flip a fair coin enough times, the
+  proportion of heads will reliably approach one half. This sounds obvious now,
   but it was the first mathematical bridge between *probability*
   (a theoretical idea) and *data* (what we actually observe).
 
@@ -109,8 +109,9 @@ For just 40 numbers, this might be:
 
 That is about half a day of careful work to analyze one
 experiment. And Fisher actually did this kind of thing routinely.
-The famous *Statistical Methods for Research Workers* (1925) is
-full of worked examples that were each many hours of arithmetic.
+The famous *Statistical Methods for Research Workers*
+(1925)[^fisher] is full of worked examples that were each many hours
+of arithmetic.
 
 <Callout type="info" title="Why statistical methods are so 'computational'">
 This is why many classical statistical techniques have such
@@ -236,7 +237,8 @@ The constraints of the pre-computer era shaped statistics in ways
 that are still with us:
 
 - **The obsession with *small samples*.** Many classical tests
-  (the t-test, ANOVA) were designed for n=10 or n=30, not n=10,000.
+  (the t-test,[^student] ANOVA) were designed for n=10 or n=30, not
+  n=10,000.
   That is because hand-computing anything bigger was infeasible.
 - **The use of *closed-form formulas*.** A formula is something you
   can compute once and be done. Modern alternatives, bootstrapping,
@@ -355,3 +357,29 @@ In the next chapter, we will see how the arrival of computers
 turned this slow, careful craft into something altogether new, and
 why the most influential of those tools came from an unexpected
 place: **Bell Labs**.
+
+[^graunt]:
+    John Graunt, *Natural and Political Observations Made upon the
+    Bills of Mortality* (London, 1662). Usually counted as the first
+    work of demography and of statistical inference from records
+    collected for another purpose entirely.
+
+[^bernoulli]:
+    Jakob Bernoulli, *Ars Conjectandi* (Basel, 1713), published eight
+    years after his death by his nephew Nicolaus. The theorem in Part
+    IV is what we now call the weak law of large numbers.
+
+[^fisher]:
+    R. A. Fisher,
+    [*Statistical Methods for Research Workers*](https://archive.org/details/statisticalmetho0000fish)
+    (Oliver and Boyd, 1925). The worked examples are the evidence for
+    the claim above: each is sized to what a person with a mechanical
+    calculator could finish.
+
+[^student]:
+    "Student" (William Sealy Gosset),
+    ["The Probable Error of a Mean"](https://www.york.ac.uk/depts/maths/histstat/student.pdf),
+    *Biometrika* 6(1), 1908. Gosset published under a pseudonym
+    because Guinness, his employer, did not allow its brewers to
+    publish; the small-sample problem he was solving was a brewery's,
+    not a university's.

--- a/content/courses/practical-r-for-beginners/the-age-of-data.mdx
+++ b/content/courses/practical-r-for-beginners/the-age-of-data.mdx
@@ -71,8 +71,8 @@ made by computer programs that scan the data.
 **Biology.** A 1960s geneticist might study a single gene over
 years. A modern lab can sequence the entire genome of an organism
 in an afternoon. The Human Genome Project, a 13-year, $3-billion
-international effort that finished in 2003, could now be repeated
-by a single graduate student in a week.
+international effort that finished in 2003,[^hgp] could now be
+repeated by a single graduate student in a week.
 
 **Climate science.** A 1900s meteorologist had a handful of weather
 stations and ship logs. A modern climate model ingests data from
@@ -212,3 +212,11 @@ In the next page we make the mental shift that the rest of the
 course depends on: learning to think about *whole collections of
 data at once* instead of one number at a time. Then we start writing
 R for real.
+
+[^hgp]:
+    The project ran from 1990 to 2003 and its US cost is usually put at
+    about $2.7 billion in 1991 dollars; see the National Human Genome
+    Research Institute's own accounting, which is careful that the
+    figure covers the whole programme rather than one genome. The
+    sequencing-cost curve NHGRI has tracked since is the source for the
+    comparison in the sentence above.

--- a/content/courses/python-basics/classes.mdx
+++ b/content/courses/python-basics/classes.mdx
@@ -109,7 +109,7 @@ When you call `Dog("Rex", 4)`, Python:
 
 ```mermaid
 flowchart TD
-    A["Dog('Rex', 4)"] --> B[Python creates empty Dog instance]
+    A["<code>Dog('Rex', 4)</code>"] --> B[Python creates empty Dog instance]
     B --> C["<code>__init__(self, 'Rex', 4)</code> runs"]
     C --> D["<code>self.name = 'Rex'</code>"]
     C --> E["<code>self.age = 4</code>"]

--- a/content/courses/python-basics/exceptions.mdx
+++ b/content/courses/python-basics/exceptions.mdx
@@ -329,7 +329,7 @@ Every exception inherits from `BaseException`. The ones you usually care about i
 ```mermaid
 flowchart TD
     Base["BaseException"] --> KI["KeyboardInterrupt<br/>(Ctrl+C)"]
-    Base --> SE["SystemExit<br/>(sys.exit())"]
+    Base --> SE["SystemExit<br/>(<code>sys.exit()</code>)"]
     Base --> Exc["Exception"]
     Exc --> VE["ValueError"]
     Exc --> TE["TypeError"]

--- a/content/courses/python-basics/files.mdx
+++ b/content/courses/python-basics/files.mdx
@@ -28,8 +28,8 @@ Mastering file I/O means you can build scripts that process data, integrate with
 flowchart TD
     A[Call open] --> B[File object created]
     B --> C{Read or Write?}
-    C -->|Read| D[f.read / f.readline / iterate]
-    C -->|Write| E[f.write / print to file]
+    C -->|Read| D["<code>f.read</code> / <code>f.readline</code> / iterate"]
+    C -->|Write| E["<code>f.write</code> / print to file"]
     D --> F[Close file]
     E --> F
     F --> G[Done]

--- a/content/courses/python-basics/iterators-and-generators.mdx
+++ b/content/courses/python-basics/iterators-and-generators.mdx
@@ -50,12 +50,12 @@ The `for` loop does exactly this, catching `StopIteration` invisibly.
 ```mermaid
 sequenceDiagram
     participant C as Caller (for loop)
-    participant I as iter(obj)
+    participant I as <code>iter(obj)</code>
     participant IT as Iterator
-    C->>I: iter(obj)
+    C->>I: <code>iter(obj)</code>
     I-->>C: returns iterator
     loop Until StopIteration
-        C->>IT: next(iterator)
+        C->>IT: <code>next(iterator)</code>
         IT-->>C: yields item
     end
     IT-->>C: raises StopIteration

--- a/content/courses/python-basics/python-history.mdx
+++ b/content/courses/python-basics/python-history.mdx
@@ -33,12 +33,12 @@ he began building a successor.
 
 He needed a name. He was, at the time, reading the published scripts of *Monty
 Python's Flying Circus*, the British comedy series, and he wanted something
-"short, unique, and slightly mysterious." He called it **Python**. The snake
+"short, unique, and slightly mysterious." He called it **Python**.[^py-name] The snake
 imagery came later, supplied by the community and by book publishers; the name
 itself is a comedy reference, not a reptile one.
 
 The first public release, **Python 0.9.0**, went out to the `alt.sources`
-Usenet newsgroup in **February 1991**. It already had functions, exceptions, and
+Usenet newsgroup in **February 1991**.[^py-090] It already had functions, exceptions, and
 the core data types, lists, dictionaries, strings, that you have spent this
 course learning. The language has grown enormously since, but its character was
 set in that first holiday.
@@ -134,7 +134,7 @@ problem.
 Python's deeper personality comes straight from ABC, the teaching language Guido
 worked on before it. ABC was designed to be learnable, readable, and forgiving,
 and Python inherited those instincts. They were eventually distilled into *The
-Zen of Python* (PEP 20), the 19 aphorisms by **Tim Peters** that you can still
+Zen of Python* (PEP 20),[^pep20] the 19 aphorisms by **Tim Peters** that you can still
 print by running `import this`. Lines like "Readability counts" and "There
 should be one, and preferably only one, obvious way to do it" are not
 decoration; they are the criteria by which Python features are accepted or
@@ -166,7 +166,7 @@ The catch was migration. Because the break was real, the ecosystem took roughly
 a decade to move. Libraries maintained dual Python 2/3 codebases, leaned on the
 `six` compatibility library, or ran the `2to3` converter. The Python core team
 eventually set a hard deadline, and on **January 1, 2020**, Python 2 reached
-official end-of-life: no more security patches, no more fixes. Today there is no
+official end-of-life:[^pep373] no more security patches, no more fixes. Today there is no
 reason to write new code in Python 2, and every example in this course assumes
 Python 3.
 
@@ -262,3 +262,25 @@ worked out in the open.
 
 That is the story behind the syntax. If it left you wanting more, the *Next
 Steps* page points to where the language is heading and what to learn next.
+
+[^py-name]:
+    The naming is confirmed in the
+    [Python General FAQ](https://docs.python.org/3/faq/general.html),
+    which is blunt about it: "Guido van Rossum, the creator of Python,
+    had the scripts from the BBC series Monty Python's Flying Circus."
+
+[^py-090]:
+    Guido van Rossum, "Python 0.9.0", posted to `alt.sources`, February
+    1991. The posting survives in Usenet archives, and the tarball is
+    still distributed by the Python Software Foundation.
+
+[^pep20]:
+    Tim Peters, [PEP 20, *The Zen of Python*](https://peps.python.org/pep-0020/)
+    (2004). Nineteen aphorisms, and Peters' own note that the twentieth
+    was left for Guido to fill in, which he never did.
+
+[^pep373]:
+    [PEP 373, *Python 2.7 Release Schedule*](https://peps.python.org/pep-0373/),
+    the document that fixed the end-of-life date. It was moved twice
+    before it stuck, which is the part of the story worth remembering
+    when a migration deadline is announced.

--- a/content/courses/scientific-computing-python/capstone-simulation.mdx
+++ b/content/courses/scientific-computing-python/capstone-simulation.mdx
@@ -45,7 +45,7 @@ $$
 
 ```mermaid
 flowchart TD
-    Cfg[Config:<br/>sweep over a] --> Sim["simulate.py:<br/><code>solve_ivp</code> + event"]
+    Cfg[Config:<br/>sweep over a] --> Sim["<code>simulate.py</code>:<br/><code>solve_ivp</code> + event"]
     Sim --> Res[results: time-series<br/>+ extinction flag]
     Res --> Agg["<code>aggregate.py</code>:<br/>per-config summary"]
     Agg --> Viz["<code>plot.py</code>:<br/>small multiples + phase portrait"]

--- a/content/courses/scientific-computing-python/interesting-discussions.mdx
+++ b/content/courses/scientific-computing-python/interesting-discussions.mdx
@@ -18,8 +18,8 @@ several connect directly to the numerical ideas you have already met.
 
 In 1950, a small team led by John von Neumann and the meteorologist
 Jule Charney used ENIAC to produce the first computer weather
-forecast. They discretized the atmosphere over North America into a
-coarse grid, used a simplified set of equations (the *barotropic
+forecast.[^eniac] They discretized the atmosphere over North America
+into a coarse grid, used a simplified set of equations (the *barotropic
 vorticity equation*), and ran a 24-hour forecast.
 
 <Figure
@@ -68,8 +68,8 @@ and each unlocked a research program that ran for a decade or two.
 
 ## A Nobel Prize for simulation
 
-The 2013 Nobel Prize in Chemistry went to Martin Karplus, Michael
-Levitt, and Arieh Warshel "for the development of multiscale models
+The 2013 Nobel Prize in Chemistry[^nobel] went to Martin Karplus,
+Michael Levitt, and Arieh Warshel "for the development of multiscale models
 for complex chemical systems." The award was not for a new chemical
 discovery, it was for the *numerical methods* that let chemists
 simulate enzymes on a computer. Computational chemistry and
@@ -125,7 +125,8 @@ in its deadliest form.
 <Callout type="warn" title="The Pentium FDIV bug, 1994">
 Intel's Pentium processor shipped with a flaw in the lookup table
 used by its floating-point division unit. For certain divisions it
-returned wrong results, a famous example being $4195835 / 3145727$,
+returned wrong results, a famous example being $4195835 /
+3145727$,[^fdiv]
 which came out wrong in about the fifth significant digit. Once the
 bug became public, Intel was forced to offer replacements, at a cost
 of about **$475 million**. The lesson: even the *hardware* that
@@ -160,3 +161,24 @@ freely available, and all far more detailed than these summaries.
 The point of this page is not completeness but motivation: the
 numerical care this course teaches is not pedantry. People have died
 for the lack of it.
+
+[^eniac]:
+    Jule G. Charney, Ragnar Fjortoft and John von Neumann, "Numerical
+    Integration of the Barotropic Vorticity Equation", *Tellus* 2(4),
+    1950. The 24-hour forecast took about 24 hours of ENIAC time, so the
+    first numerical weather prediction ran exactly as fast as the
+    weather.
+
+[^nobel]:
+    "The Nobel Prize in Chemistry 2013", awarded to Martin Karplus,
+    Michael Levitt and Arieh Warshel "for the development of multiscale
+    models for complex chemical systems". The Nobel Foundation's own
+    scientific background document is the readable account of what the
+    methods actually do.
+
+[^fdiv]:
+    Alan Edelman, "The Mathematics of the Pentium Division Bug", *SIAM
+    Review* 39(1), 1997, which works out exactly which divisors the
+    missing lookup-table entries could affect and how rare a wrong
+    answer was. The rarity is why the bug shipped, and the recall charge
+    is why rarity was not a defence.

--- a/content/courses/sql-analytics-duckdb/aggregate-functions.mdx
+++ b/content/courses/sql-analytics-duckdb/aggregate-functions.mdx
@@ -221,7 +221,7 @@ WHERE
 ```mermaid
 flowchart TD
     T[("orders")] --> W["<code>WHERE amount &gt; 50</code>"]
-    W --> A["<code>AVG(amount)</code>,<br/>COUNT(*)"]
+    W --> A["<code>AVG(amount)</code>,<br/><code>COUNT(*)</code>"]
     A --> R["summary of the<br/>filtered slice"]
 ```
 

--- a/content/courses/sqlite-for-beginners/aggregate-functions.mdx
+++ b/content/courses/sqlite-for-beginners/aggregate-functions.mdx
@@ -229,7 +229,7 @@ flowchart LR
     Data["Order rows"] --> Count["<code>COUNT(*)</code>"]
     Data --> Sum["<code>SUM(amount)</code>"]
     Data --> Avg["<code>AVG(amount)</code>"]
-    Data --> MinMax["<code>MIN(amount)</code><br/>MAX(amount)"]
+    Data --> MinMax["<code>MIN(amount)</code><br/><code>MAX(amount)</code>"]
     Count --> Report["One report row"]
     Sum --> Report
     Avg --> Report

--- a/content/courses/sqlite-for-beginners/inner-joins.mdx
+++ b/content/courses/sqlite-for-beginners/inner-joins.mdx
@@ -267,8 +267,8 @@ You can chain inner joins. Each `JOIN ... ON ...` adds another table and another
 
 ```mermaid
 flowchart TD
-    C["<code>customers</code>"] -->|"c.id = o.<code>customer_id</code>"| O["<code>orders</code>"]
-    O -->|"o.<code>product_id</code> = p.id"| P["<code>products</code>"]
+    C["<code>customers</code>"] -->|"<code>c.id</code> = <code>o.customer_id</code>"| O["<code>orders</code>"]
+    O -->|"<code>o.product_id</code> = <code>p.id</code>"| P["<code>products</code>"]
     P --> R["customer + product result"]
 ```
 

--- a/content/courses/sqlite-for-beginners/understanding-joins.mdx
+++ b/content/courses/sqlite-for-beginners/understanding-joins.mdx
@@ -82,7 +82,7 @@ A useful beginner mental model is **cartesian then filter**:
 ```mermaid
 flowchart TB
     A["Start with one order row"] --> B["Try pairing it with each customer row"]
-    B --> C{"Does<br/>order.<code>customer_id</code> = customer.id?"}
+    B --> C{"Does<br/><code>order.customer_id</code> = <code>customer.id</code>?"}
     C -->|"yes"| D["keep this pair"]
     C -->|"no"| E["discard this pair"]
 ```

--- a/content/courses/statistics-for-data-science-python/statistical-fallacies.mdx
+++ b/content/courses/statistics-for-data-science-python/statistical-fallacies.mdx
@@ -48,10 +48,11 @@ groups you're comparing.
   caption="A trend inside every group can reverse once the groups are pooled together."
 />
 
-**Concrete example.** A classic real case: the 1973 UC Berkeley graduate
-admissions. Overall, men were admitted at a higher rate than women,
-which looked like bias against women. But department by department, women
-were admitted at *equal or higher* rates than men. The catch: women
+**Concrete example.** A classic real case: the 1973 UC Berkeley
+graduate admissions.[^berkeley] Overall, men were admitted at a higher
+rate than women, which looked like bias against women. But department
+by department, women were admitted at *equal or higher* rates than
+men. The catch: women
 applied disproportionately to the most competitive departments (low
 admit rates for everyone), while men applied to easier ones. The
 department was the lurking variable.
@@ -195,10 +196,10 @@ chance of a false positive when nothing is real. But if you run *twenty*
 such tests, you'd *expect* about one "significant" result by pure chance.
 Hunting through many comparisons (or many model specifications, or many
 subgroups) and reporting only the ones that "worked" is **p-hacking**.
-The "**garden of forking paths**" is the subtler cousin: even without
-consciously fishing, the many small analysis choices you'd have made
-*differently* had the data looked different inflate your false-positive
-rate.
+The "**garden of forking paths**" is the subtler cousin:[^forking] even
+without consciously fishing, the many small analysis choices you'd have
+made *differently* had the data looked different inflate your
+false-positive rate.
 
 **Concrete example.** Test whether each of 20 unrelated variables
 predicts churn. Even if none truly does, roughly one will come back
@@ -362,7 +363,8 @@ silently dropped from your data. The survivors are a biased sample, so
 any pattern you find in them may be an artifact of *what got filtered
 out*, not a real effect.
 
-**Concrete example.** In WWII, analysts examined returning bombers to
+**Concrete example.**[^wald] In WWII, analysts examined returning
+bombers to
 decide where to add armor, and found bullet holes concentrated on the
 wings and tail. The instinct was to armor those spots. The
 statistician Abraham Wald pointed out the opposite: armor the
@@ -903,3 +905,27 @@ Patterns found by searching must be confirmed on fresh, independent data before 
 - **Regression to the mean:** extremes drift back on their own, you need a control group to credit an intervention.
 - **Cherry-picking / Texas sharpshooter:** decide the hypothesis *before* you look, report everything, and confirm on new data.
 </Callout>
+
+[^berkeley]:
+    P. J. Bickel, E. A. Hammel and J. W. O'Connell, "Sex Bias in
+    Graduate Admissions: Data from Berkeley",
+    [*Science* 187(4175)](https://archive.org/details/sim_science_1975-02-07_187_4175),
+    7 February 1975. Worth reading rather than repeating: the authors
+    are careful that the disaggregated data does not prove the absence
+    of bias either, only that the aggregate number cannot show its
+    presence.
+
+[^forking]:
+    Andrew Gelman and Eric Loken,
+    [*The garden of forking paths*](http://www.stat.columbia.edu/~gelman/research/unpublished/forking.pdf)
+    (2013), the paper that named it. Their point is the uncomfortable
+    one: the researcher need not have run multiple tests, or intended
+    anything, for the error rate to be inflated.
+
+[^wald]:
+    Abraham Wald, *A Method of Estimating Plane Vulnerability Based on
+    Damage of Survivors Returning*, Statistical Research Group,
+    Columbia University (1943). Worth knowing that the memoranda are
+    dry estimation work: the vivid "armour where the holes are not"
+    telling, including the anecdote's usual dialogue, is a later
+    retelling rather than anything Wald wrote.

--- a/content/courses/systems-programming-c/c-toolchain.mdx
+++ b/content/courses/systems-programming-c/c-toolchain.mdx
@@ -26,7 +26,7 @@ flowchart TD
     G --> H[Linker]
     I["<code>libc.a</code>"] --> H
     J["other .o files"] --> H
-    H --> K["a.out<br/>(executable)"]
+    H --> K["<code>a.out</code><br/>(executable)"]
 ```
 
 In one `clang hello.c -o hello` command, the driver actually runs all

--- a/content/courses/systems-programming-c/index.mdx
+++ b/content/courses/systems-programming-c/index.mdx
@@ -6,8 +6,8 @@ description: A hands-on, browser-based tour of systems programming and memory ma
 Welcome to **Systems Programming &amp; Memory Management in C**, a course
 that takes you from your very first `int main(void)` all the way to
 hand-rolled memory allocators, structs with carefully chosen padding,
-and the kinds of memory bugs that have powered half the CVEs of the
-last forty years.
+and the kinds of memory bugs that have powered a large share of the
+CVEs of the last forty years.[^share]
 
 <Figure
   slug="systems-programming-c-thumbnail-cutout"
@@ -161,3 +161,12 @@ A roadmap for what to study after this course: signals and processes,
 threads and synchronization, sockets and protocols, `mmap` and shared
 memory, sanitizers (ASan/UBSan/MSan), Valgrind, custom allocators,
 embedded toolchains, and Rust as a "modern C" alternative.
+
+[^share]:
+    Microsoft's Security Response Center
+    [reported](https://raw.githubusercontent.com/microsoft/MSRC-Security-Research/master/presentations/2019_02_BlueHatIL/2019_01%20-%20BlueHatIL%20-%20Trends%2C%20challenge%2C%20and%20shifts%20in%20software%20vulnerability%20mitigation.pdf)
+    in 2019 that "~70% of the vulnerabilities addressed through a
+    security update each year continue to be memory safety issues", and
+    the Chromium project puts
+    [about 70%](https://www.chromium.org/Home/chromium-security/memory-safety/)
+    of its own serious security bugs in the same category.

--- a/content/courses/systems-programming-c/memory-bugs.mdx
+++ b/content/courses/systems-programming-c/memory-bugs.mdx
@@ -20,8 +20,8 @@ The bug classes we will cover:
 - Type confusion / strict aliasing
 
 These are not "exotic" bugs, they are the source of an enormous
-share of real-world security vulnerabilities (CVEs). Recognizing the
-patterns is half the battle.
+share of real-world security vulnerabilities (CVEs).[^share]
+Recognizing the patterns is half the battle.
 
 <Figure
   slug="sysc-memory-bugs-cutout"
@@ -568,3 +568,14 @@ int main(void) {
 You know the bug classes. Tools like AddressSanitizer and Valgrind
 will be your best friends in real codebases.
 </Callout>
+
+[^share]:
+    Two large C and C++ codebases have counted this independently and
+    landed on the same number. Microsoft's Security Response Center
+    [reported](https://raw.githubusercontent.com/microsoft/MSRC-Security-Research/master/presentations/2019_02_BlueHatIL/2019_01%20-%20BlueHatIL%20-%20Trends%2C%20challenge%2C%20and%20shifts%20in%20software%20vulnerability%20mitigation.pdf)
+    that "~70% of the vulnerabilities addressed through a security
+    update each year continue to be memory safety issues" (BlueHat IL,
+    2019), and the Chromium project puts
+    [about 70%](https://www.chromium.org/Home/chromium-security/memory-safety/)
+    of its own serious security bugs in the same category. Every bug
+    class on this page is in that 70%.

--- a/content/courses/systems-programming-c/real-world-disasters.mdx
+++ b/content/courses/systems-programming-c/real-world-disasters.mdx
@@ -5,9 +5,9 @@ description: How memory management bugs in C and C++ have crashed satellites, le
 
 The bug classes from the last page are not academic curiosities.
 They are the root cause of an enormous share of real-world software
-failures, from research-lab incidents to internet-scale security
-catastrophes that affected hundreds of millions of users and cost
-billions of dollars.
+failures,[^share] from research-lab incidents to internet-scale
+security catastrophes that affected hundreds of millions of users and
+cost billions of dollars.
 
 This page is a tour of the most instructive incidents. For each one
 we identify *which* bug class from the previous page caused it, and
@@ -35,9 +35,9 @@ flowchart LR
 In November 1988, a graduate student named Robert Morris released a
 self-replicating program that within hours infected an estimated 10%
 of all computers on the internet, roughly 6,000 machines at the
-time. It was the world's first major internet worm and led directly
-to the creation of CERT/CC, the first computer-emergency response
-team.
+time.[^spafford] It was the world's first major internet worm and led
+directly to the creation of CERT/CC, the first computer-emergency
+response team.[^cert]
 
 One of its key propagation vectors exploited a *stack buffer
 overflow* in the BSD `fingerd` daemon. `fingerd` read a request into
@@ -61,9 +61,10 @@ part of the input.
 
 **Bug class:** stack buffer overflow.
 **Fallout:** Morris received the first conviction under the U.S.
-Computer Fraud and Abuse Act. `gets()` was deprecated in C99 and
-*removed* from C11. Decades later, `-fstack-protector`, ASLR, and
-non-executable stacks are all responses to this attack pattern.
+Computer Fraud and Abuse Act.[^morris-case] `gets()` was deprecated in
+C99 and *removed* from C11.[^c11] Decades later, `-fstack-protector`,
+ASLR, and non-executable stacks are all responses to this attack
+pattern.
 
 <Callout type="warn" title="`gets()` is so dangerous it was removed from the language">
 If you see `gets(buf)` in any code, replace it immediately with
@@ -74,10 +75,10 @@ original.
 ## 2. Code Red (2001), IIS, .ida, and one bad URL
 
 In July 2001, a worm called Code Red infected over 350,000 Microsoft
-IIS web servers in under 14 hours and defaced their home pages with
-the message *"HELLO! Welcome to http://www.worm.com! Hacked by
-Chinese!"*. It also tried to launch a DDoS against the White House
-web server.
+IIS web servers in under 14 hours[^caida-codered] and defaced their
+home pages with the message *"HELLO! Welcome to http://www.worm.com!
+Hacked by Chinese!"*. It also tried to launch a DDoS against the White
+House web server.
 
 <Figure
   slug="sysc-real-world-disasters-2-code-red-inline-cutout"
@@ -92,17 +93,17 @@ copied URL-decoded input with no length check, overwriting the
 return address.
 
 **Bug class:** stack buffer overflow (again).
-**Fallout:** estimated $2.6 billion in cleanup and lost productivity.
-Microsoft turned the Indexing Service off by default and the
-incident became a textbook example used in every secure-coding
-course since.
+**Fallout:** estimated $2.6 billion in cleanup and lost
+productivity.[^codered-cost] Microsoft turned the Indexing Service off
+by default and the incident became a textbook example used in every
+secure-coding course since.
 
 ## 3. SQL Slammer (2003), 376 bytes, the whole internet
 
 Slammer is famous for two things: it was tiny (the entire payload
 fit in a single 376-byte UDP packet) and it was *fast*, it doubled
 the infected population every 8.5 seconds and effectively saturated
-the global internet's routing capacity within ten minutes.
+the global internet's routing capacity within ten minutes.[^slammer]
 
 <Figure
   slug="sysc-disasters-sql-slammer-cutout"
@@ -124,10 +125,10 @@ dark for hours.
 
 ## 4. Heartbleed (2014), a two-byte length field, half a million sites
 
-Heartbleed (CVE-2014-0160) was a vulnerability in OpenSSL's
-implementation of the TLS Heartbeat extension. It did not corrupt
-memory or crash the server, it did something arguably worse: it
-let any attacker read up to ~64 KB of the server's process memory
+Heartbleed (CVE-2014-0160)[^cve-heartbleed] was a vulnerability in
+OpenSSL's implementation of the TLS Heartbeat extension. It did not
+corrupt memory or crash the server, it did something arguably worse:
+it let any attacker read up to ~64 KB of the server's process memory
 *per request*, with no authentication and no log trace.
 
 <Figure
@@ -155,9 +156,12 @@ users' HTTP requests.
 "trust attacker-supplied length" mistake, but reading rather than
 writing).
 **Fallout:** roughly 17% of all "secure" web servers in the world
-were vulnerable on the day of disclosure. Every TLS certificate that
-might have been exposed had to be reissued. The xkcd cartoon
-explaining it became one of the most-shared technical comics ever.
+were vulnerable on the day of disclosure.[^netcraft] The measurement
+study that tracked the disclosure put the initially vulnerable
+population at 24 to 55% of the HTTPS servers in the Alexa Top 1
+Million.[^matter-of-heartbleed] Every TLS certificate that might have
+been exposed had to be reissued. The xkcd cartoon explaining it became
+one of the most-shared technical comics ever.
 
 <Callout type="info" title="Lesson: never trust a length field from the network">
 Always cross-check declared lengths against what you actually
@@ -199,8 +203,8 @@ region.
 **Bug class:** *off-by-one*, leading to a buffer over-read.
 **Fallout:** during the worst stretch, Cloudflare estimated that
 roughly 1 in every 3.3 million HTTP requests passing through its
-edge leaked memory, a tiny rate multiplied by an enormous volume of
-traffic, over a period of months. The fix was a single character;
+edge leaked memory,[^cloudbleed] a tiny rate multiplied by an enormous
+volume of traffic, over a period of months. The fix was a single character;
 the cleanup, hunting down and purging leaked fragments from search
 engine caches across the entire web, took weeks of coordinated
 work with Google, Bing, and others.
@@ -210,8 +214,8 @@ work with Google, Bing, and others.
 Stagefright was a family of vulnerabilities in Android's media
 framework. The headline bug allowed remote code execution on roughly
 **95% of all Android devices** simply by sending a malicious MMS
-message. The phone would parse the attached video automatically, no
-user interaction required.
+message.[^stagefright] The phone would parse the attached video
+automatically, no user interaction required.
 
 The core defect was an *integer overflow* in a 32-bit `size` value
 inside the MP4 parser. When the parser computed `size + something`
@@ -229,7 +233,7 @@ memory-safer languages.
 ## 7. GHOST (2015), `gethostbyname` and a forgotten `+ 1`
 
 CVE-2015-0235 was a buffer overflow in glibc's `__nss_hostname_digits_dots`
-helper, reached via the venerable `gethostbyname` family. The bug:
+helper,[^ghost] reached via the venerable `gethostbyname` family. The bug:
 a length calculation forgot to include one byte for the null
 terminator, allowing a carefully sized hostname to overflow a heap
 buffer by a few bytes, enough to corrupt allocator metadata and
@@ -254,22 +258,22 @@ attacker data spill out of a heap buffer.
 A month later, the WannaCry ransomware worm picked up EternalBlue
 and used it to encrypt files on hundreds of thousands of computers
 in 150+ countries. The UK's National Health Service had to cancel
-operations. FedEx, Renault, Deutsche Bahn, and Telefónica were all
+operations.[^nao] FedEx, Renault, Deutsche Bahn, and Telefónica were all
 disrupted.
 
 **Bug class:** integer truncation / underflow → heap buffer overflow
 in a network service.
-**Fallout:** estimated $4–8 billion in total damages. The episode
-hardened the case for getting old C network services out of the
-trust path entirely.
+**Fallout:** estimated $4–8 billion in total damages.[^wannacry-cost]
+The episode hardened the case for getting old C network services out
+of the trust path entirely.
 
 ## 9. BlueKeep (2019), RDP and use-after-free
 
-CVE-2019-0708, nicknamed BlueKeep, was a *use-after-free* in
-Microsoft's Remote Desktop Protocol. A pre-authentication attacker
-could trigger an RDP channel-rebinding code path that freed a
-structure but kept a dangling pointer to it; subsequent operations
-through that pointer were attacker-controllable.
+CVE-2019-0708, nicknamed BlueKeep,[^cve-bluekeep] was a
+*use-after-free* in Microsoft's Remote Desktop Protocol. A
+pre-authentication attacker could trigger an RDP channel-rebinding
+code path that freed a structure but kept a dangling pointer to it;
+subsequent operations through that pointer were attacker-controllable.
 
 Microsoft considered BlueKeep severe enough to release patches even
 for unsupported operating systems (XP, Server 2003), something it
@@ -285,7 +289,7 @@ a board-level conversation at many enterprises.
 The Therac-25 was a radiation therapy machine produced by Atomic
 Energy of Canada Limited. Between 1985 and 1987 it gave at least six
 patients massive radiation overdoses, hundreds of times the
-intended dose. At least three died as a direct result.
+intended dose. At least three died as a direct result.[^therac]
 
 <Figure
   slug="sysc-disasters-therac-25-cutout"
@@ -318,7 +322,7 @@ removing safety hardware on the assumption that the code is correct.
 
 On its maiden flight, the European Space Agency's Ariane 5 rocket
 self-destructed 37 seconds after launch, taking with it four
-scientific satellites and roughly $370 million.
+scientific satellites and roughly $370 million.[^ariane]
 
 The cause was not, strictly, a memory bug, but it is a textbook
 example of the kind of UB-adjacent disaster C programmers are
@@ -348,7 +352,7 @@ PS3's hypervisor, the privileged layer that kept the console's
 software and a literal hardware glitch: he had Linux ask the
 hypervisor to create and then tear down memory mappings while he
 pulsed a wire on the memory bus at precisely the wrong moment, so
-the hypervisor's *deallocation write was lost in transit*. The
+the hypervisor's *deallocation write was lost in transit*.[^ps3] The
 hypervisor believed a mapping was gone; the page tables still
 contained it. Through that dangling, stale mapping he could read
 and write hypervisor-owned memory, in effect, a use-after-free
@@ -468,3 +472,145 @@ accumulated lessons of decades of expensive failures. Internalize
 them now, and you join a small group of C programmers who do not
 have to learn them the hard way.
 </Callout>
+
+[^share]:
+    Matt Miller, Microsoft Security Response Center,
+    [*Trends, challenges, and strategic shifts in the software
+    vulnerability mitigation landscape*](https://raw.githubusercontent.com/microsoft/MSRC-Security-Research/master/presentations/2019_02_BlueHatIL/2019_01%20-%20BlueHatIL%20-%20Trends%2C%20challenge%2C%20and%20shifts%20in%20software%20vulnerability%20mitigation.pdf)
+    (BlueHat IL, 2019): "~70% of the vulnerabilities addressed through
+    a security update each year continue to be memory safety issues."
+    The Chromium project
+    [reports the same proportion](https://www.chromium.org/Home/chromium-security/memory-safety/)
+    of its own serious security bugs. Two large C and C++ codebases,
+    counted independently, a decade apart, landing on the same number.
+
+[^spafford]:
+    Eugene H. Spafford,
+    [*The Internet Worm Program: An Analysis*](https://docs.lib.purdue.edu/cstech/702/),
+    Purdue University Technical Report CSD-TR-823 (1988). Written
+    weeks after the event by someone who disassembled the worm; the
+    "roughly 6,000 machines" figure is an estimate even in the primary
+    sources, because nobody had an inventory of the 1988 internet.
+
+[^cert]:
+    The CERT Coordination Center was established at Carnegie Mellon's
+    Software Engineering Institute in November 1988, days after the
+    worm, at DARPA's request.
+    [SEI, CERT Division](https://www.sei.cmu.edu/about/divisions/cert/index.cfm).
+
+[^morris-case]:
+    *United States v. Morris*, 928 F.2d 504 (2d Cir. 1991), the appeal
+    that upheld the first conviction under the Computer Fraud and
+    Abuse Act and settled what "intent" means in it.
+
+[^c11]:
+    `gets` was declared obsolescent in C99 TC3 and is absent from the
+    C11 library. See WG14
+    [N1570](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf),
+    the C11 draft, whose §7.21 has no `gets` and whose Annex K
+    documents `gets_s` as its bounded replacement.
+
+[^caida-codered]:
+    David Moore, Colleen Shannon and Jeffery Brown,
+    [*Code-Red: a case study on the spread and victims of an Internet
+    worm*](https://www.caida.org/catalog/papers/2002_codered/)
+    (IMW 2002). CAIDA watched the spread from a network telescope, so
+    the host count is measured rather than reported.
+
+[^codered-cost]:
+    The widely-quoted $2.6 billion is Computer Economics' estimate of
+    cleanup plus lost productivity. Worm cost figures like this one are
+    commercial modelling rather than audited accounting, and different
+    firms have published estimates that differ by more than a factor of
+    two; treat the order of magnitude as the claim, not the digits.
+
+[^slammer]:
+    David Moore et al.,
+    [*The Spread of the Sapphire/Slammer Worm*](https://www.caida.org/catalog/papers/2003_sapphire/)
+    (CAIDA, 2003), later published in *IEEE Security & Privacy* as
+    "Inside the Slammer Worm". The 8.5-second doubling time and the
+    ten-minute saturation are that paper's measurements.
+
+[^cve-heartbleed]:
+    [CVE-2014-0160](https://www.cve.org/CVERecord?id=CVE-2014-0160).
+    The vulnerability also has its own site,
+    [heartbleed.com](https://heartbleed.com/), written by the
+    Codenomicon engineers who found it independently of Google.
+
+[^netcraft]:
+    Netcraft,
+    [*Half a million widely trusted websites vulnerable to Heartbleed
+    bug*](https://www.netcraft.com/blog/half-a-million-widely-trusted-websites-vulnerable-to-heartbleed-bug/)
+    (April 2014), the survey the 17% figure comes from.
+
+[^matter-of-heartbleed]:
+    Zakir Durumeric et al.,
+    [*The Matter of Heartbleed*](https://jhalderm.com/pub/papers/heartbleed-imc14.pdf)
+    (IMC 2014). The range is wide because it depends on how a site is
+    counted; the paper also tracks how slowly the population patched.
+
+[^cloudbleed]:
+    John Graham-Cumming,
+    [*Incident report on memory leak caused by Cloudflare parser
+    bug*](https://blog.cloudflare.com/incident-report-on-memory-leak-caused-by-cloudflare-parser-bug/)
+    (Cloudflare, February 2017). Unusually candid for a vendor
+    post-mortem: it gives the leak rate, the exact Ragel condition, and
+    the reason the bug had been latent in the code for years.
+
+[^stagefright]:
+    Joshua Drake, Zimperium,
+    [*Experts Found a Unicorn in the Heart of Android*](https://www.zimperium.com/blog/experts-found-a-unicorn-in-the-heart-of-android/)
+    (July 2015). The 95% and 950 million figures are the discovering
+    vendor's own estimates of the affected install base, not a
+    measurement of exploited devices.
+
+[^ghost]:
+    Qualys,
+    [*GHOST: glibc gethostbyname buffer overflow*](https://www.qualys.com/2015/01/27/cve-2015-0235/GHOST-CVE-2015-0235.txt)
+    (January 2015), the disclosure advisory, with the exact
+    off-by-one and a working proof of concept.
+    [CVE-2015-0235](https://www.cve.org/CVERecord?id=CVE-2015-0235).
+
+[^nao]:
+    UK National Audit Office,
+    [*Investigation: WannaCry cyber attack and the NHS*](https://www.nao.org.uk/reports/investigation-wannacry-cyber-attack-and-the-nhs/)
+    (2018). An audited account of one organisation's disruption, which
+    is rarer and more reliable than a global damage total.
+    [CVE-2017-0144](https://www.cve.org/CVERecord?id=CVE-2017-0144) is
+    the underlying SMBv1 flaw.
+
+[^wannacry-cost]:
+    Global damage figures for WannaCry come from commercial
+    cyber-risk modelling rather than audited accounts, and the
+    published estimates span more than a factor of two. The NAO report
+    cited above is the firmer number, for one health service.
+
+[^cve-bluekeep]:
+    [CVE-2019-0708](https://www.cve.org/CVERecord?id=CVE-2019-0708).
+    Microsoft's decision to patch Windows XP and Server 2003, years
+    after their end of life, is the clearest signal of how wormable it
+    judged the bug to be.
+
+[^therac]:
+    Nancy G. Leveson and Clark S. Turner,
+    [*An Investigation of the Therac-25 Accidents*](https://web.mit.edu/6.033/2014/wwwdocs/papers/therac.pdf),
+    *IEEE Computer* 26(7), 1993. The definitive account, and the source
+    of the `Class3` overflow detail; Leveson has since noted that most
+    retellings of Therac-25 get the causes wrong, so prefer this one to
+    any summary of it, including the one above.
+
+[^ariane]:
+    J. L. Lions et al.,
+    [*ARIANE 5: Flight 501 Failure, Report by the Inquiry Board*](https://esamultimedia.esa.int/docs/esa-x-1819eng.pdf)
+    (ESA/CNES, July 1996). Eight pages, and the clearest accident
+    report in software engineering: the conversion, the exception, the
+    redundant computer running identical code, and the decision not to
+    protect the variable because an analysis had shown it could not
+    overflow on Ariane 4.
+
+[^ps3]:
+    Nate Lawson,
+    [*How the PS3 hypervisor was hacked*](https://rdist.root.org/2010/01/27/how-the-ps3-hypervisor-was-hacked/)
+    (January 2010), a technical reconstruction of the attack George
+    Hotz published, written by a cryptography engineer rather than by
+    the attacker.

--- a/content/courses/systems-programming-c/why-c-for-systems.mdx
+++ b/content/courses/systems-programming-c/why-c-for-systems.mdx
@@ -26,7 +26,8 @@ word-addressed PDP-7, but the new PDP-11 the Unix group acquired in
 or "a structure." So Ritchie extended B with types and structs, and
 the extended language needed a name. After B came **C**, the joke
 writes itself, and yes, people immediately began asking whether the
-successor would be called D or P (the next letter in "BCPL").
+successor would be called D or P (the next letter in
+"BCPL").[^ritchie]
 
 The payoff came in 1973, when Thompson and Ritchie rewrote the Unix
 kernel itself in C. This was a radical act: operating systems were
@@ -35,7 +36,7 @@ enough. A kernel in a high-level language meant the *operating
 system itself* became portable, and when Unix spread to new
 machines in the late 1970s, C went everywhere with it. Twenty years
 later, Ritchie summed up his creation with characteristic dryness:
-*"C is quirky, flawed, and an enormous success."*
+*"C is quirky, flawed, and an enormous success."*[^ritchie]
 
 ## C runs the world
 
@@ -260,3 +261,13 @@ constantly.
 - Because every C statement maps to exactly one CPU instruction.
   > Many C statements compile to several instructions, and the optimizer can collapse or reorder them.`}
 />
+
+[^ritchie]:
+    Dennis M. Ritchie,
+    [*The Development of the C Language*](https://csapp.cs.cmu.edu/3e/docs/chistory.html),
+    presented at the second History of Programming Languages conference
+    (ACM, 1993). The account of BCPL, B, the PDP-7 and the byte-addressed
+    PDP-11 in this section is his, and so is the closing quotation. It
+    is worth reading in full: the man who made the language is unusually
+    frank about which of its decisions were considered and which were
+    accidents of the machine in front of him.

--- a/content/courses/typescript-from-scratch/birth-of-typescript.mdx
+++ b/content/courses/typescript-from-scratch/birth-of-typescript.mdx
@@ -133,7 +133,7 @@ timeline
 
 ## The October 2012 announcement
 
-On October 1, 2012, Microsoft unveiled **TypeScript 0.8** to the public, with Hejlsberg introducing the language on camera and showing how a simple JavaScript object could gain type safety with a single annotation:
+On October 1, 2012, Microsoft unveiled **TypeScript 0.8** to the public,[^ts08] with Hejlsberg introducing the language on camera and showing how a simple JavaScript object could gain type safety with a single annotation:
 
 <CodeBlock
   adapter="typescript"
@@ -264,3 +264,11 @@ One of TypeScript's most distinctive features is its **structural type system** 
 
 The superset constraint, combined with clean compilation to readable JavaScript, structural typing, and excellent tooling, made TypeScript feel like a natural extension of JavaScript, not a replacement.`}
 />
+
+[^ts08]:
+    Announced on the Microsoft TypeScript blog, 1 October 2012, and
+    open-sourced under the Apache licence on day one, which is the part
+    that mattered: Flow and Closure were both released by their owners
+    but developed inside them. The
+    [TypeScript blog](https://devblogs.microsoft.com/typescript/)
+    still carries every release note since.

--- a/content/courses/typescript-from-scratch/evolution-of-javascript.mdx
+++ b/content/courses/typescript-from-scratch/evolution-of-javascript.mdx
@@ -34,7 +34,7 @@ JavaScript's initial decade was marked by chaos. The language had quirks, `==` v
 
 By the early 2000s, JavaScript had evolved from a form-validation toy into the **DOM scripting** language. Developers used it to manipulate web pages dynamically, create dropdown menus, and animate elements. But the code was still small, a few script tags, maybe a thousand lines for a large site.
 
-Then came the **AJAX revolution**. In 2004–2005, Google launched Gmail and Google Maps, web applications that felt like desktop software. They loaded once, then used `XMLHttpRequest` to fetch data in the background and update the page without reloading it. Suddenly, JavaScript wasn't just a scripting language; it was the engine of single-page applications.
+Then came the **AJAX revolution**.[^ajax] In 2004–2005, Google launched Gmail and Google Maps, web applications that felt like desktop software. They loaded once, then used `XMLHttpRequest` to fetch data in the background and update the page without reloading it. Suddenly, JavaScript wasn't just a scripting language; it was the engine of single-page applications.
 
 The **jQuery era** followed. jQuery, released in 2006, smoothed over browser inconsistencies and made DOM manipulation pleasant. Sites that once had 500 lines of JS now had 5,000. But they were still manageable. You could fit the whole codebase in your head.
 
@@ -62,7 +62,7 @@ timeline
 
 ## Node.js and the explosion
 
-In 2009, **Ryan Dahl** unveiled **Node.js** at JSConf EU. JavaScript could now run *outside* the browser, on the server, in build tools, in command-line utilities. Suddenly, JavaScript was a general-purpose language. npm (Node Package Manager) became the largest package ecosystem in the world. Developers built REST APIs, real-time chat servers, build pipelines, and desktop apps (Electron) in JavaScript.
+In 2009, **Ryan Dahl** unveiled **Node.js** at JSConf EU.[^node] JavaScript could now run *outside* the browser, on the server, in build tools, in command-line utilities. Suddenly, JavaScript was a general-purpose language. npm (Node Package Manager) became the largest package ecosystem in the world. Developers built REST APIs, real-time chat servers, build pipelines, and desktop apps (Electron) in JavaScript.
 
 Codebases exploded. A modern web application might have:
 
@@ -184,3 +184,9 @@ journey started.
 
 As projects scale from 1,000 to 100,000+ lines of code, the inability to verify types, function signatures, and property names *before* running the code becomes a major source of bugs and fragility.`}
 />
+
+[^ajax]:
+    Jesse James Garrett, "Ajax: A New Approach to Web Applications" (Adaptive Path, 18 February 2005), the essay that named the technique. `XMLHttpRequest` itself predates the name by years: Microsoft shipped it in Internet Explorer 5 in 1999, and the other browsers followed before anyone had a word for what it enabled.
+
+[^node]:
+    Ryan Dahl's original Node.js talk at JSConf EU, Berlin, November 2009. It is worth watching for the framing rather than the API: the argument is about blocking I/O being the wrong default, and JavaScript being incidentally well suited to the alternative because it already had callbacks and no standard library to conflict with.

--- a/content/courses/typescript-from-scratch/how-typescript-works.mdx
+++ b/content/courses/typescript-from-scratch/how-typescript-works.mdx
@@ -176,7 +176,7 @@ flowchart TD
     B --> C[VariableDeclaration]
     C --> D["Identifier: x"]
     C --> E["TypeAnnotation: NumberKeyword"]
-    C --> F["Initializer: NumericLiteral(42)"]
+    C --> F["Initializer: <code>NumericLiteral(42)</code>"]
 ```
 
 The AST captures the *structure* of the code: "This is a variable declaration named `x`, with type `number`, initialized to `42`." The parser checks syntax (no missing semicolons or braces), but it doesn't check *types* yet.
@@ -278,21 +278,21 @@ sequenceDiagram
     participant Checker as Type Checker
     
     User->>Editor: Types code in .ts file
-    Editor->>LS: getCompletionsAtPosition()
+    Editor->>LS: <code>getCompletionsAtPosition()</code>
     LS->>Checker: Analyze symbol at cursor
     Checker->>LS: Return type info & available members
     LS->>Editor: Completion list
     Editor->>User: Show autocomplete dropdown
     
     User->>Editor: Saves file
-    Editor->>LS: getSemanticDiagnostics()
+    Editor->>LS: <code>getSemanticDiagnostics()</code>
     LS->>Checker: Type-check updated file
     Checker->>LS: Return errors/warnings
     LS->>Editor: Diagnostic messages
     Editor->>User: Red squiggles under errors
     
     User->>Editor: Right-click → Rename Symbol
-    Editor->>LS: findRenameLocations()
+    Editor->>LS: <code>findRenameLocations()</code>
     LS->>Checker: Find all references across files
     Checker->>LS: List of locations
     LS->>Editor: Multi-file edit plan

--- a/content/courses/typescript-from-scratch/modeling-domains-with-types.mdx
+++ b/content/courses/typescript-from-scratch/modeling-domains-with-types.mdx
@@ -172,8 +172,8 @@ You can't create a user who is both active and suspended. You can't forget the s
 stateDiagram-v2
     [*] --> Active
     [*] --> Inactive
-    Active --> Suspended: violate_terms
-    Suspended --> Active: appeal_approved
+    Active --> Suspended: <code>violate_terms</code>
+    Suspended --> Active: <code>appeal_approved</code>
     Inactive --> Active: reactivate
     Active --> Inactive: deactivate
 

--- a/content/interview/analytics-engineer/dbt.mdx
+++ b/content/interview/analytics-engineer/dbt.mdx
@@ -402,10 +402,10 @@ A typical slice of that graph, raw sources flowing through staging models into m
 
 ```mermaid
 flowchart TD
-  s1["source: raw.orders"] --> stg1["stg_orders"]
-  s2["source: raw.customers"] --> stg2["stg_customers"]
-  stg1 --> fct["fct_orders"]
-  stg2 --> dim["dim_customer"]
+  s1["source: <code>raw.orders</code>"] --> stg1["<code>stg_orders</code>"]
+  s2["source: <code>raw.customers</code>"] --> stg2["<code>stg_customers</code>"]
+  stg1 --> fct["<code>fct_orders</code>"]
+  stg2 --> dim["<code>dim_customer</code>"]
   dim --> fct
 ```
 

--- a/content/interview/analytics-engineer/dimensional-modeling.mdx
+++ b/content/interview/analytics-engineer/dimensional-modeling.mdx
@@ -48,9 +48,9 @@ single-table dimensions:
 
 ```mermaid
 flowchart TB
-  d["dim_date"] --> f["fact_orders"]
-  p["dim_product"] --> f
-  c["dim_customer"] --> f
+  d["<code>dim_date</code>"] --> f["<code>fact_orders</code>"]
+  p["<code>dim_product</code>"] --> f
+  c["<code>dim_customer</code>"] --> f
 ```
 
 The query below is a textbook star-schema read: the central `fact_orders`

--- a/content/interview/data-engineer/data-modeling.mdx
+++ b/content/interview/data-engineer/data-modeling.mdx
@@ -55,9 +55,9 @@ splits that dimension further into a normalized chain (the dotted edges):
 
 ```mermaid
 flowchart TD
-  f["fact"] --> p["dim_product"]
-  p -. normalize .-> c["dim_category"]
-  c -. normalize .-> d["dim_department"]
+  f["fact"] --> p["<code>dim_product</code>"]
+  p -. normalize .-> c["<code>dim_category</code>"]
+  c -. normalize .-> d["<code>dim_department</code>"]
 ```
 
 ### What are fact and dimension tables?

--- a/lib/generated/charts.d.ts
+++ b/lib/generated/charts.d.ts
@@ -20,11 +20,23 @@ export interface ChartUsage {
   section?: string;
 }
 
+/** One reference in a chart's credit line (the spec's `sources` export). */
+export interface ChartSource {
+  /** The reference as it reads on the page: author, title, publisher, year. */
+  text: string;
+  /** Where it lives, when it has a stable public home. */
+  href?: string;
+}
+
 export interface GeneratedChart {
   /** Accessible name for the whole figure (the spec's `title` export). */
   title: string;
   /** Default caption, when the spec exports one. */
   caption?: string;
+  /** Where the chart's numbers came from, when the spec exports them. Carried
+   *  in the manifest so the credit follows the chart to every lesson that
+   *  places it, rather than being re-typed on each `<Chart>` tag. */
+  sources?: ChartSource[];
   /** Intrinsic size the SVG was laid out at, in px. */
   width: number;
   height: number;

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "check:mdx-tables": "node scripts/check-mdx-tables.mjs",
     "check:prose": "node scripts/check-prose.mjs",
     "check:diagrams": "node scripts/check-ascii-diagrams.mjs",
+    "check:mermaid-code": "node scripts/check-mermaid-code.mjs",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/scripts/build-charts.mjs
+++ b/scripts/build-charts.mjs
@@ -310,6 +310,40 @@ function undersizedType(svg) {
     .filter((n) => n < MIN_AUTHORED_PX);
 }
 
+/**
+ * Check a spec's optional `sources` export, the credit line under the chart.
+ * Returns the problem to report, or null when it is fine (including absent).
+ *
+ * ```js
+ * export const sources = [
+ *   { text: "Boehm, *Software Engineering Economics* (1981)", href: "https://…" },
+ * ];
+ * ```
+ *
+ * Checked here rather than trusted at render time because the manifest is
+ * generated: a typo in the shape would otherwise surface as a blank credit on
+ * every lesson that places the chart, which is exactly the kind of thing
+ * nobody notices. `href` is optional (not every reference has a stable public
+ * home) but must be `http(s)` when given, since it renders as a link out.
+ */
+function badSources(sources) {
+  if (sources === undefined) return null;
+  if (!Array.isArray(sources)) {
+    return "sources must be an array of { text, href? } entries";
+  }
+  for (const [i, source] of sources.entries()) {
+    const at = `sources[${i}]`;
+    if (!source || typeof source !== "object") return `${at} must be an object`;
+    if (typeof source.text !== "string" || source.text.trim() === "") {
+      return `${at}.text must be a non-empty string (the reference as it reads on the page)`;
+    }
+    if (source.href !== undefined && !/^https?:\/\//.test(source.href)) {
+      return `${at}.href must be an http(s) URL, or be left off`;
+    }
+  }
+  return null;
+}
+
 const MIN_LEGIBLE_PX = 8.5;
 
 /** Below this the floor is not worth publishing: the chart already fits the
@@ -363,6 +397,15 @@ for (const file of specs) {
   }
   if (!mod.title) {
     problems.push(`${file}: no exported title (it becomes the chart's aria-label)`);
+    continue;
+  }
+
+  // Where the numbers came from, rendered as a credit line under the caption
+  // (<FigureSources>). It lives on the spec rather than on the `<Chart>` tag
+  // so it travels with the chart to every lesson that places it.
+  const sourceProblem = badSources(mod.sources);
+  if (sourceProblem) {
+    problems.push(`${file}: ${sourceProblem}`);
     continue;
   }
 
@@ -439,6 +482,7 @@ for (const file of specs) {
   charts[slug] = {
     title: mod.title,
     ...(mod.caption ? { caption: mod.caption } : {}),
+    ...(mod.sources?.length ? { sources: mod.sources } : {}),
     width,
     height: Number(el.getAttribute("height")),
     // Omitted when the chart can shrink to any width without a label falling

--- a/scripts/check-mermaid-code.mjs
+++ b/scripts/check-mermaid-code.mjs
@@ -1,0 +1,391 @@
+// Lints lesson content for code inside a Mermaid label that is not marked as
+// code, and therefore reaches the reader set in Inter next to the same
+// identifier set in JetBrains Mono one line above it.
+//
+// The convention this enforces already exists: an author wraps the code part
+// of a diagram label in a `<code>` tag,
+//
+//     flowchart LR
+//       Doc["<code>report.qmd</code><br/>prose + R code"] --> R[quarto render]
+//
+// and the renderer sets that span in the mono face
+// (`app/_components/mdx/mermaid.module.css`). ~395 diagrams do this. What the
+// rule catches is the ones that do not: `System.out` in the sequence diagram
+// on `java-programming-for-beginners/your-first-java-program` sat in an actor
+// box in Inter, three paragraphs below the same name in a code block.
+//
+// ── What counts as code ────────────────────────────────────────────────────
+//
+// Three shapes, each chosen because prose cannot produce it by accident:
+//
+//   1. call,       an identifier with `(` directly after it: `println(`,
+//                  `group_by(`. The *absence of a space* is the whole rule.
+//                  Nearly every parenthesis in a lesson label opens an aside
+//                  ("Reality (infinite detail)", "Wide form (humans love
+//                  this)"), and every one of those has a space in front of it.
+//   2. qualified,  two identifiers joined by a dot with no spaces:
+//                  `System.out`, `Main.class`, `report.qmd`. A sentence's full
+//                  stop is always followed by a space or the end of the label,
+//                  so it cannot match. Product names that are spelled with a
+//                  dot but read as prose (`Node.js`) are in PROSE_NAMES.
+//   3. snake_case, `read_csv`, `dim_product`, `was_missing`. English does not
+//                  use underscores; a token with one is an identifier wherever
+//                  it appears.
+//
+// Deliberately NOT flagged: a bare CamelCase or lowercase word. `Main`,
+// `args`, `void` and `int` are all code in the language sense, but so are
+// `Editor`, `Reality` and `You`, and no test tells them apart. Those stay the
+// author's call, which is why this rule reports what it is sure of rather than
+// trying to be exhaustive.
+//
+// ── Which diagrams are read ────────────────────────────────────────────────
+//
+// All of them except class and ER diagrams: those are code end to end, so
+// `mermaid.tsx` renders the whole diagram in the mono face and there is
+// nothing inside one to mark (see `isCodeDiagram` there).
+//
+// Only *label* text is read, never Mermaid's own syntax and never a node id.
+// `set_types[Set types]` draws a box reading "Set types"; the snake_case id in
+// front of it is never painted, and flagging it would be asking the author to
+// mark up something no reader can see. `nodeLabels` below is the delimiter
+// walker that keeps those apart.
+//
+// ── Opting out ─────────────────────────────────────────────────────────────
+//
+// A label that genuinely wants the prose face (a sentence that happens to name
+// a file, say) says so on the line above the fence:
+//
+//     {/* allow-unmarked-code: the address is a value, not an identifier */}
+//
+// Used both as a CLI (`node scripts/check-mermaid-code.mjs [files...]`,
+// defaults to all of content/) and as a library by
+// __tests__/mermaidCode.test.ts.
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+// The fence walker check-prose.mjs and check-ascii-diagrams.mjs already share,
+// so the three linters cannot disagree about where a mermaid block starts and
+// ends or which keyword it opens with.
+import { mermaidLines } from "./check-prose.mjs";
+
+/** Diagram kinds Mermaid renders wholesale in the mono face (`isCodeDiagram`
+ *  in app/_components/mdx/mermaid.tsx). Nothing in one needs marking. */
+const MONO_DIAGRAMS = new Set(["classDiagram", "classDiagram-v2", "erDiagram"]);
+
+/** Lines whose text is a style or layout declaration rather than a label
+ *  (`style A fill:#f9f`, `classDef box ...`, `direction TB`). */
+const DIRECTIVE =
+  /^\s*(style|classDef|class|click|linkStyle|direction|dateFormat|axisFormat|accTitle|accDescr)\b/;
+
+/** Diagram kinds where a colon introduces free text that runs to the end of
+ *  the line: a sequence message, a note, a state description, a timeline
+ *  event, a pie slice. In a flowchart it means nothing of the sort. Mirrors
+ *  COLON_LABEL_DIAGRAMS in check-prose.mjs, minus the two mono kinds. */
+const COLON_LABEL_DIAGRAMS = new Set([
+  "sequenceDiagram",
+  "stateDiagram",
+  "stateDiagram-v2",
+  "timeline",
+  "journey",
+  "pie",
+]);
+
+/** Kinds that draw boxes with bracketed labels. */
+const SHAPE_DIAGRAMS = new Set([
+  "flowchart",
+  "flowchart-elk",
+  "graph",
+  "mindmap",
+  "stateDiagram",
+  "stateDiagram-v2",
+  "block-beta",
+]);
+
+const OPENERS = "[({";
+const CLOSERS = { "[": "]", "(": ")", "{": "}" };
+
+/**
+ * The label text of every bracketed node on one line.
+ *
+ * Mermaid spells a dozen shapes with the same three bracket pairs stacked in
+ * different combinations (`[text]`, `([text])`, `[[text]]`, `[(text)]`,
+ * `((text))`, `{{text}}`, `[/text/]`, `[\text\]`), so this walks the
+ * delimiters rather than trying to name each shape in a pattern. An opening
+ * run has to sit directly after an id character, which is what stops a
+ * parenthesis inside prose from opening a phantom node.
+ */
+function nodeLabels(line) {
+  const labels = [];
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+
+    // The asymmetric shape `A>text]` is the one that does not nest. The
+    // character before it has to be an id character and NOT a hyphen: the `>`
+    // ending every `-->` link is preceded by one, and reading that as a node
+    // swallows the rest of the line (`D -->|Ok| E([Final result])`).
+    if (ch === ">" && i > 0 && /\w/.test(line[i - 1])) {
+      const end = line.indexOf("]", i);
+      if (end === -1) continue;
+      labels.push(line.slice(i + 1, end));
+      i = end;
+      continue;
+    }
+
+    if (!OPENERS.includes(ch)) continue;
+    if (i === 0 || !/\w/.test(line[i - 1])) continue;
+
+    let open = i;
+    while (open + 1 < line.length && OPENERS.includes(line[open + 1])) open++;
+    const depth = open - i + 1;
+
+    const stack = [];
+    for (let k = i; k <= open; k++) stack.push(CLOSERS[line[k]]);
+
+    let k = open + 1;
+    for (; k < line.length; k++) {
+      const c = line[k];
+      if (OPENERS.includes(c)) stack.push(CLOSERS[c]);
+      else if (stack[stack.length - 1] === c && stack.pop() && stack.length === 0) break;
+    }
+    if (stack.length) break; // unbalanced: the rest of the line is not readable
+
+    // The closing run unwinds one character at a time, so the outermost close
+    // sits `depth - 1` characters past the first of them. Slashes and
+    // backslashes belong to the shape (trapezoids), not to the label.
+    labels.push(line.slice(open + 1, k - depth + 1).replace(/^[/\\]+|[/\\]+$/g, ""));
+    i = k;
+  }
+  return labels;
+}
+
+/**
+ * Every span of one mermaid line that reaches the reader as label text.
+ *
+ * Quoted runs come first and are then blanked out, so a colon or a bracket
+ * *inside* a label cannot be read as syntax: `A["ratio: x:y"] --> B` has to
+ * contribute `ratio: x:y` and nothing else.
+ */
+export function mermaidLabels(line, diagram) {
+  if (DIRECTIVE.test(line)) return [];
+
+  const labels = [];
+  for (const m of line.matchAll(/"([^"]*)"/g)) labels.push(m[1]);
+  const bare = line.replace(/"[^"]*"/g, (m) => " ".repeat(m.length));
+
+  if (SHAPE_DIAGRAMS.has(diagram)) {
+    labels.push(...nodeLabels(bare));
+    // Edge labels: `-->|text|`, `-- text -->`, `-. text .->`, `== text ==>`.
+    //
+    // The middle form is ambiguous with a plain `A --- B` link, since the `-`
+    // that closes a labelled `-- text ---` is the same `-` that ends an
+    // unlabelled one: `A((a)) --- I((4,5)) --- B((b))` reads as an edge
+    // labelled `I((4,5))`. A real edge label holding a bracket has to be
+    // quoted, and the quote pass above already has those, so anything with one
+    // in it here is a node that has been mistaken for a label.
+    for (const m of bare.matchAll(/\|([^|]*)\|/g)) labels.push(m[1]);
+    for (const m of bare.matchAll(/(?:--|==)\s+(.+?)\s+(?:--|==)[->]/g)) {
+      if (!/[[({]/.test(m[1])) labels.push(m[1]);
+    }
+    for (const m of bare.matchAll(/-\.\s+(.+?)\s+\.-[->]/g)) {
+      if (!/[[({]/.test(m[1])) labels.push(m[1]);
+    }
+    // `subgraph Name`, whose label is unbracketed and unquoted.
+    const sub = bare.match(/^\s*subgraph\s+([^[\n]+)$/);
+    if (sub) labels.push(sub[1]);
+  }
+
+  if (COLON_LABEL_DIAGRAMS.has(diagram)) {
+    const colon = bare.indexOf(":");
+    if (colon !== -1) labels.push(line.slice(colon + 1));
+    // `participant SO as System.out` / `actor U as You`.
+    const alias = line.match(/^\s*(?:participant|actor)\s+\S+\s+as\s+(.+)$/);
+    if (alias) labels.push(alias[1]);
+  }
+
+  if (diagram === "gantt") {
+    // A task is `name :meta, start, end`; the name is what gets painted.
+    const colon = bare.indexOf(":");
+    if (colon !== -1) labels.push(line.slice(0, colon));
+    const heading = line.match(/^\s*(?:title|section)\s+(.+)$/);
+    if (heading) labels.push(heading[1]);
+  }
+
+  return labels.map((l) => l.trim()).filter(Boolean);
+}
+
+/** An identifier with `(` right after it.
+ *
+ *  Two characters minimum, because a one-letter name in front of a paren is
+ *  mathematical notation rather than a call in every lesson that has one:
+ *  `P(A given B)`, `f(x)`, `y(t-1)`, `s(i)`. Mermaid cannot typeset those
+ *  (KaTeX is off in labels), so they are prose written in symbols and belong
+ *  in the prose face; a genuine one-letter function like R's `c()` is rare
+ *  enough to mark by hand. */
+const CALL = /(?<![\w$.])[A-Za-z_][\w$]+\(/g;
+
+/** Two or more identifiers joined by dots, no spaces. The `@` in the lookbehind
+ *  keeps the rule off the domain half of an email address, which lessons on
+ *  unique constraints and foreign keys use as sample *data*. */
+const QUALIFIED = /(?<![\w$.@])[A-Za-z_][\w$]*(?:\.[A-Za-z_][\w$]*)+/g;
+
+/** snake_case. */
+const SNAKE = /(?<![\w$])[a-z][a-z0-9]*(?:_[a-z0-9]+)+/g;
+
+const RULES = [
+  ["call", CALL],
+  ["qualified", QUALIFIED],
+  ["snake_case", SNAKE],
+];
+
+/**
+ * Names that match one of the patterns above but are not code: a product's
+ * name, an abbreviation, an English word, or a piece of mathematical notation
+ * that happens to be spelled like a call.
+ *
+ * The notation entries are the ones the statistics and time-series lessons
+ * write in their diagrams. `Poisson(lambda)` is the same kind of thing as
+ * `f(x)`, which the two-character minimum on CALL already covers; these just
+ * have longer names. A diagram with notation this list does not know about
+ * opts out with `{/* allow-unmarked-code: … *\/}`.
+ */
+const PROSE_NAMES = new Set([
+  "Node.js",
+  "Next.js",
+  "Nuxt.js",
+  "Vue.js",
+  "React.js",
+  "Angular.js",
+  "Backbone.js",
+  "Ember.js",
+  "Three.js",
+  "D3.js",
+  "Chart.js",
+  "Express.js",
+  "e.g",
+  "i.e",
+  "etc",
+  "vs",
+  "U.S",
+  "Ph.D",
+  "alt.sources",
+  // Notation, not calls.
+  "AR",
+  "MA",
+  "ARMA",
+  "ARIMA",
+  "Bernoulli",
+  "Binomial",
+  "Geometric",
+  "Poisson",
+  // English, with a parenthesised plural: "area in the tail(s)".
+  "tail",
+]);
+
+/** Authors opt one diagram out with this on a line above the fence. */
+const ALLOW = /allow-unmarked-code/;
+
+/** Blank out what is already marked up, plus Mermaid's own `<br/>`, so only
+ *  the unmarked remainder of a label is scanned. Lengths are preserved so a
+ *  reported token still reads against the original label. */
+function unmarked(label) {
+  return label
+    .replace(/<code>[\s\S]*?<\/code>/gi, (m) => " ".repeat(m.length))
+    .replace(/<br\s*\/?>/gi, (m) => " ".repeat(m.length));
+}
+
+/** The code-shaped tokens in one label that are not inside a `<code>` span. */
+export function unmarkedCode(label) {
+  const rest = unmarked(label);
+  const found = [];
+  for (const [rule, pattern] of RULES) {
+    pattern.lastIndex = 0;
+    for (const m of rest.matchAll(pattern)) {
+      const token = m[0];
+      if (PROSE_NAMES.has(token) || PROSE_NAMES.has(token.replace(/\($/, ""))) continue;
+      found.push({ rule, token });
+    }
+  }
+  return found;
+}
+
+/** Lint one MDX source. Returns `{ file, rule, line, detail }` violations. */
+export function lintSource(src, file) {
+  const violations = [];
+  const lines = src.split("\n");
+  const allowed = new Set();
+  lines.forEach((line, i) => {
+    // An opt-out covers the fence that follows it. A mermaid block runs to
+    // ~30 lines at the outside, and the comment is an explicit author decision
+    // either way, so the window is deliberately generous.
+    if (ALLOW.test(line)) for (let j = i; j < Math.min(lines.length, i + 60); j++) allowed.add(j);
+  });
+
+  for (const { line, text, diagram } of mermaidLines(lines)) {
+    if (MONO_DIAGRAMS.has(diagram) || allowed.has(line - 1)) continue;
+    for (const label of mermaidLabels(text, diagram)) {
+      for (const { rule, token } of unmarkedCode(label)) {
+        violations.push({
+          file,
+          rule,
+          line,
+          detail: `${token}  in  ${label.slice(0, 70)}`,
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+// --- file discovery -------------------------------------------------------
+
+function walk(dir, test, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, test, out);
+    else if (test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/** Every lesson file this linter is responsible for. */
+export function diagramFiles(root = process.cwd()) {
+  return walk(path.join(root, "content"), (n) => n.endsWith(".mdx"));
+}
+
+export function lintFiles(files) {
+  return files.flatMap((f) => lintSource(readFileSync(f, "utf8"), f));
+}
+
+// --- CLI ------------------------------------------------------------------
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const args = process.argv.slice(2);
+  const files = args.length ? args : diagramFiles();
+  const violations = lintFiles(files);
+  if (violations.length) {
+    const byFile = {};
+    for (const v of violations) (byFile[v.file] ??= []).push(v);
+    for (const [file, list] of Object.entries(byFile)) {
+      console.error(`\n✗ ${path.relative(process.cwd(), file)}`);
+      for (const v of list) console.error(`   ${v.line}: [${v.rule}] ${v.detail}`);
+    }
+    console.error(
+      `\n${violations.length} unmarked code token(s) across ` +
+        `${Object.keys(byFile).length} file(s).\n\n` +
+        "Code in a diagram label is set in JetBrains Mono, the same face it has\n" +
+        "in the code block above it, by wrapping the span in a <code> tag:\n\n" +
+        '  A["<code>System.out</code>"]        flowchart, class, state, ER, mindmap\n' +
+        "  participant SO as <code>System.out</code>   sequence, pie, gantt, timeline\n\n" +
+        "A label whose brackets hold no quotes needs them once it holds a tag:\n" +
+        "mermaid reads an unquoted `<` as syntax.\n\n" +
+        "A label that really wants the prose face can opt out with\n" +
+        "`{/* allow-unmarked-code: why */}` on a line above the fence.",
+    );
+    process.exit(1);
+  }
+  console.log(
+    `✓ code in the mermaid labels of ${files.length} lesson file(s) is marked with <code>`,
+  );
+}


### PR DESCRIPTION
Four changes: the first three are about code in diagram labels reaching the reader in the wrong face, the fourth adds somewhere to put a citation.

## 1. Four diagram kinds could not carry a `<code>` tag at all

Mermaid paints sequence, pie, gantt and journey labels as SVG `<text>` and pushes each one through d3's `.text()`, which escapes markup. A `<code>` tag written in one of those arrives on the page as the literal characters `<code>System.out</code>` sitting in the actor box — so there was no way for an author to ask for the mono face there. (`sequence.textPlacement: "fo"` does not help; its foreignObject path calls `.text()` too. Checked against mermaid 11.16.1.)

`mermaid.tsx` now strips the tags before Mermaid measures the label and splits the rendered text node back into `<tspan>`s afterwards, marking the runs that were code. A `<tspan>` with no `x` of its own continues the text chunk it sits in, so a `text-anchor: middle` label stays centered on the same point and messages stay over their arrows.

Mermaid measured in the sans face, so a code run paints a little wider than the width reserved for it. Sequence diagrams absorb that (an actor box is at least 150px wide against names measuring under 100); where it would push a label past the SVG's viewport, which is a hard clip, `growToFitText` widens the viewport by the same number of user units it adds to the `max-width` cap, so the diagram keeps its scale. `<Timeline>`, which renders `timeline` diagrams itself rather than through Mermaid, honours the tag too.

## 2. ~130 labels never had one

`System.out` sat in an actor box in Inter, three paragraphs below the same name in a code block. A sweep of all 1,177 mermaid fences marked the rest, and `scripts/check-mermaid-code.mjs` (`npm run check:mermaid-code`, plus `__tests__/mermaidCode.test.ts`) now flags a call, a dotted name or a snake_case identifier left unmarked.

Its rules are deliberately narrow, because a linter that cries wolf gets switched off:

- a **call** is an identifier with `(` *directly* after it. Nearly every parenthesis in a lesson label opens an aside ("Reality (infinite detail)"), and every one of those has a space in front of it.
- a one-letter name in front of a paren is **mathematical notation**, not a call: `P(A given B)`, `y(t-1)`, `ARIMA(p, d, q)`. Mermaid cannot typeset those, so they are prose written in symbols and stay in the prose face.
- **class and ER diagrams are skipped entirely** — they are code end to end, so the renderer already sets them wholesale in mono.
- only *label* text is read, never a node id: `set_types[Set types]` draws a box reading "Set types", and asking an author to mark up something no reader can see is noise.

A label that really wants the prose face opts out with `{/* allow-unmarked-code: why */}`, the same escape hatch `check-ascii-diagrams.mjs` offers.

## 3. `<SyntaxBreakdown>` for "Line by line"

The three bullet lists on `your-first-java-program` were naming the spans of a line of source in prose. They are now `<SyntaxBreakdown>` figures, with the explanations that went beyond naming kept as prose underneath.

## 4. Citations: a credit line for figures, footnotes for prose

A lesson that reports someone else's measurement should say whose, and neither half of that worked.

**Footnotes almost did.** `remark-gfm` is the first plugin in fumadocs-mdx's preset and our own `remarkPlugins` are appended to it, so `[^1]` already parsed and reached the page as a superscript link and a definitions section. What it did not reach the page with is a heading: fumadocs renders the section's "Footnotes" `<h2>` as `sr-only`, so the references arrived as an unexplained numbered list hanging off the bottom of the lesson. `app/docs.css` puts the heading back, rules the section off, and sets the definitions a step below body copy.

**Figures could not use one at all.** A caption is a JSX string prop, so markdown never touches it and a `[^1]` written in one arrives as those four characters. A figure also wants its credit *in place* rather than at the foot of the page: the source of a chart is part of reading it. `<FigureSources>` renders that line, and both `<Chart>` and `<Figure>` take a `sources` list. It goes inside the figure's own `<figcaption>` rather than a second one, since a `<figure>` may hold only one.

For a chart the list belongs on the **spec** rather than the tag, so it follows the chart to every lesson that places it — `bug-cost-by-stage` is on three. `build-charts` validates the shape, because a typo in a generated manifest surfaces as a blank credit on every one of those pages, which is exactly what nobody notices.

`bug-cost-by-stage` now carries Boehm, the NIST/RTI report, and Bossavit's *The Leprechauns of Software Engineering*. The last is there on purpose: the most-reproduced version of that chart traces back to no published study anyone can find, which is what the caption's "vary by an order of magnitude" was already standing on.

## Verification

- Every one of the 1,177 mermaid fences was rendered against mermaid 11.16.1 before and after the sweep: all 1,160 non-timeline diagrams parse, every stripped code span is found in the rendered output (so no marked span silently fails to match), and after `growToFitText` no label overflows its viewport.
- The pages were driven in a browser against `next dev`. On `your-first-java-program`, `System.out`, `main(args)` and `println("Hello, Java!")` compute to `"JetBrains Mono"` while `JVM`, `Main class` and `returns void` stay `Inter`. The chart credit line and the footnote section were checked in both themes.
- `build-charts` was run against a deliberately malformed `href` to confirm it fails rather than shipping a blank credit.
- `npx tsc --noEmit`, `eslint`, `check:prose`, `check:diagrams`, `check:mdx`, `check:mermaid-code` and the full `vitest` suite (95 files, 1,301 tests) all pass.