### PR TITLE
Find the other 12.6 GB: Previews Base has its own build command, and nothing was reading the size

### DIFF
--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -1,9 +1,21 @@
 name: R2 incremental-cache cleanup
 
 # Prunes stale OpenNext incremental-cache build folders from the R2 bucket.
-# Every deploy (production AND every preview) writes a fresh ~2.5 GB folder
-# under `incremental-cache/<buildId>/` and OpenNext never deletes old ones —
-# left alone the bucket grows unbounded (once reached ~78 GB in days).
+# Every deploy (production AND every preview) writes a fresh folder under
+# `incremental-cache/<buildId>/` and OpenNext never deletes old ones — left
+# alone the bucket grows unbounded (once reached ~78 GB in days).
+#
+# Two numbers set the bucket size, and this job only owns one of them:
+#
+#   bucket ≈ (folders retained, THIS JOB) × (bytes per build, THE BUILD PATH)
+#
+# Per-build bytes are ~2.34 GiB of raw JSON, or ~0.147 GiB once
+# scripts/compress-cache.mjs has run — and that script runs from the
+# Cloudflare *build command*, dashboard config outside this repo. So a bucket
+# that looks like a retention failure may be neither: step 7 samples each
+# folder's first four bytes for the brotli magic and says which it is, because
+# the read path accepts both formats and an uncompressed deploy is otherwise
+# completely silent (it was, from 2026-08-15 to 2026-08-26).
 #
 # The build ID IS the deployed commit SHA (next.config.ts generateBuildId =
 # WORKERS_CI_COMMIT_SHA on Workers Builds); that equality is what lets this
@@ -28,7 +40,7 @@ name: R2 incremental-cache cleanup
 #
 # ACTIVE branches, though: Workers Builds does NOT tear a preview down when a
 # PR merges — the alias answers as long as the branch exists, so an
-# unconditioned branch keep set pins ~2.5 GB per merged-but-undeleted branch
+# unconditioned branch keep set pins a build per merged-but-undeleted branch
 # indefinitely. A branch is RETIRED, and claims nothing, when all three hold:
 #
 #   • at least one pull request has this branch as its head,
@@ -48,7 +60,12 @@ name: R2 incremental-cache cleanup
 # The alias is DERIVED from the branch name, never read out of a check run:
 # check runs hang off a COMMIT, and a commit reachable from two branches
 # carries whichever branch's build ran, so reading it can protect the wrong
-# branch.
+# branch. The cost of deriving it is long branch names: past 63 characters
+# Cloudflare truncates and appends a hash it does not publish the recipe for
+# (changelog 2025-08-14), so those branches have a working preview this job
+# cannot name and each falls back to pinning FALLBACK_COMMITS folders. That is
+# the safe direction, and it is not free — keep branch names short, or the
+# fallback is what sets the bucket size.
 #
 # Nothing is retained on age alone: the bucket holds live + incoming
 # production, at most two folders per active branch, plus the GRACE_HOURS
@@ -56,8 +73,8 @@ name: R2 incremental-cache cleanup
 #
 # Deliberate consequence: a merged PR's preview breaks. Once its cache is
 # pruned the alias 500s, and the Cloudflare check-run link on the merged PR
-# still points at it — the alternative is paying ~2.5 GB a branch to keep
-# previews of merged code loadable. GitHub's "Automatically delete head
+# still points at it — the alternative is paying a whole build a branch to
+# keep previews of merged code loadable. GitHub's "Automatically delete head
 # branches" avoids the broken link and retires the branch in the same stroke.
 #
 # Deliberate consequence: NO rollback cover. Rolling the Worker back to a
@@ -103,6 +120,8 @@ on:
     # Every 2 hours, off the top of the hour to avoid scheduler congestion.
     # Cheap: ListObjectsV2 is Class A ($4.50/million — not Class B); ~10 LISTs
     # quiet, ~100 full sweep, ~5,000/month against R2's 1M free Class A ops.
+    # Plus one ranged GET per folder for the format sample — Class B, ~3,000 a
+    # month against 10M free.
     - cron: "17 */2 * * *"
   workflow_dispatch:
     inputs:
@@ -215,6 +234,54 @@ jobs:
           # floating point.
           gb() { awk -v b="${1:-0}" 'BEGIN { printf "%.2f", b / 1e9 }'; }
           pct() { awk -v a="${1:-0}" -v b="${2:-0}" 'BEGIN { printf "%.0f", (b > 0 ? a * 100 / b : 0) }'; }
+
+          # Everything this job needs to know about one folder, in ONE list:
+          # the bytes it occupies, the timestamps that place it in time, and a
+          # key to sample. Rows are "<size>\t<LastModified>\t<key>" — a nested
+          # --query projection prints one object per line, unlike the flat
+          # `Contents[].Size` above, so there is no page batch to flatten. Same
+          # Class A cost as listing the timestamps alone, which is what this
+          # replaced; the sizes and the sample key now ride along for free.
+          folder_rows() {
+            aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$1" \
+              --query 'Contents[].[Size,LastModified,Key]' --output text 2>/dev/null \
+              | grep -vx 'None' || true
+          }
+
+          # Is this build's cache brotli-framed, or the raw JSON that predates
+          # scripts/compress-cache.mjs? Reads the first four bytes of ONE entry
+          # and looks for the magic in lib/cache/brotliCacheFormat.ts. One
+          # sample settles the whole folder: a build's entries are written by a
+          # single populate, so the format is a property of the BUILD, not of
+          # the object. A ranged GET is a Class B op (~8 a run). This only ever
+          # reports — the reader accepts both formats, which is exactly why an
+          # uncompressed deploy is otherwise invisible.
+          cache_format() {
+            local key="$1" tmp magic
+            if [[ -z "$key" ]]; then printf 'unknown'; return 0; fi
+            tmp="$(mktemp)"
+            if ! aws s3api get-object --bucket "$BUCKET" --key "$key" \
+                 --range 'bytes=0-3' "$tmp" >/dev/null 2>&1; then
+              rm -f "$tmp"; printf 'unknown'; return 0
+            fi
+            magic="$(od -An -tx1 -N4 "$tmp" | tr -d ' \n')"
+            rm -f "$tmp"
+            # 00 42 52 31 is `\0BR1`, BROTLI_CACHE_MAGIC.
+            if [[ "$magic" == "00425231" ]]; then printf 'brotli'; else printf 'raw'; fi
+          }
+
+          # How a folder reads in the log: "2.52 GB, UNCOMPRESSED". The size is
+          # on every line, not just on folders being deleted, so a run answers
+          # "why is the bucket this big" without a second look at the bucket.
+          folder_note() {
+            local folder="$1" note
+            note="$(gb "${folder_bytes[$folder]:-0}") GB"
+            case "${folder_format[$folder]:-unknown}" in
+              raw) note="$note, UNCOMPRESSED" ;;
+              brotli) note="$note, brotli" ;;
+            esac
+            printf '%s' "$note"
+          }
 
           # Tolerates R2's transient DeleteObject 500s: `s3 rm` re-lists each
           # attempt, so retries converge. Non-zero only on persistent failure.
@@ -510,11 +577,25 @@ jobs:
           echo "Policy: keep what production and every ACTIVE branch's preview are serving or about to serve, plus anything populated in the last ${GRACE_HOURS}h (since $(date -u -d "@$grace_cutoff" '+%Y-%m-%d %H:%M:%SZ')). A branch whose pull request has merged or closed, with no commits since, keeps nothing."
           echo "Dry run: $DRY_RUN"
 
-          # 6) Date every non-production folder by when it was POPULATED, so
-          #    the grace window means what it says and the MAX_BRANCHES cap
-          #    has a global newest-first order.
+          # 6) Weigh, date and sample every folder in one pass.
+          #
+          #    Size and format are collected for ALL of them, production
+          #    included, because they are what the run log needs to explain
+          #    the bucket. Dates are only collected for the rest: production
+          #    is kept unconditionally, so nothing reads its age.
+          declare -A folder_bytes folder_format folder_gone
           entries=()
           for folder in "${folders[@]}"; do
+            rows="$(folder_rows "$folder")"
+            if [[ -z "$rows" ]]; then
+              folder_bytes["$folder"]=0; folder_format["$folder"]=unknown
+              echo "skip  $folder (empty)"; continue
+            fi
+            folder_bytes["$folder"]="$(
+              printf '%s\n' "$rows" | awk -F'\t' '{ s += $1 } END { printf "%d", s + 0 }'
+            )"
+            folder_format["$folder"]="$(cache_format "$(printf '%s\n' "$rows" | head -n 1 | cut -f3)")"
+
             [[ "$folder" == "$prod_folder" ]] && continue
 
             # MEDIAN LastModified, not the newest: objects can also arrive at
@@ -523,22 +604,14 @@ jobs:
             # The median is immune by construction — a ~1,081-object burst
             # can't be moved by a few late writes — and stays seconds-old
             # during an in-flight populate, which is what the grace window
