### PR TITLE
Add reusable Venn chart for SQL join types and embed across join docs; tighten chart build check

### DIFF
--- a/charts/sql-join-types.mjs
+++ b/charts/sql-join-types.mjs
@@ -1,0 +1,103 @@
+/**
+ * The four set-preserving SQL joins as one reusable Venn diagram.
+ *
+ * A join operates on rows rather than abstract sets, so the diagram is an
+ * intentionally narrow explanation of which unmatched keys survive. It does
+ * not imply that joins deduplicate keys or have set cardinality.
+ */
+import { Plot, plot, MUTED, PRIMARY } from "./_theme.mjs";
+
+export const title =
+  "Venn diagrams for inner, left, right, and full joins. Inner shades only the overlap; left shades the whole left set including the overlap; right shades the whole right set including the overlap; full shades both sets.";
+
+export const caption =
+  "The shaded region shows which keys can contribute rows to the result: **INNER** keeps the overlap, **LEFT** keeps all of A, **RIGHT** keeps all of B, and **FULL** keeps either side. This is a guide to unmatched-row preservation, not row counts: duplicate keys can still produce several result rows.";
+
+const PANELS = ["INNER", "LEFT", "RIGHT", "FULL"];
+const RADIUS = 0.82;
+const LEFT_X = -0.42;
+const RIGHT_X = 0.42;
+const STEPS = 80;
+
+function disk(panel, center, side) {
+  return Array.from({ length: STEPS + 1 }, (_, i) => {
+    const x = center - RADIUS + (2 * RADIUS * i) / STEPS;
+    const halfHeight = Math.sqrt(Math.max(0, RADIUS ** 2 - (x - center) ** 2));
+    return { panel, side, x, y1: -halfHeight, y2: halfHeight };
+  });
+}
+
+function outline(panel, center, side) {
+  return Array.from({ length: STEPS + 1 }, (_, i) => {
+    const angle = (2 * Math.PI * i) / STEPS;
+    return { panel, side, x: center + RADIUS * Math.cos(angle), y: RADIUS * Math.sin(angle) };
+  });
+}
+
+const disks = PANELS.flatMap((panel) => [
+  ...disk(panel, LEFT_X, "A"),
+  ...disk(panel, RIGHT_X, "B"),
+]);
+const outlines = PANELS.flatMap((panel) => [
+  ...outline(panel, LEFT_X, "A"),
+  ...outline(panel, RIGHT_X, "B"),
+]);
+const selectedDisks = disks.filter(
+  (d) =>
+    d.panel === "FULL" ||
+    (d.panel === "LEFT" && d.side === "A") ||
+    (d.panel === "RIGHT" && d.side === "B"),
+);
+
+// Take the tighter boundary of the circles at each x to form their lens.
+const innerLens = Array.from({ length: STEPS + 1 }, (_, i) => {
+  const start = RIGHT_X - RADIUS;
+  const x = start + ((LEFT_X + RADIUS - start) * i) / STEPS;
+  const leftHalf = Math.sqrt(Math.max(0, RADIUS ** 2 - (x - LEFT_X) ** 2));
+  const rightHalf = Math.sqrt(Math.max(0, RADIUS ** 2 - (x - RIGHT_X) ** 2));
+  const halfHeight = Math.min(leftHalf, rightHalf);
+  return { panel: "INNER", x, y1: -halfHeight, y2: halfHeight };
+});
+
+const labels = PANELS.flatMap((panel) => [
+  { panel, x: LEFT_X - 0.43, y: 0, text: "A" },
+  { panel, x: RIGHT_X + 0.43, y: 0, text: "B" },
+]);
+
+export function render() {
+  return plot({
+    height: 230,
+    marginTop: 30,
+    marginRight: 8,
+    marginBottom: 8,
+    marginLeft: 8,
+    ariaLabel: title,
+    // Join names belong above their diagrams. Plot facets default to a bottom
+    // axis, which made the labels look like a detached footer.
+    fx: { label: null, domain: PANELS, padding: 0.12, axis: "top" },
+    x: { axis: null, domain: [-1.38, 1.38] },
+    y: { axis: null, domain: [-1.05, 1.05], grid: false },
+    marks: [
+      Plot.areaY(disks, {
+        fx: "panel", x: "x", y1: "y1", y2: "y2", z: "side",
+        fill: MUTED, fillOpacity: 0.09,
+      }),
+      Plot.areaY(selectedDisks, {
+        fx: "panel", x: "x", y1: "y1", y2: "y2", z: "side",
+        fill: PRIMARY, fillOpacity: 0.42,
+      }),
+      Plot.areaY(innerLens, {
+        fx: "panel", x: "x", y1: "y1", y2: "y2",
+        fill: PRIMARY, fillOpacity: 0.62,
+      }),
+      Plot.line(outlines, {
+        fx: "panel", x: "x", y: "y", z: "side",
+        stroke: MUTED, strokeWidth: 1.5,
+      }),
+      Plot.text(labels, {
+        fx: "panel", x: "x", y: "y", text: "text",
+        fill: "currentColor", fontWeight: 700,
+      }),
+    ],
+  });
+}

