### PR TITLE
Swap server-execution FAQ for an AI-era one, refresh language list

### DIFF
--- a/app/_components/home/Faq.tsx
+++ b/app/_components/home/Faq.tsx
@@ -21,12 +21,12 @@ const FAQS: { q: string; a: string }[] = [
     a: "Ask AI has a daily allowance that refreshes on a rolling 24-hour basis, so prompts you use free up again over the following day. For now Dataslope only offers free memberships, so there's no paid upgrade for extra prompts, everyone gets the same free allowance. We may add more options in the future.",
   },
   {
-    q: "How does code run without a server?",
-    a: "Each language is compiled to WebAssembly and executed entirely on your own machine. Your code and data never leave the browser, so the playgrounds work even offline once a runtime has loaded.",
+    q: "Why learn the basics when AI can do the heavy lifting?",
+    a: "Because someone still has to judge what comes back. AI is fastest in the hands of people who can read the code it writes, spot the wrong join or the off-by-one, and say precisely what they wanted instead, and that judgment only comes from having written enough of it yourself. The playgrounds are here so you can run things and see the result for yourself rather than take anyone's word for it.",
   },
   {
     q: "Which languages and databases are supported?",
-    a: "Python, R, JavaScript, TypeScript, PHP, C, C++, Java, and C#, plus SQLite, PostgreSQL, and DuckDB for SQL.",
+    a: "Python, R, JavaScript, TypeScript, HTML/CSS, React, PHP, C, C++, Java, and C#, plus PostgreSQL, SQLite, and DuckDB for SQL.",
   },
   {
     q: "Is my work saved?",


### PR DESCRIPTION
Two edits to the home-page FAQ (`app/_components/home/Faq.tsx`).

## Replaced "How does code run without a server?"

That entry answered a question visitors have largely stopped asking. In its place: **"Why learn the basics when AI can do the heavy lifting?"** — the answer argues that a model's output still needs someone who can read it, catch the wrong join or the off-by-one, and say what they wanted instead, and points at the playgrounds as the way to check results rather than trust them.

It keeps the same slot in the list, directly after the "What if I want to use more prompts?" entry, so the two AI questions read together.

## Refreshed the supported-languages answer

The list had drifted from the canonical registry in `app/_components/playgrounds.ts`:

- Added **HTML/CSS** and **React**, which have playground routes (`/playground/web`, `/playground/react`) but weren't listed.
- Reordered the databases to **PostgreSQL · SQLite · DuckDB**, matching the fixed order the registry documents and the playground index and dashboard both render.

## Notes

String-only changes inside the existing `FAQS` array — no component or type changes. No test or e2e spec asserts on this copy. `tsc`/`eslint` couldn't be run to completion in this environment (dependencies aren't installed), but the edit touches only string literals in an already-typed array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJU49LLKwZbrbMxTXiXfNa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJU49LLKwZbrbMxTXiXfNa)_