### PR TITLE
Add reusable Venn diagram chart for SQL join types and embed across join lessons

### DIFF
--- a/charts/sql-join-types.mjs
+++ b/charts/sql-join-types.mjs
@@ -1,0 +1,101 @@
+/**
+ * The four set-preserving SQL joins as one reusable Venn diagram.
+ *
+ * A join operates on rows rather than abstract sets, so the diagram is an
+ * intentionally narrow explanation of which unmatched keys survive. It does
+ * not imply that joins deduplicate keys or have set cardinality.
+ */
+import { Plot, plot, MUTED, PRIMARY } from "./_theme.mjs";
+
+export const title =
+  "Venn diagrams for inner, left, right, and full joins. Inner shades only the overlap; left shades the whole left set including the overlap; right shades the whole right set including the overlap; full shades both sets.";
+
+export const caption =
+  "The shaded region shows which keys can contribute rows to the result: **INNER** keeps the overlap, **LEFT** keeps all of A, **RIGHT** keeps all of B, and **FULL** keeps either side. This is a guide to unmatched-row preservation, not row counts: duplicate keys can still produce several result rows.";
+
+const PANELS = ["INNER", "LEFT", "RIGHT", "FULL"];
+const RADIUS = 0.82;
+const LEFT_X = -0.42;
+const RIGHT_X = 0.42;
+const STEPS = 80;
+
+function disk(panel, center, side) {
+  return Array.from({ length: STEPS + 1 }, (_, i) => {
+    const x = center - RADIUS + (2 * RADIUS * i) / STEPS;
+    const halfHeight = Math.sqrt(Math.max(0, RADIUS ** 2 - (x - center) ** 2));
+    return { panel, side, x, y1: -halfHeight, y2: halfHeight };
+  });
+}
+
+function outline(panel, center, side) {
+  return Array.from({ length: STEPS + 1 }, (_, i) => {
+    const angle = (2 * Math.PI * i) / STEPS;
+    return { panel, side, x: center + RADIUS * Math.cos(angle), y: RADIUS * Math.sin(angle) };
+  });
+}
+
+const disks = PANELS.flatMap((panel) => [
+  ...disk(panel, LEFT_X, "A"),
+  ...disk(panel, RIGHT_X, "B"),
+]);
+const outlines = PANELS.flatMap((panel) => [
+  ...outline(panel, LEFT_X, "A"),
+  ...outline(panel, RIGHT_X, "B"),
+]);
+const selectedDisks = disks.filter(
+  (d) =>
+    d.panel === "FULL" ||
+    (d.panel === "LEFT" && d.side === "A") ||
+    (d.panel === "RIGHT" && d.side === "B"),
+);
+
+// Take the tighter boundary of the circles at each x to form their lens.
+const innerLens = Array.from({ length: STEPS + 1 }, (_, i) => {
+  const start = RIGHT_X - RADIUS;
+  const x = start + ((LEFT_X + RADIUS - start) * i) / STEPS;
+  const leftHalf = Math.sqrt(Math.max(0, RADIUS ** 2 - (x - LEFT_X) ** 2));
+  const rightHalf = Math.sqrt(Math.max(0, RADIUS ** 2 - (x - RIGHT_X) ** 2));
+  const halfHeight = Math.min(leftHalf, rightHalf);
+  return { panel: "INNER", x, y1: -halfHeight, y2: halfHeight };
+});
+
+const labels = PANELS.flatMap((panel) => [
+  { panel, x: LEFT_X - 0.43, y: 0, text: "A" },
+  { panel, x: RIGHT_X + 0.43, y: 0, text: "B" },
+]);
+
+export function render() {
+  return plot({
+    height: 230,
+    marginTop: 30,
+    marginRight: 8,
+    marginBottom: 8,
+    marginLeft: 8,
+    ariaLabel: title,
+    fx: { label: null, domain: PANELS, padding: 0.12 },
+    x: { axis: null, domain: [-1.38, 1.38] },
+    y: { axis: null, domain: [-1.05, 1.05], grid: false },
+    marks: [
+      Plot.areaY(disks, {
+        fx: "panel", x: "x", y1: "y1", y2: "y2", z: "side",
+        fill: MUTED, fillOpacity: 0.09,
+      }),
+      Plot.areaY(selectedDisks, {
+        fx: "panel", x: "x", y1: "y1", y2: "y2", z: "side",
+        fill: PRIMARY, fillOpacity: 0.42,
+      }),
+      Plot.areaY(innerLens, {
+        fx: "panel", x: "x", y1: "y1", y2: "y2",
+        fill: PRIMARY, fillOpacity: 0.62,
+      }),
+      Plot.line(outlines, {
+        fx: "panel", x: "x", y: "y", z: "side",
+        stroke: MUTED, strokeWidth: 1.5,
+      }),
+      Plot.text(labels, {
+        fx: "panel", x: "x", y: "y", text: "text",
+        fill: "currentColor", fontWeight: 700,
+      }),
+    ],
+  });
+}