-            # protects. Pages emit one tab-separated batch each; flatten and
-            # sort (R2's uniform UTC ISO-8601 makes lexical = chronological),
-            # dropping the "None" an empty page emits.
-            mapfile -t stamps < <(
-              aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$folder" \
-                --query 'Contents[].LastModified' --output text 2>/dev/null \
-                | tr '\t' '\n' | sed '/^$/d' | grep -vxF 'None' | sort || true
-            )
-            if [[ ${#stamps[@]} -eq 0 ]]; then
-              echo "skip  $folder (empty)"; continue
-            fi
+            # protects. Sort lexically, which R2's uniform UTC ISO-8601 makes
+            # chronological.
+            mapfile -t stamps < <(printf '%s\n' "$rows" | cut -f2 | sort)
             populated="${stamps[$(( ${#stamps[@]} / 2 ))]}"
             entries+=("$(printf '%s\t%s\t%s' "$(date -u -d "$populated" +%s)" "$populated" "$folder")")
           done
 
-          echo "KEEP  $prod_folder (${keep_reason[$prod_id]})"
+          echo "KEEP  $prod_folder (${keep_reason[$prod_id]}) — $(folder_note "$prod_folder")"
           kept=1; deleted=0; failed=0; branches=0; freed=0
           while IFS=$'\t' read -r ts populated folder; do
             [[ -z "$folder" ]] && continue
@@ -557,38 +630,38 @@ jobs:
                   # promises it unconditionally, and a just-populated folder
                   # may be an in-flight deploy for that very preview.
                   if (( ts >= grace_cutoff )); then
-                    echo "KEEP  $folder (${keep_reason[$sha]}, beyond the branch cap but populated $populated, inside the ${GRACE_HOURS}h grace window)"
+                    echo "KEEP  $folder (${keep_reason[$sha]}, beyond the branch cap but populated $populated, inside the ${GRACE_HOURS}h grace window) — $(folder_note "$folder")"
                     kept=$((kept+1)); continue
                   fi
-                  echo "DELETE $folder (${keep_reason[$sha]}, beyond the $MAX_BRANCHES most recently populated branch builds)"
+                  echo "DELETE $folder (${keep_reason[$sha]}, beyond the $MAX_BRANCHES most recently populated branch builds) — $(folder_note "$folder")"
                 else
-                  echo "KEEP  $folder (${keep_reason[$sha]}, branch ${branches}/${MAX_BRANCHES})"
+                  echo "KEEP  $folder (${keep_reason[$sha]}, branch ${branches}/${MAX_BRANCHES}) — $(folder_note "$folder")"
                   kept=$((kept+1)); continue
                 fi
               else
-                echo "KEEP  $folder (${keep_reason[$sha]})"
+                echo "KEEP  $folder (${keep_reason[$sha]}) — $(folder_note "$folder")"
                 kept=$((kept+1)); continue
               fi
             elif (( ts >= grace_cutoff )); then
               # Deliberately blind: a just-populated deploy may be visible to
               # neither a probe nor a branch head yet.
-              echo "KEEP  $folder (populated $populated, inside the ${GRACE_HOURS}h grace window, possibly an in-flight deploy)"
+              echo "KEEP  $folder (populated $populated, inside the ${GRACE_HOURS}h grace window, possibly an in-flight deploy) — $(folder_note "$folder")"
               kept=$((kept+1)); continue
             else
               # "No active branch", not "nothing is serving it": a retired
               # branch's preview may still be answering from this folder, and
               # taking it down is the intended outcome.
-              echo "DELETE $folder (populated $populated, claimed by no live deployment and no active branch)"
+              echo "DELETE $folder (populated $populated, claimed by no live deployment and no active branch) — $(folder_note "$folder")"
             fi
 
-            # Weigh BEFORE removing — afterwards there's nothing to measure.
-            folder_size="$(bucket_bytes "$folder")"
-            echo "       ($(gb "$folder_size") GB)"
+            # Weighed in step 6, before anything was removed — afterwards
+            # there would be nothing left to measure.
+            folder_size="${folder_bytes[$folder]:-0}"
 
             if [[ "$DRY_RUN" == "true" ]]; then
-              deleted=$((deleted+1)); freed=$((freed + folder_size))
+              deleted=$((deleted+1)); freed=$((freed + folder_size)); folder_gone["$folder"]=1
             elif delete_folder "$folder"; then
-              deleted=$((deleted+1)); freed=$((freed + folder_size))
+              deleted=$((deleted+1)); freed=$((freed + folder_size)); folder_gone["$folder"]=1
             else
               # Persistent failure: keep sweeping the rest, fail the job at
               # the end; the next run retries this folder.
@@ -608,6 +681,32 @@ jobs:
             # failed or a deploy wrote a new folder mid-sweep.
             bytes_after="$(bucket_bytes "$PREFIX")"
             echo "Bucket: $(gb "$bytes_before") GB before -> $(gb "$bytes_after") GB after | freed $(gb "$((bytes_before - bytes_after))") GB ($(pct "$((bytes_before - bytes_after))" "$bytes_before")%)"
+          fi
+
+          # 7) What the retained bytes are made of. Retention is only one of
+          #    the two numbers that set the bucket size; the other is what a
+          #    deploy writes per build, and that one is decided OUTSIDE this
+          #    repo. scripts/compress-cache.mjs runs from the Cloudflare
+          #    Workers Builds *build command* (DEVELOPMENT.md, "Cloudflare
+          #    Workers Builds configuration"), so a deploy path that never got
+          #    it ships ~16x the bytes with a green build and a working site —
+          #    lib/cache/brotliR2IncrementalCache.ts reads raw entries too, by
+          #    design, which is precisely what makes this failure silent. It
+          #    stayed unnoticed from 2026-08-15 to 2026-08-26, at ~2.5 GB per
+          #    retained build instead of ~0.16 GB. Nothing here can fix it;
+          #    this refuses to let it stay invisible.
+          remaining=0; raw_folders=0; raw_bytes=0
+          for folder in "${folders[@]}"; do
+            [[ -n "${folder_gone[$folder]+set}" ]] && continue
+            remaining=$((remaining+1))
+            [[ "${folder_format[$folder]:-}" == "raw" ]] || continue
+            raw_folders=$((raw_folders+1)); raw_bytes=$((raw_bytes + ${folder_bytes[$folder]:-0}))
+          done
+          if (( raw_folders > 0 )); then
+            echo "Uncompressed builds: $raw_folders of $remaining retained folders hold $(gb "$raw_bytes") GB of raw JSON; brotli (~16x, scripts/compress-cache.mjs) would leave about $(gb "$((raw_bytes / 16))") GB."
+          fi
+          if [[ "${folder_format[$prod_folder]:-}" == "raw" ]]; then
+            echo "::warning::The live production build ${prod_id:0:12} was populated WITHOUT scripts/compress-cache.mjs — its cache is $(gb "${folder_bytes[$prod_folder]:-0}") GB where brotli would make it about $(gb "$(( ${folder_bytes[$prod_folder]:-0} / 16 ))") GB, and every preview pays the same. Fix it in Cloudflare: Workers -> dataslope -> Settings -> Build -> Build command = 'npx opennextjs-cloudflare build && node scripts/compress-cache.mjs'. See DEVELOPMENT.md, 'Cloudflare Workers Builds configuration'."
           fi
 
           # Surface persistent delete failures, but only after every folder

--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -18,9 +18,15 @@ name: R2 incremental-cache cleanup
 # completely silent.
 #
 # It was silent for eleven days. On 2026-08-26 production measured 0.16 GB and
-# every one of the six preview folders 2.52 GB — compression attached to the
-# production deploy command rather than to the build command both paths share.
-# The half of the deploy path nobody reads the size of was the whole 15 GB.
+# every one of the six preview folders 2.52 GB, with the build command
+# carrying `&& node scripts/compress-cache.mjs` the whole time — so the
+# compression is being UNDONE on the preview path, not skipped. `deploy` and
+# `upload` both populate from `.open-next/cache` byte-for-byte and neither
+# rebuilds, while `opennextjs-cloudflare build` wipes that directory
+# (`initOutputDir`) and regenerates it raw. A second build after the build
+# command — a non-production branch deploy command that starts with one — is
+# the shape that produces exactly this split. The half of the deploy path
+# nobody reads the size of was the whole 15 GB.
 #
 # The build ID IS the deployed commit SHA (next.config.ts generateBuildId =
 # WORKERS_CI_COMMIT_SHA on Workers Builds); that equality is what lets this
@@ -285,7 +291,10 @@ jobs:
               raw) note="$note, UNCOMPRESSED" ;;
               brotli) note="$note, brotli" ;;
             esac
-            printf '%s' "$note"
+            # Populated-at on every line too: whether a build compressed is a
+            # question about WHEN it ran as much as which path ran it, and the
+            # two are only separable with both on the same line.
+            printf '%s' "$note, populated ${folder_date[$folder]:-unknown}"
           }
 
           # Tolerates R2's transient DeleteObject 500s: `s3 rm` re-lists each
@@ -588,7 +597,7 @@ jobs:
           #    included, because they are what the run log needs to explain
           #    the bucket. Dates are only collected for the rest: production
           #    is kept unconditionally, so nothing reads its age.
-          declare -A folder_bytes folder_format folder_gone
+          declare -A folder_bytes folder_format folder_date folder_gone
           entries=()
           for folder in "${folders[@]}"; do
             rows="$(folder_rows "$folder")"
@@ -602,8 +611,6 @@ jobs:
             first_row="${rows%%$'\n'*}"
             folder_format["$folder"]="$(cache_format "$(printf '%s' "$first_row" | cut -f3)")"
 
-            [[ "$folder" == "$prod_folder" ]] && continue
-
             # MEDIAN LastModified, not the newest: objects can also arrive at
             # REQUEST time long after the deploy (cached 404s once reset a
             # folder's apparent age for hours, holding it inside GRACE_HOURS).
@@ -614,6 +621,14 @@ jobs:
             # chronological.
             mapfile -t stamps < <(printf '%s\n' "$rows" | cut -f2 | sort)
             populated="${stamps[$(( ${#stamps[@]} / 2 ))]}"
+            folder_date["$folder"]="$populated"
+
+            # Production is kept unconditionally, so nothing reads its age and
+            # it is not a candidate in the ordering below. Its date is still
+            # collected above, because the log prints one for every folder:
+            # "which builds compress" is a question about a timeline.
+            [[ "$folder" == "$prod_folder" ]] && continue
+
             entries+=("$(printf '%s\t%s\t%s' "$(date -u -d "$populated" +%s)" "$populated" "$folder")")
           done
 
@@ -693,21 +708,24 @@ jobs:
           #    the two numbers that set the bucket size; the other is bytes
           #    per build, and that one is decided OUTSIDE this repo.
           #
-          #    scripts/compress-cache.mjs belongs on the Cloudflare *build
+          #    scripts/compress-cache.mjs runs from the Cloudflare *build
           #    command*, which Workers Builds runs for production and
-          #    non-production branches alike. Attached to the production
-          #    DEPLOY command instead it still works — for production — and
-          #    every preview keeps shipping ~16x the bytes, which is exactly
-          #    the state found on 2026-08-26: production 0.16 GB, all six
-          #    preview folders 2.52 GB, 12.6 GB of the bucket. Nothing looked
-          #    wrong from any other angle, because
-          #    lib/cache/brotliR2IncrementalCache.ts reads raw entries by
-          #    design and previews served fine throughout.
+          #    non-production branches alike — so "is it set" is not the only
+          #    question to ask of it. On 2026-08-26 it WAS set and production
+          #    measured 0.16 GB while all six preview folders measured
+          #    2.52 GB: 12.6 GB of the bucket, compressed at build time and
+          #    then thrown away before the preview populate. `deploy` and
+          #    `upload` both stream `.open-next/cache` byte-for-byte and
+          #    neither rebuilds; `opennextjs-cloudflare build` wipes that
+          #    directory and regenerates it raw. So a second build on one path
+          #    only — a non-production branch deploy command beginning with
+          #    one — undoes it for previews and leaves production correct.
           #
-          #    So the report is per folder and the warning fires on ANY raw
-          #    build, not just production's: production is the one that would
-          #    have been compressed under either mistake, i.e. the one that
-          #    hides this.
+          #    Which is why the report is per folder and the warning fires on
+          #    ANY raw build, not just production's: production is the build
+          #    that stays correct under this failure, i.e. the one that hides
+          #    it. The populated-at stamp on each line separates "this path
+          #    never compresses" from "this build predates the fix".
           remaining=0; raw_folders=0; raw_bytes=0
           for folder in "${folders[@]}"; do
             [[ -n "${folder_gone[$folder]+set}" ]] && continue
@@ -716,7 +734,7 @@ jobs:
             raw_folders=$((raw_folders+1)); raw_bytes=$((raw_bytes + ${folder_bytes[$folder]:-0}))
           done
           if (( raw_folders > 0 )); then
-            echo "::warning::${raw_folders} of ${remaining} retained build folders were populated WITHOUT scripts/compress-cache.mjs: $(gb "$raw_bytes") GB of raw JSON where brotli would leave about $(gb "$((raw_bytes / 16))") GB. The live production build is $([[ "${folder_format[$prod_folder]:-}" == "raw" ]] && echo "one of them" || echo "NOT one of them, so this is the preview path only — compression is attached to the production deploy command instead of the build command"). Fix it in Cloudflare: Workers -> dataslope -> Settings -> Build -> Build command = 'npx opennextjs-cloudflare build && node scripts/compress-cache.mjs', which runs on both paths. See DEVELOPMENT.md, 'Cloudflare Workers Builds configuration'."
+            echo "::warning::${raw_folders} of ${remaining} retained build folders carry raw JSON, not the brotli scripts/compress-cache.mjs produces: $(gb "$raw_bytes") GB where it would leave about $(gb "$((raw_bytes / 16))") GB. $([[ "${folder_format[$prod_folder]:-}" == "raw" ]] && echo "Production is one of them, so start with the build command: Workers -> dataslope -> Settings -> Build -> Build command = 'npx opennextjs-cloudflare build && node scripts/compress-cache.mjs'." || echo "Production is NOT one of them, so the build command is running compress-cache and something on the preview path is undoing it: check the non-production branch deploy command for a second 'opennextjs-cloudflare build', which wipes and regenerates the cache the build command just compressed.") See DEVELOPMENT.md, 'Cloudflare Workers Builds configuration'."
           fi
 
           # Surface persistent delete failures, but only after every folder

--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -18,15 +18,13 @@ name: R2 incremental-cache cleanup
 # completely silent.
 #
 # It was silent for eleven days. On 2026-08-26 production measured 0.16 GB and
-# every one of the six preview folders 2.52 GB, with the build command
-# carrying `&& node scripts/compress-cache.mjs` the whole time — so the
-# compression is being UNDONE on the preview path, not skipped. `deploy` and
-# `upload` both populate from `.open-next/cache` byte-for-byte and neither
-# rebuilds, while `opennextjs-cloudflare build` wipes that directory
-# (`initOutputDir`) and regenerates it raw. A second build after the build
-# command — a non-production branch deploy command that starts with one — is
-# the shape that produces exactly this split. The half of the deploy path
-# nobody reads the size of was the whole 15 GB.
+# every one of the six preview folders 2.52 GB. The cause is that Workers
+# Builds keeps TWO build configurations behind a Production / Previews Base
+# tab switch, each with its own build command: Production carried
+# `&& node scripts/compress-cache.mjs`, Previews Base was still a bare
+# `npx opennextjs-cloudflare build`. One unedited field on the tab nobody
+# opens, on the path that deploys ~10x more often than production, was 12.6 GB
+# of a 15.44 GB bucket.
 #
 # The build ID IS the deployed commit SHA (next.config.ts generateBuildId =
 # WORKERS_CI_COMMIT_SHA on Workers Builds); that equality is what lets this
@@ -709,23 +707,18 @@ jobs:
           #    per build, and that one is decided OUTSIDE this repo.
           #
           #    scripts/compress-cache.mjs runs from the Cloudflare *build
