### PR TITLE
Ask how to fill unique columns instead of refusing "Duplicate row"; Admin in the mobile drawer

### DIFF
--- a/__tests__/duplicateRow.test.ts
+++ b/__tests__/duplicateRow.test.ts
@@ -1,0 +1,533 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyDuplicateRowPlan,
+  buildDuplicateRowPlan,
+  conflictingDuplicateColumns,
+  constraintInfoFromColumns,
+  defaultDuplicateStrategy,
+  defaultGeneratesUniqueValue,
+  duplicateInsertColumns,
+  incrementMaxValue,
+  isNumericColumnType,
+  isDuplicatePlanComplete,
+  isSqliteRowidAlias,
+  looksLikeUuid,
+  newUuid,
+  suggestDuplicateText,
+  type DuplicateColumnChoice,
+  type DuplicateStrategy,
+} from "../app/_components/sql/utils/duplicateRow";
+import type {
+  ColumnConstraintInfo,
+  TableColumnInfo,
+} from "../app/_components/runtime/sqlite";
+
+function constraint(
+  partial: Partial<ColumnConstraintInfo> & { name: string },
+): ColumnConstraintInfo {
+  return {
+    isPrimaryKey: false,
+    isAutoIncrement: false,
+    isUnique: false,
+    ...partial,
+  };
+}
+
+function column(
+  partial: Partial<TableColumnInfo> & { name: string },
+): TableColumnInfo {
+  return {
+    cid: 0,
+    type: "text",
+    notNull: false,
+    defaultValue: null,
+    pk: 0,
+    generated: null,
+    ...partial,
+  };
+}
+
+describe("defaultGeneratesUniqueValue", () => {
+  it("accepts the sequence and UUID generators the engines emit", () => {
+    expect(defaultGeneratesUniqueValue("nextval('t_id_seq'::regclass)")).toBe(
+      true,
+    );
+    expect(defaultGeneratesUniqueValue("gen_random_uuid()")).toBe(true);
+    expect(defaultGeneratesUniqueValue("uuid_generate_v4()")).toBe(true);
+    expect(defaultGeneratesUniqueValue("uuid()")).toBe(true);
+  });
+
+  it("rejects defaults that generate a value but not a distinct one", () => {
+    expect(defaultGeneratesUniqueValue("now()")).toBe(false);
+    expect(defaultGeneratesUniqueValue("CURRENT_TIMESTAMP")).toBe(false);
+    expect(defaultGeneratesUniqueValue("0")).toBe(false);
+    expect(defaultGeneratesUniqueValue(null)).toBe(false);
+    expect(defaultGeneratesUniqueValue(undefined)).toBe(false);
+  });
+});
+
+describe("isNumericColumnType", () => {
+  it("recognises the integer and decimal families across engines", () => {
+    for (const type of [
+      "INTEGER",
+      "int4",
+      "bigint",
+      "SMALLINT",
+      "serial",
+      "numeric(10,2)",
+      "double precision",
+      "HUGEINT",
+    ]) {
+      expect(isNumericColumnType(type), type).toBe(true);
+    }
+  });
+
+  it("leaves types that merely contain a numeric word alone", () => {
+    for (const type of ["interval", "point", "text", "uuid", "timestamp"]) {
+      expect(isNumericColumnType(type), type).toBe(false);
+    }
+  });
+});
+
+describe("isSqliteRowidAlias", () => {
+  const alias = {
+    type: "INTEGER",
+    pk: 1,
+    singleColumnPk: true,
+    withoutRowid: false,
+  };
+
+  it("accepts a sole INTEGER PRIMARY KEY, in any case", () => {
+    expect(isSqliteRowidAlias(alias)).toBe(true);
+    expect(isSqliteRowidAlias({ ...alias, type: " integer " })).toBe(true);
+  });
+
+  it("rejects INT, which SQLite does not alias to the rowid", () => {
+    expect(isSqliteRowidAlias({ ...alias, type: "INT" })).toBe(false);
+    expect(isSqliteRowidAlias({ ...alias, type: "BIGINT" })).toBe(false);
+  });
+
+  it("rejects a composite key and a WITHOUT ROWID table", () => {
+    expect(isSqliteRowidAlias({ ...alias, singleColumnPk: false })).toBe(false);
+    expect(isSqliteRowidAlias({ ...alias, pk: 2, singleColumnPk: false })).toBe(
+      false,
+    );
+    expect(isSqliteRowidAlias({ ...alias, withoutRowid: true })).toBe(false);
+  });
+
+  it("rejects a non-key column", () => {
+    expect(isSqliteRowidAlias({ ...alias, pk: 0 })).toBe(false);
+  });
+});
+
+describe("looksLikeUuid", () => {
+  it("matches a canonical UUID, in either case", () => {
+    expect(looksLikeUuid("f47ac10b-58cc-4372-a567-0e02b2c3d479")).toBe(true);
+    expect(looksLikeUuid("F47AC10B-58CC-4372-A567-0E02B2C3D479")).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(looksLikeUuid("not-a-uuid")).toBe(false);
+    expect(looksLikeUuid(42)).toBe(false);
+    expect(looksLikeUuid(null)).toBe(false);
+  });
+});
+
+describe("duplicateInsertColumns", () => {
+  it("drops the columns the database re-populates", () => {
+    const info = [
+      constraint({ name: "id", isPrimaryKey: true, autoPopulated: true }),
+      constraint({ name: "email", isUnique: true }),
+      constraint({ name: "name" }),
+    ];
+    expect(
+      duplicateInsertColumns(
+        ["id", "email", "name"],
+        [7, "a@b.c", "Ada"],
+        info,
+      ),
+    ).toEqual({ names: ["email", "name"], values: ["a@b.c", "Ada"] });
+  });
+
+  it("keeps every column when nothing is auto-populated", () => {
+    expect(duplicateInsertColumns(["a", "b"], [1, 2], undefined)).toEqual({
+      names: ["a", "b"],
+      values: [1, 2],
+    });
+  });
+});
+
+describe("conflictingDuplicateColumns", () => {
+  it("reports nothing when the key is auto-populated", () => {
+    const info = [
+      constraint({ name: "id", isPrimaryKey: true, autoPopulated: true }),
+      constraint({ name: "name" }),
+    ];
+    expect(conflictingDuplicateColumns(["name"], ["Ada"], info)).toEqual([]);
+  });
+
+  it("reports a plain integer primary key, with the next-number option", () => {
+    const info = [
+      constraint({ name: "id", isPrimaryKey: true, type: "INT", notNull: true }),
+    ];
+    const [conflict] = conflictingDuplicateColumns(["id"], [7], info);
+    expect(conflict.name).toBe("id");
+    expect(conflict.autoKind).toBe("next-number");
+    expect(conflict.canBeNull).toBe(false);
+    expect(defaultDuplicateStrategy(conflict)).toBe("auto");
+  });
+
+  it("offers a fresh UUID for a uuid-typed key and for uuid-shaped text", () => {
+    const typed = conflictingDuplicateColumns(
+      ["id"],
+      ["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
+      [constraint({ name: "id", isPrimaryKey: true, type: "uuid" })],
+    );
+    expect(typed[0].autoKind).toBe("uuid");
+    const untyped = conflictingDuplicateColumns(
+      ["id"],
+      ["f47ac10b-58cc-4372-a567-0e02b2c3d479"],
+      [constraint({ name: "id", isPrimaryKey: true, type: "TEXT" })],
+    );
+    expect(untyped[0].autoKind).toBe("uuid");
+  });
+
+  it("has no automatic answer for a plain text unique column", () => {
+    const [conflict] = conflictingDuplicateColumns(
+      ["email"],
+      ["ada@example.com"],
+      [constraint({ name: "email", isUnique: true, type: "TEXT" })],
+    );
+    expect(conflict.autoKind).toBeNull();
+    expect(conflict.canBeNull).toBe(true);
+    expect(defaultDuplicateStrategy(conflict)).toBe("custom");
+  });
+
+  it("skips a NULL in a nullable unique column, since NULLs never collide", () => {
+    const info = [constraint({ name: "email", isUnique: true, type: "TEXT" })];
+    expect(conflictingDuplicateColumns(["email"], [null], info)).toEqual([]);
+  });
+
+  it("still reports a NOT NULL unique column holding NULL", () => {
+    const info = [
+      constraint({
+        name: "email",
+        isUnique: true,
+        type: "TEXT",
+        notNull: true,
+      }),
+    ];
+    expect(conflictingDuplicateColumns(["email"], [null], info)).toHaveLength(1);
+  });
+
+  it("reports every member of a composite primary key", () => {
+    const info = [
+      constraint({ name: "order_id", isPrimaryKey: true, type: "INT" }),
+      constraint({ name: "product_id", isPrimaryKey: true, type: "INT" }),
+      constraint({ name: "qty", type: "INT" }),
+    ];
+    const conflicts = conflictingDuplicateColumns(
+      ["order_id", "product_id", "qty"],
+      [1, 2, 3],
+      info,
+    );
+    expect(conflicts.map((c) => c.name)).toEqual(["order_id", "product_id"]);
+  });
+});
+
+describe("incrementMaxValue", () => {
+  it("starts at 1 for an empty table", () => {
+    expect(incrementMaxValue(null)).toBe(1);
+    expect(incrementMaxValue(undefined)).toBe(1);
+  });
+
+  it("adds one to numbers, bigints and numeric strings", () => {
+    expect(incrementMaxValue(7)).toBe(8);
+    expect(incrementMaxValue(-3)).toBe(-2);
+    expect(incrementMaxValue(10n)).toBe(11);
+    expect(incrementMaxValue("41")).toBe(42);
+  });
+
+  it("keeps precision past 2^53 by returning a decimal string", () => {
+    expect(incrementMaxValue("9007199254740993")).toBe("9007199254740994");
+  });
+
+  it("falls back to 1 for a value that isn't a number at all", () => {
+    expect(incrementMaxValue("abc")).toBe(1);
+  });
+});
+
+describe("suggestDuplicateText", () => {
+  const numeric: DuplicateColumnChoice = {
+    name: "id",
+    type: "INT",
+    isPrimaryKey: true,
+    isUnique: false,
+    originalValue: 7,
+    autoKind: "next-number",
+    canBeNull: false,
+  };
+
+  it("suggests one past the copied number", () => {
+    expect(suggestDuplicateText(numeric, "")).toBe("8");
+  });
+
+  it("hands a UUID column the caller's fresh UUID", () => {
+    expect(
+      suggestDuplicateText({ ...numeric, autoKind: "uuid" }, "abc-123"),
+    ).toBe("abc-123");
+  });
+
+  it('suffixes text with " (copy)"', () => {
+    expect(
+      suggestDuplicateText(
+        {
+          ...numeric,
+          type: "TEXT",
+          originalValue: "ada@example.com",
+          autoKind: null,
+        },
+        "",
+      ),
+    ).toBe("ada@example.com (copy)");
+  });
+});
+
+describe("isDuplicatePlanComplete", () => {
+  const choice: DuplicateColumnChoice = {
+    name: "email",
+    type: "TEXT",
+    isPrimaryKey: false,
+    isUnique: true,
+    originalValue: "ada@example.com",
+    autoKind: null,
+    canBeNull: true,
+  };
+
+  it("refuses a plan where every column keeps its value", () => {
+    expect(isDuplicatePlanComplete([choice], { email: "keep" }, {})).toBe(false);
+  });
+
+  it("refuses an empty custom value", () => {
+    expect(
+      isDuplicatePlanComplete([choice], { email: "custom" }, { email: "" }),
+    ).toBe(false);
+  });
+
+  it("accepts a filled custom value, or NULL", () => {
+    expect(
+      isDuplicatePlanComplete([choice], { email: "custom" }, { email: "x" }),
+    ).toBe(true);
+    expect(isDuplicatePlanComplete([choice], { email: "null" }, {})).toBe(true);
+  });
+
+  it("accepts a composite key where only one member moves", () => {
+    const a = { ...choice, name: "order_id", autoKind: "next-number" as const };
+    const b = { ...choice, name: "product_id" };
+    expect(
+      isDuplicatePlanComplete(
+        [a, b],
+        { order_id: "auto", product_id: "keep" },
+        {},
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("buildDuplicateRowPlan", () => {
+  const idChoice: DuplicateColumnChoice = {
+    name: "id",
+    type: "INT",
+    isPrimaryKey: true,
+    isUnique: false,
+    originalValue: 7,
+    autoKind: "next-number",
+    canBeNull: false,
+  };
+  const emailChoice: DuplicateColumnChoice = {
+    name: "email",
+    type: "TEXT",
+    isPrimaryKey: false,
+    isUnique: true,
+    originalValue: "ada@example.com",
+    autoKind: null,
+    canBeNull: true,
+  };
+
+  it("routes an auto number to nextNumber and a typed value to overrides", () => {
+    const plan = buildDuplicateRowPlan(
+      [idChoice, emailChoice],
+      { id: "auto", email: "custom" },
+      { email: "grace@example.com" },
+      () => "unused",
+    );
+    expect(plan.nextNumber).toEqual(["id"]);
+    expect(plan.overrides).toEqual([
+      { column: "email", value: "grace@example.com" },
+    ]);
+  });
+
+  it("coerces a typed value to a number for a numeric column", () => {
+    const plan = buildDuplicateRowPlan(
+      [idChoice],
+      { id: "custom" },
+      { id: "42" },
+      () => "unused",
+    );
+    expect(plan.overrides).toEqual([{ column: "id", value: 42 }]);
+  });
+
+  it("mints one UUID per auto UUID column", () => {
+    let n = 0;
+    const plan = buildDuplicateRowPlan(
+      [{ ...idChoice, type: "uuid", autoKind: "uuid" }],
+      { id: "auto" },
+      {},
+      () => `uuid-${++n}`,
+    );
+    expect(plan.overrides).toEqual([{ column: "id", value: "uuid-1" }]);
+    expect(plan.nextNumber).toEqual([]);
+  });
+
+  it("leaves kept columns out of the plan entirely", () => {
+    const strategies: Record<string, DuplicateStrategy> = {
+      id: "auto",
+      email: "keep",
+    };
+    const plan = buildDuplicateRowPlan(
+      [idChoice, emailChoice],
+      strategies,
+      {},
+      () => "unused",
+    );
+    expect(plan.overrides).toEqual([]);
+    expect(plan.nextNumber).toEqual(["id"]);
+  });
+
+  it("writes NULL for the set-to-NULL option", () => {
+    const plan = buildDuplicateRowPlan(
+      [emailChoice],
+      { email: "null" },
+      {},
+      () => "unused",
+    );
+    expect(plan.overrides).toEqual([{ column: "email", value: null }]);
+  });
+});
+
+describe("applyDuplicateRowPlan", () => {
+  it("returns the row untouched when there is no plan", async () => {
+    const resolved = await applyDuplicateRowPlan(
+      ["id", "name"],
+      [1, "Ada"],
+      undefined,
+      async () => {
+        throw new Error("should not be called");
+      },
+    );
+    expect(resolved).toEqual({ names: ["id", "name"], values: [1, "Ada"] });
+  });
+
+  it("substitutes overrides and resolves MAX + 1 for nextNumber columns", async () => {
+    const asked: string[] = [];
+    const resolved = await applyDuplicateRowPlan(
+      ["id", "email"],
+      [7, "ada@example.com"],
+      {
+        nextNumber: ["id"],
+        overrides: [{ column: "email", value: "grace@example.com" }],
+      },
+      async (column) => {
+        asked.push(column);
+        return 41;
+      },
+    );
+    expect(asked).toEqual(["id"]);
+    expect(resolved).toEqual({
+      names: ["id", "email"],
+      values: [42, "grace@example.com"],
+    });
+  });
+
+  it("never queries when the plan asks for no generated numbers", async () => {
+    const resolved = await applyDuplicateRowPlan(
+      ["email"],
+      ["ada@example.com"],
+      { nextNumber: [], overrides: [{ column: "email", value: null }] },
+      async () => {
+        throw new Error("should not be called");
+      },
+    );
+    expect(resolved.values).toEqual([null]);
+  });
+
+  it("ignores plan entries for columns the INSERT doesn't carry", async () => {
+    const resolved = await applyDuplicateRowPlan(
+      ["name"],
+      ["Ada"],
+      { nextNumber: ["id"], overrides: [{ column: "id", value: 1 }] },
+      async () => 0,
+    );
+    expect(resolved).toEqual({ names: ["name"], values: ["Ada"] });
+  });
+});
+
+describe("constraintInfoFromColumns", () => {
+  it("reads the primary key, uniqueness and identity off the column list", () => {
+    const info = constraintInfoFromColumns([
+      column({ name: "id", type: "integer", pk: 1, identity: true, notNull: true }),
+      column({ name: "email", type: "text", unique: true }),
+      column({ name: "name", type: "text" }),
+    ]);
+    expect(info[0]).toMatchObject({
+      name: "id",
+      isPrimaryKey: true,
+      isAutoIncrement: true,
+      autoPopulated: true,
+      notNull: true,
+    });
+    expect(info[1]).toMatchObject({
+      name: "email",
+      isUnique: true,
+      autoPopulated: false,
+    });
+    expect(info[2]).toMatchObject({ isPrimaryKey: false, isUnique: false });
+  });
+
+  it("treats a serial default as auto-populated", () => {
+    const [info] = constraintInfoFromColumns([
+      column({
+        name: "id",
+        type: "integer",
+        pk: 1,
+        defaultValue: "nextval('t_id_seq'::regclass)",
+      }),
+    ]);
+    expect(info.isAutoIncrement).toBe(true);
+    expect(info.autoPopulated).toBe(true);
+  });
+
+  it("treats a UUID default as auto-populated but not auto-increment", () => {
+    const [info] = constraintInfoFromColumns([
+      column({
+        name: "id",
+        type: "uuid",
+        pk: 1,
+        defaultValue: "gen_random_uuid()",
+      }),
+    ]);
+    expect(info.isAutoIncrement).toBe(false);
+    expect(info.autoPopulated).toBe(true);
+  });
+});
+
+describe("newUuid", () => {
+  it("returns a distinct, canonically shaped v4 UUID", () => {
+    const a = newUuid();
+    const b = newUuid();
+    expect(looksLikeUuid(a)).toBe(true);
+    expect(a[14]).toBe("4");
+    expect("89ab").toContain(a[19].toLowerCase());
+    expect(a).not.toBe(b);
+  });
+});

--- a/__tests__/duplicateRow.test.ts
+++ b/__tests__/duplicateRow.test.ts
@@ -95,6 +95,7 @@ describe("isSqliteRowidAlias", () => {
     pk: 1,
     singleColumnPk: true,
     withoutRowid: false,
+    hasPkIndex: false,
   };
 
   it("accepts a sole INTEGER PRIMARY KEY, in any case", () => {
@@ -117,6 +118,12 @@ describe("isSqliteRowidAlias", () => {
 
   it("rejects a non-key column", () => {
     expect(isSqliteRowidAlias({ ...alias, pk: 0 })).toBe(false);
+  });
+
+  it("rejects a key that needed a real index (INTEGER PRIMARY KEY DESC)", () => {
+    // SQLite deliberately does not alias `INTEGER PRIMARY KEY DESC` to the
+    // rowid; the origin-'pk' autoindex it creates is the tell.
+    expect(isSqliteRowidAlias({ ...alias, hasPkIndex: true })).toBe(false);
   });
 });
 
@@ -154,6 +161,18 @@ describe("duplicateInsertColumns", () => {
       names: ["a", "b"],
       values: [1, 2],
     });
+  });
+
+  it("copies a NON-unique generated-default column instead of regenerating it", () => {
+    // e.g. `trace VARCHAR DEFAULT uuid()`: nothing can collide, so a
+    // faithful duplicate carries the value through.
+    const info = [
+      constraint({ name: "id", isPrimaryKey: true, autoPopulated: true }),
+      constraint({ name: "trace", defaultValue: "uuid()" }),
+    ];
+    expect(
+      duplicateInsertColumns(["id", "trace"], [7, "abc"], info),
+    ).toEqual({ names: ["trace"], values: ["abc"] });
   });
 });
 
@@ -220,7 +239,7 @@ describe("conflictingDuplicateColumns", () => {
     expect(conflictingDuplicateColumns(["email"], [null], info)).toHaveLength(1);
   });
 
-  it("reports every member of a composite primary key", () => {
+  it("reports every member of a composite primary key, all keepable", () => {
     const info = [
       constraint({ name: "order_id", isPrimaryKey: true, type: "INT" }),
       constraint({ name: "product_id", isPrimaryKey: true, type: "INT" }),
@@ -232,6 +251,49 @@ describe("conflictingDuplicateColumns", () => {
       info,
     );
     expect(conflicts.map((c) => c.name)).toEqual(["order_id", "product_id"]);
+    // Composite: changing one member frees the other to keep its value.
+    expect(conflicts.map((c) => c.canKeep)).toEqual([true, true]);
+  });
+
+  it("never offers keep on a sole key or a single-column unique", () => {
+    const sole = conflictingDuplicateColumns(
+      ["id"],
+      [7],
+      [constraint({ name: "id", isPrimaryKey: true, type: "INT" })],
+    );
+    expect(sole[0].canKeep).toBe(false);
+    const unique = conflictingDuplicateColumns(
+      ["email"],
+      ["ada@example.com"],
+      [constraint({ name: "email", isUnique: true, type: "TEXT" })],
+    );
+    expect(unique[0].canKeep).toBe(false);
+  });
+
+  it("keeps a composite-key member with its own UNIQUE constraint unkeepable", () => {
+    const info = [
+      constraint({ name: "a", isPrimaryKey: true, type: "INT" }),
+      constraint({ name: "b", isPrimaryKey: true, isUnique: true, type: "INT" }),
+    ];
+    const conflicts = conflictingDuplicateColumns(["a", "b"], [1, 2], info);
+    // b's own unique constraint must change no matter what a does — and with
+    // only one pure key member left, a can't keep either.
+    expect(conflicts.map((c) => [c.name, c.canKeep])).toEqual([
+      ["a", false],
+      ["b", false],
+    ]);
+  });
+
+  it("skips the other members of a key whose auto member re-mints the pair", () => {
+    // PK (id serial, region): the database regenerates id, so the pair is
+    // fresh whatever region holds — nothing to ask about.
+    const info = [
+      constraint({ name: "id", isPrimaryKey: true, autoPopulated: true }),
+      constraint({ name: "region", isPrimaryKey: true, type: "TEXT" }),
+    ];
+    expect(
+      conflictingDuplicateColumns(["region"], ["eu"], info),
+    ).toEqual([]);
   });
 });
 
@@ -266,6 +328,7 @@ describe("suggestDuplicateText", () => {
     originalValue: 7,
     autoKind: "next-number",
     canBeNull: false,
+    canKeep: false,
   };
 
   it("suggests one past the copied number", () => {
@@ -302,9 +365,12 @@ describe("isDuplicatePlanComplete", () => {
     originalValue: "ada@example.com",
     autoKind: null,
     canBeNull: true,
+    canKeep: false,
   };
 
-  it("refuses a plan where every column keeps its value", () => {
+  it("refuses keep on a column where keep is not legal", () => {
+    // A single-column unique constraint can never keep its value: the copy
+    // would collide with the row it came from.
     expect(isDuplicatePlanComplete([choice], { email: "keep" }, {})).toBe(false);
   });
 
@@ -322,8 +388,19 @@ describe("isDuplicatePlanComplete", () => {
   });
 
   it("accepts a composite key where only one member moves", () => {
-    const a = { ...choice, name: "order_id", autoKind: "next-number" as const };
-    const b = { ...choice, name: "product_id" };
+    const a: DuplicateColumnChoice = {
+      ...choice,
+      name: "order_id",
+      isPrimaryKey: true,
+      isUnique: false,
+      autoKind: "next-number",
+      canKeep: true,
+    };
+    const b: DuplicateColumnChoice = {
+      ...a,
+      name: "product_id",
+      autoKind: null,
+    };
     expect(
       isDuplicatePlanComplete(
         [a, b],
@@ -331,6 +408,22 @@ describe("isDuplicatePlanComplete", () => {
         {},
       ),
     ).toBe(true);
+    // Keeping EVERY member reproduces the key it was copied from.
+    expect(
+      isDuplicatePlanComplete(
+        [a, b],
+        { order_id: "keep", product_id: "keep" },
+        {},
+      ),
+    ).toBe(false);
+    // A changed non-key column doesn't rescue an all-kept key.
+    expect(
+      isDuplicatePlanComplete(
+        [a, b, choice],
+        { order_id: "keep", product_id: "keep", email: "custom" },
+        { email: "x" },
+      ),
+    ).toBe(false);
   });
 });
 
@@ -343,6 +436,7 @@ describe("buildDuplicateRowPlan", () => {
     originalValue: 7,
     autoKind: "next-number",
     canBeNull: false,
+    canKeep: false,
   };
   const emailChoice: DuplicateColumnChoice = {
     name: "email",
@@ -352,6 +446,7 @@ describe("buildDuplicateRowPlan", () => {
     originalValue: "ada@example.com",
     autoKind: null,
     canBeNull: true,
+    canKeep: false,
   };
 
   it("routes an auto number to nextNumber and a typed value to overrides", () => {
@@ -375,6 +470,20 @@ describe("buildDuplicateRowPlan", () => {
       () => "unused",
     );
     expect(plan.overrides).toEqual([{ column: "id", value: 42 }]);
+  });
+
+  it("keeps an integer past 2^53 as text instead of rounding it", () => {
+    const plan = buildDuplicateRowPlan(
+      [{ ...idChoice, type: "BIGINT" }],
+      { id: "custom" },
+      { id: "9007199254740995" },
+      () => "unused",
+    );
+    // Number('9007199254740995') rounds to ...996; the engines all parse a
+    // decimal string into their own integer type, so bind the text.
+    expect(plan.overrides).toEqual([
+      { column: "id", value: "9007199254740995" },
+    ]);
   });
 
   it("mints one UUID per auto UUID column", () => {

--- a/app/_components/duckdb/DuckDbPlayground.tsx
+++ b/app/_components/duckdb/DuckDbPlayground.tsx
@@ -155,7 +155,11 @@ import { type DuckDbEngine, DUCKDB_VERSION } from "../runtime/duckdb";
 
 const DUCKDB_SAMPLE_DATABASES = duckdbAdapter.samples;
 const DUCKDB_BLANK_DATABASE = duckdbAdapter.blankSample!;
-import type { ForeignKeyInfo, TableColumnInfo } from "../runtime/sqlite";
+import type {
+  ColumnConstraintInfo,
+  ForeignKeyInfo,
+  TableColumnInfo,
+} from "../runtime/sqlite";
 import type { QueryExecResult } from "../runtime/sqlite-wasm";
 import type { QueryTab } from "../sqlitePlaygroundTabs";
 import { newTabId } from "../sqlitePlaygroundTabs";
@@ -218,6 +222,11 @@ import {
 } from "../sql/utils/persistedStorage";
 import { pushTabHistory } from "../sql/utils/tabUtils";
 import { enumHintsFromColumns } from "../sql/utils/cellEditing";
+import {
+  applyDuplicateRowPlan,
+  constraintInfoFromColumns,
+  type DuplicateRowPlan,
+} from "../sql/utils/duplicateRow";
 import { useSqlTabManagement } from "../sql/hooks/useSqlTabManagement";
 import { useViewDataTabAutoRun } from "../sql/hooks/useViewDataTabAutoRun";
 import { useSchemaTree } from "../sql/hooks/useSchemaTree";
@@ -2997,6 +3006,10 @@ function DuckDbPlaygroundInner() {
           ),
           enums: enumHintsFromColumns(cols),
         },
+        // Derived from the columns already in memory rather than a second
+        // round trip; it tells the grid which columns a duplicated row has
+        // to change.
+        constraintInfo: constraintInfoFromColumns(cols),
       };
     },
     [columnsByEntity, foreignKeysByEntity],
@@ -3016,6 +3029,13 @@ function DuckDbPlaygroundInner() {
       enums: enumHintsFromColumns(cols),
     };
   }, [result, columnsByEntity, foreignKeysByEntity]);
+
+  const resultConstraintInfo = useMemo<ColumnConstraintInfo[] | undefined>(() => {
+    const tableName = result?.sourceTable;
+    if (!tableName) return undefined;
+    const cols = columnsByEntity[tableName];
+    return cols ? constraintInfoFromColumns(cols) : undefined;
+  }, [result, columnsByEntity]);
 
   const exportResultSet = useCallback(
     async (
@@ -3204,28 +3224,53 @@ function DuckDbPlaygroundInner() {
   );
 
   const duplicateRowInTable = useCallback(
-    (tableName: string, columnNames: string[], values: unknown[]) => {
+    (
+      tableName: string,
+      columnNames: string[],
+      values: unknown[],
+      plan?: DuplicateRowPlan,
+    ) => {
       const engine = engineRef.current;
       if (!engine) return;
       const tabId = activeTabIdRef.current;
       const schema = selectedSchemaRef.current;
-      // Strip generated columns, DuckDB rejects INSERTs that target them.
-      const generatedCols = new Set(
+      // Strip generated columns and sequence-backed defaults: DuckDB rejects
+      // INSERTs that target the former, and reusing a `nextval()` value
+      // duplicate-keys.
+      const skipCols = new Set(
         (columnsByEntity[tableName] ?? [])
-          .filter((col) => col.generated !== null)
+          .filter(
+            (col) =>
+              col.generated !== null ||
+              (col.defaultValue !== null &&
+                /nextval\(/i.test(col.defaultValue)),
+          )
           .map((col) => col.name),
       );
       const filteredNames: string[] = [];
       const filteredValues: unknown[] = [];
       for (let i = 0; i < columnNames.length; i++) {
-        if (!generatedCols.has(columnNames[i])) {
+        if (!skipCols.has(columnNames[i])) {
           filteredNames.push(columnNames[i]);
           filteredValues.push(values[i]);
         }
       }
       void (async () => {
         try {
-          await engine.insertRow(tableName, filteredNames, filteredValues, schema);
+          // The duplicate dialog's answers land here: literal overrides are
+          // already decided, `MAX(col) + 1` is read off the live table.
+          const resolved = await applyDuplicateRowPlan(
+            filteredNames,
+            filteredValues,
+            plan,
+            async (column) => {
+              const res = await engine.exec(
+                `SELECT MAX(${quoteIdent(column)}) FROM ${quoteIdent(schema)}.${quoteIdent(tableName)}`,
+              );
+              return res[0]?.values?.[0]?.[0] ?? null;
+            },
+          );
+          await engine.insertRow(tableName, resolved.names, resolved.values, schema);
           showToast(`Duplicated row in "${tableName}".`);
           const sql = `SELECT * FROM ${quoteIdent(schema)}.${quoteIdent(tableName)};`;
           void runSqlForTab(tabId, sql, `Table: ${tableName}`, tableName);
@@ -5860,6 +5905,7 @@ function DuckDbPlaygroundInner() {
                 engineLabel="DuckDB"
                 keyHints={resultKeyHints}
                 sourceTable={result?.sourceTable}
+                constraintInfo={resultConstraintInfo}
                 tableMetaFor={tableMetaFor}
                 onDeleteRows={deleteRowsFromTable}
                 onUpdateRows={updateRowsInTable}

--- a/app/_components/home/HomeNav.tsx
+++ b/app/_components/home/HomeNav.tsx
@@ -9,6 +9,7 @@ import {
   LogIn,
   LogOut,
   Menu as Hamburger,
+  Shield,
   SquareTerminal,
   Tag,
   User as UserIcon,
@@ -195,6 +196,12 @@ function MobileAuthSection() {
     );
   }
 
+  // Config-listed admins get `role` promoted at sign-in (lib/auth/server.ts),
+  // so this covers them too; the dashboard's own actions are server-enforced,
+  // and a non-admin who reaches /dashboard/admin just gets the access-denied
+  // card. Same check and same placement as the desktop account menu.
+  const isAdmin = session.user.role === "admin";
+
   return (
     <>
       <div className="px-3 py-1.5 text-xs text-[var(--ds-gray-500)]">
@@ -210,6 +217,15 @@ function MobileAuthSection() {
         <UserIcon size={16} />
         Account
       </Dialog.Close>
+      {isAdmin && (
+        <Dialog.Close
+          render={<Link href="/dashboard/admin" prefetch={false} />}
+          className={rowClass}
+        >
+          <Shield size={16} />
+          Admin
+        </Dialog.Close>
+      )}
       <button
         type="button"
         onClick={() => {

--- a/app/_components/postgres/PostgresPlayground.tsx
+++ b/app/_components/postgres/PostgresPlayground.tsx
@@ -149,7 +149,11 @@ import { type PgEntityKind, type PostgresEngine } from "../runtime/postgres";
 
 const POSTGRES_SAMPLE_DATABASES = postgresAdapter.samples;
 const POSTGRES_BLANK_DATABASE = postgresAdapter.blankSample!;
-import type { ForeignKeyInfo, TableColumnInfo } from "../runtime/sqlite";
+import type {
+  ColumnConstraintInfo,
+  ForeignKeyInfo,
+  TableColumnInfo,
+} from "../runtime/sqlite";
 import type { QueryExecResult } from "../runtime/sqlite-wasm";
 import type { QueryTab } from "../sqlitePlaygroundTabs";
 import { newTabId } from "../sqlitePlaygroundTabs";
@@ -215,6 +219,11 @@ import {
 } from "../sql/utils/persistedStorage";
 import { pushTabHistory } from "../sql/utils/tabUtils";
 import { enumHintsFromColumns } from "../sql/utils/cellEditing";
+import {
+  applyDuplicateRowPlan,
+  constraintInfoFromColumns,
+  type DuplicateRowPlan,
+} from "../sql/utils/duplicateRow";
 import { useSqlTabManagement } from "../sql/hooks/useSqlTabManagement";
 import { useViewDataTabAutoRun } from "../sql/hooks/useViewDataTabAutoRun";
 import { useSchemaTree } from "../sql/hooks/useSchemaTree";
@@ -2798,6 +2807,10 @@ function PostgresPlaygroundInner() {
           ),
           enums: enumHintsFromColumns(cols),
         },
+        // Derived from the columns already in memory rather than a second
+        // round trip; it tells the grid which columns a duplicated row has
+        // to change.
+        constraintInfo: constraintInfoFromColumns(cols),
       };
     },
     [columnsByEntity, foreignKeysByEntity],
@@ -2817,6 +2830,13 @@ function PostgresPlaygroundInner() {
       enums: enumHintsFromColumns(cols),
     };
   }, [result, columnsByEntity, foreignKeysByEntity]);
+
+  const resultConstraintInfo = useMemo<ColumnConstraintInfo[] | undefined>(() => {
+    const tableName = result?.sourceTable;
+    if (!tableName) return undefined;
+    const cols = columnsByEntity[tableName];
+    return cols ? constraintInfoFromColumns(cols) : undefined;
+  }, [result, columnsByEntity]);
 
   const exportResultSet = useCallback(
     async (
@@ -3004,19 +3024,25 @@ function PostgresPlaygroundInner() {
   );
 
   const duplicateRowInTable = useCallback(
-    (tableName: string, columnNames: string[], values: unknown[]) => {
+    (
+      tableName: string,
+      columnNames: string[],
+      values: unknown[],
+      plan?: DuplicateRowPlan,
+    ) => {
       const engine = engineRef.current;
       if (!engine) return;
       const tabId = activeTabIdRef.current;
       const schema = selectedSchemaRef.current;
-      // Exclude generated columns and serial/sequence columns, PostgreSQL
-      // forbids explicit values for GENERATED ALWAYS columns and nextval()
-      // PKs will duplicate-key on reuse.
+      // Exclude generated columns and serial / IDENTITY columns: PostgreSQL
+      // forbids explicit values for GENERATED ALWAYS columns, and reusing a
+      // sequence-backed value duplicate-keys.
       const skipCols = new Set(
         (columnsByEntity[tableName] ?? [])
           .filter(
             (col) =>
               col.generated !== null ||
+              col.identity === true ||
               (col.defaultValue !== null &&
                 /nextval\(/i.test(col.defaultValue)),
           )
@@ -3032,7 +3058,20 @@ function PostgresPlaygroundInner() {
       }
       void (async () => {
         try {
-          await engine.insertRow(tableName, filteredNames, filteredValues, schema);
+          // The duplicate dialog's answers land here: literal overrides are
+          // already decided, `MAX(col) + 1` is read off the live table.
+          const resolved = await applyDuplicateRowPlan(
+            filteredNames,
+            filteredValues,
+            plan,
+            async (column) => {
+              const res = await engine.exec(
+                `SELECT MAX(${quoteIdent(column)}) FROM ${quoteIdent(schema)}.${quoteIdent(tableName)}`,
+              );
+              return res[0]?.values?.[0]?.[0] ?? null;
+            },
+          );
+          await engine.insertRow(tableName, resolved.names, resolved.values, schema);
           showToast(`Duplicated row in "${tableName}".`);
           const sql = `SELECT * FROM ${quoteIdent(schema)}.${quoteIdent(tableName)};`;
           void runSqlForTab(tabId, sql, `Table: ${tableName}`, tableName);
@@ -5758,6 +5797,7 @@ function PostgresPlaygroundInner() {
                 engineLabel="PostgreSQL"
                 keyHints={resultKeyHints}
                 sourceTable={result?.sourceTable}
+                constraintInfo={resultConstraintInfo}
                 tableMetaFor={tableMetaFor}
                 onDeleteRows={deleteRowsFromTable}
                 onUpdateRows={updateRowsInTable}

--- a/app/_components/runtime/duckdb.ts
+++ b/app/_components/runtime/duckdb.ts
@@ -18,6 +18,7 @@ import {
   type DuckDbSampleDatabase,
 } from "./duckdbSamples";
 import { datasetFileName, fetchDatasetBytes, fetchDatasetText } from "./remoteDatasets";
+import { defaultGeneratesUniqueValue } from "../sql/utils/duplicateRow";
 import {
   toDateOnlyString,
   toTimestampString,
@@ -250,6 +251,25 @@ export function toDuckDbListLiteral(arr: readonly unknown[]): string {
     return `'${String(v).replace(/'/g, "''")}'`;
   };
   return `[${arr.map(elem).join(", ")}]`;
+}
+
+/** Normalise `duckdb_constraints().constraint_column_names` (VARCHAR[]),
+ *  which may arrive as a JS array, an Arrow Vector (iterable, but not
+ *  `Array.isArray`), or a stringified list with quoted elements. */
+export function parseConstraintColumnNames(value: unknown): string[] {
+  let raw: unknown[] = [];
+  if (Array.isArray(value)) raw = value;
+  else if (typeof value === "string")
+    raw = value.replace(/^\[|\]$/g, "").split(/,\s*/);
+  else if (
+    value != null &&
+    typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] ===
+      "function"
+  )
+    raw = Array.from(value as Iterable<unknown>);
+  return raw
+    .map((x) => String(x).trim().replace(/^["']|["']$/g, ""))
+    .filter(Boolean);
 }
 
 /** Parse the labels out of a DuckDB enum `data_type` string, e.g.
@@ -1366,34 +1386,24 @@ export async function createDuckDbEngine(
          WHERE schema_name = '${safeSch}' AND table_name = '${safe}'
          ORDER BY column_index`,
       );
-      // PK columns come from duckdb_constraints, not a per-column flag.
-      const pkRows = await rowsFor(
-        `SELECT constraint_column_names
+      // PK and UNIQUE columns come from duckdb_constraints, not per-column
+      // flags. One query covers both, so `unique` costs no extra round trip.
+      const constraintRows = await rowsFor(
+        `SELECT constraint_type, constraint_column_names
          FROM duckdb_constraints()
          WHERE schema_name = '${safeSch}'
            AND table_name = '${safe}'
-           AND constraint_type = 'PRIMARY KEY'
-         LIMIT 1`,
+           AND constraint_type IN ('PRIMARY KEY', 'UNIQUE')`,
       );
-      const pkCols: string[] = (() => {
-        const v = pkRows[0]?.[0];
-        // `constraint_column_names` (VARCHAR[]) may arrive as a JS array, an
-        // Arrow Vector (iterable, not Array.isArray), or a stringified list
-        // with quoted elements. Normalise all three.
-        let raw: unknown[] = [];
-        if (Array.isArray(v)) raw = v;
-        else if (typeof v === "string")
-          raw = v.replace(/^\[|\]$/g, "").split(/,\s*/);
-        else if (
-          v != null &&
-          typeof (v as { [Symbol.iterator]?: unknown })[Symbol.iterator] ===
-            "function"
-        )
-          raw = Array.from(v as Iterable<unknown>);
-        return raw
-          .map((x) => String(x).trim().replace(/^["']|["']$/g, ""))
-          .filter(Boolean);
-      })();
+      const pkRow = constraintRows.find(
+        (row) => String(row[0]).toUpperCase() === "PRIMARY KEY",
+      );
+      const pkCols = parseConstraintColumnNames(pkRow?.[1]);
+      const uniqueCols = new Set(
+        constraintRows
+          .filter((row) => String(row[0]).toUpperCase() === "UNIQUE")
+          .flatMap((row) => parseConstraintColumnNames(row[1])),
+      );
       return rows.map((row) => {
         const colName = String(row[1]);
         const pkIndex = pkCols.indexOf(colName);
@@ -1412,6 +1422,7 @@ export async function createDuckDbEngine(
             ? { expression: "", storageType: "STORED" as const }
             : null,
           enumValues: parseDuckDbEnumValues(dataType),
+          unique: uniqueCols.has(colName),
         };
       });
     },
@@ -1453,34 +1464,25 @@ export async function createDuckDbEngine(
     },
 
     async getColumnConstraintInfo(tableName, schema = "main") {
+      // `listColumns` already resolves the UNIQUE columns from
+      // duckdb_constraints, so this needs no query of its own.
       const cols = await engine.listColumns(tableName, schema);
-      const safe = tableName.replace(/'/g, "''");
-      const safeSch = schema.replace(/'/g, "''");
-      const uniqueRows = await rowsFor(
-        `SELECT constraint_column_names
-         FROM duckdb_constraints()
-         WHERE schema_name = '${safeSch}'
-           AND table_name = '${safe}'
-           AND constraint_type = 'UNIQUE'`,
-      );
-      const unique = new Set<string>();
-      for (const row of uniqueRows) {
-        const v = row[0];
-        if (Array.isArray(v)) v.forEach((x) => unique.add(String(x)));
-        else if (typeof v === "string")
-          v.replace(/^\[|\]$/g, "")
-            .split(/,\s*/)
-            .filter(Boolean)
-            .forEach((x) => unique.add(x));
-      }
-      return cols.map((col) => ({
-        name: col.name,
-        isPrimaryKey: col.pk > 0,
-        isAutoIncrement:
+      return cols.map((col) => {
+        const isAutoIncrement =
           /nextval\(/i.test(col.defaultValue ?? "") ||
-          /^GENERATED\b/i.test(col.defaultValue ?? ""),
-        isUnique: unique.has(col.name),
-      }));
+          /^GENERATED\b/i.test(col.defaultValue ?? "");
+        return {
+          name: col.name,
+          isPrimaryKey: col.pk > 0,
+          isAutoIncrement,
+          isUnique: col.unique === true,
+          autoPopulated:
+            isAutoIncrement || defaultGeneratesUniqueValue(col.defaultValue),
+          type: col.type,
+          notNull: col.notNull,
+          defaultValue: col.defaultValue,
+        };
+      });
     },
 
     async createTable(name, columns) {

--- a/app/_components/runtime/duckdb.ts
+++ b/app/_components/runtime/duckdb.ts
@@ -18,7 +18,7 @@ import {
   type DuckDbSampleDatabase,
 } from "./duckdbSamples";
 import { datasetFileName, fetchDatasetBytes, fetchDatasetText } from "./remoteDatasets";
-import { defaultGeneratesUniqueValue } from "../sql/utils/duplicateRow";
+import { constraintInfoFromColumns } from "../sql/utils/duplicateRow";
 import {
   toDateOnlyString,
   toTimestampString,
@@ -1464,25 +1464,13 @@ export async function createDuckDbEngine(
     },
 
     async getColumnConstraintInfo(tableName, schema = "main") {
-      // `listColumns` already resolves the UNIQUE columns from
-      // duckdb_constraints, so this needs no query of its own.
-      const cols = await engine.listColumns(tableName, schema);
-      return cols.map((col) => {
-        const isAutoIncrement =
-          /nextval\(/i.test(col.defaultValue ?? "") ||
-          /^GENERATED\b/i.test(col.defaultValue ?? "");
-        return {
-          name: col.name,
-          isPrimaryKey: col.pk > 0,
-          isAutoIncrement,
-          isUnique: col.unique === true,
-          autoPopulated:
-            isAutoIncrement || defaultGeneratesUniqueValue(col.defaultValue),
-          type: col.type,
-          notNull: col.notNull,
-          defaultValue: col.defaultValue,
-        };
-      });
+      // `listColumns` already resolves PK and UNIQUE membership from
+      // duckdb_constraints, so the shared column→constraint mapping (also
+      // used by the playground's in-memory path) is all this needs — one
+      // implementation, no drift between the two.
+      return constraintInfoFromColumns(
+        await engine.listColumns(tableName, schema),
+      );
     },
 
     async createTable(name, columns) {

--- a/app/_components/runtime/postgres.ts
+++ b/app/_components/runtime/postgres.ts
@@ -22,6 +22,7 @@ import {
 } from "./postgresSamples";
 import { PGLITE_WORKER_CDN } from "./cdn";
 import { topoSortByForeignKeys } from "../sql/utils/exportOrder";
+import { defaultGeneratesUniqueValue } from "../sql/utils/duplicateRow";
 import { fetchDatasetText } from "./remoteDatasets";
 import {
   toDateOnlyString,
@@ -814,6 +815,7 @@ export async function createPostgresEngine(
         column_default: string | null;
         is_generated: string;
         generation_expression: string | null;
+        is_identity: string;
         udt_name: string;
         pk_position: number | null;
       }>(
@@ -827,6 +829,7 @@ export async function createPostgresEngine(
           c.column_default,
           c.is_generated,
           c.generation_expression,
+          c.is_identity,
           c.udt_name,
           kcu.ordinal_position AS pk_position
         FROM information_schema.columns c
@@ -915,6 +918,7 @@ export async function createPostgresEngine(
             ? (enumByType.get(row.udt_name) ?? null)
             : null,
         unique: uniqueColumns.has(row.column_name),
+        identity: row.is_identity === "YES",
       }));
     },
 
@@ -975,14 +979,24 @@ export async function createPostgresEngine(
         [tableName, schema],
       );
       const unique = new Set(uniqueRows.map((row) => row.column_name));
-      return cols.map((col) => ({
-        name: col.name,
-        isPrimaryKey: col.pk > 0,
-        isAutoIncrement: /^nextval\('([^']+)'::regclass\)$/i.test(
-          col.defaultValue ?? "",
-        ),
-        isUnique: unique.has(col.name),
-      }));
+      return cols.map((col) => {
+        // serial/bigserial columns carry a nextval() default; IDENTITY
+        // columns carry none but are assigned all the same.
+        const isAutoIncrement =
+          col.identity === true ||
+          /^nextval\('([^']+)'::regclass\)$/i.test(col.defaultValue ?? "");
+        return {
+          name: col.name,
+          isPrimaryKey: col.pk > 0,
+          isAutoIncrement,
+          isUnique: unique.has(col.name),
+          autoPopulated:
+            isAutoIncrement || defaultGeneratesUniqueValue(col.defaultValue),
+          type: col.type,
+          notNull: col.notNull,
+          defaultValue: col.defaultValue,
+        };
+      });
     },
 
     async createTable(name, columns, schema = "public") {

--- a/app/_components/runtime/sqlite-core.ts
+++ b/app/_components/runtime/sqlite-core.ts
@@ -21,6 +21,10 @@ import {
   type SqliteSampleMetadata,
 } from "./sqliteSamples";
 import { fetchDatasetBytes, fetchDatasetText } from "./remoteDatasets";
+import {
+  defaultGeneratesUniqueValue,
+  isSqliteRowidAlias,
+} from "../sql/utils/duplicateRow";
 
 export type { QueryExecResult } from "./sqlite-wasm";
 
@@ -69,10 +73,14 @@ export interface TableColumnInfo {
    *  SQLite, which has no native enum type. Drives the grid's enum dropdown. */
   enumValues?: string[] | null;
   /** Covered by a single-column UNIQUE constraint (separate from the primary
-   *  key). Reported by Postgres; absent where the engine doesn't supply it.
-   *  A foreign key can only target a PK or unique column, so the structure
-   *  editor uses this to filter the target-column list. */
+   *  key). Reported by Postgres and DuckDB; absent where the engine doesn't
+   *  supply it. A foreign key can only target a PK or unique column, so the
+   *  structure editor uses this to filter the target-column list. */
   unique?: boolean;
+  /** Postgres `GENERATED ... AS IDENTITY` column. The database assigns the
+   *  value, so an INSERT that omits the column still succeeds — which is
+   *  what lets a row with an identity primary key be duplicated. */
+  identity?: boolean;
 }
 
 /** Per-column unique/PK constraint info, used to decide whether a row can
@@ -85,6 +93,20 @@ export interface ColumnConstraintInfo {
   isAutoIncrement: boolean;
   /** Explicit UNIQUE constraint (separate from the primary key). */
   isUnique: boolean;
+  /** The database mints a fresh, distinct value whenever an INSERT leaves
+   *  this column out: AUTOINCREMENT, a SQLite rowid alias, a serial /
+   *  IDENTITY column, or a UUID-generating DEFAULT. A superset of
+   *  `isAutoIncrement`, and the flag that decides whether a unique column
+   *  blocks a row duplicate at all. */
+  autoPopulated?: boolean;
+  /** Declared type, when the engine reports one. Lets the duplicate-row
+   *  dialog pick a sensible generated value (a number vs a UUID). */
+  type?: string;
+  /** True when the column rejects NULL, so the dialog knows whether "Set to
+   *  NULL" is a legal way out of a unique conflict. */
+  notNull?: boolean;
+  /** Column default as the engine reports it, when it reports one. */
+  defaultValue?: string | null;
 }
 
 /** One column-level foreign key, from `PRAGMA foreign_key_list(...)`. */
@@ -1404,10 +1426,19 @@ export async function createSqliteEngineInProcess(
       const tableInfoResult = execAll(d, 
         `PRAGMA table_info(${quoteIdent(tableName)})`,
       );
-      const cols: Array<{ name: string; pk: number }> =
+      const cols: Array<{
+        name: string;
+        type: string;
+        notNull: boolean;
+        defaultValue: string | null;
+        pk: number;
+      }> =
         tableInfoResult.length > 0
           ? tableInfoResult[0].values.map((row) => ({
               name: String(row[1]),
+              type: row[2] == null ? "" : String(row[2]),
+              notNull: Number(row[3]) === 1,
+              defaultValue: row[4] == null ? null : String(row[4]),
               pk: Number(row[5]),
             }))
           : [];
@@ -1452,17 +1483,39 @@ export async function createSqliteEngineInProcess(
           }
         }
       }
-      return cols.map((c) => ({
-        name: c.name,
-        isPrimaryKey: c.pk > 0,
+      // A WITHOUT ROWID table has no rowid to alias, so its INTEGER PRIMARY
+      // KEY is an ordinary column the INSERT must supply.
+      const withoutRowid = /\bwithout\s+rowid\b/i.test(ddlText);
+      const singleColumnPk = cols.filter((col) => col.pk > 0).length === 1;
+      return cols.map((c) => {
         // SQLite forbids AUTOINCREMENT on composite PKs, so require a
         // single-column PK before flagging.
-        isAutoIncrement:
-          hasAutoIncrement &&
-          c.pk === 1 &&
-          cols.filter((col) => col.pk > 0).length === 1,
-        isUnique: uniqueColNames.has(c.name),
-      }));
+        const isAutoIncrement =
+          hasAutoIncrement && c.pk === 1 && singleColumnPk;
+        // A rowid alias is assigned by SQLite when the INSERT omits it,
+        // AUTOINCREMENT keyword or not. Treating it as a hard conflict is
+        // what used to make "Duplicate row" refuse the most ordinary schema
+        // there is.
+        const isRowidAlias = isSqliteRowidAlias({
+          type: c.type,
+          pk: c.pk,
+          singleColumnPk,
+          withoutRowid,
+        });
+        return {
+          name: c.name,
+          isPrimaryKey: c.pk > 0,
+          isAutoIncrement,
+          isUnique: uniqueColNames.has(c.name),
+          autoPopulated:
+            isAutoIncrement ||
+            isRowidAlias ||
+            defaultGeneratesUniqueValue(c.defaultValue),
+          type: c.type,
+          notNull: c.notNull,
+          defaultValue: c.defaultValue,
+        };
+      });
     },
     insertRow(
       tableName: string,

--- a/app/_components/runtime/sqlite-core.ts
+++ b/app/_components/runtime/sqlite-core.ts
@@ -1459,8 +1459,11 @@ export async function createSqliteEngineInProcess(
         ddlStmt.finalize();
       }
       const hasAutoIncrement = /\bautoincrement\b/i.test(ddlText);
-      // origin = 'u' in index_list means an explicit UNIQUE clause.
+      // origin = 'u' in index_list means an explicit UNIQUE clause; an
+      // origin = 'pk' row means the primary key needed a real index, which a
+      // rowid alias never does (see isSqliteRowidAlias).
       const uniqueColNames = new Set<string>();
+      let hasPkIndex = false;
       const idxListResult = execAll(d, 
         `PRAGMA index_list(${quoteIdent(tableName)})`,
       );
@@ -1469,6 +1472,7 @@ export async function createSqliteEngineInProcess(
           // index_list columns: seq, name, unique, origin, partial
           const isUnique = Number(row[2]) === 1;
           const origin = String(row[3]);
+          if (origin === "pk") hasPkIndex = true;
           if (isUnique && origin === "u") {
             const idxName = String(row[1]);
             const idxInfoResult = execAll(d, 
@@ -1484,8 +1488,13 @@ export async function createSqliteEngineInProcess(
         }
       }
       // A WITHOUT ROWID table has no rowid to alias, so its INTEGER PRIMARY
-      // KEY is an ordinary column the INSERT must supply.
-      const withoutRowid = /\bwithout\s+rowid\b/i.test(ddlText);
+      // KEY is an ordinary column the INSERT must supply. The clause can only
+      // sit among the table options after the column list's closing paren
+      // (the last ')' in the statement), so only that tail is tested — a
+      // CHECK or string literal containing the phrase must not count.
+      const withoutRowid = /\bwithout\s+rowid\b/i.test(
+        ddlText.slice(ddlText.lastIndexOf(")") + 1),
+      );
       const singleColumnPk = cols.filter((col) => col.pk > 0).length === 1;
       return cols.map((c) => {
         // SQLite forbids AUTOINCREMENT on composite PKs, so require a
@@ -1501,6 +1510,7 @@ export async function createSqliteEngineInProcess(
           pk: c.pk,
           singleColumnPk,
           withoutRowid,
+          hasPkIndex,
         });
         return {
           name: c.name,

--- a/app/_components/sql/components/DuplicateRowDialog.tsx
+++ b/app/_components/sql/components/DuplicateRowDialog.tsx
@@ -69,8 +69,12 @@ export function DuplicateRowDialog({
   // another row never shows the previous row's answers.
   if (request !== seed) {
     setSeed(request);
-    const nextStrategies: Record<string, DuplicateStrategy> = {};
-    const nextText: Record<string, string> = {};
+    // Null-prototype seeds: a column literally named "__proto__" would
+    // otherwise vanish into the prototype setter here. The spreads in the
+    // update paths use computed keys, which always define own properties.
+    const nextStrategies: Record<string, DuplicateStrategy> =
+      Object.create(null);
+    const nextText: Record<string, string> = Object.create(null);
     for (const choice of request?.choices ?? []) {
       nextStrategies[choice.name] = defaultDuplicateStrategy(choice);
       // No UUID is minted here: `newUuid()` is random, and render stays pure.
@@ -209,20 +213,22 @@ export function DuplicateRowDialog({
                         </span>
                       </label>
                     )}
-                    <label className="sql-duplicate-option">
-                      <input
-                        type="radio"
-                        name={radioName}
-                        checked={strategy === "keep"}
-                        onChange={() => selectStrategy(choice, "keep")}
-                      />
-                      <span className="sql-duplicate-option-text">
-                        <span>Keep original</span>
-                        <span className="sql-duplicate-option-hint">
-                          Only works if another column changes
+                    {choice.canKeep && (
+                      <label className="sql-duplicate-option">
+                        <input
+                          type="radio"
+                          name={radioName}
+                          checked={strategy === "keep"}
+                          onChange={() => selectStrategy(choice, "keep")}
+                        />
+                        <span className="sql-duplicate-option-text">
+                          <span>Keep original</span>
+                          <span className="sql-duplicate-option-hint">
+                            Only works if another key column changes
+                          </span>
                         </span>
-                      </span>
-                    </label>
+                      </label>
+                    )}
                   </div>
                   {strategy === "custom" && (
                     <input
@@ -245,12 +251,13 @@ export function DuplicateRowDialog({
           </div>
           {!complete && (
             <p className="confirm-desc sql-duplicate-warning">
-              {choices.every(
+              {choices.some(
                 (c) =>
-                  (strategies[c.name] ?? defaultDuplicateStrategy(c)) === "keep",
+                  (strategies[c.name] ?? defaultDuplicateStrategy(c)) ===
+                    "custom" && !(customText[c.name] ?? ""),
               )
-                ? "At least one column has to change, or the copy collides with the row it came from."
-                : "Fill in every custom value, or pick another option for it."}
+                ? "Fill in every custom value, or pick another option for it."
+                : "At least one key column has to change, or the copy collides with the row it came from."}
             </p>
           )}
           <div className="confirm-actions">

--- a/app/_components/sql/components/DuplicateRowDialog.tsx
+++ b/app/_components/sql/components/DuplicateRowDialog.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog } from "@base-ui/react/dialog";
+import { X } from "lucide-react";
+import { formatCellDisplay } from "../utils/cellUtils";
+import {
+  buildDuplicateRowPlan,
+  defaultDuplicateStrategy,
+  isDuplicatePlanComplete,
+  newUuid,
+  suggestDuplicateText,
+  type DuplicateColumnChoice,
+  type DuplicateRowPlan,
+  type DuplicateStrategy,
+} from "../utils/duplicateRow";
+
+/** The row a duplicate was asked for, plus the columns that stop it being
+ *  copied verbatim. `null` closes the dialog. */
+export interface DuplicateRowRequest {
+  tableName: string;
+  /** Columns the INSERT will carry (auto-populated ones already dropped). */
+  columns: string[];
+  /** Values copied from the source row, aligned with `columns`. */
+  values: unknown[];
+  /** The subset of `columns` under a primary-key / UNIQUE constraint the
+   *  database won't re-generate. Never empty: with no conflicts the grid
+   *  duplicates the row outright and never opens this dialog. */
+  choices: DuplicateColumnChoice[];
+}
+
+export interface DuplicateRowDialogProps {
+  request: DuplicateRowRequest | null;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (request: DuplicateRowRequest, plan: DuplicateRowPlan) => void;
+}
+
+/** Label for the "Auto" option, which differs by what can be generated. */
+function autoLabel(choice: DuplicateColumnChoice): string {
+  return choice.autoKind === "uuid" ? "New UUID" : "Next available number";
+}
+
+function autoHint(choice: DuplicateColumnChoice): string {
+  return choice.autoKind === "uuid"
+    ? "Generated in the browser"
+    : `MAX(${choice.name}) + 1, read when the row is inserted`;
+}
+
+/**
+ * "Duplicate row" for a table whose primary key or UNIQUE columns can't be
+ * copied as they are. Each conflicting column gets its own answer: generate
+ * one (a fresh UUID, the next number), type one, clear it to NULL where the
+ * column allows it, or — for a composite key, where moving one member is
+ * enough — keep the original.
+ */
+export function DuplicateRowDialog({
+  request,
+  onOpenChange,
+  onConfirm,
+}: DuplicateRowDialogProps) {
+  const [seed, setSeed] = useState<DuplicateRowRequest | null>(null);
+  const [strategies, setStrategies] = useState<
+    Record<string, DuplicateStrategy>
+  >({});
+  const [customText, setCustomText] = useState<Record<string, string>>({});
+
+  // Seed the form during the render that opens the dialog (the "adjust state
+  // when a prop changes" pattern — in render, not an effect), so reopening on
+  // another row never shows the previous row's answers.
+  if (request !== seed) {
+    setSeed(request);
+    const nextStrategies: Record<string, DuplicateStrategy> = {};
+    const nextText: Record<string, string> = {};
+    for (const choice of request?.choices ?? []) {
+      nextStrategies[choice.name] = defaultDuplicateStrategy(choice);
+      // No UUID is minted here: `newUuid()` is random, and render stays pure.
+      // A UUID column that starts on "Auto" gets one when it is inserted;
+      // switching it to "Custom value" fills the field in below.
+      nextText[choice.name] = suggestDuplicateText(choice, "");
+    }
+    setStrategies(nextStrategies);
+    setCustomText(nextText);
+  }
+
+  const choices = request?.choices ?? [];
+  const complete = isDuplicatePlanComplete(choices, strategies, customText);
+
+  function selectStrategy(
+    choice: DuplicateColumnChoice,
+    strategy: DuplicateStrategy,
+  ) {
+    setStrategies((prev) => ({ ...prev, [choice.name]: strategy }));
+    // Switching a UUID column to a typed value hands the user a fresh one to
+    // start from rather than an empty box they have to invent a UUID for.
+    if (strategy === "custom" && choice.autoKind === "uuid") {
+      setCustomText((prev) =>
+        prev[choice.name] ? prev : { ...prev, [choice.name]: newUuid() },
+      );
+    }
+  }
+
+  function handleConfirm() {
+    if (!request || !complete) return;
+    onConfirm(
+      request,
+      buildDuplicateRowPlan(choices, strategies, customText, newUuid),
+    );
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog.Root
+      open={request !== null}
+      onOpenChange={(next) => {
+        if (!next) onOpenChange(false);
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className="confirm-backdrop" />
+        <Dialog.Popup className="confirm-popup sql-duplicate-popup">
+          <div className="sql-create-header">
+            <Dialog.Title className="confirm-title">Duplicate row</Dialog.Title>
+            <Dialog.Close
+              className="sql-modify-drawer-close"
+              aria-label="Close"
+            >
+              <X size={16} aria-hidden="true" />
+            </Dialog.Close>
+          </div>
+          <Dialog.Description className="confirm-desc sql-duplicate-desc">
+            {choices.length === 1
+              ? "One column in "
+              : `${choices.length} columns in `}
+            <strong>{request?.tableName}</strong>
+            {choices.length === 1
+              ? " has to stay unique, so the copy needs its own value."
+              : " have to stay unique, so the copy needs its own values."}
+          </Dialog.Description>
+          <div className="sql-create-body sql-duplicate-body">
+            {choices.map((choice) => {
+              const strategy =
+                strategies[choice.name] ?? defaultDuplicateStrategy(choice);
+              const radioName = `sql-duplicate-${choice.name}`;
+              return (
+                <div key={choice.name} className="sql-duplicate-col">
+                  <div className="sql-duplicate-col-head">
+                    <span className="sql-duplicate-col-name">
+                      {choice.name}
+                    </span>
+                    {choice.isPrimaryKey && (
+                      <span className="sql-duplicate-badge">PRIMARY KEY</span>
+                    )}
+                    {choice.isUnique && (
+                      <span className="sql-duplicate-badge">UNIQUE</span>
+                    )}
+                    {choice.type && (
+                      <span className="sql-duplicate-type">{choice.type}</span>
+                    )}
+                  </div>
+                  <div className="sql-duplicate-current">
+                    Current value:{" "}
+                    <code>{formatCellDisplay(choice.originalValue)}</code>
+                  </div>
+                  <div
+                    className="sql-duplicate-options"
+                    role="radiogroup"
+                    aria-label={`New value for ${choice.name}`}
+                  >
+                    {choice.autoKind !== null && (
+                      <label className="sql-duplicate-option">
+                        <input
+                          type="radio"
+                          name={radioName}
+                          checked={strategy === "auto"}
+                          onChange={() => selectStrategy(choice, "auto")}
+                        />
+                        <span className="sql-duplicate-option-text">
+                          <span>{autoLabel(choice)}</span>
+                          <span className="sql-duplicate-option-hint">
+                            {autoHint(choice)}
+                          </span>
+                        </span>
+                      </label>
+                    )}
+                    <label className="sql-duplicate-option">
+                      <input
+                        type="radio"
+                        name={radioName}
+                        checked={strategy === "custom"}
+                        onChange={() => selectStrategy(choice, "custom")}
+                      />
+                      <span className="sql-duplicate-option-text">
+                        <span>Custom value</span>
+                      </span>
+                    </label>
+                    {choice.canBeNull && (
+                      <label className="sql-duplicate-option">
+                        <input
+                          type="radio"
+                          name={radioName}
+                          checked={strategy === "null"}
+                          onChange={() => selectStrategy(choice, "null")}
+                        />
+                        <span className="sql-duplicate-option-text">
+                          <span>Set to NULL</span>
+                          <span className="sql-duplicate-option-hint">
+                            NULLs never collide in a unique index
+                          </span>
+                        </span>
+                      </label>
+                    )}
+                    <label className="sql-duplicate-option">
+                      <input
+                        type="radio"
+                        name={radioName}
+                        checked={strategy === "keep"}
+                        onChange={() => selectStrategy(choice, "keep")}
+                      />
+                      <span className="sql-duplicate-option-text">
+                        <span>Keep original</span>
+                        <span className="sql-duplicate-option-hint">
+                          Only works if another column changes
+                        </span>
+                      </span>
+                    </label>
+                  </div>
+                  {strategy === "custom" && (
+                    <input
+                      className="sql-create-input sql-duplicate-input"
+                      value={customText[choice.name] ?? ""}
+                      onChange={(e) =>
+                        setCustomText((prev) => ({
+                          ...prev,
+                          [choice.name]: e.target.value,
+                        }))
+                      }
+                      spellCheck={false}
+                      placeholder={`New ${choice.name}`}
+                      aria-label={`Custom value for ${choice.name}`}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          {!complete && (
+            <p className="confirm-desc sql-duplicate-warning">
+              {choices.every(
+                (c) =>
+                  (strategies[c.name] ?? defaultDuplicateStrategy(c)) === "keep",
+              )
+                ? "At least one column has to change, or the copy collides with the row it came from."
+                : "Fill in every custom value, or pick another option for it."}
+            </p>
+          )}
+          <div className="confirm-actions">
+            <Dialog.Close className="confirm-btn confirm-btn-secondary">
+              Cancel
+            </Dialog.Close>
+            <button
+              type="button"
+              className="confirm-btn confirm-btn-primary"
+              onClick={handleConfirm}
+              disabled={!complete}
+            >
+              Duplicate row
+            </button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/app/_components/sql/components/ResultView.tsx
+++ b/app/_components/sql/components/ResultView.tsx
@@ -68,6 +68,15 @@ import type {
   PendingEditsByResult,
 } from "../types";
 import type { ColumnConstraintInfo } from "../../runtime/sqlite";
+import {
+  conflictingDuplicateColumns,
+  duplicateInsertColumns,
+  type DuplicateRowPlan,
+} from "../utils/duplicateRow";
+import {
+  DuplicateRowDialog,
+  type DuplicateRowRequest,
+} from "./DuplicateRowDialog";
 
 /** TanStack Table v9 feature set: only sorting is opted in. `manualSorting`
  *  stays on at the call site (ordering happens upstream against the full
@@ -751,6 +760,9 @@ function ResultViewImpl({
     tableName: string,
     columnNames: string[],
     values: unknown[],
+    /** Present when the user answered the duplicate dialog: how the columns
+     *  under a unique constraint should differ from the copied row. */
+    plan?: DuplicateRowPlan,
   ) => void;
   globalPageSize: number;
   onSetGlobalPageSize: (n: number) => void;
@@ -1936,8 +1948,8 @@ function ResultViewImpl({
                   }
                   onDuplicateRow={
                     sourceTable && onDuplicateRow
-                      ? (columnNames, values) =>
-                          onDuplicateRow(sourceTable, columnNames, values)
+                      ? (columnNames, values, plan) =>
+                          onDuplicateRow(sourceTable, columnNames, values, plan)
                       : undefined
                   }
                   // Virtualize above VIRTUALIZE_ROW_THRESHOLD rows; infinite
@@ -2340,7 +2352,11 @@ export function ResultTableBody({
   onClearPendingEdit: (cellKey: string) => void;
   onSetActiveEditCell: (cellKey: string | null) => void;
   onDeleteSingleRow?: (absoluteRow: number) => void;
-  onDuplicateRow?: (columnNames: string[], values: unknown[]) => void;
+  onDuplicateRow?: (
+    columnNames: string[],
+    values: unknown[],
+    plan?: DuplicateRowPlan,
+  ) => void;
   virtualized?: boolean;
   scrollParentRef?: React.RefObject<HTMLDivElement | null>;
   hasMoreRows?: boolean;
@@ -2371,6 +2387,12 @@ export function ResultTableBody({
   } | null>(null);
   // Validation message for the edit-in-modal dialog (e.g. invalid JSON).
   const [modalError, setModalError] = useState<string | null>(null);
+
+  // Set when "Duplicate row" is asked for on a row whose primary key or
+  // UNIQUE columns the database won't re-generate; null while no such
+  // duplicate is pending.
+  const [duplicateRequest, setDuplicateRequest] =
+    useState<DuplicateRowRequest | null>(null);
 
   // ── Column rename state ────────────────────────────────────────────────
   const [renamedColumns, setRenamedColumns] = useState<Map<number, string>>(
@@ -2506,28 +2528,6 @@ export function ResultTableBody({
     [onSortingChange, sorting],
   );
   handleSortingChangeRef.current = handleSortingChange;
-
-  const { canDuplicate, uniqueConstraintReason } = useMemo(() => {
-    if (!onDuplicateRow) {
-      return { canDuplicate: false, uniqueConstraintReason: "" };
-    }
-    if (!constraintInfo || constraintInfo.length === 0) {
-      return { canDuplicate: true, uniqueConstraintReason: "" };
-    }
-    // Auto-increment / IDENTITY columns regenerate on insert, so PK/UNIQUE
-    // constraints on them don't block duplication.
-    const blocking = constraintInfo.filter(
-      (c) => (c.isPrimaryKey || c.isUnique) && !c.isAutoIncrement,
-    );
-    if (blocking.length > 0) {
-      const names = blocking.map((c) => c.name).join(", ");
-      return {
-        canDuplicate: false,
-        uniqueConstraintReason: `Column${blocking.length > 1 ? "s" : ""} with unique constraint${blocking.length > 1 ? "s" : ""}: ${names}`,
-      };
-    }
-    return { canDuplicate: true, uniqueConstraintReason: "" };
-  }, [onDuplicateRow, constraintInfo]);
 
   const allVisibleSelected =
     deletable &&
@@ -3504,51 +3504,45 @@ export function ResultTableBody({
                 </ContextMenu.Item>
               )}
               {onDuplicateRow &&
-                (canDuplicate ? (
-                  <ContextMenu.Item
-                    className="example-item"
-                    onClick={() => {
-                      const autoIncCols = new Set(
-                        (constraintInfo ?? [])
-                          .filter((c) => c.isAutoIncrement)
-                          .map((c) => c.name),
-                      );
-                      const cols: string[] = [];
-                      const vals: unknown[] = [];
-                      set.columns.forEach((c, i) => {
-                        if (!autoIncCols.has(c)) {
-                          cols.push(c);
-                          vals.push(rowValues[i]);
+                (() => {
+                  // Columns the database re-populates are dropped from the
+                  // INSERT; what's left under a unique constraint is what the
+                  // copy has to answer for, and it depends on this row's
+                  // values (a NULL in a nullable UNIQUE column can't collide).
+                  const { names, values } = duplicateInsertColumns(
+                    set.columns,
+                    rowValues,
+                    constraintInfo,
+                  );
+                  const conflicts = conflictingDuplicateColumns(
+                    names,
+                    values,
+                    constraintInfo,
+                  );
+                  return (
+                    <ContextMenu.Item
+                      className="example-item"
+                      onClick={() => {
+                        if (conflicts.length === 0) {
+                          onDuplicateRow(names, values);
+                          return;
                         }
-                      });
-                      onDuplicateRow(cols, vals);
-                    }}
-                  >
-                    <div className="ex-title">Duplicate row</div>
-                  </ContextMenu.Item>
-                ) : (
-                  <Popover.Root>
-                    <Popover.Trigger
-                      openOnHover
-                      delay={200}
-                      closeDelay={100}
-                      className="example-item sql-ctx-disabled"
-                      nativeButton={false}
-                      render={<div />}
-                      aria-disabled="true"
+                        setDuplicateRequest({
+                          tableName: sourceTable ?? "",
+                          columns: names,
+                          values,
+                          choices: conflicts,
+                        });
+                      }}
                     >
-                      <div className="ex-title">Duplicate row</div>
-                    </Popover.Trigger>
-                    <Popover.Portal>
-                      <Popover.Positioner side="right" sideOffset={8}>
-                        <Popover.Popup className="bui-popup sql-unique-popover">
-                          {uniqueConstraintReason ||
-                            "Cannot duplicate: unique constraint"}
-                        </Popover.Popup>
-                      </Popover.Positioner>
-                    </Popover.Portal>
-                  </Popover.Root>
-                ))}
+                      <div className="ex-title">
+                        {conflicts.length > 0
+                          ? "Duplicate row…"
+                          : "Duplicate row"}
+                      </div>
+                    </ContextMenu.Item>
+                  );
+                })()}
               {onDeleteSingleRow && (
                 <ContextMenu.Item
                   className="example-item sql-ctx-danger"
@@ -3893,6 +3887,18 @@ export function ResultTableBody({
           </Dialog.Popup>
         </Dialog.Portal>
       </Dialog.Root>
+      {/* Duplicate row dialog: only for rows whose unique columns need an
+          answer — an unconstrained row is duplicated straight from the menu. */}
+      <DuplicateRowDialog
+        request={duplicateRequest}
+        onOpenChange={(open) => {
+          if (!open) setDuplicateRequest(null);
+        }}
+        onConfirm={(request, plan) => {
+          onDuplicateRow?.(request.columns, request.values, plan);
+          setDuplicateRequest(null);
+        }}
+      />
       {/* Column statistics dialog */}
       <Dialog.Root
         open={statsDialog !== null}

--- a/app/_components/sql/hooks/useQueryRunner.ts
+++ b/app/_components/sql/hooks/useQueryRunner.ts
@@ -13,6 +13,10 @@ import {
 } from "../../sqlitePlaygroundTabs";
 import { replaceDoc } from "../utils/editorUtils";
 import {
+  applyDuplicateRowPlan,
+  type DuplicateRowPlan,
+} from "../utils/duplicateRow";
+import {
   stripSqlComments,
   isSingleSelectSql,
   hasLimitClause,
@@ -575,7 +579,12 @@ export function useQueryRunner(refs: SqlPlaygroundRefs) {
   );
 
   const duplicateRowInTable = useCallback(
-    (tableName: string, columnNames: string[], values: unknown[]) => {
+    (
+      tableName: string,
+      columnNames: string[],
+      values: unknown[],
+      plan?: DuplicateRowPlan,
+    ) => {
       const engine = engineRef.current;
       if (!engine) return;
       const tabId = activeTabIdRef.current;
@@ -594,7 +603,20 @@ export function useQueryRunner(refs: SqlPlaygroundRefs) {
       }
       void (async () => {
       try {
-        await engine.insertRow(tableName, filteredNames, filteredValues);
+        // The dialog's answers land here: literal overrides are already
+        // decided, `MAX(col) + 1` has to be read off the live table.
+        const resolved = await applyDuplicateRowPlan(
+          filteredNames,
+          filteredValues,
+          plan,
+          async (column) => {
+            const res = await engine.exec(
+              `SELECT MAX(${quoteIdent(column)}) FROM ${quoteIdent(tableName)}`,
+            );
+            return res[0]?.values?.[0]?.[0] ?? null;
+          },
+        );
+        await engine.insertRow(tableName, resolved.names, resolved.values);
         showToast(`Duplicated row in "${tableName}".`);
         const sql = `SELECT * FROM ${quoteIdent(tableName)};`;
         runSqlForTab(tabId, sql, `Table: ${tableName}`, tableName);

--- a/app/_components/sql/utils/duplicateRow.ts
+++ b/app/_components/sql/utils/duplicateRow.ts
@@ -1,0 +1,377 @@
+/**
+ * Duplicate-row planning, shared by all three SQL playgrounds.
+ *
+ * Copying a row verbatim only works while nothing in it has to be unique.
+ * The moment the table has a primary key or a UNIQUE column whose value the
+ * database won't mint for us, the INSERT fails on a constraint violation, so
+ * the grid used to grey "Duplicate row" out and explain why. It now collects
+ * the columns that would collide and asks what to put in them instead — the
+ * planning half of that lives here, free of React and of any one engine.
+ */
+
+import type {
+  ColumnConstraintInfo,
+  TableColumnInfo,
+} from "../../runtime/sqlite";
+
+/** Column DEFAULTs that mint a fresh, distinct value on every INSERT, so a
+ *  duplicate that leaves the column out can't collide with the row it was
+ *  copied from. Sequences (`nextval`) plus the UUID generators the three
+ *  engines ship (`gen_random_uuid()`, `uuid()`, `uuid_generate_v4()`,
+ *  DuckDB's `uuid()`/`gen_random_uuid()`). Deliberately excludes defaults
+ *  like `now()`, which generate a value but not a *distinct* one. */
+const GENERATING_DEFAULT_RE =
+  /\b(?:nextval|gen_random_uuid|uuid_generate_v\d+|uuid|newid)\s*\(/i;
+
+/** True when `defaultValue` produces a fresh value per row. */
+export function defaultGeneratesUniqueValue(
+  defaultValue: string | null | undefined,
+): boolean {
+  return !!defaultValue && GENERATING_DEFAULT_RE.test(defaultValue);
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** True when the stored value is itself a UUID, which is the tell for a
+ *  `TEXT`/`VARCHAR` column holding UUIDs (SQLite has no uuid type). */
+export function looksLikeUuid(value: unknown): boolean {
+  return typeof value === "string" && UUID_RE.test(value.trim());
+}
+
+const UUID_TYPE_RE = /^(?:uuid|guid|uniqueidentifier)$/i;
+
+/** Declared types whose next value is "one more than the largest". Matches
+ *  whole words so `interval` and `point` don't read as numeric. */
+const NUMERIC_TYPE_RE =
+  /\b(?:int|int2|int4|int8|integer|bigint|smallint|tinyint|hugeint|serial|smallserial|bigserial|decimal|numeric|real|double|float|float4|float8|utinyint|usmallint|uinteger|ubigint)\b/i;
+
+export function isNumericColumnType(type: string | undefined): boolean {
+  return !!type && NUMERIC_TYPE_RE.test(type);
+}
+
+/** How the dialog's "Auto" option fills one conflicting column in.
+ *  - `next-number`: `MAX(col) + 1`, resolved against the table at insert
+ *    time (the browser only sees the current page of rows).
+ *  - `uuid`: a fresh UUID minted in the browser. */
+export type DuplicateAutoKind = "next-number" | "uuid";
+
+/** What the user picked for one conflicting column. `keep` copies the
+ *  original value through, which is only ever legal when some *other*
+ *  column of the same key changes (composite primary keys). */
+export type DuplicateStrategy = "auto" | "custom" | "null" | "keep";
+
+/** One column that stops the row being copied as-is. */
+export interface DuplicateColumnChoice {
+  name: string;
+  /** Declared type, or "" when the engine doesn't report one. */
+  type: string;
+  isPrimaryKey: boolean;
+  isUnique: boolean;
+  /** Value in the row being duplicated. */
+  originalValue: unknown;
+  /** `null` when nothing sensible can be generated and the user has to type
+   *  a value. */
+  autoKind: DuplicateAutoKind | null;
+  /** NULLs compare as distinct in a unique index, so clearing a nullable
+   *  UNIQUE column is a legal way out. Never true for a primary key. */
+  canBeNull: boolean;
+}
+
+/** The engine-facing half of the user's answers. Columns the user chose to
+ *  keep simply don't appear: the copied value carries through. */
+export interface DuplicateRowPlan {
+  /** Columns whose value is `MAX(col) + 1`, computed by the playground
+   *  against the live table just before the INSERT. */
+  nextNumber: readonly string[];
+  /** Values replacing the copied ones (a typed value, NULL, a fresh UUID). */
+  overrides: ReadonlyArray<{ column: string; value: unknown }>;
+}
+
+/** SQLite fills `INTEGER PRIMARY KEY` in by itself — that column *is* the
+ *  table's rowid, AUTOINCREMENT keyword or not. The alias holds only for the
+ *  exact declared type `INTEGER` (`INT` is a different, ordinary column), a
+ *  single-column primary key, and a table that still has a rowid. */
+export function isSqliteRowidAlias(col: {
+  /** Declared type, as `PRAGMA table_info` reports it. */
+  type: string;
+  /** Position within the primary key; 0 = not part of it. */
+  pk: number;
+  /** True when the table's primary key names exactly one column. */
+  singleColumnPk: boolean;
+  /** True for a `WITHOUT ROWID` table, which has no rowid to alias. */
+  withoutRowid: boolean;
+}): boolean {
+  return (
+    col.pk === 1 &&
+    col.singleColumnPk &&
+    !col.withoutRowid &&
+    /^integer$/i.test(col.type.trim())
+  );
+}
+
+/** Does the database fill this column in by itself when an INSERT omits it? */
+export function isAutoPopulated(info: ColumnConstraintInfo): boolean {
+  return (
+    info.autoPopulated ??
+    (info.isAutoIncrement || defaultGeneratesUniqueValue(info.defaultValue))
+  );
+}
+
+/** The column/value pairs an INSERT that copies `rowValues` should carry.
+ *  Columns the database re-populates on its own (a rowid alias, a serial or
+ *  IDENTITY column, a UUID default) are dropped so it mints fresh values for
+ *  them instead of colliding on the copied ones. */
+export function duplicateInsertColumns(
+  columns: readonly string[],
+  rowValues: readonly unknown[],
+  constraintInfo: readonly ColumnConstraintInfo[] | undefined,
+): { names: string[]; values: unknown[] } {
+  const autoNames = new Set(
+    (constraintInfo ?? []).filter(isAutoPopulated).map((c) => c.name),
+  );
+  const names: string[] = [];
+  const values: unknown[] = [];
+  columns.forEach((name, i) => {
+    if (autoNames.has(name)) return;
+    names.push(name);
+    values.push(rowValues[i]);
+  });
+  return { names, values };
+}
+
+/** The columns of `columns` that would collide if the row were inserted
+ *  verbatim, in the order they appear in the result set.
+ *
+ *  Skipped, because they can't collide: columns under no unique constraint,
+ *  columns the database re-generates when left out of the INSERT, and NULLs
+ *  in a non-key UNIQUE column (SQL treats NULLs as distinct). */
+export function conflictingDuplicateColumns(
+  columns: readonly string[],
+  values: readonly unknown[],
+  constraintInfo: readonly ColumnConstraintInfo[] | undefined,
+): DuplicateColumnChoice[] {
+  if (!constraintInfo || constraintInfo.length === 0) return [];
+  const byName = new Map(constraintInfo.map((c) => [c.name, c]));
+  const out: DuplicateColumnChoice[] = [];
+  columns.forEach((name, i) => {
+    const info = byName.get(name);
+    if (!info) return;
+    if (!info.isPrimaryKey && !info.isUnique) return;
+    if (isAutoPopulated(info)) return;
+    const value = values[i];
+    const canBeNull = !info.isPrimaryKey && info.notNull !== true;
+    if (canBeNull && (value === null || value === undefined)) return;
+    const type = info.type ?? "";
+    out.push({
+      name,
+      type,
+      isPrimaryKey: info.isPrimaryKey,
+      isUnique: info.isUnique,
+      originalValue: value,
+      autoKind: autoKindFor(type, value),
+      canBeNull,
+    });
+  });
+  return out;
+}
+
+/** UUID before number: a `uuid`-typed column never wants `MAX(col) + 1`. */
+function autoKindFor(type: string, value: unknown): DuplicateAutoKind | null {
+  if (UUID_TYPE_RE.test(type.trim()) || looksLikeUuid(value)) return "uuid";
+  if (isNumericColumnType(type)) return "next-number";
+  if (typeof value === "number" || typeof value === "bigint")
+    return "next-number";
+  return null;
+}
+
+/** The strategy a column starts on: generate where we can, otherwise put the
+ *  cursor in an input the user has to fill. */
+export function defaultDuplicateStrategy(
+  choice: DuplicateColumnChoice,
+): DuplicateStrategy {
+  return choice.autoKind === null ? "custom" : "auto";
+}
+
+/** One more than `max`, preserving integer precision past 2^53 by falling
+ *  back to a decimal string (Postgres hands `bigint` back as a string
+ *  anyway). An empty table (`MAX` of no rows is NULL) starts at 1. */
+export function incrementMaxValue(max: unknown): number | string {
+  if (max === null || max === undefined) return 1;
+  if (typeof max === "bigint") return fromBigInt(max + 1n);
+  if (typeof max === "number") {
+    return Number.isFinite(max) ? Math.floor(max) + 1 : 1;
+  }
+  const text = String(max).trim();
+  if (/^-?\d+$/.test(text)) return fromBigInt(BigInt(text) + 1n);
+  const n = Number(text);
+  return Number.isFinite(n) ? Math.floor(n) + 1 : 1;
+}
+
+function fromBigInt(value: bigint): number | string {
+  const limit = BigInt(Number.MAX_SAFE_INTEGER);
+  return value <= limit && value >= -limit ? Number(value) : value.toString();
+}
+
+/** Pre-filled text for a column's "Custom value" input. `freshUuid` is passed
+ *  in rather than minted here so the caller owns the randomness. */
+export function suggestDuplicateText(
+  choice: DuplicateColumnChoice,
+  freshUuid: string,
+): string {
+  if (choice.autoKind === "uuid") return freshUuid;
+  if (choice.autoKind === "next-number") {
+    return String(incrementMaxValue(choice.originalValue));
+  }
+  const original = choice.originalValue;
+  if (original === null || original === undefined) return "";
+  const text = String(original);
+  return text ? `${text} (copy)` : "";
+}
+
+/** A v4 UUID, from `crypto.randomUUID` where it exists (it needs a secure
+ *  context) and from `getRandomValues` otherwise. */
+export function newUuid(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") return c.randomUUID();
+  const bytes = new Uint8Array(16);
+  if (c && typeof c.getRandomValues === "function") {
+    c.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  // Version 4, variant 1.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/** A plan is only insertable once at least one conflicting column changes —
+ *  otherwise the INSERT reproduces the row it was copied from and trips the
+ *  same constraint. Composite keys need exactly one member to move, which is
+ *  why "keep" is offered per column rather than forbidden outright. */
+export function isDuplicatePlanComplete(
+  choices: readonly DuplicateColumnChoice[],
+  strategies: Readonly<Record<string, DuplicateStrategy>>,
+  customText: Readonly<Record<string, string>>,
+): boolean {
+  if (choices.length === 0) return true;
+  let changed = 0;
+  for (const choice of choices) {
+    const strategy = strategies[choice.name] ?? defaultDuplicateStrategy(choice);
+    if (strategy === "keep") continue;
+    // An empty input is not "set it to NULL" — "Set to NULL" is its own
+    // option, and it isn't offered where NULL is illegal.
+    if (strategy === "custom" && (customText[choice.name] ?? "") === "") {
+      return false;
+    }
+    changed++;
+  }
+  return changed > 0;
+}
+
+/** Fold the dialog's answers into the plan the playground executes.
+ *  `freshUuid` mints one UUID per `auto` UUID column. */
+export function buildDuplicateRowPlan(
+  choices: readonly DuplicateColumnChoice[],
+  strategies: Readonly<Record<string, DuplicateStrategy>>,
+  customText: Readonly<Record<string, string>>,
+  freshUuid: () => string,
+): DuplicateRowPlan {
+  const nextNumber: string[] = [];
+  const overrides: Array<{ column: string; value: unknown }> = [];
+  for (const choice of choices) {
+    const strategy = strategies[choice.name] ?? defaultDuplicateStrategy(choice);
+    if (strategy === "keep") continue;
+    if (strategy === "null") {
+      overrides.push({ column: choice.name, value: null });
+      continue;
+    }
+    if (strategy === "custom") {
+      const raw = customText[choice.name] ?? "";
+      overrides.push({ column: choice.name, value: coerceCustomValue(choice, raw) });
+      continue;
+    }
+    if (choice.autoKind === "uuid") {
+      overrides.push({ column: choice.name, value: freshUuid() });
+    } else if (choice.autoKind === "next-number") {
+      nextNumber.push(choice.name);
+    }
+  }
+  return { nextNumber, overrides };
+}
+
+/** Typed text becomes a number for numeric columns so the engine binds an
+ *  integer rather than a string (which SQLite would happily store as text). */
+function coerceCustomValue(
+  choice: DuplicateColumnChoice,
+  raw: string,
+): unknown {
+  const numeric =
+    isNumericColumnType(choice.type) ||
+    typeof choice.originalValue === "number" ||
+    typeof choice.originalValue === "bigint";
+  if (!numeric) return raw;
+  const trimmed = raw.trim();
+  if (trimmed === "") return raw;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : raw;
+}
+
+/** Apply a plan to the column/value arrays an INSERT is about to bind.
+ *  `nextNumber` resolves `MAX(col)` for one column; it runs once per column
+ *  the plan asks for, and never when the plan asks for none. */
+export async function applyDuplicateRowPlan(
+  columnNames: readonly string[],
+  values: readonly unknown[],
+  plan: DuplicateRowPlan | undefined,
+  nextNumber: (column: string) => Promise<unknown>,
+): Promise<{ names: string[]; values: unknown[] }> {
+  const names = [...columnNames];
+  const nextValues = [...values];
+  if (!plan) return { names, values: nextValues };
+  for (const { column, value } of plan.overrides) {
+    const i = names.indexOf(column);
+    if (i >= 0) nextValues[i] = value;
+  }
+  for (const column of plan.nextNumber) {
+    const i = names.indexOf(column);
+    if (i < 0) continue;
+    nextValues[i] = incrementMaxValue(await nextNumber(column));
+  }
+  return { names, values: nextValues };
+}
+
+/** Derive {@link ColumnConstraintInfo} from a `listColumns()` result, for the
+ *  playgrounds that already hold the column list in memory (Postgres,
+ *  DuckDB) — one round trip per table saved over asking the engine again.
+ *  SQLite is the exception: its rowid-alias rule needs the table's DDL, so
+ *  it keeps using `getColumnConstraintInfo`. */
+export function constraintInfoFromColumns(
+  columns: readonly TableColumnInfo[],
+): ColumnConstraintInfo[] {
+  return columns.map((col) => {
+    const isAutoIncrement =
+      col.identity === true || defaultGeneratesSequence(col.defaultValue);
+    return {
+      name: col.name,
+      isPrimaryKey: col.pk > 0,
+      isAutoIncrement,
+      isUnique: col.unique === true,
+      autoPopulated:
+        isAutoIncrement || defaultGeneratesUniqueValue(col.defaultValue),
+      type: col.type,
+      notNull: col.notNull,
+      defaultValue: col.defaultValue,
+    };
+  });
+}
+
+function defaultGeneratesSequence(
+  defaultValue: string | null | undefined,
+): boolean {
+  return !!defaultValue && /\bnextval\s*\(/i.test(defaultValue);
+}

--- a/app/_components/sql/utils/duplicateRow.ts
+++ b/app/_components/sql/utils/duplicateRow.ts
@@ -57,8 +57,9 @@ export function isNumericColumnType(type: string | undefined): boolean {
 export type DuplicateAutoKind = "next-number" | "uuid";
 
 /** What the user picked for one conflicting column. `keep` copies the
- *  original value through, which is only ever legal when some *other*
- *  column of the same key changes (composite primary keys). */
+ *  original value through; it is only offered on composite-primary-key
+ *  members ({@link DuplicateColumnChoice.canKeep}), where changing one
+ *  member is enough to make the whole key fresh. */
 export type DuplicateStrategy = "auto" | "custom" | "null" | "keep";
 
 /** One column that stops the row being copied as-is. */
@@ -76,6 +77,12 @@ export interface DuplicateColumnChoice {
   /** NULLs compare as distinct in a unique index, so clearing a nullable
    *  UNIQUE column is a legal way out. Never true for a primary key. */
   canBeNull: boolean;
+  /** "Keep original" is legal only where changing a *different* column can
+   *  satisfy this one's constraint: a composite-primary-key member with no
+   *  unique constraint of its own. A sole-member key, or any single-column
+   *  UNIQUE, must always change — offering keep there just promises a
+   *  constraint violation. */
+  canKeep: boolean;
 }
 
 /** The engine-facing half of the user's answers. Columns the user chose to
@@ -101,11 +108,17 @@ export function isSqliteRowidAlias(col: {
   singleColumnPk: boolean;
   /** True for a `WITHOUT ROWID` table, which has no rowid to alias. */
   withoutRowid: boolean;
+  /** True when `PRAGMA index_list` shows an origin-'pk' index. A rowid alias
+   *  needs no index at all, so the presence of one is the tell for the
+   *  non-alias forms — most notably `INTEGER PRIMARY KEY DESC`, which SQLite
+   *  deliberately does NOT treat as the rowid. */
+  hasPkIndex: boolean;
 }): boolean {
   return (
     col.pk === 1 &&
     col.singleColumnPk &&
     !col.withoutRowid &&
+    !col.hasPkIndex &&
     /^integer$/i.test(col.type.trim())
   );
 }
@@ -119,16 +132,21 @@ export function isAutoPopulated(info: ColumnConstraintInfo): boolean {
 }
 
 /** The column/value pairs an INSERT that copies `rowValues` should carry.
- *  Columns the database re-populates on its own (a rowid alias, a serial or
- *  IDENTITY column, a UUID default) are dropped so it mints fresh values for
- *  them instead of colliding on the copied ones. */
+ *  Auto-populated columns under a unique constraint (a rowid alias, a serial
+ *  or IDENTITY key, a UUID-default key) are dropped so the database mints
+ *  fresh values for them instead of colliding on the copied ones. An
+ *  auto-populated column that is NOT unique (say, a `uuid()`-default trace
+ *  column) is copied verbatim: nothing can collide, and a duplicate should
+ *  reproduce the row wherever it legally can. */
 export function duplicateInsertColumns(
   columns: readonly string[],
   rowValues: readonly unknown[],
   constraintInfo: readonly ColumnConstraintInfo[] | undefined,
 ): { names: string[]; values: unknown[] } {
   const autoNames = new Set(
-    (constraintInfo ?? []).filter(isAutoPopulated).map((c) => c.name),
+    (constraintInfo ?? [])
+      .filter((c) => (c.isPrimaryKey || c.isUnique) && isAutoPopulated(c))
+      .map((c) => c.name),
   );
   const names: string[] = [];
   const values: unknown[] = [];
@@ -153,11 +171,18 @@ export function conflictingDuplicateColumns(
 ): DuplicateColumnChoice[] {
   if (!constraintInfo || constraintInfo.length === 0) return [];
   const byName = new Map(constraintInfo.map((c) => [c.name, c]));
+  // A composite key with an auto-populated member is already fresh: the
+  // database re-mints that member, so the *pair* can't collide and the other
+  // members only conflict through unique constraints of their own.
+  const pkAuto = constraintInfo.some(
+    (c) => c.isPrimaryKey && isAutoPopulated(c),
+  );
   const out: DuplicateColumnChoice[] = [];
   columns.forEach((name, i) => {
     const info = byName.get(name);
     if (!info) return;
-    if (!info.isPrimaryKey && !info.isUnique) return;
+    const pkConflict = info.isPrimaryKey && !pkAuto;
+    if (!pkConflict && !info.isUnique) return;
     if (isAutoPopulated(info)) return;
     const value = values[i];
     const canBeNull = !info.isPrimaryKey && info.notNull !== true;
@@ -171,8 +196,16 @@ export function conflictingDuplicateColumns(
       originalValue: value,
       autoKind: autoKindFor(type, value),
       canBeNull,
+      canKeep: false,
     });
   });
+  // Keep is only sound for pure composite-PK members: with two or more of
+  // them in play, changing one frees the rest to stay. A member that also
+  // carries its own UNIQUE constraint must change regardless.
+  const pureKeyMembers = out.filter((c) => c.isPrimaryKey && !c.isUnique);
+  if (pureKeyMembers.length >= 2) {
+    for (const member of pureKeyMembers) member.canKeep = true;
+  }
   return out;
 }
 
@@ -249,28 +282,32 @@ export function newUuid(): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-/** A plan is only insertable once at least one conflicting column changes —
- *  otherwise the INSERT reproduces the row it was copied from and trips the
- *  same constraint. Composite keys need exactly one member to move, which is
- *  why "keep" is offered per column rather than forbidden outright. */
+/** A plan is insertable once every constraint in it is satisfiable: every
+ *  custom input is filled, "keep" appears only where it is legal
+ *  ({@link DuplicateColumnChoice.canKeep}), and — where a composite key
+ *  offers keep at all — at least one of its members actually changes,
+ *  otherwise the INSERT reproduces the key it was copied from. */
 export function isDuplicatePlanComplete(
   choices: readonly DuplicateColumnChoice[],
   strategies: Readonly<Record<string, DuplicateStrategy>>,
   customText: Readonly<Record<string, string>>,
 ): boolean {
-  if (choices.length === 0) return true;
-  let changed = 0;
+  const keepOffered = choices.some((c) => c.canKeep);
+  let keyChanged = false;
   for (const choice of choices) {
     const strategy = strategies[choice.name] ?? defaultDuplicateStrategy(choice);
-    if (strategy === "keep") continue;
+    if (strategy === "keep") {
+      if (!choice.canKeep) return false;
+      continue;
+    }
     // An empty input is not "set it to NULL" — "Set to NULL" is its own
     // option, and it isn't offered where NULL is illegal.
     if (strategy === "custom" && (customText[choice.name] ?? "") === "") {
       return false;
     }
-    changed++;
+    if (choice.canKeep) keyChanged = true;
   }
-  return changed > 0;
+  return !keepOffered || keyChanged;
 }
 
 /** Fold the dialog's answers into the plan the playground executes.
@@ -318,7 +355,12 @@ function coerceCustomValue(
   const trimmed = raw.trim();
   if (trimmed === "") return raw;
   const n = Number(trimmed);
-  return Number.isFinite(n) ? n : raw;
+  if (!Number.isFinite(n)) return raw;
+  // An integer past 2^53 would silently round through Number; bind the text
+  // instead — every engine parses a decimal string into its own integer type
+  // (mirrors incrementMaxValue's string fallback).
+  if (/^-?\d+$/.test(trimmed) && !Number.isSafeInteger(n)) return trimmed;
+  return n;
 }
 
 /** Apply a plan to the column/value arrays an INSERT is about to bind.
@@ -370,8 +412,13 @@ export function constraintInfoFromColumns(
   });
 }
 
+/** Sequence-style defaults: `nextval(...)`, plus the `GENERATED ...` text
+ *  some DuckDB builds report as an identity column's default. */
 function defaultGeneratesSequence(
   defaultValue: string | null | undefined,
 ): boolean {
-  return !!defaultValue && /\bnextval\s*\(/i.test(defaultValue);
+  return (
+    !!defaultValue &&
+    (/\bnextval\s*\(/i.test(defaultValue) || /^GENERATED\b/i.test(defaultValue))
+  );
 }

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -3581,24 +3581,136 @@ html[data-playground-theme="dark"] .sql-result-th-type {
   line-height: 1.5;
 }
 
-/* Disabled-looking context-menu pseudo-item (used for the Duplicate row
-   button when a unique constraint prevents duplication). */
-.sql-ctx-disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-  pointer-events: auto;
-  /* keep hover events for the popover */
-  width: 100%;
-  text-align: left;
-  background: transparent;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  font-family: inherit;
-  font-size: 13px;
+/* ─── Duplicate row dialog ───
+   Opened from the grid's row context menu when the row's primary key or
+   UNIQUE columns can't be copied as they are; one block per conflicting
+   column, each with its own answer. */
+.sql-duplicate-popup {
+  width: min(520px, calc(100vw - 32px));
+  max-height: min(86vh, 760px);
+  gap: 0;
+  padding: 0;
 }
 
-.sql-ctx-disabled:last-child {
-  border-bottom: none;
+.sql-duplicate-desc {
+  padding: 0 18px 12px;
+  line-height: 1.55;
+}
+
+.sql-duplicate-body {
+  gap: 10px;
+  padding-bottom: 8px;
+}
+
+.sql-duplicate-col {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 11px 12px;
+  min-width: 0;
+}
+
+.sql-duplicate-col-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.sql-duplicate-col-name {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.sql-duplicate-badge {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  white-space: nowrap;
+}
+
+.sql-duplicate-type {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.sql-duplicate-current {
+  font-size: 12px;
+  color: var(--text-dim);
+  min-width: 0;
+}
+
+.sql-duplicate-current code {
+  font-family: var(--font-mono);
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.sql-duplicate-options {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.sql-duplicate-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  min-width: 0;
+}
+
+.sql-duplicate-option input {
+  margin: 2px 0 0;
+  flex: 0 0 auto;
+  accent-color: var(--primary);
+}
+
+.sql-duplicate-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.sql-duplicate-option-hint {
+  font-size: 11.5px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+.sql-duplicate-input {
+  margin-top: 1px;
+}
+
+.sql-duplicate-warning {
+  padding: 0 18px 4px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+.sql-duplicate-popup .confirm-actions {
+  margin-top: 0;
+  padding: 12px 18px 16px;
+  border-top: 1px solid var(--border);
 }
 
 /* Danger-styled context-menu item (Delete row). */
@@ -3635,15 +3747,6 @@ html[data-playground-theme="dark"] .sql-result-th-type {
 .ctx-export-arrow {
   opacity: 0.5;
   flex-shrink: 0;
-}
-
-/* Small popover explaining the unique constraint. */
-.sql-unique-popover {
-  padding: 8px 10px;
-  font-size: 12px;
-  color: var(--text);
-  max-width: 240px;
-  line-height: 1.5;
 }
 
 /* ─── Placeholder text, theme-matched ─── */

--- a/app/_components/sqlPlayground.css
+++ b/app/_components/sqlPlayground.css
@@ -3598,17 +3598,18 @@ html[data-playground-theme="dark"] .sql-result-th-type {
 }
 
 .sql-duplicate-body {
-  gap: 10px;
+  gap: 0;
   padding-bottom: 8px;
 }
 
+/* Flat sections divided by rules rather than boxed cards; zero body gap
+   keeps each rule centered in the two 12px paddings it sits between. */
 .sql-duplicate-col {
   display: flex;
   flex-direction: column;
   gap: 7px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 11px 12px;
+  border-top: 1px solid var(--border);
+  padding: 12px 0;
   min-width: 0;
 }
 
@@ -3633,10 +3634,10 @@ html[data-playground-theme="dark"] .sql-result-th-type {
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--text-dim);
-  border: 1px solid var(--border);
+  color: #fff;
+  background: var(--ds-red);
   border-radius: 4px;
-  padding: 1px 5px;
+  padding: 2px 6px;
   white-space: nowrap;
 }
 

--- a/e2e/sql-duplicate-row.spec.ts
+++ b/e2e/sql-duplicate-row.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// "Duplicate row" in the shared result grid. A row whose primary key or
+// UNIQUE columns the database won't re-generate used to leave the menu item
+// greyed out with a "cannot duplicate" popover; it now opens a dialog that
+// asks what the copy should carry in each of those columns. A row with
+// nothing to answer for still duplicates straight from the menu.
+
+async function runSql(page: Page, sql: string) {
+  const editor = page.locator(".cm-content");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Delete");
+  await page.keyboard.insertText(sql);
+  await page
+    .locator("button.run-btn-split-main, button.run-btn")
+    .first()
+    .click();
+  await expect(page.locator(".run-btn-spinner")).toHaveCount(0, {
+    timeout: 60_000,
+  });
+}
+
+// Right-click the first data row and return the "Duplicate row" menu item
+// (its label gains an ellipsis when it opens the dialog).
+async function openRowMenu(page: Page) {
+  await page
+    .locator(".sql-result-table-wrap tbody tr")
+    .first()
+    .locator("td")
+    .nth(1)
+    .click({ button: "right" });
+  return page.getByRole("menuitem", { name: /^Duplicate row/ });
+}
+
+function dataRows(page: Page) {
+  return page.locator(".sql-result-table-wrap tbody tr");
+}
+
+const ENGINES = [
+  { id: "SQLite", route: "/playground/sqlite" },
+  { id: "PostgreSQL", route: "/playground/postgres" },
+  { id: "DuckDB", route: "/playground/duckdb" },
+];
+
+// A plain `INT PRIMARY KEY` (no sequence, no rowid alias) plus a UNIQUE text
+// column: two values the database can't invent, on every engine.
+const CONFLICTING = [
+  "DROP TABLE IF EXISTS zz_dup_conflict;",
+  "CREATE TABLE zz_dup_conflict (id INT PRIMARY KEY, email TEXT UNIQUE, name TEXT);",
+  "INSERT INTO zz_dup_conflict VALUES (1, 'ada@example.com', 'Ada');",
+].join("\n");
+
+for (const { id, route } of ENGINES) {
+  test(`${id}: duplicating a row with a plain primary key goes through the dialog`, async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    await page.goto(route);
+    await page.locator(".cm-content").waitFor({ timeout: 150_000 });
+
+    await runSql(page, CONFLICTING);
+    await runSql(page, "SELECT * FROM zz_dup_conflict;");
+    await expect(dataRows(page)).toHaveCount(1);
+
+    const item = await openRowMenu(page);
+    // The ellipsis is the tell that the item opens a dialog rather than
+    // inserting straight away.
+    await expect(item).toHaveText(/…$/);
+    await item.click();
+
+    const dialog = page.locator(".sql-duplicate-popup");
+    await expect(dialog).toBeVisible();
+    // Both unique columns are listed; the key defaults to the generated
+    // option, the text column to an input seeded with a "(copy)" suggestion.
+    await expect(dialog.locator(".sql-duplicate-col-name")).toHaveText([
+      "id",
+      "email",
+    ]);
+    await expect(
+      dialog.getByRole("radio", { name: /Next available number/ }),
+    ).toBeChecked();
+    await page
+      .getByLabel("Custom value for email")
+      .fill("ada+copy@example.com");
+
+    await dialog.getByRole("button", { name: "Duplicate row" }).click();
+    await expect(dialog).toBeHidden();
+
+    // The grid refetches the table: two rows, the copy carrying MAX(id) + 1
+    // and the typed email.
+    await expect(dataRows(page)).toHaveCount(2, { timeout: 60_000 });
+    await expect(
+      dataRows(page).nth(1).locator("td").nth(1),
+    ).toHaveText("2");
+    await expect(
+      dataRows(page).nth(1).locator("td").nth(2),
+    ).toHaveText("ada+copy@example.com");
+  });
+
+  test(`${id}: the dialog refuses a plan that changes nothing`, async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    await page.goto(route);
+    await page.locator(".cm-content").waitFor({ timeout: 150_000 });
+
+    await runSql(page, CONFLICTING);
+    await runSql(page, "SELECT * FROM zz_dup_conflict;");
+    (await openRowMenu(page)).click();
+
+    const dialog = page.locator(".sql-duplicate-popup");
+    await expect(dialog).toBeVisible();
+    for (const col of ["id", "email"]) {
+      await page.locator(`input[name="sql-duplicate-${col}"]`).last().check();
+    }
+    await expect(
+      dialog.getByRole("button", { name: "Duplicate row" }),
+    ).toBeDisabled();
+    await expect(dialog.locator(".sql-duplicate-warning")).toContainText(
+      "At least one column has to change",
+    );
+  });
+}
+
+test("SQLite: an INTEGER PRIMARY KEY duplicates without asking", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  await page.goto("/playground/sqlite");
+  await page.locator(".cm-content").waitFor({ timeout: 150_000 });
+
+  // `INTEGER PRIMARY KEY` is SQLite's rowid alias: leave it out of the INSERT
+  // and SQLite assigns the next id, AUTOINCREMENT keyword or not. This is the
+  // schema that used to be refused outright.
+  await runSql(
+    page,
+    [
+      "DROP TABLE IF EXISTS zz_dup_rowid;",
+      "CREATE TABLE zz_dup_rowid (id INTEGER PRIMARY KEY, name TEXT);",
+      "INSERT INTO zz_dup_rowid (name) VALUES ('Ada');",
+    ].join("\n"),
+  );
+  await runSql(page, "SELECT * FROM zz_dup_rowid;");
+  await expect(dataRows(page)).toHaveCount(1);
+
+  const item = await openRowMenu(page);
+  await expect(item).toHaveText("Duplicate row");
+  await item.click();
+
+  await expect(page.locator(".sql-duplicate-popup")).toHaveCount(0);
+  await expect(dataRows(page)).toHaveCount(2, { timeout: 60_000 });
+  await expect(dataRows(page).nth(1).locator("td").nth(1)).toHaveText("2");
+  await expect(dataRows(page).nth(1).locator("td").nth(2)).toHaveText("Ada");
+});

--- a/e2e/sql-duplicate-row.spec.ts
+++ b/e2e/sql-duplicate-row.spec.ts
@@ -80,6 +80,11 @@ for (const { id, route } of ENGINES) {
     await expect(
       dialog.getByRole("radio", { name: /Next available number/ }),
     ).toBeChecked();
+    // A sole primary key and a single-column UNIQUE can never keep their
+    // values, so "Keep original" must not be offered here at all.
+    await expect(
+      dialog.getByRole("radio", { name: "Keep original" }),
+    ).toHaveCount(0);
     await page
       .getByLabel("Custom value for email")
       .fill("ada+copy@example.com");
@@ -98,28 +103,47 @@ for (const { id, route } of ENGINES) {
     ).toHaveText("ada+copy@example.com");
   });
 
-  test(`${id}: the dialog refuses a plan that changes nothing`, async ({
+  test(`${id}: a composite key offers keep, but not for every member at once`, async ({
     page,
   }) => {
     test.setTimeout(180_000);
     await page.goto(route);
     await page.locator(".cm-content").waitFor({ timeout: 150_000 });
 
-    await runSql(page, CONFLICTING);
-    await runSql(page, "SELECT * FROM zz_dup_conflict;");
-    (await openRowMenu(page)).click();
+    await runSql(
+      page,
+      [
+        "DROP TABLE IF EXISTS zz_dup_pair;",
+        "CREATE TABLE zz_dup_pair (a INT, b INT, note TEXT, PRIMARY KEY (a, b));",
+        "INSERT INTO zz_dup_pair VALUES (1, 2, 'Ada');",
+      ].join("\n"),
+    );
+    await runSql(page, "SELECT * FROM zz_dup_pair;");
+    await (await openRowMenu(page)).click();
 
     const dialog = page.locator(".sql-duplicate-popup");
     await expect(dialog).toBeVisible();
-    for (const col of ["id", "email"]) {
+    // Both members are asked about, and both may keep their value — one
+    // member changing is enough to make the pair fresh.
+    await expect(
+      dialog.getByRole("radio", { name: "Keep original" }),
+    ).toHaveCount(2);
+    // ...but keeping EVERY member reproduces the copied key, so that plan
+    // stays blocked.
+    for (const col of ["a", "b"]) {
       await page.locator(`input[name="sql-duplicate-${col}"]`).last().check();
     }
     await expect(
       dialog.getByRole("button", { name: "Duplicate row" }),
     ).toBeDisabled();
     await expect(dialog.locator(".sql-duplicate-warning")).toContainText(
-      "At least one column has to change",
+      "At least one key column has to change",
     );
+    // Moving one member back to the generated number unblocks it.
+    await page.locator('input[name="sql-duplicate-a"]').first().check();
+    await expect(
+      dialog.getByRole("button", { name: "Duplicate row" }),
+    ).toBeEnabled();
   });
 }
 


### PR DESCRIPTION
## 1. "Duplicate row" for rows with a primary key

The row context menu greyed **Duplicate row** out whenever the table had a primary key or a UNIQUE column, with a hover popover naming the offending columns and no way forward. Two problems behind that:

- SQLite's `INTEGER PRIMARY KEY` **is** the rowid: leave it out of the INSERT and SQLite assigns the next id, AUTOINCREMENT keyword or not. Only the literal `AUTOINCREMENT` keyword counted, so the most ordinary schema there is was refused for a conflict that never existed.
- A genuine conflict left the user nothing to do.

Duplicating now asks. Columns the database re-generates when the INSERT omits them (a rowid alias, `AUTOINCREMENT`, serial / `IDENTITY`, a UUID-generating `DEFAULT`) are dropped from the copy where they're unique, and the row is copied straight from the menu when nothing conflicts, exactly as before. Anything still under a unique constraint opens a dialog with one block per column, each offering only what that column can actually take:

| Option | When it appears |
| --- | --- |
| Next available number | numeric column; resolves `MAX(col) + 1` against the live table at insert time |
| New UUID | a `uuid` column, or a text column already holding a UUID |
| Custom value | always, pre-filled with a suggestion (`… (copy)`, one past the number, a fresh UUID) |
| Set to NULL | column is nullable and not a primary key (NULLs never collide in a unique index) |
| Keep original | pure composite-primary-key members only, where changing another member frees this one |

Defaults land on the generated option wherever one exists, so the common case is one click. The primary button stays disabled until the plan is actually insertable: every custom input filled, and at least one member of an all-keepable key changed.

The menu item reads `Duplicate row…` when it opens the dialog and `Duplicate row` when it inserts directly, so the ellipsis carries the difference.

The dialog was verified visually in light and dark themes and at a 390px viewport (it scrolls in its body with the actions pinned); screenshots were captured through a temporary harness route rendering the real component and CSS, which was removed before committing.

## 2. Admin in the mobile hamburger menu

`HomeNav`'s mobile drawer (the home page and the 30 other pages that share it) showed Account and Sign out but not Admin, so an admin on a phone had no way into `/dashboard/admin`. Adds the row for `role === "admin"`, with the same check, icon and placement as the desktop account menu. Authorization is unchanged and still server-enforced.

## Scope of the engine changes

- `ColumnConstraintInfo` gains `autoPopulated` (a superset of `isAutoIncrement`: the database mints a fresh, distinct value when the INSERT omits the column) plus `type` / `notNull` / `defaultValue`, which is what lets the dialog choose between a number, a UUID, and NULL.
- `TableColumnInfo` gains `identity`, so Postgres `GENERATED … AS IDENTITY` columns stop being treated as values that must be copied.
- DuckDB's `listColumns` now reports `unique` from the constraint query it already ran, and `getColumnConstraintInfo` delegates to the shared `constraintInfoFromColumns` mapping — one implementation, no drift.
- Postgres and DuckDB now pass `constraintInfo` to the result grid, derived from the column list already in memory (no extra round trip). Previously only SQLite did, so on those two engines the duplicate quietly failed with a duplicate-key error instead of asking.
- Postgres and DuckDB also skip sequence/identity-backed columns when inserting the copy, which they didn't consistently do before.
- SQLite's rowid-alias detection covers the corners: `INTEGER PRIMARY KEY DESC` is *not* an alias (the origin-`pk` autoindex it needs is the tell), and `WITHOUT ROWID` is only read from the table options after the column list's closing paren, so a CHECK or string literal containing the phrase doesn't count.

Planning is engine-agnostic and lives in `app/_components/sql/utils/duplicateRow.ts`; each playground only resolves `MAX(col)` in its own dialect. A second self-review pass (commit 2) tightened the planner: keep restricted to composite-key members, big-integer custom values bound as text instead of rounding through `Number()`, non-unique generated-default columns copied instead of silently regenerated, composite keys with an auto-populated member no longer open the dialog needlessly, and dialog state survives a column literally named `__proto__`.

## Testing

- `npx vitest run` — 127 files, 1852 tests pass, including 49 new ones in `__tests__/duplicateRow.test.ts` covering the conflict detection and keep rules, the auto-kind choice, `MAX + 1` and custom values past 2^53, plan building and application, SQLite's rowid-alias rule (DESC included), and the constraint-info derivation.
- `npx tsc --noEmit` clean; `npx eslint .` reports 0 errors and the same pre-existing warnings as `main`.
- `npm run check:prose` clean.
- New `e2e/sql-duplicate-row.spec.ts` covers the dialog end to end on all three engines (including the composite-key keep rules) plus the SQLite rowid-alias case. **It has not been run here**: the SQL playgrounds fetch their WASM from jsDelivr at runtime and this sandbox's network policy blocks that host, so no engine can boot. The dialog's keep/blocked/enabled state transitions were verified live against the real component in a browser; everything downstream of the confirm button is covered by unit tests and needs CI, or a local run, to exercise against a real engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F65ZQpZuxrMjnF3iKWouFp