--- a/content/courses/data-analysis-python-pandas/merging-and-joining.mdx
+++ b/content/courses/data-analysis-python-pandas/merging-and-joining.mdx
@@ -21,6 +21,8 @@ with the `how` parameter.
 | `right` | All rows from the **right** table; left columns are `NaN` where no match exists |
 | `outer` | Every row from **either** table; `NaN` wherever the other side has no match |
 
+<Chart slug="sql-join-types" />
+
 ## Setting the stage
 
 <CodeBlock

--- a/content/courses/data-wrangling-python-polars/joins.mdx
+++ b/content/courses/data-wrangling-python-polars/joins.mdx
@@ -46,6 +46,8 @@ for how in ["inner", "left", "right", "full", "semi", "anti"]:
 | `anti` | left rows that have **no** match |
 | `cross` | every left row paired with every right row |
 
+<Chart slug="sql-join-types" />
+
 `semi` and `anti` are the ones people do not know they wanted. They
 are filters that use another frame as the criterion, and unlike an
 `inner` join they cannot change the row count upward.

--- a/content/courses/intro-sql-postgres/outer-joins.mdx
+++ b/content/courses/intro-sql-postgres/outer-joins.mdx
@@ -159,12 +159,7 @@ Once `LEFT JOIN` makes sense, its siblings are easy:
   caption="A left join keeps every left-hand row, filling the gaps with `NULL`."
 />
 
-```mermaid
-flowchart TD
-    I["INNER<br/>only matches"] --- LJ["LEFT<br/>all left + matches"]
-    LJ --- RJ["RIGHT<br/>all right + matches"]
-    RJ --- FJ["FULL<br/>everything,<br/>NULLs where unmatched"]
-```
+<Chart slug="sql-join-types" />
 
 <Callout type="info" title="A simple way to choose">
 Ask: *"whose rows must I keep even without a match?"* Keep the left

--- a/content/courses/sqlite-for-beginners/outer-joins.mdx
+++ b/content/courses/sqlite-for-beginners/outer-joins.mdx
@@ -286,12 +286,7 @@ For beginners, `LEFT JOIN` is the most important outer join. Recent SQLite versi
   caption="Put the table you want to keep on the left and a left join covers most needs."
 />
 
-```mermaid
-flowchart TD
-    I["<code>INNER JOIN</code><br/>only matches"] --- L["<code>LEFT JOIN</code><br/>all left rows"]
-    L --- R["<code>RIGHT JOIN</code><br/>all right rows"]
-    R --- F["<code>FULL OUTER JOIN</code><br/>all rows from both sides"]
-```
+<Chart slug="sql-join-types" />
 
 <Callout type="info" title="How to choose">
 Ask: "Which table's rows must not disappear?" Put that table first, then use `LEFT JOIN`.