--- a/content/courses/data-analysis-python-pandas/merging-and-joining.mdx
+++ b/content/courses/data-analysis-python-pandas/merging-and-joining.mdx
@@ -21,6 +21,8 @@ with the `how` parameter.
 | `right` | All rows from the **right** table; left columns are `NaN` where no match exists |
 | `outer` | Every row from **either** table; `NaN` wherever the other side has no match |
 
+<Chart slug="sql-join-types" />
+
 ## Setting the stage
 
 <CodeBlock

--- a/content/courses/data-wrangling-python-polars/joins.mdx
+++ b/content/courses/data-wrangling-python-polars/joins.mdx
@@ -46,6 +46,8 @@ for how in ["inner", "left", "right", "full", "semi", "anti"]:
 | `anti` | left rows that have **no** match |
 | `cross` | every left row paired with every right row |
 
+<Chart slug="sql-join-types" />
+
 `semi` and `anti` are the ones people do not know they wanted. They
 are filters that use another frame as the criterion, and unlike an
 `inner` join they cannot change the row count upward.

--- a/content/courses/intro-sql-postgres/outer-joins.mdx
+++ b/content/courses/intro-sql-postgres/outer-joins.mdx
@@ -159,13 +159,6 @@ Once `LEFT JOIN` makes sense, its siblings are easy:
   caption="A left join keeps every left-hand row, filling the gaps with `NULL`."
 />
 
-```mermaid
-flowchart TD
-    I["INNER<br/>only matches"] --- LJ["LEFT<br/>all left + matches"]
-    LJ --- RJ["RIGHT<br/>all right + matches"]
-    RJ --- FJ["FULL<br/>everything,<br/>NULLs where unmatched"]
-```
-
 <Callout type="info" title="A simple way to choose">
 Ask: *"whose rows must I keep even without a match?"* Keep the left
 table → `LEFT JOIN`. Keep both → `FULL JOIN`. Keep only matched rows

--- a/content/courses/intro-sql-postgres/understanding-joins.mdx
+++ b/content/courses/intro-sql-postgres/understanding-joins.mdx
@@ -10,6 +10,8 @@ model delivers on its promise: data split for storage, recombined
 for answers. This page builds the intuition; the next two cover the
 specific kinds.
 
+<Chart slug="sql-join-types" />
+
 <Figure
   slug="sql-understanding-joins-cutout"
   alt="Understanding joins, an isometric illustration"

--- a/content/courses/sqlite-for-beginners/outer-joins.mdx
+++ b/content/courses/sqlite-for-beginners/outer-joins.mdx
@@ -286,13 +286,6 @@ For beginners, `LEFT JOIN` is the most important outer join. Recent SQLite versi
   caption="Put the table you want to keep on the left and a left join covers most needs."
 />
 
-```mermaid
-flowchart TD
-    I["<code>INNER JOIN</code><br/>only matches"] --- L["<code>LEFT JOIN</code><br/>all left rows"]
-    L --- R["<code>RIGHT JOIN</code><br/>all right rows"]
-    R --- F["<code>FULL OUTER JOIN</code><br/>all rows from both sides"]
-```
-
 <Callout type="info" title="How to choose">
 Ask: "Which table's rows must not disappear?" Put that table first, then use `LEFT JOIN`.
 </Callout>

