### PR TITLE
Fix Python playground issues from the black-box audit

### DIFF
--- a/__tests__/pyodideWorkerSetup.test.ts
+++ b/__tests__/pyodideWorkerSetup.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The Python half of the Pyodide worker lives in template literals, so
+ * nothing typechecks it and nothing here can execute it (Pyodide is a CDN
+ * download). These pin the behaviours that were silently wrong, by reading
+ * the scripts back out of the source: each assertion below is a bug that
+ * shipped, not a style rule.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WORKER_SRC = readFileSync(
+  join(__dirname, "../app/_components/runtime/pyodide-worker.ts"),
+  "utf8",
+);
+const CAPTURE_SRC = readFileSync(
+  join(__dirname, "../scripts/lib/python-output-capture.mjs"),
+  "utf8",
+);
+
+/** Text between two markers in the worker source. */
+function between(start: string, end: string): string {
+  const from = WORKER_SRC.indexOf(start);
+  expect(from, `marker not found: ${start}`).toBeGreaterThan(-1);
+  const to = WORKER_SRC.indexOf(end, from + start.length);
+  expect(to, `end marker not found: ${end}`).toBeGreaterThan(-1);
+  return WORKER_SRC.slice(from + start.length, to);
+}
+
+const SETUP_B = between("const SETUP_SCRIPT_B = `", "`;");
+const RUN_WRAPPER = between("const wrappedCode = `", "`;");
+
+describe("plt.show()", () => {
+  // The bug: savefig() saves the *current* figure, and the patch then closed
+  // all of them — so "build two figures, show() once" rendered one and threw
+  // the other away with no warning.
+  it("iterates every open figure rather than saving the current one", () => {
+    const show = SETUP_B.slice(
+      SETUP_B.indexOf("def _patched_show"),
+      SETUP_B.indexOf("plt.show = _patched_show"),
+    );
+    expect(show).toContain("plt.get_fignums()");
+    expect(show).toContain("_fig.savefig(");
+    expect(show).not.toContain("plt.savefig(");
+    expect(show).not.toContain("plt.gcf()");
+  });
+
+  it("is mirrored by the build-time capture path", () => {
+    // A lesson's prepopulated panel and a live run must not disagree.
+    const show = CAPTURE_SRC.slice(
+      CAPTURE_SRC.indexOf("def _bo_show"),
+      CAPTURE_SRC.indexOf("_bo_plt.show = _bo_show"),
+    );
+    expect(show).toContain("_bo_plt.get_fignums()");
+    expect(show).not.toContain("_bo_plt.savefig(");
+    expect(show).not.toContain("_bo_plt.gcf()");
+  });
+});
+
+describe("output streaming", () => {
+  it("routes every rich cell through the emitter that flushes", () => {
+    // A raw `_display_outputs.append` for a table/image/chart would sit in
+    // the list until the run ended, which is the batching this replaced.
+    for (const script of [SETUP_B, RUN_WRAPPER]) {
+      expect(script).not.toMatch(/_display_outputs\.append\(\{"type": "(image|plot|dataframe|html)"/);
+    }
+    expect(RUN_WRAPPER).toContain('_pg_emit_cell({"type": "plot"');
+    expect(RUN_WRAPPER).toContain('_pg_emit_cell({"type": "image"');
+  });
+
+  it("drains anything left over when the run ends", () => {
+    expect(WORKER_SRC).toContain('pyodide.runPython("_pg_stream_flush(True)")');
+  });
+
+  it("detaches the sink afterwards so it can't outlive its run", () => {
+    expect(WORKER_SRC).toContain('pyodide.runPython("_pg_stream_sink = None")');
+  });
+});
+
+describe("error legibility", () => {
+  it("compiles the user's code under its real filename", () => {
+    // Frames used to read `File "<string>"`, which looks like a real file
+    // that doesn't exist.
+    expect(WORKER_SRC).toContain(
+      'async def _execute_with_last_display(code, filename="main.py")',
+    );
+    expect(WORKER_SRC).toContain('compile(tree, filename, "exec"');
+    expect(WORKER_SRC).toContain('compile(expr_tree, filename, "eval"');
+    expect(WORKER_SRC).not.toContain('compile(tree, "<string>"');
+    expect(RUN_WRAPPER).toContain(
+      "_execute_with_last_display(_user_code_str, _pg_entry_filename)",
+    );
+  });
+
+  it("replaces input() with an explanation instead of an errno", () => {
+    expect(WORKER_SRC).toContain("builtins.input = _pg_input");
+    expect(WORKER_SRC).toContain("isn't available in this playground");
+  });
+
+  it("cleans and annotates the message a failed run reports", () => {
+    expect(WORKER_SRC).toContain(
+      "annotateRunError(cleanPythonTraceback(raw))",
+    );
+  });
+});
+
+describe("files a run creates", () => {
+  it("answers the surface's request for them", () => {
+    expect(WORKER_SRC).toContain('msg.kind === "collect-created-files"');
+    expect(WORKER_SRC).toContain('kind: "created-files"');
+  });
+
+  it("stamps staged files so only genuinely new ones are reported", () => {
+    expect(WORKER_SRC).toContain("stagedStamps.set(");
+    expect(WORKER_SRC).toContain("stagedStamps.clear()");
+  });
+});

--- a/__tests__/pythonErrors.test.ts
+++ b/__tests__/pythonErrors.test.ts
@@ -1,0 +1,107 @@
+/**
+ * A Python traceback from the playground has to read like a Python
+ * traceback, not like a tour of the interpreter harness. These pin the two
+ * string fixups applied when a run fails.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  annotateRunError,
+  cleanPythonTraceback,
+} from "../app/_components/runtime/pythonErrors";
+
+const HARNESS_TRACEBACK = `Traceback (most recent call last):
+  File "/lib/python314.zip/_pyodide/_base.py", line 597, in eval_code_async
+    await CodeRunner(
+    ...<9 lines>...
+    .run_async(globals, locals)
+  File "/lib/python314.zip/_pyodide/_base.py", line 413, in run_async
+    await coroutine
+  File "<exec>", line 34, in <module>
+  File "<exec>", line 113, in _execute_with_last_display
+  File "main.py", line 10, in <module>
+  File "main.py", line 9, in a
+  File "main.py", line 8, in b
+ValueError: boom`;
+
+describe("cleanPythonTraceback", () => {
+  it("keeps only the frames the user wrote", () => {
+    expect(cleanPythonTraceback(HARNESS_TRACEBACK)).toBe(
+      `Traceback (most recent call last):
+  File "main.py", line 10, in <module>
+  File "main.py", line 9, in a
+  File "main.py", line 8, in b
+ValueError: boom`,
+    );
+  });
+
+  it("drops the source lines echoed under a harness frame", () => {
+    const cleaned = cleanPythonTraceback(HARNESS_TRACEBACK);
+    expect(cleaned).not.toContain("await CodeRunner(");
+    expect(cleaned).not.toContain("...<9 lines>...");
+    expect(cleaned).not.toContain("_pyodide");
+  });
+
+  it("keeps the joiners and both halves of a chained exception", () => {
+    const chained = `Traceback (most recent call last):
+  File "<exec>", line 34, in <module>
+  File "main.py", line 2, in <module>
+KeyError: 'x'
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/lib/python314.zip/_pyodide/_base.py", line 413, in run_async
+    await coroutine
+  File "main.py", line 4, in <module>
+ValueError: boom`;
+    const cleaned = cleanPythonTraceback(chained);
+    expect(cleaned).toContain("During handling of the above exception");
+    expect(cleaned).toContain("KeyError: 'x'");
+    expect(cleaned).toContain('File "main.py", line 2');
+    expect(cleaned).toContain('File "main.py", line 4');
+    expect(cleaned).not.toContain("_pyodide");
+    expect(cleaned).not.toContain("<exec>");
+  });
+
+  it("leaves a traceback with no harness frames untouched", () => {
+    const plain = `Traceback (most recent call last):
+  File "main.py", line 1, in <module>
+ZeroDivisionError: division by zero`;
+    expect(cleanPythonTraceback(plain)).toBe(plain);
+  });
+
+  it("shows a harness-only failure raw rather than showing nothing", () => {
+    const harnessOnly = `Traceback (most recent call last):
+  File "/lib/python314.zip/_pyodide/_base.py", line 597, in eval_code_async
+    await CodeRunner(
+RuntimeError: the harness broke`;
+    expect(cleanPythonTraceback(harnessOnly)).toBe(harnessOnly);
+  });
+
+  it("passes through a message that isn't a traceback", () => {
+    expect(cleanPythonTraceback("SyntaxError: invalid syntax")).toBe(
+      "SyntaxError: invalid syntax",
+    );
+  });
+});
+
+describe("annotateRunError", () => {
+  it("explains a CORS-blocked request in plain language", () => {
+    const urllib3Failure = `pyodide.ffi.JsException: AbortError: signal is aborted without reason
+  File ".../urllib3/contrib/emscripten/fetch.py", line 667, in _run_sync_with_timeout
+urllib3.contrib.emscripten.fetch._TimeoutError: Request timed out`;
+    const annotated = annotateRunError(urllib3Failure);
+    expect(annotated).toMatch(/^This request was blocked by the browser/);
+    expect(annotated).toContain("Access-Control-Allow-Origin");
+    // The original failure is kept: the hint is a preface, not a swap.
+    expect(annotated).toContain("_TimeoutError");
+  });
+
+  it("leaves an ordinary error alone", () => {
+    const plain = `Traceback (most recent call last):
+  File "main.py", line 1, in <module>
+ValueError: boom`;
+    expect(annotateRunError(plain)).toBe(plain);
+  });
+});

--- a/__tests__/utf8Size.test.ts
+++ b/__tests__/utf8Size.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The Files panel labels its size column "B", so `utf8ByteLength` has to
+ * agree with what `os.path.getsize()` reports inside a runtime — which
+ * `String.length` does not for anything outside ASCII.
+ */
+import { describe, expect, it } from "vitest";
+
+import { utf8ByteLength } from "../app/_components/utf8Size";
+
+describe("utf8ByteLength", () => {
+  it("matches TextEncoder across scripts and emoji", () => {
+    const samples = [
+      "",
+      "plain ascii",
+      "café",
+      "你好",
+      "😀",
+      "em — dash",
+      "# main.py — café 你好 \u{1F600}\nprint('hi')\n",
+      "mixed ascii/é/你/😀 in one line",
+    ];
+    for (const s of samples) {
+      expect(utf8ByteLength(s)).toBe(new TextEncoder().encode(s).length);
+    }
+  });
+
+  it("counts the characters the audit measured", () => {
+    // "—" is 3 bytes (+2 over its 1 UTF-16 unit), "é" 2 (+1), "你" and "好"
+    // 3 each (+2 each): 7 bytes more than String.length, which is exactly
+    // the gap the panel used to under-report.
+    const s = "—é你好";
+    expect(s.length).toBe(4);
+    expect(utf8ByteLength(s)).toBe(11);
+  });
+
+  it("counts a surrogate pair once, as four bytes", () => {
+    expect("😀".length).toBe(2);
+    expect(utf8ByteLength("😀")).toBe(4);
+  });
+
+  it("handles a lone surrogate the way an encoder does", () => {
+    const lone = "\uD83D";
+    expect(utf8ByteLength(lone)).toBe(
+      new TextEncoder().encode(lone).length,
+    );
+  });
+});

--- a/__tests__/workspacesCloud.test.ts
+++ b/__tests__/workspacesCloud.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../lib/workspaces/bundleCodec";
 import {
   BUNDLE_FILENAME_MAX,
+  BUNDLE_MAX_DATA_FILES,
   BUNDLE_MAX_FILES,
   CODE_PLAYGROUND_IDS,
   SQL_PLAYGROUND_IDS,
@@ -25,6 +26,7 @@ import {
   validateBundle,
   type WorkspaceBundle,
 } from "../lib/workspaces/types";
+import { base64ToBytes, bytesToBase64 } from "../lib/workspaces/base64";
 import {
   GUEST_SHARE_TTL_DAYS,
   INACTIVITY_EXPIRY_DAYS,
@@ -39,6 +41,9 @@ import {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const NOW = Date.UTC(2026, 6, 2, 12, 0, 0);
+
+// An uploaded CSV, with a non-ASCII byte so a lossy encode would show.
+const CSV_BYTES = new TextEncoder().encode('city,pop\nParis,2.1\n"Qu\u00e9bec, city",3.5\n');
 
 // A stand-in database image; the codec treats it as opaque bytes.
 const DB_IMAGE = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0, 255]);
@@ -359,6 +364,76 @@ describe("validateBundle, openFilenames", () => {
     expect(
       validateBundle(codeBundleWith(Array.from({ length: 201 }, () => "a.py"))),
     ).toBeNull();
+  });
+});
+
+describe("validateBundle, dataFiles", () => {
+  const withData = (dataFiles?: unknown): unknown => ({
+    ...codeBundle(),
+    dataFiles,
+  });
+
+  it("accepts a bundle without any (nothing uploaded, or an older bundle)", () => {
+    expect(validateBundle(withData())).not.toBeNull();
+  });
+
+  it("accepts uploaded data files", () => {
+    expect(
+      validateBundle(withData([{ path: "sales.csv", base64: "YSxiCjEsMgo=" }])),
+    ).not.toBeNull();
+  });
+
+  it("rejects a malformed or oversized list", () => {
+    expect(validateBundle(withData("sales.csv"))).toBeNull();
+    expect(validateBundle(withData([{ path: "sales.csv" }]))).toBeNull();
+    expect(validateBundle(withData([{ path: "", base64: "" }]))).toBeNull();
+    expect(
+      validateBundle(
+        withData(
+          Array.from({ length: BUNDLE_MAX_DATA_FILES + 1 }, () => ({
+            path: "a.csv",
+            base64: "",
+          })),
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("round-trips through the codec", async () => {
+    const bundle = codeBundle({
+      dataFiles: [{ path: "sales.csv", base64: bytesToBase64(CSV_BYTES) }],
+    });
+    const decoded = await decodeBundle(await encodeBundle(bundle));
+    expect(decoded.dataFiles).toEqual(bundle.dataFiles);
+    expect(base64ToBytes(decoded.dataFiles![0].base64)).toEqual(CSV_BYTES);
+  });
+
+  it("lists data files alongside code files in the manifest", () => {
+    // The share landing page's file table is built from this, and it was
+    // the one place a recipient could have noticed the CSV was missing.
+    const manifest = manifestForBundle(
+      codeBundle({
+        dataFiles: [{ path: "sales.csv", base64: bytesToBase64(CSV_BYTES) }],
+      }),
+    );
+    expect(manifest.files?.map((f) => f.name)).toEqual([
+      "main.py",
+      "sales.csv",
+    ]);
+    expect(manifest.files?.[1].size).toBe(CSV_BYTES.length);
+  });
+});
+
+describe("base64 for bundle data files", () => {
+  it("round-trips binary bytes, including a payload past the chunk size", () => {
+    const big = new Uint8Array(400_000);
+    for (let i = 0; i < big.length; i += 1) big[i] = i % 256;
+    expect(base64ToBytes(bytesToBase64(big))).toEqual(big);
+  });
+
+  it("round-trips an empty file", () => {
+    expect(bytesToBase64(new Uint8Array(0))).toBe("");
+    expect(base64ToBytes("")).toEqual(new Uint8Array(0));
   });
 });
 

--- a/agent-outputs/20260815-1200-python-playground-audit-response.md
+++ b/agent-outputs/20260815-1200-python-playground-audit-response.md
@@ -1,0 +1,99 @@
+# Python Playground audit — response and disposition
+
+Companion to the black-box audit of `/playground/python` (16 findings,
+`PY-01`…`PY-16`). This records what was fixed, what was declined and why, and
+what turned out not to reproduce — the last two sections matter most for the
+remaining playground audits, because several of these findings are properties
+of the architecture rather than bugs, and will look identical in every other
+language.
+
+**Verification note.** Chromium in the authoring sandbox cannot reach
+`cdn.jsdelivr.net`, so Pyodide never boots there and the browser-level checks
+could not be run locally. What was verified instead: the worker's Python
+scripts were extracted from the source and executed against CPython (streaming
+reassembly, whitespace parity, a 5,000-line burst, `input()`, `plt.show()` over
+a stub pyplot, traceback filenames); the string-level fixes have unit tests;
+and `e2e/python-playground-audit-fixes.spec.ts` covers the browser behaviour
+for a machine with CDN access.
+
+---
+
+## Fixed
+
+| ID | Severity | Fix |
+|---|---|---|
+| PY-01 | Critical | **Stop control.** `LanguageRuntime.cancelRun()` is new and optional; only a runtime that implements it gets a Stop button. Python implements it by terminating the worker and standing a fresh one up in the background, replaying the warm-package hint. The in-flight `run()` rejects with a `RunCancelledError`, which the surface renders as a plain `Run stopped.` under whatever the program had already printed — not as a failure. |
+| PY-02 | High | **Streaming output.** Python pushes each output segment to the main thread as it is produced, batched on a 60 ms timer or an 8 KB threshold, whichever comes first. The surface republishes the run's slice at most every 80 ms. Text segments stream *stripped*, so the streamed concatenation is byte-identical to what the old flush-at-the-end path produced. |
+| PY-03 | High | **Files the program writes.** The worker snapshots size+mtime of every staged file, then diffs the working directory after each run; new or rewritten files go to the Files panel and OPFS via the existing `collectCreatedFiles` hook (the same one the R playground uses). Capped at 50 files / 64 MB per run. |
+| PY-04 | High | **`plt.show()` renders every open figure**, not just `gcf()`. The build-time capture path in `scripts/lib/python-output-capture.mjs` had the same bug and got the same fix, so a lesson's prepopulated panel and a live run agree. |
+| PY-05 | High | **`.zip` keeps your filenames.** The archive now also carries `source/<path>` — a readable copy of every editor file under its real name — and `workspace.json` records the id → path mapping. Import reads an allowlist (`meta.json`, `files/`, `db/`, `data/`), so the readable copies don't pollute a restored workspace. |
+| PY-06 | High → Medium | **`input()` explains itself.** Not supported (see *Declined*), but `builtins.input` now prints the prompt and raises a playground-specific `RuntimeError` naming two ways forward, instead of `OSError: [Errno 29] I/O error`. |
+| PY-07 | Medium | **Readable tracebacks.** User code compiles under its real filename, so frames read `File "main.py"` rather than `File "<string>"`; harness frames (`/lib/python*.zip/_pyodide/…`, `<exec>`) are filtered out before rendering. Chained exceptions keep both halves. A failure with no user frames is shown raw rather than shown empty. |
+| PY-08 | Medium | **CORS failures say "CORS".** A urllib3-emscripten timeout/abort gets a plain-language preface naming the missing `Access-Control-Allow-Origin` header and suggesting a CORS-enabled host or an upload. The `requests` entry in the Packages drawer no longer claims network calls are blocked — they work, subject to CORS — and its example now makes a real request. |
+| PY-09 | Medium | **Dismissed dialogs stop swallowing clicks.** A closing `.confirm-popup` / `.confirm-backdrop` gets `pointer-events: none` for its exit transition. See *Did not reproduce* for the part of this finding that is an artifact of the audit environment. |
+| PY-11 | Low | **"Export code" → "Export current file"**, and the item now says it downloads the open file only. |
+| PY-12 | Low | **Mid-run waits are visible.** `RunOptions.onStatus` existed and was wired in `<CodeBlock>` and `<ChallengeCard>` but not in the playground, so "Installing data packages, first run only…" went nowhere. It now renders above the run blocks. |
+| PY-14 | High | **Share carries data files.** Code bundles gained `dataFiles` (base64, capped at 4 MB / 50 files); the recipient's copy writes them back into its `data/` store, and they appear in the share landing page's file table. Anything that doesn't fit is named to the sharer at creation time instead of being dropped silently. |
+| PY-15 | Low | **Guests are told before they publish.** Revocation genuinely can't work for a guest (see *Declined*), so the dialog now says a guest link stays up for its full TTL and cannot be revoked early, rather than implying otherwise. |
+| PY-16 | Low | **Byte counts are bytes.** `utf8ByteLength` replaces `String.length` in the Files panel and in the share manifest. The audit's `−7` on both non-ASCII files is exactly what it predicted. |
+
+## Declined — structural, not defects
+
+**PY-06, `input()` proper.** Supporting it needs `Atomics.wait` on a
+`SharedArrayBuffer` to block the worker while the main thread collects a
+value, which needs cross-origin isolation (COOP/COEP). Those headers break
+third-party embeds and CDN-loaded runtimes across the site, which is a much
+larger trade than one builtin is worth. The playground is a
+run-to-completion sandbox, not a REPL. **This applies to every playground**:
+any "reads from stdin interactively" finding has the same answer.
+
+**PY-15, guest link revocation.** A guest share has no owner row, so there is
+nothing for a revoke to authorise against — the `DELETE /api/shares/[id]`
+route requires a session by design. Giving guests revocation means minting a
+per-link secret and storing it client-side, which is a real feature with real
+security surface, not a fix. Signing in gives you managed, revocable links.
+
+**PY-10, run history.** Not a feature this playground offers, and the finding
+did not reproduce anyway (below).
+
+**PY-01's interrupt-buffer variant.** `pyodide.setInterruptBuffer` would
+preserve interpreter state across a Stop, but it needs the same cross-origin
+isolation as `input()`. Terminate-and-respawn costs nothing observable: globals
+are already wiped between runs. The trade-off is deliberate, and the same one
+any WASM runtime in this codebase should make.
+
+## Did not reproduce
+
+**PY-10 — "each run replaces the last".** Output accumulates by default.
+`clearBeforeRun` defaults to `false` for code playgrounds, `runCode` appends
+to the file's cell list, and the panel groups by `runId` with `Run 1..N`
+incrementing. The chrome the finding calls dishonest is accurate; the audit
+session most likely had *Clear Output Before Running* switched on in Settings.
+Worth re-checking that setting before filing this against another playground.
+
+**PY-13 — "no rename affordance".** Rename exists in two places: the Files
+panel context menu (right-click → Rename) and the tab context menu. Neither is
+a *hover* affordance, which is probably why it wasn't found. The naming
+complaint underneath it (a new tab is `untitled_2.py`, and that becomes the
+module name) is fair but is a product decision, not a defect; left as is.
+
+**PY-09, the focus half.** A dismissed dialog holding focus indefinitely is an
+artifact of the audit's own measurement caveat: the tab ran with
+`document.visibilityState === "hidden"`, which stops `requestAnimationFrame`,
+so Base UI's exit transition never completes and the modal focus trap never
+unmounts. In a foreground tab the window is ~180 ms. The click-swallowing
+inside that window is real, and is what the CSS fix addresses. **Any
+finding derived from focus or animation timing in a hidden tab should be
+re-checked in a visible one before filing** — this one was filed against all
+four playgrounds.
+
+## Notes for the remaining audits
+
+- `RunOptions.onStatus` now reaches the playground surface. If another
+  runtime has mid-run waits it doesn't report, that is a runtime-side gap.
+- `cancelRun` is opt-in per runtime. A playground without a Stop button is a
+  runtime that hasn't implemented it, and it is worth reporting — the surface
+  is ready.
+- `collectCreatedFiles` is likewise opt-in; R and Python implement it.
+- The `EmitOutput` signature grew `(cell, seq?, append?)`. Runtimes that emit
+  whole cells keep working unchanged; only streaming runtimes pass `seq`.

--- a/app/_components/Playground.tsx
+++ b/app/_components/Playground.tsx
@@ -52,6 +52,7 @@ import type {
   ExampleSnippet,
   ExportFormat,
   LanguageAdapter,
+  EmitOutput,
   LanguageRuntime,
   OutputCell,
   PackageInfo,
@@ -74,6 +75,7 @@ import {
   Share2,
   Eraser,
   Play,
+  Square,
   FileCode,
   FolderOpen,
   Info,
@@ -123,6 +125,7 @@ import {
   suggestNextFilename,
   type PlaygroundFile,
 } from "./playgroundTabs";
+import { utf8ByteLength } from "./utf8Size";
 import { getPlaygroundStore } from "./stores/createPlaygroundStore";
 import {
   deleteFile as opfsDeleteFile,
@@ -156,7 +159,16 @@ import {
   MobileMenuSubSheet,
 } from "./MobileMenuSheet";
 import { applyEntryFocus } from "./playgroundEntryFocus";
-import type { BundleCodeFile, WorkspaceBundle } from "@/lib/workspaces/types";
+import type {
+  BundleCodeFile,
+  BundleDataFile,
+  WorkspaceBundle,
+} from "@/lib/workspaces/types";
+import {
+  BUNDLE_MAX_DATA_BYTES,
+  BUNDLE_MAX_DATA_FILES,
+} from "@/lib/workspaces/types";
+import { bytesToBase64 } from "@/lib/workspaces/base64";
 import {
   FileCode2,
   PanelLeft,
@@ -189,6 +201,11 @@ const MOBILE_EDITOR_TAB = "editor" as const;
 /** Code playgrounds append runs to one scrolling history, so
  *  clear-before-run is opt-in here; the SQL playgrounds keep the default. */
 const CODE_CLEAR_BEFORE_RUN_DEFAULT = false;
+// How often the output panel repaints while a run is still producing
+// output. Fast enough to read as live, slow enough that a print-heavy loop
+// doesn't re-render per chunk.
+const LIVE_OUTPUT_FLUSH_MS = 80;
+
 // Minimum ms the "running" overlay shows so its 180ms CSS transition can
 // complete visibly.
 const MIN_ANIMATION_MS = 300;
@@ -602,6 +619,14 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   const [editorTheme, setEditorThemeState] = useState<string>("github-light");
   const [wordWrap, setWordWrapState] = useState<boolean>(true);
   const [clearBeforeRun, setClearBeforeRunState] = useState<boolean>(false);
+  /** True once a runtime that implements `cancelRun` has booted; drives the
+   *  Run button's switch to Stop while a program is running. */
+  const [canStopRun, setCanStopRun] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  /** Mid-run wait notice from the runtime (e.g. Python's first-run package
+   *  install), so a multi-second pause explains itself instead of looking
+   *  like a slow program. */
+  const [runStatusMessage, setRunStatusMessage] = useState<string | null>(null);
 
   // ─── UI state ───────────────────────────────────────────────────────────
   const [packagesOpen, setPackagesOpen] = useState(false);
@@ -744,6 +769,42 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   // Serializes the live workspace (dirty buffers, falling back to OPFS)
   // into the portable bundle /api/workspaces and /api/shares store.
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  /** Data files that didn't fit in the last bundle, so Share can say so
+   *  instead of publishing a copy that silently can't run. */
+  const excludedShareFilesRef = useRef<string[]>([]);
+
+  /** Uploaded data files as base64, newest-smallest-first so a big archive
+   *  can't crowd out the little CSV the program actually reads. */
+  const collectBundleDataFiles = useCallback(
+    async (
+      wsId: string,
+    ): Promise<{ dataFiles: BundleDataFile[]; excluded: string[] }> => {
+      const dataFiles: BundleDataFile[] = [];
+      const excluded: string[] = [];
+      const candidates = virtualFilesRef.current
+        .filter((vf) => !vf.isFolder)
+        .slice()
+        .sort((a, b) => a.size - b.size);
+      let budget = BUNDLE_MAX_DATA_BYTES;
+      for (const vf of candidates) {
+        if (dataFiles.length >= BUNDLE_MAX_DATA_FILES) {
+          excluded.push(vf.path);
+          continue;
+        }
+        const bytes = await readDataFile(wsId, vf.path);
+        if (!bytes) continue;
+        if (bytes.length > budget) {
+          excluded.push(vf.path);
+          continue;
+        }
+        budget -= bytes.length;
+        dataFiles.push({ path: vf.path, base64: bytesToBase64(bytes) });
+      }
+      return { dataFiles, excluded };
+    },
+    [],
+  );
+
   const buildCloudBundle =
     useCallback(async (): Promise<WorkspaceBundle | null> => {
       const wsId = workspaceIdRef.current;
@@ -761,6 +822,11 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       const openFilenames = openTabIdsRef.current
         .map((id) => fileList.find((f) => f.id === id)?.filename)
         .filter((name): name is string => !!name);
+      // Uploaded data files ride along: the Files panel lists them as part
+      // of the workspace and programs read them by name, so a snapshot
+      // without them is a snapshot that doesn't run.
+      const { dataFiles, excluded } = await collectBundleDataFiles(wsId);
+      excludedShareFilesRef.current = excluded;
       return {
         version: 2,
         kind: "code",
@@ -768,10 +834,11 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
         name: workspaceName || "Workspace",
         exportedAt: Date.now(),
         files: bundleFiles,
+        ...(dataFiles.length > 0 ? { dataFiles } : {}),
         activeFilename: active?.filename,
         openFilenames,
       };
-    }, [adapter.id, workspaceName]);
+    }, [adapter.id, collectBundleDataFiles, workspaceName]);
 
   useEffect(() => {
     settingsOpenRef.current = settingsOpen;
@@ -1641,6 +1708,8 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
         // The playground can't predict what the user will type, so pre-warm
         // the full optional package set unconditionally. Fire-and-forget.
         rt.warmPackages?.([], { force: true });
+        // Only runtimes that can actually stop a run get a Stop control.
+        setCanStopRun(typeof rt.cancelRun === "function");
         setLoaded(true);
         setStatusState("ready");
       } catch (err) {
@@ -1992,11 +2061,90 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
       setOutputsForFile(targetFileId, []);
     }
 
+    setRunStatusMessage(null);
+
     const t0 = performance.now();
-    const collected: Omit<OutputCell, "id" | "elapsed">[] = [];
+    // Notices the surface itself produces (a staging failure), kept out of
+    // `collected` because that array is addressed by stream position: a cell
+    // pushed at index 0 here would be overwritten by the run's first cell.
+    const preCells: Omit<OutputCell, "id" | "elapsed">[] = [];
+    // Sparse: a runtime that streams addresses cells by position, and a
+    // position can end up empty (a text segment that was only whitespace).
+    const collected: (Omit<OutputCell, "id" | "elapsed"> | undefined)[] = [];
     const firstId = outputCounter.current + 1;
     newRunFirstIdRef.current = firstId;
     const runId = ++runCounter.current;
+
+    /**
+     * Show what the run has produced so far.
+     *
+     * Called repeatedly while the program is still going (Python streams its
+     * stdout), so this replaces the run's whole slice rather than appending:
+     * `mergeConsecutiveStdout` is deterministic, so a growing input produces
+     * a growing output with a stable prefix, and deriving ids from `firstId`
+     * instead of the running counter keeps each cell's React key stable
+     * across updates.
+     */
+    const publish = (finishedAt?: number): number => {
+      const merged = mergeConsecutiveStdout([
+        ...preCells,
+        ...collected.filter(
+          (c): c is Omit<OutputCell, "id" | "elapsed"> => c !== undefined,
+        ),
+      ]);
+      const elapsed = `${((performance.now() - t0) / 1000).toFixed(2)}s`;
+      setOutputsForFile(targetFileId, (prev) => [
+        ...prev.filter((c) => c.runId !== runId),
+        ...merged.map((c, i) => ({
+          ...c,
+          id: firstId + i,
+          elapsed,
+          runId,
+          finishedAt,
+        })),
+      ]);
+      outputCounter.current = Math.max(
+        outputCounter.current,
+        firstId + merged.length - 1,
+      );
+      return merged.length;
+    };
+
+    // Throttled live publishing: the first cell shows immediately, the rest
+    // batch, so a 50,000-line run doesn't re-render per chunk.
+    let liveTimer: number | null = null;
+    let livePending = false;
+    const scheduleLive = () => {
+      if (liveTimer !== null) {
+        livePending = true;
+        return;
+      }
+      publish();
+      liveTimer = window.setTimeout(function tick() {
+        liveTimer = null;
+        if (!livePending) return;
+        livePending = false;
+        scheduleLive();
+      }, LIVE_OUTPUT_FLUSH_MS);
+    };
+    const stopLive = () => {
+      if (liveTimer !== null) {
+        window.clearTimeout(liveTimer);
+        liveTimer = null;
+      }
+    };
+    const emitCell: EmitOutput = (cell, seq, append) => {
+      if (seq === undefined) {
+        collected.push(cell);
+      } else {
+        const prev = collected[seq];
+        collected[seq] =
+          append && prev
+            ? { ...prev, content: prev.content + cell.content }
+            : cell;
+      }
+      scheduleLive();
+    };
 
     // Mirror files the runtime created during the run into the Files pane
     // + OPFS. Called on both success and error paths (a file may have been
@@ -2063,33 +2211,28 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
           // Non-fatal: execution proceeds with whatever made it in.
           const msg =
             stageErr instanceof Error ? stageErr.message : String(stageErr);
-          collected.push({
+          preCells.push({
             type: "stderr",
             content: `Failed to stage workspace files: ${msg}`,
           });
         }
       }
-      const runOptions: RunOptions = {};
+      const runOptions: RunOptions = {
+        // Mid-run waits (Python's first-run package install) explain
+        // themselves in the output panel instead of looking like a hang.
+        onStatus: (message, preparing) => {
+          setRunStatusMessage(preparing ? message : null);
+        },
+      };
       if (entryFilename) runOptions.entryFilename = entryFilename;
       // Preview adapters render into the surface-owned slot; each run
       // replaces the previous iframe (which is also the teardown story).
       if (hasPreview) runOptions.previewHost = previewHostRef.current;
-      await rt.run(code, (cell) => collected.push(cell), runOptions);
+      await rt.run(code, emitCell, runOptions);
       await syncCreatedFiles();
-      const elapsed = `${((performance.now() - t0) / 1000).toFixed(2)}s`;
-      const finishedAt = Date.now();
-      const merged = mergeConsecutiveStdout(collected);
-      setOutputsForFile(targetFileId, (prev) => [
-        ...prev,
-        ...merged.map((c) => ({
-          ...c,
-          id: ++outputCounter.current,
-          elapsed,
-          runId,
-          finishedAt,
-        })),
-      ]);
-      if (collected.length === 0 && !hasPreview) {
+      stopLive();
+      const cellCount = publish(Date.now());
+      if (cellCount === 0 && !hasPreview) {
         // Preview adapters "output" the page itself; no toast there.
         showToast("Code ran successfully, no output.");
       }
@@ -2101,34 +2244,28 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     } catch (err) {
       // User code may have created files before throwing; surface them.
       await syncCreatedFiles();
-      const elapsed = `${((performance.now() - t0) / 1000).toFixed(2)}s`;
-      const finishedAt = Date.now();
+      stopLive();
+      // A Stop is a deliberate act, not a failure: whatever the program
+      // printed before it was stopped stays on screen, with a plain note.
+      const cancelled = err instanceof Error && err.name === "RunCancelledError";
       const msg = err instanceof Error ? err.message : String(err);
-      const mergedOnErr = mergeConsecutiveStdout(collected);
-      setOutputsForFile(targetFileId, (prev) => [
-        ...prev,
-        ...mergedOnErr.map((c) => ({
-          ...c,
-          id: ++outputCounter.current,
-          elapsed,
-          runId,
-          finishedAt,
-        })),
-        {
-          id: ++outputCounter.current,
-          type: "stderr" as const,
-          content: msg,
-          elapsed,
-          runId,
-          finishedAt,
-        },
-      ]);
-      setStatusState("error");
-      errorResetTimerRef.current = window.setTimeout(() => {
-        errorResetTimerRef.current = null;
+      collected.push({
+        type: "stderr" as const,
+        content: cancelled ? "Run stopped." : msg,
+      });
+      publish(Date.now());
+      if (cancelled) {
         setStatusState("ready");
-      }, 3000);
+      } else {
+        setStatusState("error");
+        errorResetTimerRef.current = window.setTimeout(() => {
+          errorResetTimerRef.current = null;
+          setStatusState("ready");
+        }, 3000);
+      }
     } finally {
+      stopLive();
+      setRunStatusMessage(null);
       // On narrow viewports, surface the output tab once the run is done.
       // Debounced auto-runs skip this — yanking the pane mid-typing would
       // be hostile.
@@ -2136,6 +2273,24 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
     }
   },
   [clearBeforeRun, collectWorkspaceFilesForRun, hasPreview, setOutputsForFile, showToast]);
+
+  /** Stop the running program. The runtime rejects the in-flight `run()`
+   *  with a RunCancelledError, which `runCode` renders as "Run stopped."
+   *  above whatever the program had already printed. */
+  const stopRun = useCallback(async () => {
+    const rt = runtimeRef.current;
+    if (!rt?.cancelRun) return;
+    setStopping(true);
+    try {
+      await rt.cancelRun();
+    } catch (err) {
+      showToast(
+        `Couldn't stop the run: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setStopping(false);
+    }
+  }, [showToast]);
 
   const clearOutput = useCallback(() => {
     // Clear the pane the output panel is actually showing (split view
@@ -2587,9 +2742,9 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
   const mergedVirtualFiles = useMemo<VirtualFile[]>(() => {
     const codeEntries: VirtualFile[] = files.map((f) => ({
       path: f.filename,
-      // String length, not UTF-8 bytes — the same approximation FilesPanel
-      // uses everywhere else.
-      size: dirtyBuffers.get(f.id)?.length ?? 0,
+      // Real UTF-8 bytes, so the column agrees with os.path.getsize() inside
+      // the runtime for files containing accented text, CJK or emoji.
+      size: utf8ByteLength(dirtyBuffers.get(f.id) ?? ""),
       isFolder: false,
     }));
     const filteredData = virtualFiles.filter(
@@ -3397,10 +3552,13 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
         items: [
           {
             key: "export",
-            label: "Export code",
+            // "Export code" read as "export the workspace"; it only ever
+            // wrote the file in front of you. The whole-workspace path is
+            // Save -> Download copy.
+            label: "Export current file",
             icon: ArrowDownToLine,
             panel: {
-              title: "Export code",
+              title: "Export current file",
               render: (close: () => void) => (
                 <>
                   {adapter.exportFormats.map((fmt) => (
@@ -3417,7 +3575,9 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                         {fmt.label}
                         <span className="ext-badge">.{fmt.extension}</span>
                       </div>
-                      <div className="ex-desc">Download as .{fmt.extension}</div>
+                      <div className="ex-desc">
+                        Downloads the open file only, as .{fmt.extension}
+                      </div>
                     </button>
                   ))}
                 </>
@@ -3744,6 +3904,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
             <ShareControls
               workspaceName={workspaceName}
               buildBundle={buildCloudBundle}
+              excludedFiles={() => excludedShareFilesRef.current}
               shareOpen={shareDialogOpen}
               onShareOpenChange={setShareDialogOpen}
             />
@@ -4278,8 +4439,26 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                 <kbd className="kbd">Enter</kbd>
               </span>
               <div
-                className={`playground-run-multi${runButtonState.dropdownItems.length > 0 ? " has-dropdown" : ""}${statusState === "running" ? " running" : ""}`}
+                className={`playground-run-multi${runButtonState.dropdownItems.length > 0 ? " has-dropdown" : ""}${statusState === "running" ? " running" : ""}${statusState === "running" && canStopRun ? " stoppable" : ""}`}
               >
+                {/* While a stoppable runtime is running, the primary button
+                    becomes Stop — an accidental `while True:` is one of the
+                    likeliest things a beginner writes, and reloading the page
+                    must not be the only way out. */}
+                {statusState === "running" && canStopRun ? (
+                  <button
+                    type="button"
+                    className="run-btn playground-run-multi-main stop"
+                    onClick={() => void stopRun()}
+                    disabled={stopping}
+                    title="Stop the running program"
+                  >
+                    <Square size={9} aria-hidden="true" fill="currentColor" />
+                    <span className="playground-run-multi-label">
+                      {stopping ? "Stopping…" : "Stop"}
+                    </span>
+                  </button>
+                ) : (
                 <Popover.Root>
                   <Popover.Trigger
                     render={(props) => (
@@ -4287,7 +4466,9 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                         {...props}
                         type="button"
                         className={`run-btn playground-run-multi-main${statusState === "running" ? " running" : ""}${runButtonState.dropdownItems.length > 0 ? " has-chevron" : ""}`}
-                        disabled={!loaded || statusState === "running"}
+                        // `stopping`: the previous run's Stop is still
+                        // standing a fresh interpreter up.
+                        disabled={!loaded || statusState === "running" || stopping}
                         onClick={() => {
                           void runCode(runButtonState.primaryEntry ?? undefined);
                         }}
@@ -4317,6 +4498,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                     </Popover.Positioner>
                   </Popover.Portal>
                 </Popover.Root>
+                )}
                 {runButtonState.dropdownItems.length > 0 && (
                   <Menu.Root>
                     <Menu.Trigger
@@ -4325,7 +4507,7 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                           {...props}
                           type="button"
                           className={`run-btn playground-run-multi-chevron${statusState === "running" ? " running" : ""}`}
-                          disabled={!loaded || statusState === "running"}
+                          disabled={!loaded || statusState === "running" || stopping}
                           aria-label="More run options"
                         >
                           <ChevronDown size={12} aria-hidden="true" />
@@ -4672,7 +4854,15 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                   </div>
                 )
               ) : (
-                outputGroups.map((group, groupIndex) => {
+                <>
+                {/* Mid-run wait notice (package installs), so a multi-second
+                    pause before the first line explains itself. */}
+                {statusState === "running" && runStatusMessage && (
+                  <div className="run-status-note" role="status">
+                    {runStatusMessage}
+                  </div>
+                )}
+                {outputGroups.map((group, groupIndex) => {
                   // One slim cell per run. stderr-only runs read red;
                   // older runs dim, the newest stays full color.
                   const onlyStderr = group.every((c) => c.type === "stderr");
@@ -4790,7 +4980,8 @@ function PlaygroundInner({ adapter }: PlaygroundProps) {
                       </div>
                     </div>
                   );
-                })
+                })}
+                </>
               )}
             </div>
             <DataslopeRunOverlay running={statusState === "running"} />

--- a/app/_components/cloud/ShareControls.tsx
+++ b/app/_components/cloud/ShareControls.tsx
@@ -28,6 +28,10 @@ export interface ShareControlsProps {
    *  requesting the author's query history/stars, and this signature keeps
    *  anything under this component from ever asking for it. */
   buildBundle: () => Promise<WorkspaceBundle | null>;
+  /** Workspace files the last `buildBundle` had to leave out (too large,
+   *  too many). Reported next to the link so a snapshot is never quietly
+   *  published without something the program needs. */
+  excludedFiles?: () => string[];
   /** Controlled-optional dialog state (mobile menus open the dialog). */
   shareOpen?: boolean;
   onShareOpenChange?: (open: boolean) => void;
@@ -38,6 +42,7 @@ export interface ShareControlsProps {
 export function ShareControls({
   workspaceName,
   buildBundle,
+  excludedFiles,
   shareOpen: shareOpenProp,
   onShareOpenChange,
   renderTrigger = true,
@@ -72,6 +77,7 @@ export function ShareControls({
         onClose={() => setShareOpen(false)}
         workspaceName={workspaceName}
         buildBundle={buildBundle}
+        excludedFiles={excludedFiles}
       />
     </>
   );
@@ -82,17 +88,20 @@ function ShareDialog({
   onClose,
   workspaceName,
   buildBundle,
+  excludedFiles,
 }: {
   open: boolean;
   onClose: () => void;
   workspaceName: string;
   buildBundle: () => Promise<WorkspaceBundle | null>;
+  excludedFiles?: () => string[];
 }) {
   const { data: session } = useSession();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [url, setUrl] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [omitted, setOmitted] = useState<string[]>([]);
 
   useEffect(() => {
     if (open) {
@@ -102,6 +111,7 @@ function ShareDialog({
       setUrl(null);
       setError(null);
       setCopied(false);
+      setOmitted([]);
     }
   }, [open]);
 
@@ -115,6 +125,7 @@ function ShareDialog({
         return;
       }
       const res = await createShare(bundle);
+      setOmitted(excludedFiles?.() ?? []);
       setUrl(res.url);
     } catch (err) {
       setError(
@@ -123,7 +134,7 @@ function ShareDialog({
     } finally {
       setBusy(false);
     }
-  }, [buildBundle]);
+  }, [buildBundle, excludedFiles]);
 
   const handleCopy = useCallback(async () => {
     if (!url) return;
@@ -138,9 +149,12 @@ function ShareDialog({
     }
   }, [url]);
 
+  // A guest share has no owner row, so there is nothing for a revoke to
+  // authorise against — the link genuinely stands until its TTL runs out.
+  // Say so before the link is created, not after.
   const retentionNote = session
     ? `Free links expire after ${INACTIVITY_EXPIRY_DAYS} days without views; Pro links don't expire. Manage links on your account page.`
-    : `Guest links expire ${GUEST_SHARE_TTL_DAYS} days after creation. Sign in (free) to manage your links or keep them longer.`;
+    : `Guest links stay up for the full ${GUEST_SHARE_TTL_DAYS} days and can't be revoked early. Sign in (free) to keep links longer and be able to revoke them.`;
 
   return (
     <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
@@ -214,6 +228,16 @@ function ShareDialog({
           {error && (
             <p role="alert" className="cloud-error">
               {error}
+            </p>
+          )}
+          {url && omitted.length > 0 && (
+            <p role="alert" className="cloud-error">
+              Too large to include, so the copy won&rsquo;t have{" "}
+              {omitted.length === 1
+                ? omitted[0]
+                : `${omitted.length} data files (${omitted.slice(0, 3).join(", ")}${omitted.length > 3 ? ", …" : ""})`}
+              . Code that reads {omitted.length === 1 ? "it" : "them"} will
+              fail for whoever opens the link.
             </p>
           )}
           <p className="cloud-note">{retentionNote}</p>

--- a/app/_components/cloud/materialize.ts
+++ b/app/_components/cloud/materialize.ts
@@ -9,6 +9,8 @@
  */
 
 import type { WorkspaceBundle } from "@/lib/workspaces/types";
+import { base64ToBytes } from "@/lib/workspaces/base64";
+import { writeDataFile } from "../files/opfsDataStorage";
 import {
   createWorkspace,
   deleteWorkspace,
@@ -58,6 +60,17 @@ export async function materializeCodeWorkspace(
     writeFile(entry.id, file.id, bundle.files![i].content);
   });
   await flushFileWrites();
+
+  // Uploaded data files land in the copy's `data/` store under their
+  // original paths, so a program that reads one still finds it.
+  for (const data of bundle.dataFiles ?? []) {
+    try {
+      await writeDataFile(entry.id, data.path, base64ToBytes(data.base64));
+    } catch {
+      // A single unreadable entry shouldn't cost the recipient the copy;
+      // the Files panel simply won't list it.
+    }
+  }
 
   const active =
     files.find((f) => f.filename === bundle.activeFilename) ?? files[0];

--- a/app/_components/opfs/workspaceArchive.ts
+++ b/app/_components/opfs/workspaceArchive.ts
@@ -1,13 +1,26 @@
 /**
- * Workspace export / import as ZIP. The archive mirrors the OPFS directory
- * tree verbatim plus a top-level `workspace.json` header (name, playground,
- * createdAt). Imports always land under a fresh workspace id so two imports
- * of the same archive don't clash.
+ * Workspace export / import as ZIP.
+ *
+ * The archive carries the same bytes twice, for two different readers:
+ *
+ *  - `meta.json`, `files/`, `db/`, `data/` mirror the OPFS tree verbatim.
+ *    This is what `importWorkspaceFromZip` reads, and only these paths are
+ *    extracted, so anything else in the archive is decoration.
+ *  - `source/<path>` holds a readable copy of each editor file under its
+ *    real name. Editor files live in OPFS under an opaque id (`files/
+ *    f_msu82q36_kfsxf`), which is right for storage and useless to a human:
+ *    "Download copy" promises "workspace files as a .zip", and unzipping it
+ *    used to produce extensionless blobs you had to open one by one to tell
+ *    apart. `workspace.json` additionally records the id → path mapping.
+ *
+ * Imports always land under a fresh workspace id so two imports of the same
+ * archive don't clash.
  */
 
 import JSZip from "jszip";
 
 import { isOpfsSupported } from "./featureDetect";
+import { loadManifest } from "../playgroundTabs";
 import {
   createWorkspace,
   getWorkspaceRegistry,
@@ -18,6 +31,13 @@ import {
 
 const WORKSPACES_DIR = "workspaces";
 const ARCHIVE_HEADER_FILE = "workspace.json";
+/** Readable copies of the editor files; not part of the OPFS tree. */
+const ARCHIVE_SOURCE_DIR = "source";
+/** Archive paths that `extractZipIntoDir` restores. Everything else (the
+ *  header, the `source/` copies, anything a user added by hand) is ignored,
+ *  so decoration can be added without polluting the imported workspace. */
+const IMPORTABLE_PREFIXES = ["files/", "db/", "data/"];
+const IMPORTABLE_FILES = ["meta.json"];
 
 interface ArchiveHeader {
   /** Schema marker, bumped if the on-disk layout changes. */
@@ -30,6 +50,9 @@ interface ArchiveHeader {
   createdAt: number;
   /** When the archive was produced. Informational only. */
   exportedAt: number;
+  /** Editor files, mapping the opaque OPFS id under `files/` to the path the
+   *  user sees. Absent in archives written before this field existed. */
+  files?: { id: string; path: string }[];
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +109,13 @@ async function extractZipIntoDir(
     if (!path.startsWith(prefix)) return;
     const rel = path.slice(prefix.length);
     if (!rel || rel === ARCHIVE_HEADER_FILE) return;
+    // Allowlist rather than skiplist: the OPFS tree has a known shape, so
+    // anything else in the archive (the readable `source/` copies, notes a
+    // user dropped in, a hostile path) simply isn't restored.
+    const importable =
+      IMPORTABLE_FILES.includes(rel) ||
+      IMPORTABLE_PREFIXES.some((p) => rel.startsWith(p));
+    if (!importable) return;
     entries.push({ path: rel, entry });
   });
 
@@ -153,6 +183,17 @@ async function writeFileTo(
 // Public API
 // ---------------------------------------------------------------------------
 
+/** Keeps a user-chosen filename inside `source/`: no absolute paths, no
+ *  `..` traversal, no control characters. A path that sanitizes to nothing
+ *  falls back to its own name so the entry still appears. */
+function sanitizeArchivePath(path: string): string {
+  const parts = path
+    .split("/")
+    .map((seg) => seg.replace(/[\u0000-\u001f]/g, "").trim())
+    .filter((seg) => seg && seg !== "." && seg !== "..");
+  return parts.join("/") || "unnamed";
+}
+
 /** Suggested download filename for an export. Strips path separators and
  *  control chars that make an invalid Save-As suggestion on Windows. */
 export function suggestExportFilename(entry: WorkspaceEntry): string {
@@ -185,12 +226,25 @@ export async function exportWorkspaceToZip(
   const zip = new JSZip();
   await addDirToZip(wsDir, zip);
 
+  // The id → filename mapping lives in localStorage, not OPFS, so the tree
+  // above can't carry it. Without it the archive is a database dump.
+  const manifest = loadManifest(entry.playground, workspaceId);
+  const fileMap = manifest
+    ? manifest.files.map((f) => ({ id: f.id, path: f.filename }))
+    : [];
+  for (const { id, path } of fileMap) {
+    const stored = zip.file(`files/${id}`);
+    if (!stored) continue;
+    zip.file(`${ARCHIVE_SOURCE_DIR}/${sanitizeArchivePath(path)}`, await stored.async("uint8array"));
+  }
+
   const header: ArchiveHeader = {
     version: 1,
     name: entry.name,
     playground: entry.playground,
     createdAt: entry.createdAt,
     exportedAt: Date.now(),
+    ...(fileMap.length > 0 ? { files: fileMap } : {}),
   };
   zip.file(ARCHIVE_HEADER_FILE, JSON.stringify(header, null, 2));
 

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -1114,6 +1114,19 @@ body.playground-active {
 .playground-run-multi.running {
   opacity: 0.75;
 }
+/* A run that can be stopped isn't a dead control, so it keeps full contrast
+   and switches to the danger color — the button is now the way out of a
+   runaway loop, not a progress indicator. */
+.playground-run-multi.running.stoppable {
+  opacity: 1;
+  background: var(--danger);
+}
+.playground-run-multi-main.stop {
+  cursor: pointer;
+}
+.playground-run-multi-main.stop:disabled {
+  cursor: progress;
+}
 .playground-run-multi-main {
   /* Override `.run-btn` background to participate in the shared group
    * background; the parent provides the brand color. */
@@ -3456,6 +3469,16 @@ input[type="range"].fs-slider:disabled {
 .confirm-backdrop[data-starting-style],
 .confirm-backdrop[data-ending-style] {
   opacity: 0;
+}
+/* A dismissed dialog is still mounted while it fades out, and until it
+   unmounts it eats the click that follows — the first click on Run after
+   closing an Example confirmation went nowhere. Once it's on the way out
+   it has no business receiving input, so let clicks through immediately.
+   (Also the honest fix for a background tab, where the transition may
+   never run and the exit state can persist indefinitely.) */
+.confirm-backdrop[data-ending-style],
+.confirm-popup[data-ending-style] {
+  pointer-events: none;
 }
 .confirm-popup {
   /* Anchor the whole dialog to the UI font so a styled host (the
@@ -5822,6 +5845,33 @@ html[data-playground-theme="dark"] {
   font-size: 11px;
   color: var(--text-dim);
   text-align: center;
+}
+
+/* Mid-run wait notice (e.g. "Installing data packages, first run only…"),
+   pinned above the run blocks while a run is blocked on something that
+   isn't the user's code. */
+.run-status-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 10px 0;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.run-status-note::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  border-top-color: transparent;
+  animation: playground-spin 0.75s linear infinite;
 }
 
 /* Right-side header cluster (Save ▾ · Share · ⋯). */

--- a/app/_components/runtime/pyodide-worker.ts
+++ b/app/_components/runtime/pyodide-worker.ts
@@ -9,6 +9,7 @@
 import type { PyodideInterface } from "pyodide";
 import { POLARS_IMPORT_PATTERN, POLARS_WASM_SHIM } from "./polarsWasm";
 import { toOutputCells } from "./pythonDisplayOutputs";
+import { annotateRunError, cleanPythonTraceback } from "./pythonErrors";
 
 declare const self: DedicatedWorkerGlobalScope;
 
@@ -51,7 +52,15 @@ interface CompletionItemMessage {
 
 type InMessage =
   | { kind: "init" }
-  | { kind: "run"; id: number; code: string; theme?: "light" | "dark" }
+  | {
+      kind: "run";
+      id: number;
+      code: string;
+      theme?: "light" | "dark";
+      /** Workspace path of the entry file, used as the traceback filename. */
+      entryFilename?: string;
+    }
+  | { kind: "collect-created-files"; id: number }
   | {
       kind: "complete";
       id: number;
@@ -84,11 +93,27 @@ type OutMessage =
   | { kind: "ready" }
   | { kind: "init-error"; message: string }
   | { kind: "run-status"; id: number; message: string; preparing: boolean }
-  | { kind: "output"; id: number; cell: OutputCellMessage }
+  | {
+      kind: "output";
+      id: number;
+      cell: OutputCellMessage;
+      /** Position of the cell within the run's output stream. Cells are
+       *  posted as they are produced, so the same `seq` can arrive more than
+       *  once for a text segment that is still growing (see `append`). */
+      seq: number;
+      /** True when `cell.content` continues the cell already sent for `seq`
+       *  rather than replacing it. */
+      append?: boolean;
+    }
   | { kind: "done"; id: number }
   | { kind: "error"; id: number; message: string }
   | { kind: "prepare-fs-done"; id: number }
   | { kind: "prepare-fs-error"; id: number; message: string }
+  | {
+      kind: "created-files";
+      id: number;
+      files: Array<[string, Uint8Array]>;
+    }
   | {
       kind: "complete-result";
       id: number;
@@ -221,20 +246,115 @@ async function initPyodide(): Promise<void> {
   // matplotlib-free: this script must run on the bare (phase A) interpreter.
   await pyodide.runPythonAsync(`
 import sys, io, base64, json, ast as _ast, re as _re
+from time import monotonic as _pg_monotonic
 from pyodide.code import find_imports as _pg_find_imports
 
 _display_outputs = []
+
+# ─── Incremental output streaming ─────────────────────────────────────
+# Output used to be posted to the surface in one lump after the run
+# finished, so a long loop showed nothing at all until it ended (and a
+# runaway loop showed nothing, ever). The list above is still the
+# authoritative record; these push each segment to the main thread as it
+# is produced, batched on a timer so a print-heavy loop doesn't turn into
+# a postMessage storm.
+#
+# _pg_stream_sink(seq, kind, content, append) is a JS callback installed
+# per run by runCode(). Text segments are streamed *stripped*: leading
+# whitespace is skipped and trailing whitespace is held back until more
+# text arrives, so the streamed concatenation equals the .trim() the
+# non-streaming path applies in toOutputCells().
+_pg_stream_sink = None
+# Per-entry progress: for a text entry, the index in its text up to which
+# content has been sent; for a rich entry, True once posted.
+_pg_sent = []
+# First entry that may still change; everything before it is final.
+_pg_stream_from = 0
+_pg_stream_last = 0.0
+_pg_stream_dirty = 0
+_pg_stream_tick = 0
+_PG_STREAM_INTERVAL = 0.06
+_PG_STREAM_CHARS = 8192
+
+def _pg_stream_reset():
+    global _pg_stream_from, _pg_stream_last, _pg_stream_dirty, _pg_stream_tick
+    _pg_sent.clear()
+    _pg_stream_from = 0
+    _pg_stream_last = _pg_monotonic()
+    _pg_stream_dirty = 0
+    _pg_stream_tick = 0
+
+def _pg_stream_flush(force=False):
+    """Hand everything not yet sent to the surface. Cheap to call often:
+    it walks only from the first entry that can still change, and each
+    character is scanned at most once across the whole run."""
+    global _pg_stream_from, _pg_stream_last, _pg_stream_dirty
+    sink = _pg_stream_sink
+    if sink is None:
+        return
+    now = _pg_monotonic()
+    if not force and (now - _pg_stream_last) < _PG_STREAM_INTERVAL:
+        return
+    _pg_stream_last = now
+    _pg_stream_dirty = 0
+    n = len(_display_outputs)
+    i = _pg_stream_from
+    while i < n:
+        entry = _display_outputs[i]
+        while len(_pg_sent) <= i:
+            _pg_sent.append(None)
+        kind = entry.get("type")
+        if kind == "stdout" or kind == "stderr":
+            text = entry["text"]
+            end = len(text)
+            while end > 0 and text[end - 1].isspace():
+                end -= 1
+            prev = _pg_sent[i]
+            if prev is None:
+                start = 0
+                while start < end and text[start].isspace():
+                    start += 1
+                if start < end:
+                    sink(i, kind, text[start:end], False)
+                    _pg_sent[i] = end
+            elif end > prev:
+                sink(i, kind, text[prev:end], True)
+                _pg_sent[i] = end
+        elif _pg_sent[i] is None:
+            sink(i, kind, json.dumps(entry), False)
+            _pg_sent[i] = True
+        # Only the newest entry can still grow, so skip the rest next time.
+        if i < n - 1:
+            _pg_stream_from = i + 1
+        i += 1
 
 def _pg_emit_text(kind, s):
     """Append stream text to the ordered output list, merging consecutive
     writes of the same stream into one segment (print() emits the text and
     its newline as separate writes)."""
+    global _pg_stream_dirty, _pg_stream_tick
     if not s:
         return
     if _display_outputs and _display_outputs[-1].get("type") == kind:
         _display_outputs[-1]["text"] += s
     else:
         _display_outputs.append({"type": kind, "text": s})
+    # Two triggers, because either alone leaves a hole. The character count
+    # bypasses the timer so a fast loop streams by volume rather than sitting
+    # in the buffer; the tick counter catches a slow loop that never reaches
+    # the threshold, and bounds monotonic() to one call per 64 writes.
+    _pg_stream_dirty += len(s)
+    _pg_stream_tick += 1
+    if _pg_stream_dirty >= _PG_STREAM_CHARS:
+        _pg_stream_flush(True)
+    elif (_pg_stream_tick & 63) == 0:
+        _pg_stream_flush()
+
+def _pg_emit_cell(entry):
+    """Append a rich output cell (table, image, chart) and push it out
+    immediately. These are rare, and worth showing the moment they exist."""
+    _display_outputs.append(entry)
+    _pg_stream_flush(True)
 
 # Tee installed over sys.stdout/sys.stderr while user code runs, so prints
 # land in _display_outputs *in order* with display() tables, figures and
@@ -306,43 +426,65 @@ def display(*objs):
                 # Strip the <style> block pandas injects so it does not
                 # override the playground's own table/th/td styles.
                 h = _strip_html_styles(h)
-            _display_outputs.append({"type": "dataframe", "html": h})
+            _pg_emit_cell({"type": "dataframe", "html": h})
         elif hasattr(obj, "_repr_html_"):
             h = obj._repr_html_()
             if h:
                 # Strip injected <style> blocks (e.g. from polars) so they
                 # do not override the playground's own table styles.
                 h = _strip_html_styles(h)
-                _display_outputs.append({"type": "html", "html": h})
+                _pg_emit_cell({"type": "html", "html": h})
         else:
             _pg_emit_text("stdout", repr(obj) + "\\n")
 
 import builtins
 builtins.display = display
 
+def _pg_input(prompt=""):
+    """Replace builtins.input().
+
+    There is no stdin here: the run happens inside a Web Worker with no
+    channel back to the page mid-execution, and Pyodide's default stdin
+    surfaces that as a bare \`OSError: [Errno 29] I/O error\` *after*
+    printing the prompt, which reads as "the program hung, then crashed".
+    Fail immediately with an explanation and a way forward instead."""
+    if prompt:
+        sys.stdout.write(str(prompt))
+    raise RuntimeError(
+        "input() isn't available in this playground: there's no console to "
+        "type into. Assign the value directly (e.g. name = \\"Ada\\"), or "
+        "upload a file in the Files panel and read it with open()."
+    )
+
+builtins.input = _pg_input
+
 import asyncio as _asyncio
 
-async def _execute_with_last_display(code):
-    """Execute user code, auto-displaying the last expression like Jupyter."""
+async def _execute_with_last_display(code, filename="main.py"):
+    """Execute user code, auto-displaying the last expression like Jupyter.
+
+    \`filename\` is the workspace path of the entry file and becomes the
+    compile-time filename, so tracebacks name the file the user is actually
+    looking at instead of \`<string>\`."""
     _globals = globals()
     _flags = _ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
-    tree = _ast.parse(code)
+    tree = _ast.parse(code, filename=filename)
     if tree.body and isinstance(tree.body[-1], _ast.Expr):
         last_expr = tree.body.pop()
         if tree.body:
             _ast.fix_missing_locations(tree)
-            result = eval(compile(tree, "<string>", "exec", flags=_flags), _globals)
+            result = eval(compile(tree, filename, "exec", flags=_flags), _globals)
             if _asyncio.iscoroutine(result):
                 await result
         expr_tree = _ast.Expression(body=last_expr.value)
         _ast.fix_missing_locations(expr_tree)
-        result = eval(compile(expr_tree, "<string>", "eval", flags=_flags), _globals)
+        result = eval(compile(expr_tree, filename, "eval", flags=_flags), _globals)
         if _asyncio.iscoroutine(result):
             result = await result
         if result is not None:
             display(result)
     else:
-        result = eval(compile(tree, "<string>", "exec", flags=_flags), _globals)
+        result = eval(compile(tree, filename, "exec", flags=_flags), _globals)
         if _asyncio.iscoroutine(result):
             await result
 
@@ -464,12 +606,17 @@ import matplotlib.pyplot as plt
 
 _original_show = plt.show
 def _patched_show(*args, **kwargs):
-    buf = io.BytesIO()
-    plt.savefig(buf, format="png", bbox_inches="tight", dpi=130, facecolor=plt.gcf().get_facecolor())
-    buf.seek(0)
-    img_b64 = base64.b64encode(buf.read()).decode()
-    _display_outputs.append({"type": "image", "data": img_b64})
-    plt.clf()
+    """Render EVERY open figure, the way plt.show() does in a script and
+    the way the matplotlib_inline backend does in a notebook.
+
+    This used to savefig() the *current* figure only and then close them
+    all, so the common "build several figures, show() once at the end"
+    pattern silently threw away everything but the last one."""
+    for _num in plt.get_fignums():
+        _fig = plt.figure(_num)
+        buf = io.BytesIO()
+        _fig.savefig(buf, format="png", bbox_inches="tight", dpi=130, facecolor=_fig.get_facecolor())
+        _pg_emit_cell({"type": "image", "data": base64.b64encode(buf.getvalue()).decode()})
     plt.close("all")
 plt.show = _patched_show
 
@@ -658,6 +805,7 @@ async function runCode(
   id: number,
   code: string,
   theme: "light" | "dark" = "dark",
+  entryFilename = "main.py",
 ): Promise<void> {
   if (!pyodide) throw new Error("Pyodide is not initialised");
 
@@ -727,10 +875,57 @@ async function runCode(
     post({ kind: "run-status", id, message: "Running…", preparing: false });
   }
 
-  await pyodide.runPythonAsync("_pg_reset_user_globals(); _display_outputs.clear()");
+  await pyodide.runPythonAsync(
+    "_pg_reset_user_globals(); _display_outputs.clear(); _pg_stream_reset()",
+  );
+
+  // ─── Live output ────────────────────────────────────────────────────
+  // Cells are posted as Python produces them (see _pg_stream_flush), so a
+  // slow loop shows its progress and a stopped run keeps whatever it had
+  // already printed. `seq` positions each cell in the run's stream; the
+  // JS-level captures below take the first slots.
+  let seq = 0;
+  const postJsCapture = (
+    type: "stdout" | "stderr",
+    text: string,
+  ): void => {
+    if (!text.trim()) return;
+    post({ kind: "output", id, seq: seq++, cell: { type, content: text.trim() } });
+  };
+  postJsCapture("stdout", stdout);
+  postJsCapture("stderr", stderr);
+  stdout = "";
+  stderr = "";
+  const seqOffset = seq;
+
+  const streamSink = (
+    entryIndex: number,
+    type: string,
+    content: string,
+    append: boolean,
+  ): void => {
+    const cellSeq = seqOffset + entryIndex;
+    if (type === "stdout" || type === "stderr") {
+      post({ kind: "output", id, seq: cellSeq, append, cell: { type, content } });
+      return;
+    }
+    // Rich cells arrive as the JSON of one `_display_outputs` entry, so the
+    // shared converter renders them exactly like the batched path did.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      return;
+    }
+    for (const cell of toOutputCells([parsed])) {
+      post({ kind: "output", id, seq: cellSeq, cell });
+    }
+  };
+  pyodide.globals.set("_pg_stream_sink", streamSink);
 
   // Pass the code as a Python string to avoid template-literal escaping.
   pyodide.globals.set("_user_code_str", code);
+  pyodide.globals.set("_pg_entry_filename", entryFilename);
 
   // Wrap user code with a Plotly show() intercept and Jupyter-style
   // last-expression auto-display. The theme-appropriate Plotly template
@@ -754,14 +949,14 @@ if _plotly is not None:
     # Plotly figures land in the same ordered output list as prints and
     # display() tables, so fig.show() keeps its place in the run's output.
     def _patched_plotly_show(fig, *args, **kwargs):
-        _display_outputs.append({"type": "plot", "json": fig.to_json()})
+        _pg_emit_cell({"type": "plot", "json": fig.to_json()})
 
     _plotly.io.show = _patched_plotly_show
     try:
         import plotly.graph_objects as _go
         _orig_go_show = _go.Figure.show
         def _patched_go_show(self, *args, **kwargs):
-            _display_outputs.append({"type": "plot", "json": self.to_json()})
+            _pg_emit_cell({"type": "plot", "json": self.to_json()})
         _go.Figure.show = _patched_go_show
     except: pass
 
@@ -770,7 +965,7 @@ if _plotly is not None:
 _pg_prev_stdout, _pg_prev_stderr = sys.stdout, sys.stderr
 sys.stdout, sys.stderr = _PgTee("stdout"), _PgTee("stderr")
 try:
-    await _execute_with_last_display(_user_code_str)
+    await _execute_with_last_display(_user_code_str, _pg_entry_filename)
 finally:
     sys.stdout, sys.stderr = _pg_prev_stdout, _pg_prev_stderr
     if _plotly is not None:
@@ -789,32 +984,31 @@ if _plt is not None:
         _fig = _plt.figure(_fig_num)
         _buf = io.BytesIO()
         _fig.savefig(_buf, format="png", bbox_inches="tight", dpi=130, facecolor=_fig.get_facecolor())
-        _display_outputs.append({"type": "image", "data": base64.b64encode(_buf.getvalue()).decode()})
+        _pg_emit_cell({"type": "image", "data": base64.b64encode(_buf.getvalue()).decode()})
     _plt.close("all")
 `;
 
-  // Post the ordered output stream. Runs in a finally so pre-exception
-  // output still renders, followed by the traceback, like a notebook.
+  // Drain whatever Python produced but hasn't streamed yet. Runs in a
+  // finally so pre-exception output still renders, followed by the
+  // traceback, like a notebook.
   const flushOutputs = () => {
     if (!pyodide) return;
-    let displayOutputsRaw: unknown;
+    let entryCount = 0;
     try {
-      const displayProxy = pyodide.globals.get("_display_outputs");
-      displayOutputsRaw = displayProxy.toJs({
-        dict_converter: Object.fromEntries,
-      });
-      displayProxy.destroy();
+      pyodide.runPython("_pg_stream_flush(True)");
+      entryCount = pyodide.runPython("len(_display_outputs)") as number;
     } catch {
-      return;
+      /* The interpreter is wedged; the run's error is the real story. */
     }
-
-    // JS-level captures (output outside the per-run tee window, e.g. the
-    // package-loader failure note) post first.
-    if (stdout.trim()) post({ kind: "output", id, cell: { type: "stdout", content: stdout.trim() } });
-    if (stderr.trim()) post({ kind: "output", id, cell: { type: "stderr", content: stderr.trim() } });
-
-    for (const cell of toOutputCells(displayOutputsRaw)) {
-      post({ kind: "output", id, cell });
+    // Anything written outside the per-run tee window (e.g. a late
+    // package-loader note) lands after the program's own output.
+    seq = seqOffset + entryCount;
+    postJsCapture("stdout", stdout);
+    postJsCapture("stderr", stderr);
+    try {
+      pyodide.runPython("_pg_stream_sink = None");
+    } catch {
+      /* Nothing to detach if the interpreter is gone. */
     }
   };
 
@@ -942,12 +1136,16 @@ async function prepareFs(files: Array<[string, Uint8Array]>): Promise<void> {
   const FS = (pyodide as unknown as { FS: PyodideFS }).FS;
 
   const nextPaths = new Set<string>();
+  // Re-stamp from scratch: a path dropped from the workspace must also drop
+  // out of the "already known" set, or re-uploading it would look unchanged.
+  stagedStamps.clear();
   for (const [relPath, bytes] of files) {
     const abs = joinStagedPath(relPath);
     nextPaths.add(abs);
     ensureDirs(FS, abs);
     try {
       FS.writeFile(abs, bytes);
+      stagedStamps.set(relPath.replace(/^\/+/, ""), statStamp(FS, abs));
     } catch (err) {
       // Include the offending path so invalid filenames are debuggable.
       throw new Error(
@@ -981,9 +1179,104 @@ async function prepareFs(files: Array<[string, Uint8Array]>): Promise<void> {
 
 interface PyodideFS {
   writeFile(path: string, data: Uint8Array | string): void;
+  readFile(path: string): Uint8Array;
   unlink(path: string): void;
   mkdir(path: string): void;
   analyzePath(path: string): { exists: boolean };
+  readdir(path: string): string[];
+  stat(path: string): { mode: number; size: number; mtime: Date };
+  isDir(mode: number): boolean;
+  isFile(mode: number): boolean;
+}
+
+// ─── Files the program wrote ───────────────────────────────────────────
+// `df.to_csv("out.csv")`, `plt.savefig("chart.png")` and friends land in the
+// staged root and used to be invisible: not in the Files panel, not
+// downloadable, gone on reload. After each run the tree is diffed against
+// the snapshot taken at staging time and anything new (or rewritten) is
+// handed to the surface, which persists it like an upload.
+
+/** Size/mtime of each staged file right after `prepareFs` wrote it. */
+const stagedStamps = new Map<string, string>();
+
+/** Ceilings on what one run can hand back, so a program that fills the
+ *  filesystem in a loop can't wedge the tab trying to mirror it. */
+const CREATED_FILES_MAX = 50;
+const CREATED_BYTES_MAX = 64 * 1024 * 1024;
+
+/** Directories that are runtime bookkeeping, not the user's output. */
+function isIgnoredDirName(name: string): boolean {
+  return name === "__pycache__" || name.startsWith(".");
+}
+
+function statStamp(FS: PyodideFS, absPath: string): string {
+  try {
+    const st = FS.stat(absPath);
+    return `${st.size}:${st.mtime instanceof Date ? st.mtime.getTime() : 0}`;
+  } catch {
+    return "";
+  }
+}
+
+/** Every regular file under `dir`, as `[relative path, absolute path]`. */
+function walkStagedTree(
+  FS: PyodideFS,
+  dir: string,
+  relPrefix: string,
+  out: Array<[string, string]>,
+): void {
+  let names: string[];
+  try {
+    names = FS.readdir(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (name === "." || name === "..") continue;
+    if (isIgnoredDirName(name)) continue;
+    const abs = `${dir}/${name}`;
+    const rel = relPrefix ? `${relPrefix}/${name}` : name;
+    let mode: number;
+    try {
+      mode = FS.stat(abs).mode;
+    } catch {
+      continue;
+    }
+    if (FS.isDir(mode)) walkStagedTree(FS, abs, rel, out);
+    else if (FS.isFile(mode)) out.push([rel, abs]);
+    if (out.length > CREATED_FILES_MAX * 4) return;
+  }
+}
+
+/** Files the last run created or rewrote, keyed by workspace-relative path.
+ *  Clearing the stamps afterwards is what stops a file being reported twice:
+ *  the next call re-stamps it as already known. */
+function collectCreatedFiles(): Array<[string, Uint8Array]> {
+  if (!pyodide) return [];
+  const FS = (pyodide as unknown as { FS: PyodideFS }).FS;
+  const found: Array<[string, string]> = [];
+  walkStagedTree(FS, STAGED_ROOT, "", found);
+
+  const created: Array<[string, Uint8Array]> = [];
+  let bytes = 0;
+  for (const [rel, abs] of found) {
+    const stamp = statStamp(FS, abs);
+    if (stagedStamps.get(rel) === stamp) continue;
+    let data: Uint8Array;
+    try {
+      data = FS.readFile(abs);
+    } catch {
+      continue;
+    }
+    if (created.length >= CREATED_FILES_MAX) break;
+    if (bytes + data.length > CREATED_BYTES_MAX) break;
+    bytes += data.length;
+    // Copy out of the Emscripten heap; the view would otherwise be
+    // detached (or reused) by the time the main thread reads it.
+    created.push([rel, new Uint8Array(data)]);
+    stagedStamps.set(rel, stamp);
+  }
+  return created;
 }
 
 function ensureDirs(FS: PyodideFS, absFilePath: string): void {
@@ -1020,19 +1313,35 @@ self.addEventListener("message", (ev: MessageEvent<InMessage>) => {
   }
 
   if (msg.kind === "run") {
-    const { id, code, theme } = msg;
+    const { id, code, theme, entryFilename } = msg;
     enqueue(async () => {
       try {
         if (initPromise) await initPromise;
-        await runCode(id, code, theme);
+        await runCode(id, code, theme, entryFilename);
         post({ kind: "done", id });
       } catch (err) {
+        const raw = err instanceof Error ? err.message : String(err);
         post({
           kind: "error",
           id,
-          message: err instanceof Error ? err.message : String(err),
+          message: annotateRunError(cleanPythonTraceback(raw)),
         });
       }
+    });
+    return;
+  }
+
+  if (msg.kind === "collect-created-files") {
+    const { id } = msg;
+    enqueue(async () => {
+      if (initPromise) await initPromise;
+      let files: Array<[string, Uint8Array]> = [];
+      try {
+        files = collectCreatedFiles();
+      } catch {
+        // Best-effort: a filesystem hiccup must not fail the run.
+      }
+      post({ kind: "created-files", id, files });
     });
     return;
   }

--- a/app/_components/runtime/python.tsx
+++ b/app/_components/runtime/python.tsx
@@ -585,15 +585,17 @@ print("unpacked:", msgpack.unpackb(packed))
   // Networking & Utilities
   {
     cat: "Utilities", icon: "🌐", color: "#60a5fa", name: "requests", ver: "2.33",
-    desc: "HTTP requests (via micropip, pure Python)",
-    example: `# Note: real network calls are blocked in the browser sandbox; this
-# example shows the request-construction API instead of executing it.
-import requests
+    desc: "HTTP requests; real calls work, but only to hosts that allow CORS",
+    example: `import requests
 
-req = requests.Request("GET", "https://api.example.com/users",
-                       params={"q": "ada"}).prepare()
-print("URL:    ", req.url)
-print("method: ", req.method)
+# Requests really do go out, but the browser's same-origin policy applies:
+# a host that doesn't send an Access-Control-Allow-Origin header will fail
+# no matter what Python does. raw.githubusercontent.com sends one.
+url = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv"
+r = requests.get(url, timeout=15)
+print("status:", r.status_code)
+print("bytes: ", len(r.content))
+print(r.text.splitlines()[0])
 `,
   },
   {
@@ -668,11 +670,18 @@ type WorkerOutMessage =
   | { kind: "ready" }
   | { kind: "init-error"; message: string }
   | { kind: "run-status"; id: number; message: string; preparing: boolean }
-  | { kind: "output"; id: number; cell: OutputCellMessage }
+  | {
+      kind: "output";
+      id: number;
+      cell: OutputCellMessage;
+      seq: number;
+      append?: boolean;
+    }
   | { kind: "done"; id: number }
   | { kind: "error"; id: number; message: string }
   | { kind: "prepare-fs-done"; id: number }
   | { kind: "prepare-fs-error"; id: number; message: string }
+  | { kind: "created-files"; id: number; files: Array<[string, Uint8Array]> }
   | {
       kind: "complete-result";
       id: number;
@@ -692,8 +701,59 @@ function detectChartTheme(): "light" | "dark" {
   return html.classList.contains("dark") ? "dark" : "light";
 }
 
+/** Spawns the Pyodide worker and resolves once it reports `ready`.
+ *  Shared by the first boot and by the respawn a Stop triggers. */
+function spawnPyodideWorker(
+  onLoading?: (message: string, fraction?: number) => void,
+): Promise<Worker> {
+  // Pre-bundled by `scripts/build-almostnode-workers.mjs` and served
+  // as a static asset, the same pattern as the JS/TS workers. Pyodide
+  // 314's environment detection throws "Classic web workers are not
+  // supported" when `importScripts` works (i.e. in a classic worker
+  // scope), so this worker MUST run with a real `{ type: "module" }`
+  // — and Turbopack strips the `type` option from workers it bundles
+  // itself (`new Worker(new URL(...), ...)`), which is why the
+  // bundler-analyzed construction can't be used here.
+  const worker = new Worker("/_workers/pyodide-worker.js", { type: "module" });
+  return new Promise<Worker>((resolve, reject) => {
+    const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
+      const msg = ev.data;
+      if (msg.kind === "loading") {
+        onLoading?.(msg.message, msg.fraction);
+      } else if (msg.kind === "ready") {
+        worker.removeEventListener("message", onMessage);
+        resolve(worker);
+      } else if (msg.kind === "init-error") {
+        worker.removeEventListener("message", onMessage);
+        worker.terminate();
+        reject(new Error(msg.message));
+      }
+    };
+    worker.addEventListener("message", onMessage);
+    worker.addEventListener("error", (ev) => {
+      worker.removeEventListener("message", onMessage);
+      reject(new Error(ev.message || "Pyodide worker failed to start"));
+    });
+    worker.postMessage({ kind: "init" });
+  });
+}
+
 class PyodideWorkerRuntime implements LanguageRuntime {
   private nextId = 0;
+  /** Rejects the in-flight `run()` when Stop terminates the worker. */
+  private abortActiveRun: ((err: Error) => void) | null = null;
+  /** Settlers for the other in-flight requests (completions, staging,
+   *  created-file reads). A terminated worker never answers them, so Stop
+   *  has to release each one or the next run waits on a dead promise. */
+  private pendingAborts = new Set<() => void>();
+  /** Replayed after a respawn so the fresh interpreter re-warms the same
+   *  package set instead of paying for it on the user's next run. */
+  private lastWarmHint: { sources: string[]; force: boolean } | null = null;
+  /** Non-null between the Stop that killed the old worker and the moment its
+   *  replacement reports ready. Every entry point waits on (or declines for)
+   *  this, so nothing is ever posted to a terminated worker — which answers
+   *  no message, and would leave the caller's promise pending forever. */
+  private restartPromise: Promise<void> | null = null;
 
   constructor(private worker: Worker) {}
 
@@ -714,6 +774,7 @@ class PyodideWorkerRuntime implements LanguageRuntime {
       ...(options?.packages ?? []).map((mod) => `import ${mod}`),
     ].filter((s) => s.trim().length > 0);
     if (hints.length === 0 && !options?.force) return;
+    this.lastWarmHint = { sources: hints, force: options?.force ?? false };
     this.worker.postMessage({
       kind: "warm-packages",
       sources: hints,
@@ -721,13 +782,67 @@ class PyodideWorkerRuntime implements LanguageRuntime {
     });
   }
 
+  /**
+   * Stop the running program.
+   *
+   * Python has no yield point to interrupt from the outside here — a
+   * `while True:` never returns to the worker's event loop — so the only
+   * reliable lever is to kill the worker and stand a new one up. That costs
+   * the interpreter's state, which is already wiped between runs anyway
+   * (`_pg_reset_user_globals`), so nothing the user could observe is lost.
+   * Resolves once the replacement is ready to take a run.
+   */
+  async cancelRun(): Promise<void> {
+    if (this.restartPromise) return this.restartPromise;
+    // Tear down synchronously, so no caller can slip a message onto the dead
+    // worker between the terminate and the guard being in place.
+    const abort = this.abortActiveRun;
+    this.worker.terminate();
+    if (abort) {
+      const err = new Error("Run stopped.");
+      err.name = "RunCancelledError";
+      abort(err);
+    }
+    for (const release of [...this.pendingAborts]) release();
+    this.pendingAborts.clear();
+
+    this.restartPromise = (async () => {
+      try {
+        this.worker = await spawnPyodideWorker();
+        const warm = this.lastWarmHint;
+        if (warm) {
+          this.worker.postMessage({
+            kind: "warm-packages",
+            sources: warm.sources,
+            force: warm.force,
+          });
+        }
+      } finally {
+        this.restartPromise = null;
+      }
+    })();
+    return this.restartPromise;
+  }
+
   async run(
     code: string,
     emit: EmitOutput,
     options?: RunOptions,
   ): Promise<void> {
+    // A Stop leaves the runtime rebuilding itself; the next run belongs on
+    // the fresh interpreter, so wait rather than race it.
+    if (this.restartPromise) await this.restartPromise;
     const id = ++this.nextId;
+    const worker = this.worker;
     return new Promise<void>((resolve, reject) => {
+      const finish = (fn: () => void) => {
+        worker.removeEventListener("message", onMessage);
+        this.abortActiveRun = null;
+        fn();
+      };
+      // cancelRun() terminates the worker, so no further message ever
+      // arrives for this run — the promise has to be settled from here.
+      this.abortActiveRun = (err) => finish(() => reject(err));
       const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
         const msg = ev.data;
         // Ignore messages from earlier or unrelated runs.
@@ -747,30 +862,70 @@ class PyodideWorkerRuntime implements LanguageRuntime {
           return;
         }
         if (msg.kind === "output") {
-          emit(msg.cell);
+          emit(msg.cell, msg.seq, msg.append);
           return;
         }
-        this.worker.removeEventListener("message", onMessage);
-        if (msg.kind === "done") resolve();
-        else reject(new Error(msg.message));
+        if (msg.kind === "done") finish(resolve);
+        else finish(() => reject(new Error(msg.message)));
       };
-      this.worker.addEventListener("message", onMessage);
-      this.worker.postMessage({ kind: "run", id, code, theme: detectChartTheme() });
+      worker.addEventListener("message", onMessage);
+      worker.postMessage({
+        kind: "run",
+        id,
+        code,
+        theme: detectChartTheme(),
+        entryFilename: options?.entryFilename,
+      });
+    });
+  }
+
+  /** Files the run wrote into the working directory (`df.to_csv(...)`,
+   *  `plt.savefig(...)`, `open(..., "w")`). The worker re-stamps each one as
+   *  it reports it, so a file is handed over once per change. */
+  async collectCreatedFiles(): Promise<Map<string, Uint8Array>> {
+    // Terminating the worker took its filesystem with it, so a stopped run
+    // has nothing to hand back; don't stall the run's tail waiting for it.
+    if (this.restartPromise) return new Map();
+    const id = ++this.nextId;
+    const worker = this.worker;
+    return new Promise<Map<string, Uint8Array>>((resolve) => {
+      const settle = (files: Map<string, Uint8Array>) => {
+        worker.removeEventListener("message", onMessage);
+        this.pendingAborts.delete(release);
+        resolve(files);
+      };
+      const release = () => settle(new Map());
+      const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
+        const msg = ev.data;
+        if (msg.kind !== "created-files" || msg.id !== id) return;
+        settle(new Map(msg.files));
+      };
+      this.pendingAborts.add(release);
+      worker.addEventListener("message", onMessage);
+      worker.postMessage({ kind: "collect-created-files", id });
     });
   }
 
   async complete(request: CompletionRequest): Promise<CompletionResult> {
+    if (this.restartPromise) return { list: [], replaceLength: 0 };
     const id = ++this.nextId;
+    const worker = this.worker;
     return new Promise<CompletionResult>((resolve) => {
+      const settle = (result: CompletionResult) => {
+        worker.removeEventListener("message", onMessage);
+        this.pendingAborts.delete(release);
+        resolve(result);
+      };
+      const release = () => settle({ list: [], replaceLength: 0 });
       const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
         const msg = ev.data;
         if (msg.kind !== "complete-result") return;
         if (msg.id !== id) return;
-        this.worker.removeEventListener("message", onMessage);
-        resolve({ list: msg.completions, replaceLength: msg.replaceLength });
+        settle({ list: msg.completions, replaceLength: msg.replaceLength });
       };
-      this.worker.addEventListener("message", onMessage);
-      this.worker.postMessage({
+      this.pendingAborts.add(release);
+      worker.addEventListener("message", onMessage);
+      worker.postMessage({
         kind: "complete",
         id,
         doc: request.doc,
@@ -782,12 +937,22 @@ class PyodideWorkerRuntime implements LanguageRuntime {
   }
 
   async prepareFileSystem(files: Map<string, Uint8Array>): Promise<void> {
+    if (this.restartPromise) await this.restartPromise;
     const id = ++this.nextId;
     // Send the workspace's exact filenames so `os.listdir()` matches the
     // user's mental model.
     const payload: Array<[string, Uint8Array]> = [];
     for (const [path, bytes] of files) payload.push([path, bytes]);
+    const worker = this.worker;
     return new Promise<void>((resolve, reject) => {
+      const settle = (fn: () => void) => {
+        worker.removeEventListener("message", onMessage);
+        this.pendingAborts.delete(release);
+        fn();
+      };
+      // Stop mid-staging: the fresh worker re-stages on the next run, so
+      // resolving is the honest outcome, not an error.
+      const release = () => settle(resolve);
       const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
         const msg = ev.data;
         if (
@@ -797,12 +962,12 @@ class PyodideWorkerRuntime implements LanguageRuntime {
           return;
         }
         if (msg.id !== id) return;
-        this.worker.removeEventListener("message", onMessage);
-        if (msg.kind === "prepare-fs-done") resolve();
-        else reject(new Error(msg.message));
+        if (msg.kind === "prepare-fs-done") settle(resolve);
+        else settle(() => reject(new Error(msg.message)));
       };
-      this.worker.addEventListener("message", onMessage);
-      this.worker.postMessage({ kind: "prepare-fs", id, files: payload });
+      this.pendingAborts.add(release);
+      worker.addEventListener("message", onMessage);
+      worker.postMessage({ kind: "prepare-fs", id, files: payload });
     });
   }
 }
@@ -866,38 +1031,7 @@ export const pythonAdapter: LanguageAdapter = {
   },
   async init(setLoadingMessage): Promise<LanguageRuntime> {
     setLoadingMessage("Starting Python runtime…", 0.02);
-    // Pre-bundled by `scripts/build-almostnode-workers.mjs` and served
-    // as a static asset, the same pattern as the JS/TS workers. Pyodide
-    // 314's environment detection throws "Classic web workers are not
-    // supported" when `importScripts` works (i.e. in a classic worker
-    // scope), so this worker MUST run with a real `{ type: "module" }`
-    // — and Turbopack strips the `type` option from workers it bundles
-    // itself (`new Worker(new URL(...), ...)`), which is why the
-    // bundler-analyzed construction can't be used here.
-    const worker = new Worker("/_workers/pyodide-worker.js", {
-      type: "module",
-    });
-
-    return new Promise<LanguageRuntime>((resolve, reject) => {
-      const onMessage = (ev: MessageEvent<WorkerOutMessage>) => {
-        const msg = ev.data;
-        if (msg.kind === "loading") {
-          setLoadingMessage(msg.message, msg.fraction);
-        } else if (msg.kind === "ready") {
-          worker.removeEventListener("message", onMessage);
-          resolve(new PyodideWorkerRuntime(worker));
-        } else if (msg.kind === "init-error") {
-          worker.removeEventListener("message", onMessage);
-          worker.terminate();
-          reject(new Error(msg.message));
-        }
-      };
-      worker.addEventListener("message", onMessage);
-      worker.addEventListener("error", (ev) => {
-        worker.removeEventListener("message", onMessage);
-        reject(new Error(ev.message || "Pyodide worker failed to start"));
-      });
-      worker.postMessage({ kind: "init" });
-    });
+    const worker = await spawnPyodideWorker(setLoadingMessage);
+    return new PyodideWorkerRuntime(worker);
   },
 };

--- a/app/_components/runtime/pythonErrors.ts
+++ b/app/_components/runtime/pythonErrors.ts
@@ -1,0 +1,78 @@
+/**
+ * Making a Pyodide failure readable.
+ *
+ * Two things stand between the user and their actual error: the interpreter
+ * harness (Pyodide's `eval_code_async` plumbing plus the `<exec>` wrapper
+ * pyodide-worker.ts compiles around a block) shows up as five frames above
+ * the user's own, and a request the *browser* refused for cross-origin
+ * reasons surfaces as sixty lines of urllib3 internals that never say
+ * "CORS". Both are string-level fixes applied at the moment a run fails, so
+ * they're kept here, out of the worker, and pinned by
+ * `__tests__/pythonErrors.test.ts`.
+ */
+
+/** Traceback frames belonging to the harness rather than the user. */
+function isHarnessFrame(filename: string): boolean {
+  return (
+    filename === "<exec>" ||
+    /^\/lib\/python[\d.]*\.zip\//.test(filename) ||
+    filename.includes("/_pyodide/")
+  );
+}
+
+/**
+ * Strip harness frames from a Python traceback.
+ *
+ * A frame is the `  File "…", line N, in name` line plus the source lines
+ * indented under it; anything at column 0 (the `Traceback …` header, the
+ * final `ValueError: boom`, the "During handling of the above exception"
+ * joiners) is kept, so chained exceptions survive intact.
+ *
+ * Returns the input unchanged when no frame would survive — a failure
+ * inside the harness itself is better shown raw than shown empty.
+ */
+export function cleanPythonTraceback(message: string): string {
+  if (!message.includes('File "')) return message;
+  const lines = message.split("\n");
+  const out: string[] = [];
+  let dropping = false;
+  let keptFrames = 0;
+  let droppedAny = false;
+  for (const line of lines) {
+    const frame = /^\s+File "(.*)", line \d+/.exec(line);
+    if (frame) {
+      dropping = isHarnessFrame(frame[1]);
+      if (dropping) droppedAny = true;
+      else {
+        keptFrames += 1;
+        out.push(line);
+      }
+      continue;
+    }
+    // Continuation lines (the echoed source, `...<9 lines>...`) belong to
+    // the frame above them; a line at column 0 ends the frame list.
+    if (dropping && /^\s/.test(line)) continue;
+    dropping = false;
+    out.push(line);
+  }
+  if (!droppedAny || keptFrames === 0) return message;
+  return out.join("\n");
+}
+
+/** Signature of a request the browser refused for cross-origin reasons.
+ *  urllib3's emscripten backend reports it as a timeout or a bare
+ *  `AbortError`, neither of which mentions the browser or CORS. */
+const CORS_FAILURE_RE =
+  /urllib3\.contrib\.emscripten|AbortError: signal is aborted|_TimeoutError/;
+
+const CORS_HINT =
+  "This request was blocked by the browser, not by Python: the site didn't " +
+  "send an Access-Control-Allow-Origin header, so the page isn't allowed to " +
+  "read the response. Try a host that allows it (raw.githubusercontent.com " +
+  "does), or upload the file in the Files panel and read it with open().";
+
+/** Prepend a plain-language explanation to browser-level network failures. */
+export function annotateRunError(message: string): string {
+  if (CORS_FAILURE_RE.test(message)) return `${CORS_HINT}\n\n${message}`;
+  return message;
+}

--- a/app/_components/types.ts
+++ b/app/_components/types.ts
@@ -86,8 +86,21 @@ export interface ExportFormat {
   mimeType: string;
 }
 
-/** Emitter passed to `runtime.run` for streaming cells as they arrive. */
-export type EmitOutput = (cell: Omit<OutputCell, "id" | "elapsed">) => void;
+/**
+ * Emitter passed to `runtime.run` for streaming cells as they arrive.
+ *
+ * With no `seq` the cell is appended, which is all a runtime that emits
+ * once-per-complete-cell needs. Runtimes that stream a cell while it is
+ * still growing (Python's stdout during a long loop) pass `seq`, the cell's
+ * position in the run's output, and set `append` on every chunk after the
+ * first — so the surface can grow one cell instead of accumulating
+ * fragments.
+ */
+export type EmitOutput = (
+  cell: Omit<OutputCell, "id" | "elapsed">,
+  seq?: number,
+  append?: boolean,
+) => void;
 
 /** Per-run context passed to `runtime.run`. */
 export interface RunOptions {
@@ -165,6 +178,11 @@ export interface LanguageRuntime {
    *  so implementations must clear their tracking after returning to avoid
    *  double-reporting. */
   collectCreatedFiles?(): Promise<Map<string, Uint8Array>>;
+  /** Stop the run in flight, rejecting its `run()` promise with an error
+   *  named `RunCancelledError`, and leave the runtime ready for the next
+   *  run. Implementing this is what puts a Stop control in the surface, so
+   *  omit it unless a runaway program really can be stopped. */
+  cancelRun?(): Promise<void>;
   /** Tear down and free resources (worker, WASM heap); called on registry
    *  eviction, after which the instance must not be used. Runtimes that
    *  can't release resources omit this, which also exempts them from

--- a/app/_components/utf8Size.ts
+++ b/app/_components/utf8Size.ts
@@ -1,0 +1,37 @@
+/**
+ * UTF-8 byte length of a string.
+ *
+ * The Files panel labels its size column "B", so it has to agree with what
+ * `os.path.getsize()` reports inside a playground runtime. JavaScript's
+ * `String.length` counts UTF-16 code units, which understates every file
+ * containing accented text, CJK or emoji (`é` is 1 unit but 2 bytes, `你` is
+ * 1 unit but 3, `😀` is 2 units but 4).
+ *
+ * Counted rather than encoded: this runs on every keystroke for the open
+ * buffers, and `new TextEncoder().encode(s).length` would allocate a copy of
+ * the whole document each time.
+ */
+export function utf8ByteLength(text: string): number {
+  let bytes = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < text.length) {
+      const next = text.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        // Surrogate pair: one astral code point, 4 bytes.
+        bytes += 4;
+        i += 1;
+        continue;
+      }
+      // Lone surrogate; encoders emit U+FFFD, which is 3 bytes.
+      bytes += 3;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}

--- a/e2e/python-playground-audit-fixes.spec.ts
+++ b/e2e/python-playground-audit-fixes.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression cover for the Python playground audit fixes: streaming output,
+ * the Stop control, run-created files, `plt.show()` with several figures,
+ * `input()`, and traceback legibility.
+ *
+ * Kept out of the default sweep the way the other heavyweight playground
+ * specs are: booting Pyodide plus the package set is a CDN download, so this
+ * is opt-in (`npx playwright test e2e/python-playground-audit-fixes.spec.ts`).
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+test.describe.configure({ mode: "serial" });
+
+const RUN_BUTTON = ".playground-run-multi-main";
+
+async function openPlayground(page: Page): Promise<void> {
+  await page.goto("/playground/python");
+  // The Run button enables only once the runtime reports ready.
+  await expect(page.locator(RUN_BUTTON)).toBeEnabled({ timeout: 180_000 });
+}
+
+async function typeProgram(page: Page, code: string): Promise<void> {
+  const editor = page.locator(".cm-content").first();
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Delete");
+  // insertText, not type(): CodeMirror's auto-indent would mangle a
+  // character-by-character Python block.
+  await page.evaluate((source) => {
+    const el = document.querySelector(".cm-content") as HTMLElement | null;
+    el?.focus();
+    document.execCommand("insertText", false, source);
+  }, code);
+}
+
+async function runProgram(page: Page, code: string): Promise<void> {
+  await typeProgram(page, code);
+  await page.locator(RUN_BUTTON).click();
+}
+
+const outputText = (page: Page) => page.locator(".run-cell-content");
+
+test("output streams while the program is still running", async ({ page }) => {
+  await openPlayground(page);
+  await runProgram(
+    page,
+    ['import time', 'for i in range(6):', '    print("tick", i); time.sleep(1)'].join("\n"),
+  );
+
+  // The whole run takes ~6s. Seeing an early line before it ends is the
+  // entire point: output used to arrive in one lump at the end.
+  await expect(outputText(page)).toContainText("tick 0", { timeout: 20_000 });
+  await expect(page.locator(RUN_BUTTON)).toContainText("Stop");
+  await expect(outputText(page)).toContainText("tick 5", { timeout: 30_000 });
+  await expect(page.locator(RUN_BUTTON)).not.toContainText("Stop", {
+    timeout: 30_000,
+  });
+});
+
+test("a runaway loop can be stopped without reloading", async ({ page }) => {
+  await openPlayground(page);
+  await runProgram(
+    page,
+    ["n = 0", "while True:", "    n += 1"].join("\n"),
+  );
+
+  const runButton = page.locator(RUN_BUTTON);
+  await expect(runButton).toContainText("Stop", { timeout: 30_000 });
+  await runButton.click();
+
+  await expect(outputText(page)).toContainText("Run stopped.", {
+    timeout: 60_000,
+  });
+  // And the playground is usable again straight afterwards.
+  await expect(runButton).toBeEnabled({ timeout: 120_000 });
+  await runProgram(page, 'print("alive after stop")');
+  await expect(outputText(page)).toContainText("alive after stop", {
+    timeout: 120_000,
+  });
+});
+
+test("plt.show() renders every open figure", async ({ page }) => {
+  await openPlayground(page);
+  await runProgram(
+    page,
+    [
+      "import matplotlib.pyplot as plt",
+      'f1 = plt.figure(); plt.plot([1,2],[1,2]); plt.title("AAA")',
+      'f2 = plt.figure(); plt.plot([2,1],[1,2]); plt.title("BBB")',
+      "plt.show()",
+    ].join("\n"),
+  );
+
+  await expect(page.locator(".out-seg-image img")).toHaveCount(2, {
+    timeout: 240_000,
+  });
+});
+
+test("files the program writes show up in the Files panel", async ({ page }) => {
+  await openPlayground(page);
+  await runProgram(
+    page,
+    [
+      'open("written_by_python.txt", "w").write("hello\\n")',
+      'print("wrote it")',
+    ].join("\n"),
+  );
+
+  await expect(outputText(page)).toContainText("wrote it", {
+    timeout: 120_000,
+  });
+  await page.getByRole("button", { name: /^Files$/ }).click();
+  await expect(
+    page.locator(".playground-files-name", {
+      hasText: "written_by_python.txt",
+    }),
+  ).toBeVisible({ timeout: 30_000 });
+});
+
+test("input() explains itself instead of raising Errno 29", async ({ page }) => {
+  await openPlayground(page);
+  await runProgram(page, 'name = input("What is your name? ")');
+
+  const output = outputText(page);
+  await expect(output).toContainText("isn't available in this playground", {
+    timeout: 120_000,
+  });
+  await expect(output).not.toContainText("Errno 29");
+});
+
+test("a traceback names the user's file and drops harness frames", async ({
+  page,
+}) => {
+  await openPlayground(page);
+  await runProgram(
+    page,
+    ['def b(): raise ValueError("boom")', "def a(): return b()", "a()"].join("\n"),
+  );
+
+  const output = outputText(page);
+  await expect(output).toContainText("ValueError: boom", { timeout: 120_000 });
+  await expect(output).toContainText('File "main.py"');
+  await expect(output).not.toContainText("_pyodide");
+  await expect(output).not.toContainText("<exec>");
+  await expect(output).not.toContainText("<string>");
+});

--- a/lib/workspaces/base64.ts
+++ b/lib/workspaces/base64.ts
@@ -1,0 +1,28 @@
+/**
+ * Base64 for the data files a code bundle carries.
+ *
+ * `btoa(String.fromCharCode(...bytes))` is the usual one-liner and blows the
+ * argument limit somewhere around a few hundred KB, which a real uploaded
+ * CSV comfortably exceeds — so both directions work in fixed-size chunks.
+ * Isomorphic (`atob`/`btoa` exist in browsers, Workers and Node 16+), same
+ * as the rest of `lib/workspaces`.
+ */
+
+/** Characters per chunk; a multiple of 3 so no chunk boundary lands inside
+ *  a base64 group and produces stray padding. */
+const CHUNK = 0x8000 * 3;
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+export function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) out[i] = binary.charCodeAt(i);
+  return out;
+}

--- a/lib/workspaces/types.ts
+++ b/lib/workspaces/types.ts
@@ -77,6 +77,32 @@ export interface BundleCodeFile {
   content: string;
 }
 
+/**
+ * An uploaded data file travelling with a code bundle.
+ *
+ * These are the CSVs and spreadsheets the Files panel lists — not editor
+ * tabs, but every bit as much "the current files" a snapshot promises. A
+ * shared program that reads one used to arrive without it and die on
+ * `FileNotFoundError` the moment the recipient pressed Run.
+ *
+ * Base64 rather than the container's binary section: that section already
+ * carries the SQL playgrounds' single database image, and a code bundle can
+ * hold many files. Bundles are gzipped as a whole, so text data files pay
+ * little for the encoding.
+ */
+export interface BundleDataFile {
+  /** Path as shown in the Files panel, e.g. "sales.csv". */
+  path: string;
+  /** Base64-encoded file contents. */
+  base64: string;
+}
+
+/** Total decoded bytes of data files one bundle may carry. Beyond this the
+ *  sharer is told what was left out rather than publishing a broken copy. */
+export const BUNDLE_MAX_DATA_BYTES = 4 * 1024 * 1024;
+/** Cap on how many data files travel, independent of their size. */
+export const BUNDLE_MAX_DATA_FILES = 50;
+
 export interface BundleSqlTab {
   title: string;
   code: string;
@@ -182,6 +208,9 @@ export interface WorkspaceBundle {
   exportedAt: number;
   /** kind === "code" */
   files?: BundleCodeFile[];
+  /** kind === "code": uploaded data files from the Files panel. Absent in
+   *  older bundles and in workspaces that have none. */
+  dataFiles?: BundleDataFile[];
   activeFilename?: string;
   /** kind === "code": files whose editor tabs are open, in tab order (without
    *  this a reopened copy fans every file open). Filenames, not ids — ids are
@@ -239,6 +268,26 @@ export function validateBundle(value: unknown): WorkspaceBundle | null {
         b.openFilenames.some((name) => typeof name !== "string")
       ) {
         return null;
+      }
+    }
+    if (b.dataFiles !== undefined) {
+      if (
+        !Array.isArray(b.dataFiles) ||
+        b.dataFiles.length > BUNDLE_MAX_DATA_FILES
+      ) {
+        return null;
+      }
+      for (const f of b.dataFiles as unknown[]) {
+        const file = f as Record<string, unknown>;
+        if (
+          !file ||
+          typeof file.path !== "string" ||
+          !file.path.trim() ||
+          file.path.length > BUNDLE_FILENAME_MAX ||
+          typeof file.base64 !== "string"
+        ) {
+          return null;
+        }
       }
     }
     return value as WorkspaceBundle;
@@ -334,13 +383,23 @@ const MANIFEST_MAX_ENTRIES = 200;
 /** Builds a manifest from a bundle (client-side, at upload time). */
 export function manifestForBundle(bundle: WorkspaceBundle): BundleManifest {
   if (bundle.kind === "code") {
-    return {
-      kind: "code",
-      files: (bundle.files ?? []).slice(0, MANIFEST_MAX_ENTRIES).map((f) => ({
-        name: f.filename.slice(0, MANIFEST_NAME_MAX),
-        size: f.content.length,
-      })),
-    };
+    const files = (bundle.files ?? []).map((f) => ({
+      name: f.filename.slice(0, MANIFEST_NAME_MAX),
+      // UTF-8 bytes, so a share's file list agrees with the byte counts
+      // the playground shows (String.length undercounts non-ASCII).
+      size: new TextEncoder().encode(f.content).length,
+    }));
+    // Data files are listed too: the recipient's copy really does contain
+    // them, and the landing page's file table is the only preview of what a
+    // link holds.
+    for (const d of bundle.dataFiles ?? []) {
+      files.push({
+        name: d.path.slice(0, MANIFEST_NAME_MAX),
+        // 4 base64 chars per 3 bytes, minus the "=" padding.
+        size: Math.floor((d.base64.length * 3) / 4) - (d.base64.match(/=+$/)?.[0].length ?? 0),
+      });
+    }
+    return { kind: "code", files: files.slice(0, MANIFEST_MAX_ENTRIES) };
   }
   return {
     kind: "sql",

--- a/scripts/lib/python-output-capture.mjs
+++ b/scripts/lib/python-output-capture.mjs
@@ -92,12 +92,15 @@ try:
     import matplotlib.pyplot as _bo_plt
 
     def _bo_show(*a, **k):
-        buf = io.BytesIO()
-        _bo_plt.savefig(buf, format="png", bbox_inches="tight", dpi=BO_FIGURE_DPI,
-                        facecolor=_bo_plt.gcf().get_facecolor())
-        buf.seek(0)
-        _bo_outputs.append({"type": "image", "data": base64.b64encode(buf.read()).decode()})
-        _bo_plt.clf()
+        # Every open figure, not just the current one: a block that builds
+        # two and calls show() once must render two, the way a script and a
+        # notebook both do. Mirrors _patched_show in the worker.
+        for _num in _bo_plt.get_fignums():
+            _fig = _bo_plt.figure(_num)
+            buf = io.BytesIO()
+            _fig.savefig(buf, format="png", bbox_inches="tight", dpi=BO_FIGURE_DPI,
+                         facecolor=_fig.get_facecolor())
+            _bo_outputs.append({"type": "image", "data": base64.b64encode(buf.getvalue()).decode()})
         _bo_plt.close("all")
     _bo_plt.show = _bo_show
 except Exception:


### PR DESCRIPTION
Every finding in the audit is about the boundary between the Pyodide worker and the user: you could not stop a run, could not watch one progress, and could not get anything a program produced back out. The runtime layer itself was fine.

Full disposition, including what was declined and what did not reproduce, is in `agent-outputs/20260815-1200-python-playground-audit-response.md`.

## Run control and output

- **Stop control** (`PY-01`, Critical). `LanguageRuntime.cancelRun()` is new and optional; the Run button becomes Stop for any runtime that implements it. Python terminates the worker and stands a fresh one up in the background, replaying its warm-package hint. The in-flight `run()` rejects with a `RunCancelledError`, which the surface renders as a plain `Run stopped.` under whatever the program had already printed, not as a failure. Losing interpreter state costs nothing observable: globals are already wiped between runs.
- **Streaming output** (`PY-02`). Output is pushed as it is produced rather than flushed at run end. Python batches on a 60 ms timer or an 8 KB threshold; the surface republishes the run's slice at most every 80 ms. Text segments stream *stripped*, so the streamed concatenation is byte-identical to what the batched path produced.
- **Mid-run waits are visible** (`PY-12`). `RunOptions.onStatus` already existed and was wired in `<CodeBlock>` and `<ChallengeCard>`, but the playground never passed it, so "Installing data packages, first run only…" went nowhere.

## Getting work back out

- **Files the program writes** (`PY-03`). The worker stamps every staged file and diffs the working directory after each run; new or rewritten files reach the Files panel and OPFS through the existing `collectCreatedFiles` hook that R already used. Capped at 50 files / 64 MB per run.
- **Share carries data files** (`PY-14`). Code bundles gained `dataFiles` (base64, capped at 4 MB / 50 files), written back into the recipient's `data/` store and listed on the share landing page. Anything that doesn't fit is named to the sharer at creation time rather than dropped silently — a shared program that read a CSV used to die on `FileNotFoundError` the moment the recipient pressed Run.
- **The `.zip` keeps your filenames** (`PY-05`). The archive now also carries `source/<path>`, a readable copy of each editor file under its real name, and `workspace.json` records the id → path mapping. Import reads an allowlist (`meta.json`, `files/`, `db/`, `data/`) so the copies don't pollute a restored workspace.

## Correctness and legibility

- **`plt.show()` renders every open figure** (`PY-04`). It used to `savefig()` the current one and then close them all, silently destroying every figure but the last. `scripts/lib/python-output-capture.mjs` had the same bug, so a lesson's prepopulated panel and a live run would have disagreed; same fix there.
- **Readable tracebacks** (`PY-07`). User code compiles under its real filename, so frames read `File "main.py"` instead of `File "<string>"`, and harness frames are filtered before rendering. Chained exceptions keep both halves; a failure with no user frames is shown raw rather than shown empty.
- **CORS failures say so** (`PY-08`). A urllib3-emscripten timeout gets a plain-language preface. The `requests` drawer entry no longer claims network calls are blocked — they work, subject to CORS — and its example makes a real request.
- **`input()` explains itself** (`PY-06`). It cannot be supported (see below), so it now prints the prompt and raises a playground-specific `RuntimeError` naming two ways forward, instead of `OSError: [Errno 29] I/O error`.
- **UTF-8 byte counts** (`PY-16`) in the Files panel and the share manifest, replacing `String.length`.
- **A closing dialog stops swallowing the next click** (`PY-09`).
- **"Export code" → "Export current file"** (`PY-11`), which is what it does.

## Declined as structural

- **Interactive `input()`** needs `Atomics.wait` on a `SharedArrayBuffer`, which needs cross-origin isolation (COOP/COEP). Those headers break third-party embeds and CDN-loaded runtimes site-wide. The same prerequisite rules out `setInterruptBuffer` as the Stop mechanism, hence terminate-and-respawn.
- **Guest share revocation** (`PY-15`): a guest share has no owner row, so there is nothing for a revoke to authorise against. The dialog now says plainly that a guest link stays up for its full TTL, instead of implying otherwise.

## Did not reproduce

- `PY-10` ("each run replaces the last"): output accumulates by default and `Run N` increments — `clearBeforeRun` defaults to `false` for code playgrounds. The audit session most likely had *Clear Output Before Running* switched on.
- `PY-13` ("no rename affordance"): rename exists in both the Files panel and the tab context menus.
- The focus half of `PY-09` is an artifact of the audit's own caveat: the tab ran with `visibilityState === "hidden"`, so Base UI's exit transition never completed and the modal focus trap never unmounted. The click-swallowing inside the normal ~180 ms window is real and is what the CSS fix addresses.

## Testing

`npm test` (1,514 passing, including 3 new suites), `eslint`, `tsc --noEmit`.

Chromium in the authoring sandbox cannot reach `cdn.jsdelivr.net`, so Pyodide never boots there and the browser-level checks could not be run locally — this is stated plainly rather than glossed. What was verified instead:

- The worker's Python scripts were extracted from source and executed against CPython: streaming reassembly is byte-identical to the batched path across incremental prints, interleaved tables/images, whitespace-only segments and a 5,000-line burst (31 chunks); `input()`; `plt.show()` over a stub pyplot; traceback filenames.
- `__tests__/pythonErrors.test.ts` pins the traceback filter and CORS annotation, `__tests__/utf8Size.test.ts` the byte counts, `__tests__/pyodideWorkerSetup.test.ts` the invariants inside the template-literal Python that nothing else typechecks.
- `e2e/python-playground-audit-fixes.spec.ts` covers streaming, Stop, created files, multi-figure `show()`, `input()` and tracebacks in a real browser, for a machine with CDN access.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXcGjiHCvEEp5SuJwxiowP)_