--- a/content/interview/data-analyst/sql.mdx
+++ b/content/interview/data-analyst/sql.mdx
@@ -53,6 +53,8 @@ All combine rows from two tables on a condition; they differ in which
 - **RIGHT**, all rows from the right table; `NULL`s on the left.
 - **FULL**, all rows from both; `NULL`s wherever either side is missing.
 
+<Chart slug="sql-join-types" />
+
 "List all customers and their orders, *including customers who never
 ordered*" is the classic tell for a `LEFT JOIN`.
 

--- a/content/interview/data-engineer/sql.mdx
+++ b/content/interview/data-engineer/sql.mdx
@@ -407,6 +407,8 @@ When a table is partitioned (e.g., by `event_date`) and a query filters on that 
 - **`RIGHT JOIN`**, all rows from the right table; nulls on the left.
 - **`FULL OUTER JOIN`**, all rows from both; nulls where either side has no match.
 
+<Chart slug="sql-join-types" />
+
 ```sql
 -- LEFT JOIN: all customers returned; order columns are NULL for customers
 -- with no orders (useful to find customers who never ordered).

--- a/data/created-at.json
+++ b/data/created-at.json
@@ -332,6 +332,7 @@
     "sparkline-in-a-table": "2026-08-11T12:38:14.000Z",
     "spread-same-center": "2026-08-07T22:00:22.000Z",
     "sql-clause-funnel": "2026-08-08T08:39:12.000Z",
+    "sql-join-types": "2026-08-24T13:57:36.000Z",
     "sql-null-logic": "2026-08-07T22:00:22.000Z",
     "stack-depth-overflow": "2026-08-08T08:39:12.000Z",
     "stack-dodge-fill": "2026-08-07T22:00:22.000Z",


### PR DESCRIPTION
### Motivation

- Provide a clear, reusable visual explaining INNER, LEFT, RIGHT and FULL joins using Venn-style diagrams so readers can immediately see which unmatched keys survive each join.  
- Replace several small linear/Mermaid illustrations with a single theme-aware Observable Plot spec so the same accessible chart can be reused across courses and interview material.

### Description

- Add `charts/sql-join-types.mjs`, an Observable Plot spec that renders four Venn-style panels (INNER, LEFT, RIGHT, FULL) using the repo chart theme tokens and an `ariaLabel` plus a caption that clarifies the diagram shows unmatched-key preservation rather than result cardinality.  
- Insert the chart via `<Chart slug="sql-join-types" />` into the following lessons: `content/courses/data-analysis-python-pandas/merging-and-joining.mdx`, `content/courses/data-wrangling-python-polars/joins.mdx`, `content/courses/intro-sql-postgres/outer-joins.mdx`, `content/courses/sqlite-for-beginners/outer-joins.mdx`, `content/interview/data-analyst/sql.mdx`, and `content/interview/data-engineer/sql.mdx`.  
- Replace existing Mermaid/inline linear join diagrams in PostgreSQL and SQLite lessons with the new chart for consistency and clarity.  
- The chart implementation constructs circle outlines and filled regions with `Plot.areaY`/`Plot.line`/`Plot.text` and reuses `PRIMARY`/`MUTED` tokens so it renders correctly in both light and dark themes.

### Testing

- Ran chart and MDX checks: `npm run check:charts`, `npm run check:mdx`, and `npm run check:prose`, all of which completed successfully.  
- Built dev server and chart pipeline via the usual dev flow and confirmed charts rendered into `lib/generated/charts.js` during the build step (`build-charts` reported charts up to date).  
- Performed local repository lint/consistency checks (`git diff --check`) with no blocking issues.  
- Attempted a Playwright screenshot to capture the rendered chart, but the environment lacked an installed Chromium binary and `npx playwright install chromium` failed due to the CDN returning HTTP 403, so an automated screenshot could not be captured in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8be2aecce483258f714b9d5942d7c6)