--- a/content/courses/sqlite-for-beginners/understanding-joins.mdx
+++ b/content/courses/sqlite-for-beginners/understanding-joins.mdx
@@ -5,6 +5,8 @@ description: Build a visual mental model for matching rows from two SQLite table
 
 A **join** combines rows from two tables into one result. You use it when one table has part of the answer and another table has the rest.
 
+<Chart slug="sql-join-types" />
+
 For example, `orders` knows the amount. `customers` knows the name. A join lets you ask: "show each order with the customer's name."
 
 ```mermaid

--- a/content/interview/data-analyst/sql.mdx
+++ b/content/interview/data-analyst/sql.mdx
@@ -53,6 +53,8 @@ All combine rows from two tables on a condition; they differ in which
 - **RIGHT**, all rows from the right table; `NULL`s on the left.
 - **FULL**, all rows from both; `NULL`s wherever either side is missing.
 
+<Chart slug="sql-join-types" />
+
 "List all customers and their orders, *including customers who never
 ordered*" is the classic tell for a `LEFT JOIN`.
 

--- a/content/interview/data-engineer/sql.mdx
+++ b/content/interview/data-engineer/sql.mdx
@@ -407,6 +407,8 @@ When a table is partitioned (e.g., by `event_date`) and a query filters on that 
 - **`RIGHT JOIN`**, all rows from the right table; nulls on the left.
 - **`FULL OUTER JOIN`**, all rows from both; nulls where either side has no match.
 
+<Chart slug="sql-join-types" />
+
 ```sql
 -- LEFT JOIN: all customers returned; order columns are NULL for customers
 -- with no orders (useful to find customers who never ordered).

--- a/data/created-at.json
+++ b/data/created-at.json
@@ -332,6 +332,7 @@
     "sparkline-in-a-table": "2026-08-11T12:38:14.000Z",
     "spread-same-center": "2026-08-07T22:00:22.000Z",
     "sql-clause-funnel": "2026-08-08T08:39:12.000Z",
+    "sql-join-types": "2026-08-24T14:57:56.000Z",
     "sql-null-logic": "2026-08-07T22:00:22.000Z",
     "stack-depth-overflow": "2026-08-08T08:39:12.000Z",
     "stack-dodge-fill": "2026-08-07T22:00:22.000Z",

--- a/scripts/build-charts.mjs
+++ b/scripts/build-charts.mjs
@@ -292,7 +292,9 @@ const digest = computeDigest(files, usages);
 // that predates the slugs/SVG splits would skip the writes.
 const svgDirCurrent = () => {
   try {
-    return readdirSync(SVG_DIR).filter((f) => f.endsWith(".svg")).length === specs.length;
+    const expected = specs.map((file) => file.replace(/\.mjs$/, ".svg")).sort();
+    const actual = readdirSync(SVG_DIR).filter((file) => file.endsWith(".svg")).sort();
+    return expected.length === actual.length && expected.every((file, i) => file === actual[i]);
   } catch {
     return false;
   }


### PR DESCRIPTION
### Motivation

- Provide a compact, reusable visual that clarifies what `INNER`, `LEFT`, `RIGHT`, and `FULL` joins preserve across multiple courses and docs.

### Description

- Add a new chart spec `charts/sql-join-types.mjs` that renders Venn-style diagrams for `INNER`, `LEFT`, `RIGHT`, and `FULL` joins with accessible `title` and `caption` exports.
- Embed the chart via `<Chart slug="sql-join-types" />` in multiple MDX pages covering joins across Pandas, Polars, SQLite, Postgres, and interview guides to give a consistent visual aid.
- Improve `scripts/build-charts.mjs` SVG directory verification to ensure the `SVG_DIR` contains exactly the expected SVG filenames before skipping chart rebuilds.

### Testing

- Ran the chart build (`node scripts/build-charts.mjs`) to validate the new spec loads and to verify the updated SVG existence check, and the build completed successfully.
- No automated test suite changes were required and existing tests were unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8be2aecce483258f714b9d5942d7c6)