-          #    command*, which Workers Builds runs for production and
-          #    non-production branches alike — so "is it set" is not the only
-          #    question to ask of it. On 2026-08-26 it WAS set and production
-          #    measured 0.16 GB while all six preview folders measured
-          #    2.52 GB: 12.6 GB of the bucket, compressed at build time and
-          #    then thrown away before the preview populate. `deploy` and
-          #    `upload` both stream `.open-next/cache` byte-for-byte and
-          #    neither rebuilds; `opennextjs-cloudflare build` wipes that
-          #    directory and regenerates it raw. So a second build on one path
-          #    only — a non-production branch deploy command beginning with
-          #    one — undoes it for previews and leaves production correct.
+          #    command*, and there are TWO of those: the Build settings page
+          #    has a Production / Previews Base tab switch and each tab holds
+          #    its own. "Is it set" therefore has two answers, and on
+          #    2026-08-26 they differed — Production compressed (0.16 GB),
+          #    Previews Base did not (2.52 GB x 6, i.e. 12.6 GB of the
+          #    bucket), because only the tab you land on had been edited.
           #
           #    Which is why the report is per folder and the warning fires on
           #    ANY raw build, not just production's: production is the build
-          #    that stays correct under this failure, i.e. the one that hides
-          #    it. The populated-at stamp on each line separates "this path
-          #    never compresses" from "this build predates the fix".
+          #    that stays correct when one tab is missed, i.e. the one that
+          #    hides this. The populated-at stamp on each line separates "this
+          #    path never compresses" from "this build predates the fix".
           remaining=0; raw_folders=0; raw_bytes=0
           for folder in "${folders[@]}"; do
             [[ -n "${folder_gone[$folder]+set}" ]] && continue
@@ -734,7 +727,7 @@ jobs:
             raw_folders=$((raw_folders+1)); raw_bytes=$((raw_bytes + ${folder_bytes[$folder]:-0}))
           done
           if (( raw_folders > 0 )); then
-            echo "::warning::${raw_folders} of ${remaining} retained build folders carry raw JSON, not the brotli scripts/compress-cache.mjs produces: $(gb "$raw_bytes") GB where it would leave about $(gb "$((raw_bytes / 16))") GB. $([[ "${folder_format[$prod_folder]:-}" == "raw" ]] && echo "Production is one of them, so start with the build command: Workers -> dataslope -> Settings -> Build -> Build command = 'npx opennextjs-cloudflare build && node scripts/compress-cache.mjs'." || echo "Production is NOT one of them, so the build command is running compress-cache and something on the preview path is undoing it: check the non-production branch deploy command for a second 'opennextjs-cloudflare build', which wipes and regenerates the cache the build command just compressed.") See DEVELOPMENT.md, 'Cloudflare Workers Builds configuration'."
+            echo "::warning::${raw_folders} of ${remaining} retained build folders carry raw JSON, not the brotli scripts/compress-cache.mjs produces: $(gb "$raw_bytes") GB where it would leave about $(gb "$((raw_bytes / 16))") GB. $([[ "${folder_format[$prod_folder]:-}" == "raw" ]] && echo "Production is one of them, so start with the Production tab: Workers -> dataslope -> Settings -> Build -> Production -> Build command = 'npx opennextjs-cloudflare build && node scripts/compress-cache.mjs'; check the Previews Base tab too, it has its own." || echo "Production is NOT one of them, so the Production tab's build command is running compress-cache and the PREVIEWS BASE tab's is not: Workers -> dataslope -> Settings -> Build -> Previews Base -> Build command = 'npx opennextjs-cloudflare build && node scripts/compress-cache.mjs'.") See DEVELOPMENT.md, 'Cloudflare Workers Builds configuration'."
           fi
 
           # Surface persistent delete failures, but only after every folder

--- a/.github/workflows/r2-cache-cleanup.yml
+++ b/.github/workflows/r2-cache-cleanup.yml
@@ -15,7 +15,12 @@ name: R2 incremental-cache cleanup
 # that looks like a retention failure may be neither: step 7 samples each
 # folder's first four bytes for the brotli magic and says which it is, because
 # the read path accepts both formats and an uncompressed deploy is otherwise
-# completely silent (it was, from 2026-08-15 to 2026-08-26).
+# completely silent.
+#
+# It was silent for eleven days. On 2026-08-26 production measured 0.16 GB and
+# every one of the six preview folders 2.52 GB — compression attached to the
+# production deploy command rather than to the build command both paths share.
+# The half of the deploy path nobody reads the size of was the whole 15 GB.
 #
 # The build ID IS the deployed commit SHA (next.config.ts generateBuildId =
 # WORKERS_CI_COMMIT_SHA on Workers Builds); that equality is what lets this
@@ -594,7 +599,8 @@ jobs:
             folder_bytes["$folder"]="$(
               printf '%s\n' "$rows" | awk -F'\t' '{ s += $1 } END { printf "%d", s + 0 }'
             )"
-            folder_format["$folder"]="$(cache_format "$(printf '%s\n' "$rows" | head -n 1 | cut -f3)")"
+            first_row="${rows%%$'\n'*}"
+            folder_format["$folder"]="$(cache_format "$(printf '%s' "$first_row" | cut -f3)")"
 
             [[ "$folder" == "$prod_folder" ]] && continue
 
@@ -684,17 +690,24 @@ jobs:
           fi
 
           # 7) What the retained bytes are made of. Retention is only one of
-          #    the two numbers that set the bucket size; the other is what a
-          #    deploy writes per build, and that one is decided OUTSIDE this
-          #    repo. scripts/compress-cache.mjs runs from the Cloudflare
-          #    Workers Builds *build command* (DEVELOPMENT.md, "Cloudflare
-          #    Workers Builds configuration"), so a deploy path that never got
-          #    it ships ~16x the bytes with a green build and a working site —
-          #    lib/cache/brotliR2IncrementalCache.ts reads raw entries too, by
-          #    design, which is precisely what makes this failure silent. It
-          #    stayed unnoticed from 2026-08-15 to 2026-08-26, at ~2.5 GB per
-          #    retained build instead of ~0.16 GB. Nothing here can fix it;
-          #    this refuses to let it stay invisible.
+          #    the two numbers that set the bucket size; the other is bytes
+          #    per build, and that one is decided OUTSIDE this repo.
+          #
+          #    scripts/compress-cache.mjs belongs on the Cloudflare *build
+          #    command*, which Workers Builds runs for production and
+          #    non-production branches alike. Attached to the production
+          #    DEPLOY command instead it still works — for production — and
+          #    every preview keeps shipping ~16x the bytes, which is exactly
+          #    the state found on 2026-08-26: production 0.16 GB, all six
+          #    preview folders 2.52 GB, 12.6 GB of the bucket. Nothing looked
+          #    wrong from any other angle, because
+          #    lib/cache/brotliR2IncrementalCache.ts reads raw entries by
+          #    design and previews served fine throughout.
+          #
+          #    So the report is per folder and the warning fires on ANY raw
+          #    build, not just production's: production is the one that would
+          #    have been compressed under either mistake, i.e. the one that
+          #    hides this.
           remaining=0; raw_folders=0; raw_bytes=0
           for folder in "${folders[@]}"; do
             [[ -n "${folder_gone[$folder]+set}" ]] && continue
@@ -703,10 +716,7 @@ jobs:
             raw_folders=$((raw_folders+1)); raw_bytes=$((raw_bytes + ${folder_bytes[$folder]:-0}))
           done
           if (( raw_folders > 0 )); then
-            echo "Uncompressed builds: $raw_folders of $remaining retained folders hold $(gb "$raw_bytes") GB of raw JSON; brotli (~16x, scripts/compress-cache.mjs) would leave about $(gb "$((raw_bytes / 16))") GB."
-          fi
-          if [[ "${folder_format[$prod_folder]:-}" == "raw" ]]; then
-            echo "::warning::The live production build ${prod_id:0:12} was populated WITHOUT scripts/compress-cache.mjs — its cache is $(gb "${folder_bytes[$prod_folder]:-0}") GB where brotli would make it about $(gb "$(( ${folder_bytes[$prod_folder]:-0} / 16 ))") GB, and every preview pays the same. Fix it in Cloudflare: Workers -> dataslope -> Settings -> Build -> Build command = 'npx opennextjs-cloudflare build && node scripts/compress-cache.mjs'. See DEVELOPMENT.md, 'Cloudflare Workers Builds configuration'."
+            echo "::warning::${raw_folders} of ${remaining} retained build folders were populated WITHOUT scripts/compress-cache.mjs: $(gb "$raw_bytes") GB of raw JSON where brotli would leave about $(gb "$((raw_bytes / 16))") GB. The live production build is $([[ "${folder_format[$prod_folder]:-}" == "raw" ]] && echo "one of them" || echo "NOT one of them, so this is the preview path only — compression is attached to the production deploy command instead of the build command"). Fix it in Cloudflare: Workers -> dataslope -> Settings -> Build -> Build command = 'npx opennextjs-cloudflare build && node scripts/compress-cache.mjs', which runs on both paths. See DEVELOPMENT.md, 'Cloudflare Workers Builds configuration'."
           fi
 
           # Surface persistent delete failures, but only after every folder

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ Production and preview deploys run through Cloudflare Workers Builds rather than
 
 | Field | Value |
 | --- | --- |
