### PR TITLE
Shrink the R2 incremental cache: keep previews on merit, not on age

### DIFF
--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -28,7 +28,9 @@ name: R2 incremental-cache cleanup
 #   • the live production build (probed from the running Worker), a site that
 #     sits unchanged for months must never lose its cache, which would 500 the
 #     home page and /courses/* (see open-next.config.ts), AND
-#   • any folder written within the last GRACE_HOURS, whatever it matches. A
+#   • any folder POPULATED within the last GRACE_HOURS, whatever it matches
+#     (populated, not "last written" — see step 5; objects also arrive at
+#     request time and must not be mistaken for a deploy). A
 #     deploy populates its cache folder BEFORE the Worker switches to serving
 #     that build, so for some minutes the incoming production folder is
 #     protected by neither the probe (which still reports the outgoing build)
@@ -422,32 +424,58 @@ jobs:
           echo "Policy: keep live production + anything written in the last ${GRACE_HOURS}h + the head commit of up to $MAX_BRANCHES open-PR branches (any age) + anything younger than ${THRESHOLD_HOURS}h + recent '$default_branch' builds within that window (cutoff $(date -u -d "@$cutoff" '+%Y-%m-%d %H:%M:%SZ'))"
           echo "Dry run: $DRY_RUN"
 
-          # 5) Timestamp every non-production folder so active-branch previews
-          #    can be ranked newest-first, the MAX_BRANCHES cap needs a global
-          #    order, not a per-folder decision.
+          # 5) Date every non-production folder by when it was POPULATED so
+          #    active-branch previews can be ranked newest-first, the
+          #    MAX_BRANCHES cap needs a global order, not a per-folder decision.
           entries=()
           for folder in "${folders[@]}"; do
             [[ "$folder" == "$prod_folder" ]] && continue
 
