### PR TITLE
Recover from a stale build instead of dead-ending on "Something went wrong"

### DIFF
--- a/__tests__/staleBuild.test.ts
+++ b/__tests__/staleBuild.test.ts
@@ -1,0 +1,182 @@
+// Stale-build recovery (app/_components/staleBuild.ts). A tab left open
+// across a deploy asks for hashed chunks the origin no longer serves; the
+// crash that follows is an ordinary TypeError thrown at module evaluation,
+// not a ChunkLoadError, so the 404 itself has to be the signal.
+import { describe, expect, it } from "vitest";
+
+import {
+  ASSET_FAILURE_GLOBAL,
+  RELOAD_COOLDOWN_MS,
+  STALE_BUILD_WATCHER_SCRIPT,
+  isBuildAssetUrl,
+  looksLikeStaleBuildError,
+  shouldReloadForStaleBuild,
+} from "../app/_components/staleBuild";
+
+describe("isBuildAssetUrl", () => {
+  it("matches hashed build output, absolute or relative", () => {
+    expect(isBuildAssetUrl("/_next/static/chunks/23dphzdqxtiv6.js")).toBe(true);
+    expect(
+      isBuildAssetUrl("https://dataslope.com/_next/static/chunks/2j13i86rt3126.css"),
+    ).toBe(true);
+  });
+
+  it("ignores everything else", () => {
+    expect(isBuildAssetUrl("/logo-files/SVG/dataslope-logo-white.svg")).toBe(false);
+    expect(isBuildAssetUrl("https://cdn.jsdelivr.net/pyodide/pyodide.js")).toBe(false);
+    expect(isBuildAssetUrl("/_next/image?url=%2Fcover.webp")).toBe(false);
+    expect(isBuildAssetUrl(undefined)).toBe(false);
+    expect(isBuildAssetUrl(null)).toBe(false);
+  });
+});
+
+describe("looksLikeStaleBuildError", () => {
+  it("recognises the messages bundlers and browsers use", () => {
+    const err = new Error("Loading chunk 4821 failed.");
+    err.name = "ChunkLoadError";
+    expect(looksLikeStaleBuildError(err)).toBe(true);
+    expect(
+      looksLikeStaleBuildError(
+        new Error("Failed to fetch dynamically imported module: /_next/static/x.js"),
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeStaleBuildError(new Error("Importing a module script failed.")),
+    ).toBe(true);
+    expect(
+      looksLikeStaleBuildError(
+        new Error("Module was instantiated but the module factory is not available"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not recognise the error the original report actually threw", () => {
+    // The whole reason the watcher exists: a missing chunk leaves an import
+    // undefined and the crash reads like any other bug.
+    expect(
+      looksLikeStaleBuildError(
+        new TypeError("Cannot read properties of undefined (reading 'map')"),
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores non-errors", () => {
+    expect(looksLikeStaleBuildError(null)).toBe(false);
+    expect(looksLikeStaleBuildError(undefined)).toBe(false);
+    expect(looksLikeStaleBuildError({})).toBe(false);
+  });
+});
+
+describe("shouldReloadForStaleBuild", () => {
+  const anonymousCrash = new TypeError(
+    "Cannot read properties of undefined (reading 'map')",
+  );
+
+  it("reloads when an asset 404'd, whatever the error says", () => {
+    expect(
+      shouldReloadForStaleBuild({
+        assetFailed: true,
+        error: anonymousCrash,
+        now: 1_000,
+        lastReloadAt: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("reloads on a self-identifying chunk error with no 404 recorded", () => {
+    expect(
+      shouldReloadForStaleBuild({
+        assetFailed: false,
+        error: new Error("ChunkLoadError: Loading chunk 12 failed"),
+        now: 1_000,
+        lastReloadAt: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("leaves ordinary crashes alone", () => {
+    expect(
+      shouldReloadForStaleBuild({
+        assetFailed: false,
+        error: anonymousCrash,
+        now: 1_000,
+        lastReloadAt: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not loop when the reload did not help", () => {
+    const now = 10_000_000;
+    expect(
+      shouldReloadForStaleBuild({
+        assetFailed: true,
+        error: anonymousCrash,
+        now,
+        lastReloadAt: now - (RELOAD_COOLDOWN_MS - 1),
+      }),
+    ).toBe(false);
+  });
+
+  it("allows another reload once the cooldown has passed", () => {
+    const now = 10_000_000;
+    expect(
+      shouldReloadForStaleBuild({
+        assetFailed: true,
+        error: anonymousCrash,
+        now,
+        lastReloadAt: now - (RELOAD_COOLDOWN_MS + 1),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("STALE_BUILD_WATCHER_SCRIPT", () => {
+  /** Runs the inlined watcher against a stand-in window and returns it
+   *  together with the `error` listener it registered. */
+  function runWatcher() {
+    const listeners: Array<(e: unknown) => void> = [];
+    const win: Record<string, unknown> = {
+      addEventListener: (type: string, fn: (e: unknown) => void) => {
+        if (type === "error") listeners.push(fn);
+      },
+    };
+    new Function("window", STALE_BUILD_WATCHER_SCRIPT)(win);
+    expect(listeners).toHaveLength(1);
+    return { win, fire: listeners[0] };
+  }
+
+  it("sets the global the boundaries read", () => {
+    expect(STALE_BUILD_WATCHER_SCRIPT).toContain(JSON.stringify(ASSET_FAILURE_GLOBAL));
+  });
+
+  it("is safe to inline in a <script> tag", () => {
+    expect(STALE_BUILD_WATCHER_SCRIPT).not.toContain("</script");
+  });
+
+  it("flags a 404 on a build script or stylesheet", () => {
+    const { win, fire } = runWatcher();
+    fire({ target: { tagName: "SCRIPT", src: "/_next/static/chunks/23dphzdqxtiv6.js" } });
+    expect(win[ASSET_FAILURE_GLOBAL]).toBe(true);
+
+    const css = runWatcher();
+    css.fire({
+      target: { tagName: "LINK", href: "/_next/static/chunks/2j13i86rt3126.css" },
+    });
+    expect(css.win[ASSET_FAILURE_GLOBAL]).toBe(true);
+  });
+
+  it("ignores failures that are not this build's code", () => {
+    const { win, fire } = runWatcher();
+    // A broken <img>, and a CDN runtime we deliberately load off-origin.
+    fire({ target: { tagName: "IMG", src: "/_next/static/chunks/a.js" } });
+    fire({ target: { tagName: "SCRIPT", src: "https://cdn.jsdelivr.net/x.js" } });
+    fire({ target: { tagName: "LINK", href: "/logo-files/SVG/logo.svg" } });
+    expect(win[ASSET_FAILURE_GLOBAL]).toBeUndefined();
+  });
+
+  it("survives an event with no target", () => {
+    const { win, fire } = runWatcher();
+    expect(() => fire({})).not.toThrow();
+    expect(win[ASSET_FAILURE_GLOBAL]).toBeUndefined();
+  });
+});

--- a/app/_components/SegmentError.tsx
+++ b/app/_components/SegmentError.tsx
@@ -10,10 +10,15 @@
 // list (both Tailwind roots compile with source(none)); if it moves,
 // update that glob or its utilities stop being generated.
 import "@/app/tailwind.css";
-import { useEffect } from "react";
-import Link from "next/link";
+import { useEffect, useSyncExternalStore } from "react";
 
 import { THEME_BOOTSTRAP } from "@/app/_components/home/themeBootstrap";
+import {
+  isStaleBuildCrash,
+  neverStale,
+  recoverFromStaleBuild,
+  subscribeToStaleBuild,
+} from "@/app/_components/staleBuild";
 
 export default function SegmentError({
   error,
@@ -30,8 +35,17 @@ export default function SegmentError({
       boundary renders inside persistent chrome (the dashboard shell). */
   fullScreen?: boolean;
 }) {
+  // See app/_components/staleBuild.ts: a chunk this deploy no longer serves
+  // crashes the segment, and `reset()` cannot clear it.
+  const stale = useSyncExternalStore(
+    subscribeToStaleBuild,
+    () => isStaleBuildCrash(error),
+    neverStale,
+  );
+
   useEffect(() => {
     console.error("segment error boundary:", error);
+    recoverFromStaleBuild(error);
   }, [error]);
 
   return (
@@ -53,22 +67,28 @@ export default function SegmentError({
             {title}
           </h1>
           <p className="mt-3 text-sm leading-relaxed text-[var(--ds-gray-500)] dark:text-[var(--ds-gray-400)]">
-            {message}
+            {stale
+              ? "This page was left open across an update and could not finish loading. Reloading picks up the new version."
+              : message}
           </p>
           <div className="mt-6 flex justify-center gap-3">
             <button
               type="button"
-              onClick={reset}
+              onClick={() => (stale ? window.location.reload() : reset())}
               className="inline-flex items-center rounded-lg bg-[var(--ds-green-600)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--ds-green-700)]"
             >
-              Try again
+              {stale ? "Reload" : "Try again"}
             </button>
-            <Link
+            {/* Plain <a>, not next/link: a client-side navigation re-enters
+                the router that just crashed, and on a stale build it would
+                ask for the very chunks that 404'd. */}
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
               href="/"
               className="inline-flex items-center rounded-lg border border-[var(--ds-gray-200)] px-4 py-2 text-sm font-semibold text-[var(--ds-gray-700)] transition-colors hover:bg-[var(--ds-gray-50)] dark:border-white/10 dark:text-[var(--ds-gray-200)] dark:hover:bg-white/5"
             >
               Home
-            </Link>
+            </a>
           </div>
           {error?.digest && (
             <p className="mt-6 text-xs text-[var(--ds-gray-400)]">

--- a/app/_components/staleBuild.ts
+++ b/app/_components/staleBuild.ts
@@ -1,0 +1,178 @@
+/**
+ * Recovery from a stale build.
+ *
+ * Every deploy renames the hashed chunks under `/_next/static/` and drops the
+ * previous set from the Workers asset store, so a tab opened before a deploy
+ * holds a document pointing at files the origin no longer serves. The tab
+ * survives until it needs a chunk it has not already downloaded — a
+ * client-side navigation to a route it has not visited — and then that chunk
+ * 404s. `experimental.staleTimes` (next.config.ts) keeps prefetched payloads
+ * reusable for 5-30 minutes, which widens the window a tab can sit in this
+ * state.
+ *
+ * The crash that follows is not reliably a ChunkLoadError. A module whose
+ * import came from the missing chunk evaluates with that binding undefined
+ * and throws whatever its top-level code happens to throw first — the report
+ * this module was written for was `Cannot read properties of undefined
+ * (reading 'map')` thrown at module evaluation while rendering the home page,
+ * which no message-sniffing heuristic would ever recognise. So the 404 itself
+ * is the signal: `STALE_BUILD_WATCHER_SCRIPT` records asset load failures as
+ * they happen, and the error boundaries ask this module whether the crash
+ * they just caught sits downstream of one.
+ *
+ * Recovery is a hard reload, the only thing that helps: `reset()` re-renders
+ * against the same poisoned module registry, and the boundaries' "Home" link
+ * was a client-side navigation into the same missing chunks. The user in the
+ * original report escaped by refreshing manually.
+ *
+ * Deliberately dependency-free (no React, no Next) so app/global-error.tsx,
+ * which stands in for a crashed root layout, can use it without widening its
+ * own blast radius.
+ */
+
+/** Set on `window` by {@link STALE_BUILD_WATCHER_SCRIPT} when a build asset
+ *  404s. A global, not storage: the question is only ever "did this document
+ *  lose an asset", and a flag that dies with the document cannot leak into a
+ *  later, unrelated crash in the same tab. */
+export const ASSET_FAILURE_GLOBAL = "__dsStaleBuildAssetFailed";
+
+/** Timestamp of the last reload we forced. In sessionStorage because it has
+ *  to survive that reload — otherwise a genuinely broken build loops. */
+export const RELOAD_GUARD_KEY = "ds:stale-build-reloaded-at";
+
+/** How long a forced reload suppresses the next one. A reload that fixes
+ *  nothing must fall through to the error UI rather than fire again. */
+export const RELOAD_COOLDOWN_MS = 60_000;
+
+/** True for URLs of build output, whose names change every deploy. */
+export function isBuildAssetUrl(url: unknown): boolean {
+  return typeof url === "string" && url.includes("/_next/static/");
+}
+
+/** Messages browsers and bundlers use when a chunk cannot be loaded or
+ *  instantiated. A useful signal on its own, but not a sufficient one — see
+ *  the module comment for why the 404 is tracked separately. */
+const STALE_BUILD_MESSAGES = [
+  /ChunkLoadError/i,
+  /Loading chunk \S+ failed/i,
+  /Loading CSS chunk \S+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Importing a module script failed/i,
+  /module factory is not available/i,
+  /is not a valid JavaScript MIME type/i,
+];
+
+/** True when the error itself names a chunk failure. */
+export function looksLikeStaleBuildError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? `${error.name}: ${error.message}`
+      : typeof error === "string"
+        ? error
+        : "";
+  if (!message) return false;
+  return STALE_BUILD_MESSAGES.some((re) => re.test(message));
+}
+
+/** The reload decision, as a pure function so it can be tested without a
+ *  document. `assetFailed` is the watcher's flag; `lastReloadAt` is the guard
+ *  timestamp (null when we have not reloaded this session). */
+export function shouldReloadForStaleBuild({
+  assetFailed,
+  error,
+  now,
+  lastReloadAt,
+}: {
+  assetFailed: boolean;
+  error: unknown;
+  now: number;
+  lastReloadAt: number | null;
+}): boolean {
+  if (!assetFailed && !looksLikeStaleBuildError(error)) return false;
+  if (lastReloadAt !== null && now - lastReloadAt < RELOAD_COOLDOWN_MS) {
+    return false;
+  }
+  return true;
+}
+
+/** True when this document has seen a build asset fail to load. */
+export function sawBuildAssetFailure(): boolean {
+  if (typeof window === "undefined") return false;
+  return (window as unknown as Record<string, unknown>)[ASSET_FAILURE_GLOBAL] === true;
+}
+
+/** True when the boundary should offer a reload rather than `reset()`, and
+ *  say the page went stale rather than blaming the user's work. */
+export function isStaleBuildCrash(error: unknown): boolean {
+  return sawBuildAssetFailure() || looksLikeStaleBuildError(error);
+}
+
+/** `useSyncExternalStore` subscribe for {@link isStaleBuildCrash}. The flag
+ *  is written before hydration and never changes afterwards, so there is
+ *  nothing to notify; the hook exists to keep the read out of render and off
+ *  the server snapshot. */
+export function subscribeToStaleBuild(): () => void {
+  return () => {};
+}
+
+/** Server snapshot for the same hook: a server render has no document and so
+ *  never saw a 404. */
+export function neverStale(): boolean {
+  return false;
+}
+
+function readGuard(): number | null {
+  try {
+    const raw = window.sessionStorage.getItem(RELOAD_GUARD_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null; // private mode; the cooldown guard is best-effort
+  }
+}
+
+/**
+ * Reloads the page when `error` is downstream of a stale build, and reports
+ * whether it did.
+ */
+export function recoverFromStaleBuild(error: unknown): boolean {
+  if (typeof window === "undefined") return false;
+
+  const reload = shouldReloadForStaleBuild({
+    assetFailed: sawBuildAssetFailure(),
+    error,
+    now: Date.now(),
+    lastReloadAt: readGuard(),
+  });
+  if (!reload) return false;
+
+  try {
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+  } catch {
+    /* private mode; reload anyway, the cooldown is best-effort */
+  }
+  window.location.reload();
+  return true;
+}
+
+/**
+ * Runs in <head>, before any chunk can fail, and flags 404s on build assets.
+ * A capture-phase listener because resource load errors do not bubble. Kept
+ * as a string, and built from the constants above, so the watcher and the
+ * boundaries that read its flag cannot drift apart.
+ */
+export const STALE_BUILD_WATCHER_SCRIPT = `
+(function () {
+  try {
+    window.addEventListener("error", function (e) {
+      var t = e.target;
+      if (!t || (t.tagName !== "SCRIPT" && t.tagName !== "LINK")) return;
+      var url = t.src || t.href || "";
+      if (typeof url !== "string" || url.indexOf("/_next/static/") === -1) return;
+      window[${JSON.stringify(ASSET_FAILURE_GLOBAL)}] = true;
+    }, true);
+  } catch (err) { /* no window.addEventListener: nothing to recover from */ }
+})();
+`;

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -5,10 +5,15 @@
 // Deliberately self-contained (no HomeNav/HomeFooter): the less this page
 // depends on, the less likely it is to crash while reporting a crash.
 import "@/app/tailwind.css";
-import { useEffect } from "react";
-import Link from "next/link";
+import { useEffect, useSyncExternalStore } from "react";
 
 import { THEME_BOOTSTRAP } from "@/app/_components/home/themeBootstrap";
+import {
+  isStaleBuildCrash,
+  neverStale,
+  recoverFromStaleBuild,
+  subscribeToStaleBuild,
+} from "@/app/_components/staleBuild";
 
 export default function GlobalError({
   error,
@@ -17,8 +22,22 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  // A crash caused by a chunk this deploy no longer serves is not the user's
+  // to act on, and neither button below can clear it: `reset()` re-renders
+  // against the same missing module. See staleBuild.ts. Read through
+  // useSyncExternalStore because the flag lives on `window`, which a server
+  // render cannot see.
+  const stale = useSyncExternalStore(
+    subscribeToStaleBuild,
+    () => isStaleBuildCrash(error),
+    neverStale,
+  );
+
   useEffect(() => {
     console.error("app error boundary:", error);
+    // Reloads when the crash is a stale build, so the card below is on
+    // screen only until that reload commits.
+    recoverFromStaleBuild(error);
   }, [error]);
 
   return (
@@ -36,23 +55,28 @@ export default function GlobalError({
             Something went wrong
           </h1>
           <p className="mt-3 text-sm leading-relaxed text-[var(--ds-gray-500)] dark:text-[var(--ds-gray-400)]">
-            An unexpected error interrupted this page. Your playground work is
-            stored in this browser and is not affected.
+            {stale
+              ? "This page was left open across an update and could not finish loading. Reloading picks up the new version."
+              : "An unexpected error interrupted this page. Your playground work is stored in this browser and is not affected."}
           </p>
           <div className="mt-6 flex justify-center gap-3">
             <button
               type="button"
-              onClick={reset}
+              onClick={() => (stale ? window.location.reload() : reset())}
               className="inline-flex items-center rounded-lg bg-[var(--ds-green-600)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--ds-green-700)]"
             >
-              Try again
+              {stale ? "Reload" : "Try again"}
             </button>
-            <Link
+            {/* Plain <a>, not next/link: a client-side navigation re-enters
+                the router that just crashed, and on a stale build it would
+                ask for the very chunks that 404'd. */}
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
               href="/"
               className="inline-flex items-center rounded-lg border border-[var(--ds-gray-200)] px-4 py-2 text-sm font-semibold text-[var(--ds-gray-700)] transition-colors hover:bg-[var(--ds-gray-50)] dark:border-white/10 dark:text-[var(--ds-gray-200)] dark:hover:bg-white/5"
             >
               Home
-            </Link>
+            </a>
           </div>
           {error?.digest && (
             <p className="mt-6 text-xs text-[var(--ds-gray-400)]">

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -5,7 +5,16 @@
 // own <html>/<body> because it replaces the layout. Deliberately
 // dependency-free: the less this depends on, the less likely it is to crash
 // while reporting a crash.
-import { useEffect } from "react";
+import { useEffect, useSyncExternalStore } from "react";
+
+// Zero-dependency module (no React, no Next), so importing it here does not
+// widen what has to evaluate correctly for this boundary to render.
+import {
+  isStaleBuildCrash,
+  neverStale,
+  recoverFromStaleBuild,
+  subscribeToStaleBuild,
+} from "@/app/_components/staleBuild";
 
 export default function GlobalError({
   error,
@@ -14,8 +23,17 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  // See app/_components/staleBuild.ts: when the crash is a chunk this deploy
+  // no longer serves, only a reload helps.
+  const stale = useSyncExternalStore(
+    subscribeToStaleBuild,
+    () => isStaleBuildCrash(error),
+    neverStale,
+  );
+
   useEffect(() => {
     console.error("root layout error boundary:", error);
+    recoverFromStaleBuild(error);
   }, [error]);
 
   return (
@@ -68,8 +86,9 @@ export default function GlobalError({
                 color: "#6b7280",
               }}
             >
-              An unexpected error interrupted this page. Your playground work
-              is stored in this browser and is not affected.
+              {stale
+                ? "This page was left open across an update and could not finish loading. Reloading picks up the new version."
+                : "An unexpected error interrupted this page. Your playground work is stored in this browser and is not affected."}
             </p>
             <div
               style={{
@@ -81,7 +100,7 @@ export default function GlobalError({
             >
               <button
                 type="button"
-                onClick={reset}
+                onClick={() => (stale ? window.location.reload() : reset())}
                 style={{
                   border: 0,
                   borderRadius: 8,
@@ -93,7 +112,7 @@ export default function GlobalError({
                   cursor: "pointer",
                 }}
               >
-                Try again
+                {stale ? "Reload" : "Try again"}
               </button>
               {/* Plain <a>, not next/link: this boundary replaces the crashed
                   root layout, so a hard navigation is safer than relying on

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import AskAi from "@/app/_components/ai/AskAi";
 import NavigationLoadingIndicator from "@/app/_components/NavigationLoadingIndicator";
 import SkipToContent from "@/app/_components/SkipToContent";
 import { ReturnToTracker } from "@/app/_components/auth/returnTo";
+import { STALE_BUILD_WATCHER_SCRIPT } from "@/app/_components/staleBuild";
 
 // The app's two typefaces, self-hosted by next/font and published as CSS
 // variables on <html>. This is the ONLY place webfonts load — stylesheets
@@ -136,6 +137,10 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://esm.sh" />
         <link rel="dns-prefetch" href="https://unpkg.com" />
         <script dangerouslySetInnerHTML={{ __html: themeBootstrapScript }} />
+        {/* Flags 404s on hashed build assets, which is how a tab left open
+            across a deploy fails. Must run before any chunk loads, and
+            before the error boundaries that read the flag. */}
+        <script dangerouslySetInnerHTML={{ __html: STALE_BUILD_WATCHER_SCRIPT }} />
       </head>
       <body>
         {/* First tab stop on every page, playground headers alone have ~10


### PR DESCRIPTION
Clicking the Dataslope logo on `/dashboard/admin` to go home landed on the root error boundary. The console showed `Cannot read properties of undefined (reading 'map')` thrown **at module evaluation**, and — earlier in the same session — two 404s:

```
/_next/static/chunks/23dphzdqxtiv6.js  404
/_next/static/chunks/2w94dbfsoncu_.js  404
```

## What was actually happening

A tab left open across a deploy. Every deploy renames the hashed chunks under `/_next/static/` and drops the previous set from the Workers asset store, so an old document asks for files the origin no longer serves — the moment it navigates client-side to a route whose chunks it has not already downloaded. `experimental.staleTimes` (300s / 1800s) keeps prefetched payloads reusable for a long time, which widens the window a tab can sit in that state.

That accounts for both symptoms in the report: it is intermittent because it needs a deploy to land mid-session, and a hard refresh fixes it because that fetches the current document.

The crash is **not** a `ChunkLoadError` and cannot be recognised from its message. A module whose import came from the missing chunk evaluates with that binding `undefined` and throws whatever its top-level code reaches first — here a `.map` on an import at module scope. So the 404 itself has to be the signal.

I also checked the alternative explanations and ruled them out: there are no circular imports anywhere in `app/`, `lib/` or `components/`, and an AST-level sweep for module-scope `.map` over an import found only `HomeFooter`'s `COURSE_LINKS`/`PLAYGROUND_LINKS`, whose two sources (`catalogFilters.ts`, `playgrounds.ts`) are leaf modules that cannot be undefined on their own.

## Changes

- **`app/_components/staleBuild.ts`** (new) — a watcher inlined into `<head>` flags load failures on `/_next/static/` scripts and stylesheets on a per-document `window` global; `recoverFromStaleBuild()` decides whether a caught error sits downstream of one. Deliberately dependency-free (no React, no Next) so `global-error.tsx` can use it without widening its own blast radius.
- **`app/error.tsx`, `app/global-error.tsx`, `app/_components/SegmentError.tsx`** — reload once when the crash is a stale build, guarded by a 60s cooldown in sessionStorage so a genuinely broken build cannot loop. The copy says the page went stale instead of implying the user lost work, and the "Home" button is now a plain `<a>`.

The old recovery path could not work: `reset()` re-renders against the same poisoned module registry, and "Home" was a `next/link` client navigation straight back into the missing chunks. Manually refreshing was the only escape, which is exactly what happened.

The stale-build read goes through `useSyncExternalStore` with a `false` server snapshot, so a value that only exists on `window` never causes a hydration mismatch.

## Testing

- `__tests__/staleBuild.test.ts` — 15 new tests. Includes a case asserting that the error from this report is *not* recognisable from its message, which is the reason the watcher exists.
- Verified in real Chromium that a 404 on a build `<script>`/`<link>` fires the capture-phase `error` event the watcher listens for, and that an unrelated CDN script or image 404 does not.
- Full suite: 1895 passed, 131 files. `eslint .`: 0 errors. `tsc --noEmit`: clean.

## Note, not addressed here

The log is also full of `preloaded using link preload but not used` warnings for a fixed set of CSS chunks, both logo SVGs and `error-404-cutout.webp`, repeated on every page. That looks like a separate over-preloading issue and is out of scope for this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_013m3sYTi5giGpDCQKTd1f2j)_