-| Build command | `npx opennextjs-cloudflare build && node scripts/compress-cache.mjs` |
+| Build command | `npx opennextjs-cloudflare build && node scripts/compress-cache.mjs` ⚠️ **see below — the second half is not set today** |
 | Deploy command | `npx opennextjs-cloudflare deploy --cacheChunkSize 100 && npm run db:seed:search:remote` |
 | Version command *(the dashboard's label for the non-production branch deploy)* | `npx opennextjs-cloudflare upload --cacheChunkSize 100` |
 | Path | `/` |
@@ -63,6 +63,13 @@ Both `deploy` (production) and `upload` (preview versions) populate the R2 cache
 **`scripts/compress-cache.mjs` is why the build command has a second half.** The populate step uploads the files under `.open-next/cache/` to R2 byte-for-byte, so compressing them on disk is the only place that shrinks what a deploy ships. Brotli takes this cache from **2.340 GiB to 0.147 GiB — 15.9×** — for ~15 s of build time on the Workers Builds runner (quality 4, threaded across all cores; see the note on `BROTLI_CACHE_QUALITY`), and the Worker reads them back through `lib/cache/brotliR2IncrementalCache.ts` (wired up in `open-next.config.ts`). Filenames are unchanged, because OpenNext's `getCacheAssets` derives each R2 key from the path and rejects anything not ending in `.cache`.
 
 It is safe to forget. The reader accepts uncompressed entries too, so a deploy that skips this step ships a cache that is merely as large as it used to be, rather than a site that 500s — see the note in `brotliR2IncrementalCache.ts` for why that fallback is load-bearing rather than defensive clutter. Running it twice is a no-op.
+
+**It is currently forgotten, and has been since the code merged.** Step 4 of [the #665 handoff](agent-outputs/20260814-2030-build-pipeline-handoff.md) — appending `&& node scripts/compress-cache.mjs` to this field — was deliberately deferred until a deploy had shipped the brotli reader, and was then never made. Every deploy from 2026-08-15 to at least 2026-08-26 has therefore populated R2 with raw JSON: **2.52 GB per build instead of ~0.16 GB**, which is the whole of the ~15 GB the bucket has been sitting at. Nothing looked wrong from any other angle — the site serves, the build is green, and the retention job was pruning correctly the entire time. That is the fallback working exactly as designed, and it is why the size is the only symptom.
+
+Two ways to see the state of this field without opening the dashboard:
+
+- **The cleanup run log** (`.github/workflows/r2-cache-cleanup.yml`, every 2 h) prints each build folder's size and format — `2.52 GB, UNCOMPRESSED` versus `0.16 GB, brotli` — and raises a workflow warning when the live production build is the former.
+- **The build log** says `[compress-cache] N compressed … 2.340 GiB → 0.147 GiB` when the step ran. No such line means it did not.
 
 **`--cacheChunkSize` is how many cache objects are written to R2 at once, and the default is 25.** That default is not sized for this cache: the populate step ships **1,081 objects / 2.34 GiB on every deploy, production and every preview** (see [Incremental cache cleanup](#incremental-cache-cleanup) for why a full copy goes up each time), and at 25 in flight that is 44 sequential rounds of ~2.2 MB uploads. Both commands accept the flag — it is declared on `deploy` and `upload` alike, and OpenNext's arg parser consumes it rather than forwarding it to `wrangler`, so it cannot confuse the deploy underneath.
 
@@ -83,7 +90,16 @@ The search re-seed is appended to the **production** deploy command only, and th
 
 ### Incremental cache cleanup
 
-OpenNext keys cache objects as `incremental-cache/<buildId>/…`, so **every deploy, production and each preview, writes a fresh copy (~2.5 GB: one `.cache` object per prerendered page, ~1,080 of them averaging ~2.3 MB) under a new build ID, and nothing is pruned automatically.** Left alone the bucket grows by that much per deploy; at active-development velocity it reached 78 GB within days.
+OpenNext keys cache objects as `incremental-cache/<buildId>/…`, so **every deploy, production and each preview, writes a fresh copy (one `.cache` object per prerendered page, ~1,080 of them) under a new build ID, and nothing is pruned automatically.** Left alone the bucket grows by a full copy per deploy; at active-development velocity it reached 78 GB within days.
+
+Two independent numbers set the bucket size, and it is worth keeping them apart when it looks wrong:
+
+```
+bucket ≈ (build folders retained) × (bytes per build)
+             ↑ the cleanup job below      ↑ the build command above
+```
+
+**Bytes per build is ~2.34 GiB raw, or ~0.147 GiB once `compress-cache` has run** — a 16× difference that no amount of retention tuning can substitute for. The 15 GB the bucket sat at through August was 6–8 retained folders (correct) at 2.52 GB each (not correct): a build-command problem wearing a retention problem's clothes. The cleanup log now names which one it is looking at, so the next one gets diagnosed from the run log rather than from the dashboard.
 
 A scheduled GitHub Action (`.github/workflows/r2-cache-cleanup.yml`) prunes it every 2 hours. It works because the build ID is the deployed commit SHA — `next.config.ts` sets `generateBuildId` to `WORKERS_CI_COMMIT_SHA` on Workers Builds — so a cache folder's name is the commit it was built from, and every folder can be matched against a live deployment.
 
@@ -101,7 +117,7 @@ Everything else is deleted. Note it enumerates **branches, not open PRs**: Worke
 
 A branch is **retired**, and keeps nothing, once every PR with that branch as its head has merged or closed *and* no commits have been pushed since. Workers Builds does not tear a preview down when a PR merges — the alias keeps answering for as long as the branch exists — so without this a merged-but-undeleted branch would pin ~2.5 GB indefinitely for a preview nobody will open again. The "no commits since" half is what makes it safe to apply the moment a PR closes: a branch whose head has moved past its closed PR is live work again (reopened, followed up, reused) and stays protected. A branch that never had a PR is *not* retired — that is precisely the pre-PR case above — but it is named in the run log, since only deleting the branch will ever release its folders.
 
-Nothing is retained on age alone, so **deploy velocity no longer sets the bucket size — the number of branches with unfinished work does**: the bucket holds production's two builds plus at most two per active branch, capped by `MAX_BRANCHES`. The flip side is unchanged: a preview URL stops rendering once its folder is pruned (push any commit, or re-run its build, to regenerate it) — which now includes a merged PR's preview, so the check-run link on a merged PR will 500. Enabling GitHub's *Automatically delete head branches* both avoids that dead link and retires the branch here in one move. There is still **no rollback cover** — rolling the Worker back to a build whose cache has been pruned will 500 the site, so revert-and-redeploy (~12 min) is the recovery path.
+Nothing is retained on age alone, so **deploy velocity no longer sets the bucket size — the number of branches with unfinished work does**: the bucket holds production's two builds plus at most two per active branch, capped by `MAX_BRANCHES`. One exception is worth knowing about, because it is the difference between two folders and four: a branch whose name pushes `<branch-slug>-dataslope` past the 63-character DNS limit gets a preview alias Cloudflare [truncates and hashes](https://developers.cloudflare.com/changelog/post/2025-08-08-support-long-branch-names-preview-aliases/), and the recipe for that hash is not published — so the job cannot name the alias, cannot probe it, and falls back to pinning that branch's last `FALLBACK_COMMITS` (3) builds. Two such branches held 3 folders each in August. Short branch names are the whole fix. The flip side is unchanged: a preview URL stops rendering once its folder is pruned (push any commit, or re-run its build, to regenerate it) — which now includes a merged PR's preview, so the check-run link on a merged PR will 500. Enabling GitHub's *Automatically delete head branches* both avoids that dead link and retires the branch here in one move. There is still **no rollback cover** — rolling the Worker back to a build whose cache has been pruned will 500 the site, so revert-and-redeploy (~12 min) is the recovery path.
 
 The job **aborts without deleting anything** if it can't positively identify the live production folder, resolve the default branch, or list the repo's branches — a transient API error must never leave every folder unexplained and therefore deleted. A *preview* probe failing is different: it never aborts the sweep, and that branch alone falls back to keeping its last few commits, so "no answer" is never read as "nothing to keep". A failed *PR* lookup resolves the same way, in the protective direction: that branch is treated as active, because retirement is the one rule here whose job is to delete more and so the one rule that must never fire on a guess. Trigger it manually with `dry_run` to preview deletions.
 
@@ -115,7 +131,7 @@ It needs three repository secrets (Settings → Secrets and variables → Action
 
 The `R2_INC_CACHE_*` pair is named for the bucket it belongs to, because a second R2 credential now exists: `.github/workflows/r2-illustrations-lifecycle.yml` needs an **Admin Read & Write** token (`R2_ADMIN_*`) to edit bucket configuration, which is a tier this job deliberately does not get — it deletes objects unattended every two hours, and admin tokens are account-wide, so one here could destroy `dataslope-workspaces` (live user data) or `dataslope-inc-cache` itself. The job aborts rather than running credential-less, so a missing or half-renamed secret fails loudly instead of reporting a green run that pruned nothing.
 
-There is little left to tune: `MAX_BRANCHES` caps how many branch previews may coexist, and `GRACE_HOURS` sizes the in-flight-deploy safety net. `THRESHOLD_HOURS`, `MAIN_COMMITS`, `PR_COMMITS` and `MIN_CACHE_OBJECTS` were retired on 2026-08-14 — each approximated something the job now measures directly, and the age threshold in particular was the single largest contributor to the 78 GB peak. At ~2.5 GB per retained build, retention is what decides whether the bucket sits near R2's 10 GB free tier or balloons; storage beyond it is cheap ($0.015/GB-month), but there's no reason to pay for dead previews.
+There is little left to tune: `MAX_BRANCHES` caps how many branch previews may coexist, and `GRACE_HOURS` sizes the in-flight-deploy safety net. `THRESHOLD_HOURS`, `MAIN_COMMITS`, `PR_COMMITS` and `MIN_CACHE_OBJECTS` were retired on 2026-08-14 — each approximated something the job now measures directly, and the age threshold in particular was the single largest contributor to the 78 GB peak. Retention decides whether the bucket sits near R2's 10 GB free tier or balloons — but only once bytes-per-build is what it should be: at ~0.147 GiB a build the whole steady-state bucket is well under a gigabyte, and at 2.34 GiB it is over the free tier with three folders. Storage beyond the tier is cheap ($0.015/GB-month), but there's no reason to pay for dead previews or for compression that isn't running.
 
 ## Search
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,15 +42,32 @@ This is safe here because lesson content only changes on deploy and every asset 
 
 ### Cloudflare Workers Builds configuration
 
-Production and preview deploys run through Cloudflare Workers Builds rather than the local `npm run cf:*` scripts, so its build settings (Workers → the `dataslope` worker → Settings → Build) must populate the R2 cache on **both** paths. The non-production (preview) command — the dashboard labels it **Version command** — is the easy one to get wrong: a bare `npx wrangler versions upload` builds the Worker but skips the cache populate step, leaving previews with an empty cache that 500s the home page and `/courses/*`.
+Production and preview deploys run through Cloudflare Workers Builds rather than the local `npm run cf:*` scripts, so its build settings (Workers → the `dataslope` worker → Settings → Build) must populate the R2 cache on **both** paths.
+
+**There are two build configurations, not one.** The Build settings page has a **Production / Previews Base** tab switch at the top, and each tab holds its own Build command and Deploy command. Older Cloudflare docs describe a single build command plus a "Version command" for non-production branches; that is not this UI. Everything below has to be set **twice**, once per tab, and a field set on Production alone silently does nothing for previews:
+
+**Production tab**
 
 | Field | Value |
 | --- | --- |
 | Build command | `npx opennextjs-cloudflare build && node scripts/compress-cache.mjs` |
 | Deploy command | `npx opennextjs-cloudflare deploy --cacheChunkSize 100 && npm run db:seed:search:remote` |
-| Version command *(the dashboard's label for the non-production branch deploy)* | `npx opennextjs-cloudflare upload --cacheChunkSize 100` |
-| Path | `/` |
+
+**Previews Base tab**
+
+| Field | Value |
+| --- | --- |
+| Build command | `npx opennextjs-cloudflare build && node scripts/compress-cache.mjs` |
+| Deploy command | `npx opennextjs-cloudflare upload --cacheChunkSize 100` |
+
+Shared by both:
+
+| Field | Value |
+| --- | --- |
+| Root directory | `/` |
 | Build variable | `NPM_CONFIG_OMIT` = `dev` |
+
+Two things about the Previews Base deploy command are load-bearing. It must not be a bare `npx wrangler versions upload`: that builds the Worker but skips the cache populate step, leaving previews with an empty cache that 500s the home page and `/courses/*`. And it must **not** carry `npm run db:seed:search:remote` — there is one `dataslope-search` database, so a preview seed overwrites production's index with a feature branch's content and nothing looks broken until someone searches.
 
 **`NPM_CONFIG_OMIT=dev` is why `dependencies` looks the way it does.** Workers Builds runs its own `npm clean-install` and exposes no install command to override, but npm reads `NPM_CONFIG_*` from the environment, and build variables are environment. So everything `npm run build` and the deploy actually load lives in `dependencies` — including `typescript`, `tailwindcss`, `sharp`, `pyodide`, `remark-mdx` and `@cloudflare/workers-types`, several of which are imported by `app/` and `lib/` source and were mis-filed as dev dependencies to begin with. What is left in `devDependencies` is only what CI never runs: the test, lint, e2e and content-sweep tooling.
 
@@ -58,13 +75,13 @@ Measured: **98 s → 62 s** locally (2.1 GB → 1.9 GB of `node_modules`), by no
 
 Forgetting the variable is safe — CI just installs everything and takes the extra ~40 s, which is exactly today's behaviour. Do **not** reach for `NPM_CONFIG_OMIT=optional` instead: npm ships platform-specific native binaries *as* optional dependencies, so it strips them out of unrelated packages and the build dies on `Cannot find native binding` (`@ast-grep/napi`, measured).
 
-Both `deploy` (production) and `upload` (preview versions) populate the R2 cache before shipping, `upload` wraps `wrangler versions upload`, so previews get the same populated cache production does. `Path` is `/` because this Worker lives at the repo root; the CORS proxy under `cloudflare-cors-proxy/` is a separate Worker with its own config.
+Both `deploy` (production) and `upload` (preview versions) populate the R2 cache before shipping, `upload` wraps `wrangler versions upload`, so previews get the same populated cache production does. `Root directory` is `/` because this Worker lives at the repo root; the CORS proxy under `cloudflare-cors-proxy/` is a separate Worker with its own config.
 
 **`scripts/compress-cache.mjs` is why the build command has a second half.** The populate step uploads the files under `.open-next/cache/` to R2 byte-for-byte, so compressing them on disk is the only place that shrinks what a deploy ships. Brotli takes this cache from **2.340 GiB to 0.147 GiB — 15.9×** — for ~15 s of build time on the Workers Builds runner (quality 4, threaded across all cores; see the note on `BROTLI_CACHE_QUALITY`), and the Worker reads them back through `lib/cache/brotliR2IncrementalCache.ts` (wired up in `open-next.config.ts`). Filenames are unchanged, because OpenNext's `getCacheAssets` derives each R2 key from the path and rejects anything not ending in `.cache`.
 
 It is safe to forget. The reader accepts uncompressed entries too, so a deploy that skips this step ships a cache that is merely as large as it used to be, rather than a site that 500s — see the note in `brotliR2IncrementalCache.ts` for why that fallback is load-bearing rather than defensive clutter. Running it twice is a no-op.
 
-**Setting it is necessary and not sufficient — something downstream can undo it.** Measured 2026-08-26 straight out of the bucket, with the build command above set correctly:
+**Setting it on the Production tab is half the job.** Measured 2026-08-26 straight out of the bucket, with Production's build command set correctly and Previews Base's left at a bare `npx opennextjs-cloudflare build`:
 
 | Build folder | Populated | Size | Format |
 | --- | --- | ---: | --- |
@@ -76,15 +93,11 @@ It is safe to forget. The reader accepts uncompressed entries too, so a deploy t
 | preview | 2026-08-25 17:20 | 2.53 GB | **raw JSON** |
 | preview ×3 | 2026-08-24 14:06–15:05 | 2.51–2.52 GB | **raw JSON** |
 
-Read the dates as well as the sizes: production compresses on 08-24 *and* on 08-26, previews compress on neither, and the two interleave through the same afternoon. This splits by **path**, not by timeline — it is not a setting that was changed part-way through. Workers Builds runs **one** build command for production and non-production branches alike and varies only the *deploy* command ([Build branches](https://developers.cloudflare.com/workers/ci-cd/builds/build-branches/)), so the compression is reaching the preview path and being thrown away again before its populate.
-
-There is one mechanism that does that. `deploy` and `upload` are the same code as far as the cache goes: both stream `.open-next/cache` to R2 byte-for-byte and **neither rebuilds**. `opennextjs-cloudflare build`, by contrast, *wipes* `.open-next` (`initOutputDir`) and regenerates the cache assets as fresh raw JSON. So a second `opennextjs-cloudflare build` on one path only — a **non-production branch deploy command** that begins with one — reproduces this split exactly: production ships what the build command compressed, previews ship a regenerated raw copy.
-
-**The Version command must therefore not rebuild.** Keep it at `npx opennextjs-cloudflare upload --cacheChunkSize 100`; if it has to rebuild for some other reason, it must re-run `node scripts/compress-cache.mjs` after doing so.
+Read the dates as well as the sizes: production compresses on 08-24 *and* on 08-26, previews compress on neither, and the two interleave through the same afternoon. It splits by **tab**, not by timeline — 12.6 GB of a 15.44 GB bucket, from one unedited field on a tab nobody had opened. That the two configurations exist at all is the entire trap: the Production tab is the one you land on, the change looks applied, and the deploy path that runs ~10× more often than production keeps shipping raw JSON.
 
 Nothing looked wrong from any other angle, and that is the fallback working as designed: previews served fine, builds were green, and the retention job was pruning correctly the whole time. Size was the only symptom, and nothing was reading it. Two ways to check without opening the dashboard:
 
-- **The cleanup run log** (`.github/workflows/r2-cache-cleanup.yml`, every 2 h) prints every build folder's size, format and populate time — `2.52 GB, UNCOMPRESSED, populated …` versus `0.16 GB, brotli, populated …` — and warns when any retained build is raw. Whether production is among them is the fork in the diagnosis: if it is, suspect the build command; if it is not, suspect the non-production branch deploy command, because production is the build that stays correct under the failure above.
+- **The cleanup run log** (`.github/workflows/r2-cache-cleanup.yml`, every 2 h) prints every build folder's size, format and populate time — `2.52 GB, UNCOMPRESSED, populated …` versus `0.16 GB, brotli, populated …` — and warns when any retained build is raw. Whether production is among them is the fork in the diagnosis: if it is, the Production tab needs the fix; if it is not, the Previews Base tab does, because production is the build that stays correct when only one tab was edited.
 - **The build log** says `[compress-cache] N compressed … 2.340 GiB → 0.147 GiB` when the step ran. No such line means it did not.
 
 **`--cacheChunkSize` is how many cache objects are written to R2 at once, and the default is 25.** That default is not sized for this cache: the populate step ships **1,081 objects / 2.34 GiB on every deploy, production and every preview** (see [Incremental cache cleanup](#incremental-cache-cleanup) for why a full copy goes up each time), and at 25 in flight that is 44 sequential rounds of ~2.2 MB uploads. Both commands accept the flag — it is declared on `deploy` and `upload` alike, and OpenNext's arg parser consumes it rather than forwarding it to `wrangler`, so it cannot confuse the deploy underneath.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,13 +66,17 @@ It is safe to forget. The reader accepts uncompressed entries too, so a deploy t
 
 **Setting it is necessary and not sufficient — something downstream can undo it.** Measured 2026-08-26 straight out of the bucket, with the build command above set correctly:
 
-| Build folder | Size | Format |
-| --- | ---: | --- |
-| live production | 0.16 GB | brotli |
-| `main` head (production's incoming build) | 0.16 GB | brotli |
-| all six preview builds | 2.51–2.53 GB each | **raw JSON** |
+| Build folder | Populated | Size | Format |
+| --- | --- | ---: | --- |
+| production | 2026-08-26 11:14 | 0.16 GB | brotli |
+| production (previous) | 2026-08-24 18:22 | 0.16 GB | brotli |
+| `main` head | 2026-08-24 18:21 | 0.16 GB | brotli |
+| preview | 2026-08-26 09:57 | 2.52 GB | **raw JSON** |
+| preview | 2026-08-26 09:39 | 2.52 GB | **raw JSON** |
+| preview | 2026-08-25 17:20 | 2.53 GB | **raw JSON** |
+| preview ×3 | 2026-08-24 14:06–15:05 | 2.51–2.52 GB | **raw JSON** |
 
-Production compresses; no preview does — 12.6 GB of a 15.44 GB bucket. Workers Builds runs **one** build command for production and non-production branches alike and varies only the *deploy* command ([Build branches](https://developers.cloudflare.com/workers/ci-cd/builds/build-branches/)), so the compression is reaching the preview path and being thrown away again before its populate.
+Read the dates as well as the sizes: production compresses on 08-24 *and* on 08-26, previews compress on neither, and the two interleave through the same afternoon. This splits by **path**, not by timeline — it is not a setting that was changed part-way through. Workers Builds runs **one** build command for production and non-production branches alike and varies only the *deploy* command ([Build branches](https://developers.cloudflare.com/workers/ci-cd/builds/build-branches/)), so the compression is reaching the preview path and being thrown away again before its populate.
 
 There is one mechanism that does that. `deploy` and `upload` are the same code as far as the cache goes: both stream `.open-next/cache` to R2 byte-for-byte and **neither rebuilds**. `opennextjs-cloudflare build`, by contrast, *wipes* `.open-next` (`initOutputDir`) and regenerates the cache assets as fresh raw JSON. So a second `opennextjs-cloudflare build` on one path only — a **non-production branch deploy command** that begins with one — reproduces this split exactly: production ships what the build command compressed, previews ship a regenerated raw copy.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -217,6 +217,18 @@ Gating matters more than the row count suggests. A re-seed deletes and re-insert
 
 Two properties worth keeping if this is ever rewritten: the hash is written **last**, so a partial apply cannot leave a hash claiming to be current and the next deploy retries; and **any uncertainty seeds** — an unreadable remote hash means apply, because a redundant seed costs some written rows while a wrongly skipped one serves stale content. `npm run db:seed:search:remote:force` overrides the check.
 
+### When the apply fails: a resetting D1
+
+The remote apply is the last thing the production deploy command runs, *after* the Worker has shipped. So a failure there fails the whole Workers Build over an index that will be rebuilt on the next deploy anyway — which is exactly what happened on 2026-08-26: the Worker deployed, the R2 cache populated, and the build went red on `✘ [ERROR] {"D1_RESET_DO":true}`.
+
+`D1_RESET_DO` means the Durable Object behind the database was reset. D1 does that on an internal error, a D1 code update, an overloaded or unreachable node, or a write that ran too long, and its [debug table](https://developers.cloudflare.com/d1/observability/debug-d1/) names "attempting a large import" as a way to earn the last one. `seed-search.mjs` retries the family (three attempts, 5s then 10s) rather than failing the build on the first one.
+
+Two things make retrying safe rather than hopeful. The import is atomic — wrangler prints "if the execution fails to complete, your DB will return to its original state and you can safely retry" on the way in — and even a hypothetical partial apply is covered by the hash-written-last property above. Note that D1's *own* automatic retries do not help here: it retries read-only queries only, and never anything that writes.
+
+What is deliberately **not** retried: `Exceeded maximum DB size` and the free-tier daily row limits. Those fail identically on every attempt and want a person, not another 15 seconds.
+
+If the retries stop being enough, the import is probably too large to apply in one shot (it is ~22 MB / 21k rows / 285 batches today) and the fix is to shard the seed into sequential files — which the hash-written-last property already anticipates, since it makes a partial apply a self-correcting state rather than a corrupt one.
+
 Sizing, measured rather than estimated: 8,965 rows over ~890 lessons produce a **~21 MB** database (14.7 MB of stored text so `snippet()` can quote matches, 5.5 MB of actual inverted index). That is 4% of the free plan's 500 MB per-database cap and 0.2% of the paid plan's 10 GB, so storage is not a constraint this index will run into.
 
 ### Two D1 rules the seed generator exists to respect

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ Production and preview deploys run through Cloudflare Workers Builds rather than
 
 | Field | Value |
 | --- | --- |
-| Build command | `npx opennextjs-cloudflare build && node scripts/compress-cache.mjs` ⚠️ **see below — the second half is not set today** |
+| Build command | `npx opennextjs-cloudflare build && node scripts/compress-cache.mjs` ⚠️ **see below — the second half is not on this field today** |
 | Deploy command | `npx opennextjs-cloudflare deploy --cacheChunkSize 100 && npm run db:seed:search:remote` |
 | Version command *(the dashboard's label for the non-production branch deploy)* | `npx opennextjs-cloudflare upload --cacheChunkSize 100` |
 | Path | `/` |
@@ -64,11 +64,21 @@ Both `deploy` (production) and `upload` (preview versions) populate the R2 cache
 
 It is safe to forget. The reader accepts uncompressed entries too, so a deploy that skips this step ships a cache that is merely as large as it used to be, rather than a site that 500s — see the note in `brotliR2IncrementalCache.ts` for why that fallback is load-bearing rather than defensive clutter. Running it twice is a no-op.
 
-**It is currently forgotten, and has been since the code merged.** Step 4 of [the #665 handoff](agent-outputs/20260814-2030-build-pipeline-handoff.md) — appending `&& node scripts/compress-cache.mjs` to this field — was deliberately deferred until a deploy had shipped the brotli reader, and was then never made. Every deploy from 2026-08-15 to at least 2026-08-26 has therefore populated R2 with raw JSON: **2.52 GB per build instead of ~0.16 GB**, which is the whole of the ~15 GB the bucket has been sitting at. Nothing looked wrong from any other angle — the site serves, the build is green, and the retention job was pruning correctly the entire time. That is the fallback working exactly as designed, and it is why the size is the only symptom.
+**Which field it goes on is the whole point, and it is currently the wrong one.** Measured 2026-08-26, straight out of the bucket:
 
-Two ways to see the state of this field without opening the dashboard:
+| Build folder | Size | Format |
+| --- | ---: | --- |
+| live production | 0.16 GB | brotli |
+| `main` head (production's incoming build) | 0.16 GB | brotli |
+| all six preview builds | 2.51–2.53 GB each | **raw JSON** |
 
-- **The cleanup run log** (`.github/workflows/r2-cache-cleanup.yml`, every 2 h) prints each build folder's size and format — `2.52 GB, UNCOMPRESSED` versus `0.16 GB, brotli` — and raises a workflow warning when the live production build is the former.
+Production compresses; no preview does. Workers Builds runs **one** build command for production and non-production branches alike and varies only the *deploy* command ([Build branches](https://developers.cloudflare.com/workers/ci-cd/builds/build-branches/)), so a split like that can only mean `compress-cache` is attached to the **production deploy command** rather than to the build command. It has been that way since the code merged on 2026-08-15: 12.6 GB of the ~15 GB bucket is six preview builds shipping ~16× the bytes they need to.
+
+Moving it to the **build command** fixes both paths at once, which is why it belongs there and not on either deploy command. (Prepending it to the Version command as well would also work, and leaves two places to forget instead of none.)
+
+Nothing looked wrong from any other angle, and that is the fallback working as designed: previews served fine, builds were green, and the retention job was pruning correctly the whole time. Size was the only symptom, and nothing was reading it. Two ways to check without opening the dashboard:
+
+- **The cleanup run log** (`.github/workflows/r2-cache-cleanup.yml`, every 2 h) prints every build folder's size and format — `2.52 GB, UNCOMPRESSED` versus `0.16 GB, brotli` — and warns when any retained build is raw, naming whether production is among them.
 - **The build log** says `[compress-cache] N compressed … 2.340 GiB → 0.147 GiB` when the step ran. No such line means it did not.
 
 **`--cacheChunkSize` is how many cache objects are written to R2 at once, and the default is 25.** That default is not sized for this cache: the populate step ships **1,081 objects / 2.34 GiB on every deploy, production and every preview** (see [Incremental cache cleanup](#incremental-cache-cleanup) for why a full copy goes up each time), and at 25 in flight that is 44 sequential rounds of ~2.2 MB uploads. Both commands accept the flag — it is declared on `deploy` and `upload` alike, and OpenNext's arg parser consumes it rather than forwarding it to `wrangler`, so it cannot confuse the deploy underneath.
@@ -99,7 +109,7 @@ bucket ≈ (build folders retained) × (bytes per build)
              ↑ the cleanup job below      ↑ the build command above
 ```
 
-**Bytes per build is ~2.34 GiB raw, or ~0.147 GiB once `compress-cache` has run** — a 16× difference that no amount of retention tuning can substitute for. The 15 GB the bucket sat at through August was 6–8 retained folders (correct) at 2.52 GB each (not correct): a build-command problem wearing a retention problem's clothes. The cleanup log now names which one it is looking at, so the next one gets diagnosed from the run log rather than from the dashboard.
+**Bytes per build is ~2.34 GiB raw, or ~0.147 GiB once `compress-cache` has run** — a 16× difference that no amount of retention tuning can substitute for. The 15 GB the bucket sat at through August was 8 retained folders (correct) of which 6 were uncompressed previews (not correct): a build-configuration problem wearing a retention problem's clothes. The cleanup log now prints the size and format of every folder, so the next one is diagnosed from the run log rather than by guessing at the dashboard.
 
 A scheduled GitHub Action (`.github/workflows/r2-cache-cleanup.yml`) prunes it every 2 hours. It works because the build ID is the deployed commit SHA — `next.config.ts` sets `generateBuildId` to `WORKERS_CI_COMMIT_SHA` on Workers Builds — so a cache folder's name is the commit it was built from, and every folder can be matched against a live deployment.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ Production and preview deploys run through Cloudflare Workers Builds rather than
 
 | Field | Value |
 | --- | --- |
-| Build command | `npx opennextjs-cloudflare build && node scripts/compress-cache.mjs` ⚠️ **see below — the second half is not on this field today** |
+| Build command | `npx opennextjs-cloudflare build && node scripts/compress-cache.mjs` |
 | Deploy command | `npx opennextjs-cloudflare deploy --cacheChunkSize 100 && npm run db:seed:search:remote` |
 | Version command *(the dashboard's label for the non-production branch deploy)* | `npx opennextjs-cloudflare upload --cacheChunkSize 100` |
 | Path | `/` |
@@ -64,7 +64,7 @@ Both `deploy` (production) and `upload` (preview versions) populate the R2 cache
 
 It is safe to forget. The reader accepts uncompressed entries too, so a deploy that skips this step ships a cache that is merely as large as it used to be, rather than a site that 500s — see the note in `brotliR2IncrementalCache.ts` for why that fallback is load-bearing rather than defensive clutter. Running it twice is a no-op.
 
-**Which field it goes on is the whole point, and it is currently the wrong one.** Measured 2026-08-26, straight out of the bucket:
+**Setting it is necessary and not sufficient — something downstream can undo it.** Measured 2026-08-26 straight out of the bucket, with the build command above set correctly:
 
 | Build folder | Size | Format |
 | --- | ---: | --- |
@@ -72,13 +72,15 @@ It is safe to forget. The reader accepts uncompressed entries too, so a deploy t
 | `main` head (production's incoming build) | 0.16 GB | brotli |
 | all six preview builds | 2.51–2.53 GB each | **raw JSON** |
 
-Production compresses; no preview does. Workers Builds runs **one** build command for production and non-production branches alike and varies only the *deploy* command ([Build branches](https://developers.cloudflare.com/workers/ci-cd/builds/build-branches/)), so a split like that can only mean `compress-cache` is attached to the **production deploy command** rather than to the build command. It has been that way since the code merged on 2026-08-15: 12.6 GB of the ~15 GB bucket is six preview builds shipping ~16× the bytes they need to.
+Production compresses; no preview does — 12.6 GB of a 15.44 GB bucket. Workers Builds runs **one** build command for production and non-production branches alike and varies only the *deploy* command ([Build branches](https://developers.cloudflare.com/workers/ci-cd/builds/build-branches/)), so the compression is reaching the preview path and being thrown away again before its populate.
 
-Moving it to the **build command** fixes both paths at once, which is why it belongs there and not on either deploy command. (Prepending it to the Version command as well would also work, and leaves two places to forget instead of none.)
+There is one mechanism that does that. `deploy` and `upload` are the same code as far as the cache goes: both stream `.open-next/cache` to R2 byte-for-byte and **neither rebuilds**. `opennextjs-cloudflare build`, by contrast, *wipes* `.open-next` (`initOutputDir`) and regenerates the cache assets as fresh raw JSON. So a second `opennextjs-cloudflare build` on one path only — a **non-production branch deploy command** that begins with one — reproduces this split exactly: production ships what the build command compressed, previews ship a regenerated raw copy.
+
+**The Version command must therefore not rebuild.** Keep it at `npx opennextjs-cloudflare upload --cacheChunkSize 100`; if it has to rebuild for some other reason, it must re-run `node scripts/compress-cache.mjs` after doing so.
 
 Nothing looked wrong from any other angle, and that is the fallback working as designed: previews served fine, builds were green, and the retention job was pruning correctly the whole time. Size was the only symptom, and nothing was reading it. Two ways to check without opening the dashboard:
 
-- **The cleanup run log** (`.github/workflows/r2-cache-cleanup.yml`, every 2 h) prints every build folder's size and format — `2.52 GB, UNCOMPRESSED` versus `0.16 GB, brotli` — and warns when any retained build is raw, naming whether production is among them.
+- **The cleanup run log** (`.github/workflows/r2-cache-cleanup.yml`, every 2 h) prints every build folder's size, format and populate time — `2.52 GB, UNCOMPRESSED, populated …` versus `0.16 GB, brotli, populated …` — and warns when any retained build is raw. Whether production is among them is the fork in the diagnosis: if it is, suspect the build command; if it is not, suspect the non-production branch deploy command, because production is the build that stays correct under the failure above.
 - **The build log** says `[compress-cache] N compressed … 2.340 GiB → 0.147 GiB` when the step ran. No such line means it did not.
 
 **`--cacheChunkSize` is how many cache objects are written to R2 at once, and the default is 25.** That default is not sized for this cache: the populate step ships **1,081 objects / 2.34 GiB on every deploy, production and every preview** (see [Incremental cache cleanup](#incremental-cache-cleanup) for why a full copy goes up each time), and at 25 in flight that is 44 sequential rounds of ~2.2 MB uploads. Both commands accept the flag — it is declared on `deploy` and `upload` alike, and OpenNext's arg parser consumes it rather than forwarding it to `wrangler`, so it cannot confuse the deploy underneath.
@@ -109,7 +111,7 @@ bucket ≈ (build folders retained) × (bytes per build)
              ↑ the cleanup job below      ↑ the build command above
 ```
 
-**Bytes per build is ~2.34 GiB raw, or ~0.147 GiB once `compress-cache` has run** — a 16× difference that no amount of retention tuning can substitute for. The 15 GB the bucket sat at through August was 8 retained folders (correct) of which 6 were uncompressed previews (not correct): a build-configuration problem wearing a retention problem's clothes. The cleanup log now prints the size and format of every folder, so the next one is diagnosed from the run log rather than by guessing at the dashboard.
+**Bytes per build is ~2.34 GiB raw, or ~0.147 GiB once `compress-cache` has run** — a 16× difference that no amount of retention tuning can substitute for. The 15 GB the bucket sat at through August was 8 retained folders (correct) of which 6 were uncompressed previews (not correct): a build-configuration problem wearing a retention problem's clothes. The cleanup log now prints every folder's size, format and populate time, so the next one is diagnosed from the run log rather than by guessing at the dashboard.
 
 A scheduled GitHub Action (`.github/workflows/r2-cache-cleanup.yml`) prunes it every 2 hours. It works because the build ID is the deployed commit SHA — `next.config.ts` sets `generateBuildId` to `WORKERS_CI_COMMIT_SHA` on Workers Builds — so a cache folder's name is the commit it was built from, and every folder can be matched against a live deployment.
 

--- a/__tests__/seedSearchRetry.test.ts
+++ b/__tests__/seedSearchRetry.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __testing } from "../scripts/seed-search.mjs";
+
+// The search re-seed runs last in the production deploy command, after the
+// Worker has shipped, so a D1 that resets mid-import fails the whole build
+// over an index that will simply be rebuilt next time. `applySeed` retries
+// that family and only that family.
+
+const { applySeed, retryReason, APPLY_ATTEMPTS } = __testing as {
+  applySeed: (opts: { run: () => string; sleep: (ms: number) => void }) => void;
+  retryReason: (output: unknown) => string | null;
+  APPLY_ATTEMPTS: number;
+};
+
+/** An `execFileSync` failure: the two streams are separate properties, and
+ *  which one carries the message is the point of several tests below. */
+function execFailure({ stdout = "", stderr = "" }: { stdout?: string; stderr?: string }) {
+  return Object.assign(new Error("Command failed: npx wrangler d1 execute"), {
+    status: 1,
+    stdout,
+    stderr,
+  });
+}
+
+/** The banner wrangler had already printed to stdout when the real 2026-08-26
+ *  production deploy died — no error text in it at all. */
+const BANNER =
+  "\n ⛅️ wrangler 4.119.0\n🌀 Executing on remote database dataslope-search:\n" +
+  "├ Checking if file needs uploading\n│ 🌀 Uploading complete.\n";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function silenced() {
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+}
+
+describe("retryReason", () => {
+  it("recognises the reset D1 returns from a broken import", () => {
+    expect(retryReason('✘ [ERROR] {"D1_RESET_DO":true}')).toBeTruthy();
+    expect(retryReason("Internal error in D1 DB storage caused object to be reset.")).toBeTruthy();
+    expect(retryReason("D1 DB is overloaded. Too many requests queued.")).toBeTruthy();
+    expect(retryReason("Network connection lost.")).toBeTruthy();
+  });
+
+  it("refuses to retry a limit, even though another attempt would look the same", () => {
+    expect(retryReason("Exceeded maximum DB size.")).toBeNull();
+    expect(retryReason("Your account has exceeded D1's free tier daily row write limit.")).toBeNull();
+  });
+
+  it("refuses to retry an ordinary failure", () => {
+    expect(retryReason("Error: near \"INSRT\": syntax error")).toBeNull();
+    expect(retryReason("")).toBeNull();
+    expect(retryReason(undefined)).toBeNull();
+  });
+
+  it("is case-insensitive, since the code and the prose spell it differently", () => {
+    expect(retryReason('{"d1_reset_do":true}')).toBeTruthy();
+    expect(retryReason('{"D1_RESET_DO":true}')).toBeTruthy();
+  });
+});
+
+describe("applySeed", () => {
+  it("retries a reset and returns once an attempt succeeds", () => {
+    silenced();
+    const run = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw execFailure({ stdout: BANNER, stderr: '✘ [ERROR] {"D1_RESET_DO":true}' });
+      })
+      .mockReturnValueOnce("🚣 Executed 285 queries");
+    const sleep = vi.fn();
+
+    expect(() => applySeed({ run, sleep })).not.toThrow();
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  // The regression this whole change exists for: wrangler printed the banner
+  // to stdout and `D1_RESET_DO` to stderr, and the old code inherited stderr,
+  // so the reason was never visible to the process that had to decide.
+  it("reads the reason from stderr, which carries it and stdout does not", () => {
+    silenced();
+    const run = vi.fn().mockImplementation(() => {
+      throw execFailure({ stdout: BANNER, stderr: '✘ [ERROR] {"D1_RESET_DO":true}' });
+    });
+
+    expect(() => applySeed({ run, sleep: vi.fn() })).toThrow();
+    expect(run).toHaveBeenCalledTimes(APPLY_ATTEMPTS);
+  });
+
+  it("gives up after the attempt cap and rethrows the last failure", () => {
+    silenced();
+    const run = vi.fn().mockImplementation(() => {
+      throw execFailure({ stderr: '✘ [ERROR] {"D1_RESET_DO":true}' });
+    });
+
+    expect(() => applySeed({ run, sleep: vi.fn() })).toThrow(/Command failed/);
+    expect(run).toHaveBeenCalledTimes(APPLY_ATTEMPTS);
+  });
+
+  it("does not retry a failure that would fail the same way again", () => {
+    silenced();
+    const run = vi.fn().mockImplementation(() => {
+      throw execFailure({ stderr: 'Error: near "INSRT": syntax error' });
+    });
+    const sleep = vi.fn();
+
+    expect(() => applySeed({ run, sleep })).toThrow(/Command failed/);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("backs off longer on each successive reset", () => {
+    silenced();
+    const run = vi.fn().mockImplementation(() => {
+      throw execFailure({ stderr: "D1 DB storage operation exceeded timeout, object was reset" });
+    });
+    const sleep = vi.fn();
+
+    expect(() => applySeed({ run, sleep })).toThrow();
+    const waits = sleep.mock.calls.map(([ms]) => ms as number);
+    expect(waits).toHaveLength(APPLY_ATTEMPTS - 1);
+    expect(waits).toEqual([...waits].sort((a, b) => a - b));
+    expect(waits[0]).toBeGreaterThan(0);
+  });
+
+  it("runs once and sleeps not at all when the first attempt works", () => {
+    silenced();
+    const run = vi.fn().mockReturnValue("🚣 Executed 285 queries");
+    const sleep = vi.fn();
+
+    applySeed({ run, sleep });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/agent-outputs/20260814-2030-build-pipeline-handoff.md
+++ b/agent-outputs/20260814-2030-build-pipeline-handoff.md
@@ -11,23 +11,23 @@
 > verified in production (see [Where this stands](#where-this-stands)). What remains is **step 4**,
 > the one order-dependent dashboard edit, which is now safe to make.
 
-> **Status, 2026-08-26 — step 4 is applied, and it is not enough.** The build command carries
-> `&& node scripts/compress-cache.mjs`, and production is compressed: live production **0.16 GB,
-> brotli**, `main`'s head **0.16 GB, brotli**. But all six preview builds measure **2.51–2.53 GB of
-> raw JSON** — 12.6 GB of a 15.44 GB bucket. Workers Builds runs one build command for both, so
-> compression is reaching the preview path and being discarded before its populate.
+> **Status, 2026-08-26 — step 4 was applied to one of the two build commands.** This runbook says
+> "the build command" because that is what the Cloudflare docs said; the dashboard has since grown a
+> **Production / Previews Base** tab switch, and *each tab has its own*. Production got the edit and
+> is compressed — live production **0.16 GB, brotli**, `main`'s head **0.16 GB, brotli**. Previews
+> Base was still a bare `npx opennextjs-cloudflare build`, so all six preview builds measure
+> **2.51–2.53 GB of raw JSON**: 12.6 GB of a 15.44 GB bucket, from one unedited field on the tab you
+> do not land on, on the path that deploys far more often than production.
 >
-> One mechanism does that. `deploy` and `upload` both stream `.open-next/cache` byte-for-byte and
-> neither rebuilds; `opennextjs-cloudflare build` wipes `.open-next` (`initOutputDir`) and
-> regenerates the cache raw. **A non-production branch deploy command that begins with a second
-> `opennextjs-cloudflare build` reproduces this split exactly** — check that field. It must stay a
-> bare `npx opennextjs-cloudflare upload --cacheChunkSize 100`, or re-run `compress-cache` after
-> whatever rebuild it does.
+> **Step 4 must be applied twice, once per tab.** See DEVELOPMENT.md, "Cloudflare Workers Builds
+> configuration", which now lists both. The Previews Base *deploy* command stays
+> `npx opennextjs-cloudflare upload --cacheChunkSize 100` — never with the search re-seed appended.
 >
 > Why it went unnoticed for eleven days: the reader accepts raw entries, so previews served
 > normally, builds stayed green, and the retention job pruned correctly throughout. Size was the
 > only symptom and nothing read it. The cleanup run log now prints every folder's size, format and
-> populate time and warns on any raw build, so the next lapse surfaces within two hours.
+> populate time and warns on any raw build, naming which tab to look at, so the next lapse surfaces
+> within two hours.
 
 ---
 

--- a/agent-outputs/20260814-2030-build-pipeline-handoff.md
+++ b/agent-outputs/20260814-2030-build-pipeline-handoff.md
@@ -11,22 +11,23 @@
 > verified in production (see [Where this stands](#where-this-stands)). What remains is **step 4**,
 > the one order-dependent dashboard edit, which is now safe to make.
 
-> **Status, 2026-08-26 — step 4 landed on the wrong field, and that is why the R2 bucket is
-> ~15 GB.** Measured from the bucket: live production **0.16 GB, brotli**; `main`'s head **0.16 GB,
-> brotli**; all six preview builds **2.51–2.53 GB, raw JSON** — 12.6 GB of the bucket. Workers
-> Builds runs one build command for production and non-production branches alike and varies only
-> the deploy command, so compression can only be attached to the **production deploy command**
-> instead of the **build command** this step names. Production has been fine since 2026-08-15;
-> nothing has ever compressed a preview.
+> **Status, 2026-08-26 — step 4 is applied, and it is not enough.** The build command carries
+> `&& node scripts/compress-cache.mjs`, and production is compressed: live production **0.16 GB,
+> brotli**, `main`'s head **0.16 GB, brotli**. But all six preview builds measure **2.51–2.53 GB of
+> raw JSON** — 12.6 GB of a 15.44 GB bucket. Workers Builds runs one build command for both, so
+> compression is reaching the preview path and being discarded before its populate.
 >
-> **The fix is to move `&& node scripts/compress-cache.mjs` onto the Build command**, where it
-> covers both paths. Everything in step 4 below still applies — including the ordering rule, which
-> is now moot in the safe direction since the reader has been deployed for eleven days.
+> One mechanism does that. `deploy` and `upload` both stream `.open-next/cache` byte-for-byte and
+> neither rebuilds; `opennextjs-cloudflare build` wipes `.open-next` (`initOutputDir`) and
+> regenerates the cache raw. **A non-production branch deploy command that begins with a second
+> `opennextjs-cloudflare build` reproduces this split exactly** — check that field. It must stay a
+> bare `npx opennextjs-cloudflare upload --cacheChunkSize 100`, or re-run `compress-cache` after
+> whatever rebuild it does.
 >
 > Why it went unnoticed for eleven days: the reader accepts raw entries, so previews served
 > normally, builds stayed green, and the retention job pruned correctly throughout. Size was the
-> only symptom and nothing read it. The cleanup run log now prints every folder's size and format
-> and warns on any raw build, so the next lapse surfaces within two hours.
+> only symptom and nothing read it. The cleanup run log now prints every folder's size, format and
+> populate time and warns on any raw build, so the next lapse surfaces within two hours.
 
 ---
 
@@ -65,7 +66,7 @@ The live Worker is currently reading **uncompressed** entries through the raw-JS
 the build command has not been changed yet. That is the fallback doing its job, and incidental
 proof that path works. *(As of 2026-08-26 production reads compressed entries and every preview
 still reads raw ones — see the status note at the top. The fallback has now proved itself over
-eleven days and ~15 GB.)*
+eleven days and ~15 GB, on the path nobody was watching.)*
 
 **Still to do: step 4 only** — add `&& node scripts/compress-cache.mjs` to the build command. The
 merged code is on `main`, so it is safe now.

--- a/agent-outputs/20260814-2030-build-pipeline-handoff.md
+++ b/agent-outputs/20260814-2030-build-pipeline-handoff.md
@@ -11,6 +11,15 @@
 > verified in production (see [Where this stands](#where-this-stands)). What remains is **step 4**,
 > the one order-dependent dashboard edit, which is now safe to make.
 
+> **Status, 2026-08-26 — step 4 is still not made, and it is the entire reason the R2 bucket is
+> ~15 GB.** Every deploy since 2026-08-15 has populated raw JSON: the cleanup job measured a build
+> folder from that morning at **2.52 GB**, against the ~0.16 GB compression produces. Eight retained
+> folders, ~2.5 GB each. The reader's raw fallback is why eleven days of this looked like nothing at
+> all — the site served, the builds were green, and the retention job was pruning correctly the
+> whole time. Nothing in the repo can apply this edit; the cleanup run log now reports each folder's
+> size and format and warns when production is uncompressed, so the next lapse is visible in two
+> hours rather than eleven days.
+
 ---
 
 ## TL;DR
@@ -46,7 +55,8 @@ workerd. The `51400985` bug is fixed in production, not just locally.
 
 The live Worker is currently reading **uncompressed** entries through the raw-JSON fallback, since
 the build command has not been changed yet. That is the fallback doing its job, and incidental
-proof that path works.
+proof that path works. *(Still true on 2026-08-26 — see the status note at the top. The fallback has
+now proved itself over eleven days and ~15 GB.)*
 
 **Still to do: step 4 only** — add `&& node scripts/compress-cache.mjs` to the build command. The
 merged code is on `main`, so it is safe now.

--- a/agent-outputs/20260814-2030-build-pipeline-handoff.md
+++ b/agent-outputs/20260814-2030-build-pipeline-handoff.md
@@ -11,14 +11,22 @@
 > verified in production (see [Where this stands](#where-this-stands)). What remains is **step 4**,
 > the one order-dependent dashboard edit, which is now safe to make.
 
-> **Status, 2026-08-26 — step 4 is still not made, and it is the entire reason the R2 bucket is
-> ~15 GB.** Every deploy since 2026-08-15 has populated raw JSON: the cleanup job measured a build
-> folder from that morning at **2.52 GB**, against the ~0.16 GB compression produces. Eight retained
-> folders, ~2.5 GB each. The reader's raw fallback is why eleven days of this looked like nothing at
-> all — the site served, the builds were green, and the retention job was pruning correctly the
-> whole time. Nothing in the repo can apply this edit; the cleanup run log now reports each folder's
-> size and format and warns when production is uncompressed, so the next lapse is visible in two
-> hours rather than eleven days.
+> **Status, 2026-08-26 — step 4 landed on the wrong field, and that is why the R2 bucket is
+> ~15 GB.** Measured from the bucket: live production **0.16 GB, brotli**; `main`'s head **0.16 GB,
+> brotli**; all six preview builds **2.51–2.53 GB, raw JSON** — 12.6 GB of the bucket. Workers
+> Builds runs one build command for production and non-production branches alike and varies only
+> the deploy command, so compression can only be attached to the **production deploy command**
+> instead of the **build command** this step names. Production has been fine since 2026-08-15;
+> nothing has ever compressed a preview.
+>
+> **The fix is to move `&& node scripts/compress-cache.mjs` onto the Build command**, where it
+> covers both paths. Everything in step 4 below still applies — including the ordering rule, which
+> is now moot in the safe direction since the reader has been deployed for eleven days.
+>
+> Why it went unnoticed for eleven days: the reader accepts raw entries, so previews served
+> normally, builds stayed green, and the retention job pruned correctly throughout. Size was the
+> only symptom and nothing read it. The cleanup run log now prints every folder's size and format
+> and warns on any raw build, so the next lapse surfaces within two hours.
 
 ---
 
@@ -55,8 +63,9 @@ workerd. The `51400985` bug is fixed in production, not just locally.
 
 The live Worker is currently reading **uncompressed** entries through the raw-JSON fallback, since
 the build command has not been changed yet. That is the fallback doing its job, and incidental
-proof that path works. *(Still true on 2026-08-26 — see the status note at the top. The fallback has
-now proved itself over eleven days and ~15 GB.)*
+proof that path works. *(As of 2026-08-26 production reads compressed entries and every preview
+still reads raw ones — see the status note at the top. The fallback has now proved itself over
+eleven days and ~15 GB.)*
 
 **Still to do: step 4 only** — add `&& node scripts/compress-cache.mjs` to the build command. The
 merged code is on `main`, so it is safe now.

--- a/scripts/seed-search.mjs
+++ b/scripts/seed-search.mjs
@@ -13,11 +13,15 @@
  * `docs_meta.content_hash` by the seed itself — written last, so a partial
  * apply cannot leave a hash claiming to be current. Any uncertainty seeds: a
  * redundant seed costs some rows, a wrongly skipped one leaves search stale.
+ *
+ * The apply itself retries a resetting D1 (see `retryReason`), because this
+ * runs last in the production deploy command and a reset there fails the whole
+ * build after the Worker has already shipped.
  */
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const SEED_FILE = join(ROOT, "lib", "generated", "search-seed.sql");
@@ -27,13 +31,6 @@ const args = new Set(process.argv.slice(2));
 const remote = args.has("--remote");
 const force = args.has("--force");
 const target = remote ? "--remote" : "--local";
-
-if (!existsSync(SEED_FILE)) {
-  console.error(
-    "[seed-search] no lib/generated/search-seed.sql; run `npm run build:search-corpus` first",
-  );
-  process.exit(1);
-}
 
 /** The hash of the seed we are holding, read from the file we would apply. */
 function localHash() {
@@ -74,27 +71,152 @@ function remoteHash() {
   }
 }
 
-const local = localHash();
-if (!local) {
-  console.error("[seed-search] seed file carries no content-hash marker; regenerate it");
-  process.exit(1);
+// ── Applying the seed ────────────────────────────────────────────────────────
+
+/** Failures that mean "the Durable Object behind the database went away", which
+ *  D1 surfaces on an internal error, a D1 code update, an overloaded or
+ *  unreachable node, or a write that ran too long. `D1_RESET_DO` is the raw
+ *  code the remote import path returns for the family. */
+const D1_RETRYABLE = [
+  "d1_reset_do",
+  "was reset",
+  "caused object to be reset",
+  "is overloaded",
+  "transient issue on remote node",
+  "network connection lost",
+  "client disconnected",
+];
+
+/** Checked first, and never retried: these fail identically every attempt and
+ *  want a person — more space, a plan change, or tomorrow. */
+const D1_FATAL = [
+  "exceeded maximum db size",
+  "daily row read limit",
+  "daily row write limit",
+];
+
+const APPLY_ATTEMPTS = 3;
+
+/**
+ * Why a failed apply is worth another attempt, or null to give up now.
+ *
+ * Retrying is safe rather than merely hopeful: the remote import is atomic, and
+ * wrangler says so on the way in — "if the execution fails to complete, your DB
+ * will return to its original state and you can safely retry." Even a
+ * hypothetical partial apply is covered, because the content hash is the seed's
+ * last statement, so the next run still sees a mismatch and re-seeds.
+ *
+ * D1's own automatic retries do not cover this. It retries read-only queries
+ * only; anything that writes is never retried, which an import plainly is.
+ */
+function retryReason(output) {
+  const text = String(output ?? "").toLowerCase();
+  if (D1_FATAL.some((phrase) => text.includes(phrase))) return null;
+  return D1_RETRYABLE.find((phrase) => text.includes(phrase)) ?? null;
 }
 
-if (!force) {
-  const current = remoteHash();
-  if (current && current === local) {
-    console.log(
-      `[seed-search] ${DB_NAME} ${target} already holds ${local.slice(0, 12)}…, nothing to seed`,
-    );
-    process.exit(0);
-  }
-  console.log(
-    `[seed-search] content changed (${current ? `${current.slice(0, 12)}…` : "no hash on record"}` +
-      ` → ${local.slice(0, 12)}…), seeding`,
+/** Node has no synchronous sleep and this script is synchronous throughout
+ *  (`execFileSync`); waiting on a throwaway shared buffer blocks without
+ *  turning the whole file async for one pause between attempts. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** One `d1 execute --file` run, returning whatever it printed. */
+function runSeedFile() {
+  return execFileSync(
+    "npx",
+    ["wrangler", "d1", "execute", DB_NAME, target, "-y", `--file=${relative(ROOT, SEED_FILE)}`],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+      // Both streams captured rather than inherited: the retry decision is in
+      // wrangler's stderr, and `execFileSync` only exposes that when it is
+      // piped. Everything captured gets printed either way, so the build log
+      // still shows the apply. Capturing stderr also means it now counts
+      // against maxBuffer, hence the raised ceiling — the default 1 MB
+      // overflowing would kill a working seed.
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
   );
-} else {
-  console.log(`[seed-search] --force, seeding ${local.slice(0, 12)}… unconditionally`);
 }
 
-wrangler([`--file=${relative(ROOT, SEED_FILE)}`]);
-console.log(`[seed-search] seeded ${DB_NAME} ${target}`);
+/** Apply the seed, retrying a resetting D1. Throws the last failure otherwise. */
+function applySeed({ run = runSeedFile, sleep = sleepSync } = {}) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      process.stdout.write(run() ?? "");
+      return;
+    } catch (err) {
+      const output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+      process.stdout.write(output);
+      const reason = retryReason(output);
+      if (!reason || attempt >= APPLY_ATTEMPTS) {
+        if (reason) {
+          console.error(
+            `[seed-search] still resetting after ${APPLY_ATTEMPTS} attempts. The import rolled back, ` +
+              "so the index holds the previous corpus and the next deploy retries it. If this keeps " +
+              "recurring the seed is probably too large to apply in one import and wants sharding — " +
+              "see DEVELOPMENT.md, Search.",
+          );
+        }
+        throw err;
+      }
+      // 5s, 10s: long enough for a Durable Object to come back, short enough
+      // not to stall a deploy that is genuinely broken.
+      const waitMs = 5_000 * attempt;
+      console.error(
+        `  … d1 execute failed (${reason}); retry ${attempt}/${APPLY_ATTEMPTS - 1} in ${waitMs / 1000}s`,
+      );
+      sleep(waitMs);
+    }
+  }
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+function main() {
+  if (!existsSync(SEED_FILE)) {
+    console.error(
+      "[seed-search] no lib/generated/search-seed.sql; run `npm run build:search-corpus` first",
+    );
+    process.exit(1);
+  }
+
+  const local = localHash();
+  if (!local) {
+    console.error("[seed-search] seed file carries no content-hash marker; regenerate it");
+    process.exit(1);
+  }
+
+  if (!force) {
+    const current = remoteHash();
+    if (current && current === local) {
+      console.log(
+        `[seed-search] ${DB_NAME} ${target} already holds ${local.slice(0, 12)}…, nothing to seed`,
+      );
+      return;
+    }
+    console.log(
+      `[seed-search] content changed (${current ? `${current.slice(0, 12)}…` : "no hash on record"}` +
+        ` → ${local.slice(0, 12)}…), seeding`,
+    );
+  } else {
+    console.log(`[seed-search] --force, seeding ${local.slice(0, 12)}… unconditionally`);
+  }
+
+  applySeed();
+  console.log(`[seed-search] seeded ${DB_NAME} ${target}`);
+}
+
+/** Exposed for `__tests__/seedSearchRetry.test.ts`, which pins both halves of
+ *  the retry contract. */
+export const __testing = { applySeed, retryReason, APPLY_ATTEMPTS };
+
+// Only drive the CLI when executed directly: the vitest suite imports
+// `__testing`, and that import must not seed a database.
+const invokedDirectly =
+  process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (invokedDirectly) main();


### PR DESCRIPTION
Two things the R2 bucket investigation turned up, both on the deploy path and both silent by design.

# 1. The 12.6 GB: Previews Base has its own build command

`dataslope-inc-cache` sat at **15.44 GB across 8 build folders**. #663/#664/#666 shrank the *count* and are working correctly — the retention job keeps ~7 folders and prunes on schedule. The bytes are the other factor, and nothing was measuring them:

| Build folder | Populated | Size | Format |
| --- | --- | ---: | --- |
| production `daf18cce` | 08-26 11:14 | **0.16 GB** | brotli |
| production `a61da166` | 08-24 18:22 | **0.16 GB** | brotli |
| `main` head `2a2eb8f0` | 08-24 18:21 | **0.16 GB** | brotli |
| preview `af5a82e6` | 08-26 09:57 | 2.52 GB | **raw JSON** |
| preview `b02a4452` | 08-26 09:39 | 2.52 GB | **raw JSON** |
| preview `9c67bcae` | 08-25 17:20 | 2.53 GB | **raw JSON** |
| preview ×3 (codex) | 08-24 14:06–15:05 | 2.51–2.52 GB | **raw JSON** |

Production compresses. **No preview does** — 12.6 GB of the 15.44. Read the dates alongside: production compresses on 08-24 *and* 08-26, previews on neither, interleaved through the same afternoons. It splits by path, not by timeline.

Cloudflare's Build settings page has a **Production / Previews Base** tab switch, and **each tab carries its own build command**. Production's had `&& node scripts/compress-cache.mjs` from #665. Previews Base's was still a bare `npx opennextjs-cloudflare build`. That is the whole thing: one unedited field, on the tab you don't land on, on the path that deploys far more often than production. The Cloudflare docs still describe a single build command plus a "Version command" for non-production branches — which is what `DEVELOPMENT.md` documented, and why the second field was never set.

It stayed invisible for eleven days because every other signal is green *by design*: `brotliR2IncrementalCache.ts` accepts raw entries on purpose, so previews served normally, builds passed, and the cleanup job pruned correctly throughout. Size was the only symptom — and the job printed a size only for folders it was about to delete, so the ones that stayed were never weighed.

**Fix (dashboard, not code):** Previews Base → Build command → `npx opennextjs-cloudflare build && node scripts/compress-cache.mjs`.

### What changes here

- **Every KEEP/DELETE line carries size, format and populate time** — `2.52 GB, UNCOMPRESSED, populated …` vs `0.16 GB, brotli, populated …` — for every folder, not just the ones being deleted. The timestamp is what separates "this path never compresses" from "this build predates the fix".
- **A warning closes each run** when any retained build is raw, and **names the tab to open**: production among them → Production tab; production not among them → Previews Base, because production is the build that stays correct when only one tab was edited, i.e. the one that hides this.
- **Format is read, not inferred**: a ranged GET of the first four bytes of one entry per folder, checked against `BROTLI_CACHE_MAGIC`. One populate writes a whole folder, so one sample settles the build.
- **Costs less than before.** Size, timestamps and the sample key come from a single `list-objects-v2` per folder instead of a timestamps-only list, so a folder on its way out costs one Class A LIST *fewer*; the format sample adds ~8 Class B GETs a run against 10M free.

Retention logic is untouched — same keep set, same grace window, same aborts.

Also documented, since it is the next-largest lever: the two `codex/add-venn-diagrams-…` branch names push the preview alias past the 63-character DNS limit, where Cloudflare [truncates and appends an unpublished hash](https://developers.cloudflare.com/changelog/post/2025-08-08-support-long-branch-names-preview-aliases/). The job can't name that alias, so it falls back to pinning 3 builds per branch. Short branch names are the whole fix.

# 2. The red build: a resetting D1 fails a deploy that already shipped

The 2026-08-26 production build went red, and the R2 half of it had gone perfectly:

```
11:14:04  [compress-cache] 1081 compressed — 2.347 GiB → 0.148 GiB, 15.9× smaller
11:14:22  Successfully populated cache with 1081 entries
11:14:50  Deployed dataslope triggers — Current Version ID: 32e239f4-…
11:14:51  > npm run db:seed:search:remote
11:15:03  ✘ [ERROR] {"D1_RESET_DO":true}
11:15:03  Failed: error occurred while running deploy command
```

The Worker shipped; the search re-seed after it did not. That ordering is deliberate — the re-seed runs last *so a search hiccup cannot block shipping the site* — and it worked. But it still turned a good deploy into a failed build over an index the next deploy rebuilds anyway.

`D1_RESET_DO` means the Durable Object behind the database was reset: an internal error, a D1 code update, an overloaded or unreachable node, or a write that ran too long ([debug table](https://developers.cloudflare.com/d1/observability/debug-d1/), which names "attempting a large import" as a way to earn the last one). So `seed-search.mjs` now retries that family — three attempts, 5s then 10s.

Retrying is safe rather than hopeful: the import is atomic, and wrangler says so on the way in — *"if the execution fails to complete, your DB will return to its original state and you can safely retry"* — and even a partial apply is covered by the existing hash-written-last property. D1's own automatic retries do not help: they cover read-only queries only, and an import writes.

`Exceeded maximum DB size` and the free-tier daily row limits are checked **first and never retried** — they fail identically every attempt and want a person, not another 15 seconds.

One mechanical change makes this possible: the apply now **pipes stderr instead of inheriting it**, because that is where the reason lives — the failed build recorded `stderr: null` for exactly that reason. Both streams are printed either way, so the log actually gains wrangler's summary table, which the old code captured and discarded.

# Verification

**R2:** dry runs against the real bucket from this branch — [318](https://github.com/dataslope/dataslope/actions/runs/32955649964), [320](https://github.com/dataslope/dataslope/actions/runs/32962591741) — read-only, nothing deleted. Every table above is that output. Plus 10 assertions against a stubbed `aws` covering size summing, magic detection on both formats, empty folders, missing objects, and the unchanged median-timestamp selection.

**Seed retry:** 10 new tests in `__tests__/seedSearchRetry.test.ts` — classification of the reset family vs. limits vs. ordinary failures, retry-then-succeed, the attempt cap, no-retry on a deterministic failure, and increasing backoff. One of them pins the actual regression: that the reason is read from **stderr**, which carries it, and not stdout, which in the real failure held only the banner. The two runtime assumptions were checked against Node directly rather than only against the fakes — a piped `execFileSync` failure does expose both streams as strings, and `Atomics.wait` does block.