### PR TITLE
Tint the interview track topic count green at 14px

### DIFF
--- a/app/interview-prep/_components/InterviewCatalog.tsx
+++ b/app/interview-prep/_components/InterviewCatalog.tsx
@@ -207,9 +207,18 @@ function TrackRow({ track }: { track: InterviewTrack }) {
             subject areas, which is the sense this glyph already carries
             elsewhere in the app (the playgrounds use it for a stack of
             schemas). On its own line above the link, so the row reads as
-            "what's in it", then "go". */}
-        <span className="mt-2 flex items-center gap-1.5 text-[16px] leading-[1.7] text-[var(--ds-gray-400)] transition-colors group-hover:text-[var(--ds-gray-500)] dark:text-[var(--ds-gray-500)] dark:group-hover:text-[var(--ds-gray-400)]">
-          <Layers size={15} aria-hidden="true" />
+            "what's in it", then "go".
+
+            The glyph carries its own green rather than inheriting the line's
+            grey, so the count reads as a labelled quantity instead of one
+            undifferentiated grey run; it steps a notch on hover in the
+            direction that gains contrast against each appearance mode. */}
+        <span className="mt-2 flex items-center gap-1.5 text-[14px] leading-[1.7] text-[var(--ds-gray-400)] transition-colors group-hover:text-[var(--ds-gray-500)] dark:text-[var(--ds-gray-500)] dark:group-hover:text-[var(--ds-gray-400)]">
+          <Layers
+            size={14}
+            aria-hidden="true"
+            className="text-[var(--ds-green-500)] transition-colors group-hover:text-[var(--ds-green-600)] dark:group-hover:text-[var(--ds-green-400)]"
+          />
           {track.topics.length} topics
         </span>
 


### PR DESCRIPTION
Restyles the topic-count line on each `/interview-prep` track row.

## Changes

`app/interview-prep/_components/InterviewCatalog.tsx`, in `TrackRow`:

- The `Layers` glyph drops from `size={15}` to `size={14}`, and the `N topics` label drops from `text-[16px]` to `text-[14px]`, so glyph and label now match at 14px.
- The glyph takes its own color instead of inheriting the line's grey: `var(--ds-green-500)` in both appearance modes.
- On row hover it steps one notch in the direction that gains contrast against each background — `var(--ds-green-600)` on light, `var(--ds-green-400)` on dark — carried by the existing `group` on the row `Link`, so it still answers the pointer as one block with the rest of the row.

The label's own grey and its hover step are unchanged; only its size moved.

## Notes

`node_modules` is not installed in this environment, so `tsc`, `eslint`, and `next build` could not be run against the change. The edit is confined to a single JSX element's `size` prop and Tailwind classes, and the three `--ds-green-*` custom properties it uses are already in use elsewhere in the app (e.g. `components/ui/bento-grid.tsx`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5XvbMQYe9pBANCfhrPYZM)_