### PR TITLE
Stop the admin dashboard reloading on tab focus; paginate the users list

### DIFF
--- a/__tests__/pagination.test.ts
+++ b/__tests__/pagination.test.ts
@@ -1,0 +1,138 @@
+/**
+ * The page arithmetic behind the admin users table. Tested directly: the page
+ * itself sits behind an admin gate and the test environment is Node with no
+ * DOM, so the maths is the whole behaviour.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  clampPage,
+  pageCount,
+  pageItems,
+  pageRange,
+  type PageItem,
+} from "@/lib/pagination";
+
+describe("pageCount", () => {
+  it("counts whole and partial pages", () => {
+    expect(pageCount(50, 25)).toBe(2);
+    expect(pageCount(51, 25)).toBe(3);
+    expect(pageCount(1, 25)).toBe(1);
+  });
+
+  it("never drops below one page, so an empty list reads 'of 1'", () => {
+    expect(pageCount(0, 25)).toBe(1);
+    expect(pageCount(-3, 25)).toBe(1);
+  });
+
+  it("survives a nonsense page size", () => {
+    expect(pageCount(50, 0)).toBe(1);
+    expect(pageCount(50, Number.NaN)).toBe(1);
+  });
+});
+
+describe("clampPage", () => {
+  it("keeps a page that is in range", () => {
+    expect(clampPage(2, 5)).toBe(2);
+  });
+
+  it("snaps back when the list shrinks under it", () => {
+    expect(clampPage(9, 3)).toBe(2);
+    expect(clampPage(1, 1)).toBe(0);
+  });
+
+  it("floors negatives and non-integers to a real page", () => {
+    expect(clampPage(-4, 5)).toBe(0);
+    expect(clampPage(2.7, 5)).toBe(2);
+    expect(clampPage(Number.NaN, 5)).toBe(0);
+  });
+});
+
+describe("pageRange", () => {
+  it("reports the 1-based span on the page", () => {
+    expect(pageRange(0, 25, 312)).toEqual({ first: 1, last: 25 });
+    expect(pageRange(1, 25, 312)).toEqual({ first: 26, last: 50 });
+  });
+
+  it("stops the last page at the real total", () => {
+    expect(pageRange(12, 25, 312)).toEqual({ first: 301, last: 312 });
+  });
+
+  it("is 0–0 when there is nothing to show", () => {
+    expect(pageRange(0, 25, 0)).toEqual({ first: 0, last: 0 });
+  });
+
+  it("clamps a page that is past the end", () => {
+    expect(pageRange(99, 25, 30)).toEqual({ first: 26, last: 30 });
+  });
+});
+
+describe("pageItems", () => {
+  it("lists every page when they all fit", () => {
+    expect(pageItems(0, 5)).toEqual([0, 1, 2, 3, 4]);
+    expect(pageItems(3, 7)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  it("keeps first, last and current, eliding the rest", () => {
+    expect(pageItems(10, 20)).toEqual([0, "gap", 9, 10, 11, "gap", 19]);
+  });
+
+  it("spends the missing gap on another page number at either end", () => {
+    expect(pageItems(0, 20)).toEqual([0, 1, 2, 3, 4, "gap", 19]);
+    expect(pageItems(19, 20)).toEqual([0, "gap", 15, 16, 17, 18, 19]);
+  });
+
+  it("never exceeds the slot budget", () => {
+    for (let current = 0; current < 40; current++) {
+      expect(pageItems(current, 40).length).toBeLessThanOrEqual(7);
+    }
+  });
+
+  it("always includes the current page", () => {
+    for (let current = 0; current < 40; current++) {
+      expect(pageItems(current, 40)).toContain(current);
+    }
+  });
+
+  it("stays strictly ascending, with no page listed twice", () => {
+    for (let current = 0; current < 40; current++) {
+      const nums = pageItems(current, 40).filter(
+        (i): i is number => i !== "gap",
+      );
+      expect(nums).toEqual([...nums].sort((a, b) => a - b));
+      expect(new Set(nums).size).toBe(nums.length);
+    }
+  });
+
+  it("only elides where pages were actually skipped", () => {
+    for (let current = 0; current < 40; current++) {
+      const items: PageItem[] = pageItems(current, 40);
+      items.forEach((item, i) => {
+        if (item !== "gap") return;
+        const before = items[i - 1];
+        const after = items[i + 1];
+        expect(typeof before).toBe("number");
+        expect(typeof after).toBe("number");
+        expect((after as number) - (before as number)).toBeGreaterThan(1);
+      });
+    }
+  });
+
+  it("honours a wider slot budget", () => {
+    expect(pageItems(10, 20, 9)).toEqual([
+      0,
+      "gap",
+      8,
+      9,
+      10,
+      11,
+      12,
+      "gap",
+      19,
+    ]);
+  });
+
+  it("handles a single page", () => {
+    expect(pageItems(0, 1)).toEqual([0]);
+    expect(pageItems(0, 0)).toEqual([0]);
+  });
+});

--- a/app/dashboard/admin/UsersClient.tsx
+++ b/app/dashboard/admin/UsersClient.tsx
@@ -19,6 +19,7 @@ import {
   VenetianMask,
 } from "lucide-react";
 import { authClient, useSession } from "@/lib/auth/client";
+import { clampPage, pageCount, pageItems, pageRange } from "@/lib/pagination";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -67,22 +68,27 @@ interface AdminUser {
   createdAt: string | Date;
 }
 
-/** Page size for the browse list and cap per search request. */
-const LIST_LIMIT = 200;
+/** Rows per page. Browse pages are fetched one at a time (server-side
+ *  `offset`); search results are sliced from the matches held in memory. */
+const PAGE_SIZE = 25;
+
+/** Cap on matches pulled per search request, per searched field. */
+const SEARCH_LIMIT = 200;
 
 const SEARCH_DEBOUNCE_MS = 300;
 
 export function UsersClient() {
   const { data: session, isPending: sessionPending } = useSession();
+  // Browse mode holds one page; search mode holds every match (client-sliced).
   const [users, setUsers] = useState<AdminUser[]>([]);
-  // Server-reported total; `users.length` alone under-reports.
+  // Server-reported total in browse mode, match count while searching.
   const [total, setTotal] = useState(0);
   const [searchTruncated, setSearchTruncated] = useState(false);
   const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [denied, setDenied] = useState(false);
   const [query, setQuery] = useState("");
+  const [page, setPage] = useState(0);
   // User-id with an action mid-flight / with a pending "confirm remove".
   const [busyId, setBusyId] = useState<string | null>(null);
   const [confirmId, setConfirmId] = useState<string | null>(null);
@@ -90,11 +96,12 @@ export function UsersClient() {
   // Monotonic sequence: a slow stale response must not overwrite a newer one.
   const loadSeq = useRef(0);
 
-  /** Load the browse page or search results. Search runs SERVER-side (a
-   *  client-side filter would hide accounts older than the newest LIST_LIMIT).
-   *  The endpoint searches one field per request, so a query fans out to
-   *  email + name and merges. */
-  const loadUsers = useCallback(async (search: string) => {
+  /** Load one browse page, or the search results. Search runs SERVER-side (a
+   *  client-side filter would hide accounts older than the newest page). The
+   *  endpoint searches one field per request, so a query fans out to email +
+   *  name and merges — which is why search is fetched in one shot and paged in
+   *  memory: two independently-offset result sets can't be paged server-side. */
+  const loadUsers = useCallback(async (search: string, pageIndex: number) => {
     const seq = ++loadSeq.current;
     setLoading(true);
     setError(null);
@@ -102,7 +109,6 @@ export function UsersClient() {
     try {
       const q = search.trim();
       const baseQuery = {
-        limit: LIST_LIMIT,
         sortBy: "createdAt",
         sortDirection: "desc" as const,
       };
@@ -112,6 +118,7 @@ export function UsersClient() {
               authClient.admin.listUsers({
                 query: {
                   ...baseQuery,
+                  limit: SEARCH_LIMIT,
                   searchValue: q,
                   searchField,
                   searchOperator: "contains" as const,
@@ -119,7 +126,15 @@ export function UsersClient() {
               }),
             ),
           )
-        : [await authClient.admin.listUsers({ query: baseQuery })];
+        : [
+            await authClient.admin.listUsers({
+              query: {
+                ...baseQuery,
+                limit: PAGE_SIZE,
+                offset: pageIndex * PAGE_SIZE,
+              },
+            }),
+          ];
       if (seq !== loadSeq.current) return; // superseded by a newer load
 
       const failed = responses.find((r) => r.error)?.error;
@@ -152,7 +167,7 @@ export function UsersClient() {
         setTotal(merged.length);
         // Either field maxing out its page means matches were left behind.
         setSearchTruncated(
-          responses.some((r) => (r.data?.users?.length ?? 0) >= LIST_LIMIT),
+          responses.some((r) => (r.data?.users?.length ?? 0) >= SEARCH_LIMIT),
         );
       } else {
         const { data } = responses[0];
@@ -169,46 +184,49 @@ export function UsersClient() {
     if (seq === loadSeq.current) setLoading(false);
   }, []);
 
+  const trimmedQuery = query.trim();
+  const pages = pageCount(total, PAGE_SIZE);
+  // Derived rather than stored: `total` shrinks under us when a row is removed
+  // or a search narrows, and a stored page would be left pointing past the end.
+  const current = clampPage(page, pages);
+  // Searching fetches every match at once, so paging through them must not
+  // re-request: pin the fetch key to 0 and slice in memory instead.
+  const fetchPage = trimmedQuery ? 0 : current;
+
+  // Key the load on the signed-in USER, not on the `session` object: Better
+  // Auth refetches the session whenever the tab regains focus
+  // (`refetchOnWindowFocus`), and hands back a fresh object each time — the
+  // dates in the payload defeat its equality check — so depending on the
+  // object re-ran this fetch and threw away the page on every tab switch.
+  const sessionUserId = session?.user.id ?? null;
   useEffect(() => {
-    // Fetch once a session is confirmed. Search input re-runs this, debounced;
-    // the empty query fires at once.
-    if (sessionPending || !session) return;
+    if (sessionPending || !sessionUserId) return;
+    // Typing debounces; page changes and the first load fire at once.
     const timer = setTimeout(
-      () => void loadUsers(query),
-      query.trim() ? SEARCH_DEBOUNCE_MS : 0,
+      () => void loadUsers(query, fetchPage),
+      trimmedQuery ? SEARCH_DEBOUNCE_MS : 0,
     );
     return () => clearTimeout(timer);
-  }, [sessionPending, session, loadUsers, query]);
+  }, [
+    sessionPending,
+    sessionUserId,
+    loadUsers,
+    query,
+    trimmedQuery,
+    fetchPage,
+  ]);
 
-  /** Append the next browse page (search results are single-shot). */
-  async function handleLoadMore() {
-    setLoadingMore(true);
-    setError(null);
-    try {
-      const { data, error: listError } = await authClient.admin.listUsers({
-        query: {
-          limit: LIST_LIMIT,
-          offset: users.length,
-          sortBy: "createdAt",
-          sortDirection: "desc",
-        },
-      });
-      if (listError) {
-        setError(listError.message ?? "Couldn't load more users.");
-      } else {
-        setUsers((prev) => {
-          const seen = new Set(prev.map((u) => u.id));
-          const fresh = ((data?.users ?? []) as AdminUser[]).filter(
-            (u) => !seen.has(u.id),
-          );
-          return [...prev, ...fresh];
-        });
-        setTotal(data?.total ?? 0);
-      }
-    } catch {
-      setError("Couldn't reach the server. Please try again.");
-    }
-    setLoadingMore(false);
+  /** Searching restarts the result set, so it restarts the paging too. */
+  function handleQueryChange(next: string) {
+    setQuery(next);
+    setPage(0);
+    setConfirmId(null);
+  }
+
+  function goToPage(next: number) {
+    setPage(clampPage(next, pages));
+    // A confirm prompt belongs to a row that is about to scroll away.
+    setConfirmId(null);
   }
 
   async function handleRemove(userId: string) {
@@ -223,6 +241,15 @@ export function UsersClient() {
       } else {
         setUsers((prev) => prev.filter((u) => u.id !== userId));
         setTotal((t) => Math.max(0, t - 1));
+        if (!trimmedQuery) {
+          // Browse pages come from the server, so the hole the removal left
+          // has to be refilled from it. When losing the row also loses the
+          // page, the clamped `fetchPage` re-runs the effect instead.
+          const nextTotal = Math.max(0, total - 1);
+          if (clampPage(current, pageCount(nextTotal, PAGE_SIZE)) === current) {
+            void loadUsers("", current);
+          }
+        }
       }
     } catch {
       setError("Couldn't reach the server. Please try again.");
@@ -495,6 +522,22 @@ export function UsersClient() {
 
   // --- Dashboard -----------------------------------------------------------
 
+  // Browse mode already holds exactly one page; search holds every match.
+  const visible = trimmedQuery
+    ? users.slice(current * PAGE_SIZE, (current + 1) * PAGE_SIZE)
+    : users;
+  const { first, last } = pageRange(current, PAGE_SIZE, total);
+  const noun = trimmedQuery
+    ? total === 1
+      ? "match"
+      : "matches"
+    : total === 1
+      ? "account"
+      : "accounts";
+  // Only the first load blanks the panel; later ones (refresh, page step) keep
+  // the rows on screen so the table doesn't flash empty.
+  const firstLoad = loading && users.length === 0;
+
   return (
     <>
       <AdminPageHeader
@@ -505,24 +548,24 @@ export function UsersClient() {
         <PanelHeader
           title="All users"
           description={
-            loading
+            firstLoad
               ? "Loading users…"
-              : query.trim()
-                ? `${users.length} ${users.length === 1 ? "match" : "matches"}${
-                    searchTruncated
-                      ? " (more exist, narrow the search)"
-                      : ""
-                  }`
-                : users.length < total
-                  ? `Showing ${users.length} of ${total} accounts`
-                  : `${total} ${total === 1 ? "account" : "accounts"}`
+              : `${
+                  pages > 1
+                    ? `Showing ${first}–${last} of ${total} ${noun}`
+                    : `${total} ${noun}`
+                }${
+                  trimmedQuery && searchTruncated
+                    ? " (more exist, narrow the search)"
+                    : ""
+                }`
           }
           action={
             <Button
               variant="ghost"
               size="sm"
               className={quietActionClass}
-              onClick={() => void loadUsers(query)}
+              onClick={() => void loadUsers(query, fetchPage)}
               disabled={loading}
             >
               <RefreshCw className={loading ? "animate-spin" : undefined} />
@@ -538,7 +581,7 @@ export function UsersClient() {
               type="search"
               placeholder="Search by name or email"
               value={query}
-              onChange={(e) => setQuery(e.target.value)}
+              onChange={(e) => handleQueryChange(e.target.value)}
               className={`${softInputClass} pl-9`}
               aria-label="Search users"
             />
@@ -546,19 +589,22 @@ export function UsersClient() {
 
           {error && <ErrorNote>{error}</ErrorNote>}
 
-          {loading ? (
+          {firstLoad ? (
             <p className="py-12 text-center text-sm text-muted-foreground">
               <Loader2 className="mr-2 inline size-4 animate-spin" />
               Loading…
             </p>
-          ) : users.length === 0 ? (
+          ) : visible.length === 0 ? (
             <p className="py-12 text-center text-sm text-muted-foreground">
-              {query.trim()
-                ? "No users match your search."
-                : "No users yet."}
+              {trimmedQuery ? "No users match your search." : "No users yet."}
             </p>
           ) : (
-            <>
+            <div
+              aria-busy={loading || undefined}
+              className={
+                loading ? "opacity-60 transition-opacity" : "transition-opacity"
+              }
+            >
               {/* Desktop: table */}
               <div className="hidden md:block">
                 <Table>
@@ -575,7 +621,7 @@ export function UsersClient() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {users.map((user) => {
+                    {visible.map((user) => {
                       const isSelf = user.id === session.user.id;
                       const isAdminRow = user.role === "admin";
                       const isBusy = busyId === user.id;
@@ -613,7 +659,7 @@ export function UsersClient() {
 
               {/* Mobile: stacked cards */}
               <ul className="md:hidden">
-                {users.map((user) => {
+                {visible.map((user) => {
                   const isSelf = user.id === session.user.id;
                   const isAdminRow = user.role === "admin";
                   const isBusy = busyId === user.id;
@@ -638,24 +684,63 @@ export function UsersClient() {
                   );
                 })}
               </ul>
+            </div>
+          )}
 
-              {/* Browse mode pages through; search is single-shot. */}
-              {!query.trim() && users.length < total && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className={`${quietActionClass} self-center`}
-                  onClick={() => void handleLoadMore()}
-                  disabled={loadingMore}
+          {/* Pagination, same chrome as the rest of the dashboard tables.
+              Browse pages come from the server one at a time; search pages are
+              sliced from the matches already in hand. */}
+          {pages > 1 && (
+            <nav
+              aria-label="User pages"
+              className="flex flex-wrap items-center gap-x-3 gap-y-2"
+            >
+              <span className="text-[13px] text-muted-foreground">
+                Page {current + 1} of {pages}
+              </span>
+              <div className="ml-auto flex items-center gap-1.5">
+                <button
+                  type="button"
+                  className="ds-page-btn"
+                  disabled={current === 0 || loading}
+                  onClick={() => goToPage(current - 1)}
                 >
-                  {loadingMore ? (
-                    <Loader2 className="animate-spin" />
+                  Previous
+                </button>
+                {pageItems(current, pages).map((item, i) =>
+                  item === "gap" ? (
+                    <span
+                      key={`gap-${i}`}
+                      aria-hidden="true"
+                      className="px-0.5 text-[13px] text-muted-foreground"
+                    >
+                      …
+                    </span>
                   ) : (
-                    `Load ${Math.min(LIST_LIMIT, total - users.length)} more`
-                  )}
-                </Button>
-              )}
-            </>
+                    <button
+                      key={item}
+                      type="button"
+                      className="ds-page-num"
+                      data-active={item === current || undefined}
+                      aria-current={item === current ? "page" : undefined}
+                      aria-label={`Page ${item + 1}`}
+                      disabled={loading}
+                      onClick={() => goToPage(item)}
+                    >
+                      {item + 1}
+                    </button>
+                  ),
+                )}
+                <button
+                  type="button"
+                  className="ds-page-btn"
+                  disabled={current >= pages - 1 || loading}
+                  onClick={() => goToPage(current + 1)}
+                >
+                  Next
+                </button>
+              </div>
+            </nav>
           )}
 
           <p className="text-xs leading-relaxed text-muted-foreground">

--- a/app/dashboard/admin/ai-feedback/AiFeedbackClient.tsx
+++ b/app/dashboard/admin/ai-feedback/AiFeedbackClient.tsx
@@ -160,12 +160,17 @@ export function AiFeedbackClient() {
     if (seq === loadSeq.current) setLoading(false);
   }, []);
 
+  // Keyed on the signed-in USER, not the `session` object: Better Auth
+  // refetches the session whenever the tab regains focus and hands back a
+  // fresh object each time, so depending on that identity re-ran this load on
+  // every tab switch.
+  const userId = session?.user.id ?? null;
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- initial data load on mount; the fetch's setState is intentional
-    if (!sessionPending && session) void load(filter);
-    // Mount-only: later loads are driven by the filter buttons.
+    if (!sessionPending && userId) void load(filter);
+    // Once per signed-in user: later loads are driven by the filter buttons.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionPending, session, load]);
+  }, [sessionPending, userId, load]);
 
   if (sessionPending) return <CenteredNote>Loading…</CenteredNote>;
   if (!session) return <SignInPrompt />;

--- a/app/dashboard/admin/ai-usage/AiUsageClient.tsx
+++ b/app/dashboard/admin/ai-usage/AiUsageClient.tsx
@@ -237,12 +237,17 @@ export function AiUsageClient() {
     if (seq === loadSeq.current) setLoading(false);
   }, []);
 
+  // Keyed on the signed-in USER, not the `session` object: Better Auth
+  // refetches the session whenever the tab regains focus and hands back a
+  // fresh object each time, so depending on that identity re-ran this load on
+  // every tab switch.
+  const userId = session?.user.id ?? null;
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- initial data load on mount; the fetch's setState is intentional
-    if (!sessionPending && session) void load(range, anchor);
-    // Mount-only: subsequent loads are driven by the controls' handlers.
+    if (!sessionPending && userId) void load(range, anchor);
+    // Once per signed-in user: later loads are driven by the controls' handlers.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionPending, session, load]);
+  }, [sessionPending, userId, load]);
 
   const selectRange = (r: Range) => {
     setRange(r);

--- a/app/dashboard/admin/test-users/TestUsersClient.tsx
+++ b/app/dashboard/admin/test-users/TestUsersClient.tsx
@@ -157,10 +157,15 @@ export function TestUsersClient() {
     setLoading(false);
   }, []);
 
+  // Keyed on the signed-in USER, not the `session` object: Better Auth
+  // refetches the session whenever the tab regains focus and hands back a
+  // fresh object each time, so depending on that identity re-ran this load on
+  // every tab switch.
+  const userId = session?.user.id ?? null;
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- initial data load on mount; the fetch's setState is intentional
-    if (!sessionPending && session) void loadTestUsers();
-  }, [sessionPending, session, loadTestUsers]);
+    if (!sessionPending && userId) void loadTestUsers();
+  }, [sessionPending, userId, loadTestUsers]);
 
   const credentialsText = useMemo(
     () => created.map((c) => `${c.email}\t${c.password}\t${c.plan}`).join("\n"),

--- a/lib/pagination.ts
+++ b/lib/pagination.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure page arithmetic for the paginated lists (the admin users table today).
+ * Kept out of the components so it can be tested in Node: those pages sit
+ * behind an admin gate and the test environment has no DOM, so the arithmetic
+ * is the whole behaviour worth pinning down.
+ *
+ * Pages are 0-based everywhere in here; the +1 belongs to the UI.
+ */
+
+/** How many pages `total` rows fill at `size` each. Never below 1, so an empty
+ *  list still reads "Page 1 of 1" rather than "of 0". */
+export function pageCount(total: number, size: number): number {
+  if (!Number.isFinite(total) || !Number.isFinite(size) || size <= 0) return 1;
+  return Math.max(1, Math.ceil(Math.max(0, total) / size));
+}
+
+/** Snap a page into range. `count` shrinks under you when rows are removed or
+ *  a search narrows, and a page past the end would render empty. */
+export function clampPage(page: number, count: number): number {
+  if (!Number.isFinite(page)) return 0;
+  return Math.min(Math.max(0, Math.floor(page)), Math.max(0, count - 1));
+}
+
+/** The 1-based inclusive row span shown on `page` ("26–50 of 312"). Both ends
+ *  are 0 when there is nothing to show. */
+export function pageRange(
+  page: number,
+  size: number,
+  total: number,
+): { first: number; last: number } {
+  if (total <= 0 || size <= 0) return { first: 0, last: 0 };
+  const current = clampPage(page, pageCount(total, size));
+  return {
+    first: current * size + 1,
+    last: Math.min((current + 1) * size, total),
+  };
+}
+
+/** A page button, or an elided stretch of them. */
+export type PageItem = number | "gap";
+
+/**
+ * The page buttons to render, at most `maxSlots` of them. The first, last and
+ * current pages always survive; whatever is dropped in between becomes a
+ * "gap". With few enough pages every one is listed and no gap appears.
+ */
+export function pageItems(
+  current: number,
+  count: number,
+  maxSlots = 7,
+): PageItem[] {
+  const pages = Math.max(1, Math.floor(count));
+  // Below five there is no room for first + gap + current + gap + last, and
+  // the windowing degenerates.
+  const slots = Math.max(5, Math.floor(maxSlots));
+  const page = clampPage(current, pages);
+
+  if (pages <= slots) return Array.from({ length: pages }, (_, i) => i);
+
+  // Two slots go to the first/last page and up to two more to the gaps.
+  const windowSize = slots - 4;
+  let start = page - Math.floor((windowSize - 1) / 2);
+  let end = start + windowSize - 1;
+  if (start <= 1) {
+    // Butted against the front: the leading gap is gone, so spend its slot on
+    // one more page number.
+    start = 1;
+    end = Math.min(pages - 2, windowSize + 1);
+  } else if (end >= pages - 2) {
+    end = pages - 2;
+    start = Math.max(1, pages - 2 - windowSize);
+  }
+
+  const items: PageItem[] = [0];
+  if (start > 1) items.push("gap");
+  for (let p = start; p <= end; p++) items.push(p);
+  if (end < pages - 2) items.push("gap");
+  items.push(pages - 1);
+  return items;
+}


### PR DESCRIPTION
## The tab-focus reload

`/dashboard/admin` re-fetched its whole list every time the tab regained focus.

Better Auth refetches the session on `visibilitychange` — `refetchOnWindowFocus` defaults to `true` — and hands back a **new** object each time. Its store does try to keep the reference stable (`isJsonEqual` in `client/query.ts`), but the client revives ISO strings into `Date` instances, and a `Date` is neither a plain object nor an array, so the deep-equal always returns false and `useSession()` yields a fresh object on every refetch.

Every admin page keyed its data fetch on that object identity:

```js
}, [sessionPending, session, load]);   // ← re-runs on every tab switch
```

So returning to the tab re-ran the fetch, blanked the table and threw away whatever page you were on. Fixed by keying on `session.user.id` — once per signed-in user, which is what the pages' own "mount-only" comments already claimed. The illustration gallery had already hit this and carries a comment describing the trap; this brings the rest in line.

Fixed on Users, AI usage, AI feedback and Test users.

## Pagination

The users list replaced its 200-row "Load more" button with real pagination:

- **25 rows per page**, fetched a page at a time through the endpoint's `offset` — previously the whole 200-row window came down in one request, and "Load more" appended another 200.
- **Search** still fans out over `email` + `name` and merges the two result sets, which cannot be offset server-side, so those matches are paged in memory. Paging through search results costs no extra request; the 200-per-field cap and its "narrow the search" hint are unchanged.
- **Page arithmetic** lives in `lib/pagination.ts` — page count, clamping, the 1-based row span, and the windowed `1 … 9 10 11 … 20` button list. Kept pure so it can be unit-tested in Node the way `lib/review/ordering.ts` is; the page itself is behind an admin gate and the test env has no DOM.
- The pager reuses the dashboard's existing `.ds-page-btn` / `.ds-page-num` chrome (same as the playground workspace table), so it inherits light/dark automatically.
- A reload now **dims the rows in place** instead of replacing the table with a spinner. Only the very first load blanks the panel — so the Refresh button and page steps no longer flash empty.

Removing a user refetches the current page so the row it left behind refills, and steps back a page when that was the last row on the last page.

## Testing

- `npm test` — 112 files / 1533 tests pass, including 19 new ones in `__tests__/pagination.test.ts` (windowing invariants are checked across every current page of a 40-page list: slot budget, current page always present, strictly ascending, gaps only where pages were actually skipped).
- `npx tsc --noEmit` — clean.
- `npx eslint app/dashboard/admin lib/pagination.ts __tests__/pagination.test.ts` — clean (one pre-existing warning in `_components/shared.tsx`, untouched).

Not exercised in a browser: the page sits behind an admin gate that needs a real D1-backed session, so the pager markup itself has not been clicked through — worth a quick look on preview.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfe4U7pHg5TJzZ9sRmWdpc)_