### PR TITLE
Fix SQL playground mobile drawer scrolling and the DuckDB query plan rendering

### DIFF
--- a/__tests__/explain.test.ts
+++ b/__tests__/explain.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  boxDrawingToAscii,
   buildExplainSql,
   formatExplainResult,
 } from "../app/_components/sql/utils/explain";
@@ -93,12 +94,80 @@ describe("formatExplainResult", () => {
     ).toBe("SCAN users\nUSE TEMP B-TREE FOR ORDER BY");
   });
 
-  it("joins multi-column rows when there's no detail column", () => {
+  it("joins single-line multi-column rows with two spaces", () => {
+    expect(
+      formatExplainResult(
+        ["id", "detail_a", "detail_b"],
+        [
+          [1, "SCAN", "users"],
+          [2, null, "orders"],
+        ],
+      ),
+    ).toBe("1  SCAN  users\n2    orders");
+  });
+
+  // DuckDB returns (explain_key, explain_value); joining them inline indented
+  // only the drawing's first line, so the top of the tree sat 15 columns right
+  // of the rest of it. A multi-line cell stacks instead.
+  it("stacks a row's cells when one of them is multi-line", () => {
     expect(
       formatExplainResult(
         ["explain_key", "explain_value"],
         [["physical_plan", "HASH_JOIN\n  SEQ_SCAN a\n  SEQ_SCAN b"]],
       ),
-    ).toBe("physical_plan  HASH_JOIN\n  SEQ_SCAN a\n  SEQ_SCAN b");
+    ).toBe("physical_plan\nHASH_JOIN\n  SEQ_SCAN a\n  SEQ_SCAN b");
+  });
+
+  // The box-drawing block isn't in the latin subset of the site's monospace
+  // face, so the browser draws it from a wider fallback font and the tree
+  // shears. ASCII lookalikes render from the same font as the labels.
+  it("redraws DuckDB's box-drawing tree in ASCII, keeping it aligned", () => {
+    const dashes = "\u2500".repeat(12);
+    const plan = [
+      `\u250c${dashes}\u2510`,
+      "\u2502  SEQ_SCAN  \u2502",
+      `\u2514${dashes}\u2518`,
+    ].join("\n");
+    const out = formatExplainResult(
+      ["explain_key", "explain_value"],
+      [["physical_plan", plan]],
+    );
+    expect(out).toBe(
+      [
+        "physical_plan",
+        "+------------+",
+        "|  SEQ_SCAN  |",
+        "+------------+",
+      ].join("\n"),
+    );
+    // Every line of the drawing is the same width, which is the whole point.
+    const drawing = out.split("\n").slice(1);
+    expect(new Set(drawing.map((l) => l.length)).size).toBe(1);
+  });
+});
+
+describe("boxDrawingToAscii", () => {
+  it("maps every box-drawing character to one ASCII column", () => {
+    // Light, heavy, double and dashed variants of the same three shapes.
+    expect(boxDrawingToAscii("\u2500\u2501\u2550\u2504")).toBe("----");
+    expect(boxDrawingToAscii("\u2502\u2503\u2551\u2506")).toBe("||||");
+    // Corners, tees and the cross.
+    expect(
+      boxDrawingToAscii(
+        "\u250c\u2510\u2514\u2518\u251c\u2524\u252c\u2534\u253c",
+      ),
+    ).toBe("+++++++++");
+  });
+
+  it("never changes a line's length, so columns stay put", () => {
+    const line = "\u251c\u2500\u2500 Table: loans \u2500\u2500\u2524";
+    expect(boxDrawingToAscii(line)).toHaveLength(line.length);
+    expect(boxDrawingToAscii(line)).toBe("+-- Table: loans --+");
+  });
+
+  it("leaves plain ASCII plans (SQLite, Postgres) untouched", () => {
+    const plan =
+      "Seq Scan on users  (cost=0.00..1.10 rows=10)\n  Filter: active";
+    expect(boxDrawingToAscii(plan)).toBe(plan);
   });
 });

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -1878,7 +1878,13 @@ function DuckDbPlaygroundInner() {
   useEffect(() => {
     if (typeof window === "undefined") return;
     document.title = "DuckDB Playground";
-    document.body.classList.add("duckdb-active");
+    // Same body class the SQLite/Postgres playgrounds set: it pins the
+    // playground surface colors/typography and, crucially on mobile,
+    // `overflow: hidden` so the page itself can never scroll behind the
+    // fixed shell. This used to add a `duckdb-active` class no stylesheet
+    // defined, leaving the DuckDB page the only playground whose document
+    // could be dragged around under an open sheet or dropdown.
+    document.body.classList.add("playground-active");
     const D = DEFAULT_PLAYGROUND_SETTINGS;
     const savedSize =
       Number(localStorage.getItem(storageKey("fontsize")) ?? D.fontSize) ||
@@ -1931,7 +1937,7 @@ function DuckDbPlaygroundInner() {
     }
 
     return () => {
-      document.body.classList.remove("duckdb-active");
+      document.body.classList.remove("playground-active");
       clearThemePalette();
     };
   }, [

--- a/app/_components/playground.css
+++ b/app/_components/playground.css
@@ -2990,6 +2990,13 @@ input[type="range"].fs-slider:disabled {
   /* Inherits position/color from .pkg-overlay; keep it opaque enough
      that the editor underneath fades away on the small mobile screen. */
   z-index: 320;
+  /* The playground's scrolling lives in inner panes (schema tree, results,
+     editor), not on `body`, so Base UI's modal body-scroll-lock has nothing
+     to lock and a drag over the dimmed area used to scroll the playground
+     behind the open sheet. Swallow the gesture here instead, the same guard
+     `.sql-db-backdrop` uses for the database dropdown. */
+  touch-action: none;
+  overscroll-behavior: contain;
 }
 
 .mobile-drawer-viewport {
@@ -3092,6 +3099,9 @@ input[type="range"].fs-slider:disabled {
      sections (Examples / Export) expand past the drawer cap. */
   min-height: 0;
   overflow-y: auto;
+  /* Keep a flick that runs past the end of the menu inside the sheet
+     instead of chaining it to the playground underneath. */
+  overscroll-behavior: contain;
   padding: 4px 8px 16px;
   display: flex;
   flex-direction: column;

--- a/app/_components/sql/utils/explain.ts
+++ b/app/_components/sql/utils/explain.ts
@@ -45,15 +45,56 @@ export function buildExplainSql(
   return `EXPLAIN ${stmt}`;
 }
 
+/** Redraw a plan's Unicode box-drawing characters (U+2500–U+257F) with their
+ *  ASCII lookalikes, one character in one character out so every column keeps
+ *  its position.
+ *
+ *  DuckDB draws its plan tree with `┌─┬─┐ │ └─┴─┘`, but the site's monospace
+ *  face is JetBrains Mono served by next/font in its `latin` subset, which
+ *  stops well short of the box-drawing block. The browser therefore renders
+ *  those characters from a fallback font whose advance width doesn't match:
+ *  measured in the plan viewer, box characters take 8.86px against JetBrains
+ *  Mono's 7.50px, so every border drifts ~18% to the right of the text it is
+ *  supposed to frame and the tree shears apart. Characters we can render are
+ *  the fix: `-`, `|` and `+` are plain ASCII, so the whole diagram comes from
+ *  one font and lines up — in the dialog, and in whatever the Copy button's
+ *  text is pasted into. */
+export function boxDrawingToAscii(text: string): string {
+  return text.replace(/[\u2500-\u257f]/g, (ch) => {
+    const code = ch.codePointAt(0)!;
+    // Horizontal runs (light/heavy/double dashes included) read as `-`,
+    // uprights as `|`, and every corner, tee and cross as `+`.
+    if (HORIZONTAL_BOX_CHARS.has(code)) return "-";
+    if (VERTICAL_BOX_CHARS.has(code)) return "|";
+    return "+";
+  });
+}
+
+// U+2500–U+257F, split by the direction each glyph draws in. Anything not
+// listed here is a corner/junction and becomes `+`.
+const HORIZONTAL_BOX_CHARS = new Set([
+  0x2500, 0x2501, 0x2504, 0x2505, 0x2508, 0x2509, 0x254c, 0x254d, 0x2550,
+  0x2574, 0x2576, 0x2578, 0x257a, 0x257c, 0x257e,
+]);
+const VERTICAL_BOX_CHARS = new Set([
+  0x2502, 0x2503, 0x2506, 0x2507, 0x250a, 0x250b, 0x254e, 0x254f, 0x2551,
+  0x2575, 0x2577, 0x2579, 0x257b, 0x257d, 0x257f,
+]);
+
 /** Format the rows an EXPLAIN query returns into readable plan text for the
  *  plan viewer's `<pre>`.
  *
  *  The shape differs per engine: Postgres returns a single `QUERY PLAN` text
  *  column (one plan line per row); SQLite `EXPLAIN QUERY PLAN` returns
- *  `(id, parent, notused, detail)`; DuckDB returns the plan (an ASCII tree) in
- *  its column(s). When a `detail` column is present (SQLite) we show just that;
- *  otherwise each row's non-null cells are joined, then rows by newlines,
- *  which renders all three readably (DuckDB's embedded newlines included). */
+ *  `(id, parent, notused, detail)`; DuckDB returns a `(explain_key,
+ *  explain_value)` pair whose value is a multi-line tree drawing. When a
+ *  `detail` column is present (SQLite) we show just that; otherwise each row's
+ *  non-null cells are joined, then rows by newlines.
+ *
+ *  A row carrying a multi-line cell stacks its cells instead of joining them
+ *  with spaces: inlining DuckDB's `physical_plan` label ahead of the drawing
+ *  indented only the tree's *first* line, pushing the top of the box 15
+ *  columns right of the rest of it. */
 export function formatExplainResult(
   columns: readonly string[],
   rows: ReadonlyArray<ReadonlyArray<unknown>>,
@@ -61,16 +102,26 @@ export function formatExplainResult(
   if (rows.length === 0) return "(no plan returned)";
   const detailIdx = columns.findIndex((c) => c.toLowerCase() === "detail");
   if (detailIdx >= 0) {
-    return rows.map((r) => String(r[detailIdx] ?? "")).join("\n");
+    return boxDrawingToAscii(
+      rows.map((r) => String(r[detailIdx] ?? "")).join("\n"),
+    );
   }
-  return rows
-    .map((row) =>
-      row
-        .map((cell) =>
+  return boxDrawingToAscii(
+    rows
+      .map((row) => {
+        const cells = row.map((cell) =>
           cell === null || cell === undefined ? "" : String(cell),
-        )
-        .join("  ")
-        .trimEnd(),
-    )
-    .join("\n");
+        );
+        // Stacked, so a label never indents just the drawing's first line;
+        // empty cells would only add blank lines between them.
+        if (cells.some((cell) => cell.includes("\n"))) {
+          return cells
+            .filter((cell) => cell !== "")
+            .join("\n")
+            .trimEnd();
+        }
+        return cells.join("  ").trimEnd();
+      })
+      .join("\n"),
+  );
 }

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -115,12 +115,28 @@
   overscroll-behavior: contain;
 }
 
+/* Base UI positions the popup with `position: absolute; left/top: 0` plus a
+   `transform: translate(x, y)`, so its containing block is the viewport: an
+   unconstrained popup shrink-to-fits to the *full* viewport width and the
+   translate then pushes it past the right edge, giving the document a few
+   pixels of horizontal scroll (very visible inside the mobile drawer menu,
+   where the whole page — sheet included — could be dragged sideways). Cap
+   both axes to the space Base UI publishes on the positioner
+   (`--available-width` / `--available-height`, seeded to 100vw/100vh) so the
+   dropdown always fits on screen and scrolls internally instead. */
 .sql-db-positioner {
   z-index: 500;
+  max-width: var(--available-width, 100vw);
 }
 
 .sql-db-popup {
   min-width: 260px;
+  max-width: var(--available-width, 100vw);
+  max-height: var(--available-height, 100vh);
+  overflow-y: auto;
+  /* A long sample list scrolls inside the popup; don't chain that scroll
+     out to the page (or the drawer) behind it. */
+  overscroll-behavior: contain;
   z-index: 500;
   /* Both the database and schema selector dropdowns use this popup; pin
      it to the base surface so it reads a touch darker than the default
@@ -141,6 +157,9 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  /* Let the label/description column shrink below its content width so the
+     capped popup wraps the text instead of widening past the viewport. */
+  min-width: 0;
 }
 
 .sql-db-item-desc {

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -5219,9 +5219,14 @@ html[data-playground-theme="dark"] .sql-result-th-type {
 }
 
 .sql-explain-plan {
-  font-family: var(--font-mono);
+  font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 12.5px;
-  line-height: 1.5;
+  /* Tighter than the dialogs' usual 1.5: DuckDB draws its plan as a tree of
+     boxes, and the taller the line box the bigger the gap between one row's
+     `|` and the next, which turns the sides of every node into a dashed
+     line. Still comfortable for the flat text plans SQLite and Postgres
+     return. */
+  line-height: 1.25;
   color: var(--text);
   background: var(--bg);
   border-top: 1px solid var(--border);

--- a/e2e/playground-mobile.spec.ts
+++ b/e2e/playground-mobile.spec.ts
@@ -79,6 +79,64 @@ test.describe("SQL playgrounds, mobile layout (390×844)", () => {
     });
   }
 
+  // The drawer menu's database selector used to give the page a few pixels of
+  // horizontal scroll: Base UI anchors the dropdown with `left: 0` + a
+  // `translate(x, y)`, so an unconstrained popup shrink-to-fits to the full
+  // viewport width and the translate pushes it off the right edge — dragging
+  // the whole page, sheet included, sideways. It is now capped to the space
+  // Base UI publishes on the positioner and scrolls internally instead.
+  for (const engine of ENGINES) {
+    test(`${engine}: drawer database dropdown fits the viewport`, async ({
+      page,
+    }) => {
+      await gotoPlayground(page, engine);
+
+      await page.locator(".mobile-menu-btn").click();
+      const menu = page.locator(".mobile-menu-drawer[aria-label='Menu']");
+      await expect(menu).toBeVisible();
+
+      // The page can't scroll behind the open sheet: the playground body
+      // keeps `overflow: hidden` and the backdrop swallows touch gestures.
+      const guards = await page.evaluate(() => ({
+        body: getComputedStyle(document.body).overflow,
+        backdrop: getComputedStyle(
+          document.querySelector(".mobile-menu-backdrop")!,
+        ).touchAction,
+        drawerBody: getComputedStyle(
+          document.querySelector(".mobile-menu-drawer-body")!,
+        ).overscrollBehavior,
+      }));
+      expect(guards).toEqual({
+        body: "hidden",
+        backdrop: "none",
+        drawerBody: "contain",
+      });
+
+      await menu.locator(".sql-database-selector").click();
+      const popup = page.locator(".sql-db-popup");
+      await expect(popup).toBeVisible();
+
+      // Neither axis of the document overflows, and the dropdown itself
+      // stays inside the viewport.
+      expect(await hasNoHorizontalOverflow(page)).toBe(true);
+      const fits = await page.evaluate(() => {
+        const de = document.documentElement;
+        const r = document
+          .querySelector(".sql-db-popup")!
+          .getBoundingClientRect();
+        return {
+          verticalOverflow: de.scrollHeight > de.clientHeight,
+          outsideViewport:
+            r.left < 0 ||
+            r.top < 0 ||
+            r.right > de.clientWidth ||
+            r.bottom > de.clientHeight,
+        };
+      });
+      expect(fits).toEqual({ verticalOverflow: false, outsideViewport: false });
+    });
+  }
+
   // Activating a query tab restores that tab's remembered bottom pane, never
   // stranding the user on the disabled Results pane. Full Editor↔Results
   // memory needs a booted engine and is covered by the paneForActivatedTab

--- a/e2e/sql-explain.spec.ts
+++ b/e2e/sql-explain.spec.ts
@@ -61,6 +61,23 @@ for (const { id, route } of ENGINES) {
     await expect(plan).not.toHaveText("(no plan returned)");
     await expect(plan).toContainText("widgets");
 
+    // Whatever the engine draws with, the plan is rendered in characters the
+    // site's monospace face actually has. DuckDB returns a box-drawing tree,
+    // and those glyphs come from a wider fallback font, which sheared the
+    // drawing away from the labels it frames; they are redrawn in ASCII.
+    const planText = (await plan.textContent()) ?? "";
+    expect(planText).not.toMatch(/[\u2500-\u257f]/);
+
+    // Every line of a drawn tree is the same width — the borders line up.
+    // Only rows framed on both sides count, so SQLite's `|--SCAN t` detail
+    // lines aren't mistaken for box art.
+    const drawn = planText
+      .split("\n")
+      .filter((line) => /^[+|].*[+|]$/.test(line));
+    if (drawn.length > 1) {
+      expect(new Set(drawn.map((line) => line.length)).size).toBe(1);
+    }
+
     // Closes cleanly (the footer's primary "Close" button).
     await dlg.locator("button.confirm-btn-primary").click();
     await expect(dlg).toHaveCount(0);


### PR DESCRIPTION
Three rendering/scrolling fixes in the SQL playgrounds.

## 1. Opening the drawer menu's database selector created a horizontal scroll

Base UI anchors the dropdown with `position: absolute; left: 0; top: 0` plus a `transform: translate(x, y)`, so the viewport is its containing block. An unconstrained popup shrink-to-fits to the **full** viewport width and the translate then pushes it past the right edge — measured in the drawer at 390×844: a 390px-wide `.sql-db-positioner` translated 5px right, giving `documentElement.scrollWidth` 395 vs `clientWidth` 390. That few pixels is enough to drag the whole screen, bottom sheet included, sideways.

The popup and its positioner are now capped to the space Base UI publishes on the positioner (`--available-width` / `--available-height`, seeded to `100vw`/`100vh`), matching the existing `--available-height` treatment on the header's ⋯ menu. A list too tall for the screen now scrolls inside the popup instead of extending the document, and `min-width: 0` on the item text column lets long descriptions wrap rather than widen the popup.

## 2. Scrolling with the menu open scrolled the playground behind it

Two causes:

- **DuckDB never had the playground body class.** `DuckDbPlayground` added `duckdb-active`, a class no stylesheet defines anywhere in the repo (it came in with the file, copied from the SQLite shell). So the DuckDB page was the only playground missing `body.playground-active { overflow: hidden }` and its document stayed scrollable under the fixed shell. It now uses the shared `playground-active` class, like the SQLite and Postgres playgrounds. Desktop rendering is unchanged (verified against before/after screenshots).
- **The sheet let a drag chain through.** The playground's scrolling lives in inner panes, not on `body`, so a modal scroll-lock has little to lock. The drawer backdrop now carries the same `touch-action: none` guard `.sql-db-backdrop` already uses for the database dropdown, and the scrolling menu body gets `overscroll-behavior: contain`.

## 3. The DuckDB query plan rendered as sheared box art

DuckDB draws its `EXPLAIN` output as a tree of Unicode boxes, and the plan viewer rendered it in pieces that didn't line up. Two causes:

- **The font has no box-drawing glyphs.** The site's monospace face is JetBrains Mono, served by next/font in its `latin` subset, which stops well short of U+2500–U+257F. The browser drew those characters from a fallback font whose advance width doesn't match — measured in the plan viewer, 8.86px against JetBrains Mono's 7.50px, so every border drifted ~18% right of the text it frames. They are now redrawn as `-`, `|` and `+`: one character in, one out, so every column keeps its position and the whole diagram comes from one font — in the dialog, and in whatever the Copy button's text is pasted into.
- **The plan's label was inlined.** DuckDB returns `(explain_key, explain_value)`, and joining the cells put `physical_plan  ` in front of the drawing, indenting only its *first* line and pushing the top of the tree 15 columns right of the rest. A row with a multi-line cell now stacks its cells instead.

Both fixes live in the shared `formatExplainResult`, so SQLite and Postgres go through them too. Their plans are already plain ASCII — confirmed against real output from `sqlite3` (`(id, parent, notused, detail)`, e.g. `SCAN loans`) and PGlite (a single `QUERY PLAN` column) — so nothing about them changes, and a future Unicode-drawing plan would be normalized the same way. The plan's `line-height` also drops from 1.5 to 1.25: at 1.5 the gap between one row's `|` and the next turned the sides of every node into a dashed line.

## Testing

- New engine-free case in `e2e/playground-mobile.spec.ts`, run for sqlite / postgres / duckdb: asserts the scroll guards are in place with the sheet open, and that opening the dropdown leaves neither axis of the document overflowing and keeps the popup inside the viewport. **It fails on all three engines without these changes.**
- New unit tests for the character mapping (light/heavy/double/dashed variants), the one-character-in-one-out guarantee, the ASCII-plan passthrough, and the stacking rule; the existing per-engine Explain e2e now also asserts the plan carries no box-drawing characters and that a drawn tree's lines are all the same width.
- `npx vitest run` — 1538 passed; `npx playwright test e2e/playground-mobile.spec.ts` — 8 passed; `tsc --noEmit` clean; `eslint` on the changed files reports no new problems.
- Rendered the reported plan through the real stylesheet at 390px and 900px wide: every line of the tree is exactly 29 columns and the drawing fits the mobile viewport.
- Manually checked the dropdown at 320×568, 360×640 and 414×896: no overflow on either axis, and the popup scrolls internally on the short viewports.
- `e2e/sql-explain.spec.ts` and `e2e/mobile-menu.spec.ts` can't run in this sandbox — both wait for a CDN-booted engine — and fail identically on the base commit, so they are unrelated to these changes.