-            # Newest object in the folder (all written together at deploy time).
-            # The CLI auto-paginates above 1000 objects and applies --query to
-            # each page separately, so a large build folder returns one max
-            # timestamp PER PAGE (multiple lines). Collapse to the overall max,
-            # R2 reports LastModified in a uniform UTC ISO-8601 layout, so a
-            # lexical sort orders them chronologically, and drop the "None" a
-            # genuinely empty page emits, leaving `date` a single value to parse.
-            newest="$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$folder" \
-              --query 'sort_by(Contents, &LastModified)[-1].LastModified' --output text 2>/dev/null \
-              | grep -vxF 'None' | sort | tail -n1 || true)"
-            if [[ -z "$newest" ]]; then
+            # When was this folder POPULATED? Use the median object's
+            # LastModified, not the newest.
+            #
+            # A deploy writes the whole folder in one burst (measured 2026-08-14:
+            # median 0.8 min, max 1.8 min for ~1,081 objects), so any object in
+            # the burst dates the folder to within a couple of minutes. The max
+            # does NOT, because objects also arrive at REQUEST time, long after
+            # the deploy: a request for a `/courses/*` path that isn't
+            # prerendered renders the not-found page and OpenNext caches that
+            # 404 (~1.8 MB, `revalidate: false`) into whichever build folder is
+            # live. Every such write reset the folder's apparent age to zero.
+            # Folder 0127baf6 was populated at 17:54 and then took 404 writes at
+            # 18:22, 19:59, 20:46 and 21:07 — gaps of 28, 97, 47 and 21 minutes,
+            # every one inside GRACE_HOURS — so it was held by the grace rule as
+            # "possibly an in-flight deploy" more than three hours after its
+            # deploy finished. 4 of 33 folders were affected. Left unfixed this
+            # gets worse as THRESHOLD_HOURS shrinks, since there is less headroom
+            # for a stray write to erase, and it is unbounded: one crawler
+            # working through stale URLs can pin a folder open indefinitely.
+            #
+            # The median is immune (a burst of ~1,081 objects cannot be moved by
+            # a handful of late ones) and remains correct for the case the grace
+            # window exists to protect: during an in-flight populate the median
+            # of what has landed so far is also seconds old.
+            #
+            # The CLI auto-paginates above 1000 objects and applies --query per
+            # page, so this emits one tab-separated batch PER PAGE. Flatten to
+            # one stamp per line and sort globally: R2 reports LastModified in a
+            # uniform UTC ISO-8601 layout, so a lexical sort is chronological.
+            # Drop the "None" a genuinely empty page emits.
+            mapfile -t stamps < <(
+              aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$folder" \
+                --query 'Contents[].LastModified' --output text 2>/dev/null \
+                | tr '\t' '\n' | sed '/^$/d' | grep -vxF 'None' | sort || true
+            )
+            if [[ ${#stamps[@]} -eq 0 ]]; then
               echo "skip  $folder (empty)"; continue
             fi
-            entries+=("$(printf '%s\t%s\t%s' "$(date -u -d "$newest" +%s)" "$newest" "$folder")")
+            populated="${stamps[$(( ${#stamps[@]} / 2 ))]}"
+            entries+=("$(printf '%s\t%s\t%s' "$(date -u -d "$populated" +%s)" "$populated" "$folder")")
           done
 
           echo "KEEP  $prod_folder (live production)"
           kept=1; deleted=0; failed=0; branches=0
-          while IFS=$'\t' read -r ts newest folder; do
+          while IFS=$'\t' read -r ts populated folder; do
             [[ -z "$folder" ]] && continue
             # Folder name is the commit SHA: strip the prefix and trailing slash.
             sha="${folder#"$PREFIX"}"; sha="${sha%/}"
@@ -457,7 +485,7 @@ jobs:
             # is settled BEFORE age is consulted, so the age rule only ever
             # decides the fate of a build nobody is reading from.
             if (( ts >= grace_cutoff )); then
-              echo "KEEP  $folder (last written $newest, inside the ${GRACE_HOURS}h grace window, possibly an in-flight deploy)"
+              echo "KEEP  $folder (populated $populated, inside the ${GRACE_HOURS}h grace window, possibly an in-flight deploy)"
               kept=$((kept+1)); continue
             elif [[ -n "${pr_pending[$sha]+set}" ]]; then
               # Outranks the age rule deliberately: a build that is still being
@@ -480,12 +508,12 @@ jobs:
               fi
               echo "DELETE $folder (${pr_branch[$sha]}, beyond the $MAX_BRANCHES most recent branches)"
             elif (( ts < cutoff )); then
-              echo "DELETE $folder (last written $newest, older than ${THRESHOLD_HOURS}h)"
+              echo "DELETE $folder (populated $populated, older than ${THRESHOLD_HOURS}h)"
             elif [[ -n "${main_sha[$sha]+set}" ]]; then
               echo "KEEP  $folder (recent '$default_branch' commit, current or recent production build)"
               kept=$((kept+1)); continue
             else
-              echo "DELETE $folder (last written $newest, not the head of any open PR, merged, closed, or superseded)"
+              echo "DELETE $folder (populated $populated, not the head of any open PR, merged, closed, or superseded)"
             fi
 
             if [[ "$DRY_RUN" == "true" ]]; then

--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -4,11 +4,19 @@ name: R2 incremental-cache cleanup
 #
 # Why this exists: the R2 cache keys every object as
 # `incremental-cache/<buildId>/<hash>.cache` (see open-next.config.ts). Each
-# deploy, production AND every Cloudflare preview, writes a fresh ~1–1.4 GB
-# folder under a new build ID (one HTML+RSC `.cache` object per prerendered
-# page, ~1,600 of them), and OpenNext never deletes old ones. Left alone, the
-# bucket grows by that much per deploy forever; at active-development velocity
-# that reached ~34 GB in a matter of days.
+# deploy, production AND every Cloudflare preview, writes a fresh ~2.5 GB
+# folder under a new build ID (one `.cache` object per prerendered page, ~1,080
+# of them averaging ~2.3 MB), and OpenNext never deletes old ones. Left alone,
+# the bucket grows by that much per deploy forever; at active-development
+# velocity that reached ~34 GB in a matter of days.
+#
+# That per-folder figure read "~1–1.4 GB / ~1,600 objects" until 2026-08-14 and
+# was measured at 2.504 GB / 1,081 objects: fewer, much larger objects. Next 16's
+# client segment cache writes a `segmentData` map into every entry alongside
+# `html` and `rsc`, and it is ~40% of each object — half of that being
+# `segmentData["/_full"]`, which sampling found byte-identical to `rsc` in 40/40
+# objects. Nothing in this repo turns it on; it arrived as a Next default. Assume
+# the number drifts again and re-measure before trusting it.
 #
 # The build ID IS the deployed commit SHA: next.config.ts sets `generateBuildId`
 # to WORKERS_CI_COMMIT_SHA on Cloudflare Workers Builds, so a folder name equals
@@ -27,33 +35,66 @@ name: R2 incremental-cache cleanup
 #     nor the open-PR rule below (a merge commit's PR closed on merge). A
 #     scheduled run that fired inside that window deleted the incoming
 #     production cache mid-deploy and 500'd the site (2026-07-16), AND
-#   • any folder built from one of the MAIN_COMMITS most recent commits on the
-#     default branch. Production builds only ever come from that branch, so
-#     this keeps the incoming/just-switched production build even when a
-#     deploy stalls past the grace window; the THRESHOLD_HOURS age rule still
-#     retires these once they are old enough to be long superseded.
-#
 #   • any folder that a PREVIEW is still serving, i.e. a recent commit of an
 #     open PR whose head build has not populated its cache yet. A push moves
 #     the PR head immediately but the preview Worker keeps serving the previous
-#     commit until the new build lands, so the head-only rule below would
+#     commit until the new build lands, so the open-PR-head rule below would
 #     delete the cache out from under a live preview and 500 it. Production has
 #     been guarded against this since 2026-07-16 by the build-ID probe; this is
-#     the preview equivalent, added 2026-08-05 after a run did exactly that.
+#     the preview equivalent, added 2026-08-05 after a run did exactly that, AND
+#   • any folder whose commit is the current head of an OPEN pull request, i.e.
+#     the live preview of an active branch, for as long as that PR stays open
+#     and among the MAX_BRANCHES most-recently-deployed such branches. Age is
+#     deliberately NOT a factor here (see below). Superseded commits (an older
+#     head of a still-open PR) and merged/closed PR previews do not match, so
+#     they are pruned.
 #
-# Every OTHER folder is kept only while ALL of these hold:
-#   • younger than THRESHOLD_HOURS, AND
-#   • its commit is the current head of an OPEN pull request, i.e. the most
-#     recent commit on an active branch. Superseded commits (an older head of a
-#     still-open PR) and merged/closed PR previews no longer match, so they are
-#     pruned, AND
-#   • its branch is among the MAX_BRANCHES most-recently-deployed such branches.
+# Every OTHER folder is kept only while younger than THRESHOLD_HOURS. Within
+# that window one more rule applies: a folder built from one of the MAIN_COMMITS
+# most recent default-branch commits is kept even though nothing else claims it.
+# Production builds only ever come from that branch, so this covers the incoming
+# build of a deploy that stalls past the grace window. It cannot outlive
+# THRESHOLD_HOURS — deliberately, since a superseded production build has no
+# claim on the bucket and the live one is already protected by the probe.
+#
+# The rules are applied to each folder in a fixed order, and the order carries
+# the policy — see step 5:
+#
+#   1. written within GRACE_HOURS            -> KEEP
+#   2. predecessor of a pending head build   -> KEEP
+#   3. head of an open PR (within the cap)   -> KEEP
+#   4. older than THRESHOLD_HOURS            -> DELETE
+#   5. recent default-branch commit          -> KEEP
+#   6. anything else                         -> DELETE
+#
+# Rule 3 sat BELOW the age check until 2026-08-14, which meant an open PR's
+# preview lost its cache once the folder aged past THRESHOLD_HOURS even though
+# the PR was still open and that commit was still its head — the preview then
+# re-rendered on demand and 500'd every `node:fs` page (see open-next.config.ts).
+# THRESHOLD_HOURS was set to 24 mainly to paper over that ("keeps a preview alive
+# through next-morning review"), which forced a day-deep tail of every OTHER
+# folder too and was the single largest contributor to a 78 GB bucket. Keeping an
+# open PR's head on merit instead of on age decouples the two: previews now live
+# exactly as long as their PR does, and THRESHOLD_HOURS is free to be short.
+#
+# Rule 5 stays BELOW the age check on purpose, for the reason given above. Note
+# the consequence of pairing that with a short THRESHOLD_HOURS: the cover for a
+# stalled production deploy is now GRACE_HOURS..THRESHOLD_HOURS, i.e. 2-4h
+# rather than 2-24h. Populate and switchover are consecutive steps of one
+# `opennextjs-cloudflare deploy`, minutes apart, so 4h is still ~2x the margin
+# the grace window alone was documented as covering — but if that assumption
+# ever stops holding, raise THRESHOLD_HOURS rather than MAIN_COMMITS, which
+# cannot help past the cutoff.
 #
 # Net effect: the live production build, plus at most one preview per active
-# branch, capped at MAX_BRANCHES. Merging a PR (or pushing a newer commit to it)
-# drops the stale preview folder on the next run. Worst case is
-# (MAX_BRANCHES + 1) build folders, plus the transient grace-window and
-# recent-main keeps, which the age rule bounds to a THRESHOLD_HOURS-deep tail.
+# branch capped at MAX_BRANCHES, plus a THRESHOLD_HOURS-deep tail of everything
+# else. Merging a PR (or pushing a newer commit to it) drops the stale preview
+# folder on the next run. Worst case is (MAX_BRANCHES + 1) build folders plus
+# that tail; at the deploy velocity measured on 2026-08-14 (~1.2 deploys/hour)
+# the tail dominates, and its depth is the sweep interval plus THRESHOLD_HOURS,
+# NOT THRESHOLD_HOURS alone — a folder created just after a sweep is not
+# reconsidered until the next one. That is why the schedule below matters as
+# much as the threshold.
 #
 # Safety: the job aborts WITHOUT deleting anything if it cannot (a) positively
 # identify the live production build folder, (b) list the repo's open pull
@@ -79,10 +120,22 @@ name: R2 incremental-cache cleanup
 
 on:
   schedule:
-    # Every 6 hours, off the top of the hour to avoid scheduler congestion.
+    # Every 2 hours, off the top of the hour to avoid scheduler congestion.
     # (GitHub delays scheduled runs by up to a few hours under load; the
     # THRESHOLD_HOURS retention absorbs that jitter.)
-    - cron: "17 */6 * * *"
+    #
+    # Was every 6 hours until 2026-08-14. The sweep interval is an ADDEND to
+    # retention, not a detail: a folder written just after a sweep survives
+    # untouched until the next one, so the worst-case age of a prunable folder
+    # is interval + THRESHOLD_HOURS. At 6h + 24h that was a 30-hour tail, and at
+    # ~1.2 deploys/hour and ~2.5 GB/folder the tail alone accounted for most of
+    # the bucket. Lowering THRESHOLD_HOURS without also sweeping more often
+    # would have left the interval as the binding constraint.
+    #
+    # The job is cheap to run: it LISTs the bucket (Class B, $0.36/million) and
+    # DELETEs are free, so the cost of 12 runs/day over 4 is a couple of minutes
+    # of Actions time.
+    - cron: "17 */2 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -106,13 +159,25 @@ jobs:
       BUCKET: dataslope-inc-cache
       PREFIX: incremental-cache/
       BUILD_ID_URL: https://dataslope.com/api/cache-build-id
-      # A non-production build survives only while ALL hold: younger than
-      # THRESHOLD_HOURS, the current head commit of an open PR (the latest
-      # commit on an active branch), and among the MAX_BRANCHES most-recently-
-      # deployed such branches. 24 h keeps a PR's preview URL alive through
-      # next-morning review; MAX_BRANCHES bounds the bucket at
-      # (MAX_BRANCHES + 1) build folders total on busy days.
-      THRESHOLD_HOURS: "24"
+      # Blanket expiry for any folder NOT otherwise spoken for: not the live
+      # production build, not inside the grace window, not an open PR's head,
+      # not a predecessor of a pending head build. In practice that is merged
+      # and abandoned previews, plus superseded production builds.
+      #
+      # 4h, down from 24h on 2026-08-14. The 24h figure existed to keep an open
+      # PR's preview alive overnight, which rule 3 now does on merit regardless
+      # of age (see the header), so this no longer has to be generous on a
+      # preview's behalf. What is left is "how long to keep a build nobody is
+      # serving", and the answer is only long enough to absorb the races the
+      # grace window and the pending-head rule already handle explicitly.
+      # Combined with the 2h sweep interval the real worst case is ~6h.
+      THRESHOLD_HOURS: "4"
+      # Caps how many open-PR previews are protected, newest-deployed first.
+      # Now that rule 3 ignores age, this is the ONLY bound on preview
+      # retention: a PR left open for months keeps its head folder for months.
+      # At ~2.5 GB/folder that is a worst case of ~25 GB in previews, which is
+      # the deliberate price of previews that do not rot. Lower it if open-PR
+      # count grows; it has been 1-3 in practice.
       MAX_BRANCHES: "10"
       # Never delete a folder written within the last GRACE_HOURS, no matter
       # what it matches. A deploy populates its R2 folder minutes before the
@@ -126,7 +191,16 @@ jobs:
       # the default branch (production builds only come from there), so a
       # production deploy that stalls past the grace window still can't lose
       # its cache. The THRESHOLD_HOURS age rule retires these eventually.
-      MAIN_COMMITS: "30"
+      #
+      # 10, down from 30 on 2026-08-14, and non-binding either way: this rule
+      # is checked AFTER the age cutoff, so it can only ever protect a build
+      # younger than THRESHOLD_HOURS. The last 10 default-branch commits spanned
+      # 19.2 hours when measured, ~5x the 4h window, so the age rule bites first
+      # and the count is pure headroom. It is expressed as a commit count rather
+      # than a duration because that is what `gh api .../commits` takes; keep it
+      # comfortably above the number of commits the branch sees in
+      # THRESHOLD_HOURS and it does its job.
+      MAIN_COMMITS: "10"
       # A preview branch whose HEAD build has not populated its cache yet is
       # mid-deploy, and its Worker is still serving an EARLIER commit. Keep
       # that many recent commits of such a branch so the build actually being
@@ -135,7 +209,8 @@ jobs:
       # nothing extra. See step 4b.
       PR_COMMITS: "3"
       # How many objects a build folder must hold to count as populated. A
-      # healthy folder held 966-986 objects when this was written; the point is
+      # healthy folder held 1,081 objects when last measured (2026-08-14); the
+      # point is
       # only to tell "a finished deploy" from "absent, or mid-populate, or
       # half-deleted" (the folder this rule was written for had 5 left), so the
       # threshold sits an order of magnitude below a real cache rather than
@@ -344,7 +419,7 @@ jobs:
           now=$(date -u +%s)
           cutoff=$(( now - THRESHOLD_HOURS * 3600 ))
           grace_cutoff=$(( now - GRACE_HOURS * 3600 ))
-          echo "Policy: keep live production + anything written in the last ${GRACE_HOURS}h + recent '$default_branch' builds + the latest commit of up to $MAX_BRANCHES open-PR branches, each younger than ${THRESHOLD_HOURS}h (cutoff $(date -u -d "@$cutoff" '+%Y-%m-%d %H:%M:%SZ'))"
+          echo "Policy: keep live production + anything written in the last ${GRACE_HOURS}h + the head commit of up to $MAX_BRANCHES open-PR branches (any age) + anything younger than ${THRESHOLD_HOURS}h + recent '$default_branch' builds within that window (cutoff $(date -u -d "@$cutoff" '+%Y-%m-%d %H:%M:%SZ'))"
           echo "Dry run: $DRY_RUN"
 
           # 5) Timestamp every non-production folder so active-branch previews
@@ -377,11 +452,10 @@ jobs:
             # Folder name is the commit SHA: strip the prefix and trailing slash.
             sha="${folder#"$PREFIX"}"; sha="${sha%/}"
 
-            # Order matters: the grace window shields everything first (a
-            # freshly written folder may be an in-flight deploy that nothing
-            # else matches), then age retires old folders (the 24h floor
-            # applies even to an open PR's head), then the default-branch and
-            # per-branch keeps, then the cap.
+            # Order matters, and it IS the policy (see the header for the full
+            # ladder): everything a deploy or a preview might still be serving
+            # is settled BEFORE age is consulted, so the age rule only ever
+            # decides the fate of a build nobody is reading from.
             if (( ts >= grace_cutoff )); then
               echo "KEEP  $folder (last written $newest, inside the ${GRACE_HOURS}h grace window, possibly an in-flight deploy)"
               kept=$((kept+1)); continue
@@ -392,18 +466,24 @@ jobs:
               # by PR_COMMITS x MAX_BRANCHES, and only while a head is pending.
               echo "KEEP  $folder (${pr_pending[$sha]}, still being served while that branch's head build is pending)"
               kept=$((kept+1)); continue
-            elif (( ts < cutoff )); then
-              echo "DELETE $folder (last written $newest, older than ${THRESHOLD_HOURS}h)"
-            elif [[ -n "${main_sha[$sha]+set}" ]]; then
-              echo "KEEP  $folder (recent '$default_branch' commit, current or recent production build)"
-              kept=$((kept+1)); continue
             elif [[ -n "${pr_branch[$sha]+set}" ]]; then
+              # Moved above the age check on 2026-08-14. An open PR's head is
+              # its live preview; how long ago it was built says nothing about
+              # whether someone is about to open the URL, and expiring it just
+              # 500s the preview (see open-next.config.ts). A PR going stale is
+              # what closing it is for. Still capped by MAX_BRANCHES, evaluated
+              # newest-deployed first, which is the only bound on this rule now.
               branches=$((branches+1))
               if (( branches <= MAX_BRANCHES )); then
                 echo "KEEP  $folder (${pr_branch[$sha]}, latest commit, branch ${branches}/${MAX_BRANCHES})"
                 kept=$((kept+1)); continue
               fi
               echo "DELETE $folder (${pr_branch[$sha]}, beyond the $MAX_BRANCHES most recent branches)"
+            elif (( ts < cutoff )); then
+              echo "DELETE $folder (last written $newest, older than ${THRESHOLD_HOURS}h)"
+            elif [[ -n "${main_sha[$sha]+set}" ]]; then
+              echo "KEEP  $folder (recent '$default_branch' commit, current or recent production build)"
+              kept=$((kept+1)); continue
             else
               echo "DELETE $folder (last written $newest, not the head of any open PR, merged, closed, or superseded)"
             fi

--- a/agent-outputs/20260814-0352-r2-incremental-cache-retention-handoff.md
+++ b/agent-outputs/20260814-0352-r2-incremental-cache-retention-handoff.md
@@ -1,0 +1,328 @@
+# R2 Incremental-Cache Retention — Agent Handoff
+
+**Date:** 2026-08-14
+**Project:** DataSlope (`dataslope/dataslope`)
+**Branch:** `claude/dataslope-cache-r2-size-d8vwxc` → PR **#663** (2 commits ahead of `main`)
+**State at:** `ff511af8`
+**Trigger:** the Cloudflare dashboard reported `dataslope-inc-cache` at **78.04 GB**, which looked wrong.
+
+> **You are the operator.** PR #663 is written, tested and pushed but **not merged**.
+> This document is the investigation record plus the runbook for what comes next.
+> Every measurement below is reproducible with the scripts in
+> [Reproducing the measurements](#reproducing-the-measurements) — re-run them before
+> trusting any number, because several of them already drifted once.
+>
+> `.github/workflows/r2-cache-cleanup.yml` and `open-next.config.ts` are the spec.
+> This is the reasoning behind their current values.
+
+---
+
+## TL;DR
+
+The 78 GB was real, not a dashboard artifact. Two independent causes, both of which had
+silently drifted away from what the code comments asserted:
+
+1. **Each build folder is ~2× its documented size** — 2.504 GB / 1,081 objects, not the
+   "~1–1.4 GB / ~1,600 objects" both files claimed. Next 16's client segment cache adds a
+   `segmentData` map to every entry (~40% of each object), of which `segmentData["/_full"]`
+   is a byte-identical duplicate of `rsc` (40/40 sampled) — ~20% of the bucket is redundant.
+2. **Retention kept ~24h of every build**, not the "(MAX_BRANCHES + 1) folders" the header
+   promised. At ~1.2 deploys/hour × 2.5 GB, a 24h tail *is* the bucket.
+
+PR #663 fixes the retention half and corrects the comments. The segment-cache half is
+**documented but deliberately not acted on** — see [Open items](#open-items) #5.
+
+A third, unrelated bug surfaced during the investigation: **cached 404s were resetting
+folder age**, defeating the cleanup entirely. Fixed in the second commit.
+
+**Do these next:** [Open items](#open-items). #1 gates #2, and #2 is the real prize.
+
+---
+
+## Current state
+
+| | |
+|---|---|
+| Bucket, post-sweep (2026-08-14 03:52 UTC) | **31.27 GB** — 13 folders, 14,055 objects |
+| Bucket, pre-sweep peak (2026-08-14 00:26 UTC) | **~75 GB** — 32 folders, 32,435 objects |
+| Dashboard reading that started this | 78.04 GB (a lagging snapshot near peak) |
+| Incomplete multipart uploads | **0** (checked via `ListMultipartUploads`) |
+| Per-folder size | 2.504 GB / 1,081 objects, mean 2.32 MB/object |
+| Deploy velocity | ~1.2 folders/hour (all branches), ~0.54/hour on `main` |
+| Populate duration | median **0.8 min**, max 1.8 min |
+| Populate → worker live | **< 2 min** (measured on `5834910a`) |
+| Commit → live (full pipeline) | median **~10–12 min** |
+| Last 10 `main` commits span | 19.2 hours |
+
+**The bucket oscillates.** It is not a steady 78 GB — it sawtooths between roughly 31 GB
+(just after a sweep) and 78 GB (just before one) on the pre-PR 6h/24h policy. Read any
+single dashboard number with that in mind.
+
+---
+
+## What PR #663 changes
+
+Two commits. Neither has been merged or run against the real bucket yet.
+
+### `aa85399e` — keep open-PR previews on merit, not on age
+
+The core move: **the open-PR-head check was below the age check**, so a still-open PR's
+preview lost its cache once the folder aged past `THRESHOLD_HOURS`, then re-rendered on
+demand and 500'd every `node:fs` page. `THRESHOLD_HOURS: 24` existed mainly to paper over
+that ("keeps a preview alive through next-morning review"), which forced a day-deep tail
+onto every *other* folder too. Moving the check above the age line decouples the two.
+
+The resulting ladder, now stated explicitly in the workflow header:
+
+```
+1. populated within GRACE_HOURS          -> KEEP
+2. predecessor of a pending head build   -> KEEP
+3. head of an open PR (within the cap)   -> KEEP   <- moved up
+4. older than THRESHOLD_HOURS            -> DELETE
+5. recent default-branch commit          -> KEEP
+6. anything else                         -> DELETE
+```
+
+| knob | before | after | why |
+|---|---|---|---|
+| `THRESHOLD_HOURS` | 24 | **4** | no longer has to keep previews alive |
+| sweep interval | 6h | **2h** | worst-case age is `interval + THRESHOLD_HOURS`, so the interval was about to become the binding constraint |
+| `MAIN_COMMITS` | 30 | **10** | non-binding either way (checked *after* the cutoff); lowered for honesty |
+| `MAX_BRANCHES` | 10 | 10 | now the **only** bound on preview retention |
+
+Also corrects the stale per-folder figures in the workflow header, `open-next.config.ts`,
+and the `MIN_CACHE_OBJECTS` comment.
+
+### `ff511af8` — date folders by median write, not newest
+
+The job aged each folder by its **newest** object. Objects also arrive at *request* time:
+a request for a `/courses/*` path that isn't prerendered matches the `[...slug]` catch-all,
+misses, renders the not-found page, and OpenNext caches that 404 (~1.8 MB, `revalidate:
+false`) into whichever build folder is live.
+
+Folder `0127baf6` was populated at 17:54, then took 404 writes at 18:22, 19:59, 20:46 and
+21:07 — gaps of 28, 97, 47 and 21 minutes, **every one inside `GRACE_HOURS`** — so it was
+held as "possibly an in-flight deploy" more than three hours after its deploy finished.
+4 of 33 folders affected, 14 writes total.
+
+The median is immune: ~1,081 burst-written objects date the folder and a handful of late
+ones cannot move the middle. It stays correct for in-flight populates, where the median of
+what has landed so far is also seconds old.
+
+---
+
+## Verification already done
+
+Do not redo these from scratch; extend them.
+
+- **YAML parses**, and the extracted `run:` step passes `bash -n`.
+- **The decision ladder was extracted verbatim from the workflow** and driven against mock
+  state (`test-ladder.sh` below). Results:
+  - open-PR head → KEEP at 1h / 6h / 12h / 30h under both the old 24h and new 4h thresholds
+    (before the reorder, 6h/12h/30h were DELETE at 4h)
+  - predecessor whose head build is still populating → KEEP under both thresholds; DELETE
+    once the head lands
+  - merged previews pruned, grace-window folders kept, main builds kept within the window
+    and retired past it — all unchanged
+- **Median extraction tested** against four real distributions: the `0127baf6` shape now
+  dates to 17:54 instead of 21:07 (3h13m of drift removed); a 400-object in-flight populate
+  still dates to now; a 7-object partial folder and an empty folder behave as before.
+
+**Not yet done:** a real `dry_run=true` run against the live bucket. Do that before or
+immediately after merge — see [Open items](#open-items) #0.
+
+---
+
+## Non-negotiables
+
+Already investigated and settled. Don't re-litigate without new measurements.
+
+- **Never let the job delete the folder a deployment is serving.** Two outages came from
+  exactly this (2026-07-16 production, 2026-08-05 preview). The build-ID probe and the
+  abort-on-API-failure guards exist for it. Any rewrite keeps both.
+- **`prefetchInlining: false` in `next.config.ts` stays.** It is load-bearing — see the long
+  note there about the ~150 req/s client-side request storm. Unrelated to this work, but a
+  tempting-looking flag in the same file.
+- **Don't flip `experimental.clientSegmentCache: false` casually.** It would cut the bucket
+  to ~60%, but the segment cache interacts with `prefetchInlining: false` and that
+  combination has never been tested on a preview deploy.
+- **`MAIN_COMMITS` cannot rescue anything past `THRESHOLD_HOURS`** — it is checked *after*
+  the cutoff. If stalled-deploy cover ever needs to be longer, raise `THRESHOLD_HOURS`.
+  Raising `MAIN_COMMITS` does nothing.
+- **The 24h threshold is not a preview-keepalive mechanism any more.** Rule 3 does that on
+  merit. Don't restore 24h "to keep previews alive."
+
+---
+
+## Open items
+
+### 0. Run `dry_run=true` before trusting the new thresholds — **do this first**
+
+Actions → *R2 incremental-cache cleanup* → Run workflow → `dry_run: true`. Read the KEEP/
+DELETE lines against the ladder above. The ladder is unit-tested; the *inputs* (probe,
+`gh pr list`, folder dating) are not, and this is the cheapest way to see them all at once.
+
+### 1. Does Workers Builds build branches with no open PR? — **gates #2**
+
+Cannot be answered from the repo; it's a Cloudflare Workers Builds setting. It matters
+because under the proposed rewrite (#2) such a branch would be protected only by
+`GRACE_HOURS`, where today `THRESHOLD_HOURS` gives it 4h. If the answer is yes, #2 must
+enumerate **branches** rather than open PRs.
+
+### 2. Rewrite the keep-set around live probes — **the real prize**
+
+The current job uses six knobs to approximate two facts: *what is each deployment serving*,
+and *what is it about to serve*. Both are directly obtainable, so the approximations can go.
+
+```
+KEEP = { probe(production) }                     # what prod serves now
+     ∪ { probe(alias_i) ∀ open PR i }            # what each preview serves now
+     ∪ { head(default_branch) }                  # what prod is about to serve
+     ∪ { head(pr_i) ∀ open PR i }                # what each preview is about to serve
+     ∪ { folders populated < GRACE_HOURS }       # catch-all for the unclassifiable
+DELETE everything else
+```
+
+`THRESHOLD_HOURS`, `MAIN_COMMITS`, `PR_COMMITS` and `MIN_CACHE_OBJECTS` all disappear.
+`GRACE_HOURS` survives as a safety net rather than policy; `MAX_BRANCHES` as a sanity cap.
+Roughly 277 lines of bash → ~100.
+
+**This is verified feasible.** The per-branch preview alias is in the Cloudflare check-run
+summary, and probing it works:
+
+```
+$ gh api repos/dataslope/dataslope/commits/<sha>/check-runs   # "Workers Builds: dataslope"
+  output.summary contains:
+    Preview URL: https://4a5ed0c9-dataslope.subwaymatch.workers.dev
+    Preview Alias URL: https://claude-sql-playground-info-wrap-gdt49u-dataslope.subwaymatch.workers.dev
+
+$ curl -fsS https://claude-sql-playground-info-wrap-gdt49u-dataslope.subwaymatch.workers.dev/api/cache-build-id
+  81f3560f39873e5f25dff322706e99c650b0bfaa      # == PR #659's head. Exact, not inferred.
+```
+
+Why it's *more* correct, not merely shorter:
+
+- The `pr_pending` heuristic has a live race: a head stops counting as "pending" once its
+  folder crosses `MIN_CACHE_OBJECTS: 100` of 1,081 objects, but the worker hasn't switched
+  yet — so the folder actually being served loses protection. A probe has no such window.
+- `PR_COMMITS: 3` is a guess. A preview 4+ commits stale (rapid pushes, or a failed build)
+  is unprotected today. A probe doesn't care how far behind it is.
+- `MAIN_COMMITS` exists solely to cover the incoming production build. That build *is*
+  `head(main)` — one value instead of 30, and unbounded in time, so the stalled-deploy
+  trade-off #663 introduces disappears rather than narrowing to 2–4h.
+
+Required care:
+
+- **A probe failure must never delete anything.** Retry; on persistent failure fall back to
+  conservative behavior for *that branch only* (keep its recent commits, as today). Never
+  treat "no answer" as "nothing to keep", and never let one flaky preview abort the sweep.
+- **Treat the alias URL as untrusted data.** It comes from check-run output. Validate against
+  `^https://[a-z0-9-]+-dataslope\.subwaymatch\.workers\.dev$` before probing. The alias is
+  also derivable from the branch name (`/` and `_` → `-`), but read it from the check run
+  rather than reconstructing it.
+- Keep the existing abort-without-deleting guards.
+
+### 3. Fix the flat `/courses/<lesson>` links — user-facing, independent of storage
+
+The cached 404s are requests for **real lessons missing their course segment**. Confirmed
+live:
+
+| requested | result | actual content |
+|---|---|---|
+| `/courses/capstone-data-pipeline` | **404** | `/courses/csharp-linq-functional/capstone-data-pipeline` → 200 |
+| `/courses/setup-and-tsconfig` | **404** | `/courses/typescript-from-scratch/setup-and-tsconfig` → 200 |
+
+`app/sitemap.ts` emits correct two-segment URLs, so the flat shape comes from somewhere
+else — old URL scheme, inbound external links, or generated guesses. **Source not
+identified.** These are broken links to content that exists: an SEO and UX bug on its own
+merits, and fixing it removes the 404 cache writes at the source. A redirect from the
+one-segment shape to the correct path likely fixes both.
+
+### 4. Should a permanent 404 be in the incremental cache at all?
+
+Each is ~1.8 MB with `revalidate: false` — cached forever — and the hit rate on a mistyped
+URL is near zero. The mechanism is unbounded in the number of distinct bad URLs: a crawler
+working through stale links, or a script hitting `/courses/<random>`, mints a fresh 1.8 MB
+object and a full SSR render per unique path. Observed volume today is low (14 entries over
+~2 days), so this is a design question, not an incident. `ff511af8` makes the *cleanup*
+immune to it; it does not stop the writes.
+
+### 5. Decide on `segmentData` (~40% of the bucket)
+
+`experimental.clientSegmentCache: false` would take the bucket to ~60% of current size.
+`segmentData["/_full"]` alone is a byte-identical duplicate of `rsc` (40/40 sampled) —
+~20% of the bucket. Left on deliberately; see [Non-negotiables](#non-negotiables). If
+picked up: test on a preview deploy, and watch for the prefetch storm described in
+`next.config.ts`.
+
+### 6. Decide whether rollback cover is wanted
+
+Rolling the Worker back to a build whose cache has been pruned 500s the site — same
+`node:fs` mechanism. Cover was ~24h before #663, is ~4–6h after, and would be ~0 under #2.
+The trap is that Cloudflare's Deployments tab offers rollback targets with no warning that
+their cache is gone.
+
+Mitigating context: revert-and-redeploy is ~12 min end-to-end (measured), so the fallback
+is cheap. If you do want rollback, add it back **deliberately** as its own rule — "keep the
+last N production builds", count-bounded, above the age line — rather than as an emergent
+side effect of a time threshold. At N=5 that is ~9h of history for ~5 GB incremental cost
+(the 4h tail already retains ~3 main builds).
+
+---
+
+## Reproducing the measurements
+
+All read-only. Credentials come from the environment (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`,
+`R2_SECRET_ACCESS_KEY`); the helper is `scripts/lib/r2.mjs`, whose `listDetailed()` returns
+size and `lastModified` per object.
+
+**Weigh the bucket and group by build folder:**
+
+```js
+import { createR2Client, credentialsFromEnv } from "./scripts/lib/r2.mjs";
+const r2 = createR2Client(credentialsFromEnv(), "dataslope-inc-cache");
+const objs = await r2.listDetailed("incremental-cache/");
+const f = new Map();
+for (const o of objs) {
+  const id = o.key.split("/")[1];
+  const e = f.get(id) ?? { n: 0, b: 0, min: Infinity, max: -Infinity };
+  e.n++; e.b += o.size;
+  const t = Date.parse(o.lastModified);
+  e.min = Math.min(e.min, t); e.max = Math.max(e.max, t);
+  f.set(id, e);
+}
+console.log(f.size, "folders", (objs.reduce((s,o)=>s+o.size,0)/1e9).toFixed(2), "GB");
+```
+
+**Find stray (post-populate) writes** — cluster each folder's timestamps with a >5 min gap;
+the largest cluster is the populate, everything else is a runtime write. Fetch one and read
+`JSON.parse(buf).value.meta.status` (404) and `.headers["x-next-cache-tags"]` (the path).
+
+**Where the bytes go inside an entry** — `JSON.parse` a `.cache` object and measure
+`html` / `rsc` / `segmentData`, comparing `segmentData["/_full"] === rsc`.
+
+**Incomplete multipart uploads** — `GET /<bucket>?uploads` signed with
+`buildSignedRequest`, paginating on `NextKeyMarker` / `NextUploadIdMarker`.
+
+**Test the ladder without running the workflow** — parse the YAML, pull
+`jobs.cleanup.steps[0].run`, slice from `if (( ts >= grace_cutoff` to the matching outer
+`fi`, then `source` that fragment with `ts`, `sha`, `cutoff`, `grace_cutoff` and the
+`pr_pending` / `pr_branch` / `main_sha` associative arrays set by hand. This tests the real
+code rather than a paraphrase of it — keep it that way.
+
+---
+
+## Things that misled me, so they don't mislead you
+
+- **The dashboard number is a lagging snapshot of a sawtooth.** My first LIST read 72.53 GB
+  against a dashboard 78.04 GB; the gap was a folder being written *during* the scan, not an
+  accounting discrepancy.
+- **Production's folder appeared to be missing.** It was mid-populate during the listing and
+  landed two minutes later. Probe `/api/cache-build-id` and check the folder again before
+  concluding anything is wrong.
+- **Four folders looked like 4-hour populates.** They were 1-minute populates plus stray 404
+  writes hours later. Cluster the timestamps before believing a duration.
+- **`MAIN_COMMITS` looks like a retention knob.** It is checked after the age cutoff, so at
+  any `THRESHOLD_HOURS` shorter than the span of the last N main commits it does nothing.
+- **The workflow header was confidently wrong** about per-folder size and worst-case folder
+  count. Both predated changes that invalidated them. Measure, don't read.

--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -23,9 +23,21 @@ import { withRegionalCache } from "@opennextjs/cloudflare/overrides/incremental-
 // fall through to a re-render and 500 on exactly those `node:fs` pages. R2 is
 // read from identically on production and preview deployments, so previews
 // render correctly too. Each deploy's populate step writes a full copy of the
-// cache under a new build ID, ~1–1.4 GB (one HTML+RSC `.cache` object per
-// prerendered page), so stale build folders are pruned on a schedule by
-// .github/workflows/r2-cache-cleanup.yml.
+// cache under a new build ID, ~2.5 GB (one `.cache` object per prerendered
+// page, ~1,080 of them averaging ~2.3 MB), so stale build folders are pruned on
+// a schedule by .github/workflows/r2-cache-cleanup.yml.
+//
+// That figure read "~1–1.4 GB" until 2026-08-14 and was measured at 2.504 GB.
+// Each entry now carries a `segmentData` map next to `html` and `rsc` — Next
+// 16's client segment cache, on by default, nothing here opts in — and it is
+// ~40% of every object. Half of that is `segmentData["/_full"]`, byte-identical
+// to `rsc` in 40/40 sampled objects, so ~20% of the bucket is a duplicate of
+// bytes already stored one key over. Setting `experimental.clientSegmentCache:
+// false` in next.config.ts would take the bucket to ~60% of its current size;
+// it is left ON because the segment cache is load-bearing for prefetching here
+// and the interaction with `prefetchInlining: false` (see the long note in
+// next.config.ts) has not been tested on a preview deploy. Measure before
+// trusting either number again.
 //
 // Reads are NOT rare, which this comment used to claim. Next sets
 // `s-maxage=31536000` on the prerendered responses, but a Worker runs *ahead*


### PR DESCRIPTION
`dataslope-inc-cache` reached **78.04 GB**. It was real, not a dashboard artifact — but it turned out to be two independent drifts from what the code comments asserted, plus a third bug that was quietly defeating the cleanup job altogether.

📄 **Full investigation record and follow-up runbook: [`agent-outputs/20260814-0352-r2-incremental-cache-retention-handoff.md`](agent-outputs/20260814-0352-r2-incremental-cache-retention-handoff.md)** — read that before picking up any of the open items.

## What I measured

| | |
|---|---|
| Pre-sweep peak | ~75 GB — 32 folders, 32,435 objects |
| Post-sweep | 31.27 GB — 13 folders |
| Incomplete multipart uploads | **0** (`ListMultipartUploads`) |
| Per-folder size | **2.504 GB / 1,081 objects** (documented: "~1–1.4 GB / ~1,600") |
| Deploy velocity | ~1.2 folders/hour |
| Populate duration | median **0.8 min** |
| Populate → worker live | **< 2 min** |

**The bucket oscillates** between ~31 GB just after a sweep and ~78 GB just before one. The dashboard caught it near peak.

## Cause 1 — folders are ~2× their documented size

Next 16's client segment cache writes a `segmentData` map into every entry alongside `html` and `rsc`. Sampling 40 objects:

```
html             29.9 MB  31.2%
rsc              19.6 MB  20.4%
segmentData      38.1 MB  39.8%
  of which /_full  19.6 MB  20.4%   <- byte-identical to rsc in 40/40
```

So ~20% of the bucket duplicates bytes stored one key over. Nothing here opts in; it arrived as a Next default. This PR **corrects the figures** in the workflow header and `open-next.config.ts` and records the opt-out (`experimental.clientSegmentCache: false`, worth ~40%) **without taking it** — the segment cache interacts with `prefetchInlining: false` and that combination has never been tested on a preview deploy.

## Cause 2 — retention kept ~24h of every build

The header promised "worst case (MAX_BRANCHES + 1) folders"; the real ceiling was ~70. At ~1.2 deploys/hour × 2.5 GB, a 24h tail *is* the bucket.

It was 24h only because **the open-PR-head check sat below the age check** — a still-open PR's preview lost its cache after 24h and 500'd every `node:fs` page, so the threshold was set high to compensate, forcing that depth onto every unclaimed folder too.

**Moving the open-PR-head check above the age check decouples the two.** Previews live as long as their PR does; the blanket expiry is then free to be short.

```
1. populated within GRACE_HOURS          -> KEEP
2. predecessor of a pending head build   -> KEEP
3. head of an open PR (within the cap)   -> KEEP   <- moved up
4. older than THRESHOLD_HOURS            -> DELETE
5. recent default-branch commit          -> KEEP
6. anything else                         -> DELETE
```

| knob | before | after |
|---|---|---|
| `THRESHOLD_HOURS` | 24 | **4** |
| sweep interval | 6h | **2h** |
| `MAIN_COMMITS` | 30 | **10** |

The sweep interval matters as much as the threshold: worst-case age is `interval + THRESHOLD_HOURS`, so leaving it at 6h would have made it the binding constraint. `MAIN_COMMITS` is non-binding either way — it's checked *after* the cutoff, and the last 10 default-branch commits span 19.2h against a 4h window.

## Cause 3 — cached 404s were resetting folder age

Found while measuring populate durations. The job aged each folder by its **newest** object, but objects also arrive at *request* time: a request for a `/courses/*` path that isn't prerendered matches the `[...slug]` catch-all, misses, renders the not-found page, and OpenNext caches that 404 (~1.8 MB, `revalidate: false`) into whichever folder is live.

Folder `0127baf6` was populated at 17:54, then took 404 writes at 18:22, 19:59, 20:46 and 21:07 — gaps of 28, 97, 47 and 21 minutes, **every one inside `GRACE_HOURS`** — so it was held as "possibly an in-flight deploy" for over three hours after its deploy finished. 4 of 33 folders affected.

Dating folders by the **median** write fixes it: ~1,081 burst-written objects set the date and a handful of late ones can't move the middle, while an in-flight populate still dates to now. This would have gotten worse under a 4h threshold, which leaves less headroom for a stray write to erase.

## Verification

- YAML parses; extracted `run:` step passes `bash -n`.
- **The decision ladder was extracted verbatim from the workflow** and driven against mock state — open-PR head KEEP at 1/6/12/30h under both old and new thresholds (before the reorder, 6/12/30h were DELETE at 4h); pending-head predecessor KEEP under both, DELETE once the head lands; merged previews, grace-window folders and main builds all unchanged.
- Median extraction tested against four real distributions: the `0127baf6` shape now dates to 17:54 instead of 21:07 (3h13m of drift removed); a 400-object in-flight populate still dates to now; partial and empty folders unchanged.

**Not yet run against the live bucket.** Recommend merging, then Actions → Run workflow with `dry_run: true` and reading the KEEP/DELETE lines before it fires on schedule. Expected steady state ~6–8 folders, **~15–20 GB**.

## Trade-off to weigh

Cover for a production deploy stalled between populate and switchover narrows from 2–24h to **2–4h**. Measured, those are consecutive steps minutes apart (<2 min observed), so 4h is ~120× the observed gap — and the live build is protected unconditionally by the build-ID probe regardless, so this can't repeat the 2026-07-16 outage.

The related cost is **rollback**: rolling back to a build whose cache was pruned 500s the site, and that window goes from ~24h to ~4–6h. Revert-and-redeploy is ~12 min end-to-end (measured), so the fallback is cheap — but if you want rollback cover, the handoff doc argues for adding it back deliberately as a count-bounded rule rather than as a side effect of a time threshold.

## Follow-ups (not in this PR)

Detailed in the handoff doc, in priority order:

1. **Verify whether Workers Builds builds non-PR branches** — gates #2.
2. **Rewrite the keep-set around live probes.** The job uses six knobs to approximate two facts: what each deployment is *serving* and what it's *about to serve*. Both are directly obtainable — I verified the per-branch preview alias is in the Cloudflare check-run summary and that probing `<alias>/api/cache-build-id` returns exactly the serving commit. That removes `THRESHOLD_HOURS`, `MAIN_COMMITS`, `PR_COMMITS` and `MIN_CACHE_OBJECTS`, eliminates the `MIN_CACHE_OBJECTS` race, and makes the stalled-deploy trade-off above disappear. ~277 lines of bash → ~100.
3. **Fix the flat `/courses/<lesson>` links.** The cached 404s are real lessons missing their course segment — `/courses/capstone-data-pipeline` 404s while `/courses/csharp-linq-functional/capstone-data-pipeline` returns 200. Broken links to existing content, independent of storage.
4. Decide whether a permanent 404 belongs in the incremental cache at all.
5. Decide on `segmentData` (~40% of the bucket).
6. Decide whether rollback cover is wanted, and add it explicitly if so.